### PR TITLE
[chore](thirdparty) env.sh may report error while JAVA_HOME is not set

### DIFF
--- a/env.sh
+++ b/env.sh
@@ -122,7 +122,7 @@ if test -z "${BUILD_THIRDPARTY_WIP}"; then
 
     # check java home
     if [ -z "$JAVA_HOME" ]; then
-        export JAVACMD=$(which java)
+        export JAVA=$(which java)
         JAVAP=$(which javap)
     else
         export JAVA="${JAVA_HOME}/bin/java"


### PR DESCRIPTION
If "JAVA_HOME" is not set, env.sh will set "JAVACMD" as "$(which java)" which may cause error in some cases.