### PR TITLE
[fix](checksum) checksum should respect DELETE_SIGN column

### DIFF
--- a/be/src/olap/compaction.cpp
+++ b/be/src/olap/compaction.cpp
@@ -172,7 +172,8 @@ Status Compaction::do_compaction_impl(int64_t permits) {
     }
 
     if (use_vectorized_compaction) {
-        res = Merger::vmerge_rowsets(_tablet, compaction_type(), _input_rowsets, _output_rs_writer.get(), &stats);
+        res = Merger::vmerge_rowsets(_tablet, compaction_type(), _input_rowsets,
+                                     _output_rs_writer.get(), &stats);
     } else {
         res = Merger::merge_rowsets(_tablet, compaction_type(), cur_tablet_schema,
                                     _input_rs_readers, _output_rs_writer.get(), &stats);

--- a/be/src/olap/compaction.cpp
+++ b/be/src/olap/compaction.cpp
@@ -150,6 +150,7 @@ Status Compaction::do_compaction_impl(int64_t permits) {
 
     LOG(INFO) << "start " << merge_type << compaction_name() << ". tablet=" << _tablet->full_name()
               << ", output_version=" << _output_version << ", permits: " << permits;
+    // TODO: dataroaring. Remove below code after non vectorized code is removed.
     // get cur schema if rowset schema exist, rowset schema must be newer than tablet schema
     std::vector<RowsetMetaSharedPtr> rowset_metas(_input_rowsets.size());
     std::transform(_input_rowsets.begin(), _input_rowsets.end(), rowset_metas.begin(),
@@ -171,8 +172,7 @@ Status Compaction::do_compaction_impl(int64_t permits) {
     }
 
     if (use_vectorized_compaction) {
-        res = Merger::vmerge_rowsets(_tablet, compaction_type(), cur_tablet_schema,
-                                     _input_rs_readers, _output_rs_writer.get(), &stats);
+        res = Merger::vmerge_rowsets(_tablet, compaction_type(), _input_rowsets, _output_rs_writer.get(), &stats);
     } else {
         res = Merger::merge_rowsets(_tablet, compaction_type(), cur_tablet_schema,
                                     _input_rs_readers, _output_rs_writer.get(), &stats);

--- a/be/src/olap/merger.cpp
+++ b/be/src/olap/merger.cpp
@@ -109,7 +109,8 @@ Status Merger::vmerge_rowsets(TabletSharedPtr tablet, ReaderType reader_type,
 
     TabletReader::ReaderParams reader_params;
     vectorized::Block block;
-    RETURN_NOT_OK(TabletReader::init_reader_params_and_create_block(tablet, reader_type, input_rowsets, &reader_params, &block));
+    RETURN_NOT_OK(TabletReader::init_reader_params_and_create_block(
+            tablet, reader_type, input_rowsets, &reader_params, &block));
 
     if (stats_output && stats_output->rowid_conversion) {
         reader_params.record_rowids = true;

--- a/be/src/olap/merger.h
+++ b/be/src/olap/merger.h
@@ -43,8 +43,7 @@ public:
                                 RowsetWriter* dst_rowset_writer, Statistics* stats_output);
 
     static Status vmerge_rowsets(TabletSharedPtr tablet, ReaderType reader_type,
-                                 TabletSchemaSPtr cur_tablet_schema,
-                                 const std::vector<RowsetReaderSharedPtr>& src_rowset_readers,
+                                 const std::vector<RowsetSharedPtr>& input_rowsets,
                                  RowsetWriter* dst_rowset_writer, Statistics* stats_output);
 };
 

--- a/be/src/olap/reader.cpp
+++ b/be/src/olap/reader.cpp
@@ -563,7 +563,8 @@ Status TabletReader::_init_delete_condition(const ReaderParams& read_params) {
     // other reader type:
     // QUERY will filter the row in query layer to keep right result use where clause.
     // CUMULATIVE_COMPACTION will lost the filter_delete info of base rowset
-    if (read_params.reader_type == READER_BASE_COMPACTION || read_params.reader_type == READER_CHECKSUM) {
+    if (read_params.reader_type == READER_BASE_COMPACTION ||
+        read_params.reader_type == READER_CHECKSUM) {
         _filter_delete = true;
     }
 
@@ -571,13 +572,14 @@ Status TabletReader::_init_delete_condition(const ReaderParams& read_params) {
                                 read_params.version.second);
 }
 
-Status TabletReader::init_reader_params_and_create_block(TabletSharedPtr tablet, ReaderType reader_type,
-                                                         const std::vector<RowsetSharedPtr>& input_rowsets,
-                                                         TabletReader::ReaderParams* reader_params,
-                                                         vectorized::Block* block) {
+Status TabletReader::init_reader_params_and_create_block(
+        TabletSharedPtr tablet, ReaderType reader_type,
+        const std::vector<RowsetSharedPtr>& input_rowsets,
+        TabletReader::ReaderParams* reader_params, vectorized::Block* block) {
     reader_params->tablet = tablet;
     reader_params->reader_type = reader_type;
-    reader_params->version = Version(input_rowsets.front()->start_version(), input_rowsets.back()->end_version());
+    reader_params->version =
+            Version(input_rowsets.front()->start_version(), input_rowsets.back()->end_version());
 
     for (auto& rowset : input_rowsets) {
         RowsetReaderSharedPtr rs_reader;

--- a/be/src/olap/reader.h
+++ b/be/src/olap/reader.h
@@ -146,6 +146,10 @@ public:
 
     const OlapReaderStatistics& stats() const { return _stats; }
     OlapReaderStatistics* mutable_stats() { return &_stats; }
+    static Status init_reader_params_and_create_block(TabletSharedPtr tablet, ReaderType reader_type,
+                                                      const std::vector<RowsetSharedPtr>& input_rowsets,
+                                                      TabletReader::ReaderParams* reader_params,
+                                                      vectorized::Block* block);
 
 protected:
     friend class CollectIterator;

--- a/be/src/olap/reader.h
+++ b/be/src/olap/reader.h
@@ -146,10 +146,10 @@ public:
 
     const OlapReaderStatistics& stats() const { return _stats; }
     OlapReaderStatistics* mutable_stats() { return &_stats; }
-    static Status init_reader_params_and_create_block(TabletSharedPtr tablet, ReaderType reader_type,
-                                                      const std::vector<RowsetSharedPtr>& input_rowsets,
-                                                      TabletReader::ReaderParams* reader_params,
-                                                      vectorized::Block* block);
+    static Status init_reader_params_and_create_block(
+            TabletSharedPtr tablet, ReaderType reader_type,
+            const std::vector<RowsetSharedPtr>& input_rowsets,
+            TabletReader::ReaderParams* reader_params, vectorized::Block* block);
 
 protected:
     friend class CollectIterator;

--- a/be/src/olap/schema_change.cpp
+++ b/be/src/olap/schema_change.cpp
@@ -1652,17 +1652,9 @@ bool SchemaChangeWithSorting::_external_sorting(vector<RowsetSharedPtr>& src_row
 Status VSchemaChangeWithSorting::_external_sorting(vector<RowsetSharedPtr>& src_rowsets,
                                                    RowsetWriter* rowset_writer,
                                                    TabletSharedPtr new_tablet) {
-    std::vector<RowsetReaderSharedPtr> rs_readers;
-    for (auto& rowset : src_rowsets) {
-        RowsetReaderSharedPtr rs_reader;
-        RETURN_IF_ERROR(rowset->create_reader(&rs_reader));
-        rs_readers.push_back(rs_reader);
-    }
-
     Merger::Statistics stats;
     RETURN_IF_ERROR(Merger::vmerge_rowsets(new_tablet, READER_ALTER_TABLE,
-                                           new_tablet->tablet_schema(), rs_readers, rowset_writer,
-                                           &stats));
+                                           src_rowsets, rowset_writer, &stats));
 
     _add_merged_rows(stats.merged_rows);
     _add_filtered_rows(stats.filtered_rows);

--- a/be/src/olap/task/engine_checksum_task.cpp
+++ b/be/src/olap/task/engine_checksum_task.cpp
@@ -67,8 +67,8 @@ Status EngineChecksumTask::_compute_checksum() {
     vectorized::BlockReader reader;
     TabletReader::ReaderParams reader_params;
     vectorized::Block block;
-    RETURN_NOT_OK(TabletReader::init_reader_params_and_create_block(tablet, READER_CHECKSUM,
-                                                                    input_rowsets, &reader_params, &block));
+    RETURN_NOT_OK(TabletReader::init_reader_params_and_create_block(
+            tablet, READER_CHECKSUM, input_rowsets, &reader_params, &block));
 
     res = reader.init(reader_params);
     if (!res.ok()) {

--- a/be/src/olap/task/engine_checksum_task.cpp
+++ b/be/src/olap/task/engine_checksum_task.cpp
@@ -76,15 +76,6 @@ Status EngineChecksumTask::_compute_checksum() {
         return res;
     }
 
-    LOG(INFO) << "yyq columns " << reader_params.return_columns.size();
-    RowCursor row;
-    res = row.init(reader_params.tablet_schema, reader_params.return_columns);
-    if (!res.ok()) {
-        LOG(WARNING) << "failed to init row cursor. res = " << res;
-        return res;
-    }
-    row.allocate_memory_for_string_type(reader_params.tablet_schema);
-
     bool eof = false;
     uint32_t row_checksum = 0;
     SipHash block_hash;

--- a/be/test/olap/rowid_conversion_test.cpp
+++ b/be/test/olap/rowid_conversion_test.cpp
@@ -355,14 +355,6 @@ protected:
             input_rowsets.push_back(rowset);
         }
 
-        // create input rowset reader
-        vector<RowsetReaderSharedPtr> input_rs_readers;
-        for (auto& rowset : input_rowsets) {
-            RowsetReaderSharedPtr rs_reader;
-            EXPECT_TRUE(rowset->create_reader(&rs_reader).ok());
-            input_rs_readers.push_back(std::move(rs_reader));
-        }
-
         // create output rowset writer
         RowsetWriterContext writer_context;
         create_rowset_writer_context(tablet_schema, NONOVERLAPPING, 3456, &writer_context);
@@ -377,7 +369,7 @@ protected:
         Merger::Statistics stats;
         RowIdConversion rowid_conversion;
         stats.rowid_conversion = &rowid_conversion;
-        s = Merger::vmerge_rowsets(tablet, READER_BASE_COMPACTION, tablet_schema, input_rs_readers,
+        s = Merger::vmerge_rowsets(tablet, READER_BASE_COMPACTION, input_rowsets,
                                    output_rs_writer.get(), &stats);
         EXPECT_TRUE(s.ok());
         RowsetSharedPtr out_rowset = output_rs_writer->build();


### PR DESCRIPTION
If checksum does not respect DELETE_SIGN column, then is 2 replicas'
compaction status is not same, then they may generate different checksums
probabaly.

BTW: We change checksum to vectorized engine.

# Proposed changes

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

