### PR TITLE
[fix](Nereids) fix a bug in multJoin: if there is no condition, create cross join

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/logical/MultiJoin.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/logical/MultiJoin.java
@@ -79,14 +79,15 @@ public class MultiJoin extends PlanVisitor<Void, Void> {
             List<Expression> joinConditions = split.get(true);
             List<Expression> nonJoinConditions = split.get(false);
 
-            Optional<Expression> cond;
+            LogicalJoin join;
             if (joinConditions.isEmpty()) {
-                cond = Optional.empty();
+                join = new LogicalJoin(JoinType.CROSS_JOIN, Optional.empty(), joinInputs.get(0), joinInputs.get(1));
             } else {
-                cond = Optional.of(ExpressionUtils.and(joinConditions));
+                join = new LogicalJoin(JoinType.INNER_JOIN,
+                        Optional.of(ExpressionUtils.and(joinConditions)),
+                        joinInputs.get(0), joinInputs.get(1));
             }
 
-            LogicalJoin join = new LogicalJoin(JoinType.INNER_JOIN, cond, joinInputs.get(0), joinInputs.get(1));
             if (nonJoinConditions.isEmpty()) {
                 return join;
             } else {


### PR DESCRIPTION
# Proposed changes
In MultiJoin transform, if there is no condition, we should generate cross join instead of inner join

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

