### PR TITLE
[docs](typo) fix some typo in bitmap docs

### DIFF
--- a/docs/en/docs/sql-manual/sql-functions/bitmap-functions/bitmap_contains.md
+++ b/docs/en/docs/sql-manual/sql-functions/bitmap-functions/bitmap_contains.md
@@ -28,7 +28,7 @@ under the License.
 ### description
 #### Syntax
 
-`B00LEAN BITMAP_CONTAINS(BITMAP bitmap, BIGINT input)`
+`BOOLEAN BITMAP_CONTAINS(BITMAP bitmap, BIGINT input)`
 
 Calculates whether the input value is in the Bitmap column and returns a Boolean value.
 

--- a/docs/en/docs/sql-manual/sql-functions/bitmap-functions/bitmap_has_all.md
+++ b/docs/en/docs/sql-manual/sql-functions/bitmap-functions/bitmap_has_all.md
@@ -28,7 +28,7 @@ under the License.
 ### description
 #### Syntax
 
-`B00LEAN BITMAP_HAS_ALL(BITMAP lhs, BITMAP rhs)`
+`BOOLEAN BITMAP_HAS_ALL(BITMAP lhs, BITMAP rhs)`
 
 Returns true if the first bitmap contains all the elements of the second bitmap.
 Returns true if the second bitmap contains an empty element.

--- a/docs/en/docs/sql-manual/sql-functions/bitmap-functions/bitmap_has_any.md
+++ b/docs/en/docs/sql-manual/sql-functions/bitmap-functions/bitmap_has_any.md
@@ -28,7 +28,7 @@ under the License.
 ### description
 #### Syntax
 
-`B00LEAN BITMAP_HAS_ANY(BITMAP lhs, BITMAP rhs)`
+`BOOLEAN BITMAP_HAS_ANY(BITMAP lhs, BITMAP rhs)`
 
 Calculate whether there are intersecting elements in the two Bitmap columns. The return value is Boolean.
 

--- a/docs/zh-CN/docs/sql-manual/sql-functions/bitmap-functions/bitmap_contains.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/bitmap-functions/bitmap_contains.md
@@ -28,7 +28,7 @@ under the License.
 ### description
 #### Syntax
 
-`B00LEAN BITMAP_CONTAINS(BITMAP bitmap, BIGINT input)`
+`BOOLEAN BITMAP_CONTAINS(BITMAP bitmap, BIGINT input)`
 
 计算输入值是否在Bitmap列中，返回值是Boolean值.
 

--- a/docs/zh-CN/docs/sql-manual/sql-functions/bitmap-functions/bitmap_has_all.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/bitmap-functions/bitmap_has_all.md
@@ -28,7 +28,7 @@ under the License.
 ### description
 #### Syntax
 
-`B00LEAN BITMAP_HAS_ALL(BITMAP lhs, BITMAP rhs)`
+`BOOLEAN BITMAP_HAS_ALL(BITMAP lhs, BITMAP rhs)`
 
 如果第一个bitmap包含第二个bitmap的全部元素，则返回true。
 如果第二个bitmap包含的元素为空，返回true。

--- a/docs/zh-CN/docs/sql-manual/sql-functions/bitmap-functions/bitmap_has_any.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/bitmap-functions/bitmap_has_any.md
@@ -28,7 +28,7 @@ under the License.
 ### description
 #### Syntax
 
-`B00LEAN BITMAP_HAS_ANY(BITMAP lhs, BITMAP rhs)`
+`BOOLEAN BITMAP_HAS_ANY(BITMAP lhs, BITMAP rhs)`
 
 计算两个Bitmap列是否存在相交元素，返回值是Boolean值. 
 


### PR DESCRIPTION
# Proposed changes

fix some typo in bitmap docs
## Problem summary

fix some typo in bitmap docs

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

