### PR TITLE
[feature-wip][multi-catalog]Support caseSensitive field name in file scan node

### DIFF
--- a/be/src/exec/arrow/arrow_reader.h
+++ b/be/src/exec/arrow/arrow_reader.h
@@ -79,7 +79,8 @@ private:
 // base of arrow reader
 class ArrowReaderWrap {
 public:
-    ArrowReaderWrap(FileReader* file_reader, int64_t batch_size, int32_t num_of_columns_from_file);
+    ArrowReaderWrap(FileReader* file_reader, int64_t batch_size, int32_t num_of_columns_from_file,
+                    bool caseSensitive);
     virtual ~ArrowReaderWrap();
 
     virtual Status init_reader(const TupleDescriptor* tuple_desc,
@@ -96,6 +97,7 @@ public:
     std::shared_ptr<Statistics>& statistics() { return _statistics; }
     void close();
     virtual Status size(int64_t* size) { return Status::NotSupported("Not Implemented size"); }
+    int get_cloumn_index(std::string column_name);
 
     void prefetch_batch();
 
@@ -124,6 +126,7 @@ protected:
     std::list<std::shared_ptr<arrow::RecordBatch>> _queue;
     const size_t _max_queue_size = config::parquet_reader_max_buffer_size;
     std::thread _thread;
+    bool _caseSensitive;
 };
 
 } // namespace doris

--- a/be/src/exec/arrow/orc_reader.h
+++ b/be/src/exec/arrow/orc_reader.h
@@ -33,7 +33,7 @@ namespace doris {
 class ORCReaderWrap final : public ArrowReaderWrap {
 public:
     ORCReaderWrap(FileReader* file_reader, int64_t batch_size, int32_t num_of_columns_from_file,
-                  int64_t range_start_offset, int64_t range_size);
+                  int64_t range_start_offset, int64_t range_size, bool caseSensitive = true);
     ~ORCReaderWrap() override = default;
 
     Status init_reader(const TupleDescriptor* tuple_desc,

--- a/be/src/exec/arrow/parquet_reader.h
+++ b/be/src/exec/arrow/parquet_reader.h
@@ -64,7 +64,7 @@ public:
     // batch_size is not use here
     ParquetReaderWrap(FileReader* file_reader, int64_t batch_size, int32_t num_of_columns_from_file,
                       int64_t range_start_offset, int64_t range_size, bool caseSensitive = true);
-    ~ParquetReaderWrap() override  = default;
+    ~ParquetReaderWrap() override = default;
 
     // Read
     Status read(Tuple* tuple, const std::vector<SlotDescriptor*>& tuple_slot_descs,

--- a/be/src/exec/arrow/parquet_reader.h
+++ b/be/src/exec/arrow/parquet_reader.h
@@ -63,8 +63,8 @@ class ParquetReaderWrap final : public ArrowReaderWrap {
 public:
     // batch_size is not use here
     ParquetReaderWrap(FileReader* file_reader, int64_t batch_size, int32_t num_of_columns_from_file,
-                      int64_t range_start_offset, int64_t range_size);
-    ~ParquetReaderWrap() override = default;
+                      int64_t range_start_offset, int64_t range_size, bool caseSensitive = true);
+    ~ParquetReaderWrap() override  = default;
 
     // Read
     Status read(Tuple* tuple, const std::vector<SlotDescriptor*>& tuple_slot_descs,

--- a/be/src/vec/exec/file_arrow_scanner.cpp
+++ b/be/src/vec/exec/file_arrow_scanner.cpp
@@ -186,7 +186,11 @@ Status FileArrowScanner::_append_batch_to_block(Block* block) {
         if (slot_desc == nullptr) {
             continue;
         }
-        auto* array = _batch->GetColumnByName(slot_desc->col_name()).get();
+        int file_index = _cur_file_reader->get_cloumn_index(slot_desc->col_name());
+        if (file_index == -1) {
+            continue;
+        }
+        auto* array = _batch->column(file_index).get();
         auto& column_with_type_and_name = block->get_by_name(slot_desc->col_name());
         RETURN_IF_ERROR(arrow_column_to_doris_column(
                 array, _arrow_batch_cur_idx, column_with_type_and_name.column,
@@ -228,7 +232,7 @@ ArrowReaderWrap* VFileParquetScanner::_new_arrow_reader(FileReader* file_reader,
                                                         int64_t range_start_offset,
                                                         int64_t range_size) {
     return new ParquetReaderWrap(file_reader, batch_size, num_of_columns_from_file,
-                                 range_start_offset, range_size);
+                                 range_start_offset, range_size, false);
 }
 
 void VFileParquetScanner::_init_profiles(RuntimeProfile* profile) {
@@ -252,7 +256,7 @@ ArrowReaderWrap* VFileORCScanner::_new_arrow_reader(FileReader* file_reader, int
                                                     int64_t range_start_offset,
                                                     int64_t range_size) {
     return new ORCReaderWrap(file_reader, batch_size, num_of_columns_from_file, range_start_offset,
-                             range_size);
+                             range_size, false);
 }
 
 } // namespace doris::vectorized

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/BrokerUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/BrokerUtil.java
@@ -222,6 +222,14 @@ public class BrokerUtil {
 
     public static List<String> parseColumnsFromPath(String filePath, List<String> columnsFromPath)
             throws UserException {
+        return parseColumnsFromPath(filePath, columnsFromPath, true);
+    }
+
+    public static List<String> parseColumnsFromPath(
+            String filePath,
+            List<String> columnsFromPath,
+            boolean caseSensitive)
+            throws UserException {
         if (columnsFromPath == null || columnsFromPath.isEmpty()) {
             return Collections.emptyList();
         }
@@ -246,7 +254,8 @@ public class BrokerUtil {
                 throw new UserException("Fail to parse columnsFromPath, expected: "
                         + columnsFromPath + ", filePath: " + filePath);
             }
-            int index = columnsFromPath.indexOf(pair[0]);
+            String parsedColumnName = caseSensitive ? pair[0] : pair[0].toLowerCase();
+            int index = columnsFromPath.indexOf(parsedColumnName);
             if (index == -1) {
                 continue;
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/HudiScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/HudiScanNode.java
@@ -274,7 +274,7 @@ public class HudiScanNode extends BrokerScanNode {
 
             TScanRangeLocations curLocations = newLocations(context.params, brokerDesc);
             List<String> partitionValuesFromPath = BrokerUtil.parseColumnsFromPath(fileSplit.getPath().toString(),
-                    getPartitionKeys());
+                    getPartitionKeys(), false);
             int numberOfColumnsFromFile = context.slotDescByName.size() - partitionValuesFromPath.size();
 
             TBrokerRangeDesc rangeDesc = createBrokerRangeDesc(fileSplit, fileFormatType,

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/external/ExternalFileScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/external/ExternalFileScanNode.java
@@ -309,7 +309,7 @@ public class ExternalFileScanNode extends ExternalScanNode {
             totalFileSize += split.getLength();
 
             List<String> partitionValuesFromPath = BrokerUtil.parseColumnsFromPath(fileSplit.getPath().toString(),
-                    partitionKeys);
+                    partitionKeys, false);
 
             TFileRangeDesc rangeDesc = createFileRangeDesc(fileSplit, partitionValuesFromPath);
 


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:
Spark support upper case column name and the column name will persist in parquet and orc.
But the hms table only record the lower case column name, so it need to support read the  upper case column in file.
In file scan node, it's not caseSensitive, col_a and Col_a is the same column.
In broker scan node, it's caseSensitive, col_a and Col_a is not the same column.

Create table in spark 
```sql
CREATE TABLE `default`.`emp3` (
  `Name` STRING,
  `AGE` INT,
  `provice` STRING,
  `City` STRING)
USING parquet
PARTITIONED BY (City)
TBLPROPERTIES (
  'transient_lastDdlTime' = '1658550652')
```

doris result
```sql
MySQL [default]> select * from emp3;
+------+------+---------+------+
| name | age  | provice | city |
+------+------+---------+------+
| a    |    1 | zj      | hz   |
+------+------+---------+------+
1 row in set (1.492 sec)
```


## Checklist(Required)

1. Type of your changes:
    - [ ] Improvement
    - [ ] Fix
    - [x] Feature-WIP
    - [ ] Feature
    - [ ] Doc
    - [ ] Refator
    - [ ] Others: 
2. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
3. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
4. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
5. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
6. Are there any changes that cannot be rolled back:
    - [ ] Yes
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

