### PR TITLE
[fix](doc) remove docs for direct compiling on Centos

### DIFF
--- a/docs/en/docs/install/source-install/compilation.md
+++ b/docs/en/docs/install/source-install/compilation.md
@@ -144,7 +144,7 @@ This document focuses on how to code Doris through source code.
 You can also create a Doris development environment mirror yourself, referring specifically to the `docker/README.md` file.
 
 
-## Direct Compilation (CentOS/Ubuntu)
+## Direct Compilation (Ubuntu)
 
 You can try to compile Doris directly in your own Linux environment.
 
@@ -179,28 +179,6 @@ You can try to compile Doris directly in your own Linux environment.
        ln -s /usr/bin/g++-11 /usr/bin/g++
        ln -s /usr/bin/gcc-11 /usr/bin/gcc
        sudo apt-get install autoconf automake libtool autopoint
-       ```
-        If you are using CentOS you can use the following command to install the dependencies
-
-       ```
-       sudo yum groupinstall 'Development Tools' && sudo yum install maven cmake byacc flex automake libtool bison binutils-devel zip unzip ncurses-devel curl git wget python2 glibc-static libstdc++-static java-1.8.0-openjdk
-       sudo yum install centos-release-scl
-       sudo yum install devtoolset-10
-       scl enable devtoolset-10 bash
-       ```
-       If devtoolset-10 is not found in current repo. Oracle has already rebuilt the devtoolset-10 packages. You can use this repo file:
-       ```
-       [ol7_software_collections]
-       name=Software Collection packages for Oracle Linux 7 ($basearch)
-       baseurl=http://yum.oracle.com/repo/OracleLinux/OL7/SoftwareCollections/$basearch/
-       gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-oracle
-       gpgcheck=1
-       enabled=1
-       ```
-       After installation, set environment variables `PATH`, `JAVA_HOME`, etc.
-       > nit: you can find the jdk install directory by using command `alternatives --list`
-
-       Doris 0.14.0 will use gcc7 env to compile.
 
 2. Compile Doris
 

--- a/docs/zh-CN/docs/install/source-install/compilation.md
+++ b/docs/zh-CN/docs/install/source-install/compilation.md
@@ -143,7 +143,7 @@ under the License.
 你也可以自己创建一个 Doris 开发环境镜像，具体可参阅 `docker/README.md` 文件。
 
 
-## 直接编译（CentOS/Ubuntu）
+## 直接编译（Ubuntu）
 
 你可以在自己的 linux 环境中直接尝试编译 Doris。
 
@@ -173,26 +173,6 @@ under the License.
        sudo apt install gcc-10 g++-10 
        sudo apt-get install autoconf automake libtool autopoint
        ```
-
-      如果是CentOS 可以执行以下命令
-       ```
-       sudo yum groupinstall 'Development Tools' && sudo yum install maven cmake byacc flex automake libtool bison binutils-devel zip unzip ncurses-devel curl git wget python2 glibc-static libstdc++-static java-1.8.0-openjdk
-       sudo yum install centos-release-scl
-       sudo yum install devtoolset-10
-       scl enable devtoolset-10 bash
-       ```
-      如果当前仓库没有提供devtoolset-10 可以添加如下repo 使用oracle 提供 package
-       ```
-       [ol7_software_collections]
-       name=Software Collection packages for Oracle Linux 7 ($basearch)
-       baseurl=http://yum.oracle.com/repo/OracleLinux/OL7/SoftwareCollections/$basearch/
-       gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-oracle
-       gpgcheck=1
-       enabled=1
-       ```
-
-   安装完成后，自行设置环境变量 `PATH`, `JAVA_HOME` 等。(可以通过`alternatives --list`命令找到jdk的安装目录)
-   注意： Doris 0.14.0 的版本仍然使用gcc7 的依赖编译，之后的代码将使用gcc10 的依赖
 
 2. 编译 Doris
 


### PR DESCRIPTION
I tried to compile doris on Centos directly according to docs, however
it does not work. It is very difficult to find tools needed by doris
compilation on Centos.

# Proposed changes

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
3. Has document been added or modified:
    - [x] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

