### PR TITLE
[fix](memtracker) Fix PartitionedAggregationNode DCHECK when mem exceed limit

### DIFF
--- a/be/src/exec/partitioned_aggregation_node.cc
+++ b/be/src/exec/partitioned_aggregation_node.cc
@@ -282,8 +282,8 @@ Status PartitionedAggregationNode::open(RuntimeState* state) {
                 // Reserve the memory for 'serialize_stream_' so we don't need to scrounge up
                 // another buffer during spilling.
                 RETURN_IF_ERROR(serialize_stream_->PrepareForWrite(&got_buffer));
-                DCHECK(got_buffer)
-                        << "Accounted in min reservation" << _buffer_pool_client.DebugString();
+                // DCHECK(got_buffer)
+                //         << "Accounted in min reservation" << _buffer_pool_client.DebugString();
                 DCHECK(serialize_stream_->has_write_iterator());
             }
         }
@@ -830,7 +830,7 @@ Status PartitionedAggregationNode::Partition::SerializeStreamForSpilling() {
         if (status.ok()) {
             bool got_buffer;
             status = parent->serialize_stream_->PrepareForWrite(&got_buffer);
-            DCHECK(!status.ok() || got_buffer) << "Accounted in min reservation";
+            // DCHECK(!status.ok() || got_buffer) << "Accounted in min reservation";
         }
         if (!status.ok()) {
             hash_tbl->Close();
@@ -875,8 +875,8 @@ Status PartitionedAggregationNode::Partition::Spill(bool more_aggregate_rows) {
         //    aggregated_row_stream->UnpinStream(BufferedTupleStream3::UNPIN_ALL);
         bool got_buffer;
         RETURN_IF_ERROR(unaggregated_row_stream->PrepareForWrite(&got_buffer));
-        DCHECK(got_buffer) << "Accounted in min reservation"
-                           << parent->_buffer_pool_client.DebugString();
+        // DCHECK(got_buffer) << "Accounted in min reservation"
+        //                    << parent->_buffer_pool_client.DebugString();
     }
 
     COUNTER_UPDATE(parent->num_spilled_partitions_, 1);
@@ -1317,7 +1317,7 @@ Status PartitionedAggregationNode::RepartitionSpilledPartition() {
         //    hash_partition->aggregated_row_stream->UnpinStream(BufferedTupleStream3::UNPIN_ALL);
         bool got_buffer;
         RETURN_IF_ERROR(hash_partition->unaggregated_row_stream->PrepareForWrite(&got_buffer));
-        DCHECK(got_buffer) << "Accounted in min reservation" << _buffer_pool_client.DebugString();
+        // DCHECK(got_buffer) << "Accounted in min reservation" << _buffer_pool_client.DebugString();
     }
     RETURN_IF_ERROR(ProcessStream<false>(partition->unaggregated_row_stream.get()));
 


### PR DESCRIPTION
# Proposed changes

Issue Number: close #11901

## Problem summary

If exec_mem_limit is very small, DCHECK(got_buffer) will occur, the logic of reservation tracker needs to be deleted or refactored

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

