### PR TITLE
[enhancement](array-type) support export files in 'select into outfile'

### DIFF
--- a/be/src/runtime/file_result_writer.cpp
+++ b/be/src/runtime/file_result_writer.cpp
@@ -337,6 +337,12 @@ Status FileResultWriter::_write_one_row_as_csv(TupleRow* row) {
                 }
                 break;
             }
+            case TYPE_ARRAY: {
+                auto col_type = _output_expr_ctxs[i]->root()->type();
+                int output_scale = _output_expr_ctxs[i]->root()->output_scale();
+                RawValue::print_value(item, col_type, output_scale, &_plain_text_outstream);
+                break;
+            }
             default: {
                 // not supported type, like BITMAP, HLL, just export null
                 _plain_text_outstream << NULL_IN_CSV;

--- a/be/src/vec/runtime/vfile_result_writer.cpp
+++ b/be/src/vec/runtime/vfile_result_writer.cpp
@@ -312,6 +312,10 @@ Status VFileResultWriter::_write_csv_file(const Block& block) {
                     _plain_text_outstream << col.type->to_string(*col.column, i);
                     break;
                 }
+                case TYPE_ARRAY: {
+                    _plain_text_outstream << col.type->to_string(*col.column, i);
+                    break;
+                }
                 default: {
                     // not supported type, like BITMAP, HLL, just export null
                     _plain_text_outstream << NULL_IN_CSV;


### PR DESCRIPTION
# Proposed changes
1. this pr is used to support export files in 'select into outfile'.
2. the usage is as follow:
MySQL [example_db]> set enable_array_type=true;
MySQL [example_db]> select * from array_test order by id INTO OUTFILE "file:///home/disk1/hugo_work/doris_env/";
+------------+-----------+----------+---------------------------------------------------------------------------------------+
| FileNumber | TotalRows | FileSize | URL                                                                                   |
+------------+-----------+----------+---------------------------------------------------------------------------------------+
|          1 |         8 |       99 | file:///10.81.85.89/home/disk1/hugo_work/doris_env/44b19bb155d14a6c-a9d796a18aeac4a3_ |
+------------+-----------+----------+---------------------------------------------------------------------------------------+
1 row in set (0.016 sec)
Issue Number: #7570

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
4. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
5. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
6. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
7. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

