### PR TITLE
[Optimize](page cache): bypass page cache during compaction

### DIFF
--- a/be/src/olap/merger.cpp
+++ b/be/src/olap/merger.cpp
@@ -41,8 +41,9 @@ Status Merger::merge_rowsets(TabletSharedPtr tablet, ReaderType reader_type,
     reader_params.reader_type = reader_type;
     reader_params.rs_readers = src_rowset_readers;
     reader_params.version = dst_rowset_writer->version();
-
     reader_params.tablet_schema = cur_tablet_schema;
+    reader_params.use_page_cache = false; // shouldn't use page cache
+
     RETURN_NOT_OK(reader.init(reader_params));
 
     RowCursor row_cursor;
@@ -103,6 +104,7 @@ Status Merger::vmerge_rowsets(TabletSharedPtr tablet, ReaderType reader_type,
     reader_params.rs_readers = src_rowset_readers;
     reader_params.version = dst_rowset_writer->version();
     reader_params.tablet_schema = cur_tablet_schema;
+    reader_params.use_page_cache = false; // shouldn't use page cache
 
     const auto& schema = *cur_tablet_schema;
     reader_params.return_columns.resize(schema.num_columns());

--- a/be/src/olap/rowset/beta_rowset.cpp
+++ b/be/src/olap/rowset/beta_rowset.cpp
@@ -69,7 +69,8 @@ Status BetaRowset::do_load(bool /*use_cache*/) {
     return Status::OK();
 }
 
-Status BetaRowset::load_segments(std::vector<segment_v2::SegmentSharedPtr>* segments) {
+Status BetaRowset::load_segments(std::vector<segment_v2::SegmentSharedPtr>* segments,
+                                 bool use_page_cache) {
     auto fs = _rowset_meta->fs();
     if (!fs || _schema == nullptr) {
         return Status::OLAPInternalError(OLAP_ERR_INIT_FAILED);
@@ -77,7 +78,7 @@ Status BetaRowset::load_segments(std::vector<segment_v2::SegmentSharedPtr>* segm
     for (int seg_id = 0; seg_id < num_segments(); ++seg_id) {
         auto seg_path = segment_file_path(seg_id);
         std::shared_ptr<segment_v2::Segment> segment;
-        auto s = segment_v2::Segment::open(fs, seg_path, seg_id, _schema, &segment);
+        auto s = segment_v2::Segment::open(fs, seg_path, seg_id, _schema, &segment, use_page_cache);
         if (!s.ok()) {
             LOG(WARNING) << "failed to open segment. " << seg_path << " under rowset "
                          << unique_id() << " : " << s.to_string();

--- a/be/src/olap/rowset/beta_rowset.h
+++ b/be/src/olap/rowset/beta_rowset.h
@@ -70,7 +70,7 @@ public:
 
     bool check_file_exist() override;
 
-    Status load_segments(std::vector<segment_v2::SegmentSharedPtr>* segments);
+    Status load_segments(std::vector<segment_v2::SegmentSharedPtr>* segments, bool use_page_cache);
 
 protected:
     BetaRowset(const TabletSchema* schema, const std::string& tablet_path,

--- a/be/src/olap/rowset/beta_rowset_reader.cpp
+++ b/be/src/olap/rowset/beta_rowset_reader.cpp
@@ -88,7 +88,7 @@ Status BetaRowsetReader::init(RowsetReaderContext* read_context) {
     // load segments
     RETURN_NOT_OK(SegmentLoader::instance()->load_segments(
             _rowset, &_segment_cache_handle,
-            read_context->reader_type == ReaderType::READER_QUERY));
+            read_context->reader_type == ReaderType::READER_QUERY && read_options.use_page_cache));
 
     // create iterator for each segment
     std::vector<std::unique_ptr<RowwiseIterator>> seg_iterators;

--- a/be/src/olap/rowset/segment_v2/column_reader.h
+++ b/be/src/olap/rowset/segment_v2/column_reader.h
@@ -61,6 +61,8 @@ struct ColumnReaderOptions {
     bool verify_checksum = true;
     // for in memory olap table, use DURABLE CachePriority in page cache
     bool kept_in_memory = false;
+    // for compaction will set to false as earlier as possible
+    bool use_page_cache = true;
 };
 
 struct ColumnIteratorOptions {
@@ -154,7 +156,7 @@ private:
     // May be called multiple times, subsequent calls will no op.
     Status _ensure_index_loaded() {
         return _load_index_once.call([this] {
-            bool use_page_cache = !config::disable_storage_page_cache;
+            bool use_page_cache = !config::disable_storage_page_cache && _opts.use_page_cache;
             RETURN_IF_ERROR(_load_zone_map_index(use_page_cache, _opts.kept_in_memory));
             RETURN_IF_ERROR(_load_ordinal_index(use_page_cache, _opts.kept_in_memory));
             RETURN_IF_ERROR(_load_bitmap_index(use_page_cache, _opts.kept_in_memory));

--- a/be/src/olap/rowset/segment_v2/segment.h
+++ b/be/src/olap/rowset/segment_v2/segment.h
@@ -62,7 +62,8 @@ using SegmentSharedPtr = std::shared_ptr<Segment>;
 class Segment : public std::enable_shared_from_this<Segment> {
 public:
     static Status open(io::FileSystem* fs, const std::string& path, uint32_t segment_id,
-                       const TabletSchema* tablet_schema, std::shared_ptr<Segment>* output);
+                       const TabletSchema* tablet_schema, std::shared_ptr<Segment>* output,
+                       bool use_page_cache);
 
     ~Segment();
 
@@ -108,7 +109,7 @@ public:
 
 private:
     DISALLOW_COPY_AND_ASSIGN(Segment);
-    Segment(uint32_t segment_id, const TabletSchema* tablet_schema);
+    Segment(uint32_t segment_id, const TabletSchema* tablet_schema, bool use_page_cache);
     // open segment file and read the minimum amount of necessary information (footer)
     Status _open();
     Status _parse_footer();
@@ -123,7 +124,7 @@ private:
 
     uint32_t _segment_id;
     TabletSchema _tablet_schema;
-
+    bool _use_page_cache;
     // This mem tracker is only for tracking memory use by segment meta data such as footer or index page.
     // The memory consumed by querying is tracked in segment iterator.
     std::shared_ptr<MemTracker> _mem_tracker;

--- a/be/src/olap/segment_loader.cpp
+++ b/be/src/olap/segment_loader.cpp
@@ -68,7 +68,7 @@ Status SegmentLoader::load_segments(const BetaRowsetSharedPtr& rowset,
     cache_handle->owned = !use_cache;
 
     std::vector<segment_v2::SegmentSharedPtr> segments;
-    RETURN_NOT_OK(rowset->load_segments(&segments));
+    RETURN_NOT_OK(rowset->load_segments(&segments, use_cache));
 
     if (use_cache) {
         // memory of SegmentLoader::CacheValue will be handled by SegmentLoader

--- a/be/test/olap/rowset/beta_rowset_test.cpp
+++ b/be/test/olap/rowset/beta_rowset_test.cpp
@@ -445,7 +445,7 @@ TEST_F(BetaRowsetTest, ReadTest) {
         rowset.rowset_meta()->set_fs(fs);
 
         std::vector<segment_v2::SegmentSharedPtr> segments;
-        Status st = rowset.load_segments(&segments);
+        Status st = rowset.load_segments(&segments, true);
         ASSERT_FALSE(st.ok());
     }
 
@@ -460,7 +460,7 @@ TEST_F(BetaRowsetTest, ReadTest) {
         rowset.rowset_meta()->set_fs(fs);
 
         std::vector<segment_v2::SegmentSharedPtr> segments;
-        Status st = rowset.load_segments(&segments);
+        Status st = rowset.load_segments(&segments, true);
         ASSERT_FALSE(st.ok());
     }
 
@@ -475,7 +475,7 @@ TEST_F(BetaRowsetTest, ReadTest) {
         rowset.rowset_meta()->set_fs(fs);
 
         std::vector<segment_v2::SegmentSharedPtr> segments;
-        Status st = rowset.load_segments(&segments);
+        Status st = rowset.load_segments(&segments, true);
         ASSERT_FALSE(st.ok());
     }
 

--- a/be/test/olap/rowset/segment_v2/segment_test.cpp
+++ b/be/test/olap/rowset/segment_v2/segment_test.cpp
@@ -141,7 +141,7 @@ protected:
         EXPECT_TRUE(st.ok());
         EXPECT_TRUE(file_writer->close().ok());
 
-        st = Segment::open(fs, path, 0, &query_schema, res);
+        st = Segment::open(fs, path, 0, &query_schema, res, true);
         EXPECT_TRUE(st.ok());
         EXPECT_EQ(nrows, (*res)->num_rows());
     }
@@ -831,7 +831,7 @@ TEST_F(SegmentReaderWriterTest, TestStringDict) {
 
     {
         std::shared_ptr<Segment> segment;
-        st = Segment::open(fs, fname, 0, tablet_schema.get(), &segment);
+        st = Segment::open(fs, fname, 0, tablet_schema.get(), &segment, true);
         EXPECT_TRUE(st.ok());
         EXPECT_EQ(4096, segment->num_rows());
         Schema schema(*tablet_schema);


### PR DESCRIPTION

# Proposed changes

Issue Number: close #xxx

## Problem Summary:
This PR help bypass the page cache during compaction. Before this , the index page cache and segment cache will be polluted during compaction, which would lead to query latency shaking when under high load of compaction. 


## Checklist(Required)

1. Does it affect the original behavior: (No)
2. Has unit tests been added: (No Need)
3. Has document been added or modified: (No Need)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
