### PR TITLE
[fix](TabletInvertedIndex) fix potential deadlock between ForkJoinPool and TabletInvertedIndex

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/LoadColumnsInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/LoadColumnsInfo.java
@@ -66,10 +66,10 @@ public class LoadColumnsInfo implements ParseNode {
         sb.append(Joiner.on(",").join(columnNames));
         sb.append(")");
 
-        if (columnMappingList != null || columnMappingList.size() != 0) {
+        if (columnMappingList != null && !columnMappingList.isEmpty()) {
             sb.append(" SET (");
-            sb.append(Joiner.on(",").join(columnMappingList.parallelStream()
-                                                  .map(entity -> entity.toSql()).collect(Collectors.toList())));
+            sb.append(Joiner.on(",").join(columnMappingList.stream()
+                                                  .map(Expr::toSql).collect(Collectors.toList())));
             sb.append(")");
         }
         return sb.toString();

--- a/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/LoadManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/LoadManager.java
@@ -128,7 +128,7 @@ public class LoadManager implements Writable {
     }
 
     private long unprotectedGetUnfinishedJobNum() {
-        return idToLoadJob.values().parallelStream()
+        return idToLoadJob.values().stream()
                 .filter(j -> (j.getState() != JobState.FINISHED && j.getState() != JobState.CANCELLED)).count();
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/load/routineload/RoutineLoadManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/routineload/RoutineLoadManager.java
@@ -204,7 +204,7 @@ public class RoutineLoadManager implements Writable {
             Map<String, List<RoutineLoadJob>> labelToRoutineLoadJob = dbToNameToRoutineLoadJob.get(dbId);
             if (labelToRoutineLoadJob.containsKey(name)) {
                 List<RoutineLoadJob> routineLoadJobList = labelToRoutineLoadJob.get(name);
-                Optional<RoutineLoadJob> optional = routineLoadJobList.parallelStream()
+                Optional<RoutineLoadJob> optional = routineLoadJobList.stream()
                         .filter(entity -> entity.getName().equals(name))
                         .filter(entity -> !entity.getState().isFinalState()).findFirst();
                 return optional.isPresent();

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/external/ExternalHiveScanProvider.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/external/ExternalHiveScanProvider.java
@@ -112,7 +112,7 @@ public class ExternalHiveScanProvider implements ExternalFileScanProvider {
         InputFormat<?, ?> inputFormat = HiveUtil.getInputFormat(configuration, inputFormatName, false);
         List<InputSplit> splits;
         if (!hivePartitions.isEmpty()) {
-            splits = hivePartitions.parallelStream()
+            splits = hivePartitions.stream()
                     .flatMap(x -> getSplitsByPath(inputFormat, configuration, x.getSd().getLocation()).stream())
                     .collect(Collectors.toList());
         } else {


### PR DESCRIPTION
# Proposed changes

Issue Number: close #11319 

## Problem Summary:
The default  ForkJoinPool is shared by all parallelStream by default, and we obtain  read lock outside the ForkJoinPool in TabletInvertIndex while we obtain read lock inside the same ForkJoinPool in TabletStatMgr which may cause deadlock


## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

