### PR TITLE
[feature](planner)add projection info into TPlanNode to support projection on ExecNode

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/planner/HashJoinNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/HashJoinNode.java
@@ -1055,10 +1055,12 @@ public class HashJoinNode extends PlanNode {
         if (vSrcToOutputSMap != null) {
             for (int i = 0; i < vSrcToOutputSMap.size(); i++) {
                 msg.hash_join_node.addToSrcExprList(vSrcToOutputSMap.getLhs().get(i).treeToThrift());
+                msg.addToProjections(vSrcToOutputSMap.getLhs().get(i).treeToThrift());
             }
         }
         if (vOutputTupleDesc != null) {
             msg.hash_join_node.setVoutputTupleId(vOutputTupleDesc.getId().asInt());
+            msg.setOutputTupleId(vOutputTupleDesc.getId().asInt());
         }
         if (vIntermediateTupleDescList != null) {
             for (TupleDescriptor tupleDescriptor : vIntermediateTupleDescList) {

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -473,6 +473,7 @@ struct THashJoinNode {
   // hash output column
   6: optional list<Types.TSlotId> hash_output_slot_ids
 
+  // TODO: remove 7 and 8 in the version after the version include projection on ExecNode
   7: optional list<Exprs.TExpr> srcExprList
 
   8: optional Types.TTupleId voutput_tuple_id
@@ -878,6 +879,9 @@ struct TPlanNode {
 
   // file scan node
   44: optional TFileScanNode file_scan_node
+
+  101: optional list<Exprs.TExpr> projections
+  102: optional Types.TTupleId output_tuple_id
 }
 
 // A flattened representation of a tree of PlanNodes, obtained by depth-first


### PR DESCRIPTION
# Proposed changes

## Problem Summary:

currently, Doris has no ability to do project after each node, and do lazy compute. This increases the complexity of planning and executing. We plan to add projections info into ExecNode, so that every node has the ability to do projections. This is the first commit about it to add essential information into thrift structure to add the ability that transporting projections info from FE to BE.

## Checklist(Required)

1. Type of your changes:
    - [ ] Improvement
    - [ ] Fix
    - [ ] Feature-WIP
    - [x] Feature
    - [ ] Doc
    - [ ] Refator
    - [ ] Others: 
2. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
3. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
5. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
6. Are there any changes that cannot be rolled back:
    - [ ] Yes
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

