### PR TITLE
[improvement](log) Avoid too many 'not found query' warn log

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/QeProcessorImpl.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/QeProcessorImpl.java
@@ -89,6 +89,7 @@ public final class QeProcessorImpl implements QeProcessor {
         }
     }
 
+    @Override
     public void registerInstances(TUniqueId queryId, Integer instancesNum) throws UserException {
         if (!coordinatorMap.containsKey(queryId)) {
             throw new UserException("query not exists in coordinatorMap:" + DebugUtil.printId(queryId));
@@ -143,7 +144,9 @@ public final class QeProcessorImpl implements QeProcessor {
                 }
             }
         } else {
-            LOG.warn("not found query {} when unregisterQuery", DebugUtil.printId(queryId));
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("not found query {} when unregisterQuery", DebugUtil.printId(queryId));
+            }
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -478,8 +478,6 @@ public class StmtExecutor implements ProfileWriter {
                     LOG.warn("handle insert stmt fail", t);
                     // the transaction of this insert may already begun, we will abort it at outer finally block.
                     throw t;
-                } finally {
-                    QeProcessorImpl.INSTANCE.unregisterQuery(context.queryId());
                 }
             } else if (parsedStmt instanceof DdlStmt) {
                 handleDdlStmt();
@@ -1448,6 +1446,8 @@ public class StmtExecutor implements ProfileWriter {
                  * which exactly like the old insert stmt usage pattern.
                  */
                 throwable = t;
+            } finally {
+                QeProcessorImpl.INSTANCE.unregisterQuery(context.queryId());
             }
 
             // Go here, which means:

--- a/fe/fe-core/src/main/java/org/apache/doris/transaction/TransactionState.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/transaction/TransactionState.java
@@ -207,7 +207,7 @@ public class TransactionState implements Writable {
     // 2. callback object has been removed from CallbackFactory
     // 3. in afterStateTransform(), callback object can not be found, so the write lock can not be released.
     private TxnStateChangeCallback callback = null;
-    private long timeoutMs = Config.stream_load_default_timeout_second;
+    private long timeoutMs = Config.stream_load_default_timeout_second * 1000;
     private long preCommittedTimeoutMs = Config.stream_load_default_precommit_timeout_second * 1000;
     private String authCode = "";
 


### PR DESCRIPTION
# Proposed changes

`QeProcessorImpl#unregisterQuery` is called when finish execute a query. But some queries are not registered, such as:
`1. explain select/insert;
 2. begin, insert, commit;`
So when unregister, the query cann't be found, there are many warn logs as the following, which is confusing for users.
`2022-07-20 19:36:24,979 WARN (doris-mysql-nio-pool-0|129) [QeProcessorImpl.unregisterQuery():147] not found query 69acee382d134b49-9d3ff6975eb1ef11 when unregisterQuery`

Issue Number: close #xxx

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
4. Has unit tests been added: (Yes/No/No Need)
5. Has document been added or modified: (Yes/No/No Need)
6. Does it need to update dependencies: (Yes/No)
7. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
