### PR TITLE
[fix](script) Fix hdfs-site.xml file name typo.

### DIFF
--- a/bin/start_be.sh
+++ b/bin/start_be.sh
@@ -187,7 +187,7 @@ if [ ${RUN_IN_AWS} -eq 0 ]; then
 fi
 
 ## set hdfs conf
-export LIBHDFS3_CONF=${DORIS_HOME}/conf/hdfs_site.xml
+export LIBHDFS3_CONF=${DORIS_HOME}/conf/hdfs-site.xml
 
 if [ ${RUN_DAEMON} -eq 1 ]; then
     nohup $LIMIT ${DORIS_HOME}/lib/doris_be "$@" >> $LOG_DIR/be.out 2>&1 < /dev/null &


### PR DESCRIPTION
# Proposed changes

hdfs-site.xml file name is incorrect in start-be.sh script.

## Problem summary

Couldn't start be because the start-be.sh script couldn't find hdfs_site.xml file.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

