### PR TITLE
[feature-wip](datev2) Support bloom filter index / partition column for datev2

### DIFF
--- a/be/src/exprs/hybrid_set.h
+++ b/be/src/exprs/hybrid_set.h
@@ -51,6 +51,8 @@ public:
     virtual Status to_vexpr_list(doris::ObjectPool* pool,
                                  std::vector<doris::vectorized::VExpr*>* vexpr_list, int precision,
                                  int scale) = 0;
+
+    virtual bool is_date_v2() { return false; }
     class IteratorBase {
     public:
         IteratorBase() {}
@@ -72,6 +74,8 @@ public:
     HybridSet() = default;
 
     ~HybridSet() override = default;
+
+    bool is_date_v2() override { return T == TYPE_DATEV2; }
 
     Status to_vexpr_list(doris::ObjectPool* pool,
                          std::vector<doris::vectorized::VExpr*>* vexpr_list, int precision,

--- a/be/src/olap/rowset/segment_v2/bloom_filter_index_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/bloom_filter_index_writer.cpp
@@ -210,6 +210,13 @@ Status BloomFilterIndexWriter::create(const BloomFilterOptions& bf_options,
     case OLAP_FIELD_TYPE_DECIMAL:
         res->reset(new BloomFilterIndexWriterImpl<OLAP_FIELD_TYPE_DECIMAL>(bf_options, type_info));
         break;
+    case OLAP_FIELD_TYPE_DATEV2:
+        res->reset(new BloomFilterIndexWriterImpl<OLAP_FIELD_TYPE_DATEV2>(bf_options, type_info));
+        break;
+    case OLAP_FIELD_TYPE_DATETIMEV2:
+        res->reset(
+                new BloomFilterIndexWriterImpl<OLAP_FIELD_TYPE_DATETIMEV2>(bf_options, type_info));
+        break;
     default:
         return Status::NotSupported("unsupported type for bitmap index: {}", std::to_string(type));
     }

--- a/be/src/olap/rowset/segment_v2/segment_iterator.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.cpp
@@ -908,10 +908,6 @@ void SegmentIterator::_init_current_block(
                 current_columns[cid]->set_date_type();
             } else if (column_desc->type() == OLAP_FIELD_TYPE_DATETIME) {
                 current_columns[cid]->set_datetime_type();
-            } else if (column_desc->type() == OLAP_FIELD_TYPE_DATEV2) {
-                current_columns[cid]->set_date_v2_type();
-            } else if (column_desc->type() == OLAP_FIELD_TYPE_DATETIMEV2) {
-                current_columns[cid]->set_datetime_v2_type();
             } else if (column_desc->type() == OLAP_FIELD_TYPE_DECIMAL) {
                 current_columns[cid]->set_decimalv2_type();
             }

--- a/be/src/vec/columns/column.h
+++ b/be/src/vec/columns/column.h
@@ -513,22 +513,16 @@ public:
     virtual void replace_column_data_default(size_t self_row = 0) = 0;
 
     virtual bool is_date_type() const { return is_date; }
-    virtual bool is_date_v2_type() const { return is_date_v2; }
-    virtual bool is_datetime_v2_type() const { return is_datetime_v2; }
     virtual bool is_datetime_type() const { return is_date_time; }
     virtual bool is_decimalv2_type() const { return is_decimalv2; }
 
     virtual void set_date_type() { is_date = true; }
-    virtual void set_date_v2_type() { is_date_v2 = true; }
-    virtual void set_datetime_v2_type() { is_datetime_v2 = true; }
     virtual void set_datetime_type() { is_date_time = true; }
     virtual void set_decimalv2_type() { is_decimalv2 = true; }
 
     // todo(wb): a temporary implemention, need re-abstract here
     bool is_date = false;
     bool is_date_time = false;
-    bool is_date_v2 = false;
-    bool is_datetime_v2 = false;
     bool is_decimalv2 = false;
 
 protected:

--- a/be/src/vec/columns/column_nullable.h
+++ b/be/src/vec/columns/column_nullable.h
@@ -180,12 +180,9 @@ public:
     }
 
     bool is_date_type() const override { return get_nested_column().is_date_type(); }
-    bool is_date_v2_type() const override { return get_nested_column().is_date_v2_type(); }
-    bool is_datetime_v2_type() const override { return get_nested_column().is_datetime_v2_type(); }
     bool is_datetime_type() const override { return get_nested_column().is_datetime_type(); }
     bool is_decimalv2_type() const override { return get_nested_column().is_decimalv2_type(); }
     void set_date_type() override { get_nested_column().set_date_type(); }
-    void set_date_v2_type() override { get_nested_column().set_date_v2_type(); }
     void set_datetime_type() override { get_nested_column().set_datetime_type(); }
     void set_decimalv2_type() override { get_nested_column().set_decimalv2_type(); }
 

--- a/be/src/vec/data_types/data_type_time_v2.cpp
+++ b/be/src/vec/data_types/data_type_time_v2.cpp
@@ -49,25 +49,35 @@ void DataTypeDateV2::to_string(const IColumn& column, size_t row_num, BufferWrit
 }
 
 MutableColumnPtr DataTypeDateV2::create_column() const {
-    auto col = DataTypeNumberBase<UInt32>::create_column();
-    col->set_date_v2_type();
-    return col;
+    return DataTypeNumberBase<UInt32>::create_column();
 }
 
 void DataTypeDateV2::cast_to_date_time(const UInt32 from, Int64& to) {
-    auto& to_value = (doris::vectorized::VecDateTimeValue&)to;
-    auto& from_value = (doris::vectorized::DateV2Value<DateV2ValueType>&)from;
+    auto& to_value = (VecDateTimeValue&)to;
+    auto& from_value = (DateV2Value<DateV2ValueType>&)from;
     to_value.create_from_date_v2(from_value, TimeType::TIME_DATETIME);
 }
 
 void DataTypeDateV2::cast_to_date(const UInt32 from, Int64& to) {
-    auto& to_value = (doris::vectorized::VecDateTimeValue&)(to);
-    auto& from_value = (doris::vectorized::DateV2Value<DateV2ValueType>&)from;
+    auto& to_value = (VecDateTimeValue&)(to);
+    auto& from_value = (DateV2Value<DateV2ValueType>&)from;
     to_value.create_from_date_v2(from_value, TimeType::TIME_DATE);
 }
 
 void DataTypeDateV2::cast_to_date_time_v2(const UInt32 from, UInt64& to) {
     to = ((UInt64)from) << TIME_PART_LENGTH;
+}
+
+void DataTypeDateV2::cast_from_date(const Int64 from, UInt32& to) {
+    auto& to_value = (DateV2Value<DateV2ValueType>&)(to);
+    auto from_value = binary_cast<Int64, VecDateTimeValue>(from);
+    to_value.set_time(from_value.year(), from_value.month(), from_value.day(), 0, 0, 0, 0);
+}
+
+void DataTypeDateV2::cast_from_date_time(const Int64 from, UInt32& to) {
+    auto& to_value = (DateV2Value<DateV2ValueType>&)(to);
+    auto from_value = binary_cast<Int64, VecDateTimeValue>(from);
+    to_value.set_time(from_value.year(), from_value.month(), from_value.day(), 0, 0, 0, 0);
 }
 
 bool DataTypeDateTimeV2::equals(const IDataType& rhs) const {
@@ -100,21 +110,33 @@ void DataTypeDateTimeV2::to_string(const IColumn& column, size_t row_num,
 }
 
 MutableColumnPtr DataTypeDateTimeV2::create_column() const {
-    auto col = DataTypeNumberBase<UInt64>::create_column();
-    col->set_datetime_v2_type();
-    return col;
+    return DataTypeNumberBase<UInt64>::create_column();
 }
 
 void DataTypeDateTimeV2::cast_to_date_time(const UInt64 from, Int64& to) {
-    auto& to_value = (doris::vectorized::VecDateTimeValue&)to;
-    auto& from_value = (doris::vectorized::DateV2Value<DateTimeV2ValueType>&)from;
+    auto& to_value = (VecDateTimeValue&)to;
+    auto& from_value = (DateV2Value<DateTimeV2ValueType>&)from;
     to_value.create_from_date_v2(from_value, TimeType::TIME_DATETIME);
 }
 
 void DataTypeDateTimeV2::cast_to_date(const UInt64 from, Int64& to) {
-    auto& to_value = (doris::vectorized::VecDateTimeValue&)(to);
-    auto& from_value = (doris::vectorized::DateV2Value<DateTimeV2ValueType>&)from;
+    auto& to_value = (VecDateTimeValue&)(to);
+    auto& from_value = (DateV2Value<DateTimeV2ValueType>&)from;
     to_value.create_from_date_v2(from_value, TimeType::TIME_DATE);
+}
+
+void DataTypeDateTimeV2::cast_from_date(const Int64 from, UInt64& to) {
+    auto& to_value = (DateV2Value<DateTimeV2ValueType>&)(to);
+    auto from_value = binary_cast<Int64, VecDateTimeValue>(from);
+    to_value.set_time(from_value.year(), from_value.month(), from_value.day(), from_value.hour(),
+                      from_value.minute(), from_value.second(), 0);
+}
+
+void DataTypeDateTimeV2::cast_from_date_time(const Int64 from, UInt64& to) {
+    auto& to_value = (DateV2Value<DateTimeV2ValueType>&)(to);
+    auto from_value = binary_cast<Int64, VecDateTimeValue>(from);
+    to_value.set_time(from_value.year(), from_value.month(), from_value.day(), from_value.hour(),
+                      from_value.minute(), from_value.second(), 0);
 }
 
 void DataTypeDateTimeV2::cast_to_date_v2(const UInt64 from, UInt32& to) {

--- a/be/src/vec/data_types/data_type_time_v2.h
+++ b/be/src/vec/data_types/data_type_time_v2.h
@@ -43,6 +43,8 @@ public:
     static void cast_to_date(const UInt32 from, Int64& to);
     static void cast_to_date_time(const UInt32 from, Int64& to);
     static void cast_to_date_time_v2(const UInt32 from, UInt64& to);
+    static void cast_from_date(const Int64 from, UInt32& to);
+    static void cast_from_date_time(const Int64 from, UInt32& to);
 };
 
 class DataTypeDateTimeV2 final : public DataTypeNumberBase<UInt64> {
@@ -74,6 +76,8 @@ public:
     static void cast_to_date(const UInt64 from, Int64& to);
     static void cast_to_date_time(const UInt64 from, Int64& to);
     static void cast_to_date_v2(const UInt64 from, UInt32& to);
+    static void cast_from_date(const Int64 from, UInt64& to);
+    static void cast_from_date_time(const Int64 from, UInt64& to);
 
 private:
     UInt32 scale_;

--- a/be/src/vec/exec/volap_scan_node.cpp
+++ b/be/src/vec/exec/volap_scan_node.cpp
@@ -801,7 +801,8 @@ static bool ignore_cast(SlotDescriptor* slot, VExpr* expr) {
 template <bool IsFixed, PrimitiveType PrimitiveType, typename ChangeFixedValueRangeFunc>
 Status VOlapScanNode::change_value_range(ColumnValueRange<PrimitiveType>& temp_range, void* value,
                                          const ChangeFixedValueRangeFunc& func,
-                                         const std::string& fn_name, int slot_ref_child) {
+                                         const std::string& fn_name, bool cast_date_to_datetime,
+                                         int slot_ref_child) {
     if constexpr (PrimitiveType == TYPE_DATE) {
         DateTimeValue date_value;
         reinterpret_cast<VecDateTimeValue*>(value)->convert_vec_dt_to_dt(&date_value);
@@ -834,27 +835,39 @@ Status VOlapScanNode::change_value_range(ColumnValueRange<PrimitiveType>& temp_r
                          reinterpret_cast<char*>(&date_value)));
         }
     } else if constexpr (PrimitiveType == TYPE_DATEV2) {
-        DateV2Value<DateTimeV2ValueType> datetimev2_value =
-                *reinterpret_cast<DateV2Value<DateTimeV2ValueType>*>(value);
-        if constexpr (IsFixed) {
-            if (datetimev2_value.can_cast_to_date_without_loss_accuracy()) {
-                DateV2Value<DateV2ValueType> date_v2;
+        if (cast_date_to_datetime) {
+            DateV2Value<DateTimeV2ValueType> datetimev2_value =
+                    *reinterpret_cast<DateV2Value<DateTimeV2ValueType>*>(value);
+            if constexpr (IsFixed) {
+                if (datetimev2_value.can_cast_to_date_without_loss_accuracy()) {
+                    DateV2Value<DateV2ValueType> date_v2;
+                    date_v2.set_date_uint32(binary_cast<DateV2Value<DateTimeV2ValueType>, uint64_t>(
+                                                    datetimev2_value) >>
+                                            TIME_PART_LENGTH);
+                    func(temp_range, &date_v2);
+                }
+            } else {
+                doris::vectorized::DateV2Value<DateV2ValueType> date_v2;
                 date_v2.set_date_uint32(
                         binary_cast<DateV2Value<DateTimeV2ValueType>, uint64_t>(datetimev2_value) >>
                         TIME_PART_LENGTH);
-                func(temp_range, &date_v2);
+                if (!datetimev2_value.can_cast_to_date_without_loss_accuracy()) {
+                    if (fn_name == "lt" || fn_name == "ge") {
+                        ++date_v2;
+                    }
+                }
+                func(temp_range, to_olap_filter_type(fn_name, slot_ref_child), &date_v2);
             }
         } else {
-            doris::vectorized::DateV2Value<DateV2ValueType> date_v2;
-            date_v2.set_date_uint32(
-                    binary_cast<DateV2Value<DateTimeV2ValueType>, uint64_t>(datetimev2_value) >>
-                    TIME_PART_LENGTH);
-            if (!datetimev2_value.can_cast_to_date_without_loss_accuracy()) {
-                if (fn_name == "lt" || fn_name == "ge") {
-                    ++date_v2;
-                }
+            if constexpr (IsFixed) {
+                func(temp_range,
+                     reinterpret_cast<typename PrimitiveTypeTraits<PrimitiveType>::CppType*>(
+                             value));
+            } else {
+                func(temp_range, to_olap_filter_type(fn_name, slot_ref_child),
+                     reinterpret_cast<typename PrimitiveTypeTraits<PrimitiveType>::CppType*>(
+                             value));
             }
-            func(temp_range, to_olap_filter_type(fn_name, slot_ref_child), &date_v2);
         }
     } else if constexpr ((PrimitiveType == TYPE_DECIMALV2) || (PrimitiveType == TYPE_CHAR) ||
                          (PrimitiveType == TYPE_VARCHAR) || (PrimitiveType == TYPE_HLL) ||
@@ -1490,8 +1503,9 @@ Status VOlapScanNode::_normalize_in_and_eq_predicate(VExpr* expr, VExprContext* 
                 continue;
             }
             auto value = const_cast<void*>(iter->get_value());
-            RETURN_IF_ERROR(change_value_range<true>(
-                    temp_range, value, ColumnValueRange<T>::add_fixed_value_range, fn_name));
+            RETURN_IF_ERROR(change_value_range<true>(temp_range, value,
+                                                     ColumnValueRange<T>::add_fixed_value_range,
+                                                     fn_name, !state->hybrid_set->is_date_v2()));
             iter->next();
         }
 
@@ -1564,10 +1578,12 @@ Status VOlapScanNode::_normalize_not_in_and_not_eq_predicate(VExpr* expr, VExprC
             auto value = const_cast<void*>(iter->get_value());
             if (is_fixed_range) {
                 RETURN_IF_ERROR(change_value_range<true>(
-                        range, value, ColumnValueRange<T>::remove_fixed_value_range, fn_name));
+                        range, value, ColumnValueRange<T>::remove_fixed_value_range, fn_name,
+                        !state->hybrid_set->is_date_v2()));
             } else {
                 RETURN_IF_ERROR(change_value_range<true>(
-                        not_in_range, value, ColumnValueRange<T>::add_fixed_value_range, fn_name));
+                        not_in_range, value, ColumnValueRange<T>::add_fixed_value_range, fn_name,
+                        !state->hybrid_set->is_date_v2()));
             }
             iter->next();
         }
@@ -1674,11 +1690,11 @@ Status VOlapScanNode::_normalize_noneq_binary_predicate(VExpr* expr, VExprContex
                     auto val = StringValue(value.data, value.size);
                     RETURN_IF_ERROR(change_value_range<false>(range, reinterpret_cast<void*>(&val),
                                                               ColumnValueRange<T>::add_value_range,
-                                                              fn_name, slot_ref_child));
+                                                              fn_name, true, slot_ref_child));
                 } else {
                     RETURN_IF_ERROR(change_value_range<false>(
                             range, reinterpret_cast<void*>(const_cast<char*>(value.data)),
-                            ColumnValueRange<T>::add_value_range, fn_name, slot_ref_child));
+                            ColumnValueRange<T>::add_value_range, fn_name, true, slot_ref_child));
                 }
             }
         }

--- a/be/src/vec/exec/volap_scan_node.h
+++ b/be/src/vec/exec/volap_scan_node.h
@@ -74,7 +74,8 @@ private:
     template <bool IsFixed, PrimitiveType PrimitiveType, typename ChangeFixedValueRangeFunc>
     static Status change_value_range(ColumnValueRange<PrimitiveType>& range, void* value,
                                      const ChangeFixedValueRangeFunc& func,
-                                     const std::string& fn_name, int slot_ref_child = -1);
+                                     const std::string& fn_name, bool cast_date_to_datetime = true,
+                                     int slot_ref_child = -1);
 
     void transfer_thread(RuntimeState* state);
     void scanner_thread(VOlapScanner* scanner);

--- a/be/src/vec/functions/array/function_array_element.h
+++ b/be/src/vec/functions/array/function_array_element.h
@@ -199,18 +199,10 @@ private:
         if (nested_column->is_date_type()) {
             res = _execute_number<ColumnDate>(offsets, *nested_column, src_null_map,
                                               *arguments[1].column, nested_null_map, dst_null_map);
-        } else if (nested_column->is_date_v2_type()) {
-            res = _execute_number<ColumnDateV2>(offsets, *nested_column, src_null_map,
-                                                *arguments[1].column, nested_null_map,
-                                                dst_null_map);
         } else if (nested_column->is_datetime_type()) {
             res = _execute_number<ColumnDateTime>(offsets, *nested_column, src_null_map,
                                                   *arguments[1].column, nested_null_map,
                                                   dst_null_map);
-        } else if (nested_column->is_datetime_v2_type()) {
-            res = _execute_number<ColumnDateTimeV2>(offsets, *nested_column, src_null_map,
-                                                    *arguments[1].column, nested_null_map,
-                                                    dst_null_map);
         } else if (check_column<ColumnUInt8>(*nested_column)) {
             res = _execute_number<ColumnUInt8>(offsets, *nested_column, src_null_map,
                                                *arguments[1].column, nested_null_map, dst_null_map);

--- a/be/src/vec/functions/array/function_array_index.h
+++ b/be/src/vec/functions/array/function_array_index.h
@@ -174,12 +174,6 @@ private:
         } else if (right_column.is_date_type()) {
             return _execute_number<NestedColumnType, ColumnDate>(offsets, nested_null_map,
                                                                  nested_column, right_column);
-        } else if (right_column.is_date_v2_type()) {
-            return _execute_number<NestedColumnType, ColumnDateV2>(offsets, nested_null_map,
-                                                                   nested_column, right_column);
-        } else if (right_column.is_datetime_v2_type()) {
-            return _execute_number<NestedColumnType, ColumnDateTimeV2>(offsets, nested_null_map,
-                                                                       nested_column, right_column);
         } else if (right_column.is_datetime_type()) {
             return _execute_number<NestedColumnType, ColumnDateTime>(offsets, nested_null_map,
                                                                      nested_column, right_column);
@@ -257,14 +251,8 @@ private:
             if (nested_column->is_date_type()) {
                 return_column = _execute_number_expanded<ColumnDate>(offsets, nested_null_map,
                                                                      *nested_column, *right_column);
-            } else if (nested_column->is_date_v2_type()) {
-                return_column = _execute_number_expanded<ColumnDateV2>(
-                        offsets, nested_null_map, *nested_column, *right_column);
             } else if (nested_column->is_datetime_type()) {
                 return_column = _execute_number_expanded<ColumnDateTime>(
-                        offsets, nested_null_map, *nested_column, *right_column);
-            } else if (nested_column->is_datetime_v2_type()) {
-                return_column = _execute_number_expanded<ColumnDateTimeV2>(
                         offsets, nested_null_map, *nested_column, *right_column);
             }
         }

--- a/be/src/vec/functions/function_cast.h
+++ b/be/src/vec/functions/function_cast.h
@@ -145,14 +145,9 @@ struct ConvertImpl {
                             DataTypeDate::cast_to_date(vec_to[i]);
                         }
                     } else if constexpr (IsDateV2Type<ToDataType>) {
-                        auto date_v2 = binary_cast<UInt32, DateV2Value<DateV2ValueType>>(vec_to[i]);
-                        date_v2.from_date_int64(
-                                reinterpret_cast<const VecDateTimeValue&>(vec_from[i]).to_int64());
+                        DataTypeDateV2::cast_from_date(vec_from[i], vec_to[i]);
                     } else if constexpr (IsDateTimeV2Type<ToDataType>) {
-                        auto date_v2 =
-                                binary_cast<UInt64, DateV2Value<DateTimeV2ValueType>>(vec_to[i]);
-                        date_v2.from_date_int64(
-                                reinterpret_cast<const VecDateTimeValue&>(vec_from[i]).to_int64());
+                        DataTypeDateTimeV2::cast_from_date(vec_from[i], vec_to[i]);
                     } else {
                         vec_to[i] =
                                 reinterpret_cast<const VecDateTimeValue&>(vec_from[i]).to_int64();

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/FunctionCallExpr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/FunctionCallExpr.java
@@ -829,7 +829,7 @@ public class FunctionCallExpr extends Expr {
      */
     public void analyzeImplForDefaultValue() throws AnalysisException {
         fn = getBuiltinFunction(fnName.getFunction(), new Type[0], Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
-        type = fn.getReturnType();
+        type = ScalarType.getDefaultDateType(fn.getReturnType());
         for (int i = 0; i < children.size(); ++i) {
             if (getChild(i).getType().isNull()) {
                 uncheckedCastChild(Type.BOOLEAN, i);

--- a/gensrc/script/doris_builtins_functions.py
+++ b/gensrc/script/doris_builtins_functions.py
@@ -1826,6 +1826,8 @@ visible_functions = [
     [['if'], 'DOUBLE', ['BOOLEAN', 'DOUBLE', 'DOUBLE'], '', '', '', 'vec', 'CUSTOM'],
     [['if'], 'DATETIME', ['BOOLEAN', 'DATETIME', 'DATETIME'], '', '', '', 'vec', 'CUSTOM'],
     [['if'], 'DATE', ['BOOLEAN', 'DATE', 'DATE'], '', '', '', 'vec', 'CUSTOM'],
+    [['if'], 'DATETIMEV2', ['BOOLEAN', 'DATETIMEV2', 'DATETIMEV2'], '', '', '', 'vec', 'CUSTOM'],
+    [['if'], 'DATEV2', ['BOOLEAN', 'DATEV2', 'DATEV2'], '', '', '', 'vec', 'CUSTOM'],
     [['if'], 'DECIMALV2', ['BOOLEAN', 'DECIMALV2', 'DECIMALV2'], '', '', '', 'vec', 'CUSTOM'],
     [['if'], 'BITMAP', ['BOOLEAN', 'BITMAP', 'BITMAP'], '', '', '', 'vec', 'CUSTOM'],
     # The priority of varchar should be lower than decimal in IS_SUPERTYPE_OF mode.


### PR DESCRIPTION
# Proposed changes

After this PR, all existing test cases will pass when `enable_date_conversion` is `true`.

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

