### PR TITLE
add java format style

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -14,3 +14,19 @@ ReflowComments: false
 SortUsingDeclarations: false
 SpacesBeforeTrailingComments: 1
 SpaceBeforeCpp11BracedList: true
+---
+Language: Java
+BasedOnStyle: Google
+AccessModifierOffset: -4
+AllowShortFunctionsOnASingleLine: Inline
+ColumnLimit: 100
+ConstructorInitializerIndentWidth: 8 # double of IndentWidth
+ContinuationIndentWidth: 8 # double of IndentWidth
+DerivePointerAlignment: false # always use PointerAlignment
+IndentCaseLabels: false
+IndentWidth: 4
+PointerAlignment: Left
+ReflowComments: false
+SortUsingDeclarations: false
+SpacesBeforeTrailingComments: 1
+SpaceBeforeCpp11BracedList: true


### PR DESCRIPTION
Add java style in clang-format to avoid format error when writing java code:
![image](https://user-images.githubusercontent.com/22127746/183027175-8d292c7c-76be-4bb7-98a0-9063496b1f45.png)
