### PR TITLE
[refactor](BE) return error status when vslot_ref contains invalid slot_id

### DIFF
--- a/be/src/vec/exprs/vslot_ref.cpp
+++ b/be/src/vec/exprs/vslot_ref.cpp
@@ -52,8 +52,7 @@ Status VSlotRef::prepare(doris::RuntimeState* state, const doris::RowDescriptor&
     }
     _column_id = desc.get_column_id(_slot_id);
     if (_column_id < 0) {
-        LOG(INFO) << "VSlotRef - invalid slot id: " << _slot_id 
-                  << " desc:" << desc.debug_string();
+        LOG(INFO) << "VSlotRef - invalid slot id: " << _slot_id << " desc:" << desc.debug_string();
         return Status::InternalError("VSlotRef - invalid slot id {}", _slot_id);
     }
     _column_name = &slot_desc->col_name();

--- a/be/src/vec/exprs/vslot_ref.cpp
+++ b/be/src/vec/exprs/vslot_ref.cpp
@@ -51,16 +51,16 @@ Status VSlotRef::prepare(doris::RuntimeState* state, const doris::RowDescriptor&
         return Status::InternalError("couldn't resolve slot descriptor {}", _slot_id);
     }
     _column_id = desc.get_column_id(_slot_id);
+    if (_column_id < 0) {
+        LOG(INFO) << "VSlotRef - invalid slot id ";
+        LOG(INFO) << _slot_id<<desc.debug_string();
+        return Status::InternalError("VSlotRef - invalid slot id {}", _slot_id);
+    }
     _column_name = &slot_desc->col_name();
     return Status::OK();
 }
 
 Status VSlotRef::execute(VExprContext* context, Block* block, int* result_column_id) {
-    // comment DCHECK temporarily to make fuzzy test run smoothly
-    // DCHECK_GE(_column_id, 0);
-    if (_column_id < 0) {
-        return Status::InternalError("invalid column id {}", _column_id);
-    }
     *result_column_id = _column_id;
     return Status::OK();
 }

--- a/be/src/vec/exprs/vslot_ref.cpp
+++ b/be/src/vec/exprs/vslot_ref.cpp
@@ -52,8 +52,8 @@ Status VSlotRef::prepare(doris::RuntimeState* state, const doris::RowDescriptor&
     }
     _column_id = desc.get_column_id(_slot_id);
     if (_column_id < 0) {
-        LOG(INFO) << "VSlotRef - invalid slot id " << _slot_id;
-        LOG(INFO) << desc.debug_string();
+        LOG(INFO) << "VSlotRef - invalid slot id: " << _slot_id 
+                  << " desc:" << desc.debug_string();
         return Status::InternalError("VSlotRef - invalid slot id {}", _slot_id);
     }
     _column_name = &slot_desc->col_name();

--- a/be/src/vec/exprs/vslot_ref.cpp
+++ b/be/src/vec/exprs/vslot_ref.cpp
@@ -52,8 +52,8 @@ Status VSlotRef::prepare(doris::RuntimeState* state, const doris::RowDescriptor&
     }
     _column_id = desc.get_column_id(_slot_id);
     if (_column_id < 0) {
-        LOG(INFO) << "VSlotRef - invalid slot id ";
-        LOG(INFO) << _slot_id<<desc.debug_string();
+        LOG(INFO) << "VSlotRef - invalid slot id " << _slot_id;
+        LOG(INFO) << desc.debug_string();
         return Status::InternalError("VSlotRef - invalid slot id {}", _slot_id);
     }
     _column_name = &slot_desc->col_name();


### PR DESCRIPTION
# Proposed changes
In current implementation, we detect invalid slot at execute phase. At execute phase, it is hard to get useful information for further debug. This pr moves error detection ahead to prepare phase, so that we can log related tuple descriptors.

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

