### PR TITLE
[feature](http) add api for showing current queries and kill query

### DIFF
--- a/docs/en/docs/admin-manual/http-actions/fe/manager/query-profile-action.md
+++ b/docs/en/docs/admin-manual/http-actions/fe/manager/query-profile-action.md
@@ -306,3 +306,63 @@ Get the tree profile information of the specified query id, same as `show query 
     "count": 0
 }
 ```
+
+## Current running queries
+
+`GET /rest/v2/manager/query/current_queries`
+
+### Description
+
+Same as `show proc "/current_query_stmts"`, return current running queries.
+    
+### Path parameters
+
+### Query parameters
+
+* `is_all_node`
+  
+    Optional. Return current running queries from all FE if set to true. Default is true.
+
+### Response
+
+```
+{
+	"msg": "success",
+	"code": 0,
+	"data": {
+		"columnNames": ["Frontend", "QueryId", "ConnectionId", "Database", "User", "ExecTime", "SqlHash", "Statement"],
+		"rows": [
+			["172.19.0.3", "108e47ab438a4560-ab1651d16c036491", "2", "", "root", "6074", "1a35f62f4b14b9d7961b057b77c3102f", "select sleep(60)"],
+			["172.19.0.11", "3606cad4e34b49c6-867bf6862cacc645", "3", "", "root", "9306", "1a35f62f4b14b9d7961b057b77c3102f", "select sleep(60)"]
+		]
+	},
+	"count": 0
+}
+```
+
+## Cancel query
+
+`POST /rest/v2/manager/query/kill/{connection_id}`
+
+### Description
+
+Cancel query of specified connection.
+    
+### Path parameters
+
+* `{connection_id}`
+
+    connection id
+
+### Query parameters
+
+### Response
+
+```
+{
+    "msg": "success",
+    "code": 0,
+    "data": "",
+    "count": 0
+}
+```

--- a/docs/zh-CN/docs/admin-manual/http-actions/fe/manager/query-profile-action.md
+++ b/docs/zh-CN/docs/admin-manual/http-actions/fe/manager/query-profile-action.md
@@ -281,7 +281,7 @@ GET /rest/v2/manager/query/query_info
 
 ### Description
 
-同 `show proc "/current_query_stmts"`
+获取指定query id树状profile信息，同 `show query profile` 指令。
     
 ### Path parameters
 

--- a/docs/zh-CN/docs/admin-manual/http-actions/fe/manager/query-profile-action.md
+++ b/docs/zh-CN/docs/admin-manual/http-actions/fe/manager/query-profile-action.md
@@ -34,9 +34,16 @@ under the License.
 
 `GET /rest/v2/manager/query/profile/text/{query_id}`
 
+`GET /rest/v2/manager/query/profile/graph/{query_id}`
+
+`GET /rest/v2/manager/query/profile/json/{query_id}`
+
 `GET /rest/v2/manager/query/profile/fragments/{query_id}`
 
-`GET /rest/v2/manager/query/profile/graph/{query_id}`
+`GET /rest/v2/manager/query/current_queries`
+
+`GET /rest/v2/manager/query/kill/{connection_id}`
+
 
 ## 获取查询信息
 
@@ -274,7 +281,7 @@ GET /rest/v2/manager/query/query_info
 
 ### Description
 
-获取指定query id树状profile信息，同 `show query profile` 指令。
+同 `show proc "/current_query_stmts"`
     
 ### Path parameters
 
@@ -303,6 +310,66 @@ GET /rest/v2/manager/query/query_info
     "data": {
         "graph":""
     },
+    "count": 0
+}
+```
+
+## 正在执行的query
+
+`GET /rest/v2/manager/query/current_queries`
+
+### Description
+
+同 `show proc "/current_query_stmts"`，返回当前正在执行的 query
+    
+### Path parameters
+
+### Query parameters
+
+* `is_all_node`
+  
+    可选，若为 true 则返回所有FE节点当前正在执行的 query 信息。默认为 true。
+
+### Response
+
+```
+{
+	"msg": "success",
+	"code": 0,
+	"data": {
+		"columnNames": ["Frontend", "QueryId", "ConnectionId", "Database", "User", "ExecTime", "SqlHash", "Statement"],
+		"rows": [
+			["172.19.0.3", "108e47ab438a4560-ab1651d16c036491", "2", "", "root", "6074", "1a35f62f4b14b9d7961b057b77c3102f", "select sleep(60)"],
+			["172.19.0.11", "3606cad4e34b49c6-867bf6862cacc645", "3", "", "root", "9306", "1a35f62f4b14b9d7961b057b77c3102f", "select sleep(60)"]
+		]
+	},
+	"count": 0
+}
+```
+
+## 取消query
+
+`POST /rest/v2/manager/query/kill/{connection_id}`
+
+### Description
+
+取消执行连接中正在执行的 query
+    
+### Path parameters
+
+* `{connection_id}`
+
+    connection id
+
+### Query parameters
+
+### Response
+
+```
+{
+    "msg": "success",
+    "code": 0,
+    "data": "",
     "count": 0
 }
 ```

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/manager/QueryAdminAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/manager/QueryAdminAction.java
@@ -21,6 +21,8 @@ import org.apache.doris.catalog.Env;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.Pair;
+import org.apache.doris.common.proc.CurrentQueryStatementsProcNode;
+import org.apache.doris.common.proc.ProcResult;
 import org.apache.doris.common.profile.ProfileTreeNode;
 import org.apache.doris.common.profile.ProfileTreePrinter;
 import org.apache.doris.common.util.ProfileManager;
@@ -29,6 +31,9 @@ import org.apache.doris.httpv2.rest.RestBaseController;
 import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.persist.gson.GsonUtils;
 import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.service.ExecuteEnv;
+import org.apache.doris.service.FrontendOptions;
+import org.apache.doris.thrift.TNetworkAddress;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
@@ -59,11 +64,18 @@ import javax.servlet.http.HttpServletResponse;
 
 /*
  * Used to return query information and query profile.
+ * base: /rest/v2/manager/query
+ * 1. /query_info
+ * 2. /sql/{query_id}
+ * 3. /profile/{format}/{query_id}
+ * 4. /trace_id/{trace_id}
+ * 5. /profile/fragments/{query_id}
+ * 6. /current_queries/
  */
 @RestController
 @RequestMapping("/rest/v2/manager/query")
-public class QueryProfileAction extends RestBaseController {
-    private static final Logger LOG = LogManager.getLogger(QueryProfileAction.class);
+public class QueryAdminAction extends RestBaseController {
+    private static final Logger LOG = LogManager.getLogger(QueryAdminAction.class);
 
     public static final String QUERY_ID = "Query ID";
     public static final String NODE = "FE节点";
@@ -82,10 +94,11 @@ public class QueryProfileAction extends RestBaseController {
     private static final String FRAGMENT_ID = "fragment_id";
     private static final String INSTANCE_ID = "instance_id";
 
-    public static final ImmutableList<String> QUERY_TITLE_NAMES = new ImmutableList.Builder<String>()
-            .add(QUERY_ID).add(NODE).add(USER).add(DEFAULT_DB).add(SQL_STATEMENT)
-            .add(QUERY_TYPE).add(START_TIME).add(END_TIME).add(TOTAL).add(QUERY_STATE)
-            .build();
+    private static final String FRONTEND = "Frontend";
+
+    public static final ImmutableList<String> QUERY_TITLE_NAMES = new ImmutableList.Builder<String>().add(QUERY_ID)
+            .add(NODE).add(USER).add(DEFAULT_DB).add(SQL_STATEMENT).add(QUERY_TYPE).add(START_TIME).add(END_TIME)
+            .add(TOTAL).add(QUERY_STATE).build();
 
     private List<String> requestAllFe(String httpPath, Map<String, String> arguments, String authorization) {
         List<Pair<String, Integer>> frontends = HttpUtils.getFeList();
@@ -413,5 +426,86 @@ public class QueryProfileAction extends RestBaseController {
             }
         }
         return ResponseEntityBuilder.ok(result);
+    }
+
+    /**
+     * return the result of CurrentQueryStatementsProcNode.
+     *
+     * @param request
+     * @param response
+     * @param isAllNode
+     * @return
+     */
+    @RequestMapping(path = "/current_queries/", method = RequestMethod.GET)
+    public Object currentQueries(HttpServletRequest request, HttpServletResponse response,
+            @RequestParam(value = IS_ALL_NODE_PARA, required = false, defaultValue = "true") boolean isAllNode) {
+        executeCheckPassword(request, response);
+        checkGlobalAuth(ConnectContext.get().getCurrentUserIdentity(), PrivPredicate.ADMIN);
+
+        if (isAllNode) {
+            // Get current queries from all FE
+            String httpPath = "/rest/v2/manager/query/current_queries";
+            Map<String, String> arguments = Maps.newHashMap();
+            arguments.put(IS_ALL_NODE_PARA, "false");
+            List<List<String>> queries = Lists.newArrayList();
+            List<String> dataList = requestAllFe(httpPath, arguments, request.getHeader(NodeAction.AUTHORIZATION));
+            for (String data : dataList) {
+                try {
+                    NodeAction.NodeInfo nodeInfo = GsonUtils.GSON.fromJson(data, new TypeToken<NodeAction.NodeInfo>() {
+                    }.getType());
+                    queries.addAll(nodeInfo.getRows());
+                } catch (Exception e) {
+                    LOG.warn("parse query info error: {}", data, e);
+                }
+            }
+            List<String> titles = Lists.newArrayList(CurrentQueryStatementsProcNode.TITLE_NAMES);
+            titles.add(0, FRONTEND);
+            return ResponseEntityBuilder.ok(new NodeAction.NodeInfo(titles, queries));
+        } else {
+            try {
+                CurrentQueryStatementsProcNode node = new CurrentQueryStatementsProcNode();
+                ProcResult result = node.fetchResult();
+                // add frontend info at first column.
+                result.getColumnNames().add(0, FRONTEND);
+                List<List<String>> rows = result.getRows();
+                String feIp = FrontendOptions.getLocalHostAddress();
+                for (List<String> row : rows) {
+                    row.add(0, feIp);
+                }
+                return ResponseEntityBuilder.ok(new NodeAction.NodeInfo(result.getColumnNames(), rows));
+            } catch (AnalysisException e) {
+                return ResponseEntityBuilder.badRequest(e.getMessage());
+            }
+        }
+    }
+
+    /**
+     * kill queries in specified connection in specified FE.
+     *
+     * @param request
+     * @param response
+     * @param connectionId
+     * @param frontend
+     * @return
+     */
+    @RequestMapping(path = "/kill/{connection_id}", method = RequestMethod.POST)
+    public Object killQuery(HttpServletRequest request, HttpServletResponse response,
+            @PathVariable("connection_id") int connectionId,
+            @RequestParam(value = "frontend", required = true) String frontend) {
+        executeCheckPassword(request, response);
+        checkGlobalAuth(ConnectContext.get().getCurrentUserIdentity(), PrivPredicate.ADMIN);
+
+        String curFeIp = FrontendOptions.getLocalHostAddress();
+        if (!curFeIp.equals(frontend)) {
+            return redirectTo(request, new TNetworkAddress(frontend, Config.http_port));
+        } else {
+            ExecuteEnv env = ExecuteEnv.getInstance();
+            ConnectContext ctx = env.getScheduler().getContext(connectionId);
+            if (ctx == null) {
+                return ResponseEntityBuilder.notFound("connection not found");
+            }
+            ctx.cancelQuery();
+            return ResponseEntityBuilder.ok();
+        }
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectContext.java
@@ -512,7 +512,11 @@ public class ConnectContext {
             // Close channel to break connection with client
             getMysqlChannel().close();
         }
-        // Now, cancel running process.
+        // Now, cancel running query.
+        cancelQuery();
+    }
+
+    public void cancelQuery() {
         StmtExecutor executorRef = executor;
         if (executorRef != null) {
             executorRef.cancel();


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

Add 2 new http api in FE:
1. `GET /rest/v2/manager/query/current_queries`
2. `POST /rest/v2/manager/query/kill/{connection_id}`

See doc for details

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
3. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
4. Has document been added or modified:
    - [x] Yes
    - [ ] No
    - [ ] No Need
5. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
6. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

