### PR TITLE
[enhancement](memory) Fix too much cache leads to less memory available for queries

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -446,9 +446,15 @@ CONF_Bool(use_mmap_allocate_chunk, "false");
 // must larger than 0. and if larger than physical memory size, it will be set to physical memory size.
 // increase this variable can improve performance,
 // but will acquire more free memory which can not be used by other modules.
-CONF_mString(chunk_reserved_bytes_limit, "20%");
+CONF_mString(chunk_reserved_bytes_limit, "10%");
 // 1024, The minimum chunk allocator size (in bytes)
 CONF_Int32(min_chunk_reserved_bytes, "1024");
+// Disable Chunk Allocator in Vectorized Allocator, this will reduce memory cache.
+// For high concurrent queries, using Chunk Allocator with vectorized Allocator can reduce the impact
+// of gperftools tcmalloc central lock.
+// Jemalloc or google tcmalloc have core cache, Chunk Allocator may no longer be needed after replacing
+// gperftools tcmalloc.
+CONF_mBool(disable_chunk_allocator_in_vec, "true");
 
 // The probing algorithm of partitioned hash table.
 // Enable quadratic probing hash table

--- a/be/src/runtime/memory/chunk_allocator.cpp
+++ b/be/src/runtime/memory/chunk_allocator.cpp
@@ -147,7 +147,7 @@ ChunkAllocator::ChunkAllocator(size_t reserve_limit)
 }
 
 Status ChunkAllocator::allocate(size_t size, Chunk* chunk) {
-    DCHECK(BitUtil::RoundUpToPowerOfTwo(size) == size);
+    CHECK((size > 0 && (size & (size - 1)) == 0));
 
     // fast path: allocate from current core arena
     int core_id = CpuInfo::get_current_core();
@@ -198,6 +198,8 @@ Status ChunkAllocator::allocate(size_t size, Chunk* chunk) {
 
 void ChunkAllocator::free(const Chunk& chunk) {
     DCHECK(chunk.core_id != -1);
+    CHECK((chunk.size & (chunk.size - 1)) == 0);
+
     int64_t old_reserved_bytes = _reserved_bytes;
     int64_t new_reserved_bytes = 0;
     do {

--- a/be/src/vec/common/allocator.h
+++ b/be/src/vec/common/allocator.h
@@ -134,7 +134,7 @@ public:
             }
 
             /// No need for zero-fill, because mmap guarantees it.
-        } else if (doris::config::disable_chunk_allocator_in_vec && size >= CHUNK_THRESHOLD) {
+        } else if (!doris::config::disable_chunk_allocator_in_vec && size >= CHUNK_THRESHOLD) {
             doris::Chunk chunk;
             if (!doris::ChunkAllocator::instance()->allocate_align(size, &chunk)) {
                 doris::vectorized::throwFromErrno(
@@ -178,7 +178,7 @@ public:
             } else {
                 RELEASE_THREAD_MEM_TRACKER(size);
             }
-        } else if (doris::config::disable_chunk_allocator_in_vec && size >= CHUNK_THRESHOLD &&
+        } else if (!doris::config::disable_chunk_allocator_in_vec && size >= CHUNK_THRESHOLD &&
                    ((size & (size - 1)) == 0)) {
             // Only power-of-two length are added to ChunkAllocator
             doris::ChunkAllocator::instance()->free((uint8_t*)buf, size);

--- a/be/src/vec/common/allocator.h
+++ b/be/src/vec/common/allocator.h
@@ -27,6 +27,7 @@
 
 #include <exception>
 
+#include "common/config.h"
 #include "common/status.h"
 #include "runtime/memory/chunk.h"
 #include "runtime/memory/chunk_allocator.h"
@@ -133,7 +134,7 @@ public:
             }
 
             /// No need for zero-fill, because mmap guarantees it.
-        } else if (size >= CHUNK_THRESHOLD) {
+        } else if (doris::config::disable_chunk_allocator_in_vec && size >= CHUNK_THRESHOLD) {
             doris::Chunk chunk;
             if (!doris::ChunkAllocator::instance()->allocate_align(size, &chunk)) {
                 doris::vectorized::throwFromErrno(
@@ -177,7 +178,9 @@ public:
             } else {
                 RELEASE_THREAD_MEM_TRACKER(size);
             }
-        } else if (size >= CHUNK_THRESHOLD) {
+        } else if (doris::config::disable_chunk_allocator_in_vec && size >= CHUNK_THRESHOLD &&
+                   ((size & (size - 1)) == 0)) {
+            // Only power-of-two length are added to ChunkAllocator
             doris::ChunkAllocator::instance()->free((uint8_t*)buf, size);
         } else {
             ::free(buf);
@@ -192,7 +195,7 @@ public:
         if (old_size == new_size) {
             /// nothing to do.
             /// BTW, it's not possible to change alignment while doing realloc.
-        } else if (old_size < CHUNK_THRESHOLD && new_size < CHUNK_THRESHOLD &&
+        } else if (old_size < MMAP_THRESHOLD && new_size < MMAP_THRESHOLD &&
                    alignment <= MALLOC_MIN_ALIGNMENT) {
             /// Resize malloc'd memory region with no special alignment requirement.
             void* new_buf = ::realloc(buf, new_size);
@@ -230,6 +233,7 @@ public:
                     memset(reinterpret_cast<char*>(buf) + old_size, 0, new_size - old_size);
             }
         } else {
+            // Big allocs that requires a copy.
             void* new_buf = alloc(new_size, alignment);
             memcpy(new_buf, buf, std::min(old_size, new_size));
             free(buf, old_size);


### PR DESCRIPTION
# Proposed changes

Issue Number: close #11750

## Problem summary

Disable Chunk Allocator in Vectorized Allocator, this will reduce memory cache.

For high concurrent queries, using Chunk Allocator with vectorized Allocator can reduce the impact of gperftools tcmalloc central lock.

Jemalloc or google tcmalloc have core cache, Chunk Allocator may no longer be needed after replacing gperftools tcmalloc.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [x] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

