### PR TITLE
[Fix](load) Report brpc port of single replica load to FE

### DIFF
--- a/be/src/agent/heartbeat_server.cpp
+++ b/be/src/agent/heartbeat_server.cpp
@@ -71,6 +71,8 @@ void HeartbeatServer::heartbeat(THeartbeatResult& heartbeat_result,
         heartbeat_result.backend_info.__set_brpc_port(config::brpc_port);
         heartbeat_result.backend_info.__set_version(get_short_version());
         heartbeat_result.backend_info.__set_be_start_time(_be_epoch);
+        heartbeat_result.backend_info.__set_single_replica_load_brpc_port(
+                config::single_replica_load_brpc_port);
     }
 }
 

--- a/be/src/exec/tablet_info.h
+++ b/be/src/exec/tablet_info.h
@@ -341,6 +341,7 @@ struct NodeInfo {
     int64_t option;
     std::string host;
     int32_t brpc_port;
+    int32_t single_replica_load_brpc_port;
 
     NodeInfo() = default;
 
@@ -348,7 +349,8 @@ struct NodeInfo {
             : id(tnode.id),
               option(tnode.option),
               host(tnode.host),
-              brpc_port(tnode.async_internal_port) {}
+              brpc_port(tnode.async_internal_port),
+              single_replica_load_brpc_port(tnode.single_replica_load_brpc_port) {}
 };
 
 class DorisNodesInfo {

--- a/be/src/exec/tablet_sink.cpp
+++ b/be/src/exec/tablet_sink.cpp
@@ -545,7 +545,7 @@ void NodeChannel::try_send_batch(RuntimeState* state) {
                     pnode->set_id(node->id);
                     pnode->set_option(node->option);
                     pnode->set_host(node->host);
-                    pnode->set_async_internal_port(config::single_replica_load_brpc_port);
+                    pnode->set_async_internal_port(node->single_replica_load_brpc_port);
                 }
                 request.mutable_slave_tablet_nodes()->insert({iter->first, slave_tablet_nodes});
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/OlapTableSink.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/OlapTableSink.java
@@ -392,7 +392,9 @@ public class OlapTableSink extends DataSink {
         SystemInfoService systemInfoService = Env.getCurrentSystemInfo();
         for (Long id : systemInfoService.getBackendIds(false)) {
             Backend backend = systemInfoService.getBackend(id);
-            nodesInfo.addToNodes(new TNodeInfo(backend.getId(), 0, backend.getHost(), backend.getBrpcPort()));
+            TNodeInfo nodeInfo = new TNodeInfo(backend.getId(), 0, backend.getHost(), backend.getBrpcPort());
+            nodeInfo.setSingleReplicaLoadBrpcPort(backend.getSingleReplicaLoadBrpcPort());
+            nodesInfo.addToNodes(nodeInfo);
         }
         return nodesInfo;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/system/Backend.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/system/Backend.java
@@ -128,6 +128,8 @@ public class Backend implements Writable {
     @SerializedName("tagMap")
     private Map<String, String> tagMap = Maps.newHashMap();
 
+    private volatile int singleReplicaLoadBrpcPort = -1; // brpc port for single replica load to notify slave replica
+
     public Backend() {
         this.host = "";
         this.version = "";
@@ -198,6 +200,10 @@ public class Backend implements Writable {
 
     public int getBrpcPort() {
         return brpcPort;
+    }
+
+    public int getSingleReplicaLoadBrpcPort() {
+        return singleReplicaLoadBrpcPort;
     }
 
     public String getHeartbeatErrMsg() {
@@ -283,6 +289,10 @@ public class Backend implements Writable {
 
     public void setBrpcPort(int brpcPort) {
         this.brpcPort = brpcPort;
+    }
+
+    public void setSingleReplicaLoadBrpcPort(int singleReplicaLoadBrpcPort) {
+        this.singleReplicaLoadBrpcPort = singleReplicaLoadBrpcPort;
     }
 
     public long getLastUpdateMs() {
@@ -672,6 +682,12 @@ public class Backend implements Writable {
                 this.isAlive.set(true);
             } else if (this.lastStartTime <= 0) {
                 this.lastStartTime = hbResponse.getBeStartTime();
+            }
+
+            if (this.singleReplicaLoadBrpcPort != hbResponse.getSingleReplicaLoadBrpcPort()
+                    && !FeConstants.runningUnitTest) {
+                isChanged = true;
+                this.singleReplicaLoadBrpcPort = hbResponse.getSingleReplicaLoadBrpcPort();
             }
 
             heartbeatErrMsg = "";

--- a/fe/fe-core/src/main/java/org/apache/doris/system/BackendHbResponse.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/system/BackendHbResponse.java
@@ -31,6 +31,7 @@ public class BackendHbResponse extends HeartbeatResponse implements Writable {
     private int bePort;
     private int httpPort;
     private int brpcPort;
+    private int singleReplicaLoadBrpcPort;
     private long beStartTime;
     private String host;
     private String version = "";
@@ -39,7 +40,7 @@ public class BackendHbResponse extends HeartbeatResponse implements Writable {
         super(HeartbeatResponse.Type.BACKEND);
     }
 
-    public BackendHbResponse(long beId, int bePort, int httpPort, int brpcPort,
+    public BackendHbResponse(long beId, int bePort, int httpPort, int brpcPort, int singleReplicaLoadBrpcPort,
             long hbTime, long beStartTime, String version) {
         super(HeartbeatResponse.Type.BACKEND);
         this.beId = beId;
@@ -47,6 +48,7 @@ public class BackendHbResponse extends HeartbeatResponse implements Writable {
         this.bePort = bePort;
         this.httpPort = httpPort;
         this.brpcPort = brpcPort;
+        this.singleReplicaLoadBrpcPort = singleReplicaLoadBrpcPort;
         this.hbTime = hbTime;
         this.beStartTime = beStartTime;
         this.version = version;
@@ -81,6 +83,10 @@ public class BackendHbResponse extends HeartbeatResponse implements Writable {
 
     public int getBrpcPort() {
         return brpcPort;
+    }
+
+    public int getSingleReplicaLoadBrpcPort() {
+        return singleReplicaLoadBrpcPort;
     }
 
     public long getBeStartTime() {

--- a/fe/fe-core/src/main/java/org/apache/doris/system/HeartbeatMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/system/HeartbeatMgr.java
@@ -245,6 +245,10 @@ public class HeartbeatMgr extends MasterDaemon {
                     if (tBackendInfo.isSetBrpcPort()) {
                         brpcPort = tBackendInfo.getBrpcPort();
                     }
+                    int singleReplicaLoadBrpcPort = -1;
+                    if (tBackendInfo.isSetSingleReplicaLoadBrpcPort()) {
+                        singleReplicaLoadBrpcPort = tBackendInfo.getSingleReplicaLoadBrpcPort();
+                    }
                     String version = "";
                     if (tBackendInfo.isSetVersion()) {
                         version = tBackendInfo.getVersion();
@@ -252,7 +256,7 @@ public class HeartbeatMgr extends MasterDaemon {
                     long beStartTime = tBackendInfo.isSetBeStartTime()
                             ? tBackendInfo.getBeStartTime() : System.currentTimeMillis();
                     // backend.updateOnce(bePort, httpPort, beRpcPort, brpcPort);
-                    return new BackendHbResponse(backendId, bePort, httpPort, brpcPort,
+                    return new BackendHbResponse(backendId, bePort, httpPort, brpcPort, singleReplicaLoadBrpcPort,
                             System.currentTimeMillis(), beStartTime, version);
                 } else {
                     return new BackendHbResponse(backendId, backend.getHost(),

--- a/gensrc/thrift/Descriptors.thrift
+++ b/gensrc/thrift/Descriptors.thrift
@@ -214,6 +214,7 @@ struct TNodeInfo {
     3: required string host
     // used to transfer data between nodes
     4: required i32 async_internal_port
+    5: optional i32 single_replica_load_brpc_port
 }
 
 struct TPaloNodesInfo {

--- a/gensrc/thrift/HeartbeatService.thrift
+++ b/gensrc/thrift/HeartbeatService.thrift
@@ -42,6 +42,7 @@ struct TBackendInfo {
     4: optional Types.TPort brpc_port
     5: optional string version
     6: optional i64 be_start_time
+    7: optional Types.TPort single_replica_load_brpc_port
 }
 
 struct THeartbeatResult {


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

Master replica will notify slave replicas through local brpc port (default `8070`) for single replica load. If the brpc port of single replica load are inconsistent between different BE, the function of single replica load will get into trouble. It's necessary to report brpc port of single replica load to FE so that master replica would know accurate brpc port of BE that slave replica locates on during generating load plan.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No
