### PR TITLE
[fix](planner)do not change non-null to nullable for outer join table slot

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/Analyzer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/Analyzer.java
@@ -38,6 +38,7 @@ import org.apache.doris.common.ErrorReport;
 import org.apache.doris.common.IdGenerator;
 import org.apache.doris.common.Pair;
 import org.apache.doris.common.util.TimeUtils;
+import org.apache.doris.common.util.VectorizedUtil;
 import org.apache.doris.external.hudi.HudiTable;
 import org.apache.doris.external.hudi.HudiUtils;
 import org.apache.doris.planner.PlanNode;
@@ -799,7 +800,13 @@ public class Analyzer {
         }
         result = globalState.descTbl.addSlotDescriptor(d);
         result.setColumn(col);
-        result.setIsNullable(col.isAllowNull());
+        boolean isNullable;
+        if (VectorizedUtil.isVectorized()) {
+            isNullable = col.isAllowNull();
+        } else {
+            isNullable = col.isAllowNull() || isOuterJoined(d.getId());
+        }
+        result.setIsNullable(isNullable);
 
         slotRefMap.put(key, result);
         return result;

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/Analyzer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/Analyzer.java
@@ -799,7 +799,6 @@ public class Analyzer {
         }
         result = globalState.descTbl.addSlotDescriptor(d);
         result.setColumn(col);
-        // TODO: need to remove this outer join'
         result.setIsNullable(col.isAllowNull());
 
         slotRefMap.put(key, result);

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/Analyzer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/Analyzer.java
@@ -800,7 +800,7 @@ public class Analyzer {
         result = globalState.descTbl.addSlotDescriptor(d);
         result.setColumn(col);
         // TODO: need to remove this outer join'
-        result.setIsNullable(col.isAllowNull() || isOuterJoined(d.getId()));
+        result.setIsNullable(col.isAllowNull());
 
         slotRefMap.put(key, result);
         return result;

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/SelectStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/SelectStmtTest.java
@@ -805,8 +805,8 @@ public class SelectStmtTest {
         String sql1 = "select l.citycode, group_concat(distinct r.username) from db1.table1 l "
                 + "left join db1.table2 r on l.citycode=r.citycode group by l.citycode";
         SelectStmt stmt1 = (SelectStmt) UtFrameUtils.parseAndAnalyzeStmt(sql1, ctx);
-        Assert.assertTrue(stmt1.getAnalyzer().getSlotDesc(new SlotId(2)).getIsNullable());
-        Assert.assertTrue(stmt1.getAnalyzer().getSlotDescriptor("r.username").getIsNullable());
+        Assert.assertFalse(stmt1.getAnalyzer().getSlotDesc(new SlotId(2)).getIsNullable());
+        Assert.assertFalse(stmt1.getAnalyzer().getSlotDescriptor("r.username").getIsNullable());
         FunctionCallExpr expr = (FunctionCallExpr) stmt1.getSelectList().getItems().get(1).getExpr();
         Assert.assertTrue(expr.getFnParams().isDistinct());
     }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #11250

## Problem Summary:

currently we set nullable to all slot of outer join table. but we should follow nullable attribute of column in table under vectorized engine.

## Checklist(Required)

1. Type of your changes:
    - [ ] Improvement
    - [x] Fix
    - [ ] Feature-WIP
    - [ ] Feature
    - [ ] Doc
    - [ ] Refator
    - [ ] Others: 
2. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
3. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
4. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
5. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
6. Are there any changes that cannot be rolled back:
    - [ ] Yes
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

