### PR TITLE
[regression] fix the case fail when enable Hdfs

### DIFF
--- a/regression-test/suites/csv_header/test_csv_with_header.groovy
+++ b/regression-test/suites/csv_header/test_csv_with_header.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_csv_with_header", "csv_with_header") {
+suite("test_csv_with_header", "csv_header") {
      //define format
     def format_csv = "csv"
     def format_csv_with_names = "csv_with_names"


### PR DESCRIPTION
# Proposed changes
1. this pr is used to solve the case fail when we  enable Hdfs.
the fail message is as below:
2022-07-20 20:34:25.531 INFO [pool-3-thread-1] (Suite.groovy:189) - Execute sql: select count(*) from test_csv_with_header
java.io.FileNotFoundException: File /home/disk1/hugo_work/doris_dev/baidu/bdg/doris/core/regression-test/data/csv_with_header/csv.txt does not exist

But the real path is “ /home/disk1/hugo_work/doris_dev/baidu/bdg/doris/core/regression-test/data/csv_header/csv.txt”.

Issue Number: close #xxx

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (No)
3. Has unit tests been added: (No)
4. Has document been added or modified: (No)
5. Does it need to update dependencies: (No)
6. Are there any changes that cannot be rolled back: (No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
