### PR TITLE
[Enhancement](vectorized) Runtime Filter support equivalent slot of outer join

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ExprSubstitutionMap.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ExprSubstitutionMap.java
@@ -29,6 +29,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Map of expression substitutions: lhs[i] gets substituted with rhs[i].
@@ -162,7 +163,7 @@ public final class ExprSubstitutionMap {
      * f [A.id, B.id] g [A.id, C.id]
      * return: g-f [B,id, C,id]
      */
-    public static ExprSubstitutionMap subtraction(ExprSubstitutionMap f, ExprSubstitutionMap g) {
+    public static ExprSubstitutionMap subtraction(ExprSubstitutionMap f, ExprSubstitutionMap g, Analyzer analyzer) {
         if (f == null && g == null) {
             return new ExprSubstitutionMap();
         }
@@ -176,8 +177,16 @@ public final class ExprSubstitutionMap {
         for (int i = 0; i < g.size(); i++) {
             if (f.containsMappingFor(g.lhs.get(i))) {
                 result.put(f.get(g.lhs.get(i)), g.rhs.get(i));
+                if (f.get(g.lhs.get(i)) instanceof SlotRef && g.rhs.get(i) instanceof SlotRef) {
+                    analyzer.putEquivalentSlot(((SlotRef) g.rhs.get(i)).getSlotId(),
+                            ((SlotRef) Objects.requireNonNull(f.get(g.lhs.get(i)))).getSlotId());
+                }
             } else {
                 result.put(g.lhs.get(i), g.rhs.get(i));
+                if (g.lhs.get(i) instanceof SlotRef && g.rhs.get(i) instanceof SlotRef) {
+                    analyzer.putEquivalentSlot(((SlotRef) g.rhs.get(i)).getSlotId(),
+                            ((SlotRef) g.lhs.get(i)).getSlotId());
+                }
             }
         }
         return result;

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/HashJoinNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/HashJoinNode.java
@@ -473,7 +473,7 @@ public class HashJoinNode extends PlanNode {
             }
         }
         // 2. compute srcToOutputMap
-        vSrcToOutputSMap = ExprSubstitutionMap.subtraction(outputSmap, srcTblRefToOutputTupleSmap);
+        vSrcToOutputSMap = ExprSubstitutionMap.subtraction(outputSmap, srcTblRefToOutputTupleSmap, analyzer);
         for (int i = 0; i < vSrcToOutputSMap.size(); i++) {
             Preconditions.checkState(vSrcToOutputSMap.getRhs().get(i) instanceof SlotRef);
             SlotRef rSlotRef = (SlotRef) vSrcToOutputSMap.getRhs().get(i);

--- a/regression-test/suites/tpch_sf1/explain/test_q10.groovy
+++ b/regression-test/suites/tpch_sf1/explain/test_q10.groovy
@@ -70,28 +70,32 @@ suite("test_explain_tpch_sf_1_q10", "tpch_sf1") {
 				"  |  output: sum(<slot 53> * (1 - <slot 54>))\n" + 
 				"  |  group by: <slot 60>, <slot 61>, <slot 62>, <slot 64>, <slot 67>, <slot 63>, <slot 65>") && 
 		explainStr.contains("join op: INNER JOIN(BROADCAST)[The src data has been redistributed]\n" + 
-				"  |  equal join conjunct: <slot 52> = `n_nationkey`") && 
+				"  |  equal join conjunct: <slot 52> = `n_nationkey`\n" + 
+				"  |  runtime filters: RF000[in_or_bloom] <- `n_nationkey`") && 
 		explainStr.contains("vec output tuple id: 8") && 
 		explainStr.contains("output slot ids: 53 54 60 61 62 63 64 65 67 \n" + 
 				"  |  hash output slot ids: 48 49 50 51 5 39 40 46 47 ") && 
 		explainStr.contains("join op: INNER JOIN(BROADCAST)[The src data has been redistributed]\n" + 
-				"  |  equal join conjunct: <slot 36> = `c_custkey`") && 
+				"  |  equal join conjunct: <slot 36> = `c_custkey`\n" + 
+				"  |  runtime filters: RF001[in_or_bloom] <- `c_custkey`") && 
 		explainStr.contains("vec output tuple id: 7") && 
 		explainStr.contains("output slot ids: 39 40 46 47 48 49 50 51 52 \n" + 
 				"  |  hash output slot ids: 32 0 33 1 4 6 7 8 14 ") && 
 		explainStr.contains("join op: INNER JOIN(BROADCAST)[Tables are not in the same group]\n" + 
 				"  |  equal join conjunct: `l_orderkey` = `o_orderkey`\n" + 
-				"  |  runtime filters: RF000[in_or_bloom] <- `o_orderkey`") && 
+				"  |  runtime filters: RF002[in_or_bloom] <- `o_orderkey`") && 
 		explainStr.contains("vec output tuple id: 6") && 
 		explainStr.contains("output slot ids: 32 33 36 \n" + 
 				"  |  hash output slot ids: 2 3 9 ") && 
 		explainStr.contains("TABLE: lineitem(lineitem), PREAGGREGATION: ON\n" + 
 				"     PREDICATES: `l_returnflag` = 'R'\n" + 
-				"     runtime filters: RF000[in_or_bloom] -> `l_orderkey`") && 
+				"     runtime filters: RF002[in_or_bloom] -> `l_orderkey`") && 
 		explainStr.contains("TABLE: nation(nation), PREAGGREGATION: ON") && 
-		explainStr.contains("TABLE: customer(customer), PREAGGREGATION: ON") && 
+		explainStr.contains("TABLE: customer(customer), PREAGGREGATION: ON\n" + 
+				"     runtime filters: RF000[in_or_bloom] -> <slot 14>") && 
 		explainStr.contains("TABLE: orders(orders), PREAGGREGATION: ON\n" + 
-				"     PREDICATES: `o_orderdate` >= '1993-10-01 00:00:00', `o_orderdate` < '1994-01-01 00:00:00'") 
+				"     PREDICATES: `o_orderdate` >= '1993-10-01 00:00:00', `o_orderdate` < '1994-01-01 00:00:00'\n" + 
+				"     runtime filters: RF001[in_or_bloom] -> <slot 9>")
             
         }
     }

--- a/regression-test/suites/tpch_sf1/explain/test_q11.groovy
+++ b/regression-test/suites/tpch_sf1/explain/test_q11.groovy
@@ -69,41 +69,45 @@ suite("test_explain_tpch_sf_1_q11", "tpch_sf1") {
 				"  |  output: sum(<slot 43> * <slot 44>)\n" + 
 				"  |  group by: ") && 
 		explainStr.contains("join op: INNER JOIN(BROADCAST)[The src data has been redistributed]\n" + 
-				"  |  equal join conjunct: <slot 42> = `n_nationkey`") && 
+				"  |  equal join conjunct: <slot 42> = `n_nationkey`\n" + 
+				"  |  runtime filters: RF002[in_or_bloom] <- `n_nationkey`") && 
 		explainStr.contains("vec output tuple id: 15") && 
 		explainStr.contains("output slot ids: 43 44 \n" + 
 				"  |  hash output slot ids: 38 39 ") && 
 		explainStr.contains("join op: INNER JOIN(BROADCAST)[Tables are not in the same group]\n" + 
 				"  |  equal join conjunct: `ps_suppkey` = `s_suppkey`\n" + 
-				"  |  runtime filters: RF001[in_or_bloom] <- `s_suppkey`") && 
+				"  |  runtime filters: RF003[in_or_bloom] <- `s_suppkey`") && 
 		explainStr.contains("vec output tuple id: 14") && 
 		explainStr.contains("output slot ids: 38 39 42 \n" + 
 				"  |  hash output slot ids: 16 12 13 ") && 
 		explainStr.contains("TABLE: partsupp(partsupp), PREAGGREGATION: ON\n" + 
-				"     runtime filters: RF001[in_or_bloom] -> `ps_suppkey`") && 
+				"     runtime filters: RF003[in_or_bloom] -> `ps_suppkey`") && 
 		explainStr.contains("TABLE: nation(nation), PREAGGREGATION: ON\n" + 
 				"     PREDICATES: `n_name` = 'GERMANY'") && 
-		explainStr.contains("TABLE: supplier(supplier), PREAGGREGATION: ON") && 
+		explainStr.contains("TABLE: supplier(supplier), PREAGGREGATION: ON\n" + 
+				"     runtime filters: RF002[in_or_bloom] -> <slot 16>") && 
 		explainStr.contains("VAGGREGATE (update serialize)\n" + 
 				"  |  STREAMING\n" + 
 				"  |  output: sum(<slot 31> * <slot 32>)\n" + 
 				"  |  group by: <slot 30>") && 
 		explainStr.contains("join op: INNER JOIN(BROADCAST)[The src data has been redistributed]\n" + 
-				"  |  equal join conjunct: <slot 29> = `n_nationkey`") && 
+				"  |  equal join conjunct: <slot 29> = `n_nationkey`\n" + 
+				"  |  runtime filters: RF000[in_or_bloom] <- `n_nationkey`") && 
 		explainStr.contains("vec output tuple id: 13") && 
 		explainStr.contains("output slot ids: 30 31 32 \n" + 
 				"  |  hash output slot ids: 24 25 26 ") && 
 		explainStr.contains("join op: INNER JOIN(BROADCAST)[Tables are not in the same group]\n" + 
 				"  |  equal join conjunct: `ps_suppkey` = `s_suppkey`\n" + 
-				"  |  runtime filters: RF000[in_or_bloom] <- `s_suppkey`") && 
+				"  |  runtime filters: RF001[in_or_bloom] <- `s_suppkey`") && 
 		explainStr.contains("vec output tuple id: 12") && 
 		explainStr.contains("output slot ids: 24 25 26 29 \n" + 
 				"  |  hash output slot ids: 0 1 2 5 ") && 
 		explainStr.contains("TABLE: partsupp(partsupp), PREAGGREGATION: ON\n" + 
-				"     runtime filters: RF000[in_or_bloom] -> `ps_suppkey`") && 
+				"     runtime filters: RF001[in_or_bloom] -> `ps_suppkey`") && 
 		explainStr.contains("TABLE: nation(nation), PREAGGREGATION: ON\n" + 
 				"     PREDICATES: `n_name` = 'GERMANY'") && 
-		explainStr.contains("TABLE: supplier(supplier), PREAGGREGATION: ON") 
+		explainStr.contains("TABLE: supplier(supplier), PREAGGREGATION: ON\n" + 
+				"     runtime filters: RF000[in_or_bloom] -> <slot 5>")
             
         }
     }

--- a/regression-test/suites/tpch_sf1/explain/test_q17.groovy
+++ b/regression-test/suites/tpch_sf1/explain/test_q17.groovy
@@ -51,19 +51,20 @@ suite("test_explain_tpch_sf_1_q17", "tpch_sf1") {
 				"  |  group by: ") && 
 		explainStr.contains("join op: LEFT SEMI JOIN(BROADCAST)[The src data has been redistributed]\n" + 
 				"  |  equal join conjunct: <slot 17> = <slot 2> `l_partkey`\n" + 
-				"  |  other join predicates: <slot 32> < 0.2 * <slot 36>") && 
+				"  |  other join predicates: <slot 32> < 0.2 * <slot 36>\n" + 
+				"  |  runtime filters: RF000[in_or_bloom] <- <slot 2> `l_partkey`") && 
 		explainStr.contains("other join predicates: <slot 32> < 0.2 * <slot 36>") && 
 		explainStr.contains("vec output tuple id: 8") && 
 		explainStr.contains("output slot ids: 21 \n" + 
 				"  |  hash output slot ids: 3 14 15 ") && 
 		explainStr.contains("join op: INNER JOIN(BROADCAST)[Tables are not in the same group]\n" + 
 				"  |  equal join conjunct: `l_partkey` = `p_partkey`\n" + 
-				"  |  runtime filters: RF000[in_or_bloom] <- `p_partkey`") && 
+				"  |  runtime filters: RF001[in_or_bloom] <- `p_partkey`") && 
 		explainStr.contains("vec output tuple id: 7") && 
 		explainStr.contains("output slot ids: 14 15 17 \n" + 
 				"  |  hash output slot ids: 6 7 8 ") && 
 		explainStr.contains("TABLE: lineitem(lineitem), PREAGGREGATION: ON\n" + 
-				"     runtime filters: RF000[in_or_bloom] -> `l_partkey`") && 
+				"     runtime filters: RF001[in_or_bloom] -> `l_partkey`") && 
 		explainStr.contains("VAGGREGATE (merge finalize)\n" + 
 				"  |  output: avg(<slot 3> avg(`l_quantity`))\n" + 
 				"  |  group by: <slot 2> `l_partkey`") && 
@@ -73,7 +74,8 @@ suite("test_explain_tpch_sf_1_q17", "tpch_sf1") {
 				"  |  group by: `l_partkey`") && 
 		explainStr.contains("TABLE: lineitem(lineitem), PREAGGREGATION: ON") && 
 		explainStr.contains("TABLE: part(part), PREAGGREGATION: ON\n" + 
-				"     PREDICATES: `p_brand` = 'Brand#23', `p_container` = 'MED BOX'") 
+				"     PREDICATES: `p_brand` = 'Brand#23', `p_container` = 'MED BOX'\n" + 
+				"     runtime filters: RF000[in_or_bloom] -> <slot 7>") && 
             
         }
     }

--- a/regression-test/suites/tpch_sf1/explain/test_q17.groovy
+++ b/regression-test/suites/tpch_sf1/explain/test_q17.groovy
@@ -75,7 +75,7 @@ suite("test_explain_tpch_sf_1_q17", "tpch_sf1") {
 		explainStr.contains("TABLE: lineitem(lineitem), PREAGGREGATION: ON") && 
 		explainStr.contains("TABLE: part(part), PREAGGREGATION: ON\n" + 
 				"     PREDICATES: `p_brand` = 'Brand#23', `p_container` = 'MED BOX'\n" + 
-				"     runtime filters: RF000[in_or_bloom] -> <slot 7>") && 
+				"     runtime filters: RF000[in_or_bloom] -> <slot 7>")
             
         }
     }

--- a/regression-test/suites/tpch_sf1/explain/test_q18.groovy
+++ b/regression-test/suites/tpch_sf1/explain/test_q18.groovy
@@ -71,28 +71,31 @@ suite("test_explain_tpch_sf_1_q18", "tpch_sf1") {
 				"  |  output: sum(<slot 53>)\n" + 
 				"  |  group by: <slot 58>, <slot 59>, <slot 54>, <slot 55>, <slot 56>") && 
 		explainStr.contains("join op: LEFT SEMI JOIN(BROADCAST)[The src data has been redistributed]\n" + 
-				"  |  equal join conjunct: <slot 44> = <slot 8> `l_orderkey`") && 
+				"  |  equal join conjunct: <slot 44> = <slot 8> `l_orderkey`\n" + 
+				"  |  runtime filters: RF000[in_or_bloom] <- <slot 8> `l_orderkey`") && 
 		explainStr.contains("vec output tuple id: 14") && 
 		explainStr.contains("output slot ids: 53 54 55 56 58 59 \n" + 
 				"  |  hash output slot ids: 48 50 51 45 46 47 ") && 
 		explainStr.contains("join op: LEFT SEMI JOIN(BROADCAST)[The src data has been redistributed]\n" + 
-				"  |  equal join conjunct: <slot 38> = <slot 2> `l_orderkey`") && 
+				"  |  equal join conjunct: <slot 38> = <slot 2> `l_orderkey`\n" + 
+				"  |  runtime filters: RF001[in_or_bloom] <- <slot 2> `l_orderkey`") && 
 		explainStr.contains("vec output tuple id: 13") && 
 		explainStr.contains("output slot ids: 44 45 46 47 48 50 51 \n" + 
 				"  |  hash output slot ids: 36 37 38 39 40 42 43 ") && 
 		explainStr.contains("join op: INNER JOIN(BROADCAST)[The src data has been redistributed]\n" + 
-				"  |  equal join conjunct: <slot 35> = `c_custkey`") && 
+				"  |  equal join conjunct: <slot 35> = `c_custkey`\n" + 
+				"  |  runtime filters: RF002[in_or_bloom] <- `c_custkey`") && 
 		explainStr.contains("vec output tuple id: 12") && 
 		explainStr.contains("output slot ids: 36 37 38 39 40 42 43 \n" + 
 				"  |  hash output slot ids: 32 33 34 12 13 30 31 ") && 
 		explainStr.contains("join op: INNER JOIN(BROADCAST)[Tables are not in the same group]\n" + 
 				"  |  equal join conjunct: `l_orderkey` = `o_orderkey`\n" + 
-				"  |  runtime filters: RF000[in_or_bloom] <- `o_orderkey`") && 
+				"  |  runtime filters: RF003[in_or_bloom] <- `o_orderkey`") && 
 		explainStr.contains("vec output tuple id: 11") && 
 		explainStr.contains("output slot ids: 30 31 32 33 34 35 \n" + 
 				"  |  hash output slot ids: 16 17 5 11 14 15 ") && 
 		explainStr.contains("TABLE: lineitem(lineitem), PREAGGREGATION: ON\n" + 
-				"     runtime filters: RF000[in_or_bloom] -> `l_orderkey`") && 
+				"     runtime filters: RF000[in_or_bloom] -> <slot 11>, RF003[in_or_bloom] -> `l_orderkey`") && 
 		explainStr.contains("VAGGREGATE (update finalize)\n" + 
 				"  |  output: sum(`l_quantity`)\n" + 
 				"  |  group by: `l_orderkey`") && 
@@ -102,7 +105,8 @@ suite("test_explain_tpch_sf_1_q18", "tpch_sf1") {
 				"  |  group by: `l_orderkey`") && 
 		explainStr.contains("TABLE: lineitem(lineitem), PREAGGREGATION: ON") && 
 		explainStr.contains("TABLE: customer(customer), PREAGGREGATION: ON") && 
-		explainStr.contains("TABLE: orders(orders), PREAGGREGATION: ON") 
+		explainStr.contains("TABLE: orders(orders), PREAGGREGATION: ON\n" + 
+				"     runtime filters: RF001[in_or_bloom] -> <slot 5>, RF002[in_or_bloom] -> <slot 17>")
             
         }
     }

--- a/regression-test/suites/tpch_sf1/explain/test_q2.groovy
+++ b/regression-test/suites/tpch_sf1/explain/test_q2.groovy
@@ -73,33 +73,37 @@ suite("test_explain_tpch_sf_1_q2", "tpch_sf1") {
 				"  |  order by: <slot 32> `s_acctbal` DESC, <slot 33> `n_name` ASC, <slot 34> `s_name` ASC, <slot 35> `p_partkey` ASC") && 
 		explainStr.contains("join op: LEFT SEMI JOIN(BROADCAST)[The src data has been redistributed]\n" + 
 				"  |  equal join conjunct: <slot 78> = <slot 10> min(`ps_supplycost`)\n" + 
-				"  |  equal join conjunct: <slot 81> = <slot 9> `ps_partkey`") && 
+				"  |  equal join conjunct: <slot 81> = <slot 9> `ps_partkey`\n" + 
+				"  |  runtime filters: RF000[in_or_bloom] <- <slot 10> min(`ps_supplycost`), RF001[in_or_bloom] <- <slot 9> `ps_partkey`") && 
 		explainStr.contains("vec output tuple id: 19") && 
 		explainStr.contains("output slot ids: 121 122 125 126 127 128 129 132 \n" + 
 				"  |  hash output slot ids: 81 82 85 86 87 88 89 92 ") && 
 		explainStr.contains("join op: INNER JOIN(BROADCAST)[The src data has been redistributed]\n" + 
-				"  |  equal join conjunct: <slot 77> = `r_regionkey`") && 
+				"  |  equal join conjunct: <slot 77> = `r_regionkey`\n" + 
+				"  |  runtime filters: RF002[in_or_bloom] <- `r_regionkey`") && 
 		explainStr.contains("vec output tuple id: 15") && 
 		explainStr.contains("output slot ids: 78 81 82 85 86 87 88 89 92 \n" + 
 				"  |  hash output slot ids: 64 65 68 69 70 71 72 75 61 ") && 
 		explainStr.contains("join op: INNER JOIN(BROADCAST)[The src data has been redistributed]\n" + 
-				"  |  equal join conjunct: <slot 60> = `n_nationkey`") && 
+				"  |  equal join conjunct: <slot 60> = `n_nationkey`\n" + 
+				"  |  runtime filters: RF003[in_or_bloom] <- `n_nationkey`") && 
 		explainStr.contains("vec output tuple id: 14") && 
 		explainStr.contains("output slot ids: 61 64 65 68 69 70 71 72 75 77 \n" + 
 				"  |  hash output slot ids: 17 50 51 54 55 56 57 58 29 47 ") && 
 		explainStr.contains("join op: INNER JOIN(BROADCAST)[The src data has been redistributed]\n" + 
-				"  |  equal join conjunct: <slot 42> = `s_suppkey`") && 
+				"  |  equal join conjunct: <slot 42> = `s_suppkey`\n" + 
+				"  |  runtime filters: RF004[in_or_bloom] <- `s_suppkey`") && 
 		explainStr.contains("vec output tuple id: 13") && 
 		explainStr.contains("output slot ids: 47 50 51 54 55 56 57 58 60 \n" + 
 				"  |  hash output slot ids: 16 19 20 21 40 43 27 44 15 ") && 
 		explainStr.contains("join op: INNER JOIN(BROADCAST)[Tables are not in the same group]\n" + 
 				"  |  equal join conjunct: `ps_partkey` = `p_partkey`\n" + 
-				"  |  runtime filters: RF000[in_or_bloom] <- `p_partkey`") && 
+				"  |  runtime filters: RF005[in_or_bloom] <- `p_partkey`") && 
 		explainStr.contains("vec output tuple id: 12") && 
 		explainStr.contains("output slot ids: 40 42 43 44 \n" + 
 				"  |  hash output slot ids: 18 24 13 14 ") && 
 		explainStr.contains("TABLE: partsupp(partsupp), PREAGGREGATION: ON\n" + 
-				"     runtime filters: RF000[in_or_bloom] -> `ps_partkey`") && 
+				"     runtime filters: RF000[in_or_bloom] -> <slot 13>, RF004[in_or_bloom] -> <slot 24>, RF005[in_or_bloom] -> `ps_partkey`") && 
 		explainStr.contains("VAGGREGATE (merge finalize)\n" + 
 				"  |  output: min(<slot 10> min(`ps_supplycost`))\n" + 
 				"  |  group by: <slot 9> `ps_partkey`") && 
@@ -108,33 +112,40 @@ suite("test_explain_tpch_sf_1_q2", "tpch_sf1") {
 				"  |  output: min(<slot 109>)\n" + 
 				"  |  group by: <slot 110>") && 
 		explainStr.contains("join op: INNER JOIN(BROADCAST)[The src data has been redistributed]\n" + 
-				"  |  equal join conjunct: <slot 108> = `r_regionkey`") && 
+				"  |  equal join conjunct: <slot 108> = `r_regionkey`\n" + 
+				"  |  runtime filters: RF006[in_or_bloom] <- `r_regionkey`") && 
 		explainStr.contains("vec output tuple id: 18") && 
 		explainStr.contains("output slot ids: 109 110 \n" + 
 				"  |  hash output slot ids: 102 103 ") && 
 		explainStr.contains("join op: INNER JOIN(BROADCAST)[The src data has been redistributed]\n" + 
-				"  |  equal join conjunct: <slot 101> = `n_nationkey`") && 
+				"  |  equal join conjunct: <slot 101> = `n_nationkey`\n" + 
+				"  |  runtime filters: RF007[in_or_bloom] <- `n_nationkey`") && 
 		explainStr.contains("vec output tuple id: 17") && 
 		explainStr.contains("output slot ids: 102 103 108 \n" + 
 				"  |  hash output slot ids: 97 98 6 ") && 
 		explainStr.contains("join op: INNER JOIN(BROADCAST)[Tables are not in the same group]\n" + 
 				"  |  equal join conjunct: `ps_suppkey` = `s_suppkey`\n" + 
-				"  |  runtime filters: RF001[in_or_bloom] <- `s_suppkey`") && 
+				"  |  runtime filters: RF008[in_or_bloom] <- `s_suppkey`") && 
 		explainStr.contains("vec output tuple id: 16") && 
 		explainStr.contains("output slot ids: 97 98 101 \n" + 
 				"  |  hash output slot ids: 0 1 4 ") && 
 		explainStr.contains("TABLE: partsupp(partsupp), PREAGGREGATION: ON\n" + 
-				"     runtime filters: RF001[in_or_bloom] -> `ps_suppkey`") && 
+				"     runtime filters: RF008[in_or_bloom] -> `ps_suppkey`") && 
 		explainStr.contains("TABLE: region(region), PREAGGREGATION: ON\n" + 
 				"     PREDICATES: `r_name` = 'EUROPE'") && 
-		explainStr.contains("TABLE: nation(nation), PREAGGREGATION: ON") && 
-		explainStr.contains("TABLE: supplier(supplier), PREAGGREGATION: ON") && 
+		explainStr.contains("TABLE: nation(nation), PREAGGREGATION: ON\n" + 
+				"     runtime filters: RF006[in_or_bloom] -> <slot 6>") && 
+		explainStr.contains("TABLE: supplier(supplier), PREAGGREGATION: ON\n" + 
+				"     runtime filters: RF007[in_or_bloom] -> <slot 4>") && 
 		explainStr.contains("TABLE: region(region), PREAGGREGATION: ON\n" + 
 				"     PREDICATES: `r_name` = 'EUROPE'") && 
-		explainStr.contains("TABLE: nation(nation), PREAGGREGATION: ON") && 
-		explainStr.contains("TABLE: supplier(supplier), PREAGGREGATION: ON") && 
+		explainStr.contains("TABLE: nation(nation), PREAGGREGATION: ON\n" + 
+				"     runtime filters: RF002[in_or_bloom] -> <slot 29>") && 
+		explainStr.contains("TABLE: supplier(supplier), PREAGGREGATION: ON\n" + 
+				"     runtime filters: RF003[in_or_bloom] -> <slot 27>") && 
 		explainStr.contains("TABLE: part(part), PREAGGREGATION: ON\n" + 
-				"     PREDICATES: `p_size` = 15, `p_type` LIKE '%BRASS'") 
+				"     PREDICATES: `p_size` = 15, `p_type` LIKE '%BRASS'\n" + 
+				"     runtime filters: RF001[in_or_bloom] -> <slot 14>")
             
         }
     }

--- a/regression-test/suites/tpch_sf1/explain/test_q20.groovy
+++ b/regression-test/suites/tpch_sf1/explain/test_q20.groovy
@@ -63,34 +63,35 @@ suite("test_explain_tpch_sf_1_q20", "tpch_sf1") {
 		explainStr.contains("VTOP-N\n" + 
 				"  |  order by: <slot 23> `s_name` ASC") && 
 		explainStr.contains("join op: LEFT SEMI JOIN(BROADCAST)[The src data has been redistributed]\n" + 
-				"  |  equal join conjunct: <slot 25> = <slot 36>") && 
+				"  |  equal join conjunct: <slot 25> = <slot 36>\n" + 
+				"     runtime filters: RF000[in_or_bloom] <- <slot 36>") && 
 		explainStr.contains("vec output tuple id: 13") && 
 		explainStr.contains("output slot ids: 38 39 \n" + 
 				"  |  hash output slot ids: 26 27 ") && 
 		explainStr.contains("join op: INNER JOIN(BROADCAST)[Tables are not in the same group]\n" + 
 				"  |  equal join conjunct: `s_nationkey` = `n_nationkey`\n" + 
-				"  |  runtime filters: RF000[in_or_bloom] <- `n_nationkey`") && 
+				"  |  runtime filters: RF001[in_or_bloom] <- `n_nationkey`") && 
 		explainStr.contains("vec output tuple id: 10") && 
 		explainStr.contains("output slot ids: 25 26 27 \n" + 
 				"  |  hash output slot ids: 17 18 19 ") && 
 		explainStr.contains("TABLE: supplier(supplier), PREAGGREGATION: ON\n" + 
-				"     runtime filters: RF000[in_or_bloom] -> `s_nationkey`") && 
+				"     runtime filters: RF000[in_or_bloom] -> <slot 17>, RF001[in_or_bloom] -> `s_nationkey`") && 
 		explainStr.contains("join op: LEFT SEMI JOIN(BROADCAST)[The src data has been redistributed]\n" + 
 				"  |  equal join conjunct: <slot 33> = <slot 9> `l_suppkey`\n" + 
 				"  |  equal join conjunct: <slot 31> = <slot 8> `l_partkey`\n" + 
-				"  |  other join predicates: <slot 53> > 0.5 * <slot 57>") && 
-		explainStr.contains("other join predicates: <slot 53> > 0.5 * <slot 57>") && 
+				"  |  other join predicates: <slot 53> > 0.5 * <slot 57>\n" + 
+				"  |  runtime filters: RF002[in_or_bloom] <- <slot 9> `l_suppkey`, RF003[in_or_bloom] <- <slot 8> `l_partkey`") && 
 		explainStr.contains("vec output tuple id: 12") && 
 		explainStr.contains("output slot ids: 36 \n" + 
 				"  |  hash output slot ids: 32 33 10 ") && 
 		explainStr.contains("join op: LEFT SEMI JOIN(BROADCAST)[Tables are not in the same group]\n" + 
 				"  |  equal join conjunct: `ps_partkey` = `p_partkey`\n" + 
-				"  |  runtime filters: RF001[in_or_bloom] <- `p_partkey`") && 
+				"  |  runtime filters: RF004[in_or_bloom] <- `p_partkey`") && 
 		explainStr.contains("vec output tuple id: 11") && 
 		explainStr.contains("output slot ids: 31 32 33 \n" + 
 				"  |  hash output slot ids: 3 14 15 ") && 
 		explainStr.contains("TABLE: partsupp(partsupp), PREAGGREGATION: ON\n" + 
-				"     runtime filters: RF001[in_or_bloom] -> `ps_partkey`") && 
+				"     runtime filters: RF002[in_or_bloom] -> <slot 15>, RF003[in_or_bloom] -> <slot 3>, RF004[in_or_bloom] -> `ps_partkey`") && 
 		explainStr.contains("VAGGREGATE (merge finalize)\n" + 
 				"  |  output: sum(<slot 10> sum(`l_quantity`))\n" + 
 				"  |  group by: <slot 8> `l_partkey`, <slot 9> `l_suppkey`") && 

--- a/regression-test/suites/tpch_sf1/explain/test_q20.groovy
+++ b/regression-test/suites/tpch_sf1/explain/test_q20.groovy
@@ -64,7 +64,7 @@ suite("test_explain_tpch_sf_1_q20", "tpch_sf1") {
 				"  |  order by: <slot 23> `s_name` ASC") && 
 		explainStr.contains("join op: LEFT SEMI JOIN(BROADCAST)[The src data has been redistributed]\n" + 
 				"  |  equal join conjunct: <slot 25> = <slot 36>\n" + 
-				"     runtime filters: RF000[in_or_bloom] <- <slot 36>") && 
+				"  |  runtime filters: RF000[in_or_bloom] <- <slot 36>") && 
 		explainStr.contains("vec output tuple id: 13") && 
 		explainStr.contains("output slot ids: 38 39 \n" + 
 				"  |  hash output slot ids: 26 27 ") && 

--- a/regression-test/suites/tpch_sf1/explain/test_q21.groovy
+++ b/regression-test/suites/tpch_sf1/explain/test_q21.groovy
@@ -118,7 +118,7 @@ suite("test_explain_tpch_sf_1_q21", "tpch_sf1") {
 		explainStr.contains("TABLE: orders(orders), PREAGGREGATION: ON\n" + 
 				"     PREDICATES: `o_orderstatus` = 'F'") && 
 		explainStr.contains("TABLE: supplier(supplier), PREAGGREGATION: ON\n" + 
-				"     runtime filters: RF001[in_or_bloom] -> <slot 76>") && 
+				"     runtime filters: RF001[in_or_bloom] -> <slot 76>")
             
         }
     }

--- a/regression-test/suites/tpch_sf1/explain/test_q21.groovy
+++ b/regression-test/suites/tpch_sf1/explain/test_q21.groovy
@@ -84,30 +84,32 @@ suite("test_explain_tpch_sf_1_q21", "tpch_sf1") {
 				"  |  hash output slot ids: 114 37 110 ") && 
 		explainStr.contains("join op: LEFT SEMI JOIN(BROADCAST)[The src data has been redistributed]\n" + 
 				"  |  equal join conjunct: <slot 100> = `l2`.`l_orderkey`\n" + 
-				"  |  other join predicates: <slot 155> != <slot 151>") && 
-		explainStr.contains("other join predicates: <slot 155> != <slot 151>") && 
+				"  |  other join predicates: <slot 155> != <slot 151>\n" + 
+				"  |  runtime filters: RF000[in_or_bloom] <- `l2`.`l_orderkey`") && 
 		explainStr.contains("vec output tuple id: 13") && 
 		explainStr.contains("output slot ids: 110 111 114 \n" + 
 				"  |  hash output slot ids: 1 99 100 103 ") && 
 		explainStr.contains("join op: INNER JOIN(BROADCAST)[The src data has been redistributed]\n" + 
-				"  |  equal join conjunct: <slot 96> = `n_nationkey`") && 
+				"  |  equal join conjunct: <slot 96> = `n_nationkey`\n" + 
+				"  |  runtime filters: RF001[in_or_bloom] <- `n_nationkey`") && 
 		explainStr.contains("vec output tuple id: 12") && 
 		explainStr.contains("output slot ids: 99 100 103 \n" + 
 				"  |  hash output slot ids: 90 91 94 ") && 
 		explainStr.contains("join op: INNER JOIN(BROADCAST)[The src data has been redistributed]\n" + 
-				"  |  equal join conjunct: <slot 84> = `o_orderkey`") && 
+				"  |  equal join conjunct: <slot 84> = `o_orderkey`\n" + 
+				"  |  runtime filters: RF002[in_or_bloom] <- `o_orderkey`") && 
 		explainStr.contains("vec output tuple id: 11") && 
 		explainStr.contains("output slot ids: 90 91 94 96 \n" + 
 				"  |  hash output slot ids: 83 84 87 89 ") && 
 		explainStr.contains("join op: INNER JOIN(BROADCAST)[Tables are not in the same group]\n" + 
 				"  |  equal join conjunct: `l1`.`l_suppkey` = `s_suppkey`\n" + 
-				"  |  runtime filters: RF000[in_or_bloom] <- `s_suppkey`") && 
+				"  |  runtime filters: RF003[in_or_bloom] <- `s_suppkey`") && 
 		explainStr.contains("vec output tuple id: 10") && 
 		explainStr.contains("output slot ids: 83 84 87 89 \n" + 
 				"  |  hash output slot ids: 34 35 70 76 ") && 
 		explainStr.contains("TABLE: lineitem(lineitem), PREAGGREGATION: ON\n" + 
 				"     PREDICATES: `l1`.`l_receiptdate` > `l1`.`l_commitdate`\n" + 
-				"     runtime filters: RF000[in_or_bloom] -> `l1`.`l_suppkey`") && 
+				"     runtime filters: RF000[in_or_bloom] -> <slot 35>, RF002[in_or_bloom] -> <slot 35>, RF003[in_or_bloom] -> `l1`.`l_suppkey`") && 
 		explainStr.contains("TABLE: lineitem(lineitem), PREAGGREGATION: ON\n" + 
 				"     PREDICATES: `l3`.`l_receiptdate` > `l3`.`l_commitdate`") && 
 		explainStr.contains("TABLE: lineitem(lineitem), PREAGGREGATION: ON") && 
@@ -115,7 +117,8 @@ suite("test_explain_tpch_sf_1_q21", "tpch_sf1") {
 				"     PREDICATES: `n_name` = 'SAUDI ARABIA'") && 
 		explainStr.contains("TABLE: orders(orders), PREAGGREGATION: ON\n" + 
 				"     PREDICATES: `o_orderstatus` = 'F'") && 
-		explainStr.contains("TABLE: supplier(supplier), PREAGGREGATION: ON") 
+		explainStr.contains("TABLE: supplier(supplier), PREAGGREGATION: ON\n" + 
+				"     runtime filters: RF001[in_or_bloom] -> <slot 76>") && 
             
         }
     }

--- a/regression-test/suites/tpch_sf1/explain/test_q3.groovy
+++ b/regression-test/suites/tpch_sf1/explain/test_q3.groovy
@@ -61,23 +61,25 @@ suite("test_explain_tpch_sf_1_q3", "tpch_sf1") {
 				"  |  output: sum(<slot 27> * (1 - <slot 28>))\n" + 
 				"  |  group by: <slot 26>, <slot 30>, <slot 31>") && 
 		explainStr.contains("join op: INNER JOIN(BROADCAST)[The src data has been redistributed]\n" + 
-				"  |  equal join conjunct: <slot 24> = `c_custkey`") && 
+				"  |  equal join conjunct: <slot 24> = `c_custkey`\n" + 
+				"  |  runtime filters: RF000[in_or_bloom] <- `c_custkey`") && 
 		explainStr.contains("vec output tuple id: 6") && 
 		explainStr.contains("output slot ids: 26 27 28 30 31 \n" + 
 				"  |  hash output slot ids: 18 19 20 22 23 ") && 
 		explainStr.contains("join op: INNER JOIN(BROADCAST)[Tables are not in the same group]\n" + 
 				"  |  equal join conjunct: `l_orderkey` = `o_orderkey`\n" + 
-				"  |  runtime filters: RF000[in_or_bloom] <- `o_orderkey`") && 
+				"  |  runtime filters: RF001[in_or_bloom] <- `o_orderkey`") && 
 		explainStr.contains("vec output tuple id: 5") && 
 		explainStr.contains("output slot ids: 18 19 20 22 23 24 \n" + 
 				"  |  hash output slot ids: 0 1 2 3 4 7 ") && 
 		explainStr.contains("TABLE: lineitem(lineitem), PREAGGREGATION: ON\n" + 
 				"     PREDICATES: `l_shipdate` > '1995-03-15 00:00:00'\n" + 
-				"     runtime filters: RF000[in_or_bloom] -> `l_orderkey`") && 
+				"     runtime filters: RF001[in_or_bloom] -> `l_orderkey`") && 
 		explainStr.contains("TABLE: customer(customer), PREAGGREGATION: ON\n" + 
 				"     PREDICATES: `c_mktsegment` = 'BUILDING'") && 
 		explainStr.contains("TABLE: orders(orders), PREAGGREGATION: ON\n" + 
-				"     PREDICATES: `o_orderdate` < '1995-03-15 00:00:00'") 
+				"     PREDICATES: `o_orderdate` < '1995-03-15 00:00:00'\n" + 
+				"     runtime filters: RF000[in_or_bloom] -> <slot 7>")
             
         }
     }

--- a/regression-test/suites/tpch_sf1/explain/test_q5.groovy
+++ b/regression-test/suites/tpch_sf1/explain/test_q5.groovy
@@ -62,41 +62,48 @@ suite("test_explain_tpch_sf_1_q5", "tpch_sf1") {
 				"  |  output: sum(<slot 61> * (1 - <slot 62>))\n" + 
 				"  |  group by: <slot 72>") && 
 		explainStr.contains("join op: INNER JOIN(BROADCAST)[The src data has been redistributed]\n" + 
-				"  |  equal join conjunct: <slot 60> = `r_regionkey`") && 
+				"  |  equal join conjunct: <slot 60> = `r_regionkey`\n" + 
+				"  |  runtime filters: RF000[in_or_bloom] <- `r_regionkey`") && 
 		explainStr.contains("vec output tuple id: 12") && 
 		explainStr.contains("output slot ids: 61 62 72 \n" + 
 				"  |  hash output slot ids: 48 58 47 ") && 
 		explainStr.contains("join op: INNER JOIN(BROADCAST)[The src data has been redistributed]\n" + 
-				"  |  equal join conjunct: <slot 44> = `n_nationkey`") && 
+				"  |  equal join conjunct: <slot 44> = `n_nationkey`\n" + 
+				"  |  runtime filters: RF001[in_or_bloom] <- `n_nationkey`") && 
 		explainStr.contains("vec output tuple id: 11") && 
 		explainStr.contains("output slot ids: 47 48 58 60 \n" + 
 				"  |  hash output slot ids: 0 36 37 12 ") && 
 		explainStr.contains("join op: INNER JOIN(BROADCAST)[The src data has been redistributed]\n" + 
 				"  |  equal join conjunct: <slot 31> = `c_custkey`\n" + 
-				"  |  equal join conjunct: <slot 35> = `c_nationkey`") && 
+				"  |  equal join conjunct: <slot 35> = `c_nationkey`\n" + 
+				"  |  runtime filters: RF002[in_or_bloom] <- `c_custkey`, RF003[in_or_bloom] <- `c_nationkey`") &&  
 		explainStr.contains("vec output tuple id: 10") && 
 		explainStr.contains("output slot ids: 36 37 44 \n" + 
 				"  |  hash output slot ids: 35 27 28 ") && 
 		explainStr.contains("join op: INNER JOIN(BROADCAST)[The src data has been redistributed]\n" + 
-				"  |  equal join conjunct: <slot 23> = `s_suppkey`") && 
+				"  |  equal join conjunct: <slot 23> = `s_suppkey`\n" + 
+				"  |  runtime filters: RF004[in_or_bloom] <- `s_suppkey`") &&  
 		explainStr.contains("vec output tuple id: 9") && 
 		explainStr.contains("output slot ids: 27 28 31 35 \n" + 
 				"  |  hash output slot ids: 20 21 24 10 ") && 
 		explainStr.contains("join op: INNER JOIN(BROADCAST)[Tables are not in the same group]\n" + 
 				"  |  equal join conjunct: `l_orderkey` = `o_orderkey`\n" + 
-				"  |  runtime filters: RF000[in_or_bloom] <- `o_orderkey`") && 
+				"  |  runtime filters: RF005[in_or_bloom] <- `o_orderkey`") && 
 		explainStr.contains("vec output tuple id: 8") && 
 		explainStr.contains("output slot ids: 20 21 23 24 \n" + 
 				"  |  hash output slot ids: 1 2 4 7 ") && 
 		explainStr.contains("TABLE: lineitem(lineitem), PREAGGREGATION: ON\n" + 
-				"     runtime filters: RF000[in_or_bloom] -> `l_orderkey`") && 
+				"     runtime filters: RF004[in_or_bloom] -> <slot 7>, RF005[in_or_bloom] -> `l_orderkey`") && 
 		explainStr.contains("TABLE: region(region), PREAGGREGATION: ON\n" + 
 				"     PREDICATES: `r_name` = 'ASIA'") && 
-		explainStr.contains("TABLE: nation(nation), PREAGGREGATION: ON") && 
+		explainStr.contains("TABLE: nation(nation), PREAGGREGATION: ON\n" + 
+				"     runtime filters: RF000[in_or_bloom] -> <slot 12>") && 
 		explainStr.contains("TABLE: customer(customer), PREAGGREGATION: ON") && 
-		explainStr.contains("TABLE: supplier(supplier), PREAGGREGATION: ON") && 
+		explainStr.contains("TABLE: supplier(supplier), PREAGGREGATION: ON\n" + 
+				"     runtime filters: RF001[in_or_bloom] -> <slot 10>, RF003[in_or_bloom] -> <slot 10>") && 
 		explainStr.contains("TABLE: orders(orders), PREAGGREGATION: ON\n" + 
-				"     PREDICATES: `o_orderdate` >= '1994-01-01 00:00:00', `o_orderdate` < '1995-01-01 00:00:00'") 
+				"     PREDICATES: `o_orderdate` >= '1994-01-01 00:00:00', `o_orderdate` < '1995-01-01 00:00:00'\n" + 
+				"     runtime filters: RF002[in_or_bloom] -> <slot 4>")
             
         }
     }

--- a/regression-test/suites/tpch_sf1/explain/test_q7.groovy
+++ b/regression-test/suites/tpch_sf1/explain/test_q7.groovy
@@ -77,42 +77,49 @@ suite("test_explain_tpch_sf_1_q7", "tpch_sf1") {
 				"  |  group by: <slot 76>, <slot 80>, year(<slot 67>)") && 
 		explainStr.contains("join op: INNER JOIN(BROADCAST)[The src data has been redistributed]\n" + 
 				"  |  equal join conjunct: <slot 66> = `n2`.`n_nationkey`\n" + 
-				"  |  other predicates: ((<slot 113> = 'FRANCE' AND <slot 115> = 'GERMANY') OR (<slot 113> = 'GERMANY' AND <slot 115> = 'FRANCE'))") && 
+				"  |  other predicates: ((<slot 113> = 'FRANCE' AND <slot 115> = 'GERMANY') OR (<slot 113> = 'GERMANY' AND <slot 115> = 'FRANCE'))\n" + 
+				"  |  runtime filters: RF000[in_or_bloom] <- `n2`.`n_nationkey`") && 
 		explainStr.contains("other predicates: ((<slot 113> = 'FRANCE' AND <slot 115> = 'GERMANY') OR (<slot 113> = 'GERMANY' AND <slot 115> = 'FRANCE'))") && 
 		explainStr.contains("vec output tuple id: 13") && 
 		explainStr.contains("output slot ids: 67 68 69 76 80 \n" + 
 				"  |  hash output slot ids: 1 54 55 56 63 ") && 
 		explainStr.contains("join op: INNER JOIN(BROADCAST)[The src data has been redistributed]\n" + 
-				"  |  equal join conjunct: <slot 51> = `c_custkey`") && 
+				"  |  equal join conjunct: <slot 51> = `c_custkey`\n" + 
+				"  |  runtime filters: RF001[in_or_bloom] <- `c_custkey`") && 
 		explainStr.contains("vec output tuple id: 12") && 
 		explainStr.contains("output slot ids: 54 55 56 63 66 \n" + 
 				"  |  hash output slot ids: 52 43 44 45 13 ") && 
 		explainStr.contains("join op: INNER JOIN(BROADCAST)[The src data has been redistributed]\n" + 
-				"  |  equal join conjunct: <slot 40> = `n1`.`n_nationkey`") && 
+				"  |  equal join conjunct: <slot 40> = `n1`.`n_nationkey`\n" + 
+				"  |  runtime filters: RF002[in_or_bloom] <- `n1`.`n_nationkey`") && 
 		explainStr.contains("vec output tuple id: 11") && 
 		explainStr.contains("output slot ids: 43 44 45 51 52 \n" + 
 				"  |  hash output slot ids: 0 34 35 36 42 ") && 
 		explainStr.contains("join op: INNER JOIN(BROADCAST)[The src data has been redistributed]\n" + 
-				"  |  equal join conjunct: <slot 31> = `o_orderkey`") && 
+				"  |  equal join conjunct: <slot 31> = `o_orderkey`\n" + 
+				"  |  runtime filters: RF003[in_or_bloom] <- `o_orderkey`") && 
 		explainStr.contains("vec output tuple id: 10") && 
 		explainStr.contains("output slot ids: 34 35 36 40 42 \n" + 
 				"  |  hash output slot ids: 33 10 27 28 29 ") && 
 		explainStr.contains("join op: INNER JOIN(BROADCAST)[Tables are not in the same group]\n" + 
 				"  |  equal join conjunct: `l_suppkey` = `s_suppkey`\n" + 
-				"  |  runtime filters: RF000[in_or_bloom] <- `s_suppkey`") && 
+				"  |  runtime filters: RF004[in_or_bloom] <- `s_suppkey`") && 
 		explainStr.contains("vec output tuple id: 9") && 
 		explainStr.contains("output slot ids: 27 28 29 31 33 \n" + 
 				"  |  hash output slot ids: 2 3 4 8 11 ") && 
 		explainStr.contains("TABLE: lineitem(lineitem), PREAGGREGATION: ON\n" + 
 				"     PREDICATES: `l_shipdate` >= '1995-01-01 00:00:00', `l_shipdate` <= '1996-12-31 00:00:00'\n" + 
-				"     runtime filters: RF000[in_or_bloom] -> `l_suppkey`") && 
+				"     runtime filters: RF003[in_or_bloom] -> <slot 8>, RF004[in_or_bloom] -> `l_suppkey`") && 
 		explainStr.contains("TABLE: nation(nation), PREAGGREGATION: ON\n" + 
 				"     PREDICATES: (`n2`.`n_name` = 'FRANCE' OR `n2`.`n_name` = 'GERMANY')") && 
-		explainStr.contains("TABLE: customer(customer), PREAGGREGATION: ON") && 
+		explainStr.contains("TABLE: customer(customer), PREAGGREGATION: ON\n" + 
+				"     runtime filters: RF000[in_or_bloom] -> <slot 13>") && 
 		explainStr.contains("TABLE: nation(nation), PREAGGREGATION: ON\n" + 
 				"     PREDICATES: (`n1`.`n_name` = 'FRANCE' OR `n1`.`n_name` = 'GERMANY')") && 
-		explainStr.contains("TABLE: orders(orders), PREAGGREGATION: ON") && 
-		explainStr.contains("TABLE: supplier(supplier), PREAGGREGATION: ON") 
+		explainStr.contains("TABLE: orders(orders), PREAGGREGATION: ON\n" + 
+				"     runtime filters: RF001[in_or_bloom] -> <slot 10>") && 
+		explainStr.contains("TABLE: supplier(supplier), PREAGGREGATION: ON\n" + 
+				"     runtime filters: RF002[in_or_bloom] -> <slot 11>")
             
         }
     }

--- a/regression-test/suites/tpch_sf1/explain/test_q8.groovy
+++ b/regression-test/suites/tpch_sf1/explain/test_q8.groovy
@@ -75,51 +75,61 @@ suite("test_explain_tpch_sf_1_q8", "tpch_sf1") {
 				"  |  output: sum(CASE WHEN <slot 117> = 'BRAZIL' THEN <slot 105> * (1 - <slot 106>) ELSE 0 END), sum(<slot 105> * (1 - <slot 106>))\n" + 
 				"  |  group by: year(<slot 114>)") && 
 		explainStr.contains("join op: INNER JOIN(BROADCAST)[The src data has been redistributed]\n" + 
-				"  |  equal join conjunct: <slot 104> = `r_regionkey`") && 
+				"  |  equal join conjunct: <slot 104> = `r_regionkey`\n" + 
+				"  |  runtime filters: RF000[in_or_bloom] <- `r_regionkey`") && 
 		explainStr.contains("vec output tuple id: 17") && 
 		explainStr.contains("output slot ids: 105 106 114 117 \n" + 
 				"  |  hash output slot ids: 96 99 87 88 ") && 
 		explainStr.contains("join op: INNER JOIN(BROADCAST)[The src data has been redistributed]\n" + 
-				"  |  equal join conjunct: <slot 86> = `n1`.`n_nationkey`") && 
+				"  |  equal join conjunct: <slot 86> = `n1`.`n_nationkey`\n" + 
+				"  |  runtime filters: RF001[in_or_bloom] <- `n1`.`n_nationkey`") && 
 		explainStr.contains("vec output tuple id: 16") && 
 		explainStr.contains("output slot ids: 87 88 96 99 104 \n" + 
 				"  |  hash output slot ids: 80 83 71 72 14 ") && 
 		explainStr.contains("join op: INNER JOIN(BROADCAST)[The src data has been redistributed]\n" + 
-				"  |  equal join conjunct: <slot 68> = `c_custkey`") && 
+				"  |  equal join conjunct: <slot 68> = `c_custkey`\n" + 
+				"  |  runtime filters: RF002[in_or_bloom] <- `c_custkey`") && 
 		explainStr.contains("vec output tuple id: 15") && 
 		explainStr.contains("output slot ids: 71 72 80 83 86 \n" + 
 				"  |  hash output slot ids: 66 69 57 58 12 ") && 
 		explainStr.contains("join op: INNER JOIN(BROADCAST)[The src data has been redistributed]\n" + 
-				"  |  equal join conjunct: <slot 53> = `n2`.`n_nationkey`") && 
+				"  |  equal join conjunct: <slot 53> = `n2`.`n_nationkey`\n" + 
+				"  |  runtime filters: RF003[in_or_bloom] <- `n2`.`n_nationkey`") && 
 		explainStr.contains("vec output tuple id: 14") && 
 		explainStr.contains("output slot ids: 57 58 66 68 69 \n" + 
 				"  |  hash output slot ids: 3 54 56 45 46 ") && 
 		explainStr.contains("join op: INNER JOIN(BROADCAST)[The src data has been redistributed]\n" + 
-				"  |  equal join conjunct: <slot 40> = `o_orderkey`") && 
+				"  |  equal join conjunct: <slot 40> = `o_orderkey`\n" + 
+				"  |  runtime filters: RF004[in_or_bloom] <- `o_orderkey`") && 
 		explainStr.contains("vec output tuple id: 13") && 
 		explainStr.contains("output slot ids: 45 46 53 54 56 \n" + 
 				"  |  hash output slot ids: 0 36 37 10 44 ") && 
 		explainStr.contains("join op: INNER JOIN(BROADCAST)[The src data has been redistributed]\n" + 
-				"  |  equal join conjunct: <slot 32> = `s_suppkey`") && 
+				"  |  equal join conjunct: <slot 32> = `s_suppkey`\n" + 
+				"  |  runtime filters: RF005[in_or_bloom] <- `s_suppkey`") && 
 		explainStr.contains("vec output tuple id: 12") && 
 		explainStr.contains("output slot ids: 36 37 40 44 \n" + 
 				"  |  hash output slot ids: 33 17 29 30 ") && 
 		explainStr.contains("join op: INNER JOIN(BROADCAST)[Tables are not in the same group]\n" + 
 				"  |  equal join conjunct: `l_partkey` = `p_partkey`\n" + 
-				"  |  runtime filters: RF000[in_or_bloom] <- `p_partkey`") && 
+				"  |  runtime filters: RF006[in_or_bloom] <- `p_partkey`") && 
 		explainStr.contains("vec output tuple id: 11") && 
 		explainStr.contains("output slot ids: 29 30 32 33 \n" + 
 				"  |  hash output slot ids: 1 2 7 8 ") && 
 		explainStr.contains("TABLE: lineitem(lineitem), PREAGGREGATION: ON\n" + 
-				"     runtime filters: RF000[in_or_bloom] -> `l_partkey`") && 
+				"     runtime filters: RF004[in_or_bloom] -> <slot 8>, RF005[in_or_bloom] -> <slot 7>, RF006[in_or_bloom] -> `l_partkey`") && 
 		explainStr.contains("TABLE: region(region), PREAGGREGATION: ON\n" + 
 				"     PREDICATES: `r_name` = 'AMERICA'") && 
-		explainStr.contains("TABLE: nation(nation), PREAGGREGATION: ON") && 
-		explainStr.contains("TABLE: customer(customer), PREAGGREGATION: ON") && 
+		explainStr.contains("TABLE: nation(nation), PREAGGREGATION: ON\n" + 
+				"     runtime filters: RF000[in_or_bloom] -> <slot 14>") && 
+		explainStr.contains("TABLE: customer(customer), PREAGGREGATION: ON\n" + 
+				"     runtime filters: RF001[in_or_bloom] -> <slot 12>") && 
 		explainStr.contains("TABLE: nation(nation), PREAGGREGATION: ON") && 
 		explainStr.contains("TABLE: orders(orders), PREAGGREGATION: ON\n" + 
-				"     PREDICATES: `o_orderdate` >= '1995-01-01 00:00:00', `o_orderdate` <= '1996-12-31 00:00:00'") && 
-		explainStr.contains("TABLE: supplier(supplier), PREAGGREGATION: ON") && 
+				"     PREDICATES: `o_orderdate` >= '1995-01-01 00:00:00', `o_orderdate` <= '1996-12-31 00:00:00'\n" + 
+				"     runtime filters: RF002[in_or_bloom] -> <slot 10>") && 
+		explainStr.contains("TABLE: supplier(supplier), PREAGGREGATION: ON\n" + 
+				"     runtime filters: RF003[in_or_bloom] -> <slot 17>") && 
 		explainStr.contains("TABLE: part(part), PREAGGREGATION: ON\n" + 
 				"     PREDICATES: `p_type` = 'ECONOMY ANODIZED STEEL'") 
             

--- a/regression-test/suites/tpch_sf1/explain/test_q9.groovy
+++ b/regression-test/suites/tpch_sf1/explain/test_q9.groovy
@@ -69,40 +69,45 @@ suite("test_explain_tpch_sf_1_q9", "tpch_sf1") {
 				"  |  output: sum(<slot 73> * (1 - <slot 74>) - <slot 81> * <slot 75>)\n" + 
 				"  |  group by: <slot 88>, year(<slot 86>)") && 
 		explainStr.contains("join op: INNER JOIN(BROADCAST)[The src data has been redistributed]\n" + 
-				"  |  equal join conjunct: <slot 65> = `n_nationkey`") && 
+				"  |  equal join conjunct: <slot 65> = `n_nationkey`\n" + 
+				"  |  runtime filters: RF000[in_or_bloom] <- `n_nationkey`") && 
 		explainStr.contains("vec output tuple id: 13") && 
 		explainStr.contains("output slot ids: 73 74 75 81 86 88 \n" + 
 				"  |  hash output slot ids: 0 66 71 58 59 60 ") && 
 		explainStr.contains("join op: INNER JOIN(BROADCAST)[The src data has been redistributed]\n" + 
-				"  |  equal join conjunct: <slot 50> = `o_orderkey`") && 
+				"  |  equal join conjunct: <slot 50> = `o_orderkey`\n" + 
+				"  |  runtime filters: RF001[in_or_bloom] <- `o_orderkey`") && 
 		explainStr.contains("vec output tuple id: 12") && 
 		explainStr.contains("output slot ids: 58 59 60 65 66 71 \n" + 
 				"  |  hash output slot ids: 1 52 53 45 46 47 ") && 
 		explainStr.contains("join op: INNER JOIN(BROADCAST)[The src data has been redistributed]\n" + 
-				"  |  equal join conjunct: <slot 38> = `p_partkey`") && 
+				"  |  equal join conjunct: <slot 38> = `p_partkey`\n" + 
+				"  |  runtime filters: RF002[in_or_bloom] <- `p_partkey`") && 
 		explainStr.contains("vec output tuple id: 11") && 
 		explainStr.contains("output slot ids: 45 46 47 50 52 53 \n" + 
 				"  |  hash output slot ids: 34 35 36 39 41 42 ") && 
 		explainStr.contains("join op: INNER JOIN(BROADCAST)[The src data has been redistributed]\n" + 
 				"  |  equal join conjunct: <slot 29> = `ps_suppkey`\n" + 
-				"  |  equal join conjunct: <slot 30> = `ps_partkey`") && 
+				"  |  equal join conjunct: <slot 30> = `ps_partkey`\n" + 
+				"  |  runtime filters: RF003[in_or_bloom] <- `ps_suppkey`, RF004[in_or_bloom] <- `ps_partkey`") && 
 		explainStr.contains("vec output tuple id: 10") && 
 		explainStr.contains("output slot ids: 34 35 36 38 39 41 42 \n" + 
 				"  |  hash output slot ids: 33 4 26 27 28 30 31 ") && 
 		explainStr.contains("join op: INNER JOIN(BROADCAST)[Tables are not in the same group]\n" + 
 				"  |  equal join conjunct: `l_suppkey` = `s_suppkey`\n" + 
-				"  |  runtime filters: RF000[in_or_bloom] <- `s_suppkey`") && 
+				"  |  runtime filters: RF005[in_or_bloom] <- `s_suppkey`") && 
 		explainStr.contains("vec output tuple id: 9") && 
 		explainStr.contains("output slot ids: 26 27 28 29 30 31 33 \n" + 
 				"  |  hash output slot ids: 2 3 5 7 10 13 14 ") && 
 		explainStr.contains("TABLE: lineitem(lineitem), PREAGGREGATION: ON\n" + 
-				"     runtime filters: RF000[in_or_bloom] -> `l_suppkey`") && 
+				"     runtime filters: RF001[in_or_bloom] -> <slot 13>, RF002[in_or_bloom] -> <slot 10>, RF003[in_or_bloom] -> <slot 7>, RF004[in_or_bloom] -> <slot 10>, RF005[in_or_bloom] -> `l_suppkey`") && 
 		explainStr.contains("TABLE: nation(nation), PREAGGREGATION: ON") && 
 		explainStr.contains("TABLE: orders(orders), PREAGGREGATION: ON") && 
 		explainStr.contains("TABLE: part(part), PREAGGREGATION: ON\n" + 
 				"     PREDICATES: `p_name` LIKE '%green%'") && 
 		explainStr.contains("TABLE: partsupp(partsupp), PREAGGREGATION: ON") && 
-		explainStr.contains("TABLE: supplier(supplier), PREAGGREGATION: ON") 
+		explainStr.contains("TABLE: supplier(supplier), PREAGGREGATION: ON\n" + 
+				"     runtime filters: RF000[in_or_bloom] -> <slot 14>")
             
         }
     }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

This code mainly merges the contents of two v1.1.1 PRs:
1.  [Enhancement] [vectorized] Runtime Filter support equivalent slot of outer join (https://github.com/apache/doris/pull/10654)
2. [hotfix](dev-1.0.1) Fix Runtime Filter support equivalent slot of outer join (https://github.com/apache/doris/pull/10669)

This problem was introduced by (#11068)

## Checklist(Required)

1. Does it affect the original behavior: 
    - [x] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

