### PR TITLE
[Bug](httpserver) Fix bug that http server should not be stoped in destructor if it not running

### DIFF
--- a/be/src/http/ev_http_server.cpp
+++ b/be/src/http/ev_http_server.cpp
@@ -83,10 +83,13 @@ EvHttpServer::EvHttpServer(const std::string& host, int port, int num_workers)
 }
 
 EvHttpServer::~EvHttpServer() {
-    stop();
+    if (_started) {
+        stop();
+    }
 }
 
 void EvHttpServer::start() {
+    _started = true;
     // bind to
     auto s = _bind();
     CHECK(s.ok()) << s.to_string();
@@ -137,6 +140,7 @@ void EvHttpServer::stop() {
     }
     _workers->shutdown();
     close(_server_fd);
+    _started = false;
 }
 
 void EvHttpServer::join() {}

--- a/be/src/http/ev_http_server.h
+++ b/be/src/http/ev_http_server.h
@@ -78,6 +78,7 @@ private:
     PathTrie<HttpHandler*> _delete_handlers;
     PathTrie<HttpHandler*> _head_handlers;
     PathTrie<HttpHandler*> _options_handlers;
+    bool _started = false;
 };
 
 } // namespace doris


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

Http server should not be stoped when destruction if it not running .

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

