### PR TITLE
[Enhancement](IdGenerator) Use IdGeneratorBuffer to get better performance for getNextId operation when create table, truncate table, add partition and so on

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
@@ -83,6 +83,7 @@ import org.apache.doris.blockrule.SqlBlockRuleMgr;
 import org.apache.doris.catalog.ColocateTableIndex.GroupId;
 import org.apache.doris.catalog.DistributionInfo.DistributionInfoType;
 import org.apache.doris.catalog.MaterializedIndex.IndexExtState;
+import org.apache.doris.catalog.MetaIdGenerator.IdGeneratorBuffer;
 import org.apache.doris.catalog.OlapTable.OlapTableState;
 import org.apache.doris.catalog.Replica.ReplicaStatus;
 import org.apache.doris.catalog.TableIf.TableType;
@@ -344,7 +345,7 @@ public class Env {
     private int masterHttpPort;
     private String masterIp;
 
-    private CatalogIdGenerator idGenerator = new CatalogIdGenerator(NEXT_ID_INIT_VALUE);
+    private MetaIdGenerator idGenerator = new MetaIdGenerator(NEXT_ID_INIT_VALUE);
 
     private EditLog editLog;
     private int clusterId;
@@ -3203,6 +3204,10 @@ public class Env {
     // Get the next available, needn't lock because of nextId is atomic.
     public long getNextId() {
         return idGenerator.getNextId();
+    }
+
+    public IdGeneratorBuffer getIdGeneratorBuffer(long bufferSize) {
+        return idGenerator.getIdGeneratorBuffer(bufferSize);
     }
 
     public HashMap<Long, TStorageMedium> getPartitionIdToStorageMediumMap() {

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/IdGeneratorUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/IdGeneratorUtil.java
@@ -1,0 +1,61 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.common.util;
+
+import org.apache.doris.analysis.CreateTableStmt;
+import org.apache.doris.analysis.SinglePartitionDesc;
+import org.apache.doris.catalog.OlapTable;
+import org.apache.doris.catalog.ReplicaAllocation;
+import org.apache.doris.common.AnalysisException;
+import org.apache.doris.common.DdlException;
+
+import java.util.Collection;
+
+public class IdGeneratorUtil {
+
+    public static long getBufferSize(CreateTableStmt stmt, ReplicaAllocation replicaAlloc) throws DdlException,
+            AnalysisException {
+        long bufferSize = 1;
+        long partitionNum = stmt.getPartitionDesc() == null ? 1 :
+                stmt.getPartitionDesc().getSinglePartitionDescs().size();
+        long indexNum = stmt.getRollupAlterClauseList().size() + 1;
+        long bucketNum = stmt.getDistributionDesc().toDistributionInfo(stmt.getColumns()).getBucketNum();
+        bufferSize = bufferSize + partitionNum + indexNum;
+        if (stmt.getPartitionDesc() == null) {
+            bufferSize = bufferSize + (replicaAlloc.getTotalReplicaNum() + 1) * indexNum * bucketNum;
+        } else {
+            for (SinglePartitionDesc partitionDesc : stmt.getPartitionDesc().getSinglePartitionDescs()) {
+                long replicaNum = partitionDesc.getReplicaAlloc().getTotalReplicaNum();
+                bufferSize = bufferSize + (replicaNum + 1) * indexNum * bucketNum;
+            }
+        }
+        return bufferSize;
+    }
+
+    public static long getBufferSize(OlapTable table, Collection<Long> partitionIds) {
+        long bufferSize = 0;
+        for (Long partitionId : partitionIds) {
+            bufferSize = bufferSize + 1;
+            long replicaNum = table.getPartitionInfo().getReplicaAllocation(partitionId).getTotalReplicaNum();
+            long indexNum = table.getIndexIdToMeta().size();
+            long bucketNum = table.getPartition(partitionId).getDistributionInfo().getBucketNum();
+            bufferSize = bufferSize + (replicaNum + 1) * indexNum * bucketNum;
+        }
+        return bufferSize;
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/transaction/DatabaseTransactionMgr.java
@@ -326,7 +326,7 @@ public class DatabaseTransactionMgr {
             checkRunningTxnExceedLimit(sourceType);
 
             long tid = idGenerator.getNextTransactionId();
-            LOG.info("begin transaction: txn id {} with label {} from coordinator {}, listner id: {}",
+            LOG.info("begin transaction: txn id {} with label {} from coordinator {}, listener id: {}",
                     tid, label, coordinator, listenerId);
             TransactionState transactionState = new TransactionState(dbId, tableIdList,
                     tid, label, requestId, sourceType, coordinator, listenerId, timeoutSecond * 1000);


### PR DESCRIPTION
# Proposed changes

Issue Number: close #11478 

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

