### PR TITLE
[fix](Nereids)memo copy in cannot rewrite current plan with its child

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Memo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Memo.java
@@ -75,7 +75,7 @@ public class Memo {
     public Pair<Boolean, GroupExpression> copyIn(Plan node, @Nullable Group target, boolean rewrite) {
         Optional<GroupExpression> groupExpr = node.getGroupExpression();
         if (!rewrite && groupExpr.isPresent() && groupExpressions.containsKey(groupExpr.get())) {
-            return new Pair(false, groupExpr.get());
+            return new Pair<>(false, groupExpr.get());
         }
         List<Group> childrenGroups = Lists.newArrayList();
         for (int i = 0; i < node.children().size(); i++) {
@@ -169,7 +169,8 @@ public class Memo {
             GroupExpression groupExpression, Group target, LogicalProperties logicalProperties) {
         boolean newGroupExpressionGenerated = true;
         GroupExpression existedGroupExpression = groupExpressions.get(groupExpression);
-        if (existedGroupExpression != null) {
+        if (existedGroupExpression != null
+                && (target == null || target.equals(existedGroupExpression.getOwnerGroup()))) {
             target = existedGroupExpression.getOwnerGroup();
             newGroupExpressionGenerated = false;
         }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/memo/MemoTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/memo/MemoTest.java
@@ -122,14 +122,16 @@ public class MemoTest {
     /**
      * Test rewrite current Plan with its child.
      *
-     * Original:
-     * Project(outside)
-     * |---Project(inside)
-     *     |---UnboundRelation
+     * Original(Group 2 is root):
+     * Group2: Project(outside)
+     * Group1: |---Project(inside)
+     * Group0:     |---UnboundRelation
      *
-     * After rewrite:
-     * Project(inside)
-     * |---UnboundRelation
+     * and we want to rewrite group 2 by Project(inside, GroupPlan(group 0))
+     *
+     * After rewriting we should get(Group 2 is root):
+     * Group2: Project(inside)
+     * Group0: |---UnboundRelation
      */
     @Test
     public void testRewriteByChild() {
@@ -157,6 +159,11 @@ public class MemoTest {
         node = node.child(0);
         Assertions.assertTrue(node instanceof UnboundRelation);
         Assertions.assertEquals("test", ((UnboundRelation) node).getTableName());
+
+        // check Group 1's GroupExpression is not in GroupExpressionMaps anymore
+        GroupExpression groupExpression = new GroupExpression(rewriteProject, Lists.newArrayList(leafGroup));
+        Assertions.assertEquals(2,
+                memo.getGroupExpressions().get(groupExpression).getOwnerGroup().getGroupId().asInt());
     }
 
     /**


### PR DESCRIPTION
# Proposed changes

When we do write current plan with its child. Currently, nereids memo do nothing indeed.
This PR fix this situation by add a predicate in rewrite that only replaced target group and set newGroupExpressionGenerated to false when target is null or target is same with existed group expression's group.

here we need to handle one situation that original target is not the same with
existedGroupExpression.getOwnerGroup(). In this case, if we change target to
existedGroupExpression.getOwnerGroup(), we could not rewrite plan as we expected and the plan
will not be changed anymore.
Think below example:
We have a plan like this:

```
Original (Group 2 is root):
Group2: Project(outside)
Group1: |---Project(inside)
Group0:     |---UnboundRelation

and we want to rewrite group 2 by Project(inside, GroupPlan(group 0))

After rewriting we should get (Group 2 is root):
Group2: Project(inside)
Group0: |---UnboundRelation
Group1: Project(inside)
```

After rewriting, Group 1's GroupExpression is not in GroupExpressionsMap anymore and Group 1 is unreachable.
Merge Group 1 into Group 2 is better, but in consideration of there is others way to let a Group take into
unreachable. There's no need to complicate to add a merge step. Instead, we need to have a clear step to
remove unreachable groups and GroupExpressions after rewrite.
## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [x] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

