### PR TITLE
[fix](broker-load) Correction of kerberos authentication time determination rule

### DIFF
--- a/fs_brokers/apache_hdfs_broker/conf/apache_hdfs_broker.conf
+++ b/fs_brokers/apache_hdfs_broker/conf/apache_hdfs_broker.conf
@@ -27,7 +27,7 @@
 broker_ipc_port = 8000
 
 # client session will be deleted if not receive ping after this time
-client_expire_seconds = 1800
+client_expire_seconds = 3600
 
 # Advanced configurations
 # sys_log_dir = ${BROKER_HOME}/log

--- a/fs_brokers/apache_hdfs_broker/src/main/java/org/apache/doris/broker/hdfs/BrokerConfig.java
+++ b/fs_brokers/apache_hdfs_broker/src/main/java/org/apache/doris/broker/hdfs/BrokerConfig.java
@@ -21,19 +21,19 @@ import org.apache.doris.common.ConfigBase;
 
 
 public class BrokerConfig extends ConfigBase {
-    
+
     @ConfField
     public static int hdfs_read_buffer_size_kb = 1024;
-    
+
     @ConfField
     public static int hdfs_write_buffer_size_kb = 1024;
-    
+
     @ConfField
-    public static int client_expire_seconds = 1800;
-    
+    public static int client_expire_seconds = 3600;
+
     @ConfField
     public static int broker_ipc_port = 8000;
-    
+
     @ConfField
     public static String sys_log_dir = System.getenv("BROKER_HOME") + "/log";
     @ConfField

--- a/fs_brokers/apache_hdfs_broker/src/main/java/org/apache/doris/broker/hdfs/BrokerFileSystem.java
+++ b/fs_brokers/apache_hdfs_broker/src/main/java/org/apache/doris/broker/hdfs/BrokerFileSystem.java
@@ -31,20 +31,23 @@ public class BrokerFileSystem {
     private ReentrantLock lock;
     private FileSystemIdentity identity;
     private FileSystem dfsFileSystem;
-    private long accessTimestamp;
+    private long lastAccessTimestamp;
+    private long createTimestamp;
     private UUID fileSystemId;
 
     public BrokerFileSystem(FileSystemIdentity identity) {
         this.identity = identity;
         this.lock = new ReentrantLock();
         this.dfsFileSystem = null;
-        this.accessTimestamp = System.currentTimeMillis();
+        this.lastAccessTimestamp = System.currentTimeMillis();
+        this.createTimestamp = System.currentTimeMillis();
         this.fileSystemId = UUID.randomUUID();
     }
 
     public synchronized void setFileSystem(FileSystem fileSystem) {
         this.dfsFileSystem = fileSystem;
-        this.accessTimestamp = System.currentTimeMillis();
+        this.lastAccessTimestamp = System.currentTimeMillis();
+        this.createTimestamp = System.currentTimeMillis();
     }
 
     public void closeFileSystem() {
@@ -65,7 +68,12 @@ public class BrokerFileSystem {
     }
 
     public FileSystem getDFSFileSystem() {
+        this.lastAccessTimestamp = System.currentTimeMillis();
         return dfsFileSystem;
+    }
+
+    public void updateLastUpdateAccessTime() {
+        this.lastAccessTimestamp = System.currentTimeMillis();
     }
 
     public FileSystemIdentity getIdentity() {
@@ -76,8 +84,12 @@ public class BrokerFileSystem {
         return lock;
     }
 
-    public boolean isExpired(long expirationIntervalSecs) {
-        return System.currentTimeMillis() - accessTimestamp > expirationIntervalSecs * 1000;
+    public boolean isExpiredByLastAccessTime(long expirationIntervalSecs) {
+        return System.currentTimeMillis() - lastAccessTimestamp > expirationIntervalSecs * 1000;
+    }
+
+    public boolean isExpiredByCreateTime(long expirationIntervalSecs) {
+        return System.currentTimeMillis() - createTimestamp > expirationIntervalSecs * 1000;
     }
 
     @Override

--- a/fs_brokers/apache_hdfs_broker/src/main/java/org/apache/doris/broker/hdfs/BrokerFileSystem.java
+++ b/fs_brokers/apache_hdfs_broker/src/main/java/org/apache/doris/broker/hdfs/BrokerFileSystem.java
@@ -27,26 +27,26 @@ public class BrokerFileSystem {
 
     private static Logger logger = Logger
             .getLogger(BrokerFileSystem.class.getName());
-    
+
     private ReentrantLock lock;
     private FileSystemIdentity identity;
     private FileSystem dfsFileSystem;
-    private long lastAccessTimestamp;
+    private long accessTimestamp;
     private UUID fileSystemId;
-    
+
     public BrokerFileSystem(FileSystemIdentity identity) {
         this.identity = identity;
         this.lock = new ReentrantLock();
         this.dfsFileSystem = null;
-        this.lastAccessTimestamp = System.currentTimeMillis();
+        this.accessTimestamp = System.currentTimeMillis();
         this.fileSystemId = UUID.randomUUID();
     }
-    
+
     public synchronized void setFileSystem(FileSystem fileSystem) {
         this.dfsFileSystem = fileSystem;
-        this.lastAccessTimestamp = System.currentTimeMillis();
+        this.accessTimestamp = System.currentTimeMillis();
     }
-    
+
     public void closeFileSystem() {
         lock.lock();
         try {
@@ -63,31 +63,23 @@ public class BrokerFileSystem {
             lock.unlock();
         }
     }
-    
+
     public FileSystem getDFSFileSystem() {
-        this.lastAccessTimestamp = System.currentTimeMillis();
         return dfsFileSystem;
     }
-    
-    public void updateLastUpdateAccessTime() {
-        this.lastAccessTimestamp = System.currentTimeMillis();
-    }
-    
+
     public FileSystemIdentity getIdentity() {
         return identity;
     }
-    
+
     public ReentrantLock getLock() {
         return lock;
     }
-    
+
     public boolean isExpired(long expirationIntervalSecs) {
-        if (System.currentTimeMillis() - lastAccessTimestamp > expirationIntervalSecs * 1000) {
-            return true;
-        }
-        return false;
+        return System.currentTimeMillis() - accessTimestamp > expirationIntervalSecs * 1000;
     }
-    
+
     @Override
     public String toString() {
         return "BrokerFileSystem [identity=" + identity + ", dfsFileSystem="

--- a/fs_brokers/apache_hdfs_broker/src/main/java/org/apache/doris/broker/hdfs/ClientContextManager.java
+++ b/fs_brokers/apache_hdfs_broker/src/main/java/org/apache/doris/broker/hdfs/ClientContextManager.java
@@ -36,23 +36,21 @@ public class ClientContextManager {
     private ConcurrentHashMap<String, ClientResourceContext> clientContexts;
     private ConcurrentHashMap<TBrokerFD, String> fdToClientMap;
     private int clientExpirationSeconds = BrokerConfig.client_expire_seconds;
-    
+
     public ClientContextManager(ScheduledExecutorService executorService) {
         clientContexts = new ConcurrentHashMap<>();
         fdToClientMap = new ConcurrentHashMap<>();
         this.executorService = executorService;
         this.executorService.schedule(new CheckClientExpirationTask(), 0, TimeUnit.SECONDS);
     }
-    
+
     public void onPing(String clientId) {
         if (!clientContexts.containsKey(clientId)) {
             clientContexts.putIfAbsent(clientId, new ClientResourceContext(clientId));
         }
-        ClientResourceContext clientContext = clientContexts.get(clientId);
-        clientContext.updateLastPingTime();
     }
-    
-    public synchronized void putNewOutputStream(String clientId, TBrokerFD fd, FSDataOutputStream fsDataOutputStream, 
+
+    public synchronized void putNewOutputStream(String clientId, TBrokerFD fd, FSDataOutputStream fsDataOutputStream,
             BrokerFileSystem brokerFileSystem) {
         if (!clientContexts.containsKey(clientId)) {
             clientContexts.putIfAbsent(clientId, new ClientResourceContext(clientId));
@@ -61,8 +59,8 @@ public class ClientContextManager {
         clientContext.putOutputStream(fd, fsDataOutputStream, brokerFileSystem);
         fdToClientMap.putIfAbsent(fd, clientId);
     }
-    
-    public synchronized void putNewInputStream(String clientId, TBrokerFD fd, FSDataInputStream fsDataInputStream, 
+
+    public synchronized void putNewInputStream(String clientId, TBrokerFD fd, FSDataInputStream fsDataInputStream,
             BrokerFileSystem brokerFileSystem) {
         if (!clientContexts.containsKey(clientId)) {
             clientContexts.putIfAbsent(clientId, new ClientResourceContext(clientId));
@@ -71,29 +69,28 @@ public class ClientContextManager {
         clientContext.putInputStream(fd, fsDataInputStream, brokerFileSystem);
         fdToClientMap.putIfAbsent(fd, clientId);
     }
-    
+
     public synchronized FSDataInputStream getFsDataInputStream(TBrokerFD fd) {
         String clientId = fdToClientMap.get(fd);
         if (clientId == null) {
-            throw new BrokerException(TBrokerOperationStatusCode.TARGET_STORAGE_SERVICE_ERROR, 
+            throw new BrokerException(TBrokerOperationStatusCode.TARGET_STORAGE_SERVICE_ERROR,
                     "the fd is not owned by client {}", clientId);
         }
         ClientResourceContext clientContext = clientContexts.get(clientId);
-        FSDataInputStream fsDataInputStream = clientContext.getInputStream(fd);
-        return fsDataInputStream;
+        return clientContext.getInputStream(fd);
     }
-    
+
     public synchronized FSDataOutputStream getFsDataOutputStream(TBrokerFD fd) {
         String clientId = fdToClientMap.get(fd);
         if (clientId == null) {
-            throw new BrokerException(TBrokerOperationStatusCode.TARGET_STORAGE_SERVICE_ERROR, 
+            throw new BrokerException(TBrokerOperationStatusCode.TARGET_STORAGE_SERVICE_ERROR,
                     "the fd is not owned by client {}", clientId);
         }
         ClientResourceContext clientContext = clientContexts.get(clientId);
         FSDataOutputStream fsDataOutputStream = clientContext.getOutputStream(fd);
         return fsDataOutputStream;
     }
-    
+
     public synchronized void removeInputStream(TBrokerFD fd) {
         String clientId = fdToClientMap.remove(fd);
         if (clientId == null) {
@@ -109,7 +106,7 @@ public class ClientContextManager {
             logger.error("errors while close file data input stream", e);
         }
     }
-    
+
     public synchronized void removeOutputStream(TBrokerFD fd) {
         String clientId = fdToClientMap.remove(fd);
         if (clientId == null) {
@@ -125,7 +122,7 @@ public class ClientContextManager {
             logger.error("errors while close file data output stream", e);
         }
     }
-    
+
     class CheckClientExpirationTask implements Runnable {
         @Override
         public void run() {
@@ -139,8 +136,8 @@ public class ClientContextManager {
                             ClientContextManager.this.removeOutputStream(fd);
                         }
                         clientContexts.remove(clientContext.clientId);
-                        logger.info("client [" + clientContext.clientId 
-                                + "] is expired, remove it from contexts. last ping time is " 
+                        logger.info("client [" + clientContext.clientId
+                                + "] is expired, remove it from contexts. last ping time is "
                                 + clientContext.lastPingTimestamp);
                     }
                 }
@@ -149,71 +146,59 @@ public class ClientContextManager {
             }
         }
     }
-    
+
     private static class BrokerOutputStream {
-        
+
         private final FSDataOutputStream outputStream;
         private final BrokerFileSystem brokerFileSystem;
-        
+
         public BrokerOutputStream(FSDataOutputStream outputStream, BrokerFileSystem brokerFileSystem) {
             this.outputStream = outputStream;
             this.brokerFileSystem = brokerFileSystem;
-            this.brokerFileSystem.updateLastUpdateAccessTime();
         }
-        
+
         public FSDataOutputStream getOutputStream() {
-            this.brokerFileSystem.updateLastUpdateAccessTime();
             return outputStream;
         }
-        
-        public void updateLastUpdateAccessTime() {
-            this.brokerFileSystem.updateLastUpdateAccessTime();
-        }
     }
-    
+
     private static class BrokerInputStream {
-        
+
         private final FSDataInputStream inputStream;
         private final BrokerFileSystem brokerFileSystem;
-        
+
         public BrokerInputStream(FSDataInputStream inputStream, BrokerFileSystem brokerFileSystem) {
             this.inputStream = inputStream;
             this.brokerFileSystem = brokerFileSystem;
-            this.brokerFileSystem.updateLastUpdateAccessTime();
         }
-        
+
         public FSDataInputStream getInputStream() {
-            this.brokerFileSystem.updateLastUpdateAccessTime();
             return inputStream;
         }
-        
-        public void updateLastUpdateAccessTime() {
-            this.brokerFileSystem.updateLastUpdateAccessTime();
-        }
     }
-    
+
     static class ClientResourceContext {
 
         private String clientId;
         private ConcurrentHashMap<TBrokerFD, BrokerInputStream> inputStreams;
         private ConcurrentHashMap<TBrokerFD, BrokerOutputStream> outputStreams;
         private long lastPingTimestamp;
-        
+
         public ClientResourceContext(String clientId) {
             this.clientId = clientId;
             this.inputStreams = new ConcurrentHashMap<>();
             this.outputStreams = new ConcurrentHashMap<>();
             this.lastPingTimestamp = System.currentTimeMillis();
         }
-        
+
         public void putInputStream(TBrokerFD fd, FSDataInputStream inputStream, BrokerFileSystem fileSystem) {
             inputStreams.putIfAbsent(fd, new BrokerInputStream(inputStream, fileSystem));
         }
-        
+
         public void putOutputStream(TBrokerFD fd, FSDataOutputStream outputStream, BrokerFileSystem fileSystem) {
             outputStreams.putIfAbsent(fd, new BrokerOutputStream(outputStream, fileSystem));
         }
-        
+
         public FSDataInputStream getInputStream(TBrokerFD fd) {
             BrokerInputStream brokerInputStream = inputStreams.get(fd);
             if (brokerInputStream != null) {
@@ -221,25 +206,13 @@ public class ClientContextManager {
             }
             return null;
         }
-        
+
         public FSDataOutputStream getOutputStream(TBrokerFD fd) {
             BrokerOutputStream brokerOutputStream = outputStreams.get(fd);
             if (brokerOutputStream != null) {
                 return brokerOutputStream.getOutputStream();
             }
             return null;
-        }
-        
-        public void updateLastPingTime() {
-            this.lastPingTimestamp = System.currentTimeMillis();
-            // Should we also update the underline filesystem? maybe it is time cost
-            for (BrokerInputStream brokerInputStream : inputStreams.values()) {
-                brokerInputStream.updateLastUpdateAccessTime();
-            }
-            
-            for (BrokerOutputStream brokerOutputStream : outputStreams.values()) {
-                brokerOutputStream.updateLastUpdateAccessTime();
-            }
         }
     }
 }

--- a/fs_brokers/apache_hdfs_broker/src/main/java/org/apache/doris/broker/hdfs/FileSystemManager.java
+++ b/fs_brokers/apache_hdfs_broker/src/main/java/org/apache/doris/broker/hdfs/FileSystemManager.java
@@ -857,9 +857,7 @@ public class FileSystemManager {
         BrokerFileSystem brokerFileSystem;
         if (cachedFileSystem.containsKey(fileSystemIdentity)) {
             brokerFileSystem = cachedFileSystem.get(fileSystemIdentity);
-            if ((properties.containsKey(KERBEROS_KEYTAB) && properties.containsKey(KERBEROS_PRINCIPAL))
-                || (properties.containsKey(FS_KS3_ACCESS_KEY) && properties.containsKey(FS_KS3_SECRET_KEY))
-                || (properties.containsKey(FS_S3A_ACCESS_KEY) && properties.containsKey(FS_S3A_SECRET_KEY))) {
+            if (properties.containsKey(KERBEROS_KEYTAB) && properties.containsKey(KERBEROS_PRINCIPAL)) {
                 if (brokerFileSystem.isExpiredByCreateTime(BrokerConfig.client_expire_seconds)) {
                     logger.info("file system " + brokerFileSystem + " is expired, update it.");
                     try {

--- a/fs_brokers/apache_hdfs_broker/src/main/java/org/apache/doris/broker/hdfs/FileSystemManager.java
+++ b/fs_brokers/apache_hdfs_broker/src/main/java/org/apache/doris/broker/hdfs/FileSystemManager.java
@@ -108,13 +108,13 @@ public class FileSystemManager {
     private static final String FS_KS3_IMPL_DISABLE_CACHE = "fs.ks3.impl.disable.cache";
 
     private ScheduledExecutorService handleManagementPool = Executors.newScheduledThreadPool(2);
-    
+
     private int readBufferSize = 128 << 10; // 128k
     private int writeBufferSize = 128 << 10; // 128k
-    
+
     private ConcurrentHashMap<FileSystemIdentity, BrokerFileSystem> cachedFileSystem;
     private ClientContextManager clientContextManager;
-    
+
     public FileSystemManager() {
         cachedFileSystem = new ConcurrentHashMap<>();
         clientContextManager = new ClientContextManager(handleManagementPool);
@@ -140,15 +140,15 @@ public class FileSystemManager {
 
         return finalPrincipal;
     }
-    
+
     /**
      * visible for test
-     * 
+     *
      * @param path
      * @param properties
      * @return BrokerFileSystem with different FileSystem based on scheme
-     * @throws URISyntaxException 
-     * @throws Exception 
+     * @throws URISyntaxException
+     * @throws Exception
      */
     public BrokerFileSystem getFileSystem(String path, Map<String, String> properties) {
         WildcardURI pathUri = new WildcardURI(path);
@@ -394,7 +394,6 @@ public class FileSystemManager {
         String disableCache = properties.getOrDefault(FS_S3A_IMPL_DISABLE_CACHE, "true");
         String s3aUgi = accessKey + "," + secretKey;
         FileSystemIdentity fileSystemIdentity = new FileSystemIdentity(host, s3aUgi);
-        cachedFileSystem.putIfAbsent(fileSystemIdentity, new BrokerFileSystem(fileSystemIdentity));
         BrokerFileSystem fileSystem = updateCachedFileSystem(fileSystemIdentity);
         fileSystem.getLock().lock();
         try {
@@ -618,12 +617,12 @@ public class FileSystemManager {
         } catch (Exception e) {
             logger.error("errors while get file status ", e);
             fileSystem.closeFileSystem();
-            throw new BrokerException(TBrokerOperationStatusCode.TARGET_STORAGE_SERVICE_ERROR, 
+            throw new BrokerException(TBrokerOperationStatusCode.TARGET_STORAGE_SERVICE_ERROR,
                     e, "unknown error when get file status");
         }
         return resultFileStatus;
     }
-    
+
     public void deletePath(String path, Map<String, String> properties) {
         WildcardURI pathUri = new WildcardURI(path);
         BrokerFileSystem fileSystem = getFileSystem(path, properties);
@@ -633,16 +632,16 @@ public class FileSystemManager {
         } catch (IOException e) {
             logger.error("errors while delete path " + path);
             fileSystem.closeFileSystem();
-            throw new BrokerException(TBrokerOperationStatusCode.TARGET_STORAGE_SERVICE_ERROR, 
+            throw new BrokerException(TBrokerOperationStatusCode.TARGET_STORAGE_SERVICE_ERROR,
                     e, "delete path {} error", path);
         }
     }
-    
+
     public void renamePath(String srcPath, String destPath, Map<String, String> properties) {
         WildcardURI srcPathUri = new WildcardURI(srcPath);
         WildcardURI destPathUri = new WildcardURI(destPath);
         if (!srcPathUri.getAuthority().trim().equals(destPathUri.getAuthority().trim())) {
-            throw new BrokerException(TBrokerOperationStatusCode.TARGET_STORAGE_SERVICE_ERROR, 
+            throw new BrokerException(TBrokerOperationStatusCode.TARGET_STORAGE_SERVICE_ERROR,
                     "only allow rename in same file system");
         }
         BrokerFileSystem fileSystem = getFileSystem(srcPath, properties);
@@ -651,17 +650,17 @@ public class FileSystemManager {
         try {
             boolean isRenameSuccess = fileSystem.getDFSFileSystem().rename(srcfilePath, destfilePath);
             if (!isRenameSuccess) {
-                throw new BrokerException(TBrokerOperationStatusCode.TARGET_STORAGE_SERVICE_ERROR, 
-                        "failed to rename path from {} to {}", srcPath, destPath); 
+                throw new BrokerException(TBrokerOperationStatusCode.TARGET_STORAGE_SERVICE_ERROR,
+                        "failed to rename path from {} to {}", srcPath, destPath);
             }
         } catch (IOException e) {
             logger.error("errors while rename path from " + srcPath + " to " + destPath);
             fileSystem.closeFileSystem();
-            throw new BrokerException(TBrokerOperationStatusCode.TARGET_STORAGE_SERVICE_ERROR, 
+            throw new BrokerException(TBrokerOperationStatusCode.TARGET_STORAGE_SERVICE_ERROR,
                     e, "errors while rename {} to {}", srcPath, destPath);
         }
     }
-    
+
     public boolean checkPathExist(String path, Map<String, String> properties) {
         WildcardURI pathUri = new WildcardURI(path);
         BrokerFileSystem fileSystem = getFileSystem(path, properties);
@@ -672,11 +671,11 @@ public class FileSystemManager {
         } catch (IOException e) {
             logger.error("errors while check path exist: " + path);
             fileSystem.closeFileSystem();
-            throw new BrokerException(TBrokerOperationStatusCode.TARGET_STORAGE_SERVICE_ERROR, 
+            throw new BrokerException(TBrokerOperationStatusCode.TARGET_STORAGE_SERVICE_ERROR,
                     e, "errors while check if path {} exist", path);
         }
     }
-    
+
     public TBrokerFD openReader(String clientId, String path, long startOffset, Map<String, String> properties) {
         WildcardURI pathUri = new WildcardURI(path);
         Path inputFilePath = new Path(pathUri.getPath());
@@ -691,11 +690,11 @@ public class FileSystemManager {
         } catch (IOException e) {
             logger.error("errors while open path", e);
             fileSystem.closeFileSystem();
-            throw new BrokerException(TBrokerOperationStatusCode.TARGET_STORAGE_SERVICE_ERROR, 
+            throw new BrokerException(TBrokerOperationStatusCode.TARGET_STORAGE_SERVICE_ERROR,
                     e, "could not open file {}", path);
         }
     }
-    
+
     public ByteBuffer pread(TBrokerFD fd, long offset, long length) {
         FSDataInputStream fsDataInputStream = clientContextManager.getFsDataInputStream(fd);
         synchronized (fsDataInputStream) {
@@ -746,12 +745,12 @@ public class FileSystemManager {
             }
         }
     }
-    
+
     public void seek(TBrokerFD fd, long offset) {
-        throw new BrokerException(TBrokerOperationStatusCode.OPERATION_NOT_SUPPORTED, 
+        throw new BrokerException(TBrokerOperationStatusCode.OPERATION_NOT_SUPPORTED,
                 "seek this method is not supported");
     }
-    
+
     public void closeReader(TBrokerFD fd) {
         FSDataInputStream fsDataInputStream = clientContextManager.getFsDataInputStream(fd);
         synchronized (fsDataInputStream) {
@@ -766,13 +765,13 @@ public class FileSystemManager {
             }
         }
     }
-    
+
     public TBrokerFD openWriter(String clientId, String path, Map<String, String> properties) {
         WildcardURI pathUri = new WildcardURI(path);
         Path inputFilePath = new Path(pathUri.getPath());
         BrokerFileSystem fileSystem = getFileSystem(path, properties);
         try {
-            FSDataOutputStream fsDataOutputStream = fileSystem.getDFSFileSystem().create(inputFilePath, 
+            FSDataOutputStream fsDataOutputStream = fileSystem.getDFSFileSystem().create(inputFilePath,
                     true, writeBufferSize);
             UUID uuid = UUID.randomUUID();
             TBrokerFD fd = parseUUIDToFD(uuid);
@@ -781,11 +780,11 @@ public class FileSystemManager {
         } catch (IOException e) {
             logger.error("errors while open path", e);
             fileSystem.closeFileSystem();
-            throw new BrokerException(TBrokerOperationStatusCode.TARGET_STORAGE_SERVICE_ERROR, 
+            throw new BrokerException(TBrokerOperationStatusCode.TARGET_STORAGE_SERVICE_ERROR,
                     e, "could not open file {}", path);
         }
     }
-    
+
     public void pwrite(TBrokerFD fd, long offset, byte[] data) {
         FSDataOutputStream fsDataOutputStream = clientContextManager.getFsDataOutputStream(fd);
         synchronized (fsDataOutputStream) {
@@ -811,7 +810,7 @@ public class FileSystemManager {
             }
         }
     }
-    
+
     public void closeWriter(TBrokerFD fd) {
         FSDataOutputStream fsDataOutputStream = clientContextManager.getFsDataOutputStream(fd);
         synchronized (fsDataOutputStream) {
@@ -827,11 +826,11 @@ public class FileSystemManager {
             }
         }
     }
-    
+
     public void ping(String clientId) {
         clientContextManager.onPing(clientId);
     }
-    
+
     private static TBrokerFD parseUUIDToFD(UUID uuid) {
         return new TBrokerFD(uuid.getMostSignificantBits(), uuid.getLeastSignificantBits());
     }


### PR DESCRIPTION
# Proposed changes

Issue Number: https://github.com/apache/doris/issues/11792

## Problem summary

Every time a new broker load comes in, Doris will update the start time of Kerberos authentication, and this logic is wrong. Because the authentication duration of Kerberos is calculated from the moment when the ticket is obtained.

Describe your changes.

Delete the code that updates the lastAccessTime to get the correct judgment.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ✅ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ✅ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ✅ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ✅ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ✅ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

