### PR TITLE
[Bug][Vectorized] Support the .* in hyperscan to valid the % in SQL

### DIFF
--- a/be/src/vec/functions/like.cpp
+++ b/be/src/vec/functions/like.cpp
@@ -117,14 +117,15 @@ Status FunctionLikeBase::regexp_fn(LikeSearchState* state, const StringValue& va
 Status FunctionLikeBase::hs_prepare(FunctionContext* context, const char* expression,
                                     hs_database_t** database, hs_scratch_t** scratch) {
     hs_compile_error_t* compile_err;
-    if (hs_compile(expression, HS_FLAG_DOTALL, HS_MODE_BLOCK, NULL, database, &compile_err) !=
-        HS_SUCCESS) {
-        hs_free_compile_error(compile_err);
+    Defer free_compile {[compile_err] { hs_free_compile_error(compile_err); }};
+
+    if (hs_compile(expression, HS_FLAG_DOTALL | HS_FLAG_ALLOWEMPTY, HS_MODE_BLOCK, NULL, database,
+                   &compile_err) != HS_SUCCESS) {
         *database = nullptr;
         if (context) context->set_error("hs_compile regex pattern error");
-        return Status::RuntimeError("hs_compile regex pattern error");
+        return Status::RuntimeError("hs_compile regex pattern error:" +
+                                    std::string(compile_err->message));
     }
-    hs_free_compile_error(compile_err);
 
     if (hs_alloc_scratch(*database, scratch) != HS_SUCCESS) {
         hs_free_database(*database);

--- a/regression-test/data/query/sql_functions/string_functions/test_string_function_like.out
+++ b/regression-test/data/query/sql_functions/string_functions/test_string_function_like.out
@@ -87,3 +87,14 @@ ba
 bab
 bb
 
+-- !sql --
+a
+ab
+accb
+b
+ba
+bab
+bb
+
+-- !sql --
+

--- a/regression-test/suites/query/sql_functions/string_functions/test_string_function_like.groovy
+++ b/regression-test/suites/query/sql_functions/string_functions/test_string_function_like.groovy
@@ -57,5 +57,8 @@ suite("test_string_function_like", "query") {
     qt_sql "SELECT k FROM ${tbName} WHERE k NOT LIKE \"_a_\" ORDER BY k;"
     qt_sql "SELECT k FROM ${tbName} WHERE k NOT LIKE \"a__b\" ORDER BY k;"
 
+    qt_sql "SELECT k FROM ${tbName} WHERE k LIKE \"%\" ORDER BY k;"
+    qt_sql "SELECT k FROM ${tbName} WHERE k NOT LIKE \"%\" ORDER BY k;"
+
     sql "DROP TABLE ${tbName};"
 }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #11369

## Problem Summary:

## Checklist(Required)

1. Does it affect the original behavior: 
    - [x] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [x] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [x] Yes
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

