### PR TITLE
[bugfix](odbc) return error if convert unicode failed

### DIFF
--- a/be/src/exec/odbc_connector.cpp
+++ b/be/src/exec/odbc_connector.cpp
@@ -48,9 +48,14 @@ static constexpr uint32_t BIG_COLUMN_SIZE_BUFFER = 65535;
 // Default max buffer size use in insert to: 50MB, normally a batch is smaller than the size
 static constexpr uint32_t INSERT_BUFFER_SIZE = 1024l * 1024 * 50;
 
-static std::u16string utf8_to_wstring(const std::string& str) {
+static doris::Status utf8_to_wstring(const std::string& str, std::u16string& out ) {
     std::wstring_convert<std::codecvt_utf8<char16_t>, char16_t> utf8_ucs2_cvt;
-    return utf8_ucs2_cvt.from_bytes(str);
+    try {
+        out = utf8_ucs2_cvt.from_bytes(str);
+    } catch (std::range_error& e) {
+        return doris::Status::InternalError("UNICODE out of supported range");
+    }
+    return doris::Status::OK();
 }
 
 namespace doris {
@@ -128,7 +133,8 @@ Status ODBCConnector::query() {
                  "alloc statement");
 
     // Translate utf8 string to utf16 to use unicode encoding
-    auto wquery = utf8_to_wstring(_sql_str);
+    std::u16string wquery;
+    RETURN_IF_ERROR(utf8_to_wstring(_sql_str, wquery));
     ODBC_DISPOSE(_stmt, SQL_HANDLE_STMT,
                  SQLExecDirectW(_stmt, (SQLWCHAR*)(wquery.c_str()), SQL_NTS), "exec direct");
 
@@ -307,9 +313,10 @@ Status ODBCConnector::append(const std::string& table_name, RowBatch* batch,
             }
         }
         // Translate utf8 string to utf16 to use unicode encodeing
-        insert_stmt = utf8_to_wstring(
+        RETURN_IF_ERROR(utf8_to_wstring(
                 std::string(_insert_stmt_buffer.data(),
-                            _insert_stmt_buffer.data() + _insert_stmt_buffer.size()));
+                            _insert_stmt_buffer.data() + _insert_stmt_buffer.size()),
+                insert_stmt));
     }
 
     {
@@ -492,9 +499,10 @@ Status ODBCConnector::append(const std::string& table_name, vectorized::Block* b
             }
         }
         // Translate utf8 string to utf16 to use unicode encodeing
-        insert_stmt = utf8_to_wstring(
+        RETURN_IF_ERROR(utf8_to_wstring(
                 std::string(_insert_stmt_buffer.data(),
-                            _insert_stmt_buffer.data() + _insert_stmt_buffer.size()));
+                            _insert_stmt_buffer.data() + _insert_stmt_buffer.size()),
+                insert_stmt));
     }
 
     {

--- a/be/src/exec/odbc_connector.cpp
+++ b/be/src/exec/odbc_connector.cpp
@@ -48,7 +48,7 @@ static constexpr uint32_t BIG_COLUMN_SIZE_BUFFER = 65535;
 // Default max buffer size use in insert to: 50MB, normally a batch is smaller than the size
 static constexpr uint32_t INSERT_BUFFER_SIZE = 1024l * 1024 * 50;
 
-static doris::Status utf8_to_wstring(const std::string& str, std::u16string& out ) {
+static doris::Status utf8_to_wstring(const std::string& str, std::u16string& out) {
     std::wstring_convert<std::codecvt_utf8<char16_t>, char16_t> utf8_ucs2_cvt;
     try {
         out = utf8_ucs2_cvt.from_bytes(str);


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

When inserting into external ODBC table, if data contains unicode chars whose code point value is bigger than max int16, `utf8_ucs2_cvt.from_bytes` throws exception `std::range_error` and causes BE coredump.

This is a temporary solution only to avoid BE coredump. A final solution to support UNICODE chars bigger than max int16 should be provided later.

How to reproduce:

```
-- mysql table
CREATE TABLE t1 (
  room_id  bigint,
  space_name  varchar(300)
);


-- doris table
CREATE EXTERNAL RESOURCE `mysql_resource`
PROPERTIES (
"host" = "127.0.0.1",
"port" = "3306",
"user" = "root",
"password" = "",
"database" = "test",
"driver" = "MySQL ODBC 5.3",
"odbc_type" = "mysql",
"type" = "odbc_catalog");

CREATE EXTERNAL TABLE `t1` (
  `room_id` bigint(20) NULL COMMENT "ID",
  `space_name` text NULL COMMENT "name"
) ENGINE=ODBC
COMMENT "ODBC"
PROPERTIES (
"odbc_catalog_resource" = "mysql_resource",
"database" = "test",
"table" = "t1"
);


CREATE TABLE `t2` (
  `room_id` bigint(20) NULL COMMENT "ID",
  `space_name` text NULL COMMENT "name"
) ENGINE=OLAP
UNIQUE KEY(`room_id`)
COMMENT "OLAP"
DISTRIBUTED BY HASH(`room_id`) BUCKETS 2
PROPERTIES (
"replication_allocation" = "tag.location.default: 1",
"in_memory" = "false",
"storage_format" = "V2"
);

insert  into `t2`(`room_id`,`space_name`) values (1, "a🐷b");

insert into t1 select * from t2;
```

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

