### PR TITLE
[UDAF](sample) impl rpc avg udaf

### DIFF
--- a/be/src/vec/aggregate_functions/aggregate_function_rpc.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_rpc.h
@@ -252,7 +252,7 @@ public:
                     reinterpret_cast<const DataTypeNullable*>(return_type.get())->get_nested_type();
         }
         WhichDataType which(result_type);
-        if (which.is_float()) {
+        if (which.is_float32()) {
             float ret = response.result(0).float_value(0);
             to.insert_data((char*)&ret, 0);
         }

--- a/samples/doris-demo/remote-udaf-cpp-demo/cpp_function_service_demo.cpp
+++ b/samples/doris-demo/remote-udaf-cpp-demo/cpp_function_service_demo.cpp
@@ -59,7 +59,40 @@ public:
             }
             result->add_int32_value(sum);
         }
+        if(fun_name=="rpc_avg_update"){
+            result->mutable_type()->set_id(PGenericType::DOUBLE);
+            double sum=0;
+            int64_t size = request->args(0).int32_value_size();
+            for (size_t i = 0; i < request->args(0).int32_value_size(); ++i) {
+                sum += request->args(0).int32_value(i);
+            }
+            if(request->has_context() && request->context().has_function_context()){
+                sum += request->context().function_context().args_data(0).double_value(0);
+                size += request->context().function_context().args_data(0).int32_value(0);
+            }
+            result->add_double_value(sum);
+            result->add_int32_value(size);
+        }
+        if(fun_name=="rpc_avg_merge"){
+            result->mutable_type()->set_id(PGenericType::INT32);
+            double sum= 0;
+            int32_t size = 0;
+            for (size_t i = 0; i < request->args_size(); ++i) {
+                sum += request->args(i).double_value(0);
+                size += request->args(i).int32_value(0);
+            }
+            result->add_double_value(sum);
+            result->add_int32_value(size);
+        }
+        if(fun_name=="rpc_avg_finalize"){
+             result->mutable_type()->set_id(PGenericType::DOUBLE);
+             double sum = request->context().function_context().args_data(0).double_value(0);
+             int64_t size = request->context().function_context().args_data(0).int32_value(0);
+             double avg = sum / size;
+             result->add_double_value(avg);
+        }
         response->mutable_status()->set_status_code(0);
+        //std::cout<< "result:"<< response->DebugString();
     }
 
     void check_fn(google::protobuf::RpcController* controller, const PCheckFunctionRequest* request,

--- a/samples/doris-demo/remote-udaf-cpp-demo/cpp_function_service_demo.cpp
+++ b/samples/doris-demo/remote-udaf-cpp-demo/cpp_function_service_demo.cpp
@@ -92,7 +92,6 @@ public:
              result->add_double_value(avg);
         }
         response->mutable_status()->set_status_code(0);
-        //std::cout<< "result:"<< response->DebugString();
     }
 
     void check_fn(google::protobuf::RpcController* controller, const PCheckFunctionRequest* request,


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

add rpc avg udaf  sample 
```
CREATE AGGREGATE FUNCTION  rpc_avg(int) RETURNS double PROPERTIES (
    "TYPE"="RPC",
    "OBJECT_FILE"="127.0.0.1:9000",
    "update_fn"="rpc_avg_update",
    "merge_fn"="rpc_avg_merge",
    "finalize_fn"="rpc_avg_finalize"
);

CREATE TABLE `table1` (
  `event_day` date NULL,
  `siteid` int(11) NULL DEFAULT "10",
  `citycode` smallint(6) NULL,
  `username` varchar(32) NULL DEFAULT "",
  `pv` bigint(20) SUM NULL DEFAULT "0"
) ENGINE=OLAP
AGGREGATE KEY(`event_day`, `siteid`, `citycode`, `username`)
COMMENT 'OLAP'
DISTRIBUTED BY HASH(`siteid`) BUCKETS 1
PROPERTIES (
"replication_allocation" = "tag.location.default: 1",
"in_memory" = "false",
"storage_format" = "V2"
)
```
import  100w rows data
## result

![image](https://user-images.githubusercontent.com/11487604/180424853-d8dfa11f-0736-440b-8e2b-c1d19635ec3d.png)

The performance of calculating the mean value alone is similar to that of the built-in function

![image](https://user-images.githubusercontent.com/11487604/180424654-557cfd53-001f-40be-888f-a42891a04b41.png)
Double the performance loss of the group by scenario



## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
