### PR TITLE
[improvement](agg)limit the output of agg node

### DIFF
--- a/be/src/vec/common/columns_hashing.h
+++ b/be/src/vec/common/columns_hashing.h
@@ -257,6 +257,24 @@ struct HashMethodSingleLowNullableColumn : public SingleColumnMethod {
         } else
             return EmplaceResult(inserted);
     }
+
+    template <typename Data>
+    ALWAYS_INLINE FindResult find_key(Data& data, size_t row, Arena& pool) {
+        if (key_columns[0]->is_null_at(row)) {
+            bool has_null_key = data.has_null_key_data();
+            if constexpr (has_mapped)
+                return FindResult(&data.get_null_key_data(), has_null_key);
+            else
+                return FindResult(has_null_key);
+        }
+        auto key_holder = Base::get_key_holder(row, pool);
+        auto key = key_holder_get_key(key_holder);
+        auto it = data.find(key);
+        if constexpr (has_mapped)
+            return FindResult(it ? lookup_result_get_mapped(it) : nullptr, it != nullptr);
+        else
+            return FindResult(it != nullptr);
+    }
 };
 
 } // namespace ColumnsHashing

--- a/be/src/vec/common/hash_table/hash_map.h
+++ b/be/src/vec/common/hash_table/hash_map.h
@@ -68,6 +68,8 @@ struct HashMapCell {
     const value_type& get_value() const { return value; }
 
     static const Key& get_key(const value_type& value) { return value.first; }
+    Mapped & get_mapped() { return value.second; }
+    const Mapped & get_mapped() const { return value.second; }
 
     bool key_equals(const Key& key_) const { return value.first == key_; }
     bool key_equals(const Key& key_, size_t /*hash_*/) const { return value.first == key_; }

--- a/be/src/vec/common/hash_table/hash_map.h
+++ b/be/src/vec/common/hash_table/hash_map.h
@@ -68,8 +68,8 @@ struct HashMapCell {
     const value_type& get_value() const { return value; }
 
     static const Key& get_key(const value_type& value) { return value.first; }
-    Mapped & get_mapped() { return value.second; }
-    const Mapped & get_mapped() const { return value.second; }
+    Mapped& get_mapped() { return value.second; }
+    const Mapped& get_mapped() const { return value.second; }
 
     bool key_equals(const Key& key_) const { return value.first == key_; }
     bool key_equals(const Key& key_, size_t /*hash_*/) const { return value.first == key_; }

--- a/be/src/vec/common/hash_table/ph_hash_map.h
+++ b/be/src/vec/common/hash_table/ph_hash_map.h
@@ -140,6 +140,20 @@ public:
         }
     }
 
+    template <typename KeyHolder>
+    LookupResult ALWAYS_INLINE find(KeyHolder&& key_holder) {
+        const auto& key = key_holder_get_key(key_holder);
+        auto it = _hash_map.find(key);
+        return it != _hash_map.end() ? &*it : nullptr;
+    }
+
+    template <typename KeyHolder>
+    LookupResult ALWAYS_INLINE find(KeyHolder&& key_holder, size_t hash_value) {
+        const auto& key = key_holder_get_key(key_holder);
+        auto it = _hash_map.find(key, hash_value);
+        return it != _hash_map.end() ? &*it : nullptr;
+    }
+
     size_t hash(const Key& x) const { return _hash_map.hash(x); }
 
     void ALWAYS_INLINE prefetch_by_hash(size_t hash_value) {

--- a/be/src/vec/exec/vaggregation_node.cpp
+++ b/be/src/vec/exec/vaggregation_node.cpp
@@ -393,6 +393,10 @@ Status AggregationNode::prepare(RuntimeState* state) {
         _executor.update_memusage =
                 std::bind<void>(&AggregationNode::_update_memusage_with_serialized_key, this);
         _executor.close = std::bind<void>(&AggregationNode::_close_with_serialized_key, this);
+
+        _should_limit_output = _limit != -1 &&        // has limit
+                               !_vconjunct_ctx_ptr && // no having conjunct
+                               _needs_finalize;       // agg's finalize step
     }
 
     return Status::OK();
@@ -704,6 +708,11 @@ bool AggregationNode::_should_expand_preagg_hash_tables() {
             _agg_data._aggregated_method_variant);
 }
 
+size_t AggregationNode::_get_hash_table_size() {
+    return std::visit([&](auto&& agg_method) { return agg_method.data.size(); },
+                      _agg_data._aggregated_method_variant);
+}
+
 void AggregationNode::_emplace_into_hash_table(AggregateDataPtr* places, ColumnRawPtrs& key_columns,
                                                const size_t num_rows) {
     std::visit(
@@ -769,6 +778,63 @@ void AggregationNode::_emplace_into_hash_table(AggregateDataPtr* places, ColumnR
 
                     places[i] = aggregate_data;
                     assert(places[i] != nullptr);
+                }
+            },
+            _agg_data._aggregated_method_variant);
+}
+
+void AggregationNode::_find_in_hash_table(AggregateDataPtr* places, ColumnRawPtrs& key_columns,
+                                          size_t rows) {
+    std::visit(
+            [&](auto&& agg_method) -> void {
+                using HashMethodType = std::decay_t<decltype(agg_method)>;
+                using HashTableType = std::decay_t<decltype(agg_method.data)>;
+                using AggState = typename HashMethodType::State;
+                AggState state(key_columns, _probe_key_sz, nullptr);
+
+                _pre_serialize_key_if_need(state, agg_method, key_columns, rows);
+
+                std::vector<size_t> hash_values;
+
+                if constexpr (HashTableTraits<HashTableType>::is_phmap) {
+                    if (hash_values.size() < rows) hash_values.resize(rows);
+                    if constexpr (ColumnsHashing::IsPreSerializedKeysHashMethodTraits<
+                                          AggState>::value) {
+                        for (size_t i = 0; i < rows; ++i) {
+                            hash_values[i] = agg_method.data.hash(agg_method.keys[i]);
+                        }
+                    } else {
+                        for (size_t i = 0; i < rows; ++i) {
+                            hash_values[i] =
+                                    agg_method.data.hash(state.get_key_holder(i, _agg_arena_pool));
+                        }
+                    }
+                }
+
+                /// For all rows.
+                for (size_t i = 0; i < rows; ++i) {
+                    auto find_result = [&]() {
+                        if constexpr (HashTableTraits<HashTableType>::is_phmap) {
+                            if (LIKELY(i + HASH_MAP_PREFETCH_DIST < rows)) {
+                                if constexpr (HashTableTraits<HashTableType>::is_parallel_phmap) {
+                                    agg_method.data.prefetch_by_key(state.get_key_holder(
+                                            i + HASH_MAP_PREFETCH_DIST, _agg_arena_pool));
+                                } else
+                                    agg_method.data.prefetch_by_hash(
+                                            hash_values[i + HASH_MAP_PREFETCH_DIST]);
+                            }
+
+                            return state.find_key(agg_method.data, hash_values[i], i,
+                                                  _agg_arena_pool);
+                        } else {
+                            return state.find_key(agg_method.data, i, _agg_arena_pool);
+                        }
+                    }();
+
+                    if (find_result.is_found()) {
+                        places[i] = find_result.get_mapped();
+                    } else
+                        places[i] = nullptr;
                 }
             },
             _agg_data._aggregated_method_variant);
@@ -895,7 +961,40 @@ Status AggregationNode::_pre_agg_with_serialized_key(doris::vectorized::Block* i
     return Status::OK();
 }
 
+Status AggregationNode::_execute_with_serialized_key_limited(Block* block) {
+    SCOPED_TIMER(_build_timer);
+    DCHECK(!_probe_expr_ctxs.empty());
+
+    size_t key_size = _probe_expr_ctxs.size();
+    ColumnRawPtrs key_columns(key_size);
+    {
+        SCOPED_TIMER(_expr_timer);
+        for (size_t i = 0; i < key_size; ++i) {
+            int result_column_id = -1;
+            RETURN_IF_ERROR(_probe_expr_ctxs[i]->execute(block, &result_column_id));
+            block->get_by_position(result_column_id).column =
+                    block->get_by_position(result_column_id)
+                            .column->convert_to_full_column_if_const();
+            key_columns[i] = block->get_by_position(result_column_id).column.get();
+        }
+    }
+
+    int rows = block->rows();
+    PODArray<AggregateDataPtr> places(rows);
+    _find_in_hash_table(places.data(), key_columns, rows);
+
+    for (int i = 0; i < _aggregate_evaluators.size(); ++i) {
+        _aggregate_evaluators[i]->execute_batch_add_selected(block, _offsets_of_aggregate_states[i],
+                                                             places.data(), &_agg_arena_pool);
+    }
+
+    return Status::OK();
+}
+
 Status AggregationNode::_execute_with_serialized_key(Block* block) {
+    if (_reach_limit) {
+        return _execute_with_serialized_key_limited(block);
+    }
     SCOPED_TIMER(_build_timer);
     DCHECK(!_probe_expr_ctxs.empty());
 
@@ -921,6 +1020,10 @@ Status AggregationNode::_execute_with_serialized_key(Block* block) {
     for (int i = 0; i < _aggregate_evaluators.size(); ++i) {
         _aggregate_evaluators[i]->execute_batch_add(block, _offsets_of_aggregate_states[i],
                                                     places.data(), &_agg_arena_pool);
+    }
+
+    if (_should_limit_output) {
+        _reach_limit = _get_hash_table_size() >= _limit;
     }
 
     return Status::OK();
@@ -1110,7 +1213,55 @@ Status AggregationNode::_serialize_with_serialized_key_result(RuntimeState* stat
     return Status::OK();
 }
 
+Status AggregationNode::_merge_with_serialized_key_limited(Block* block) {
+    SCOPED_TIMER(_merge_timer);
+
+    size_t key_size = _probe_expr_ctxs.size();
+    ColumnRawPtrs key_columns(key_size);
+
+    for (size_t i = 0; i < key_size; ++i) {
+        int result_column_id = -1;
+        RETURN_IF_ERROR(_probe_expr_ctxs[i]->execute(block, &result_column_id));
+        key_columns[i] = block->get_by_position(result_column_id).column.get();
+    }
+
+    int rows = block->rows();
+    PODArray<AggregateDataPtr> places(rows);
+    _find_in_hash_table(places.data(), key_columns, rows);
+
+    for (int i = 0; i < _aggregate_evaluators.size(); ++i) {
+        DCHECK(_aggregate_evaluators[i]->input_exprs_ctxs().size() == 1 &&
+               _aggregate_evaluators[i]->input_exprs_ctxs()[0]->root()->is_slot_ref());
+        int col_id =
+                ((VSlotRef*)_aggregate_evaluators[i]->input_exprs_ctxs()[0]->root())->column_id();
+        if (_aggregate_evaluators[i]->is_merge()) {
+            auto column = block->get_by_position(col_id).column;
+            if (column->is_nullable()) {
+                column = ((ColumnNullable*)column.get())->get_nested_column_ptr();
+            }
+
+            std::unique_ptr<char[]> deserialize_buffer(
+                    new char[_aggregate_evaluators[i]->function()->size_of_data() * rows]);
+
+            _aggregate_evaluators[i]->function()->deserialize_vec(deserialize_buffer.get(),
+                                                                  (ColumnString*)(column.get()),
+                                                                  &_agg_arena_pool, rows);
+            _aggregate_evaluators[i]->function()->merge_vec_selected(
+                    places.data(), _offsets_of_aggregate_states[i], deserialize_buffer.get(),
+                    &_agg_arena_pool, rows);
+
+        } else {
+            _aggregate_evaluators[i]->execute_batch_add_selected(
+                    block, _offsets_of_aggregate_states[i], places.data(), &_agg_arena_pool);
+        }
+    }
+    return Status::OK();
+}
+
 Status AggregationNode::_merge_with_serialized_key(Block* block) {
+    if (_reach_limit) {
+        return _merge_with_serialized_key_limited(block);
+    }
     SCOPED_TIMER(_merge_timer);
 
     size_t key_size = _probe_expr_ctxs.size();
@@ -1153,6 +1304,11 @@ Status AggregationNode::_merge_with_serialized_key(Block* block) {
                                                         places.data(), &_agg_arena_pool);
         }
     }
+
+    if (_should_limit_output) {
+        _reach_limit = _get_hash_table_size() >= _limit;
+    }
+
     return Status::OK();
 }
 

--- a/be/src/vec/exec/vaggregation_node.h
+++ b/be/src/vec/exec/vaggregation_node.h
@@ -674,10 +674,15 @@ private:
     bool _should_expand_hash_table = true;
     std::vector<char*> _streaming_pre_places;
 
+    bool _should_limit_output = false;
+    bool _reach_limit = false;
+
 private:
     /// Return true if we should keep expanding hash tables in the preagg. If false,
     /// the preagg should pass through any rows it can't fit in its tables.
     bool _should_expand_preagg_hash_tables();
+
+    size_t _get_hash_table_size();
 
     void _make_nullable_output_key(Block* block);
 
@@ -695,7 +700,9 @@ private:
     Status _serialize_with_serialized_key_result(RuntimeState* state, Block* block, bool* eos);
     Status _pre_agg_with_serialized_key(Block* in_block, Block* out_block);
     Status _execute_with_serialized_key(Block* block);
+    Status _execute_with_serialized_key_limited(Block* block);
     Status _merge_with_serialized_key(Block* block);
+    Status _merge_with_serialized_key_limited(Block* block);
     void _update_memusage_with_serialized_key();
     void _close_with_serialized_key();
     void _init_hash_method(std::vector<VExprContext*>& probe_exprs);
@@ -712,6 +719,8 @@ private:
 
     void _emplace_into_hash_table(AggregateDataPtr* places, ColumnRawPtrs& key_columns,
                                   const size_t num_rows);
+
+    void _find_in_hash_table(AggregateDataPtr* places, ColumnRawPtrs& key_columns, size_t num_rows);
 
     void release_tracker();
 

--- a/be/src/vec/exec/vaggregation_node.h
+++ b/be/src/vec/exec/vaggregation_node.h
@@ -26,6 +26,7 @@
 #include "vec/common/columns_hashing.h"
 #include "vec/common/hash_table/fixed_hash_map.h"
 #include "vec/exprs/vectorized_agg_fn.h"
+#include "vec/exprs/vslot_ref.h"
 
 namespace doris {
 class TPlanNode;
@@ -700,9 +701,7 @@ private:
     Status _serialize_with_serialized_key_result(RuntimeState* state, Block* block, bool* eos);
     Status _pre_agg_with_serialized_key(Block* in_block, Block* out_block);
     Status _execute_with_serialized_key(Block* block);
-    Status _execute_with_serialized_key_limited(Block* block);
     Status _merge_with_serialized_key(Block* block);
-    Status _merge_with_serialized_key_limited(Block* block);
     void _update_memusage_with_serialized_key();
     void _close_with_serialized_key();
     void _init_hash_method(std::vector<VExprContext*>& probe_exprs);
@@ -715,6 +714,136 @@ private:
             agg_method.serialize_keys(key_columns, num_rows);
             state.set_serialized_keys(agg_method.keys.data());
         }
+    }
+
+    template <bool limit>
+    Status _execute_with_serialized_key_helper(Block* block) {
+        SCOPED_TIMER(_build_timer);
+        DCHECK(!_probe_expr_ctxs.empty());
+
+        size_t key_size = _probe_expr_ctxs.size();
+        ColumnRawPtrs key_columns(key_size);
+        {
+            SCOPED_TIMER(_expr_timer);
+            for (size_t i = 0; i < key_size; ++i) {
+                int result_column_id = -1;
+                RETURN_IF_ERROR(_probe_expr_ctxs[i]->execute(block, &result_column_id));
+                block->get_by_position(result_column_id).column =
+                        block->get_by_position(result_column_id)
+                                .column->convert_to_full_column_if_const();
+                key_columns[i] = block->get_by_position(result_column_id).column.get();
+            }
+        }
+
+        int rows = block->rows();
+        PODArray<AggregateDataPtr> places(rows);
+
+        if constexpr (limit) {
+            _find_in_hash_table(places.data(), key_columns, rows);
+
+            for (int i = 0; i < _aggregate_evaluators.size(); ++i) {
+                _aggregate_evaluators[i]->execute_batch_add_selected(
+                        block, _offsets_of_aggregate_states[i], places.data(), &_agg_arena_pool);
+            }
+        } else {
+            _emplace_into_hash_table(places.data(), key_columns, rows);
+
+            for (int i = 0; i < _aggregate_evaluators.size(); ++i) {
+                _aggregate_evaluators[i]->execute_batch_add(block, _offsets_of_aggregate_states[i],
+                                                            places.data(), &_agg_arena_pool);
+            }
+
+            if (_should_limit_output) {
+                _reach_limit = _get_hash_table_size() >= _limit;
+            }
+        }
+
+        return Status::OK();
+    }
+
+    template <bool limit>
+    Status _merge_with_serialized_key_helper(Block* block) {
+        SCOPED_TIMER(_merge_timer);
+
+        size_t key_size = _probe_expr_ctxs.size();
+        ColumnRawPtrs key_columns(key_size);
+
+        for (size_t i = 0; i < key_size; ++i) {
+            int result_column_id = -1;
+            RETURN_IF_ERROR(_probe_expr_ctxs[i]->execute(block, &result_column_id));
+            key_columns[i] = block->get_by_position(result_column_id).column.get();
+        }
+
+        int rows = block->rows();
+        PODArray<AggregateDataPtr> places(rows);
+
+        if constexpr (limit) {
+            _find_in_hash_table(places.data(), key_columns, rows);
+
+            for (int i = 0; i < _aggregate_evaluators.size(); ++i) {
+                DCHECK(_aggregate_evaluators[i]->input_exprs_ctxs().size() == 1 &&
+                       _aggregate_evaluators[i]->input_exprs_ctxs()[0]->root()->is_slot_ref());
+                int col_id = ((VSlotRef*)_aggregate_evaluators[i]->input_exprs_ctxs()[0]->root())
+                                     ->column_id();
+                if (_aggregate_evaluators[i]->is_merge()) {
+                    auto column = block->get_by_position(col_id).column;
+                    if (column->is_nullable()) {
+                        column = ((ColumnNullable*)column.get())->get_nested_column_ptr();
+                    }
+
+                    std::unique_ptr<char[]> deserialize_buffer(
+                            new char[_aggregate_evaluators[i]->function()->size_of_data() * rows]);
+
+                    _aggregate_evaluators[i]->function()->deserialize_vec(
+                            deserialize_buffer.get(), (ColumnString*)(column.get()),
+                            &_agg_arena_pool, rows);
+                    _aggregate_evaluators[i]->function()->merge_vec_selected(
+                            places.data(), _offsets_of_aggregate_states[i],
+                            deserialize_buffer.get(), &_agg_arena_pool, rows);
+
+                } else {
+                    _aggregate_evaluators[i]->execute_batch_add_selected(
+                            block, _offsets_of_aggregate_states[i], places.data(),
+                            &_agg_arena_pool);
+                }
+            }
+        } else {
+            _emplace_into_hash_table(places.data(), key_columns, rows);
+
+            for (int i = 0; i < _aggregate_evaluators.size(); ++i) {
+                DCHECK(_aggregate_evaluators[i]->input_exprs_ctxs().size() == 1 &&
+                       _aggregate_evaluators[i]->input_exprs_ctxs()[0]->root()->is_slot_ref());
+                int col_id = ((VSlotRef*)_aggregate_evaluators[i]->input_exprs_ctxs()[0]->root())
+                                     ->column_id();
+                if (_aggregate_evaluators[i]->is_merge()) {
+                    auto column = block->get_by_position(col_id).column;
+                    if (column->is_nullable()) {
+                        column = ((ColumnNullable*)column.get())->get_nested_column_ptr();
+                    }
+
+                    std::unique_ptr<char[]> deserialize_buffer(
+                            new char[_aggregate_evaluators[i]->function()->size_of_data() * rows]);
+
+                    _aggregate_evaluators[i]->function()->deserialize_vec(
+                            deserialize_buffer.get(), (ColumnString*)(column.get()),
+                            &_agg_arena_pool, rows);
+                    _aggregate_evaluators[i]->function()->merge_vec(
+                            places.data(), _offsets_of_aggregate_states[i],
+                            deserialize_buffer.get(), &_agg_arena_pool, rows);
+
+                } else {
+                    _aggregate_evaluators[i]->execute_batch_add(block,
+                                                                _offsets_of_aggregate_states[i],
+                                                                places.data(), &_agg_arena_pool);
+                }
+            }
+
+            if (_should_limit_output) {
+                _reach_limit = _get_hash_table_size() >= _limit;
+            }
+        }
+
+        return Status::OK();
     }
 
     void _emplace_into_hash_table(AggregateDataPtr* places, ColumnRawPtrs& key_columns,

--- a/be/src/vec/exprs/vectorized_agg_fn.cpp
+++ b/be/src/vec/exprs/vectorized_agg_fn.cpp
@@ -156,6 +156,13 @@ void AggFnEvaluator::execute_batch_add(Block* block, size_t offset, AggregateDat
     _function->add_batch(block->rows(), places, offset, _agg_columns.data(), arena);
 }
 
+void AggFnEvaluator::execute_batch_add_selected(Block* block, size_t offset,
+                                                AggregateDataPtr* places, Arena* arena) {
+    _calc_argment_columns(block);
+    SCOPED_TIMER(_exec_timer);
+    _function->add_batch_selected(block->rows(), places, offset, _agg_columns.data(), arena);
+}
+
 void AggFnEvaluator::insert_result_info(AggregateDataPtr place, IColumn* column) {
     _function->insert_result_into(place, *column);
 }

--- a/be/src/vec/exprs/vectorized_agg_fn.h
+++ b/be/src/vec/exprs/vectorized_agg_fn.h
@@ -58,6 +58,9 @@ public:
     void execute_batch_add(Block* block, size_t offset, AggregateDataPtr* places,
                            Arena* arena = nullptr);
 
+    void execute_batch_add_selected(Block* block, size_t offset, AggregateDataPtr* places,
+                                    Arena* arena = nullptr);
+
     void insert_result_info(AggregateDataPtr place, IColumn* column);
 
     void insert_result_info_vec(const std::vector<AggregateDataPtr>& place, size_t offset,


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary
The limit operation can be done at agg node instead of last topN node. This can reduce the time cost to 1/3 of the old one. The sql is as bellow:
SELECT UserID, SearchPhrase, COUNT(*) FROM hits GROUP BY UserID, SearchPhrase LIMIT 10;


## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

