### PR TITLE
[fix](orderby)disallow hll and bitmap data type in order by list

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/QueryStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/QueryStmt.java
@@ -21,6 +21,7 @@
 package org.apache.doris.analysis;
 
 import org.apache.doris.catalog.TableIf;
+import org.apache.doris.catalog.Type;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.ErrorReport;
@@ -316,6 +317,12 @@ public abstract class QueryStmt extends StatementBase implements Queriable {
         if (!analyzer.isRootAnalyzer() && hasOffset() && !hasLimit()) {
             throw new AnalysisException("Order-by with offset without limit not supported"
                     + " in nested queries.");
+        }
+
+        for (Expr expr : orderingExprs) {
+            if (expr.getType().isOnlyMetricType()) {
+                throw new AnalysisException(Type.OnlyMetricTypeErrorMsg);
+            }
         }
 
         sortInfo = new SortInfo(orderingExprs, isAscOrder, nullsFirstParams);

--- a/regression-test/suites/query/aggregate/aggregate_group_by_hll_and_bitmap.groovy
+++ b/regression-test/suites/query/aggregate/aggregate_group_by_hll_and_bitmap.groovy
@@ -36,12 +36,12 @@ suite("aggregate_group_by_hll_and_bitmap") {
     }
 
     test {
-        sql "select user_ids from test_group_by_hll_and_bitmap group by user_ids"
+        sql "select user_ids from test_group_by_hll_and_bitmap order by user_ids"
         exception "Doris hll and bitmap column must use with specific function, and don't support filter or group by.please run 'help hll' or 'help bitmap' in your mysql client"
     }
 
     test {
-        sql "select hll_set from test_group_by_hll_and_bitmap group by hll_set"
+        sql "select hll_set from test_group_by_hll_and_bitmap order by hll_set"
         exception "Doris hll and bitmap column must use with specific function, and don't support filter or group by.please run 'help hll' or 'help bitmap' in your mysql client"
     }
 

--- a/regression-test/suites/query/aggregate/aggregate_group_by_hll_and_bitmap.groovy
+++ b/regression-test/suites/query/aggregate/aggregate_group_by_hll_and_bitmap.groovy
@@ -35,5 +35,15 @@ suite("aggregate_group_by_hll_and_bitmap") {
         exception "Doris hll and bitmap column must use with specific function, and don't support filter or group by.please run 'help hll' or 'help bitmap' in your mysql client"
     }
 
+    test {
+        sql "select user_ids from test_group_by_hll_and_bitmap group by user_ids"
+        exception "Doris hll and bitmap column must use with specific function, and don't support filter or group by.please run 'help hll' or 'help bitmap' in your mysql client"
+    }
+
+    test {
+        sql "select hll_set from test_group_by_hll_and_bitmap group by hll_set"
+        exception "Doris hll and bitmap column must use with specific function, and don't support filter or group by.please run 'help hll' or 'help bitmap' in your mysql client"
+    }
+
     sql "DROP TABLE test_group_by_hll_and_bitmap"
 }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

disallow hll and bitmap data type in order by list

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

