### PR TITLE
[feature-wip](unique-key-merge-on-write) opt lock and only save valid rowsets delete_bitmap when save meta

### DIFF
--- a/be/src/olap/compaction.cpp
+++ b/be/src/olap/compaction.cpp
@@ -256,17 +256,23 @@ Status Compaction::construct_input_rowset_readers() {
 Status Compaction::modify_rowsets() {
     std::vector<RowsetSharedPtr> output_rowsets;
     output_rowsets.push_back(_output_rowset);
-    std::lock_guard<std::shared_mutex> wrlock(_tablet->get_header_lock());
+    {
+        std::lock_guard<std::mutex> wrlock_(_tablet->get_rowset_update_lock());
+        std::lock_guard<std::shared_mutex> wrlock(_tablet->get_header_lock());
 
-    // update dst rowset delete bitmap
-    if (_tablet->keys_type() == KeysType::UNIQUE_KEYS &&
-        _tablet->enable_unique_key_merge_on_write()) {
-        _tablet->tablet_meta()->update_delete_bitmap(_input_rowsets, _output_rs_writer->version(),
-                                                     _rowid_conversion);
+        // update dst rowset delete bitmap
+        if (_tablet->keys_type() == KeysType::UNIQUE_KEYS &&
+            _tablet->enable_unique_key_merge_on_write()) {
+            _tablet->tablet_meta()->update_delete_bitmap(
+                    _input_rowsets, _output_rs_writer->version(), _rowid_conversion);
+        }
+
+        RETURN_NOT_OK(_tablet->modify_rowsets(output_rowsets, _input_rowsets, true));
     }
-
-    RETURN_NOT_OK(_tablet->modify_rowsets(output_rowsets, _input_rowsets, true));
-    _tablet->save_meta();
+    {
+        std::shared_lock rlock(_tablet->get_header_lock());
+        _tablet->save_meta();
+    }
     return Status::OK();
 }
 

--- a/be/src/olap/delta_writer.cpp
+++ b/be/src/olap/delta_writer.cpp
@@ -282,7 +282,7 @@ Status DeltaWriter::wait_flush() {
 
 void DeltaWriter::_reset_mem_table() {
     if (_tablet->enable_unique_key_merge_on_write()) {
-        _delete_bitmap.reset(new DeleteBitmap(-1));
+        _delete_bitmap.reset(new DeleteBitmap(_tablet->tablet_id()));
     }
     _mem_table.reset(new MemTable(_tablet, _schema.get(), _tablet_schema.get(), _req.slots,
                                   _req.tuple_desc, _rowset_writer.get(), _delete_bitmap,

--- a/be/src/olap/tablet_meta.cpp
+++ b/be/src/olap/tablet_meta.cpp
@@ -536,11 +536,17 @@ void TabletMeta::to_meta_pb(TabletMetaPB* tablet_meta_pb) {
     tablet_meta_pb->set_storage_policy(_storage_policy);
     tablet_meta_pb->set_enable_unique_key_merge_on_write(_enable_unique_key_merge_on_write);
 
-    {
-        std::shared_lock l(delete_bitmap().lock);
+    if (_enable_unique_key_merge_on_write) {
+        std::set<RowsetId> rs_ids;
+        for (const auto& rowset : _rs_metas) {
+            rs_ids.insert(rowset->rowset_id());
+        }
         DeleteBitmapPB* delete_bitmap_pb = tablet_meta_pb->mutable_delete_bitmap();
-        for (auto& [id, bitmap] : delete_bitmap().delete_bitmap) {
+        for (auto& [id, bitmap] : delete_bitmap().snapshot().delete_bitmap) {
             auto& [rowset_id, segment_id, ver] = id;
+            if (rs_ids.count(rowset_id) == 0) {
+                continue;
+            }
             delete_bitmap_pb->add_rowset_ids(rowset_id.to_string());
             delete_bitmap_pb->add_segment_ids(segment_id);
             delete_bitmap_pb->add_versions(ver);

--- a/be/src/olap/tablet_meta.h
+++ b/be/src/olap/tablet_meta.h
@@ -404,7 +404,7 @@ public:
             static std::once_flag once;
             std::call_once(once, [size_in_bytes] {
                 auto tmp = new ShardedLRUCache("DeleteBitmap AggCache", size_in_bytes,
-                                               LRUCacheType::SIZE, 2048);
+                                               LRUCacheType::SIZE, 256);
                 AggCache::s_repr.store(tmp, std::memory_order_release);
             });
 

--- a/be/src/olap/task/engine_publish_version_task.cpp
+++ b/be/src/olap/task/engine_publish_version_task.cpp
@@ -126,11 +126,11 @@ Status EnginePublishVersionTask::finish() {
                     max_version = tablet->max_version();
                 }
                 if (version.first != max_version.second + 1) {
-                    LOG(INFO) << "uniq key with merge-on-write version not continuous, current "
-                                 "max "
-                                 "version="
-                              << max_version.second << ", publish_version=" << version.first
-                              << " tablet_id=" << tablet->tablet_id();
+                    VLOG_NOTICE << "uniq key with merge-on-write version not continuous, current "
+                                   "max "
+                                   "version="
+                                << max_version.second << ", publish_version=" << version.first
+                                << " tablet_id=" << tablet->tablet_id();
                     meet_version_not_continuous = true;
                     res = Status::OLAPInternalError(OLAP_ERR_PUBLISH_VERSION_NOT_CONTINUOUS);
                     continue;
@@ -180,7 +180,7 @@ Status EnginePublishVersionTask::finish() {
 
     LOG(INFO) << "finish to publish version on transaction."
               << "transaction_id=" << transaction_id
-              << ", error_tablet_size=" << _error_tablet_ids->size();
+              << ", error_tablet_size=" << _error_tablet_ids->size() << ", res=" << res.to_string();
     return res;
 }
 

--- a/be/test/olap/test_data/header_without_inc_rs.txt
+++ b/be/test/olap/test_data/header_without_inc_rs.txt
@@ -147,6 +147,5 @@
     "tablet_type": "TABLET_TYPE_DISK",
     "replica_id": 0,
     "storage_policy": "",
-    "delete_bitmap": {},
     "enable_unique_key_merge_on_write": false
 }


### PR DESCRIPTION

1. use rlock in most logic instead of wrlock
2. filter stale rowset's delete bitmap in save meta
3. add a delete_bitmap lock to handle compaction and publish_txn confict

# Proposed changes

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

