### PR TITLE
[chore](checkstyle)forbid import all kind of relocated guava

### DIFF
--- a/fe/check/checkstyle/import-control.xml
+++ b/fe/check/checkstyle/import-control.xml
@@ -25,6 +25,11 @@ under the License.
 <import-control pkg="org.apache.doris" strategyOnMismatch="allowed">
     <disallow pkg="com.clearspring.analytics.util" />
     <disallow pkg="com.alibaba.google" />
+    <disallow pkg="org.spark_project.guava" />
+    <disallow pkg="org.glassfish.jersey.internal.guava" />
+    <disallow pkg="io.fabric8.zjsonpatch.internal.guava" />
+    <disallow pkg="org.checkerframework.com.google" />
+    <disallow pkg="org.apache.iceberg.relocated" />
     <subpackage name="nereids">
         <allow pkg="org.junit.jupiter"/>
         <disallow pkg="org.junit"/>

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/ScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/ScanNode.java
@@ -43,9 +43,9 @@ import com.google.common.base.MoreObjects;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Range;
+import com.google.common.collect.Sets;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.glassfish.jersey.internal.guava.Sets;
 
 import java.util.List;
 import java.util.Map;


### PR DESCRIPTION
# Proposed changes

there are many kind of relocated guava in Doris's FE dependencies. Their versions are different with guava we dependent directly. they may have potential for inconsistent behavior with our  dependent one. So i add some import-control rules to forbid them at all.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

