### PR TITLE
check vm.max_map_count before starting

### DIFF
--- a/bin/start_be.sh
+++ b/bin/start_be.sh
@@ -53,6 +53,12 @@ export DORIS_HOME=$(
     pwd
 )
 
+MAX_MAP_COUNT=`sysctl -n vm.max_map_count`
+if [ $MAX_MAP_COUNT -lt 2000000 ]; then
+    echo "Please set vm.max_map_count to be 2000000. sysctl -w vm.max_map_count=2000000"
+    exit 1
+fi
+
 # add libs to CLASSPATH
 for f in $DORIS_HOME/lib/*.jar; do
   if [ ! -n "${DORIS_JNI_CLASSPATH_PARAMETER}" ]; then


### PR DESCRIPTION
When vectorized engine is enabled, doris uses much more vmas than before,
and it leads to core dump due to memory allocation failure.

# Proposed changes

Issue Number: close #xxx

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
