### PR TITLE
Optimize regexp and like using hyperscan

### DIFF
--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -144,6 +144,9 @@ set_target_properties(backtrace PROPERTIES IMPORTED_LOCATION ${THIRDPARTY_DIR}/l
 add_library(re2 STATIC IMPORTED)
 set_target_properties(re2 PROPERTIES IMPORTED_LOCATION ${THIRDPARTY_DIR}/lib/libre2.a)
 
+add_library(hyperscan STATIC IMPORTED)
+set_target_properties(hyperscan PROPERTIES IMPORTED_LOCATION ${THIRDPARTY_DIR}/lib64/libhs.a)
+
 add_library(odbc STATIC IMPORTED)
 set_target_properties(odbc PROPERTIES IMPORTED_LOCATION ${THIRDPARTY_DIR}/lib/libodbc.a)
 
@@ -638,6 +641,7 @@ set(COMMON_THIRDPARTY
     thriftnb
     glog
     re2
+    hyperscan
     pprof
     lz4
     libevent

--- a/be/src/vec/functions/like.cpp
+++ b/be/src/vec/functions/like.cpp
@@ -83,9 +83,9 @@ Status FunctionLikeBase::constant_substring_fn(LikeSearchState* state, const Str
 }
 
 Status FunctionLikeBase::constant_regex_fn(LikeSearchState* state, const StringValue& val,
-                                            const StringValue& pattern, unsigned char* result) {
-    auto ret = hs_scan(state->hs_database.get(), val.ptr, val.len, 0,
-                       state->hs_scratch.get(), state->hs_match_handler, (void*)result);
+                                           const StringValue& pattern, unsigned char* result) {
+    auto ret = hs_scan(state->hs_database.get(), val.ptr, val.len, 0, state->hs_scratch.get(),
+                       state->hs_match_handler, (void*)result);
     if (ret != HS_SUCCESS && ret != HS_SCAN_TERMINATED) {
         return Status::RuntimeError(fmt::format("hyperscan error: {}", ret));
     }
@@ -94,15 +94,15 @@ Status FunctionLikeBase::constant_regex_fn(LikeSearchState* state, const StringV
 }
 
 Status FunctionLikeBase::regexp_fn(LikeSearchState* state, const StringValue& val,
-                                 const StringValue& pattern, unsigned char* result) {
+                                   const StringValue& pattern, unsigned char* result) {
     std::string re_pattern(pattern.ptr, pattern.len);
 
-    hs_database_t *database = nullptr;
-    hs_scratch_t *scratch = nullptr;
+    hs_database_t* database = nullptr;
+    hs_scratch_t* scratch = nullptr;
     RETURN_IF_ERROR(hs_prepare(nullptr, re_pattern.c_str(), &database, &scratch));
 
-    auto ret = hs_scan(database, val.ptr, val.len, 0,
-                       scratch, state->hs_match_handler, (void*)result);
+    auto ret =
+            hs_scan(database, val.ptr, val.len, 0, scratch, state->hs_match_handler, (void*)result);
     if (ret != HS_SUCCESS && ret != HS_SCAN_TERMINATED) {
         return Status::RuntimeError(fmt::format("hyperscan error: {}", ret));
     }
@@ -115,10 +115,10 @@ Status FunctionLikeBase::regexp_fn(LikeSearchState* state, const StringValue& va
 
 // hyperscan compile expression to database and allocate scratch space
 Status FunctionLikeBase::hs_prepare(FunctionContext* context, const char* expression,
-                                    hs_database_t **database, hs_scratch_t **scratch) {
-    hs_compile_error_t *compile_err;
-    if (hs_compile(expression, HS_FLAG_DOTALL, HS_MODE_BLOCK, NULL, database,
-                &compile_err) != HS_SUCCESS) {
+                                    hs_database_t** database, hs_scratch_t** scratch) {
+    hs_compile_error_t* compile_err;
+    if (hs_compile(expression, HS_FLAG_DOTALL, HS_MODE_BLOCK, NULL, database, &compile_err) !=
+        HS_SUCCESS) {
         hs_free_compile_error(compile_err);
         *database = nullptr;
         if (context) context->set_error("hs_compile regex pattern error");
@@ -278,7 +278,7 @@ void FunctionLike::convert_like_pattern(LikeSearchState* state, const std::strin
     }
 
     // add $ to pattern tail to match line tail
-    if (pattern.size() > 0 && pattern[pattern.size()-1] != '%') {
+    if (pattern.size() > 0 && pattern[pattern.size() - 1] != '%') {
         re_pattern->append("$");
     }
 }
@@ -332,8 +332,8 @@ Status FunctionLike::prepare(FunctionContext* context, FunctionContext::Function
             std::string re_pattern;
             convert_like_pattern(&state->search_state, pattern_str, &re_pattern);
 
-            hs_database_t *database = nullptr;
-            hs_scratch_t *scratch = nullptr;
+            hs_database_t* database = nullptr;
+            hs_scratch_t* scratch = nullptr;
             RETURN_IF_ERROR(hs_prepare(context, re_pattern.c_str(), &database, &scratch));
 
             state->search_state.hs_database.reset(database);
@@ -372,8 +372,8 @@ Status FunctionRegexp::prepare(FunctionContext* context,
             state->search_state.set_search_string(search_string);
             state->function = constant_substring_fn;
         } else {
-            hs_database_t *database = nullptr;
-            hs_scratch_t *scratch = nullptr;
+            hs_database_t* database = nullptr;
+            hs_scratch_t* scratch = nullptr;
             RETURN_IF_ERROR(hs_prepare(context, pattern_str.c_str(), &database, &scratch));
 
             state->search_state.hs_database.reset(database);
@@ -384,6 +384,5 @@ Status FunctionRegexp::prepare(FunctionContext* context,
     }
     return Status::OK();
 }
-
 
 } // namespace doris::vectorized

--- a/be/src/vec/functions/like.cpp
+++ b/be/src/vec/functions/like.cpp
@@ -82,6 +82,17 @@ Status FunctionLikeBase::constant_substring_fn(LikeSearchState* state, const Str
     return Status::OK();
 }
 
+Status FunctionLikeBase::constant_regex_fn(LikeSearchState* state, const StringValue& val,
+                                            const StringValue& pattern, unsigned char* result) {
+    auto ret = hs_scan(state->hs_database.get(), val.ptr, val.len, 0,
+                       state->hs_scratch.get(), state->hs_match_handler, (void*)result);
+    if (ret != HS_SUCCESS && ret != HS_SCAN_TERMINATED) {
+        return Status::RuntimeError(fmt::format("hyperscan error: {}", ret));
+    }
+
+    return Status::OK();
+}
+
 Status FunctionLikeBase::execute_impl(FunctionContext* context, Block& block,
                                       const ColumnNumbers& arguments, size_t result,
                                       size_t /*input_rows_count*/) {
@@ -211,17 +222,6 @@ Status FunctionLike::like_fn(LikeSearchState* state, const StringValue& val,
     return Status::OK();
 }
 
-Status FunctionLike::constant_regex_full_fn(LikeSearchState* state, const StringValue& val,
-                                            const StringValue& pattern, unsigned char* result) {
-    auto ret = hs_scan(state->hs_database.get(), val.ptr, val.len, 0,
-                       state->hs_scratch.get(), state->hs_match_handler, (void*)result);
-    if (ret != HS_SUCCESS && ret != HS_SCAN_TERMINATED) {
-        return Status::RuntimeError(fmt::format("hyperscan error: {}", ret));
-    }
-
-    return Status::OK();
-}
-
 void FunctionLike::convert_like_pattern(LikeSearchState* state, const std::string& pattern,
                                         std::string* re_pattern) {
     re_pattern->clear();
@@ -325,7 +325,7 @@ Status FunctionLike::prepare(FunctionContext* context, FunctionContext::Function
             state->search_state.hs_database.reset(database);
             state->search_state.hs_scratch.reset(scratch);
 
-            state->function = constant_regex_full_fn;
+            state->function = constant_regex_fn;
         }
     }
     return Status::OK();
@@ -375,21 +375,9 @@ Status FunctionRegexp::prepare(FunctionContext* context,
             state->search_state.hs_database.reset(database);
             state->search_state.hs_scratch.reset(scratch);
 
-            state->function = constant_regex_partial_fn;
+            state->function = constant_regex_fn;
         }
     }
-    return Status::OK();
-}
-
-Status FunctionRegexp::constant_regex_partial_fn(LikeSearchState* state, const StringValue& val,
-                                                 const StringValue& pattern,
-                                                 unsigned char* result) {
-    auto ret = hs_scan(state->hs_database.get(), val.ptr, val.len, 0,
-                       state->hs_scratch.get(), state->hs_match_handler, (void*)result);
-    if (ret != HS_SUCCESS && ret != HS_SCAN_TERMINATED) {
-        return Status::RuntimeError(fmt::format("hyperscan error: {}", ret));
-    }
-
     return Status::OK();
 }
 

--- a/be/src/vec/functions/like.h
+++ b/be/src/vec/functions/like.h
@@ -131,6 +131,9 @@ protected:
 
     static Status constant_substring_fn(LikeSearchState* state, const StringValue& val,
                                         const StringValue& pattern, unsigned char* result);
+
+    static Status constant_regex_fn(LikeSearchState* state, const StringValue& val,
+                                         const StringValue& pattern, unsigned char* result);
 };
 
 class FunctionLike : public FunctionLikeBase {
@@ -146,9 +149,6 @@ public:
 private:
     static Status like_fn(LikeSearchState* state, const StringValue& val,
                           const StringValue& pattern, unsigned char* result);
-
-    static Status constant_regex_full_fn(LikeSearchState* state, const StringValue& val,
-                                         const StringValue& pattern, unsigned char* result);
 
     static void convert_like_pattern(LikeSearchState* state, const std::string& pattern,
                                      std::string* re_pattern);

--- a/be/src/vec/functions/like.h
+++ b/be/src/vec/functions/like.h
@@ -68,15 +68,18 @@ struct LikeSearchState {
         }
     };
 
+    // hyperscan compiled pattern database and scratch space, reused for performance
     std::unique_ptr<hs_database_t, HyperscanDeleter<decltype(&hs_free_database), &hs_free_database>> hs_database;
     std::unique_ptr<hs_scratch_t, HyperscanDeleter<decltype(&hs_free_scratch), &hs_free_scratch>> hs_scratch;
 
+    // hyperscan match callback
     static int hs_match_handler(unsigned int /* from */, // NOLINT
                                 unsigned long long /* from */, // NOLINT
                                 unsigned long long /* to */, // NOLINT
                                 unsigned int /* flags */,
                                 void * ctx)
     {
+        // set result to 1 for matched row
         *((unsigned char*)ctx) = 1;
         /// return non-zero to indicate hyperscan stop after first matched
         return 1;
@@ -138,6 +141,7 @@ protected:
     static Status regexp_fn(LikeSearchState* state, const StringValue& val,
                             const StringValue& pattern, unsigned char* result);
 
+    // hyperscan compile expression to database and allocate scratch space
     static Status hs_prepare(FunctionContext* context, const char* expression,
                              hs_database_t **database, hs_scratch_t **scratch);
 };

--- a/be/src/vec/functions/like.h
+++ b/be/src/vec/functions/like.h
@@ -134,6 +134,9 @@ protected:
 
     static Status constant_regex_fn(LikeSearchState* state, const StringValue& val,
                                          const StringValue& pattern, unsigned char* result);
+
+    static Status regexp_fn(LikeSearchState* state, const StringValue& val,
+                            const StringValue& pattern, unsigned char* result);
 };
 
 class FunctionLike : public FunctionLikeBase {
@@ -165,13 +168,6 @@ public:
     String get_name() const override { return name; }
 
     Status prepare(FunctionContext* context, FunctionContext::FunctionStateScope scope) override;
-
-private:
-    static Status regexp_fn(LikeSearchState* state, const StringValue& val,
-                            const StringValue& pattern, unsigned char* result);
-
-    static Status constant_regex_partial_fn(LikeSearchState* state, const StringValue& val,
-                                            const StringValue& pattern, unsigned char* result);
 };
 
 void register_function_like(SimpleFunctionFactory& factory) {

--- a/be/src/vec/functions/like.h
+++ b/be/src/vec/functions/like.h
@@ -17,10 +17,10 @@
 
 #pragma once
 
+#include <hs/hs.h>
+
 #include <functional>
 #include <memory>
-
-#include <hs/hs.h>
 
 #include "runtime/string_search.hpp"
 #include "runtime/string_value.h"
@@ -59,26 +59,24 @@ struct LikeSearchState {
     std::unique_ptr<re2::RE2> regex;
 
     template <typename Deleter, Deleter deleter>
-    struct HyperscanDeleter
-    {
+    struct HyperscanDeleter {
         template <typename T>
-        void operator()(T * ptr) const
-        {
+        void operator()(T* ptr) const {
             deleter(ptr);
         }
     };
 
     // hyperscan compiled pattern database and scratch space, reused for performance
-    std::unique_ptr<hs_database_t, HyperscanDeleter<decltype(&hs_free_database), &hs_free_database>> hs_database;
-    std::unique_ptr<hs_scratch_t, HyperscanDeleter<decltype(&hs_free_scratch), &hs_free_scratch>> hs_scratch;
+    std::unique_ptr<hs_database_t, HyperscanDeleter<decltype(&hs_free_database), &hs_free_database>>
+            hs_database;
+    std::unique_ptr<hs_scratch_t, HyperscanDeleter<decltype(&hs_free_scratch), &hs_free_scratch>>
+            hs_scratch;
 
     // hyperscan match callback
-    static int hs_match_handler(unsigned int /* from */, // NOLINT
+    static int hs_match_handler(unsigned int /* from */,       // NOLINT
                                 unsigned long long /* from */, // NOLINT
-                                unsigned long long /* to */, // NOLINT
-                                unsigned int /* flags */,
-                                void * ctx)
-    {
+                                unsigned long long /* to */,   // NOLINT
+                                unsigned int /* flags */, void* ctx) {
         // set result to 1 for matched row
         *((unsigned char*)ctx) = 1;
         /// return non-zero to indicate hyperscan stop after first matched
@@ -136,14 +134,14 @@ protected:
                                         const StringValue& pattern, unsigned char* result);
 
     static Status constant_regex_fn(LikeSearchState* state, const StringValue& val,
-                                         const StringValue& pattern, unsigned char* result);
+                                    const StringValue& pattern, unsigned char* result);
 
     static Status regexp_fn(LikeSearchState* state, const StringValue& val,
                             const StringValue& pattern, unsigned char* result);
 
     // hyperscan compile expression to database and allocate scratch space
     static Status hs_prepare(FunctionContext* context, const char* expression,
-                             hs_database_t **database, hs_scratch_t **scratch);
+                             hs_database_t** database, hs_scratch_t** scratch);
 };
 
 class FunctionLike : public FunctionLikeBase {

--- a/be/src/vec/functions/like.h
+++ b/be/src/vec/functions/like.h
@@ -137,6 +137,9 @@ protected:
 
     static Status regexp_fn(LikeSearchState* state, const StringValue& val,
                             const StringValue& pattern, unsigned char* result);
+
+    static Status hs_prepare(FunctionContext* context, const char* expression,
+                             hs_database_t **database, hs_scratch_t **scratch);
 };
 
 class FunctionLike : public FunctionLikeBase {


### PR DESCRIPTION
# Proposed changes

Issue Number: depends on #9964 #11102  

## Problem Summary:

Describe the overview of changes.

Use hyperscan for high performance regular expression matching, which is used by regexp and like SQL functions.

## Checklist(Required)

1. Does it affect the original behavior: (No)
2. Has unit tests been added: (No Need)
3. Has document been added or modified: (No Need)
4. Does it need to update dependencies: (Yes)
5. Are there any changes that cannot be rolled back: (No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
