### PR TITLE
[improvement](olapscan) Simplify data block queue of VOlapScanNode

### DIFF
--- a/be/src/vec/exec/vaggregation_node.cpp
+++ b/be/src/vec/exec/vaggregation_node.cpp
@@ -68,10 +68,10 @@ static constexpr StreamingHtMinReductionEntry STREAMING_HT_MIN_REDUCTION[] = {
         {0, 0.0},
         // Expand into L3 cache if we look like we're getting some reduction.
         // At present, The L2 cache is generally 1024k or more
-        {1024 * 1024, 1.1},
+        {8 * 1024 * 1024, 1.1},
         // Expand into main memory if we're getting a significant reduction.
         // The L3 cache is generally 16MB or more
-        {16 * 1024 * 1024, 2.0},
+        {32 * 1024 * 1024, 2.0},
 };
 
 static constexpr int STREAMING_HT_MIN_REDUCTION_SIZE =

--- a/be/src/vec/exec/volap_scan_node.h
+++ b/be/src/vec/exec/volap_scan_node.h
@@ -294,6 +294,7 @@ private:
 
     std::mutex _scan_blocks_lock;
     std::condition_variable _scan_block_added_cv;
+    std::condition_variable _scan_block_consumed_cv;
 
     std::vector<Block*> _free_blocks;
     std::mutex _free_blocks_lock;


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

Simplify logic of VOlapScanNode:
1. Remove _materialized_blocks and data block transfer;
2. Remove some unused code.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
3. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
4. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
5. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
6. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

