### PR TITLE
[minor](log) add a warn log to observer invalid query profile

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/profile/ProfileTreeBuilder.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/profile/ProfileTreeBuilder.java
@@ -30,6 +30,8 @@ import lombok.Getter;
 import lombok.Setter;
 import org.apache.commons.lang3.tuple.ImmutableTriple;
 import org.apache.commons.lang3.tuple.Triple;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
 import java.util.Formatter;
@@ -48,6 +50,7 @@ import java.util.regex.Pattern;
  * Each runtime profile of a query should be built once and be read every where.
  */
 public class ProfileTreeBuilder {
+    private static final Logger LOG = LogManager.getLogger(ProfileTreeBuilder.class);
 
     private static final String PROFILE_NAME_DATA_STREAM_SENDER = "DataStreamSender";
     private static final String PROFILE_NAME_VDATA_STREAM_SENDER = "VDataStreamSender";
@@ -228,6 +231,12 @@ public class ProfileTreeBuilder {
             }
         }
         if (senderNode == null || execNode == null) {
+            // TODO(cmy): This shouldn't happen, but there are sporadic errors. So I add a log to observe this error.
+            // Issue: https://github.com/apache/doris/issues/10095
+            StringBuilder sb = new StringBuilder();
+            instanceProfile.prettyPrint(sb, "");
+            LOG.warn("Invalid instance profile, sender is null: {}, execNode is null: {}, instance profile: {}",
+                    (senderNode == null), (execNode == null), sb.toString());
             throw new UserException("Invalid instance profile, without sender or exec node: " + instanceProfile);
         }
         senderNode.addChild(execNode);


### PR DESCRIPTION
# Proposed changes

Issue Number: #10095 

## Problem summary

I try to fix the bug in #10095. the error occurred when I first create a empty table and query it.
But I can't reproduced it again.
So I add a warn log here to observer

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

