### PR TITLE
[Refactor](Nereids) Refactor aggregate plan

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslator.java
@@ -149,8 +149,8 @@ public class PhysicalPlanTranslator extends DefaultPlanVisitor<PlanFragment, Pla
         //    1. add a project after agg, if agg function is not the top output expression.
         //    2. introduce canonicalized, semanticEquals and deterministic in Expression
         //       for removing duplicate.
-        List<Expression> groupByExpressionList = aggregate.getGroupByExprList();
-        List<NamedExpression> outputExpressionList = aggregate.getOutputExpressionList();
+        List<Expression> groupByExpressionList = aggregate.getGroupByExpressions();
+        List<NamedExpression> outputExpressionList = aggregate.getOutputExpressions();
 
         // 1. generate slot reference for each group expression
         List<SlotReference> groupSlotList = Lists.newArrayList();
@@ -189,7 +189,7 @@ public class PhysicalPlanTranslator extends DefaultPlanVisitor<PlanFragment, Pla
         }
 
         // process partition list
-        List<Expression> partitionExpressionList = aggregate.getPartitionExprList();
+        List<Expression> partitionExpressionList = aggregate.getPartitionExpressions();
         List<Expr> execPartitionExpressions = partitionExpressionList.stream()
                 .map(e -> ExpressionTranslator.translate(e, context)).collect(Collectors.toList());
         DataPartition mergePartition = DataPartition.UNPARTITIONED;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/BindFunction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/BindFunction.java
@@ -47,8 +47,8 @@ public class BindFunction implements AnalysisRuleFactory {
             ),
             RuleType.BINDING_AGGREGATE_FUNCTION.build(
                 logicalAggregate().then(agg -> {
-                    List<Expression> groupBy = bind(agg.getGroupByExpressionList());
-                    List<NamedExpression> output = bind(agg.getOutputExpressionList());
+                    List<Expression> groupBy = bind(agg.getGroupByExpressions());
+                    List<NamedExpression> output = bind(agg.getOutputExpressions());
                     return agg.withGroupByAndOutput(groupBy, output);
                 })
             )

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/BindSlotReference.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/BindSlotReference.java
@@ -73,8 +73,8 @@ public class BindSlotReference implements AnalysisRuleFactory {
             ),
             RuleType.BINDING_AGGREGATE_SLOT.build(
                 logicalAggregate().then(agg -> {
-                    List<Expression> groupBy = bind(agg.getGroupByExpressionList(), agg.children(), agg);
-                    List<NamedExpression> output = bind(agg.getOutputExpressionList(), agg.children(), agg);
+                    List<Expression> groupBy = bind(agg.getGroupByExpressions(), agg.children(), agg);
+                    List<NamedExpression> output = bind(agg.getOutputExpressions(), agg.children(), agg);
                     return agg.withGroupByAndOutput(groupBy, output);
                 })
             ),

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rewrite/ExpressionOfPlanRewrite.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rewrite/ExpressionOfPlanRewrite.java
@@ -87,10 +87,10 @@ public class ExpressionOfPlanRewrite implements RewriteRuleFactory {
         @Override
         public Rule build() {
             return logicalAggregate().then(agg -> {
-                List<Expression> groupByExprs = agg.getGroupByExpressionList();
+                List<Expression> groupByExprs = agg.getGroupByExpressions();
                 List<Expression> newGroupByExprs = rewriter.rewrite(groupByExprs);
 
-                List<NamedExpression> outputExpressions = agg.getOutputExpressionList();
+                List<NamedExpression> outputExpressions = agg.getOutputExpressions();
                 List<NamedExpression> newOutputExpressions = outputExpressions.stream()
                         .map(expr -> (NamedExpression) rewriter.rewrite(expr)).collect(Collectors.toList());
                 if (outputExpressions.containsAll(newOutputExpressions)) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/implementation/LogicalAggToPhysicalHashAgg.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/implementation/LogicalAggToPhysicalHashAgg.java
@@ -21,6 +21,8 @@ import org.apache.doris.nereids.rules.Rule;
 import org.apache.doris.nereids.rules.RuleType;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalAggregate;
 
+import com.google.common.collect.ImmutableList;
+
 /**
  * Implementation rule that convert logical aggregation to physical hash aggregation.
  */
@@ -29,9 +31,9 @@ public class LogicalAggToPhysicalHashAgg extends OneImplementationRuleFactory {
     public Rule build() {
         return logicalAggregate().then(agg -> new PhysicalAggregate<>(
                 // TODO: for use a function to judge whether use stream
-                agg.getGroupByExpressionList(),
-                agg.getOutputExpressionList(),
-                agg.getPartitionExprList(),
+                agg.getGroupByExpressions(),
+                agg.getOutputExpressions(),
+                ImmutableList.of(),
                 agg.getAggPhase(),
                 false,
                 agg.getLogicalProperties(),

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/AggregateDisassemble.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/AggregateDisassemble.java
@@ -59,8 +59,8 @@ public class AggregateDisassemble extends OneRewriteRuleFactory {
     public Rule build() {
         return logicalAggregate().when(agg -> !agg.isDisassembled()).thenApply(ctx -> {
             LogicalAggregate<GroupPlan> aggregate = ctx.root;
-            List<NamedExpression> originOutputExprs = aggregate.getOutputExpressionList();
-            List<Expression> originGroupByExprs = aggregate.getGroupByExpressionList();
+            List<NamedExpression> originOutputExprs = aggregate.getOutputExpressions();
+            List<Expression> originGroupByExprs = aggregate.getGroupByExpressions();
 
             // 1. generate a map from local aggregate output to global aggregate expr substitution.
             //    inputSubstitutionMap use for replacing expression in global aggregate
@@ -80,7 +80,7 @@ public class AggregateDisassemble extends OneRewriteRuleFactory {
             //    NOTICE: Ref: SlotReference, A: Alias, AF: AggregateFunction, #x: ExprId x
             // 2. collect local aggregate output expressions and local aggregate group by expression list
             Map<Expression, Expression> inputSubstitutionMap = Maps.newHashMap();
-            List<Expression> localGroupByExprs = aggregate.getGroupByExpressionList();
+            List<Expression> localGroupByExprs = aggregate.getGroupByExpressions();
             List<NamedExpression> localOutputExprs = Lists.newArrayList();
             for (Expression originGroupByExpr : originGroupByExprs) {
                 if (inputSubstitutionMap.containsKey(originGroupByExpr)) {
@@ -111,7 +111,7 @@ public class AggregateDisassemble extends OneRewriteRuleFactory {
             }
 
             // 3. replace expression in globalOutputExprs and globalGroupByExprs
-            List<NamedExpression> globalOutputExprs = aggregate.getOutputExpressionList().stream()
+            List<NamedExpression> globalOutputExprs = aggregate.getOutputExpressions().stream()
                     .map(e -> ExpressionReplacer.INSTANCE.visit(e, inputSubstitutionMap))
                     .map(NamedExpression.class::cast)
                     .collect(Collectors.toList());

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalAggregate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalAggregate.java
@@ -51,62 +51,53 @@ import java.util.Optional;
 public class LogicalAggregate<CHILD_TYPE extends Plan> extends LogicalUnary<CHILD_TYPE> {
 
     private final boolean disassembled;
-    private final List<Expression> groupByExpressionList;
-    private final List<NamedExpression> outputExpressionList;
-    private final List<Expression> partitionExprList;
+    private final List<Expression> groupByExpressions;
+    private final List<NamedExpression> outputExpressions;
     private final AggPhase aggPhase;
 
     /**
      * Desc: Constructor for LogicalAggregate.
      */
-    public LogicalAggregate(List<Expression> groupByExpressionList, List<NamedExpression> outputExpressionList,
-                            CHILD_TYPE child) {
-        this(groupByExpressionList, outputExpressionList, false, AggPhase.GLOBAL, child);
+    public LogicalAggregate(
+            List<Expression> groupByExpressions,
+            List<NamedExpression> outputExpressions,
+            CHILD_TYPE child) {
+        this(groupByExpressions, outputExpressions, false, AggPhase.GLOBAL, child);
     }
 
-    public LogicalAggregate(List<Expression> groupByExpressionList,
-            List<NamedExpression> outputExpressionList,
-            boolean disassembled, AggPhase aggPhase, CHILD_TYPE child) {
-        this(groupByExpressionList, outputExpressionList, null, disassembled, aggPhase, child);
-    }
-
-    public LogicalAggregate(List<Expression> groupByExpressionList,
-                            List<NamedExpression> outputExpressionList,
-                            List<Expression> partitionExprList,
-                            boolean disassembled, AggPhase aggPhase,
-                            CHILD_TYPE child) {
-        this(groupByExpressionList, outputExpressionList, partitionExprList, disassembled, aggPhase,
-                Optional.empty(), Optional.empty(), child);
+    public LogicalAggregate(
+            List<Expression> groupByExpressions,
+            List<NamedExpression> outputExpressions,
+            boolean disassembled,
+            AggPhase aggPhase,
+            CHILD_TYPE child) {
+        this(groupByExpressions, outputExpressions, disassembled, aggPhase, Optional.empty(), Optional.empty(), child);
     }
 
     /**
      * Whole parameters constructor for LogicalAggregate.
      */
-    public LogicalAggregate(List<Expression> groupByExpressionList,
-                            List<NamedExpression> outputExpressionList,
-                            List<Expression> partitionExprList,
-                            boolean disassembled, AggPhase aggPhase,
-                            Optional<GroupExpression> groupExpression,
-                            Optional<LogicalProperties> logicalProperties,
-                            CHILD_TYPE child) {
+    public LogicalAggregate(
+            List<Expression> groupByExpressions,
+            List<NamedExpression> outputExpressions,
+            boolean disassembled,
+            AggPhase aggPhase,
+            Optional<GroupExpression> groupExpression,
+            Optional<LogicalProperties> logicalProperties,
+            CHILD_TYPE child) {
         super(PlanType.LOGICAL_AGGREGATE, groupExpression, logicalProperties, child);
-        this.groupByExpressionList = groupByExpressionList;
-        this.outputExpressionList = outputExpressionList;
-        this.partitionExprList = partitionExprList;
+        this.groupByExpressions = groupByExpressions;
+        this.outputExpressions = outputExpressions;
         this.disassembled = disassembled;
         this.aggPhase = aggPhase;
     }
 
-    public List<Expression> getPartitionExprList() {
-        return partitionExprList == null ? groupByExpressionList : partitionExprList;
+    public List<Expression> getGroupByExpressions() {
+        return groupByExpressions;
     }
 
-    public List<Expression> getGroupByExpressionList() {
-        return groupByExpressionList;
-    }
-
-    public List<NamedExpression> getOutputExpressionList() {
-        return outputExpressionList;
+    public List<NamedExpression> getOutputExpressions() {
+        return outputExpressions;
     }
 
     public AggPhase getAggPhase() {
@@ -115,14 +106,14 @@ public class LogicalAggregate<CHILD_TYPE extends Plan> extends LogicalUnary<CHIL
 
     @Override
     public String toString() {
-        return "LogicalAggregate (phase: [" + aggPhase.name() + "], outputExpressionList: ["
-                + StringUtils.join(outputExpressionList, ", ")
-                + "], groupByExprList: [" + StringUtils.join(groupByExpressionList, ", ") + "])";
+        return "LogicalAggregate (phase: [" + aggPhase.name() + "], output: ["
+                + StringUtils.join(outputExpressions, ", ")
+                + "], groupBy: [" + StringUtils.join(groupByExpressions, ", ") + "])";
     }
 
     @Override
     public List<Slot> computeOutput(Plan input) {
-        return outputExpressionList.stream()
+        return outputExpressions.stream()
                 .map(NamedExpression::toSlot)
                 .collect(ImmutableList.toImmutableList());
     }
@@ -135,8 +126,8 @@ public class LogicalAggregate<CHILD_TYPE extends Plan> extends LogicalUnary<CHIL
     @Override
     public List<Expression> getExpressions() {
         return new ImmutableList.Builder<Expression>()
-                .addAll(groupByExpressionList)
-                .addAll(outputExpressionList)
+                .addAll(groupByExpressions)
+                .addAll(outputExpressions)
                 .build();
     }
 
@@ -155,41 +146,36 @@ public class LogicalAggregate<CHILD_TYPE extends Plan> extends LogicalUnary<CHIL
             return false;
         }
         LogicalAggregate that = (LogicalAggregate) o;
-        return Objects.equals(groupByExpressionList, that.groupByExpressionList)
-                && Objects.equals(outputExpressionList, that.outputExpressionList)
-                && Objects.equals(partitionExprList, that.partitionExprList)
+        return Objects.equals(groupByExpressions, that.groupByExpressions)
+                && Objects.equals(outputExpressions, that.outputExpressions)
                 && aggPhase == that.aggPhase;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(groupByExpressionList, outputExpressionList, partitionExprList, aggPhase);
+        return Objects.hash(groupByExpressions, outputExpressions, aggPhase);
     }
 
     @Override
     public LogicalAggregate<Plan> withChildren(List<Plan> children) {
         Preconditions.checkArgument(children.size() == 1);
-        return new LogicalAggregate(groupByExpressionList, outputExpressionList,
-            partitionExprList, disassembled, aggPhase, children.get(0));
+        return new LogicalAggregate(groupByExpressions, outputExpressions, disassembled, aggPhase, children.get(0));
     }
 
     @Override
     public LogicalAggregate<Plan> withGroupExpression(Optional<GroupExpression> groupExpression) {
-        return new LogicalAggregate(groupByExpressionList, outputExpressionList,
-            partitionExprList, disassembled, aggPhase, groupExpression,
+        return new LogicalAggregate(groupByExpressions, outputExpressions, disassembled, aggPhase, groupExpression,
             Optional.of(logicalProperties), children.get(0));
     }
 
     @Override
     public LogicalAggregate<Plan> withLogicalProperties(Optional<LogicalProperties> logicalProperties) {
-        return new LogicalAggregate(groupByExpressionList, outputExpressionList,
-            partitionExprList, disassembled, aggPhase, Optional.empty(),
+        return new LogicalAggregate(groupByExpressions, outputExpressions, disassembled, aggPhase, Optional.empty(),
             logicalProperties, children.get(0));
     }
 
     public LogicalAggregate<Plan> withGroupByAndOutput(List<Expression> groupByExprList,
                                                  List<NamedExpression> outputExpressionList) {
-        return new LogicalAggregate(groupByExprList, outputExpressionList,
-            partitionExprList, disassembled, aggPhase, child());
+        return new LogicalAggregate(groupByExprList, outputExpressionList, disassembled, aggPhase, child());
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/logical/AggregateDisassembleTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/logical/AggregateDisassembleTest.java
@@ -91,31 +91,31 @@ public class AggregateDisassembleTest {
         Expression localOutput1 = new Sum(rStudent.getOutput().get(0).toSlot());
         Expression localGroupBy = rStudent.getOutput().get(2).toSlot();
 
-        Assertions.assertEquals(2, local.getOutputExpressionList().size());
-        Assertions.assertTrue(local.getOutputExpressionList().get(0) instanceof SlotReference);
-        Assertions.assertEquals(localOutput0, local.getOutputExpressionList().get(0));
-        Assertions.assertTrue(local.getOutputExpressionList().get(1) instanceof Alias);
-        Assertions.assertEquals(localOutput1, local.getOutputExpressionList().get(1).child(0));
-        Assertions.assertEquals(1, local.getGroupByExpressionList().size());
-        Assertions.assertEquals(localGroupBy, local.getGroupByExpressionList().get(0));
+        Assertions.assertEquals(2, local.getOutputExpressions().size());
+        Assertions.assertTrue(local.getOutputExpressions().get(0) instanceof SlotReference);
+        Assertions.assertEquals(localOutput0, local.getOutputExpressions().get(0));
+        Assertions.assertTrue(local.getOutputExpressions().get(1) instanceof Alias);
+        Assertions.assertEquals(localOutput1, local.getOutputExpressions().get(1).child(0));
+        Assertions.assertEquals(1, local.getGroupByExpressions().size());
+        Assertions.assertEquals(localGroupBy, local.getGroupByExpressions().get(0));
 
-        Expression globalOutput0 = local.getOutputExpressionList().get(0).toSlot();
-        Expression globalOutput1 = new Sum(local.getOutputExpressionList().get(1).toSlot());
-        Expression globalGroupBy = local.getOutputExpressionList().get(0).toSlot();
+        Expression globalOutput0 = local.getOutputExpressions().get(0).toSlot();
+        Expression globalOutput1 = new Sum(local.getOutputExpressions().get(1).toSlot());
+        Expression globalGroupBy = local.getOutputExpressions().get(0).toSlot();
 
-        Assertions.assertEquals(2, global.getOutputExpressionList().size());
-        Assertions.assertTrue(global.getOutputExpressionList().get(0) instanceof SlotReference);
-        Assertions.assertEquals(globalOutput0, global.getOutputExpressionList().get(0));
-        Assertions.assertTrue(global.getOutputExpressionList().get(1) instanceof Alias);
-        Assertions.assertEquals(globalOutput1, global.getOutputExpressionList().get(1).child(0));
-        Assertions.assertEquals(1, global.getGroupByExpressionList().size());
-        Assertions.assertEquals(globalGroupBy, global.getGroupByExpressionList().get(0));
+        Assertions.assertEquals(2, global.getOutputExpressions().size());
+        Assertions.assertTrue(global.getOutputExpressions().get(0) instanceof SlotReference);
+        Assertions.assertEquals(globalOutput0, global.getOutputExpressions().get(0));
+        Assertions.assertTrue(global.getOutputExpressions().get(1) instanceof Alias);
+        Assertions.assertEquals(globalOutput1, global.getOutputExpressions().get(1).child(0));
+        Assertions.assertEquals(1, global.getGroupByExpressions().size());
+        Assertions.assertEquals(globalGroupBy, global.getGroupByExpressions().get(0));
 
         // check id:
         Assertions.assertEquals(outputExpressionList.get(0).getExprId(),
-                global.getOutputExpressionList().get(0).getExprId());
+                global.getOutputExpressions().get(0).getExprId());
         Assertions.assertEquals(outputExpressionList.get(1).getExprId(),
-                global.getOutputExpressionList().get(1).getExprId());
+                global.getOutputExpressions().get(1).getExprId());
     }
 
     /**
@@ -150,31 +150,31 @@ public class AggregateDisassembleTest {
         Expression localOutput1 = new Sum(rStudent.getOutput().get(0).toSlot());
         Expression localGroupBy = new Add(rStudent.getOutput().get(2).toSlot(), new IntegerLiteral(1));
 
-        Assertions.assertEquals(2, local.getOutputExpressionList().size());
-        Assertions.assertTrue(local.getOutputExpressionList().get(0) instanceof Alias);
-        Assertions.assertEquals(localOutput0, local.getOutputExpressionList().get(0).child(0));
-        Assertions.assertTrue(local.getOutputExpressionList().get(1) instanceof Alias);
-        Assertions.assertEquals(localOutput1, local.getOutputExpressionList().get(1).child(0));
-        Assertions.assertEquals(1, local.getGroupByExpressionList().size());
-        Assertions.assertEquals(localGroupBy, local.getGroupByExpressionList().get(0));
+        Assertions.assertEquals(2, local.getOutputExpressions().size());
+        Assertions.assertTrue(local.getOutputExpressions().get(0) instanceof Alias);
+        Assertions.assertEquals(localOutput0, local.getOutputExpressions().get(0).child(0));
+        Assertions.assertTrue(local.getOutputExpressions().get(1) instanceof Alias);
+        Assertions.assertEquals(localOutput1, local.getOutputExpressions().get(1).child(0));
+        Assertions.assertEquals(1, local.getGroupByExpressions().size());
+        Assertions.assertEquals(localGroupBy, local.getGroupByExpressions().get(0));
 
-        Expression globalOutput0 = local.getOutputExpressionList().get(0).toSlot();
-        Expression globalOutput1 = new Sum(local.getOutputExpressionList().get(1).toSlot());
-        Expression globalGroupBy = local.getOutputExpressionList().get(0).toSlot();
+        Expression globalOutput0 = local.getOutputExpressions().get(0).toSlot();
+        Expression globalOutput1 = new Sum(local.getOutputExpressions().get(1).toSlot());
+        Expression globalGroupBy = local.getOutputExpressions().get(0).toSlot();
 
-        Assertions.assertEquals(2, global.getOutputExpressionList().size());
-        Assertions.assertTrue(global.getOutputExpressionList().get(0) instanceof Alias);
-        Assertions.assertEquals(globalOutput0, global.getOutputExpressionList().get(0).child(0));
-        Assertions.assertTrue(global.getOutputExpressionList().get(1) instanceof Alias);
-        Assertions.assertEquals(globalOutput1, global.getOutputExpressionList().get(1).child(0));
-        Assertions.assertEquals(1, global.getGroupByExpressionList().size());
-        Assertions.assertEquals(globalGroupBy, global.getGroupByExpressionList().get(0));
+        Assertions.assertEquals(2, global.getOutputExpressions().size());
+        Assertions.assertTrue(global.getOutputExpressions().get(0) instanceof Alias);
+        Assertions.assertEquals(globalOutput0, global.getOutputExpressions().get(0).child(0));
+        Assertions.assertTrue(global.getOutputExpressions().get(1) instanceof Alias);
+        Assertions.assertEquals(globalOutput1, global.getOutputExpressions().get(1).child(0));
+        Assertions.assertEquals(1, global.getGroupByExpressions().size());
+        Assertions.assertEquals(globalGroupBy, global.getGroupByExpressions().get(0));
 
         // check id:
         Assertions.assertEquals(outputExpressionList.get(0).getExprId(),
-                global.getOutputExpressionList().get(0).getExprId());
+                global.getOutputExpressions().get(0).getExprId());
         Assertions.assertEquals(outputExpressionList.get(1).getExprId(),
-                global.getOutputExpressionList().get(1).getExprId());
+                global.getOutputExpressions().get(1).getExprId());
     }
 
     /**
@@ -205,21 +205,21 @@ public class AggregateDisassembleTest {
 
         Expression localOutput0 = new Sum(rStudent.getOutput().get(0).toSlot());
 
-        Assertions.assertEquals(1, local.getOutputExpressionList().size());
-        Assertions.assertTrue(local.getOutputExpressionList().get(0) instanceof Alias);
-        Assertions.assertEquals(localOutput0, local.getOutputExpressionList().get(0).child(0));
-        Assertions.assertEquals(0, local.getGroupByExpressionList().size());
+        Assertions.assertEquals(1, local.getOutputExpressions().size());
+        Assertions.assertTrue(local.getOutputExpressions().get(0) instanceof Alias);
+        Assertions.assertEquals(localOutput0, local.getOutputExpressions().get(0).child(0));
+        Assertions.assertEquals(0, local.getGroupByExpressions().size());
 
-        Expression globalOutput0 = new Sum(local.getOutputExpressionList().get(0).toSlot());
+        Expression globalOutput0 = new Sum(local.getOutputExpressions().get(0).toSlot());
 
-        Assertions.assertEquals(1, global.getOutputExpressionList().size());
-        Assertions.assertTrue(global.getOutputExpressionList().get(0) instanceof Alias);
-        Assertions.assertEquals(globalOutput0, global.getOutputExpressionList().get(0).child(0));
-        Assertions.assertEquals(0, global.getGroupByExpressionList().size());
+        Assertions.assertEquals(1, global.getOutputExpressions().size());
+        Assertions.assertTrue(global.getOutputExpressions().get(0) instanceof Alias);
+        Assertions.assertEquals(globalOutput0, global.getOutputExpressions().get(0).child(0));
+        Assertions.assertEquals(0, global.getGroupByExpressions().size());
 
         // check id:
         Assertions.assertEquals(outputExpressionList.get(0).getExprId(),
-                global.getOutputExpressionList().get(0).getExprId());
+                global.getOutputExpressions().get(0).getExprId());
     }
 
     /**
@@ -253,26 +253,26 @@ public class AggregateDisassembleTest {
         Expression localOutput1 = new Sum(rStudent.getOutput().get(0).toSlot());
         Expression localGroupBy = rStudent.getOutput().get(2).toSlot();
 
-        Assertions.assertEquals(2, local.getOutputExpressionList().size());
-        Assertions.assertTrue(local.getOutputExpressionList().get(0) instanceof SlotReference);
-        Assertions.assertEquals(localOutput0, local.getOutputExpressionList().get(0));
-        Assertions.assertTrue(local.getOutputExpressionList().get(1) instanceof Alias);
-        Assertions.assertEquals(localOutput1, local.getOutputExpressionList().get(1).child(0));
-        Assertions.assertEquals(1, local.getGroupByExpressionList().size());
-        Assertions.assertEquals(localGroupBy, local.getGroupByExpressionList().get(0));
+        Assertions.assertEquals(2, local.getOutputExpressions().size());
+        Assertions.assertTrue(local.getOutputExpressions().get(0) instanceof SlotReference);
+        Assertions.assertEquals(localOutput0, local.getOutputExpressions().get(0));
+        Assertions.assertTrue(local.getOutputExpressions().get(1) instanceof Alias);
+        Assertions.assertEquals(localOutput1, local.getOutputExpressions().get(1).child(0));
+        Assertions.assertEquals(1, local.getGroupByExpressions().size());
+        Assertions.assertEquals(localGroupBy, local.getGroupByExpressions().get(0));
 
-        Expression globalOutput0 = new Sum(local.getOutputExpressionList().get(1).toSlot());
-        Expression globalGroupBy = local.getOutputExpressionList().get(0).toSlot();
+        Expression globalOutput0 = new Sum(local.getOutputExpressions().get(1).toSlot());
+        Expression globalGroupBy = local.getOutputExpressions().get(0).toSlot();
 
-        Assertions.assertEquals(1, global.getOutputExpressionList().size());
-        Assertions.assertTrue(global.getOutputExpressionList().get(0) instanceof Alias);
-        Assertions.assertEquals(globalOutput0, global.getOutputExpressionList().get(0).child(0));
-        Assertions.assertEquals(1, global.getGroupByExpressionList().size());
-        Assertions.assertEquals(globalGroupBy, global.getGroupByExpressionList().get(0));
+        Assertions.assertEquals(1, global.getOutputExpressions().size());
+        Assertions.assertTrue(global.getOutputExpressions().get(0) instanceof Alias);
+        Assertions.assertEquals(globalOutput0, global.getOutputExpressions().get(0).child(0));
+        Assertions.assertEquals(1, global.getGroupByExpressions().size());
+        Assertions.assertEquals(globalGroupBy, global.getGroupByExpressions().get(0));
 
         // check id:
         Assertions.assertEquals(outputExpressionList.get(0).getExprId(),
-                global.getOutputExpressionList().get(0).getExprId());
+                global.getOutputExpressions().get(0).getExprId());
     }
 
     private Plan rewrite(Plan input) {


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

1. Unify and refine property names in `LogicalAggregate` and `PhysicalAggregate`
2. Remove `partitionExpressions` in `LogicalAggregate` since it's a physical property, and should not appear in the logical plan. It should be generated when converting logical aggregate to physical aggregate or in enforcing rules.

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
3. Has unit tests been added: (Yes/No/No Need)
4. Has document been added or modified: (Yes/No/No Need)
5. Does it need to update dependencies: (Yes/No)
6. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
