### PR TITLE
[fix](planner) Fix an issue where outputSmap's size  could grow exponentially

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ExprSubstitutionMap.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ExprSubstitutionMap.java
@@ -39,7 +39,7 @@ import java.util.List;
  * See Expr.substitute() and related functions for details on the actual substitution.
  */
 public final class ExprSubstitutionMap {
-    private static final Logger LOG = LogManager.getLogger(SlotRef.class);
+    private static final Logger LOG = LogManager.getLogger(ExprSubstitutionMap.class);
 
     private boolean checkAnalyzed = true;
     private List<Expr> lhs; // left-hand side

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ExprSubstitutionMap.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ExprSubstitutionMap.java
@@ -25,8 +25,8 @@ import org.apache.doris.common.AnalysisException;
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.List;
 
@@ -39,7 +39,7 @@ import java.util.List;
  * See Expr.substitute() and related functions for details on the actual substitution.
  */
 public final class ExprSubstitutionMap {
-    private static final Logger LOG = LoggerFactory.getLogger(ExprSubstitutionMap.class);
+    private static final Logger LOG = LogManager.getLogger(SlotRef.class);
 
     private boolean checkAnalyzed = true;
     private List<Expr> lhs; // left-hand side
@@ -209,7 +209,9 @@ public final class ExprSubstitutionMap {
                 Expr fRhs = f.getRhs().get(j);
                 if (fRhs.contains(gLhs)) {
                     Expr newRhs = fRhs.trySubstitute(g, analyzer, false);
-                    result.put(f.getLhs().get(j), newRhs);
+                    if (!result.containsMappingFor(f.getLhs().get(j))) {
+                        result.put(f.getLhs().get(j), newRhs);
+                    }
                     findGMatch = true;
                 }
             }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary

In `ExprSubstitutionMap.composeAndReplace()` method, for example:

f: 
`a -> fn(x, y, z)`
g:
`x -> x1`
`y -> y1`
`z -> z1`

Expected result should be:
`a -> fn(x1, y1, z1)`

But the origin implementation will return:
```
a -> fn(x1, y1, z1)
a -> fn(x1, y1, z1)
a -> fn(x1, y1, z1)
```

You can see there are 3 duplicate substitutions in `outputSmap`.
And if there are multi joins in SQL with hundreds of columns in schema,
the `outputSmap`'s size may grow exponentially,
and it will take too much time in analysis phase and even cause FE OOM.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

