### PR TITLE
Revert "[dev-1.1.2](memtracker) Fix DCHECK consumption is greater than 0 in old mem tracker"

### DIFF
--- a/be/src/runtime/mem_tracker.cpp
+++ b/be/src/runtime/mem_tracker.cpp
@@ -266,8 +266,8 @@ MemTracker::~MemTracker() {
     delete reservation_counters_.load();
 
     if (parent()) {
-        // DCHECK(consumption() == 0) << "Memory tracker " << debug_string()
-        //                            << " has unreleased consumption " << consumption();
+        DCHECK(consumption() == 0) << "Memory tracker " << debug_string()
+                                   << " has unreleased consumption " << consumption();
         parent_->Release(consumption());
 
         lock_guard<SpinLock> l(parent_->child_trackers_lock_);

--- a/be/src/runtime/mem_tracker.h
+++ b/be/src/runtime/mem_tracker.h
@@ -249,11 +249,11 @@ public:
             /// metric. Don't blow up in this case. (Note that this doesn't affect non-process
             /// trackers since we can enforce that the reported memory usage is internally
             /// consistent.)
-            // if (LIKELY(tracker->consumption_metric_ == nullptr)) {
-            //     DCHECK_GE(tracker->consumption_->current_value(), 0)
-            //             << std::endl
-            //             << tracker->LogUsage(UNLIMITED_DEPTH);
-            // }
+            if (LIKELY(tracker->consumption_metric_ == nullptr)) {
+                DCHECK_GE(tracker->consumption_->current_value(), 0)
+                        << std::endl
+                        << tracker->LogUsage(UNLIMITED_DEPTH);
+            }
         }
     }
 


### PR DESCRIPTION
Reverts apache/doris#11980
true error fixed in #12000