### PR TITLE
[fix](agg)Add field of 'is_first_phase' in TAggregationNode

### DIFF
--- a/be/src/vec/exec/vaggregation_node.h
+++ b/be/src/vec/exec/vaggregation_node.h
@@ -647,6 +647,7 @@ private:
 
     bool _needs_finalize;
     bool _is_merge;
+    bool _is_first_phase;
     std::unique_ptr<MemPool> _mem_pool;
 
     std::unique_ptr<MemTracker> _data_mem_tracker;

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/AggregateInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/AggregateInfo.java
@@ -373,6 +373,10 @@ public final class AggregateInfo extends AggregateInfoBase {
         return aggPhase.isMerge();
     }
 
+    public boolean isFirstPhase() {
+        return aggPhase == AggPhase.FIRST;
+    }
+
     public boolean isDistinctAgg() {
         return secondPhaseDistinctAggInfo != null;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/AggregationNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/AggregationNode.java
@@ -272,6 +272,7 @@ public class AggregationNode extends PlanNode {
                 aggInfo.getOutputTupleId().asInt(), needsFinalize);
         msg.agg_node.setAggSortInfos(aggSortInfos);
         msg.agg_node.setUseStreamingPreaggregation(useStreamingPreagg);
+        msg.agg_node.setIsFirstPhase(aggInfo.isFirstPhase());
         List<Expr> groupingExprs = aggInfo.getGroupingExprs();
         if (groupingExprs != null) {
             msg.agg_node.setGroupingExprs(Expr.treesToThrift(groupingExprs));

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -545,6 +545,7 @@ struct TAggregationNode {
   5: required bool need_finalize
   6: optional bool use_streaming_preaggregation
   7: optional list<TSortInfo> agg_sort_infos
+  8: optional bool is_first_phase;
 }
 
 struct TRepeatNode {


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

For better performance, the second aggregation phase should use a different hash algorithm from phase 1.
Here add `is_merge` to indicate the second aggregation phase.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

