### PR TITLE
[enhancement](build-be) Support customizing extra compile flags

### DIFF
--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -548,7 +548,7 @@ else()
 endif()
 
 # Add flags that are common across build types
-SET(CMAKE_CXX_FLAGS "${CXX_COMMON_FLAGS} ${CMAKE_CXX_FLAGS}")
+SET(CMAKE_CXX_FLAGS "${CXX_COMMON_FLAGS} ${CMAKE_CXX_FLAGS} ${EXTRA_CXX_FLAGS}")
 
 message(STATUS "Compiler Flags: ${CMAKE_CXX_FLAGS}")
 

--- a/build.sh
+++ b/build.sh
@@ -293,6 +293,7 @@ if [ ${BUILD_BE} -eq 1 ] ; then
     MAKE_PROGRAM="$(which "${BUILD_SYSTEM}")"
     echo "-- Make program: ${MAKE_PROGRAM}"
     echo "-- Use ccache: ${CMAKE_USE_CCACHE}"
+    echo "-- Extra cxx flags: ${EXTRA_CXX_FLAGS}"
 
     mkdir -p ${CMAKE_BUILD_DIR}
     cd ${CMAKE_BUILD_DIR}
@@ -313,7 +314,9 @@ if [ ${BUILD_BE} -eq 1 ] ; then
             -DUSE_JEMALLOC=${USE_JEMALLOC} \
             -DSTRICT_MEMORY_USE=${STRICT_MEMORY_USE} \
             -DUSE_AVX2=${USE_AVX2} \
-            -DGLIBC_COMPATIBILITY=${GLIBC_COMPATIBILITY} ${DORIS_HOME}/be/
+            -DGLIBC_COMPATIBILITY=${GLIBC_COMPATIBILITY} \
+            -DEXTRA_CXX_FLAGS="${EXTRA_CXX_FLAGS}" \
+            ${DORIS_HOME}/be/
     ${BUILD_SYSTEM} -j ${PARALLEL}
     ${BUILD_SYSTEM} install
     cd ${DORIS_HOME}

--- a/run-be-ut.sh
+++ b/run-be-ut.sh
@@ -125,6 +125,7 @@ fi
 MAKE_PROGRAM="$(which "${BUILD_SYSTEM}")"
 echo "-- Make program: ${MAKE_PROGRAM}"
 echo "-- Use ccache: ${CMAKE_USE_CCACHE}"
+echo "-- Extra cxx flags: ${EXTRA_CXX_FLAGS}"
 
 cd ${CMAKE_BUILD_DIR}
 ${CMAKE_CMD} -G "${GENERATOR}" \
@@ -139,7 +140,9 @@ ${CMAKE_CMD} -G "${GENERATOR}" \
     -DUSE_MEM_TRACKER=ON \
     -DUSE_JEMALLOC=OFF \
     -DSTRICT_MEMORY_USE=OFF \
-    ${CMAKE_USE_CCACHE} ${DORIS_HOME}/be/
+    -DEXTRA_CXX_FLAGS="${EXTRA_CXX_FLAGS}" \
+    ${CMAKE_USE_CCACHE} \
+    ${DORIS_HOME}/be/
 ${BUILD_SYSTEM} -j ${PARALLEL}
 
 if [ ${RUN} -ne 1 ]; then


### PR DESCRIPTION
# Proposed changes

Add an environment variable `EXTRA_CXX_FLAGS` to customize the extra compile flags.

## Problem summary

In our daily work, someones may want to change the compile flags to satisfy their requirements. This pr introduces a way to customize extra compile flags.

E.g.

Change the optimization level:

1. Change it once.
```shell
BUILD_TYPE=ASAN EXTRA_CXX_FLAGS=-O3 ./build.sh --be
```

2. Change it during login.
```shell
export EXTRA_CXX_FLAGS=-O3
BUILD_TYPE=ASAN ./build.sh --be
```

3. Store it in file.
```shell
echo EXTRA_CXX_FLAGS=-O3 >> custom_env.sh
BUILD_TYPE=ASAN ./build.sh --be
```

Reference:

> If you use multiple -O options, with or without level numbers, the last such option is the one that is effective.

[Optimize-Options](https://gcc.gnu.org/onlinedocs/gcc-12.1.0/gcc/Optimize-Options.html#Optimize-Options)

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

