### PR TITLE
[enhancement](memtracker) Optimize readability of mem exceed limit error message

### DIFF
--- a/be/src/exec/hash_table.h
+++ b/be/src/exec/hash_table.h
@@ -415,11 +415,6 @@ private:
     // Grow the node array.
     void grow_node_array();
 
-    // Sets _mem_tracker_exceeded to true and MEM_LIMIT_EXCEEDED for the query.
-    // allocation_size is the attempted size of the allocation that would have
-    // brought us over the mem limit.
-    void mem_limit_exceeded(int64_t allocation_size);
-
     const std::vector<ExprContext*>& _build_expr_ctxs;
     const std::vector<ExprContext*>& _probe_expr_ctxs;
 

--- a/be/src/olap/compaction.cpp
+++ b/be/src/olap/compaction.cpp
@@ -45,8 +45,8 @@ Compaction::Compaction(TabletSharedPtr tablet, const std::string& label)
 Compaction::~Compaction() {
 #ifndef BE_TEST
     // Compaction tracker cannot be completely accurate, offset the global impact.
-    StorageEngine::instance()->compaction_mem_tracker()->consumption_revise(
-            -_mem_tracker->consumption());
+    StorageEngine::instance()->compaction_mem_tracker()->consume_local(
+            -_mem_tracker->consumption(), ExecEnv::GetInstance()->process_mem_tracker().get());
 #endif
 }
 

--- a/be/src/runtime/load_channel.cpp
+++ b/be/src/runtime/load_channel.cpp
@@ -46,7 +46,8 @@ LoadChannel::~LoadChannel() {
               << ", is high priority=" << _is_high_priority << ", sender_ip=" << _sender_ip
               << ", is_vec=" << _is_vec;
     // Load channel tracker cannot be completely accurate, offsetting the impact on the load channel mgr tracker.
-    _mem_tracker->parent()->consumption_revise(-_mem_tracker->consumption());
+    _mem_tracker->parent()->consume_local(-_mem_tracker->consumption(),
+                                          ExecEnv::GetInstance()->process_mem_tracker().get());
 }
 
 Status LoadChannel::open(const PTabletWriterOpenRequest& params) {

--- a/be/src/runtime/memory/mem_tracker.cpp
+++ b/be/src/runtime/memory/mem_tracker.cpp
@@ -42,7 +42,7 @@ struct TrackerGroup {
 // Multiple groups are used to reduce the impact of locks.
 static std::vector<TrackerGroup> mem_tracker_pool(1000);
 
-MemTracker::MemTracker(const std::string& label, RuntimeProfile* profile, bool is_limiter) {
+MemTracker::MemTracker(const std::string& label, RuntimeProfile* profile) {
     if (profile == nullptr) {
         _consumption = std::make_shared<RuntimeProfile::HighWaterMarkCounter>(TUnit::BYTES);
     } else {
@@ -58,30 +58,24 @@ MemTracker::MemTracker(const std::string& label, RuntimeProfile* profile, bool i
         _consumption = profile->AddSharedHighWaterMarkCounter(COUNTER_NAME, TUnit::BYTES);
     }
 
-    _is_limiter = is_limiter;
-    if (!_is_limiter) {
-        if (thread_context()->_thread_mem_tracker_mgr->limiter_mem_tracker()) {
-            _label = fmt::format(
-                    "{} | {}", label,
-                    thread_context()->_thread_mem_tracker_mgr->limiter_mem_tracker()->label());
-        } else {
-            _label = label + " | ";
-        }
-
-        _bind_group_num =
-                thread_context()->_thread_mem_tracker_mgr->limiter_mem_tracker()->group_num();
-        {
-            std::lock_guard<std::mutex> l(mem_tracker_pool[_bind_group_num].group_lock);
-            _tracker_group_it = mem_tracker_pool[_bind_group_num].trackers.insert(
-                    mem_tracker_pool[_bind_group_num].trackers.end(), this);
-        }
+    if (thread_context()->_thread_mem_tracker_mgr->limiter_mem_tracker()) {
+        _label = fmt::format(
+                "{} | {}", label,
+                thread_context()->_thread_mem_tracker_mgr->limiter_mem_tracker()->label());
     } else {
-        _label = label;
+        _label = label + " | ";
+    }
+
+    _bind_group_num = thread_context()->_thread_mem_tracker_mgr->limiter_mem_tracker()->group_num();
+    {
+        std::lock_guard<std::mutex> l(mem_tracker_pool[_bind_group_num].group_lock);
+        _tracker_group_it = mem_tracker_pool[_bind_group_num].trackers.insert(
+                mem_tracker_pool[_bind_group_num].trackers.end(), this);
     }
 }
 
 MemTracker::~MemTracker() {
-    if (!_is_limiter) {
+    if (_bind_group_num != -1) {
         std::lock_guard<std::mutex> l(mem_tracker_pool[_bind_group_num].group_lock);
         if (_tracker_group_it != mem_tracker_pool[_bind_group_num].trackers.end()) {
             mem_tracker_pool[_bind_group_num].trackers.erase(_tracker_group_it);

--- a/be/src/runtime/memory/mem_tracker.h
+++ b/be/src/runtime/memory/mem_tracker.h
@@ -44,8 +44,9 @@ public:
     };
 
     // Creates and adds the tracker to the mem_tracker_pool.
-    MemTracker(const std::string& label = std::string(), RuntimeProfile* profile = nullptr,
-               bool is_limiter = false);
+    MemTracker(const std::string& label, RuntimeProfile* profile = nullptr);
+    // For MemTrackerLimiter
+    MemTracker() { _bind_group_num = -1; }
 
     ~MemTracker();
 
@@ -98,9 +99,6 @@ protected:
 
     // Tracker is located in group num in mem_tracker_pool
     int64_t _bind_group_num;
-
-    // Whether is a MemTrackerLimiter
-    bool _is_limiter;
 
     // Iterator into mem_tracker_pool for this object. Stored to have O(1) remove.
     std::list<MemTracker*>::iterator _tracker_group_it;

--- a/be/src/runtime/memory/mem_tracker_task_pool.cpp
+++ b/be/src/runtime/memory/mem_tracker_task_pool.cpp
@@ -93,7 +93,9 @@ void MemTrackerTaskPool::logout_task_mem_tracker() {
             // In order to ensure that the query pool mem tracker is the sum of all currently running query mem trackers,
             // the effect of the ended query mem tracker on the query pool mem tracker should be cleared, that is,
             // the negative number of the current value of consume.
-            it->second->parent()->consumption_revise(-it->second->consumption());
+            it->second->parent()->consume_local(
+                    -it->second->consumption(),
+                    ExecEnv::GetInstance()->process_mem_tracker().get());
             LOG(INFO) << fmt::format(
                     "Deregister query/load memory tracker, queryId={}, Limit={}, PeakUsed={}",
                     it->first, it->second->limit(), it->second->peak_consumption());

--- a/be/src/runtime/memory/thread_mem_tracker_mgr.cpp
+++ b/be/src/runtime/memory/thread_mem_tracker_mgr.cpp
@@ -49,21 +49,15 @@ void ThreadMemTrackerMgr::exceeded_cancel_task(const std::string& cancel_details
     }
 }
 
-void ThreadMemTrackerMgr::exceeded(int64_t failed_consume_size) {
+void ThreadMemTrackerMgr::exceeded(Status failed_try_consume_st) {
     if (_cb_func != nullptr) {
         _cb_func();
     }
     if (is_attach_query()) {
-        std::string cancel_msg;
-        if (!_consumer_tracker_stack.empty()) {
-            cancel_msg = fmt::format(
-                    "exec node:<name={}>, can change the limit by `set exec_mem_limit=xxx`",
-                    _consumer_tracker_stack[-1]->label());
-        } else {
-            cancel_msg = "exec node:unknown, can change the limit by `set exec_mem_limit=xxx`";
-        }
-        auto st = _limiter_tracker->mem_limit_exceeded(cancel_msg, failed_consume_size);
-        exceeded_cancel_task(st.to_string());
+        auto st = _limiter_tracker->mem_limit_exceeded(
+                fmt::format("exec node:<{}>", last_consumer_tracker()),
+                _limiter_tracker->parent().get(), failed_try_consume_st);
+        exceeded_cancel_task(st.get_error_msg());
         _check_limit = false; // Make sure it will only be canceled once
     }
 }

--- a/be/src/runtime/memory/thread_mem_tracker_mgr.h
+++ b/be/src/runtime/memory/thread_mem_tracker_mgr.h
@@ -67,6 +67,9 @@ public:
     // So for performance, add tracker as early as possible, and then call update_tracker<Existed>.
     void push_consumer_tracker(MemTracker* mem_tracker);
     void pop_consumer_tracker();
+    std::string last_consumer_tracker() {
+        return _consumer_tracker_stack.empty() ? "" : _consumer_tracker_stack[-1]->label();
+    }
 
     void set_exceed_call_back(ExceedCallBack cb_func) { _cb_func = cb_func; }
 
@@ -112,7 +115,7 @@ private:
     // If tryConsume fails due to task mem tracker exceeding the limit, the task must be canceled
     void exceeded_cancel_task(const std::string& cancel_details);
 
-    void exceeded(int64_t failed_consume_size);
+    void exceeded(Status failed_try_consume_st);
 
 private:
     // Cache untracked mem, only update to _untracked_mems when switching mem tracker.
@@ -191,7 +194,7 @@ inline void ThreadMemTrackerMgr::flush_untracked_mem() {
             // The memory has been allocated, so when TryConsume fails, need to continue to complete
             // the consume to ensure the accuracy of the statistics.
             _limiter_tracker->consume(_untracked_mem);
-            exceeded(_untracked_mem);
+            exceeded(st);
         }
     } else {
         _limiter_tracker->consume(_untracked_mem);

--- a/be/src/runtime/runtime_state.cpp
+++ b/be/src/runtime/runtime_state.cpp
@@ -245,8 +245,8 @@ Status RuntimeState::init_mem_trackers(const TUniqueId& query_id) {
     }
 
     _instance_mem_tracker = std::make_shared<MemTrackerLimiter>(
-            bytes_limit, "RuntimeState:instance:" + print_id(_fragment_instance_id),
-            _query_mem_tracker, &_profile);
+            -1, "RuntimeState:instance:" + print_id(_fragment_instance_id), _query_mem_tracker,
+            &_profile);
 
     RETURN_IF_ERROR(init_buffer_poolstate());
 

--- a/be/src/runtime/thread_context.h
+++ b/be/src/runtime/thread_context.h
@@ -260,8 +260,14 @@ public:
     doris::thread_context()->_thread_mem_tracker_mgr->transfer_to(size, tracker)
 #define THREAD_MEM_TRACKER_TRANSFER_FROM(size, tracker) \
     doris::thread_context()->_thread_mem_tracker_mgr->transfer_from(size, tracker)
-#define RETURN_LIMIT_EXCEEDED(state, msg, ...)               \
-    return doris::thread_context()                           \
-            ->_thread_mem_tracker_mgr->limiter_mem_tracker() \
-            ->mem_limit_exceeded(state, msg, ##__VA_ARGS__);
+#define RETURN_LIMIT_EXCEEDED(state, msg, ...)                                              \
+    return doris::thread_context()                                                          \
+            ->_thread_mem_tracker_mgr->limiter_mem_tracker()                                \
+            ->mem_limit_exceeded(                                                           \
+                    state,                                                                  \
+                    fmt::format("exec node:<{}>, {}",                                       \
+                                doris::thread_context()                                     \
+                                        ->_thread_mem_tracker_mgr->last_consumer_tracker(), \
+                                msg),                                                       \
+                    ##__VA_ARGS__);
 } // namespace doris

--- a/be/src/service/doris_main.cpp
+++ b/be/src/service/doris_main.cpp
@@ -503,6 +503,7 @@ int main(int argc, char** argv) {
         // this will cause coredump for ASAN build when running regression test,
         // disable temporarily.
         doris::ExecEnv::GetInstance()->task_pool_mem_tracker_registry()->logout_task_mem_tracker();
+        doris::ExecEnv::GetInstance()->process_mem_tracker()->enable_print_log_usage();
         sleep(1);
     }
 


### PR DESCRIPTION
# Proposed changes

Issue Number: close #11876

## Problem summary

1. Mem exceed limit error message after optimization
```
memory limit exceeded:<exceeded_tracker=Query#queryId=1720e4ca3ac541c0-8dee8f4667ee7176, limit=80000, peak_used=133111504, current_used=133168448>, executing:<exec node:, vsort, while open.>, backend=172.24.47.117 free memory left=12.01 GB. If is query, can change the limit by `set exec_mem_limit=xxx`, details mem usage see be.INFO.
```
2. Optimize the constructor of mem tracker.
3. Restore `consume_local`, which has better applicability.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [x] Yes
    - [ ] No
    - [ ] I don't know
4. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
5. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
6. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
7. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

