### PR TITLE
[enhancement](memory) Reduce virtual memory used by PaddedPODArray

### DIFF
--- a/be/src/exec/hash_join_node.cpp
+++ b/be/src/exec/hash_join_node.cpp
@@ -145,7 +145,7 @@ Status HashJoinNode::prepare(RuntimeState* state) {
              _is_null_safe_eq_join.end());
     _hash_tbl.reset(new HashTable(_build_expr_ctxs, _probe_expr_ctxs, _build_tuple_size,
                                   stores_nulls, _is_null_safe_eq_join, id(),
-                                  BitUtil::RoundUpToPowerOfTwo(state->batch_size()) * 2));
+                                  BitUtil::RoundUpToPowerOfTwo(state->batch_size())));
 
     _probe_batch.reset(new RowBatch(child(0)->row_desc(), state->batch_size()));
 

--- a/be/src/exec/hash_join_node.cpp
+++ b/be/src/exec/hash_join_node.cpp
@@ -145,7 +145,7 @@ Status HashJoinNode::prepare(RuntimeState* state) {
              _is_null_safe_eq_join.end());
     _hash_tbl.reset(new HashTable(_build_expr_ctxs, _probe_expr_ctxs, _build_tuple_size,
                                   stores_nulls, _is_null_safe_eq_join, id(),
-                                  state->batch_size() * 2));
+                                  BitUtil::RoundUpToPowerOfTwo(state->batch_size()) * 2));
 
     _probe_batch.reset(new RowBatch(child(0)->row_desc(), state->batch_size()));
 

--- a/be/src/exec/set_operation_node.cpp
+++ b/be/src/exec/set_operation_node.cpp
@@ -144,7 +144,7 @@ Status SetOperationNode::open(RuntimeState* state) {
     // initial build hash table used for remove duplicated
     _hash_tbl.reset(new HashTable(_child_expr_lists[0], _child_expr_lists[1], _build_tuple_size,
                                   true, _find_nulls, id(),
-                                  BitUtil::RoundUpToPowerOfTwo(state->batch_size()) * 2));
+                                  BitUtil::RoundUpToPowerOfTwo(state->batch_size())));
     RowBatch build_batch(child(0)->row_desc(), state->batch_size());
     RETURN_IF_ERROR(child(0)->open(state));
 

--- a/be/src/exec/set_operation_node.cpp
+++ b/be/src/exec/set_operation_node.cpp
@@ -143,7 +143,8 @@ Status SetOperationNode::open(RuntimeState* state) {
     }
     // initial build hash table used for remove duplicated
     _hash_tbl.reset(new HashTable(_child_expr_lists[0], _child_expr_lists[1], _build_tuple_size,
-                                  true, _find_nulls, id(), state->batch_size() * 2));
+                                  true, _find_nulls, id(),
+                                  BitUtil::RoundUpToPowerOfTwo(state->batch_size()) * 2));
     RowBatch build_batch(child(0)->row_desc(), state->batch_size());
     RETURN_IF_ERROR(child(0)->open(state));
 

--- a/be/src/vec/olap/vgeneric_iterators.cpp
+++ b/be/src/vec/olap/vgeneric_iterators.cpp
@@ -239,7 +239,8 @@ private:
     bool _valid = false;
     mutable bool _skip = false;
     size_t _index_in_block = -1;
-    int _block_row_max = 4096;
+    // 4096 minus 16 + 16 bytes padding that in padding pod array
+    int _block_row_max = 4064;
     int _num_columns;
     int _num_key_columns;
     std::vector<uint32_t>* _compare_columns;

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -340,8 +340,9 @@ public class SessionVariable implements Serializable, Writable {
     @VariableMgr.VarAttr(name = CODEGEN_LEVEL)
     public int codegenLevel = 0;
 
+    // 1024 minus 16 + 16 bytes padding that in padding pod array
     @VariableMgr.VarAttr(name = BATCH_SIZE)
-    public int batchSize = 1024;
+    public int batchSize = 992;
 
     @VariableMgr.VarAttr(name = DISABLE_STREAMING_PREAGGREGATIONS)
     public boolean disableStreamPreaggregations = false;


### PR DESCRIPTION
# Proposed changes

Issue Number: #11815

## Problem summary

The default batch_size is 1024, assuming the element size is 1, then the minimum amount of memory to allocate for num_elements is 1024 + 16 bytes of pad right + 16 bytes of pad left, and will eventually alloc 1056 bytes, which will apply to the next The size of a power of 2.
So, 1024 minus 16 + 16 bytes padding that in padding pod array.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

