### PR TITLE
[improvement](arrow) add arrow block convertion time profile

### DIFF
--- a/be/src/vec/exec/file_arrow_scanner.cpp
+++ b/be/src/vec/exec/file_arrow_scanner.cpp
@@ -34,7 +34,11 @@ FileArrowScanner::FileArrowScanner(RuntimeState* state, RuntimeProfile* profile,
           _cur_file_reader(nullptr),
           _cur_file_eof(false),
           _batch(nullptr),
-          _arrow_batch_cur_idx(0) {}
+          _arrow_batch_cur_idx(0) {
+
+    _convert_arrow_block_timer = ADD_TIMER(_profile, "ConvertArrowBlockTimer");
+    
+}
 
 FileArrowScanner::~FileArrowScanner() {
     FileArrowScanner::close();
@@ -174,6 +178,7 @@ Status FileArrowScanner::get_next(vectorized::Block* block, bool* eof) {
 }
 
 Status FileArrowScanner::_append_batch_to_block(Block* block) {
+    SCOPED_TIMER(_convert_arrow_block_timer);
     size_t num_elements = std::min<size_t>((_state->batch_size() - block->rows()),
                                            (_batch->num_rows() - _arrow_batch_cur_idx));
     for (auto i = 0; i < _file_slot_descs.size(); ++i) {

--- a/be/src/vec/exec/file_arrow_scanner.cpp
+++ b/be/src/vec/exec/file_arrow_scanner.cpp
@@ -35,9 +35,7 @@ FileArrowScanner::FileArrowScanner(RuntimeState* state, RuntimeProfile* profile,
           _cur_file_eof(false),
           _batch(nullptr),
           _arrow_batch_cur_idx(0) {
-
     _convert_arrow_block_timer = ADD_TIMER(_profile, "ConvertArrowBlockTimer");
-    
 }
 
 FileArrowScanner::~FileArrowScanner() {

--- a/be/src/vec/exec/file_arrow_scanner.h
+++ b/be/src/vec/exec/file_arrow_scanner.h
@@ -70,6 +70,7 @@ private:
     bool _cur_file_eof; // is read over?
     std::shared_ptr<arrow::RecordBatch> _batch;
     size_t _arrow_batch_cur_idx;
+    RuntimeProfile::Counter* _convert_arrow_block_timer;
 };
 
 class VFileParquetScanner final : public FileArrowScanner {


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

Add a new timer `ConvertArrowBlockTimer` for `FileArrowScanner` to record the time
of converting arrow batch to doris column block.

## Checklist(Required)

1. Does it affect the original behavior: (No)
2. Has unit tests been added: (No)
3. Has document been added or modified: (No)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
