### PR TITLE
 [fix](planner) fix orthogonal_bitmap_union_count plan : wrong PREAGGREGATION

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/planner/SingleNodePlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/SingleNodePlanner.java
@@ -550,8 +550,11 @@ public class SingleNodePlanner {
                     if (col == null) {
                         continue;
                     }
+
+                    String functionName = aggExpr.getFnName().getFunction();
+
                     if (col.isKey()) {
-                        if ((!aggExpr.getFnName().getFunction().equalsIgnoreCase("MAX"))
+                        if ((!functionName.equalsIgnoreCase("MAX"))
                                 && (!aggExpr.getFnName().getFunction().equalsIgnoreCase("MIN"))) {
                             returnColumnValidate = false;
                             turnOffReason = "the type of agg on StorageEngine's Key column should only be MAX or MIN."
@@ -560,57 +563,57 @@ public class SingleNodePlanner {
                         }
                     }
 
-                    if (aggExpr.getFnName().getFunction().equalsIgnoreCase("SUM")) {
+                    if (functionName.equalsIgnoreCase("SUM")) {
                         if (col.getAggregationType() != AggregateType.SUM) {
                             turnOffReason = "Aggregate Operator not match: SUM <--> " + col.getAggregationType();
                             returnColumnValidate = false;
                             break;
                         }
-                    } else if (aggExpr.getFnName().getFunction().equalsIgnoreCase("MAX")) {
+                    } else if (functionName.equalsIgnoreCase("MAX")) {
                         if ((!col.isKey()) && col.getAggregationType() != AggregateType.MAX) {
                             turnOffReason = "Aggregate Operator not match: MAX <--> " + col.getAggregationType();
                             returnColumnValidate = false;
                             break;
                         }
-                    } else if (aggExpr.getFnName().getFunction().equalsIgnoreCase("MIN")) {
+                    } else if (functionName.equalsIgnoreCase("MIN")) {
                         if ((!col.isKey()) && col.getAggregationType() != AggregateType.MIN) {
                             turnOffReason = "Aggregate Operator not match: MIN <--> " + col.getAggregationType();
                             returnColumnValidate = false;
                             break;
                         }
-                    } else if (aggExpr.getFnName().getFunction().equalsIgnoreCase("HLL_UNION_AGG")) {
+                    } else if (functionName.equalsIgnoreCase("HLL_UNION_AGG")) {
                         // do nothing
-                    } else if (aggExpr.getFnName().getFunction().equalsIgnoreCase("HLL_RAW_AGG")) {
+                    } else if (functionName.equalsIgnoreCase("HLL_RAW_AGG")) {
                         // do nothing
-                    } else if (aggExpr.getFnName().getFunction().equalsIgnoreCase("NDV")) {
+                    } else if (functionName.equalsIgnoreCase("NDV")) {
                         if ((!col.isKey())) {
                             turnOffReason = "NDV function with non-key column: " + col.getName();
                             returnColumnValidate = false;
                             break;
                         }
-                    } else if (aggExpr.getFnName().getFunction().equalsIgnoreCase(FunctionSet.BITMAP_UNION_INT)) {
+                    } else if (functionName.equalsIgnoreCase(FunctionSet.BITMAP_UNION_INT)) {
                         if ((!col.isKey())) {
                             turnOffReason = "BITMAP_UNION_INT function with non-key column: " + col.getName();
                             returnColumnValidate = false;
                             break;
                         }
-                    } else if (aggExpr.getFnName().getFunction().equalsIgnoreCase(FunctionSet.BITMAP_UNION)
-                            || aggExpr.getFnName().getFunction().equalsIgnoreCase(FunctionSet.BITMAP_UNION_COUNT)
-                            || aggExpr.getFnName().getFunction().equalsIgnoreCase(FunctionSet.ORTHOGONAL_BITMAP_UNION_COUNT)) {
+                    } else if (functionName.equalsIgnoreCase(FunctionSet.BITMAP_UNION)
+                            || functionName.equalsIgnoreCase(FunctionSet.BITMAP_UNION_COUNT)
+                            || functionName.equalsIgnoreCase(FunctionSet.ORTHOGONAL_BITMAP_UNION_COUNT)) {
                         if (col.getAggregationType() != AggregateType.BITMAP_UNION) {
                             turnOffReason =
                                     "Aggregate Operator not match: BITMAP_UNION <--> " + col.getAggregationType();
                             returnColumnValidate = false;
                             break;
                         }
-                    } else if (aggExpr.getFnName().getFunction().equalsIgnoreCase(FunctionSet.QUANTILE_UNION)) {
+                    } else if (functionName.equalsIgnoreCase(FunctionSet.QUANTILE_UNION)) {
                         if (col.getAggregationType() != AggregateType.QUANTILE_UNION) {
                             turnOffReason =
                                     "Aggregate Operator not match: QUANTILE_UNION <---> " + col.getAggregationType();
                             returnColumnValidate = false;
                             break;
                         }
-                    } else if (aggExpr.getFnName().getFunction().equalsIgnoreCase("multi_distinct_count")) {
+                    } else if (functionName.equalsIgnoreCase("multi_distinct_count")) {
                         // count(distinct k1), count(distinct k2) / count(distinct k1,k2) can turn on pre aggregation
                         if ((!col.isKey())) {
                             turnOffReason = "Multi count or sum distinct with non-key column: " + col.getName();
@@ -618,7 +621,7 @@ public class SingleNodePlanner {
                             break;
                         }
                     } else {
-                        turnOffReason = "Invalid Aggregate Operator: " + aggExpr.getFnName().getFunction();
+                        turnOffReason = "Invalid Aggregate Operator: " + functionName;
                         returnColumnValidate = false;
                         break;
                     }

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/SingleNodePlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/SingleNodePlanner.java
@@ -595,7 +595,8 @@ public class SingleNodePlanner {
                             break;
                         }
                     } else if (aggExpr.getFnName().getFunction().equalsIgnoreCase(FunctionSet.BITMAP_UNION)
-                            || aggExpr.getFnName().getFunction().equalsIgnoreCase(FunctionSet.BITMAP_UNION_COUNT)) {
+                            || aggExpr.getFnName().getFunction().equalsIgnoreCase(FunctionSet.BITMAP_UNION_COUNT)
+                            || aggExpr.getFnName().getFunction().equalsIgnoreCase(FunctionSet.ORTHOGONAL_BITMAP_UNION_COUNT)) {
                         if (col.getAggregationType() != AggregateType.BITMAP_UNION) {
                             turnOffReason =
                                     "Aggregate Operator not match: BITMAP_UNION <--> " + col.getAggregationType();

--- a/fe/fe-core/src/test/java/org/apache/doris/planner/QueryPlanTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/planner/QueryPlanTest.java
@@ -2178,21 +2178,21 @@ public class QueryPlanTest extends TestWithFeService {
     public void testOrthogonalBitmapUnionCountUDAFcanHitRollup() throws Exception {
         connectContext.setDatabase("default_cluster:test");
         createTable("CREATE TABLE test.bitmap_tb (\n"
-            + "  `id` int(11) NULL COMMENT \"\",\n"
-            + "  `id2` int(11) NULL COMMENT \"\",\n"
-            + "  `id3` bitmap bitmap_union NULL\n"
-            + ") ENGINE=OLAP\n"
-            + "AGGREGATE KEY(`id`,`id2`)\n"
-            + "DISTRIBUTED BY HASH(`id`) BUCKETS 1\n"
-            + "PROPERTIES (\n"
-            + " \"replication_num\" = \"1\"\n"
-            + ");");
+                + "  `id` int(11) NULL COMMENT \"\",\n"
+                + "  `id2` int(11) NULL COMMENT \"\",\n"
+                + "  `id3` bitmap bitmap_union NULL\n"
+                + ") ENGINE=OLAP\n"
+                + "AGGREGATE KEY(`id`,`id2`)\n"
+                + "DISTRIBUTED BY HASH(`id`) BUCKETS 1\n"
+                + "PROPERTIES (\n"
+                + " \"replication_num\" = \"1\"\n"
+                + ");");
 
         // String insertTableSql = "insert into test.bitmap_tb select 1 as id, 2 as id2, to_bitmap(3) as id3";
         //getSqlStmtExecutor(insertTableSql).execute();
 
         String createRollupSql = "alter TABLE test.bitmap_tb add rollup bitmap_tb_rollup(`id`,`id3`)";
-        AlterTableStmt alterTableStmt = (AlterTableStmt)parseAndAnalyzeStmt(createRollupSql);
+        AlterTableStmt alterTableStmt = (AlterTableStmt) parseAndAnalyzeStmt(createRollupSql);
         Catalog.getCurrentCatalog().getAlterInstance().processAlterTable(alterTableStmt);
 
         Map<Long, AlterJobV2> alterJobs = Catalog.getCurrentCatalog().getMaterializedViewHandler().getAlterJobsV2();
@@ -2202,7 +2202,7 @@ public class QueryPlanTest extends TestWithFeService {
             }
             while (!alterJobV2.getJobState().isFinalState()) {
                 System.out.println(
-                    "rollup job " + alterJobV2.getJobId() + " is running. state: " + alterJobV2.getJobState());
+                        "rollup job " + alterJobV2.getJobId() + " is running. state: " + alterJobV2.getJobState());
                 Thread.sleep(5000);
             }
             System.out.println("rollup job " + alterJobV2.getJobId() + " is done. state: " + alterJobV2.getJobState());

--- a/fe/fe-core/src/test/java/org/apache/doris/planner/QueryPlanTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/planner/QueryPlanTest.java
@@ -2172,15 +2172,15 @@ public class QueryPlanTest extends TestWithFeService {
     public void testPreaggregationOfOrthogonalBitmapUDAF() throws Exception {
         connectContext.setDatabase("default_cluster:test");
         createTable("CREATE TABLE test.bitmap_tb (\n"
-            + "  `id` int(11) NULL COMMENT \"\",\n"
-            + "  `id2` int(11) NULL COMMENT \"\",\n"
-            + "  `id3` bitmap bitmap_union NULL\n"
-            + ") ENGINE=OLAP\n"
-            + "AGGREGATE KEY(`id`,`id2`)\n"
-            + "DISTRIBUTED BY HASH(`id`) BUCKETS 1\n"
-            + "PROPERTIES (\n"
-            + " \"replication_num\" = \"1\"\n"
-            + ");");
+                + "  `id` int(11) NULL COMMENT \"\",\n"
+                + "  `id2` int(11) NULL COMMENT \"\",\n"
+                + "  `id3` bitmap bitmap_union NULL\n"
+                + ") ENGINE=OLAP\n"
+                + "AGGREGATE KEY(`id`,`id2`)\n"
+                + "DISTRIBUTED BY HASH(`id`) BUCKETS 1\n"
+                + "PROPERTIES (\n"
+                + " \"replication_num\" = \"1\"\n"
+                + ");");
 
         String queryBaseTableStr = "explain select id,id2,orthogonal_bitmap_union_count(id3) from test.bitmap_tb t1 group by id,id2";
         String explainString1 = getSQLPlanOrErrorMsg(queryBaseTableStr);

--- a/fe/fe-core/src/test/java/org/apache/doris/planner/QueryPlanTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/planner/QueryPlanTest.java
@@ -2168,56 +2168,26 @@ public class QueryPlanTest extends TestWithFeService {
                 + "but corresponding column is k2 in the previous columns declaration."));
     }
 
-    /*
-     At present, after the doris olap table writes data, it can test whether the rollup is hit,
-     but in the unit test environment, be cannot write data, so it cannot be tested.
-     The alternative is to determine whether pre-aggregation is turned on.
-     However, in the normal environment of doris, it can hit rollup
-    */
     @Test
-    public void testOrthogonalBitmapUnionCountUDAFcanHitRollup() throws Exception {
+    public void testPreaggregationOfOrthogonalBitmapUDAF() throws Exception {
         connectContext.setDatabase("default_cluster:test");
         createTable("CREATE TABLE test.bitmap_tb (\n"
-                + "  `id` int(11) NULL COMMENT \"\",\n"
-                + "  `id2` int(11) NULL COMMENT \"\",\n"
-                + "  `id3` bitmap bitmap_union NULL\n"
-                + ") ENGINE=OLAP\n"
-                + "AGGREGATE KEY(`id`,`id2`)\n"
-                + "DISTRIBUTED BY HASH(`id`) BUCKETS 1\n"
-                + "PROPERTIES (\n"
-                + " \"replication_num\" = \"1\"\n"
-                + ");");
-
-        // String insertTableSql = "insert into test.bitmap_tb select 1 as id, 2 as id2, to_bitmap(3) as id3";
-        //getSqlStmtExecutor(insertTableSql).execute();
-
-        String createRollupSql = "alter TABLE test.bitmap_tb add rollup bitmap_tb_rollup(`id`,`id3`)";
-        AlterTableStmt alterTableStmt = (AlterTableStmt) parseAndAnalyzeStmt(createRollupSql);
-        Catalog.getCurrentCatalog().getAlterInstance().processAlterTable(alterTableStmt);
-
-        Map<Long, AlterJobV2> alterJobs = Catalog.getCurrentCatalog().getMaterializedViewHandler().getAlterJobsV2();
-        for (AlterJobV2 alterJobV2 : alterJobs.values()) {
-            if (alterJobV2.getType() != AlterJobV2.JobType.ROLLUP) {
-                continue;
-            }
-            while (!alterJobV2.getJobState().isFinalState()) {
-                System.out.println(
-                        "rollup job " + alterJobV2.getJobId() + " is running. state: " + alterJobV2.getJobState());
-                Thread.sleep(5000);
-            }
-            System.out.println("rollup job " + alterJobV2.getJobId() + " is done. state: " + alterJobV2.getJobState());
-            Assert.assertEquals(AlterJobV2.JobState.FINISHED, alterJobV2.getJobState());
-        }
+            + "  `id` int(11) NULL COMMENT \"\",\n"
+            + "  `id2` int(11) NULL COMMENT \"\",\n"
+            + "  `id3` bitmap bitmap_union NULL\n"
+            + ") ENGINE=OLAP\n"
+            + "AGGREGATE KEY(`id`,`id2`)\n"
+            + "DISTRIBUTED BY HASH(`id`) BUCKETS 1\n"
+            + "PROPERTIES (\n"
+            + " \"replication_num\" = \"1\"\n"
+            + ");");
 
         String queryBaseTableStr = "explain select id,id2,orthogonal_bitmap_union_count(id3) from test.bitmap_tb t1 group by id,id2";
         String explainString1 = getSQLPlanOrErrorMsg(queryBaseTableStr);
         Assert.assertTrue(explainString1.contains("PREAGGREGATION: ON"));
 
-        String queryRollupTableStr = "explain select id,orthogonal_bitmap_union_count(id3) from test.bitmap_tb t1 group by id";
-        String explainString2 = getSQLPlanOrErrorMsg(queryRollupTableStr);
+        String queryTableStr = "explain select id,orthogonal_bitmap_union_count(id3) from test.bitmap_tb t1 group by id";
+        String explainString2 = getSQLPlanOrErrorMsg(queryTableStr);
         Assert.assertTrue(explainString2.contains("PREAGGREGATION: ON"));
-
-        //Assert.assertTrue(explainString2.contains("rollup: bitmap_tb_rollup"));
-        //Assert.assertTrue(explainString1.contains("rollup: bitmap_tb"));
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/planner/QueryPlanTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/planner/QueryPlanTest.java
@@ -2177,16 +2177,16 @@ public class QueryPlanTest extends TestWithFeService {
     @Test
     public void testOrthogonalBitmapUnionCountUDAFcanHitRollup() throws Exception {
         connectContext.setDatabase("default_cluster:test");
-        createTable("CREATE TABLE test.bitmap_tb (\n" +
-            "  `id` int(11) NULL COMMENT \"\",\n" +
-            "  `id2` int(11) NULL COMMENT \"\",\n" +
-            "  `id3` bitmap bitmap_union NULL\n" +
-            ") ENGINE=OLAP\n" +
-            "AGGREGATE KEY(`id`,`id2`)\n" +
-            "DISTRIBUTED BY HASH(`id`) BUCKETS 1\n" +
-            "PROPERTIES (\n" +
-            " \"replication_num\" = \"1\"\n" +
-            ");");
+        createTable("CREATE TABLE test.bitmap_tb (\n"
+            + "  `id` int(11) NULL COMMENT \"\",\n"
+            + "  `id2` int(11) NULL COMMENT \"\",\n"
+            + "  `id3` bitmap bitmap_union NULL\n"
+            + ") ENGINE=OLAP\n"
+            + "AGGREGATE KEY(`id`,`id2`)\n"
+            + "DISTRIBUTED BY HASH(`id`) BUCKETS 1\n"
+            + "PROPERTIES (\n"
+            + " \"replication_num\" = \"1\"\n"
+            + ");");
 
         // String insertTableSql = "insert into test.bitmap_tb select 1 as id, 2 as id2, to_bitmap(3) as id3";
         //getSqlStmtExecutor(insertTableSql).execute();


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

Execution plan display when using orthogonal_bitmap_union_count function: 

- PREAGGREGATION: OFF

- Reason: Invalid Aggregate Operator: orthogonal_bitmap_union_count

The correct plan is: PREAGGREGATION: ON

![image](https://user-images.githubusercontent.com/35155212/188358618-093b942a-803f-42e2-8fdb-48378606f657.png)
[](url)

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [x] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

