### PR TITLE
[docs] using asf offical slack channel replace outdated slack url

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ For the first time in Doris community, you can:
 
 * Follow [Doris Github](https://github.com/apache/doris)
 * Subscribe to our [mailing list](./docs/en/community/subscribe-mail-list.md);
-* Join Doris [Slack](https://join.slack.com/t/apachedoriscommunity/shared_invite/zt-11jb8gesh-7IukzSrdea6mqoG0HB4gZg)
+* Join Doris [Slack](https://the-asf.slack.com/archives/C02P2JBD72A)
 
 Learn the development trends of Doris project in time and give your opinions on the topics you are concerned about.
 

--- a/CONTRIBUTING_CN.md
+++ b/CONTRIBUTING_CN.md
@@ -33,7 +33,7 @@ under the License.
 
 * 关注 Doris [Github 代码库](https://github.com/apache/doris)
 * 订阅我们的 [邮件列表](./docs/zh-CN/community/subscribe-mail-list.md)；
-* 加入 Doris 的 [Slack](https://join.slack.com/t/apachedoriscommunity/shared_invite/zt-11jb8gesh-7IukzSrdea6mqoG0HB4gZg)
+* 加入 Doris 的 [Slack](https://the-asf.slack.com/archives/C02P2JBD72A)
 
 通过以上方式及时了解 Doris 项目的开发动态并为您关注的话题发表意见。
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ under the License.
 [![License](https://img.shields.io/badge/license-Apache%202-4EB1BA.svg)](https://www.apache.org/licenses/LICENSE-2.0.html)
 [![Total Lines](https://tokei.rs/b1/github/apache/doris?category=lines)](https://github.com/apache/doris)
 [![GitHub release](https://img.shields.io/github/release/apache/doris.svg)](https://github.com/apache/doris/releases)
-[![Join the Doris Community at Slack](https://img.shields.io/badge/chat-slack-brightgreen)](https://join.slack.com/t/apachedoriscommunity/shared_invite/zt-11jb8gesh-7IukzSrdea6mqoG0HB4gZg)
+[![Join the Doris Community at Slack](https://img.shields.io/badge/chat-slack-brightgreen)](https://the-asf.slack.com/archives/C02P2JBD72A)
 [![Join the chat at https://gitter.im/apache-doris/Lobby](https://badges.gitter.im/apache-doris/Lobby.svg)](https://gitter.im/apache-doris/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 Doris is an MPP-based interactive SQL data warehousing for reporting and analysis.
@@ -91,4 +91,4 @@ Contact us through the following mailing list.
 
 * Doris official site - <https://doris.apache.org>
 * Developer Mailing list - <dev@doris.apache.org>. Mail to <dev-subscribe@doris.apache.org>, follow the reply to subscribe the mail list.
-* Slack channel - [Join the Slack](https://join.slack.com/t/apachedoriscommunity/shared_invite/zt-18u6vjopj-Th15vTVfmCzVfhhL5rz26A)
+* Slack channel - [Join the Slack](https://the-asf.slack.com/archives/C02P2JBD72A)

--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -31,7 +31,7 @@ under the License.
         <div class="bannerHref">
           <a href="/en/docs/get-starting/get-starting.html" class="button1">GET STARTED</a> 
           <a href="https://github.com/apache/doris" target="_blank" class="button2 black"><i class="doris doris-github-fill"></i>GITHUB</a>
-          <a href="https://join.slack.com/t/apachedoriscommunity/shared_invite/zt-18u6vjopj-Th15vTVfmCzVfhhL5rz26A" target="_blank" class="button2 white">
+          <a href="https://the-asf.slack.com/archives/C02P2JBD72A" target="_blank" class="button2 white">
           <i><img style="width: 20px; position: relative; left: 4px; top: 2px; margin: 0;" src="/images/slack.png" alt="Slack" /></i>SLACK</a>
         </div>
       </div> 
@@ -326,7 +326,7 @@ under the License.
           <li><a href="mailto:dev@doris.apache.org" target="_blank"><img src="/blog-images/fx1.png" alt="Email" /></a></li>
           <li><a href="https://github.com/apache/incubator-doris" target="_blank"><img src="/blog-images/fx2.png" alt="Github" /></a></li>
           <li><a href="https://twitter.com/doris_apache" target="_blank"><img src="/blog-images/fx3.png" alt="Twitter" /></a></li>
-          <li><a href="https://join.slack.com/t/apachedoriscommunity/shared_invite/zt-18u6vjopj-Th15vTVfmCzVfhhL5rz26A" target="_blank"><img src="/blog-images/fx4.png" alt="Slack" /></a></li>
+          <li><a href="https://the-asf.slack.com/archives/C02P2JBD72A" target="_blank"><img src="/blog-images/fx4.png" alt="Slack" /></a></li>
           <!-- <li><a href="https://mp.weixin.qq.com/mp/homepage?__biz=Mzg5MDEyODc1OA==&hid=1&sn=eb2d31c20d5c4fc638b897c764e11195&scene=18" target="_blank"><img src="/blog-images/fx5.png" alt="WeChart" /></a></li> -->
           <li><a href="https://space.bilibili.com/362350065" target="_blank"><img src="/blog-images/fx6.png" alt="bilibili" /></a></li>
         </ul>

--- a/docs/en/community/how-to-contribute/how-to-contribute.md
+++ b/docs/en/community/how-to-contribute/how-to-contribute.md
@@ -41,7 +41,7 @@ For the first time in Doris community, you can:
 * Follow [Doris Github](https://github.com/apache/incubator-doris)
 * Subscribe to our [mailing list](./subscribe-mail-list.md);
 * Join Doris Wechat Group (add WeChat-ID: morningman-cmy, note: join Doris Group) and ask questions at any time.
-* Enter Doris's [Slack](https://join.slack.com/t/apachedoriscommunity/shared_invite/zt-11jb8gesh-7IukzSrdea6mqoG0HB4gZg)
+* Enter Doris's [Slack](https://the-asf.slack.com/archives/C02P2JBD72A)
 
 Learn the development trends of Doris project in time and give your opinions on the topics you are concerned about.
 

--- a/docs/zh-CN/README.md
+++ b/docs/zh-CN/README.md
@@ -33,7 +33,7 @@ under the License.
         <div class="bannerHref">
           <a href="/zh-CN/docs/get-starting/get-starting.html" class="button1">快速开始</a> 
           <a href="https://github.com/apache/doris" target="_blank" class="button2"><i class="doris doris-github-fill"></i>GITHUB</a>
-          <a href="https://join.slack.com/t/apachedoriscommunity/shared_invite/zt-18u6vjopj-Th15vTVfmCzVfhhL5rz26A" target="_blank" class="button2 white">
+          <a href="https://the-asf.slack.com/archives/C02P2JBD72A" target="_blank" class="button2 white">
           <i><img style="width: 20px; position: relative; left: 4px; top: 2px; margin: 0;" src="/images/slack.png" alt="Slack" /></i>SLACK</a>
         </div>
       </div> 
@@ -327,7 +327,7 @@ under the License.
           <li><a href="mailto:dev@doris.apache.org" target="_blank"><img src="/blog-images/fx1.png" alt="Email" /></a></li>
           <li><a href="https://github.com/apache/incubator-doris" target="_blank"><img src="/blog-images/fx2.png" alt="Github" /></a></li>
           <li><a href="https://twitter.com/doris_apache" target="_blank"><img src="/blog-images/fx3.png" alt="Twitter" /></a></li>
-          <li><a href="https://join.slack.com/t/apachedoriscommunity/shared_invite/zt-18u6vjopj-Th15vTVfmCzVfhhL5rz26A" target="_blank"><img src="/blog-images/fx4.png" alt="Slack" /></a></li>
+          <li><a href="https://the-asf.slack.com/archives/C02P2JBD72A" target="_blank"><img src="/blog-images/fx4.png" alt="Slack" /></a></li>
           <!-- <li><a href="https://mp.weixin.qq.com/mp/homepage?__biz=Mzg5MDEyODc1OA==&hid=1&sn=eb2d31c20d5c4fc638b897c764e11195&scene=18" target="_blank"><img src="/blog-images/fx5.png" alt="WeChart" /></a></li> -->
           <li><a href="https://space.bilibili.com/362350065" target="_blank"><img src="/blog-images/fx6.png" alt="bilibili" /></a></li>
         </ul>

--- a/docs/zh-CN/community/how-to-contribute/how-to-contribute.md
+++ b/docs/zh-CN/community/how-to-contribute/how-to-contribute.md
@@ -41,7 +41,7 @@ under the License.
 * 关注 Doris [Github 代码库](https://github.com/apache/incubator-doris)
 * 订阅我们的 [邮件列表](../subscribe-mail-list.md)； 
 * 加入 Doris 微信群(加微信号：morningman-cmy, 备注：加入Doris群) 随时提问；
-* 加入 [Slack](https://join.slack.com/t/apachedoriscommunity/shared_invite/zt-11jb8gesh-7IukzSrdea6mqoG0HB4gZg);
+* 加入 [Slack](https://the-asf.slack.com/archives/C02P2JBD72A);
 
 通过以上方式及时了解 Doris 项目的开发动态并为您关注的话题发表意见。
 


### PR DESCRIPTION
# Proposed changes

Issue Number: close https://lists.apache.org/thread/29h6grfylvtkmmcxkhbn1fjzccwk60hy

## Problem Summary:

using asf offical pernament slack channel replace outdated slack url

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
