### PR TITLE
[feature] (Nereids) Merge memo group recursively

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Group.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Group.java
@@ -265,4 +265,27 @@ public class Group {
     public String toString() {
         return "Group[" + groupId + "]";
     }
+
+    /**
+     * move the ownerGroup of all logical expressions to target group
+     * @param target the new owner group of expressions
+     */
+    public void moveLogicalExpressionOwnership(Group target) {
+        for (GroupExpression expression : logicalExpressions) {
+            target.addGroupExpression(expression);
+        }
+        logicalExpressions.clear();
+    }
+
+    /**
+     * move the ownerGroup of all physical expressions to target group
+     * @param target the new owner group of expressions
+     */
+    public void movePhysicalExpressionOwnership(Group target) {
+        for (GroupExpression expression : physicalExpressions) {
+            target.addGroupExpression(expression);
+        }
+        physicalExpressions.clear();
+    }
+
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Group.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Group.java
@@ -272,7 +272,9 @@ public class Group {
      * @param target the new owner group of expressions
      */
     public void moveLogicalExpressionOwnership(Group target) {
-        if (equals(target)) return;
+        if (equals(target)) {
+            return;
+        }
         for (GroupExpression expression : logicalExpressions) {
             target.addGroupExpression(expression);
         }
@@ -285,7 +287,9 @@ public class Group {
      * @param target the new owner group of expressions
      */
     public void movePhysicalExpressionOwnership(Group target) {
-        if (equals(target)) return;
+        if (equals(target)) {
+            return;
+        }
         for (GroupExpression expression : physicalExpressions) {
             target.addGroupExpression(expression);
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Group.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Group.java
@@ -30,10 +30,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
+import java.util.*;
 
 /**
  * Representation for group in cascades optimizer.
@@ -113,6 +110,18 @@ public class Group {
         return groupExpression;
     }
 
+    public void removeAllExpressions() {
+        Iterator<GroupExpression> iter = logicalExpressions.iterator();
+        while( iter.hasNext() ) {
+            iter.next().setParent(null);
+            iter.remove();
+        }
+        iter = physicalExpressions.iterator();
+        while( iter.hasNext() ) {
+            iter.next().setParent(null);
+            iter.remove();
+        }
+    }
     /**
      * Rewrite the logical group expression to the new logical group expression.
      *

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Group.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Group.java
@@ -114,18 +114,23 @@ public class Group {
         return groupExpression;
     }
 
+    /**
+     * remove all logical and physical expressions
+     * if this group is merged with other group, all the expressions should be removed.
+     */
     public void removeAllExpressions() {
         Iterator<GroupExpression> iter = logicalExpressions.iterator();
-        while(iter.hasNext()) {
+        while (iter.hasNext()) {
             iter.next().setOwnerGroup(null);
             iter.remove();
         }
         iter = physicalExpressions.iterator();
-        while(iter.hasNext()) {
+        while (iter.hasNext()) {
             iter.next().setOwnerGroup(null);
             iter.remove();
         }
     }
+
     /**
      * Rewrite the logical group expression to the new logical group expression.
      *

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Group.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Group.java
@@ -268,9 +268,11 @@ public class Group {
 
     /**
      * move the ownerGroup of all logical expressions to target group
+     * if this.equals(target), do nothing.
      * @param target the new owner group of expressions
      */
     public void moveLogicalExpressionOwnership(Group target) {
+        if (equals(target)) return;
         for (GroupExpression expression : logicalExpressions) {
             target.addGroupExpression(expression);
         }
@@ -279,9 +281,11 @@ public class Group {
 
     /**
      * move the ownerGroup of all physical expressions to target group
+     * if this.equals(target), do nothing.
      * @param target the new owner group of expressions
      */
     public void movePhysicalExpressionOwnership(Group target) {
+        if (equals(target)) return;
         for (GroupExpression expression : physicalExpressions) {
             target.addGroupExpression(expression);
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Group.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Group.java
@@ -115,23 +115,6 @@ public class Group {
     }
 
     /**
-     * remove all logical and physical expressions
-     * if this group is merged with other group, all the expressions should be removed.
-     */
-    public void removeAllExpressions() {
-        Iterator<GroupExpression> iter = logicalExpressions.iterator();
-        while (iter.hasNext()) {
-            iter.next().setOwnerGroup(null);
-            iter.remove();
-        }
-        iter = physicalExpressions.iterator();
-        while (iter.hasNext()) {
-            iter.next().setOwnerGroup(null);
-            iter.remove();
-        }
-    }
-
-    /**
      * Rewrite the logical group expression to the new logical group expression.
      *
      * @param newExpression new logical group expression

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Group.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Group.java
@@ -30,7 +30,6 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Group.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Group.java
@@ -30,7 +30,11 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 
-import java.util.*;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 
 /**
  * Representation for group in cascades optimizer.
@@ -112,13 +116,13 @@ public class Group {
 
     public void removeAllExpressions() {
         Iterator<GroupExpression> iter = logicalExpressions.iterator();
-        while( iter.hasNext() ) {
-            iter.next().setParent(null);
+        while(iter.hasNext()) {
+            iter.next().setOwnerGroup(null);
             iter.remove();
         }
         iter = physicalExpressions.iterator();
-        while( iter.hasNext() ) {
-            iter.next().setParent(null);
+        while(iter.hasNext()) {
+            iter.next().setOwnerGroup(null);
             iter.remove();
         }
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Memo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Memo.java
@@ -30,6 +30,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -195,13 +196,19 @@ public class Memo {
                 groupExpressions.put(groupExpression, groupExpression);
             }
         }
-        for (GroupExpression groupExpression : source.getLogicalExpressions()) {
+
+        Iterator<GroupExpression> iterator = source.getLogicalExpressions().iterator();
+        while (iterator.hasNext()) {
+            GroupExpression groupExpression = iterator.next();
+            iterator.remove();
             destination.addGroupExpression(groupExpression);
         }
-        for (GroupExpression groupExpression : source.getPhysicalExpressions()) {
+        iterator = source.getPhysicalExpressions().iterator();
+        while (iterator.hasNext()) {
+            GroupExpression groupExpression = iterator.next();
+            iterator.remove();
             destination.addGroupExpression(groupExpression);
         }
-        source.removeAllExpressions();
         groups.remove(source);
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Memo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Memo.java
@@ -189,7 +189,8 @@ public class Memo {
                 }
             }
             GroupExpression that = groupExpressions.get(groupExpression);
-            if (that != null) {
+            if (that != null && that.getOwnerGroup() != null
+                    && !that.getOwnerGroup().equals(groupExpression.getOwnerGroup())) {
                 // remove groupExpression from its owner group to avoid adding it to that.getOwnerGroup()
                 // that.getOwnerGroup() already has this groupExpression.
                 Group ownerGroup = groupExpression.getOwnerGroup();
@@ -199,10 +200,11 @@ public class Memo {
                 groupExpressions.put(groupExpression, groupExpression);
             }
         }
-
-        source.moveLogicalExpressionOwnership(destination);
-        source.movePhysicalExpressionOwnership(destination);
-        groups.remove(source);
+        if (!source.equals(destination)) {
+            source.moveLogicalExpressionOwnership(destination);
+            source.movePhysicalExpressionOwnership(destination);
+            groups.remove(source);
+        }
     }
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Memo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Memo.java
@@ -30,7 +30,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -191,9 +190,6 @@ public class Memo {
             }
             GroupExpression that = groupExpressions.get(groupExpression);
             if (that != null) {
-                // TODO: need to merge group recursively
-                //groupExpression.getParent().removeGroupExpression(groupExpression);
-
                 mergeGroup(groupExpression.getOwnerGroup(), that.getOwnerGroup());
             } else {
                 groupExpressions.put(groupExpression, groupExpression);
@@ -202,7 +198,6 @@ public class Memo {
         for (GroupExpression groupExpression : source.getLogicalExpressions()) {
             destination.addGroupExpression(groupExpression);
         }
-
         for (GroupExpression groupExpression : source.getPhysicalExpressions()) {
             destination.addGroupExpression(groupExpression);
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Memo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Memo.java
@@ -30,6 +30,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -188,21 +189,24 @@ public class Memo {
                     children.set(i, destination);
                 }
             }
-            if (groupExpressions.containsKey(groupExpression)) {
-                GroupExpression that = groupExpressions.get(groupExpression);
+            GroupExpression that = groupExpressions.get(groupExpression);
+            if (that != null) {
+                // TODO: need to merge group recursively
+                //groupExpression.getParent().removeGroupExpression(groupExpression);
+
                 mergeGroup(groupExpression.getOwnerGroup(), that.getOwnerGroup());
             } else {
                 groupExpressions.put(groupExpression, groupExpression);
             }
         }
         for (GroupExpression groupExpression : source.getLogicalExpressions()) {
-            source.removeGroupExpression(groupExpression);
             destination.addGroupExpression(groupExpression);
         }
+
         for (GroupExpression groupExpression : source.getPhysicalExpressions()) {
-            source.removeGroupExpression(groupExpression);
             destination.addGroupExpression(groupExpression);
         }
+        source.removeAllExpressions();
         groups.remove(source);
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Memo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Memo.java
@@ -191,7 +191,11 @@ public class Memo {
             }
             GroupExpression that = groupExpressions.get(groupExpression);
             if (that != null) {
-                mergeGroup(groupExpression.getOwnerGroup(), that.getOwnerGroup());
+                // remove groupExpression from its owner group to avoid adding it to that.getOwnerGroup()
+                // that.getOwnerGroup() already has this groupExpression.
+                Group ownerGroup = groupExpression.getOwnerGroup();
+                groupExpression.getOwnerGroup().removeGroupExpression(groupExpression);
+                mergeGroup(ownerGroup, that.getOwnerGroup());
             } else {
                 groupExpressions.put(groupExpression, groupExpression);
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Memo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Memo.java
@@ -189,8 +189,8 @@ public class Memo {
                 }
             }
             if (groupExpressions.containsKey(groupExpression)) {
-                // TODO: need to merge group recursively
-                groupExpression.getOwnerGroup().removeGroupExpression(groupExpression);
+                GroupExpression that = groupExpressions.get(groupExpression);
+                mergeGroup(groupExpression.getOwnerGroup(), that.getOwnerGroup());
             } else {
                 groupExpressions.put(groupExpression, groupExpression);
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Memo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Memo.java
@@ -30,7 +30,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -201,18 +200,8 @@ public class Memo {
             }
         }
 
-        Iterator<GroupExpression> iterator = source.getLogicalExpressions().iterator();
-        while (iterator.hasNext()) {
-            GroupExpression groupExpression = iterator.next();
-            iterator.remove();
-            destination.addGroupExpression(groupExpression);
-        }
-        iterator = source.getPhysicalExpressions().iterator();
-        while (iterator.hasNext()) {
-            GroupExpression groupExpression = iterator.next();
-            iterator.remove();
-            destination.addGroupExpression(groupExpression);
-        }
+        source.moveLogicalExpressionOwnership(destination);
+        source.movePhysicalExpressionOwnership(destination);
         groups.remove(source);
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/memo/MemoTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/memo/MemoTest.java
@@ -58,9 +58,20 @@ public class MemoTest {
                         .getPlan().getType());
     }
 
+    /**
+     * initial Memo status:
+     *      group#1(project1)-->group#0(relationA)
+     *      group#3(project2)-->group#2(relationB)
+     *      group#4(project3)-->group#2(relationB)
+     * copy relationA into group#2
+     * after merge:
+     *      group#1(project1)-->group#0(relationA, relationB)
+     *      group#4(project3)-->group#0
+     * merging group#2 and group#0 recursively invoke merging group#3 and group#1 and merging group#4 and group#1
+     */
     @Test
     public void testMergeGroup() {
-        UnboundRelation relation1 = new UnboundRelation(Lists.newArrayList("test"));
+        UnboundRelation relation1 = new UnboundRelation(Lists.newArrayList("A"));
         LogicalProject project1 = new LogicalProject(
                 ImmutableList.of(new SlotReference(new ExprId(1), "name", StringType.INSTANCE, true, ImmutableList.of("test"))),
                 relation1
@@ -68,19 +79,43 @@ public class MemoTest {
 
         Memo memo = new Memo(project1);
 
-        UnboundRelation relation2 = new UnboundRelation(Lists.newArrayList("test2"));
+        UnboundRelation relation2 = new UnboundRelation(Lists.newArrayList("B"));
         LogicalProject project2 = new LogicalProject(
                 ImmutableList.of(new SlotReference(new ExprId(1), "name", StringType.INSTANCE, true, ImmutableList.of("test"))),
                 relation2
         );
         memo.copyIn(project2, null, false);
         Assert.assertEquals(4, memo.getGroups().size());
+
+        LogicalProject project3 = new LogicalProject(
+                ImmutableList.of(new SlotReference(new ExprId(1), "other", StringType.INSTANCE, true, ImmutableList.of("other"))),
+                relation2
+        );
+
+        memo.copyIn(project3, null, false);
+
+        //after copyIn, group#2 contains relationA and relationB
         memo.copyIn(relation1, memo.getGroups().get(2), true);
-        Assert.assertEquals(2, memo.getGroups().size());
+
+
+        Assert.assertEquals(3, memo.getGroups().size());
         Group root = memo.getRoot();
+        Assert.assertEquals(1, root.getLogicalExpressions().size());
         Assert.assertEquals(PlanType.LOGICAL_PROJECT,
                 root.logicalExpressionsAt(0).getPlan().getType());
+        GroupExpression rootExpression = root.logicalExpressionsAt(0);
+        Assert.assertEquals(1, rootExpression.children().size());
+        //two expressions: relationA and relationB
+        Assert.assertEquals(2, rootExpression.child(0).getLogicalExpressions().size());
+        GroupExpression childExpression = rootExpression.child(0).logicalExpressionsAt(0);
         Assert.assertEquals(PlanType.LOGICAL_UNBOUND_RELATION,
-                root.logicalExpressionsAt(0).child(0).logicalExpressionsAt(0).getPlan().getType());
+                childExpression.getPlan().getType());
+
+        Group groupProjct3 = memo.getGroups().get(2); //group for project3
+        Group groupRelation = memo.getGroups().get(0); //group for relation
+        //group0 is child of group4
+        Assert.assertEquals(groupRelation, groupProjct3.logicalExpressionsAt(0).child(0));
+        Assert.assertEquals(1, groupProjct3.getLogicalExpressions().size());
+        Assert.assertEquals(1, groupProjct3.logicalExpressionsAt(0).children().size());
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/memo/MemoTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/memo/MemoTest.java
@@ -60,17 +60,18 @@ public class MemoTest {
 
     @Test
     public void testMergeGroup() {
-        Memo memo = new Memo();
+
         UnboundRelation rel1 = new UnboundRelation(Lists.newArrayList("test"));
         LogicalProject proj1 = new LogicalProject(
-                ImmutableList.of(new SlotReference(new ExprId(1),"name", StringType.INSTANCE, true, ImmutableList.of("test"))),
+                ImmutableList.of(new SlotReference(new ExprId(1), "name", StringType.INSTANCE, true, ImmutableList.of("test"))),
                 rel1
         );
-        memo.copyIn(proj1, null, false);
+
+        Memo memo = new Memo(proj1);
 
         UnboundRelation rel2 = new UnboundRelation(Lists.newArrayList("test2"));
         LogicalProject proj2 = new LogicalProject(
-                ImmutableList.of(new SlotReference(new ExprId(1),"name", StringType.INSTANCE, true, ImmutableList.of("test"))),
+                ImmutableList.of(new SlotReference(new ExprId(1), "name", StringType.INSTANCE, true, ImmutableList.of("test"))),
                 rel2
         );
         memo.copyIn(proj2, null, false);

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/memo/MemoTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/memo/MemoTest.java
@@ -60,23 +60,27 @@ public class MemoTest {
 
     @Test
     public void testMergeGroup() {
-
-        UnboundRelation rel1 = new UnboundRelation(Lists.newArrayList("test"));
-        LogicalProject proj1 = new LogicalProject(
+        UnboundRelation relation1 = new UnboundRelation(Lists.newArrayList("test"));
+        LogicalProject project1 = new LogicalProject(
                 ImmutableList.of(new SlotReference(new ExprId(1), "name", StringType.INSTANCE, true, ImmutableList.of("test"))),
-                rel1
+                relation1
         );
 
-        Memo memo = new Memo(proj1);
+        Memo memo = new Memo(project1);
 
-        UnboundRelation rel2 = new UnboundRelation(Lists.newArrayList("test2"));
-        LogicalProject proj2 = new LogicalProject(
+        UnboundRelation relation2 = new UnboundRelation(Lists.newArrayList("test2"));
+        LogicalProject project2 = new LogicalProject(
                 ImmutableList.of(new SlotReference(new ExprId(1), "name", StringType.INSTANCE, true, ImmutableList.of("test"))),
-                rel2
+                relation2
         );
-        memo.copyIn(proj2, null, false);
-
-        memo.copyIn(rel1, memo.getGroups().get(2), true);
+        memo.copyIn(project2, null, false);
+        Assert.assertEquals(4, memo.getGroups().size());
+        memo.copyIn(relation1, memo.getGroups().get(2), true);
         Assert.assertEquals(2, memo.getGroups().size());
+        Group root = memo.getRoot();
+        Assert.assertEquals(PlanType.LOGICAL_PROJECT,
+                root.logicalExpressionsAt(0).getPlan().getType());
+        Assert.assertEquals(PlanType.LOGICAL_UNBOUND_RELATION,
+                root.logicalExpressionsAt(0).child(0).logicalExpressionsAt(0).getPlan().getType());
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/memo/MemoTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/memo/MemoTest.java
@@ -18,6 +18,7 @@
 package org.apache.doris.nereids.memo;
 
 import org.apache.doris.nereids.analyzer.UnboundRelation;
+import org.apache.doris.nereids.trees.expressions.ExprId;
 import org.apache.doris.nereids.trees.expressions.SlotReference;
 import org.apache.doris.nereids.trees.plans.PlanType;
 import org.apache.doris.nereids.trees.plans.logical.LogicalProject;
@@ -55,5 +56,32 @@ public class MemoTest {
         Assert.assertEquals(PlanType.LOGICAL_UNBOUND_RELATION,
                 rootGroup.logicalExpressionsAt(0).child(0).logicalExpressionsAt(0).child(0).logicalExpressionsAt(0)
                         .getPlan().getType());
+    }
+
+    @Test
+    public void testMergeGroup() {
+        Memo memo = new Memo();
+        UnboundRelation rel1 = new UnboundRelation(Lists.newArrayList("test"));
+        LogicalProject proj1 = new LogicalProject(
+                ImmutableList.of(new SlotReference(new ExprId(1),"name", StringType.INSTANCE, true, ImmutableList.of("test"))),
+                rel1
+        );
+
+
+        memo.copyIn(proj1, null, false);
+
+        UnboundRelation rel2 = new UnboundRelation(Lists.newArrayList("test2"));
+
+        LogicalProject proj2 = new LogicalProject(
+                ImmutableList.of(new SlotReference(new ExprId(1),"name", StringType.INSTANCE, true, ImmutableList.of("test"))),
+                rel2
+        );
+
+        memo.copyIn(proj2, null, false);
+
+
+        memo.copyIn(rel1, memo.getGroups().get(2), true);
+        Assert.assertEquals(2, memo.getGroups().size());
+
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/memo/MemoTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/memo/MemoTest.java
@@ -66,22 +66,16 @@ public class MemoTest {
                 ImmutableList.of(new SlotReference(new ExprId(1),"name", StringType.INSTANCE, true, ImmutableList.of("test"))),
                 rel1
         );
-
-
         memo.copyIn(proj1, null, false);
 
         UnboundRelation rel2 = new UnboundRelation(Lists.newArrayList("test2"));
-
         LogicalProject proj2 = new LogicalProject(
                 ImmutableList.of(new SlotReference(new ExprId(1),"name", StringType.INSTANCE, true, ImmutableList.of("test"))),
                 rel2
         );
-
         memo.copyIn(proj2, null, false);
-
 
         memo.copyIn(rel1, memo.getGroups().get(2), true);
         Assert.assertEquals(2, memo.getGroups().size());
-
     }
 }


### PR DESCRIPTION
# Proposed changes
In Memo.copyIn( plan, group1, isRewrite), one branch is that the plan is already recorded in Memo, and owned by group 'group2'. In such case, 'group1' should be merged with 'group2', because they are equivalent.
After merge, the upper level of 'group1', saying 'p1 = group1.getLogicalExpression().getOwnerGroup()' of 'group1', and that of 'group2', saying 'p2', are equivalent. We need to merge 'p1' and 'p2'. And this process is recursive. 

@morrySnow  could you review thie pr, please?

Issue Number: close #xxx

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
