### PR TITLE
[Fix](metric) Fix FE max_instances_num_per_user metric

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/metric/MetricRepo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/metric/MetricRepo.java
@@ -38,7 +38,6 @@ import org.apache.doris.service.ExecuteEnv;
 import org.apache.doris.system.Backend;
 import org.apache.doris.system.SystemInfoService;
 
-import com.codahale.metrics.Gauge;
 import com.codahale.metrics.Histogram;
 import com.codahale.metrics.MetricRegistry;
 import com.google.common.collect.Sets;
@@ -232,6 +231,21 @@ public final class MetricRepo {
         };
         PALO_METRIC_REGISTER.addPaloMetrics(scheduledTabletNum);
 
+        GaugeMetric<Long> maxInstanceNum = new GaugeMetric<Long>("max_instances_num_per_user",
+            MetricUnit.NOUNIT, "max instances num of all current users") {
+                @Override
+                public Long getValue() {
+                    try {
+                        return ((QeProcessorImpl) QeProcessorImpl.INSTANCE).getInstancesNumPerUser().values().stream()
+                            .reduce(-1, BinaryOperator.maxBy(Integer::compareTo)).longValue();
+                    } catch (Throwable ex) {
+                        LOG.warn("Get max_instances_num_per_user error", ex);
+                        return -2L;
+                    }
+                }
+        };
+        PALO_METRIC_REGISTER.addPaloMetrics(maxInstanceNum);
+
         // qps, rps and error rate
         // these metrics should be set an init value, in case that metric calculator is not running
         GAUGE_QUERY_PER_SECOND = new GaugeMetricImpl<>("qps", MetricUnit.NOUNIT,
@@ -376,18 +390,6 @@ public final class MetricRepo {
                 MetricRegistry.name("query", "latency", "ms"));
         HISTO_EDIT_LOG_WRITE_LATENCY = METRIC_REGISTER.histogram(
                 MetricRegistry.name("editlog", "write", "latency", "ms"));
-
-        METRIC_REGISTER.register(MetricRegistry.name("palo", "fe", "query", "max_instances_num_per_user"),
-                (Gauge<Integer>) () -> {
-                    try {
-                        return ((QeProcessorImpl) QeProcessorImpl.INSTANCE).getInstancesNumPerUser().values().stream()
-                                .reduce(-1, BinaryOperator.maxBy(Integer::compareTo));
-                    } catch (Throwable ex) {
-                        LOG.warn("Get max_instances_num_per_user error", ex);
-                        return -2;
-                    }
-            }
-        );
 
         // init system metrics
         initSystemMetrics();

--- a/fe/fe-core/src/main/java/org/apache/doris/metric/MetricRepo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/metric/MetricRepo.java
@@ -232,7 +232,7 @@ public final class MetricRepo {
         PALO_METRIC_REGISTER.addPaloMetrics(scheduledTabletNum);
 
         GaugeMetric<Long> maxInstanceNum = new GaugeMetric<Long>("max_instances_num_per_user",
-            MetricUnit.NOUNIT, "max instances num of all current users") {
+                MetricUnit.NOUNIT, "max instances num of all current users") {
                 @Override
                 public Long getValue() {
                     try {


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:
Add metric in right metric register.
After this PR, fe_host:fe_http_port/metrics will show `doris_fe_max_instances_num_per_user` like follows:
```
# HELP doris_fe_max_instances_num_per_user max instances num of all current users
# TYPE doris_fe_max_instances_num_per_user gauge
doris_fe_max_instances_num_per_user -1
```


## Checklist(Required)

1. Type of your changes:
    - [ ] Improvement
    - [x] Fix
    - [ ] Feature-WIP
    - [ ] Feature
    - [ ] Doc
    - [ ] Refator
    - [ ] Others: 
2. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
3. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
5. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
6. Are there any changes that cannot be rolled back:
    - [ ] Yes
    - [x] No

## Further comments


