### PR TITLE
[Enhancement](Planner) Improve error message when columns order and keys orders don't match.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/KeysDesc.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/KeysDesc.java
@@ -75,7 +75,10 @@ public class KeysDesc implements Writable {
                 if (cols.stream().noneMatch(col -> col.getName().equalsIgnoreCase(keyName))) {
                     throw new AnalysisException("Key column[" + keyName + "] doesn't exist.");
                 }
-                throw new AnalysisException("Key columns should be a ordered prefix of the schema.");
+                throw new AnalysisException("Key columns should be a ordered prefix of the schema."
+                        + " KeyColumns[" + i + "] (starts from zero) is " + keyName + ", "
+                        + "but corresponding column is " + name  + " in the previous "
+                        + "columns declaration.");
             }
 
             if (cols.get(i).getAggregateType() != null) {

--- a/fe/fe-core/src/test/java/org/apache/doris/planner/QueryPlanTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/planner/QueryPlanTest.java
@@ -53,6 +53,7 @@ import com.google.common.collect.Lists;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.Assert;
 import org.junit.Ignore;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -2146,5 +2147,24 @@ public class QueryPlanTest extends TestWithFeService {
         System.out.println(explainString);
         // errCode = 2, detailMessage = Unknown column 'col2' in 't_2'
         Assert.assertFalse(explainString.contains("errCode"));
+    }
+
+    @Test
+    public void testKeyOrderError() throws Exception {
+        Assertions.assertTrue(getSQLPlanOrErrorMsg("CREATE TABLE `test`.`test_key_order` (\n"
+                + "  `k1` tinyint(4) NULL COMMENT \"\",\n"
+                + "  `k2` smallint(6) NULL COMMENT \"\",\n"
+                + "  `k3` int(11) NULL COMMENT \"\",\n"
+                + "  `v1` double MAX NULL COMMENT \"\",\n"
+                + "  `v2` float SUM NULL COMMENT \"\"\n"
+                + ") ENGINE=OLAP\n"
+                + "AGGREGATE KEY(`k1`, `k3`, `k2`)\n"
+                + "COMMENT \"OLAP\"\n"
+                + "DISTRIBUTED BY HASH(`k1`) BUCKETS 5\n"
+                + "PROPERTIES (\n"
+                + "\"replication_num\" = \"1\"\n"
+                + ");").contains("Key columns should be a ordered prefix of the schema. "
+                + "KeyColumns[1] (starts from zero) is k3, "
+                + "but corresponding column is k2 in the previous columns declaration."));
     }
 }


### PR DESCRIPTION
# Proposed changes
Show more clear error messages when columns order and keys order do not match.

When creating table like this:
```sql
CREATE TABLE `test`.`test_key_order` (
  `k1` tinyint(4) NULL COMMENT "",
  `k2` smallint(6) NULL COMMENT "",
  `k3` int(11) NULL COMMENT "",
  `v1` double MAX NULL COMMENT "",
  `v2` float SUM NULL COMMENT ""
) ENGINE=OLAP
AGGREGATE KEY(`k1`, `k3`, `k2`)
COMMENT "OLAP"
DISTRIBUTED BY HASH(`k1`) BUCKETS 5
PROPERTIES (
"replication_num" = "1"
);
```
The error message before is:
```
Key columns should be a ordered prefix of the schema.
```
With this PR, the error message is:
```
Key columns should be a ordered prefix of the schema. KeyColumns[1] (starts from zero) is k3, but corresponding column is k2 in the previous columns declaration.
```

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [x] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [x] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

