### PR TITLE
[dev-1.1.2][api-change](http) change kill query http api by using query id

### DIFF
--- a/docs/en/administrator-guide/http-actions/fe/manager/query-profile-action.md
+++ b/docs/en/administrator-guide/http-actions/fe/manager/query-profile-action.md
@@ -34,9 +34,15 @@ under the License.
 
 `GET /rest/v2/manager/query/profile/text/{query_id}`
 
+`GET /rest/v2/manager/query/profile/graph/{query_id}`
+
+`GET /rest/v2/manager/query/profile/json/{query_id}`
+
 `GET /rest/v2/manager/query/profile/fragments/{query_id}`
 
-`GET /rest/v2/manager/query/profile/graph/{query_id}`
+`GET /rest/v2/manager/query/current_queries`
+
+`GET /rest/v2/manager/query/kill/{query_id}`
 
 ## Get the query information
 
@@ -342,7 +348,7 @@ Same as `show proc "/current_query_stmts"`, return current running queries.
 
 ## Cancel query
 
-`POST /rest/v2/manager/query/kill/{connection_id}`
+`POST /rest/v2/manager/query/kill/{query_id}`
 
 ### Description
 
@@ -350,9 +356,9 @@ Cancel query of specified connection.
     
 ### Path parameters
 
-* `{connection_id}`
+* `{query_id}`
 
-    connection id
+    query id. You can get query id by `trance_id` api.
 
 ### Query parameters
 
@@ -362,7 +368,7 @@ Cancel query of specified connection.
 {
     "msg": "success",
     "code": 0,
-    "data": "",
+    "data": null,
     "count": 0
 }
 ```

--- a/docs/zh-CN/administrator-guide/http-actions/fe/manager/query-profile-action.md
+++ b/docs/zh-CN/administrator-guide/http-actions/fe/manager/query-profile-action.md
@@ -42,8 +42,7 @@ under the License.
 
 `GET /rest/v2/manager/query/current_queries`
 
-`GET /rest/v2/manager/query/kill/{connection_id}`
-
+`GET /rest/v2/manager/query/kill/{query_id}`
 
 ## 获取查询信息
 
@@ -349,7 +348,7 @@ GET /rest/v2/manager/query/query_info
 
 ## 取消query
 
-`POST /rest/v2/manager/query/kill/{connection_id}`
+`POST /rest/v2/manager/query/kill/{query_id}`
 
 ### Description
 
@@ -357,9 +356,9 @@ GET /rest/v2/manager/query/query_info
     
 ### Path parameters
 
-* `{connection_id}`
+* `{query_id}`
 
-    connection id
+    query id. 你可以通过 trace_id 接口，获取 query id。
 
 ### Query parameters
 
@@ -369,7 +368,7 @@ GET /rest/v2/manager/query/query_info
 {
     "msg": "success",
     "code": 0,
-    "data": "",
+    "data": null,
     "count": 0
 }
 ```

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectContext.java
@@ -35,6 +35,7 @@ import org.apache.doris.thrift.TUniqueId;
 import org.apache.doris.transaction.TransactionEntry;
 import org.apache.doris.transaction.TransactionStatus;
 
+import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 
@@ -58,6 +59,7 @@ public class ConnectContext {
     protected volatile long forwardedStmtId;
 
     protected volatile TUniqueId queryId;
+    protected volatile String traceId;
     // id for this connection
     protected volatile int connectionId;
     // mysql net
@@ -438,6 +440,17 @@ public class ConnectContext {
 
     public void setQueryId(TUniqueId queryId) {
         this.queryId = queryId;
+        if (connectScheduler != null && !Strings.isNullOrEmpty(traceId)) {
+            connectScheduler.putTraceId2QueryId(traceId, queryId);
+        }
+    }
+
+    public void setTraceId(String traceId) {
+        this.traceId = traceId;
+    }
+
+    public String traceId() {
+        return traceId;
     }
 
     public TUniqueId queryId() {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectScheduler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectScheduler.java
@@ -22,9 +22,11 @@ import org.apache.doris.common.Config;
 import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.ThreadPoolManager;
 import org.apache.doris.ldap.LdapAuthenticate;
+import org.apache.doris.common.util.DebugUtil;
 import org.apache.doris.mysql.MysqlProto;
 import org.apache.doris.mysql.nio.NConnectContext;
 import org.apache.doris.mysql.privilege.PrivPredicate;
+import org.apache.doris.thrift.TUniqueId;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -51,6 +53,9 @@ public class ConnectScheduler {
     private Map<Integer, ConnectContext> connectionMap = Maps.newConcurrentMap();
     private Map<String, AtomicInteger> connByUser = Maps.newConcurrentMap();
     private ExecutorService executor = ThreadPoolManager.newDaemonCacheThreadPool(Config.max_connection_scheduler_threads_num, "connect-scheduler-pool", true);
+
+    // valid trace id -> query id
+    private final Map<String, TUniqueId> traceId2QueryId = Maps.newConcurrentMap();
 
     // Use a thread to check whether connection is timeout. Because
     // 1. If use a scheduler, the task maybe a huge number when query is messy.
@@ -132,6 +137,16 @@ public class ConnectScheduler {
         return connectionMap.get(connectionId);
     }
 
+    public void cancelQuery(String queryId) {
+        for (ConnectContext ctx : connectionMap.values()) {
+            TUniqueId qid = ctx.queryId();
+            if (qid != null && DebugUtil.printId(qid).equals(queryId)) {
+                ctx.cancelQuery();
+                break;
+            }
+        }
+    }
+
     public int getConnectionNum() {
         return numberConnection.get();
     }
@@ -149,6 +164,15 @@ public class ConnectScheduler {
             infos.add(ctx.toThreadInfo(isFull));
         }
         return infos;
+    }
+
+    public void putTraceId2QueryId(String traceId, TUniqueId queryId) {
+        traceId2QueryId.put(traceId, queryId);
+    }
+
+    public String getQueryIdByTraceId(String traceId) {
+        TUniqueId queryId = traceId2QueryId.get(traceId);
+        return queryId == null ? "" : DebugUtil.printId(queryId);
     }
 
     private class LoopHandler implements Runnable {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/VariableMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/VariableMgr.java
@@ -187,6 +187,10 @@ public class VariableMgr {
             ErrorReport.reportDdlException(ErrorCode.ERR_WRONG_VALUE_FOR_VAR, attr.name(), value);
         }
 
+        if (VariableVarCallbacks.hasCallback(attr.name())) {
+            VariableVarCallbacks.call(attr.name(), value);
+        }
+
         return true;
     }
 
@@ -516,9 +520,6 @@ public class VariableMgr {
 
         // Set to true if the variables need to be forwarded along with forward statement.
         boolean needForward() default false;
-
-        // Set to true if the variables need to be set in TQueryOptions
-        boolean isQueryOption() default false;
     }
 
     private static class VarContext {
@@ -586,8 +587,7 @@ public class VariableMgr {
             }
 
             field.setAccessible(true);
-            builder.put(attr.name(),
-                    new VarContext(field, null, GLOBAL | attr.flag(), getValue(null, field)));
+            builder.put(attr.name(), new VarContext(field, null, GLOBAL | attr.flag(), getValue(null, field)));
         }
         return builder;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/VariableVarCallbackI.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/VariableVarCallbackI.java
@@ -1,0 +1,24 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.qe;
+
+import org.apache.doris.common.DdlException;
+
+public interface VariableVarCallbackI {
+    public void call(String value) throws DdlException;
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/VariableVarCallbacks.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/VariableVarCallbacks.java
@@ -1,0 +1,73 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.qe;
+
+import org.apache.doris.common.DdlException;
+
+import com.google.common.base.Strings;
+import com.google.common.collect.Maps;
+
+import java.util.Map;
+
+/**
+ * Callback after setting the session variable
+ */
+public class VariableVarCallbacks {
+
+    public static final Map<String, VariableVarCallbackI> callbacks = Maps.newHashMap();
+
+    static {
+        SessionContextCallback sessionContextCallback = new SessionContextCallback();
+        callbacks.put(SessionVariable.SESSION_CONTEXT, sessionContextCallback);
+    }
+
+    public static Boolean hasCallback(String varName) {
+        return callbacks.containsKey(varName);
+    }
+
+    public static void call(String varName, String value) throws DdlException {
+        if (hasCallback(varName)) {
+            callbacks.get(varName).call(value);
+        }
+    }
+
+    // Converter to convert runtime filter type variable
+    public static class SessionContextCallback implements VariableVarCallbackI {
+        public void call(String value) throws DdlException {
+            if (Strings.isNullOrEmpty(value)) {
+                return;
+            }
+            /**
+             * The sessionContext is as follows:
+             * "k1:v1;k2:v2;..."
+             * Here we want to get value with key named "trace_id".
+             */
+            String[] parts = value.split(";");
+            for (String part : parts) {
+                String[] innerParts = part.split(":");
+                if (innerParts.length != 2) {
+                    continue;
+                }
+                if (innerParts[0].equals("trace_id")) {
+                    ConnectContext.get().setTraceId(innerParts[1]);
+                    break;
+                }
+            }
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/qe/VariableMgrTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/qe/VariableMgrTest.java
@@ -235,5 +235,13 @@ public class VariableMgrTest {
         VariableMgr.setVar(null, setVar);
         Assert.fail("No exception throws.");
     }
+
+    @Test
+    public void testVariableCallback() throws Exception {
+        SetStmt stmt = (SetStmt) UtFrameUtils.parseAndAnalyzeStmt("set session_context='trace_id:123'", ctx);
+        SetExecutor executor = new SetExecutor(ctx, stmt);
+        executor.execute();
+        Assert.assertEquals("123", ctx.traceId());
+    }
 }
 


### PR DESCRIPTION
# Proposed changes

cherry pick from #12120

## Problem summary

Now user can cancel query id by http by following steps:
1. Get query id by trace id
2. cancel query by query id

The modified api has not been released yet.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

