### PR TITLE
[github] disable clang build action

### DIFF
--- a/.github/workflows/clang-build.yml
+++ b/.github/workflows/clang-build.yml
@@ -17,7 +17,7 @@
 
 name: Clang Build
 
-on: [push, pull_request]
+on: []
 
 jobs:
   build:


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

the clang build action takes too much time and will block other actions to run.
we may consider using teamcity to do that.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
