### PR TITLE
[fix](auth) no need to degrade USAGE_PRIV in userPrivTable

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/PrivBitSet.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/PrivBitSet.java
@@ -47,7 +47,7 @@ public class PrivBitSet implements Writable {
 
     public void unset(int index) {
         Preconditions.checkState(index < PaloPrivilege.privileges.length, index);
-        set &= 1 << index;
+        set ^= 1 << index;
     }
 
     public boolean get(int index) {


### PR DESCRIPTION
# Proposed changes
## Problem summary
FE failed when updating from v1.1.2 to master:
```
java.io.IOException: java.lang.reflect.InvocationTargetException
	at org.apache.doris.persist.meta.MetaReader.read(MetaReader.java:97)
	at org.apache.doris.catalog.Env.loadImage(Env.java:1615)
	at org.apache.doris.catalog.Env.initialize(Env.java:830)
	at org.apache.doris.PaloFe.start(PaloFe.java:132)
	at org.apache.doris.PaloFe.main(PaloFe.java:67)
Caused by: java.lang.reflect.InvocationTargetException
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.apache.doris.persist.meta.MetaReader.read(MetaReader.java:94)
	... 4 more
Caused by: java.io.IOException: errCode = 2, detailMessage = Catalog privilege can not contains node or resource privileges: Select_priv Load_priv Alter_priv Create_priv Usage_priv 
	at org.apache.doris.mysql.privilege.UserPrivTable.degradeToInternalCatalogPriv(UserPrivTable.java:200)
	at org.apache.doris.mysql.privilege.PaloAuth.readFields(PaloAuth.java:1829)
	at org.apache.doris.catalog.Env.loadPaloAuth(Env.java:1823)
	... 9 more
```
USAGE_PRIV is save in userPrivTable, and is no need to degrade to catalogPrivTable.
when replaying USAGE_PRIV in Editlog, the PrivInfo will return right `ResourcePattern` and create the right `GlobalPriveEntry`.

## Update
v1.1.2:
```
MySQL [(none)]> show all grants;
+---------------------------------+----------+---------------------------------+----------------------------------------------------------+------------+---------------+
| UserIdentity                    | Password | GlobalPrivs                     | DatabasePrivs                                            | TablePrivs | ResourcePrivs |
+---------------------------------+----------+---------------------------------+----------------------------------------------------------+------------+---------------+
| 'root'@'%'                      | No       | Node_priv Admin_priv  (false)   | NULL                                                     | NULL       | NULL          |
| 'admin'@'%'                     | No       | Admin_priv  (false)             | NULL                                                     | NULL       | NULL          |
| 'default_cluster:user1'@'127.%' | Yes      | Select_priv Usage_priv  (false) | default_cluster:information_schema: Select_priv  (false) | NULL       | NULL          |
+---------------------------------+----------+---------------------------------+----------------------------------------------------------+------------+---------------+
```
this commit:
```
MySQL [(none)]> show all grants;
+---------------------------------+----------+-------------------------------+--------------------------------+-------------------------------------------------------------------+------------+---------------+
| UserIdentity                    | Password | GlobalPrivs                   | CatalogPrivs                   | DatabasePrivs                                                     | TablePrivs | ResourcePrivs |
+---------------------------------+----------+-------------------------------+--------------------------------+-------------------------------------------------------------------+------------+---------------+
| 'root'@'%'                      | No       | Node_priv Admin_priv  (false) | NULL                           | NULL                                                              | NULL       | NULL          |
| 'admin'@'%'                     | No       | Admin_priv  (false)           | NULL                           | NULL                                                              | NULL       | NULL          |
| 'default_cluster:user1'@'127.%' | Yes      | Usage_priv  (false)           | internal: Select_priv  (false) | internal.default_cluster:information_schema: Select_priv  (false) | NULL       | NULL          |
+---------------------------------+----------+-------------------------------+--------------------------------+-------------------------------------------------------------------+------------+---------------+
```

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

