### PR TITLE
[feature] (Nereids) add rule to push down predicate through aggregate

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/RuleType.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/RuleType.java
@@ -41,6 +41,7 @@ public enum RuleType {
     COLUMN_PRUNE_PROJECTION(RuleTypeClass.REWRITE),
     // predicate push down rules
     PUSH_DOWN_PREDICATE_THROUGH_JOIN(RuleTypeClass.REWRITE),
+    PUSH_DOWN_PREDICATE_THROUGH_AGGREGATION(RuleTypeClass.REWRITE),
     // column prune rules,
     COLUMN_PRUNE_AGGREGATION_CHILD(RuleTypeClass.REWRITE),
     COLUMN_PRUNE_FILTER_CHILD(RuleTypeClass.REWRITE),

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/logical/PushPredicateThroughAggregation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/logical/PushPredicateThroughAggregation.java
@@ -1,0 +1,111 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.rules.rewrite.logical;
+
+import org.apache.doris.nereids.rules.Rule;
+import org.apache.doris.nereids.rules.RuleType;
+import org.apache.doris.nereids.rules.rewrite.OneRewriteRuleFactory;
+import org.apache.doris.nereids.trees.expressions.Expression;
+import org.apache.doris.nereids.trees.expressions.Slot;
+import org.apache.doris.nereids.trees.expressions.visitor.SlotExtractor;
+import org.apache.doris.nereids.trees.plans.GroupPlan;
+import org.apache.doris.nereids.trees.plans.Plan;
+import org.apache.doris.nereids.trees.plans.logical.LogicalAggregate;
+import org.apache.doris.nereids.trees.plans.logical.LogicalFilter;
+import org.apache.doris.nereids.util.ExpressionUtils;
+
+import com.google.common.collect.Lists;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+
+/**
+ * Push the predicate in the LogicalFilter to the aggregate child.
+ * For example:
+ * Logical plan tree:
+ *                 any_node
+ *                   |
+ *                filter (a>0 and b>0)
+ *                   |
+ *                group by(a, c)
+ *                   |
+ *                 scan
+ * transformed to:
+ *                 project
+ *                   |
+ *              upper filter (b>0)
+ *                   |
+ *                group by(a, c)
+ *                   |
+ *              bottom filter (a>0)
+ *                   |
+ *                 scan
+ * Note:
+ * 1. 'a>0' could be push down, because 'a' is in group by keys;
+ *    but 'b>0' could not push down, because 'b' is not in group by keys.
+ * 2. filter (a>0) ---> group by (a+1), 'a>0' cannot be pushed down
+ *
+ */
+
+public class PushPredicateThroughAggregation extends OneRewriteRuleFactory {
+
+    @Override
+    public Rule build() {
+        return logicalFilter(logicalAggregate()).then(filter -> {
+            LogicalAggregate<GroupPlan> aggregate = filter.child();
+            Set<Slot> groupBySlots = new HashSet<>();
+            for (Expression groupByExpression : aggregate.getGroupByExpressionList()) {
+                if (groupByExpression instanceof Slot) {
+                    groupBySlots.add((Slot) groupByExpression);
+                }
+            }
+            List<Expression> pushDownPredicates = Lists.newArrayList();
+            List<Expression> filterPredicates = Lists.newArrayList();
+            ExpressionUtils.extractConjunct(filter.getPredicates()).forEach(conjunct -> {
+                Set<Slot> conjunctSlots = SlotExtractor.extractSlot(conjunct);
+                if (groupBySlots.containsAll(conjunctSlots)) {
+                    pushDownPredicates.add(conjunct);
+                } else {
+                    //TODO here
+                    filterPredicates.add(conjunct);
+                }
+            });
+
+            return pushDownPredicate(filter, aggregate, pushDownPredicates, filterPredicates);
+        }).toRule(RuleType.PUSH_DOWN_PREDICATE_THROUGH_AGGREGATION);
+    }
+
+    private Plan pushDownPredicate(LogicalFilter filter, LogicalAggregate aggregate,
+                                   List<Expression> pushDownPredicates, List<Expression> filterPredicates) {
+        Plan root;
+        if (filterPredicates.isEmpty()) {
+            //all predicates are pushed down, just exchange filter and aggregate
+            LogicalFilter bottomFilter = new LogicalFilter(ExpressionUtils.and(pushDownPredicates),
+                    (Plan) aggregate.child(0));
+            root = aggregate.withChildren(Lists.newArrayList(bottomFilter));
+        } else {
+            LogicalFilter bottomFilter = new LogicalFilter(ExpressionUtils.and(pushDownPredicates),
+                    (Plan) aggregate.child(0));
+            aggregate = aggregate.withChildren(Lists.newArrayList(bottomFilter));
+            root = new LogicalFilter<>(ExpressionUtils.and(filterPredicates), aggregate);
+        }
+        return root;
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/logical/PushPredicateThroughAggregation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/logical/PushPredicateThroughAggregation.java
@@ -82,7 +82,6 @@ public class PushPredicateThroughAggregation extends OneRewriteRuleFactory {
                 if (groupBySlots.containsAll(conjunctSlots)) {
                     pushDownPredicates.add(conjunct);
                 } else {
-                    //TODO here
                     filterPredicates.add(conjunct);
                 }
             });

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/logical/PushPredicateThroughAggregation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/logical/PushPredicateThroughAggregation.java
@@ -58,9 +58,8 @@ import java.util.Set;
  *                   |
  *                 scan
  * Note:
- * 1. 'a>0' could be push down, because 'a' is in group by keys;
+ *    'a>0' could be push down, because 'a' is in group by keys;
  *    but 'b>0' could not push down, because 'b' is not in group by keys.
- * 2. filter (a>0) ---> group by (a+1), 'a>0' cannot be pushed down
  *
  */
 

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/logical/PushDownPredicateThroughAggregationTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/logical/PushDownPredicateThroughAggregationTest.java
@@ -1,0 +1,202 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.rules.rewrite.logical;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import org.apache.doris.analysis.IntLiteral;
+import org.apache.doris.catalog.AggregateType;
+import org.apache.doris.catalog.Column;
+import org.apache.doris.catalog.Table;
+import org.apache.doris.catalog.Type;
+import org.apache.doris.nereids.memo.Group;
+import org.apache.doris.nereids.memo.GroupExpression;
+import org.apache.doris.nereids.memo.Memo;
+import org.apache.doris.nereids.trees.expressions.*;
+import org.apache.doris.nereids.trees.plans.Plan;
+import org.apache.doris.nereids.trees.plans.logical.LogicalAggregate;
+import org.apache.doris.nereids.trees.plans.logical.LogicalFilter;
+import org.apache.doris.nereids.trees.plans.logical.LogicalOlapScan;
+import org.apache.doris.nereids.trees.plans.logical.LogicalProject;
+import org.apache.doris.nereids.util.ExpressionUtils;
+import org.apache.doris.nereids.util.PlanRewriter;
+import org.apache.doris.planner.OlapScanNode;
+import org.apache.doris.qe.ConnectContext;
+import org.apache.spark.sql.catalyst.expressions.Exp;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
+
+import java.util.List;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class PushDownPredicateThroughAggregationTest {
+
+     /**
+     * origin plan:
+     *                project
+     *                  |
+     *                filter gender=1
+     *                  |
+     *               aggregation group by gender
+     *                  |
+     *               scan(student)
+     *
+     *  transformed plan:
+     *                project
+     *                  |
+     *               aggregation group by gender
+     *                  |
+     *               filter gender=1
+     *                  |
+     *               scan(student)
+     */
+    @Test
+    public void pushDownPredicateOneFilterTest(){
+        Table student = new Table(0L, "student", Table.TableType.OLAP,
+                ImmutableList.<Column>of(new Column("id", Type.INT, true, AggregateType.NONE, "0", ""),
+                        new Column("gender", Type.INT, false, AggregateType.NONE, "0", ""),
+                        new Column("name", Type.STRING, true, AggregateType.NONE, "", ""),
+                        new Column("age", Type.INT, true, AggregateType.NONE, "", "")));
+        Plan scan = new LogicalOlapScan(student, ImmutableList.of("student"));
+        Slot gender = scan.getOutput().get(1);
+        Slot name = scan.getOutput().get(2);
+        Slot age = scan.getOutput().get(3);
+
+        List<Expression> groupByKeys = Lists.newArrayList(age, gender);
+        List<NamedExpression> outputExpressionList = Lists.newArrayList(gender, age);
+        Plan aggregation = new LogicalAggregate<>(groupByKeys, outputExpressionList, scan);
+        Expression filterPredicate = new GreaterThan(gender, Literal.of(1));
+        LogicalFilter filter = new LogicalFilter(filterPredicate, aggregation);
+        Plan root = new LogicalProject<>(
+                Lists.newArrayList(gender),
+                filter
+        );
+
+        Memo memo = rewrite(root);
+        System.out.println(memo.copyOut().treeString());
+        Group rootGroup = memo.getRoot();
+
+        GroupExpression groupExpression = rootGroup
+                .getLogicalExpression().child(0)
+                .getLogicalExpression();
+        aggregation = groupExpression.getPlan();
+        Assert.assertTrue(aggregation instanceof LogicalAggregate);
+
+        groupExpression = groupExpression.child(0).getLogicalExpression();
+        Plan bottomFilter = groupExpression.getPlan();
+        Assert.assertTrue(bottomFilter instanceof LogicalFilter);
+        Expression greater = ((LogicalFilter<?>) bottomFilter).getPredicates();
+        Assert.assertEquals(ExpressionType.GREATER_THAN, greater.getType());
+        Assert.assertTrue(greater.child(0) instanceof Slot);
+        Assert.assertEquals("gender",((Slot) greater.child(0)).getName());
+
+        groupExpression = groupExpression.child(0).getLogicalExpression();
+        Plan scan2 = groupExpression.getPlan();
+        Assert.assertTrue(scan2 instanceof LogicalOlapScan);
+    }
+
+    /**
+     * origin plan:
+     *                project
+     *                  |
+     *                filter gender=1 and name="abc" and (gender+10)<100
+     *                  |
+     *               aggregation group by gender
+     *                  |
+     *               scan(student)
+     *
+     *  transformed plan:
+     *                project
+     *                  |
+     *                filter name="abc"
+     *                  |
+     *               aggregation group by gender
+     *                  |
+     *               filter gender=1 and  and (gender+10)<100
+     *                  |
+     *               scan(student)
+     */
+    @Test
+    public void pushDownPredicateTwoFilterTest(){
+        Table student = new Table(0L, "student", Table.TableType.OLAP,
+                ImmutableList.<Column>of(new Column("id", Type.INT, true, AggregateType.NONE, "0", ""),
+                        new Column("gender", Type.INT, false, AggregateType.NONE, "0", ""),
+                        new Column("name", Type.STRING, true, AggregateType.NONE, "", ""),
+                        new Column("age", Type.INT, true, AggregateType.NONE, "", "")));
+        Plan scan = new LogicalOlapScan(student, ImmutableList.of("student"));
+        Slot gender = scan.getOutput().get(1);
+        Slot name = scan.getOutput().get(2);
+        Slot age = scan.getOutput().get(3);
+
+        List<Expression> groupByKeys = Lists.newArrayList(age, gender);
+        List<NamedExpression> outputExpressionList = Lists.newArrayList(gender, age);
+        Plan aggregation = new LogicalAggregate<>(groupByKeys, outputExpressionList, scan);
+        Expression filterPredicate = ExpressionUtils.and(
+                new GreaterThan(gender, Literal.of(1)),
+                new LessThanEqual(
+                        new Add(
+                                gender,
+                                Literal.of(10)
+                        ),
+                        Literal.of(100)
+                ),
+                new EqualTo(name, Literal.of("abc"))
+        );
+        LogicalFilter filter = new LogicalFilter(filterPredicate, aggregation);
+        Plan root = new LogicalProject<>(
+                Lists.newArrayList(gender),
+                filter
+        );
+
+        Memo memo = rewrite(root);
+        System.out.println(memo.copyOut().treeString());
+        Group rootGroup = memo.getRoot();
+        GroupExpression groupExpression = rootGroup.getLogicalExpression().child(0).getLogicalExpression();
+        Plan upperFilter = groupExpression.getPlan();
+        Assert.assertTrue(upperFilter instanceof LogicalFilter);
+        Expression upperPredicates = ((LogicalFilter<?>) upperFilter).getPredicates();
+        Assert.assertEquals(ExpressionType.EQUAL_TO, upperPredicates.getType());
+        Assert.assertTrue(upperPredicates.child(0) instanceof Slot);
+        groupExpression = groupExpression.child(0).getLogicalExpression();aggregation = groupExpression.getPlan();
+        Assert.assertTrue(aggregation instanceof LogicalAggregate);
+
+        groupExpression = groupExpression.child(0).getLogicalExpression();
+        Plan bottomFilter = groupExpression.getPlan();
+        Assert.assertTrue(bottomFilter instanceof LogicalFilter);
+        Expression bottomPredicates = ((LogicalFilter<?>) bottomFilter).getPredicates();
+        Assert.assertEquals(ExpressionType.AND, bottomPredicates.getType());
+        Assert.assertEquals(2, bottomPredicates.children().size());
+        Expression greater = bottomPredicates.child(0);
+        Assert.assertEquals(ExpressionType.GREATER_THAN, greater.getType());
+        Assert.assertTrue(greater.child(0) instanceof Slot);
+        Assert.assertEquals("gender",((Slot) greater.child(0)).getName());
+        Expression less = bottomPredicates.child(1);
+        Assert.assertEquals(ExpressionType.LESS_THAN_EQUAL, less.getType());
+        Assert.assertEquals(ExpressionType.ADD, less.child(0).getType());
+
+        groupExpression = groupExpression.child(0).getLogicalExpression();
+        Plan scan2 = groupExpression.getPlan();
+        Assert.assertTrue(scan2 instanceof LogicalOlapScan);
+    }
+    private Memo rewrite(Plan plan) {
+        return PlanRewriter.topDownRewriteMemo(plan, new ConnectContext(), new PushPredicateThroughAggregation());
+    }
+}


### PR DESCRIPTION
# Proposed changes
add rule to push predicates down to aggregation node
1. add PushDownPredicatesThroughAggregation.java
2. add ut for PushDownPredicatesThroughAggregation

  For example:
```
  Logical plan tree:
                  any_node
                    |
                 filter (a>0 and b>0)
                    |
                 group by(a, c)
                    |
                  scan
```
 transformed to:
```
                  project
                    |
               upper filter (b>0)
                    |
                 group by(a, c)
                    |
               bottom filter (a>0)
                    |
                  scan
```
  Note:
    'a>0' could be push down, because 'a' is in group by keys;
    but 'b>0' could not push down, because 'b' is not in group by keys.

 
Issue Number: close #xxx

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
4. Has unit tests been added: (Yes/No/No Need)
5. Has document been added or modified: (Yes/No/No Need)
6. Does it need to update dependencies: (Yes/No)
7. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
