### PR TITLE
[fix](memtracker) Fix mem limit exceed return wrong format

### DIFF
--- a/be/src/runtime/memory/mem_tracker_limiter.cpp
+++ b/be/src/runtime/memory/mem_tracker_limiter.cpp
@@ -259,9 +259,6 @@ Status MemTrackerLimiter::mem_limit_exceeded(const std::string& msg,
                                              int64_t failed_allocation_size) {
     STOP_CHECK_THREAD_MEM_TRACKER_LIMIT();
     std::string detail = fmt::format("Memory limit exceeded, <consuming_tracker={}, ", _label);
-    if (failed_allocation_size != 0)
-        detail += fmt::format("failed_alloc_size={}B, ",
-                              PrettyPrinter::print(failed_allocation_size, TUnit::BYTES));
     MemTrackerLimiter* exceeded_tracker = nullptr;
     MemTrackerLimiter* max_consumption_tracker = nullptr;
     int64_t free_size = INT64_MAX;
@@ -284,19 +281,20 @@ Status MemTrackerLimiter::mem_limit_exceeded(const std::string& msg,
     MemTrackerLimiter* print_log_usage_tracker = nullptr;
     if (exceeded_tracker != nullptr) {
         detail += fmt::format(
-                "exceeded_tracker={}, limit={}B, peak_used={}B, current_used={}B>, "
-                "executing_msg:<{}>",
+                "failed_alloc_size={}B, exceeded_tracker={}, limit={}B, peak_used={}B, "
+                "current_used={}B>, executing_msg:<{}>",
+                PrettyPrinter::print(failed_allocation_size, TUnit::BYTES),
                 exceeded_tracker->label(), exceeded_tracker->limit(),
                 exceeded_tracker->peak_consumption(), exceeded_tracker->consumption(), msg);
         print_log_usage_tracker = exceeded_tracker;
     } else if (!sys_exceed_st) {
-        detail = fmt::format("Memory limit exceeded, {}, executing_msg:<{}>",
-                             sys_exceed_st.get_error_msg(), msg);
+        detail += fmt::format("{}>, executing_msg:<{}>", sys_exceed_st.get_error_msg(), msg);
     } else if (max_consumption_tracker != nullptr) {
         // must after check_sys_mem_info false
         detail += fmt::format(
-                "max_consumption_tracker={}, limit={}B, peak_used={}B, current_used={}B>, "
-                "executing_msg:<{}>",
+                "failed_alloc_size={}B, max_consumption_tracker={}, limit={}B, peak_used={}B, "
+                "current_used={}B>, executing_msg:<{}>",
+                PrettyPrinter::print(failed_allocation_size, TUnit::BYTES),
                 max_consumption_tracker->label(), max_consumption_tracker->limit(),
                 max_consumption_tracker->peak_consumption(), max_consumption_tracker->consumption(),
                 msg);
@@ -318,7 +316,7 @@ Status MemTrackerLimiter::mem_limit_exceeded(const std::string& msg,
                                              Status failed_try_consume_st) {
     STOP_CHECK_THREAD_MEM_TRACKER_LIMIT();
     std::string detail =
-            fmt::format("memory limit exceeded:<consuming_tracker={}, {}>, executing_msg:<{}>",
+            fmt::format("Memory limit exceeded:<consuming_tracker={}, {}>, executing_msg:<{}>",
                         _label, failed_try_consume_st.get_error_msg(), msg);
     auto st = MemTrackerLimiter::mem_limit_exceeded_construct(detail);
     failed_tracker->print_log_usage(st.get_error_msg());

--- a/be/src/runtime/memory/mem_tracker_limiter.cpp
+++ b/be/src/runtime/memory/mem_tracker_limiter.cpp
@@ -258,7 +258,7 @@ void MemTrackerLimiter::print_log_usage(const std::string& msg) {
 Status MemTrackerLimiter::mem_limit_exceeded(const std::string& msg,
                                              int64_t failed_allocation_size) {
     STOP_CHECK_THREAD_MEM_TRACKER_LIMIT();
-    std::string detail = fmt::format("Memory limit exceeded, <consuming_tracker={}, ", _label);
+    std::string detail = fmt::format("Memory limit exceeded:<consuming_tracker={}, ", _label);
     MemTrackerLimiter* exceeded_tracker = nullptr;
     MemTrackerLimiter* max_consumption_tracker = nullptr;
     int64_t free_size = INT64_MAX;

--- a/be/src/runtime/memory/mem_tracker_limiter.h
+++ b/be/src/runtime/memory/mem_tracker_limiter.h
@@ -64,16 +64,15 @@ public:
                        size_t upper_level) const;
 
 public:
-    Status check_sys_mem_info(int64_t bytes) {
+    static Status check_sys_mem_info(int64_t bytes) {
         // Limit process memory usage using the actual physical memory of the process in `/proc/self/status`.
         // This is independent of the consumption value of the mem tracker, which counts the virtual memory
         // of the process malloc.
         // for fast, expect MemInfo::initialized() to be true.
         if (PerfCounters::get_vm_rss() + bytes >= MemInfo::mem_limit()) {
             auto st = Status::MemoryLimitExceeded(
-                    "Memory limit exceeded, process memory used {} exceed limit {}, "
-                    "consuming_tracker={}, failed_alloc_size={}",
-                    PerfCounters::get_vm_rss(), MemInfo::mem_limit(), _label, bytes);
+                    "process memory used {} exceed limit {}, failed_alloc_size={}",
+                    PerfCounters::get_vm_rss(), MemInfo::mem_limit(), bytes);
             ExecEnv::GetInstance()->process_mem_tracker()->print_log_usage(st.get_error_msg());
             return st;
         }

--- a/be/src/runtime/memory/mem_tracker_limiter.h
+++ b/be/src/runtime/memory/mem_tracker_limiter.h
@@ -71,7 +71,7 @@ public:
         // for fast, expect MemInfo::initialized() to be true.
         if (PerfCounters::get_vm_rss() + bytes >= MemInfo::mem_limit()) {
             auto st = Status::MemoryLimitExceeded(
-                    "Memory limit exceeded, process memory used {}Bytes exceed limit {}B, "
+                    "Memory limit exceeded, process memory used {} exceed limit {}, "
                     "consuming_tracker={}, failed_alloc_size={}",
                     PerfCounters::get_vm_rss(), MemInfo::mem_limit(), _label, bytes);
             ExecEnv::GetInstance()->process_mem_tracker()->print_log_usage(st.get_error_msg());
@@ -212,7 +212,7 @@ private:
 
     // this tracker limiter plus all of its ancestors
     std::vector<MemTrackerLimiter*> _all_ancestors;
-    // _all_ancestors with valid limits
+    // _all_ancestors with valid limits, except process tracker
     std::vector<MemTrackerLimiter*> _limited_ancestors;
 
     // Consume size smaller than mem_tracker_consume_min_size_bytes will continue to accumulate
@@ -284,7 +284,7 @@ inline Status MemTrackerLimiter::try_consume(int64_t bytes) {
         MemTrackerLimiter* tracker = _all_ancestors[i];
         // Process tracker does not participate in the process memory limit, process tracker consumption is virtual memory,
         // and there is a diff between the real physical memory value of the process. It is replaced by check_sys_mem_info.
-        if (tracker->limit() < 0 || _label == "Process") {
+        if (tracker->limit() < 0 || tracker->label() == "Process") {
             tracker->_consumption->add(bytes); // No limit at this tracker.
         } else {
             // If TryConsume fails, we can try to GC, but we may need to try several times if
@@ -317,7 +317,6 @@ inline Status MemTrackerLimiter::check_limit(int64_t bytes) {
         MemTrackerLimiter* tracker = _limited_ancestors[i];
         // Process tracker does not participate in the process memory limit, process tracker consumption is virtual memory,
         // and there is a diff between the real physical memory value of the process. It is replaced by check_sys_mem_info.
-        if (tracker->label() == "Process") continue;
         while (true) {
             if (LIKELY(tracker->_consumption->current_value() + bytes < tracker->limit())) break;
             RETURN_IF_ERROR(tracker->try_gc_memory(bytes));


### PR DESCRIPTION
## Problem summary

Fix some details about mem limit exceed returning wrong format.

query mem tracker exceed limit:
```
Memory limit exceeded:<consuming_tracker=RuntimeState:instance:d02ea8588b624d67-9075c686cfdcaa2a, failed_alloc_size=0B, exceeded_tracker=Query#queryId=d02ea8588b624d67-9075c686cfdcaa27, limit=8589934592B, peak_used=8474578035B, current_used=8607861507B>, executing_msg:<exec node:<>, vsort, while sorting input.>, backend 172.24.47.117 process memory used 6.15 GB, process limit 8.66 GB. If is query, can change the limit by `set exec_mem_limit=xxx`, details mem usage see be.INFO.
```

process memory exceed limit:
```
Memory limit exceeded:<consuming_tracker=RuntimeState:instance:fc1cb901b8364698-a091b4c5584de85a, process memory used 9559965696 exceed limit 9293981204, failed_alloc_size=134273552>, executing_msg:<exec node:<>>, backend 172.24.47.117 process memory used 8.90 GB, process limit 8.66 GB. If is query, can change the limit by `set exec_mem_limit=xxx`, details mem usage see be.INFO.
```

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

