### PR TITLE
[fix](agg)disallow group by bitmap or hll data type

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/AggregateInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/AggregateInfo.java
@@ -21,7 +21,7 @@
 package org.apache.doris.analysis;
 
 import org.apache.doris.catalog.FunctionSet;
-import org.apache.doris.catalog.PrimitiveType;
+import org.apache.doris.catalog.Type;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.util.VectorizedUtil;
 import org.apache.doris.planner.DataPartition;
@@ -163,9 +163,8 @@ public final class AggregateInfo extends AggregateInfoBase {
 
     private static void validateGroupingExprs(List<Expr> groupingExprs) throws AnalysisException {
         for (Expr expr : groupingExprs) {
-            PrimitiveType type = expr.getType().getPrimitiveType();
-            if (type == PrimitiveType.BITMAP || type == PrimitiveType.HLL) {
-                throw new AnalysisException("Group by bitmap or hll type is not supported");
+            if (expr.getType().isOnlyMetricType()) {
+                throw new AnalysisException(Type.OnlyMetricTypeErrorMsg);
             }
         }
     }

--- a/regression-test/suites/query/aggregate/aggregate_group_by_hll_and_bitmap.groovy
+++ b/regression-test/suites/query/aggregate/aggregate_group_by_hll_and_bitmap.groovy
@@ -27,12 +27,12 @@ suite("aggregate_group_by_hll_and_bitmap") {
 
     test {
         sql "select distinct user_ids from test_group_by_hll_and_bitmap"
-        exception "Group by bitmap or hll type is not supported"
+        exception "Doris hll and bitmap column must use with specific function, and don't support filter or group by.please run 'help hll' or 'help bitmap' in your mysql client"
     }
 
     test {
         sql "select distinct hll_set from test_group_by_hll_and_bitmap"
-        exception "Group by bitmap or hll type is not supported"
+        exception "Doris hll and bitmap column must use with specific function, and don't support filter or group by.please run 'help hll' or 'help bitmap' in your mysql client"
     }
 
     sql "DROP TABLE test_group_by_hll_and_bitmap"

--- a/regression-test/suites/query/aggregate/aggregate_group_by_hll_and_bitmap.groovy
+++ b/regression-test/suites/query/aggregate/aggregate_group_by_hll_and_bitmap.groovy
@@ -1,0 +1,39 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("aggregate_group_by_hll_and_bitmap") {
+    sql "DROP TABLE IF EXISTS test_group_by_hll_and_bitmap"
+
+    sql """
+        CREATE TABLE test_group_by_hll_and_bitmap (id int, user_ids bitmap bitmap_union, hll_set hll hll_union) 
+        ENGINE=OLAP DISTRIBUTED BY HASH(`id`) BUCKETS 5 properties("replication_num" = "1");
+        """
+
+    sql "insert into test_group_by_hll_and_bitmap values(1, bitmap_hash(1), hll_hash(1))"
+
+    test {
+        sql "select distinct user_ids from test_group_by_hll_and_bitmap"
+        exception "Group by bitmap or hll type is not supported"
+    }
+
+    test {
+        sql "select distinct hll_set from test_group_by_hll_and_bitmap"
+        exception "Group by bitmap or hll type is not supported"
+    }
+
+    sql "DROP TABLE test_group_by_hll_and_bitmap"
+}


### PR DESCRIPTION
# Proposed changes

disallow "select distinct bitmap, hll from xxx", because in some case, the FE will introduce a agg node with group by bitmap or hll exprs to  implement the "distinct" operator. But group by bitmap or hll data type are not supported in BE.

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

