### PR TITLE
[RegressionTest][Array] Fix the bug of regression of array test:

### DIFF
--- a/be/src/vec/data_types/data_type_array.cpp
+++ b/be/src/vec/data_types/data_type_array.cpp
@@ -168,7 +168,14 @@ Status DataTypeArray::from_string(ReadBuffer& rb, IColumn* column) const {
             temp_char = rb.position() + nested_str_len;
         }
 
+        // dispose the case of ["123"] or ['123']
         ReadBuffer read_buffer(rb.position(), nested_str_len);
+        auto begin_char = *rb.position();
+        auto end_char = *(rb.position() + nested_str_len - 1);
+        if (begin_char == end_char && (begin_char == '"' || begin_char == '\'')) {
+            read_buffer = ReadBuffer(rb.position() + 1, nested_str_len - 2);
+        }
+
         auto st = nested->from_string(read_buffer, &nested_column);
         if (!st.ok()) {
             // we should do revert if error

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Type.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Type.java
@@ -149,8 +149,8 @@ public abstract class Type {
         supportedTypes.add(QUANTILE_STATE);
 
         arraySubTypes = Lists.newArrayList();
-        arraySubTypes.addAll(integerTypes);
         arraySubTypes.add(BOOLEAN);
+        arraySubTypes.addAll(integerTypes);
         arraySubTypes.add(FLOAT);
         arraySubTypes.add(DOUBLE);
         arraySubTypes.add(DECIMALV2);


### PR DESCRIPTION
1. [] do not have a proper array nested type, cause BE coredump
2. [abc] or ['abc'] load by vectorized load get error result

# Proposed changes

Issue Number: close #11172

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
