### PR TITLE
[fix] (mem tracker) Fix MemTracker accuracy

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -651,7 +651,7 @@ CONF_Bool(memory_verbose_track, "false");
 // smaller than this value will continue to accumulate. specified as number of bytes.
 // Decreasing this value will increase the frequency of consume/release.
 // Increasing this value will cause MemTracker statistics to be inaccurate.
-CONF_mInt32(mem_tracker_consume_min_size_bytes, "4194304");
+CONF_mInt32(mem_tracker_consume_min_size_bytes, "1048576");
 
 // The version information of the tablet will be stored in the memory
 // in an adjacency graph data structure.

--- a/be/src/exec/broker_scan_node.cpp
+++ b/be/src/exec/broker_scan_node.cpp
@@ -373,6 +373,8 @@ Status BrokerScanNode::scanner_scan(const TBrokerScanRange& scan_range,
 }
 
 void BrokerScanNode::scanner_worker(int start_idx, int length) {
+    SCOPED_ATTACH_TASK(_runtime_state);
+    SCOPED_CONSUME_MEM_TRACKER(mem_tracker());
     // Clone expr context
     std::vector<ExprContext*> scanner_expr_ctxs;
     auto status = Expr::clone_if_not_exists(_conjunct_ctxs, _runtime_state, &scanner_expr_ctxs);

--- a/be/src/exec/es_http_scan_node.cpp
+++ b/be/src/exec/es_http_scan_node.cpp
@@ -419,6 +419,7 @@ static std::string get_host_port(const std::vector<TNetworkAddress>& es_hosts) {
 
 void EsHttpScanNode::scanner_worker(int start_idx, int length, std::promise<Status>& p_status) {
     SCOPED_ATTACH_TASK(_runtime_state);
+    SCOPED_CONSUME_MEM_TRACKER(mem_tracker());
     // Clone expr context
     std::vector<ExprContext*> scanner_expr_ctxs;
     DCHECK(start_idx < length);

--- a/be/src/exec/tablet_sink.cpp
+++ b/be/src/exec/tablet_sink.cpp
@@ -600,7 +600,6 @@ Status IndexChannel::init(RuntimeState* state, const std::vector<TTabletWithPart
 
 void IndexChannel::mark_as_failed(int64_t node_id, const std::string& host, const std::string& err,
                                   int64_t tablet_id) {
-    SCOPED_CONSUME_MEM_TRACKER(_index_channel_tracker.get());
     const auto& it = _tablets_by_channel.find(node_id);
     if (it == _tablets_by_channel.end()) {
         return;

--- a/be/src/http/ev_http_server.cpp
+++ b/be/src/http/ev_http_server.cpp
@@ -33,6 +33,7 @@
 #include "http/http_handler.h"
 #include "http/http_headers.h"
 #include "http/http_request.h"
+#include "runtime/thread_context.h"
 #include "service/brpc.h"
 #include "util/debug_util.h"
 #include "util/threadpool.h"
@@ -98,6 +99,7 @@ void EvHttpServer::start() {
     _event_bases.resize(_num_workers);
     for (int i = 0; i < _num_workers; ++i) {
         CHECK(_workers->submit_func([this, i]() {
+                          thread_context()->_thread_mem_tracker_mgr->set_check_attach(false);
                           std::shared_ptr<event_base> base(event_base_new(), [](event_base* base) {
                               event_base_free(base);
                           });

--- a/be/src/olap/compaction.cpp
+++ b/be/src/olap/compaction.cpp
@@ -43,6 +43,7 @@ Compaction::Compaction(TabletSharedPtr tablet, const std::string& label)
 
 Compaction::~Compaction() {
 #ifndef BE_TEST
+    // Compaction tracker cannot be completely accurate, offset the global impact.
     StorageEngine::instance()->compaction_mem_tracker()->consumption_revise(
             -_mem_tracker->consumption());
 #endif

--- a/be/src/olap/compaction.cpp
+++ b/be/src/olap/compaction.cpp
@@ -41,7 +41,10 @@ Compaction::Compaction(TabletSharedPtr tablet, const std::string& label)
 #endif
 }
 
-Compaction::~Compaction() {}
+Compaction::~Compaction() {
+    StorageEngine::instance()->compaction_mem_tracker()->consumption_revise(
+            -_mem_tracker->consumption());
+}
 
 Status Compaction::compact() {
     RETURN_NOT_OK(prepare_compact());

--- a/be/src/olap/compaction.cpp
+++ b/be/src/olap/compaction.cpp
@@ -42,8 +42,10 @@ Compaction::Compaction(TabletSharedPtr tablet, const std::string& label)
 }
 
 Compaction::~Compaction() {
+#ifndef BE_TEST
     StorageEngine::instance()->compaction_mem_tracker()->consumption_revise(
             -_mem_tracker->consumption());
+#endif
 }
 
 Status Compaction::compact() {

--- a/be/src/olap/delta_writer.cpp
+++ b/be/src/olap/delta_writer.cpp
@@ -30,12 +30,14 @@
 
 namespace doris {
 
-Status DeltaWriter::open(WriteRequest* req, DeltaWriter** writer, bool is_vec) {
-    *writer = new DeltaWriter(req, StorageEngine::instance(), is_vec);
+Status DeltaWriter::open(WriteRequest* req, DeltaWriter** writer, MemTrackerLimiter* parent_tracker,
+                         bool is_vec) {
+    *writer = new DeltaWriter(req, StorageEngine::instance(), parent_tracker, is_vec);
     return Status::OK();
 }
 
-DeltaWriter::DeltaWriter(WriteRequest* req, StorageEngine* storage_engine, bool is_vec)
+DeltaWriter::DeltaWriter(WriteRequest* req, StorageEngine* storage_engine,
+                         MemTrackerLimiter* parent_tracker, bool is_vec)
         : _req(*req),
           _tablet(nullptr),
           _cur_rowset(nullptr),
@@ -43,6 +45,7 @@ DeltaWriter::DeltaWriter(WriteRequest* req, StorageEngine* storage_engine, bool 
           _tablet_schema(new TabletSchema),
           _delta_written_success(false),
           _storage_engine(storage_engine),
+          _parent_tracker(parent_tracker),
           _is_vec(is_vec) {}
 
 DeltaWriter::~DeltaWriter() {
@@ -95,9 +98,9 @@ Status DeltaWriter::init() {
                      << ", schema_hash=" << _req.schema_hash;
         return Status::OLAPInternalError(OLAP_ERR_TABLE_NOT_FOUND);
     }
-
-    _flushed_mem_tracker = std::make_unique<MemTracker>(
-            fmt::format("DeltaWriter:tabletId={}", std::to_string(_tablet->tablet_id())));
+    _mem_tracker = std::make_unique<MemTrackerLimiter>(
+            -1, fmt::format("DeltaWriter:tabletId={}", _tablet->tablet_id()), _parent_tracker);
+    SCOPED_ATTACH_TASK(_mem_tracker.get(), ThreadContext::TaskType::LOAD);
     // check tablet version number
     if (_tablet->version_count() > config::max_tablet_version_num) {
         //trigger quick compaction
@@ -147,7 +150,10 @@ Status DeltaWriter::write(Tuple* tuple) {
         return Status::OLAPInternalError(OLAP_ERR_ALREADY_CANCELLED);
     }
 
+    int64_t prev_memtable_usage = _mem_table->memory_usage();
     _mem_table->insert(tuple);
+    THREAD_MEM_TRACKER_TRANSFER_TO(_mem_table->memory_usage() - prev_memtable_usage,
+                                   _mem_tracker.get());
 
     // if memtable is full, push it to the flush executor,
     // and create a new memtable for incoming data
@@ -171,9 +177,15 @@ Status DeltaWriter::write(const RowBatch* row_batch, const std::vector<int>& row
     if (_is_cancelled) {
         return Status::OLAPInternalError(OLAP_ERR_ALREADY_CANCELLED);
     }
+
+    // Hook automatically records that the memory is lower than the real value, so manual tracking is used.
+    // Because multiple places freed memory that doesn't belong to DeltaWriter
+    int64_t prev_memtable_usage = _mem_table->memory_usage();
     for (const auto& row_idx : row_idxs) {
         _mem_table->insert(row_batch->get_row(row_idx)->get_tuple(0));
     }
+    THREAD_MEM_TRACKER_TRANSFER_TO(_mem_table->memory_usage() - prev_memtable_usage,
+                                   _mem_tracker.get());
 
     if (_mem_table->memory_usage() >= config::write_buffer_size) {
         RETURN_NOT_OK(_flush_memtable_async());
@@ -196,6 +208,7 @@ Status DeltaWriter::write(const vectorized::Block* block, const std::vector<int>
         return Status::OLAPInternalError(OLAP_ERR_ALREADY_CANCELLED);
     }
 
+    SCOPED_ATTACH_TASK(_mem_tracker.get(), ThreadContext::TaskType::LOAD);
     _mem_table->insert(block, row_idxs);
 
     if (_mem_table->need_to_agg()) {
@@ -213,8 +226,7 @@ Status DeltaWriter::_flush_memtable_async() {
     if (++_segment_counter > config::max_segment_num_per_rowset) {
         return Status::OLAPInternalError(OLAP_ERR_TOO_MANY_SEGMENTS);
     }
-    _flushed_mem_tracker->consume(_mem_table->memory_usage());
-    return _flush_token->submit(_mem_table);
+    return _flush_token->submit(std::move(_mem_table), _mem_tracker.get());
 }
 
 Status DeltaWriter::flush_memtable_and_wait(bool need_wait) {
@@ -231,6 +243,7 @@ Status DeltaWriter::flush_memtable_and_wait(bool need_wait) {
         return Status::OLAPInternalError(OLAP_ERR_ALREADY_CANCELLED);
     }
 
+    SCOPED_ATTACH_TASK(_mem_tracker.get(), ThreadContext::TaskType::LOAD);
     if (mem_consumption() == _mem_table->memory_usage()) {
         // equal means there is no memtable in flush queue, just flush this memtable
         VLOG_NOTICE << "flush memtable to reduce mem consumption. memtable size: "
@@ -267,7 +280,7 @@ Status DeltaWriter::wait_flush() {
 void DeltaWriter::_reset_mem_table() {
     _mem_table.reset(new MemTable(_tablet->tablet_id(), _schema.get(), _tablet_schema.get(),
                                   _req.slots, _req.tuple_desc, _tablet->keys_type(),
-                                  _rowset_writer.get(), _flushed_mem_tracker.get(), _is_vec));
+                                  _rowset_writer.get(), _is_vec));
 }
 
 Status DeltaWriter::close() {
@@ -285,6 +298,7 @@ Status DeltaWriter::close() {
         return Status::OLAPInternalError(OLAP_ERR_ALREADY_CANCELLED);
     }
 
+    SCOPED_ATTACH_TASK(_mem_tracker.get(), ThreadContext::TaskType::LOAD);
     RETURN_NOT_OK(_flush_memtable_async());
     _mem_table.reset();
     return Status::OK();
@@ -299,6 +313,7 @@ Status DeltaWriter::close_wait() {
         return Status::OLAPInternalError(OLAP_ERR_ALREADY_CANCELLED);
     }
 
+    SCOPED_ATTACH_TASK(_mem_tracker.get(), ThreadContext::TaskType::LOAD);
     // return error if previous flush failed
     RETURN_NOT_OK(_flush_token->wait());
 
@@ -350,12 +365,12 @@ int64_t DeltaWriter::get_mem_consumption_snapshot() const {
 }
 
 int64_t DeltaWriter::mem_consumption() const {
-    if (_flushed_mem_tracker == nullptr) {
+    if (_mem_tracker == nullptr) {
         // This method may be called before this writer is initialized.
-        // So _flushed_mem_tracker may be null.
+        // So _mem_tracker may be null.
         return 0;
     }
-    return _flushed_mem_tracker->consumption() + _mem_table->memory_usage();
+    return _mem_tracker->consumption();
 }
 
 int64_t DeltaWriter::partition_id() const {

--- a/be/src/olap/delta_writer.h
+++ b/be/src/olap/delta_writer.h
@@ -55,8 +55,8 @@ struct WriteRequest {
 // This class is NOT thread-safe, external synchronization is required.
 class DeltaWriter {
 public:
-    static Status open(WriteRequest* req, DeltaWriter** writer, MemTrackerLimiter* parent_tracker = nullptr,
-                       bool is_vec = false);
+    static Status open(WriteRequest* req, DeltaWriter** writer,
+                       MemTrackerLimiter* parent_tracker = nullptr, bool is_vec = false);
 
     ~DeltaWriter();
 

--- a/be/src/olap/delta_writer.h
+++ b/be/src/olap/delta_writer.h
@@ -55,7 +55,7 @@ struct WriteRequest {
 // This class is NOT thread-safe, external synchronization is required.
 class DeltaWriter {
 public:
-    static Status open(WriteRequest* req, DeltaWriter** writer, MemTrackerLimiter* parent_tracker,
+    static Status open(WriteRequest* req, DeltaWriter** writer, MemTrackerLimiter* parent_tracker = nullptr,
                        bool is_vec = false);
 
     ~DeltaWriter();

--- a/be/src/olap/delta_writer.h
+++ b/be/src/olap/delta_writer.h
@@ -55,7 +55,8 @@ struct WriteRequest {
 // This class is NOT thread-safe, external synchronization is required.
 class DeltaWriter {
 public:
-    static Status open(WriteRequest* req, DeltaWriter** writer, bool is_vec = false);
+    static Status open(WriteRequest* req, DeltaWriter** writer, MemTrackerLimiter* parent_tracker,
+                       bool is_vec = false);
 
     ~DeltaWriter();
 
@@ -100,7 +101,8 @@ public:
     int64_t get_mem_consumption_snapshot() const;
 
 private:
-    DeltaWriter(WriteRequest* req, StorageEngine* storage_engine, bool is_vec);
+    DeltaWriter(WriteRequest* req, StorageEngine* storage_engine, MemTrackerLimiter* parent_tracker,
+                bool is_vec);
 
     // push a full memtable to flush executor
     Status _flush_memtable_async();
@@ -120,7 +122,7 @@ private:
     RowsetSharedPtr _cur_rowset;
     std::unique_ptr<RowsetWriter> _rowset_writer;
     // TODO: Recheck the lifetime of _mem_table, Look should use unique_ptr
-    std::shared_ptr<MemTable> _mem_table;
+    std::unique_ptr<MemTable> _mem_table;
     std::unique_ptr<Schema> _schema;
     //const TabletSchema* _tablet_schema;
     // tablet schema owned by delta writer, all write will use this tablet schema
@@ -131,7 +133,8 @@ private:
 
     StorageEngine* _storage_engine;
     std::unique_ptr<FlushToken> _flush_token;
-    std::unique_ptr<MemTracker> _flushed_mem_tracker;
+    std::unique_ptr<MemTrackerLimiter> _mem_tracker;
+    MemTrackerLimiter* _parent_tracker;
 
     // The counter of number of segment flushed already.
     int64_t _segment_counter = 0;

--- a/be/src/olap/memtable.cpp
+++ b/be/src/olap/memtable.cpp
@@ -31,8 +31,7 @@ namespace doris {
 
 MemTable::MemTable(int64_t tablet_id, Schema* schema, const TabletSchema* tablet_schema,
                    const std::vector<SlotDescriptor*>* slot_descs, TupleDescriptor* tuple_desc,
-                   KeysType keys_type, RowsetWriter* rowset_writer, MemTracker* writer_mem_tracker,
-                   bool support_vec)
+                   KeysType keys_type, RowsetWriter* rowset_writer, bool support_vec)
         : _tablet_id(tablet_id),
           _schema(schema),
           _tablet_schema(tablet_schema),
@@ -40,7 +39,6 @@ MemTable::MemTable(int64_t tablet_id, Schema* schema, const TabletSchema* tablet
           _keys_type(keys_type),
           _mem_tracker(std::make_unique<MemTracker>(
                   fmt::format("MemTable:tabletId={}", std::to_string(tablet_id)))),
-          _writer_mem_tracker(writer_mem_tracker),
           _buffer_mem_pool(new MemPool(_mem_tracker.get())),
           _table_mem_pool(new MemPool(_mem_tracker.get())),
           _schema_size(_schema->schema_size()),
@@ -134,7 +132,6 @@ MemTable::~MemTable() {
         }
     }
     std::for_each(_row_in_blocks.begin(), _row_in_blocks.end(), std::default_delete<RowInBlock>());
-    _writer_mem_tracker->release(_mem_tracker->consumption());
     _mem_tracker->release(_mem_usage);
     _buffer_mem_pool->free_all();
     _table_mem_pool->free_all();

--- a/be/src/olap/memtable.h
+++ b/be/src/olap/memtable.h
@@ -42,8 +42,7 @@ class MemTable {
 public:
     MemTable(int64_t tablet_id, Schema* schema, const TabletSchema* tablet_schema,
              const std::vector<SlotDescriptor*>* slot_descs, TupleDescriptor* tuple_desc,
-             KeysType keys_type, RowsetWriter* rowset_writer, MemTracker* writer_mem_tracker,
-             bool support_vec = false);
+             KeysType keys_type, RowsetWriter* rowset_writer, bool support_vec = false);
     ~MemTable();
 
     int64_t tablet_id() const { return _tablet_id; }
@@ -153,7 +152,6 @@ private:
     std::shared_ptr<RowInBlockComparator> _vec_row_comparator;
 
     std::unique_ptr<MemTracker> _mem_tracker;
-    MemTracker* _writer_mem_tracker;
     // This is a buffer, to hold the memory referenced by the rows that have not
     // been inserted into the SkipList
     std::unique_ptr<MemPool> _buffer_mem_pool;

--- a/be/src/olap/olap_server.cpp
+++ b/be/src/olap/olap_server.cpp
@@ -44,31 +44,20 @@ volatile uint32_t g_schema_change_active_threads = 0;
 Status StorageEngine::start_bg_threads() {
     RETURN_IF_ERROR(Thread::create(
             "StorageEngine", "unused_rowset_monitor_thread",
-            [this]() {
-                SCOPED_ATTACH_TASK(_mem_tracker.get(), ThreadContext::TaskType::STORAGE);
-                this->_unused_rowset_monitor_thread_callback();
-            },
+            [this]() { this->_unused_rowset_monitor_thread_callback(); },
             &_unused_rowset_monitor_thread));
     LOG(INFO) << "unused rowset monitor thread started";
 
     // start thread for monitoring the snapshot and trash folder
     RETURN_IF_ERROR(Thread::create(
             "StorageEngine", "garbage_sweeper_thread",
-            [this]() {
-                SCOPED_ATTACH_TASK(_mem_tracker.get(), ThreadContext::TaskType::STORAGE);
-                this->_garbage_sweeper_thread_callback();
-            },
-            &_garbage_sweeper_thread));
+            [this]() { this->_garbage_sweeper_thread_callback(); }, &_garbage_sweeper_thread));
     LOG(INFO) << "garbage sweeper thread started";
 
     // start thread for monitoring the tablet with io error
     RETURN_IF_ERROR(Thread::create(
             "StorageEngine", "disk_stat_monitor_thread",
-            [this]() {
-                SCOPED_ATTACH_TASK(_mem_tracker.get(), ThreadContext::TaskType::STORAGE);
-                this->_disk_stat_monitor_thread_callback();
-            },
-            &_disk_stat_monitor_thread));
+            [this]() { this->_disk_stat_monitor_thread_callback(); }, &_disk_stat_monitor_thread));
     LOG(INFO) << "disk stat monitor thread started";
 
     // convert store map to vector
@@ -93,10 +82,7 @@ Status StorageEngine::start_bg_threads() {
     // compaction tasks producer thread
     RETURN_IF_ERROR(Thread::create(
             "StorageEngine", "compaction_tasks_producer_thread",
-            [this]() {
-                SCOPED_ATTACH_TASK(_mem_tracker.get(), ThreadContext::TaskType::STORAGE);
-                this->_compaction_tasks_producer_callback();
-            },
+            [this]() { this->_compaction_tasks_producer_callback(); },
             &_compaction_tasks_producer_thread));
     LOG(INFO) << "compaction tasks producer thread started";
     int32_t max_checkpoint_thread_num = config::max_meta_checkpoint_threads;
@@ -109,21 +95,14 @@ Status StorageEngine::start_bg_threads() {
 
     RETURN_IF_ERROR(Thread::create(
             "StorageEngine", "tablet_checkpoint_tasks_producer_thread",
-            [this, data_dirs]() {
-                SCOPED_ATTACH_TASK(_mem_tracker.get(), ThreadContext::TaskType::STORAGE);
-                this->_tablet_checkpoint_callback(data_dirs);
-            },
+            [this, data_dirs]() { this->_tablet_checkpoint_callback(data_dirs); },
             &_tablet_checkpoint_tasks_producer_thread));
     LOG(INFO) << "tablet checkpoint tasks producer thread started";
 
     // fd cache clean thread
     RETURN_IF_ERROR(Thread::create(
             "StorageEngine", "fd_cache_clean_thread",
-            [this]() {
-                SCOPED_ATTACH_TASK(_mem_tracker.get(), ThreadContext::TaskType::STORAGE);
-                this->_fd_cache_clean_callback();
-            },
-            &_fd_cache_clean_thread));
+            [this]() { this->_fd_cache_clean_callback(); }, &_fd_cache_clean_thread));
     LOG(INFO) << "fd cache clean thread started";
 
     // path scan and gc thread
@@ -160,10 +139,7 @@ Status StorageEngine::start_bg_threads() {
 
     RETURN_IF_ERROR(Thread::create(
             "StorageEngine", "cooldown_tasks_producer_thread",
-            [this]() {
-                SCOPED_ATTACH_TASK(_mem_tracker.get(), ThreadContext::TaskType::STORAGE);
-                this->_cooldown_tasks_producer_callback();
-            },
+            [this]() { this->_cooldown_tasks_producer_callback(); },
             &_cooldown_tasks_producer_thread));
     LOG(INFO) << "cooldown tasks producer thread started";
 

--- a/be/src/olap/olap_server.cpp
+++ b/be/src/olap/olap_server.cpp
@@ -44,20 +44,31 @@ volatile uint32_t g_schema_change_active_threads = 0;
 Status StorageEngine::start_bg_threads() {
     RETURN_IF_ERROR(Thread::create(
             "StorageEngine", "unused_rowset_monitor_thread",
-            [this]() { SCOPED_ATTACH_TASK(_mem_tracker.get(), ThreadContext::TaskType::STORAGE); this->_unused_rowset_monitor_thread_callback(); },
+            [this]() {
+                SCOPED_ATTACH_TASK(_mem_tracker.get(), ThreadContext::TaskType::STORAGE);
+                this->_unused_rowset_monitor_thread_callback();
+            },
             &_unused_rowset_monitor_thread));
     LOG(INFO) << "unused rowset monitor thread started";
 
     // start thread for monitoring the snapshot and trash folder
     RETURN_IF_ERROR(Thread::create(
             "StorageEngine", "garbage_sweeper_thread",
-            [this]() { SCOPED_ATTACH_TASK(_mem_tracker.get(), ThreadContext::TaskType::STORAGE); this->_garbage_sweeper_thread_callback(); }, &_garbage_sweeper_thread));
+            [this]() {
+                SCOPED_ATTACH_TASK(_mem_tracker.get(), ThreadContext::TaskType::STORAGE);
+                this->_garbage_sweeper_thread_callback();
+            },
+            &_garbage_sweeper_thread));
     LOG(INFO) << "garbage sweeper thread started";
 
     // start thread for monitoring the tablet with io error
     RETURN_IF_ERROR(Thread::create(
             "StorageEngine", "disk_stat_monitor_thread",
-            [this]() { SCOPED_ATTACH_TASK(_mem_tracker.get(), ThreadContext::TaskType::STORAGE); this->_disk_stat_monitor_thread_callback(); }, &_disk_stat_monitor_thread));
+            [this]() {
+                SCOPED_ATTACH_TASK(_mem_tracker.get(), ThreadContext::TaskType::STORAGE);
+                this->_disk_stat_monitor_thread_callback();
+            },
+            &_disk_stat_monitor_thread));
     LOG(INFO) << "disk stat monitor thread started";
 
     // convert store map to vector
@@ -82,7 +93,10 @@ Status StorageEngine::start_bg_threads() {
     // compaction tasks producer thread
     RETURN_IF_ERROR(Thread::create(
             "StorageEngine", "compaction_tasks_producer_thread",
-            [this]() { SCOPED_ATTACH_TASK(_mem_tracker.get(), ThreadContext::TaskType::STORAGE); this->_compaction_tasks_producer_callback(); },
+            [this]() {
+                SCOPED_ATTACH_TASK(_mem_tracker.get(), ThreadContext::TaskType::STORAGE);
+                this->_compaction_tasks_producer_callback();
+            },
             &_compaction_tasks_producer_thread));
     LOG(INFO) << "compaction tasks producer thread started";
     int32_t max_checkpoint_thread_num = config::max_meta_checkpoint_threads;
@@ -95,14 +109,21 @@ Status StorageEngine::start_bg_threads() {
 
     RETURN_IF_ERROR(Thread::create(
             "StorageEngine", "tablet_checkpoint_tasks_producer_thread",
-            [this, data_dirs]() { SCOPED_ATTACH_TASK(_mem_tracker.get(), ThreadContext::TaskType::STORAGE); this->_tablet_checkpoint_callback(data_dirs); },
+            [this, data_dirs]() {
+                SCOPED_ATTACH_TASK(_mem_tracker.get(), ThreadContext::TaskType::STORAGE);
+                this->_tablet_checkpoint_callback(data_dirs);
+            },
             &_tablet_checkpoint_tasks_producer_thread));
     LOG(INFO) << "tablet checkpoint tasks producer thread started";
 
     // fd cache clean thread
     RETURN_IF_ERROR(Thread::create(
             "StorageEngine", "fd_cache_clean_thread",
-            [this]() { SCOPED_ATTACH_TASK(_mem_tracker.get(), ThreadContext::TaskType::STORAGE); this->_fd_cache_clean_callback(); }, &_fd_cache_clean_thread));
+            [this]() {
+                SCOPED_ATTACH_TASK(_mem_tracker.get(), ThreadContext::TaskType::STORAGE);
+                this->_fd_cache_clean_callback();
+            },
+            &_fd_cache_clean_thread));
     LOG(INFO) << "fd cache clean thread started";
 
     // path scan and gc thread
@@ -139,7 +160,10 @@ Status StorageEngine::start_bg_threads() {
 
     RETURN_IF_ERROR(Thread::create(
             "StorageEngine", "cooldown_tasks_producer_thread",
-            [this]() { SCOPED_ATTACH_TASK(_mem_tracker.get(), ThreadContext::TaskType::STORAGE); this->_cooldown_tasks_producer_callback(); },
+            [this]() {
+                SCOPED_ATTACH_TASK(_mem_tracker.get(), ThreadContext::TaskType::STORAGE);
+                this->_cooldown_tasks_producer_callback();
+            },
             &_cooldown_tasks_producer_thread));
     LOG(INFO) << "cooldown tasks producer thread started";
 

--- a/be/src/olap/storage_engine.h
+++ b/be/src/olap/storage_engine.h
@@ -342,6 +342,8 @@ private:
     std::unique_ptr<MemTrackerLimiter> _batch_load_mem_tracker;
     // Count the memory consumption of all EngineChecksumTask.
     std::unique_ptr<MemTrackerLimiter> _consistency_mem_tracker;
+    // StorageEngine oneself
+    std::unique_ptr<MemTrackerLimiter> _mem_tracker;
 
     CountDownLatch _stop_background_threads_latch;
     scoped_refptr<Thread> _unused_rowset_monitor_thread;

--- a/be/src/runtime/disk_io_mgr.cc
+++ b/be/src/runtime/disk_io_mgr.cc
@@ -373,8 +373,8 @@ Status DiskIoMgr::init(const int64_t mem_limit) {
             ss << "work-loop(Disk: " << i << ", Thread: " << j << ")";
             // _disk_thread_group.AddThread(new Thread("disk-io-mgr", ss.str(),
             //             &DiskIoMgr::work_loop, this, _disk_queues[i]));
-            _disk_thread_group.add_thread(new std::thread(
-                    std::bind(&DiskIoMgr::work_loop, this, _disk_queues[i])));
+            _disk_thread_group.add_thread(
+                    new std::thread(std::bind(&DiskIoMgr::work_loop, this, _disk_queues[i])));
         }
     }
     _request_context_cache.reset(new RequestContextCache(this));

--- a/be/src/runtime/disk_io_mgr.cc
+++ b/be/src/runtime/disk_io_mgr.cc
@@ -374,7 +374,7 @@ Status DiskIoMgr::init(const int64_t mem_limit) {
             // _disk_thread_group.AddThread(new Thread("disk-io-mgr", ss.str(),
             //             &DiskIoMgr::work_loop, this, _disk_queues[i]));
             _disk_thread_group.add_thread(new std::thread(
-                    std::bind(&DiskIoMgr::work_loop, this, _disk_queues[i], _mem_tracker.get())));
+                    std::bind(&DiskIoMgr::work_loop, this, _disk_queues[i])));
         }
     }
     _request_context_cache.reset(new RequestContextCache(this));
@@ -947,7 +947,7 @@ void DiskIoMgr::handle_read_finished(DiskQueue* disk_queue, RequestContext* read
     state.decrement_request_thread();
 }
 
-void DiskIoMgr::work_loop(DiskQueue* disk_queue, MemTrackerLimiter* mem_tracker) {
+void DiskIoMgr::work_loop(DiskQueue* disk_queue) {
     // The thread waits until there is work or the entire system is being shut down.
     // If there is work, performs the read or write requested and re-enqueues the
     // requesting context.
@@ -960,8 +960,7 @@ void DiskIoMgr::work_loop(DiskQueue* disk_queue, MemTrackerLimiter* mem_tracker)
     //   3. Perform the read or write as specified.
     // Cancellation checking needs to happen in both steps 1 and 3.
 
-    // tracked in the process tracker
-    // SCOPED_ATTACH_TASK(ThreadContext::TaskType::STORAGE, mem_tracker);
+    thread_context()->_thread_mem_tracker_mgr->set_check_attach(false);
     while (!_shut_down) {
         RequestContext* worker_context = nullptr;
         ;

--- a/be/src/runtime/disk_io_mgr.h
+++ b/be/src/runtime/disk_io_mgr.h
@@ -795,7 +795,7 @@ private:
     // Disk worker thread loop. This function retrieves the next range to process on
     // the disk queue and invokes read_range() or Write() depending on the type of Range().
     // There can be multiple threads per disk running this loop.
-    void work_loop(DiskQueue* queue, MemTrackerLimiter* mem_tracker);
+    void work_loop(DiskQueue* queue);
 
     // This is called from the disk thread to get the next range to process. It will
     // wait until a scan range and buffer are available, or a write range is available.

--- a/be/src/runtime/exec_env_init.cpp
+++ b/be/src/runtime/exec_env_init.cpp
@@ -191,6 +191,7 @@ Status ExecEnv::_init_mem_tracker() {
     }
     _process_mem_tracker = new MemTrackerLimiter(global_memory_limit_bytes, "Process");
     thread_context()->_thread_mem_tracker_mgr->init();
+    thread_context()->_thread_mem_tracker_mgr->set_check_attach(false);
 #if defined(USE_MEM_TRACKER) && !defined(__SANITIZE_ADDRESS__) && !defined(ADDRESS_SANITIZER) && \
         !defined(LEAK_SANITIZER) && !defined(THREAD_SANITIZER) && !defined(USE_JEMALLOC)
     if (doris::config::enable_tcmalloc_hook) {

--- a/be/src/runtime/fragment_mgr.cpp
+++ b/be/src/runtime/fragment_mgr.cpp
@@ -477,6 +477,7 @@ void FragmentMgr::_exec_actual(std::shared_ptr<FragmentExecState> exec_state, Fi
     std::string func_name {"PlanFragmentExecutor::_exec_actual"};
 #ifndef BE_TEST
     auto span = exec_state->executor()->runtime_state()->get_tracer()->StartSpan(func_name);
+    SCOPED_ATTACH_TASK(exec_state->executor()->runtime_state());
 #else
     auto span = telemetry::get_noop_tracer()->StartSpan(func_name);
 #endif
@@ -493,9 +494,7 @@ void FragmentMgr::_exec_actual(std::shared_ptr<FragmentExecState> exec_state, Fi
             .query_id(exec_state->query_id())
             .instance_id(exec_state->fragment_instance_id())
             .tag("pthread_id", std::to_string((uintptr_t)pthread_self()));
-#ifndef BE_TEST
-    SCOPED_ATTACH_TASK(exec_state->executor()->runtime_state());
-#endif
+
     exec_state->execute();
 
     std::shared_ptr<QueryFragmentsCtx> fragments_ctx = exec_state->get_fragments_ctx();

--- a/be/src/runtime/load_channel.cpp
+++ b/be/src/runtime/load_channel.cpp
@@ -50,7 +50,6 @@ LoadChannel::~LoadChannel() {
 }
 
 Status LoadChannel::open(const PTabletWriterOpenRequest& params) {
-    // SCOPED_ATTACH_TASK(_mem_tracker.get(), ThreadContext::TaskType::LOAD);
     int64_t index_id = params.index_id();
     std::shared_ptr<TabletsChannel> channel;
     {
@@ -61,7 +60,7 @@ Status LoadChannel::open(const PTabletWriterOpenRequest& params) {
         } else {
             // create a new tablets channel
             TabletsChannelKey key(params.id(), index_id);
-            channel.reset(new TabletsChannel(key, _is_high_priority, _is_vec));
+            channel.reset(new TabletsChannel(key, _mem_tracker.get(), _is_high_priority, _is_vec));
             _tablets_channels.insert({index_id, channel});
         }
     }
@@ -137,7 +136,6 @@ bool LoadChannel::is_finished() {
 
 Status LoadChannel::cancel() {
     std::lock_guard<std::mutex> l(_lock);
-    // SCOPED_ATTACH_TASK(_mem_tracker.get(), ThreadContext::TaskType::LOAD);
     for (auto& it : _tablets_channels) {
         it.second->cancel();
     }

--- a/be/src/runtime/load_channel.h
+++ b/be/src/runtime/load_channel.h
@@ -129,7 +129,6 @@ private:
 template <typename TabletWriterAddRequest, typename TabletWriterAddResult>
 Status LoadChannel::add_batch(const TabletWriterAddRequest& request,
                               TabletWriterAddResult* response) {
-    // SCOPED_ATTACH_TASK(_mem_tracker.get(), ThreadContext::TaskType::LOAD);
     int64_t index_id = request.index_id();
     // 1. get tablets channel
     std::shared_ptr<TabletsChannel> channel;

--- a/be/src/runtime/memory/mem_tracker.h
+++ b/be/src/runtime/memory/mem_tracker.h
@@ -30,9 +30,9 @@ class MemTrackerLimiter;
 // MemTracker can be consumed manually by consume()/release(), or put into SCOPED_CONSUME_MEM_TRACKER,
 // which will automatically track all memory usage of the code segment where it is located.
 //
-// MemTracker's father can only be MemTrackerLimiter, which is only used to print tree-like statistics.
-// Consuming MemTracker will not consume its father synchronously.
-// Usually, it is not necessary to specify the father. by default, the MemTrackerLimiter in the thread context
+// MemTracker's parent can only be MemTrackerLimiter, which is only used to print tree-like statistics.
+// Consuming MemTracker will not consume its parent synchronously.
+// Usually, it is not necessary to specify the parent. by default, the MemTrackerLimiter in the thread context
 // is used as the parent, which is specified when the thread starts.
 //
 // This class is thread-safe.

--- a/be/src/runtime/memory/mem_tracker_limiter.h
+++ b/be/src/runtime/memory/mem_tracker_limiter.h
@@ -119,7 +119,13 @@ public:
     Status try_gc_memory(int64_t bytes);
 
 public:
-    void consumption_revise(int64_t bytes) { _consumption->add(bytes); }
+    // It is used for revise mem tracker consumption.
+    // If the location of memory alloc and free is different, the consumption value of mem tracker will be inaccurate.
+    // But the consumption value of the process mem tracker is not affecte
+    void consumption_revise(int64_t bytes) {
+        DCHECK(_label != "Process");
+        _consumption->add(bytes);
+    }
 
     // Logs the usage of this tracker limiter and optionally its children (recursively).
     // If 'logged_consumption' is non-nullptr, sets the consumption value logged.

--- a/be/src/runtime/memory/mem_tracker_task_pool.h
+++ b/be/src/runtime/memory/mem_tracker_task_pool.h
@@ -24,9 +24,10 @@
 namespace doris {
 
 using TaskTrackersMap = phmap::parallel_flat_hash_map<
-        std::string, MemTrackerLimiter*, phmap::priv::hash_default_hash<std::string>,
-        phmap::priv::hash_default_eq<std::string>,
-        std::allocator<std::pair<const std::string, MemTrackerLimiter*>>, 12, std::mutex>;
+        std::string, std::shared_ptr<MemTrackerLimiter>,
+        phmap::priv::hash_default_hash<std::string>, phmap::priv::hash_default_eq<std::string>,
+        std::allocator<std::pair<const std::string, std::shared_ptr<MemTrackerLimiter>>>, 12,
+        std::mutex>;
 
 // Global task pool for query MemTrackers. Owned by ExecEnv.
 class MemTrackerTaskPool {
@@ -53,8 +54,6 @@ private:
     // The life cycle of task memtracker in the process is the same as task runtime state,
     // MemTrackers will be removed from this map after query finish or cancel.
     TaskTrackersMap _task_mem_trackers;
-
-    mutable std::mutex _logout_task_lock;
 };
 
 } // namespace doris

--- a/be/src/runtime/memory/mem_tracker_task_pool.h
+++ b/be/src/runtime/memory/mem_tracker_task_pool.h
@@ -53,6 +53,8 @@ private:
     // The life cycle of task memtracker in the process is the same as task runtime state,
     // MemTrackers will be removed from this map after query finish or cancel.
     TaskTrackersMap _task_mem_trackers;
+
+    mutable std::mutex _logout_task_lock;
 };
 
 } // namespace doris

--- a/be/src/runtime/memory/thread_mem_tracker_mgr.cpp
+++ b/be/src/runtime/memory/thread_mem_tracker_mgr.cpp
@@ -29,6 +29,7 @@ void ThreadMemTrackerMgr::attach_limiter_tracker(const std::string& cancel_msg,
                                                  const TUniqueId& fragment_instance_id,
                                                  MemTrackerLimiter* mem_tracker) {
     DCHECK(mem_tracker);
+    flush_untracked_mem<false>();
     _task_id = task_id;
     _fragment_instance_id = fragment_instance_id;
     _exceed_cb.cancel_msg = cancel_msg;
@@ -36,6 +37,11 @@ void ThreadMemTrackerMgr::attach_limiter_tracker(const std::string& cancel_msg,
 }
 
 void ThreadMemTrackerMgr::detach_limiter_tracker() {
+    // Unexpectedly, the runtime state is destructed before the end of the query sub-thread,
+    // (_hash_table_build_thread has appeared) which is not a graceful exit.
+    // consider replacing CHECK with a conditional statement and checking for runtime state survival.
+    CHECK(_task_id == "" ||
+          ExecEnv::GetInstance()->task_pool_mem_tracker_registry()->get_task_mem_tracker(_task_id));
     flush_untracked_mem<false>();
     _task_id = "";
     _fragment_instance_id = TUniqueId();

--- a/be/src/runtime/memory/thread_mem_tracker_mgr.cpp
+++ b/be/src/runtime/memory/thread_mem_tracker_mgr.cpp
@@ -37,11 +37,13 @@ void ThreadMemTrackerMgr::attach_limiter_tracker(const std::string& cancel_msg,
 }
 
 void ThreadMemTrackerMgr::detach_limiter_tracker() {
+#ifndef BE_TEST
     // Unexpectedly, the runtime state is destructed before the end of the query sub-thread,
     // (_hash_table_build_thread has appeared) which is not a graceful exit.
     // consider replacing CHECK with a conditional statement and checking for runtime state survival.
     CHECK(_task_id == "" ||
           ExecEnv::GetInstance()->task_pool_mem_tracker_registry()->get_task_mem_tracker(_task_id));
+#endif
     flush_untracked_mem<false>();
     _task_id = "";
     _fragment_instance_id = TUniqueId();

--- a/be/src/runtime/tablets_channel.h
+++ b/be/src/runtime/tablets_channel.h
@@ -60,7 +60,8 @@ class OlapTableSchemaParam;
 // Write channel for a particular (load, index).
 class TabletsChannel {
 public:
-    TabletsChannel(const TabletsChannelKey& key, bool is_high_priority, bool is_vec);
+    TabletsChannel(const TabletsChannelKey& key, MemTrackerLimiter* parent_tracker,
+                   bool is_high_priority, bool is_vec);
 
     ~TabletsChannel();
 
@@ -88,7 +89,7 @@ public:
     // no-op when this channel has been closed or cancelled
     Status reduce_mem_usage(int64_t mem_limit);
 
-    int64_t mem_consumption();
+    int64_t mem_consumption() const { return _mem_tracker->consumption(); }
 
 private:
     template <typename Request>
@@ -142,6 +143,8 @@ private:
     std::unordered_set<int64_t> _partition_ids;
 
     static std::atomic<uint64_t> _s_tablet_writer_count;
+
+    std::unique_ptr<MemTrackerLimiter> _mem_tracker;
 
     bool _is_high_priority = false;
 

--- a/be/src/runtime/thread_context.cpp
+++ b/be/src/runtime/thread_context.cpp
@@ -37,25 +37,6 @@ AttachTask::AttachTask(MemTrackerLimiter* mem_tracker, const ThreadContext::Task
 #endif
 }
 
-// AttachTask::AttachTask(const TQueryType::type& query_type,
-//                                    MemTrackerLimiter* mem_tracker) {
-//     DCHECK(mem_tracker);
-// #ifdef USE_MEM_TRACKER
-//     thread_context()->attach_task(query_to_task_type(query_type), "", TUniqueId(), mem_tracker);
-// #endif
-// }
-
-// AttachTask::AttachTask(const TQueryType::type& query_type,
-//                                    MemTrackerLimiter* mem_tracker, const std::string& task_id,
-//                                    const TUniqueId& fragment_instance_id) {
-//     DCHECK(task_id != "");
-//     DCHECK(fragment_instance_id != TUniqueId());
-//     DCHECK(mem_tracker);
-// #ifdef USE_MEM_TRACKER
-//     thread_context()->attach_task(query_to_task_type(query_type), task_id, fragment_instance_id, mem_tracker);
-// #endif
-// }
-
 AttachTask::AttachTask(RuntimeState* runtime_state) {
 #ifndef BE_TEST
     DCHECK(print_id(runtime_state->query_id()) != "");

--- a/be/src/runtime/thread_context.h
+++ b/be/src/runtime/thread_context.h
@@ -43,7 +43,6 @@ class TUniqueId;
 class ThreadContext;
 
 extern bthread_key_t btls_key;
-static const bthread_key_t EMPTY_BTLS_KEY = {0, 0};
 
 // Using gcc11 compiles thread_local variable on lower versions of GLIBC will report an error,
 // see https://github.com/apache/doris/pull/7911

--- a/be/src/service/doris_main.cpp
+++ b/be/src/service/doris_main.cpp
@@ -472,9 +472,7 @@ int main(int argc, char** argv) {
 #endif
         doris::PerfCounters::refresh_proc_status();
 
-        // TODO(zxy) 10s is too long to clear the expired task mem tracker.
-        // A query mem tracker is about 57 bytes, assuming 10000 qps, which wastes about 55M of memory.
-        // It should be actively triggered at the end of query/load.
+        // 1s clear the expired task mem tracker, a query mem tracker is about 57 bytes.
         doris::ExecEnv::GetInstance()->task_pool_mem_tracker_registry()->logout_task_mem_tracker();
         sleep(1);
     }

--- a/be/src/vec/exec/vbroker_scan_node.cpp
+++ b/be/src/vec/exec/vbroker_scan_node.cpp
@@ -109,6 +109,7 @@ Status VBrokerScanNode::start_scanners() {
 Status VBrokerScanNode::get_next(RuntimeState* state, vectorized::Block* block, bool* eos) {
     INIT_AND_SCOPE_GET_NEXT_SPAN(state->get_tracer(), _get_next_span, "VBrokerScanNode::get_next");
     SCOPED_TIMER(_runtime_profile->total_time_counter());
+    SCOPED_CONSUME_MEM_TRACKER(mem_tracker());
     // check if CANCELLED.
     if (state->is_cancelled()) {
         std::unique_lock<std::mutex> l(_batch_queue_lock);
@@ -275,6 +276,8 @@ Status VBrokerScanNode::scanner_scan(const TBrokerScanRange& scan_range, Scanner
 
 void VBrokerScanNode::scanner_worker(int start_idx, int length) {
     START_AND_SCOPE_SPAN(_runtime_state->get_tracer(), span, "VBrokerScanNode::scanner_worker");
+    SCOPED_ATTACH_TASK(_runtime_state);
+    SCOPED_CONSUME_MEM_TRACKER(mem_tracker());
     Thread::set_self_name("vbroker_scanner");
     Status status = Status::OK();
     ScannerCounter counter;

--- a/be/src/vec/exec/ves_http_scan_node.cpp
+++ b/be/src/vec/exec/ves_http_scan_node.cpp
@@ -385,6 +385,7 @@ void VEsHttpScanNode::debug_string(int ident_level, std::stringstream* out) cons
 void VEsHttpScanNode::scanner_worker(int start_idx, int length, std::promise<Status>& p_status) {
     START_AND_SCOPE_SPAN(_runtime_state->get_tracer(), span, "VEsHttpScanNode::scanner_worker");
     SCOPED_ATTACH_TASK(_runtime_state);
+    SCOPED_CONSUME_MEM_TRACKER(mem_tracker());
     // Clone expr context
     std::vector<ExprContext*> scanner_expr_ctxs;
     DCHECK(start_idx < length);

--- a/be/src/vec/sink/vtablet_sink.cpp
+++ b/be/src/vec/sink/vtablet_sink.cpp
@@ -141,6 +141,7 @@ Status VNodeChannel::open_wait() {
 }
 
 Status VNodeChannel::add_row(const BlockRow& block_row, int64_t tablet_id) {
+    SCOPED_CONSUME_MEM_TRACKER(_node_channel_tracker.get());
     // If add_row() when _eos_is_produced==true, there must be sth wrong, we can only mark this channel as failed.
     auto st = none_of({_cancelled, _eos_is_produced});
     if (!st.ok()) {

--- a/be/test/olap/delta_writer_test.cpp
+++ b/be/test/olap/delta_writer_test.cpp
@@ -398,7 +398,7 @@ TEST_F(TestDeltaWriter, open) {
     SAFE_DELETE(delta_writer);
 
     // test vec delta writer
-    DeltaWriter::open(&write_req, &delta_writer, true);
+    DeltaWriter::open(&write_req, &delta_writer, nullptr, true);
     EXPECT_NE(delta_writer, nullptr);
     res = delta_writer->close();
     EXPECT_EQ(Status::OK(), res);
@@ -551,7 +551,7 @@ TEST_F(TestDeltaWriter, vec_write) {
     WriteRequest write_req = {10004, 270068376, WriteType::LOAD, 20002,
                               30002, load_id,   tuple_desc,      &(tuple_desc->slots())};
     DeltaWriter* delta_writer = nullptr;
-    DeltaWriter::open(&write_req, &delta_writer, true);
+    DeltaWriter::open(&write_req, &delta_writer, nullptr, true);
     ASSERT_NE(delta_writer, nullptr);
 
     MemPool pool;
@@ -764,7 +764,7 @@ TEST_F(TestDeltaWriter, vec_sequence_col) {
     WriteRequest write_req = {10005, 270068377, WriteType::LOAD, 20003,
                               30003, load_id,   tuple_desc,      &(tuple_desc->slots())};
     DeltaWriter* delta_writer = nullptr;
-    DeltaWriter::open(&write_req, &delta_writer, true);
+    DeltaWriter::open(&write_req, &delta_writer, nullptr, true);
     ASSERT_NE(delta_writer, nullptr);
 
     MemPool pool;

--- a/build-support/clang-format.sh
+++ b/build-support/clang-format.sh
@@ -29,6 +29,6 @@ ROOT=`cd "$ROOT"; pwd`
 export DORIS_HOME=`cd "${ROOT}/.."; pwd`
 
 CLANG_FORMAT=/mnt/disk1/liyifan/doris/ldb_toolchain/bin/clang-format
-#CLANG_FORMAT=${CLANG_FORMAT_BINARY:=$(which clang-format)}
+# CLANG_FORMAT=${CLANG_FORMAT_BINARY:=$(which clang-format)}
 
 python ${DORIS_HOME}/build-support/run_clang_format.py "--clang-format-executable" "${CLANG_FORMAT}" "-r" "--style" "file" "--inplace" "true" "--extensions" "c,h,C,H,cpp,hpp,cc,hh,c++,h++,cxx,hxx" "--exclude" "none" "be/src be/test"

--- a/build-support/clang-format.sh
+++ b/build-support/clang-format.sh
@@ -28,7 +28,6 @@ ROOT=`cd "$ROOT"; pwd`
 
 export DORIS_HOME=`cd "${ROOT}/.."; pwd`
 
-CLANG_FORMAT=/mnt/disk1/liyifan/doris/ldb_toolchain/bin/clang-format
-# CLANG_FORMAT=${CLANG_FORMAT_BINARY:=$(which clang-format)}
+CLANG_FORMAT=${CLANG_FORMAT_BINARY:=$(which clang-format)}
 
 python ${DORIS_HOME}/build-support/run_clang_format.py "--clang-format-executable" "${CLANG_FORMAT}" "-r" "--style" "file" "--inplace" "true" "--extensions" "c,h,C,H,cpp,hpp,cc,hh,c++,h++,cxx,hxx" "--exclude" "none" "be/src be/test"

--- a/build-support/clang-format.sh
+++ b/build-support/clang-format.sh
@@ -28,6 +28,7 @@ ROOT=`cd "$ROOT"; pwd`
 
 export DORIS_HOME=`cd "${ROOT}/.."; pwd`
 
-CLANG_FORMAT=${CLANG_FORMAT_BINARY:=$(which clang-format)}
+CLANG_FORMAT=/mnt/disk1/liyifan/doris/ldb_toolchain/bin/clang-format
+#CLANG_FORMAT=${CLANG_FORMAT_BINARY:=$(which clang-format)}
 
 python ${DORIS_HOME}/build-support/run_clang_format.py "--clang-format-executable" "${CLANG_FORMAT}" "-r" "--style" "file" "--inplace" "true" "--extensions" "c,h,C,H,cpp,hpp,cc,hh,c++,h++,cxx,hxx" "--exclude" "none" "be/src be/test"

--- a/regression-test/conf/regression-conf.groovy
+++ b/regression-test/conf/regression-conf.groovy
@@ -20,11 +20,11 @@
 // **Note**: default db will be create if not exist
 defaultDb = "regression_test"
 
-jdbcUrl = "jdbc:mysql://127.0.0.1:9030/?"
+jdbcUrl = "jdbc:mysql://127.0.0.1:9083/?"
 jdbcUser = "root"
 jdbcPassword = ""
 
-feHttpAddress = "127.0.0.1:8030"
+feHttpAddress = "127.0.0.1:8033"
 feHttpUser = "root"
 feHttpPassword = ""
 

--- a/regression-test/conf/regression-conf.groovy
+++ b/regression-test/conf/regression-conf.groovy
@@ -20,11 +20,11 @@
 // **Note**: default db will be create if not exist
 defaultDb = "regression_test"
 
-jdbcUrl = "jdbc:mysql://127.0.0.1:9083/?"
+jdbcUrl = "jdbc:mysql://127.0.0.1:9030/?"
 jdbcUser = "root"
 jdbcPassword = ""
 
-feHttpAddress = "127.0.0.1:8033"
+feHttpAddress = "127.0.0.1:8030"
 feHttpUser = "root"
 feHttpPassword = ""
 


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

#### 1 Accuracy Analysis of Tracking Memory Based on Hook
See: https://github.com/gperftools/gperftools/issues/1361
All memory of BE cannot be tracked through TCMalloc hook. There are diffs with `top -p pid VIRT` and `generic.total_physical_bytes`, which affect the observation effect, but do not affect the limit query memory usage. detailed:

1. I found that Hook and `generic.total_physical_bytes` can only track virtual memory usage.
2. Use `tc_nallocx(size, 0)` and `tc_malloc_size(ptr)` in Hook to calculate and record the memory of `new` and `delete`, which is different from `generic.total_physical_bytes`.
3. After a period of time, Hook and `generic.total_physical_bytes` have a big gap with the actual virtual memory `VIRT` of the process seen by `top -p pid`.

In future, based on Jemalloc's mem tracker, expect to be more accurate : )

#### 2 Fix `LoadChannel` memory tracking inaccurate
Restore the mem tracker level of `LoadChannel` `TabletsChannel` `DeltaWriter` so that `LoadChannelMgr` can handle mem exceed limit correctly.

In non-vectorized load, because DeltaWriter Write releases memory that does not belong to it, Hook automatically tracks that the memory is lower than the real value, so manually track memory in `Memtable`.

In vectorized loads, Hooks are used to automatically track memory usage, which is accurate.

#### 3 Other fix
Some bug fix and detail optimizations

#### 4 Performance
parallel_fragment_exec_instance_num=10

|  test  | proportion of tcmalloc hook in flame graph   |
|  ---- | ---- |
| ssb 2.1,  jmeter thread 1 | 1.1%  |
| ssb 3.1,  jmeter thread 1 |  1.3% |
| ssb 4.1,  jmeter thread 1 | 1.3%  |
| ssb 2.1,  jmeter thread 20 |  0.8% |
| ssb 4.1,  jmeter thread 20 |  0.7% |
| select * from T limit 10,  jmeter thread 100 | 1.9%  |
| load ssb lineorder |  1.2% |
| load big json dict | 4.3%  |

## Checklist(Required)

1. Does it affect the original behavior: (Yes)
5. Has unit tests been added: (Yes)
6. Has document been added or modified: (No Need)
7. Does it need to update dependencies: (Yes)
8. Are there any changes that cannot be rolled back: (No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
