### PR TITLE
[enhancement](RowDescriptor) enhance tuple_idx check during runtime

### DIFF
--- a/be/src/exec/blocking_join_node.cpp
+++ b/be/src/exec/blocking_join_node.cpp
@@ -72,7 +72,7 @@ Status BlockingJoinNode::prepare(RuntimeState* state) {
     for (int i = 0; i < _build_tuple_size; ++i) {
         TupleDescriptor* build_tuple_desc = child(1)->row_desc().tuple_descriptors()[i];
         auto tuple_idx = _row_descriptor.get_tuple_idx(build_tuple_desc->id());
-        RETURN_IF_INVALID_IDX(build_tuple_desc->id(), tuple_idx);
+        RETURN_IF_INVALID_TUPLE_IDX(build_tuple_desc->id(), tuple_idx);
         _build_tuple_idx.push_back(tuple_idx);
     }
 

--- a/be/src/exec/blocking_join_node.cpp
+++ b/be/src/exec/blocking_join_node.cpp
@@ -72,7 +72,7 @@ Status BlockingJoinNode::prepare(RuntimeState* state) {
     for (int i = 0; i < _build_tuple_size; ++i) {
         TupleDescriptor* build_tuple_desc = child(1)->row_desc().tuple_descriptors()[i];
         auto tuple_idx = _row_descriptor.get_tuple_idx(build_tuple_desc->id());
-        RETURN_IF_VALID_IDX(build_tuple_desc->id(), tuple_idx);
+        RETURN_IF_INVALID_IDX(build_tuple_desc->id(), tuple_idx);
         _build_tuple_idx.push_back(tuple_idx);
     }
 

--- a/be/src/exec/blocking_join_node.cpp
+++ b/be/src/exec/blocking_join_node.cpp
@@ -23,6 +23,7 @@
 #include <sstream>
 
 #include "gen_cpp/PlanNodes_types.h"
+#include "runtime/descriptors.h"
 #include "runtime/row_batch.h"
 #include "runtime/runtime_state.h"
 #include "runtime/tuple.h"
@@ -70,7 +71,9 @@ Status BlockingJoinNode::prepare(RuntimeState* state) {
 
     for (int i = 0; i < _build_tuple_size; ++i) {
         TupleDescriptor* build_tuple_desc = child(1)->row_desc().tuple_descriptors()[i];
-        _build_tuple_idx.push_back(_row_descriptor.get_tuple_idx(build_tuple_desc->id()));
+        auto tuple_idx = _row_descriptor.get_tuple_idx(build_tuple_desc->id());
+        RETURN_IF_VALID_IDX(build_tuple_desc->id(), tuple_idx);
+        _build_tuple_idx.push_back(tuple_idx);
     }
 
     _probe_tuple_row_size = num_left_tuples * sizeof(Tuple*);

--- a/be/src/exec/hash_join_node.cpp
+++ b/be/src/exec/hash_join_node.cpp
@@ -134,7 +134,7 @@ Status HashJoinNode::prepare(RuntimeState* state) {
     for (int i = 0; i < _build_tuple_size; ++i) {
         TupleDescriptor* build_tuple_desc = child(1)->row_desc().tuple_descriptors()[i];
         auto tuple_idx = _row_descriptor.get_tuple_idx(build_tuple_desc->id());
-        RETURN_IF_INVALID_IDX(build_tuple_desc->id(), tuple_idx);
+        RETURN_IF_INVALID_TUPLE_IDX(build_tuple_desc->id(), tuple_idx);
         _build_tuple_idx.push_back(tuple_idx);
     }
     _probe_tuple_row_size = num_left_tuples * sizeof(Tuple*);

--- a/be/src/exec/hash_join_node.cpp
+++ b/be/src/exec/hash_join_node.cpp
@@ -134,7 +134,7 @@ Status HashJoinNode::prepare(RuntimeState* state) {
     for (int i = 0; i < _build_tuple_size; ++i) {
         TupleDescriptor* build_tuple_desc = child(1)->row_desc().tuple_descriptors()[i];
         auto tuple_idx = _row_descriptor.get_tuple_idx(build_tuple_desc->id());
-        RETURN_IF_VALID_IDX(build_tuple_desc->id(), tuple_idx);
+        RETURN_IF_INVALID_IDX(build_tuple_desc->id(), tuple_idx);
         _build_tuple_idx.push_back(tuple_idx);
     }
     _probe_tuple_row_size = num_left_tuples * sizeof(Tuple*);

--- a/be/src/exec/hash_join_node.cpp
+++ b/be/src/exec/hash_join_node.cpp
@@ -29,6 +29,7 @@
 #include "exprs/runtime_filter.h"
 #include "exprs/runtime_filter_slots.h"
 #include "gen_cpp/PlanNodes_types.h"
+#include "runtime/descriptors.h"
 #include "runtime/row_batch.h"
 #include "runtime/runtime_filter_mgr.h"
 #include "runtime/runtime_state.h"
@@ -132,7 +133,9 @@ Status HashJoinNode::prepare(RuntimeState* state) {
 
     for (int i = 0; i < _build_tuple_size; ++i) {
         TupleDescriptor* build_tuple_desc = child(1)->row_desc().tuple_descriptors()[i];
-        _build_tuple_idx.push_back(_row_descriptor.get_tuple_idx(build_tuple_desc->id()));
+        auto tuple_idx = _row_descriptor.get_tuple_idx(build_tuple_desc->id());
+        RETURN_IF_VALID_IDX(build_tuple_desc->id(), tuple_idx);
+        _build_tuple_idx.push_back(tuple_idx);
     }
     _probe_tuple_row_size = num_left_tuples * sizeof(Tuple*);
     _build_tuple_row_size = num_build_tuples * sizeof(Tuple*);

--- a/be/src/exec/set_operation_node.cpp
+++ b/be/src/exec/set_operation_node.cpp
@@ -19,6 +19,7 @@
 
 #include "exprs/expr.h"
 #include "exprs/expr_context.h"
+#include "runtime/descriptors.h"
 #include "runtime/raw_value.h"
 #include "runtime/row_batch.h"
 #include "runtime/runtime_state.h"
@@ -57,7 +58,9 @@ Status SetOperationNode::prepare(RuntimeState* state) {
 
     for (int i = 0; i < _build_tuple_size; ++i) {
         TupleDescriptor* build_tuple_desc = child(0)->row_desc().tuple_descriptors()[i];
-        _build_tuple_idx.push_back(_row_descriptor.get_tuple_idx(build_tuple_desc->id()));
+        auto tuple_idx = _row_descriptor.get_tuple_idx(build_tuple_desc->id());
+        RETURN_IF_VALID_IDX(build_tuple_desc->id(), tuple_idx);
+        _build_tuple_idx.push_back(tuple_idx);
     }
     _find_nulls = std::vector<bool>();
     for (auto ctx : _child_expr_lists[0]) {

--- a/be/src/exec/set_operation_node.cpp
+++ b/be/src/exec/set_operation_node.cpp
@@ -59,7 +59,7 @@ Status SetOperationNode::prepare(RuntimeState* state) {
     for (int i = 0; i < _build_tuple_size; ++i) {
         TupleDescriptor* build_tuple_desc = child(0)->row_desc().tuple_descriptors()[i];
         auto tuple_idx = _row_descriptor.get_tuple_idx(build_tuple_desc->id());
-        RETURN_IF_INVALID_IDX(build_tuple_desc->id(), tuple_idx);
+        RETURN_IF_INVALID_TUPLE_IDX(build_tuple_desc->id(), tuple_idx);
         _build_tuple_idx.push_back(tuple_idx);
     }
     _find_nulls = std::vector<bool>();

--- a/be/src/exec/set_operation_node.cpp
+++ b/be/src/exec/set_operation_node.cpp
@@ -59,7 +59,7 @@ Status SetOperationNode::prepare(RuntimeState* state) {
     for (int i = 0; i < _build_tuple_size; ++i) {
         TupleDescriptor* build_tuple_desc = child(0)->row_desc().tuple_descriptors()[i];
         auto tuple_idx = _row_descriptor.get_tuple_idx(build_tuple_desc->id());
-        RETURN_IF_VALID_IDX(build_tuple_desc->id(), tuple_idx);
+        RETURN_IF_INVALID_IDX(build_tuple_desc->id(), tuple_idx);
         _build_tuple_idx.push_back(tuple_idx);
     }
     _find_nulls = std::vector<bool>();

--- a/be/src/exec/table_function_node.cpp
+++ b/be/src/exec/table_function_node.cpp
@@ -287,7 +287,7 @@ Status TableFunctionNode::get_next(RuntimeState* state, RowBatch* row_batch, boo
                 TupleDescriptor* parent_tuple_desc = parent_rowdesc.tuple_descriptors()[tuple_idx];
 
                 auto tuple_idx = child_rowdesc.get_tuple_idx(child_tuple_desc->id());
-                RETURN_IF_VALID_IDX(child_tuple_desc->id(), tuple_idx);
+                RETURN_IF_INVALID_IDX(child_tuple_desc->id(), tuple_idx);
                 Tuple* child_tuple = _cur_child_tuple_row->get_tuple(tuple_idx);
 
                 // The child tuple is nullptr, only when the child tuple is from outer join. so we directly set

--- a/be/src/exec/table_function_node.cpp
+++ b/be/src/exec/table_function_node.cpp
@@ -287,7 +287,7 @@ Status TableFunctionNode::get_next(RuntimeState* state, RowBatch* row_batch, boo
                 TupleDescriptor* parent_tuple_desc = parent_rowdesc.tuple_descriptors()[tuple_idx];
 
                 auto tuple_idx = child_rowdesc.get_tuple_idx(child_tuple_desc->id());
-                RETURN_IF_INVALID_IDX(child_tuple_desc->id(), tuple_idx);
+                RETURN_IF_INVALID_TUPLE_IDX(child_tuple_desc->id(), tuple_idx);
                 Tuple* child_tuple = _cur_child_tuple_row->get_tuple(tuple_idx);
 
                 // The child tuple is nullptr, only when the child tuple is from outer join. so we directly set

--- a/be/src/exec/table_function_node.cpp
+++ b/be/src/exec/table_function_node.cpp
@@ -286,8 +286,9 @@ Status TableFunctionNode::get_next(RuntimeState* state, RowBatch* row_batch, boo
                 TupleDescriptor* child_tuple_desc = child_rowdesc.tuple_descriptors()[tuple_idx];
                 TupleDescriptor* parent_tuple_desc = parent_rowdesc.tuple_descriptors()[tuple_idx];
 
-                Tuple* child_tuple = _cur_child_tuple_row->get_tuple(
-                        child_rowdesc.get_tuple_idx(child_tuple_desc->id()));
+                auto tuple_idx = child_rowdesc.get_tuple_idx(child_tuple_desc->id());
+                RETURN_IF_VALID_IDX(child_tuple_desc->id(), tuple_idx);
+                Tuple* child_tuple = _cur_child_tuple_row->get_tuple(tuple_idx);
 
                 // The child tuple is nullptr, only when the child tuple is from outer join. so we directly set
                 // parent_tuple have same tuple_idx nullptr to mock the behavior

--- a/be/src/exprs/tuple_is_null_predicate.cpp
+++ b/be/src/exprs/tuple_is_null_predicate.cpp
@@ -40,7 +40,7 @@ Status TupleIsNullPredicate::prepare(RuntimeState* state, const RowDescriptor& r
     // Resolve tuple ids to tuple indexes.
     for (int i = 0; i < _tuple_ids.size(); ++i) {
         int32_t tuple_idx = row_desc.get_tuple_idx(_tuple_ids[i]);
-        RETURN_IF_VALID_IDX(_tuple_ids[i], tuple_idx);
+        RETURN_IF_INVALID_IDX(_tuple_ids[i], tuple_idx);
         if (row_desc.tuple_is_nullable(tuple_idx)) {
             _tuple_idxs.push_back(tuple_idx);
         }

--- a/be/src/exprs/tuple_is_null_predicate.cpp
+++ b/be/src/exprs/tuple_is_null_predicate.cpp
@@ -23,6 +23,7 @@
 #include <sstream>
 
 #include "gen_cpp/Exprs_types.h"
+#include "runtime/descriptors.h"
 
 namespace doris {
 
@@ -39,6 +40,7 @@ Status TupleIsNullPredicate::prepare(RuntimeState* state, const RowDescriptor& r
     // Resolve tuple ids to tuple indexes.
     for (int i = 0; i < _tuple_ids.size(); ++i) {
         int32_t tuple_idx = row_desc.get_tuple_idx(_tuple_ids[i]);
+        RETURN_IF_VALID_IDX(_tuple_ids[i], tuple_idx);
         if (row_desc.tuple_is_nullable(tuple_idx)) {
             _tuple_idxs.push_back(tuple_idx);
         }

--- a/be/src/exprs/tuple_is_null_predicate.cpp
+++ b/be/src/exprs/tuple_is_null_predicate.cpp
@@ -40,7 +40,7 @@ Status TupleIsNullPredicate::prepare(RuntimeState* state, const RowDescriptor& r
     // Resolve tuple ids to tuple indexes.
     for (int i = 0; i < _tuple_ids.size(); ++i) {
         int32_t tuple_idx = row_desc.get_tuple_idx(_tuple_ids[i]);
-        RETURN_IF_INVALID_IDX(_tuple_ids[i], tuple_idx);
+        RETURN_IF_INVALID_TUPLE_IDX(_tuple_ids[i], tuple_idx);
         if (row_desc.tuple_is_nullable(tuple_idx)) {
             _tuple_idxs.push_back(tuple_idx);
         }

--- a/be/src/olap/olap_server.cpp
+++ b/be/src/olap/olap_server.cpp
@@ -524,13 +524,13 @@ std::vector<TabletSharedPtr> StorageEngine::_generate_compaction_tasks(
                             : copied_base_map[data_dir],
                     &disk_max_score, _cumulative_compaction_policy);
             if (tablet != nullptr &&
-                !tablet->tablet_meta()->tablet_schema().disable_auto_compaction()) {
+                !tablet->tablet_meta()->tablet_schema()->disable_auto_compaction()) {
                 if (need_pick_tablet) {
                     tablets_compaction.emplace_back(tablet);
                 }
                 max_compaction_score = std::max(max_compaction_score, disk_max_score);
             } else if (tablet != nullptr &&
-                       tablet->tablet_meta()->tablet_schema().disable_auto_compaction()) {
+                       tablet->tablet_meta()->tablet_schema()->disable_auto_compaction()) {
                 LOG(INFO) << "Tablet " << tablet->full_name()
                           << " will be ignored by automatic compaction tasks since it's set to "
                           << "disabled automatic compaction.";

--- a/be/src/runtime/descriptors.cpp
+++ b/be/src/runtime/descriptors.cpp
@@ -399,7 +399,8 @@ int RowDescriptor::get_row_size() const {
 }
 
 int RowDescriptor::get_tuple_idx(TupleId id) const {
-    DCHECK_LT(id, _tuple_idx_map.size()) << "RowDescriptor: " << debug_string();
+    // comment CHECK temporarily to make fuzzy test run smoothly
+    // DCHECK_LT(id, _tuple_idx_map.size()) << "RowDescriptor: " << debug_string();
     if (_tuple_idx_map.size() <= id) {
         return RowDescriptor::INVALID_IDX;
     }

--- a/be/src/runtime/descriptors.cpp
+++ b/be/src/runtime/descriptors.cpp
@@ -399,7 +399,10 @@ int RowDescriptor::get_row_size() const {
 }
 
 int RowDescriptor::get_tuple_idx(TupleId id) const {
-    CHECK_LT(id, _tuple_idx_map.size()) << "RowDescriptor: " << debug_string();
+    DCHECK_LT(id, _tuple_idx_map.size()) << "RowDescriptor: " << debug_string();
+    if (_tuple_idx_map.size() <= id) {
+        return RowDescriptor::INVALID_IDX;
+    }
     return _tuple_idx_map[id];
 }
 

--- a/be/src/runtime/descriptors.h
+++ b/be/src/runtime/descriptors.h
@@ -382,7 +382,7 @@ private:
     DescriptorTbl() = default;
 };
 
-#define RETURN_IF_VALID_IDX(tuple_id, tuple_idx)                                                 \
+#define RETURN_IF_INVALID_IDX(tuple_id, tuple_idx)                                                 \
     do {                                                                                         \
         if (UNLIKELY(RowDescriptor::INVALID_IDX == tuple_idx)) {                                 \
             return Status::InternalError("failed to get tuple idx with tuple id: {}", tuple_id); \

--- a/be/src/runtime/descriptors.h
+++ b/be/src/runtime/descriptors.h
@@ -382,6 +382,13 @@ private:
     DescriptorTbl() = default;
 };
 
+#define RETURN_IF_VALID_IDX(tuple_id, tuple_idx)                                                 \
+    do {                                                                                         \
+        if (UNLIKELY(RowDescriptor::INVALID_IDX == tuple_idx)) {                                 \
+            return Status::InternalError("failed to get tuple idx with tuple id: {}", tuple_id); \
+        }                                                                                        \
+    } while (false)
+
 // Records positions of tuples within row produced by ExecNode.
 // TODO: this needs to differentiate between tuples contained in row
 // and tuples produced by ExecNode (parallel to PlanNode.rowTupleIds and

--- a/be/src/runtime/descriptors.h
+++ b/be/src/runtime/descriptors.h
@@ -382,7 +382,7 @@ private:
     DescriptorTbl() = default;
 };
 
-#define RETURN_IF_INVALID_IDX(tuple_id, tuple_idx)                                               \
+#define RETURN_IF_INVALID_TUPLE_IDX(tuple_id, tuple_idx)                                               \
     do {                                                                                         \
         if (UNLIKELY(RowDescriptor::INVALID_IDX == tuple_idx)) {                                 \
             return Status::InternalError("failed to get tuple idx with tuple id: {}", tuple_id); \

--- a/be/src/runtime/descriptors.h
+++ b/be/src/runtime/descriptors.h
@@ -382,7 +382,7 @@ private:
     DescriptorTbl() = default;
 };
 
-#define RETURN_IF_INVALID_TUPLE_IDX(tuple_id, tuple_idx)                                               \
+#define RETURN_IF_INVALID_TUPLE_IDX(tuple_id, tuple_idx)                                         \
     do {                                                                                         \
         if (UNLIKELY(RowDescriptor::INVALID_IDX == tuple_idx)) {                                 \
             return Status::InternalError("failed to get tuple idx with tuple id: {}", tuple_id); \

--- a/be/src/runtime/descriptors.h
+++ b/be/src/runtime/descriptors.h
@@ -382,7 +382,7 @@ private:
     DescriptorTbl() = default;
 };
 
-#define RETURN_IF_INVALID_IDX(tuple_id, tuple_idx)                                                 \
+#define RETURN_IF_INVALID_IDX(tuple_id, tuple_idx)                                               \
     do {                                                                                         \
         if (UNLIKELY(RowDescriptor::INVALID_IDX == tuple_idx)) {                                 \
             return Status::InternalError("failed to get tuple idx with tuple id: {}", tuple_id); \

--- a/be/src/vec/exec/vblocking_join_node.cpp
+++ b/be/src/vec/exec/vblocking_join_node.cpp
@@ -21,6 +21,7 @@
 
 #include "exprs/expr.h"
 #include "gen_cpp/PlanNodes_types.h"
+#include "runtime/descriptors.h"
 #include "runtime/runtime_state.h"
 #include "util/runtime_profile.h"
 
@@ -57,7 +58,9 @@ Status VBlockingJoinNode::prepare(RuntimeState* state) {
 
     for (int i = 0; i < _build_tuple_size; ++i) {
         TupleDescriptor* build_tuple_desc = child(1)->row_desc().tuple_descriptors()[i];
-        _build_tuple_idx.push_back(_row_descriptor.get_tuple_idx(build_tuple_desc->id()));
+        auto tuple_idx = _row_descriptor.get_tuple_idx(build_tuple_desc->id());
+        RETURN_IF_VALID_IDX(build_tuple_desc->id(), tuple_idx);
+        _build_tuple_idx.push_back(tuple_idx);
     }
 
     return Status::OK();

--- a/be/src/vec/exec/vblocking_join_node.cpp
+++ b/be/src/vec/exec/vblocking_join_node.cpp
@@ -59,7 +59,7 @@ Status VBlockingJoinNode::prepare(RuntimeState* state) {
     for (int i = 0; i < _build_tuple_size; ++i) {
         TupleDescriptor* build_tuple_desc = child(1)->row_desc().tuple_descriptors()[i];
         auto tuple_idx = _row_descriptor.get_tuple_idx(build_tuple_desc->id());
-        RETURN_IF_INVALID_IDX(build_tuple_desc->id(), tuple_idx);
+        RETURN_IF_INVALID_TUPLE_IDX(build_tuple_desc->id(), tuple_idx);
         _build_tuple_idx.push_back(tuple_idx);
     }
 

--- a/be/src/vec/exec/vblocking_join_node.cpp
+++ b/be/src/vec/exec/vblocking_join_node.cpp
@@ -59,7 +59,7 @@ Status VBlockingJoinNode::prepare(RuntimeState* state) {
     for (int i = 0; i < _build_tuple_size; ++i) {
         TupleDescriptor* build_tuple_desc = child(1)->row_desc().tuple_descriptors()[i];
         auto tuple_idx = _row_descriptor.get_tuple_idx(build_tuple_desc->id());
-        RETURN_IF_VALID_IDX(build_tuple_desc->id(), tuple_idx);
+        RETURN_IF_INVALID_IDX(build_tuple_desc->id(), tuple_idx);
         _build_tuple_idx.push_back(tuple_idx);
     }
 


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

The original get_tuple_idx function would check whether tuple_id is less than tuple map' size using CHECK macro. It might shut down the whole process once the check failed like the image below.

![image](https://user-images.githubusercontent.com/43750022/184841609-6747fd5b-d781-427e-9dc6-d298d6c52b28.png)

Meanwhile, there exists other occasions where the caller of get_tuple_idx never checks if it returns a valid tuple_idx or not.
This pr aims to enhance the robust during runtime by :
1. use DCHECK instead of CHECK to prevent surprisingly shutdown
2. add check logic when calling get_tuple_idx function 
## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] No
3. Has unit tests been added:
    - [ ] No
4. Has document been added or modified:
    - [ ] No
5. Does it need to update dependencies:
    - [ ] No
6. Are there any changes that cannot be rolled back:
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

