### PR TITLE
[Improvement] Replace `switch` with `constexpr` to boost date functions

### DIFF
--- a/be/src/exprs/cast_functions.cpp
+++ b/be/src/exprs/cast_functions.cpp
@@ -34,15 +34,6 @@
 #include "vec/data_types/data_type_decimal.h"
 #include "vec/runtime/vdatetime_value.h"
 
-namespace doris::vectorized {
-template <>
-void doris::vectorized::DateV2Value<doris::vectorized::DateV2ValueType>::convert_date_v2_to_dt(
-        doris::DateTimeValue* dt);
-template <>
-void doris::vectorized::DateV2Value<doris::vectorized::DateTimeV2ValueType>::convert_date_v2_to_dt(
-        doris::DateTimeValue* dt);
-} // namespace doris::vectorized
-
 namespace doris {
 
 void CastFunctions::init() {}
@@ -626,7 +617,7 @@ DateTimeVal CastFunctions::cast_to_date_val(FunctionContext* ctx, const DateV2Va
     vectorized::DateV2Value<doris::vectorized::DateV2ValueType> datev2_val =
             vectorized::DateV2Value<doris::vectorized::DateV2ValueType>::from_datev2_val(val);
     DateTimeValue datetime_value;
-    datev2_val.convert_date_v2_to_dt(&datetime_value);
+    datetime_value.convert_from_date_v2<doris::vectorized::DateV2ValueType>(&datev2_val);
     DateTimeVal result;
     datetime_value.to_datetime_val(&result);
     return result;
@@ -640,7 +631,7 @@ DateTimeVal CastFunctions::cast_to_date_val(FunctionContext* ctx, const DateTime
             vectorized::DateV2Value<doris::vectorized::DateTimeV2ValueType>::from_datetimev2_val(
                     val);
     DateTimeValue datetime_value;
-    datev2_val.convert_date_v2_to_dt(&datetime_value);
+    datetime_value.convert_from_date_v2<doris::vectorized::DateTimeV2ValueType>(&datev2_val);
     DateTimeVal result;
     datetime_value.to_datetime_val(&result);
     return result;
@@ -653,7 +644,7 @@ DateTimeVal CastFunctions::cast_to_datetime_val(FunctionContext* ctx, const Date
     vectorized::DateV2Value<doris::vectorized::DateV2ValueType> datev2_val =
             vectorized::DateV2Value<doris::vectorized::DateV2ValueType>::from_datev2_val(val);
     DateTimeValue datetime_value;
-    datev2_val.convert_date_v2_to_dt(&datetime_value);
+    datetime_value.convert_from_date_v2<doris::vectorized::DateV2ValueType>(&datev2_val);
     datetime_value.set_type(TYPE_DATETIME);
     DateTimeVal result;
     datetime_value.to_datetime_val(&result);
@@ -668,7 +659,7 @@ DateTimeVal CastFunctions::cast_to_datetime_val(FunctionContext* ctx, const Date
             vectorized::DateV2Value<doris::vectorized::DateTimeV2ValueType>::from_datetimev2_val(
                     val);
     DateTimeValue datetime_value;
-    datev2_val.convert_date_v2_to_dt(&datetime_value);
+    datetime_value.convert_from_date_v2<doris::vectorized::DateTimeV2ValueType>(&datev2_val);
     datetime_value.set_type(TYPE_DATETIME);
     DateTimeVal result;
     datetime_value.to_datetime_val(&result);

--- a/be/src/runtime/datetime_value.h
+++ b/be/src/runtime/datetime_value.h
@@ -565,19 +565,36 @@ public:
                _month > 0 && _day > 0;
     }
 
+    template <typename T>
+    void convert_from_date_v2(doris::vectorized::DateV2Value<T>* dt) {
+        if constexpr (doris::vectorized::DateV2Value<T>::is_datetime) {
+            this->_type = TIME_DATETIME;
+            this->_hour = dt->hour();
+            this->_minute = dt->minute();
+            this->_second = dt->second();
+        } else {
+            this->_type = TIME_DATE;
+            this->_hour = 0;
+            this->_minute = 0;
+            this->_second = 0;
+        }
+        this->_neg = 0;
+        this->_year = dt->year();
+        this->_month = dt->month();
+        this->_day = dt->day();
+        this->_microsecond = 0;
+    }
+
+    template <typename T>
+    void convert_to_date_v2(doris::vectorized::DateV2Value<T>* dt) {
+        dt->set_time(dt->year(), dt->month(), dt->_day, dt->hour(), dt->minute(), dt->second(), 0);
+    }
+
 private:
     // Used to make sure sizeof DateTimeValue
     friend class UnusedClass;
     friend void doris::vectorized::VecDateTimeValue::convert_vec_dt_to_dt(DateTimeValue* dt);
     friend void doris::vectorized::VecDateTimeValue::convert_dt_to_vec_dt(DateTimeValue* dt);
-    friend void doris::vectorized::DateV2Value<
-            doris::vectorized::DateV2ValueType>::convert_date_v2_to_dt(DateTimeValue* dt);
-    friend void doris::vectorized::DateV2Value<
-            doris::vectorized::DateV2ValueType>::convert_dt_to_date_v2(DateTimeValue* dt);
-    friend void doris::vectorized::DateV2Value<
-            doris::vectorized::DateTimeV2ValueType>::convert_date_v2_to_dt(DateTimeValue* dt);
-    friend void doris::vectorized::DateV2Value<
-            doris::vectorized::DateTimeV2ValueType>::convert_dt_to_date_v2(DateTimeValue* dt);
 
     void from_packed_time(int64_t packed_time) {
         _microsecond = packed_time % (1LL << 24);

--- a/be/src/vec/aggregate_functions/aggregate_function_window_funnel.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_window_funnel.h
@@ -82,7 +82,7 @@ struct WindowFunnelState {
                 const DateValueType& first_timestamp = events_timestamp[event_idx - 1].value();
                 DateValueType last_timestamp = first_timestamp;
                 TimeInterval interval(SECOND, window, false);
-                last_timestamp.date_add_interval(interval, SECOND);
+                last_timestamp.template date_add_interval<SECOND>(interval);
 
                 if (timestamp <= last_timestamp) {
                     events_timestamp[event_idx] = first_timestamp;

--- a/be/src/vec/functions/function_date_or_datetime_computation.h
+++ b/be/src/vec/functions/function_date_or_datetime_computation.h
@@ -39,12 +39,12 @@ inline ResultType date_time_add(const Arg& t, Int64 delta, bool& is_null) {
     TimeInterval interval(unit, delta, false);
     if constexpr (std::is_same_v<VecDateTimeValue, DateValueType> ||
                   std::is_same_v<DateValueType, ResultDateValueType>) {
-        is_null = !ts_value.date_add_interval(interval, unit);
+        is_null = !(ts_value.template date_add_interval<unit>(interval));
 
         return binary_cast<ResultDateValueType, ResultType>(ts_value);
     } else {
         ResultDateValueType res;
-        is_null = !ts_value.date_add_interval(interval, unit, res);
+        is_null = !(ts_value.template date_add_interval<unit>(interval, res));
 
         return binary_cast<ResultDateValueType, ResultType>(res);
     }

--- a/be/src/vec/functions/function_datetime_floor_ceil.cpp
+++ b/be/src/vec/functions/function_datetime_floor_ceil.cpp
@@ -239,7 +239,7 @@ struct TimeRound {
                                                    : count);
         bool is_neg = step < 0;
         TimeInterval interval(Impl::Unit, is_neg ? -step : step, is_neg);
-        is_null = !ts1.date_add_interval(interval, Impl::Unit);
+        is_null = !ts1.date_add_interval<Impl::Unit>(interval);
         return;
     }
 

--- a/be/src/vec/functions/function_timestamp.cpp
+++ b/be/src/vec/functions/function_timestamp.cpp
@@ -113,7 +113,7 @@ struct MakeDateImpl {
 
                 TimeInterval interval(DAY, r - 1, false);
                 res_val = VecDateTimeValue::from_datetime_val(ts_val);
-                if (!res_val.date_add_interval(interval, DAY)) {
+                if (!res_val.date_add_interval<DAY>(interval)) {
                     null_map[i] = 1;
                     continue;
                 }
@@ -122,7 +122,7 @@ struct MakeDateImpl {
                 DateV2Value<DateV2ValueType>* value = new (&res[i]) DateV2Value<DateV2ValueType>();
                 value->set_time(l, 1, 1);
                 TimeInterval interval(DAY, r - 1, false);
-                if (!value->date_add_interval(interval, DAY, *value)) {
+                if (!value->date_add_interval<DAY>(interval, *value)) {
                     null_map[i] = 1;
                 }
             }

--- a/be/src/vec/runtime/vdatetime_value.h
+++ b/be/src/vec/runtime/vdatetime_value.h
@@ -458,7 +458,8 @@ public:
     uint32_t year_week(uint8_t mode) const;
 
     // Add interval
-    bool date_add_interval(const TimeInterval& interval, TimeUnit unit);
+    template <TimeUnit unit>
+    bool date_add_interval(const TimeInterval& interval);
 
     //unix_timestamp is called with a timezone argument,
     //it returns seconds of the value of date literal since '1970-01-01 00:00:00' UTC
@@ -526,17 +527,17 @@ public:
         switch (_type) {
         case TIME_DATE: {
             TimeInterval interval(DAY, 1, false);
-            date_add_interval(interval, DAY);
+            date_add_interval<DAY>(interval);
             break;
         }
         case TIME_DATETIME: {
             TimeInterval interval(SECOND, 1, false);
-            date_add_interval(interval, SECOND);
+            date_add_interval<SECOND>(interval);
             break;
         }
         case TIME_TIME: {
             TimeInterval interval(SECOND, 1, false);
-            date_add_interval(interval, SECOND);
+            date_add_interval<SECOND>(interval);
             break;
         }
         }
@@ -907,11 +908,12 @@ public:
     uint32_t year_week(uint8_t mode) const;
 
     // Add interval
-    template <typename TO>
-    bool date_add_interval(const TimeInterval& interval, TimeUnit unit, DateV2Value<TO>& to_value);
+    template <TimeUnit unit, typename TO>
+    bool date_add_interval(const TimeInterval& interval, DateV2Value<TO>& to_value);
 
-    bool date_add_interval(const TimeInterval& interval, TimeUnit unit) {
-        return this->date_add_interval(interval, unit, *this);
+    template <TimeUnit unit>
+    bool date_add_interval(const TimeInterval& interval) {
+        return this->date_add_interval<unit>(interval, *this);
     }
 
     //unix_timestamp is called with a timezone argument,
@@ -1006,10 +1008,10 @@ public:
     DateV2Value<T>& operator++() {
         if constexpr (is_datetime) {
             TimeInterval interval(SECOND, 1, false);
-            date_add_interval(interval, SECOND, *this);
+            date_add_interval<SECOND>(interval, *this);
         } else {
             TimeInterval interval(DAY, 1, false);
-            date_add_interval(interval, DAY, *this);
+            date_add_interval<DAY>(interval, *this);
         }
         return *this;
     }
@@ -1051,9 +1053,6 @@ public:
                         (rhs.hour() * 3600 + rhs.minute() * 60 + rhs.second());
         return time_diff;
     }
-
-    void convert_date_v2_to_dt(doris::DateTimeValue* dt);
-    void convert_dt_to_date_v2(doris::DateTimeValue* dt);
 
     bool can_cast_to_date_without_loss_accuracy() {
         return this->hour() == 0 && this->minute() == 0 && this->second() == 0 &&

--- a/be/test/vec/core/block_test.cpp
+++ b/be/test/vec/core/block_test.cpp
@@ -110,14 +110,14 @@ TEST(BlockTest, RowBatchCovertToBlock) {
         std::string now_time("2020-12-02");
         k7.from_date_str(now_time.c_str(), now_time.size());
         vectorized::TimeInterval time_interval(vectorized::TimeUnit::DAY, k1, false);
-        k7.date_add_interval(time_interval, vectorized::TimeUnit::DAY);
+        k7.date_add_interval<vectorized::TimeUnit::DAY>(time_interval);
         memcpy(tuple->get_slot(slot_desc->tuple_offset()), &k7, column_descs[6].size);
 
         slot_desc = tuple_desc->slots()[7];
         vectorized::DateV2Value<doris::vectorized::DateV2ValueType> k8;
         std::string now_date("2020-12-02");
         k8.from_date_str(now_date.c_str(), now_date.size());
-        k8.date_add_interval(time_interval, vectorized::TimeUnit::DAY, k8);
+        k8.date_add_interval<vectorized::TimeUnit::DAY>(time_interval);
         memcpy(tuple->get_slot(slot_desc->tuple_offset()), &k8, column_descs[7].size);
 
         tuple_row->set_tuple(0, tuple);
@@ -161,7 +161,7 @@ TEST(BlockTest, RowBatchCovertToBlock) {
         std::string now_time("2020-12-02");
         date_time_value.from_date_str(now_time.c_str(), now_time.size());
         vectorized::TimeInterval time_interval(vectorized::TimeUnit::DAY, k1, false);
-        date_time_value.date_add_interval(time_interval, vectorized::TimeUnit::DAY);
+        date_time_value.date_add_interval<vectorized::TimeUnit::DAY>(time_interval);
 
         EXPECT_EQ(k7, date_time_value);
 
@@ -171,7 +171,7 @@ TEST(BlockTest, RowBatchCovertToBlock) {
         vectorized::DateV2Value<doris::vectorized::DateV2ValueType> date_v2_value;
         std::string now_date("2020-12-02");
         date_v2_value.from_date_str(now_date.c_str(), now_date.size());
-        date_v2_value.date_add_interval(time_interval, vectorized::TimeUnit::DAY, date_v2_value);
+        date_v2_value.date_add_interval<vectorized::TimeUnit::DAY>(time_interval);
 
         EXPECT_EQ(k8, date_v2_value);
 


### PR DESCRIPTION
# Proposed changes

This also resolves clang building problem which introduced by PR #11085

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
