### PR TITLE
[Fix](stream-load-json) fix VJsonReader::_write_data_to_column invali…

### DIFF
--- a/regression-test/data/load/stream_load/simple_object_json.json
+++ b/regression-test/data/load/stream_load/simple_object_json.json
@@ -8,3 +8,5 @@
 {"id": 8, "city": "chengdu", "code": 2345678}
 {"id": 9, "city": "xian", "code": 2345679}
 {"id": 10, "city": "hefei", "code": 23456710}
+{"id": 10, "city": null, "code": 23456711}
+{"id": 10, "city": "hefei", "code": null}


### PR DESCRIPTION
…d column type cast when meet null

column_ptr will be a none nullable column pointer after `column_ptr = &nullable_column->get_nested_column()`
so we should not cast column_ptr to ColumnNullable any more

# Proposed changes

Issue Number: close #11567

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

