### PR TITLE
[fix](scan) use serial scan thread token only for scan node

### DIFF
--- a/be/src/runtime/fragment_mgr.cpp
+++ b/be/src/runtime/fragment_mgr.cpp
@@ -654,6 +654,10 @@ Status FragmentMgr::exec_plan_fragment(const TExecPlanFragmentParams& params, Fi
         if (params.__isset.fragment && params.fragment.__isset.plan &&
             params.fragment.plan.nodes.size() > 0) {
             for (auto& node : params.fragment.plan.nodes) {
+                // Only for SCAN NODE
+                if (!_is_scan_node(node.node_type)) {
+                    continue;
+                }
                 if (node.limit > 0 && node.limit < 1024) {
                     concurrency = 1;
                     is_serial = true;
@@ -715,6 +719,19 @@ Status FragmentMgr::exec_plan_fragment(const TExecPlanFragmentParams& params, Fi
     }
 
     return Status::OK();
+}
+
+bool FragmentMgr::_is_scan_node(const TPlanNodeType::type& type) {
+    return type == TPlanNodeType::OLAP_SCAN_NODE
+        || type == TPlanNodeType::MYSQL_SCAN_NODE
+        || type == TPlanNodeType::SCHEMA_SCAN_NODE
+        || type == TPlanNodeType::META_SCAN_NODE
+        || type == TPlanNodeType::BROKER_SCAN_NODE
+        || type == TPlanNodeType::ES_SCAN_NODE
+        || type == TPlanNodeType::ES_HTTP_SCAN_NODE
+        || type == TPlanNodeType::ODBC_SCAN_NODE
+        || type == TPlanNodeType::TABLE_VALUED_FUNCTION_SCAN_NODE
+        || type == TPlanNodeType::FILE_SCAN_NODE;
 }
 
 Status FragmentMgr::cancel(const TUniqueId& fragment_id, const PPlanFragmentCancelReason& reason,

--- a/be/src/runtime/fragment_mgr.cpp
+++ b/be/src/runtime/fragment_mgr.cpp
@@ -722,16 +722,12 @@ Status FragmentMgr::exec_plan_fragment(const TExecPlanFragmentParams& params, Fi
 }
 
 bool FragmentMgr::_is_scan_node(const TPlanNodeType::type& type) {
-    return type == TPlanNodeType::OLAP_SCAN_NODE
-        || type == TPlanNodeType::MYSQL_SCAN_NODE
-        || type == TPlanNodeType::SCHEMA_SCAN_NODE
-        || type == TPlanNodeType::META_SCAN_NODE
-        || type == TPlanNodeType::BROKER_SCAN_NODE
-        || type == TPlanNodeType::ES_SCAN_NODE
-        || type == TPlanNodeType::ES_HTTP_SCAN_NODE
-        || type == TPlanNodeType::ODBC_SCAN_NODE
-        || type == TPlanNodeType::TABLE_VALUED_FUNCTION_SCAN_NODE
-        || type == TPlanNodeType::FILE_SCAN_NODE;
+    return type == TPlanNodeType::OLAP_SCAN_NODE || type == TPlanNodeType::MYSQL_SCAN_NODE ||
+           type == TPlanNodeType::SCHEMA_SCAN_NODE || type == TPlanNodeType::META_SCAN_NODE ||
+           type == TPlanNodeType::BROKER_SCAN_NODE || type == TPlanNodeType::ES_SCAN_NODE ||
+           type == TPlanNodeType::ES_HTTP_SCAN_NODE || type == TPlanNodeType::ODBC_SCAN_NODE ||
+           type == TPlanNodeType::TABLE_VALUED_FUNCTION_SCAN_NODE ||
+           type == TPlanNodeType::FILE_SCAN_NODE;
 }
 
 Status FragmentMgr::cancel(const TUniqueId& fragment_id, const PPlanFragmentCancelReason& reason,

--- a/be/src/runtime/fragment_mgr.h
+++ b/be/src/runtime/fragment_mgr.h
@@ -96,6 +96,8 @@ public:
 private:
     void _exec_actual(std::shared_ptr<FragmentExecState> exec_state, FinishCallback cb);
 
+    bool _is_scan_node(const TPlanNodeType::type& type);
+
     // This is input params
     ExecEnv* _exec_env;
 


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

Only the scan node's limit is less than 1024, we can use serial thread token to submit scanners.
Or it will slow down the query.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

