### PR TITLE
fix_arena_push_size

### DIFF
--- a/be/src/runtime/memory/chunk_allocator.cpp
+++ b/be/src/runtime/memory/chunk_allocator.cpp
@@ -97,7 +97,7 @@ public:
     }
 
     void push_free_chunk(uint8_t* ptr, size_t size) {
-        int idx = BitUtil::Log2Ceiling64(size);
+        int idx = BitUtil::Log2Floor64(size);
         // Poison this chunk to make asan can detect invalid access
         ASAN_POISON_MEMORY_REGION(ptr, size);
         std::lock_guard<SpinLock> l(_lock);

--- a/be/src/runtime/memory/chunk_allocator.cpp
+++ b/be/src/runtime/memory/chunk_allocator.cpp
@@ -97,7 +97,7 @@ public:
     }
 
     void push_free_chunk(uint8_t* ptr, size_t size) {
-        int idx = BitUtil::Log2Floor64(size);
+        int idx = BitUtil::Log2Ceiling64(size);
         // Poison this chunk to make asan can detect invalid access
         ASAN_POISON_MEMORY_REGION(ptr, size);
         std::lock_guard<SpinLock> l(_lock);
@@ -139,6 +139,8 @@ ChunkAllocator::ChunkAllocator(size_t reserve_limit)
 }
 
 Status ChunkAllocator::allocate(size_t size, Chunk* chunk, MemTracker* tracker, bool check_limits) {
+    DCHECK(BitUtil::RoundUpToPowerOfTwo(size) == size);
+
     MemTracker* reset_tracker =
             tracker ? tracker : tls_ctx()->_thread_mem_tracker_mgr->mem_tracker().get();
     // In advance, transfer the memory ownership of allocate from ChunkAllocator::tracker to the parameter tracker.

--- a/be/src/runtime/memory/chunk_allocator.h
+++ b/be/src/runtime/memory/chunk_allocator.h
@@ -62,12 +62,6 @@ public:
 
     ChunkAllocator(size_t reserve_limit);
 
-    // Allocate a Chunk with a power-of-two length "size".
-    // Return true if success and allocated chunk is saved in "chunk".
-    // Otherwise return false.
-    Status allocate(size_t size, Chunk* chunk, MemTracker* tracker = nullptr,
-                    bool check_limits = false);
-
     Status allocate_align(size_t size, Chunk* chunk, MemTracker* tracker = nullptr,
                           bool check_limits = false);
 
@@ -81,6 +75,8 @@ public:
     void free(uint8_t* data, size_t size, MemTracker* tracker = nullptr);
 
 private:
+    friend class MemPool;
+
     static ChunkAllocator* _s_instance;
 
     size_t _reserve_bytes_limit;
@@ -94,6 +90,11 @@ private:
     std::shared_ptr<MetricEntity> _chunk_allocator_metric_entity;
 
     std::shared_ptr<MemTracker> _mem_tracker;
+
+    // Allocate a Chunk with a power-of-two length "size".
+    // Return true if success and allocated chunk is saved in "chunk".
+    // Otherwise return false.
+    Status allocate(size_t size, Chunk* Chunk);
 };
 
 } // namespace doris


### PR DESCRIPTION
Chunk* c1 = ChunkAllocator::allocate(1025);
ChunkAllocator::free(c1);
ChunkAllocator::allocate(2000); //会返回之前的chunk，这是不符合预期的

修改后，如果申请1025的话，就是从free_list[11]中取，放回free_list[10]里面去；free_list[11]里面应该放size >= 2048 && size < 4096的chunk，以此保证申请到的size大于需要申请的size.