### PR TITLE
[refractor](bitmap) bitmap serialize and deserialize refractor

### DIFF
--- a/be/test/vec/core/column_complex_test.cpp
+++ b/be/test/vec/core/column_complex_test.cpp
@@ -64,7 +64,7 @@ public:
     void check_serialize_and_deserialize(MutableColumnPtr& col) {
         auto column = assert_cast<ColumnBitmap*>(col.get());
         auto size = _bitmap_type.get_uncompressed_serialized_bytes(*column);
-        std::unique_ptr<char> buf = std::make_unique<char>(size);
+        std::unique_ptr<char[]> buf = std::make_unique<char[]>(size);
         auto result = _bitmap_type.serialize(*column, buf.get());
         ASSERT_EQ(result, buf.get() + size);
 

--- a/be/test/vec/core/column_complex_test.cpp
+++ b/be/test/vec/core/column_complex_test.cpp
@@ -27,7 +27,7 @@ namespace doris::vectorized {
 TEST(ColumnComplexTest, BasicTest) {
     using ColumnSTLString = ColumnComplexType<std::string>;
     auto column = ColumnSTLString::create();
-    ASSERT_EQ(column->size(), 0);
+    EXPECT_EQ(column->size(), 0);
     std::string val0 = "";
     std::string val1 = "str-1";
 
@@ -35,9 +35,9 @@ TEST(ColumnComplexTest, BasicTest) {
     column->insert_data(reinterpret_cast<const char*>(&val1), sizeof(val1));
 
     StringRef ref = column->get_data_at(0);
-    ASSERT_EQ((*reinterpret_cast<const std::string*>(ref.data)), "");
+    EXPECT_EQ((*reinterpret_cast<const std::string*>(ref.data)), "");
     ref = column->get_data_at(1);
-    ASSERT_EQ((*reinterpret_cast<const std::string*>(ref.data)), val1);
+    EXPECT_EQ((*reinterpret_cast<const std::string*>(ref.data)), val1);
 }
 
 // Test the compile failed
@@ -101,8 +101,3 @@ TEST_F(ColumnBitmapTest, SerializeAndDeserialize) {
 }
 
 } // namespace doris::vectorized
-
-int main(int argc, char** argv) {
-    ::testing::InitGoogleTest(&argc, argv);
-    return RUN_ALL_TESTS();
-}

--- a/be/test/vec/core/column_complex_test.cpp
+++ b/be/test/vec/core/column_complex_test.cpp
@@ -64,7 +64,7 @@ public:
     void check_serialize_and_deserialize(MutableColumnPtr& col) {
         auto column = assert_cast<ColumnBitmap*>(col.get());
         auto size = _bitmap_type.get_uncompressed_serialized_bytes(*column);
-        std::unique_ptr<char> buf(new char[size]);
+        std::unique_ptr<char> buf = std::make_unique<char>(size);
         auto result = _bitmap_type.serialize(*column, buf.get());
         ASSERT_EQ(result, buf.get() + size);
 

--- a/be/test/vec/core/column_complex_test.cpp
+++ b/be/test/vec/core/column_complex_test.cpp
@@ -27,7 +27,7 @@ namespace doris::vectorized {
 TEST(ColumnComplexTest, BasicTest) {
     using ColumnSTLString = ColumnComplexType<std::string>;
     auto column = ColumnSTLString::create();
-    EXPECT_EQ(column->size(), 0);
+    ASSERT_EQ(column->size(), 0);
     std::string val0 = "";
     std::string val1 = "str-1";
 
@@ -35,13 +35,74 @@ TEST(ColumnComplexTest, BasicTest) {
     column->insert_data(reinterpret_cast<const char*>(&val1), sizeof(val1));
 
     StringRef ref = column->get_data_at(0);
-    EXPECT_EQ((*reinterpret_cast<const std::string*>(ref.data)), "");
+    ASSERT_EQ((*reinterpret_cast<const std::string*>(ref.data)), "");
     ref = column->get_data_at(1);
-    EXPECT_EQ((*reinterpret_cast<const std::string*>(ref.data)), val1);
+    ASSERT_EQ((*reinterpret_cast<const std::string*>(ref.data)), val1);
 }
 
 // Test the compile failed
 TEST(ColumnComplexType, DataTypeBitmapTest) {
     std::make_shared<DataTypeBitMap>();
 }
+
+class ColumnBitmapTest : public testing::Test {
+public:
+    virtual void SetUp() override {}
+    virtual void TearDown() override {}
+
+    void check_bitmap_column(const IColumn& l, const IColumn& r) {
+        ASSERT_EQ(l.size(), r.size());
+        const auto& l_col = assert_cast<const ColumnBitmap&>(l);
+        const auto& r_col = assert_cast<const ColumnBitmap&>(r);
+        for (size_t i = 0; i < l_col.size(); ++i) {
+            auto& l_bitmap = const_cast<BitmapValue&>(l_col.get_element(i));
+            auto& r_bitmap = const_cast<BitmapValue&>(r_col.get_element(i));
+            ASSERT_EQ(l_bitmap.xor_cardinality(r_bitmap), 0);
+        }
+    }
+
+    void check_serialize_and_deserialize(MutableColumnPtr& col) {
+        auto column = assert_cast<ColumnBitmap*>(col.get());
+        auto size = _bitmap_type.get_uncompressed_serialized_bytes(*column);
+        std::unique_ptr<char> buf(new char[size]);
+        auto result = _bitmap_type.serialize(*column, buf.get());
+        ASSERT_EQ(result, buf.get() + size);
+
+        auto column2 = _bitmap_type.create_column();
+        _bitmap_type.deserialize(buf.get(), column2.get());
+        check_bitmap_column(*column, *column2.get());
+    }
+
+private:
+    DataTypeBitMap _bitmap_type;
+};
+
+TEST_F(ColumnBitmapTest, SerializeAndDeserialize) {
+    auto column = _bitmap_type.create_column();
+
+    // empty column
+    check_serialize_and_deserialize(column);
+
+    // bitmap with lots of rows
+    const size_t row_size = 20000;
+    auto& data = assert_cast<ColumnBitmap&>(*column.get()).get_data();
+    data.resize(row_size);
+    check_serialize_and_deserialize(column);
+
+    // bitmap with values case 1
+    data[0].add(10);
+    data[0].add(1000000);
+    check_serialize_and_deserialize(column);
+
+    // bitmap with values case 2
+    data[row_size - 1].add(33333);
+    data[row_size - 1].add(0);
+    check_serialize_and_deserialize(column);
+}
+
 } // namespace doris::vectorized
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

If bitmap column have too many rows, the stack will overflow, because of the big vector on stack.
So I refractor bitmap serialize and deserialize to fix this problem.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

