### PR TITLE
[improvement](orc)improve hdfs scan performance

### DIFF
--- a/thirdparty/vars.sh
+++ b/thirdparty/vars.sh
@@ -355,10 +355,10 @@ KRB5_SOURCE="krb5-1.19"
 KRB5_MD5SUM="aaf18447a5a014aa3b7e81814923f4c9"
 
 # hdfs3
-HDFS3_DOWNLOAD="https://github.com/yangzhg/libhdfs3/archive/refs/tags/v2.3.1.tar.gz"
-HDFS3_NAME="libhdfs3-2.3.1.tar.gz"
-HDFS3_SOURCE="libhdfs3-2.3.1"
-HDFS3_MD5SUM="64ab3004826d83b23522ccf26940db94"
+HDFS3_DOWNLOAD="https://github.com/apache/doris-thirdparty/archive/refs/tags/libhdfs3-v2.3.2.tar.gz"
+HDFS3_NAME="doris-thirdparty-libhdfs3-v2.3.2.tar.gz"
+HDFS3_SOURCE="doris-thirdparty-libhdfs3-v2.3.2"
+HDFS3_MD5SUM="5087ffec0fda4fbcd60a53ed92eb4d2d"
 
 #libdivide
 LIBDIVIDE_DOWNLOAD="https://github.com/ridiculousfish/libdivide/archive/5.0.tar.gz"


### PR DESCRIPTION
# Proposed changes

Issue Number: close #11498

## Problem summary
When run ssb testsuite for hive orc table, the performance is very slow than trino.
10.9s ( doris) vs 5.61s (trino).

Describe your changes.
fix libhdfs3 seek performance issue
https://github.com/apache/doris-thirdparty/pull/2
performance improvment on ssb 30G orc file format

query | after | before
-- | -- | --
Q1.1 | 3.05 | 10.944
Q1.2 | 2.99 | 10.65
Q1.3 | 3.47 | 10.88
Q2.1 | 5.39 | 51.97
Q2.2 | 5.56 | 51.02
Q2.3 | 5.45 | 52.52
Q3.1 | 42 | 82.34
Q3.2 | 34.75 | 77.48
Q3.3 | 33.2 | 71.16
Q3.4 | 32.81 | 72.98
Q4.1 | 101.34 | 143.61
Q4.2 | 43.27 | 96.59
Q4.3 | 47.65 | 111.22
total(s) | 360.93 | 843.364


## Checklist(Required)

1. Does it affect the original behavior: 
    - [Y] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [N ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ N] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [N ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [N ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

