### PR TITLE
[bugfix](load) get max version in read lock

### DIFF
--- a/be/src/olap/task/engine_publish_version_task.cpp
+++ b/be/src/olap/task/engine_publish_version_task.cpp
@@ -115,20 +115,26 @@ Status EnginePublishVersionTask::finish() {
                 res = Status::OLAPInternalError(OLAP_ERR_PUSH_TABLE_NOT_EXIST);
                 continue;
             }
-            Version max_version = tablet->max_version();
             // in uniq key model with merge-on-write, we should see all
             // previous version when update delete bitmap, so add a check
             // here and wait pre version publish or lock timeout
             if (tablet->keys_type() == KeysType::UNIQUE_KEYS &&
-                tablet->enable_unique_key_merge_on_write() &&
-                version.first != max_version.second + 1) {
-                LOG(INFO) << "uniq key with merge-on-write version not continuous, current max "
-                             "version="
-                          << max_version.second << ", publish_version=" << version.first
-                          << " tablet_id=" << tablet->tablet_id();
-                meet_version_not_continuous = true;
-                res = Status::OLAPInternalError(OLAP_ERR_PUBLISH_VERSION_NOT_CONTINUOUS);
-                continue;
+                tablet->enable_unique_key_merge_on_write()) {
+                Version max_version;
+                {
+                    std::shared_lock rdlock(tablet->get_header_lock());
+                    max_version = tablet->max_version();
+                }
+                if (version.first != max_version.second + 1) {
+                    LOG(INFO) << "uniq key with merge-on-write version not continuous, current "
+                                 "max "
+                                 "version="
+                              << max_version.second << ", publish_version=" << version.first
+                              << " tablet_id=" << tablet->tablet_id();
+                    meet_version_not_continuous = true;
+                    res = Status::OLAPInternalError(OLAP_ERR_PUBLISH_VERSION_NOT_CONTINUOUS);
+                    continue;
+                }
             }
             total_task_num.fetch_add(1);
             auto tablet_publish_txn_ptr = std::make_shared<TabletPublishTxnTask>(


### PR DESCRIPTION
# Proposed changes

Introduced by #11195。 Get max version from tablet meta should in read lock in multi-thread load。
coredump:
![image](https://user-images.githubusercontent.com/102007456/184794657-a84f4580-6595-491d-a6b9-0b988af64ccc.png)


## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

