### PR TITLE
[fix](stop-script) use kill -9 to stop fe

### DIFF
--- a/bin/stop_fe.sh
+++ b/bin/stop_fe.sh
@@ -31,6 +31,11 @@ export PID_DIR=$(
     pwd
 )
 
+signum=9
+if [ "x"$1 = "x--grace" ]; then
+    signum=15
+fi
+
 while read line; do
     envline=$(echo $line | sed 's/[[:blank:]]*=[[:blank:]]*/=/g' | sed 's/^[[:blank:]]*//g' | egrep "^[[:upper:]]([[:upper:]]|_|[[:digit:]])*=")
     envline=$(eval "echo $envline")
@@ -64,9 +69,9 @@ if [ -f $pidfile ]; then
     fi
 
     # kill pid process and check it
-    if kill $pid >/dev/null 2>&1; then
+    if kill -${signum} $pid >/dev/null 2>&1; then
         while true; do
-            if kill -0 $pid >/dev/null; then
+            if kill -0 $pid >/dev/null 2>&1; then
                 echo "waiting fe to stop, pid: $pid"
                 sleep 2
             else


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:
restore to use kill -9 to stop fe, in case of can't kill fe in some situation.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

