### PR TITLE
[fix](memtracker) Fix flush memtable to reduce load channel mem not executed

### DIFF
--- a/be/src/http/default_path_handlers.cpp
+++ b/be/src/http/default_path_handlers.cpp
@@ -155,6 +155,7 @@ void mem_tracker_handler(const WebPageHandler::ArgumentMap& args, std::stringstr
     std::vector<MemTracker::Snapshot> snapshots;
     ExecEnv::GetInstance()->process_mem_tracker()->make_snapshot(&snapshots, cur_level,
                                                                  upper_level);
+    MemTracker::make_global_mem_tracker_snapshot(&snapshots);
     for (const auto& item : snapshots) {
         string limit_str = item.limit == -1 ? "none" : AccurateItoaKMGT(item.limit);
         string current_consumption_normalize = AccurateItoaKMGT(item.cur_consumption);

--- a/be/src/olap/delta_writer.cpp
+++ b/be/src/olap/delta_writer.cpp
@@ -69,7 +69,7 @@ DeltaWriter::~DeltaWriter() {
         if (_tablet != nullptr) {
             const FlushStatistic& stat = _flush_token->get_stats();
             _tablet->flush_bytes->increment(stat.flush_size_bytes);
-            _tablet->flush_count->increment(stat.flush_count);
+            _tablet->flush_finish_count->increment(stat.flush_finish_count);
         }
     }
 
@@ -103,7 +103,6 @@ Status DeltaWriter::init() {
     }
     _mem_tracker = std::make_shared<MemTrackerLimiter>(
             -1, fmt::format("DeltaWriter:tabletId={}", _tablet->tablet_id()), _parent_tracker);
-    SCOPED_ATTACH_TASK(_mem_tracker, ThreadContext::TaskType::LOAD);
     // check tablet version number
     if (_tablet->version_count() > config::max_tablet_version_num) {
         //trigger quick compaction
@@ -161,10 +160,9 @@ Status DeltaWriter::write(Tuple* tuple) {
         return Status::OLAPInternalError(OLAP_ERR_ALREADY_CANCELLED);
     }
 
-    int64_t prev_memtable_usage = _mem_table->memory_usage();
+    SCOPED_ATTACH_TASK(_mem_tracker, ThreadContext::TaskType::LOAD);
+
     _mem_table->insert(tuple);
-    THREAD_MEM_TRACKER_TRANSFER_TO(_mem_table->memory_usage() - prev_memtable_usage,
-                                   _mem_tracker.get());
 
     // if memtable is full, push it to the flush executor,
     // and create a new memtable for incoming data
@@ -189,14 +187,11 @@ Status DeltaWriter::write(const RowBatch* row_batch, const std::vector<int>& row
         return Status::OLAPInternalError(OLAP_ERR_ALREADY_CANCELLED);
     }
 
-    // Hook automatically records that the memory is lower than the real value, so manual tracking is used.
-    // Because multiple places freed memory that doesn't belong to DeltaWriter
-    int64_t prev_memtable_usage = _mem_table->memory_usage();
+    SCOPED_ATTACH_TASK(_mem_tracker, ThreadContext::TaskType::LOAD);
+
     for (const auto& row_idx : row_idxs) {
         _mem_table->insert(row_batch->get_row(row_idx)->get_tuple(0));
     }
-    THREAD_MEM_TRACKER_TRANSFER_TO(_mem_table->memory_usage() - prev_memtable_usage,
-                                   _mem_tracker.get());
 
     if (_mem_table->memory_usage() >= config::write_buffer_size) {
         RETURN_NOT_OK(_flush_memtable_async());
@@ -255,7 +250,7 @@ Status DeltaWriter::flush_memtable_and_wait(bool need_wait) {
     }
 
     SCOPED_ATTACH_TASK(_mem_tracker, ThreadContext::TaskType::LOAD);
-    if (mem_consumption() == _mem_table->memory_usage()) {
+    if (_flush_token->get_stats().flush_running_count == 0) {
         // equal means there is no memtable in flush queue, just flush this memtable
         VLOG_NOTICE << "flush memtable to reduce mem consumption. memtable size: "
                     << _mem_table->memory_usage() << ", tablet: " << _req.tablet_id

--- a/be/src/olap/delta_writer.cpp
+++ b/be/src/olap/delta_writer.cpp
@@ -257,9 +257,6 @@ Status DeltaWriter::flush_memtable_and_wait(bool need_wait) {
                     << ", load id: " << print_id(_req.load_id);
         RETURN_NOT_OK(_flush_memtable_async());
         _reset_mem_table();
-    } else {
-        DCHECK(mem_consumption() > _mem_table->memory_usage());
-        // this means there should be at least one memtable in flush queue.
     }
 
     if (need_wait) {

--- a/be/src/olap/delta_writer.h
+++ b/be/src/olap/delta_writer.h
@@ -145,6 +145,11 @@ private:
 
     StorageEngine* _storage_engine;
     std::unique_ptr<FlushToken> _flush_token;
+    // The memory value automatically tracked by the Tcmalloc hook is 20% less than the manually recorded
+    // value in the memtable, because some freed memory is not allocated in the DeltaWriter.
+    // The memory value automatically tracked by the Tcmalloc hook, used for load channel mgr to trigger
+    // flush memtable when the sum of all channel memory exceeds the limit.
+    // The manually recorded value of memtable is used to flush when it is larger than write_buffer_size.
     std::shared_ptr<MemTrackerLimiter> _mem_tracker;
     std::shared_ptr<MemTrackerLimiter> _parent_tracker;
 

--- a/be/src/olap/memtable.h
+++ b/be/src/olap/memtable.h
@@ -205,6 +205,7 @@ private:
     std::vector<size_t> _offsets_of_aggregate_states;
     size_t _total_size_of_aggregate_states;
     std::vector<RowInBlock*> _row_in_blocks;
+    // Memory usage without mempool.
     size_t _mem_usage;
 
     DeleteBitmapPtr _delete_bitmap;

--- a/be/src/olap/memtable_flush_executor.h
+++ b/be/src/olap/memtable_flush_executor.h
@@ -37,7 +37,8 @@ class MemTrackerLimiter;
 // use atomic because it may be updated by multi threads
 struct FlushStatistic {
     std::atomic_uint64_t flush_time_ns = 0;
-    std::atomic_uint64_t flush_count = 0;
+    std::atomic_uint64_t flush_running_count = 0;
+    std::atomic_uint64_t flush_finish_count = 0;
     std::atomic_uint64_t flush_size_bytes = 0;
     std::atomic_uint64_t flush_disk_size_bytes = 0;
     std::atomic_uint64_t flush_wait_time_ns = 0;

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -72,7 +72,7 @@ using std::string;
 using std::vector;
 
 DEFINE_COUNTER_METRIC_PROTOTYPE_2ARG(flush_bytes, MetricUnit::BYTES);
-DEFINE_COUNTER_METRIC_PROTOTYPE_2ARG(flush_count, MetricUnit::OPERATIONS);
+DEFINE_COUNTER_METRIC_PROTOTYPE_2ARG(flush_finish_count, MetricUnit::OPERATIONS);
 
 TabletSharedPtr Tablet::create_tablet_from_meta(TabletMetaSharedPtr tablet_meta,
                                                 DataDir* data_dir) {
@@ -101,7 +101,7 @@ Tablet::Tablet(TabletMetaSharedPtr tablet_meta, DataDir* data_dir,
                                                              _tablet_meta->all_stale_rs_metas());
 
     INT_COUNTER_METRIC_REGISTER(_metric_entity, flush_bytes);
-    INT_COUNTER_METRIC_REGISTER(_metric_entity, flush_count);
+    INT_COUNTER_METRIC_REGISTER(_metric_entity, flush_finish_count);
 }
 
 Status Tablet::_init_once_action() {

--- a/be/src/olap/tablet.h
+++ b/be/src/olap/tablet.h
@@ -444,7 +444,7 @@ private:
 
 public:
     IntCounter* flush_bytes;
-    IntCounter* flush_count;
+    IntCounter* flush_finish_count;
     std::atomic<int64_t> publised_count = 0;
 };
 

--- a/be/src/runtime/memory/mem_tracker.h
+++ b/be/src/runtime/memory/mem_tracker.h
@@ -49,6 +49,12 @@ public:
 
     ~MemTracker();
 
+    // Get a global tracker with a specified label, and the tracker will be created when the label is first get.
+    // use SCOPED_CONSUME_MEM_TRACKER count the memory in the scope to a global tracker with the specified label name.
+    // which is usually used for debugging, to finding memory hotspots.
+    static std::shared_ptr<MemTracker> get_global_mem_tracker(const std::string& label);
+    static void make_global_mem_tracker_snapshot(std::vector<MemTracker::Snapshot>* snapshots);
+
 public:
     const std::string& label() const { return _label; }
     // Returns the memory consumed in bytes.


### PR DESCRIPTION
# Proposed changes

Issue Number: close #11770

## Problem summary

### Reason
The memory value automatically tracked by the tcmalloc hook in the DeltaWriter is smaller than the value recorded manually in the memtable, because the first 4096-byte Chunk requested by each MemPool when the memtable is initialized is not tracked to the DeltaWriter by the hook.

The values ​​of the two are not equal, causing the `mem_consumption() == _mem_table->memory_usage ` branch judgment to fail.

### Solution
`mem_consumption() == _mem_table->memory_usage `The purpose of this condition is to determine whether the current DeltaWriter has a memtable being flushed, increase flush_running_count in FlushToken, and completely separate `load channel mgr reduce mem` and `memtable > write_buffer_size` Two flush logic.

Memory value automatically tracked by tcmalloc hook in DeltaWriter for load channel
 Flush memtable is triggered when the mem limit is exceeded. The manually recorded value of the memtable is used to flush the memtable when it is larger than write_buffer_size.

### Can use independent variables to control flush
When the flush is greater than write_buffer_size, it is already manually controlled independently;
When the flush is larger than the mem limit, the tcmallloc hook is still used for automatic statistics, and the selection of the flush DeltaWriter is realized based on the hierarchical relationship of the mem tracker.

Currently, the memory value automatically tracked by the tcmalloc hook is 20% less than the manually recorded value in the memtable, because some of the freed memory is not allocated by the DeltaWriter. `

## Checklist(Required)

1. Does it affect the original behavior: 
    - [x] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

