### PR TITLE
[Enhancement](meta) add err type/code/msg in audit event

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/plugin/AuditEvent.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/plugin/AuditEvent.java
@@ -86,9 +86,14 @@ public class AuditEvent {
     public long peakMemoryBytes = -1;
     @AuditField(value = "SqlDigest")
     public String sqlDigest = "";
-
     @AuditField(value = "TraceId")
     public String traceId = "";
+    @AuditField(value = "ErrType")
+    public String errType = "";
+    @AuditField(value = "ErrCode")
+    public String errCode = "";
+    @AuditField(value = "ErrMsg")
+    public String errMsg = "";
 
     public static class AuditEventBuilder {
 
@@ -198,6 +203,21 @@ public class AuditEvent {
 
         public AuditEventBuilder setTraceId(String traceId) {
             auditEvent.traceId = traceId;
+            return this;
+        }
+
+        public AuditEventBuilder setErrMsg(String errMsg) {
+            auditEvent.errMsg = errMsg;
+            return this;
+        }
+
+        public AuditEventBuilder setErrType(String errType) {
+            auditEvent.errType = errType;
+            return this;
+        }
+
+        public AuditEventBuilder setErrCode(String errCode) {
+            auditEvent.errCode = errCode;
             return this;
         }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectProcessor.java
@@ -166,10 +166,17 @@ public class ConnectProcessor {
 
         if (ctx.getState().isQuery()) {
             MetricRepo.COUNTER_QUERY_ALL.increase(1L);
-            if (ctx.getState().getStateType() == MysqlStateType.ERR
-                    && ctx.getState().getErrType() != QueryState.ErrType.ANALYSIS_ERR) {
-                // err query
-                MetricRepo.COUNTER_QUERY_ERR.increase(1L);
+            if (ctx.getState().getStateType() == MysqlStateType.ERR) {
+                // audit error msg
+                ctx.getAuditEventBuilder().setErrType(ctx.getState().getErrType().name());
+                ctx.getAuditEventBuilder().setErrCode(ctx.getState().getErrorCode().name());
+                ctx.getAuditEventBuilder().setErrMsg(ctx.getState().getErrorMessage());
+
+                // not analysis error
+                if (ctx.getState().getErrType() != QueryState.ErrType.ANALYSIS_ERR) {
+                    // err query
+                    MetricRepo.COUNTER_QUERY_ERR.increase(1L);
+                }
             } else if (ctx.getState().getStateType() == MysqlStateType.OK) {
                 // ok query
                 MetricRepo.HISTO_QUERY_LATENCY.update(elapseMs);

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectProcessor.java
@@ -166,9 +166,9 @@ public class ConnectProcessor {
 
         // audit error msg
         if (ctx.getState().getStateType() == MysqlStateType.ERR) {
-            ctx.getAuditEventBuilder().setErrType(ctx.getState().getErrType().name())
-                .setErrCode(ctx.getState().getErrorCode().name())
-                .setErrMsg(ctx.getState().getErrorMessage());
+            ctx.getAuditEventBuilder().setErrMsg(ctx.getState().getErrorMessage())
+                .setErrType(ctx.getState().getErrType() == null ? "" : ctx.getState().getErrType().name())
+                .setErrCode(ctx.getState().getErrorCode() == null ? "" : ctx.getState().getErrorCode().name());
         }
 
         if (ctx.getState().isQuery()) {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectProcessor.java
@@ -164,19 +164,19 @@ public class ConnectProcessor {
                 .setQueryId(ctx.queryId() == null ? "NaN" : DebugUtil.printId(ctx.queryId()))
                 .setTraceId(spanContext.isValid() ? spanContext.getTraceId() : "");
 
+        // audit error msg
+        if (ctx.getState().getStateType() == MysqlStateType.ERR) {
+            ctx.getAuditEventBuilder().setErrType(ctx.getState().getErrType().name())
+                .setErrCode(ctx.getState().getErrorCode().name())
+                .setErrMsg(ctx.getState().getErrorMessage());
+        }
+
         if (ctx.getState().isQuery()) {
             MetricRepo.COUNTER_QUERY_ALL.increase(1L);
-            if (ctx.getState().getStateType() == MysqlStateType.ERR) {
-                // audit error msg
-                ctx.getAuditEventBuilder().setErrType(ctx.getState().getErrType().name());
-                ctx.getAuditEventBuilder().setErrCode(ctx.getState().getErrorCode().name());
-                ctx.getAuditEventBuilder().setErrMsg(ctx.getState().getErrorMessage());
-
-                // not analysis error
-                if (ctx.getState().getErrType() != QueryState.ErrType.ANALYSIS_ERR) {
-                    // err query
-                    MetricRepo.COUNTER_QUERY_ERR.increase(1L);
-                }
+            if (ctx.getState().getStateType() == MysqlStateType.ERR
+                    && ctx.getState().getErrType() != QueryState.ErrType.ANALYSIS_ERR) {
+                // err query
+                MetricRepo.COUNTER_QUERY_ERR.increase(1L);
             } else if (ctx.getState().getStateType() == MysqlStateType.OK) {
                 // ok query
                 MetricRepo.HISTO_QUERY_LATENCY.update(elapseMs);


### PR DESCRIPTION
# Proposed changes

Print "err msg" "err type"  and "err code" when sql execute failed .

Add "err msg" "err code" and "err type" in audit event .

Help developers diagnose the causes of failures.

For example:
```shell
errCode = 2, detailMessage = failed to initialize storage reader. tablet=76927688.1343432537.bd4a545605c7d580-8c277220384848b0, res=-230, backend=xxxxx
```


## Problem summary

Get more error information to help diagnose when sql execute failed .

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

