### PR TITLE
[improvement](sink) Support local exchange for multi fragment instances

### DIFF
--- a/be/src/vec/sink/vdata_stream_sender.h
+++ b/be/src/vec/sink/vdata_stream_sender.h
@@ -135,6 +135,7 @@ protected:
     RuntimeProfile::Counter* _bytes_sent_counter;
     RuntimeProfile::Counter* _uncompressed_bytes_counter;
     RuntimeProfile::Counter* _ignore_rows;
+    RuntimeProfile::Counter* _local_sent_rows;
 
     std::unique_ptr<MemTracker> _mem_tracker;
 
@@ -302,6 +303,8 @@ private:
     PBlock* _ch_cur_pb_block = nullptr;
     PBlock _ch_pb_block1;
     PBlock _ch_pb_block2;
+
+    bool _enable_local_exchange = false;
 };
 
 template <typename Channels, typename HashVals>

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -209,6 +209,8 @@ public class SessionVariable implements Serializable, Writable {
 
     public static final String FRAGMENT_TRANSMISSION_COMPRESSION_CODEC = "fragment_transmission_compression_codec";
 
+    public static final String ENABLE_LOCAL_EXCHANGE = "enable_local_exchange";
+
     // session origin value
     public Map<Field, String> sessionOriginValue = new HashMap<Field, String>();
     // check stmt is or not [select /*+ SET_VAR(...)*/ ...]
@@ -524,6 +526,9 @@ public class SessionVariable implements Serializable, Writable {
 
     @VariableMgr.VarAttr(name = ENABLE_FUNCTION_PUSHDOWN)
     public boolean enableFunctionPushdown;
+
+    @VariableMgr.VarAttr(name = ENABLE_LOCAL_EXCHANGE)
+    public boolean enableLocalExchange = false;
 
     public String getBlockEncryptionMode() {
         return blockEncryptionMode;
@@ -918,6 +923,10 @@ public class SessionVariable implements Serializable, Writable {
         return this.enableFunctionPushdown;
     }
 
+    public boolean getEnableLocalExchange() {
+        return enableLocalExchange;
+    }
+
     /**
      * getInsertVisibleTimeoutMs.
      **/
@@ -1113,6 +1122,7 @@ public class SessionVariable implements Serializable, Writable {
 
         tResult.setEnableFunctionPushdown(enableFunctionPushdown);
         tResult.setFragmentTransmissionCompressionCodec(fragmentTransmissionCompressionCodec);
+        tResult.setEnableLocalExchange(enableLocalExchange);
 
         return tResult;
     }

--- a/gensrc/thrift/PaloInternalService.thrift
+++ b/gensrc/thrift/PaloInternalService.thrift
@@ -167,6 +167,8 @@ struct TQueryOptions {
   45: optional bool enable_function_pushdown;
 
   46: optional string fragment_transmission_compression_codec;
+
+  47: optional bool enable_local_exchange;
 }
     
 


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

The local exchange will avoid compressing/decompressing and serializing/deserializing.

Here add one session variable of `enable_local_exchange` to enable/disable this experimental feature.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [x] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

