### PR TITLE
[docs](hive)add hadoop.username config item

### DIFF
--- a/docs/en/docs/ecosystem/external-table/hive-of-doris.md
+++ b/docs/en/docs/ecosystem/external-table/hive-of-doris.md
@@ -148,6 +148,7 @@ PROPERTIES (
     - `hive.metastore.uris`: Hive Metastore service address
     - `database`: the name of the database to which Hive is mounted
     - `table`: the name of the table to which Hive is mounted
+    - `hadoop.username`: the username to visit hdfs, when the authentication type is sample need to set 
     - `dfs.nameservices`: the logical name for this new nameservice. See hdfs-site.xml
     - `dfs.ha.namenodes.[nameservice ID]`：unique identifiers for each NameNode in the nameservice. See hdfs-site.xml
     - `dfs.namenode.rpc-address.[nameservice ID].[name node ID]`：the fully-qualified RPC address for each NameNode to listen on. See hdfs-site.xml

--- a/docs/en/docs/ecosystem/external-table/hive-of-doris.md
+++ b/docs/en/docs/ecosystem/external-table/hive-of-doris.md
@@ -148,7 +148,7 @@ PROPERTIES (
     - `hive.metastore.uris`: Hive Metastore service address
     - `database`: the name of the database to which Hive is mounted
     - `table`: the name of the table to which Hive is mounted
-    - `hadoop.username`: the username to visit hdfs, when the authentication type is simple need to set 
+    - `hadoop.username`: the username to visit HDFS (need to specify it when the authentication type is simple)
     - `dfs.nameservices`: the logical name for this new nameservice. See hdfs-site.xml
     - `dfs.ha.namenodes.[nameservice ID]`：unique identifiers for each NameNode in the nameservice. See hdfs-site.xml
     - `dfs.namenode.rpc-address.[nameservice ID].[name node ID]`：the fully-qualified RPC address for each NameNode to listen on. See hdfs-site.xml

--- a/docs/en/docs/ecosystem/external-table/hive-of-doris.md
+++ b/docs/en/docs/ecosystem/external-table/hive-of-doris.md
@@ -148,7 +148,7 @@ PROPERTIES (
     - `hive.metastore.uris`: Hive Metastore service address
     - `database`: the name of the database to which Hive is mounted
     - `table`: the name of the table to which Hive is mounted
-    - `hadoop.username`: the username to visit hdfs, when the authentication type is sample need to set 
+    - `hadoop.username`: the username to visit hdfs, when the authentication type is simple need to set 
     - `dfs.nameservices`: the logical name for this new nameservice. See hdfs-site.xml
     - `dfs.ha.namenodes.[nameservice ID]`：unique identifiers for each NameNode in the nameservice. See hdfs-site.xml
     - `dfs.namenode.rpc-address.[nameservice ID].[name node ID]`：the fully-qualified RPC address for each NameNode to listen on. See hdfs-site.xml

--- a/docs/zh-CN/docs/ecosystem/external-table/hive-of-doris.md
+++ b/docs/zh-CN/docs/ecosystem/external-table/hive-of-doris.md
@@ -148,6 +148,7 @@ PROPERTIES (
     - `hive.metastore.uris`：Hive Metastore 服务地址
     - `database`：挂载 Hive 对应的数据库名
     - `table`：挂载 Hive 对应的表名
+    - `hadoop.username`: 访问hdfs用户名,当认证为sample时需要
     - `dfs.nameservices`：name service名称，与hdfs-site.xml保持一致
     - `dfs.ha.namenodes.[nameservice ID]：namenode的id列表,与hdfs-site.xml保持一致
     - `dfs.namenode.rpc-address.[nameservice ID].[name node ID]`：Name node的rpc地址，数量与namenode数量相同，与hdfs-site.xml保持一致

--- a/docs/zh-CN/docs/ecosystem/external-table/hive-of-doris.md
+++ b/docs/zh-CN/docs/ecosystem/external-table/hive-of-doris.md
@@ -148,7 +148,7 @@ PROPERTIES (
     - `hive.metastore.uris`：Hive Metastore 服务地址
     - `database`：挂载 Hive 对应的数据库名
     - `table`：挂载 Hive 对应的表名
-    - `hadoop.username`: 访问hdfs用户名,当认证为sample时需要
+    - `hadoop.username`: 访问hdfs用户名,当认证为simple时需要
     - `dfs.nameservices`：name service名称，与hdfs-site.xml保持一致
     - `dfs.ha.namenodes.[nameservice ID]：namenode的id列表,与hdfs-site.xml保持一致
     - `dfs.namenode.rpc-address.[nameservice ID].[name node ID]`：Name node的rpc地址，数量与namenode数量相同，与hdfs-site.xml保持一致


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

add `hadoop.username`  property  ,which is used to visit hdfs when your authentication type is sample

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

