### PR TITLE
[dev-1.1.2](memtracker) Fix DCHECK consumption is greater than 0 in old mem tracker

### DIFF
--- a/be/src/runtime/mem_tracker.cpp
+++ b/be/src/runtime/mem_tracker.cpp
@@ -266,8 +266,8 @@ MemTracker::~MemTracker() {
     delete reservation_counters_.load();
 
     if (parent()) {
-        DCHECK(consumption() == 0) << "Memory tracker " << debug_string()
-                                   << " has unreleased consumption " << consumption();
+        // DCHECK(consumption() == 0) << "Memory tracker " << debug_string()
+        //                            << " has unreleased consumption " << consumption();
         parent_->Release(consumption());
 
         lock_guard<SpinLock> l(parent_->child_trackers_lock_);

--- a/be/src/runtime/mem_tracker.h
+++ b/be/src/runtime/mem_tracker.h
@@ -249,11 +249,11 @@ public:
             /// metric. Don't blow up in this case. (Note that this doesn't affect non-process
             /// trackers since we can enforce that the reported memory usage is internally
             /// consistent.)
-            if (LIKELY(tracker->consumption_metric_ == nullptr)) {
-                DCHECK_GE(tracker->consumption_->current_value(), 0)
-                        << std::endl
-                        << tracker->LogUsage(UNLIMITED_DEPTH);
-            }
+            // if (LIKELY(tracker->consumption_metric_ == nullptr)) {
+            //     DCHECK_GE(tracker->consumption_->current_value(), 0)
+            //             << std::endl
+            //             << tracker->LogUsage(UNLIMITED_DEPTH);
+            // }
         }
     }
 


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

```
#0  0x00007f00aa2f2fbb in raise () from /lib/x86_64-linux-gnu/libc.so.6
#1  0x00007f00aa2d8864 in abort () from /lib/x86_64-linux-gnu/libc.so.6
#2  0x000055797ba76bf2 in google::DumpStackTraceAndExit () at src/utilities.cc:160
#3  0x00005579824a62bd in google::LogMessage::Fail () at src/logging.cc:1650
#4  0x00005579824a87f9 in google::LogMessage::SendToLog (this=0x7f0066e6f2a0) at src/logging.cc:1607
#5  0x00005579824a5e26 in google::LogMessage::Flush (this=0x7f0066e6f2a0) at src/logging.cc:1476
#6  0x00005579824a8e69 in google::LogMessageFatal::~LogMessageFatal (this=<optimized out>, __in_chrg=<optimized out>) at src/logging.cc:2226
#7  0x000055797c4f6a8b in doris::MemTracker::Release (this=0x613000200380, bytes=8192) at /doris/be/src/runtime/mem_tracker.h:253
#8  0x000055797d090315 in doris::RowBatch::clear (this=0x614000314c40) at /doris/be/src/runtime/row_batch.cpp:230
#9  0x000055797d0904c1 in doris::RowBatch::~RowBatch (this=0x614000314c40, __in_chrg=<optimized out>) at /doris/be/src/runtime/row_batch.cpp:236
#10 0x000055797d090576 in doris::RowBatch::~RowBatch (this=0x614000314c40, __in_chrg=<optimized out>) at /doris/be/src/runtime/row_batch.cpp:237
#11 0x000055797d08261f in std::default_delete<doris::RowBatch>::operator() (this=0x62100287ee98, __ptr=0x614000314c40) at /include/c++/11/bits/unique_ptr.h:85
#12 0x000055797d082de8 in std::__uniq_ptr_impl<doris::RowBatch, std::default_delete<doris::RowBatch> >::reset (this=0x62100287ee98, __p=0x0)
    at /include/c++/11/bits/unique_ptr.h:182
#13 0x000055797d081022 in std::unique_ptr<doris::RowBatch, std::default_delete<doris::RowBatch> >::reset (this=0x62100287ee98,
    __p=<error reading variable: Cannot access memory at address 0xffffffffffffffc0>) at /include/c++/11/bits/unique_ptr.h:456
#14 0x000055797d07b065 in doris::PlanFragmentExecutor::close (this=0x62100287e570) at /doris/be/src/runtime/plan_fragment_executor.cpp:668
#15 0x000055797ce43727 in doris::FragmentExecState::execute (this=0x62100287e500) at /doris/be/src/runtime/fragment_mgr.cpp:244
#16 0x000055797ce4adb3 in doris::FragmentMgr::_exec_actual(std::shared_ptr<doris::FragmentExecState>, std::function<void (doris::PlanFragmentExecutor*)>) (this=0x614000013c40,
    exec_state=std::shared_ptr<doris::FragmentExecState> (use count 3, weak count 0) = {...}, cb=...) at /doris/be/src/runtime/fragment_mgr.cpp:482
```

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

