### PR TITLE
[FIX]string pad function should be always nullable for both string an…

### DIFF
--- a/gensrc/script/doris_builtins_functions.py
+++ b/gensrc/script/doris_builtins_functions.py
@@ -1135,10 +1135,10 @@ visible_functions = [
         '15FunctionContextERKNS1_9StringValERKNS1_6IntValE', '', '', 'vec', ''],
     [['lpad'], 'STRING', ['STRING', 'INT', 'STRING'],
             '_ZN5doris15StringFunctions4lpadEPN9doris_udf'
-            '15FunctionContextERKNS1_9StringValERKNS1_6IntValES6_', '', '', 'vec', ''],
+            '15FunctionContextERKNS1_9StringValERKNS1_6IntValES6_', '', '', 'vec', 'ALWAYS_NULLABLE'],
     [['rpad'], 'STRING', ['STRING', 'INT', 'STRING'],
             '_ZN5doris15StringFunctions4rpadEPN9doris_udf'
-            '15FunctionContextERKNS1_9StringValERKNS1_6IntValES6_', '', '', 'vec', ''],
+            '15FunctionContextERKNS1_9StringValERKNS1_6IntValES6_', '', '', 'vec', 'ALWAYS_NULLABLE'],
     [['append_trailing_char_if_absent'], 'STRING', ['STRING', 'STRING'],
             '_ZN5doris15StringFunctions30append_trailing_char_if_absentEPN9doris_udf15FunctionContextERKNS1_9StringValES6_',
             '', '', 'vec', 'ALWAYS_NULLABLE'],


### PR DESCRIPTION
…d varchar type

# Proposed changes

Issue Number: close #xxx

## Problem Summary:

Fix p0 regression  
suite("test_numbers", "correctness") { 
...
qt_stringfunction_18 """ select number,lpad(cast (number as string),3,'0') as string_fucntion_res from numbers("1000") where number>95 limit 15; """
...
}

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
