### PR TITLE
[fix] (mem tracker) Fix runtime instance tracker null pointer

### DIFF
--- a/be/src/olap/rowset/beta_rowset_writer.h
+++ b/be/src/olap/rowset/beta_rowset_writer.h
@@ -65,7 +65,7 @@ public:
 
     RowsetTypePB type() const override { return RowsetTypePB::BETA_ROWSET; }
 
-    Status get_segment_num_rows(std::vector<uint32_t>* segment_num_rows) const {
+    Status get_segment_num_rows(std::vector<uint32_t>* segment_num_rows) const override {
         *segment_num_rows = _segment_num_rows;
         return Status::OK();
     }

--- a/be/src/runtime/data_stream_mgr.cpp
+++ b/be/src/runtime/data_stream_mgr.cpp
@@ -72,9 +72,9 @@ shared_ptr<DataStreamRecvr> DataStreamMgr::create_recvr(
     DCHECK(profile != nullptr);
     VLOG_FILE << "creating receiver for fragment=" << fragment_instance_id
               << ", node=" << dest_node_id;
-    shared_ptr<DataStreamRecvr> recvr(
-            new DataStreamRecvr(this, row_desc, fragment_instance_id, dest_node_id, num_senders,
-                                is_merging, buffer_size, profile, sub_plan_query_statistics_recvr));
+    shared_ptr<DataStreamRecvr> recvr(new DataStreamRecvr(
+            this, row_desc, state->query_mem_tracker(), fragment_instance_id, dest_node_id,
+            num_senders, is_merging, buffer_size, profile, sub_plan_query_statistics_recvr));
     uint32_t hash_value = get_hash_value(fragment_instance_id, dest_node_id);
     lock_guard<mutex> l(_lock);
     _fragment_stream_set.insert(std::make_pair(fragment_instance_id, dest_node_id));

--- a/be/src/runtime/data_stream_recvr.cc
+++ b/be/src/runtime/data_stream_recvr.cc
@@ -447,8 +447,9 @@ void DataStreamRecvr::transfer_all_resources(RowBatch* transfer_batch) {
 
 DataStreamRecvr::DataStreamRecvr(
         DataStreamMgr* stream_mgr, const RowDescriptor& row_desc,
-        const TUniqueId& fragment_instance_id, PlanNodeId dest_node_id, int num_senders,
-        bool is_merging, int total_buffer_limit, RuntimeProfile* profile,
+        MemTrackerLimiter* query_mem_tracker, const TUniqueId& fragment_instance_id,
+        PlanNodeId dest_node_id, int num_senders, bool is_merging, int total_buffer_limit,
+        RuntimeProfile* profile,
         std::shared_ptr<QueryStatisticsRecvr> sub_plan_query_statistics_recvr)
         : _mgr(stream_mgr),
           _fragment_instance_id(fragment_instance_id),
@@ -459,7 +460,8 @@ DataStreamRecvr::DataStreamRecvr(
           _num_buffered_bytes(0),
           _profile(profile),
           _sub_plan_query_statistics_recvr(sub_plan_query_statistics_recvr) {
-    _mem_tracker = std::make_unique<MemTracker>("DataStreamRecvr", nullptr, _profile);
+    _mem_tracker = std::make_unique<MemTracker>(
+            "DataStreamRecvr:" + print_id(_fragment_instance_id), query_mem_tracker, _profile);
 
     // Create one queue per sender if is_merging is true.
     int num_queues = is_merging ? num_senders : 1;

--- a/be/src/runtime/data_stream_recvr.h
+++ b/be/src/runtime/data_stream_recvr.h
@@ -116,8 +116,9 @@ private:
     class SenderQueue;
 
     DataStreamRecvr(DataStreamMgr* stream_mgr, const RowDescriptor& row_desc,
-                    const TUniqueId& fragment_instance_id, PlanNodeId dest_node_id, int num_senders,
-                    bool is_merging, int total_buffer_limit, RuntimeProfile* profile,
+                    MemTrackerLimiter* query_mem_tracker, const TUniqueId& fragment_instance_id,
+                    PlanNodeId dest_node_id, int num_senders, bool is_merging,
+                    int total_buffer_limit, RuntimeProfile* profile,
                     std::shared_ptr<QueryStatisticsRecvr> sub_plan_query_statistics_recvr);
 
     // If receive queue is full, done is enqueue pending, and return with *done is nullptr

--- a/be/src/runtime/memory/mem_tracker.cpp
+++ b/be/src/runtime/memory/mem_tracker.cpp
@@ -45,6 +45,13 @@ MemTracker::MemTracker(const std::string& label, MemTrackerLimiter* parent, Runt
     STOP_CHECK_THREAD_MEM_TRACKER_LIMIT();
     _parent = parent ? parent : thread_context()->_thread_mem_tracker_mgr->limiter_mem_tracker();
     DCHECK(_parent || label == "Process");
+    if (_parent && _parent->label().find("queryId=") != _parent->label().npos) {
+        // Add the queryId suffix to the tracker below the query.
+        _label = fmt::format("{}#{}", label,
+                             _parent->label().substr(_parent->label().find("queryId="), -1));
+    } else {
+        _label = label;
+    }
     if (profile == nullptr) {
         _consumption = std::make_shared<RuntimeProfile::HighWaterMarkCounter>(TUnit::BYTES);
     } else {

--- a/be/src/runtime/memory/mem_tracker.cpp
+++ b/be/src/runtime/memory/mem_tracker.cpp
@@ -45,13 +45,6 @@ MemTracker::MemTracker(const std::string& label, MemTrackerLimiter* parent, Runt
     STOP_CHECK_THREAD_MEM_TRACKER_LIMIT();
     _parent = parent ? parent : thread_context()->_thread_mem_tracker_mgr->limiter_mem_tracker();
     DCHECK(_parent || label == "Process");
-    if (_parent && _parent->label().find("queryId=") != _parent->label().npos) {
-        // Add the queryId suffix to the tracker below the query.
-        _label = fmt::format("{}#{}", label,
-                             _parent->label().substr(_parent->label().find("queryId="), -1));
-    } else {
-        _label = label;
-    }
     if (profile == nullptr) {
         _consumption = std::make_shared<RuntimeProfile::HighWaterMarkCounter>(TUnit::BYTES);
     } else {

--- a/be/src/runtime/memory/mem_tracker_limiter.h
+++ b/be/src/runtime/memory/mem_tracker_limiter.h
@@ -111,6 +111,7 @@ public:
     // Note that 'f' must be valid for the lifetime of this tracker limiter.
     void add_gc_function(GcFunction f) { _gc_functions.push_back(f); }
 
+    // TODO Should be managed in a separate process_mem_mgr, not in MemTracker
     // If consumption is higher than max_consumption, attempts to free memory by calling
     // any added GC functions.  Returns true if max_consumption is still exceeded. Takes gc_lock.
     // Note: If the cache of segment/chunk is released due to insufficient query memory at a certain moment,

--- a/be/src/runtime/memory/mem_tracker_task_pool.cpp
+++ b/be/src/runtime/memory/mem_tracker_task_pool.cpp
@@ -34,7 +34,7 @@ MemTrackerLimiter* MemTrackerTaskPool::register_task_mem_tracker_impl(const std:
     bool new_emplace = _task_mem_trackers.lazy_emplace_l(
             task_id, [&](std::shared_ptr<MemTrackerLimiter>) {},
             [&](const auto& ctor) {
-                ctor(task_id, std::make_unique<MemTrackerLimiter>(mem_limit, label, parent));
+                ctor(task_id, std::make_shared<MemTrackerLimiter>(mem_limit, label, parent));
             });
     if (new_emplace) {
         LOG(INFO) << "Register query/load memory tracker, query/load id: " << task_id

--- a/be/src/runtime/memory/thread_mem_tracker_mgr.cpp
+++ b/be/src/runtime/memory/thread_mem_tracker_mgr.cpp
@@ -37,14 +37,8 @@ void ThreadMemTrackerMgr::attach_limiter_tracker(const std::string& cancel_msg,
 }
 
 void ThreadMemTrackerMgr::detach_limiter_tracker() {
-#ifndef BE_TEST
-    // Unexpectedly, the runtime state is destructed before the end of the query sub-thread,
-    // (_hash_table_build_thread has appeared) which is not a graceful exit.
-    // consider replacing CHECK with a conditional statement and checking for runtime state survival.
-    CHECK(_task_id == "" ||
-          ExecEnv::GetInstance()->task_pool_mem_tracker_registry()->get_task_mem_tracker(_task_id));
-#endif
-    flush_untracked_mem<false>();
+    // Do not flush untracked mem, instance executor thread may exit after instance fragment executor thread,
+    // `instance_mem_tracker` will be null pointer, which is not a graceful exit.
     _task_id = "";
     _fragment_instance_id = TUniqueId();
     _exceed_cb.cancel_msg = "";

--- a/be/src/runtime/memory/thread_mem_tracker_mgr.h
+++ b/be/src/runtime/memory/thread_mem_tracker_mgr.h
@@ -210,8 +210,8 @@ inline void ThreadMemTrackerMgr::flush_untracked_mem() {
         // If you do not want this check, set_check_attach=true
         // TODO(zxy) The current p0 test cannot guarantee that all threads are checked,
         // so disable it and try to open it when memory tracking is not on time.
-        DCHECK(!_check_attach || btls_key != EMPTY_BTLS_KEY ||
-               _limiter_tracker->label() != "Process");
+        // DCHECK(!_check_attach || btls_key != EMPTY_BTLS_KEY ||
+        //        _limiter_tracker->label() != "Process");
 #endif
         Status st = _limiter_tracker->try_consume(_untracked_mem);
         if (!st) {

--- a/be/src/runtime/runtime_state.cpp
+++ b/be/src/runtime/runtime_state.cpp
@@ -265,6 +265,7 @@ Status RuntimeState::init_mem_trackers(const TUniqueId& query_id) {
 }
 
 Status RuntimeState::init_instance_mem_tracker() {
+    _query_mem_tracker = nullptr;
     _instance_mem_tracker = std::make_unique<MemTrackerLimiter>(-1, "RuntimeState:instance");
     return Status::OK();
 }

--- a/be/src/vec/runtime/vdata_stream_mgr.cpp
+++ b/be/src/vec/runtime/vdata_stream_mgr.cpp
@@ -53,8 +53,8 @@ std::shared_ptr<VDataStreamRecvr> VDataStreamMgr::create_recvr(
     VLOG_FILE << "creating receiver for fragment=" << fragment_instance_id
               << ", node=" << dest_node_id;
     std::shared_ptr<VDataStreamRecvr> recvr(new VDataStreamRecvr(
-            this, row_desc, fragment_instance_id, dest_node_id, num_senders, is_merging,
-            buffer_size, profile, sub_plan_query_statistics_recvr));
+            this, row_desc, state->query_mem_tracker(), fragment_instance_id, dest_node_id,
+            num_senders, is_merging, buffer_size, profile, sub_plan_query_statistics_recvr));
     uint32_t hash_value = get_hash_value(fragment_instance_id, dest_node_id);
     std::lock_guard<std::mutex> l(_lock);
     _fragment_stream_set.insert(std::make_pair(fragment_instance_id, dest_node_id));

--- a/be/src/vec/runtime/vdata_stream_recvr.cpp
+++ b/be/src/vec/runtime/vdata_stream_recvr.cpp
@@ -249,8 +249,9 @@ void VDataStreamRecvr::SenderQueue::close() {
 
 VDataStreamRecvr::VDataStreamRecvr(
         VDataStreamMgr* stream_mgr, const RowDescriptor& row_desc,
-        const TUniqueId& fragment_instance_id, PlanNodeId dest_node_id, int num_senders,
-        bool is_merging, int total_buffer_limit, RuntimeProfile* profile,
+        MemTrackerLimiter* query_mem_tracker, const TUniqueId& fragment_instance_id,
+        PlanNodeId dest_node_id, int num_senders, bool is_merging, int total_buffer_limit,
+        RuntimeProfile* profile,
         std::shared_ptr<QueryStatisticsRecvr> sub_plan_query_statistics_recvr)
         : _mgr(stream_mgr),
           _fragment_instance_id(fragment_instance_id),
@@ -262,8 +263,10 @@ VDataStreamRecvr::VDataStreamRecvr(
           _num_buffered_bytes(0),
           _profile(profile),
           _sub_plan_query_statistics_recvr(sub_plan_query_statistics_recvr) {
+    // DataStreamRecvr may be destructed after the instance execution thread ends, `instance_mem_tracker`
+    // will be a null pointer, and remove_child fails when _mem_tracker is destructed.
     _mem_tracker = std::make_unique<MemTracker>(
-            "VDataStreamRecvr:" + print_id(_fragment_instance_id), nullptr, _profile);
+            "VDataStreamRecvr:" + print_id(_fragment_instance_id), query_mem_tracker, _profile);
     SCOPED_CONSUME_MEM_TRACKER(_mem_tracker.get());
 
     // Create one queue per sender if is_merging is true.

--- a/be/src/vec/runtime/vdata_stream_recvr.h
+++ b/be/src/vec/runtime/vdata_stream_recvr.h
@@ -51,9 +51,9 @@ class VExprContext;
 class VDataStreamRecvr {
 public:
     VDataStreamRecvr(VDataStreamMgr* stream_mgr, const RowDescriptor& row_desc,
-                     const TUniqueId& fragment_instance_id, PlanNodeId dest_node_id,
-                     int num_senders, bool is_merging, int total_buffer_limit,
-                     RuntimeProfile* profile,
+                     MemTrackerLimiter* query_mem_tracker, const TUniqueId& fragment_instance_id,
+                     PlanNodeId dest_node_id, int num_senders, bool is_merging,
+                     int total_buffer_limit, RuntimeProfile* profile,
                      std::shared_ptr<QueryStatisticsRecvr> sub_plan_query_statistics_recvr);
 
     ~VDataStreamRecvr();


### PR DESCRIPTION
# Proposed changes

Issue Number: close #11271

## Problem Summary:

1. Fix instance executor thread exiting after instance fragment executor thread, resulting in `instance_mem_tracker` null pointer, this is not a graceful exit, this occurs in multiple places.

2. TCMalloc hook consumes MemTracker every 4M, change it to 1M. this will reduce the extra accuracy diff without reducing performance because the level num is less after MemTracker refactoring.


-- | fist run regression-test | second | third 
-- | -- | -- | --
Hook counts memory size directly to atomic variables | top -p VIRT 14.2g，RES 3.9g, tracker : 3466189368, total_physical_bytes 4330799104 | top -p VIRT 15.5g，RES 4.5g, tracker : 3832933824, total_physical_bytes 4936269824 | top -p VIRT 16.1g，RES 4.8g, tracker : 4257143536, total_physical_bytes 5388296192 
Hook direct consumption process tracker | top -p VIRT 14.1g, RES 3.9g, tracker : 3405358776 | top -p VIRT 15.3g, RES 4.4g, tracker : 3797935648 | top -p VIRT 16.0g, RES 4.9g, tracker : 4285174248 |  
Hook no cumulative consumption | top -p VIRT 15.6g, RES 4.2g, tracker : 3388843528 | top -p VIRT 16.6g, RES 4.7g, tracker : 3776410936 | top -p VIRT 17.3g, RES 5.1g, tracker : 4145513568 |  
Consumption per 4M | top -p VIRT 16.3g, RES 3.9g, tracker : 3076821168 | top -p VIRT 17.7g, RES 4.4g, tracker : 3222870752 | top -p VIRT 20.6g, RES 5.1g, tracker : 3212606896 |  
Consumption per 1M | top -p VIRT 18.0g, RES 4.3g, tracker : 3135795496 | top -p VIRT 19.8g, RES 4.9g, tracker : 3330870208 | top -p VIRT 24.2g, RES 5.7g, tracker : 3465682128 |  



## Checklist(Required)

1. Type of your changes:
    - [ ] Improvement
    - [x] Fix
    - [ ] Feature-WIP
    - [ ] Feature
    - [ ] Doc
    - [ ] Refator
    - [ ] Others: 
4. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
5. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
6. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
7. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
8. Are there any changes that cannot be rolled back:
    - [ ] Yes
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

