### PR TITLE
[fix](auth) remove USAGE_PRIV in CatalogPrivEntry when loading meta image from old version

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/GrantStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/GrantStmt.java
@@ -190,7 +190,7 @@ public class GrantStmt extends DdlStmt {
 
         // Rule 6
         if (privileges.contains(PaloPrivilege.USAGE_PRIV)) {
-            throw new AnalysisException("Can not grant/revoke USAGE_PRIV to/from database or table");
+            throw new AnalysisException("Can not grant/revoke USAGE_PRIV to/from catalog/database/table");
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/DbPrivEntry.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/DbPrivEntry.java
@@ -65,7 +65,7 @@ public class DbPrivEntry extends CatalogPrivEntry {
         PatternMatcher userPattern = PatternMatcher.createFlatPattern(user, CaseSensibility.USER.getCaseSensibility());
 
         if (privs.containsNodePriv() || privs.containsResourcePriv()) {
-            throw new AnalysisException("Db privilege can not contains global or resource privileges: " + privs);
+            throw new AnalysisException("Db privilege can not contain node or resource privileges: " + privs);
         }
 
         return new DbPrivEntry(userPattern, user, hostPattern, host, ctlPattern, ctl, dbPattern, db, isDomain, privs);

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/GlobalPrivEntry.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/GlobalPrivEntry.java
@@ -54,6 +54,9 @@ public class GlobalPrivEntry extends PrivEntry {
             throws AnalysisException {
         PatternMatcher hostPattern = PatternMatcher.createMysqlPattern(host, CaseSensibility.HOST.getCaseSensibility());
         PatternMatcher userPattern = PatternMatcher.createFlatPattern(user, CaseSensibility.USER.getCaseSensibility());
+        if (privs.containsResourcePriv()) {
+            throw new AnalysisException("Global privilege can not contain resource privileges: " + privs);
+        }
         return new GlobalPrivEntry(hostPattern, host, userPattern, user, isDomain, password, privs);
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/PrivBitSet.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/PrivBitSet.java
@@ -47,7 +47,7 @@ public class PrivBitSet implements Writable {
 
     public void unset(int index) {
         Preconditions.checkState(index < PaloPrivilege.privileges.length, index);
-        set &= 1 << index;
+        set ^= 1 << index;
     }
 
     public boolean get(int index) {

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/TablePrivEntry.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/TablePrivEntry.java
@@ -64,7 +64,7 @@ public class TablePrivEntry extends DbPrivEntry {
                 tbl, CaseSensibility.TABLE.getCaseSensibility(), tbl.equals(ANY_TBL));
 
         if (privs.containsNodePriv() || privs.containsResourcePriv()) {
-            throw new AnalysisException("Table privilege can not contains global or resource privileges: " + privs);
+            throw new AnalysisException("Table privilege can not contain node or resource privileges: " + privs);
         }
 
         return new TablePrivEntry(userPattern, user, hostPattern, host,

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/UserPrivTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/UserPrivTable.java
@@ -187,6 +187,11 @@ public class UserPrivTable extends PrivTable {
         List<PrivEntry> degradedEntries = new LinkedList<>();
         for (PrivEntry privEntry : entries) {
             GlobalPrivEntry globalPrivEntry = (GlobalPrivEntry) privEntry;
+            if (privEntry.privSet.containsResourcePriv()) {
+                // This only happened in loading meta image from old version
+                privEntry.privSet.xor(PrivBitSet.of(PaloPrivilege.USAGE_PRIV));
+                LOG.warn("USAGE_PRIV is granted to global privileges, and is ignored in current version");
+            }
             if (!globalPrivEntry.match(UserIdentity.ROOT, true)
                     && !globalPrivEntry.match(UserIdentity.ADMIN, true)
                     && !globalPrivEntry.privSet.isEmpty()) {


### PR DESCRIPTION
# Proposed changes

## Problem summary
FE  failed when updating from v1.1.2 to master:
```
java.io.IOException: java.lang.reflect.InvocationTargetException
	at org.apache.doris.persist.meta.MetaReader.read(MetaReader.java:97)
	at org.apache.doris.catalog.Env.loadImage(Env.java:1615)
	at org.apache.doris.catalog.Env.initialize(Env.java:830)
	at org.apache.doris.PaloFe.start(PaloFe.java:132)
	at org.apache.doris.PaloFe.main(PaloFe.java:67)
Caused by: java.lang.reflect.InvocationTargetException
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.apache.doris.persist.meta.MetaReader.read(MetaReader.java:94)
	... 4 more
Caused by: java.io.IOException: errCode = 2, detailMessage = Catalog privilege can not contains node or resource privileges: Select_priv Load_priv Alter_priv Create_priv Usage_priv 
	at org.apache.doris.mysql.privilege.UserPrivTable.degradeToInternalCatalogPriv(UserPrivTable.java:200)
	at org.apache.doris.mysql.privilege.PaloAuth.readFields(PaloAuth.java:1829)
	at org.apache.doris.catalog.Env.loadPaloAuth(Env.java:1823)
	... 9 more
```
This only happened in loading meta image from old version:
GlobalPrivEntry of the previous version does not check 'privs.containsResourcePriv()',
so GlobalPrivEntry maybe contians USAGE_PRIV which is wrong operation and useless priv.
In order to be compatible with this scenario, we should delete USAGE_PRIV.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

