### PR TITLE
[feature] (Nereids) add rewrite rule to merge consecutive filter nodes

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/NereidsPlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/NereidsPlanner.java
@@ -111,7 +111,6 @@ public class NereidsPlanner extends Planner {
             deriveStats();
         }
         optimize();
-
         // Get plan directly. Just for SSB.
         return getRoot().extractPlan();
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/batch/JoinReorderRulesJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/batch/JoinReorderRulesJob.java
@@ -27,7 +27,7 @@ import com.google.common.collect.ImmutableList;
  */
 public class JoinReorderRulesJob extends BatchRulesJob {
 
-    public JoinReorderRulesJob(PlannerContext plannerContext) {
+    public  JoinReorderRulesJob(PlannerContext plannerContext) {
         super(plannerContext);
         rulesJob.addAll(ImmutableList.of(
                 topDownBatch(ImmutableList.of(new ReorderJoin()))

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/batch/JoinReorderRulesJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/batch/JoinReorderRulesJob.java
@@ -27,7 +27,7 @@ import com.google.common.collect.ImmutableList;
  */
 public class JoinReorderRulesJob extends BatchRulesJob {
 
-    public  JoinReorderRulesJob(PlannerContext plannerContext) {
+    public JoinReorderRulesJob(PlannerContext plannerContext) {
         super(plannerContext);
         rulesJob.addAll(ImmutableList.of(
                 topDownBatch(ImmutableList.of(new ReorderJoin()))

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/RuleType.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/RuleType.java
@@ -54,9 +54,8 @@ public enum RuleType {
     REWRITE_AGG_EXPRESSION(RuleTypeClass.REWRITE),
     REWRITE_FILTER_EXPRESSION(RuleTypeClass.REWRITE),
     REWRITE_JOIN_EXPRESSION(RuleTypeClass.REWRITE),
-
     REORDER_JOIN(RuleTypeClass.REWRITE),
-
+    MERGE_CONSECUTIVE_FILTERS(RuleTypeClass.REWRITE),
     REWRITE_SENTINEL(RuleTypeClass.REWRITE),
 
     // exploration rules

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/logical/MergeConsecutiveFilters.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/logical/MergeConsecutiveFilters.java
@@ -24,8 +24,6 @@ import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.plans.logical.LogicalFilter;
 import org.apache.doris.nereids.util.ExpressionUtils;
 
-import java.util.Optional;
-
 /**
  * this rule aims to merge consecutive filters.
  * For example:
@@ -52,11 +50,7 @@ public class MergeConsecutiveFilters  extends OneRewriteRuleFactory {
             Expression predicates = filter.getPredicates();
             Expression childPredicates = childFilter.getPredicates();
             Expression mergedPredicates = ExpressionUtils.and(predicates, childPredicates);
-            LogicalFilter mergedFilter = new LogicalFilter(
-                    mergedPredicates,
-                    Optional.empty(),
-                    Optional.of(filter.getLogicalProperties()),
-                    childFilter.child());
+            LogicalFilter mergedFilter = new LogicalFilter(mergedPredicates, childFilter.child());
             return mergedFilter;
         }).toRule(RuleType.MERGE_CONSECUTIVE_FILTERS);
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/logical/MergeConsecutiveFilters.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/logical/MergeConsecutiveFilters.java
@@ -1,0 +1,64 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.rules.rewrite.logical;
+
+import org.apache.doris.nereids.rules.Rule;
+import org.apache.doris.nereids.rules.RuleType;
+import org.apache.doris.nereids.rules.rewrite.OneRewriteRuleFactory;
+import org.apache.doris.nereids.trees.expressions.Expression;
+import org.apache.doris.nereids.trees.plans.logical.LogicalFilter;
+import org.apache.doris.nereids.util.ExpressionUtils;
+
+import java.util.Optional;
+
+/**
+ * this rule aims to merge consecutive filters.
+ * For example:
+ * logical plan tree:
+ *               project
+ *                  |
+ *                filter(a>0)
+ *                  |
+ *                filter(b>0)
+ *                  |
+ *                scan
+ * transformed to:
+ *                project
+ *                   |
+ *                filter(a>0 and b>0)
+ *                   |
+ *                 scan
+ */
+public class MergeConsecutiveFilters  extends OneRewriteRuleFactory {
+    @Override
+    public Rule build() {
+        return logicalFilter(logicalFilter()).then(filter -> {
+            LogicalFilter<?> childFilter = filter.child();
+            Expression predicates = filter.getPredicates();
+            Expression childPredicates = childFilter.getPredicates();
+            Expression mergedPredicates = ExpressionUtils.and(predicates, childPredicates);
+            LogicalFilter mergedFilter = new LogicalFilter(
+                    mergedPredicates,
+                    Optional.empty(),
+                    Optional.of(filter.getLogicalProperties()),
+                    childFilter.child());
+            return mergedFilter;
+        }).toRule(RuleType.MERGE_CONSECUTIVE_FILTERS);
+    }
+
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/logical/MergeConsecutiveFilterTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/logical/MergeConsecutiveFilterTest.java
@@ -29,8 +29,8 @@ import org.apache.doris.nereids.util.ExpressionUtils;
 import org.apache.doris.qe.ConnectContext;
 
 import com.google.common.collect.Lists;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
@@ -56,10 +56,10 @@ public class MergeConsecutiveFilterTest {
         //check transformed plan
         Plan resultPlan = plannerContext.getMemo().copyOut();
         System.out.println(resultPlan.treeString());
-        Assert.assertTrue(resultPlan instanceof LogicalFilter);
+        Assertions.assertTrue(resultPlan instanceof LogicalFilter);
         Expression allPredicates = ExpressionUtils.and(expression3,
                 ExpressionUtils.and(expression2, expression1));
-        Assert.assertTrue(((LogicalFilter<?>) resultPlan).getPredicates().equals(allPredicates));
-        Assert.assertTrue(resultPlan.child(0) instanceof UnboundRelation);
+        Assertions.assertTrue(((LogicalFilter<?>) resultPlan).getPredicates().equals(allPredicates));
+        Assertions.assertTrue(resultPlan.child(0) instanceof UnboundRelation);
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/logical/MergeConsecutiveFilterTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/logical/MergeConsecutiveFilterTest.java
@@ -1,0 +1,65 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.rules.rewrite.logical;
+
+import org.apache.doris.nereids.PlannerContext;
+import org.apache.doris.nereids.analyzer.UnboundRelation;
+import org.apache.doris.nereids.memo.Memo;
+import org.apache.doris.nereids.rules.Rule;
+import org.apache.doris.nereids.trees.expressions.Expression;
+import org.apache.doris.nereids.trees.expressions.IntegerLiteral;
+import org.apache.doris.nereids.trees.plans.Plan;
+import org.apache.doris.nereids.trees.plans.logical.LogicalFilter;
+import org.apache.doris.nereids.util.ExpressionUtils;
+import org.apache.doris.qe.ConnectContext;
+
+import com.google.common.collect.Lists;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.List;
+
+/**
+ * MergeConsecutiveFilter ut
+ */
+public class MergeConsecutiveFilterTest {
+    @Test
+    public void testMergeConsecutiveFilters() {
+        UnboundRelation relation = new UnboundRelation(Lists.newArrayList("db", "table"));
+        Expression expression1 = new IntegerLiteral(1);
+        LogicalFilter filter1 = new LogicalFilter(expression1, relation);
+        Expression expression2 = new IntegerLiteral(2);
+        LogicalFilter filter2 = new LogicalFilter(expression2, filter1);
+        Expression expression3 = new IntegerLiteral(3);
+        LogicalFilter filter3 = new LogicalFilter(expression3, filter2);
+
+        PlannerContext plannerContext = new Memo(filter3)
+                .newPlannerContext(new ConnectContext())
+                .setDefaultJobContext();
+        List<Rule> rules = Lists.newArrayList(new MergeConsecutiveFilters().build());
+        plannerContext.bottomUpRewrite(rules);
+        //check transformed plan
+        Plan resultPlan = plannerContext.getMemo().copyOut();
+        System.out.println(resultPlan.treeString());
+        Assert.assertTrue(resultPlan instanceof LogicalFilter);
+        Expression allPredicates = ExpressionUtils.and(expression3,
+                ExpressionUtils.and(expression2, expression1));
+        Assert.assertTrue(((LogicalFilter<?>) resultPlan).getPredicates().equals(allPredicates));
+        Assert.assertTrue(resultPlan.child(0) instanceof UnboundRelation);
+    }
+}


### PR DESCRIPTION
# Proposed changes

 this rule aims to merge consecutive filters.
  For example:
  logical plan tree:
```
                project
                   |
                 filter(a>0)
                   |
                 filter(b>0)
                   |
                 scan
```
  transformed to:
```
                 project
                    |
                 filter(a>0 and b>0)
                    |
                  scan
 ```
Issue Number: close #xxx

## Problem Summary:

## Checklist(Required)

1. Type of your changes:
    - [ ] Improvement
    - [ ] Fix
    - [ ] Feature-WIP
    - [ ] Feature
    - [ ] Doc
    - [ ] Refator
    - [ ] Others: 
2. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
3. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
5. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
6. Are there any changes that cannot be rolled back:
    - [ ] Yes
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

