### PR TITLE
Fix file arrow scanner column index out of range core.

### DIFF
--- a/be/src/exec/arrow/arrow_reader.cpp
+++ b/be/src/exec/arrow/arrow_reader.cpp
@@ -38,10 +38,10 @@ namespace doris {
 // Broker
 
 ArrowReaderWrap::ArrowReaderWrap(FileReader* file_reader, int64_t batch_size,
-                                 int32_t num_of_columns_from_file, bool caseSensitive)
+                                 int32_t num_of_columns_from_file, bool case_sensitive)
         : _batch_size(batch_size),
           _num_of_columns_from_file(num_of_columns_from_file),
-          _caseSensitive(caseSensitive) {
+          _case_sensitive(case_sensitive) {
     _arrow_file = std::shared_ptr<ArrowFile>(new ArrowFile(file_reader));
     _rb_reader = nullptr;
     _total_groups = 0;
@@ -85,7 +85,7 @@ Status ArrowReaderWrap::column_indices(const std::vector<SlotDescriptor*>& tuple
 }
 
 int ArrowReaderWrap::get_cloumn_index(std::string column_name) {
-    std::string real_column_name = _caseSensitive ? column_name : to_lower(column_name);
+    std::string real_column_name = _case_sensitive ? column_name : to_lower(column_name);
     auto iter = _map_column.find(real_column_name);
     if (iter != _map_column.end()) {
         return iter->second;

--- a/be/src/exec/arrow/arrow_reader.h
+++ b/be/src/exec/arrow/arrow_reader.h
@@ -100,6 +100,7 @@ public:
     int get_cloumn_index(std::string column_name);
 
     void prefetch_batch();
+    bool is_case_sensitive() {return _caseSensitive; }
 
 protected:
     virtual Status column_indices(const std::vector<SlotDescriptor*>& tuple_slot_descs);

--- a/be/src/exec/arrow/arrow_reader.h
+++ b/be/src/exec/arrow/arrow_reader.h
@@ -100,7 +100,7 @@ public:
     int get_cloumn_index(std::string column_name);
 
     void prefetch_batch();
-    bool is_case_sensitive() {return _caseSensitive; }
+    bool is_case_sensitive() { return _case_sensitive; }
 
 protected:
     virtual Status column_indices(const std::vector<SlotDescriptor*>& tuple_slot_descs);
@@ -127,7 +127,7 @@ protected:
     std::list<std::shared_ptr<arrow::RecordBatch>> _queue;
     const size_t _max_queue_size = config::parquet_reader_max_buffer_size;
     std::thread _thread;
-    bool _caseSensitive;
+    bool _case_sensitive;
 };
 
 } // namespace doris

--- a/be/src/exec/arrow/orc_reader.cpp
+++ b/be/src/exec/arrow/orc_reader.cpp
@@ -30,8 +30,8 @@ namespace doris {
 
 ORCReaderWrap::ORCReaderWrap(FileReader* file_reader, int64_t batch_size,
                              int32_t num_of_columns_from_file, int64_t range_start_offset,
-                             int64_t range_size, bool caseSensitive)
-        : ArrowReaderWrap(file_reader, batch_size, num_of_columns_from_file, caseSensitive),
+                             int64_t range_size, bool case_sensitive)
+        : ArrowReaderWrap(file_reader, batch_size, num_of_columns_from_file, case_sensitive),
           _range_start_offset(range_start_offset),
           _range_size(range_size) {
     _reader = nullptr;
@@ -68,7 +68,7 @@ Status ORCReaderWrap::init_reader(const TupleDescriptor* tuple_desc,
     std::shared_ptr<arrow::Schema> schema = maybe_schema.ValueOrDie();
     for (size_t i = 0; i < schema->num_fields(); ++i) {
         std::string schemaName =
-                _caseSensitive ? schema->field(i)->name() : to_lower(schema->field(i)->name());
+                _case_sensitive ? schema->field(i)->name() : to_lower(schema->field(i)->name());
         // orc index started from 1.
 
         _map_column.emplace(schemaName, i + 1);

--- a/be/src/exec/arrow/orc_reader.h
+++ b/be/src/exec/arrow/orc_reader.h
@@ -33,7 +33,7 @@ namespace doris {
 class ORCReaderWrap final : public ArrowReaderWrap {
 public:
     ORCReaderWrap(FileReader* file_reader, int64_t batch_size, int32_t num_of_columns_from_file,
-                  int64_t range_start_offset, int64_t range_size, bool caseSensitive = true);
+                  int64_t range_start_offset, int64_t range_size, bool case_sensitive = true);
     ~ORCReaderWrap() override = default;
 
     Status init_reader(const TupleDescriptor* tuple_desc,

--- a/be/src/exec/arrow/parquet_reader.cpp
+++ b/be/src/exec/arrow/parquet_reader.cpp
@@ -39,8 +39,8 @@ namespace doris {
 // Broker
 ParquetReaderWrap::ParquetReaderWrap(FileReader* file_reader, int64_t batch_size,
                                      int32_t num_of_columns_from_file, int64_t range_start_offset,
-                                     int64_t range_size, bool caseSensitive)
-        : ArrowReaderWrap(file_reader, batch_size, num_of_columns_from_file, caseSensitive),
+                                     int64_t range_size, bool case_sensitive)
+        : ArrowReaderWrap(file_reader, batch_size, num_of_columns_from_file, case_sensitive),
           _rows_of_group(0),
           _current_line_of_group(0),
           _current_line_of_batch(0),
@@ -92,7 +92,7 @@ Status ParquetReaderWrap::init_reader(const TupleDescriptor* tuple_desc,
             } else {
                 schemaName = schemaDescriptor->Column(i)->name();
             }
-            _map_column.emplace(_caseSensitive ? schemaName : to_lower(schemaName), i);
+            _map_column.emplace(_case_sensitive ? schemaName : to_lower(schemaName), i);
         }
 
         _timezone = timezone;

--- a/be/src/exec/arrow/parquet_reader.h
+++ b/be/src/exec/arrow/parquet_reader.h
@@ -63,7 +63,7 @@ class ParquetReaderWrap final : public ArrowReaderWrap {
 public:
     // batch_size is not use here
     ParquetReaderWrap(FileReader* file_reader, int64_t batch_size, int32_t num_of_columns_from_file,
-                      int64_t range_start_offset, int64_t range_size, bool caseSensitive = true);
+                      int64_t range_start_offset, int64_t range_size, bool case_sensitive = true);
     ~ParquetReaderWrap() override = default;
 
     // Read

--- a/be/src/runtime/descriptors.cpp
+++ b/be/src/runtime/descriptors.cpp
@@ -27,6 +27,7 @@
 #include "common/object_pool.h"
 #include "gen_cpp/Descriptors_types.h"
 #include "gen_cpp/descriptors.pb.h"
+#include "util/string_util.h"
 #include "vec/columns/column_nullable.h"
 #include "vec/data_types/data_type_factory.hpp"
 #include "vec/data_types/data_type_nullable.h"
@@ -55,6 +56,7 @@ SlotDescriptor::SlotDescriptor(const TSlotDescriptor& tdesc)
           _tuple_offset(tdesc.byteOffset),
           _null_indicator_offset(tdesc.nullIndicatorByte, tdesc.nullIndicatorBit),
           _col_name(tdesc.colName),
+          _col_name_lower_case(to_lower(tdesc.colName)),
           _col_unique_id(tdesc.col_unique_id),
           _slot_idx(tdesc.slotIdx),
           _slot_size(_type.get_slot_size()),
@@ -69,6 +71,7 @@ SlotDescriptor::SlotDescriptor(const PSlotDescriptor& pdesc)
           _tuple_offset(pdesc.byte_offset()),
           _null_indicator_offset(pdesc.null_indicator_byte(), pdesc.null_indicator_bit()),
           _col_name(pdesc.col_name()),
+          _col_name_lower_case(to_lower(pdesc.col_name())),
           _col_unique_id(-1),
           _slot_idx(pdesc.slot_idx()),
           _slot_size(_type.get_slot_size()),

--- a/be/src/runtime/descriptors.h
+++ b/be/src/runtime/descriptors.h
@@ -100,6 +100,7 @@ public:
     int slot_size() const { return _slot_size; }
 
     const std::string& col_name() const { return _col_name; }
+    const std::string& col_name_lower_case() const { return _col_name_lower_case; }
 
     /// Return true if the physical layout of this descriptor matches the physical layout
     /// of other_desc, but not necessarily ids.
@@ -128,6 +129,7 @@ private:
     const int _tuple_offset;
     const NullIndicatorOffset _null_indicator_offset;
     const std::string _col_name;
+    const std::string _col_name_lower_case;
 
     const int32_t _col_unique_id;
 

--- a/be/src/vec/exec/file_arrow_scanner.cpp
+++ b/be/src/vec/exec/file_arrow_scanner.cpp
@@ -186,8 +186,9 @@ Status FileArrowScanner::_append_batch_to_block(Block* block) {
         if (slot_desc == nullptr) {
             continue;
         }
-        std::string real_column_name =
-                _cur_file_reader->is_case_sensitive() ? slot_desc->col_name() : slot_desc->col_name_lower_case();
+        std::string real_column_name = _cur_file_reader->is_case_sensitive()
+                                               ? slot_desc->col_name()
+                                               : slot_desc->col_name_lower_case();
         auto* array = _batch->GetColumnByName(real_column_name).get();
         auto& column_with_type_and_name = block->get_by_name(slot_desc->col_name());
         RETURN_IF_ERROR(arrow_column_to_doris_column(

--- a/be/src/vec/exec/file_arrow_scanner.cpp
+++ b/be/src/vec/exec/file_arrow_scanner.cpp
@@ -24,7 +24,6 @@
 #include "io/file_factory.h"
 #include "io/hdfs_reader_writer.h"
 #include "runtime/descriptors.h"
-#include "util/string_util.h"
 #include "vec/utils/arrow_column_to_doris_column.h"
 
 namespace doris::vectorized {
@@ -188,7 +187,7 @@ Status FileArrowScanner::_append_batch_to_block(Block* block) {
             continue;
         }
         std::string real_column_name =
-                _cur_file_reader->is_case_sensitive() ? slot_desc->col_name() : to_lower(slot_desc->col_name());
+                _cur_file_reader->is_case_sensitive() ? slot_desc->col_name() : slot_desc->col_name_lower_case();
         auto* array = _batch->GetColumnByName(real_column_name).get();
         auto& column_with_type_and_name = block->get_by_name(slot_desc->col_name());
         RETURN_IF_ERROR(arrow_column_to_doris_column(


### PR DESCRIPTION
# Proposed changes

```FileArrowScanner::_append_batch_to_block``` may core while executing tpch queries. It also may core while executing query like ```select count(1) from xxx```.

## Problem summary
The `get_column_index(column_name)` may return an index value that out of the `_batch` column range. For example, 
```select count(1) from xxx``` has only 1 column, but `get_column_index(column_name)` may return a value >= 1.

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

