### PR TITLE
[feature](light-schema-change) add a http interface for flink-doris-connector

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/TableSchemaAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/TableSchemaAction.java
@@ -110,4 +110,25 @@ public class TableSchemaAction extends RestBaseController {
 
         return ResponseEntityBuilder.ok(resultMap);
     }
+
+    @RequestMapping(path = "/api/enable_light_schema_change/{" + DB_KEY
+                    + "}/{" + TABLE_KEY + "}", method = { RequestMethod.GET })
+    public Object columnChangeCanSync(
+            @PathVariable(value = DB_KEY) String dbName,
+            @PathVariable(value = TABLE_KEY) String tableName,
+            HttpServletRequest request, HttpServletResponse response) {
+        executeCheckPassword(request, response);
+        String fullDbName = getFullDbName(dbName);
+        OlapTable table;
+        try {
+            Database db = Env.getCurrentInternalCatalog().getDbOrMetaException(fullDbName);
+            table = (OlapTable) db.getTableOrMetaException(tableName, Table.TableType.OLAP);
+        } catch (MetaNotFoundException e) {
+            return ResponseEntityBuilder.okWithCommonError(e.getMessage());
+        }
+        if (!table.getUseLightSchemaChange()) {
+            return ResponseEntityBuilder.okWithCommonError("table " + tableName + " disable light schema change");
+        }
+        return ResponseEntityBuilder.ok();
+    }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/http/TableSchemaActionTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/http/TableSchemaActionTest.java
@@ -48,4 +48,19 @@ public class TableSchemaActionTest extends DorisHttpTestCase {
         // k1, k2
         Assert.assertEquals(2, propArray.size());
     }
+
+    @Test
+    public void testEnableLightSchemaChange() throws IOException {
+        Request request = new Request.Builder()
+                .get()
+                .addHeader("Authorization", rootAuth)
+                .url(LIGHT_SCHEMA_CHANGE_URI)
+                .build();
+        Response response = networkClient.newCall(request).execute();
+        Assert.assertTrue(response.isSuccessful());
+        String respStr = response.body().string();
+        Assert.assertNotNull(respStr);
+        JSONObject object = (JSONObject) JSONValue.parse(respStr);
+        Assert.assertEquals(0, (long) object.get("code"));
+    }
 }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

The http interface is use for flink-doris-connector to sync ddl command from mysql to doris. flink-doris-connector need to check the downstream table whether enable light schema change. If true, connector can sync the add/drop column command to doris.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

