### PR TITLE
[dev-1.1.2](doc) fix help doc invalid format

### DIFF
--- a/docs/zh-CN/sql-reference/sql-functions/bitmap-functions/intersect_count.md
+++ b/docs/zh-CN/sql-reference/sql-functions/bitmap-functions/intersect_count.md
@@ -22,15 +22,16 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-## intersect_count
-### description
-#### Syntax
+# intersect_count
+
+## description
+### Syntax
 
 `BITMAP INTERSECT_COUNT(bitmap_column, column_to_filter, filter_values)`
 聚合函数，求bitmap交集大小的函数, 不要求数据分布正交
 第一个参数是Bitmap列，第二个参数是用来过滤的维度列，第三个参数是变长参数，含义是过滤维度列的不同取值
 
-### example
+## example
 
 ```
 MySQL [test_query_qa]> select dt,bitmap_to_string(user_id) from pv_bitmap where dt in (3,4);
@@ -51,6 +52,6 @@ MySQL [test_query_qa]> select intersect_count(user_id,dt,3,4) from pv_bitmap;
 1 row in set (0.014 sec)
 ```
 
-### keywords
+## keywords
 
     INTERSECT_COUNT,BITMAP


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

This will cause FE start with error in log:
```
org.apache.doris.common.UserException: errCode = 2, detailMessage = Head first read is not h1.
```
And can not use `help` command

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

