### PR TITLE
[Bug](external iceberg table)Fix iceberg on ha-hdfs unknown hostname bug.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/external/iceberg/HiveCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/external/iceberg/HiveCatalog.java
@@ -47,6 +47,9 @@ public class HiveCatalog implements IcebergCatalog {
     public void initialize(IcebergProperty icebergProperty) {
         // set hadoop conf
         Configuration conf = new HdfsConfiguration();
+        for (Map.Entry<String, String> entry : icebergProperty.getDfsProperties().entrySet()) {
+            conf.set(entry.getKey(), entry.getValue());
+        }
         hiveCatalog.setConf(conf);
         // initialize hive catalog
         Map<String, String> catalogProperties = new HashMap<>();


### PR DESCRIPTION
# Proposed changes

Iceberg external table may encounter `java.net.UnknownHostException` while hdfs enabled HA. This is because HiveCatalog doesn't get the ha configuration while initializing.

## Problem summary

Query for iceberg external table failed with error `java.net.UnknownHostException`. 

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

