### PR TITLE
Support hive external table on Ali oss.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/HiveMetaStoreClientHelper.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/HiveMetaStoreClientHelper.java
@@ -274,7 +274,7 @@ public class HiveMetaStoreClientHelper {
             location = location.replaceFirst("oss", "s3");
         } else if (location.startsWith("cos:")) {
             location = location.replaceFirst("cos", "s3");
-        } else if (location.startsWith("bos")) {
+        } else if (location.startsWith("bos:")) {
             location = location.replaceFirst("bos", "s3");
         }
         return location;

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/HiveMetaStoreClientHelper.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/HiveMetaStoreClientHelper.java
@@ -264,7 +264,6 @@ public class HiveMetaStoreClientHelper {
             iterators.add(fileSystem.listLocatedStatus(path));
         } catch (IOException e) {
             LOG.warn("Get HDFS file remote iterator failed. {}", e.getMessage());
-            e.printStackTrace();
             throw new DdlException("Get HDFS file remote iterator failed. Error: " + e.getMessage());
         }
         return iterators;

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/HiveMetaStoreClientHelper.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/HiveMetaStoreClientHelper.java
@@ -31,6 +31,7 @@ import org.apache.doris.analysis.NullLiteral;
 import org.apache.doris.analysis.SlotRef;
 import org.apache.doris.analysis.StorageBackend;
 import org.apache.doris.analysis.StringLiteral;
+import org.apache.doris.common.Config;
 import org.apache.doris.common.DdlException;
 import org.apache.doris.common.util.BrokerUtil;
 import org.apache.doris.thrift.TBrokerFileStatus;
@@ -270,12 +271,12 @@ public class HiveMetaStoreClientHelper {
     }
 
     public static String normalizeS3LikeSchema(String location) {
-        if (location.startsWith("oss:")) {
-            location = location.replaceFirst("oss", "s3");
-        } else if (location.startsWith("cos:")) {
-            location = location.replaceFirst("cos", "s3");
-        } else if (location.startsWith("bos:")) {
-            location = location.replaceFirst("bos", "s3");
+        String[] objectStorages = Config.s3_compatible_object_storages.split(",");
+        for (String objectStorage : objectStorages) {
+            if (location.startsWith(objectStorage + "://")) {
+                location = location.replaceFirst(objectStorage, "s3");
+                break;
+            }
         }
         return location;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/HiveMetaStoreClientHelper.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/HiveMetaStoreClientHelper.java
@@ -263,7 +263,8 @@ public class HiveMetaStoreClientHelper {
             FileSystem fileSystem = path.getFileSystem(conf);
             iterators.add(fileSystem.listLocatedStatus(path));
         } catch (IOException e) {
-            LOG.warn("Get HDFS file remote iterator failed. {}" + e.getMessage());
+            LOG.warn("Get HDFS file remote iterator failed. {}", e.getMessage());
+            e.printStackTrace();
             throw new DdlException("Get HDFS file remote iterator failed. Error: " + e.getMessage());
         }
         return iterators;

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/HiveMetaStoreClientHelper.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/HiveMetaStoreClientHelper.java
@@ -245,6 +245,11 @@ public class HiveMetaStoreClientHelper {
     private static List<RemoteIterator<LocatedFileStatus>> getRemoteIterator(Table table, Configuration configuration,
             boolean isSecurityEnabled, Map<String, String> properties, boolean onS3) throws DdlException {
         String location = table.getSd().getLocation();
+        LOG.warn("location 1 {}", location);
+        if (location.startsWith("oss:")) {
+            location = location.replaceFirst("oss:", "s3:");
+            LOG.warn("location 2 {}", location);
+        }
         Path path = new Path(location);
         return getRemoteIterator(path, configuration, properties, isSecurityEnabled);
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/IcebergTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/IcebergTable.java
@@ -128,7 +128,10 @@ public class IcebergTable extends Table {
 
         // analyze storage type
         String storagePrefix = strings[0].split(":")[0];
-        if (storagePrefix.equalsIgnoreCase("s3")) {
+        if (storagePrefix.equalsIgnoreCase("s3")
+                || storagePrefix.equalsIgnoreCase("oss")
+                || storagePrefix.equalsIgnoreCase("cos")
+                || storagePrefix.equalsIgnoreCase("bos")) {
             this.storageType = StorageBackend.StorageType.S3;
         } else if (storagePrefix.equalsIgnoreCase("hdfs")) {
             this.storageType = StorageBackend.StorageType.HDFS;

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/IcebergTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/IcebergTable.java
@@ -18,9 +18,9 @@
 package org.apache.doris.catalog;
 
 import org.apache.doris.analysis.StorageBackend;
-import org.apache.doris.common.Config;
 import org.apache.doris.common.UserException;
 import org.apache.doris.common.io.Text;
+import org.apache.doris.common.util.Util;
 import org.apache.doris.external.iceberg.IcebergCatalog;
 import org.apache.doris.external.iceberg.IcebergCatalogMgr;
 import org.apache.doris.thrift.TBrokerFileStatus;
@@ -129,7 +129,7 @@ public class IcebergTable extends Table {
 
         // analyze storage type
         String storagePrefix = strings[0].split(":")[0];
-        if (isS3LikeStorageSchema(storagePrefix)) {
+        if (Util.isS3CompatibleStorageSchema(storagePrefix)) {
             this.storageType = StorageBackend.StorageType.S3;
         } else if (storagePrefix.equalsIgnoreCase("hdfs")) {
             this.storageType = StorageBackend.StorageType.HDFS;
@@ -143,16 +143,6 @@ public class IcebergTable extends Table {
         String host = strings[1];
         this.hostUri = storagePrefix + "://" + host;
         this.isAnalyzed = true;
-    }
-
-    private boolean isS3LikeStorageSchema(String schema) {
-        String[] objectStorageList = Config.s3_compatible_object_storages.split(",");
-        for (String objectStorage : objectStorageList) {
-            if (objectStorage.equalsIgnoreCase(schema)) {
-                return true;
-            }
-        }
-        return false;
     }
 
     public String getHostUri() throws UserException {

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/IcebergTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/IcebergTable.java
@@ -18,6 +18,7 @@
 package org.apache.doris.catalog;
 
 import org.apache.doris.analysis.StorageBackend;
+import org.apache.doris.common.Config;
 import org.apache.doris.common.UserException;
 import org.apache.doris.common.io.Text;
 import org.apache.doris.external.iceberg.IcebergCatalog;
@@ -128,10 +129,7 @@ public class IcebergTable extends Table {
 
         // analyze storage type
         String storagePrefix = strings[0].split(":")[0];
-        if (storagePrefix.equalsIgnoreCase("s3")
-                || storagePrefix.equalsIgnoreCase("oss")
-                || storagePrefix.equalsIgnoreCase("cos")
-                || storagePrefix.equalsIgnoreCase("bos")) {
+        if (isS3LikeStorageSchema(storagePrefix)) {
             this.storageType = StorageBackend.StorageType.S3;
         } else if (storagePrefix.equalsIgnoreCase("hdfs")) {
             this.storageType = StorageBackend.StorageType.HDFS;
@@ -145,6 +143,16 @@ public class IcebergTable extends Table {
         String host = strings[1];
         this.hostUri = storagePrefix + "://" + host;
         this.isAnalyzed = true;
+    }
+
+    private boolean isS3LikeStorageSchema(String schema) {
+        String[] objectStorageList = Config.s3_compatible_object_storages.split(",");
+        for (String objectStorage : objectStorageList) {
+            if (objectStorage.equalsIgnoreCase(schema)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     public String getHostUri() throws UserException {

--- a/fe/fe-core/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/Config.java
@@ -1726,4 +1726,10 @@ public class Config extends ConfigBase {
      */
     @ConfField(mutable = true, masterOnly = true)
     public static boolean enable_decimal_conversion = false;
+
+    /**
+     * List of S3 API compatible object storage systems.
+     */
+    @ConfField
+    public static String s3_compatible_object_storages = "s3,oss,cos,bos";
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/Util.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/Util.java
@@ -496,4 +496,13 @@ public class Util {
             throw new AnalysisException(String.format("External catalog '%s' is not allowed in '%s'", catalog, msg));
         }
     }
+
+    public static boolean isS3CompatibleStorageSchema(String schema) {
+        for (String objectStorage : Config.s3_compatible_object_storages.split(",")) {
+            if (objectStorage.equalsIgnoreCase(schema)) {
+                return true;
+            }
+        }
+        return false;
+    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/HiveScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/HiveScanNode.java
@@ -126,7 +126,10 @@ public class HiveScanNode extends BrokerScanNode {
     private void setStorageType(String location) throws UserException {
         String[] strings = StringUtils.split(location, "/");
         String storagePrefix = strings[0].split(":")[0];
-        if (storagePrefix.equalsIgnoreCase("s3") || storagePrefix.equalsIgnoreCase("oss")) {
+        if (storagePrefix.equalsIgnoreCase("s3")
+                || storagePrefix.equalsIgnoreCase("oss")
+                || storagePrefix.equalsIgnoreCase("cos")
+                || storagePrefix.equalsIgnoreCase("bos")) {
             this.storageType = StorageBackend.StorageType.S3;
         } else if (storagePrefix.equalsIgnoreCase("hdfs")) {
             this.storageType = StorageBackend.StorageType.HDFS;

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/HiveScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/HiveScanNode.java
@@ -24,6 +24,7 @@ import org.apache.doris.analysis.StorageBackend;
 import org.apache.doris.analysis.TupleDescriptor;
 import org.apache.doris.catalog.HiveMetaStoreClientHelper;
 import org.apache.doris.catalog.HiveTable;
+import org.apache.doris.common.Config;
 import org.apache.doris.common.UserException;
 import org.apache.doris.load.BrokerFileGroup;
 import org.apache.doris.statistics.StatisticalType;
@@ -126,16 +127,23 @@ public class HiveScanNode extends BrokerScanNode {
     private void setStorageType(String location) throws UserException {
         String[] strings = StringUtils.split(location, "/");
         String storagePrefix = strings[0].split(":")[0];
-        if (storagePrefix.equalsIgnoreCase("s3")
-                || storagePrefix.equalsIgnoreCase("oss")
-                || storagePrefix.equalsIgnoreCase("cos")
-                || storagePrefix.equalsIgnoreCase("bos")) {
+        if (isS3LikeStorageSchema(storagePrefix)) {
             this.storageType = StorageBackend.StorageType.S3;
         } else if (storagePrefix.equalsIgnoreCase("hdfs")) {
             this.storageType = StorageBackend.StorageType.HDFS;
         } else {
             throw new UserException("Not supported storage type: " + storagePrefix);
         }
+    }
+
+    private boolean isS3LikeStorageSchema(String schema) {
+        String[] objectStorageList = Config.s3_compatible_object_storages.split(",");
+        for (String objectStorage : objectStorageList) {
+            if (objectStorage.equalsIgnoreCase(schema)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private void initHiveTblProperties() throws UserException {

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/HiveScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/HiveScanNode.java
@@ -126,7 +126,7 @@ public class HiveScanNode extends BrokerScanNode {
     private void setStorageType(String location) throws UserException {
         String[] strings = StringUtils.split(location, "/");
         String storagePrefix = strings[0].split(":")[0];
-        if (storagePrefix.equalsIgnoreCase("s3")) {
+        if (storagePrefix.equalsIgnoreCase("s3") || storagePrefix.equalsIgnoreCase("oss")) {
             this.storageType = StorageBackend.StorageType.S3;
         } else if (storagePrefix.equalsIgnoreCase("hdfs")) {
             this.storageType = StorageBackend.StorageType.HDFS;

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/HiveScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/HiveScanNode.java
@@ -24,8 +24,8 @@ import org.apache.doris.analysis.StorageBackend;
 import org.apache.doris.analysis.TupleDescriptor;
 import org.apache.doris.catalog.HiveMetaStoreClientHelper;
 import org.apache.doris.catalog.HiveTable;
-import org.apache.doris.common.Config;
 import org.apache.doris.common.UserException;
+import org.apache.doris.common.util.Util;
 import org.apache.doris.load.BrokerFileGroup;
 import org.apache.doris.statistics.StatisticalType;
 import org.apache.doris.thrift.TBrokerFileStatus;
@@ -127,23 +127,13 @@ public class HiveScanNode extends BrokerScanNode {
     private void setStorageType(String location) throws UserException {
         String[] strings = StringUtils.split(location, "/");
         String storagePrefix = strings[0].split(":")[0];
-        if (isS3LikeStorageSchema(storagePrefix)) {
+        if (Util.isS3CompatibleStorageSchema(storagePrefix)) {
             this.storageType = StorageBackend.StorageType.S3;
         } else if (storagePrefix.equalsIgnoreCase("hdfs")) {
             this.storageType = StorageBackend.StorageType.HDFS;
         } else {
             throw new UserException("Not supported storage type: " + storagePrefix);
         }
-    }
-
-    private boolean isS3LikeStorageSchema(String schema) {
-        String[] objectStorageList = Config.s3_compatible_object_storages.split(",");
-        for (String objectStorage : objectStorageList) {
-            if (objectStorage.equalsIgnoreCase(schema)) {
-                return true;
-            }
-        }
-        return false;
     }
 
     private void initHiveTblProperties() throws UserException {


### PR DESCRIPTION
# Proposed changes

Provide support for hive external table on Ali oss. Create table:
```
CREATE TABLE `test` (   `k1` integer NOT NULL,   `k2` integer NOT NULL,   `k3` integer ) 
engine=hive properties 
("database"="default", 
"table"="test2", 
"hive.metastore.uris"="thrift://host:port"
"AWS_ACCESS_KEY" = "YOUR_ALI_ACCESS_KEY",
"AWS_SECRET_KEY" = "YOUR_ALI_SECRET_KEY",
"AWS_ENDPOINT" = "YOUR_ALI_ENDPOINT",
"AWS_REGION" = "YOUR_ALI_REGION");
```
select result:
```
MySQL [test]> select * from test;
+------+------+------+
| k1   | k2   | k3   |
+------+------+------+
|    1 |    2 |    3 |
+------+------+------+
1 row in set (0.55 sec)
```

## Problem summary
Fe doesn't support hive external table on oss. While querying for this kind of tables, we get
```Not supported storage type: oss```


## Checklist(Required)

1. Does it affect the original behavior: No
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:No need
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified: No need
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies: No
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back: No
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

