### PR TITLE
[fix](s3) Fix bug in S3FileSystem delete directory

### DIFF
--- a/be/src/io/fs/s3_file_system.cpp
+++ b/be/src/io/fs/s3_file_system.cpp
@@ -174,6 +174,9 @@ Status S3FileSystem::delete_directory(const Path& path) {
 
     Aws::S3::Model::ListObjectsV2Request request;
     auto prefix = get_key(path);
+    if (!prefix.empty() && prefix.back() != '/') {
+        prefix.push_back('/');
+    }
     request.WithBucket(_s3_conf.bucket).WithPrefix(prefix);
 
     Aws::S3::Model::DeleteObjectsRequest delete_request;


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

If `path` is not end with '/', deleting by prefix will delete data which should not be deleted.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [x] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

