### PR TITLE
[fix](storage)fix column dict incorrect result

### DIFF
--- a/be/src/vec/columns/column_dictionary.h
+++ b/be/src/vec/columns/column_dictionary.h
@@ -257,6 +257,7 @@ public:
     bool is_dict_code_converted() const { return _dict_code_converted; }
 
     MutableColumnPtr convert_to_predicate_column_if_dictionary() override {
+        convert_dict_codes_if_necessary();
         auto res = vectorized::PredicateColumnType<TYPE_STRING>::create();
         res->reserve(_reserve_size);
         for (size_t i = 0; i < _codes.size(); ++i) {

--- a/be/src/vec/columns/column_dictionary.h
+++ b/be/src/vec/columns/column_dictionary.h
@@ -257,7 +257,9 @@ public:
     bool is_dict_code_converted() const { return _dict_code_converted; }
 
     MutableColumnPtr convert_to_predicate_column_if_dictionary() override {
-        convert_dict_codes_if_necessary();
+        if (is_dict_sorted() && !is_dict_code_converted()) {
+            convert_dict_codes_if_necessary();
+        }
         auto res = vectorized::PredicateColumnType<TYPE_STRING>::create();
         res->reserve(_reserve_size);
         for (size_t i = 0; i < _codes.size(); ++i) {


### PR DESCRIPTION
# Proposed changes

Issue Number: close #11644

## Problem summary

When ColumnIterator::next_batch put data from several pages to a batch, the 1st page may use DICT encoding while the 2nd page may use PLAIN encoding. Then we have to convert ColumnDictionary to PredicateColumn due to dict is not working any more.

There are two parts in a ColumnDictionary, codes and dict.  Codes is read from page decoder and converted if necessary to do range predicate. When a new batch is read, ColumnDictionary is cleared especially codes is  cleared, but dict is keep. So for a new batch, dict may be sorted but codes is same as on disk.

SegmentIterator convert dict codes to do range predicate by calling convert_dict_codes_if_necessary.  However if a ColumnDictionary is changed PredicateColumn by ColumnIterator, SegmentIterator does not know it, so ColumnIterator should handle it by itself.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [x] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

