### PR TITLE
[feature-wip](unique-key-merge-on-write) fix that IndexedColumnIterator next batch may return empty result

### DIFF
--- a/be/src/olap/rowset/segment_v2/index_page.h
+++ b/be/src/olap/rowset/segment_v2/index_page.h
@@ -138,6 +138,14 @@ public:
         return true;
     }
 
+    // Return true when has next page.
+    bool has_next() {
+        if ((_pos + 1) >= _reader->count()) {
+            return false;
+        }
+        return true;
+    }
+
     const Slice& current_key() const { return _reader->get_key(_pos); }
 
     const PagePointer& current_page_pointer() const { return _reader->get_value(_pos); }

--- a/be/src/olap/rowset/segment_v2/index_page.h
+++ b/be/src/olap/rowset/segment_v2/index_page.h
@@ -139,12 +139,7 @@ public:
     }
 
     // Return true when has next page.
-    bool has_next() {
-        if ((_pos + 1) >= _reader->count()) {
-            return false;
-        }
-        return true;
-    }
+    bool has_next() { return (_pos + 1) < _reader->count(); }
 
     const Slice& current_key() const { return _reader->get_key(_pos); }
 

--- a/be/src/olap/rowset/segment_v2/indexed_column_reader.cpp
+++ b/be/src/olap/rowset/segment_v2/indexed_column_reader.cpp
@@ -202,6 +202,8 @@ Status IndexedColumnIterator::seek_at_or_after(const void* key, bool* exact_matc
             _seeked = true;
             *exact_match = false;
             _current_ordinal = _data_page.first_ordinal + _data_page.num_rows;
+            // move offset to the end of the page
+            _data_page.offset_in_page = _data_page.num_rows;
             return Status::OK();
         }
     }

--- a/be/src/olap/rowset/segment_v2/indexed_column_reader.cpp
+++ b/be/src/olap/rowset/segment_v2/indexed_column_reader.cpp
@@ -198,7 +198,7 @@ Status IndexedColumnIterator::seek_at_or_after(const void* key, bool* exact_matc
     Status st = _data_page.data_decoder->seek_at_or_after_value(key, exact_match);
     // return the first row of next page when not found
     if (st.is_not_found() && _reader->_has_index_page) {
-        if (_value_iter.move_next()) {
+        if (_value_iter.has_next()) {
             _seeked = true;
             *exact_match = false;
             _current_ordinal = _data_page.first_ordinal + _data_page.num_rows;


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary
F0819 11:08:01.494653 1043021 indexed_column_reader.cpp:249] Check failed: rows_to_read == rows_read  rows_to_read: 1 rows_read:0

When the key is between two pages，the result of `seek_at_or_after_value` will be the first row of next page. But `seek_at_or_after_value` doesn't move the page's offset, so next_batch will get an empty result.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

