### PR TITLE
[chore](deps) update bdbje and  libhdfs3

### DIFF
--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -183,7 +183,7 @@ under the License.
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.sleepycat</groupId>
+            <groupId>org.apache.doris</groupId>
             <artifactId>je</artifactId>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.mortbay.jetty/jetty -->

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -181,7 +181,7 @@ under the License.
         <java-cup.version>0.11-a-czt02-cdh</java-cup.version>
         <javassist.version>3.18.2-GA</javassist.version>
         <javax.servlet-api.version>3.0.1</javax.servlet-api.version>
-        <je.version>18.3.12</je.version>
+        <je.version>18.3.13-doris-SNAPSHOT</je.version>
         <jetty.version>6.1.14</jetty.version>
         <jflex.version>1.4.3</jflex.version>
         <jmockit.version>1.49</jmockit.version>
@@ -401,7 +401,7 @@ under the License.
                 <scope>provided</scope>
             </dependency>
             <dependency>
-                <groupId>com.sleepycat</groupId>
+                <groupId>org.apache.doris</groupId>
                 <artifactId>je</artifactId>
                 <version>${je.version}</version>
             </dependency>

--- a/thirdparty/CHANGELOG.md
+++ b/thirdparty/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file contains version of the third-party dependency libraries in the build-env image. The docker build-env image is apache/doris, and the tag is `build-env-${version}`
 
+## v20220812
+
+- Modified: libhdfs3 2.3.1 -> 2.3.2
+
 ## v20220718
 
 - Modified: brpc 1.0.0 -> 1.1.0

--- a/thirdparty/vars.sh
+++ b/thirdparty/vars.sh
@@ -355,10 +355,10 @@ KRB5_SOURCE="krb5-1.19"
 KRB5_MD5SUM="aaf18447a5a014aa3b7e81814923f4c9"
 
 # hdfs3
-HDFS3_DOWNLOAD="https://github.com/yangzhg/libhdfs3/archive/refs/tags/v2.3.1.tar.gz"
-HDFS3_NAME="libhdfs3-2.3.1.tar.gz"
-HDFS3_SOURCE="libhdfs3-2.3.1"
-HDFS3_MD5SUM="64ab3004826d83b23522ccf26940db94"
+HDFS3_DOWNLOAD="https://github.com/apache/doris-thirdparty/archive/refs/tags/libhdfs3-v2.3.2.tar.gz"
+HDFS3_NAME="doris-thirdparty-libhdfs3-v2.3.2.tar.gz"
+HDFS3_SOURCE="doris-thirdparty-libhdfs3-v2.3.2"
+HDFS3_MD5SUM="5087ffec0fda4fbcd60a53ed92eb4d2d"
 
 #libdivide
 LIBDIVIDE_DOWNLOAD="https://github.com/ridiculousfish/libdivide/archive/5.0.tar.gz"


### PR DESCRIPTION
# Proposed changes

1. update bdbje to doris bdbje 18.3.13, this will fix await consistent bug for replica node
2. update libhdfs3 to v2.3.2 to improve performance

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
3. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
5. Does it need to update dependencies:
    - [x]Yes
    - [ ] No
6. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

