### PR TITLE
always copy data to agg status

### DIFF
--- a/be/src/vec/aggregate_functions/aggregate_function_reader.cpp
+++ b/be/src/vec/aggregate_functions/aggregate_function_reader.cpp
@@ -44,23 +44,19 @@ void register_aggregate_function_replace_reader_load(AggregateFunctionSimpleFact
         factory.register_function(name + suffix, creator, nullable);
     };
 
-    register_function("replace", AGG_READER_SUFFIX, create_aggregate_function_first<false, true>,
-                      false);
-    register_function("replace", AGG_READER_SUFFIX, create_aggregate_function_first<true, true>,
-                      true);
-    register_function("replace", AGG_LOAD_SUFFIX, create_aggregate_function_last<false, false>,
-                      false);
-    register_function("replace", AGG_LOAD_SUFFIX, create_aggregate_function_last<true, false>,
-                      true);
+    register_function("replace", AGG_READER_SUFFIX, create_aggregate_function_first<false>, false);
+    register_function("replace", AGG_READER_SUFFIX, create_aggregate_function_first<true>, true);
+    register_function("replace", AGG_LOAD_SUFFIX, create_aggregate_function_last<false>, false);
+    register_function("replace", AGG_LOAD_SUFFIX, create_aggregate_function_last<true>, true);
 
     register_function("replace_if_not_null", AGG_READER_SUFFIX,
-                      create_aggregate_function_first_non_null_value<false, true>, false);
+                      create_aggregate_function_first_non_null_value<false>, false);
     register_function("replace_if_not_null", AGG_READER_SUFFIX,
-                      create_aggregate_function_first_non_null_value<true, true>, true);
+                      create_aggregate_function_first_non_null_value<true>, true);
     register_function("replace_if_not_null", AGG_LOAD_SUFFIX,
-                      create_aggregate_function_last_non_null_value<false, false>, false);
+                      create_aggregate_function_last_non_null_value<false>, false);
     register_function("replace_if_not_null", AGG_LOAD_SUFFIX,
-                      create_aggregate_function_last_non_null_value<true, false>, true);
+                      create_aggregate_function_last_non_null_value<true>, true);
 }
 
 } // namespace doris::vectorized

--- a/be/src/vec/aggregate_functions/aggregate_function_window.cpp
+++ b/be/src/vec/aggregate_functions/aggregate_function_window.cpp
@@ -94,10 +94,10 @@ void register_aggregate_function_window_lead_lag(AggregateFunctionSimpleFactory&
     factory.register_function("lead", create_aggregate_function_lead<true>, true);
     factory.register_function("lag", create_aggregate_function_lag<false>);
     factory.register_function("lag", create_aggregate_function_lag<true>, true);
-    factory.register_function("first_value", create_aggregate_function_first<false, false>);
-    factory.register_function("first_value", create_aggregate_function_first<true, false>, true);
-    factory.register_function("last_value", create_aggregate_function_last<false, false>);
-    factory.register_function("last_value", create_aggregate_function_last<true, false>, true);
+    factory.register_function("first_value", create_aggregate_function_first<false>);
+    factory.register_function("first_value", create_aggregate_function_first<true>, true);
+    factory.register_function("last_value", create_aggregate_function_last<false>);
+    factory.register_function("last_value", create_aggregate_function_last<true>, true);
 }
 
 } // namespace doris::vectorized

--- a/be/src/vec/aggregate_functions/aggregate_function_window.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_window.h
@@ -527,7 +527,7 @@ private:
 };
 
 template <template <typename> class AggregateFunctionTemplate, template <typename> class Data,
-          bool result_is_nullable, bool is_copy = false>
+          bool result_is_nullable, bool is_copy = true>
 static IAggregateFunction* create_function_single_value(const String& name,
                                                         const DataTypes& argument_types,
                                                         const Array& parameters) {
@@ -570,7 +570,7 @@ static IAggregateFunction* create_function_single_value(const String& name,
     return nullptr;
 }
 
-template <bool is_nullable, bool is_copy>
+template <bool is_nullable, bool is_copy = true>
 AggregateFunctionPtr create_aggregate_function_first(const std::string& name,
                                                      const DataTypes& argument_types,
                                                      const Array& parameters,
@@ -580,7 +580,7 @@ AggregateFunctionPtr create_aggregate_function_first(const std::string& name,
                                          is_copy>(name, argument_types, parameters));
 }
 
-template <bool is_nullable, bool is_copy>
+template <bool is_nullable, bool is_copy = true>
 AggregateFunctionPtr create_aggregate_function_first_non_null_value(const std::string& name,
                                                                     const DataTypes& argument_types,
                                                                     const Array& parameters,
@@ -590,7 +590,7 @@ AggregateFunctionPtr create_aggregate_function_first_non_null_value(const std::s
                                          is_nullable, is_copy>(name, argument_types, parameters));
 }
 
-template <bool is_nullable, bool is_copy>
+template <bool is_nullable, bool is_copy = true>
 AggregateFunctionPtr create_aggregate_function_last(const std::string& name,
                                                     const DataTypes& argument_types,
                                                     const Array& parameters,
@@ -600,7 +600,7 @@ AggregateFunctionPtr create_aggregate_function_last(const std::string& name,
                                          is_copy>(name, argument_types, parameters));
 }
 
-template <bool is_nullable, bool is_copy>
+template <bool is_nullable, bool is_copy = true>
 AggregateFunctionPtr create_aggregate_function_last_non_null_value(const std::string& name,
                                                                    const DataTypes& argument_types,
                                                                    const Array& parameters,


### PR DESCRIPTION
# Proposed changes

Issue Number: close (https://github.com/apache/doris/issues/11115)

## Problem Summary:

The agg data should always be copided instead of keep a column ptr + row pos. Because the column may be freed later, the agg data would have an invalid ptr.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
