### PR TITLE
[enhancement](workflow) Use ccache to speed the BE UT (Clang) up

### DIFF
--- a/.github/workflows/be-ut-clang.yml
+++ b/.github/workflows/be-ut-clang.yml
@@ -35,6 +35,12 @@ jobs:
           persist-credentials: false
           submodules: recursive
 
+      - name: Ccache ${{ github.ref }}
+        uses: ./.github/actions/ccache-action
+        with:
+          key: ${{ github.ref }} (BE UT Clang)
+          max-size: "1G"
+
       - name: Paths filter
         uses: ./.github/actions/paths-filter
         id: filter
@@ -64,7 +70,7 @@ jobs:
 
           sudo apt update
           sudo apt upgrade --yes
-          sudo DEBIAN_FRONTEND=noninteractive apt install --yes tzdata ccache byacc
+          sudo DEBIAN_FRONTEND=noninteractive apt install --yes tzdata byacc
 
           # set timezone
           sudo ln -snf /usr/share/zoneinfo/Asia/Shanghai /etc/localtime

--- a/.gitmodules
+++ b/.gitmodules
@@ -16,3 +16,6 @@
 [submodule ".github/actions/action-pr-title"]
 	path = .github/actions/action-pr-title
 	url = https://github.com/deepakputhraya/action-pr-title.git
+[submodule ".github/actions/ccache-action"]
+	path = .github/actions/ccache-action
+	url = https://github.com/hendrikmuhs/ccache-action

--- a/build.sh
+++ b/build.sh
@@ -285,6 +285,8 @@ if [ ${BUILD_BE} -eq 1 ] ; then
     fi
     MAKE_PROGRAM="$(which "${BUILD_SYSTEM}")"
     echo "-- Make program: ${MAKE_PROGRAM}"
+    echo "-- Use ccache: ${CMAKE_USE_CCACHE}"
+
     mkdir -p ${CMAKE_BUILD_DIR}
     cd ${CMAKE_BUILD_DIR}
     ${CMAKE_CMD} -G "${GENERATOR}"  \

--- a/run-be-ut.sh
+++ b/run-be-ut.sh
@@ -124,6 +124,7 @@ fi
 
 MAKE_PROGRAM="$(which "${BUILD_SYSTEM}")"
 echo "-- Make program: ${MAKE_PROGRAM}"
+echo "-- Use ccache: ${CMAKE_USE_CCACHE}"
 
 cd ${CMAKE_BUILD_DIR}
 ${CMAKE_CMD} -G "${GENERATOR}" \


### PR DESCRIPTION
# Proposed changes

~~Issue Number: close #xxx~~

## Problem Summary:

We can use [ccache-action](https://github.com/hendrikmuhs/ccache-action) to speed the workflow BE UT (Clang) up.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

