### PR TITLE
[Fix](audit) do not use duplicate query id in fe.audit.log

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectProcessor.java
@@ -273,6 +273,9 @@ public class ConnectProcessor {
             ctx.getState().setError(e.getMysqlErrorCode(), e.getMessage());
             // set is as ANALYSIS_ERR so that it won't be treated as a query failure.
             ctx.getState().setErrType(QueryState.ErrType.ANALYSIS_ERR);
+            UUID uuid = UUID.randomUUID();
+            TUniqueId queryId = new TUniqueId(uuid.getMostSignificantBits(), uuid.getLeastSignificantBits());
+            ctx.setQueryId(queryId);
         } catch (Throwable e) {
             // Catch all throwable.
             // If reach here, maybe palo bug.


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

The original logic in ConnectProcessor.java might result in duplicate query id for different query statement in fe.audit.log as follows.

![image](https://user-images.githubusercontent.com/43750022/184353465-66955fe2-be96-4541-ba18-2362dc5f0d39.png)

This pr solves this by assigning new query id for wrong query.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] No
2. Has unit tests been added:
    - [ ] No
3. Has document been added or modified:
    - [ ] No
4. Does it need to update dependencies:
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

