### PR TITLE
[fix](array-type) fix be occasional coredump when use stream load

### DIFF
--- a/be/src/runtime/collection_value.cpp
+++ b/be/src/runtime/collection_value.cpp
@@ -184,6 +184,7 @@ struct ArrayIteratorFunctionsForString : public GenericArrayIteratorFunctions<ty
         string->ptr = (convert_ptrs ? convert_to<char*>(offset) : copied_string);
     }
     static void deserialize(void* item, const char* tuple_data, const TypeDescriptor& type_desc) {
+        DCHECK((item != nullptr) && (tuple_data != nullptr)) << "item or tuple_data is nullptr";
         auto* string_value = static_cast<CppType*>(item);
         if (string_value->len) {
             int64_t offset = convert_to<int64_t>(string_value->ptr);

--- a/be/src/runtime/row_batch.cpp
+++ b/be/src/runtime/row_batch.cpp
@@ -172,6 +172,9 @@ RowBatch::RowBatch(const RowDescriptor& row_desc, const PRowBatch& input_batch)
             // copy collection slots
             for (auto slot_collection : desc->collection_slots()) {
                 DCHECK(slot_collection->type().is_collection_type());
+                if (tuple->is_null(slot_collection->null_indicator_offset())) {
+                    continue;
+                }
 
                 CollectionValue* array_val =
                         tuple->get_collection_slot(slot_collection->tuple_offset());


### PR DESCRIPTION
# Proposed changes
1.this pr is used to solve the be occasional coredump when use stream load.
2. the be core dump stack is as below:

*** Query id: 0-0 ***
*** Aborted at 1660906376 (unix time) try "date -d @1660906376" if you are using GNU date ***
*** Current BE git commitID: 1b0b5b5f0 ***
*** SIGSEGV unkown detail explain (@0x0) received by PID 76232 (TID 0x7fc4c42c7700) from PID 0; stack trace: ***
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /home/disk1/hugo_work/doris_dev/baidu/bdg/doris/core/be/src/common/signal_handler.h:420
 1# 0x00007FC588ACB920 in /lib64/libc.so.6
 2# doris::ArrayIteratorFunctionsForString<(doris::PrimitiveType)15>::deserialize(void*, char const*, doris::TypeDescriptor const&) at /home/disk1/hugo_work/doris_dev/baidu/bdg/doris/core/be/src/runtime/collection_value.cpp:192
 3# doris::CollectionValue::deserialize_collection(doris::CollectionValue*, char const*, doris::TypeDescriptor const&) at /home/disk1/hugo_work/doris_dev/baidu/bdg/doris/core/be/src/runtime/collection_value.cpp:567
 4# doris::RowBatch::RowBatch(doris::RowDescriptor const&, doris::PRowBatch const&) at /home/disk1/hugo_work/doris_dev/baidu/bdg/doris/core/be/src/runtime/row_batch.cpp:173
 5# doris::Status doris::TabletsChannel::add_batch<doris::PTabletWriterAddBatchRequest, doris::PTabletWriterAddBatchResult>(doris::PTabletWriterAddBatchRequest const&, doris::PTabletWriterAddBatchResult*) at /home/disk1/hugo_work/doris_dev/baidu/bdg/doris/core/be/src/runtime/tablets_channel.cpp:368
 6# doris::Status doris::LoadChannel::add_batch<doris::PTabletWriterAddBatchRequest, doris::PTabletWriterAddBatchResult>(doris::PTabletWriterAddBatchRequest const&, doris::PTabletWriterAddBatchResult*) at /home/disk1/hugo_work/doris_dev/baidu/bdg/doris/core/be/src/runtime/load_channel.h:149
 7# doris::Status doris::LoadChannelMgr::add_batch<doris::PTabletWriterAddBatchRequest, doris::PTabletWriterAddBatchResult>(doris::PTabletWriterAddBatchRequest const&, doris::PTabletWriterAddBatchResult*) at /home/disk1/hugo_work/doris_dev/baidu/bdg/doris/core/be/src/runtime/load_channel_mgr.h:134
 8# std::_Function_handler<void (), doris::PInternalServiceImpl::_tablet_writer_add_batch(google::protobuf::RpcController*, doris::PTabletWriterAddBatchRequest const*, doris::PTabletWriterAddBatchResult*, google::protobuf::Closure*)::{lambda()#1}>::_M_invoke(std::_Any_data const&) at /home/disk1/hugo_work/doris_dev/baidu/bdg/doris/palo-toolchain/ldb_toolchain/include/c++/11/bits/std_function.h:291
 9# doris::PriorityThreadPool::work_thread(int) at /home/disk1/hugo_work/doris_dev/baidu/bdg/doris/core/be/src/util/priority_thread_pool.hpp:138
10# execute_native_thread_routine in /home/disk1/hugo_work/doris_env/output/be/lib/palo_be
11# start_thread in /lib64/libpthread.so.0
12# clone in /lib64/libc.so.6

Issue Number: #7570

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
4. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
5. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
6. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

