### PR TITLE
[Bug](datetimev2) fix bugs for datev2/datetimev2

### DIFF
--- a/be/src/vec/data_types/data_type_time_v2.cpp
+++ b/be/src/vec/data_types/data_type_time_v2.cpp
@@ -67,7 +67,7 @@ void DataTypeDateV2::cast_to_date(const UInt32 from, Int64& to) {
 }
 
 void DataTypeDateV2::cast_to_date_time_v2(const UInt32 from, UInt64& to) {
-    to = (UInt64)from << TIME_PART_LENGTH;
+    to = ((UInt64)from) << TIME_PART_LENGTH;
 }
 
 bool DataTypeDateTimeV2::equals(const IDataType& rhs) const {

--- a/be/src/vec/functions/function_cast.h
+++ b/be/src/vec/functions/function_cast.h
@@ -146,11 +146,13 @@ struct ConvertImpl {
                         }
                     } else if constexpr (IsDateV2Type<ToDataType>) {
                         auto date_v2 = binary_cast<UInt32, DateV2Value<DateV2ValueType>>(vec_to[i]);
-                        date_v2.from_date_int64(vec_from[i]);
+                        date_v2.from_date_int64(
+                                reinterpret_cast<const VecDateTimeValue&>(vec_from[i]).to_int64());
                     } else if constexpr (IsDateTimeV2Type<ToDataType>) {
                         auto date_v2 =
                                 binary_cast<UInt64, DateV2Value<DateTimeV2ValueType>>(vec_to[i]);
-                        date_v2.from_date_int64(vec_from[i]);
+                        date_v2.from_date_int64(
+                                reinterpret_cast<const VecDateTimeValue&>(vec_from[i]).to_int64());
                     } else {
                         vec_to[i] =
                                 reinterpret_cast<const VecDateTimeValue&>(vec_from[i]).to_int64();
@@ -180,14 +182,14 @@ struct ConvertImpl {
                             DataTypeDateTimeV2::cast_to_date(vec_from[i], vec_to[i]);
                         }
                     } else {
-                        if constexpr (IsDateTimeV2Type<ToDataType>) {
+                        if constexpr (IsDateTimeV2Type<FromDataType>) {
                             vec_to[i] = reinterpret_cast<const DateV2Value<DateTimeV2ValueType>&>(
                                                 vec_from[i])
-                                                .to_date_int_val();
+                                                .to_int64();
                         } else {
                             vec_to[i] = reinterpret_cast<const DateV2Value<DateV2ValueType>&>(
                                                 vec_from[i])
-                                                .to_date_int_val();
+                                                .to_int64();
                         }
                     }
                 } else {

--- a/be/src/vec/functions/function_datetime_floor_ceil.cpp
+++ b/be/src/vec/functions/function_datetime_floor_ceil.cpp
@@ -270,11 +270,11 @@ struct TimeRound {
     static constexpr int8_t FLOOR = 0;
     static constexpr int8_t CEIL = 1;
 
-    static constexpr uint32_t MASK_YEAR_FOR_DATEV2 = -1 >> 23;
-    static constexpr uint32_t MASK_YEAR_MONTH_FOR_DATEV2 = -1 >> 27;
+    static constexpr uint32_t MASK_YEAR_FOR_DATEV2 = ((uint32_t)-1) >> 23;
+    static constexpr uint32_t MASK_YEAR_MONTH_FOR_DATEV2 = ((uint32_t)-1) >> 27;
 
-    static constexpr uint64_t MASK_YEAR_FOR_DATETIMEV2 = -1 >> 18;
-    static constexpr uint64_t MASK_YEAR_MONTH_FOR_DATETIMEV2 = -1 >> 22;
+    static constexpr uint64_t MASK_YEAR_FOR_DATETIMEV2 = ((uint64_t)-1) >> 18;
+    static constexpr uint64_t MASK_YEAR_MONTH_FOR_DATETIMEV2 = ((uint64_t)-1) >> 22;
 
     template <typename NativeType, typename DateValueType>
     static void time_round(const DateValueType& ts2, Int32 period, DateValueType& ts1,

--- a/be/src/vec/runtime/vdatetime_value.h
+++ b/be/src/vec/runtime/vdatetime_value.h
@@ -1006,10 +1006,10 @@ public:
     DateV2Value<T>& operator++() {
         if constexpr (is_datetime) {
             TimeInterval interval(SECOND, 1, false);
-            date_add_interval<SECOND>(interval, *this);
+            date_add_interval<SECOND>(interval);
         } else {
             TimeInterval interval(DAY, 1, false);
-            date_add_interval<DAY>(interval, *this);
+            date_add_interval<DAY>(interval);
         }
         return *this;
     }
@@ -1119,6 +1119,19 @@ public:
             }
         }
     }
+    operator int64_t() const { return to_int64(); }
+
+    int64_t to_int64() const {
+        if constexpr (is_datetime) {
+            return (date_v2_value_.year_ * 10000L + date_v2_value_.month_ * 100 +
+                    date_v2_value_.day_) *
+                           1000000L +
+                   date_v2_value_.hour_ * 10000 + date_v2_value_.minute_ * 100 +
+                   date_v2_value_.second_;
+        } else {
+            return date_v2_value_.year_ * 10000 + date_v2_value_.month_ * 100 + date_v2_value_.day_;
+        }
+    };
 
 private:
     static uint8_t calc_week(const uint32_t& day_nr, const uint16_t& year, const uint8_t& month,
@@ -1230,37 +1243,42 @@ int64_t datetime_diff(const VecDateTimeValue& ts_value1, const VecDateTimeValue&
 
 template <TimeUnit unit, typename T0, typename T1>
 int64_t datetime_diff(const DateV2Value<T0>& ts_value1, const DateV2Value<T1>& ts_value2) {
-    constexpr uint32_t minus_one = -1;
+    constexpr uint64_t uint64_minus_one = -1;
     switch (unit) {
     case YEAR: {
         int year = (ts_value2.year() - ts_value1.year());
         if constexpr (std::is_same_v<T0, T1>) {
             int year_width =
                     DateV2Value<T0>::is_datetime ? DATETIMEV2_YEAR_WIDTH : DATEV2_YEAR_WIDTH;
+            decltype(ts_value2.to_date_int_val()) minus_one = -1;
             if (year > 0) {
-                year -= ((ts_value2.to_date_int_val() & (minus_one >> year_width)) -
-                         (ts_value1.to_date_int_val() & (minus_one >> year_width))) < 0;
+                year -= ((ts_value2.to_date_int_val() & (minus_one >> year_width)) <
+                         (ts_value1.to_date_int_val() & (minus_one >> year_width)));
             } else if (year < 0) {
-                year += ((ts_value2.to_date_int_val() & (minus_one >> year_width)) -
-                         (ts_value1.to_date_int_val() & (minus_one >> year_width))) > 0;
+                year += ((ts_value2.to_date_int_val() & (minus_one >> year_width)) >
+                         (ts_value1.to_date_int_val() & (minus_one >> year_width)));
             }
         } else if constexpr (std::is_same_v<T0, DateV2ValueType>) {
-            auto ts2_int_value = (uint64_t)ts_value2.to_date_int_val() << TIME_PART_LENGTH;
+            auto ts1_int_value = ((uint64_t)ts_value1.to_date_int_val()) << TIME_PART_LENGTH;
             if (year > 0) {
-                year -= ((ts2_int_value & (minus_one >> DATETIMEV2_YEAR_WIDTH)) -
-                         (ts_value1.to_date_int_val() & (minus_one >> DATETIMEV2_YEAR_WIDTH))) < 0;
+                year -= ((ts_value2.to_date_int_val() &
+                          (uint64_minus_one >> DATETIMEV2_YEAR_WIDTH)) <
+                         (ts1_int_value & (uint64_minus_one >> DATETIMEV2_YEAR_WIDTH)));
             } else if (year < 0) {
-                year += ((ts2_int_value & (minus_one >> DATETIMEV2_YEAR_WIDTH)) -
-                         (ts_value1.to_date_int_val() & (minus_one >> DATETIMEV2_YEAR_WIDTH))) > 0;
+                year += ((ts_value2.to_date_int_val() &
+                          (uint64_minus_one >> DATETIMEV2_YEAR_WIDTH)) >
+                         (ts1_int_value & (uint64_minus_one >> DATETIMEV2_YEAR_WIDTH)));
             }
         } else {
-            auto ts1_int_value = (uint64_t)ts_value2.to_date_int_val() << TIME_PART_LENGTH;
+            auto ts2_int_value = ((uint64_t)ts_value2.to_date_int_val()) << TIME_PART_LENGTH;
             if (year > 0) {
-                year -= ((ts_value2.to_date_int_val() & (minus_one >> DATETIMEV2_YEAR_WIDTH)) -
-                         (ts1_int_value & (minus_one >> DATETIMEV2_YEAR_WIDTH))) < 0;
+                year -= ((ts2_int_value & (uint64_minus_one >> DATETIMEV2_YEAR_WIDTH)) <
+                         (ts_value1.to_date_int_val() &
+                          (uint64_minus_one >> DATETIMEV2_YEAR_WIDTH)));
             } else if (year < 0) {
-                year += ((ts_value2.to_date_int_val() & (minus_one >> DATETIMEV2_YEAR_WIDTH)) -
-                         (ts1_int_value & (minus_one >> DATETIMEV2_YEAR_WIDTH))) > 0;
+                year += ((ts2_int_value & (uint64_minus_one >> DATETIMEV2_YEAR_WIDTH)) >
+                         (ts_value1.to_date_int_val() &
+                          (uint64_minus_one >> DATETIMEV2_YEAR_WIDTH)));
             }
         }
 
@@ -1272,34 +1290,35 @@ int64_t datetime_diff(const DateV2Value<T0>& ts_value1, const DateV2Value<T1>& t
         if constexpr (std::is_same_v<T0, T1>) {
             int shift_bits = DateV2Value<T0>::is_datetime ? DATETIMEV2_YEAR_WIDTH + 5
                                                           : DATEV2_YEAR_WIDTH + 5;
+            decltype(ts_value2.to_date_int_val()) minus_one = -1;
             if (month > 0) {
-                month -= ((ts_value2.to_date_int_val() & (minus_one >> shift_bits)) -
-                          (ts_value1.to_date_int_val() & (minus_one >> shift_bits))) < 0;
+                month -= ((ts_value2.to_date_int_val() & (minus_one >> shift_bits)) <
+                          (ts_value1.to_date_int_val() & (minus_one >> shift_bits)));
             } else if (month < 0) {
-                month += ((ts_value2.to_date_int_val() & (minus_one >> shift_bits)) -
-                          (ts_value1.to_date_int_val() & (minus_one >> shift_bits))) > 0;
+                month += ((ts_value2.to_date_int_val() & (minus_one >> shift_bits)) >
+                          (ts_value1.to_date_int_val() & (minus_one >> shift_bits)));
             }
         } else if constexpr (std::is_same_v<T0, DateV2ValueType>) {
-            auto ts2_int_value = (uint64_t)ts_value2.to_date_int_val() << TIME_PART_LENGTH;
-            if (month > 0) {
-                month -= ((ts2_int_value & (minus_one >> DATETIMEV2_YEAR_WIDTH)) -
-                          (ts_value1.to_date_int_val() &
-                           (minus_one >> (DATETIMEV2_YEAR_WIDTH + 5)))) < 0;
-            } else if (month < 0) {
-                month += ((ts2_int_value & (minus_one >> DATETIMEV2_YEAR_WIDTH)) -
-                          (ts_value1.to_date_int_val() &
-                           (minus_one >> (DATETIMEV2_YEAR_WIDTH + 5)))) > 0;
-            }
-        } else {
-            auto ts1_int_value = (uint64_t)ts_value2.to_date_int_val() << TIME_PART_LENGTH;
+            auto ts1_int_value = ((uint64_t)ts_value1.to_date_int_val()) << TIME_PART_LENGTH;
             if (month > 0) {
                 month -= ((ts_value2.to_date_int_val() &
-                           (minus_one >> (DATETIMEV2_YEAR_WIDTH + 5))) -
-                          (ts1_int_value & (minus_one >> DATETIMEV2_YEAR_WIDTH))) < 0;
+                           (uint64_minus_one >> (DATETIMEV2_YEAR_WIDTH + 5))) <
+                          (ts1_int_value & (uint64_minus_one >> (DATETIMEV2_YEAR_WIDTH + 5))));
             } else if (month < 0) {
                 month += ((ts_value2.to_date_int_val() &
-                           (minus_one >> (DATETIMEV2_YEAR_WIDTH + 5))) -
-                          (ts1_int_value & (minus_one >> DATETIMEV2_YEAR_WIDTH))) > 0;
+                           (uint64_minus_one >> (DATETIMEV2_YEAR_WIDTH + 5))) >
+                          (ts1_int_value & (uint64_minus_one >> (DATETIMEV2_YEAR_WIDTH + 5))));
+            }
+        } else {
+            auto ts2_int_value = ((uint64_t)ts_value2.to_date_int_val()) << TIME_PART_LENGTH;
+            if (month > 0) {
+                month -= ((ts2_int_value & (uint64_minus_one >> (DATETIMEV2_YEAR_WIDTH + 5))) <
+                          (ts_value1.to_date_int_val() &
+                           (uint64_minus_one >> (DATETIMEV2_YEAR_WIDTH + 5))));
+            } else if (month < 0) {
+                month += ((ts2_int_value & (uint64_minus_one >> (DATETIMEV2_YEAR_WIDTH + 5))) >
+                          (ts_value1.to_date_int_val() &
+                           (uint64_minus_one >> (DATETIMEV2_YEAR_WIDTH + 5))));
             }
         }
         return month;

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/AggregateType.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/AggregateType.java
@@ -64,6 +64,8 @@ public enum AggregateType {
         primitiveTypeList.add(PrimitiveType.DECIMALV2);
         primitiveTypeList.add(PrimitiveType.DATE);
         primitiveTypeList.add(PrimitiveType.DATETIME);
+        primitiveTypeList.add(PrimitiveType.DATEV2);
+        primitiveTypeList.add(PrimitiveType.DATETIMEV2);
         primitiveTypeList.add(PrimitiveType.CHAR);
         primitiveTypeList.add(PrimitiveType.VARCHAR);
         primitiveTypeList.add(PrimitiveType.STRING);
@@ -80,6 +82,8 @@ public enum AggregateType {
         primitiveTypeList.add(PrimitiveType.DECIMALV2);
         primitiveTypeList.add(PrimitiveType.DATE);
         primitiveTypeList.add(PrimitiveType.DATETIME);
+        primitiveTypeList.add(PrimitiveType.DATEV2);
+        primitiveTypeList.add(PrimitiveType.DATETIMEV2);
         primitiveTypeList.add(PrimitiveType.CHAR);
         primitiveTypeList.add(PrimitiveType.VARCHAR);
         primitiveTypeList.add(PrimitiveType.STRING);

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Type.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Type.java
@@ -1374,6 +1374,8 @@ public abstract class Type {
         compatibilityMatrix[TIME.ordinal()][DECIMAL32.ordinal()] = PrimitiveType.INVALID_TYPE;
         compatibilityMatrix[TIME.ordinal()][DECIMAL64.ordinal()] = PrimitiveType.INVALID_TYPE;
         compatibilityMatrix[TIME.ordinal()][DECIMAL128.ordinal()] = PrimitiveType.INVALID_TYPE;
+        compatibilityMatrix[TIME.ordinal()][DATEV2.ordinal()] = PrimitiveType.INVALID_TYPE;
+        compatibilityMatrix[TIME.ordinal()][DATETIMEV2.ordinal()] = PrimitiveType.INVALID_TYPE;
 
         compatibilityMatrix[TIMEV2.ordinal()][TIMEV2.ordinal()] = PrimitiveType.INVALID_TYPE;
         compatibilityMatrix[TIMEV2.ordinal()][TIME.ordinal()] = PrimitiveType.INVALID_TYPE;


### PR DESCRIPTION
# Proposed changes

After this PR, all BE/FE UTs will pass if we turn on the knob for datev2/datetimev2. Most of regression tests also pass except queries including push-down date functions (need to refactor push-down predicates later)

## Problem Summary:

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

