### PR TITLE
[bugfix] fix coredump caused by wrong type cast of OlapScanNode

### DIFF
--- a/be/src/exec/exec_node.cpp
+++ b/be/src/exec/exec_node.cpp
@@ -669,7 +669,7 @@ void ExecNode::try_do_aggregate_serde_improve() {
         return;
     }
 
-    OlapScanNode* scan_node = static_cast<OlapScanNode*>(agg_node[0]->_children[0]);
+    ScanNode* scan_node = static_cast<ScanNode*>(agg_node[0]->_children[0]);
     scan_node->set_no_agg_finalize();
 }
 

--- a/be/src/exec/olap_scan_node.h
+++ b/be/src/exec/olap_scan_node.h
@@ -55,7 +55,6 @@ public:
     Status collect_query_statistics(QueryStatistics* statistics) override;
     Status close(RuntimeState* state) override;
     Status set_scan_ranges(const std::vector<TScanRangeParams>& scan_ranges) override;
-    void set_no_agg_finalize() { _need_agg_finalize = false; }
     Status get_hints(TabletSharedPtr table, const TPaloScanRange& scan_range, int block_row_count,
                      bool is_begin_include, bool is_end_include,
                      const std::vector<std::unique_ptr<OlapScanRange>>& scan_key_range,
@@ -266,8 +265,6 @@ protected:
     // Count the memory consumption of Rowset Reader and Tablet Reader in OlapScanner.
     std::unique_ptr<MemTracker> _scanner_mem_tracker;
     EvalConjunctsFn _eval_conjuncts_fn;
-
-    bool _need_agg_finalize = true;
 
     // the max num of scan keys of this scan request.
     // it will set as BE's config `doris_max_scan_key_num`,

--- a/be/src/exec/scan_node.h
+++ b/be/src/exec/scan_node.h
@@ -81,6 +81,8 @@ public:
 
     bool is_scan_node() const override { return true; }
 
+    void set_no_agg_finalize() { _need_agg_finalize = false; }
+
     RuntimeProfile::Counter* bytes_read_counter() const { return _bytes_read_counter; }
     RuntimeProfile::Counter* rows_read_counter() const { return _rows_read_counter; }
     RuntimeProfile::Counter* total_throughput_counter() const { return _total_throughput_counter; }
@@ -102,6 +104,9 @@ protected:
     // Wall based aggregate read throughput [bytes/sec]
     RuntimeProfile::Counter* _total_throughput_counter;
     RuntimeProfile::Counter* _num_disks_accessed_counter;
+
+protected:
+    bool _need_agg_finalize = true;
 };
 
 } // namespace doris


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

Type cast of OlapScanNode is wrong in `ExecNode::try_do_aggregate_serde_improve()`:
`OlapScanNode* scan_node = static_cast<OlapScanNode*>(agg_node[0]->_children[0]);`

which will result in memory corruption.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
