### PR TITLE
[fix](auth) Forbid grant USAGE_PRIV to database.table

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateRoleStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateRoleStmt.java
@@ -56,7 +56,7 @@ public class CreateRoleStmt extends DdlStmt {
 
         // check if current user has GRANT priv on GLOBAL level.
         if (!Env.getCurrentEnv().getAuth().checkGlobalPriv(ConnectContext.get(), PrivPredicate.GRANT)) {
-            ErrorReport.reportAnalysisException(ErrorCode.ERR_SPECIFIC_ACCESS_DENIED_ERROR, "CREATE USER");
+            ErrorReport.reportAnalysisException(ErrorCode.ERR_SPECIFIC_ACCESS_DENIED_ERROR, "CREATE ROLE");
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/RevokeStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/RevokeStmt.java
@@ -112,9 +112,9 @@ public class RevokeStmt extends DdlStmt {
 
         // Revoke operation obey the same rule as Grant operation. reuse the same method
         if (tblPattern != null) {
-            GrantStmt.checkPrivileges(analyzer, privileges, role, tblPattern);
+            GrantStmt.checkTablePrivileges(privileges, role, tblPattern);
         } else {
-            GrantStmt.checkPrivileges(analyzer, privileges, role, resourcePattern);
+            GrantStmt.checkResourcePrivileges(privileges, role, resourcePattern);
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/PaloAuth.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/PaloAuth.java
@@ -711,26 +711,35 @@ public class PaloAuth implements Writable {
                 throw new DdlException("User " + userIdent + " already exist");
             }
 
-            // 3. set password
-            setPasswordInternal(userIdent, password, null, false /* err on non exist */,
-                    false /* set by resolver */, true /* is replay */);
+            try {
+                // 3. set password
+                setPasswordInternal(userIdent, password, null, false /* err on non exist */,
+                        false /* set by resolver */, true /* is replay */);
 
-            // 4. grant privs of role to user
-            grantPrivsByRole(userIdent, role);
+                // 4. grant privs of role to user
+                grantPrivsByRole(userIdent, role);
 
-            // other user properties
-            propertyMgr.addUserResource(userIdent.getQualifiedUser(), false /* not system user */);
+                // other user properties
+                propertyMgr.addUserResource(userIdent.getQualifiedUser(), false /* not system user */);
 
-            if (!userIdent.getQualifiedUser().equals(ROOT_USER) && !userIdent.getQualifiedUser().equals(ADMIN_USER)) {
-                // grant read privs to database information_schema
-                TablePattern tblPattern = new TablePattern(DEFAULT_CATALOG, InfoSchemaDb.DATABASE_NAME, "*");
-                try {
-                    tblPattern.analyze(ClusterNamespace.getClusterNameFromFullName(userIdent.getQualifiedUser()));
-                } catch (AnalysisException e) {
-                    LOG.warn("should not happen", e);
+                if (!userIdent.getQualifiedUser().equals(ROOT_USER) && !userIdent.getQualifiedUser()
+                        .equals(ADMIN_USER)) {
+                    // grant read privs to database information_schema
+                    TablePattern tblPattern = new TablePattern(DEFAULT_CATALOG, InfoSchemaDb.DATABASE_NAME, "*");
+                    try {
+                        tblPattern.analyze(ClusterNamespace.getClusterNameFromFullName(userIdent.getQualifiedUser()));
+                    } catch (AnalysisException e) {
+                        LOG.warn("should not happen", e);
+                    }
+                    grantInternal(userIdent, null /* role */, tblPattern, PrivBitSet.of(PaloPrivilege.SELECT_PRIV),
+                            false /* err on non exist */, true /* is replay */);
                 }
-                grantInternal(userIdent, null /* role */, tblPattern, PrivBitSet.of(PaloPrivilege.SELECT_PRIV),
-                        false /* err on non exist */, true /* is replay */);
+            } catch (Throwable t) {
+                // This is a temp protection to avoid bug such as described in
+                // https://github.com/apache/doris/issues/11235
+                // Normally, all operations in try {} should not fail
+                LOG.error("got unexpected exception when creating user. exit", t);
+                System.exit(-1);
             }
 
             if (!isReplay) {

--- a/fe/fe-core/src/test/java/org/apache/doris/mysql/privilege/AuthTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/mysql/privilege/AuthTest.java
@@ -34,6 +34,7 @@ import org.apache.doris.catalog.Env;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.DdlException;
+import org.apache.doris.common.ExceptionChecker;
 import org.apache.doris.common.UserException;
 import org.apache.doris.datasource.InternalDataSource;
 import org.apache.doris.persist.EditLog;
@@ -1591,15 +1592,14 @@ public class AuthTest {
 
         // 2. grant resource priv to db table
         TablePattern tablePattern = new TablePattern("db1", "*");
-        grantStmt = new GrantStmt(userIdentity, null, tablePattern, usagePrivileges);
-        hasException = false;
-        try {
-            grantStmt.analyze(analyzer);
-            auth.grant(grantStmt);
-        } catch (UserException e) {
-            e.printStackTrace();
-            hasException = true;
-        }
-        Assert.assertTrue(hasException);
+        GrantStmt grantStmt2 = new GrantStmt(userIdentity, null, tablePattern, usagePrivileges);
+        ExceptionChecker.expectThrowsWithMsg(AnalysisException.class,
+                "Can not grant/revoke USAGE_PRIV to/from database or table", () -> grantStmt2.analyze(analyzer));
+
+        // 3. grant resource prov to role on db.table
+        tablePattern = new TablePattern("db1", "*");
+        GrantStmt grantStmt3 = new GrantStmt(userIdentity, "test_role", tablePattern, usagePrivileges);
+        ExceptionChecker.expectThrowsWithMsg(AnalysisException.class,
+                "Can not grant/revoke USAGE_PRIV to/from database or table", () -> grantStmt3.analyze(analyzer));
     }
 }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #11235 

## Problem Summary:

The USAGE_PRIV can not be granted to database.table level.
And it may cause editlog replay bug.

## Checklist(Required)

1. Type of your changes:
    - [ ] Improvement
    - [x] Fix
    - [ ] Feature-WIP
    - [ ] Feature
    - [ ] Doc
    - [ ] Refator
    - [ ] Others: 
2. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
3. Has unit tests been added:
    - [x] Yes
    - [ ] No
    - [ ] No Need
4. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
5. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
6. Are there any changes that cannot be rolled back:
    - [ ] Yes
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

