### PR TITLE
[Planner](fix)fix index out of bound exception

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/planner/Planner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/Planner.java
@@ -173,12 +173,12 @@ public class Planner {
         }
 
         // disable ProjectPlanner for now because there is some bug to be fixed
-        // if (analyzer.getContext() != null
-        //         && analyzer.getContext().getSessionVariable().isEnableProjection()
-        //         && statement instanceof SelectStmt) {
-        //     ProjectPlanner projectPlanner = new ProjectPlanner(analyzer);
-        //     projectPlanner.projectSingleNodePlan(queryStmt.getResultExprs(), singleNodePlan);
-        // }
+         if (analyzer.getContext() != null
+                 && analyzer.getContext().getSessionVariable().isEnableProjection()
+                 && statement instanceof SelectStmt) {
+             ProjectPlanner projectPlanner = new ProjectPlanner(analyzer);
+             projectPlanner.projectSingleNodePlan(queryStmt.getResultExprs(), singleNodePlan);
+         }
 
         if (statement instanceof InsertStmt) {
             InsertStmt insertStmt = (InsertStmt) statement;

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/SortNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/SortNode.java
@@ -156,7 +156,7 @@ public class SortNode extends PlanNode {
     @Override
     public Set<SlotId> computeInputSlotIds(Analyzer analyzer) throws NotImplementedException {
         List<SlotDescriptor> slotDescriptorList = this.info.getSortTupleDescriptor().getSlots();
-        for (int i = 0; i < slotDescriptorList.size(); i++) {
+        for (int i = slotDescriptorList.size() - 1; i >= 0; i--) {
             if (!slotDescriptorList.get(i).isMaterialized()) {
                 resolvedTupleExprs.remove(i);
             }


### PR DESCRIPTION
# Proposed changes

Issue Number: #11681 

## Problem summary

Iterate in reverse order to avoid index out of bound exception during iteration.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [x] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

