### PR TITLE
[enhancement](nereids) Fix the wrong order of arguments of Assert.assertEquals

### DIFF
--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/jobs/RewriteTopDownJobTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/jobs/RewriteTopDownJobTest.java
@@ -81,19 +81,19 @@ public class RewriteTopDownJobTest {
         Assertions.assertEquals(1, rootGroup.getLogicalExpressions().size());
         GroupExpression rootGroupExpression = rootGroup.getLogicalExpression();
         List<Slot> output = rootGroup.getLogicalProperties().getOutput();
-        Assertions.assertEquals(output.size(), 1);
-        Assertions.assertEquals(output.get(0).getName(), "name");
-        Assertions.assertEquals(output.get(0).getDataType(), StringType.INSTANCE);
+        Assertions.assertEquals(1, output.size());
+        Assertions.assertEquals("name", output.get(0).getName());
+        Assertions.assertEquals(StringType.INSTANCE, output.get(0).getDataType());
         Assertions.assertEquals(1, rootGroupExpression.children().size());
         Assertions.assertEquals(PlanType.LOGICAL_PROJECT, rootGroupExpression.getPlan().getType());
 
         Group leafGroup = rootGroupExpression.child(0);
         output = leafGroup.getLogicalProperties().getOutput();
-        Assertions.assertEquals(output.size(), 2);
-        Assertions.assertEquals(output.get(0).getName(), "id");
-        Assertions.assertEquals(output.get(0).getDataType(), IntegerType.INSTANCE);
-        Assertions.assertEquals(output.get(1).getName(), "name");
-        Assertions.assertEquals(output.get(1).getDataType(), StringType.INSTANCE);
+        Assertions.assertEquals(2, output.size());
+        Assertions.assertEquals("id", output.get(0).getName());
+        Assertions.assertEquals(IntegerType.INSTANCE, output.get(0).getDataType());
+        Assertions.assertEquals("name", output.get(1).getName());
+        Assertions.assertEquals(StringType.INSTANCE, output.get(1).getDataType());
         Assertions.assertEquals(1, leafGroup.getLogicalExpressions().size());
         GroupExpression leafGroupExpression = leafGroup.getLogicalExpression();
         Assertions.assertEquals(PlanType.LOGICAL_BOUND_RELATION, leafGroupExpression.getPlan().getType());

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/pattern/GroupExpressionMatchingTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/pattern/GroupExpressionMatchingTest.java
@@ -265,7 +265,7 @@ public class GroupExpressionMatchingTest {
                 case LEFT_OUTER_JOIN:
                     Assertions.assertTrue(context.parent instanceof LogicalJoin);
                     LogicalJoin parent = (LogicalJoin) context.parent;
-                    Assertions.assertEquals(parent.getJoinType(), JoinType.INNER_JOIN);
+                    Assertions.assertEquals(JoinType.INNER_JOIN, parent.getJoinType());
                     break;
                 default:
                     notExpectedPlan(join, context);
@@ -287,13 +287,13 @@ public class GroupExpressionMatchingTest {
                 case "b": {
                     Assertions.assertTrue(context.parent instanceof LogicalJoin);
                     LogicalJoin parent = (LogicalJoin) context.parent;
-                    Assertions.assertEquals(parent.getJoinType(), JoinType.LEFT_OUTER_JOIN);
+                    Assertions.assertEquals(JoinType.LEFT_OUTER_JOIN, parent.getJoinType());
                     break;
                 }
                 case "c": {
                     Assertions.assertTrue(context.parent instanceof LogicalJoin);
                     LogicalJoin parent = (LogicalJoin) context.parent;
-                    Assertions.assertEquals(parent.getJoinType(), JoinType.INNER_JOIN);
+                    Assertions.assertEquals(JoinType.INNER_JOIN, parent.getJoinType());
                     break;
                 }
                 default:

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/exploration/join/JoinCommuteTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/exploration/join/JoinCommuteTest.java
@@ -63,8 +63,8 @@ public class JoinCommuteTest {
         Assert.assertEquals(1, transform.size());
         Plan newJoin = transform.get(0);
 
-        Assert.assertEquals(newJoin.child(1), join.child(0));
-        Assert.assertEquals(newJoin.child(0), join.child(1));
+        Assert.assertEquals(join.child(0), newJoin.child(1));
+        Assert.assertEquals(join.child(1), newJoin.child(0));
     }
 
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/logical/PushDownPredicateTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/logical/PushDownPredicateTest.java
@@ -135,9 +135,9 @@ public class PushDownPredicateTest {
         LogicalFilter filter1 = (LogicalFilter) op2;
         LogicalFilter filter2 = (LogicalFilter) op3;
 
-        Assertions.assertEquals(join1.getCondition().get(), onCondition1);
-        Assertions.assertEquals(filter1.getPredicates(), ExpressionUtils.and(onCondition2, whereCondition1));
-        Assertions.assertEquals(filter2.getPredicates(), ExpressionUtils.and(onCondition3, whereCondition2));
+        Assertions.assertEquals(onCondition1, join1.getCondition().get());
+        Assertions.assertEquals(ExpressionUtils.and(onCondition2, whereCondition1), filter1.getPredicates());
+        Assertions.assertEquals(ExpressionUtils.and(onCondition3, whereCondition2), filter2.getPredicates());
     }
 
     @Test
@@ -176,9 +176,9 @@ public class PushDownPredicateTest {
         LogicalJoin join1 = (LogicalJoin) op1;
         LogicalFilter filter1 = (LogicalFilter) op2;
         LogicalFilter filter2 = (LogicalFilter) op3;
-        Assertions.assertEquals(join1.getCondition().get(), whereCondition1);
-        Assertions.assertEquals(filter1.getPredicates(), whereCondition2);
-        Assertions.assertEquals(filter2.getPredicates(), whereCondition3);
+        Assertions.assertEquals(whereCondition1, join1.getCondition().get());
+        Assertions.assertEquals(whereCondition2, filter1.getPredicates());
+        Assertions.assertEquals(whereCondition3, filter2.getPredicates());
     }
 
     @Test
@@ -235,10 +235,10 @@ public class PushDownPredicateTest {
         Assertions.assertTrue(op1 instanceof LogicalFilter);
         Assertions.assertTrue(op2 instanceof LogicalFilter);
 
-        Assertions.assertEquals(((LogicalJoin) join2).getCondition().get(), whereCondition2);
-        Assertions.assertEquals(((LogicalJoin) join3).getCondition().get(), whereCondition1);
-        Assertions.assertEquals(((LogicalFilter) op1).getPredicates().toSql(), whereCondition3result.toSql());
-        Assertions.assertEquals(((LogicalFilter) op2).getPredicates(), whereCondition4);
+        Assertions.assertEquals(whereCondition2, ((LogicalJoin) join2).getCondition().get());
+        Assertions.assertEquals(whereCondition1, ((LogicalJoin) join3).getCondition().get());
+        Assertions.assertEquals(whereCondition3result.toSql(), ((LogicalFilter) op1).getPredicates().toSql());
+        Assertions.assertEquals(whereCondition4, ((LogicalFilter) op2).getPredicates());
     }
 
     private Memo rewrite(Plan plan) {

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/util/ExpressionUtilsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/util/ExpressionUtilsTest.java
@@ -39,8 +39,8 @@ public class ExpressionUtilsTest {
 
         expr = PARSER.parseExpression("a");
         expressions = ExpressionUtils.extractConjunctive(expr);
-        Assertions.assertEquals(expressions.size(), 1);
-        Assertions.assertEquals(expressions.get(0), expr);
+        Assertions.assertEquals(1, expressions.size());
+        Assertions.assertEquals(expr, expressions.get(0));
 
         expr = PARSER.parseExpression("a and b and c");
         Expression a = PARSER.parseExpression("a");
@@ -48,20 +48,20 @@ public class ExpressionUtilsTest {
         Expression c = PARSER.parseExpression("c");
 
         expressions = ExpressionUtils.extractConjunctive(expr);
-        Assertions.assertEquals(expressions.size(), 3);
-        Assertions.assertEquals(expressions.get(0), a);
-        Assertions.assertEquals(expressions.get(1), b);
-        Assertions.assertEquals(expressions.get(2), c);
+        Assertions.assertEquals(3, expressions.size());
+        Assertions.assertEquals(a, expressions.get(0));
+        Assertions.assertEquals(b, expressions.get(1));
+        Assertions.assertEquals(c, expressions.get(2));
 
 
         expr = PARSER.parseExpression("(a or b) and c and (e or f)");
         expressions = ExpressionUtils.extractConjunctive(expr);
         Expression aOrb = PARSER.parseExpression("a or b");
         Expression eOrf = PARSER.parseExpression("e or f");
-        Assertions.assertEquals(expressions.size(), 3);
-        Assertions.assertEquals(expressions.get(0), aOrb);
-        Assertions.assertEquals(expressions.get(1), c);
-        Assertions.assertEquals(expressions.get(2), eOrf);
+        Assertions.assertEquals(3, expressions.size());
+        Assertions.assertEquals(aOrb, expressions.get(0));
+        Assertions.assertEquals(c, expressions.get(1));
+        Assertions.assertEquals(eOrf, expressions.get(2));
     }
 
     @Test
@@ -71,8 +71,8 @@ public class ExpressionUtilsTest {
 
         expr = PARSER.parseExpression("a");
         expressions = ExpressionUtils.extractDisjunctive(expr);
-        Assertions.assertEquals(expressions.size(), 1);
-        Assertions.assertEquals(expressions.get(0), expr);
+        Assertions.assertEquals(1, expressions.size());
+        Assertions.assertEquals(expr, expressions.get(0));
 
         expr = PARSER.parseExpression("a or b or c");
         Expression a = PARSER.parseExpression("a");
@@ -80,18 +80,18 @@ public class ExpressionUtilsTest {
         Expression c = PARSER.parseExpression("c");
 
         expressions = ExpressionUtils.extractDisjunctive(expr);
-        Assertions.assertEquals(expressions.size(), 3);
-        Assertions.assertEquals(expressions.get(0), a);
-        Assertions.assertEquals(expressions.get(1), b);
-        Assertions.assertEquals(expressions.get(2), c);
+        Assertions.assertEquals(3, expressions.size());
+        Assertions.assertEquals(a, expressions.get(0));
+        Assertions.assertEquals(b, expressions.get(1));
+        Assertions.assertEquals(c, expressions.get(2));
 
         expr = PARSER.parseExpression("(a and b) or c or (e and f)");
         expressions = ExpressionUtils.extractDisjunctive(expr);
         Expression aAndb = PARSER.parseExpression("a and b");
         Expression eAndf = PARSER.parseExpression("e and f");
-        Assertions.assertEquals(expressions.size(), 3);
-        Assertions.assertEquals(expressions.get(0), aAndb);
-        Assertions.assertEquals(expressions.get(1), c);
-        Assertions.assertEquals(expressions.get(2), eAndf);
+        Assertions.assertEquals(3, expressions.size());
+        Assertions.assertEquals(aAndb, expressions.get(0));
+        Assertions.assertEquals(c, expressions.get(1));
+        Assertions.assertEquals(eAndf, expressions.get(2));
     }
 }


### PR DESCRIPTION

# Proposed changes

~~Issue Number: close #xxx~~

## Problem Summary:

The first argument of method `Assert.assertEquals` should be an expected value. Wrong order may confuse us when cases fail.

## Checklist(Required)

1. Does it affect the original behavior: No
2. Has unit tests been added: No Need
3. Has document been added or modified: No Need
4. Does it need to update dependencies: No
5. Are there any changes that cannot be rolled back: No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
