### PR TITLE
[feature](Nereids) Add subquery analyze

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/analyzer/NereidsAnalyzer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/analyzer/NereidsAnalyzer.java
@@ -26,6 +26,8 @@ import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalPlan;
 import org.apache.doris.qe.ConnectContext;
 
+import java.util.Optional;
+
 /**
  * Bind symbols according to metadata in the catalog, perform semantic analysis, etc.
  * TODO: revisit the interface after subquery analysis is supported.
@@ -41,13 +43,13 @@ public class NereidsAnalyzer {
      * Analyze plan.
      */
     public LogicalPlan analyze(Plan plan) {
-        return analyze(plan, null);
+        return analyze(plan, Optional.empty());
     }
 
     /**
      * Analyze plan with scope.
      */
-    public LogicalPlan analyze(Plan plan, Scope scope) {
+    public LogicalPlan analyze(Plan plan, Optional<Scope> scope) {
         return (LogicalPlan) analyzeWithPlannerContext(plan, scope).getMemo().copyOut();
     }
 
@@ -55,7 +57,7 @@ public class NereidsAnalyzer {
      * Convert SQL String to analyzed plan.
      */
     public LogicalPlan analyze(String sql) {
-        return analyze(parse(sql), null);
+        return analyze(parse(sql), Optional.empty());
     }
 
     /**
@@ -64,13 +66,13 @@ public class NereidsAnalyzer {
      * further plan optimization without creating new {@link Memo} and {@link PlannerContext}.
      */
     public PlannerContext analyzeWithPlannerContext(Plan plan) {
-        return analyzeWithPlannerContext(plan, null);
+        return analyzeWithPlannerContext(plan, Optional.empty());
     }
 
     /**
      * Analyze plan with scope.
      */
-    public PlannerContext analyzeWithPlannerContext(Plan plan, Scope scope) {
+    public PlannerContext analyzeWithPlannerContext(Plan plan, Optional<Scope> scope) {
         PlannerContext plannerContext = new Memo(plan)
                 .newPlannerContext(connectContext)
                 .setDefaultJobContext();

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/analyzer/NereidsAnalyzer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/analyzer/NereidsAnalyzer.java
@@ -21,6 +21,7 @@ import org.apache.doris.nereids.PlannerContext;
 import org.apache.doris.nereids.jobs.batch.AnalyzeRulesJob;
 import org.apache.doris.nereids.memo.Memo;
 import org.apache.doris.nereids.parser.NereidsParser;
+import org.apache.doris.nereids.rules.analysis.Scope;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalPlan;
 import org.apache.doris.qe.ConnectContext;
@@ -40,14 +41,21 @@ public class NereidsAnalyzer {
      * Analyze plan.
      */
     public LogicalPlan analyze(Plan plan) {
-        return (LogicalPlan) analyzeWithPlannerContext(plan).getMemo().copyOut();
+        return analyze(plan, null);
+    }
+
+    /**
+     * Analyze plan with scope.
+     */
+    public LogicalPlan analyze(Plan plan, Scope scope) {
+        return (LogicalPlan) analyzeWithPlannerContext(plan, scope).getMemo().copyOut();
     }
 
     /**
      * Convert SQL String to analyzed plan.
      */
     public LogicalPlan analyze(String sql) {
-        return analyze(parse(sql));
+        return analyze(parse(sql), null);
     }
 
     /**
@@ -56,11 +64,18 @@ public class NereidsAnalyzer {
      * further plan optimization without creating new {@link Memo} and {@link PlannerContext}.
      */
     public PlannerContext analyzeWithPlannerContext(Plan plan) {
+        return analyzeWithPlannerContext(plan, null);
+    }
+
+    /**
+     * Analyze plan with scope.
+     */
+    public PlannerContext analyzeWithPlannerContext(Plan plan, Scope scope) {
         PlannerContext plannerContext = new Memo(plan)
                 .newPlannerContext(connectContext)
                 .setDefaultJobContext();
 
-        new AnalyzeRulesJob(plannerContext).execute();
+        new AnalyzeRulesJob(plannerContext, scope).execute();
         return plannerContext;
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/batch/AnalyzeRulesJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/batch/AnalyzeRulesJob.java
@@ -38,12 +38,12 @@ public class AnalyzeRulesJob extends BatchRulesJob {
      * @param plannerContext planner context for execute job
      * @param scope Parse the symbolic scope of the field
      */
-    public AnalyzeRulesJob(PlannerContext plannerContext, Scope scope) {
+    public AnalyzeRulesJob(PlannerContext plannerContext, Optional<Scope> scope) {
         super(plannerContext);
         rulesJob.addAll(ImmutableList.of(
                 bottomUpBatch(ImmutableList.of(
                         new BindRelation(),
-                        new BindSlotReference(Optional.ofNullable(scope)),
+                        new BindSlotReference(scope),
                         new BindFunction(),
                         new ProjectToGlobalAggregate())
                 )));

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/batch/AnalyzeRulesJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/batch/AnalyzeRulesJob.java
@@ -22,8 +22,11 @@ import org.apache.doris.nereids.rules.analysis.BindFunction;
 import org.apache.doris.nereids.rules.analysis.BindRelation;
 import org.apache.doris.nereids.rules.analysis.BindSlotReference;
 import org.apache.doris.nereids.rules.analysis.ProjectToGlobalAggregate;
+import org.apache.doris.nereids.rules.analysis.Scope;
 
 import com.google.common.collect.ImmutableList;
+
+import java.util.Optional;
 
 /**
  * Execute the analysis rules.
@@ -31,15 +34,16 @@ import com.google.common.collect.ImmutableList;
 public class AnalyzeRulesJob extends BatchRulesJob {
 
     /**
-     * Execute the analysis job
+     * Execute the analysis job with scope.
      * @param plannerContext planner context for execute job
+     * @param scope Parse the symbolic scope of the field
      */
-    public AnalyzeRulesJob(PlannerContext plannerContext) {
+    public AnalyzeRulesJob(PlannerContext plannerContext, Scope scope) {
         super(plannerContext);
         rulesJob.addAll(ImmutableList.of(
                 bottomUpBatch(ImmutableList.of(
                         new BindRelation(),
-                        new BindSlotReference(),
+                        new BindSlotReference(Optional.ofNullable(scope)),
                         new BindFunction(),
                         new ProjectToGlobalAggregate())
                 )));

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/Scope.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/Scope.java
@@ -19,6 +19,9 @@ package org.apache.doris.nereids.rules.analysis;
 
 import org.apache.doris.nereids.trees.expressions.Slot;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableList.Builder;
+
 import java.util.List;
 import java.util.Optional;
 
@@ -45,5 +48,18 @@ public class Scope {
 
     public Optional<Scope> getOuterScope() {
         return outerScope;
+    }
+
+    /**
+     * generate scope link from inner to outer.
+     */
+    public List<Scope> toScopeLink() {
+        Scope scope = this;
+        Builder<Scope> builder = ImmutableList.<Scope>builder().add(scope);
+        while (scope.getOuterScope().isPresent()) {
+            scope = scope.getOuterScope().get();
+            builder.add(scope);
+        }
+        return builder.build();
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/Scope.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/Scope.java
@@ -15,36 +15,35 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package org.apache.doris.nereids.trees.plans;
+package org.apache.doris.nereids.rules.analysis;
+
+import org.apache.doris.nereids.trees.expressions.Slot;
+
+import java.util.List;
+import java.util.Optional;
 
 /**
- * Types for all Plan in Nereids.
+ * The slot range required for expression analyze.
  */
-public enum PlanType {
-    UNKNOWN,
+public class Scope {
+    private final Optional<Scope> outerScope;
+    private final List<Slot> slots;
 
-    // logical plan
-    LOGICAL_UNBOUND_RELATION,
-    LOGICAL_BOUND_RELATION,
-    LOGICAL_PROJECT,
-    LOGICAL_FILTER,
-    LOGICAL_JOIN,
-    LOGICAL_AGGREGATE,
-    LOGICAL_SORT,
-    LOGICAL_OLAP_SCAN,
-    LOGICAL_APPLY,
-    LOGICAL_CORRELATED_JOIN,
-    LOGICAL_ENFORCE_SINGLE_ROW,
-    GROUP_PLAN,
+    public Scope(Optional<Scope> outerScope, List<Slot> slots) {
+        this.outerScope = outerScope;
+        this.slots = slots;
+    }
 
-    // physical plan
-    PHYSICAL_OLAP_SCAN,
-    PHYSICAL_PROJECT,
-    PHYSICAL_FILTER,
-    PHYSICAL_BROADCAST_HASH_JOIN,
-    PHYSICAL_AGGREGATE,
-    PHYSICAL_SORT,
-    PHYSICAL_HASH_JOIN,
-    PHYSICAL_EXCHANGE,
-    PHYSICAL_DISTRIBUTION;
+    public Scope(List<Slot> slots) {
+        this.outerScope = Optional.empty();
+        this.slots = slots;
+    }
+
+    public List<Slot> getSlots() {
+        return slots;
+    }
+
+    public Optional<Scope> getOuterScope() {
+        return outerScope;
+    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/visitor/DefaultSubExprRewriter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/visitor/DefaultSubExprRewriter.java
@@ -1,0 +1,57 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.trees.expressions.visitor;
+
+import org.apache.doris.nereids.analyzer.NereidsAnalyzer;
+import org.apache.doris.nereids.rules.analysis.Scope;
+import org.apache.doris.nereids.trees.expressions.Exists;
+import org.apache.doris.nereids.trees.expressions.Expression;
+import org.apache.doris.nereids.trees.expressions.InSubquery;
+import org.apache.doris.nereids.trees.expressions.SubqueryExpr;
+import org.apache.doris.nereids.trees.plans.logical.LogicalPlan;
+import org.apache.doris.qe.ConnectContext;
+
+/**
+ * Use the visitor to iterate sub expression.
+ */
+public class DefaultSubExprRewriter<C> extends DefaultExpressionRewriter<C> {
+    private final Scope scope;
+
+    public DefaultSubExprRewriter(Scope scope) {
+        this.scope = scope;
+    }
+
+    @Override
+    public Expression visit(Expression expr, C context) {
+        if (expr instanceof SubqueryExpr) {
+            NereidsAnalyzer subAnalyzer = new NereidsAnalyzer(ConnectContext.get());
+            LogicalPlan analyzed = subAnalyzer.analyze(((SubqueryExpr) expr).getQueryPlan(), scope);
+            if (expr instanceof InSubquery) {
+                return new InSubquery(((InSubquery) expr).getCompareExpr(), analyzed);
+            } else if (expr instanceof Exists) {
+                return new Exists(analyzed);
+            }
+            return new SubqueryExpr(analyzed);
+        }
+        return super.visit(expr, context);
+    }
+
+    public Scope getScope() {
+        return scope;
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalApply.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalApply.java
@@ -1,0 +1,117 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.trees.plans.logical;
+
+import org.apache.doris.nereids.memo.GroupExpression;
+import org.apache.doris.nereids.properties.LogicalProperties;
+import org.apache.doris.nereids.trees.expressions.Expression;
+import org.apache.doris.nereids.trees.expressions.Slot;
+import org.apache.doris.nereids.trees.plans.Plan;
+import org.apache.doris.nereids.trees.plans.PlanType;
+import org.apache.doris.nereids.trees.plans.visitor.PlanVisitor;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Apply Node for subquery.
+ * Use this node to display the subquery in the relational algebra tree.
+ * refer to "Orthogonal Optimization of Subqueries and Aggregation"
+ *
+ * @param <LEFT_CHILD_TYPE> input
+ * @param <RIGHT_CHILD_TYPE> subquery
+ */
+public class LogicalApply<LEFT_CHILD_TYPE extends Plan, RIGHT_CHILD_TYPE extends Plan>
+        extends LogicalBinary<LEFT_CHILD_TYPE, RIGHT_CHILD_TYPE> {
+    // correlation : subqueries and outer associated columns
+    private final List<Expression> correlation;
+
+    public LogicalApply(LEFT_CHILD_TYPE input, RIGHT_CHILD_TYPE subquery, List<Expression> correlation) {
+        this(Optional.empty(), Optional.empty(), input, subquery, correlation);
+    }
+
+    public LogicalApply(Optional<GroupExpression> groupExpression, Optional<LogicalProperties> logicalProperties,
+            LEFT_CHILD_TYPE leftChild, RIGHT_CHILD_TYPE rightChild, List<Expression> correlation) {
+        super(PlanType.LOGICAL_APPLY, groupExpression, logicalProperties, leftChild, rightChild);
+        this.correlation = ImmutableList.copyOf(correlation);
+    }
+
+    public List<Expression> getCorrelation() {
+        return correlation;
+    }
+
+    @Override
+    public List<Slot> computeOutput(Plan left, Plan right) {
+        return ImmutableList.<Slot>builder()
+                .addAll(left.getOutput())
+                .addAll(right.getOutput())
+                .build();
+    }
+
+    @Override
+    public String toString() {
+        return "LogicalApply (" + this.child(1).toString() + ")";
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        LogicalApply that = (LogicalApply) o;
+        return Objects.equals(correlation, that.getCorrelation());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(correlation);
+    }
+
+    @Override
+    public <R, C> R accept(PlanVisitor<R, C> visitor, C context) {
+        return visitor.visitLogicalApply((LogicalApply<Plan, Plan>) this, context);
+    }
+
+    @Override
+    public List<Expression> getExpressions() {
+        return correlation;
+    }
+
+    @Override
+    public LogicalBinary<Plan, Plan> withChildren(List<Plan> children) {
+        Preconditions.checkArgument(children.size() == 2);
+        return new LogicalApply<>(children.get(0), children.get(1), correlation);
+    }
+
+    @Override
+    public Plan withGroupExpression(Optional<GroupExpression> groupExpression) {
+        return new LogicalApply<>(groupExpression, Optional.of(logicalProperties), left(), right(), correlation);
+    }
+
+    @Override
+    public Plan withLogicalProperties(Optional<LogicalProperties> logicalProperties) {
+        return new LogicalApply<>(Optional.empty(), logicalProperties, left(), right(), correlation);
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalCorrelatedJoin.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalCorrelatedJoin.java
@@ -1,0 +1,184 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.trees.plans.logical;
+
+import org.apache.doris.nereids.memo.GroupExpression;
+import org.apache.doris.nereids.properties.LogicalProperties;
+import org.apache.doris.nereids.trees.expressions.Expression;
+import org.apache.doris.nereids.trees.expressions.Slot;
+import org.apache.doris.nereids.trees.plans.JoinType;
+import org.apache.doris.nereids.trees.plans.Plan;
+import org.apache.doris.nereids.trees.plans.PlanType;
+import org.apache.doris.nereids.trees.plans.visitor.PlanVisitor;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * A relational algebra node with join type converted from apply node to subquery.
+ * @param <LEFT_CHILD_TYPE> input.
+ * @param <RIGHT_CHILD_TYPE> subquery.
+ */
+public class LogicalCorrelatedJoin<LEFT_CHILD_TYPE extends Plan, RIGHT_CHILD_TYPE extends Plan>
+        extends LogicalBinary<LEFT_CHILD_TYPE, RIGHT_CHILD_TYPE> {
+
+    /**
+     * Coorelated Join Type.
+     */
+    public enum Type {
+        INNER(JoinType.INNER_JOIN),
+        LEFT(JoinType.LEFT_OUTER_JOIN),
+        RIGHT(JoinType.RIGHT_OUTER_JOIN),
+        FULL(JoinType.FULL_OUTER_JOIN);
+
+        private final JoinType joinType;
+
+        Type(JoinType joinType) {
+            this.joinType = joinType;
+        }
+
+        public JoinType toLogicalJoinType() {
+            return joinType;
+        }
+
+        /**
+         * Convert the type of ordinary join to the type of correlatedJoin.
+         * @param joinType ordinary type.
+         * @return correlatedJoin type.
+         */
+        public static Type typeConvert(JoinType joinType) {
+            switch (joinType) {
+                case CROSS_JOIN:
+                case INNER_JOIN:
+                    return Type.INNER;
+                case LEFT_OUTER_JOIN:
+                    return Type.LEFT;
+                case RIGHT_OUTER_JOIN:
+                    return Type.RIGHT;
+                case FULL_OUTER_JOIN:
+                    return Type.FULL;
+                default:
+                    throw new UnsupportedOperationException("Unsupported join type: " + joinType);
+            }
+        }
+    }
+
+    private final List<Expression> correlation;
+    private final Type type;
+    private final Optional<Expression> filter;
+
+    public LogicalCorrelatedJoin(LEFT_CHILD_TYPE input, RIGHT_CHILD_TYPE subquery, List<Expression> correlation,
+            Type type, Optional<Expression> filter) {
+        this(Optional.empty(), Optional.empty(), input, subquery,
+                correlation, type, filter);
+    }
+
+    public LogicalCorrelatedJoin(Optional<GroupExpression> groupExpression,
+            Optional<LogicalProperties> logicalProperties,
+            LEFT_CHILD_TYPE leftChild, RIGHT_CHILD_TYPE rightChild, List<Expression> correlation,
+            Type type, Optional<Expression> filter) {
+        super(PlanType.LOGICAL_CORRELATED_JOIN, groupExpression, logicalProperties, leftChild, rightChild);
+        this.correlation = ImmutableList.copyOf(correlation);
+        this.type = Objects.requireNonNull(type, "type can not be null");
+        this.filter = Objects.requireNonNull(filter, "filter can not be null");
+    }
+
+    public List<Expression> getCorrelation() {
+        return correlation;
+    }
+
+    public Type getJoinType() {
+        return type;
+    }
+
+    public Optional<Expression> getFilter() {
+        return filter;
+    }
+
+    @Override
+    public List<Slot> computeOutput(Plan left, Plan right) {
+        return ImmutableList.<Slot>builder()
+                .addAll(left.getOutput())
+                .addAll(right.getOutput())
+                .build();
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder("LogicalCorrelated ((correlation: ").append(type);
+        correlation.stream().map(c -> sb.append(", ").append(c));
+        sb.append("), (filter: ");
+        filter.ifPresent(expression -> sb.append(", ").append(expression));
+        return sb.append("))").toString();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        LogicalCorrelatedJoin that = (LogicalCorrelatedJoin) o;
+        return Objects.equals(correlation, that.getCorrelation())
+                && Objects.equals(type, that.getType())
+                && Objects.equals(filter, that.getFilter());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(correlation, type, filter);
+    }
+
+    @Override
+    public <R, C> R accept(PlanVisitor<R, C> visitor, C context) {
+        return visitor.visitLogicalCorrelated((LogicalCorrelatedJoin<Plan, Plan>) this, context);
+    }
+
+    @Override
+    public List<Expression> getExpressions() {
+        return new ImmutableList.Builder<Expression>()
+                .addAll(correlation)
+                .add(filter.get())
+                .build();
+    }
+
+    @Override
+    public LogicalBinary<Plan, Plan> withChildren(List<Plan> children) {
+        Preconditions.checkArgument(children.size() == 2);
+        return new LogicalCorrelatedJoin<>(children.get(0), children.get(1),
+                correlation, type, filter);
+    }
+
+    @Override
+    public Plan withGroupExpression(Optional<GroupExpression> groupExpression) {
+        return new LogicalCorrelatedJoin<>(groupExpression, Optional.of(logicalProperties),
+                left(), right(), correlation, type, filter);
+    }
+
+    @Override
+    public Plan withLogicalProperties(Optional<LogicalProperties> logicalProperties) {
+        return new LogicalCorrelatedJoin<>(Optional.empty(), logicalProperties,
+                left(), right(), correlation, type, filter);
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalEnforceSingleRow.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalEnforceSingleRow.java
@@ -33,6 +33,10 @@ import java.util.Optional;
 
 /**
  * Guaranteed to return a result of 1 row.
+ * eg: select * from t1 where t1.a = (select sum(t2.b) from t2 where t1.b = t2.a);
+ * filter()
+ *   +--enforceSingleRow()
+ *     +--apply()
  * @param <CHILD_TYPE> plan
  */
 public class LogicalEnforceSingleRow<CHILD_TYPE extends Plan> extends LogicalUnary<CHILD_TYPE> {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalEnforceSingleRow.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalEnforceSingleRow.java
@@ -1,0 +1,94 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.trees.plans.logical;
+
+import org.apache.doris.nereids.memo.GroupExpression;
+import org.apache.doris.nereids.properties.LogicalProperties;
+import org.apache.doris.nereids.trees.expressions.Expression;
+import org.apache.doris.nereids.trees.expressions.Slot;
+import org.apache.doris.nereids.trees.plans.Plan;
+import org.apache.doris.nereids.trees.plans.PlanType;
+import org.apache.doris.nereids.trees.plans.visitor.PlanVisitor;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Guaranteed to return a result of 1 row.
+ * @param <CHILD_TYPE> plan
+ */
+public class LogicalEnforceSingleRow<CHILD_TYPE extends Plan> extends LogicalUnary<CHILD_TYPE> {
+
+    LogicalEnforceSingleRow(CHILD_TYPE plan) {
+        this(Optional.empty(), Optional.empty(), plan);
+    }
+
+    LogicalEnforceSingleRow(Optional<GroupExpression> groupExpression, Optional<LogicalProperties> logicalProperties,
+            CHILD_TYPE plan) {
+        super(PlanType.LOGICAL_ENFORCE_SINGLE_ROW, groupExpression, logicalProperties, plan);
+    }
+
+    @Override
+    public List<Slot> computeOutput(Plan child) {
+        return ImmutableList.<Slot>builder()
+                .addAll(child.getOutput())
+                .build();
+    }
+
+    @Override
+    public String toString() {
+        return "LogicalEnforceSingleRow (" + this.child(0).toString() + ")";
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public <R, C> R accept(PlanVisitor<R, C> visitor, C context) {
+        return visitor.visitLogicalEnforceSingleRow((LogicalEnforceSingleRow<Plan>) this, context);
+    }
+
+    @Override
+    public Plan withChildren(List<Plan> children) {
+        Preconditions.checkArgument(children.size() == 1);
+        return new LogicalEnforceSingleRow<>(children.get(0));
+    }
+
+    @Override
+    public List<Expression> getExpressions() {
+        return ImmutableList.of();
+    }
+
+    @Override
+    public Plan withGroupExpression(Optional<GroupExpression> groupExpression) {
+        return new LogicalEnforceSingleRow<>(groupExpression, Optional.of(logicalProperties), child());
+    }
+
+    @Override
+    public Plan withLogicalProperties(Optional<LogicalProperties> logicalProperties) {
+        return new LogicalEnforceSingleRow<>(Optional.empty(), logicalProperties, child());
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/visitor/PlanVisitor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/visitor/PlanVisitor.java
@@ -21,6 +21,9 @@ import org.apache.doris.nereids.analyzer.UnboundRelation;
 import org.apache.doris.nereids.trees.plans.GroupPlan;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalAggregate;
+import org.apache.doris.nereids.trees.plans.logical.LogicalApply;
+import org.apache.doris.nereids.trees.plans.logical.LogicalCorrelatedJoin;
+import org.apache.doris.nereids.trees.plans.logical.LogicalEnforceSingleRow;
 import org.apache.doris.nereids.trees.plans.logical.LogicalFilter;
 import org.apache.doris.nereids.trees.plans.logical.LogicalJoin;
 import org.apache.doris.nereids.trees.plans.logical.LogicalOlapScan;
@@ -85,6 +88,18 @@ public abstract class PlanVisitor<R, C> {
 
     public R visitGroupPlan(GroupPlan groupPlan, C context) {
         return visit(groupPlan, context);
+    }
+
+    public R visitLogicalApply(LogicalApply<Plan, Plan> apply, C context) {
+        return visit(apply, context);
+    }
+
+    public R visitLogicalCorrelated(LogicalCorrelatedJoin<Plan, Plan> correlatedJoin, C context) {
+        return visit(correlatedJoin, context);
+    }
+
+    public R visitLogicalEnforceSingleRow(LogicalEnforceSingleRow<Plan> enforceSingleRow, C context) {
+        return visit(enforceSingleRow, context);
     }
 
     // *******************************

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/SubqueryTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/SubqueryTest.java
@@ -17,9 +17,7 @@
 
 package org.apache.doris.nereids.trees.expressions;
 
-import org.apache.doris.nereids.parser.NereidsParser;
 import org.apache.doris.nereids.tpch.AnalyzeCheckTestBase;
-import org.apache.doris.nereids.trees.plans.logical.LogicalPlan;
 
 import org.junit.jupiter.api.Test;
 
@@ -43,20 +41,57 @@ public class SubqueryTest extends AnalyzeCheckTestBase {
                 + "v2 int)\n"
                 + "distributed by hash(k1) buckets 1\n"
                 + "properties('replication_num' = '1');";
-        createTables(t0, t1);
+
+        String t2 = "create table t2("
+                + "id int, \n"
+                + "k1 int, \n"
+                + "v2 int)\n"
+                + "distributed by hash(k1) buckets 1\n"
+                + "properties('replication_num' = '1');";
+        createTables(t0, t1, t2);
     }
 
     @Test
-    public void test() {
+    public void inTest() {
         String sql = "select t0.k1\n"
                 + "from t0\n"
                 + "where t0.k2 in\n"
                 + "    (select id\n"
                 + "     from t1\n"
                 + "     where t0.k2=t1.k1)";
-        NereidsParser parser = new NereidsParser();
-        LogicalPlan parsed = parser.parseSingle(sql);
-        assert parsed != null;
-        //checkAnalyze(sql);
+        checkAnalyze(sql);
+    }
+
+    @Test
+    public void existTest() {
+        String sql1 = "select * from t0 where exists (select * from t1 where t0.k1 = t1.k1);";
+        checkAnalyze(sql1);
+    }
+
+    @Test
+    public void existAndExistTest() {
+        String sql1 = "select * from t0 where exists (select * from t1 where t0.k1 = t1.k1) "
+                + "and not exists (select * from t2 where t0.id != t2.id);";
+        checkAnalyze(sql1);
+
+        // This type of sql cannot be parsed and cannot recognize t1.id.
+        // Other systems also cannot resolve such as presto.
+        String sql2 = "select * from t0 where exists (select * from t1 where t0.k1 = t1.k1) "
+                + "and not exists (select * from t2 where t1.id != t2.id);";
+    }
+
+    @Test
+    public void scalarTest() {
+        String sql = "select * from t0 where t0.id = "
+                + "(select min(t1.id) from t1 where t0.k1 = t1.k1)";
+        checkAnalyze(sql);
+    }
+
+    @Test
+    public void inScalarTest() {
+        String sql = "select * from t0 where t0.id in "
+                + "(select * from t1 where t1.k1 = "
+                + "(select * from t2 where t0.id = t2.id));";
+        checkAnalyze(sql);
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/SubqueryTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/SubqueryTest.java
@@ -78,6 +78,7 @@ public class SubqueryTest extends AnalyzeCheckTestBase {
         // Other systems also cannot resolve such as presto.
         String sql2 = "select * from t0 where exists (select * from t1 where t0.k1 = t1.k1) "
                 + "and not exists (select * from t2 where t1.id != t2.id);";
+        assert sql2 != null;
     }
 
     @Test


### PR DESCRIPTION
# Proposed changes

Issue Number: no

## Problem Summary:

Increase the parsing of subquery.

Add LogicalApply and LogicalCorrelatedJoin and LogicalEnforceSingleRow.
(These structures are temporarily in use, in preparation for the follow-up)

LogicalApply:
Apply Node for subquery.
Use this node to display the subquery in the relational algebra tree.
refer to "Orthogonal Optimization of Subqueries and Aggregation"

LogicalCorrelatedJoin:
A relational algebra node with join type converted from apply node to subquery.

LogicalEnforceSingleRow:
Guaranteed to return a result of 1 row.

## Checklist(Required)

1. Type of your changes:
    - [ ] Improvement
    - [ ] Fix
    - [ ] Feature-WIP
    - [x] Feature
    - [ ] Doc
    - [ ] Refator
    - [ ] Others: 
2. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
3. Has unit tests been added:
    - [x] Yes
    - [ ] No
    - [ ] No Need
4. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
5. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
6. Are there any changes that cannot be rolled back:
    - [ ] Yes
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

