### PR TITLE
[fix](array-type) fix the be core dump when import number larger than…

### DIFF
--- a/be/src/util/array_parser.h
+++ b/be/src/util/array_parser.h
@@ -171,7 +171,13 @@ private:
         case TYPE_LARGEINT: {
             __int128 value = 0;
             if (iterator->IsNumber()) {
-                value = iterator->GetUint64();
+                if (iterator->IsUint64()) {
+                    value = iterator->GetUint64();
+                } else {
+                    return Status::RuntimeError(
+                            "rapidjson can't parse the number larger than Uint64, please use "
+                            "String to parse as LARGEINT");
+                }
             } else {
                 std::string_view view(iterator->GetString(), iterator->GetStringLength());
                 std::stringstream stream;


### PR DESCRIPTION
# Proposed changes
1. this pr is used to fix the be core dump when import number larger than unit64.

Issue Number: #7570

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
3. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
5. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
6. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

