### PR TITLE
[Chore](script) support custom python version on build script

### DIFF
--- a/env.sh
+++ b/env.sh
@@ -45,7 +45,12 @@ if [[ -z "${DORIS_THIRDPARTY}" ]]; then
 fi
 
 # check python
-export PYTHON='python'
+if [[ -z "${DORIS_BUILD_PYTHON_VERSION}" ]]; then
+    DORIS_BUILD_PYTHON_VERSION="python"
+fi
+
+export PYTHON="${DORIS_BUILD_PYTHON_VERSION}"
+
 if ! ${PYTHON} --version; then
     export PYTHON=python2.7
     if ! ${PYTHON} --version; then

--- a/env.sh
+++ b/env.sh
@@ -52,11 +52,8 @@ fi
 export PYTHON="${DORIS_BUILD_PYTHON_VERSION}"
 
 if ! ${PYTHON} --version; then
-    export PYTHON=python2.7
-    if ! ${PYTHON} --version; then
-        echo "Error: python is not found"
-        exit 1
-    fi
+    echo "Error: ${PYTHON} is not found, maybe you should set DORIS_BUILD_PYTHON_VERSION."
+    exit 1
 fi
 
 if [[ -z "${DORIS_TOOLCHAIN}" ]]; then


### PR DESCRIPTION
# Proposed changes

Sometime, we want to specify a python version for build script.
we can set `export DORIS_BUILD_PYTHON_VERSION=python3` now.

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

