### PR TITLE
[refactor] (Nereids) rename GroupExpression.getParent() to getOwnerGroup()

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/cascades/ApplyRuleJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/cascades/ApplyRuleJob.java
@@ -63,7 +63,7 @@ public class ApplyRuleJob extends Job {
             List<Plan> newPlans = rule.transform(plan, context.getPlannerContext());
             for (Plan newPlan : newPlans) {
                 GroupExpression newGroupExpression = context.getPlannerContext().getMemo()
-                        .copyIn(newPlan, groupExpression.getParent(), rule.isRewrite());
+                        .copyIn(newPlan, groupExpression.getOwnerGroup(), rule.isRewrite());
                 if (newPlan instanceof LogicalPlan) {
                     pushTask(new DeriveStatsJob(newGroupExpression, context));
                     if (exploredOnly) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/cascades/CostAndEnforcerJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/cascades/CostAndEnforcerJob.java
@@ -162,7 +162,7 @@ public class CostAndEnforcerJob extends Job {
                 }
                 PlanContext planContext = new PlanContext(groupExpression);
                 // TODO: calculate stats.
-                groupExpression.getParent().setStatistics(planContext.getStatistics());
+                groupExpression.getOwnerGroup().setStatistics(planContext.getStatistics());
 
                 enforce(outputProperty, childrenInputProperties);
             }
@@ -193,7 +193,7 @@ public class CostAndEnforcerJob extends Job {
 
             // enforcedProperty is superset of requiredProperty
             if (!addEnforcedProperty.equals(requiredProperties)) {
-                putProperty(groupExpression.getParent().getBestExpression(addEnforcedProperty),
+                putProperty(groupExpression.getOwnerGroup().getBestExpression(addEnforcedProperty),
                         requiredProperties, requiredProperties, Lists.newArrayList(outputProperty));
             }
         } else {
@@ -217,7 +217,7 @@ public class CostAndEnforcerJob extends Job {
             // and shuffle join two types outputProperty.
             groupExpression.putOutputPropertiesMap(outputProperty, requiredProperty);
         }
-        this.groupExpression.getParent().setBestPlan(groupExpression,
+        this.groupExpression.getOwnerGroup().setBestPlan(groupExpression,
                 curTotalCost, requiredProperty);
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Group.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Group.java
@@ -66,7 +66,7 @@ public class Group {
             this.physicalExpressions.add(groupExpression);
         }
         this.logicalProperties = logicalProperties;
-        groupExpression.setParent(this);
+        groupExpression.setOwnerGroup(this);
     }
 
     public GroupId getGroupId() {
@@ -93,7 +93,7 @@ public class Group {
         } else {
             physicalExpressions.add(groupExpression);
         }
-        groupExpression.setParent(this);
+        groupExpression.setOwnerGroup(this);
         return groupExpression;
     }
 
@@ -109,7 +109,7 @@ public class Group {
         } else {
             physicalExpressions.remove(groupExpression);
         }
-        groupExpression.setParent(null);
+        groupExpression.setOwnerGroup(null);
         return groupExpression;
     }
 
@@ -121,7 +121,7 @@ public class Group {
      */
     public GroupExpression rewriteLogicalExpression(GroupExpression newExpression,
             LogicalProperties logicalProperties) {
-        newExpression.setParent(this);
+        newExpression.setOwnerGroup(this);
         this.logicalProperties = logicalProperties;
         GroupExpression oldExpression = getLogicalExpression();
         logicalExpressions.clear();

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/GroupExpression.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/GroupExpression.java
@@ -36,7 +36,7 @@ import java.util.Objects;
  * Representation for group expression in cascades optimizer.
  */
 public class GroupExpression {
-    private Group parent;
+    private Group ownerGroup;
     private List<Group> children;
     private final Plan plan;
     private final BitSet ruleMasks;
@@ -81,12 +81,12 @@ public class GroupExpression {
         children.add(child);
     }
 
-    public Group getParent() {
-        return parent;
+    public Group getOwnerGroup() {
+        return ownerGroup;
     }
 
-    public void setParent(Group parent) {
-        this.parent = parent;
+    public void setOwnerGroup(Group ownerGroup) {
+        this.ownerGroup = ownerGroup;
     }
 
     public Plan getPlan() {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Memo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Memo.java
@@ -47,7 +47,7 @@ public class Memo {
     private Group root;
 
     public Memo(Plan plan) {
-        root = copyIn(plan, null, false).getParent();
+        root = copyIn(plan, null, false).getOwnerGroup();
     }
 
     public Group getRoot() {
@@ -82,9 +82,9 @@ public class Memo {
             if (child instanceof GroupPlan) {
                 childrenGroups.add(((GroupPlan) child).getGroup());
             } else if (child.getGroupExpression().isPresent()) {
-                childrenGroups.add(child.getGroupExpression().get().getParent());
+                childrenGroups.add(child.getGroupExpression().get().getOwnerGroup());
             } else {
-                childrenGroups.add(copyIn(child, null, rewrite).getParent());
+                childrenGroups.add(copyIn(child, null, rewrite).getOwnerGroup());
             }
         }
         node = replaceChildrenToGroupPlan(node, childrenGroups);
@@ -133,9 +133,9 @@ public class Memo {
             boolean rewrite, LogicalProperties logicalProperties) {
         GroupExpression existedGroupExpression = groupExpressions.get(groupExpression);
         if (existedGroupExpression != null
-                && existedGroupExpression.getParent().getLogicalProperties().equals(logicalProperties)) {
-            if (target != null && !target.getGroupId().equals(existedGroupExpression.getParent().getGroupId())) {
-                mergeGroup(target, existedGroupExpression.getParent());
+                && existedGroupExpression.getOwnerGroup().getLogicalProperties().equals(logicalProperties)) {
+            if (target != null && !target.getGroupId().equals(existedGroupExpression.getOwnerGroup().getGroupId())) {
+                mergeGroup(target, existedGroupExpression.getOwnerGroup());
             }
             return existedGroupExpression;
         }
@@ -172,7 +172,7 @@ public class Memo {
         List<GroupExpression> needReplaceChild = Lists.newArrayList();
         groupExpressions.values().forEach(groupExpression -> {
             if (groupExpression.children().contains(source)) {
-                if (groupExpression.getParent().equals(destination)) {
+                if (groupExpression.getOwnerGroup().equals(destination)) {
                     // cycle, we should not merge
                     return;
                 }
@@ -189,8 +189,8 @@ public class Memo {
                 }
             }
             if (groupExpressions.containsKey(groupExpression)) {
-                // TODO: need to merge group recursively
-                groupExpression.getParent().removeGroupExpression(groupExpression);
+                GroupExpression that = groupExpressions.get(groupExpression);
+                mergeGroup(groupExpression.getOwnerGroup(), that.getOwnerGroup());
             } else {
                 groupExpressions.put(groupExpression, groupExpression);
             }
@@ -210,7 +210,7 @@ public class Memo {
      * Add enforcer expression into the target group.
      */
     public void addEnforcerPlan(GroupExpression groupExpression, Group group) {
-        groupExpression.setParent(group);
+        groupExpression.setOwnerGroup(group);
     }
 
     private Plan replaceChildrenToGroupPlan(Plan plan, List<Group> childrenGroups) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Memo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Memo.java
@@ -189,8 +189,8 @@ public class Memo {
                 }
             }
             if (groupExpressions.containsKey(groupExpression)) {
-                GroupExpression that = groupExpressions.get(groupExpression);
-                mergeGroup(groupExpression.getOwnerGroup(), that.getOwnerGroup());
+                // TODO: need to merge group recursively
+                groupExpression.getOwnerGroup().removeGroupExpression(groupExpression);
             } else {
                 groupExpressions.put(groupExpression, groupExpression);
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/pattern/GroupExpressionMatching.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/pattern/GroupExpressionMatching.java
@@ -159,7 +159,7 @@ public class GroupExpressionMatching implements Iterable<Plan> {
                     children.add(childrenPlans.get(i).get(childrenPlanIndex[i]));
                 }
 
-                LogicalProperties logicalProperties = groupExpression.getParent().getLogicalProperties();
+                LogicalProperties logicalProperties = groupExpression.getOwnerGroup().getLogicalProperties();
                 // assemble children: replace GroupPlan to real plan,
                 // withChildren will erase groupExpression, so we must
                 // withGroupExpression too.

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/EnforceMissingPropertiesHelper.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/EnforceMissingPropertiesHelper.java
@@ -77,7 +77,7 @@ public class EnforceMissingPropertiesHelper {
                 oldOutputProperty.getOrderSpec());
         newOutputProperty.setOrderSpec(context.getRequiredProperties().getOrderSpec());
         GroupExpression enforcer =
-                context.getRequiredProperties().getOrderSpec().addEnforcer(groupExpression.getParent());
+                context.getRequiredProperties().getOrderSpec().addEnforcer(groupExpression.getOwnerGroup());
 
         updateCostWithEnforcer(enforcer, oldOutputProperty, newOutputProperty);
 
@@ -89,7 +89,7 @@ public class EnforceMissingPropertiesHelper {
                 oldOutputProperty.getOrderSpec());
         newOutputProperty.setDistributionSpec(context.getRequiredProperties().getDistributionSpec());
         GroupExpression enforcer =
-                context.getRequiredProperties().getDistributionSpec().addEnforcer(groupExpression.getParent());
+                context.getRequiredProperties().getDistributionSpec().addEnforcer(groupExpression.getOwnerGroup());
 
         updateCostWithEnforcer(enforcer, oldOutputProperty, newOutputProperty);
 
@@ -99,13 +99,13 @@ public class EnforceMissingPropertiesHelper {
     private void updateCostWithEnforcer(GroupExpression enforcer,
             PhysicalProperties oldOutputProperty,
             PhysicalProperties newOutputProperty) {
-        context.getPlannerContext().getMemo().addEnforcerPlan(enforcer, groupExpression.getParent());
+        context.getPlannerContext().getMemo().addEnforcerPlan(enforcer, groupExpression.getOwnerGroup());
         curTotalCost += CostCalculator.calculateCost(enforcer);
 
         if (enforcer.updateLowestCostTable(newOutputProperty, Lists.newArrayList(oldOutputProperty), curTotalCost)) {
             enforcer.putOutputPropertiesMap(newOutputProperty, newOutputProperty);
         }
-        groupExpression.getParent().setBestPlan(enforcer, curTotalCost, newOutputProperty);
+        groupExpression.getOwnerGroup().setBestPlan(enforcer, curTotalCost, newOutputProperty);
     }
 
     private PhysicalProperties enforceSortAndDistribution(PhysicalProperties outputProperty,


### PR DESCRIPTION
# Proposed changes
GroupExpression.getParent() returns the group which contains this expr. This name is missleading especially in tree structures.
So we change the name to getOwnerGroup.

@924060929  could u review, please?

Issue Number: close #xxx

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
