### PR TITLE
[feature-wip](unique-key-merge-on-write) update bitmap after compaction, DSIP-018

### DIFF
--- a/be/src/olap/compaction.cpp
+++ b/be/src/olap/compaction.cpp
@@ -252,6 +252,14 @@ Status Compaction::modify_rowsets() {
     std::vector<RowsetSharedPtr> output_rowsets;
     output_rowsets.push_back(_output_rowset);
     std::lock_guard<std::shared_mutex> wrlock(_tablet->get_header_lock());
+
+    // update dst rowset delete bitmap
+    if (_tablet->keys_type() == KeysType::UNIQUE_KEYS &&
+        _tablet->enable_unique_key_merge_on_write()) {
+        _tablet->tablet_meta()->update_delete_bitmap(_input_rowsets, _output_rs_writer->version(),
+                                                     _rowid_conversion);
+    }
+
     RETURN_NOT_OK(_tablet->modify_rowsets(output_rowsets, _input_rowsets, true));
     _tablet->save_meta();
     return Status::OK();

--- a/be/src/olap/merger.cpp
+++ b/be/src/olap/merger.cpp
@@ -103,6 +103,7 @@ Status Merger::vmerge_rowsets(TabletSharedPtr tablet, ReaderType reader_type,
     reader_params.rs_readers = src_rowset_readers;
     reader_params.version = dst_rowset_writer->version();
     reader_params.tablet_schema = cur_tablet_schema;
+    reader_params.delete_bitmap = &tablet->tablet_meta()->delete_bitmap();
     if (stats_output && stats_output->rowid_conversion) {
         reader_params.record_rowids = true;
     }

--- a/be/src/olap/tablet_meta.cpp
+++ b/be/src/olap/tablet_meta.cpp
@@ -734,6 +734,45 @@ Status TabletMeta::set_partition_id(int64_t partition_id) {
     return Status::OK();
 }
 
+// update dst rowset delete bitmap for unique key merge on write table.
+// we take a delete bitmap's snapshot of origin rowset, but the
+// detele bitmap of origin rowset may update when compaction.
+// some key deleted on compaction will exist in dst rowset.
+// so after compaction, need to update the bitmap of dst rowset.
+// ANNT: should take a tablet lock before calling the function
+void TabletMeta::update_delete_bitmap(const std::vector<RowsetSharedPtr>& input_rowsets,
+                                      const Version& version,
+                                      const RowIdConversion& rowid_conversion) {
+    RowLocation src;
+    RowLocation dst;
+    DeleteBitmap output_rowset_delete_bitmap(_tablet_id);
+    for (auto& rowset : input_rowsets) {
+        src.rowset_id = rowset->rowset_id();
+        for (uint32_t seg_id = 0; seg_id < rowset->num_segments(); ++seg_id) {
+            src.segment_id = seg_id;
+            DeleteBitmap upper_map(_tablet_id);
+            delete_bitmap().subset({rowset->rowset_id(), seg_id, version.second},
+                                   {rowset->rowset_id(), seg_id, INT64_MAX}, &upper_map);
+            // traverse all versions and convert rowid
+            for (auto iter = upper_map.delete_bitmap.begin(); iter != upper_map.delete_bitmap.end();
+                 ++iter) {
+                auto cur_version = std::get<2>(iter->first);
+                for (auto index = iter->second.begin(); index != iter->second.end(); ++index) {
+                    src.row_id = *index;
+                    if (rowid_conversion.get(src, &dst) != 0) {
+                        LOG(WARNING) << "Can't find rowid, may be deleted by the delete_handler.";
+                        continue;
+                    }
+                    output_rowset_delete_bitmap.add({dst.rowset_id, dst.segment_id, cur_version},
+                                                    dst.row_id);
+                }
+            }
+        }
+    }
+    // update output rowset delete bitmap
+    delete_bitmap().merge(output_rowset_delete_bitmap);
+}
+
 bool operator==(const TabletMeta& a, const TabletMeta& b) {
     if (a._table_id != b._table_id) return false;
     if (a._partition_id != b._partition_id) return false;

--- a/be/src/olap/tablet_meta.cpp
+++ b/be/src/olap/tablet_meta.cpp
@@ -736,12 +736,10 @@ Status TabletMeta::set_partition_id(int64_t partition_id) {
     return Status::OK();
 }
 
-// update dst rowset delete bitmap for unique key merge on write table.
-// we take a delete bitmap's snapshot of origin rowset at the beginning
-// of compaction, but the detele bitmap of origin rowset may update when
-// compaction. some key might be deleted during compaction, which would
-// exist in dst rowset. so after compaction, need to update the bitmap
-// of dst rowset.
+// We take a delete bitmap's snapshot of origin rowset at the beginning of
+// compaction, some keys of origin rowsets might be deleted during compaction,
+// but exist in dest rowset. so we need to update the bitmap of dest rowset
+// after compaction.
 // ANNT: should take a tablet lock before calling the function
 void TabletMeta::update_delete_bitmap(const std::vector<RowsetSharedPtr>& input_rowsets,
                                       const Version& version,

--- a/be/src/olap/tablet_meta.h
+++ b/be/src/olap/tablet_meta.h
@@ -30,6 +30,7 @@
 #include "olap/delete_handler.h"
 #include "olap/olap_common.h"
 #include "olap/olap_define.h"
+#include "olap/rowid_conversion.h"
 #include "olap/rowset/rowset.h"
 #include "olap/rowset/rowset_meta.h"
 #include "olap/tablet_schema.h"
@@ -203,6 +204,9 @@ public:
     DeleteBitmap& delete_bitmap() { return *_delete_bitmap; }
 
     bool enable_unique_key_merge_on_write() { return _enable_unique_key_merge_on_write; }
+
+    void update_delete_bitmap(const std::vector<RowsetSharedPtr>& input_rowsets,
+                              const Version& version, const RowIdConversion& rowid_conversion);
 
 private:
     Status _save_meta(DataDir* data_dir);


### PR DESCRIPTION

# Proposed changes

Issue Number: close #xxx

## Problem Summary:

see DISP-018: https://cwiki.apache.org/confluence/display/DORIS/DSIP-018%3A+Support+Merge-On-Write+implementation+for+UNIQUE+KEY+data+model
This patch is for step 4-2

## Checklist(Required)

1. Type of your changes:
    - [ ] Improvement
    - [ ] Fix
    - [ ] Feature-WIP
    - [ ] Feature
    - [ ] Doc
    - [ ] Refator
    - [ ] Others: 
2. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
3. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
5. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
6. Are there any changes that cannot be rolled back:
    - [ ] Yes
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

