### PR TITLE
[Bugfix](datetime) fix DateLiteral range check is no longer valid

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/DateLiteral.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/DateLiteral.java
@@ -435,6 +435,9 @@ public class DateLiteral extends LiteralExpr {
                 this.roundFloor(((ScalarType) type).getScalarScale());
             }
             this.type = type;
+            if (checkRange() || checkDate()) {
+                throw new AnalysisException("Datetime value is out of range");
+            }
         } catch (Exception ex) {
             throw new AnalysisException("date literal [" + s + "] is invalid: " + ex.getMessage());
         }

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/DateLiteralTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/DateLiteralTest.java
@@ -57,7 +57,6 @@ public class DateLiteralTest {
             e.printStackTrace();
             hasException = true;
         }
-        Assert.assertFalse(hasException);
     }
 
     @Test
@@ -166,6 +165,14 @@ public class DateLiteralTest {
             hasException = true;
         }
         Assert.assertFalse(hasException);
+
+        try {
+            DateLiteral literal = new DateLiteral("10000-10-07", Type.DATE);
+            Assert.assertEquals(10000, literal.getYear());
+            Assert.assertTrue(false);
+        } catch (AnalysisException e) {
+            // pass
+        }
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/DateLiteralTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/DateLiteralTest.java
@@ -57,6 +57,7 @@ public class DateLiteralTest {
             e.printStackTrace();
             hasException = true;
         }
+        Assert.assertFalse(hasException);
     }
 
     @Test
@@ -165,7 +166,6 @@ public class DateLiteralTest {
             hasException = true;
         }
         Assert.assertFalse(hasException);
-
         try {
             DateLiteral literal = new DateLiteral("10000-10-07", Type.DATE);
             Assert.assertEquals(10000, literal.getYear());


### PR DESCRIPTION
# Proposed changes

Issue Number: close #11914 

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [x] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

