### PR TITLE
[feature-wip](parquet-reader) parquet physical type to doris logical type

### DIFF
--- a/be/src/vec/exec/format/parquet/vparquet_column_chunk_reader.h
+++ b/be/src/vec/exec/format/parquet/vparquet_column_chunk_reader.h
@@ -59,13 +59,11 @@ namespace doris::vectorized {
 class ColumnChunkReader {
 public:
     ColumnChunkReader(BufferedStreamReader* reader, tparquet::ColumnChunk* column_chunk,
-                      FieldSchema* fieldSchema);
+                      FieldSchema* field_schema);
     ~ColumnChunkReader() = default;
 
     // Initialize chunk reader, will generate the decoder and codec.
-    // We can set the type_length if the length of colum type if fixed,
-    // or not set, the decoder will try to infer the type_length.
-    Status init(size_t type_length = -1);
+    Status init();
 
     // Whether the chunk reader has a more page to read.
     bool has_next_page() { return _page_reader->has_next_page(); }
@@ -86,8 +84,11 @@ public:
     // Load page data into the underlying container,
     // and initialize the repetition and definition level decoder for current page data.
     Status load_page_data();
-    // The remaining number of values in current page. Decreased when reading or skipping.
+    // The remaining number of values in current page(including null values). Decreased when reading or skipping.
     uint32_t num_values() const { return _num_values; };
+    // null values are not analyzing from definition levels
+    // the caller should maintain the consistency after analyzing null values from definition levels.
+    void dec_num_values(uint32_t dec_num) { _num_values -= dec_num; };
     // Get the raw data of current page.
     Slice& get_page_data() { return _page_data; }
 
@@ -97,7 +98,8 @@ public:
     size_t get_def_levels(level_t* levels, size_t n);
 
     // Decode values in current page into doris column.
-    Status decode_values(ColumnPtr& doris_column, size_t num_values);
+    Status decode_values(ColumnPtr& doris_column, DataTypePtr& data_type, size_t num_values);
+    Status decode_values(MutableColumnPtr& doris_column, DataTypePtr& data_type, size_t num_values);
     // For test, Decode values in current page into slice.
     Status decode_values(Slice& slice, size_t num_values);
 
@@ -109,7 +111,9 @@ public:
 private:
     Status _decode_dict_page();
     void _reserve_decompress_buf(size_t size);
+    int32_t _get_type_length();
 
+    FieldSchema* _field_schema;
     level_t _max_rep_level;
     level_t _max_def_level;
 
@@ -131,7 +135,6 @@ private:
     // Map: encoding -> Decoder
     // Plain or Dictionary encoding. If the dictionary grows too big, the encoding will fall back to the plain encoding
     std::unordered_map<int, std::unique_ptr<Decoder>> _decoders;
-    size_t _type_length = -1;
 };
 
 } // namespace doris::vectorized

--- a/be/test/vec/exec/parquet/parquet_thrift_test.cpp
+++ b/be/test/vec/exec/parquet/parquet_thrift_test.cpp
@@ -22,10 +22,15 @@
 
 #include <string>
 
+#include "exec/schema_scanner.h"
 #include "io/buffered_reader.h"
 #include "io/file_reader.h"
 #include "io/local_file_reader.h"
+#include "runtime/string_value.h"
 #include "util/runtime_profile.h"
+#include "vec/core/block.h"
+#include "vec/core/column_with_type_and_name.h"
+#include "vec/data_types/data_type_factory.hpp"
 #include "vec/exec/format/parquet/parquet_thrift_util.h"
 #include "vec/exec/format/parquet/vparquet_column_chunk_reader.h"
 #include "vec/exec/format/parquet/vparquet_file_metadata.h"
@@ -125,7 +130,8 @@ TEST_F(ParquetThriftReaderTest, complex_nested_file) {
 }
 
 static Status get_column_values(FileReader* file_reader, tparquet::ColumnChunk* column_chunk,
-                                FieldSchema* field_schema, Slice& slice) {
+                                FieldSchema* field_schema, ColumnPtr& doris_column,
+                                DataTypePtr& data_type) {
     tparquet::ColumnMetaData chunk_meta = column_chunk->meta_data;
     size_t start_offset = chunk_meta.__isset.dictionary_page_offset
                                   ? chunk_meta.dictionary_page_offset
@@ -141,7 +147,35 @@ static Status get_column_values(FileReader* file_reader, tparquet::ColumnChunk* 
     // load page data into underlying container
     chunk_reader.load_page_data();
     // decode page data
-    return chunk_reader.decode_values(slice, chunk_reader.num_values());
+    return chunk_reader.decode_values(doris_column, data_type, chunk_reader.num_values());
+}
+
+static void create_block(std::unique_ptr<vectorized::Block>& block) {
+    // Current supported column type:
+    SchemaScanner::ColumnDesc column_descs[] = {
+            {"tinyint_col", TYPE_TINYINT, sizeof(int8_t), true},
+            {"smallint_col", TYPE_SMALLINT, sizeof(int16_t), true},
+            {"int_col", TYPE_INT, sizeof(int32_t), true},
+            {"bigint_col", TYPE_BIGINT, sizeof(int64_t), true},
+            {"boolean_col", TYPE_BOOLEAN, sizeof(bool), true},
+            {"float_col", TYPE_FLOAT, sizeof(float_t), true},
+            {"double_col", TYPE_DOUBLE, sizeof(double_t), true},
+            {"string_col", TYPE_STRING, sizeof(StringValue), true}};
+    SchemaScanner schema_scanner(column_descs,
+                                 sizeof(column_descs) / sizeof(SchemaScanner::ColumnDesc));
+    ObjectPool object_pool;
+    SchemaScannerParam param;
+    schema_scanner.init(&param, &object_pool);
+    auto tuple_slots = const_cast<TupleDescriptor*>(schema_scanner.tuple_desc())->slots();
+    block.reset(new vectorized::Block());
+    for (const auto& slot_desc : tuple_slots) {
+        auto is_nullable = slot_desc->is_nullable();
+        auto data_type = vectorized::DataTypeFactory::instance().create_data_type(slot_desc->type(),
+                                                                                  is_nullable);
+        MutableColumnPtr data_column = data_type->create_column();
+        block->insert(
+                ColumnWithTypeAndName(std::move(data_column), data_type, slot_desc->col_name()));
+    }
 }
 
 TEST_F(ParquetThriftReaderTest, type_decoder) {
@@ -164,6 +198,7 @@ TEST_F(ParquetThriftReaderTest, type_decoder) {
      * `date_col` date, // 13
      * `list_string` array<string>) // 14
      */
+
     LocalFileReader reader("./be/test/exec/test_data/parquet_scanner/type-decoder.parquet", 0);
     /*
      * Data in type-decoder.parquet:
@@ -181,6 +216,8 @@ TEST_F(ParquetThriftReaderTest, type_decoder) {
     auto st = reader.open();
     EXPECT_TRUE(st.ok());
 
+    std::unique_ptr<vectorized::Block> block;
+    create_block(block);
     std::shared_ptr<FileMetaData> metaData;
     parse_thrift_footer(&reader, metaData);
     tparquet::FileMetaData t_metadata = metaData->to_thrift_metadata();
@@ -190,51 +227,98 @@ TEST_F(ParquetThriftReaderTest, type_decoder) {
 
     // the physical_type of tinyint_col, smallint_col and int_col are all INT32
     // they are distinguished by converted_type(in FieldSchema.parquet_schema.converted_type)
-    for (int col_idx = 0; col_idx < 3; ++col_idx) {
-        char data[4 * rows];
-        Slice slice(data, 4 * rows);
-        get_column_values(&reader, &t_metadata.row_groups[0].columns[col_idx],
-                          const_cast<FieldSchema*>(schema_descriptor.get_column(col_idx)), slice);
-        auto out_data = reinterpret_cast<int32_t*>(data);
+    {
+        auto& column_name_with_type = block->get_by_position(0);
+        auto& data_column = column_name_with_type.column;
+        auto& data_type = column_name_with_type.type;
+        get_column_values(&reader, &t_metadata.row_groups[0].columns[0],
+                          const_cast<FieldSchema*>(schema_descriptor.get_column(0)), data_column,
+                          data_type);
         int int_sum = 0;
         for (int i = 0; i < rows; ++i) {
-            int_sum += out_data[i];
+            int_sum += (int8_t)data_column->get64(i);
         }
         ASSERT_EQ(int_sum, 5);
     }
-    // `bigint_col` bigint, // 3
     {
-        char data[8 * rows];
-        Slice slice(data, 8 * rows);
-        get_column_values(&reader, &t_metadata.row_groups[0].columns[3],
-                          const_cast<FieldSchema*>(schema_descriptor.get_column(3)), slice);
-        auto out_data = reinterpret_cast<int64_t*>(data);
+        auto& column_name_with_type = block->get_by_position(1);
+        auto& data_column = column_name_with_type.column;
+        auto& data_type = column_name_with_type.type;
+        get_column_values(&reader, &t_metadata.row_groups[0].columns[1],
+                          const_cast<FieldSchema*>(schema_descriptor.get_column(1)), data_column,
+                          data_type);
         int int_sum = 0;
         for (int i = 0; i < rows; ++i) {
-            int_sum += out_data[i];
+            int_sum += (int16_t)data_column->get64(i);
+        }
+        ASSERT_EQ(int_sum, 5);
+    }
+    {
+        auto& column_name_with_type = block->get_by_position(2);
+        auto& data_column = column_name_with_type.column;
+        auto& data_type = column_name_with_type.type;
+        get_column_values(&reader, &t_metadata.row_groups[0].columns[2],
+                          const_cast<FieldSchema*>(schema_descriptor.get_column(2)), data_column,
+                          data_type);
+        int int_sum = 0;
+        for (int i = 0; i < rows; ++i) {
+            int_sum += (int32_t)data_column->get64(i);
+        }
+        ASSERT_EQ(int_sum, 5);
+    }
+    {
+        auto& column_name_with_type = block->get_by_position(3);
+        auto& data_column = column_name_with_type.column;
+        auto& data_type = column_name_with_type.type;
+        get_column_values(&reader, &t_metadata.row_groups[0].columns[3],
+                          const_cast<FieldSchema*>(schema_descriptor.get_column(3)), data_column,
+                          data_type);
+        int64_t int_sum = 0;
+        for (int i = 0; i < rows; ++i) {
+            int_sum += (int64_t)data_column->get64(i);
         }
         ASSERT_EQ(int_sum, 5);
     }
     // `boolean_col` boolean, // 4
     {
-        char data[1 * rows];
-        Slice slice(data, 1 * rows);
+        auto& column_name_with_type = block->get_by_position(4);
+        auto& data_column = column_name_with_type.column;
+        auto& data_type = column_name_with_type.type;
         get_column_values(&reader, &t_metadata.row_groups[0].columns[4],
-                          const_cast<FieldSchema*>(schema_descriptor.get_column(4)), slice);
-        auto out_data = reinterpret_cast<bool*>(data);
-        ASSERT_FALSE(out_data[0]);
-        ASSERT_TRUE(out_data[1]);
-        ASSERT_FALSE(out_data[2]);
-        ASSERT_TRUE(out_data[3]);
-        ASSERT_FALSE(out_data[4]);
-        ASSERT_FALSE(out_data[5]);
-        ASSERT_TRUE(out_data[6]);
-        ASSERT_FALSE(out_data[7]);
-        ASSERT_FALSE(out_data[8]);
-        ASSERT_FALSE(out_data[9]);
+                          const_cast<FieldSchema*>(schema_descriptor.get_column(4)), data_column,
+                          data_type);
+        ASSERT_FALSE(static_cast<bool>(data_column->get64(0)));
+        ASSERT_TRUE(static_cast<bool>(data_column->get64(1)));
+        ASSERT_FALSE(static_cast<bool>(data_column->get64(2)));
+        ASSERT_TRUE(static_cast<bool>(data_column->get64(3)));
+        ASSERT_FALSE(static_cast<bool>(data_column->get64(4)));
+        ASSERT_FALSE(static_cast<bool>(data_column->get64(5)));
+        ASSERT_TRUE(static_cast<bool>(data_column->get64(6)));
+        ASSERT_FALSE(static_cast<bool>(data_column->get64(7)));
+        ASSERT_FALSE(static_cast<bool>(data_column->get64(8)));
+        ASSERT_FALSE(static_cast<bool>(data_column->get64(9)));
+    }
+    // `double_col` double, // 6
+    {
+        auto& column_name_with_type = block->get_by_position(6);
+        auto& data_column = column_name_with_type.column;
+        auto& data_type = column_name_with_type.type;
+        get_column_values(&reader, &t_metadata.row_groups[0].columns[6],
+                          const_cast<FieldSchema*>(schema_descriptor.get_column(6)), data_column,
+                          data_type);
+        auto* nullable_column = reinterpret_cast<vectorized::ColumnNullable*>(
+                (*std::move(data_column)).mutate().get());
+        MutableColumnPtr nested_column = nullable_column->get_nested_column_ptr();
+        ASSERT_EQ(nested_column->get_float64(0), -1.14);
+        ASSERT_EQ(nested_column->get_float64(1), 2.14);
+        ASSERT_EQ(nested_column->get_float64(2), -3.14);
+        ASSERT_EQ(nested_column->get_float64(3), 4.14);
     }
     // `string_col` string, // 7
     {
+        auto& column_name_with_type = block->get_by_position(7);
+        auto& data_column = column_name_with_type.column;
+        auto& data_type = column_name_with_type.type;
         tparquet::ColumnChunk column_chunk = t_metadata.row_groups[0].columns[7];
         tparquet::ColumnMetaData chunk_meta = column_chunk.meta_data;
         size_t start_offset = chunk_meta.__isset.dictionary_page_offset
@@ -242,7 +326,6 @@ TEST_F(ParquetThriftReaderTest, type_decoder) {
                                       : chunk_meta.data_page_offset;
         size_t chunk_size = chunk_meta.total_compressed_size;
         BufferedFileStreamReader stream_reader(&reader, start_offset, chunk_size);
-
         ColumnChunkReader chunk_reader(&stream_reader, &column_chunk,
                                        const_cast<FieldSchema*>(schema_descriptor.get_column(7)));
         // initialize chunk reader
@@ -252,8 +335,6 @@ TEST_F(ParquetThriftReaderTest, type_decoder) {
         // load page data into underlying container
         chunk_reader.load_page_data();
 
-        char data[50 * rows];
-        Slice slice(data, 50 * rows);
         level_t defs[rows];
         // Analyze null string
         chunk_reader.get_def_levels(defs, rows);
@@ -261,9 +342,14 @@ TEST_F(ParquetThriftReaderTest, type_decoder) {
         ASSERT_EQ(defs[3], 0);
         ASSERT_EQ(defs[7], 0);
 
-        chunk_reader.decode_values(slice, 7);
-        ASSERT_STREQ("s-row0", slice.data);
-        ASSERT_STREQ("s-row2", slice.data + 7);
+        chunk_reader.decode_values(data_column, data_type, 7);
+        auto* nullable_column = reinterpret_cast<vectorized::ColumnNullable*>(
+                (*std::move(data_column)).mutate().get());
+        MutableColumnPtr nested_column = nullable_column->get_nested_column_ptr();
+        auto row0 = nested_column->get_data_at(0).data;
+        auto row2 = nested_column->get_data_at(1).data;
+        ASSERT_STREQ("s-row0", row0);
+        ASSERT_STREQ("s-row2", row2);
     }
 }
 


### PR DESCRIPTION
# Proposed changes

Two improvements have been added:
1. Translate parquet physical type into doris logical type.
2. Decode parquet column chunk into doris ColumnPtr, and add unit tests to show how to use related API.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
3. Has unit tests been added:
    - [x] Yes
    - [ ] No
    - [ ] No Need
4. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
5. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
6. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

