### PR TITLE
[Bug](show data skew)fix show data skew logic

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/MetadataViewer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/MetadataViewer.java
@@ -245,7 +245,7 @@ public class MetadataViewer {
 
     private static String graph(long num, long totalNum) {
         StringBuilder sb = new StringBuilder();
-        long normalized = num == totalNum ? 100 : (int) Math.ceil(num * 100 / totalNum);
+        long normalized = num == totalNum ? (totalNum == 0L ? 0 : 100) : (int) Math.ceil(num * 100 / totalNum);
         for (int i = 0; i < normalized; ++i) {
             sb.append(">");
         }
@@ -309,8 +309,8 @@ public class MetadataViewer {
                 row.add(rowCountTabletInfos.get(i).toString());
                 row.add(dataSizeTabletInfos.get(i).toString());
                 row.add(graph(dataSizeTabletInfos.get(i), totalSize));
-                row.add(totalSize == dataSizeTabletInfos.get(i)
-                        ? "100.00%" : df.format((double) dataSizeTabletInfos.get(i) / totalSize));
+                row.add(totalSize == dataSizeTabletInfos.get(i) ? (totalSize == 0L ? "0.00%" : "100.00%") :
+                        df.format((double) dataSizeTabletInfos.get(i) / totalSize));
                 result.add(row);
             }
         } finally {


### PR DESCRIPTION
# Proposed changes

Issue Number: close #11614 

## Problem summary

Percentage should be `0.00%` when show data skew from an empty partition.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [x] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

