### PR TITLE
[fix](query) fix orderby keys limit return less or no result

### DIFF
--- a/be/src/vec/exec/volap_scanner.cpp
+++ b/be/src/vec/exec/volap_scanner.cpp
@@ -335,6 +335,8 @@ Status VOlapScanner::get_block(RuntimeState* state, vectorized::Block* block, bo
             _update_realtime_counter();
             RETURN_IF_ERROR(
                     VExprContext::filter_block(_vconjunct_ctx, block, _tuple_desc->slots().size()));
+            // record rows return (after filter) for _limit check
+            _num_rows_return += block->rows();
         } while (block->rows() == 0 && !(*eof) && raw_rows_read() < raw_rows_threshold);
     }
     // NOTE:
@@ -344,7 +346,7 @@ Status VOlapScanner::get_block(RuntimeState* state, vectorized::Block* block, bo
 
     // set eof to true if per scanner limit is reached
     // currently for query: ORDER BY key LIMIT n
-    if (_limit > 0 && _num_rows_read > _limit) {
+    if (_limit > 0 && _num_rows_return > _limit) {
         *eof = true;
     }
 

--- a/be/src/vec/exec/volap_scanner.h
+++ b/be/src/vec/exec/volap_scanner.h
@@ -134,6 +134,7 @@ private:
     // time costed and row returned statistics
     int64_t _num_rows_read = 0;
     int64_t _raw_rows_read = 0;
+    int64_t _num_rows_return = 0;
     int64_t _compressed_bytes_read = 0;
 
     // number rows filtered by pushed condition


### PR DESCRIPTION
fix orderby keys limit return less or no result when a WHERE predicte filter most rows

# Proposed changes

Issue Number: close #xxx

## Problem summary

Describe your changes.

The bug is caused by use _num_rows_read for limit check. _num_rows_read is count of rows read from storage, but may be  filtered by filter_block for WHERE predicate.

Add a _num_rows_return, which is rows after filter_block for WHERE predicate, for count for really returned rows.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

