### PR TITLE
[Improvement](light-schema-change) support tablet schema cache

### DIFF
--- a/be/src/exec/olap_scanner.cpp
+++ b/be/src/exec/olap_scanner.cpp
@@ -83,7 +83,7 @@ Status OlapScanner::prepare(
             LOG(WARNING) << ss.str();
             return Status::InternalError(ss.str());
         }
-        _tablet_schema = _tablet->tablet_schema();
+        _tablet_schema.copy_from(*_tablet->tablet_schema());
         if (!_parent->_olap_scan_node.columns_desc.empty() &&
             _parent->_olap_scan_node.columns_desc[0].col_unique_id >= 0) {
             _tablet_schema.clear_columns();
@@ -289,7 +289,7 @@ Status OlapScanner::_init_return_columns(bool need_seq_col) {
     }
 
     // expand the sequence column
-    if (_tablet->tablet_schema().has_sequence_col() && need_seq_col) {
+    if (_tablet_schema.has_sequence_col() && need_seq_col) {
         bool has_replace_col = false;
         for (auto col : _return_columns) {
             if (_tablet_schema.column(col).aggregation() ==

--- a/be/src/olap/base_tablet.h
+++ b/be/src/olap/base_tablet.h
@@ -22,6 +22,7 @@
 
 #include "olap/olap_define.h"
 #include "olap/tablet_meta.h"
+#include "olap/tablet_schema.h"
 #include "olap/utils.h"
 #include "util/metrics.h"
 
@@ -64,7 +65,7 @@ public:
     void set_storage_policy(const std::string& policy) { _tablet_meta->set_storage_policy(policy); }
 
     // properties encapsulated in TabletSchema
-    virtual const TabletSchema& tablet_schema() const;
+    virtual TabletSchemaSPtr tablet_schema() const;
 
     bool set_tablet_schema_into_rowset_meta();
 
@@ -74,7 +75,7 @@ protected:
 protected:
     TabletState _state;
     TabletMetaSharedPtr _tablet_meta;
-    const TabletSchema& _schema;
+    TabletSchemaSPtr _schema;
 
     DataDir* _data_dir;
     std::string _tablet_path;
@@ -145,7 +146,7 @@ inline bool BaseTablet::equal(int64_t id, int32_t hash) {
     return (tablet_id() == id) && (schema_hash() == hash);
 }
 
-inline const TabletSchema& BaseTablet::tablet_schema() const {
+inline TabletSchemaSPtr BaseTablet::tablet_schema() const {
     return _schema;
 }
 

--- a/be/src/olap/compaction.h
+++ b/be/src/olap/compaction.h
@@ -65,7 +65,7 @@ protected:
     Status modify_rowsets();
     void gc_output_rowset();
 
-    Status construct_output_rowset_writer(const TabletSchema* schema);
+    Status construct_output_rowset_writer(TabletSchemaSPtr schema);
     Status construct_input_rowset_readers();
 
     Status check_version_continuity(const std::vector<RowsetSharedPtr>& rowsets);

--- a/be/src/olap/data_dir.cpp
+++ b/be/src/olap/data_dir.cpp
@@ -18,6 +18,7 @@
 #include "olap/data_dir.h"
 
 #include <ctype.h>
+#include <gen_cpp/olap_file.pb.h>
 #include <mntent.h>
 #include <stdio.h>
 #include <sys/file.h>
@@ -475,8 +476,8 @@ Status DataDir::load() {
         }
         if (rowset_meta->rowset_state() == RowsetStatePB::COMMITTED &&
             rowset_meta->tablet_uid() == tablet->tablet_uid()) {
-            if (!rowset_meta->get_rowset_pb().has_tablet_schema()) {
-                rowset_meta->set_tablet_schema(&tablet->tablet_schema());
+            if (!rowset_meta->tablet_schema()) {
+                rowset_meta->set_tablet_schema(tablet->tablet_schema());
                 RowsetMetaManager::save(_meta, rowset_meta->tablet_uid(), rowset_meta->rowset_id(),
                                         rowset_meta->get_rowset_pb());
             }
@@ -498,8 +499,8 @@ Status DataDir::load() {
             }
         } else if (rowset_meta->rowset_state() == RowsetStatePB::VISIBLE &&
                    rowset_meta->tablet_uid() == tablet->tablet_uid()) {
-            if (!rowset_meta->get_rowset_pb().has_tablet_schema()) {
-                rowset_meta->set_tablet_schema(&tablet->tablet_schema());
+            if (!rowset_meta->tablet_schema()) {
+                rowset_meta->set_tablet_schema(tablet->tablet_schema());
                 RowsetMetaManager::save(_meta, rowset_meta->tablet_uid(), rowset_meta->rowset_id(),
                                         rowset_meta->get_rowset_pb());
             }

--- a/be/src/olap/delta_writer.cpp
+++ b/be/src/olap/delta_writer.cpp
@@ -123,10 +123,11 @@ Status DeltaWriter::init() {
                                                                   _req.txn_id, _req.load_id));
     }
     // build tablet schema in request level
-    _build_current_tablet_schema(_req.index_id, _req.ptable_schema_param, _tablet->tablet_schema());
+    _build_current_tablet_schema(_req.index_id, _req.ptable_schema_param,
+                                 *_tablet->tablet_schema());
 
     RETURN_NOT_OK(_tablet->create_rowset_writer(_req.txn_id, _req.load_id, PREPARED, OVERLAPPING,
-                                                _tablet_schema.get(), &_rowset_writer));
+                                                _tablet_schema, &_rowset_writer));
     _schema.reset(new Schema(*_tablet_schema));
     _reset_mem_table();
 
@@ -379,7 +380,7 @@ int64_t DeltaWriter::partition_id() const {
 void DeltaWriter::_build_current_tablet_schema(int64_t index_id,
                                                const POlapTableSchemaParam& ptable_schema_param,
                                                const TabletSchema& ori_tablet_schema) {
-    *_tablet_schema = ori_tablet_schema;
+    _tablet_schema->copy_from(ori_tablet_schema);
     //new tablet schame if new table
     if (ptable_schema_param.indexes_size() > 0 &&
         ptable_schema_param.indexes(0).columns_desc_size() != 0 &&

--- a/be/src/olap/delta_writer.h
+++ b/be/src/olap/delta_writer.h
@@ -128,7 +128,7 @@ private:
     // tablet schema owned by delta writer, all write will use this tablet schema
     // it's build from tablet_schema（stored when create tablet） and OlapTableSchema
     // every request will have it's own tablet schema so simple schema change can work
-    std::unique_ptr<TabletSchema> _tablet_schema;
+    TabletSchemaSPtr _tablet_schema;
     bool _delta_written_success;
 
     StorageEngine* _storage_engine;

--- a/be/src/olap/push_handler.h
+++ b/be/src/olap/push_handler.h
@@ -30,6 +30,7 @@
 #include "olap/olap_common.h"
 #include "olap/row_cursor.h"
 #include "olap/rowset/rowset.h"
+#include "olap/tablet_schema.h"
 
 namespace doris {
 
@@ -61,12 +62,12 @@ public:
 private:
     Status _convert_v2(TabletSharedPtr cur_tablet, TabletSharedPtr new_tablet_vec,
                        RowsetSharedPtr* cur_rowset, RowsetSharedPtr* new_rowset,
-                       const TabletSchema* tablet_schema);
+                       TabletSchemaSPtr tablet_schema);
     // Convert local data file to internal formatted delta,
     // return new delta's SegmentGroup
     Status _convert(TabletSharedPtr cur_tablet, TabletSharedPtr new_tablet_vec,
                     RowsetSharedPtr* cur_rowset, RowsetSharedPtr* new_rowset,
-                    const TabletSchema* tablet_schema);
+                    TabletSchemaSPtr tablet_schema);
 
     // Only for debug
     std::string _debug_version_list(const Versions& versions) const;
@@ -114,7 +115,7 @@ public:
     static IBinaryReader* create(bool need_decompress);
     virtual ~IBinaryReader() = default;
 
-    virtual Status init(const TabletSchema* tablet_schema, BinaryFile* file) = 0;
+    virtual Status init(TabletSchemaSPtr tablet_schema, BinaryFile* file) = 0;
     virtual Status finalize() = 0;
 
     virtual Status next(RowCursor* row) = 0;
@@ -133,7 +134,7 @@ protected:
               _ready(false) {}
 
     BinaryFile* _file;
-    const TabletSchema* _tablet_schema;
+    TabletSchemaSPtr _tablet_schema;
     size_t _content_len;
     size_t _curr;
     uint32_t _adler_checksum;
@@ -146,7 +147,7 @@ public:
     explicit BinaryReader();
     ~BinaryReader() override { finalize(); }
 
-    Status init(const TabletSchema* tablet_schema, BinaryFile* file) override;
+    Status init(TabletSchemaSPtr tablet_schema, BinaryFile* file) override;
     Status finalize() override;
 
     Status next(RowCursor* row) override;
@@ -163,7 +164,7 @@ public:
     explicit LzoBinaryReader();
     ~LzoBinaryReader() override { finalize(); }
 
-    Status init(const TabletSchema* tablet_schema, BinaryFile* file) override;
+    Status init(TabletSchemaSPtr tablet_schema, BinaryFile* file) override;
     Status finalize() override;
 
     Status next(RowCursor* row) override;

--- a/be/src/olap/rowset/beta_rowset.cpp
+++ b/be/src/olap/rowset/beta_rowset.cpp
@@ -28,6 +28,7 @@
 #include "io/fs/s3_file_system.h"
 #include "olap/olap_define.h"
 #include "olap/rowset/beta_rowset_reader.h"
+#include "olap/tablet_schema.h"
 #include "olap/utils.h"
 #include "util/doris_metrics.h"
 
@@ -59,7 +60,7 @@ std::string BetaRowset::remote_segment_path(int64_t tablet_id, const RowsetId& r
                        segment_id);
 }
 
-BetaRowset::BetaRowset(const TabletSchema* schema, const std::string& tablet_path,
+BetaRowset::BetaRowset(TabletSchemaSPtr schema, const std::string& tablet_path,
                        RowsetMetaSharedPtr rowset_meta)
         : Rowset(schema, tablet_path, std::move(rowset_meta)) {}
 

--- a/be/src/olap/rowset/beta_rowset.h
+++ b/be/src/olap/rowset/beta_rowset.h
@@ -77,7 +77,7 @@ public:
     Status load_segments(std::vector<segment_v2::SegmentSharedPtr>* segments);
 
 protected:
-    BetaRowset(const TabletSchema* schema, const std::string& tablet_path,
+    BetaRowset(TabletSchemaSPtr schema, const std::string& tablet_path,
                RowsetMetaSharedPtr rowset_meta);
 
     // init segment groups

--- a/be/src/olap/rowset/rowset.cpp
+++ b/be/src/olap/rowset/rowset.cpp
@@ -17,11 +17,13 @@
 
 #include "olap/rowset/rowset.h"
 
+#include "olap/tablet_schema.h"
+#include "olap/tablet_schema_cache.h"
 #include "util/time.h"
 
 namespace doris {
 
-Rowset::Rowset(const TabletSchema* schema, const std::string& tablet_path,
+Rowset::Rowset(TabletSchemaSPtr schema, const std::string& tablet_path,
                RowsetMetaSharedPtr rowset_meta)
         : _tablet_path(tablet_path), _rowset_meta(std::move(rowset_meta)), _refs_by_reader(0) {
     _is_pending = !_rowset_meta->has_version();
@@ -32,7 +34,7 @@ Rowset::Rowset(const TabletSchema* schema, const std::string& tablet_path,
         _is_cumulative = version.first != version.second;
     }
     // build schema from RowsetMeta.tablet_schema or Tablet.tablet_schema
-    _schema = _rowset_meta->tablet_schema() != nullptr ? _rowset_meta->tablet_schema() : schema;
+    _schema = _rowset_meta->tablet_schema() ? _rowset_meta->tablet_schema() : schema;
 }
 
 Status Rowset::load(bool use_cache) {

--- a/be/src/olap/rowset/rowset.h
+++ b/be/src/olap/rowset/rowset.h
@@ -138,7 +138,7 @@ public:
 
     // publish rowset to make it visible to read
     void make_visible(Version version);
-    const TabletSchema* tablet_schema() { return _schema; }
+    TabletSchemaSPtr tablet_schema() { return _schema; }
 
     // helper class to access RowsetMeta
     int64_t start_version() const { return rowset_meta()->version().first; }
@@ -158,7 +158,7 @@ public:
     bool delete_flag() const { return rowset_meta()->delete_flag(); }
     int64_t num_segments() const { return rowset_meta()->num_segments(); }
     void to_rowset_pb(RowsetMetaPB* rs_meta) const { return rowset_meta()->to_rowset_pb(rs_meta); }
-    const RowsetMetaPB& get_rowset_pb() const { return rowset_meta()->get_rowset_pb(); }
+    RowsetMetaPB get_rowset_pb() const { return rowset_meta()->get_rowset_pb(); }
     int64_t oldest_write_timestamp() const { return rowset_meta()->oldest_write_timestamp(); }
     int64_t newest_write_timestamp() const { return rowset_meta()->newest_write_timestamp(); }
     KeysType keys_type() { return _schema->keys_type(); }
@@ -269,7 +269,7 @@ protected:
 
     DISALLOW_COPY_AND_ASSIGN(Rowset);
     // this is non-public because all clients should use RowsetFactory to obtain pointer to initialized Rowset
-    Rowset(const TabletSchema* schema, const std::string& tablet_path,
+    Rowset(TabletSchemaSPtr schema, const std::string& tablet_path,
            RowsetMetaSharedPtr rowset_meta);
 
     // this is non-public because all clients should use RowsetFactory to obtain pointer to initialized Rowset
@@ -284,7 +284,7 @@ protected:
     // allow subclass to add custom logic when rowset is being published
     virtual void make_visible_extra(Version version) {}
 
-    const TabletSchema* _schema;
+    TabletSchemaSPtr _schema;
     std::string _tablet_path;
     RowsetMetaSharedPtr _rowset_meta;
     // init in constructor

--- a/be/src/olap/rowset/rowset_factory.cpp
+++ b/be/src/olap/rowset/rowset_factory.cpp
@@ -26,7 +26,7 @@
 
 namespace doris {
 
-Status RowsetFactory::create_rowset(const TabletSchema* schema, const std::string& tablet_path,
+Status RowsetFactory::create_rowset(TabletSchemaSPtr schema, const std::string& tablet_path,
                                     RowsetMetaSharedPtr rowset_meta, RowsetSharedPtr* rowset) {
     if (rowset_meta->rowset_type() == ALPHA_ROWSET) {
         return Status::OLAPInternalError(OLAP_ERR_ROWSET_INVALID);

--- a/be/src/olap/rowset/rowset_factory.h
+++ b/be/src/olap/rowset/rowset_factory.h
@@ -31,7 +31,7 @@ class RowsetFactory {
 public:
     // return OLAP_SUCCESS and set inited rowset in `*rowset`.
     // return others if failed to create or init rowset.
-    static Status create_rowset(const TabletSchema* schema, const std::string& tablet_path,
+    static Status create_rowset(TabletSchemaSPtr schema, const std::string& tablet_path,
                                 RowsetMetaSharedPtr rowset_meta, RowsetSharedPtr* rowset);
 
     // create and init rowset writer.

--- a/be/src/olap/rowset/rowset_writer_context.h
+++ b/be/src/olap/rowset/rowset_writer_context.h
@@ -55,7 +55,7 @@ struct RowsetWriterContext {
         context.tablet_schema_hash = new_tablet->schema_hash();
         context.rowset_type = new_rowset_type;
         context.tablet_path = new_tablet->tablet_path();
-        context.tablet_schema = &(new_tablet->tablet_schema());
+        context.tablet_schema = new_tablet->tablet_schema();
         context.data_dir = new_tablet->data_dir();
         context.rowset_state = VISIBLE;
         context.version = version;
@@ -70,7 +70,7 @@ struct RowsetWriterContext {
     int64_t partition_id;
     RowsetTypePB rowset_type;
     std::string tablet_path;
-    const TabletSchema* tablet_schema;
+    TabletSchemaSPtr tablet_schema;
     // PREPARED/COMMITTED for pending rowset
     // VISIBLE for non-pending rowset
     RowsetStatePB rowset_state;

--- a/be/src/olap/rowset/segment_v2/segment.cpp
+++ b/be/src/olap/rowset/segment_v2/segment.cpp
@@ -17,6 +17,8 @@
 
 #include "olap/rowset/segment_v2/segment.h"
 
+#include <gen_cpp/olap_file.pb.h>
+
 #include <memory>
 #include <utility>
 
@@ -35,7 +37,7 @@ namespace doris {
 namespace segment_v2 {
 
 Status Segment::open(io::FileSystem* fs, const std::string& path, uint32_t segment_id,
-                     const TabletSchema* tablet_schema, std::shared_ptr<Segment>* output) {
+                     TabletSchemaSPtr tablet_schema, std::shared_ptr<Segment>* output) {
     std::shared_ptr<Segment> segment(new Segment(segment_id, tablet_schema));
     io::FileReaderSPtr file_reader;
     RETURN_IF_ERROR(fs->open_file(path, &file_reader));
@@ -45,8 +47,8 @@ Status Segment::open(io::FileSystem* fs, const std::string& path, uint32_t segme
     return Status::OK();
 }
 
-Segment::Segment(uint32_t segment_id, const TabletSchema* tablet_schema)
-        : _segment_id(segment_id), _tablet_schema(*tablet_schema), _meta_mem_usage(0) {}
+Segment::Segment(uint32_t segment_id, TabletSchemaSPtr tablet_schema)
+        : _segment_id(segment_id), _tablet_schema(tablet_schema), _meta_mem_usage(0) {}
 
 Segment::~Segment() {
     StorageEngine::instance()->segment_meta_mem_tracker()->release(_meta_mem_usage);
@@ -64,7 +66,7 @@ Status Segment::new_iterator(const Schema& schema, const StorageReadOptions& rea
     // trying to prune the current segment by segment-level zone map
     if (read_options.conditions != nullptr) {
         for (auto& column_condition : read_options.conditions->columns()) {
-            int32_t column_unique_id = _tablet_schema.column(column_condition.first).unique_id();
+            int32_t column_unique_id = _tablet_schema->column(column_condition.first).unique_id();
             if (_column_readers.count(column_unique_id) < 1 ||
                 !_column_readers.at(column_unique_id)->has_zone_map()) {
                 continue;
@@ -145,7 +147,7 @@ Status Segment::load_index() {
         opts.stats = &tmp_stats;
         opts.type = INDEX_PAGE;
 
-        if (_tablet_schema.keys_type() == UNIQUE_KEYS && _footer.has_primary_key_index_meta()) {
+        if (_tablet_schema->keys_type() == UNIQUE_KEYS && _footer.has_primary_key_index_meta()) {
             _pk_index_reader.reset(new PrimaryKeyIndexReader());
             RETURN_IF_ERROR(
                     _pk_index_reader->parse(_file_reader, _footer.primary_key_index_meta()));
@@ -173,15 +175,15 @@ Status Segment::_create_column_readers() {
         _column_id_to_footer_ordinal.emplace(column_pb.unique_id(), ordinal);
     }
 
-    for (uint32_t ordinal = 0; ordinal < _tablet_schema.num_columns(); ++ordinal) {
-        auto& column = _tablet_schema.column(ordinal);
+    for (uint32_t ordinal = 0; ordinal < _tablet_schema->num_columns(); ++ordinal) {
+        auto& column = _tablet_schema->column(ordinal);
         auto iter = _column_id_to_footer_ordinal.find(column.unique_id());
         if (iter == _column_id_to_footer_ordinal.end()) {
             continue;
         }
 
         ColumnReaderOptions opts;
-        opts.kept_in_memory = _tablet_schema.is_in_memory();
+        opts.kept_in_memory = _tablet_schema->is_in_memory();
         std::unique_ptr<ColumnReader> reader;
         RETURN_IF_ERROR(ColumnReader::create(opts, _footer.columns(iter->second),
                                              _footer.num_rows(), _file_reader, &reader));

--- a/be/src/olap/rowset/segment_v2/segment.h
+++ b/be/src/olap/rowset/segment_v2/segment.h
@@ -62,7 +62,7 @@ using SegmentSharedPtr = std::shared_ptr<Segment>;
 class Segment : public std::enable_shared_from_this<Segment> {
 public:
     static Status open(io::FileSystem* fs, const std::string& path, uint32_t segment_id,
-                       const TabletSchema* tablet_schema, std::shared_ptr<Segment>* output);
+                       TabletSchemaSPtr tablet_schema, std::shared_ptr<Segment>* output);
 
     ~Segment();
 
@@ -96,7 +96,7 @@ public:
 
 private:
     DISALLOW_COPY_AND_ASSIGN(Segment);
-    Segment(uint32_t segment_id, const TabletSchema* tablet_schema);
+    Segment(uint32_t segment_id, TabletSchemaSPtr tablet_schema);
     // open segment file and read the minimum amount of necessary information (footer)
     Status _open();
     Status _parse_footer();
@@ -107,7 +107,7 @@ private:
     io::FileReaderSPtr _file_reader;
 
     uint32_t _segment_id;
-    TabletSchema _tablet_schema;
+    TabletSchemaSPtr _tablet_schema;
 
     int64_t _meta_mem_usage;
     SegmentFooterPB _footer;

--- a/be/src/olap/rowset/segment_v2/segment_iterator.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.cpp
@@ -143,7 +143,7 @@ Status SegmentIterator::_init(bool is_vec) {
     RETURN_IF_ERROR(_init_return_column_iterators());
     RETURN_IF_ERROR(_init_bitmap_index_iterators());
     // z-order can not use prefix index
-    if (_segment->_tablet_schema.sort_type() != SortType::ZORDER) {
+    if (_segment->_tablet_schema->sort_type() != SortType::ZORDER) {
         RETURN_IF_ERROR(_get_row_ranges_by_keys());
     }
     RETURN_IF_ERROR(_get_row_ranges_by_column_conditions());
@@ -393,7 +393,7 @@ int compare_row_with_lhs_columns(const LhsRowType& lhs, const RhsRowType& rhs) {
 
 Status SegmentIterator::_lookup_ordinal(const RowCursor& key, bool is_include, rowid_t upper_bound,
                                         rowid_t* rowid) {
-    if (_segment->_tablet_schema.keys_type() == UNIQUE_KEYS &&
+    if (_segment->_tablet_schema->keys_type() == UNIQUE_KEYS &&
         _segment->get_primary_key_index() != nullptr) {
         return _lookup_ordinal_from_pk_index(key, is_include, rowid);
     }
@@ -415,7 +415,7 @@ Status SegmentIterator::_lookup_ordinal_from_sk_index(const RowCursor& key, bool
     DCHECK(sk_index_decoder != nullptr);
 
     std::string index_key;
-    encode_key_with_padding(&index_key, key, _segment->_tablet_schema.num_short_key_columns(),
+    encode_key_with_padding(&index_key, key, _segment->_tablet_schema->num_short_key_columns(),
                             is_include);
 
     uint32_t start_block_id = 0;
@@ -467,13 +467,13 @@ Status SegmentIterator::_lookup_ordinal_from_sk_index(const RowCursor& key, bool
 
 Status SegmentIterator::_lookup_ordinal_from_pk_index(const RowCursor& key, bool is_include,
                                                       rowid_t* rowid) {
-    DCHECK(_segment->_tablet_schema.keys_type() == UNIQUE_KEYS);
+    DCHECK(_segment->_tablet_schema->keys_type() == UNIQUE_KEYS);
     const PrimaryKeyIndexReader* pk_index_reader = _segment->get_primary_key_index();
     DCHECK(pk_index_reader != nullptr);
 
     std::string index_key;
     encode_key_with_padding<RowCursor, true, true>(
-            &index_key, key, _segment->_tablet_schema.num_key_columns(), is_include);
+            &index_key, key, _segment->_tablet_schema->num_key_columns(), is_include);
     bool exact_match = false;
 
     std::unique_ptr<segment_v2::IndexedColumnIterator> index_iterator;

--- a/be/src/olap/rowset/segment_v2/segment_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_writer.cpp
@@ -40,7 +40,7 @@ const char* k_segment_magic = "D0R1";
 const uint32_t k_segment_magic_length = 4;
 
 SegmentWriter::SegmentWriter(io::FileWriter* file_writer, uint32_t segment_id,
-                             const TabletSchema* tablet_schema, DataDir* data_dir,
+                             TabletSchemaSPtr tablet_schema, DataDir* data_dir,
                              uint32_t max_row_per_segment, const SegmentWriterOptions& opts)
         : _segment_id(segment_id),
           _tablet_schema(tablet_schema),
@@ -50,7 +50,7 @@ SegmentWriter::SegmentWriter(io::FileWriter* file_writer, uint32_t segment_id,
           _file_writer(file_writer),
           _mem_tracker(std::make_unique<MemTracker>("SegmentWriter:Segment-" +
                                                     std::to_string(segment_id))),
-          _olap_data_convertor(tablet_schema) {
+          _olap_data_convertor(tablet_schema.get()) {
     CHECK_NOTNULL(file_writer);
     if (_tablet_schema->keys_type() == UNIQUE_KEYS && _opts.enable_unique_key_merge_on_write) {
         _num_key_columns = _tablet_schema->num_key_columns();
@@ -92,7 +92,7 @@ Status SegmentWriter::init(uint32_t write_mbytes_per_sec __attribute__((unused))
         ColumnWriterOptions opts;
         opts.meta = _footer.add_columns();
 
-        init_column_meta(opts.meta, &column_id, column, _tablet_schema);
+        init_column_meta(opts.meta, &column_id, column, _tablet_schema.get());
 
         // now we create zone map for key columns in AGG_KEYS or all column in UNIQUE_KEYS or DUP_KEYS
         // and not support zone map for array type.

--- a/be/src/olap/rowset/segment_v2/segment_writer.h
+++ b/be/src/olap/rowset/segment_v2/segment_writer.h
@@ -25,6 +25,7 @@
 #include "common/status.h" // Status
 #include "gen_cpp/segment_v2.pb.h"
 #include "gutil/macros.h"
+#include "olap/tablet_schema.h"
 #include "vec/core/block.h"
 #include "vec/olap/olap_data_convertor.h"
 
@@ -62,7 +63,7 @@ struct SegmentWriterOptions {
 class SegmentWriter {
 public:
     explicit SegmentWriter(io::FileWriter* file_writer, uint32_t segment_id,
-                           const TabletSchema* tablet_schema, DataDir* data_dir,
+                           TabletSchemaSPtr tablet_schema, DataDir* data_dir,
                            uint32_t max_row_per_segment, const SegmentWriterOptions& opts);
     ~SegmentWriter();
 
@@ -102,7 +103,7 @@ private:
 
 private:
     uint32_t _segment_id;
-    const TabletSchema* _tablet_schema;
+    TabletSchemaSPtr _tablet_schema;
     DataDir* _data_dir;
     uint32_t _max_row_per_segment;
     SegmentWriterOptions _opts;

--- a/be/src/olap/schema_change.h
+++ b/be/src/olap/schema_change.h
@@ -252,7 +252,7 @@ public:
     static Status schema_version_convert(TabletSharedPtr base_tablet, TabletSharedPtr new_tablet,
                                          RowsetSharedPtr* base_rowset, RowsetSharedPtr* new_rowset,
                                          DescriptorTbl desc_tbl,
-                                         const TabletSchema* base_schema_change);
+                                         TabletSchemaSPtr base_schema_change);
 
     // schema change v2, it will not set alter task in base tablet
     static Status process_alter_tablet_v2(const TAlterTabletReqV2& request);

--- a/be/src/olap/snapshot_manager.h
+++ b/be/src/olap/snapshot_manager.h
@@ -84,7 +84,7 @@ private:
     Status _prepare_snapshot_dir(const TabletSharedPtr& ref_tablet, std::string* snapshot_id_path);
 
     Status _rename_rowset_id(const RowsetMetaPB& rs_meta_pb, const std::string& new_tablet_path,
-                             TabletSchema& tablet_schema, const RowsetId& next_id,
+                             TabletSchemaSPtr tablet_schema, const RowsetId& next_id,
                              RowsetMetaPB* new_rs_meta_pb);
 
 private:

--- a/be/src/olap/tablet.h
+++ b/be/src/olap/tablet.h
@@ -125,7 +125,7 @@ public:
 
     const RowsetSharedPtr rowset_with_max_version() const;
 
-    static const RowsetMetaSharedPtr rowset_meta_with_max_schema_version(
+    static RowsetMetaSharedPtr rowset_meta_with_max_schema_version(
             const std::vector<RowsetMetaSharedPtr>& rowset_metas);
 
     Status add_inc_rowset(const RowsetSharedPtr& rowset);
@@ -282,16 +282,16 @@ public:
         return _tablet_meta->all_beta();
     }
 
-    const TabletSchema& tablet_schema() const override;
+    TabletSchemaSPtr tablet_schema() const override;
 
     Status create_rowset_writer(const Version& version, const RowsetStatePB& rowset_state,
-                                const SegmentsOverlapPB& overlap, const TabletSchema* tablet_schema,
+                                const SegmentsOverlapPB& overlap, TabletSchemaSPtr tablet_schema,
                                 int64_t oldest_write_timestamp, int64_t newest_write_timestamp,
                                 std::unique_ptr<RowsetWriter>* rowset_writer);
 
     Status create_rowset_writer(const int64_t& txn_id, const PUniqueId& load_id,
                                 const RowsetStatePB& rowset_state, const SegmentsOverlapPB& overlap,
-                                const TabletSchema* tablet_schema,
+                                TabletSchemaSPtr tablet_schema,
                                 std::unique_ptr<RowsetWriter>* rowset_writer);
 
     Status create_rowset(RowsetMetaSharedPtr rowset_meta, RowsetSharedPtr* rowset);
@@ -494,55 +494,55 @@ inline Version Tablet::max_version() const {
 }
 
 inline KeysType Tablet::keys_type() const {
-    return _schema.keys_type();
+    return _schema->keys_type();
 }
 
 inline SortType Tablet::sort_type() const {
-    return _schema.sort_type();
+    return _schema->sort_type();
 }
 
 inline size_t Tablet::sort_col_num() const {
-    return _schema.sort_col_num();
+    return _schema->sort_col_num();
 }
 
 inline size_t Tablet::num_columns() const {
-    return _schema.num_columns();
+    return _schema->num_columns();
 }
 
 inline size_t Tablet::num_null_columns() const {
-    return _schema.num_null_columns();
+    return _schema->num_null_columns();
 }
 
 inline size_t Tablet::num_key_columns() const {
-    return _schema.num_key_columns();
+    return _schema->num_key_columns();
 }
 
 inline size_t Tablet::num_short_key_columns() const {
-    return _schema.num_short_key_columns();
+    return _schema->num_short_key_columns();
 }
 
 inline size_t Tablet::num_rows_per_row_block() const {
-    return _schema.num_rows_per_row_block();
+    return _schema->num_rows_per_row_block();
 }
 
 inline CompressKind Tablet::compress_kind() const {
-    return _schema.compress_kind();
+    return _schema->compress_kind();
 }
 
 inline double Tablet::bloom_filter_fpp() const {
-    return _schema.bloom_filter_fpp();
+    return _schema->bloom_filter_fpp();
 }
 
 inline size_t Tablet::next_unique_id() const {
-    return _schema.next_column_unique_id();
+    return _schema->next_column_unique_id();
 }
 
 inline int32_t Tablet::field_index(const std::string& field_name) const {
-    return _schema.field_index(field_name);
+    return _schema->field_index(field_name);
 }
 
 inline size_t Tablet::row_size() const {
-    return _schema.row_size();
+    return _schema->row_size();
 }
 
 } // namespace doris

--- a/be/src/olap/tablet_manager.cpp
+++ b/be/src/olap/tablet_manager.cpp
@@ -1134,7 +1134,7 @@ Status TabletManager::_create_tablet_meta_unlocked(const TCreateTabletReq& reque
             int32_t old_col_idx = base_tablet->field_index(column.column_name);
             if (old_col_idx != -1) {
                 uint32_t old_unique_id =
-                        base_tablet->tablet_schema().column(old_col_idx).unique_id();
+                        base_tablet->tablet_schema()->column(old_col_idx).unique_id();
                 col_idx_to_unique_id[new_col_idx] = old_unique_id;
             } else {
                 // Not exist in old tablet, it is a new added column

--- a/be/src/olap/tablet_schema.cpp
+++ b/be/src/olap/tablet_schema.cpp
@@ -17,6 +17,8 @@
 
 #include "olap/tablet_schema.h"
 
+#include <gen_cpp/olap_file.pb.h>
+
 #include "gen_cpp/descriptors.pb.h"
 #include "tablet_meta.h"
 #include "vec/aggregate_functions/aggregate_function_reader.h"
@@ -527,6 +529,18 @@ void TabletSchema::init_from_pb(const TabletSchemaPB& schema) {
     _sort_col_num = schema.sort_col_num();
     _compression_type = schema.compression_type();
     _schema_version = schema.schema_version();
+}
+
+void TabletSchema::copy_from(const TabletSchema& tablet_schema) {
+    TabletSchemaPB tablet_schema_pb;
+    tablet_schema.to_schema_pb(&tablet_schema_pb);
+    init_from_pb(tablet_schema_pb);
+}
+
+std::string TabletSchema::to_key() const {
+    TabletSchemaPB pb;
+    to_schema_pb(&pb);
+    return pb.SerializeAsString();
 }
 
 void TabletSchema::build_current_tablet_schema(int64_t index_id,

--- a/be/src/olap/tablet_schema.h
+++ b/be/src/olap/tablet_schema.h
@@ -133,6 +133,8 @@ public:
     void init_from_pb(const TabletSchemaPB& schema);
     void to_schema_pb(TabletSchemaPB* tablet_meta_pb) const;
     void append_column(TabletColumn column);
+    void copy_from(const TabletSchema& tablet_schema);
+    std::string to_key() const;
     uint32_t mem_size() const;
 
     size_t row_size() const;
@@ -204,5 +206,7 @@ private:
 
 bool operator==(const TabletSchema& a, const TabletSchema& b);
 bool operator!=(const TabletSchema& a, const TabletSchema& b);
+
+using TabletSchemaSPtr = std::shared_ptr<TabletSchema>;
 
 } // namespace doris

--- a/be/src/olap/tablet_schema_cache.h
+++ b/be/src/olap/tablet_schema_cache.h
@@ -1,0 +1,61 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <gen_cpp/olap_file.pb.h>
+
+#include <memory>
+#include <mutex>
+#include <unordered_map>
+
+#include "olap/tablet_schema.h"
+
+namespace doris {
+
+class TabletSchemaCache {
+public:
+    static void create_global_schema_cache() {
+        DCHECK(_s_instance == nullptr);
+        static TabletSchemaCache instance;
+        _s_instance = &instance;
+    }
+
+    static TabletSchemaCache* instance() { return _s_instance; }
+
+    TabletSchemaSPtr insert(const std::string& key) {
+        DCHECK(_s_instance != nullptr);
+        std::lock_guard guard(_mtx);
+        auto iter = _cache.find(key);
+        if (iter == _cache.end()) {
+            TabletSchemaSPtr tablet_schema_ptr = std::make_shared<TabletSchema>();
+            TabletSchemaPB pb;
+            pb.ParseFromString(key);
+            tablet_schema_ptr->init_from_pb(pb);
+            _cache[key] = tablet_schema_ptr;
+            return tablet_schema_ptr;
+        }
+        return iter->second;
+    }
+
+private:
+    static inline TabletSchemaCache* _s_instance = nullptr;
+    std::mutex _mtx;
+    std::unordered_map<std::string, TabletSchemaSPtr> _cache;
+};
+
+} // namespace doris

--- a/be/src/olap/task/engine_checksum_task.cpp
+++ b/be/src/olap/task/engine_checksum_task.cpp
@@ -77,7 +77,7 @@ Status EngineChecksumTask::_compute_checksum() {
         }
     }
 
-    for (size_t i = 0; i < tablet->tablet_schema().num_columns(); ++i) {
+    for (size_t i = 0; i < tablet->tablet_schema()->num_columns(); ++i) {
         reader_params.return_columns.push_back(i);
     }
 
@@ -90,12 +90,12 @@ Status EngineChecksumTask::_compute_checksum() {
     RowCursor row;
     std::unique_ptr<MemPool> mem_pool(new MemPool());
     std::unique_ptr<ObjectPool> agg_object_pool(new ObjectPool());
-    res = row.init(tablet->tablet_schema(), reader_params.return_columns);
+    res = row.init(*tablet->tablet_schema(), reader_params.return_columns);
     if (!res.ok()) {
         LOG(WARNING) << "failed to init row cursor. res = " << res;
         return res;
     }
-    row.allocate_memory_for_string_type(tablet->tablet_schema());
+    row.allocate_memory_for_string_type(*tablet->tablet_schema());
 
     bool eof = false;
     uint32_t row_checksum = 0;

--- a/be/src/olap/task/engine_clone_task.cpp
+++ b/be/src/olap/task/engine_clone_task.cpp
@@ -766,9 +766,8 @@ Status EngineCloneTask::_finish_full_clone(Tablet* tablet, TabletMeta* cloned_ta
     // but some rowset is useless, so that remove them here
     for (auto& rs_meta_ptr : rs_metas_found_in_src) {
         RowsetSharedPtr rowset_to_remove;
-        auto s =
-                RowsetFactory::create_rowset(&(cloned_tablet_meta->tablet_schema()),
-                                             tablet->tablet_path(), rs_meta_ptr, &rowset_to_remove);
+        auto s = RowsetFactory::create_rowset(tablet->tablet_schema(), tablet->tablet_path(),
+                                              rs_meta_ptr, &rowset_to_remove);
         if (!s.ok()) {
             LOG(WARNING) << "failed to init rowset to remove: "
                          << rs_meta_ptr->rowset_id().to_string();

--- a/be/src/service/doris_main.cpp
+++ b/be/src/service/doris_main.cpp
@@ -379,6 +379,7 @@ int main(int argc, char** argv) {
     // init exec env
     auto exec_env = doris::ExecEnv::GetInstance();
     doris::ExecEnv::init(exec_env, paths);
+    doris::TabletSchemaCache::create_global_schema_cache();
 
     // init and open storage engine
     doris::EngineOptions options;

--- a/be/src/vec/exec/volap_scanner.cpp
+++ b/be/src/vec/exec/volap_scanner.cpp
@@ -68,7 +68,7 @@ Status VOlapScanner::prepare(
             LOG(WARNING) << ss.str();
             return Status::InternalError(ss.str());
         }
-        _tablet_schema = _tablet->tablet_schema();
+        _tablet_schema.copy_from(*_tablet->tablet_schema());
         if (!_parent->_olap_scan_node.columns_desc.empty() &&
             _parent->_olap_scan_node.columns_desc[0].col_unique_id >= 0) {
             // Originally scanner get TabletSchema from tablet object in BE.

--- a/be/test/olap/delete_handler_test.cpp
+++ b/be/test/olap/delete_handler_test.cpp
@@ -339,7 +339,7 @@ TEST_F(TestDeleteConditionHandler, StoreCondSucceed) {
     conditions.push_back(condition);
 
     DeletePredicatePB del_pred;
-    success_res = DeleteHandler::generate_delete_predicate(tablet->tablet_schema(), conditions,
+    success_res = DeleteHandler::generate_delete_predicate(*tablet->tablet_schema(), conditions,
                                                            &del_pred);
     EXPECT_EQ(Status::OK(), success_res);
 
@@ -363,7 +363,7 @@ TEST_F(TestDeleteConditionHandler, StoreCondInvalidParameters) {
     // 空的过滤条件
     std::vector<TCondition> conditions;
     DeletePredicatePB del_pred;
-    Status failed_res = DeleteHandler::generate_delete_predicate(tablet->tablet_schema(),
+    Status failed_res = DeleteHandler::generate_delete_predicate(*tablet->tablet_schema(),
                                                                  conditions, &del_pred);
     ;
     EXPECT_EQ(Status::OLAPInternalError(OLAP_ERR_DELETE_INVALID_PARAMETERS), failed_res);
@@ -380,7 +380,7 @@ TEST_F(TestDeleteConditionHandler, StoreCondNonexistentColumn) {
     condition.condition_values.push_back("2");
     conditions.push_back(condition);
     DeletePredicatePB del_pred;
-    Status failed_res = DeleteHandler::generate_delete_predicate(tablet->tablet_schema(),
+    Status failed_res = DeleteHandler::generate_delete_predicate(*tablet->tablet_schema(),
                                                                  conditions, &del_pred);
     ;
     EXPECT_EQ(Status::OLAPInternalError(OLAP_ERR_DELETE_INVALID_CONDITION), failed_res);
@@ -393,7 +393,7 @@ TEST_F(TestDeleteConditionHandler, StoreCondNonexistentColumn) {
     condition.condition_values.push_back("5");
     conditions.push_back(condition);
 
-    failed_res = DeleteHandler::generate_delete_predicate(tablet->tablet_schema(), conditions,
+    failed_res = DeleteHandler::generate_delete_predicate(*tablet->tablet_schema(), conditions,
                                                           &del_pred);
     ;
     EXPECT_EQ(Status::OLAPInternalError(OLAP_ERR_DELETE_INVALID_CONDITION), failed_res);
@@ -406,7 +406,7 @@ TEST_F(TestDeleteConditionHandler, StoreCondNonexistentColumn) {
     condition.condition_values.push_back("5");
     conditions.push_back(condition);
 
-    Status success_res = DeleteHandler::generate_delete_predicate(dup_tablet->tablet_schema(),
+    Status success_res = DeleteHandler::generate_delete_predicate(*dup_tablet->tablet_schema(),
                                                                   conditions, &del_pred);
     ;
     EXPECT_EQ(Status::OK(), success_res);
@@ -484,7 +484,7 @@ TEST_F(TestDeleteConditionHandler2, ValidConditionValue) {
     conditions.push_back(condition);
 
     DeletePredicatePB del_pred;
-    res = DeleteHandler::generate_delete_predicate(tablet->tablet_schema(), conditions, &del_pred);
+    res = DeleteHandler::generate_delete_predicate(*tablet->tablet_schema(), conditions, &del_pred);
     EXPECT_EQ(Status::OK(), res);
 
     // k5类型为int128
@@ -496,7 +496,7 @@ TEST_F(TestDeleteConditionHandler2, ValidConditionValue) {
     conditions.push_back(condition);
 
     DeletePredicatePB del_pred_2;
-    res = DeleteHandler::generate_delete_predicate(tablet->tablet_schema(), conditions,
+    res = DeleteHandler::generate_delete_predicate(*tablet->tablet_schema(), conditions,
                                                    &del_pred_2);
     EXPECT_EQ(Status::OK(), res);
 
@@ -509,28 +509,28 @@ TEST_F(TestDeleteConditionHandler2, ValidConditionValue) {
     conditions.push_back(condition);
 
     DeletePredicatePB del_pred_3;
-    res = DeleteHandler::generate_delete_predicate(tablet->tablet_schema(), conditions,
+    res = DeleteHandler::generate_delete_predicate(*tablet->tablet_schema(), conditions,
                                                    &del_pred_3);
     EXPECT_EQ(Status::OK(), res);
 
     conditions[0].condition_values.clear();
     conditions[0].condition_values.push_back("2");
     DeletePredicatePB del_pred_4;
-    res = DeleteHandler::generate_delete_predicate(tablet->tablet_schema(), conditions,
+    res = DeleteHandler::generate_delete_predicate(*tablet->tablet_schema(), conditions,
                                                    &del_pred_4);
     EXPECT_EQ(Status::OK(), res);
 
     conditions[0].condition_values.clear();
     conditions[0].condition_values.push_back("-2");
     DeletePredicatePB del_pred_5;
-    res = DeleteHandler::generate_delete_predicate(tablet->tablet_schema(), conditions,
+    res = DeleteHandler::generate_delete_predicate(*tablet->tablet_schema(), conditions,
                                                    &del_pred_5);
     EXPECT_EQ(Status::OK(), res);
 
     conditions[0].condition_values.clear();
     conditions[0].condition_values.push_back("-2.3");
     DeletePredicatePB del_pred_6;
-    res = DeleteHandler::generate_delete_predicate(tablet->tablet_schema(), conditions,
+    res = DeleteHandler::generate_delete_predicate(*tablet->tablet_schema(), conditions,
                                                    &del_pred_6);
     EXPECT_EQ(Status::OK(), res);
 
@@ -549,7 +549,7 @@ TEST_F(TestDeleteConditionHandler2, ValidConditionValue) {
     conditions.push_back(condition);
 
     DeletePredicatePB del_pred_7;
-    res = DeleteHandler::generate_delete_predicate(tablet->tablet_schema(), conditions,
+    res = DeleteHandler::generate_delete_predicate(*tablet->tablet_schema(), conditions,
                                                    &del_pred_7);
     EXPECT_EQ(Status::OK(), res);
 
@@ -568,7 +568,7 @@ TEST_F(TestDeleteConditionHandler2, ValidConditionValue) {
     conditions.push_back(condition);
 
     DeletePredicatePB del_pred_8;
-    res = DeleteHandler::generate_delete_predicate(tablet->tablet_schema(), conditions,
+    res = DeleteHandler::generate_delete_predicate(*tablet->tablet_schema(), conditions,
                                                    &del_pred_8);
     EXPECT_EQ(Status::OK(), res);
 }
@@ -586,7 +586,7 @@ TEST_F(TestDeleteConditionHandler2, InvalidConditionValue) {
     conditions.push_back(condition);
 
     DeletePredicatePB del_pred_1;
-    res = DeleteHandler::generate_delete_predicate(tablet->tablet_schema(), conditions,
+    res = DeleteHandler::generate_delete_predicate(*tablet->tablet_schema(), conditions,
                                                    &del_pred_1);
     EXPECT_EQ(Status::OLAPInternalError(OLAP_ERR_DELETE_INVALID_CONDITION), res);
 
@@ -594,7 +594,7 @@ TEST_F(TestDeleteConditionHandler2, InvalidConditionValue) {
     conditions[0].condition_values.clear();
     conditions[0].condition_values.push_back("-1000");
     DeletePredicatePB del_pred_2;
-    res = DeleteHandler::generate_delete_predicate(tablet->tablet_schema(), conditions,
+    res = DeleteHandler::generate_delete_predicate(*tablet->tablet_schema(), conditions,
                                                    &del_pred_2);
     EXPECT_EQ(Status::OLAPInternalError(OLAP_ERR_DELETE_INVALID_CONDITION), res);
 
@@ -603,7 +603,7 @@ TEST_F(TestDeleteConditionHandler2, InvalidConditionValue) {
     conditions[0].column_name = "k2";
     conditions[0].condition_values.push_back("32768");
     DeletePredicatePB del_pred_3;
-    res = DeleteHandler::generate_delete_predicate(tablet->tablet_schema(), conditions,
+    res = DeleteHandler::generate_delete_predicate(*tablet->tablet_schema(), conditions,
                                                    &del_pred_3);
     EXPECT_EQ(Status::OLAPInternalError(OLAP_ERR_DELETE_INVALID_CONDITION), res);
 
@@ -611,7 +611,7 @@ TEST_F(TestDeleteConditionHandler2, InvalidConditionValue) {
     conditions[0].condition_values.clear();
     conditions[0].condition_values.push_back("-32769");
     DeletePredicatePB del_pred_4;
-    res = DeleteHandler::generate_delete_predicate(tablet->tablet_schema(), conditions,
+    res = DeleteHandler::generate_delete_predicate(*tablet->tablet_schema(), conditions,
                                                    &del_pred_4);
     EXPECT_EQ(Status::OLAPInternalError(OLAP_ERR_DELETE_INVALID_CONDITION), res);
 
@@ -620,7 +620,7 @@ TEST_F(TestDeleteConditionHandler2, InvalidConditionValue) {
     conditions[0].column_name = "k3";
     conditions[0].condition_values.push_back("2147483648");
     DeletePredicatePB del_pred_5;
-    res = DeleteHandler::generate_delete_predicate(tablet->tablet_schema(), conditions,
+    res = DeleteHandler::generate_delete_predicate(*tablet->tablet_schema(), conditions,
                                                    &del_pred_5);
     EXPECT_EQ(Status::OLAPInternalError(OLAP_ERR_DELETE_INVALID_CONDITION), res);
 
@@ -628,7 +628,7 @@ TEST_F(TestDeleteConditionHandler2, InvalidConditionValue) {
     conditions[0].condition_values.clear();
     conditions[0].condition_values.push_back("-2147483649");
     DeletePredicatePB del_pred_6;
-    res = DeleteHandler::generate_delete_predicate(tablet->tablet_schema(), conditions,
+    res = DeleteHandler::generate_delete_predicate(*tablet->tablet_schema(), conditions,
                                                    &del_pred_6);
     EXPECT_EQ(Status::OLAPInternalError(OLAP_ERR_DELETE_INVALID_CONDITION), res);
 
@@ -637,7 +637,7 @@ TEST_F(TestDeleteConditionHandler2, InvalidConditionValue) {
     conditions[0].column_name = "k4";
     conditions[0].condition_values.push_back("9223372036854775808");
     DeletePredicatePB del_pred_7;
-    res = DeleteHandler::generate_delete_predicate(tablet->tablet_schema(), conditions,
+    res = DeleteHandler::generate_delete_predicate(*tablet->tablet_schema(), conditions,
                                                    &del_pred_7);
     EXPECT_EQ(Status::OLAPInternalError(OLAP_ERR_DELETE_INVALID_CONDITION), res);
 
@@ -645,7 +645,7 @@ TEST_F(TestDeleteConditionHandler2, InvalidConditionValue) {
     conditions[0].condition_values.clear();
     conditions[0].condition_values.push_back("-9223372036854775809");
     DeletePredicatePB del_pred_8;
-    res = DeleteHandler::generate_delete_predicate(tablet->tablet_schema(), conditions,
+    res = DeleteHandler::generate_delete_predicate(*tablet->tablet_schema(), conditions,
                                                    &del_pred_8);
     EXPECT_EQ(Status::OLAPInternalError(OLAP_ERR_DELETE_INVALID_CONDITION), res);
 
@@ -654,7 +654,7 @@ TEST_F(TestDeleteConditionHandler2, InvalidConditionValue) {
     conditions[0].column_name = "k5";
     conditions[0].condition_values.push_back("170141183460469231731687303715884105728");
     DeletePredicatePB del_pred_9;
-    res = DeleteHandler::generate_delete_predicate(tablet->tablet_schema(), conditions,
+    res = DeleteHandler::generate_delete_predicate(*tablet->tablet_schema(), conditions,
                                                    &del_pred_9);
     EXPECT_EQ(Status::OLAPInternalError(OLAP_ERR_DELETE_INVALID_CONDITION), res);
 
@@ -662,7 +662,7 @@ TEST_F(TestDeleteConditionHandler2, InvalidConditionValue) {
     conditions[0].condition_values.clear();
     conditions[0].condition_values.push_back("-170141183460469231731687303715884105729");
     DeletePredicatePB del_pred_10;
-    res = DeleteHandler::generate_delete_predicate(tablet->tablet_schema(), conditions,
+    res = DeleteHandler::generate_delete_predicate(*tablet->tablet_schema(), conditions,
                                                    &del_pred_10);
     EXPECT_EQ(Status::OLAPInternalError(OLAP_ERR_DELETE_INVALID_CONDITION), res);
 
@@ -671,7 +671,7 @@ TEST_F(TestDeleteConditionHandler2, InvalidConditionValue) {
     conditions[0].column_name = "k9";
     conditions[0].condition_values.push_back("12347876.5");
     DeletePredicatePB del_pred_11;
-    res = DeleteHandler::generate_delete_predicate(tablet->tablet_schema(), conditions,
+    res = DeleteHandler::generate_delete_predicate(*tablet->tablet_schema(), conditions,
                                                    &del_pred_11);
     EXPECT_EQ(Status::OLAPInternalError(OLAP_ERR_DELETE_INVALID_CONDITION), res);
 
@@ -679,7 +679,7 @@ TEST_F(TestDeleteConditionHandler2, InvalidConditionValue) {
     conditions[0].condition_values.clear();
     conditions[0].condition_values.push_back("1.2345678");
     DeletePredicatePB del_pred_12;
-    res = DeleteHandler::generate_delete_predicate(tablet->tablet_schema(), conditions,
+    res = DeleteHandler::generate_delete_predicate(*tablet->tablet_schema(), conditions,
                                                    &del_pred_12);
     EXPECT_EQ(Status::OLAPInternalError(OLAP_ERR_DELETE_INVALID_CONDITION), res);
 
@@ -687,7 +687,7 @@ TEST_F(TestDeleteConditionHandler2, InvalidConditionValue) {
     conditions[0].condition_values.clear();
     conditions[0].condition_values.push_back("1.");
     DeletePredicatePB del_pred_13;
-    res = DeleteHandler::generate_delete_predicate(tablet->tablet_schema(), conditions,
+    res = DeleteHandler::generate_delete_predicate(*tablet->tablet_schema(), conditions,
                                                    &del_pred_13);
     EXPECT_EQ(Status::OLAPInternalError(OLAP_ERR_DELETE_INVALID_CONDITION), res);
 
@@ -696,21 +696,21 @@ TEST_F(TestDeleteConditionHandler2, InvalidConditionValue) {
     conditions[0].column_name = "k10";
     conditions[0].condition_values.push_back("20130101");
     DeletePredicatePB del_pred_14;
-    res = DeleteHandler::generate_delete_predicate(tablet->tablet_schema(), conditions,
+    res = DeleteHandler::generate_delete_predicate(*tablet->tablet_schema(), conditions,
                                                    &del_pred_14);
     EXPECT_EQ(Status::OLAPInternalError(OLAP_ERR_DELETE_INVALID_CONDITION), res);
 
     conditions[0].condition_values.clear();
     conditions[0].condition_values.push_back("2013-64-01");
     DeletePredicatePB del_pred_15;
-    res = DeleteHandler::generate_delete_predicate(tablet->tablet_schema(), conditions,
+    res = DeleteHandler::generate_delete_predicate(*tablet->tablet_schema(), conditions,
                                                    &del_pred_15);
     EXPECT_EQ(Status::OLAPInternalError(OLAP_ERR_DELETE_INVALID_CONDITION), res);
 
     conditions[0].condition_values.clear();
     conditions[0].condition_values.push_back("2013-01-40");
     DeletePredicatePB del_pred_16;
-    res = DeleteHandler::generate_delete_predicate(tablet->tablet_schema(), conditions,
+    res = DeleteHandler::generate_delete_predicate(*tablet->tablet_schema(), conditions,
                                                    &del_pred_16);
     EXPECT_EQ(Status::OLAPInternalError(OLAP_ERR_DELETE_INVALID_CONDITION), res);
 
@@ -719,42 +719,42 @@ TEST_F(TestDeleteConditionHandler2, InvalidConditionValue) {
     conditions[0].column_name = "k11";
     conditions[0].condition_values.push_back("20130101 00:00:00");
     DeletePredicatePB del_pred_17;
-    res = DeleteHandler::generate_delete_predicate(tablet->tablet_schema(), conditions,
+    res = DeleteHandler::generate_delete_predicate(*tablet->tablet_schema(), conditions,
                                                    &del_pred_17);
     EXPECT_EQ(Status::OLAPInternalError(OLAP_ERR_DELETE_INVALID_CONDITION), res);
 
     conditions[0].condition_values.clear();
     conditions[0].condition_values.push_back("2013-64-01 00:00:00");
     DeletePredicatePB del_pred_18;
-    res = DeleteHandler::generate_delete_predicate(tablet->tablet_schema(), conditions,
+    res = DeleteHandler::generate_delete_predicate(*tablet->tablet_schema(), conditions,
                                                    &del_pred_18);
     EXPECT_EQ(Status::OLAPInternalError(OLAP_ERR_DELETE_INVALID_CONDITION), res);
 
     conditions[0].condition_values.clear();
     conditions[0].condition_values.push_back("2013-01-40 00:00:00");
     DeletePredicatePB del_pred_19;
-    res = DeleteHandler::generate_delete_predicate(tablet->tablet_schema(), conditions,
+    res = DeleteHandler::generate_delete_predicate(*tablet->tablet_schema(), conditions,
                                                    &del_pred_19);
     EXPECT_EQ(Status::OLAPInternalError(OLAP_ERR_DELETE_INVALID_CONDITION), res);
 
     conditions[0].condition_values.clear();
     conditions[0].condition_values.push_back("2013-01-01 24:00:00");
     DeletePredicatePB del_pred_20;
-    res = DeleteHandler::generate_delete_predicate(tablet->tablet_schema(), conditions,
+    res = DeleteHandler::generate_delete_predicate(*tablet->tablet_schema(), conditions,
                                                    &del_pred_20);
     EXPECT_EQ(Status::OLAPInternalError(OLAP_ERR_DELETE_INVALID_CONDITION), res);
 
     conditions[0].condition_values.clear();
     conditions[0].condition_values.push_back("2013-01-01 00:60:00");
     DeletePredicatePB del_pred_21;
-    res = DeleteHandler::generate_delete_predicate(tablet->tablet_schema(), conditions,
+    res = DeleteHandler::generate_delete_predicate(*tablet->tablet_schema(), conditions,
                                                    &del_pred_21);
     EXPECT_EQ(Status::OLAPInternalError(OLAP_ERR_DELETE_INVALID_CONDITION), res);
 
     conditions[0].condition_values.clear();
     conditions[0].condition_values.push_back("2013-01-01 00:00:60");
     DeletePredicatePB del_pred_22;
-    res = DeleteHandler::generate_delete_predicate(tablet->tablet_schema(), conditions,
+    res = DeleteHandler::generate_delete_predicate(*tablet->tablet_schema(), conditions,
                                                    &del_pred_22);
     EXPECT_EQ(Status::OLAPInternalError(OLAP_ERR_DELETE_INVALID_CONDITION), res);
 
@@ -766,7 +766,7 @@ TEST_F(TestDeleteConditionHandler2, InvalidConditionValue) {
             "FhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYW"
             "FhYWFhYWFhYWFhYWFhYWFhYWFhYWE=;k13=YWFhYQ==");
     DeletePredicatePB del_pred_23;
-    res = DeleteHandler::generate_delete_predicate(tablet->tablet_schema(), conditions,
+    res = DeleteHandler::generate_delete_predicate(*tablet->tablet_schema(), conditions,
                                                    &del_pred_23);
     EXPECT_EQ(Status::OLAPInternalError(OLAP_ERR_DELETE_INVALID_CONDITION), res);
 
@@ -777,7 +777,7 @@ TEST_F(TestDeleteConditionHandler2, InvalidConditionValue) {
             "FhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYW"
             "FhYWFhYWFhYWFhYWFhYWFhYWFhYWE=;k13=YWFhYQ==");
     DeletePredicatePB del_pred_24;
-    res = DeleteHandler::generate_delete_predicate(tablet->tablet_schema(), conditions,
+    res = DeleteHandler::generate_delete_predicate(*tablet->tablet_schema(), conditions,
                                                    &del_pred_24);
     EXPECT_EQ(Status::OLAPInternalError(OLAP_ERR_DELETE_INVALID_CONDITION), res);
 }
@@ -811,8 +811,8 @@ protected:
         EXPECT_TRUE(tablet != nullptr);
         _tablet_path = tablet->tablet_path();
 
-        _data_row_cursor.init(tablet->tablet_schema());
-        _data_row_cursor.allocate_memory_for_string_type(tablet->tablet_schema());
+        _data_row_cursor.init(*tablet->tablet_schema());
+        _data_row_cursor.allocate_memory_for_string_type(*tablet->tablet_schema());
     }
 
     void TearDown() {
@@ -856,7 +856,7 @@ TEST_F(TestDeleteHandler, InitSuccess) {
     conditions.push_back(condition);
 
     DeletePredicatePB del_pred;
-    res = DeleteHandler::generate_delete_predicate(tablet->tablet_schema(), conditions, &del_pred);
+    res = DeleteHandler::generate_delete_predicate(*tablet->tablet_schema(), conditions, &del_pred);
     EXPECT_EQ(Status::OK(), res);
     tablet->add_delete_predicate(del_pred, 1);
 
@@ -868,7 +868,7 @@ TEST_F(TestDeleteHandler, InitSuccess) {
     conditions.push_back(condition);
 
     DeletePredicatePB del_pred_2;
-    res = DeleteHandler::generate_delete_predicate(tablet->tablet_schema(), conditions,
+    res = DeleteHandler::generate_delete_predicate(*tablet->tablet_schema(), conditions,
                                                    &del_pred_2);
     EXPECT_EQ(Status::OK(), res);
     tablet->add_delete_predicate(del_pred_2, 2);
@@ -881,7 +881,7 @@ TEST_F(TestDeleteHandler, InitSuccess) {
     conditions.push_back(condition);
 
     DeletePredicatePB del_pred_3;
-    res = DeleteHandler::generate_delete_predicate(tablet->tablet_schema(), conditions,
+    res = DeleteHandler::generate_delete_predicate(*tablet->tablet_schema(), conditions,
                                                    &del_pred_3);
     EXPECT_EQ(Status::OK(), res);
     tablet->add_delete_predicate(del_pred_3, 3);
@@ -894,13 +894,13 @@ TEST_F(TestDeleteHandler, InitSuccess) {
     conditions.push_back(condition);
 
     DeletePredicatePB del_pred_4;
-    res = DeleteHandler::generate_delete_predicate(tablet->tablet_schema(), conditions,
+    res = DeleteHandler::generate_delete_predicate(*tablet->tablet_schema(), conditions,
                                                    &del_pred_4);
     EXPECT_EQ(Status::OK(), res);
     tablet->add_delete_predicate(del_pred_4, 4);
 
     // 从header文件中取出版本号小于等于7的过滤条件
-    res = _delete_handler.init(tablet->tablet_schema(), tablet->delete_predicates(), 4);
+    res = _delete_handler.init(*tablet->tablet_schema(), tablet->delete_predicates(), 4);
     EXPECT_EQ(Status::OK(), res);
     EXPECT_EQ(4, _delete_handler.conditions_num());
     std::vector<int64_t> conds_version = _delete_handler.get_conds_version();
@@ -936,12 +936,12 @@ TEST_F(TestDeleteHandler, FilterDataSubconditions) {
     conditions.push_back(condition);
 
     DeletePredicatePB del_pred;
-    res = DeleteHandler::generate_delete_predicate(tablet->tablet_schema(), conditions, &del_pred);
+    res = DeleteHandler::generate_delete_predicate(*tablet->tablet_schema(), conditions, &del_pred);
     EXPECT_EQ(Status::OK(), res);
     tablet->add_delete_predicate(del_pred, 1);
 
     // 指定版本号为10以载入Header中的所有过滤条件(在这个case中，只有过滤条件1)
-    res = _delete_handler.init(tablet->tablet_schema(), tablet->delete_predicates(), 4);
+    res = _delete_handler.init(*tablet->tablet_schema(), tablet->delete_predicates(), 4);
     EXPECT_EQ(Status::OK(), res);
     EXPECT_EQ(1, _delete_handler.conditions_num());
 
@@ -996,7 +996,7 @@ TEST_F(TestDeleteHandler, FilterDataConditions) {
     conditions.push_back(condition);
 
     DeletePredicatePB del_pred;
-    res = DeleteHandler::generate_delete_predicate(tablet->tablet_schema(), conditions, &del_pred);
+    res = DeleteHandler::generate_delete_predicate(*tablet->tablet_schema(), conditions, &del_pred);
     EXPECT_EQ(Status::OK(), res);
     tablet->add_delete_predicate(del_pred, 1);
 
@@ -1009,7 +1009,7 @@ TEST_F(TestDeleteHandler, FilterDataConditions) {
     conditions.push_back(condition);
 
     DeletePredicatePB del_pred_2;
-    res = DeleteHandler::generate_delete_predicate(tablet->tablet_schema(), conditions,
+    res = DeleteHandler::generate_delete_predicate(*tablet->tablet_schema(), conditions,
                                                    &del_pred_2);
     EXPECT_EQ(Status::OK(), res);
     tablet->add_delete_predicate(del_pred_2, 2);
@@ -1023,13 +1023,13 @@ TEST_F(TestDeleteHandler, FilterDataConditions) {
     conditions.push_back(condition);
 
     DeletePredicatePB del_pred_3;
-    res = DeleteHandler::generate_delete_predicate(tablet->tablet_schema(), conditions,
+    res = DeleteHandler::generate_delete_predicate(*tablet->tablet_schema(), conditions,
                                                    &del_pred_3);
     EXPECT_EQ(Status::OK(), res);
     tablet->add_delete_predicate(del_pred_3, 3);
 
     // 指定版本号为4以载入meta中的所有过滤条件(在这个case中，只有过滤条件1)
-    res = _delete_handler.init(tablet->tablet_schema(), tablet->delete_predicates(), 4);
+    res = _delete_handler.init(*tablet->tablet_schema(), tablet->delete_predicates(), 4);
     EXPECT_EQ(Status::OK(), res);
     EXPECT_EQ(3, _delete_handler.conditions_num());
 
@@ -1075,7 +1075,7 @@ TEST_F(TestDeleteHandler, FilterDataVersion) {
     conditions.push_back(condition);
 
     DeletePredicatePB del_pred;
-    res = DeleteHandler::generate_delete_predicate(tablet->tablet_schema(), conditions, &del_pred);
+    res = DeleteHandler::generate_delete_predicate(*tablet->tablet_schema(), conditions, &del_pred);
     EXPECT_EQ(Status::OK(), res);
     tablet->add_delete_predicate(del_pred, 3);
 
@@ -1088,13 +1088,13 @@ TEST_F(TestDeleteHandler, FilterDataVersion) {
     conditions.push_back(condition);
 
     DeletePredicatePB del_pred_2;
-    res = DeleteHandler::generate_delete_predicate(tablet->tablet_schema(), conditions,
+    res = DeleteHandler::generate_delete_predicate(*tablet->tablet_schema(), conditions,
                                                    &del_pred_2);
     EXPECT_EQ(Status::OK(), res);
     tablet->add_delete_predicate(del_pred_2, 4);
 
     // 指定版本号为4以载入meta中的所有过滤条件(过滤条件1，过滤条件2)
-    res = _delete_handler.init(tablet->tablet_schema(), tablet->delete_predicates(), 4);
+    res = _delete_handler.init(*tablet->tablet_schema(), tablet->delete_predicates(), 4);
     EXPECT_EQ(Status::OK(), res);
     EXPECT_EQ(2, _delete_handler.conditions_num());
 

--- a/be/test/olap/engine_storage_migration_task_test.cpp
+++ b/be/test/olap/engine_storage_migration_task_test.cpp
@@ -67,7 +67,6 @@ static void set_up() {
     options.store_paths = paths;
     Status s = doris::StorageEngine::open(options, &k_engine);
     EXPECT_TRUE(s.ok()) << s.to_string();
-
     ExecEnv* exec_env = doris::ExecEnv::GetInstance();
     exec_env->set_storage_engine(k_engine);
     k_engine->start_bg_threads();

--- a/be/test/olap/rowset/beta_rowset_test.cpp
+++ b/be/test/olap/rowset/beta_rowset_test.cpp
@@ -94,7 +94,7 @@ protected:
     OlapReaderStatistics _stats;
 
     // (k1 int, k2 varchar(20), k3 int) duplicated key (k1, k2)
-    void create_tablet_schema(TabletSchema* tablet_schema) {
+    void create_tablet_schema(TabletSchemaSPtr tablet_schema) {
         TabletSchemaPB tablet_schema_pb;
         tablet_schema_pb.set_keys_type(DUP_KEYS);
         tablet_schema_pb.set_num_short_key_columns(2);
@@ -137,7 +137,7 @@ protected:
         tablet_schema->init_from_pb(tablet_schema_pb);
     }
 
-    void create_rowset_writer_context(TabletSchema* tablet_schema,
+    void create_rowset_writer_context(TabletSchemaSPtr tablet_schema,
                                       RowsetWriterContext* rowset_writer_context) {
         RowsetId rowset_id;
         rowset_id.init(10000);
@@ -170,8 +170,8 @@ private:
 
 TEST_F(BetaRowsetTest, BasicFunctionTest) {
     Status s;
-    TabletSchema tablet_schema;
-    create_tablet_schema(&tablet_schema);
+    TabletSchemaSPtr tablet_schema = std::make_shared<TabletSchema>();
+    create_tablet_schema(tablet_schema);
 
     RowsetSharedPtr rowset;
     const int num_segments = 3;
@@ -179,14 +179,14 @@ TEST_F(BetaRowsetTest, BasicFunctionTest) {
     std::vector<uint32_t> segment_num_rows;
     { // write `num_segments * rows_per_segment` rows to rowset
         RowsetWriterContext writer_context;
-        create_rowset_writer_context(&tablet_schema, &writer_context);
+        create_rowset_writer_context(tablet_schema, &writer_context);
 
         std::unique_ptr<RowsetWriter> rowset_writer;
         s = RowsetFactory::create_rowset_writer(writer_context, &rowset_writer);
         EXPECT_EQ(Status::OK(), s);
 
         RowCursor input_row;
-        input_row.init(tablet_schema);
+        input_row.init(*tablet_schema);
 
         // for segment "i", row "rid"
         // k1 := rid*10 + i
@@ -216,7 +216,7 @@ TEST_F(BetaRowsetTest, BasicFunctionTest) {
 
     { // test return ordered results and return k1 and k2
         RowsetReaderContext reader_context;
-        reader_context.tablet_schema = &tablet_schema;
+        reader_context.tablet_schema = tablet_schema.get();
         reader_context.need_ordered_result = true;
         std::vector<uint32_t> return_columns = {0, 1};
         reader_context.return_columns = &return_columns;
@@ -306,7 +306,7 @@ TEST_F(BetaRowsetTest, BasicFunctionTest) {
 
     { // test return unordered data and only k3
         RowsetReaderContext reader_context;
-        reader_context.tablet_schema = &tablet_schema;
+        reader_context.tablet_schema = tablet_schema.get();
         reader_context.need_ordered_result = false;
         std::vector<uint32_t> return_columns = {2};
         reader_context.return_columns = &return_columns;

--- a/be/test/olap/rowset/rowset_tree_test.cpp
+++ b/be/test/olap/rowset/rowset_tree_test.cpp
@@ -40,6 +40,7 @@
 #include "gutil/strings/substitute.h"
 #include "olap/rowset/rowset.h"
 #include "olap/rowset/unique_rowset_id_generator.h"
+#include "olap/tablet_schema.h"
 #include "testutil/mock_rowset.h"
 #include "testutil/test_util.h"
 #include "util/slice.h"
@@ -59,9 +60,10 @@ public:
     TestRowsetTree() : rowset_id_generator_({0, 0}) {}
 
     void SetUp() {
+        schema_ = std::make_shared<TabletSchema>();
         TabletSchemaPB schema_pb;
         schema_pb.set_keys_type(UNIQUE_KEYS);
-        schema_.init_from_pb(schema_pb);
+        schema_->init_from_pb(schema_pb);
     }
 
     // Generates random rowsets with keys between 0 and 10000
@@ -88,12 +90,12 @@ public:
         RowsetMetaSharedPtr meta_ptr = make_shared<RowsetMeta>();
         meta_ptr->init_from_pb(rs_meta_pb);
         RowsetSharedPtr res_ptr;
-        MockRowset::create_rowset(&schema_, rowset_path_, meta_ptr, &res_ptr, is_mem_rowset);
+        MockRowset::create_rowset(schema_, rowset_path_, meta_ptr, &res_ptr, is_mem_rowset);
         return res_ptr;
     }
 
 private:
-    TabletSchema schema_;
+    TabletSchemaSPtr schema_;
     std::string rowset_path_;
     UniqueRowsetIdGenerator rowset_id_generator_;
 };

--- a/be/test/olap/tablet_meta_test.cpp
+++ b/be/test/olap/tablet_meta_test.cpp
@@ -19,8 +19,10 @@
 
 #include <gtest/gtest.h>
 
+#include <memory>
 #include <string>
 
+#include "olap/tablet_schema.h"
 #include "testutil/mock_rowset.h"
 
 namespace doris {
@@ -60,8 +62,8 @@ TEST(TabletMetaTest, TestReviseMeta) {
         RowsetMetaSharedPtr meta_ptr = std::make_shared<RowsetMeta>();
         meta_ptr->init_from_pb(rs_meta_pb);
         RowsetSharedPtr rowset_ptr;
-        TabletSchema schema;
-        MockRowset::create_rowset(&schema, "", meta_ptr, &rowset_ptr, false);
+        TabletSchemaSPtr schema = std::make_shared<TabletSchema>();
+        MockRowset::create_rowset(schema, "", meta_ptr, &rowset_ptr, false);
         src_rowsets.push_back(rowset_ptr);
         tablet_meta.add_rs_meta(rowset_ptr->rowset_meta());
     }

--- a/be/test/olap/tablet_test.cpp
+++ b/be/test/olap/tablet_test.cpp
@@ -26,6 +26,7 @@
 #include "olap/storage_engine.h"
 #include "olap/storage_policy_mgr.h"
 #include "olap/tablet_meta.h"
+#include "olap/tablet_schema_cache.h"
 #include "testutil/mock_rowset.h"
 #include "util/time.h"
 
@@ -379,19 +380,21 @@ TEST_F(TestTablet, rowset_tree_update) {
 
     RowsetMetaSharedPtr rsm1(new RowsetMeta());
     init_rs_meta(rsm1, 6, 7, convert_key_bounds({{"100", "200"}, {"300", "400"}}));
+    rsm1->set_tablet_schema(tablet->tablet_schema());
     RowsetId id1;
     id1.init(10010);
     RowsetSharedPtr rs_ptr1;
-    MockRowset::create_rowset(&tablet_meta->tablet_schema(), "", rsm1, &rs_ptr1, false);
+    MockRowset::create_rowset(tablet->tablet_schema(), "", rsm1, &rs_ptr1, false);
     tablet->add_inc_rowset(rs_ptr1);
 
     RowsetMetaSharedPtr rsm2(new RowsetMeta());
     init_rs_meta(rsm2, 8, 8, convert_key_bounds({{"500", "999"}}));
+    rsm2->set_tablet_schema(tablet->tablet_schema());
     RowsetId id2;
     id2.init(10086);
     rsm2->set_rowset_id(id2);
     RowsetSharedPtr rs_ptr2;
-    MockRowset::create_rowset(&tablet_meta->tablet_schema(), "", rsm2, &rs_ptr2, false);
+    MockRowset::create_rowset(tablet->tablet_schema(), "", rsm2, &rs_ptr2, false);
     tablet->add_inc_rowset(rs_ptr2);
 
     RowLocation loc;

--- a/be/test/olap/txn_manager_test.cpp
+++ b/be/test/olap/txn_manager_test.cpp
@@ -132,10 +132,10 @@ public:
         RowsetMetaSharedPtr rowset_meta(new RowsetMeta());
         rowset_meta->init_from_json(_json_rowset_meta);
         EXPECT_EQ(rowset_meta->rowset_id(), rowset_id);
-        EXPECT_EQ(Status::OK(), RowsetFactory::create_rowset(_schema.get(), rowset_meta_path,
-                                                             rowset_meta, &_rowset));
-        EXPECT_EQ(Status::OK(), RowsetFactory::create_rowset(_schema.get(), rowset_meta_path,
-                                                             rowset_meta, &_rowset_same_id));
+        EXPECT_EQ(Status::OK(),
+                  RowsetFactory::create_rowset(_schema, rowset_meta_path, rowset_meta, &_rowset));
+        EXPECT_EQ(Status::OK(), RowsetFactory::create_rowset(_schema, rowset_meta_path, rowset_meta,
+                                                             &_rowset_same_id));
 
         // init rowset meta 2
         _json_rowset_meta = "";
@@ -150,7 +150,7 @@ public:
         RowsetMetaSharedPtr rowset_meta2(new RowsetMeta());
         rowset_meta2->init_from_json(_json_rowset_meta);
         EXPECT_EQ(rowset_meta2->rowset_id(), rowset_id);
-        EXPECT_EQ(Status::OK(), RowsetFactory::create_rowset(_schema.get(), rowset_meta_path_2,
+        EXPECT_EQ(Status::OK(), RowsetFactory::create_rowset(_schema, rowset_meta_path_2,
                                                              rowset_meta2, &_rowset_diff_id));
         _tablet_uid = TabletUid(10, 10);
     }
@@ -170,7 +170,7 @@ private:
     SchemaHash schema_hash = 333;
     TabletUid _tablet_uid {0, 0};
     PUniqueId load_id;
-    std::unique_ptr<TabletSchema> _schema;
+    TabletSchemaSPtr _schema;
     RowsetSharedPtr _rowset;
     RowsetSharedPtr _rowset_same_id;
     RowsetSharedPtr _rowset_diff_id;

--- a/be/test/testutil/mock_rowset.h
+++ b/be/test/testutil/mock_rowset.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include "olap/rowset/rowset.h"
+#include "olap/tablet_schema.h"
 
 namespace doris {
 
@@ -64,7 +65,7 @@ class MockRowset : public Rowset {
         return Rowset::get_segments_key_bounds(segments_key_bounds);
     }
 
-    static Status create_rowset(const TabletSchema* schema, const std::string& rowset_path,
+    static Status create_rowset(TabletSchemaSPtr schema, const std::string& rowset_path,
                                 RowsetMetaSharedPtr rowset_meta, RowsetSharedPtr* rowset,
                                 bool is_mem_rowset = false) {
         rowset->reset(new MockRowset(schema, rowset_path, rowset_meta));
@@ -73,7 +74,7 @@ class MockRowset : public Rowset {
     }
 
 protected:
-    MockRowset(const TabletSchema* schema, const std::string& rowset_path,
+    MockRowset(TabletSchemaSPtr schema, const std::string& rowset_path,
                RowsetMetaSharedPtr rowset_meta)
             : Rowset(schema, rowset_path, rowset_meta) {}
 

--- a/be/test/testutil/run_all_tests.cpp
+++ b/be/test/testutil/run_all_tests.cpp
@@ -32,6 +32,7 @@ int main(int argc, char** argv) {
     doris::MemTrackerLimiter* process_mem_tracker = new doris::MemTrackerLimiter(-1, "Process");
     doris::ExecEnv::GetInstance()->set_process_mem_tracker(process_mem_tracker);
     doris::thread_context()->_thread_mem_tracker_mgr->init();
+    doris::TabletSchemaCache::create_global_schema_cache();
     doris::StoragePageCache::create_global_cache(1 << 30, 10);
     doris::SegmentLoader::create_global_instance(1000);
     std::string conf = std::string(getenv("DORIS_HOME")) + "/conf/be.conf";


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

The PR is for #10136. In that, every rowset will presist a tablet schema and use in memory by rowsetMetaPB. But When tablets and rowsets in tablet too more,  memory will has a lot of pressure. So we need a way to avoid it.

In this pr, it will implement a global tablet schema cache. Every rowset will hold a tablet schema sptr from cache. That mean even we has  tens of thousands of rowsets, if their schema is same, there will be one schema in memory.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
