### PR TITLE
(Git)[Nereids] ignore ANTLR4 generated files and dir.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,8 @@ samples/doris-demo/remote-udf-cpp-demo/function_server_demo
 fe/mocked/
 fe/fe-core/gen/
 fe/fe-core/src/main/resources/static/
+fe/fe-core/src/main/antlr4/org/apache/doris/nereids/DorisLexer.tokens
+fe/fe-core/src/main/antlr4/org/apache/doris/nereids/gen/
 
 # BE
 be/build*/


### PR DESCRIPTION
# Proposed changes
This PR proposes to ignore tracking the following file and dir auto-generated by ANTLR4:

```
fe/fe-core/src/main/antlr4/org/apache/doris/nereids/DorisLexer.tokens
fe/fe-core/src/main/antlr4/org/apache/doris/nereids/gen/
```

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
