### PR TITLE
[Bugfix](Be)the return of get_const_col may be nullptr

### DIFF
--- a/be/src/vec/exprs/varray_literal.cpp
+++ b/be/src/vec/exprs/varray_literal.cpp
@@ -28,7 +28,10 @@ Status VArrayLiteral::prepare(RuntimeState* state, const RowDescriptor& row_desc
     Field array = is_null ? Field() : Array();
     for (const auto child : _children) {
         Field item;
-        child->get_const_col(context)->column_ptr->get(0, item);
+        auto col_ptr = child->get_const_col(context);
+        if (nullptr != col_ptr) {
+          col_ptr->column_ptr->get(0,item);
+        }
         array.get<Array>().push_back(item);
     }
     _column_ptr = _data_type->create_column_const(1, array);


### PR DESCRIPTION
underlying problem: the return of get_const_col may be nullptr,but there is no judgment

# Proposed changes

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

