### PR TITLE
[bugfix](load) fix cancel load stmt cannot recognize key words in upper case

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/CancelLoadStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/CancelLoadStmt.java
@@ -23,10 +23,10 @@ import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.UserException;
 
 import com.google.common.base.Strings;
-import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 import lombok.Getter;
 
-import java.util.List;
+import java.util.Set;
 
 
 /**
@@ -36,7 +36,7 @@ import java.util.List;
  **/
 public class CancelLoadStmt extends DdlStmt {
 
-    private static final List<String> SUPPORT_COLUMNS = Lists.newArrayList("label", "state");
+    private static final Set<String> SUPPORT_COLUMNS = Sets.newTreeSet(String.CASE_INSENSITIVE_ORDER);
 
     @Getter
     private String dbName;
@@ -55,6 +55,8 @@ public class CancelLoadStmt extends DdlStmt {
     public CancelLoadStmt(String dbName, Expr whereClause) {
         this.dbName = dbName;
         this.whereClause = whereClause;
+        this.SUPPORT_COLUMNS.add("label");
+        this.SUPPORT_COLUMNS.add("state");
     }
 
     private void checkColumn(Expr expr, boolean like) throws AnalysisException {

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/CancelLoadStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/CancelLoadStmtTest.java
@@ -67,6 +67,14 @@ public class CancelLoadStmtTest extends TestWithFeService {
         Assertions.assertEquals("CANCEL LOAD FROM default_cluster:testDb WHERE `label` = 'doris_test_label'",
                 stmt.toString());
 
+        SlotRef labelSlotRefUpper = new SlotRef(null, "LABEL");
+        BinaryPredicate labelBinaryPredicateUpper = new BinaryPredicate(BinaryPredicate.Operator.EQ, labelSlotRefUpper,
+                labelStringLiteral);
+        CancelLoadStmt stmtUpper = new CancelLoadStmt(null, labelBinaryPredicateUpper);
+        stmtUpper.analyze(analyzer);
+        Assertions.assertEquals("CANCEL LOAD FROM default_cluster:testDb WHERE `LABEL` = 'doris_test_label'",
+                stmtUpper.toString());
+
         BinaryPredicate stateBinaryPredicate = new BinaryPredicate(BinaryPredicate.Operator.EQ, stateSlotRef,
                 stateStringLiteral);
         stmt = new CancelLoadStmt(null, stateBinaryPredicate);


### PR DESCRIPTION

# Proposed changes

fix cancel load stmt cannot recognize key words in upper case

## Problem summary

this  bug is intoduced by #9537

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [x] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

