### PR TITLE
[Improvement][chore] replace from_decv2_to_packed128 to decv2.value

### DIFF
--- a/be/src/exec/text_converter.hpp
+++ b/be/src/exec/text_converter.hpp
@@ -148,8 +148,7 @@ inline bool TextConverter::write_slot(const SlotDescriptor* slot_desc, Tuple* tu
             parse_result = StringParser::PARSE_FAILURE;
         }
 
-        *reinterpret_cast<PackedInt128*>(slot) =
-                binary_cast<DecimalV2Value, PackedInt128>(decimal_slot);
+        *reinterpret_cast<PackedInt128*>(slot) = decimal_slot.value();
         break;
     }
 
@@ -301,9 +300,8 @@ inline bool TextConverter::write_vec_column(const SlotDescriptor* slot_desc,
             parse_result = StringParser::PARSE_FAILURE;
             break;
         }
-        PackedInt128 num = binary_cast<DecimalV2Value, PackedInt128>(decimal_slot);
-        reinterpret_cast<vectorized::ColumnVector<doris::PackedInt128>*>(col_ptr)->insert_value(
-                num.value);
+        reinterpret_cast<vectorized::ColumnVector<vectorized::Int128>*>(col_ptr)->insert_value(
+                decimal_slot.value());
         break;
     }
 

--- a/be/src/olap/rowset/beta_rowset_writer.h
+++ b/be/src/olap/rowset/beta_rowset_writer.h
@@ -65,7 +65,7 @@ public:
 
     RowsetTypePB type() const override { return RowsetTypePB::BETA_ROWSET; }
 
-    Status get_segment_num_rows(std::vector<uint32_t>* segment_num_rows) const {
+    Status get_segment_num_rows(std::vector<uint32_t>* segment_num_rows) const override {
         *segment_num_rows = _segment_num_rows;
         return Status::OK();
     }

--- a/be/src/util/binary_cast.hpp
+++ b/be/src/util/binary_cast.hpp
@@ -82,7 +82,6 @@ To binary_cast(From from) {
     constexpr bool from_i64_to_db = match_v<From, int64_t, To, double>;
     constexpr bool from_db_to_i64 = match_v<From, double, To, int64_t>;
     constexpr bool from_db_to_u64 = match_v<From, double, To, uint64_t>;
-    constexpr bool from_decv2_to_packed128 = match_v<From, DecimalV2Value, To, PackedInt128>;
     constexpr bool from_i128_to_dt = match_v<From, __int128_t, To, DateTimeValue>;
     constexpr bool from_dt_to_i128 = match_v<From, DateTimeValue, To, __int128_t>;
     constexpr bool from_i64_to_vec_dt =
@@ -109,10 +108,9 @@ To binary_cast(From from) {
                     To, uint64_t>;
 
     static_assert(from_u64_to_db || from_i64_to_db || from_db_to_i64 || from_db_to_u64 ||
-                  from_decv2_to_packed128 || from_i128_to_dt || from_dt_to_i128 ||
-                  from_i64_to_vec_dt || from_vec_dt_to_i64 || from_i128_to_decv2 ||
-                  from_decv2_to_i128 || from_ui32_to_date_v2 || from_date_v2_to_ui32 ||
-                  from_ui64_to_datetime_v2 || from_datetime_v2_to_ui64);
+                  from_i128_to_dt || from_dt_to_i128 || from_i64_to_vec_dt || from_vec_dt_to_i64 ||
+                  from_i128_to_decv2 || from_decv2_to_i128 || from_ui32_to_date_v2 ||
+                  from_date_v2_to_ui32 || from_ui64_to_datetime_v2 || from_datetime_v2_to_ui64);
 
     if constexpr (from_u64_to_db) {
         TypeConverter conv;
@@ -130,10 +128,6 @@ To binary_cast(From from) {
         TypeConverter conv;
         conv.dbl = from;
         return conv.u64;
-    } else if constexpr (from_decv2_to_packed128) {
-        DecimalInt128Union conv;
-        conv.decimal = from;
-        return conv.packed128;
     } else if constexpr (from_i128_to_dt) {
         DateTimeInt128Union conv = {.i128 = from};
         return conv.dt;

--- a/be/src/vec/aggregate_functions/aggregate_function_window_funnel.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_window_funnel.h
@@ -184,14 +184,14 @@ public:
         // TODO: handle mode in the future.
         // be/src/olap/row_block2.cpp copy_data_to_column
         const auto& timestamp =
-                static_cast<const ColumnVector<DateValueType>&>(*columns[2]).get_data()[row_num];
+                static_cast<const ColumnVector<NativeType>&>(*columns[2]).get_data()[row_num];
         const int NON_EVENT_NUM = 3;
         for (int i = NON_EVENT_NUM; i < IAggregateFunction::get_argument_types().size(); i++) {
             const auto& is_set =
                     static_cast<const ColumnVector<UInt8>&>(*columns[i]).get_data()[row_num];
             if (is_set) {
                 this->data(place).add(
-                        timestamp, i - NON_EVENT_NUM,
+                        binary_cast<NativeType, DateValueType>(timestamp), i - NON_EVENT_NUM,
                         IAggregateFunction::get_argument_types().size() - NON_EVENT_NUM, window);
             }
         }

--- a/be/src/vec/exec/vschema_scan_node.cpp
+++ b/be/src/vec/exec/vschema_scan_node.cpp
@@ -26,6 +26,7 @@
 #include "runtime/tuple_row.h"
 #include "util/runtime_profile.h"
 #include "util/types.h"
+#include "vec/core/types.h"
 namespace doris::vectorized {
 
 VSchemaScanNode::VSchemaScanNode(ObjectPool* pool, const TPlanNode& tnode,
@@ -425,9 +426,8 @@ Status VSchemaScanNode::write_slot_to_vectorized_column(void* slot, SlotDescript
 
     case TYPE_DECIMALV2:
     case TYPE_DECIMAL128: {
-        __int128 num = (reinterpret_cast<PackedInt128*>(slot))->value;
-        reinterpret_cast<vectorized::ColumnVector<doris::PackedInt128>*>(col_ptr)->insert_value(
-                num);
+        Int128 num = (reinterpret_cast<PackedInt128*>(slot))->value;
+        reinterpret_cast<vectorized::ColumnVector<Int128>*>(col_ptr)->insert_value(num);
         break;
     }
 

--- a/be/src/vec/io/io_helper.h
+++ b/be/src/vec/io/io_helper.h
@@ -322,7 +322,7 @@ bool read_decimal_text_impl(T& x, ReadBuffer& buf, UInt32 precision, UInt32 scal
     // only to match the is_all_read() check to prevent return null
     buf.position() = buf.end();
 
-    x.value = binary_cast<DecimalV2Value, Int128>(dv);
+    x.value = dv.value();
     return ans;
 }
 

--- a/be/src/vec/sink/vtablet_sink.cpp
+++ b/be/src/vec/sink/vtablet_sink.cpp
@@ -572,8 +572,7 @@ Status VOlapTableSink::_validate_data(RuntimeState* state, vectorized::Block* bl
 
                     if (dec_val.greater_than_scale(desc->type().scale)) {
                         auto code = dec_val.round(&dec_val, desc->type().scale, HALF_UP);
-                        column_decimal->get_data()[j] =
-                                binary_cast<DecimalV2Value, vectorized::Int128>(dec_val);
+                        column_decimal->get_data()[j] = dec_val.value();
 
                         if (code != E_DEC_OK) {
                             fmt::format_to(error_msg, "round one decimal failed.value={}; ",

--- a/be/test/vec/utils/arrow_column_to_doris_column_test.cpp
+++ b/be/test/vec/utils/arrow_column_to_doris_column_test.cpp
@@ -396,8 +396,7 @@ void test_decimalv2(std::shared_ptr<arrow::Decimal128Type> type,
     MutableColumnPtr data_column = data_type->create_column();
     ColumnWithTypeAndName column(std::move(data_column), data_type, "test_numeric_column");
     for (auto& str : test_cases) {
-        DecimalV2Value decimal_value(str);
-        int128_t value = binary_cast<DecimalV2Value, int128_t>(decimal_value);
+        int128_t value = DecimalV2Value(str).value();
         int128_t expect_value =
                 convert_decimals<vectorized::DataTypeDecimal<vectorized::Decimal128>,
                                  vectorized::DataTypeDecimal<vectorized::Decimal128>>(


### PR DESCRIPTION
# Proposed changes

part of work with https://github.com/apache/doris/issues/9312

1. use vdatatime.value() to replace binary_cast<DecimalV2Value, PackedInt128>.
2. change some Irregular usage like `ColumnVector<PackedInt128>`,`ColumnVector<VDataTime>`.

## Problem Summary:

## Checklist(Required)

1. Type of your changes:
    - [ ] Improvement
    - [ ] Fix
    - [ ] Feature-WIP
    - [ ] Feature
    - [ ] Doc
    - [ ] Refator
    - [ ] Others: 
3. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
4. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
5. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
6. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
7. Are there any changes that cannot be rolled back:
    - [ ] Yes
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

