### PR TITLE
[fix](fe_plugins) update fe plugins' dependency to fe 1.0-SNAPSHOT

### DIFF
--- a/docs/en/docs/ecosystem/audit-plugin.md
+++ b/docs/en/docs/ecosystem/audit-plugin.md
@@ -58,7 +58,7 @@ After deployment is complete, and before installing the plugin, you need to crea
 create table doris_audit_tbl__
 (
     query_id varchar(48) comment "Unique query id",
-    time datetime not null comment "Query start time",
+    `time` datetime not null comment "Query start time",
     client_ip varchar(32) comment "Client IP",
     user varchar(64) comment "User name",
     db varchar(96) comment "Database of this query",
@@ -76,8 +76,8 @@ create table doris_audit_tbl__
     peak_memory_bytes bigint comment "Peak memory bytes used on all backends of this query",
     stmt string comment "The original statement, trimed if longer than 2G"
 ) engine=OLAP
-duplicate key(query_id, time, client_ip)
-partition by range(time) ()
+duplicate key(query_id, `time`, client_ip)
+partition by range(`time`) ()
 distributed by hash(query_id) buckets 1
 properties(
     "dynamic_partition.time_unit" = "DAY",

--- a/docs/zh-CN/docs/ecosystem/audit-plugin.md
+++ b/docs/zh-CN/docs/ecosystem/audit-plugin.md
@@ -58,7 +58,7 @@ auditloader plugin的配置位于`${DORIS}/fe_plugins/auditloader/src/main/assem
 create table doris_audit_tbl__
 (
     query_id varchar(48) comment "Unique query id",
-    time datetime not null comment "Query start time",
+    `time` datetime not null comment "Query start time",
     client_ip varchar(32) comment "Client IP",
     user varchar(64) comment "User name",
     db varchar(96) comment "Database of this query",
@@ -76,8 +76,8 @@ create table doris_audit_tbl__
     peak_memory_bytes bigint comment "Peak memory bytes used on all backends of this query",
     stmt string comment "The original statement, trimed if longer than 2G "
 ) engine=OLAP
-duplicate key(query_id, time, client_ip)
-partition by range(time) ()
+duplicate key(query_id, `time`, client_ip)
+partition by range(`time`) ()
 distributed by hash(query_id) buckets 1
 properties(
     "dynamic_partition.time_unit" = "DAY",

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/DigitalVersion.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/DigitalVersion.java
@@ -80,7 +80,8 @@ public class DigitalVersion implements Comparable<DigitalVersion> {
             int revision = Integer.parseInt(list[2].trim());
 
             if (major >= 100 || minor >= 100 || revision >= 100) {
-                throw new IllegalArgumentException("Illegal version format: " + version);
+                throw new IllegalArgumentException(
+                        "Illegal version format: " + version + ". Expected: major.minor.revision");
             }
 
             return new DigitalVersion((byte) major, (byte) minor, (byte) revision);

--- a/fe_plugins/auditloader/src/main/assembly/plugin.properties
+++ b/fe_plugins/auditloader/src/main/assembly/plugin.properties
@@ -18,6 +18,6 @@
 name=AuditLoader
 type=AUDIT
 description=load audit log to olap load, and user can view the statistic of queries
-version=0.13.1
+version=1.0.0
 java.version=1.8.0
 classname=org.apache.doris.plugin.audit.AuditLoaderPlugin

--- a/fe_plugins/auditloader/src/main/java/org/apache/doris/plugin/audit/DorisStreamLoader.java
+++ b/fe_plugins/auditloader/src/main/java/org/apache/doris/plugin/audit/DorisStreamLoader.java
@@ -69,7 +69,7 @@ public class DorisStreamLoader {
 
         conn.addRequestProperty("label", label);
         conn.addRequestProperty("max_filter_ratio", "1.0");
-        conn.addRequestProperty("columns", "query_id, time, client_ip, user, db, state, query_time, scan_bytes," +
+        conn.addRequestProperty("columns", "query_id, `time`, client_ip, user, db, state, query_time, scan_bytes," +
                 " scan_rows, return_rows, stmt_id, is_query, frontend_ip, cpu_time_ms, sql_hash, sql_digest, peak_memory_bytes, stmt");
 
         conn.setDoOutput(true);

--- a/fe_plugins/pom.xml
+++ b/fe_plugins/pom.xml
@@ -68,7 +68,7 @@ under the License.
     </modules>
     <properties>
         <log4j2.version>2.17.1</log4j2.version>
-        <doris.version>0.15-SNAPSHOT</doris.version>
+        <doris.version>1.0-SNAPSHOT</doris.version>
         <project.scm.id>github</project.scm.id>
     </properties>
     <profiles>
@@ -92,6 +92,21 @@ under the License.
                     <url>${env.CUSTOM_MAVEN_REPO}</url>
                 </pluginRepository>
             </pluginRepositories>
+        </profile>
+        <profile>
+            <id>general-env</id>
+            <activation>
+                <property>
+                    <name>!env.CUSTOM_MAVEN_REPO</name>
+                </property>
+            </activation>
+            <repositories>
+                <!-- for java-cup -->
+                <repository>
+                    <id>cloudera-public</id>
+                    <url>https://repository.cloudera.com/artifactory/public/</url>
+                </repository>
+            </repositories>
         </profile>
     </profiles>
     <dependencyManagement>


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

the fe 0.15-SNAPSHOT does not contains the newly added field for audit log such as sqlHash.
Upgrade it to 1.0-SNAPSHOT

And the 1.0-SNAPSHOT has been deployed:
https://repository.apache.org/content/repositories/snapshots/org/apache/doris/fe-common/1.0-SNAPSHOT/

## Checklist(Required)

1. Does it affect the original behavior: (No)
2. Has unit tests been added: (No Need)
3. Has document been added or modified: (No Need)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
