### PR TITLE
[enhancement](workflow) Add a workflow for Clang check

### DIFF
--- a/.github/workflows/clang-build.yml
+++ b/.github/workflows/clang-build.yml
@@ -9,11 +9,6 @@ jobs:
         type: [build, ut]
     runs-on: ubuntu-20.04
     steps:
-      - name: Set timezone
-        uses: szenius/set-timezone@v1.0
-        with:
-          timezoneLinux: "Asia/Shanghai"
-
       - name: Checkout
         uses: actions/checkout@v3
 
@@ -35,7 +30,13 @@ jobs:
 
           sudo apt update
           sudo apt upgrade
-          sudo apt install --yes ccache byacc
+          sudo apt install --yes tzdata ccache byacc
+
+          # set timezone
+          sudo ln -snf /usr/share/zoneinfo/Asia/Shanghai /etc/localtime
+          sudo dpkg-reconfigure --frontend noninteractive tzdata
+
+          date
 
           if [[ "${{ matrix.type }}" == 'build' ]]; then
             DORIS_TOOLCHAIN=clang ./build.sh -j "$(nproc)" --be --clean

--- a/.github/workflows/clang-build.yml
+++ b/.github/workflows/clang-build.yml
@@ -1,0 +1,44 @@
+name: Clang Build
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        type: [build, ut]
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Set timezone
+        uses: szenius/set-timezone@v1.0
+        with:
+          timezoneLinux: "Asia/Shanghai"
+
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Run ${{ matrix.type }}
+        run: |
+          export DEFAULT_DIR='/opt/doris'
+          export PATH="${DEFAULT_DIR}/ldb-toolchain/bin/:${DEFAULT_DIR}/thirdparty/installed/bin/:${PATH}"
+          export DORIS_THIRDPARTY="${DEFAULT_DIR}/thirdparty"
+
+          mkdir "${DEFAULT_DIR}"
+
+          wget https://github.com/amosbird/ldb_toolchain_gen/releases/download/v0.12/ldb_toolchain_gen.sh \
+            -q -O /tmp/ldb_toolchain_gen.sh
+          bash /tmp/ldb_toolchain_gen.sh "${DEFAULT_DIR}/ldb-toolchain"
+
+          mkdir -p "${DORIS_THIRDPARTY}/installed"
+          docker run --rm --mount=type=bind,source="${DORIS_THIRDPARTY}/installed",target=/installed \
+            apache/doris:build-env-ldb-toolchain-latest bash -c 'mv /var/local/thirdparty/installed/* /installed'
+
+          sudo apt update
+          sudo apt upgrade
+          sudo apt install --yes ccache byacc
+
+          if [[ "${{ matrix.type }}" == 'build' ]]; then
+            DORIS_TOOLCHAIN=clang ./build.sh -j "$(nproc)" --be --clean
+          else
+            DORIS_TOOLCHAIN=clang ./run-be-ut.sh -j "$(nproc)" --run --clean
+          fi

--- a/.github/workflows/clang-build.yml
+++ b/.github/workflows/clang-build.yml
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 name: Clang Build
 
 on: [push, pull_request]
@@ -29,14 +46,12 @@ jobs:
             apache/doris:build-env-ldb-toolchain-latest bash -c 'mv /var/local/thirdparty/installed/* /installed'
 
           sudo apt update
-          sudo apt upgrade
-          sudo apt install --yes tzdata ccache byacc
+          sudo apt upgrade --yes
+          sudo DEBIAN_FRONTEND=noninteractive apt install --yes tzdata ccache byacc
 
           # set timezone
           sudo ln -snf /usr/share/zoneinfo/Asia/Shanghai /etc/localtime
           sudo dpkg-reconfigure --frontend noninteractive tzdata
-
-          date
 
           if [[ "${{ matrix.type }}" == 'build' ]]; then
             DORIS_TOOLCHAIN=clang ./build.sh -j "$(nproc)" --be --clean


### PR DESCRIPTION
# Proposed changes

~~Issue Number: close #xxx~~

## Problem Summary:

Currently, we should support building from source by Clang, but we lack related checks. It is __*inconvenient*__ to inspect and fix compilation errors reported by Clang manually.

This pr adds a workflow for Clang check.

### REMARK

For the sake of speed, the workflow copy the prebuilt third-party packages from [docker image](https://hub.docker.com/r/apache/doris) directly rather than build them from source. We must update the image if we modify the third-party packages.

## Checklist(Required)

1. Does it affect the original behavior: No
2. Has unit tests been added: No Need
3. Has document been added or modified: No Need
4. Does it need to update dependencies: No
5. Are there any changes that cannot be rolled back: No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
