### PR TITLE
[bugifx](compaction) fix filter_delete if schema has sequence column

### DIFF
--- a/be/src/vec/core/block.h
+++ b/be/src/vec/core/block.h
@@ -252,7 +252,7 @@ public:
     // copy a new block by the offset column
     Block copy_block(const std::vector<int>& column_offset) const;
 
-    static Status filter_block(Block* block, int filter_conlumn_id, int column_to_keep);
+    static Status filter_block(Block* block, int filter_column_id, int column_to_keep);
 
     static void erase_useless_column(Block* block, int column_to_keep) {
         for (int i = block->columns() - 1; i >= column_to_keep; --i) {


### PR DESCRIPTION
introduced in #11721. Use last column as delete sign, but if sequence column
exist, it's wrong.

# Proposed changes

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

