### PR TITLE
[enhancement](memtracker) Optimize exceed memory limit log readability

### DIFF
--- a/be/src/exec/cross_join_node.cpp
+++ b/be/src/exec/cross_join_node.cpp
@@ -52,7 +52,6 @@ Status CrossJoinNode::close(RuntimeState* state) {
 Status CrossJoinNode::construct_build_side(RuntimeState* state) {
     // Do a full scan of child(1) and store all build row batches.
     RETURN_IF_ERROR(child(1)->open(state));
-    SCOPED_UPDATE_MEM_EXCEED_CALL_BACK("Cross join, while getting next from child 1");
 
     while (true) {
         RowBatch* batch =

--- a/be/src/exec/es/es_scroll_parser.cpp
+++ b/be/src/exec/es/es_scroll_parser.cpp
@@ -348,12 +348,11 @@ Status ScrollParser::fill_tuple(const TupleDescriptor* tuple_desc, Tuple* tuple,
             // obj[FIELD_ID] must not be nullptr
             std::string _id = obj[FIELD_ID].GetString();
             size_t len = _id.length();
-            Status rst;
-            char* buffer = reinterpret_cast<char*>(tuple_pool->try_allocate_unaligned(len, &rst));
+            char* buffer = reinterpret_cast<char*>(tuple_pool->try_allocate_unaligned(len));
             if (UNLIKELY(buffer == nullptr)) {
                 std::string details = strings::Substitute(ERROR_MEM_LIMIT_EXCEEDED,
                                                           "MaterializeNextRow", len, "string slot");
-                RETURN_LIMIT_EXCEEDED(nullptr, details, len, rst);
+                RETURN_LIMIT_EXCEEDED(nullptr, details, len);
             }
             memcpy(buffer, _id.data(), len);
             reinterpret_cast<StringValue*>(slot)->ptr = buffer;
@@ -407,13 +406,11 @@ Status ScrollParser::fill_tuple(const TupleDescriptor* tuple_desc, Tuple* tuple,
                 }
             }
             size_t val_size = val.length();
-            Status rst;
-            char* buffer =
-                    reinterpret_cast<char*>(tuple_pool->try_allocate_unaligned(val_size, &rst));
+            char* buffer = reinterpret_cast<char*>(tuple_pool->try_allocate_unaligned(val_size));
             if (UNLIKELY(buffer == nullptr)) {
                 std::string details = strings::Substitute(
                         ERROR_MEM_LIMIT_EXCEEDED, "MaterializeNextRow", val_size, "string slot");
-                RETURN_LIMIT_EXCEEDED(nullptr, details, val_size, rst);
+                RETURN_LIMIT_EXCEEDED(nullptr, details, val_size);
             }
             memcpy(buffer, val.data(), val_size);
             reinterpret_cast<StringValue*>(slot)->ptr = buffer;

--- a/be/src/exec/except_node.cpp
+++ b/be/src/exec/except_node.cpp
@@ -40,7 +40,6 @@ Status ExceptNode::init(const TPlanNode& tnode, RuntimeState* state) {
 
 Status ExceptNode::open(RuntimeState* state) {
     SCOPED_CONSUME_MEM_TRACKER(mem_tracker());
-    SCOPED_UPDATE_MEM_EXCEED_CALL_BACK("Except Node, while probing the hash table.");
     RETURN_IF_ERROR(SetOperationNode::open(state));
     // if a table is empty, the result must be empty
     if (_hash_tbl->size() == 0) {

--- a/be/src/exec/hash_join_node.cpp
+++ b/be/src/exec/hash_join_node.cpp
@@ -184,7 +184,6 @@ Status HashJoinNode::construct_hash_table(RuntimeState* state) {
     // The hash join node needs to keep in memory all build tuples, including the tuple
     // row ptrs.  The row ptrs are copied into the hash table's internal structure so they
     // don't need to be stored in the _build_pool.
-    SCOPED_UPDATE_MEM_EXCEED_CALL_BACK("Hash join, while constructing the hash table.");
     RowBatch build_batch(child(1)->row_desc(), state->batch_size());
     RETURN_IF_ERROR(child(1)->open(state));
 
@@ -301,7 +300,6 @@ Status HashJoinNode::get_next(RuntimeState* state, RowBatch* out_batch, bool* eo
     // In most cases, no additional memory overhead will be applied for at this stage,
     // but if the expression calculation in this node needs to apply for additional memory,
     // it may cause the memory to exceed the limit.
-    SCOPED_UPDATE_MEM_EXCEED_CALL_BACK("Hash join, while execute get_next.");
     SCOPED_TIMER(_runtime_profile->total_time_counter());
     SCOPED_CONSUME_MEM_TRACKER(mem_tracker());
 

--- a/be/src/exec/intersect_node.cpp
+++ b/be/src/exec/intersect_node.cpp
@@ -44,7 +44,6 @@ Status IntersectNode::init(const TPlanNode& tnode, RuntimeState* state) {
 // repeat [2] this for all the rest child
 Status IntersectNode::open(RuntimeState* state) {
     SCOPED_CONSUME_MEM_TRACKER(mem_tracker());
-    SCOPED_UPDATE_MEM_EXCEED_CALL_BACK("Intersect Node, while probing the hash table.");
     RETURN_IF_ERROR(SetOperationNode::open(state));
     // if a table is empty, the result must be empty
     if (_hash_tbl->size() == 0) {

--- a/be/src/exec/olap_scanner.cpp
+++ b/be/src/exec/olap_scanner.cpp
@@ -310,10 +310,7 @@ Status OlapScanner::_init_return_columns(bool need_seq_col) {
 Status OlapScanner::get_batch(RuntimeState* state, RowBatch* batch, bool* eof) {
     SCOPED_CONSUME_MEM_TRACKER(_mem_tracker);
     // 2. Allocate Row's Tuple buf
-    Status st = Status::OK();
-    uint8_t* tuple_buf =
-            batch->tuple_data_pool()->allocate(_batch_size * _tuple_desc->byte_size(), &st);
-    RETURN_NOT_OK_STATUS_WITH_WARN(st, "Allocate mem for row batch failed");
+    uint8_t* tuple_buf = batch->tuple_data_pool()->allocate(_batch_size * _tuple_desc->byte_size());
     if (tuple_buf == nullptr) {
         LOG(WARNING) << "Allocate mem for row batch failed.";
         return Status::RuntimeError("Allocate mem for row batch failed.");

--- a/be/src/exec/partitioned_hash_table.cc
+++ b/be/src/exec/partitioned_hash_table.cc
@@ -307,13 +307,12 @@ Status PartitionedHashTableCtx::ExprValuesCache::Init(RuntimeState* state,
                                      MAX_EXPR_VALUES_ARRAY_SIZE / expr_values_bytes_per_row_));
 
     int mem_usage = MemUsage(capacity_, expr_values_bytes_per_row_, num_exprs_);
-    Status st = thread_context()->_thread_mem_tracker_mgr->limiter_mem_tracker()->check_limit(
-            mem_usage);
-    if (UNLIKELY(!st)) {
+    if (UNLIKELY(!thread_context()->_thread_mem_tracker_mgr->limiter_mem_tracker()->check_limit(
+                mem_usage))) {
         capacity_ = 0;
         string details = Substitute(
                 "PartitionedHashTableCtx::ExprValuesCache failed to allocate $0 bytes", mem_usage);
-        RETURN_LIMIT_EXCEEDED(state, details, mem_usage, st);
+        RETURN_LIMIT_EXCEEDED(state, details, mem_usage);
     }
 
     int expr_values_size = expr_values_bytes_per_row_ * capacity_;

--- a/be/src/exec/set_operation_node.cpp
+++ b/be/src/exec/set_operation_node.cpp
@@ -136,7 +136,6 @@ Status SetOperationNode::open(RuntimeState* state) {
     RETURN_IF_ERROR(ExecNode::open(state));
     SCOPED_TIMER(_runtime_profile->total_time_counter());
     SCOPED_CONSUME_MEM_TRACKER(mem_tracker());
-    SCOPED_UPDATE_MEM_EXCEED_CALL_BACK("SetOperation, while constructing the hash table.");
     RETURN_IF_CANCELLED(state);
     // open result expr lists.
     for (const std::vector<ExprContext*>& exprs : _child_expr_lists) {

--- a/be/src/exprs/anyval_util.cpp
+++ b/be/src/exprs/anyval_util.cpp
@@ -44,11 +44,9 @@ Status allocate_any_val(RuntimeState* state, MemPool* pool, const TypeDescriptor
                         const std::string& mem_limit_exceeded_msg, AnyVal** result) {
     const int anyval_size = AnyValUtil::any_val_size(type);
     const int anyval_alignment = AnyValUtil::any_val_alignment(type);
-    Status rst;
-    *result = reinterpret_cast<AnyVal*>(
-            pool->try_allocate_aligned(anyval_size, anyval_alignment, &rst));
+    *result = reinterpret_cast<AnyVal*>(pool->try_allocate_aligned(anyval_size, anyval_alignment));
     if (*result == nullptr) {
-        RETURN_LIMIT_EXCEEDED(state, mem_limit_exceeded_msg, anyval_size, rst);
+        RETURN_LIMIT_EXCEEDED(state, mem_limit_exceeded_msg, anyval_size);
     }
     memset(static_cast<void*>(*result), 0, anyval_size);
     return Status::OK();

--- a/be/src/exprs/expr_context.cpp
+++ b/be/src/exprs/expr_context.cpp
@@ -413,11 +413,9 @@ Status ExprContext::get_const_value(RuntimeState* state, Expr& expr, AnyVal** co
         StringVal* sv = reinterpret_cast<StringVal*>(*const_val);
         if (!sv->is_null && sv->len > 0) {
             // Make sure the memory is owned by this evaluator.
-            Status rst;
-            char* ptr_copy = reinterpret_cast<char*>(_pool->try_allocate(sv->len, &rst));
+            char* ptr_copy = reinterpret_cast<char*>(_pool->try_allocate(sv->len));
             if (ptr_copy == nullptr) {
-                RETURN_LIMIT_EXCEEDED(state, "Could not allocate constant string value", sv->len,
-                                      rst);
+                RETURN_LIMIT_EXCEEDED(state, "Could not allocate constant string value", sv->len);
             }
             memcpy(ptr_copy, sv->ptr, sv->len);
             sv->ptr = reinterpret_cast<uint8_t*>(ptr_copy);

--- a/be/src/runtime/memory/mem_tracker_limiter.cpp
+++ b/be/src/runtime/memory/mem_tracker_limiter.cpp
@@ -143,8 +143,8 @@ bool MemTrackerLimiter::gc_memory(int64_t max_consumption) {
 Status MemTrackerLimiter::try_gc_memory(int64_t bytes) {
     if (UNLIKELY(gc_memory(_limit - bytes))) {
         return Status::MemoryLimitExceeded(
-                fmt::format("label={} TryConsume failed size={}, used={}, limit={}", label(), bytes,
-                            _consumption->current_value(), _limit));
+                fmt::format("label={}, limit={}, used={}, failed consume size={}", label(), _limit,
+                            _consumption->current_value(), bytes));
     }
     VLOG_NOTICE << "GC succeeded, TryConsume bytes=" << bytes
                 << " consumption=" << _consumption->current_value() << " limit=" << _limit;
@@ -197,9 +197,9 @@ std::string MemTrackerLimiter::log_usage(int max_recursive_depth, int64_t* logge
     std::vector<MemTracker::Snapshot> snapshots;
     MemTracker::make_group_snapshot(&snapshots, 0, _group_num, _label);
     for (const auto& snapshot : snapshots) {
-        child_trackers_usage += MemTracker::log_usage(snapshot);
+        child_trackers_usage += "\n    " + MemTracker::log_usage(snapshot);
     }
-    if (!child_trackers_usage.empty()) detail += "\n" + child_trackers_usage;
+    if (!child_trackers_usage.empty()) detail += child_trackers_usage;
     return detail;
 }
 
@@ -217,41 +217,38 @@ std::string MemTrackerLimiter::log_usage(int max_recursive_depth,
     return join(usage_strings, "\n");
 }
 
-Status MemTrackerLimiter::mem_limit_exceeded(RuntimeState* state, const std::string& details,
-                                             int64_t failed_allocation_size, Status failed_alloc) {
+Status MemTrackerLimiter::mem_limit_exceeded(const std::string& msg, int64_t failed_consume_size) {
     STOP_CHECK_THREAD_MEM_TRACKER_LIMIT();
-    std::string detail =
-            "Memory exceed limit. fragment={}, details={}, on backend={}. Memory left in process "
-            "limit={}.";
-    detail = fmt::format(
-            detail, state != nullptr ? print_id(state->fragment_instance_id()) : "", details,
-            BackendOptions::get_localhost(),
+    std::string detail = fmt::format(
+            "{}, failed mem consume:<consume_size={}, mem_limit={}, mem_used={}, tracker_label={}, "
+            "in backend={} free memory left={}. details mem usage see be.INFO.",
+            msg, PrettyPrinter::print(failed_consume_size, TUnit::BYTES), _limit,
+            _consumption->current_value(), _label, BackendOptions::get_localhost(),
             PrettyPrinter::print(ExecEnv::GetInstance()->process_mem_tracker()->spare_capacity(),
                                  TUnit::BYTES));
-    if (!failed_alloc) {
-        detail += " failed alloc=<{}>. current tracker={}.";
-        detail = fmt::format(detail, failed_alloc.to_string(), _label);
-    } else {
-        detail += " current tracker <label={}, used={}, limit={}, failed alloc size={}>.";
-        detail = fmt::format(detail, _label, _consumption->current_value(), _limit,
-                             PrettyPrinter::print(failed_allocation_size, TUnit::BYTES));
-    }
-    detail += " If this is a query, can change the limit by session variable exec_mem_limit.";
     Status status = Status::MemoryLimitExceeded(detail);
-    if (state != nullptr) state->log_error(detail);
 
-    detail += "\n" + boost::stacktrace::to_string(boost::stacktrace::stacktrace());
     // only print the tracker log_usage in be log.
-    if (ExecEnv::GetInstance()->process_mem_tracker()->spare_capacity() < failed_allocation_size) {
-        // Dumping the process MemTracker is expensive. Limiting the recursive depth to two
-        // levels limits the level of detail to a one-line summary for each query MemTracker.
-        detail += "\n" + ExecEnv::GetInstance()->process_mem_tracker()->log_usage(2);
-    } else {
-        detail += "\n" + log_usage();
+    if (_print_log_usage) {
+        if (ExecEnv::GetInstance()->process_mem_tracker()->spare_capacity() < failed_consume_size) {
+            // Dumping the process MemTracker is expensive. Limiting the recursive depth to two
+            // levels limits the level of detail to a one-line summary for each query MemTracker.
+            detail += "\n" + ExecEnv::GetInstance()->process_mem_tracker()->log_usage(2);
+        } else {
+            detail += "\n" + log_usage();
+        }
+        detail += "\n" + boost::stacktrace::to_string(boost::stacktrace::stacktrace());
+        LOG(WARNING) << detail;
+        _print_log_usage = false;
     }
-
-    LOG(WARNING) << detail;
     return status;
+}
+
+Status MemTrackerLimiter::mem_limit_exceeded(RuntimeState* state, const std::string& msg,
+                                             int64_t failed_alloc_size) {
+    Status rt = mem_limit_exceeded(msg, failed_alloc_size);
+    state->log_error(rt.to_string());
+    return rt;
 }
 
 } // namespace doris

--- a/be/src/runtime/plan_fragment_executor.cpp
+++ b/be/src/runtime/plan_fragment_executor.cpp
@@ -251,6 +251,7 @@ Status PlanFragmentExecutor::open() {
         if (_cancel_reason == PPlanFragmentCancelReason::CALL_RPC_ERROR) {
             status = Status::RuntimeError(_cancel_msg);
         } else if (_cancel_reason == PPlanFragmentCancelReason::MEMORY_LIMIT_EXCEED) {
+            // status = Status::MemoryAllocFailed(_cancel_msg);
             status = Status::MemoryLimitExceeded(_cancel_msg);
         }
     }

--- a/be/src/runtime/runtime_state.cpp
+++ b/be/src/runtime/runtime_state.cpp
@@ -351,7 +351,9 @@ Status RuntimeState::set_mem_limit_exceeded(const std::string& msg) {
 Status RuntimeState::check_query_state(const std::string& msg) {
     // TODO: it would be nice if this also checked for cancellation, but doing so breaks
     // cases where we use Status::Cancelled("Cancelled") to indicate that the limit was reached.
-    RETURN_IF_LIMIT_EXCEEDED(this, msg);
+    if (thread_context()->_thread_mem_tracker_mgr->limiter_mem_tracker()->any_limit_exceeded()) {
+        RETURN_LIMIT_EXCEEDED(this, msg);
+    }
     return query_status();
 }
 

--- a/be/src/runtime/thread_context.cpp
+++ b/be/src/runtime/thread_context.cpp
@@ -79,24 +79,6 @@ AddThreadMemTrackerConsumer::~AddThreadMemTrackerConsumer() {
 #endif // USE_MEM_TRACKER
 }
 
-UpdateMemExceedCallBack::UpdateMemExceedCallBack(const std::string& cancel_msg, bool cancel_task,
-                                                 ExceedCallBack cb_func) {
-#ifdef USE_MEM_TRACKER
-    DCHECK(cancel_msg != std::string());
-    _old_cb = thread_context()->_thread_mem_tracker_mgr->update_exceed_call_back(
-            cancel_msg, cancel_task, cb_func);
-#endif
-}
-
-UpdateMemExceedCallBack::~UpdateMemExceedCallBack() {
-#ifdef USE_MEM_TRACKER
-    thread_context()->_thread_mem_tracker_mgr->update_exceed_call_back(_old_cb);
-#ifndef NDEBUG
-    DorisMetrics::instance()->thread_mem_tracker_exceed_call_back_count->increment(1);
-#endif
-#endif // USE_MEM_TRACKER
-}
-
 SwitchBthread::SwitchBthread() {
 #ifdef USE_MEM_TRACKER
     _bthread_context = static_cast<ThreadContext*>(bthread_getspecific(btls_key));

--- a/be/src/vec/exec/join/vhash_join_node.cpp
+++ b/be/src/vec/exec/join/vhash_join_node.cpp
@@ -1115,7 +1115,6 @@ void HashJoinNode::_hash_table_build_thread(RuntimeState* state, std::promise<St
 
 Status HashJoinNode::_hash_table_build(RuntimeState* state) {
     RETURN_IF_ERROR(child(1)->open(state));
-    SCOPED_UPDATE_MEM_EXCEED_CALL_BACK("Hash join, while constructing the hash table.");
     SCOPED_TIMER(_build_timer);
     MutableBlock mutable_block(child(1)->row_desc().tuple_descriptors());
 

--- a/be/src/vec/exec/vaggregation_node.cpp
+++ b/be/src/vec/exec/vaggregation_node.cpp
@@ -401,7 +401,6 @@ Status AggregationNode::prepare(RuntimeState* state) {
 Status AggregationNode::open(RuntimeState* state) {
     START_AND_SCOPE_SPAN(state->get_tracer(), span, "AggregationNode::open");
     SCOPED_TIMER(_runtime_profile->total_time_counter());
-    SCOPED_UPDATE_MEM_EXCEED_CALL_BACK("aggregator, while execute open.");
     RETURN_IF_ERROR(ExecNode::open(state));
     SCOPED_CONSUME_MEM_TRACKER(mem_tracker());
 
@@ -446,7 +445,6 @@ Status AggregationNode::get_next(RuntimeState* state, Block* block, bool* eos) {
     INIT_AND_SCOPE_GET_NEXT_SPAN(state->get_tracer(), _get_next_span, "AggregationNode::get_next");
     SCOPED_TIMER(_runtime_profile->total_time_counter());
     SCOPED_CONSUME_MEM_TRACKER(mem_tracker());
-    SCOPED_UPDATE_MEM_EXCEED_CALL_BACK("aggregator, while execute get_next.");
 
     if (_is_streaming_preagg) {
         bool child_eos = false;

--- a/be/src/vec/exec/vcross_join_node.cpp
+++ b/be/src/vec/exec/vcross_join_node.cpp
@@ -53,7 +53,6 @@ Status VCrossJoinNode::close(RuntimeState* state) {
 Status VCrossJoinNode::construct_build_side(RuntimeState* state) {
     // Do a full scan of child(1) and store all build row batches.
     RETURN_IF_ERROR(child(1)->open(state));
-    SCOPED_UPDATE_MEM_EXCEED_CALL_BACK("Vec Cross join, while getting next from the child 1");
 
     bool eos = false;
     while (true) {

--- a/be/src/vec/exec/vset_operation_node.cpp
+++ b/be/src/vec/exec/vset_operation_node.cpp
@@ -233,7 +233,6 @@ void VSetOperationNode::hash_table_init() {
 //build a hash table from child(0)
 Status VSetOperationNode::hash_table_build(RuntimeState* state) {
     RETURN_IF_ERROR(child(0)->open(state));
-    SCOPED_UPDATE_MEM_EXCEED_CALL_BACK("Vec Set Operation Node, while constructing the hash table");
     Block block;
     MutableBlock mutable_block(child(0)->row_desc().tuple_descriptors());
 


### PR DESCRIPTION
# Proposed changes

Issue Number: close #11480

## Problem summary

Optimize the returned information when query exceeds memory limit.

mysql client return error:
````
Memory limit exceeded: exec node:ExecNode:VAGGREGATION_NODE (id=14), can change the limit by `set exec_mem_limit=xxx`, failed mem consume:<consume_size=977.55 KB, mem_limit=222, mem_used=1088408, tracker_label=RuntimeState:instance:2147f2fe254a49b1-ad986d48faa4c9d9, in backend=172.24.47.117 free memory left=98.58 GB. details mem usage see be.INFO.
````

be.INFO log, divided into three parts:
1. Exceed memory limit info;
2. mem tracker limiter and child snapshots
3. Stack trace
```
W0803 22:10:10.533586 3537580 mem_tracker_limiter.cpp:239] exec node:unknown, `set exec_mem_limit=xxx` to change limit, failed mem consume:<consume_size=979.46 KB, mem_limit=222, mem_used=2874039, tracker_label=RuntimeState:instance:2147f2fe254a49b1-ad986d48faa4ca12, in
 backend=172.24.47.117 free memory left=98.44 GB. details mem usage see be.INFO
MemTrackerLimiter Label=RuntimeState:instance:2147f2fe254a49b1-ad986d48faa4ca12, Limit=222.00 B, Used=2.74 MB, Peak=1.78 MB, Exceeded=true
    MemTracker Label=RuntimeFilterMgr, Parent Label=RuntimeState:instance:2147f2fe254a49b1-ad986d48faa4ca12, Used=0, Peak=0
    MemTracker Label=BufferedBlockMgr2, Parent Label=RuntimeState:instance:2147f2fe254a49b1-ad986d48faa4ca12, Used=0, Peak=0
    MemTracker Label=ExecNode:VAGGREGATION_NODE (id=14), Parent Label=RuntimeState:instance:2147f2fe254a49b1-ad986d48faa4ca12, Used=0, Peak=0
    MemTracker Label=ExecNode:VOLAP_SCAN_NODE (id=13), Parent Label=RuntimeState:instance:2147f2fe254a49b1-ad986d48faa4ca12, Used=0, Peak=0
    MemTracker Label=OlapScanners, Parent Label=RuntimeState:instance:2147f2fe254a49b1-ad986d48faa4ca12, Used=0, Peak=0
    MemTracker Label=AggregationNode:Data, Parent Label=RuntimeState:instance:2147f2fe254a49b1-ad986d48faa4ca12, Used=515.98 KB, Peak=259.98 KB
    MemTracker Label=VDataStreamSender:2147f2fe254a49b1-ad986d48faa4ca12, Parent Label=RuntimeState:instance:2147f2fe254a49b1-ad986d48faa4ca12, Used=0, Peak=0
 0# doris::MemTrackerLimiter::mem_limit_exceeded(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, long) at /mnt/disk1/liyifan/doris/core/be/src/runtime/memory/mem_tracker_limiter.cpp:238
 1# doris::ThreadMemTrackerMgr::exceeded(long) at /mnt/disk1/liyifan/doris/core/be/src/runtime/memory/thread_mem_tracker_mgr.cpp:65
 2# void doris::ThreadMemTrackerMgr::flush_untracked_mem<true>() at /mnt/disk1/liyifan/doris/core/be/src/runtime/memory/thread_mem_tracker_mgr.h:199
 3# doris::ThreadMemTrackerMgr::consume(long) at /mnt/disk1/liyifan/doris/core/be/src/runtime/memory/thread_mem_tracker_mgr.h:170
 4# new_hook(void const*, unsigned long) at /mnt/disk1/liyifan/doris/core/be/src/runtime/memory/tcmalloc_hook.h:48
 5# MallocHook::InvokeNewHookSlow(void const*, unsigned long) at src/malloc_hook.cc:498
 6# tcmalloc::allocate_full_cpp_throw_oom(unsigned long) at src/tcmalloc.cc:1815
 7# snappy::internal::WorkingMemory::WorkingMemory(unsigned long) in /mnt/disk1/liyifan/doris/core/output_run/be/lib/doris_be
 8# snappy::Compress(snappy::Source*, snappy::Sink*) in /mnt/disk1/liyifan/doris/core/output_run/be/lib/doris_be
 9# snappy::RawCompress(char const*, unsigned long, char*, unsigned long*) in /mnt/disk1/liyifan/doris/core/output_run/be/lib/doris_be
10# doris::vectorized::Block::serialize(doris::PBlock*, unsigned long*, unsigned long*, bool) const at /mnt/disk1/liyifan/doris/core/be/src/vec/core/block.cpp:722
11# doris::vectorized::VDataStreamSender::serialize_block(doris::vectorized::Block*, doris::PBlock*, int) at /mnt/disk1/liyifan/doris/core/be/src/vec/sink/vdata_stream_sender.cpp:592
12# doris::vectorized::VDataStreamSender::Channel::send_current_block(bool) at /mnt/disk1/liyifan/doris/core/be/src/vec/sink/vdata_stream_sender.cpp:87
13# doris::vectorized::VDataStreamSender::Channel::add_rows(doris::vectorized::Block*, std::vector<int, std::allocator<int> > const&) at /mnt/disk1/liyifan/doris/core/be/src/vec/sink/vdata_stream_sender.cpp:218
14# doris::Status doris::vectorized::VDataStreamSender::channel_add_rows<std::vector<doris::vectorized::VDataStreamSender::Channel*, std::allocator<doris::vectorized::VDataStreamSender::Channel*> >, std::vector<unsigned long, std::allocator<unsigned long> > >(std::vecto
r<doris::vectorized::VDataStreamSender::Channel*, std::allocator<doris::vectorized::VDataStreamSender::Channel*> >&, int, std::vector<unsigned long, std::allocator<unsigned long> > const&, int, doris::vectorized::Block*) at /mnt/disk1/liyifan/doris/core/be/src/vec/sink/
vdata_stream_sender.h:316
15# doris::vectorized::VDataStreamSender::send(doris::RuntimeState*, doris::vectorized::Block*) at /mnt/disk1/liyifan/doris/core/be/src/vec/sink/vdata_stream_sender.cpp:516
16# doris::PlanFragmentExecutor::open_vectorized_internal() at /mnt/disk1/liyifan/doris/core/be/src/runtime/plan_fragment_executor.cpp:299
17# doris::PlanFragmentExecutor::open() at /mnt/disk1/liyifan/doris/core/be/src/runtime/plan_fragment_executor.cpp:239
18# doris::FragmentExecState::execute() at /mnt/disk1/liyifan/doris/core/be/src/runtime/fragment_mgr.cpp:246
19# doris::FragmentMgr::_exec_actual(std::shared_ptr<doris::FragmentExecState>, std::function<void (doris::PlanFragmentExecutor*)>) at /mnt/disk1/liyifan/doris/core/be/src/runtime/fragment_mgr.cpp:500
20# doris::FragmentMgr::exec_plan_fragment(doris::TExecPlanFragmentParams const&, std::function<void (doris::PlanFragmentExecutor*)>)::{lambda()#1}::operator()() const at /mnt/disk1/liyifan/doris/core/be/src/runtime/fragment_mgr.cpp:681
21# void std::__invoke_impl<void, doris::FragmentMgr::exec_plan_fragment(doris::TExecPlanFragmentParams const&, std::function<void (doris::PlanFragmentExecutor*)>)::{lambda()#1}&>(std::__invoke_other, doris::FragmentMgr::exec_plan_fragment(doris::TExecPlanFragmentParams
 const&, std::function<void (doris::PlanFragmentExecutor*)>)::{lambda()#1}&) at /mnt/disk1/liyifan/doris/ldb_toolchain/include/c++/11/bits/invoke.h:61
22# std::enable_if<is_invocable_r_v<void, doris::FragmentMgr::exec_plan_fragment(doris::TExecPlanFragmentParams const&, std::function<void (doris::PlanFragmentExecutor*)>)::{lambda()#1}&>, void>::type std::__invoke_r<void, doris::FragmentMgr::exec_plan_fragment(doris::T
ExecPlanFragmentParams const&, std::function<void (doris::PlanFragmentExecutor*)>)::{lambda()#1}&>(doris::FragmentMgr::exec_plan_fragment(doris::TExecPlanFragmentParams const&, std::function<void (doris::PlanFragmentExecutor*)>)::{lambda()#1}&) at /mnt/disk1/liyifan/dor
is/ldb_toolchain/include/c++/11/bits/invoke.h:117
23# std::_Function_handler<void (), doris::FragmentMgr::exec_plan_fragment(doris::TExecPlanFragmentParams const&, std::function<void (doris::PlanFragmentExecutor*)>)::{lambda()#1}>::_M_invoke(std::_Any_data const&) at /mnt/disk1/liyifan/doris/ldb_toolchain/include/c++/1
1/bits/std_function.h:292
24# std::function<void ()>::operator()() const at /mnt/disk1/liyifan/doris/ldb_toolchain/include/c++/11/bits/std_function.h:560
25# doris::FunctionRunnable::run() at /mnt/disk1/liyifan/doris/core/be/src/util/threadpool.cpp:45
26# doris::ThreadPool::dispatch_thread() at /mnt/disk1/liyifan/doris/core/be/src/util/threadpool.cpp:548
27# void std::__invoke_impl<void, void (doris::ThreadPool::*&)(), doris::ThreadPool*&>(std::__invoke_memfun_deref, void (doris::ThreadPool::*&)(), doris::ThreadPool*&) at /mnt/disk1/liyifan/doris/ldb_toolchain/include/c++/11/bits/invoke.h:74
28# std::__invoke_result<void (doris::ThreadPool::*&)(), doris::ThreadPool*&>::type std::__invoke<void (doris::ThreadPool::*&)(), doris::ThreadPool*&>(void (doris::ThreadPool::*&)(), doris::ThreadPool*&) at /mnt/disk1/liyifan/doris/ldb_toolchain/include/c++/11/bits/invo
ke.h:97
29# void std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>::__call<void, , 0ul>(std::tuple<>&&, std::_Index_tuple<0ul>) at /mnt/disk1/liyifan/doris/ldb_toolchain/include/c++/11/functional:422
30# void std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>::operator()<, void>() at /mnt/disk1/liyifan/doris/ldb_toolchain/include/c++/11/functional:505
31# void std::__invoke_impl<void, std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>&>(std::__invoke_other, std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>&) at /mnt/disk1/liyifan/doris/ldb_toolchain/include/c++/11/bits/invoke.h:61
32# std::enable_if<is_invocable_r_v<void, std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>&>, void>::type std::__invoke_r<void, std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>&>(std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>&) a
t /mnt/disk1/liyifan/doris/ldb_toolchain/include/c++/11/bits/invoke.h:117
33# std::_Function_handler<void (), std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()> >::_M_invoke(std::_Any_data const&) at /mnt/disk1/liyifan/doris/ldb_toolchain/include/c++/11/bits/std_function.h:292
34# std::function<void ()>::operator()() const at /mnt/disk1/liyifan/doris/ldb_toolchain/include/c++/11/bits/std_function.h:560
35# doris::Thread::supervise_thread(void*) at /mnt/disk1/liyifan/doris/core/be/src/util/thread.cpp:409
36# start_thread in /lib64/libpthread.so.0
37# clone in /lib64/libc.so.6
```

## Checklist(Required)

1. Does it affect the original behavior: 
    - [x] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

