### PR TITLE
[fix](planner)unnecessary cast will be added on children in InPredicate

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/Analyzer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/Analyzer.java
@@ -1897,7 +1897,7 @@ public class Analyzer {
         }
         // Add implicit casts if necessary.
         for (int i = 0; i < exprs.size(); ++i) {
-            if (exprs.get(i).getType() != compatibleType) {
+            if (!exprs.get(i).getType().equals(compatibleType)) {
                 Expr castExpr = exprs.get(i).castTo(compatibleType);
                 exprs.set(i, castExpr);
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/FunctionCallExpr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/FunctionCallExpr.java
@@ -695,7 +695,7 @@ public class FunctionCallExpr extends Expr {
                 throw new AnalysisException("topn requires second parameter must be a constant Integer Type: "
                         + this.toSql());
             }
-            if (getChild(1).getType() != ScalarType.INT) {
+            if (!getChild(1).getType().equals(ScalarType.INT)) {
                 Expr e = getChild(1).castTo(ScalarType.INT);
                 setChild(1, e);
             }
@@ -704,7 +704,7 @@ public class FunctionCallExpr extends Expr {
                     throw new AnalysisException("topn requires the third parameter must be a constant Integer Type: "
                             + this.toSql());
                 }
-                if (getChild(2).getType() != ScalarType.INT) {
+                if (!getChild(2).getType().equals(ScalarType.INT)) {
                     Expr e = getChild(2).castTo(ScalarType.INT);
                     setChild(2, e);
                 }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #10881

## Problem Summary:

We should use equals function rather than Use equals operator to compare two Type in Analyzer#castAllToCompatibleType.

## Checklist(Required)

1. Does it affect the original behavior: No
2. Has unit tests been added: No
3. Has document been added or modified: No
4. Does it need to update dependencies:No
5. Are there any changes that cannot be rolled back: No

## Further comments
