### PR TITLE
[feature](nereids) add scalar subquery expression

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/LogicalPlanBuilder.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/LogicalPlanBuilder.java
@@ -89,6 +89,7 @@ import org.apache.doris.nereids.trees.expressions.IntervalLiteral;
 import org.apache.doris.nereids.trees.expressions.LessThan;
 import org.apache.doris.nereids.trees.expressions.LessThanEqual;
 import org.apache.doris.nereids.trees.expressions.Like;
+import org.apache.doris.nereids.trees.expressions.ListQuery;
 import org.apache.doris.nereids.trees.expressions.Literal;
 import org.apache.doris.nereids.trees.expressions.Mod;
 import org.apache.doris.nereids.trees.expressions.Multiply;
@@ -804,7 +805,7 @@ public class LogicalPlanBuilder extends DorisParserBaseVisitor<Object> {
                     } else {
                         outExpression = new InSubquery(
                                 valueExpression,
-                                typedVisit(ctx.query())
+                                new ListQuery(typedVisit(ctx.query()))
                         );
                     }
                     break;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/LogicalPlanBuilder.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/LogicalPlanBuilder.java
@@ -100,7 +100,6 @@ import org.apache.doris.nereids.trees.expressions.Or;
 import org.apache.doris.nereids.trees.expressions.Regexp;
 import org.apache.doris.nereids.trees.expressions.ScalarSubquery;
 import org.apache.doris.nereids.trees.expressions.StringLiteral;
-import org.apache.doris.nereids.trees.expressions.SubqueryExpr;
 import org.apache.doris.nereids.trees.expressions.Subtract;
 import org.apache.doris.nereids.trees.expressions.TimestampArithmetic;
 import org.apache.doris.nereids.trees.expressions.WhenClause;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/LogicalPlanBuilder.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/LogicalPlanBuilder.java
@@ -98,6 +98,7 @@ import org.apache.doris.nereids.trees.expressions.NullLiteral;
 import org.apache.doris.nereids.trees.expressions.NullSafeEqual;
 import org.apache.doris.nereids.trees.expressions.Or;
 import org.apache.doris.nereids.trees.expressions.Regexp;
+import org.apache.doris.nereids.trees.expressions.ScalarSubquery;
 import org.apache.doris.nereids.trees.expressions.StringLiteral;
 import org.apache.doris.nereids.trees.expressions.SubqueryExpr;
 import org.apache.doris.nereids.trees.expressions.Subtract;
@@ -831,7 +832,7 @@ public class LogicalPlanBuilder extends DorisParserBaseVisitor<Object> {
 
     @Override
     public Expression visitSubqueryExpression(SubqueryExpressionContext subqueryExprCtx) {
-        return ParserUtils.withOrigin(subqueryExprCtx, () -> new SubqueryExpr(typedVisit(subqueryExprCtx.query())));
+        return ParserUtils.withOrigin(subqueryExprCtx, () -> new ScalarSubquery(typedVisit(subqueryExprCtx.query())));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/Exists.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/Exists.java
@@ -20,6 +20,7 @@ package org.apache.doris.nereids.trees.expressions;
 import org.apache.doris.nereids.exceptions.UnboundException;
 import org.apache.doris.nereids.trees.expressions.visitor.ExpressionVisitor;
 import org.apache.doris.nereids.trees.plans.logical.LogicalPlan;
+import org.apache.doris.nereids.types.BooleanType;
 import org.apache.doris.nereids.types.DataType;
 
 import java.util.Objects;
@@ -35,10 +36,7 @@ public class Exists extends SubqueryExpr implements LeafExpression {
 
     @Override
     public DataType getDataType() throws UnboundException {
-        // TODO:
-        // For multiple lines, struct type is returned, in the form of splicing,
-        // but it seems that struct type is not currently supported
-        throw new UnboundException("not support");
+        return BooleanType.INSTANCE;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/InSubquery.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/InSubquery.java
@@ -19,8 +19,6 @@ package org.apache.doris.nereids.trees.expressions;
 
 import org.apache.doris.nereids.exceptions.UnboundException;
 import org.apache.doris.nereids.trees.expressions.visitor.ExpressionVisitor;
-import org.apache.doris.nereids.trees.plans.logical.LogicalPlan;
-import org.apache.doris.nereids.types.BooleanType;
 import org.apache.doris.nereids.types.DataType;
 
 import com.google.common.base.Preconditions;
@@ -33,15 +31,17 @@ import java.util.Objects;
  */
 public class InSubquery extends SubqueryExpr implements BinaryExpression {
     private Expression compareExpr;
+    private ListQuery listQuery;
 
-    public InSubquery(Expression compareExpression, LogicalPlan subquery) {
-        super(Objects.requireNonNull(subquery, "subquery can not be null"));
+    public InSubquery(Expression compareExpression, ListQuery listQuery) {
+        super(Objects.requireNonNull(listQuery.getQueryPlan(), "subquery can not be null"));
         this.compareExpr = compareExpression;
+        this.listQuery = listQuery;
     }
 
     @Override
     public DataType getDataType() throws UnboundException {
-        return BooleanType.INSTANCE;
+        return listQuery.getDataType();
     }
 
     @Override
@@ -71,8 +71,8 @@ public class InSubquery extends SubqueryExpr implements BinaryExpression {
     public Expression withChildren(List<Expression> children) {
         Preconditions.checkArgument(children.size() == 2);
         Preconditions.checkArgument(children.get(0) instanceof Expression);
-        Preconditions.checkArgument(children.get(1) instanceof InSubquery);
-        return new InSubquery(children.get(0), ((SubqueryExpr) children.get(1)).getQueryPlan());
+        Preconditions.checkArgument(children.get(1) instanceof ListQuery);
+        return new InSubquery(children.get(0), (ListQuery) children.get(1));
     }
 
     @Override
@@ -90,6 +90,6 @@ public class InSubquery extends SubqueryExpr implements BinaryExpression {
 
     @Override
     public int hashCode() {
-        return Objects.hash(this.compareExpr, this.queryPlan);
+        return Objects.hash(this.compareExpr, this.listQuery);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/InSubquery.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/InSubquery.java
@@ -71,7 +71,7 @@ public class InSubquery extends SubqueryExpr implements BinaryExpression {
     public Expression withChildren(List<Expression> children) {
         Preconditions.checkArgument(children.size() == 2);
         Preconditions.checkArgument(children.get(0) instanceof Expression);
-        Preconditions.checkArgument(children.get(1) instanceof SubqueryExpr);
+        Preconditions.checkArgument(children.get(1) instanceof InSubquery);
         return new InSubquery(children.get(0), ((SubqueryExpr) children.get(1)).getQueryPlan());
     }
 
@@ -85,7 +85,7 @@ public class InSubquery extends SubqueryExpr implements BinaryExpression {
         }
         InSubquery inSubquery = (InSubquery) o;
         return Objects.equals(this.compareExpr, inSubquery.getCompareExpr())
-                && Objects.equals(this.queryPlan, inSubquery.getQueryPlan());
+                && checkEquals(this.queryPlan, inSubquery.queryPlan);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/ListQuery.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/ListQuery.java
@@ -25,11 +25,11 @@ import org.apache.doris.nereids.types.DataType;
 import java.util.Objects;
 
 /**
- * Exists subquery expression.
+ * Encapsulate LogicalPlan as Expression.
+ * just for subquery.
  */
-public class Exists extends SubqueryExpr implements LeafExpression {
-
-    public Exists(LogicalPlan subquery) {
+public class ListQuery extends SubqueryExpr implements LeafExpression {
+    public ListQuery(LogicalPlan subquery) {
         super(Objects.requireNonNull(subquery, "subquery can not be null"));
     }
 
@@ -43,15 +43,15 @@ public class Exists extends SubqueryExpr implements LeafExpression {
 
     @Override
     public String toSql() {
-        return "EXISTS (SUBQUERY) " + super.toSql();
+        return " (LISTQUERY) " + super.toSql();
     }
 
     @Override
     public String toString() {
-        return "EXISTS (SUBQUERY) " + super.toString();
+        return " (LISTQUERY) " + super.toString();
     }
 
     public <R, C> R accept(ExpressionVisitor<R, C> visitor, C context) {
-        return visitor.visitExistsSubquery(this, context);
+        return visitor.visitListQuery(this, context);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/ScalarSubquery.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/ScalarSubquery.java
@@ -24,13 +24,12 @@ import org.apache.doris.nereids.types.DataType;
 
 import com.google.common.base.Preconditions;
 
-import java.util.List;
 import java.util.Objects;
 
 /**
  * A subquery that will return only one row and one column.
  */
-public class ScalarSubquery extends SubqueryExpr {
+public class ScalarSubquery extends SubqueryExpr implements LeafExpression {
     public ScalarSubquery(LogicalPlan subquery) {
         super(Objects.requireNonNull(subquery, "subquery can not be null"));
     }
@@ -53,12 +52,5 @@ public class ScalarSubquery extends SubqueryExpr {
 
     public <R, C> R accept(ExpressionVisitor<R, C> visitor, C context) {
         return visitor.visitScalarSubquery(this, context);
-    }
-
-    @Override
-    public Expression withChildren(List<Expression> children) {
-        Preconditions.checkArgument(children.size() == 1);
-        Preconditions.checkArgument(children.get(0) instanceof ScalarSubquery);
-        return new ScalarSubquery(((SubqueryExpr) children.get(0)).getQueryPlan());
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/ScalarSubquery.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/ScalarSubquery.java
@@ -20,7 +20,6 @@ package org.apache.doris.nereids.trees.expressions;
 import org.apache.doris.nereids.exceptions.UnboundException;
 import org.apache.doris.nereids.trees.expressions.visitor.ExpressionVisitor;
 import org.apache.doris.nereids.trees.plans.logical.LogicalPlan;
-import org.apache.doris.nereids.types.BooleanType;
 import org.apache.doris.nereids.types.DataType;
 
 import com.google.common.base.Preconditions;
@@ -29,37 +28,37 @@ import java.util.List;
 import java.util.Objects;
 
 /**
- * Exists subquery expression.
+ * A subquery that will return only one row and one column.
  */
-public class Exists extends SubqueryExpr {
-
-    public Exists(LogicalPlan subquery) {
+public class ScalarSubquery extends SubqueryExpr {
+    public ScalarSubquery(LogicalPlan subquery) {
         super(Objects.requireNonNull(subquery, "subquery can not be null"));
     }
 
     @Override
     public DataType getDataType() throws UnboundException {
-        return BooleanType.INSTANCE;
+        Preconditions.checkArgument(queryPlan.getOutput().size() == 1);
+        return queryPlan.getOutput().get(0).getDataType();
     }
 
     @Override
     public String toSql() {
-        return "EXISTS (SUBQUERY) " + super.toSql();
+        return " (SCALARSUBQUERY) " + super.toSql();
     }
 
     @Override
     public String toString() {
-        return "EXISTS (SUBQUERY) " + super.toString();
+        return " (SCALARSUBQUERY) " + super.toString();
     }
 
     public <R, C> R accept(ExpressionVisitor<R, C> visitor, C context) {
-        return visitor.visitExistsSubquery(this, context);
+        return visitor.visitScalarSubquery(this, context);
     }
 
     @Override
     public Expression withChildren(List<Expression> children) {
         Preconditions.checkArgument(children.size() == 1);
-        Preconditions.checkArgument(children.get(0) instanceof Exists);
-        return new Exists(((SubqueryExpr) children.get(0)).getQueryPlan());
+        Preconditions.checkArgument(children.get(0) instanceof ScalarSubquery);
+        return new ScalarSubquery(((SubqueryExpr) children.get(0)).getQueryPlan());
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/SubqueryExpr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/SubqueryExpr.java
@@ -39,10 +39,6 @@ public class SubqueryExpr extends Expression {
 
     @Override
     public DataType getDataType() throws UnboundException {
-        // TODO:
-        // Returns the data type of the row on a single line
-        // For multiple lines, struct type is returned, in the form of splicing,
-        // but it seems that struct type is not currently supported
         throw new UnboundException("not support");
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/SubqueryExpr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/SubqueryExpr.java
@@ -95,7 +95,7 @@ public class SubqueryExpr extends Expression {
      * @param o compared query.
      * @return equal ? true : false;
      */
-    private boolean checkEquals(Object i, Object o) {
+    protected boolean checkEquals(Object i, Object o) {
         if (!(i instanceof LogicalPlan) || !(o instanceof LogicalPlan)) {
             return false;
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/visitor/DefaultSubExprRewriter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/visitor/DefaultSubExprRewriter.java
@@ -18,9 +18,11 @@
 package org.apache.doris.nereids.trees.expressions.visitor;
 
 import org.apache.doris.nereids.analyzer.NereidsAnalyzer;
+import org.apache.doris.nereids.exceptions.AnalysisException;
 import org.apache.doris.nereids.rules.analysis.Scope;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.InSubquery;
+import org.apache.doris.nereids.trees.expressions.ScalarSubquery;
 import org.apache.doris.nereids.trees.expressions.SubqueryExpr;
 import org.apache.doris.nereids.trees.plans.logical.LogicalPlan;
 import org.apache.doris.qe.ConnectContext;
@@ -45,6 +47,16 @@ public class DefaultSubExprRewriter<C> extends DefaultExpressionRewriter<C> {
     @Override
     public Expression visitInSubquery(InSubquery expr, C context) {
         return new InSubquery(expr.getCompareExpr(), analyzeSubquery(expr));
+    }
+
+    @Override
+    public Expression visitScalarSubquery(ScalarSubquery scalar, C context) {
+        LogicalPlan analyzed = analyzeSubquery(scalar);
+        if (analyzed.getOutput().size() != 1) {
+            throw new AnalysisException("Multiple columns returned by subquery are not yet supported. Found "
+                    + analyzed.getOutput().size());
+        }
+        return new ScalarSubquery(analyzed);
     }
 
     private LogicalPlan analyzeSubquery(SubqueryExpr expr) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/visitor/DefaultSubExprRewriter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/visitor/DefaultSubExprRewriter.java
@@ -22,6 +22,7 @@ import org.apache.doris.nereids.exceptions.AnalysisException;
 import org.apache.doris.nereids.rules.analysis.Scope;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.InSubquery;
+import org.apache.doris.nereids.trees.expressions.ListQuery;
 import org.apache.doris.nereids.trees.expressions.ScalarSubquery;
 import org.apache.doris.nereids.trees.expressions.SubqueryExpr;
 import org.apache.doris.nereids.trees.plans.logical.LogicalPlan;
@@ -46,7 +47,7 @@ public class DefaultSubExprRewriter<C> extends DefaultExpressionRewriter<C> {
 
     @Override
     public Expression visitInSubquery(InSubquery expr, C context) {
-        return new InSubquery(expr.getCompareExpr(), analyzeSubquery(expr));
+        return new InSubquery(expr.getCompareExpr(), new ListQuery(analyzeSubquery(expr)));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/visitor/ExpressionVisitor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/visitor/ExpressionVisitor.java
@@ -54,6 +54,7 @@ import org.apache.doris.nereids.trees.expressions.NullLiteral;
 import org.apache.doris.nereids.trees.expressions.NullSafeEqual;
 import org.apache.doris.nereids.trees.expressions.Or;
 import org.apache.doris.nereids.trees.expressions.Regexp;
+import org.apache.doris.nereids.trees.expressions.ScalarSubquery;
 import org.apache.doris.nereids.trees.expressions.Slot;
 import org.apache.doris.nereids.trees.expressions.SlotReference;
 import org.apache.doris.nereids.trees.expressions.StringLiteral;
@@ -238,6 +239,10 @@ public abstract class ExpressionVisitor<R, C> {
 
     public R visitTimestampArithmetic(TimestampArithmetic arithmetic, C context) {
         return visit(arithmetic, context);
+    }
+
+    public R visitScalarSubquery(ScalarSubquery scalar, C context) {
+        return visitSubqueryExpr(scalar, context);
     }
 
     /* ********************************************************************************************

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/visitor/ExpressionVisitor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/visitor/ExpressionVisitor.java
@@ -45,6 +45,7 @@ import org.apache.doris.nereids.trees.expressions.IntegerLiteral;
 import org.apache.doris.nereids.trees.expressions.LessThan;
 import org.apache.doris.nereids.trees.expressions.LessThanEqual;
 import org.apache.doris.nereids.trees.expressions.Like;
+import org.apache.doris.nereids.trees.expressions.ListQuery;
 import org.apache.doris.nereids.trees.expressions.Literal;
 import org.apache.doris.nereids.trees.expressions.Mod;
 import org.apache.doris.nereids.trees.expressions.Multiply;
@@ -243,6 +244,10 @@ public abstract class ExpressionVisitor<R, C> {
 
     public R visitScalarSubquery(ScalarSubquery scalar, C context) {
         return visitSubqueryExpr(scalar, context);
+    }
+
+    public R visitListQuery(ListQuery listQuery, C context) {
+        return visitSubqueryExpr(listQuery, context);
     }
 
     /* ********************************************************************************************

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/SubqueryTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/SubqueryTest.java
@@ -83,16 +83,30 @@ public class SubqueryTest extends AnalyzeCheckTestBase {
 
     @Test
     public void scalarTest() {
-        String sql = "select * from t0 where t0.id = "
+        // min will be rewritten as as, it needs to be bound
+        /*String sql = "select * from t0 where t0.id = "
                 + "(select min(t1.id) from t1 where t0.k1 = t1.k1)";
-        checkAnalyze(sql);
+        checkAnalyze(sql);*/
+
+        // Require that the return value in the where subquery must have only 1 column.
+        String sql1 = "select * from t0 where t0.id = "
+                + "(select t1.k1, t1.id from t1 where t0.k1 = t1.k1)";
+        assert sql1 != null;
+
+        String sql2 = "select * from t0 where t0.id = "
+                + "(select t1.k1 from t1 where t0.k1 = t1.k1)";
+        checkAnalyze(sql2);
+
+        String sql3 = "select * from t0 where t0.id = "
+                + "(select * from t1 where t0.k1 = t1.k1)";
+        assert sql3 != null;
     }
 
     @Test
     public void inScalarTest() {
         String sql = "select * from t0 where t0.id in "
                 + "(select * from t1 where t1.k1 = "
-                + "(select * from t2 where t0.id = t2.id));";
+                + "(select t2.id from t2 where t0.id = t2.id));";
         checkAnalyze(sql);
     }
 }


### PR DESCRIPTION
# Proposed changes

Issue Number: 

## Problem Summary:
scalar subquery:
A subquery that will return only one row and one column.

A limit has been added, where a = subquery returns a result of 1 row and 1 column. 
Here, the first limit is to return 1 column.

TODO: the subsequent return will limit the return to 1 row

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [x] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

