### PR TITLE
[Bugfix](FE) fix npe issue when exec 'show tablets'

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/proc/TabletsProcDir.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/proc/TabletsProcDir.java
@@ -120,16 +120,20 @@ public class TabletsProcDir implements ProcDirInterface {
                         tabletInfo.add(tablet.getCheckedVersion());
                         tabletInfo.add(replica.getVersionCount());
                         tabletInfo.add(replica.getPathHash());
+
+                        Backend be = backendMap.get(replica.getBackendId());
+                        String host = (be == null ? Backend.DUMMY_IP : be.getHost());
+                        int port = (be == null ? 0 : be.getHttpPort());
                         String metaUrl = String.format("http://%s:%d/api/meta/header/%d",
-                                backendMap.get(replica.getBackendId()).getHost(),
-                                backendMap.get(replica.getBackendId()).getHttpPort(),
+                                host,
+                                port,
                                 tabletId,
                                 replica.getSchemaHash());
                         tabletInfo.add(metaUrl);
                         String compactionUrl = String.format(
                                 "http://%s:%d/api/compaction/show?tablet_id=%d",
-                                backendMap.get(replica.getBackendId()).getHost(),
-                                backendMap.get(replica.getBackendId()).getHttpPort(),
+                                host,
+                                port,
                                 tabletId,
                                 replica.getSchemaHash());
                         tabletInfo.add(compactionUrl);


### PR DESCRIPTION
# Proposed changes

fix npe issue: 
2022-08-18 14:03:53,621 WARN (doris-mysql-nio-pool-28905|72952) [StmtExecutor.execute():453] execute Exception. stmt[8887797, 91f144bc73d849f3-a2ae56c7fb6d41c9]
java.lang.NullPointerException: null
        at org.apache.doris.common.proc.TabletsProcDir.fetchComparableResult(TabletsProcDir.java:124) ~[palo-fe.jar:1.1-SNAPSHOT]
        at org.apache.doris.qe.ShowExecutor.handleShowTablet(ShowExecutor.java:1514) ~[palo-fe.jar:1.1-SNAPSHOT]
        at org.apache.doris.qe.ShowExecutor.execute(ShowExecutor.java:268) ~[palo-fe.jar:1.1-SNAPSHOT]
        at org.apache.doris.qe.StmtExecutor.handleShow(StmtExecutor.java:1469) ~[palo-fe.jar:1.1-SNAPSHOT]
        at org.apache.doris.qe.StmtExecutor.execute(StmtExecutor.java:427) ~[palo-fe.jar:1.1-SNAPSHOT]

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

