### PR TITLE
fix empty storage policy, be refresh exception log.

### DIFF
--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -365,7 +365,7 @@ void TaskWorkerPool::_create_tablet_worker_thread_callback() {
         TStatus task_status;
 
         std::vector<TTabletInfo> finish_tablet_infos;
-        LOG(INFO) << "create tablet: " << create_tablet_req;
+        VLOG_NOTICE << "create tablet: " << create_tablet_req;
         Status create_status = _env->storage_engine()->create_tablet(create_tablet_req);
         if (!create_status.ok()) {
             LOG(WARNING) << "create table failed. status: " << create_status

--- a/be/src/agent/utils.cpp
+++ b/be/src/agent/utils.cpp
@@ -164,7 +164,7 @@ Status MasterServerClient::refresh_storage_policy(TGetStoragePolicyResult* resul
         LOG(WARNING) << "fail to report to master. "
                      << "host=" << _master_info.network_address.hostname
                      << ", port=" << _master_info.network_address.port
-                     << ", code=" << client_status.code();
+                     << ", code=" << client_status.code() << ", e.what: " << e.what();
         return Status::InternalError("Fail to refresh storage policy from master");
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/policy/StoragePolicy.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/policy/StoragePolicy.java
@@ -399,9 +399,9 @@ public class StoragePolicy extends Policy {
                 tmpMap.put(COOLDOWN_TTL, this.getCooldownTtl());
             });
             tmpMap.put(MD5_CHECKSUM, this.getMd5Checksum());
-            NotifyUpdateStoragePolicyTask createReplicaTask
+            NotifyUpdateStoragePolicyTask notifyUpdateStoragePolicyTask
                     = new NotifyUpdateStoragePolicyTask(beId, getPolicyName(), tmpMap);
-            batchTask.addTask(createReplicaTask);
+            batchTask.addTask(notifyUpdateStoragePolicyTask);
             LOG.info("update policy info to be: {}, policy name: {}, "
                         + "properties: {} to modify S3 resource batch task.",
                     beId, getPolicyName(), tmpMap);

--- a/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
@@ -1053,7 +1053,7 @@ public class FrontendServiceImpl implements FrontendService.Iface {
             result.setResultEntrys(new ArrayList<>());
         }
 
-        LOG.info("refresh storage policy request: {}", result);
+        LOG.debug("refresh storage policy request: {}", result);
         return result;
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
@@ -122,6 +122,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.thrift.TException;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -1000,7 +1001,6 @@ public class FrontendServiceImpl implements FrontendService.Iface {
 
     @Override
     public TGetStoragePolicyResult refreshStoragePolicy() throws TException {
-        LOG.debug("refresh storage policy request");
         TGetStoragePolicyResult result = new TGetStoragePolicyResult();
         TStatus status = new TStatus(TStatusCode.OK);
         result.setStatus(status);
@@ -1049,6 +1049,9 @@ public class FrontendServiceImpl implements FrontendService.Iface {
                     result.addToResultEntrys(rEntry);
                 }
         );
+        if (policyList.size() == 0) {
+            result.setResultEntrys(new ArrayList<>());
+        }
 
         LOG.info("refresh storage policy request: {}", result);
         return result;


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:
fix empty storage policy, be refresh exception log.

when storage policy empty，not set. now be refresh policy will be write a exception log, as shown below.
so i fix it.

![origin_img_v2_4b0a220e-7b9b-4120-a384-37c3ac51111g](https://user-images.githubusercontent.com/3887565/180400332-0aa5d498-1848-4835-b324-b4604ec0fc66.jpg)



## Checklist(Required)

1. Does it affect the original behavior:NO
2. Has unit tests been added: NO
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
