### PR TITLE
[feature-wip](multi-catalog)(fix) partition value error when a block contains multiple splits.

### DIFF
--- a/be/src/vec/exec/file_arrow_scanner.h
+++ b/be/src/vec/exec/file_arrow_scanner.h
@@ -61,7 +61,6 @@ private:
     // Read next buffer from reader
     Status _open_next_reader();
     Status _next_arrow_batch();
-    Status _init_arrow_batch_if_necessary();
     Status _append_batch_to_block(Block* block);
 
 private:


### PR DESCRIPTION
# Proposed changes
`FileArrowScanner::get_next` returns a block when full, so it maybe contains multiple splits in small files or crosses two splits in large files. However, a block can only fill the partition values from one file. Different splits may be from different files, causing the error of embed partition values. so we should return the block when reading at the `EOF` of a split.

## Checklist(Required)

1. Type of your changes:
    - [x] Fix
2. Does it affect the original behavior: 
    - [x] No
3. Has unit tests been added:
    - [x] No
4. Has document been added or modified:
    - [x] No
5. Does it need to update dependencies:
    - [x] No
6. Are there any changes that cannot be rolled back:
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

