### PR TITLE
[fix](array-type) adjust enable_array_type config

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateTableStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateTableStmt.java
@@ -389,6 +389,9 @@ public class CreateTableStmt extends DdlStmt {
             columnDef.analyze(engineName.equals("olap"));
 
             if (columnDef.getType().isArrayType()) {
+                if (!Config.enable_array_type) {
+                    throw new AnalysisException("Please open enable_array_type config before use Array.");
+                }
                 if (columnDef.getAggregateType() != null && columnDef.getAggregateType() != AggregateType.NONE) {
                     throw new AnalysisException("Array column can't support aggregation "
                             + columnDef.getAggregateType());

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/ArrayType.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/ArrayType.java
@@ -155,9 +155,6 @@ public class ArrayType extends Type {
 
     @Override
     public boolean isSupported() {
-        if (!Config.enable_array_type) {
-            return false;
-        }
         return !itemType.isNull();
     }
 
@@ -180,7 +177,7 @@ public class ArrayType extends Type {
 
     @Override
     public boolean supportsTablePartitioning() {
-        return isSupported() && !isComplexType();
+        return false;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/ArrayType.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/ArrayType.java
@@ -17,7 +17,6 @@
 
 package org.apache.doris.catalog;
 
-import org.apache.doris.common.Config;
 import org.apache.doris.thrift.TColumnType;
 import org.apache.doris.thrift.TTypeDesc;
 import org.apache.doris.thrift.TTypeNode;


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary
Problem:
1. `enable_array_type` is masterOnly;
2. dynamic open config only affect FE MASTER
`admin set frontend config("enable_array_type"="true");`
3. query in FE FOLLOWER will fail, because of `enable_array_type` is false in FE FOLLOWER
`select * from table_with_array `

Solution:
Only check `enable_array_type` while creating new tables with array column.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
6. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
7. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
8. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
9. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

