### PR TITLE
[fix](storage-policy) fix bug that missing field when refreshing storage policy

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/policy/StoragePolicy.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/policy/StoragePolicy.java
@@ -373,7 +373,6 @@ public class StoragePolicy extends Policy {
             storageResource = alterStorageResource;
         }
 
-
         md5Checksum = calcPropertiesMd5();
         notifyUpdate();
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
@@ -1046,7 +1046,7 @@ public class FrontendServiceImpl implements FrontendService.Iface {
                     result.addToResultEntrys(rEntry);
                 }
         );
-        if (policyList.size() == 0) {
+        if (!result.isSetResultEntrys()) {
             result.setResultEntrys(new ArrayList<>());
         }
 

--- a/gensrc/thrift/AgentService.thrift
+++ b/gensrc/thrift/AgentService.thrift
@@ -67,16 +67,16 @@ struct TS3StorageParam {
 }
 
 struct TGetStoragePolicy {
-    1: required string policy_name
-    2: required i64 cooldown_datetime
-    3: required i64 cooldown_ttl
-    4: required TS3StorageParam s3_storage_param
-    5: required string md5_checksum
+    1: optional string policy_name
+    2: optional i64 cooldown_datetime
+    3: optional i64 cooldown_ttl
+    4: optional TS3StorageParam s3_storage_param
+    5: optional string md5_checksum
 }
 
 struct TGetStoragePolicyResult {
-    1: required Status.TStatus status
-    2: required list<TGetStoragePolicy> result_entrys
+    1: optional Status.TStatus status
+    2: optional list<TGetStoragePolicy> result_entrys
 }
 
 enum TCompressionType {


### PR DESCRIPTION
# Proposed changes

Issue Number: close #11581

## Problem summary

1. Change all required fields to optional
    Although they all "required", but it not recommended to use `required`, because it is hard to modify in future.
2. Fix a missing field bug

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
3. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
4. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
5. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
6. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

