### PR TITLE
[feature-wip](unique-key-merge-on-write) fix IndexedColumnReader and add primary key index memory tracker, DSIP-018

### DIFF
--- a/be/src/olap/primary_key_index.cpp
+++ b/be/src/olap/primary_key_index.cpp
@@ -17,6 +17,7 @@
 
 #include "olap/primary_key_index.h"
 
+#include "common/config.h"
 #include "io/fs/file_reader.h"
 #include "olap/rowset/segment_v2/encoding_info.h"
 
@@ -67,13 +68,13 @@ Status PrimaryKeyIndexReader::parse(io::FileReaderSPtr file_reader,
                                     const segment_v2::PrimaryKeyIndexMetaPB& meta) {
     // parse primary key index
     _index_reader.reset(new segment_v2::IndexedColumnReader(file_reader, meta.primary_key_index()));
-    RETURN_IF_ERROR(_index_reader->load(_use_page_cache, _kept_in_memory));
+    RETURN_IF_ERROR(_index_reader->load(!config::disable_storage_page_cache, false));
 
     // parse bloom filter
     segment_v2::ColumnIndexMetaPB column_index_meta = meta.bloom_filter_index();
     segment_v2::BloomFilterIndexReader bf_index_reader(std::move(file_reader),
                                                        &column_index_meta.bloom_filter_index());
-    RETURN_IF_ERROR(bf_index_reader.load(_use_page_cache, _kept_in_memory));
+    RETURN_IF_ERROR(bf_index_reader.load(!config::disable_storage_page_cache, false));
     std::unique_ptr<segment_v2::BloomFilterIndexIterator> bf_iter;
     RETURN_IF_ERROR(bf_index_reader.new_iterator(&bf_iter));
     RETURN_IF_ERROR(bf_iter->read_bloom_filter(0, &_bf));

--- a/be/src/olap/primary_key_index.h
+++ b/be/src/olap/primary_key_index.h
@@ -93,10 +93,13 @@ public:
         return _index_reader->num_values();
     }
 
+    uint64_t get_memory_size() {
+        DCHECK(_parsed);
+        return _index_reader->get_memory_size() + _bf->size();
+    }
+
 private:
     bool _parsed;
-    bool _use_page_cache = true;
-    bool _kept_in_memory = true;
     std::unique_ptr<segment_v2::IndexedColumnReader> _index_reader;
     std::unique_ptr<segment_v2::BloomFilter> _bf;
 };

--- a/be/src/olap/rowset/segment_v2/indexed_column_reader.h
+++ b/be/src/olap/rowset/segment_v2/indexed_column_reader.h
@@ -63,6 +63,7 @@ public:
     bool support_value_seek() const { return _meta.has_value_index_meta(); }
 
     CompressionTypePB get_compression() const { return _meta.compression(); }
+    uint64_t get_memory_size() const { return _mem_size; }
 
 private:
     Status load_index_page(const PagePointerPB& pp, PageHandle* handle, IndexPageReader* reader);
@@ -88,6 +89,7 @@ private:
     const TypeInfo* _type_info = nullptr;
     const EncodingInfo* _encoding_info = nullptr;
     const KeyCoder* _value_key_coder = nullptr;
+    uint64_t _mem_size = 0;
 };
 
 class IndexedColumnIterator {

--- a/be/src/olap/rowset/segment_v2/segment.cpp
+++ b/be/src/olap/rowset/segment_v2/segment.cpp
@@ -147,7 +147,10 @@ Status Segment::load_index() {
 
         if (_tablet_schema.keys_type() == UNIQUE_KEYS && _footer.has_primary_key_index_meta()) {
             _pk_index_reader.reset(new PrimaryKeyIndexReader());
-            return _pk_index_reader->parse(_file_reader, _footer.primary_key_index_meta());
+            RETURN_IF_ERROR(
+                    _pk_index_reader->parse(_file_reader, _footer.primary_key_index_meta()));
+            _meta_mem_usage += _pk_index_reader->get_memory_size();
+            return Status::OK();
         } else {
             Slice body;
             PageFooterPB footer;


### PR DESCRIPTION

# Proposed changes

Issue Number: close #xxx

## Problem Summary:
see DISP-018: https://cwiki.apache.org/confluence/display/DORIS/DSIP-018%3A+Support+Merge-On-Write+implementation+for+UNIQUE+KEY+data+model,
fix IndexedColumnReader return not found in some case. Add primay key index memory tracker.

## Checklist(Required)

1. Type of your changes:
    - [ ] Improvement
    - [ ] Fix
    - [x] Feature-WIP
    - [ ] Feature
    - [ ] Doc
    - [ ] Refator
    - [ ] Others: 
2. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
3. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
5. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
6. Are there any changes that cannot be rolled back:
    - [ ] Yes
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

