### PR TITLE
[fix](build) The `nproc` command does not exist in macos by default, use `sysctl -n hw.logicalcpu` instead to get the number of logical cores available

### DIFF
--- a/thirdparty/build-thirdparty.sh
+++ b/thirdparty/build-thirdparty.sh
@@ -59,7 +59,14 @@ fi
 
 eval set -- "$OPTS"
 
-PARALLEL=$(($(nproc) / 4 + 1))
+KERNEL="$(uname -s)"
+
+if [[ "${KERNEL}" == 'Darwin' ]]; then
+    PARALLEL=$(($(sysctl -n hw.logicalcpu) / 4 + 1))
+else
+    PARALLEL=$(($(nproc) / 4 + 1))
+fi
+
 if [[ $# -ne 1 ]]; then
     while true; do
         case "$1" in
@@ -140,8 +147,6 @@ elif [[ "$CC" == *clang ]]; then
     boost_toolset=clang
     libhdfs_cxx17=-std=c++1z
 fi
-
-KERNEL="$(uname -s)"
 
 # prepare installed prefix
 mkdir -p "${TP_DIR}/installed/lib64"


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

The `nproc` command does not exist in macos by default, use `sysctl -n hw.logicalcpu` instead to get the number of logical cores available.

Otherwise `PARALLEL` cannot be initialised correctly, resulting in the following error
```log
make: the `-j' option requires a positive integral argument
```

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [x] No, but my mac compiles doris fine under this pr
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

