### PR TITLE
[fix](be): fix stack overflow in unhex function

### DIFF
--- a/be/src/exprs/math_functions.cpp
+++ b/be/src/exprs/math_functions.cpp
@@ -381,7 +381,8 @@ StringVal MathFunctions::unhex(FunctionContext* ctx, const StringVal& s) {
     }
 
     int result_len = s.len / 2;
-    char result[result_len];
+    StringVal result_string_val(ctx, result_len);
+    char* result = reinterpret_cast<char*>(result_string_val.ptr);
     int res_index = 0;
     int s_index = 0;
     while (s_index < s.len) {
@@ -426,7 +427,7 @@ StringVal MathFunctions::unhex(FunctionContext* ctx, const StringVal& s) {
         result[res_index] = c;
         ++res_index;
     }
-    return AnyValUtil::from_buffer_temp(ctx, result, result_len);
+    return result_string_val;
 }
 
 StringVal MathFunctions::conv_int(FunctionContext* ctx, const BigIntVal& num,

--- a/be/src/udf/udf.cpp
+++ b/be/src/udf/udf.cpp
@@ -209,11 +209,11 @@ FunctionContext* FunctionContextImpl::clone(MemPool* pool) {
 namespace doris_udf {
 static const int MAX_WARNINGS = 1000;
 
-FunctionContext* FunctionContext::create_test_context() {
+FunctionContext* FunctionContext::create_test_context(doris::MemPool* mem_pool = nullptr) {
     FunctionContext* context = new FunctionContext();
     context->impl()->_debug = true;
     context->impl()->_state = nullptr;
-    context->impl()->_pool = new doris::FreePool(nullptr);
+    context->impl()->_pool = new doris::FreePool(mem_pool);
     return context;
 }
 

--- a/be/src/udf/udf.h
+++ b/be/src/udf/udf.h
@@ -37,6 +37,7 @@ class BitmapValue;
 class DecimalV2Value;
 class DateTimeValue;
 class CollectionValue;
+class MemPool;
 } // namespace doris
 
 namespace doris_udf {
@@ -255,7 +256,8 @@ public:
 
     // Create a test FunctionContext object. The caller is responsible for calling delete
     // on it. This context has additional debugging validation enabled.
-    static FunctionContext* create_test_context();
+    // And the default value of mem_pool is nullprt.
+    static FunctionContext* create_test_context(doris::MemPool* mem_pool);
 
     ~FunctionContext();
 

--- a/be/test/exprs/math_functions_test.cpp
+++ b/be/test/exprs/math_functions_test.cpp
@@ -23,6 +23,7 @@
 #include <string>
 
 #include "runtime/large_int_value.h"
+#include "runtime/mem_pool.h"
 #include "testutil/function_utils.h"
 #include "udf/udf_internal.h"
 
@@ -217,7 +218,9 @@ TEST_F(MathFunctionsTest, hex_string) {
 }
 
 TEST_F(MathFunctionsTest, unhex) {
-    doris_udf::FunctionContext* context = new doris_udf::FunctionContext();
+    MemPool mem_pool;
+    doris_udf::FunctionContext* context =
+            doris_udf::FunctionContext::create_test_context(&mem_pool);
 
     EXPECT_EQ(StringVal::null(), MathFunctions::unhex(context, StringVal::null()));
 


### PR DESCRIPTION
# Proposed changes

Fix be crushed due to stack overflow  in the `unhex` function.

Located and fixed by @924060929 

## Problem Summary:

This bug will be reproduced when  the input length of `unhex` function is more than 20 MB 

## Checklist(Required)

1. Does it affect the original behavior: (No)
2. Has unit tests been added: (No Need)
3. Has document been added or modified: (No Need)
4. Does it need to update dependencies: (No)
5. Are there any changes that cannot be rolled back: (No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
