### PR TITLE
[feature-wip](unique-key-merge-on-write) unique key table with MOW supports update

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/UpdateStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/UpdateStmt.java
@@ -17,7 +17,6 @@
 
 package org.apache.doris.analysis;
 
-import org.apache.doris.catalog.AggregateType;
 import org.apache.doris.catalog.Database;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.KeysType;
@@ -170,7 +169,7 @@ public class UpdateStmt extends DdlStmt {
                 throw new AnalysisException("The left side of the set expr must be the column name");
             }
             lhs.analyze(analyzer);
-            if (((SlotRef) lhs).getColumn().getAggregationType() != AggregateType.REPLACE) {
+            if (((SlotRef) lhs).getColumn().isKey()) {
                 throw new AnalysisException("Only value columns of unique table could be updated.");
             }
             // check set expr of target column


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

The aggregation type of value column in unique key table with merge on write is None.  so we can't judge whether it is a value column by whether the aggregation type is a replace type.  
In order to support update for unique key table with merge on write, using `isKey` function to judge whether it is a value column.

For detailed implementation of merge on write， see DSIP-018: https://cwiki.apache.org/confluence/display/DORIS/DSIP-018%3A+Support+Merge-On-Write+implementation+for+UNIQUE+KEY+data+model

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

