### PR TITLE
[improvement](alter) modify table's default replica if table is unpartitioned

### DIFF
--- a/docs/en/docs/sql-manual/sql-reference/Data-Definition-Statements/Alter/ALTER-TABLE-PROPERTY.md
+++ b/docs/en/docs/sql-manual/sql-reference/Data-Definition-Statements/Alter/ALTER-TABLE-PROPERTY.md
@@ -154,6 +154,21 @@ Only the MySQL type can be changed to the ODBC type. The value of driver is the 
 ALTER TABLE example_db.mysql_table MODIFY ENGINE TO odbc PROPERTIES("driver" = "MySQL");
 ```
 
+12. Modify the number of copies
+
+```sql
+ALTER TABLE example_db.mysql_table SET ("replication_num" = "2");
+ALTER TABLE example_db.mysql_table SET ("default.replication_num" = "2");
+ALTER TABLE example_db.mysql_table SET ("replication_allocation" = "tag.location.tag1: 1");
+ALTER TABLE example_db.mysql_table SET ("default.replication_allocation" = "tag.location.tag1: 1");
+````
+
+Note:
+1. The property with the default prefix indicates the default replica distribution for the modified table. This modification does not modify the current actual replica distribution of the table, but only affects the replica distribution of newly created partitions on the partitioned table.
+2. For non-partitioned tables, modifying the replica distribution property without the default prefix will modify both the default replica distribution and the actual replica distribution of the table. That is, after the modification, through the `show create table` and `show partitions from tbl` statements, you can see that the replica distribution has been modified.
+changed.
+3. For partitioned tables, the actual replica distribution of the table is at the partition level, that is, each partition has its own replica distribution, which can be viewed through the `show partitions from tbl` statement. If you want to modify the actual replica distribution, see `ALTER TABLE PARTITION`.
+
 ### Example
 
 1. Modify the bloom filter column of the table

--- a/docs/zh-CN/docs/sql-manual/sql-reference/Data-Definition-Statements/Alter/ALTER-TABLE-PROPERTY.md
+++ b/docs/zh-CN/docs/sql-manual/sql-reference/Data-Definition-Statements/Alter/ALTER-TABLE-PROPERTY.md
@@ -148,6 +148,20 @@ ALTER TABLE example_db.my_table MODIFY COLUMN k1 COMMENT "k1", MODIFY COLUMN k2 
 ALTER TABLE example_db.mysql_table MODIFY ENGINE TO odbc PROPERTIES("driver" = "MySQL");
 ```
 
+12. 修改副本数
+
+```sql
+ALTER TABLE example_db.mysql_table SET ("replication_num" = "2");
+ALTER TABLE example_db.mysql_table SET ("default.replication_num" = "2");
+ALTER TABLE example_db.mysql_table SET ("replication_allocation" = "tag.location.tag1: 1");
+ALTER TABLE example_db.mysql_table SET ("default.replication_allocation" = "tag.location.tag1: 1");
+```
+
+注：
+1. default 前缀的属性表示修改表的默认副本分布。这种修改不会修改表的当前实际副本分布，而只影响分区表上新建分区的副本分布。
+2. 对于非分区表，修改不带 default 前缀的副本分布属性，会同时修改表的默认副本分布和实际副本分布。即修改后，通过 `show create table` 和 `show partitions from tbl` 语句可以看到副本分布数据都被修改了。
+3. 对于分区表，表的实际副本分布是分区级别的，即每个分区有自己的副本分布，可以通过 `show partitions from tbl` 语句查看。如果想修改实际副本分布，请参阅 `ALTER TABLE PARTITION`。
+
 ### Example
 
 1. 修改表的 bloom filter 列

--- a/fe/fe-core/src/main/java/org/apache/doris/alter/Alter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/Alter.java
@@ -755,7 +755,8 @@ public class Alter {
                 partitionInfo.setTabletType(partition.getId(), tTabletType);
             }
             ModifyPartitionInfo info = new ModifyPartitionInfo(db.getId(), olapTable.getId(), partition.getId(),
-                    newDataProperty, replicaAlloc, hasInMemory ? newInMemory : oldInMemory, currentStoragePolicy);
+                    newDataProperty, replicaAlloc, hasInMemory ? newInMemory : oldInMemory, currentStoragePolicy,
+                    Maps.newHashMap());
             modifyPartitionInfos.add(info);
         }
 
@@ -779,6 +780,11 @@ public class Alter {
             Optional.ofNullable(info.getStoragePolicy()).filter(p -> !p.isEmpty())
                     .ifPresent(p -> partitionInfo.setStoragePolicy(info.getPartitionId(), p));
             partitionInfo.setIsInMemory(info.getPartitionId(), info.isInMemory());
+
+            Map<String, String> tblProperties = info.getTblProperties();
+            if (tblProperties != null && !tblProperties.isEmpty()) {
+                olapTable.setReplicaAllocation(tblProperties);
+            }
         } finally {
             olapTable.writeUnlock();
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
@@ -3310,13 +3310,10 @@ public class Env {
                                     partitionId);
 
                             // log
-                            ModifyPartitionInfo info =
-                                    new ModifyPartitionInfo(db.getId(), olapTable.getId(),
-                                            partition.getId(),
-                                            hddProperty,
-                                            ReplicaAllocation.NOT_SET,
-                                            partitionInfo.getIsInMemory(partition.getId()),
-                                            partitionInfo.getStoragePolicy(partitionId));
+                            ModifyPartitionInfo info = new ModifyPartitionInfo(db.getId(), olapTable.getId(),
+                                    partition.getId(), hddProperty, ReplicaAllocation.NOT_SET,
+                                    partitionInfo.getIsInMemory(partition.getId()),
+                                    partitionInfo.getStoragePolicy(partitionId), Maps.newHashMap());
 
                             editLog.logModifyPartition(info);
                         }
@@ -4039,9 +4036,16 @@ public class Env {
         boolean isInMemory = partitionInfo.getIsInMemory(partition.getId());
         DataProperty newDataProperty = partitionInfo.getDataProperty(partition.getId());
         partitionInfo.setReplicaAllocation(partition.getId(), replicaAlloc);
+
+        // set table's default replication number.
+        Map<String, String> tblProperties = Maps.newHashMap();
+        tblProperties.put("default.replication_allocation", replicaAlloc.toCreateStmt());
+        table.setReplicaAllocation(tblProperties);
+
         // log
         ModifyPartitionInfo info = new ModifyPartitionInfo(db.getId(), table.getId(), partition.getId(),
-                newDataProperty, replicaAlloc, isInMemory, partitionInfo.getStoragePolicy(partition.getId()));
+                newDataProperty, replicaAlloc, isInMemory, partitionInfo.getStoragePolicy(partition.getId()),
+                tblProperties);
         editLog.logModifyPartition(info);
         LOG.debug("modify partition[{}-{}-{}] replica allocation to {}", db.getId(), table.getId(), partition.getName(),
                 replicaAlloc.toCreateStmt());
@@ -4058,16 +4062,7 @@ public class Env {
     // The caller need to hold the table write lock
     public void modifyTableDefaultReplicaAllocation(Database db, OlapTable table, Map<String, String> properties) {
         Preconditions.checkArgument(table.isWriteLockHeldByCurrentThread());
-
-        TableProperty tableProperty = table.getTableProperty();
-        if (tableProperty == null) {
-            tableProperty = new TableProperty(properties);
-            table.setTableProperty(tableProperty);
-        } else {
-            tableProperty.modifyTableProperties(properties);
-        }
-        tableProperty.buildReplicaAllocation();
-
+        table.setReplicaAllocation(properties);
         // log
         ModifyTablePropertyOperationLog info = new ModifyTablePropertyOperationLog(db.getId(), table.getId(),
                 properties);

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
@@ -1862,11 +1862,21 @@ public class OlapTable extends Table {
                         curMap.put(be.getLocationTag(), (short) (num + 1));
                     }
                     if (!curMap.equals(allocMap)) {
-                        throw new UserException("replica allocation of tablet " + tablet.getId() + " is not expected"
-                                + ", expected: " + allocMap.toString() + ", actual: " + curMap.toString());
+                        throw new UserException(
+                                "replica allocation of tablet " + tablet.getId() + " is not expected" + ", expected: "
+                                        + allocMap.toString() + ", actual: " + curMap.toString());
                     }
                 }
             }
         }
+    }
+
+    public void setReplicaAllocation(Map<String, String> properties) {
+        if (tableProperty == null) {
+            tableProperty = new TableProperty(properties);
+        } else {
+            tableProperty.modifyTableProperties(properties);
+        }
+        tableProperty.buildReplicaAllocation();
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/TableProperty.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/TableProperty.java
@@ -276,7 +276,7 @@ public class TableProperty implements Writable {
 
     public void buildReplicaAllocation() {
         try {
-            // Must copy the properties because "analyzeReplicaAllocation" with remove the property
+            // Must copy the properties because "analyzeReplicaAllocation" will remove the property
             // from the properties.
             Map<String, String> copiedProperties = Maps.newHashMap(properties);
             this.replicaAlloc = PropertyAnalyzer.analyzeReplicaAllocation(copiedProperties, "default");

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/ModifyPartitionInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/ModifyPartitionInfo.java
@@ -25,11 +25,13 @@ import org.apache.doris.common.io.Text;
 import org.apache.doris.common.io.Writable;
 import org.apache.doris.persist.gson.GsonUtils;
 
+import com.google.common.collect.Maps;
 import com.google.gson.annotations.SerializedName;
 
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
+import java.util.Map;
 
 public class ModifyPartitionInfo implements Writable {
 
@@ -50,6 +52,8 @@ public class ModifyPartitionInfo implements Writable {
 
     @SerializedName(value = "storagePolicy")
     private String storagePolicy;
+    @SerializedName(value = "tableProperties")
+    private Map<String, String> tblProperties;
 
     public String getStoragePolicy() {
         return storagePolicy;
@@ -59,9 +63,9 @@ public class ModifyPartitionInfo implements Writable {
         // for persist
     }
 
-    public ModifyPartitionInfo(long dbId, long tableId, long partitionId,
-                               DataProperty dataProperty, ReplicaAllocation replicaAlloc,
-                               boolean isInMemory, String storagePolicy) {
+    public ModifyPartitionInfo(long dbId, long tableId, long partitionId, DataProperty dataProperty,
+            ReplicaAllocation replicaAlloc, boolean isInMemory, String storagePolicy,
+            Map<String, String> tblProperties) {
         this.dbId = dbId;
         this.tableId = tableId;
         this.partitionId = partitionId;
@@ -69,6 +73,10 @@ public class ModifyPartitionInfo implements Writable {
         this.replicaAlloc = replicaAlloc;
         this.isInMemory = isInMemory;
         this.storagePolicy = storagePolicy;
+        this.tblProperties = tblProperties;
+        if (this.tblProperties == null) {
+            this.tblProperties = Maps.newHashMap();
+        }
     }
 
     public long getDbId() {
@@ -93,6 +101,14 @@ public class ModifyPartitionInfo implements Writable {
 
     public boolean isInMemory() {
         return isInMemory;
+    }
+
+    public void setTblProperties(Map<String, String> tblProperties) {
+        this.tblProperties = tblProperties;
+    }
+
+    public Map<String, String> getTblProperties() {
+        return tblProperties;
     }
 
     public static ModifyPartitionInfo read(DataInput in) throws IOException {

--- a/fe/fe-core/src/test/java/org/apache/doris/alter/AlterTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/alter/AlterTest.java
@@ -48,6 +48,8 @@ import org.apache.doris.common.FeConstants;
 import org.apache.doris.common.util.TimeUtils;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.ShowExecutor;
+import org.apache.doris.resource.Tag;
+import org.apache.doris.system.Backend;
 import org.apache.doris.thrift.TStorageMedium;
 import org.apache.doris.utframe.UtFrameUtils;
 
@@ -68,6 +70,7 @@ public class AlterTest {
     private static String runningDir = "fe/mocked/AlterTest/" + UUID.randomUUID().toString() + "/";
 
     private static ConnectContext connectContext;
+    private static Backend be;
 
     @BeforeClass
     public static void beforeClass() throws Exception {
@@ -77,6 +80,8 @@ public class AlterTest {
         Config.disable_storage_medium_check = true;
         UtFrameUtils.createDorisCluster(runningDir);
 
+        be = Env.getCurrentSystemInfo().getIdToBackend().values().asList().get(0);
+
         // create connect context
         connectContext = UtFrameUtils.createDefaultCtx();
         // create database
@@ -84,63 +89,26 @@ public class AlterTest {
         CreateDbStmt createDbStmt = (CreateDbStmt) UtFrameUtils.parseAndAnalyzeStmt(createDbStmtStr, connectContext);
         Env.getCurrentEnv().createDb(createDbStmt);
 
-        createTable("CREATE TABLE test.tbl1\n"
-                + "(\n"
-                + "    k1 date,\n"
-                + "    k2 int,\n"
-                + "    v1 int sum\n"
-                + ")\n"
-                + "PARTITION BY RANGE(k1)\n"
-                + "(\n"
-                + "    PARTITION p1 values less than('2020-02-01'),\n"
-                + "    PARTITION p2 values less than('2020-03-01')\n"
-                + ")\n"
-                + "DISTRIBUTED BY HASH(k2) BUCKETS 3\n"
+        createTable("CREATE TABLE test.tbl1\n" + "(\n" + "    k1 date,\n" + "    k2 int,\n" + "    v1 int sum\n" + ")\n"
+                + "PARTITION BY RANGE(k1)\n" + "(\n" + "    PARTITION p1 values less than('2020-02-01'),\n"
+                + "    PARTITION p2 values less than('2020-03-01')\n" + ")\n" + "DISTRIBUTED BY HASH(k2) BUCKETS 3\n"
                 + "PROPERTIES('replication_num' = '1');");
 
-        createTable("CREATE TABLE test.tbl2\n"
-                + "(\n"
-                + "    k1 date,\n"
-                + "    v1 int sum\n"
-                + ")\n"
-                + "DISTRIBUTED BY HASH (k1) BUCKETS 3\n"
+        createTable("CREATE TABLE test.tbl2\n" + "(\n" + "    k1 date,\n" + "    v1 int sum\n" + ")\n"
+                + "DISTRIBUTED BY HASH (k1) BUCKETS 3\n" + "PROPERTIES('replication_num' = '1');");
+
+        createTable("CREATE TABLE test.tbl3\n" + "(\n" + "    k1 date,\n" + "    k2 int,\n" + "    v1 int sum\n" + ")\n"
+                + "PARTITION BY RANGE(k1)\n" + "(\n" + "    PARTITION p1 values less than('2020-02-01'),\n"
+                + "    PARTITION p2 values less than('2020-03-01')\n" + ")\n" + "DISTRIBUTED BY HASH(k2) BUCKETS 3\n"
                 + "PROPERTIES('replication_num' = '1');");
 
-        createTable("CREATE TABLE test.tbl3\n"
-                + "(\n"
-                + "    k1 date,\n"
-                + "    k2 int,\n"
-                + "    v1 int sum\n"
-                + ")\n"
-                + "PARTITION BY RANGE(k1)\n"
-                + "(\n"
-                + "    PARTITION p1 values less than('2020-02-01'),\n"
-                + "    PARTITION p2 values less than('2020-03-01')\n"
-                + ")\n"
-                + "DISTRIBUTED BY HASH(k2) BUCKETS 3\n"
-                + "PROPERTIES('replication_num' = '1');");
-
-        createTable("CREATE TABLE test.tbl4\n"
-                + "(\n"
-                + "    k1 date,\n"
-                + "    k2 int,\n"
-                + "    v1 int sum\n"
-                + ")\n"
-                + "PARTITION BY RANGE(k1)\n"
-                + "(\n"
-                + "    PARTITION p1 values less than('2020-02-01'),\n"
+        createTable("CREATE TABLE test.tbl4\n" + "(\n" + "    k1 date,\n" + "    k2 int,\n" + "    v1 int sum\n" + ")\n"
+                + "PARTITION BY RANGE(k1)\n" + "(\n" + "    PARTITION p1 values less than('2020-02-01'),\n"
                 + "    PARTITION p2 values less than('2020-03-01'),\n"
                 + "    PARTITION p3 values less than('2020-04-01'),\n"
-                + "    PARTITION p4 values less than('2020-05-01')\n"
-                + ")\n"
-                + "DISTRIBUTED BY HASH(k2) BUCKETS 3\n"
-                + "PROPERTIES"
-                + "("
-                + "    'replication_num' = '1',\n"
-                + "    'in_memory' = 'false',\n"
-                + "    'storage_medium' = 'SSD',\n"
-                + "    'storage_cooldown_time' = '2999-12-31 00:00:00'\n"
-                + ");");
+                + "    PARTITION p4 values less than('2020-05-01')\n" + ")\n" + "DISTRIBUTED BY HASH(k2) BUCKETS 3\n"
+                + "PROPERTIES" + "(" + "    'replication_num' = '1',\n" + "    'in_memory' = 'false',\n"
+                + "    'storage_medium' = 'SSD',\n" + "    'storage_cooldown_time' = '2999-12-31 00:00:00'\n" + ");");
 
         createTable("CREATE TABLE test.tbl5\n" + "(\n" + "    k1 date,\n" + "    k2 int,\n" + "    v1 int \n"
                 + ") ENGINE=OLAP\n" + "UNIQUE KEY (k1,k2)\n" + "PARTITION BY RANGE(k1)\n" + "(\n"
@@ -386,19 +354,31 @@ public class AlterTest {
 
         // set range table's real replication num
         Partition p1 = tbl.getPartition("p1");
-        Assert.assertEquals(Short.valueOf("1"), Short.valueOf(tbl.getPartitionInfo().getReplicaAllocation(p1.getId()).getTotalReplicaNum()));
+        Assert.assertEquals(Short.valueOf("1"),
+                Short.valueOf(tbl.getPartitionInfo().getReplicaAllocation(p1.getId()).getTotalReplicaNum()));
         stmt = "alter table test.tbl1 set ('replication_num' = '3');";
         alterTable(stmt, true);
-        Assert.assertEquals(Short.valueOf("1"), Short.valueOf(tbl.getPartitionInfo().getReplicaAllocation(p1.getId()).getTotalReplicaNum()));
+        Assert.assertEquals(Short.valueOf("1"),
+                Short.valueOf(tbl.getPartitionInfo().getReplicaAllocation(p1.getId()).getTotalReplicaNum()));
 
         // set un-partitioned table's real replication num
+        // first we need to change be's tag
+        Map<String, String> originTagMap = be.getTagMap();
+        Map<String, String> tagMap = Maps.newHashMap();
+        tagMap.put(Tag.TYPE_LOCATION, "group1");
+        be.setTagMap(tagMap);
         OlapTable tbl2 = (OlapTable) db.getTableOrMetaException("tbl2");
         Partition partition = tbl2.getPartition(tbl2.getName());
-        Assert.assertEquals(Short.valueOf("1"), Short.valueOf(tbl2.getPartitionInfo().getReplicaAllocation(partition.getId()).getTotalReplicaNum()));
-        stmt = "alter table test.tbl2 set ('replication_num' = '3');";
-        alterTable(stmt, true);
-        // Assert.assertEquals(Short.valueOf("3"), Short.valueOf(tbl2.getPartitionInfo().getReplicaAllocation(partition.getId()).getTotalReplicaNum()));
-
+        Assert.assertEquals(Short.valueOf("1"),
+                Short.valueOf(tbl2.getPartitionInfo().getReplicaAllocation(partition.getId()).getTotalReplicaNum()));
+        stmt = "alter table test.tbl2 set ('replication_allocation' = 'tag.location.group1:1');";
+        alterTable(stmt, false);
+        Assert.assertEquals((short) 1, (short) tbl2.getPartitionInfo().getReplicaAllocation(partition.getId())
+                .getReplicaNumByTag(Tag.createNotCheck(Tag.TYPE_LOCATION, "group1")));
+        Assert.assertEquals((short) 1, (short) tbl2.getTableProperty().getReplicaAllocation()
+                .getReplicaNumByTag(Tag.createNotCheck(Tag.TYPE_LOCATION, "group1")));
+        be.setTagMap(originTagMap);
+        
         Thread.sleep(5000); // sleep to wait dynamic partition scheduler run
         // add partition without set replication num, and default num is 3.
         stmt = "alter table test.tbl1 add partition p4 values less than('2020-04-10')";

--- a/fe/fe-core/src/test/java/org/apache/doris/alter/AlterTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/alter/AlterTest.java
@@ -378,7 +378,7 @@ public class AlterTest {
         Assert.assertEquals((short) 1, (short) tbl2.getTableProperty().getReplicaAllocation()
                 .getReplicaNumByTag(Tag.createNotCheck(Tag.TYPE_LOCATION, "group1")));
         be.setTagMap(originTagMap);
-        
+
         Thread.sleep(5000); // sleep to wait dynamic partition scheduler run
         // add partition without set replication num, and default num is 3.
         stmt = "alter table test.tbl1 add partition p4 values less than('2020-04-10')";

--- a/fe/fe-core/src/test/java/org/apache/doris/persist/BatchModifyPartitionsInfoTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/persist/BatchModifyPartitionsInfoTest.java
@@ -22,6 +22,7 @@ import org.apache.doris.catalog.ReplicaAllocation;
 import org.apache.doris.common.AnalysisException;
 
 import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
@@ -59,8 +60,8 @@ public class BatchModifyPartitionsInfoTest {
 
         List<Long> partitionIds = Lists.newArrayList(PARTITION_ID_1, PARTITION_ID_2, PARTITION_ID_3);
         for (long partitionId : partitionIds) {
-            modifyInfos.add(new ModifyPartitionInfo(DB_ID, TB_ID, partitionId,
-                    DataProperty.DEFAULT_DATA_PROPERTY, ReplicaAllocation.DEFAULT_ALLOCATION, true, ""));
+            modifyInfos.add(new ModifyPartitionInfo(DB_ID, TB_ID, partitionId, DataProperty.DEFAULT_DATA_PROPERTY,
+                    ReplicaAllocation.DEFAULT_ALLOCATION, true, "", Maps.newHashMap()));
         }
 
         BatchModifyPartitionsInfo batchModifyPartitionsInfo = new BatchModifyPartitionsInfo(modifyInfos);


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

Before, if a table is unpartitioned, when executing following alter stmt:
```
alter table tbl1 set ("replication_num" = "1");
```
Only the tbl1 partition's replication_num is changed
(for unpartitioned table, it also has a single partition with same name as table's)
But the table's default replication_num is unchanged.
So when executing `show create table tbl1`, you will find that the replication_num is still the origin value.

This CL mainly changes:
1. For unpartitioned table, if user change it's replication num, both table's and partition's replication_num will be changed.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [x] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [x] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [x] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

