### PR TITLE
[dev-1.1.2][fix](parquet-reader) fix concurrency bug

### DIFF
--- a/be/src/exec/parquet_reader.cpp
+++ b/be/src/exec/parquet_reader.cpp
@@ -37,8 +37,6 @@
 #include "runtime/mem_pool.h"
 #include "runtime/tuple.h"
 #include "util/thrift_util.h"
-#include "util/stack_util.h"
-#include "util/stack_util.h"
 
 namespace doris {
 

--- a/be/src/exec/parquet_reader.h
+++ b/be/src/exec/parquet_reader.h
@@ -59,18 +59,24 @@ class ParquetFile : public arrow::io::RandomAccessFile {
 public:
     ParquetFile(FileReader* file);
     ~ParquetFile() override;
-    arrow::Result<int64_t> Read(int64_t nbytes, void* buffer) override;
-    arrow::Result<int64_t> ReadAt(int64_t position, int64_t nbytes, void* out) override;
-    arrow::Result<int64_t> GetSize() override;
+
     arrow::Status Seek(int64_t position) override;
+    arrow::Result<int64_t> Read(int64_t nbytes, void* buffer) override;
     arrow::Result<std::shared_ptr<arrow::Buffer>> Read(int64_t nbytes) override;
+
+    arrow::Result<int64_t> ReadAt(int64_t position, int64_t nbytes, void* out) override;
+    arrow::Result<std::shared_ptr<arrow::Buffer>> ReadAt(int64_t position, int64_t nbytes) override;
+
+    arrow::Result<int64_t> GetSize() override;
     arrow::Result<int64_t> Tell() const override;
     arrow::Status Close() override;
     bool closed() const override;
 
 private:
+    std::mutex _lock;
     FileReader* _file;
     int64_t _pos = 0;
+    bool _is_closed = false;
 };
 
 // Reader of broker parquet file

--- a/be/src/exec/parquet_reader.h
+++ b/be/src/exec/parquet_reader.h
@@ -37,6 +37,7 @@
 #include <mutex>
 #include <string>
 #include <thread>
+#include <future>
 
 #include "common/status.h"
 #include "common/config.h"
@@ -103,7 +104,7 @@ private:
                             int32_t* wbtyes);
 
 private:
-    void prefetch_batch();
+    void prefetch_batch(std::promise<Status>* status);
     Status read_next_batch();
 
 private:
@@ -135,6 +136,8 @@ private:
     std::condition_variable _queue_writer_cond;
     std::list<std::shared_ptr<arrow::RecordBatch>> _queue;
     const size_t _max_queue_size = config::parquet_reader_max_buffer_size;
+
+    std::promise<Status> thread_status;
 };
 
 } // namespace doris

--- a/be/src/exec/parquet_scanner.cpp
+++ b/be/src/exec/parquet_scanner.cpp
@@ -135,8 +135,7 @@ Status ParquetScanner::open_next_reader() {
             break;
         }
         case TFileType::FILE_S3: {
-            file_reader.reset(new BufferedReader(
-                    _profile, new S3Reader(_params.properties, range.path, range.start_offset)));
+            file_reader.reset(new S3Reader(_params.properties, range.path, range.start_offset));
             break;
         }
         default: {


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

Only fixed in v1.1.x.
I will push another PR to master branch.

This CL mainly changes:
1. wait for the prefetch thread in parquet reader to stop before closing the parquet file, to avoid heap-use-after-free bug
2. Make ParquetFile thread-safe, required by arrow.


## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
3. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
5. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
6. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

