### PR TITLE
[fix](script) Support starting BE without Java environment

### DIFF
--- a/bin/start_fe.sh
+++ b/bin/start_fe.sh
@@ -118,8 +118,8 @@ fi
 # get jdk version, return version as an Integer.
 # 1.8 => 8, 13.0 => 13
 jdk_version() {
+    local java_cmd="${1}"
     local result
-    local java_cmd="${JAVA_HOME:-.}/bin/java"
     local IFS=$'\n'
 
     if [[ -z "${java_cmd}" ]]; then
@@ -148,7 +148,7 @@ fi
 # check java version and choose correct JAVA_OPTS
 java_version="$(
     set -e
-    jdk_version
+    jdk_version "${JAVA}"
 )"
 final_java_opt="${JAVA_OPTS}"
 if [[ "${java_version}" -gt 8 ]]; then

--- a/run-be-ut.sh
+++ b/run-be-ut.sh
@@ -193,10 +193,9 @@ done < <(find "${DORIS_TEST_BINARY_DIR}" -name "*gcda")
 
 export DORIS_TEST_BINARY_DIR="${DORIS_TEST_BINARY_DIR}/test"
 
-# prepare jvm if needed
 jdk_version() {
+    local java_cmd="${1}"
     local result
-    local java_cmd="${JAVA_HOME}/bin/java"
     local IFS=$'\n'
 
     if [[ -z "${java_cmd}" ]]; then
@@ -217,24 +216,34 @@ jdk_version() {
     return 0
 }
 
-jvm_arch="amd64"
-MACHINE_TYPE="$(uname -m)"
-if [[ "${MACHINE_TYPE}" == "aarch64" ]]; then
-    jvm_arch="aarch64"
-fi
-java_version="$(
-    set -e
-    jdk_version
-)"
-if [[ "${java_version}" -gt 8 ]]; then
-    export LD_LIBRARY_PATH="${JAVA_HOME}/lib/server:${JAVA_HOME}/lib:${LD_LIBRARY_PATH}"
-# JAVA_HOME is jdk
-elif [[ -d "${JAVA_HOME}/jre" ]]; then
-    export LD_LIBRARY_PATH="${JAVA_HOME}/jre/lib/${jvm_arch}/server:${JAVA_HOME}/jre/lib/${jvm_arch}:${LD_LIBRARY_PATH}"
-# JAVA_HOME is jre
-else
-    export LD_LIBRARY_PATH="${JAVA_HOME}/lib/${jvm_arch}/server:${JAVA_HOME}/lib/${jvm_arch}:${LD_LIBRARY_PATH}"
-fi
+setup_java_env() {
+    local java_version
+
+    if [[ -z "${JAVA_HOME}" ]]; then
+        return 1
+    fi
+
+    local jvm_arch='amd64'
+    if [[ "$(uname -m)" == 'aarch64' ]]; then
+        jvm_arch='aarch64'
+    fi
+    java_version="$(
+        set -e
+        jdk_version "${JAVA_HOME}/bin/java"
+    )"
+    if [[ "${java_version}" -gt 8 ]]; then
+        export LD_LIBRARY_PATH="${JAVA_HOME}/lib/server:${JAVA_HOME}/lib:${LD_LIBRARY_PATH}"
+        # JAVA_HOME is jdk
+    elif [[ -d "${JAVA_HOME}/jre" ]]; then
+        export LD_LIBRARY_PATH="${JAVA_HOME}/jre/lib/${jvm_arch}/server:${JAVA_HOME}/jre/lib/${jvm_arch}:${LD_LIBRARY_PATH}"
+        # JAVA_HOME is jre
+    else
+        export LD_LIBRARY_PATH="${JAVA_HOME}/lib/${jvm_arch}/server:${JAVA_HOME}/lib/${jvm_arch}:${LD_LIBRARY_PATH}"
+    fi
+}
+
+# prepare jvm if needed
+setup_java_env || true
 
 # prepare gtest output dir
 GTEST_OUTPUT_DIR="${CMAKE_BUILD_DIR}/gtest_output"

--- a/tools/find_libjvm.sh
+++ b/tools/find_libjvm.sh
@@ -17,8 +17,8 @@
 # under the License.
 
 jdk_version() {
+    local java_cmd="${1}"
     local result
-    local java_cmd="${JAVA_HOME:-.}/bin/java"
     local IFS=$'\n'
 
     if [[ -z "${java_cmd}" ]]; then
@@ -39,11 +39,10 @@ jdk_version() {
     return 0
 }
 
-java_version=$(jdk_version)
-MACHINE_TYPE=$(uname -m)
-jvm_arch="amd64"
-if [[ "${MACHINE_TYPE}" == "aarch64" ]]; then
-    jvm_arch="aarch64"
+java_version=$(jdk_version "${JAVA_HOME:-}/bin/java")
+jvm_arch='amd64'
+if [[ "$(uname -m)" == 'aarch64' ]]; then
+    jvm_arch='aarch64'
 fi
 if [[ "${java_version}" -gt 8 ]]; then
     export LIBJVM_PATH="${JAVA_HOME}/lib"


### PR DESCRIPTION
# Proposed changes

Support starting BE without Java environment

## Problem summary

If we built BE without `--java-udf`, we should support starting it without Java environment.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

