### PR TITLE
[Fix] Coredump in column dictionary insert data from DefaultValueColumnIterator

### DIFF
--- a/be/src/olap/rowset/segment_v2/column_reader.cpp
+++ b/be/src/olap/rowset/segment_v2/column_reader.cpp
@@ -938,6 +938,7 @@ void DefaultValueColumnIterator::insert_default_data(const TypeInfo* type_info, 
     vectorized::Int128 int128;
     char* data_ptr = (char*)&int128;
     size_t data_len = sizeof(int128);
+    dst = dst->convert_to_predicate_column_if_dictionary();
 
     switch (type_info->type()) {
     case OLAP_FIELD_TYPE_OBJECT:


### PR DESCRIPTION
# Proposed changes

Issue Number: close #11216

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
