### PR TITLE
[fix](error-code) prompt error when MySQL client login password is incorrect

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/MysqlProto.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/MysqlProto.java
@@ -56,7 +56,7 @@ public class MysqlProto {
         List<UserIdentity> currentUserIdentity = Lists.newArrayList();
         if (!Env.getCurrentEnv().getAuth().checkPassword(qualifiedUser, remoteIp,
                 scramble, randomString, currentUserIdentity)) {
-            ErrorReport.report(ErrorCode.ERR_ACCESS_DENIED_ERROR, qualifiedUser, context.getRemoteIP(), usePasswd);
+            ErrorReport.report(ErrorCode.ERR_ACCESS_DENIED_ERROR, qualifiedUser, usePasswd);
             return false;
         }
 


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

prompt error when MySQL client login password is incorrect, because of multi-parameter error. 

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ✔️] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ✔️] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [✔️] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [✔️] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [✔️] No

## Further comments

