### PR TITLE
[improvement](storage) For debugging problems: add session variable to treat agg and unique data model as dup model

### DIFF
--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -349,6 +349,15 @@ public:
         return segment_v2::CompressionTypePB::SNAPPY;
     }
 
+    bool skip_storage_engine_merge() const {
+        return _query_options.__isset.skip_storage_engine_merge &&
+               _query_options.skip_storage_engine_merge;
+    }
+
+    bool skip_delete_predicate() const {
+        return _query_options.__isset.skip_delete_predicate && _query_options.skip_delete_predicate;
+    }
+
     const std::vector<TTabletCommitInfo>& tablet_commit_infos() const {
         return _tablet_commit_infos;
     }

--- a/docs/en/docs/advanced/variables.md
+++ b/docs/en/docs/advanced/variables.md
@@ -526,3 +526,9 @@ Translated with www.DeepL.com/Translator (free version)
 * `trim_tailing_spaces_for_external_table_query`
 
   Used to control whether trim the tailing spaces while quering Hive external tables. The default is false.
+
+* `skip_storage_engine_merge`
+  For debugging purpose. In vectorized execution engine, in case of problems of reading data of Aggregate Key model and Unique Key model, setting value to `true` will read data as Duplicate Key model.
+
+* `skip_delete_predicate`
+  For debugging purpose. In vectorized execution engine, in case of problems of reading data, setting value to `true` will also read deleted data.

--- a/docs/zh-CN/docs/advanced/variables.md
+++ b/docs/zh-CN/docs/advanced/variables.md
@@ -515,3 +515,9 @@ SELECT /*+ SET_VAR(query_timeout = 1, enable_partition_cache=true) */ sleep(3);
 - `trim_tailing_spaces_for_external_table_query`
 
   用于控制查询Hive外表时是否过滤掉字段末尾的空格。默认为false。
+
+* `skip_storage_engine_merge`
+  用于调试目的。在向量化执行引擎中，当发现读取Aggregate Key模型或者Unique Key模型的数据结果有问题的时候，把此变量的值设置为`true`，将会把Aggregate Key模型或者Unique Key模型的数据当成Duplicate Key模型读取。
+
+* `skip_delete_predicate`
+  用于调试目的。在向量化执行引擎中，当发现读取表的数据结果有误的时候，把此变量的值设置为`true`，将会把被删除的数据当成正常数据读取。

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/Util.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/Util.java
@@ -455,7 +455,9 @@ public class Util {
     }
 
     public static boolean showHiddenColumns() {
-        return ConnectContext.get() != null && ConnectContext.get().getSessionVariable().showHiddenColumns();
+        return ConnectContext.get() != null && (
+            ConnectContext.get().getSessionVariable().showHiddenColumns()
+            || ConnectContext.get().getSessionVariable().skipStorageEngineMerge());
     }
 
     public static String escapeSingleRegex(String s) {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -211,6 +211,10 @@ public class SessionVariable implements Serializable, Writable {
 
     public static final String ENABLE_LOCAL_EXCHANGE = "enable_local_exchange";
 
+    public static final String SKIP_STORAGE_ENGINE_MERGE = "skip_storage_engine_merge";
+
+    public static final String SKIP_DELETE_PREDICATE = "skip_delete_predicate";
+
     // session origin value
     public Map<Field, String> sessionOriginValue = new HashMap<Field, String>();
     // check stmt is or not [select /*+ SET_VAR(...)*/ ...]
@@ -530,6 +534,18 @@ public class SessionVariable implements Serializable, Writable {
     @VariableMgr.VarAttr(name = ENABLE_LOCAL_EXCHANGE)
     public boolean enableLocalExchange = false;
 
+    /**
+     * For debugg purpose, dont' merge unique key and agg key when reading data.
+     */
+    @VariableMgr.VarAttr(name = SKIP_STORAGE_ENGINE_MERGE)
+    public boolean skipStorageEngineMerge = false;
+
+    /**
+     * For debugg purpose, skip delte predicate when reading data.
+     */
+    @VariableMgr.VarAttr(name = SKIP_DELETE_PREDICATE)
+    public boolean skipDeletePredicate = false;
+
     public String getBlockEncryptionMode() {
         return blockEncryptionMode;
     }
@@ -843,6 +859,10 @@ public class SessionVariable implements Serializable, Writable {
         this.showHiddenColumns = showHiddenColumns;
     }
 
+    public boolean skipStorageEngineMerge() {
+        return skipStorageEngineMerge;
+    }
+
     public boolean isAllowPartitionColumnNullable() {
         return allowPartitionColumnNullable;
     }
@@ -1123,6 +1143,10 @@ public class SessionVariable implements Serializable, Writable {
         tResult.setEnableFunctionPushdown(enableFunctionPushdown);
         tResult.setFragmentTransmissionCompressionCodec(fragmentTransmissionCompressionCodec);
         tResult.setEnableLocalExchange(enableLocalExchange);
+
+        tResult.setSkipStorageEngineMerge(skipStorageEngineMerge);
+
+        tResult.setSkipDeletePredicate(skipDeletePredicate);
 
         return tResult;
     }

--- a/gensrc/thrift/PaloInternalService.thrift
+++ b/gensrc/thrift/PaloInternalService.thrift
@@ -169,6 +169,12 @@ struct TQueryOptions {
   46: optional string fragment_transmission_compression_codec;
 
   47: optional bool enable_local_exchange;
+
+  // For debug purpose, dont' merge unique key and agg key when reading data.
+  48: optional bool skip_storage_engine_merge = false
+
+  // For debug purpose, skip delete predicates when reading data
+  49: optional bool skip_delete_predicate = false
 }
     
 


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

For debug purpose:
Add session variable `skip_storage_engine_merge`, when set to true, tables of aggregate key model and unique key model will be read as duplicate key model.
Add session variable `skip_delete_predicate`, when set to true, rows deleted with `delete` statement will be selected.

Test result( withc auto compaction off):

create test table and insert data:
```
drop table if exists t1;
create table t1(a int, b int) engine = olap unique key (a) distributed by hash(a) buckets 16 properties("replication_allocation" = "tag.location.default:1");

insert into t1 values (1,1),(2,1);
insert into t1 values (1,11),(2,11);
insert into t1 values (3,1);
```

initial session variables and data:
```
mysql> show variables like "%skip%";
+---------------------------+-------+
| Variable_name             | Value |
+---------------------------+-------+
| skip_delete_predicate     | false |
| skip_storage_engine_merge | false  |
+---------------------------+-------+
2 rows in set (0.00 sec)

mysql> show variables like "%hidd%";
+---------------------+-------+
| Variable_name       | Value |
+---------------------+-------+
| show_hidden_columns | false |
+---------------------+-------+
1 row in set (0.00 sec)

mysql> select * from t1;
+------+------+
| a    | b    |
+------+------+
|    1 |   11 |
|    2 |   11 |
|    3 |    1 |
+------+------+
3 rows in set (0.50 sec)
```

enable skip_storage_engine_merge and check select result, not merged original rows are returned:
```
mysql> set skip_storage_engine_merge = true;
Query OK, 0 rows affected (0.01 sec)

mysql> select * from t1;
+------+------+-----------------------+
| a    | b    | __DORIS_DELETE_SIGN__ |
+------+------+-----------------------+
|    3 |    1 |                     0 |
|    2 |    1 |                     0 |
|    2 |   11 |                     0 |
|    1 |    1 |                     0 |
|    1 |   11 |                     0 |
+------+------+-----------------------+
5 rows in set (0.04 sec)
```

turn off skip_storage_engine_merge
```
mysql> set skip_storage_engine_merge = false;
```

load delete and select again:
csv:
```
1|111
```
```
curl --location-trusted -uroot: -H "column_separator:|" -H "columns:a, b" -H "merge_type: delete" -T delete.csv http://127.0.0.1:8030/api/test_skip/t1/_stream_load

mysql> select * from t1;
+------+------+
| a    | b    |
+------+------+
|    3 |    1 |
|    2 |   11 |
+------+------+
2 rows in set (0.05 sec)
```

delete rows with `a = 2`:
```
mysql> delete from t1 where a = 2;
Query OK, 0 rows affected (0.09 sec)
{'label':'delete_3b7fc2c3-becb-4586-bc46-dc225274186d', 'status':'VISIBLE', 'txnId':'30049'}

mysql> select * from t1;
+------+------+
| a    | b    |
+------+------+
|    3 |    1 |
+------+------+
1 row in set (0.04 sec)
```

enable skip_storage_engine_merge and select, rows deleted with `delete` statement is not returned:
```
mysql> set skip_storage_engine_merge = true;
Query OK, 0 rows affected (0.00 sec)

mysql> select * from t1;
+------+------+-----------------------+
| a    | b    | __DORIS_DELETE_SIGN__ |
+------+------+-----------------------+
|    3 |    1 |                     0 |
|    1 |    1 |                     0 |
|    1 |   11 |                     0 |
|    1 |  111 |                     1 |
+------+------+-----------------------+
4 rows in set (0.04 sec)
```

enable skip_delete_predicate,  rows deleted with `delete` statement is also returned:
```
mysql> set skip_delete_predicate = true;
Query OK, 0 rows affected (0.00 sec)

mysql> select * from t1;
+------+------+-----------------------+
| a    | b    | __DORIS_DELETE_SIGN__ |
+------+------+-----------------------+
|    3 |    1 |                     0 |
|    2 |    1 |                     0 |
|    2 |   11 |                     0 |
|    1 |    1 |                     0 |
|    1 |   11 |                     0 |
|    1 |  111 |                     1 |
+------+------+-----------------------+
6 rows in set (0.03 sec)
```

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

