### PR TITLE
[enhance](nereids): use optional for combine()

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rewrite/rules/DistinctPredicatesRule.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rewrite/rules/DistinctPredicatesRule.java
@@ -23,6 +23,7 @@ import org.apache.doris.nereids.trees.expressions.CompoundPredicate;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.util.ExpressionUtils;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 
 import java.util.LinkedHashSet;
@@ -41,10 +42,11 @@ public class DistinctPredicatesRule extends AbstractExpressionRewriteRule {
 
     @Override
     public Expression visitCompoundPredicate(CompoundPredicate expr, ExpressionRewriteContext context) {
+        Preconditions.checkNotNull(expr);
         List<Expression> extractExpressions = ExpressionUtils.extract(expr);
         Set<Expression> distinctExpressions = new LinkedHashSet<>(extractExpressions);
         if (distinctExpressions.size() != extractExpressions.size()) {
-            return ExpressionUtils.combine(expr.getClass(), Lists.newArrayList(distinctExpressions));
+            return ExpressionUtils.combine(expr.getClass(), Lists.newArrayList(distinctExpressions)).get();
         }
         return expr;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/logical/ReorderJoin.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/logical/ReorderJoin.java
@@ -102,14 +102,14 @@ public class ReorderJoin extends OneRewriteRuleFactory {
             if (joinConditions.isEmpty()) {
                 cond = Optional.empty();
             } else {
-                cond = Optional.of(ExpressionUtils.and(joinConditions));
+                cond = ExpressionUtils.and(joinConditions);
             }
 
             LogicalJoin join = new LogicalJoin(JoinType.INNER_JOIN, cond, joinInputs.get(0), joinInputs.get(1));
             if (nonJoinConditions.isEmpty()) {
                 return join;
             } else {
-                return new LogicalFilter(ExpressionUtils.and(nonJoinConditions), join);
+                return new LogicalFilter(ExpressionUtils.and(nonJoinConditions).get(), join);
             }
         } else {
             Plan left = joinInputs.get(0);
@@ -150,7 +150,7 @@ public class ReorderJoin extends OneRewriteRuleFactory {
             if (joinConditions.isEmpty()) {
                 cond = Optional.empty();
             } else {
-                cond = Optional.of(ExpressionUtils.and(joinConditions));
+                cond = ExpressionUtils.and(joinConditions);
             }
 
             LogicalJoin join = new LogicalJoin(JoinType.INNER_JOIN, cond, left, right);

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/util/ExpressionUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/util/ExpressionUtils.java
@@ -30,6 +30,7 @@ import com.google.common.collect.Sets;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Expression rewrite helper class.
@@ -83,9 +84,11 @@ public class ExpressionUtils {
     /**
      * Use AND/OR to combine expressions together.
      */
-    public static Expression combine(Class<? extends Expression> type, List<Expression> expressions) {
+    public static Expression combine(Class<? extends Expression> type, List<Expression> inputExpressions) {
         Preconditions.checkArgument(type == And.class || type == Or.class);
-        Objects.requireNonNull(expressions, "expressions is null");
+        Objects.requireNonNull(inputExpressions, "expressions is null");
+
+        List<Expression> expressions = inputExpressions.stream().filter(Objects::nonNull).collect(Collectors.toList());
 
         Expression shortCircuit = (type == And.class ? BooleanLiteral.FALSE : BooleanLiteral.TRUE);
         Expression skip = (type == And.class ? BooleanLiteral.TRUE : BooleanLiteral.FALSE);

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/util/ExpressionUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/util/ExpressionUtils.java
@@ -29,6 +29,7 @@ import com.google.common.collect.Sets;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -65,26 +66,26 @@ public class ExpressionUtils {
         }
     }
 
-    public static Expression and(List<Expression> expressions) {
+    public static Optional<Expression> and(List<Expression> expressions) {
         return combine(And.class, expressions);
     }
 
-    public static Expression and(Expression... expressions) {
+    public static Optional<Expression> and(Expression... expressions) {
         return combine(And.class, Lists.newArrayList(expressions));
     }
 
-    public static Expression or(Expression... expressions) {
+    public static Optional<Expression> or(Expression... expressions) {
         return combine(Or.class, Lists.newArrayList(expressions));
     }
 
-    public static Expression or(List<Expression> expressions) {
+    public static Optional<Expression> or(List<Expression> expressions) {
         return combine(Or.class, expressions);
     }
 
     /**
      * Use AND/OR to combine expressions together.
      */
-    public static Expression combine(Class<? extends Expression> type, List<Expression> inputExpressions) {
+    public static Optional<Expression> combine(Class<? extends Expression> type, List<Expression> inputExpressions) {
         Preconditions.checkArgument(type == And.class || type == Or.class);
         Objects.requireNonNull(inputExpressions, "expressions is null");
 
@@ -95,14 +96,12 @@ public class ExpressionUtils {
         Set<Expression> distinctExpressions = Sets.newLinkedHashSetWithExpectedSize(expressions.size());
         for (Expression expression : expressions) {
             if (expression.equals(shortCircuit)) {
-                return shortCircuit;
+                return Optional.of(shortCircuit);
             } else if (!expression.equals(skip)) {
                 distinctExpressions.add(expression);
             }
         }
 
-        return distinctExpressions.stream()
-                .reduce(type == And.class ? And::new : Or::new)
-                .orElse(new BooleanLiteral(type == And.class));
+        return distinctExpressions.stream().reduce(type == And.class ? And::new : Or::new);
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/logical/PushDownPredicateTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/logical/PushDownPredicateTest.java
@@ -100,11 +100,11 @@ public class PushDownPredicateTest {
         Expression onCondition1 = new EqualTo(rStudent.getOutput().get(0), rScore.getOutput().get(0));
         Expression onCondition2 = new GreaterThan(rStudent.getOutput().get(0), Literal.of(1));
         Expression onCondition3 = new GreaterThan(rScore.getOutput().get(0), Literal.of(2));
-        Expression onCondition = ExpressionUtils.and(onCondition1, onCondition2, onCondition3);
+        Expression onCondition = ExpressionUtils.and(onCondition1, onCondition2, onCondition3).get();
 
         Expression whereCondition1 = new GreaterThan(rStudent.getOutput().get(1), Literal.of(18));
         Expression whereCondition2 = new GreaterThan(rScore.getOutput().get(2), Literal.of(60));
-        Expression whereCondition = ExpressionUtils.and(whereCondition1, whereCondition2);
+        Expression whereCondition = ExpressionUtils.and(whereCondition1, whereCondition2).get();
 
 
         Plan join = new LogicalJoin(JoinType.INNER_JOIN, Optional.of(onCondition), rStudent, rScore);
@@ -136,8 +136,8 @@ public class PushDownPredicateTest {
         LogicalFilter filter2 = (LogicalFilter) op3;
 
         Assertions.assertEquals(join1.getCondition().get(), onCondition1);
-        Assertions.assertEquals(filter1.getPredicates(), ExpressionUtils.and(onCondition2, whereCondition1));
-        Assertions.assertEquals(filter2.getPredicates(), ExpressionUtils.and(onCondition3, whereCondition2));
+        Assertions.assertEquals(filter1.getPredicates(), ExpressionUtils.and(onCondition2, whereCondition1).get());
+        Assertions.assertEquals(filter2.getPredicates(), ExpressionUtils.and(onCondition3, whereCondition2).get());
     }
 
     @Test
@@ -148,7 +148,7 @@ public class PushDownPredicateTest {
                 new Subtract(rScore.getOutput().get(0), Literal.of(2)));
         Expression whereCondition2 = new GreaterThan(rStudent.getOutput().get(1), Literal.of(18));
         Expression whereCondition3 = new GreaterThan(rScore.getOutput().get(2), Literal.of(60));
-        Expression whereCondition = ExpressionUtils.and(whereCondition1, whereCondition2, whereCondition3);
+        Expression whereCondition = ExpressionUtils.and(whereCondition1, whereCondition2, whereCondition3).get();
 
         Plan join = new LogicalJoin(JoinType.INNER_JOIN, Optional.empty(), rStudent, rScore);
         Plan filter = new LogicalFilter(whereCondition, join);
@@ -207,7 +207,7 @@ public class PushDownPredicateTest {
         Expression whereCondition4 = new GreaterThan(rScore.getOutput().get(2), Literal.of(60));
 
         Expression whereCondition = ExpressionUtils.and(whereCondition1, whereCondition2, whereCondition3,
-                whereCondition4);
+                whereCondition4).get();
 
         Plan join = new LogicalJoin(JoinType.INNER_JOIN, Optional.empty(), rStudent, rScore);
         Plan join1 = new LogicalJoin(JoinType.INNER_JOIN, Optional.empty(), join, rCourse);


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

use optional for combine()

If input list is empty, combine will return true. It's strange.

Use optional to correct it.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
