### PR TITLE
[dev-1.1.2](cherry-pick) Fix ctas default timestamp insert error

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Catalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Catalog.java
@@ -3152,7 +3152,11 @@ public class Catalog {
                     } else {
                         defaultValue = new DefaultValue(setDefault, column.getDefaultValue());
                     }
-                    columnDef = new ColumnDef(name, typeDef, column.isKey(), column.getAggregationType(),
+                    // AggregateType.NONE cause the table to change to the AGGREGATE KEY when analyze is used,
+                    // cause CURRENT_TIMESTAMP to report an error.
+                    columnDef = new ColumnDef(name, typeDef, column.isKey(),
+                            AggregateType.NONE.equals(column.getAggregationType())
+                                    ? null : column.getAggregationType(),
                             column.isAllowNull(), defaultValue, column.getComment());
                 }
                 createTableStmt.addColumnDef(columnDef);


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

https://github.com/apache/doris/pull/12056

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

