### PR TITLE
[enhancement](load) enhance load from parquet or orc file

### DIFF
--- a/be/src/exec/arrow/arrow_reader.cpp
+++ b/be/src/exec/arrow/arrow_reader.cpp
@@ -73,12 +73,11 @@ Status ArrowReaderWrap::column_indices(const std::vector<SlotDescriptor*>& tuple
         // Get the Column Reader for the boolean column
         auto iter = _map_column.find(slot_desc->col_name());
         if (iter != _map_column.end()) {
+            _map_parquet_column_ids_idx[_include_column_ids.size()] = i;
             _include_column_ids.emplace_back(iter->second);
         } else {
-            std::stringstream str_error;
-            str_error << "Invalid Column Name:" << slot_desc->col_name();
-            LOG(WARNING) << str_error.str();
-            return Status::InvalidArgument(str_error.str());
+            // will give null to the slot, if not found in src file
+            _skipped_read_idx.emplace(i);
         }
     }
     return Status::OK();

--- a/be/src/exec/arrow/arrow_reader.h
+++ b/be/src/exec/arrow/arrow_reader.h
@@ -117,6 +117,11 @@ protected:
     std::vector<int> _include_column_ids;   // columns that need to get from file
     std::shared_ptr<Statistics> _statistics;
 
+    // the src slot index which need to set to null as not the column not exist in parquet file
+    std::set<int> _skipped_read_idx;
+    // map from column id index to src slot index
+    std::map<int, int> _map_parquet_column_ids_idx;
+
     std::atomic<bool> _closed = false;
     std::atomic<bool> _batch_eof = false;
     arrow::Status _status;

--- a/be/src/exec/arrow/parquet_reader.cpp
+++ b/be/src/exec/arrow/parquet_reader.cpp
@@ -249,9 +249,15 @@ Status ParquetReaderWrap::read(Tuple* tuple, const std::vector<SlotDescriptor*>&
     const uint8_t* value = nullptr;
     int column_index = 0;
     try {
+        // set null value for slots not found in src files
+        for (auto it = _skipped_read_idx.begin(); it != _skipped_read_idx.end(); ++it) {
+            auto slot_desc = tuple_slot_descs[*it];
+            RETURN_IF_ERROR(set_field_null(tuple, slot_desc));
+        }
+
         size_t slots = _include_column_ids.size();
         for (size_t i = 0; i < slots; ++i) {
-            auto slot_desc = tuple_slot_descs[i];
+            auto slot_desc = tuple_slot_descs[_map_parquet_column_ids_idx[i]];
             column_index = i; // column index in batch record
             switch (_parquet_column_type[i]) {
             case arrow::Type::type::STRING: {

--- a/be/src/exec/orc_scanner.cpp
+++ b/be/src/exec/orc_scanner.cpp
@@ -124,18 +124,6 @@ ORCScanner::~ORCScanner() {
 
 Status ORCScanner::open() {
     RETURN_IF_ERROR(BaseScanner::open());
-    if (!_ranges.empty()) {
-        std::list<std::string> include_cols;
-        TBrokerRangeDesc range = _ranges[0];
-        _num_of_columns_from_file = range.__isset.num_of_columns_from_file
-                                            ? range.num_of_columns_from_file
-                                            : _src_slot_descs.size();
-        for (int i = 0; i < _num_of_columns_from_file; i++) {
-            auto slot_desc = _src_slot_descs.at(i);
-            include_cols.push_back(slot_desc->col_name());
-        }
-        _row_reader_options.include(include_cols);
-    }
 
     return Status::OK();
 }
@@ -171,8 +159,13 @@ Status ORCScanner::get_next(Tuple* tuple, MemPool* tuple_pool, bool* eof, bool* 
                     ((orc::StructVectorBatch*)_batch.get())->fields;
             for (int column_ipos = 0; column_ipos < _num_of_columns_from_file; ++column_ipos) {
                 auto slot_desc = _src_slot_descs[column_ipos];
-                orc::ColumnVectorBatch* cvb = batch_vec[_position_in_orc_original[column_ipos]];
+                if (_map_column_to_id.find(slot_desc->col_name()) == _map_column_to_id.end()) {
+                    // if slot not exist in file, set to null
+                    _src_tuple->set_null(slot_desc->null_indicator_offset());
+                    continue;
+                }
 
+                orc::ColumnVectorBatch* cvb = batch_vec[_position_in_orc_original[column_ipos]];
                 if (cvb->hasNulls && !cvb->notNull[_current_line_of_group]) {
                     if (!slot_desc->is_nullable()) {
                         std::stringstream str_error;
@@ -400,6 +393,25 @@ Status ORCScanner::open_next_reader() {
             continue;
         }
 
+        // build map from column name to type id
+        build_name_id_map();
+        // set include names into read options
+        std::map<int,int> _include_cols_in_src_slots;
+        std::list<std::string> cols;
+        _num_of_columns_from_file = range.__isset.num_of_columns_from_file
+                                            ? range.num_of_columns_from_file
+                                            : _src_slot_descs.size();
+        for (int i = 0; i < _num_of_columns_from_file; i++) {
+            auto slot_desc = _src_slot_descs.at(i);
+
+            // get only columns exist orc file
+            if (_map_column_to_id.find(slot_desc->col_name()) != _map_column_to_id.end()) {
+                _include_cols_in_src_slots[cols.size()] = i;
+                cols.push_back(slot_desc->col_name());
+            }
+        }
+        _row_reader_options.include(cols);
+
         _total_groups = _reader->getNumberOfStripes();
         _current_group = 0;
         _rows_of_group = 0;
@@ -415,7 +427,7 @@ Status ORCScanner::open_next_reader() {
             //include columns must in reader field, otherwise createRowReader will throw exception
             auto pos = std::find(include_cols.begin(), include_cols.end(),
                                  _row_reader->getSelectedType().getFieldName(i));
-            _position_in_orc_original.at(std::distance(include_cols.begin(), pos)) = orc_index++;
+            _position_in_orc_original.at(_include_cols_in_src_slots[std::distance(include_cols.begin(), pos)]) = orc_index++;
         }
         return Status::OK();
     }
@@ -427,5 +439,40 @@ void ORCScanner::close() {
     _reader.reset(nullptr);
     _row_reader.reset(nullptr);
 }
+
+void ORCScanner::build_name_id_map() {
+    std::vector<std::string> columns;
+    const orc::Type &type = _reader->getType();
+    build_name_id_map_impl(columns, &type);
+}
+
+void ORCScanner::build_name_id_map_impl(std::vector<std::string> &columns, const orc::Type *type) {
+    if (orc::STRUCT == type->getKind()) {
+        for (size_t i = 0; i < type->getSubtypeCount(); ++i) {
+          const std::string& fieldName = type->getFieldName(i);
+          columns.push_back(fieldName);
+          _map_column_to_id[dot_column_path(columns)] = type->getSubtype(i)->getColumnId();
+          build_name_id_map_impl(columns, type->getSubtype(i));
+          columns.pop_back();
+        }
+    } else {
+        // other non-primitive type
+        for (size_t j = 0; j < type->getSubtypeCount(); ++j) {
+            build_name_id_map_impl(columns, type->getSubtype(j));
+        }
+    }
+}
+
+std::string ORCScanner::dot_column_path(const std::vector<std::string> &columns) {
+      if (columns.empty()) {
+          return std::string();
+      }
+      std::ostringstream columnStream;
+      std::copy(columns.begin(), columns.end(),
+              std::ostream_iterator<std::string>(columnStream, "."));
+      std::string columnPath = columnStream.str();
+      return columnPath.substr(0, columnPath.length() - 1);
+  }
+
 
 } // namespace doris

--- a/be/src/exec/orc_scanner.cpp
+++ b/be/src/exec/orc_scanner.cpp
@@ -396,7 +396,7 @@ Status ORCScanner::open_next_reader() {
         // build map from column name to type id
         build_name_id_map();
         // set include names into read options
-        std::map<int,int> _include_cols_in_src_slots;
+        std::map<int, int> _include_cols_in_src_slots;
         std::list<std::string> cols;
         _num_of_columns_from_file = range.__isset.num_of_columns_from_file
                                             ? range.num_of_columns_from_file
@@ -427,7 +427,9 @@ Status ORCScanner::open_next_reader() {
             //include columns must in reader field, otherwise createRowReader will throw exception
             auto pos = std::find(include_cols.begin(), include_cols.end(),
                                  _row_reader->getSelectedType().getFieldName(i));
-            _position_in_orc_original.at(_include_cols_in_src_slots[std::distance(include_cols.begin(), pos)]) = orc_index++;
+            _position_in_orc_original.at(
+                    _include_cols_in_src_slots[std::distance(include_cols.begin(), pos)]) =
+                    orc_index++;
         }
         return Status::OK();
     }
@@ -442,18 +444,18 @@ void ORCScanner::close() {
 
 void ORCScanner::build_name_id_map() {
     std::vector<std::string> columns;
-    const orc::Type &type = _reader->getType();
+    const orc::Type& type = _reader->getType();
     build_name_id_map_impl(columns, &type);
 }
 
-void ORCScanner::build_name_id_map_impl(std::vector<std::string> &columns, const orc::Type *type) {
+void ORCScanner::build_name_id_map_impl(std::vector<std::string>& columns, const orc::Type* type) {
     if (orc::STRUCT == type->getKind()) {
         for (size_t i = 0; i < type->getSubtypeCount(); ++i) {
-          const std::string& fieldName = type->getFieldName(i);
-          columns.push_back(fieldName);
-          _map_column_to_id[dot_column_path(columns)] = type->getSubtype(i)->getColumnId();
-          build_name_id_map_impl(columns, type->getSubtype(i));
-          columns.pop_back();
+            const std::string& fieldName = type->getFieldName(i);
+            columns.push_back(fieldName);
+            _map_column_to_id[dot_column_path(columns)] = type->getSubtype(i)->getColumnId();
+            build_name_id_map_impl(columns, type->getSubtype(i));
+            columns.pop_back();
         }
     } else {
         // other non-primitive type
@@ -464,15 +466,14 @@ void ORCScanner::build_name_id_map_impl(std::vector<std::string> &columns, const
 }
 
 std::string ORCScanner::dot_column_path(const std::vector<std::string> &columns) {
-      if (columns.empty()) {
-          return std::string();
-      }
-      std::ostringstream columnStream;
-      std::copy(columns.begin(), columns.end(),
-              std::ostream_iterator<std::string>(columnStream, "."));
-      std::string columnPath = columnStream.str();
-      return columnPath.substr(0, columnPath.length() - 1);
+    if (columns.empty()) {
+        return std::string();
+    }
+    std::ostringstream columnStream;
+    std::copy(columns.begin(), columns.end(),
+            std::ostream_iterator<std::string>(columnStream, "."));
+    std::string columnPath = columnStream.str();
+    return columnPath.substr(0, columnPath.length() - 1);
   }
-
 
 } // namespace doris

--- a/be/src/exec/orc_scanner.cpp
+++ b/be/src/exec/orc_scanner.cpp
@@ -465,15 +465,15 @@ void ORCScanner::build_name_id_map_impl(std::vector<std::string>& columns, const
     }
 }
 
-std::string ORCScanner::dot_column_path(const std::vector<std::string> &columns) {
+std::string ORCScanner::dot_column_path(const std::vector<std::string>& columns) {
     if (columns.empty()) {
         return std::string();
     }
     std::ostringstream columnStream;
     std::copy(columns.begin(), columns.end(),
-            std::ostream_iterator<std::string>(columnStream, "."));
+              std::ostream_iterator<std::string>(columnStream, "."));
     std::string columnPath = columnStream.str();
     return columnPath.substr(0, columnPath.length() - 1);
-  }
+}
 
 } // namespace doris

--- a/be/src/exec/orc_scanner.h
+++ b/be/src/exec/orc_scanner.h
@@ -48,9 +48,10 @@ private:
     Status open_next_reader();
     // Generate column path
     std::string dot_column_path(const std::vector<std::string>& columns);
-    // Build map from column name to type id 
+    // Build map from column name to type id
     void build_name_id_map();
     void build_name_id_map_impl(std::vector<std::string>& columns, const orc::Type* type);
+    
 private:
     // Reader
     bool _cur_file_eof;

--- a/be/src/exec/orc_scanner.h
+++ b/be/src/exec/orc_scanner.h
@@ -51,7 +51,7 @@ private:
     // Build map from column name to type id
     void build_name_id_map();
     void build_name_id_map_impl(std::vector<std::string>& columns, const orc::Type* type);
-    
+
 private:
     // Reader
     bool _cur_file_eof;

--- a/be/src/exec/orc_scanner.h
+++ b/be/src/exec/orc_scanner.h
@@ -47,10 +47,10 @@ private:
     // Read next buffer from reader
     Status open_next_reader();
     // Generate column path
-    std::string dot_column_path(const std::vector<std::string> &columns);
+    std::string dot_column_path(const std::vector<std::string>& columns);
     // Build map from column name to type id 
     void build_name_id_map();
-    void build_name_id_map_impl(std::vector<std::string> &columns, const orc::Type *type);
+    void build_name_id_map_impl(std::vector<std::string>& columns, const orc::Type* type);
 private:
     // Reader
     bool _cur_file_eof;

--- a/be/src/exec/orc_scanner.h
+++ b/be/src/exec/orc_scanner.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <orc/OrcFile.hh>
+#include <orc/Type.hh>
 
 #include "exec/base_scanner.h"
 
@@ -45,7 +46,11 @@ public:
 private:
     // Read next buffer from reader
     Status open_next_reader();
-
+    // Generate column path
+    std::string dot_column_path(const std::vector<std::string> &columns);
+    // Build map from column name to type id 
+    void build_name_id_map();
+    void build_name_id_map_impl(std::vector<std::string> &columns, const orc::Type *type);
 private:
     // Reader
     bool _cur_file_eof;
@@ -56,6 +61,7 @@ private:
     std::shared_ptr<orc::ColumnVectorBatch> _batch;
     std::unique_ptr<orc::Reader> _reader;
     std::unique_ptr<orc::RowReader> _row_reader;
+    std::map<std::string, int> _map_column_to_id;
     // The batch after reading from orc data is arranged in the original order,
     // so we need to record the index in the original order to correspond the column names to the order
     std::vector<int> _position_in_orc_original;

--- a/be/src/vec/exec/format/parquet/vparquet_reader.cpp
+++ b/be/src/vec/exec/format/parquet/vparquet_reader.cpp
@@ -79,10 +79,8 @@ Status ParquetReader::_init_read_columns(const std::vector<SlotDescriptor*>& tup
         if (iter != _map_column.end()) {
             _include_column_ids.emplace_back(parquet_col_id);
         } else {
-            std::stringstream str_error;
-            str_error << "Invalid Column Name:" << slot_desc->col_name();
-            LOG(WARNING) << str_error.str();
-            return Status::InvalidArgument(str_error.str());
+            // just continue, as the invalid column will be set to null by default
+            continue;
         }
         ParquetReadColumn column;
         column.slot_desc = slot_desc;


### PR DESCRIPTION
# Proposed changes

enhance loading from parquet or orc file, when given column not exist in file, set to null default instead of fails with "Invalid Column"

## Problem summary
1, create table:
CREATE TABLE `t22` (
  `name` bigint(20) NOT NULL COMMENT "",
  `id` bigint(20) NOT NULL COMMENT "",
  `id2` bigint(20) NULL COMMENT "",
  `impressions` bigint(20) SUM NULL DEFAULT "0" COMMENT "用户总展现",
  `click` double SUM NULL DEFAULT "0" COMMENT "用户总点击",
  `cost` bigint(20) SUM NULL DEFAULT "0" COMMENT "用户总消费"
) ENGINE=OLAP
AGGREGATE KEY(`name`, `id`, `id2`)
COMMENT "OLAP"
PARTITION BY RANGE(`name`)
(PARTITION p201901 VALUES [("1"), ("100")))
DISTRIBUTED BY HASH(`id`) BUCKETS 16
PROPERTIES (
"replication_allocation" = "tag.location.default: 3",
"in_memory" = "false",
"storage_format" = "V2"
)
2, try to load data in parquet or orc  with  broker load 
2.1 data like below:
name,id,click,impressions,cost
1,111,1111,11111,111111
1,11,,1111,11111
22,222,2222,22222,22222
3,33,333,3333,33333
4,44,444,4444,44444
5,55,555,5555,55555

2.2 broker load without columns  like below:
LOAD LABEL label1 (DATA INFILE (hdfs://filepath) into table 't22' format as "parquet" with broker broker_name (....)

3, the result should like below instead of failed with "Invalid Column with ", the column id2 is NULL as it not exist in file.
+------+------+------+-------------+-------+--------+
| name | id   | id2  | impressions | click | cost   |
+------+------+------+-------------+-------+--------+
|   22 |  222 | NULL |       22222 |  2222 |  22222 |
|   11 |  111 | NULL |       11111 |  1111 | 111111 |
|    5 |   55 | NULL |        5555 |   555 |  55555 |
|    4 |   44 | NULL |        4444 |   444 |  44444 |
|    3 |   33 | NULL |        3333 |   333 |  33333 |
|    1 |   11 | NULL |        1111 |  NULL |  11111 |
+------+------+------+-------------+-------+--------+

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [Y ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

