### PR TITLE
[BugFix](FE alter table)fix time accuracy to pass regression test

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/TimeUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/TimeUtils.java
@@ -83,7 +83,7 @@ public class TimeUtils {
             ThreadLocal.withInitial(() -> new SimpleDateFormat("yyyy-MM-dd HH:mm:ss"));
 
     private static ThreadLocal<SimpleDateFormat> datetimeMSFormatThreadLocal =
-            ThreadLocal.withInitial(() -> new SimpleDateFormat("yyyy-MM-dd HH:mm:ss:S"));
+            ThreadLocal.withInitial(() -> new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS"));
 
     static {
         TIME_ZONE = new SimpleTimeZone(8 * 3600 * 1000, "");


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

The alter table job time returns a wrong millisecond accuracy as follows:
![CprGrnqB1U](https://user-images.githubusercontent.com/43750022/182839118-7b09c58a-b2e5-47b8-abd3-672648bc553c.png)

This pr aims to make it more accurate to pass the regression test with high time accuracy requirement.
## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] No
2. Has unit tests been added:
    - [ ] No
3. Has document been added or modified:
    - [ ] No
4. Does it need to update dependencies:
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

