### PR TITLE
[fix](workflow) Fix the errors when using sh to run shell scripts

### DIFF
--- a/build-support/shell-check.sh
+++ b/build-support/shell-check.sh
@@ -19,6 +19,7 @@
 # under the License.
 
 set -eo pipefail
+set +o posix
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 DORIS_HOME="$(

--- a/run-be-ut.sh
+++ b/run-be-ut.sh
@@ -33,6 +33,7 @@
 #####################################################################
 
 set -eo pipefail
+set +o posix
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 


### PR DESCRIPTION
# Proposed changes

~~Issue Number: close #xxx~~

## Problem summary

I seems that the workflow (BE UT) use `sh` to run `run-be-ut.sh` according to the following snapshot.

<img width="691" alt="image" src="https://user-images.githubusercontent.com/1443003/185374167-0cb4918b-4ea8-4d6a-9958-907430e23f3b.png">

[process substitution](https://www.gnu.org/software/bash/manual/html_node/Process-Substitution.html) isn't supported in `sh` which causes the errors.

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

