### PR TITLE
[feature-wip](unique-key-merge-on-write) add min/max key in segment

### DIFF
--- a/be/src/olap/primary_key_index.cpp
+++ b/be/src/olap/primary_key_index.cpp
@@ -60,17 +60,27 @@ Status PrimaryKeyIndexBuilder::finalize(segment_v2::PrimaryKeyIndexMetaPB* meta)
     // finish primary key index
     RETURN_IF_ERROR(_primary_key_index_builder->finish(meta->mutable_primary_key_index()));
 
+    // set min_max key
+    meta->set_min_key(_min_key.ToString());
+    meta->set_max_key(_max_key.ToString());
+
     // finish bloom filter index
     RETURN_IF_ERROR(_bloom_filter_index_builder->flush());
     return _bloom_filter_index_builder->finish(_file_writer, meta->mutable_bloom_filter_index());
 }
 
-Status PrimaryKeyIndexReader::parse(io::FileReaderSPtr file_reader,
-                                    const segment_v2::PrimaryKeyIndexMetaPB& meta) {
+Status PrimaryKeyIndexReader::parse_index(io::FileReaderSPtr file_reader,
+                                          const segment_v2::PrimaryKeyIndexMetaPB& meta) {
     // parse primary key index
     _index_reader.reset(new segment_v2::IndexedColumnReader(file_reader, meta.primary_key_index()));
     RETURN_IF_ERROR(_index_reader->load(!config::disable_storage_page_cache, false));
 
+    _index_parsed = true;
+    return Status::OK();
+}
+
+Status PrimaryKeyIndexReader::parse_bf(io::FileReaderSPtr file_reader,
+                                       const segment_v2::PrimaryKeyIndexMetaPB& meta) {
     // parse bloom filter
     segment_v2::ColumnIndexMetaPB column_index_meta = meta.bloom_filter_index();
     segment_v2::BloomFilterIndexReader bf_index_reader(std::move(file_reader),
@@ -79,8 +89,8 @@ Status PrimaryKeyIndexReader::parse(io::FileReaderSPtr file_reader,
     std::unique_ptr<segment_v2::BloomFilterIndexIterator> bf_iter;
     RETURN_IF_ERROR(bf_index_reader.new_iterator(&bf_iter));
     RETURN_IF_ERROR(bf_iter->read_bloom_filter(0, &_bf));
+    _bf_parsed = true;
 
-    _parsed = true;
     return Status::OK();
 }
 

--- a/be/src/olap/primary_key_index.h
+++ b/be/src/olap/primary_key_index.h
@@ -68,39 +68,48 @@ private:
 
 class PrimaryKeyIndexReader {
 public:
-    PrimaryKeyIndexReader() : _parsed(false) {}
+    PrimaryKeyIndexReader() : _index_parsed(false), _bf_parsed(false) {}
 
-    Status parse(io::FileReaderSPtr file_reader, const segment_v2::PrimaryKeyIndexMetaPB& meta);
+    Status parse_index(io::FileReaderSPtr file_reader,
+                       const segment_v2::PrimaryKeyIndexMetaPB& meta);
+
+    Status parse_bf(io::FileReaderSPtr file_reader, const segment_v2::PrimaryKeyIndexMetaPB& meta);
 
     Status new_iterator(std::unique_ptr<segment_v2::IndexedColumnIterator>* index_iterator) const {
-        DCHECK(_parsed);
+        DCHECK(_index_parsed);
         index_iterator->reset(new segment_v2::IndexedColumnIterator(_index_reader.get()));
         return Status::OK();
     }
 
     const TypeInfo* type_info() const {
-        DCHECK(_parsed);
+        DCHECK(_index_parsed);
         return _index_reader->type_info();
     }
 
     // verify whether exist in BloomFilter
     bool check_present(const Slice& key) {
-        DCHECK(_parsed);
+        DCHECK(_bf_parsed);
         return _bf->test_bytes(key.data, key.size);
     }
 
     uint32_t num_rows() const {
-        DCHECK(_parsed);
+        DCHECK(_index_parsed);
         return _index_reader->num_values();
     }
 
+    uint64_t get_bf_memory_size() {
+        DCHECK(_bf_parsed);
+        return _bf->size();
+    }
+
     uint64_t get_memory_size() {
-        DCHECK(_parsed);
-        return _index_reader->get_memory_size() + _bf->size();
+        DCHECK(_index_parsed);
+        return _index_reader->get_memory_size();
     }
 
 private:
-    bool _parsed;
+    bool _index_parsed;
+    bool _bf_parsed;
     std::unique_ptr<segment_v2::IndexedColumnReader> _index_reader;
     std::unique_ptr<segment_v2::BloomFilter> _bf;
 };

--- a/be/src/olap/rowset/segment_v2/segment.h
+++ b/be/src/olap/rowset/segment_v2/segment.h
@@ -95,6 +95,17 @@ public:
 
     Status load_index();
 
+    Status load_pk_index_and_bf();
+
+    std::string min_key() {
+        DCHECK(_tablet_schema->keys_type() == UNIQUE_KEYS && _footer.has_primary_key_index_meta());
+        return _footer.primary_key_index_meta().min_key();
+    };
+    std::string max_key() {
+        DCHECK(_tablet_schema->keys_type() == UNIQUE_KEYS && _footer.has_primary_key_index_meta());
+        return _footer.primary_key_index_meta().max_key();
+    };
+
 private:
     DISALLOW_COPY_AND_ASSIGN(Segment);
     Segment(uint32_t segment_id, TabletSchemaSPtr tablet_schema);
@@ -102,6 +113,7 @@ private:
     Status _open();
     Status _parse_footer();
     Status _create_column_readers();
+    Status _load_pk_bloom_filter();
 
 private:
     friend class SegmentIterator;
@@ -126,6 +138,8 @@ private:
 
     // used to guarantee that short key index will be loaded at most once in a thread-safe way
     DorisCallOnce<Status> _load_index_once;
+    // used to guarantee that primary key bloom filter will be loaded at most once in a thread-safe way
+    DorisCallOnce<Status> _load_pk_bf_once;
     // used to hold short key index page in memory
     PageHandle _sk_index_handle;
     // short key index decoder

--- a/be/src/olap/rowset/segment_v2/segment_iterator.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.cpp
@@ -522,6 +522,13 @@ Status SegmentIterator::_lookup_ordinal_from_pk_index(const RowCursor& key, bool
     std::string index_key;
     encode_key_with_padding<RowCursor, true, true>(
             &index_key, key, _segment->_tablet_schema->num_key_columns(), is_include);
+    if (index_key < _segment->min_key()) {
+        *rowid = 0;
+        return Status::OK();
+    } else if (index_key > _segment->max_key()) {
+        *rowid = num_rows();
+        return Status::OK();
+    }
     bool exact_match = false;
 
     std::unique_ptr<segment_v2::IndexedColumnIterator> index_iterator;

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -1950,7 +1950,7 @@ Status Tablet::calc_delete_bitmap(RowsetId rowset_id,
     int64_t end_version = max_version_unlocked().second;
     Version dummy_version(end_version + 1, end_version + 1);
     for (auto& seg : segments) {
-        seg->load_index(); // We need index blocks to iterate
+        seg->load_pk_index_and_bf(); // We need index blocks to iterate
         auto pk_idx = seg->get_primary_key_index();
         int cnt = 0;
         int total = pk_idx->num_rows();

--- a/be/test/olap/primary_key_index_test.cpp
+++ b/be/test/olap/primary_key_index_test.cpp
@@ -76,7 +76,8 @@ TEST_F(PrimaryKeyIndexTest, builder) {
     PrimaryKeyIndexReader index_reader;
     io::FileReaderSPtr file_reader;
     EXPECT_TRUE(fs->open_file(filename, &file_reader).ok());
-    EXPECT_TRUE(index_reader.parse(file_reader, index_meta).ok());
+    EXPECT_TRUE(index_reader.parse_index(file_reader, index_meta).ok());
+    EXPECT_TRUE(index_reader.parse_bf(file_reader, index_meta).ok());
     EXPECT_EQ(num_rows, index_reader.num_rows());
 
     std::unique_ptr<segment_v2::IndexedColumnIterator> index_iterator;

--- a/gensrc/proto/segment_v2.proto
+++ b/gensrc/proto/segment_v2.proto
@@ -167,6 +167,9 @@ message PrimaryKeyIndexMetaPB {
     optional IndexedColumnMetaPB primary_key_index = 1;
     // bloom filter index
     optional ColumnIndexMetaPB bloom_filter_index = 2;
+
+    optional bytes min_key = 3;
+    optional bytes max_key = 4;
 }
 
 message SegmentFooterPB {


### PR DESCRIPTION
some feature:
1. add min max key in segment footer to speed up get_row_ranges_by_keys
2. do not load pk bloom filter in query

# Proposed changes

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

