### PR TITLE
[feature-wip](unique-key-merge-on-write) fix that sort segments by segment id in descending order

### DIFF
--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -1887,6 +1887,9 @@ Status Tablet::lookup_row_key(const Slice& encoded_key, const RowsetIdUnorderedS
     // to search the key in the rowset with larger version.
     std::sort(selected_rs.begin(), selected_rs.end(),
               [](std::pair<RowsetSharedPtr, int32_t>& a, std::pair<RowsetSharedPtr, int32_t>& b) {
+                  if (a.first->end_version() == b.first->end_version()) {
+                      return a.second > b.second;
+                  }
                   return a.first->end_version() > b.first->end_version();
               });
     RowLocation loc;


### PR DESCRIPTION

# Proposed changes

Issue Number: close #xxx

## Problem summary

we should lookup row key in the segment with version is larger and segment id is larger firstly. So once we find it, we can end the lookup.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

