### PR TITLE
[Improvement][chore] add const to all operator==

### DIFF
--- a/be/src/common/status.h
+++ b/be/src/common/status.h
@@ -506,12 +506,12 @@ public:
     // Used like if (res == Status::OK())
     // if the state is ok, then both code and precise code is not initialized properly, so that should check ok state
     // ignore error messages during comparison
-    bool operator==(const Status& st) {
+    bool operator==(const Status& st) const {
         return ok() ? st.ok() : code() == st.code() && precise_code() == st.precise_code();
     }
 
     // Used like if (res != Status::OK())
-    bool operator!=(const Status& st) {
+    bool operator!=(const Status& st) const {
         return ok() ? !st.ok() : code() != st.code() || precise_code() != st.precise_code();
     }
 

--- a/be/src/exec/hash_table.h
+++ b/be/src/exec/hash_table.h
@@ -152,7 +152,7 @@ public:
     int64_t size() const { return _num_nodes; }
 
     // Returns the number of buckets
-    int64_t num_buckets() { return _buckets.size(); }
+    int64_t num_buckets() const { return _buckets.size(); }
 
     // Returns the number of filled buckets
     int64_t num_filled_buckets() const { return _num_filled_buckets; }
@@ -286,11 +286,11 @@ public:
             return _node->matched;
         }
 
-        bool operator==(const Iterator& rhs) {
+        bool operator==(const Iterator& rhs) const {
             return _bucket_idx == rhs._bucket_idx && _node == rhs._node;
         }
 
-        bool operator!=(const Iterator& rhs) {
+        bool operator!=(const Iterator& rhs) const {
             return _bucket_idx != rhs._bucket_idx || _node != rhs._node;
         }
 

--- a/be/src/runtime/exec_env_init.cpp
+++ b/be/src/runtime/exec_env_init.cpp
@@ -361,6 +361,7 @@ void ExecEnv::_destroy() {
     SAFE_DELETE(_query_pool_mem_tracker);
     SAFE_DELETE(_load_pool_mem_tracker);
     SAFE_DELETE(_task_pool_mem_tracker_registry);
+    SAFE_DELETE(_buffer_reservation);
 
     DEREGISTER_HOOK_METRIC(query_mem_consumption);
     DEREGISTER_HOOK_METRIC(load_mem_consumption);

--- a/be/src/util/bitmap_value.h
+++ b/be/src/util/bitmap_value.h
@@ -1032,13 +1032,13 @@ public:
         return false;
     }
 
-    bool operator==(const Roaring64MapSetBitForwardIterator& o) {
+    bool operator==(const Roaring64MapSetBitForwardIterator& o) const {
         if (map_iter == map_end && o.map_iter == o.map_end) return true;
         if (o.map_iter == o.map_end) return false;
         return **this == *o;
     }
 
-    bool operator!=(const Roaring64MapSetBitForwardIterator& o) {
+    bool operator!=(const Roaring64MapSetBitForwardIterator& o) const {
         if (map_iter == map_end && o.map_iter == o.map_end) return false;
         if (o.map_iter == o.map_end) return true;
         return **this != *o;

--- a/be/test/util/metrics_test.cpp
+++ b/be/test/util/metrics_test.cpp
@@ -87,7 +87,7 @@ TEST_F(MetricsTest, CounterPerf) {
     static const int kThreadLoopCount = LOOP_LESS_OR_MORE(1000, 1000000);
     // volatile int64_t
     {
-        volatile int64_t sum = 0;
+        int64_t sum = 0;
         MonotonicStopWatch watch;
         watch.start();
         for (int i = 0; i < kLoopCount; ++i) {

--- a/be/test/util/metrics_test.cpp
+++ b/be/test/util/metrics_test.cpp
@@ -85,7 +85,6 @@ void mt_updater(int32_t loop, T* counter, std::atomic<uint64_t>* used_time) {
 TEST_F(MetricsTest, CounterPerf) {
     static const int kLoopCount = LOOP_LESS_OR_MORE(10, 100000000);
     static const int kThreadLoopCount = LOOP_LESS_OR_MORE(1000, 1000000);
-    // volatile int64_t
     {
         int64_t sum = 0;
         MonotonicStopWatch watch;


### PR DESCRIPTION
# Proposed changes

part of work with #9312

1. add const to all `operator==`
2. remove template argument to `construtor/desctructor`, and some unsed code.
3. remove some volatile usage [P1152R4](https://wg21.link/P1152R4)

## Problem Summary:

## Checklist(Required)

1. Type of your changes:
    - [X] Improvement
    - [ ] Fix
    - [ ] Feature-WIP
    - [ ] Feature
    - [ ] Doc
    - [ ] Refator
    - [ ] Others: 
4. Does it affect the original behavior: 
    - [ ] Yes
    - [X] No
    - [ ] I don't know
5. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [X] No Need
6. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [X] No Need
7. Does it need to update dependencies:
    - [ ] Yes
    - [X] No
8. Are there any changes that cannot be rolled back:
    - [ ] Yes
    - [X] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

