### PR TITLE
[fix](Nereids)join reorder throw unexpected exception when join type is not cross and inner

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/logical/MultiJoin.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/logical/MultiJoin.java
@@ -28,8 +28,6 @@ import org.apache.doris.nereids.trees.plans.visitor.PlanVisitor;
 import org.apache.doris.nereids.util.ExpressionUtils;
 import org.apache.doris.nereids.util.SlotExtractor;
 
-import com.google.common.base.Preconditions;
-
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -53,9 +51,11 @@ public class MultiJoin extends PlanVisitor<Void, Void> {
     public final List<Plan> joinInputs = new ArrayList<>();
     public final List<Expression> conjuncts = new ArrayList<>();
 
-    public Plan reorderJoinsAccordingToConditions() {
-        Preconditions.checkArgument(joinInputs.size() >= 2);
-        return reorderJoinsAccordingToConditions(joinInputs, conjuncts);
+    public Optional<Plan> reorderJoinsAccordingToConditions() {
+        if (joinInputs.size() >= 2) {
+            return Optional.of(reorderJoinsAccordingToConditions(joinInputs, conjuncts));
+        }
+        return Optional.empty();
     }
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/logical/ReorderJoin.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/logical/ReorderJoin.java
@@ -51,8 +51,7 @@ public class ReorderJoin extends OneRewriteRuleFactory {
             }
             MultiJoin multiJoin = new MultiJoin();
             filter.accept(multiJoin, null);
-
-            return multiJoin.reorderJoinsAccordingToConditions();
+            return multiJoin.reorderJoinsAccordingToConditions().orElse(filter);
         }).toRule(RuleType.REORDER_JOIN);
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/logical/JoinReorderTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/logical/JoinReorderTest.java
@@ -1,0 +1,48 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.rules.rewrite.logical;
+
+import org.apache.doris.nereids.analyzer.UnboundRelation;
+import org.apache.doris.nereids.trees.expressions.BooleanLiteral;
+import org.apache.doris.nereids.trees.plans.JoinType;
+import org.apache.doris.nereids.trees.plans.logical.LogicalFilter;
+import org.apache.doris.nereids.trees.plans.logical.LogicalJoin;
+import org.apache.doris.nereids.util.MemoTestUtils;
+import org.apache.doris.nereids.util.PatternMatchSupported;
+import org.apache.doris.nereids.util.PlanChecker;
+
+import com.google.common.collect.Lists;
+import org.junit.jupiter.api.Test;
+
+public class JoinReorderTest implements PatternMatchSupported {
+
+    /**
+     * To test do not throw unexpected exception when join type is not inner or cross.
+     */
+    @Test
+    public void testWithOuterJoin() {
+        UnboundRelation relation1 = new UnboundRelation(Lists.newArrayList("db", "table1"));
+        UnboundRelation relation2 = new UnboundRelation(Lists.newArrayList("db", "table2"));
+        LogicalJoin outerJoin = new LogicalJoin<>(JoinType.LEFT_OUTER_JOIN, relation1, relation2);
+        LogicalFilter logicalFilter = new LogicalFilter<>(new BooleanLiteral(false), outerJoin);
+
+        PlanChecker.from(MemoTestUtils.createConnectContext(), logicalFilter)
+                .applyBottomUp(new ReorderJoin())
+                .matches(logicalFilter(leftOuterLogicalJoin(unboundRelation(), unboundRelation())));
+    }
+}


### PR DESCRIPTION
## Problem summary

join reorder throw unexpected exception when join type is not cross and inner

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [x] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No