### PR TITLE
[fix](memtracker) Improve performance of tracking real physical memory of PodArray

### DIFF
--- a/be/src/olap/compaction.cpp
+++ b/be/src/olap/compaction.cpp
@@ -45,8 +45,8 @@ Compaction::Compaction(TabletSharedPtr tablet, const std::string& label)
 Compaction::~Compaction() {
 #ifndef BE_TEST
     // Compaction tracker cannot be completely accurate, offset the global impact.
-    StorageEngine::instance()->compaction_mem_tracker()->consume_local(
-            -_mem_tracker->consumption(), ExecEnv::GetInstance()->process_mem_tracker().get());
+    StorageEngine::instance()->compaction_mem_tracker()->cache_consume_local(
+            -_mem_tracker->consumption());
 #endif
 }
 

--- a/be/src/runtime/exec_env_init.cpp
+++ b/be/src/runtime/exec_env_init.cpp
@@ -194,8 +194,7 @@ Status ExecEnv::_init_mem_tracker() {
                      << ". Using physical memory instead";
         global_memory_limit_bytes = MemInfo::physical_mem();
     }
-    _process_mem_tracker =
-            std::make_shared<MemTrackerLimiter>(global_memory_limit_bytes, "Process");
+    _process_mem_tracker = std::make_shared<MemTrackerLimiter>(-1, "Process");
     thread_context()->_thread_mem_tracker_mgr->init();
     thread_context()->_thread_mem_tracker_mgr->set_check_attach(false);
 #if defined(USE_MEM_TRACKER) && !defined(__SANITIZE_ADDRESS__) && !defined(ADDRESS_SANITIZER) && \

--- a/be/src/runtime/load_channel.cpp
+++ b/be/src/runtime/load_channel.cpp
@@ -46,8 +46,7 @@ LoadChannel::~LoadChannel() {
               << ", is high priority=" << _is_high_priority << ", sender_ip=" << _sender_ip
               << ", is_vec=" << _is_vec;
     // Load channel tracker cannot be completely accurate, offsetting the impact on the load channel mgr tracker.
-    _mem_tracker->parent()->consume_local(-_mem_tracker->consumption(),
-                                          ExecEnv::GetInstance()->process_mem_tracker().get());
+    _mem_tracker->parent()->cache_consume_local(-_mem_tracker->consumption());
 }
 
 Status LoadChannel::open(const PTabletWriterOpenRequest& params) {

--- a/be/src/runtime/mem_pool.h
+++ b/be/src/runtime/mem_pool.h
@@ -212,7 +212,7 @@ private:
     bool check_integrity(bool check_current_chunk_empty);
 
     void reset_peak() {
-        if (total_allocated_bytes_ - peak_allocated_bytes_ > 1024) {
+        if (total_allocated_bytes_ - peak_allocated_bytes_ > 4096) {
             THREAD_MEM_TRACKER_TRANSFER_FROM(total_allocated_bytes_ - peak_allocated_bytes_,
                                              ExecEnv::GetInstance()->process_mem_tracker().get());
             peak_allocated_bytes_ = total_allocated_bytes_;

--- a/be/src/runtime/memory/mem_tracker_task_pool.cpp
+++ b/be/src/runtime/memory/mem_tracker_task_pool.cpp
@@ -93,9 +93,7 @@ void MemTrackerTaskPool::logout_task_mem_tracker() {
             // In order to ensure that the query pool mem tracker is the sum of all currently running query mem trackers,
             // the effect of the ended query mem tracker on the query pool mem tracker should be cleared, that is,
             // the negative number of the current value of consume.
-            it->second->parent()->consume_local(
-                    -it->second->consumption(),
-                    ExecEnv::GetInstance()->process_mem_tracker().get());
+            it->second->parent()->cache_consume_local(-it->second->consumption());
             LOG(INFO) << fmt::format(
                     "Deregister query/load memory tracker, queryId={}, Limit={}, PeakUsed={}",
                     it->first, it->second->limit(), it->second->peak_consumption());

--- a/be/src/runtime/memory/thread_mem_tracker_mgr.h
+++ b/be/src/runtime/memory/thread_mem_tracker_mgr.h
@@ -78,16 +78,6 @@ public:
     // must increase the control to avoid entering infinite recursion, otherwise it may cause crash or stuck,
     void consume(int64_t size);
 
-    // Will not change the value of process_mem_tracker, even though mem_tracker == process_mem_tracker.
-    void transfer_to(int64_t size, MemTrackerLimiter* mem_tracker) {
-        consume(-size);
-        mem_tracker->consume_cache(size);
-    }
-    void transfer_from(int64_t size, MemTrackerLimiter* mem_tracker) {
-        mem_tracker->consume_cache(-size);
-        consume(size);
-    }
-
     template <bool CheckLimit>
     void flush_untracked_mem();
 

--- a/be/src/runtime/thread_context.h
+++ b/be/src/runtime/thread_context.h
@@ -256,10 +256,12 @@ public:
     doris::thread_context()->_thread_mem_tracker_mgr->consume(size)
 #define RELEASE_THREAD_MEM_TRACKER(size) \
     doris::thread_context()->_thread_mem_tracker_mgr->consume(-size)
-#define THREAD_MEM_TRACKER_TRANSFER_TO(size, tracker) \
-    doris::thread_context()->_thread_mem_tracker_mgr->transfer_to(size, tracker)
+#define THREAD_MEM_TRACKER_TRANSFER_TO(size, tracker)                                          \
+    doris::thread_context()->_thread_mem_tracker_mgr->limiter_mem_tracker()->transfer_to(size, \
+                                                                                         tracker)
 #define THREAD_MEM_TRACKER_TRANSFER_FROM(size, tracker) \
-    doris::thread_context()->_thread_mem_tracker_mgr->transfer_from(size, tracker)
+    tracker->transfer_to(                               \
+            size, doris::thread_context()->_thread_mem_tracker_mgr->limiter_mem_tracker().get())
 #define RETURN_LIMIT_EXCEEDED(state, msg, ...)                                              \
     return doris::thread_context()                                                          \
             ->_thread_mem_tracker_mgr->limiter_mem_tracker()                                \

--- a/be/src/vec/common/pod_array.h
+++ b/be/src/vec/common/pod_array.h
@@ -113,7 +113,7 @@ protected:
     }
 
     inline void reset_peak() {
-        if (UNLIKELY(c_end - c_end_peak > 1024)) {
+        if (UNLIKELY(c_end - c_end_peak > 4096)) {
             THREAD_MEM_TRACKER_TRANSFER_FROM(c_end - c_end_peak,
                                              ExecEnv::GetInstance()->process_mem_tracker().get());
             c_end_peak = c_end;


### PR DESCRIPTION
# Proposed changes

Issue Number: close #12019

## Problem summary

1. Transfer to between mem tracke limiters, no longer consume process mem tracker.
2. Change `consume_local` to `cache_consume_local`.
3. The threshold of PodArray `reset_peak` is changed to 4096.
4. `process_mem_tracker` is no longer used to limit memory, mem limit is changed to -1,

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
5. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
6. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

