### PR TITLE
[Bug][Vectorized] Support the .* in hyperscan to valid the % in SQL

### DIFF
--- a/regression-test/data/query/sql_functions/string_functions/test_string_function_like.out
+++ b/regression-test/data/query/sql_functions/string_functions/test_string_function_like.out
@@ -87,3 +87,14 @@ ba
 bab
 bb
 
+-- !sql --
+a
+ab
+accb
+b
+ba
+bab
+bb
+
+-- !sql --
+

--- a/regression-test/suites/query/sql_functions/string_functions/test_string_function_like.groovy
+++ b/regression-test/suites/query/sql_functions/string_functions/test_string_function_like.groovy
@@ -57,5 +57,8 @@ suite("test_string_function_like", "query") {
     qt_sql "SELECT k FROM ${tbName} WHERE k NOT LIKE \"_a_\" ORDER BY k;"
     qt_sql "SELECT k FROM ${tbName} WHERE k NOT LIKE \"a__b\" ORDER BY k;"
 
+    qt_sql "SELECT k FROM ${tbName} WHERE k LIKE \"%\" ORDER BY k;"
+    qt_sql "SELECT k FROM ${tbName} WHERE k NOT LIKE \"%\" ORDER BY k;"
+
     sql "DROP TABLE ${tbName};"
 }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #11369

## Problem Summary:

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

