### PR TITLE
[feature-wip](unique-key-merge-on-write) fix rowid conversion ut that may create a directory under an incorrect path

### DIFF
--- a/be/test/olap/rowid_conversion_test.cpp
+++ b/be/test/olap/rowid_conversion_test.cpp
@@ -400,7 +400,7 @@ protected:
     }
 
 private:
-    const std::string kTestDir = "ut_dir/rowid_conversion_test";
+    const std::string kTestDir = "/ut_dir/rowid_conversion_test";
     string absolute_dir;
     std::unique_ptr<DataDir> _data_dir;
 };


### PR DESCRIPTION

# Proposed changes

Issue Number: close #xxx

## Problem summary

The path missing backslash，so create a directory under an incorrect path.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

