### PR TITLE
[fix](hive-table) fix bug that hive external table can not query table created by Tez

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/planner/external/ExternalFileScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/external/ExternalFileScanNode.java
@@ -272,8 +272,8 @@ public class ExternalFileScanNode extends ExternalScanNode {
         try {
             buildScanRange();
         } catch (IOException e) {
-            LOG.error("Finalize failed.", e);
-            throw new UserException("Finalize failed.", e);
+            LOG.warn("Finalize failed.", e);
+            throw new UserException("Finalize failed: " + e.getMessage());
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/external/ExternalHiveScanProvider.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/external/ExternalHiveScanProvider.java
@@ -112,33 +112,31 @@ public class ExternalHiveScanProvider implements ExternalFileScanProvider {
         InputFormat<?, ?> inputFormat = HiveUtil.getInputFormat(configuration, inputFormatName, false);
         List<InputSplit> splits;
         if (!hivePartitions.isEmpty()) {
-            splits = hivePartitions.stream()
-                    .flatMap(x -> getSplitsByPath(inputFormat, configuration, x.getSd().getLocation()).stream())
-                    .collect(Collectors.toList());
+            try {
+                splits = hivePartitions.stream().flatMap(x -> {
+                    try {
+                        return getSplitsByPath(inputFormat, configuration, x.getSd().getLocation()).stream();
+                    } catch (IOException e) {
+                        throw new RuntimeException(e);
+                    }
+                }).collect(Collectors.toList());
+            } catch (RuntimeException e) {
+                throw new IOException(e);
+            }
         } else {
             splits = getSplitsByPath(inputFormat, configuration, splitsPath);
         }
-        return HiveBucketUtil.getPrunedSplitsByBuckets(
-                splits,
-                hmsTable.getName(),
-                exprs,
-                getRemoteHiveTable().getSd().getBucketCols(),
-                getRemoteHiveTable().getSd().getNumBuckets(),
+        return HiveBucketUtil.getPrunedSplitsByBuckets(splits, hmsTable.getName(), exprs,
+                getRemoteHiveTable().getSd().getBucketCols(), getRemoteHiveTable().getSd().getNumBuckets(),
                 getRemoteHiveTable().getParameters());
     }
 
-    private List<InputSplit> getSplitsByPath(
-            InputFormat<?, ?> inputFormat,
-            Configuration configuration,
-            String splitsPath) {
+    private List<InputSplit> getSplitsByPath(InputFormat<?, ?> inputFormat, Configuration configuration,
+            String splitsPath) throws IOException {
         JobConf jobConf = new JobConf(configuration);
         FileInputFormat.setInputPaths(jobConf, splitsPath);
-        try {
-            InputSplit[] splits = inputFormat.getSplits(jobConf, 0);
-            return Lists.newArrayList(splits);
-        } catch (IOException e) {
-            return new ArrayList<InputSplit>();
-        }
+        InputSplit[] splits = inputFormat.getSplits(jobConf, 0);
+        return Lists.newArrayList(splits);
     }
 
 

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/external/ExternalHiveScanProvider.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/external/ExternalHiveScanProvider.java
@@ -39,6 +39,8 @@ import org.apache.hadoop.mapred.FileInputFormat;
 import org.apache.hadoop.mapred.InputFormat;
 import org.apache.hadoop.mapred.InputSplit;
 import org.apache.hadoop.mapred.JobConf;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -50,6 +52,8 @@ import java.util.stream.Collectors;
  * A HiveScanProvider to get information for scan node.
  */
 public class ExternalHiveScanProvider implements ExternalFileScanProvider {
+    private static final Logger LOG = LogManager.getLogger(ExternalHiveScanProvider.class);
+
     protected HMSExternalTable hmsTable;
 
     public ExternalHiveScanProvider(HMSExternalTable hmsTable) {
@@ -134,6 +138,15 @@ public class ExternalHiveScanProvider implements ExternalFileScanProvider {
     private List<InputSplit> getSplitsByPath(InputFormat<?, ?> inputFormat, Configuration configuration,
             String splitsPath) throws IOException {
         JobConf jobConf = new JobConf(configuration);
+        // For Tez engine, it may generate subdirectoies for "union" query.
+        // So there may be files and directories in the table directory at the same time. eg:
+        //      /user/hive/warehouse/region_tmp_union_all2/000000_0
+        //      /user/hive/warehouse/region_tmp_union_all2/1
+        //      /user/hive/warehouse/region_tmp_union_all2/2
+        // So we need to set this config to support visit dir recursively.
+        // Otherwise, getSplits() may throw exception: "Not a file xxx"
+        // https://blog.actorsfit.com/a?ID=00550-ce56ec63-1bff-4b0c-a6f7-447b93efaa31
+        jobConf.set("mapreduce.input.fileinputformat.input.dir.recursive", "true");
         FileInputFormat.setInputPaths(jobConf, splitsPath);
         InputSplit[] splits = inputFormat.getSplits(jobConf, 0);
         return Lists.newArrayList(splits);


### PR DESCRIPTION
# Proposed changes

Issue Number: close #11346 

## Problem Summary

If the hive is created by Tez using "union" query, the location of the table is a second-level director, eg:

/user/hive/warehouse/region_tmp_union_all/
---/user/hive/warehouse/region_tmp_union_all/1
---/user/hive/warehouse/region_tmp_union_all/2

We should recursive traverse the directory to get the real files.
This fix the hive external table, but it still has problem when use Catalog feature. Will be fixed later.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes
    - [x] No

## Further comments
