### PR TITLE
[fix](array-type) array can not be distributed key and aggregation key

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/HashDistributionDesc.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/HashDistributionDesc.java
@@ -80,6 +80,9 @@ public class HashDistributionDesc extends DistributionDesc {
                     if (columnDef.getType().isScalarType(PrimitiveType.STRING)) {
                         throw new AnalysisException("String Type should not be used in distribution column["
                                 + columnDef.getName() + "].");
+                    } else if (columnDef.getType().isArrayType()) {
+                        throw new AnalysisException("Array Type should not be used in distribution column["
+                                + columnDef.getName() + "].");
                     }
                 }
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/HashDistributionDesc.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/HashDistributionDesc.java
@@ -75,17 +75,6 @@ public class HashDistributionDesc extends DistributionDesc {
             if (!distColSet.add(columnName)) {
                 throw new AnalysisException("Duplicated distribution column " + columnName);
             }
-            for (ColumnDef columnDef : columnDefs) {
-                if (columnDef.getName().equals(columnName)) {
-                    if (columnDef.getType().isScalarType(PrimitiveType.STRING)) {
-                        throw new AnalysisException("String Type should not be used in distribution column["
-                                + columnDef.getName() + "].");
-                    } else if (columnDef.getType().isArrayType()) {
-                        throw new AnalysisException("Array Type should not be used in distribution column["
-                                + columnDef.getName() + "].");
-                    }
-                }
-            }
         }
     }
 
@@ -124,8 +113,15 @@ public class HashDistributionDesc extends DistributionDesc {
                         throw new DdlException("Distribution column[" + colName + "] is not key column");
                     }
 
-                    if (column.getType().isFloatingPointType()) {
-                        throw new DdlException("Floating point type column can not be distribution column");
+                    if (column.getType().isScalarType(PrimitiveType.STRING)) {
+                        throw new DdlException("String Type should not be used in distribution column["
+                                + column.getName() + "].");
+                    } else if (column.getType().isArrayType()) {
+                        throw new DdlException("Array Type should not be used in distribution column["
+                                + column.getName() + "].");
+                    } else if (column.getType().isFloatingPointType()) {
+                        throw new DdlException("Floating point type should not be used in distribution column["
+                                + column.getName() + "].");
                     }
 
                     distributionColumns.add(column);

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Type.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Type.java
@@ -270,14 +270,12 @@ public abstract class Type {
     // 3. don't support group by
     // 4. don't support index
     public boolean isOnlyMetricType() {
-        // now only_metric_type is the same to object_stored_type
-        // but actually they are not same in semantics.
-        return isObjectStored();
+        return isObjectStored() || isArrayType();
     }
 
     public static final String OnlyMetricTypeErrorMsg =
-            "Doris hll and bitmap column must use with specific function, and don't support filter or group by."
-                    + "please run 'help hll' or 'help bitmap' in your mysql client.";
+            "Doris hll, bitmap and array column must use with specific function, and don't support filter or group by."
+                    + "please run 'help hll' or 'help bitmap' or 'help array' in your mysql client.";
 
     public boolean isHllType() {
         return isScalarType(PrimitiveType.HLL);

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/CreateTableTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/CreateTableTest.java
@@ -230,7 +230,7 @@ public class CreateTableTest {
     @Test
     public void testAbnormal() throws DdlException {
         ExceptionChecker.expectThrowsWithMsg(DdlException.class,
-                "Floating point type column can not be distribution column",
+                "Floating point type should not be used in distribution column",
                 () -> createTable("create table test.atbl1\n" + "(k1 int, k2 float)\n" + "duplicate key(k1)\n"
                         + "distributed by hash(k2) buckets 1\n" + "properties('replication_num' = '1'); "));
 


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

Array column should not be `distributed key` or `group by` or `aggregate key`, we should forbid it before create table.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [x] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

