### PR TITLE
[fix](scanner) delete predicates might be inconsistent with rowset readers

### DIFF
--- a/be/src/exec/olap_scanner.cpp
+++ b/be/src/exec/olap_scanner.cpp
@@ -113,8 +113,8 @@ Status OlapScanner::prepare(
                 return Status::InternalError(ss.str().c_str());
             }
             // Initialize _params
-            RETURN_IF_ERROR(
-                    _init_tablet_reader_params(key_ranges, filters, bloom_filters, function_filters));
+            RETURN_IF_ERROR(_init_tablet_reader_params(key_ranges, filters, bloom_filters,
+                                                       function_filters));
         }
     }
 

--- a/be/src/exec/olap_scanner.cpp
+++ b/be/src/exec/olap_scanner.cpp
@@ -203,6 +203,9 @@ Status OlapScanner::_init_tablet_reader_params(
     std::copy(function_filters.cbegin(), function_filters.cend(),
               std::inserter(_tablet_reader_params.function_filters,
                             _tablet_reader_params.function_filters.begin()));
+    std::copy(_tablet->delete_predicates().cbegin(), _tablet->delete_predicates().cend(),
+              std::inserter(_tablet_reader_params.delete_predicates,
+                            _tablet_reader_params.delete_predicates.begin()));
 
     // Range
     for (auto key_range : key_ranges) {

--- a/be/src/exec/olap_scanner.cpp
+++ b/be/src/exec/olap_scanner.cpp
@@ -112,13 +112,10 @@ Status OlapScanner::prepare(
                    << ", backend=" << BackendOptions::get_localhost();
                 return Status::InternalError(ss.str().c_str());
             }
+            // Initialize _params
+            RETURN_IF_ERROR(
+                    _init_tablet_reader_params(key_ranges, filters, bloom_filters, function_filters));
         }
-    }
-
-    {
-        // Initialize _params
-        RETURN_IF_ERROR(
-                _init_tablet_reader_params(key_ranges, filters, bloom_filters, function_filters));
     }
 
     return Status::OK();

--- a/be/src/olap/merger.cpp
+++ b/be/src/olap/merger.cpp
@@ -41,6 +41,7 @@ Status Merger::merge_rowsets(TabletSharedPtr tablet, ReaderType reader_type,
     reader_params.reader_type = reader_type;
     reader_params.rs_readers = src_rowset_readers;
     reader_params.version = dst_rowset_writer->version();
+    reader_params.delete_predicates = tablet->delete_predicates();
 
     reader_params.tablet_schema = cur_tablet_schema;
     RETURN_NOT_OK(reader.init(reader_params));
@@ -103,6 +104,7 @@ Status Merger::vmerge_rowsets(TabletSharedPtr tablet, ReaderType reader_type,
     reader_params.rs_readers = src_rowset_readers;
     reader_params.version = dst_rowset_writer->version();
     reader_params.tablet_schema = cur_tablet_schema;
+    reader_params.delete_predicates = tablet->delete_predicates();
     reader_params.delete_bitmap = &tablet->tablet_meta()->delete_bitmap();
     if (stats_output && stats_output->rowid_conversion) {
         reader_params.record_rowids = true;

--- a/be/src/olap/merger.cpp
+++ b/be/src/olap/merger.cpp
@@ -41,10 +41,12 @@ Status Merger::merge_rowsets(TabletSharedPtr tablet, ReaderType reader_type,
     reader_params.reader_type = reader_type;
     reader_params.rs_readers = src_rowset_readers;
     reader_params.version = dst_rowset_writer->version();
-    reader_params.delete_predicates = tablet->delete_predicates();
-    std::copy(tablet->delete_predicates().cbegin(), tablet->delete_predicates().cend(),
-              std::inserter(reader_params.delete_predicates,
-                            reader_params.delete_predicates.begin()));
+    {
+        std::shared_lock rdlock(tablet->get_header_lock());
+        std::copy(tablet->delete_predicates().cbegin(), tablet->delete_predicates().cend(),
+                  std::inserter(reader_params.delete_predicates,
+                                reader_params.delete_predicates.begin()));
+    }
 
     reader_params.tablet_schema = cur_tablet_schema;
     RETURN_NOT_OK(reader.init(reader_params));
@@ -107,9 +109,12 @@ Status Merger::vmerge_rowsets(TabletSharedPtr tablet, ReaderType reader_type,
     reader_params.rs_readers = src_rowset_readers;
     reader_params.version = dst_rowset_writer->version();
     reader_params.tablet_schema = cur_tablet_schema;
-    std::copy(tablet->delete_predicates().cbegin(), tablet->delete_predicates().cend(),
-              std::inserter(reader_params.delete_predicates,
-                            reader_params.delete_predicates.begin()));
+    {
+        std::shared_lock rdlock(tablet->get_header_lock());
+        std::copy(tablet->delete_predicates().cbegin(), tablet->delete_predicates().cend(),
+                  std::inserter(reader_params.delete_predicates,
+                                reader_params.delete_predicates.begin()));
+    }
     reader_params.delete_bitmap = &tablet->tablet_meta()->delete_bitmap();
     if (stats_output && stats_output->rowid_conversion) {
         reader_params.record_rowids = true;

--- a/be/src/olap/merger.cpp
+++ b/be/src/olap/merger.cpp
@@ -42,6 +42,9 @@ Status Merger::merge_rowsets(TabletSharedPtr tablet, ReaderType reader_type,
     reader_params.rs_readers = src_rowset_readers;
     reader_params.version = dst_rowset_writer->version();
     reader_params.delete_predicates = tablet->delete_predicates();
+    std::copy(tablet->delete_predicates().cbegin(), tablet->delete_predicates().cend(),
+              std::inserter(reader_params.delete_predicates,
+                            reader_params.delete_predicates.begin()));
 
     reader_params.tablet_schema = cur_tablet_schema;
     RETURN_NOT_OK(reader.init(reader_params));
@@ -104,7 +107,9 @@ Status Merger::vmerge_rowsets(TabletSharedPtr tablet, ReaderType reader_type,
     reader_params.rs_readers = src_rowset_readers;
     reader_params.version = dst_rowset_writer->version();
     reader_params.tablet_schema = cur_tablet_schema;
-    reader_params.delete_predicates = tablet->delete_predicates();
+    std::copy(tablet->delete_predicates().cbegin(), tablet->delete_predicates().cend(),
+              std::inserter(reader_params.delete_predicates,
+                            reader_params.delete_predicates.begin()));
     reader_params.delete_bitmap = &tablet->tablet_meta()->delete_bitmap();
     if (stats_output && stats_output->rowid_conversion) {
         reader_params.record_rowids = true;

--- a/be/src/olap/reader.cpp
+++ b/be/src/olap/reader.cpp
@@ -613,7 +613,7 @@ Status TabletReader::_init_delete_condition(const ReaderParams& read_params) {
     }
 
     auto delete_init = [&]() -> Status {
-        return _delete_handler.init(_tablet_schema, _tablet->delete_predicates(),
+        return _delete_handler.init(_tablet_schema, read_params.delete_predicates,
                                     read_params.version.second, this);
     };
 
@@ -621,7 +621,6 @@ Status TabletReader::_init_delete_condition(const ReaderParams& read_params) {
         return delete_init();
     }
 
-    std::shared_lock rdlock(_tablet->get_header_lock());
     return delete_init();
 }
 

--- a/be/src/olap/reader.cpp
+++ b/be/src/olap/reader.cpp
@@ -612,16 +612,8 @@ Status TabletReader::_init_delete_condition(const ReaderParams& read_params) {
         _filter_delete = true;
     }
 
-    auto delete_init = [&]() -> Status {
-        return _delete_handler.init(_tablet_schema, read_params.delete_predicates,
-                                    read_params.version.second, this);
-    };
-
-    if (read_params.reader_type == READER_ALTER_TABLE) {
-        return delete_init();
-    }
-
-    return delete_init();
+    return _delete_handler.init(_tablet_schema, read_params.delete_predicates,
+                                read_params.version.second, this);
 }
 
 } // namespace doris

--- a/be/src/olap/reader.h
+++ b/be/src/olap/reader.h
@@ -79,8 +79,9 @@ public:
         std::vector<TCondition> conditions;
         std::vector<std::pair<string, std::shared_ptr<IBloomFilterFuncBase>>> bloom_filters;
         std::vector<FunctionFilter> function_filters;
+        std::vector<DeletePredicatePB> delete_predicates;
 
-        // For primary-key table
+        // For unique key table with merge-on-write
         DeleteBitmap* delete_bitmap {nullptr};
 
         std::vector<RowsetReaderSharedPtr> rs_readers;

--- a/be/src/vec/exec/volap_scanner.cpp
+++ b/be/src/vec/exec/volap_scanner.cpp
@@ -106,13 +106,11 @@ Status VOlapScanner::prepare(
                    << ", backend=" << BackendOptions::get_localhost();
                 return Status::InternalError(ss.str());
             }
-        }
-    }
 
-    {
-        // Initialize tablet_reader_params
-        RETURN_IF_ERROR(
-                _init_tablet_reader_params(key_ranges, filters, bloom_filters, function_filters));
+            // Initialize tablet_reader_params
+            RETURN_IF_ERROR(
+                    _init_tablet_reader_params(key_ranges, filters, bloom_filters, function_filters));
+        }
     }
 
     return Status::OK();
@@ -194,6 +192,10 @@ Status VOlapScanner::_init_tablet_reader_params(
     std::copy(function_filters.cbegin(), function_filters.cend(),
               std::inserter(_tablet_reader_params.function_filters,
                             _tablet_reader_params.function_filters.begin()));
+
+    std::copy(_tablet->delete_predicates().cbegin(), _tablet->delete_predicates().cend(),
+              std::inserter(_tablet_reader_params.delete_predicates,
+                            _tablet_reader_params.delete_predicates.begin()));
 
     // Range
     for (auto key_range : key_ranges) {

--- a/be/src/vec/exec/volap_scanner.cpp
+++ b/be/src/vec/exec/volap_scanner.cpp
@@ -108,8 +108,8 @@ Status VOlapScanner::prepare(
             }
 
             // Initialize tablet_reader_params
-            RETURN_IF_ERROR(
-                    _init_tablet_reader_params(key_ranges, filters, bloom_filters, function_filters));
+            RETURN_IF_ERROR(_init_tablet_reader_params(key_ranges, filters, bloom_filters,
+                                                       function_filters));
         }
     }
 


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

For now, the scanner capture rowset readers and init delete_handler in different place, although both of these operations acquired the _meta_lock of Tablet class, but they are separate.

So the following situation would happen:
1. scanner will read rowset A, B, C, D, rowset C has delete predicate
2. scanner capture the rowset reader for A, B, C, D
3. a base compaction just completed, merged A, B, C to C1, then removed the delete predicate of rowset C
4. scanner try to init the delete handler, but it can't get the delete predicate of rowset C 
5. scanner will read all data which should be deleted in rowset C, the result is incorrect

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
7. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
8. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
9. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
10. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

