### PR TITLE
[feature-wip](unique-key-merge-on-write) speed up publish_txn

### DIFF
--- a/be/src/exec/olap_scanner.cpp
+++ b/be/src/exec/olap_scanner.cpp
@@ -259,7 +259,9 @@ Status OlapScanner::_init_tablet_reader_params(
         _tablet_reader_params.use_page_cache = true;
     }
 
-    _tablet_reader_params.delete_bitmap = &_tablet->tablet_meta()->delete_bitmap();
+    if (_tablet->enable_unique_key_merge_on_write()) {
+        _tablet_reader_params.delete_bitmap = &_tablet->tablet_meta()->delete_bitmap();
+    }
 
     return Status::OK();
 }

--- a/be/src/olap/delta_writer.cpp
+++ b/be/src/olap/delta_writer.cpp
@@ -138,6 +138,13 @@ Status DeltaWriter::init() {
     RETURN_NOT_OK(_storage_engine->memtable_flush_executor()->create_flush_token(
             &_flush_token, _rowset_writer->type(), _req.is_high_priority));
 
+    // create delete bitmap and get rowset ids snapshot
+    if (_tablet->enable_unique_key_merge_on_write()) {
+        _delete_bitmap = std::make_shared<DeleteBitmap>(-1);
+        std::lock_guard<std::shared_mutex> lck(_tablet->get_header_lock());
+        _rowset_ids = _tablet->all_rs_id();
+    }
+
     _is_init = true;
     return Status::OK();
 }
@@ -283,7 +290,8 @@ Status DeltaWriter::wait_flush() {
 
 void DeltaWriter::_reset_mem_table() {
     _mem_table.reset(new MemTable(_tablet, _schema.get(), _tablet_schema.get(), _req.slots,
-                                  _req.tuple_desc, _rowset_writer.get(), _is_vec));
+                                  _req.tuple_desc, _rowset_writer.get(), _delete_bitmap,
+                                  _rowset_ids, _is_vec));
 }
 
 Status DeltaWriter::close() {
@@ -335,6 +343,11 @@ Status DeltaWriter::close_wait(const PSlaveTabletNodes& slave_tablet_nodes,
         LOG(WARNING) << "Failed to commit txn: " << _req.txn_id
                      << " for rowset: " << _cur_rowset->rowset_id();
         return res;
+    }
+    if (_tablet->enable_unique_key_merge_on_write()) {
+        _storage_engine->txn_manager()->set_txn_related_delete_bitmap(
+                _req.partition_id, _req.txn_id, _tablet->tablet_id(), _tablet->schema_hash(),
+                _tablet->tablet_uid(), true, _delete_bitmap, _rowset_ids);
     }
 
     _delta_written_success = true;

--- a/be/src/olap/delta_writer.h
+++ b/be/src/olap/delta_writer.h
@@ -162,6 +162,10 @@ private:
     std::unordered_set<int64_t> _unfinished_slave_node;
     PSuccessSlaveTabletNodeIds _success_slave_node_ids;
     std::shared_mutex _slave_node_lock;
+
+    DeleteBitmapPtr _delete_bitmap;
+    // current rowset_ids, used to do diff in publish_version
+    RowsetIdUnorderedSet _rowset_ids;
 };
 
 } // namespace doris

--- a/be/src/olap/memtable.h
+++ b/be/src/olap/memtable.h
@@ -43,7 +43,8 @@ class MemTable {
 public:
     MemTable(TabletSharedPtr tablet, Schema* schema, const TabletSchema* tablet_schema,
              const std::vector<SlotDescriptor*>* slot_descs, TupleDescriptor* tuple_desc,
-             RowsetWriter* rowset_writer, bool support_vec = false);
+             RowsetWriter* rowset_writer, DeleteBitmapPtr delete_bitmap,
+             const RowsetIdUnorderedSet& rowset_ids, bool support_vec = false);
     ~MemTable();
 
     int64_t tablet_id() const { return _tablet->tablet_id(); }
@@ -141,6 +142,8 @@ private:
     void _insert_one_row_from_block(RowInBlock* row_in_block);
     void _aggregate_two_row_in_block(RowInBlock* new_row, RowInBlock* row_in_skiplist);
 
+    Status _generate_delete_bitmap();
+
 private:
     TabletSharedPtr _tablet;
     Schema* _schema;
@@ -203,6 +206,9 @@ private:
     size_t _total_size_of_aggregate_states;
     std::vector<RowInBlock*> _row_in_blocks;
     size_t _mem_usage;
+
+    DeleteBitmapPtr _delete_bitmap;
+    RowsetIdUnorderedSet _rowset_ids;
 }; // class MemTable
 
 inline std::ostream& operator<<(std::ostream& os, const MemTable& table) {

--- a/be/src/olap/olap_common.h
+++ b/be/src/olap/olap_common.h
@@ -430,4 +430,6 @@ struct HashOfRowsetId {
     }
 };
 
+using RowsetIdUnorderedSet = std::unordered_set<RowsetId, HashOfRowsetId>;
+
 } // namespace doris

--- a/be/src/olap/rowset/beta_rowset.h
+++ b/be/src/olap/rowset/beta_rowset.h
@@ -76,6 +76,8 @@ public:
 
     Status load_segments(std::vector<segment_v2::SegmentSharedPtr>* segments);
 
+    Status load_segment(int64_t seg_id, segment_v2::SegmentSharedPtr* segment);
+
 protected:
     BetaRowset(TabletSchemaSPtr schema, const std::string& tablet_path,
                RowsetMetaSharedPtr rowset_meta);

--- a/be/src/olap/rowset/beta_rowset_writer.h
+++ b/be/src/olap/rowset/beta_rowset_writer.h
@@ -57,6 +57,10 @@ public:
 
     RowsetSharedPtr build() override;
 
+    // build a tmp rowset for load segment to calc delete_bitmap
+    // for this segment
+    RowsetSharedPtr build_tmp() override;
+
     Version version() override { return _context.version; }
 
     int64_t num_rows() const override { return _num_rows_written; }
@@ -79,6 +83,7 @@ private:
     Status _create_segment_writer(std::unique_ptr<segment_v2::SegmentWriter>* writer);
 
     Status _flush_segment_writer(std::unique_ptr<segment_v2::SegmentWriter>* writer);
+    void _build_rowset_meta(std::shared_ptr<RowsetMeta> rowset_meta);
 
 private:
     RowsetWriterContext _context;

--- a/be/src/olap/rowset/rowset_tree.h
+++ b/be/src/olap/rowset/rowset_tree.h
@@ -72,11 +72,11 @@ public:
     Status Init(const RowsetVector& rowsets);
     ~RowsetTree();
 
-    // Return all Rowsets whose range may contain the given encoded key.
+    // Return Rowsets whose id in rowset_ids and range may contain the given encoded key.
     //
     // The returned pointers are guaranteed to be valid at least until this
     // RowsetTree object is Reset().
-    void FindRowsetsWithKeyInRange(const Slice& encoded_key,
+    void FindRowsetsWithKeyInRange(const Slice& encoded_key, const RowsetIdUnorderedSet* rowset_ids,
                                    vector<std::pair<RowsetSharedPtr, int32_t>>* rowsets) const;
 
     // Call 'cb(rowset, index)' for each (rowset, index) pair such that

--- a/be/src/olap/rowset/rowset_writer.h
+++ b/be/src/olap/rowset/rowset_writer.h
@@ -68,6 +68,11 @@ public:
     // return nullptr when failed
     virtual RowsetSharedPtr build() = 0;
 
+    // we have to load segment data to build delete_bitmap for current segment,
+    // so we  build a tmp rowset ptr to load segment data.
+    // real build will be called in DeltaWriter close_wait.
+    virtual RowsetSharedPtr build_tmp() = 0;
+
     virtual Version version() = 0;
 
     virtual int64_t num_rows() const = 0;

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -1876,10 +1876,10 @@ TabletSchemaSPtr Tablet::tablet_schema() const {
     return rowset_meta->tablet_schema();
 }
 
-Status Tablet::lookup_row_key(const Slice& encoded_key, RowLocation* row_location,
-                              uint32_t version) {
+Status Tablet::lookup_row_key(const Slice& encoded_key, const RowsetIdUnorderedSet* rowset_ids,
+                              RowLocation* row_location, uint32_t version) {
     std::vector<std::pair<RowsetSharedPtr, int32_t>> selected_rs;
-    _rowset_tree->FindRowsetsWithKeyInRange(encoded_key, &selected_rs);
+    _rowset_tree->FindRowsetsWithKeyInRange(encoded_key, rowset_ids, &selected_rs);
     if (selected_rs.empty()) {
         return Status::NotFound("No rowsets contains the key in key range");
     }
@@ -1917,6 +1917,159 @@ Status Tablet::lookup_row_key(const Slice& encoded_key, RowLocation* row_locatio
         return s;
     }
     return Status::NotFound("can't find key in all rowsets");
+}
+
+// load segment may do io so it should out lock
+Status Tablet::_load_rowset_segments(const RowsetSharedPtr& rowset,
+                                     std::vector<segment_v2::SegmentSharedPtr>* segments) {
+    auto beta_rowset = reinterpret_cast<BetaRowset*>(rowset.get());
+    RETURN_IF_ERROR(beta_rowset->load_segments(segments));
+    return Status::OK();
+}
+
+// caller should hold meta_lock
+Status Tablet::calc_delete_bitmap(RowsetId rowset_id,
+                                  const std::vector<segment_v2::SegmentSharedPtr>& segments,
+                                  const RowsetIdUnorderedSet* specified_rowset_ids,
+                                  DeleteBitmapPtr delete_bitmap, bool check_pre_segments) {
+    std::vector<segment_v2::SegmentSharedPtr> pre_segments;
+    OlapStopWatch watch;
+    int64_t end_version = max_version_unlocked().second;
+    Version dummy_version(end_version + 1, end_version + 1);
+    for (auto& seg : segments) {
+        seg->load_index(); // We need index blocks to iterate
+        auto pk_idx = seg->get_primary_key_index();
+        int cnt = 0;
+        int total = pk_idx->num_rows();
+        int32_t remaining = total;
+        bool exact_match = false;
+        std::string last_key;
+        int batch_size = 1024;
+        MemPool pool;
+        while (remaining > 0) {
+            std::unique_ptr<segment_v2::IndexedColumnIterator> iter;
+            RETURN_IF_ERROR(pk_idx->new_iterator(&iter));
+
+            size_t num_to_read = std::min(batch_size, remaining);
+            std::unique_ptr<ColumnVectorBatch> cvb;
+            RETURN_IF_ERROR(ColumnVectorBatch::create(num_to_read, false, pk_idx->type_info(),
+                                                      nullptr, &cvb));
+            ColumnBlock block(cvb.get(), &pool);
+            ColumnBlockView column_block_view(&block);
+            Slice last_key_slice(last_key);
+            RETURN_IF_ERROR(iter->seek_at_or_after(&last_key_slice, &exact_match));
+
+            size_t num_read = num_to_read;
+            RETURN_IF_ERROR(iter->next_batch(&num_read, &column_block_view));
+            DCHECK(num_to_read == num_read);
+            last_key = (reinterpret_cast<const Slice*>(cvb->cell_ptr(num_read - 1)))->to_string();
+
+            // exclude last_key, last_key will be read in next batch.
+            if (num_read == batch_size && num_read != remaining) {
+                num_read -= 1;
+            }
+            for (size_t i = 0; i < num_read; i++) {
+                const Slice* key = reinterpret_cast<const Slice*>(cvb->cell_ptr(i));
+                // first check if exist in pre segment
+                if (check_pre_segments) {
+                    bool find = _check_pk_in_pre_segments(pre_segments, *key, dummy_version,
+                                                          delete_bitmap);
+                    if (find) {
+                        cnt++;
+                        continue;
+                    }
+                }
+                RowLocation loc;
+                auto st = lookup_row_key(*key, specified_rowset_ids, &loc, dummy_version.first - 1);
+                CHECK(st.ok() || st.is_not_found());
+                if (st.is_not_found()) continue;
+                ++cnt;
+                delete_bitmap->add({loc.rowset_id, loc.segment_id, dummy_version.first},
+                                   loc.row_id);
+            }
+            remaining -= num_read;
+        }
+        if (check_pre_segments) {
+            pre_segments.emplace_back(seg);
+        }
+    }
+    LOG(INFO) << "construct delete bitmap tablet: " << tablet_id() << " rowset: " << rowset_id
+              << " dummy_version: " << dummy_version << " cost: " << watch.get_elapse_time_us()
+              << "(us)";
+    return Status::OK();
+}
+
+bool Tablet::_check_pk_in_pre_segments(
+        const std::vector<segment_v2::SegmentSharedPtr>& pre_segments, const Slice& key,
+        const Version& version, DeleteBitmapPtr delete_bitmap) {
+    for (auto it = pre_segments.rbegin(); it != pre_segments.rend(); ++it) {
+        RowLocation loc;
+        auto st = (*it)->lookup_row_key(key, &loc);
+        CHECK(st.ok() || st.is_not_found());
+        if (st.is_not_found()) {
+            continue;
+        }
+        delete_bitmap->add({loc.rowset_id, loc.segment_id, version.first}, loc.row_id);
+        return true;
+    }
+    return false;
+}
+
+void Tablet::_rowset_ids_difference(const RowsetIdUnorderedSet& cur,
+                                    const RowsetIdUnorderedSet& pre, RowsetIdUnorderedSet* to_add,
+                                    RowsetIdUnorderedSet* to_del) {
+    for (const auto& id : cur) {
+        if (pre.find(id) == pre.end()) {
+            to_add->insert(id);
+        }
+    }
+    for (const auto& id : pre) {
+        if (cur.find(id) == cur.end()) {
+            to_del->insert(id);
+        }
+    }
+}
+
+Status Tablet::update_delete_bitmap(const RowsetSharedPtr& rowset, DeleteBitmapPtr delete_bitmap,
+                                    const RowsetIdUnorderedSet& pre_rowset_ids) {
+    RowsetIdUnorderedSet cur_rowset_ids;
+    RowsetIdUnorderedSet rowset_ids_to_add;
+    RowsetIdUnorderedSet rowset_ids_to_del;
+    int64_t cur_version = rowset->start_version();
+
+    std::vector<segment_v2::SegmentSharedPtr> segments;
+    _load_rowset_segments(rowset, &segments);
+
+    std::lock_guard<std::shared_mutex> meta_wrlock(_meta_lock);
+    cur_rowset_ids = all_rs_id();
+    _rowset_ids_difference(cur_rowset_ids, pre_rowset_ids, &rowset_ids_to_add, &rowset_ids_to_del);
+    LOG(INFO) << "rowset_ids_to_add: " << rowset_ids_to_add.size()
+              << ", rowset_ids_to_del: " << rowset_ids_to_del.size();
+    for (const auto& to_del : rowset_ids_to_del) {
+        delete_bitmap->remove({to_del, 0, 0}, {to_del, UINT32_MAX, INT64_MAX});
+    }
+    if (!rowset_ids_to_add.empty()) {
+        RETURN_IF_ERROR(calc_delete_bitmap(rowset->rowset_id(), segments, &rowset_ids_to_add,
+                                           delete_bitmap, true));
+    }
+
+    // update version
+    for (auto iter = delete_bitmap->delete_bitmap.begin();
+         iter != delete_bitmap->delete_bitmap.end(); ++iter) {
+        int ret = _tablet_meta->delete_bitmap().set(
+                {std::get<0>(iter->first), std::get<1>(iter->first), cur_version}, iter->second);
+        DCHECK(ret == 1);
+    }
+
+    return Status::OK();
+}
+
+RowsetIdUnorderedSet Tablet::all_rs_id() const {
+    RowsetIdUnorderedSet rowset_ids;
+    for (const auto& rs_it : _rs_version_map) {
+        rowset_ids.insert(rs_it.second->rowset_id());
+    }
+    return rowset_ids;
 }
 
 void Tablet::remove_self_owned_remote_rowsets() {

--- a/be/src/olap/tablet_meta.h
+++ b/be/src/olap/tablet_meta.h
@@ -70,6 +70,7 @@ class DataDir;
 class TabletMeta;
 class DeleteBitmap;
 using TabletMetaSharedPtr = std::shared_ptr<TabletMeta>;
+using DeleteBitmapPtr = std::shared_ptr<DeleteBitmap>;
 
 // Class encapsulates meta of tablet.
 // The concurrency control is handled in Tablet Class, not in this class.
@@ -337,7 +338,7 @@ public:
     /**
      * Sets the bitmap of specific segment, it's may be insertion or replacement
      *
-     * @return 0 if the insertion took place, 1 if the assignment took place
+     * @return 1 if the insertion took place, 0 if the assignment took place
      */
     int set(const BitmapKey& bmk, const roaring::Roaring& segment_delete_bitmap);
 

--- a/be/src/olap/txn_manager.cpp
+++ b/be/src/olap/txn_manager.cpp
@@ -168,6 +168,31 @@ Status TxnManager::prepare_txn(TPartitionId partition_id, TTransactionId transac
     return Status::OK();
 }
 
+void TxnManager::set_txn_related_delete_bitmap(TPartitionId partition_id,
+                                               TTransactionId transaction_id, TTabletId tablet_id,
+                                               SchemaHash schema_hash, TabletUid tablet_uid,
+                                               bool unique_key_merge_on_write,
+                                               DeleteBitmapPtr delete_bitmap,
+                                               const RowsetIdUnorderedSet& rowset_ids) {
+    pair<int64_t, int64_t> key(partition_id, transaction_id);
+    TabletInfo tablet_info(tablet_id, schema_hash, tablet_uid);
+
+    std::unique_lock<std::mutex> txn_lock(_get_txn_lock(transaction_id));
+    {
+        // get tx
+        std::shared_lock rdlock(_get_txn_map_lock(transaction_id));
+        txn_tablet_map_t& txn_tablet_map = _get_txn_tablet_map(transaction_id);
+        auto it = txn_tablet_map.find(key);
+        DCHECK(it != txn_tablet_map.end());
+        auto load_itr = it->second.find(tablet_info);
+        DCHECK(load_itr != it->second.end());
+        TabletTxnInfo& load_info = load_itr->second;
+        load_info.unique_key_merge_on_write = unique_key_merge_on_write;
+        load_info.delete_bitmap = delete_bitmap;
+        load_info.rowset_ids = rowset_ids;
+    }
+}
+
 Status TxnManager::commit_txn(OlapMeta* meta, TPartitionId partition_id,
                               TTransactionId transaction_id, TTabletId tablet_id,
                               SchemaHash schema_hash, TabletUid tablet_uid,
@@ -264,39 +289,59 @@ Status TxnManager::publish_txn(OlapMeta* meta, TPartitionId partition_id,
     pair<int64_t, int64_t> key(partition_id, transaction_id);
     TabletInfo tablet_info(tablet_id, schema_hash, tablet_uid);
     RowsetSharedPtr rowset_ptr = nullptr;
-    std::unique_lock<std::mutex> txn_lock(_get_txn_lock(transaction_id));
+    TabletTxnInfo* load_info = nullptr;
     {
-        std::shared_lock rlock(_get_txn_map_lock(transaction_id));
-        txn_tablet_map_t& txn_tablet_map = _get_txn_tablet_map(transaction_id);
-        auto it = txn_tablet_map.find(key);
-        if (it != txn_tablet_map.end()) {
-            auto load_itr = it->second.find(tablet_info);
-            if (load_itr != it->second.end()) {
-                // found load for txn,tablet
-                // case 1: user commit rowset, then the load id must be equal
-                TabletTxnInfo& load_info = load_itr->second;
-                rowset_ptr = load_info.rowset;
+        std::unique_lock<std::mutex> txn_lock(_get_txn_lock(transaction_id));
+        {
+            std::shared_lock rlock(_get_txn_map_lock(transaction_id));
+            txn_tablet_map_t& txn_tablet_map = _get_txn_tablet_map(transaction_id);
+            auto it = txn_tablet_map.find(key);
+            if (it != txn_tablet_map.end()) {
+                auto load_itr = it->second.find(tablet_info);
+                if (load_itr != it->second.end()) {
+                    // found load for txn,tablet
+                    // case 1: user commit rowset, then the load id must be equal
+                    load_info = &load_itr->second;
+                    rowset_ptr = load_info->rowset;
+                }
             }
         }
-    }
-    // save meta need access disk, it maybe very slow, so that it is not in global txn lock
-    // it is under a single txn lock
-    if (rowset_ptr != nullptr) {
-        // TODO(ygl): rowset is already set version here, memory is changed, if save failed
-        // it maybe a fatal error
-        rowset_ptr->make_visible(version);
-        Status save_status = RowsetMetaManager::save(meta, tablet_uid, rowset_ptr->rowset_id(),
-                                                     rowset_ptr->rowset_meta()->get_rowset_pb());
-        if (save_status != Status::OK()) {
-            LOG(WARNING) << "save committed rowset failed. when publish txn rowset_id:"
-                         << rowset_ptr->rowset_id() << ", tablet id: " << tablet_id
-                         << ", txn id:" << transaction_id;
-            return Status::OLAPInternalError(OLAP_ERR_ROWSET_SAVE_FAILED);
+        // save meta need access disk, it maybe very slow, so that it is not in global txn lock
+        // it is under a single txn lock
+        if (rowset_ptr != nullptr) {
+            // TODO(ygl): rowset is already set version here, memory is changed, if save failed
+            // it maybe a fatal error
+            rowset_ptr->make_visible(version);
+            Status save_status =
+                    RowsetMetaManager::save(meta, tablet_uid, rowset_ptr->rowset_id(),
+                                            rowset_ptr->rowset_meta()->get_rowset_pb());
+            if (save_status != Status::OK()) {
+                LOG(WARNING) << "save committed rowset failed. when publish txn rowset_id:"
+                             << rowset_ptr->rowset_id() << ", tablet id: " << tablet_id
+                             << ", txn id:" << transaction_id;
+                return Status::OLAPInternalError(OLAP_ERR_ROWSET_SAVE_FAILED);
+            }
+        } else {
+            return Status::OLAPInternalError(OLAP_ERR_TRANSACTION_NOT_EXIST);
         }
-    } else {
-        return Status::OLAPInternalError(OLAP_ERR_TRANSACTION_NOT_EXIST);
+    }
+    // update delete_bitmap
+    {
+        auto tablet = StorageEngine::instance()->tablet_manager()->get_tablet(tablet_id);
+#ifdef BE_TEST
+        if (tablet == nullptr) {
+            return Status::OK();
+        }
+#endif
+        if (load_info != nullptr && load_info->unique_key_merge_on_write) {
+            RETURN_IF_ERROR(tablet->update_delete_bitmap(rowset_ptr, load_info->delete_bitmap,
+                                                         load_info->rowset_ids));
+            std::lock_guard<std::shared_mutex> wrlock(tablet->get_header_lock());
+            tablet->save_meta();
+        }
     }
     {
+        std::unique_lock<std::mutex> txn_lock(_get_txn_lock(transaction_id));
         std::lock_guard<std::shared_mutex> wrlock(_get_txn_map_lock(transaction_id));
         txn_tablet_map_t& txn_tablet_map = _get_txn_tablet_map(transaction_id);
         auto it = txn_tablet_map.find(key);
@@ -313,108 +358,7 @@ Status TxnManager::publish_txn(OlapMeta* meta, TPartitionId partition_id,
             }
         }
     }
-    auto tablet = StorageEngine::instance()->tablet_manager()->get_tablet(tablet_id);
-#ifdef BE_TEST
-    if (tablet == nullptr) {
-        return Status::OK();
-    }
-#endif
-    // Check if have to build extra delete bitmap for table of UNIQUE_KEY model
-    if (!tablet->enable_unique_key_merge_on_write() ||
-        tablet->tablet_meta()->preferred_rowset_type() != RowsetTypePB::BETA_ROWSET ||
-        rowset_ptr->keys_type() != KeysType::UNIQUE_KEYS) {
-        return Status::OK();
-    }
-    CHECK(version.first == version.second) << "impossible: " << version;
-
-    // For each key in current set, check if it overwrites any previously
-    // written keys
-    OlapStopWatch watch;
-    std::vector<segment_v2::SegmentSharedPtr> segments;
-    std::vector<segment_v2::SegmentSharedPtr> pre_segments;
-    auto beta_rowset = reinterpret_cast<BetaRowset*>(rowset_ptr.get());
-    Status st = beta_rowset->load_segments(&segments);
-    if (!st.ok()) return st;
-    // lock tablet meta to modify delete bitmap
-    std::lock_guard<std::shared_mutex> meta_wrlock(tablet->get_header_lock());
-    for (auto& seg : segments) {
-        seg->load_index(); // We need index blocks to iterate
-        auto pk_idx = seg->get_primary_key_index();
-        int cnt = 0;
-        int total = pk_idx->num_rows();
-        int32_t remaining = total;
-        bool exact_match = false;
-        std::string last_key;
-        int batch_size = 1024;
-        MemPool pool;
-        while (remaining > 0) {
-            std::unique_ptr<segment_v2::IndexedColumnIterator> iter;
-            RETURN_IF_ERROR(pk_idx->new_iterator(&iter));
-
-            size_t num_to_read = std::min(batch_size, remaining);
-            std::unique_ptr<ColumnVectorBatch> cvb;
-            RETURN_IF_ERROR(ColumnVectorBatch::create(num_to_read, false, pk_idx->type_info(),
-                                                      nullptr, &cvb));
-            ColumnBlock block(cvb.get(), &pool);
-            ColumnBlockView column_block_view(&block);
-            Slice last_key_slice(last_key);
-            RETURN_IF_ERROR(iter->seek_at_or_after(&last_key_slice, &exact_match));
-
-            size_t num_read = num_to_read;
-            RETURN_IF_ERROR(iter->next_batch(&num_read, &column_block_view));
-            DCHECK(num_to_read == num_read);
-            last_key = (reinterpret_cast<const Slice*>(cvb->cell_ptr(num_read - 1)))->to_string();
-
-            // exclude last_key, last_key will be read in next batch.
-            if (num_read == batch_size && num_read != remaining) {
-                num_read -= 1;
-            }
-            for (size_t i = 0; i < num_read; i++) {
-                const Slice* key = reinterpret_cast<const Slice*>(cvb->cell_ptr(i));
-                // first check if exist in pre segment
-                bool find = _check_pk_in_pre_segments(pre_segments, *key, tablet, version);
-                if (find) {
-                    cnt++;
-                    continue;
-                }
-                RowLocation loc;
-                st = tablet->lookup_row_key(*key, &loc, version.first - 1);
-                CHECK(st.ok() || st.is_not_found());
-                if (st.is_not_found()) continue;
-                ++cnt;
-                // TODO: we can just set a bitmap onece we are done while iteration
-                tablet->tablet_meta()->delete_bitmap().add(
-                        {loc.rowset_id, loc.segment_id, version.first}, loc.row_id);
-            }
-            remaining -= num_read;
-        }
-
-        LOG(INFO) << "construct delete bitmap tablet: " << tablet->tablet_id()
-                  << " rowset: " << beta_rowset->rowset_id() << " segment: " << seg->id()
-                  << " version: " << version << " delete: " << cnt << "/" << total;
-        pre_segments.emplace_back(seg);
-    }
-    tablet->save_meta();
-    LOG(INFO) << "finished to update delete bitmap, tablet: " << tablet->tablet_id()
-              << " version: " << version << ", elapse(us): " << watch.get_elapse_time_us();
     return Status::OK();
-}
-
-bool TxnManager::_check_pk_in_pre_segments(
-        const std::vector<segment_v2::SegmentSharedPtr>& pre_segments, const Slice& key,
-        TabletSharedPtr tablet, const Version& version) {
-    for (auto it = pre_segments.rbegin(); it != pre_segments.rend(); ++it) {
-        RowLocation loc;
-        auto st = (*it)->lookup_row_key(key, &loc);
-        CHECK(st.ok() || st.is_not_found());
-        if (st.is_not_found()) {
-            continue;
-        }
-        tablet->tablet_meta()->delete_bitmap().add({loc.rowset_id, loc.segment_id, version.first},
-                                                   loc.row_id);
-        return true;
-    }
-    return false;
 }
 
 // txn could be rollbacked if it does not have related rowset


### PR DESCRIPTION
In our origin design, we calc delete bitmap in publish txn, and this operation
will cost too much time as it will load segment data and lookup row key in pre
rowset and segments.And publish version task should run in order, so it'll lead
to timeout in publish_txn.

In this pr, we seperate delete_bitmap calculation to tow part, one of it will be
done in flush mem table, so this work can run parallel. And we calc final
delete_bitmap in publish_txn, get a rowset_id set that should be included and
remove rowsets that has been compacted, the rowset difference between memtable_flush
and publish_txn is really small so publish_txn become very fast.In our test,
publish_txn cost about 10ms.

# Proposed changes

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

