### PR TITLE
[bugfix](delete hanlder) delete predicate is merged and could not find schema cause core dump

### DIFF
--- a/be/src/exec/olap_scanner.cpp
+++ b/be/src/exec/olap_scanner.cpp
@@ -208,9 +208,8 @@ Status OlapScanner::_init_tablet_reader_params(
               std::inserter(_tablet_reader_params.delete_predicates,
                             _tablet_reader_params.delete_predicates.begin()));
     // Merge the columns in delete predicate that not in latest schema in to current tablet schema
-    for (auto& del_pred_pb : _tablet_reader_params.delete_predicates) {
-        _tablet_schema->merge_dropped_columns(
-                _tablet->tablet_schema(Version(del_pred_pb.version(), del_pred_pb.version())));
+    for (auto& del_pred_rs : _tablet_reader_params.delete_predicates) {
+        _tablet_schema->merge_dropped_columns(_tablet->tablet_schema(del_pred_rs.version()));
     }
     // Range
     for (auto key_range : key_ranges) {

--- a/be/src/exec/olap_scanner.cpp
+++ b/be/src/exec/olap_scanner.cpp
@@ -209,7 +209,7 @@ Status OlapScanner::_init_tablet_reader_params(
                             _tablet_reader_params.delete_predicates.begin()));
     // Merge the columns in delete predicate that not in latest schema in to current tablet schema
     for (auto& del_pred_rs : _tablet_reader_params.delete_predicates) {
-        _tablet_schema->merge_dropped_columns(_tablet->tablet_schema(del_pred_rs.version()));
+        _tablet_schema->merge_dropped_columns(_tablet->tablet_schema(del_pred_rs->version()));
     }
     // Range
     for (auto key_range : key_ranges) {

--- a/be/src/exec/olap_scanner.cpp
+++ b/be/src/exec/olap_scanner.cpp
@@ -203,7 +203,8 @@ Status OlapScanner::_init_tablet_reader_params(
     std::copy(function_filters.cbegin(), function_filters.cend(),
               std::inserter(_tablet_reader_params.function_filters,
                             _tablet_reader_params.function_filters.begin()));
-    std::copy(_tablet->delete_predicates().cbegin(), _tablet->delete_predicates().cend(),
+    auto& delete_preds = _tablet->delete_predicates();
+    std::copy(delete_preds.cbegin(), delete_preds.cend(),
               std::inserter(_tablet_reader_params.delete_predicates,
                             _tablet_reader_params.delete_predicates.begin()));
     // Merge the columns in delete predicate that not in latest schema in to current tablet schema

--- a/be/src/olap/base_compaction.cpp
+++ b/be/src/olap/base_compaction.cpp
@@ -105,7 +105,8 @@ void BaseCompaction::_filter_input_rowset() {
 
 Status BaseCompaction::pick_rowsets_to_compact() {
     _input_rowsets.clear();
-    _tablet->pick_candidate_rowsets_to_base_compaction(&_input_rowsets);
+    std::shared_lock rdlock(_tablet->get_header_lock());
+    _tablet->pick_candidate_rowsets_to_base_compaction(&_input_rowsets, rdlock);
     std::sort(_input_rowsets.begin(), _input_rowsets.end(), Rowset::comparator);
     RETURN_NOT_OK(check_version_continuity(_input_rowsets));
     RETURN_NOT_OK(_check_rowset_overlapping(_input_rowsets));

--- a/be/src/olap/cumulative_compaction.cpp
+++ b/be/src/olap/cumulative_compaction.cpp
@@ -96,8 +96,8 @@ Status CumulativeCompaction::execute_compact_impl() {
 
 Status CumulativeCompaction::pick_rowsets_to_compact() {
     std::vector<RowsetSharedPtr> candidate_rowsets;
-
-    _tablet->pick_candidate_rowsets_to_cumulative_compaction(&candidate_rowsets);
+    std::shared_lock rdlock(_tablet->get_header_lock());
+    _tablet->pick_candidate_rowsets_to_cumulative_compaction(&candidate_rowsets, rdlock);
 
     if (candidate_rowsets.empty()) {
         return Status::OLAPInternalError(OLAP_ERR_CUMULATIVE_NO_SUITABLE_VERSION);

--- a/be/src/olap/delete_handler.cpp
+++ b/be/src/olap/delete_handler.cpp
@@ -252,7 +252,7 @@ Status DeleteHandler::init(TabletSchemaSPtr tablet_schema,
         TabletSchemaSPtr delete_pred_related_schema = delete_pred->tablet_schema();
         auto& delete_condition = delete_pred->delete_predicate();
         DeleteConditions temp;
-        temp.filter_version = delete_condition.version();
+        temp.filter_version = delete_pred->version().first;
         for (const auto& sub_predicate : delete_condition.sub_predicates()) {
             TCondition condition;
             if (!_parse_condition(sub_predicate, &condition)) {

--- a/be/src/olap/delete_handler.cpp
+++ b/be/src/olap/delete_handler.cpp
@@ -245,7 +245,7 @@ Status DeleteHandler::init(TabletSchemaSPtr tablet_schema,
 
     for (const auto& delete_pred : delete_preds) {
         // Skip the delete condition with large version
-        if (delete_pred->version() > version) {
+        if (delete_pred->version().first > version) {
             continue;
         }
         // Need the tablet schema at the delete condition to parse the accurate column unique id

--- a/be/src/olap/delete_handler.cpp
+++ b/be/src/olap/delete_handler.cpp
@@ -237,21 +237,20 @@ bool DeleteHandler::_parse_condition(const std::string& condition_str, TConditio
     return true;
 }
 
-Status DeleteHandler::init(std::shared_ptr<Tablet> tablet, TabletSchemaSPtr tablet_schema,
-                           const std::vector<DeletePredicatePB>& delete_conditions,
-                           int64_t version) {
+Status DeleteHandler::init(TabletSchemaSPtr tablet_schema,
+                           const std::vector<RowsetMetaSharedPtr>& delete_preds, int64_t version) {
     DCHECK(!_is_inited) << "reinitialize delete handler.";
     DCHECK(version >= 0) << "invalid parameters. version=" << version;
     _predicate_mem_pool.reset(new MemPool());
 
-    for (const auto& delete_condition : delete_conditions) {
+    for (const auto& delete_pred : delete_preds) {
         // Skip the delete condition with large version
-        if (delete_condition.version() > version) {
+        if (delete_pred.version() > version) {
             continue;
         }
         // Need the tablet schema at the delete condition to parse the accurate column unique id
-        TabletSchemaSPtr delete_pred_related_schema = tablet->tablet_schema(
-                Version(delete_condition.version(), delete_condition.version()));
+        TabletSchemaSPtr delete_pred_related_schema = delete_pred->tablet_schema();
+        auto& delete_condition = delete_pred->delete_predicate();
         DeleteConditions temp;
         temp.filter_version = delete_condition.version();
         for (const auto& sub_predicate : delete_condition.sub_predicates()) {

--- a/be/src/olap/delete_handler.cpp
+++ b/be/src/olap/delete_handler.cpp
@@ -245,7 +245,7 @@ Status DeleteHandler::init(TabletSchemaSPtr tablet_schema,
 
     for (const auto& delete_pred : delete_preds) {
         // Skip the delete condition with large version
-        if (delete_pred.version() > version) {
+        if (delete_pred->version() > version) {
             continue;
         }
         // Need the tablet schema at the delete condition to parse the accurate column unique id

--- a/be/src/olap/delete_handler.h
+++ b/be/src/olap/delete_handler.h
@@ -25,6 +25,7 @@
 #include "olap/block_column_predicate.h"
 #include "olap/column_predicate.h"
 #include "olap/olap_define.h"
+#include "olap/rowset/rowset_meta.h"
 #include "olap/tablet_schema.h"
 
 namespace doris {

--- a/be/src/olap/delete_handler.h
+++ b/be/src/olap/delete_handler.h
@@ -89,8 +89,8 @@ public:
     // return:
     //     * Status::OLAPInternalError(OLAP_ERR_DELETE_INVALID_PARAMETERS): input parameters are not valid
     //     * Status::OLAPInternalError(OLAP_ERR_MALLOC_ERROR): alloc memory failed
-    Status init(std::shared_ptr<Tablet> tablet, TabletSchemaSPtr tablet_schema,
-                const std::vector<DeletePredicatePB>& delete_conditions, int64_t version);
+    Status init(TabletSchemaSPtr tablet_schema,
+                const std::vector<RowsetMetaSharedPtr>& delete_conditions, int64_t version);
 
     bool empty() const { return _del_conds.empty(); }
 

--- a/be/src/olap/merger.cpp
+++ b/be/src/olap/merger.cpp
@@ -43,7 +43,7 @@ Status Merger::merge_rowsets(TabletSharedPtr tablet, ReaderType reader_type,
     reader_params.version = dst_rowset_writer->version();
     {
         std::shared_lock rdlock(tablet->get_header_lock());
-        auto& delete_preds = tablet->delete_predicates();
+        auto delete_preds = tablet->delete_predicates();
         std::copy(delete_preds.cbegin(), delete_preds.cend(),
                   std::inserter(reader_params.delete_predicates,
                                 reader_params.delete_predicates.begin()));
@@ -116,7 +116,7 @@ Status Merger::vmerge_rowsets(TabletSharedPtr tablet, ReaderType reader_type,
     reader_params.version = dst_rowset_writer->version();
     {
         std::shared_lock rdlock(tablet->get_header_lock());
-        auto& delete_preds = tablet->delete_predicates();
+        auto delete_preds = tablet->delete_predicates();
         std::copy(delete_preds.cbegin(), delete_preds.cend(),
                   std::inserter(reader_params.delete_predicates,
                                 reader_params.delete_predicates.begin()));

--- a/be/src/olap/merger.cpp
+++ b/be/src/olap/merger.cpp
@@ -43,7 +43,7 @@ Status Merger::merge_rowsets(TabletSharedPtr tablet, ReaderType reader_type,
     reader_params.version = dst_rowset_writer->version();
     {
         std::shared_lock rdlock(tablet->get_header_lock());
-        auto& delete_preds = _tablet->delete_predicates();
+        auto& delete_preds = tablet->delete_predicates();
         std::copy(delete_preds.cbegin(), delete_preds.cend(),
                   std::inserter(reader_params.delete_predicates,
                                 reader_params.delete_predicates.begin()));
@@ -116,7 +116,7 @@ Status Merger::vmerge_rowsets(TabletSharedPtr tablet, ReaderType reader_type,
     reader_params.version = dst_rowset_writer->version();
     {
         std::shared_lock rdlock(tablet->get_header_lock());
-        auto& delete_preds = _tablet->delete_predicates();
+        auto& delete_preds = tablet->delete_predicates();
         std::copy(delete_preds.cbegin(), delete_preds.cend(),
                   std::inserter(reader_params.delete_predicates,
                                 reader_params.delete_predicates.begin()));

--- a/be/src/olap/merger.cpp
+++ b/be/src/olap/merger.cpp
@@ -43,7 +43,8 @@ Status Merger::merge_rowsets(TabletSharedPtr tablet, ReaderType reader_type,
     reader_params.version = dst_rowset_writer->version();
     {
         std::shared_lock rdlock(tablet->get_header_lock());
-        std::copy(tablet->delete_predicates().cbegin(), tablet->delete_predicates().cend(),
+        auto& delete_preds = _tablet->delete_predicates();
+        std::copy(delete_preds.cbegin(), delete_preds.cend(),
                   std::inserter(reader_params.delete_predicates,
                                 reader_params.delete_predicates.begin()));
     }
@@ -116,7 +117,8 @@ Status Merger::vmerge_rowsets(TabletSharedPtr tablet, ReaderType reader_type,
     reader_params.version = dst_rowset_writer->version();
     {
         std::shared_lock rdlock(tablet->get_header_lock());
-        std::copy(tablet->delete_predicates().cbegin(), tablet->delete_predicates().cend(),
+        auto& delete_preds = _tablet->delete_predicates();
+        std::copy(delete_preds.cbegin(), delete_preds.cend(),
                   std::inserter(reader_params.delete_predicates,
                                 reader_params.delete_predicates.begin()));
     }

--- a/be/src/olap/merger.cpp
+++ b/be/src/olap/merger.cpp
@@ -52,7 +52,7 @@ Status Merger::merge_rowsets(TabletSharedPtr tablet, ReaderType reader_type,
     merge_tablet_schema->copy_from(*cur_tablet_schema);
     // Merge the columns in delete predicate that not in latest schema in to current tablet schema
     for (auto& del_pred_rs : reader_params.delete_predicates) {
-        merge_tablet_schema->merge_dropped_columns(tablet->tablet_schema(del_pred_rs.version()));
+        merge_tablet_schema->merge_dropped_columns(tablet->tablet_schema(del_pred_rs->version()));
     }
     reader_params.tablet_schema = merge_tablet_schema;
     RETURN_NOT_OK(reader.init(reader_params));
@@ -125,7 +125,7 @@ Status Merger::vmerge_rowsets(TabletSharedPtr tablet, ReaderType reader_type,
     merge_tablet_schema->copy_from(*cur_tablet_schema);
     // Merge the columns in delete predicate that not in latest schema in to current tablet schema
     for (auto& del_pred_rs : reader_params.delete_predicates) {
-        merge_tablet_schema->merge_dropped_columns(tablet->tablet_schema(del_pred_rs.version()));
+        merge_tablet_schema->merge_dropped_columns(tablet->tablet_schema(del_pred_rs->version()));
     }
     reader_params.tablet_schema = merge_tablet_schema;
     if (tablet->enable_unique_key_merge_on_write()) {

--- a/be/src/olap/merger.cpp
+++ b/be/src/olap/merger.cpp
@@ -51,9 +51,8 @@ Status Merger::merge_rowsets(TabletSharedPtr tablet, ReaderType reader_type,
     TabletSchemaSPtr merge_tablet_schema = std::make_shared<TabletSchema>();
     merge_tablet_schema->copy_from(*cur_tablet_schema);
     // Merge the columns in delete predicate that not in latest schema in to current tablet schema
-    for (auto& del_pred_pb : reader_params.delete_predicates) {
-        merge_tablet_schema->merge_dropped_columns(
-                tablet->tablet_schema(Version(del_pred_pb.version(), del_pred_pb.version())));
+    for (auto& del_pred_rs : reader_params.delete_predicates) {
+        merge_tablet_schema->merge_dropped_columns(tablet->tablet_schema(del_pred_rs.version()));
     }
     reader_params.tablet_schema = merge_tablet_schema;
     RETURN_NOT_OK(reader.init(reader_params));
@@ -125,9 +124,8 @@ Status Merger::vmerge_rowsets(TabletSharedPtr tablet, ReaderType reader_type,
     TabletSchemaSPtr merge_tablet_schema = std::make_shared<TabletSchema>();
     merge_tablet_schema->copy_from(*cur_tablet_schema);
     // Merge the columns in delete predicate that not in latest schema in to current tablet schema
-    for (auto& del_pred_pb : reader_params.delete_predicates) {
-        merge_tablet_schema->merge_dropped_columns(
-                tablet->tablet_schema(Version(del_pred_pb.version(), del_pred_pb.version())));
+    for (auto& del_pred_rs : reader_params.delete_predicates) {
+        merge_tablet_schema->merge_dropped_columns(tablet->tablet_schema(del_pred_rs.version()));
     }
     reader_params.tablet_schema = merge_tablet_schema;
     if (tablet->enable_unique_key_merge_on_write()) {

--- a/be/src/olap/reader.cpp
+++ b/be/src/olap/reader.cpp
@@ -497,7 +497,7 @@ Status TabletReader::_init_delete_condition(const ReaderParams& read_params) {
         _filter_delete = true;
     }
 
-    return _delete_handler.init(_tablet, _tablet_schema, read_params.delete_predicates,
+    return _delete_handler.init(_tablet_schema, read_params.delete_predicates,
                                 read_params.version.second);
 }
 

--- a/be/src/olap/reader.h
+++ b/be/src/olap/reader.h
@@ -78,7 +78,7 @@ public:
         std::vector<TCondition> conditions;
         std::vector<std::pair<string, std::shared_ptr<IBloomFilterFuncBase>>> bloom_filters;
         std::vector<FunctionFilter> function_filters;
-        std::vector<DeletePredicatePB> delete_predicates;
+        std::vector<RowsetMetaSharedPtr> delete_predicates;
 
         // For unique key table with merge-on-write
         DeleteBitmap* delete_bitmap {nullptr};

--- a/be/src/olap/schema_change.cpp
+++ b/be/src/olap/schema_change.cpp
@@ -1852,7 +1852,7 @@ Status SchemaChangeHandler::_do_process_alter_tablet_v2(const TAlterTabletReqV2&
             }
             auto& all_del_preds = base_tablet->delete_predicates();
             for (auto& delete_pred : all_del_preds) {
-                if (delete_pred->version() > end_version) {
+                if (delete_pred->version().first > end_version) {
                     continue;
                 }
                 base_tablet_schema->merge_dropped_columns(
@@ -2118,6 +2118,7 @@ Status SchemaChangeHandler::_parse_request(const SchemaChangeParams& sc_params,
                                            bool* sc_directly) {
     TabletSharedPtr base_tablet = sc_params.base_tablet;
     TabletSharedPtr new_tablet = sc_params.new_tablet;
+    TabletSchemaSPtr base_tablet_schema = sc_params.base_tablet_schema;
     const std::unordered_map<std::string, AlterMaterializedViewParam>& materialized_function_map =
             sc_params.materialized_params_map;
     DescriptorTbl desc_tbl = *sc_params.desc_tbl;

--- a/be/src/olap/schema_change.cpp
+++ b/be/src/olap/schema_change.cpp
@@ -1852,11 +1852,11 @@ Status SchemaChangeHandler::_do_process_alter_tablet_v2(const TAlterTabletReqV2&
             }
             auto& all_del_preds = base_tablet->delete_predicates();
             for (auto& delete_pred : all_del_preds) {
-                if (delete_pred.version() > end_version) {
+                if (delete_pred->version() > end_version) {
                     continue;
                 }
-                base_tablet_schema->merge_dropped_columns(base_tablet->tablet_schema(
-                        Version(delete_pred.version(), delete_pred.version())));
+                base_tablet_schema->merge_dropped_columns(
+                        base_tablet->tablet_schema(delete_pred->version()));
             }
             res = delete_handler.init(base_tablet_schema, all_del_preds, end_version);
             if (!res) {

--- a/be/src/olap/schema_change.h
+++ b/be/src/olap/schema_change.h
@@ -305,11 +305,8 @@ private:
 
     static Status _convert_historical_rowsets(const SchemaChangeParams& sc_params);
 
-    static Status _parse_request(TabletSharedPtr base_tablet, TabletSharedPtr new_tablet,
-                                 RowBlockChanger* rb_changer, bool* sc_sorting, bool* sc_directly,
-                                 const std::unordered_map<std::string, AlterMaterializedViewParam>&
-                                         materialized_function_map,
-                                 DescriptorTbl desc_tbl, TabletSchemaSPtr base_tablet_schema);
+    static Status _parse_request(const SchemaChangeParams& sc_params, RowBlockChanger* rb_changer,
+                                 bool* sc_sorting, bool* sc_directly);
 
     // Initialization Settings for creating a default value
     static Status _init_column_mapping(ColumnMapping* column_mapping,

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -1134,7 +1134,8 @@ TabletInfo Tablet::get_tablet_info() const {
 }
 
 void Tablet::pick_candidate_rowsets_to_cumulative_compaction(
-        std::vector<RowsetSharedPtr>* candidate_rowsets, std::shared_lock& /* meta lock*/) {
+        std::vector<RowsetSharedPtr>* candidate_rowsets,
+        std::shared_lock<std::shared_mutex>& /* meta lock*/) {
     if (_cumulative_point == K_INVALID_CUMULATIVE_POINT) {
         return;
     }
@@ -1142,8 +1143,9 @@ void Tablet::pick_candidate_rowsets_to_cumulative_compaction(
                                                           candidate_rowsets);
 }
 
-void Tablet::pick_candidate_rowsets_to_base_compaction(vector<RowsetSharedPtr>* candidate_rowsets,
-                                                       std::shared_lock& /* meta lock*/) {
+void Tablet::pick_candidate_rowsets_to_base_compaction(
+        vector<RowsetSharedPtr>* candidate_rowsets,
+        std::shared_lock<std::shared_mutex>& /* meta lock*/) {
     for (auto& it : _rs_version_map) {
         // Do compaction on local rowsets only.
         if (it.first.first < _cumulative_point && it.second->is_local()) {

--- a/be/src/olap/tablet.h
+++ b/be/src/olap/tablet.h
@@ -20,6 +20,7 @@
 #include <functional>
 #include <memory>
 #include <set>
+#include <shared_mutex>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
@@ -228,9 +229,11 @@ public:
     TabletInfo get_tablet_info() const;
 
     void pick_candidate_rowsets_to_cumulative_compaction(
-            std::vector<RowsetSharedPtr>* candidate_rowsets, std::shared_lock& /* meta lock*/);
-    void pick_candidate_rowsets_to_base_compaction(std::vector<RowsetSharedPtr>* candidate_rowsets,
-                                                   std::shared_lock& /* meta lock*/);
+            std::vector<RowsetSharedPtr>* candidate_rowsets,
+            std::shared_lock<std::shared_mutex>& /* meta lock*/);
+    void pick_candidate_rowsets_to_base_compaction(
+            std::vector<RowsetSharedPtr>* candidate_rowsets,
+            std::shared_lock<std::shared_mutex>& /* meta lock*/);
 
     void calculate_cumulative_point();
     // TODO(ygl):

--- a/be/src/olap/tablet.h
+++ b/be/src/olap/tablet.h
@@ -156,7 +156,7 @@ public:
     Status capture_rs_readers(const std::vector<Version>& version_path,
                               std::vector<RowsetReaderSharedPtr>* rs_readers) const;
 
-    const std::vector<DeletePredicatePB>& delete_predicates() {
+    const std::vector<RowsetMetaSharedPtr> delete_predicates() {
         return _tablet_meta->delete_predicates();
     }
     bool version_for_delete_predicate(const Version& version);
@@ -228,8 +228,9 @@ public:
     TabletInfo get_tablet_info() const;
 
     void pick_candidate_rowsets_to_cumulative_compaction(
-            std::vector<RowsetSharedPtr>* candidate_rowsets);
-    void pick_candidate_rowsets_to_base_compaction(std::vector<RowsetSharedPtr>* candidate_rowsets);
+            std::vector<RowsetSharedPtr>* candidate_rowsets, std::shared_lock& /* meta lock*/);
+    void pick_candidate_rowsets_to_base_compaction(std::vector<RowsetSharedPtr>* candidate_rowsets,
+                                                   std::shared_lock& /* meta lock*/);
 
     void calculate_cumulative_point();
     // TODO(ygl):

--- a/be/src/olap/tablet_meta.cpp
+++ b/be/src/olap/tablet_meta.cpp
@@ -725,7 +725,7 @@ bool TabletMeta::version_for_delete_predicate(const Version& version) {
     }
 
     for (auto& del_pred : _rs_metas) {
-        if (del_pred.version() == version.first && del_pred->has_delete_predicate()) {
+        if (del_pred->version().first == version.first && del_pred->has_delete_predicate()) {
             return true;
         }
     }

--- a/be/src/olap/tablet_meta.cpp
+++ b/be/src/olap/tablet_meta.cpp
@@ -208,7 +208,6 @@ TabletMeta::TabletMeta(const TabletMeta& b)
           _schema(b._schema),
           _rs_metas(b._rs_metas),
           _stale_rs_metas(b._stale_rs_metas),
-          _del_predicates(b._del_predicates),
           _in_restore_mode(b._in_restore_mode),
           _preferred_rowset_type(b._preferred_rowset_type),
           _storage_policy(b._storage_policy),
@@ -447,9 +446,6 @@ void TabletMeta::init_from_pb(const TabletMetaPB& tablet_meta_pb) {
     for (auto& it : tablet_meta_pb.rs_metas()) {
         RowsetMetaSharedPtr rs_meta(new RowsetMeta());
         rs_meta->init_from_pb(it);
-        if (rs_meta->has_delete_predicate()) {
-            add_delete_predicate(rs_meta->delete_predicate(), rs_meta->version().first);
-        }
         _rs_metas.push_back(std::move(rs_meta));
     }
 
@@ -607,12 +603,7 @@ Status TabletMeta::add_rs_meta(const RowsetMetaSharedPtr& rs_meta) {
             }
         }
     }
-
     _rs_metas.push_back(rs_meta);
-    if (rs_meta->has_delete_predicate()) {
-        add_delete_predicate(rs_meta->delete_predicate(), rs_meta->version().first);
-    }
-
     return Status::OK();
 }
 
@@ -640,9 +631,6 @@ void TabletMeta::modify_rs_metas(const std::vector<RowsetMetaSharedPtr>& to_add,
         auto it = _rs_metas.begin();
         while (it != _rs_metas.end()) {
             if (rs_to_del->version() == (*it)->version()) {
-                if ((*it)->has_delete_predicate()) {
-                    remove_delete_predicate_by_version((*it)->version());
-                }
                 _rs_metas.erase(it);
                 // there should be only one rowset match the version
                 break;
@@ -721,36 +709,14 @@ RowsetMetaSharedPtr TabletMeta::acquire_stale_rs_meta_by_version(const Version& 
     return nullptr;
 }
 
-void TabletMeta::add_delete_predicate(const DeletePredicatePB& delete_predicate, int64_t version) {
-    for (auto& del_pred : _del_predicates) {
-        if (del_pred.version() == version) {
-            *del_pred.mutable_sub_predicates() = delete_predicate.sub_predicates();
-            return;
+const std::vector<RowsetMetaSharedPtr> TabletMeta::delete_predicates() const {
+    std::vector<RowsetMetaSharedPtr> res;
+    for (auto& del_pred : _rs_metas) {
+        if (del_pred->has_delete_predicate()) {
+            res.push_back(del_pred);
         }
     }
-    DeletePredicatePB copied_pred = delete_predicate;
-    copied_pred.set_version(version);
-    _del_predicates.emplace_back(copied_pred);
-}
-
-void TabletMeta::remove_delete_predicate_by_version(const Version& version) {
-    DCHECK(version.first == version.second) << "version=" << version;
-    int pred_to_del = -1;
-    for (int i = 0; i < _del_predicates.size(); ++i) {
-        if (_del_predicates[i].version() == version.first) {
-            pred_to_del = i;
-            // one DeletePredicatePB stands for a nested predicate, such as user submit a delete predicate a=1 and b=2
-            // they could be saved as a one DeletePredicatePB
-            break;
-        }
-    }
-    if (pred_to_del > -1) {
-        _del_predicates.erase(_del_predicates.begin() + pred_to_del);
-    }
-}
-
-const std::vector<DeletePredicatePB>& TabletMeta::delete_predicates() const {
-    return _del_predicates;
+    return res;
 }
 
 bool TabletMeta::version_for_delete_predicate(const Version& version) {
@@ -758,8 +724,8 @@ bool TabletMeta::version_for_delete_predicate(const Version& version) {
         return false;
     }
 
-    for (auto& del_pred : _del_predicates) {
-        if (del_pred.version() == version.first) {
+    for (auto& del_pred : _rs_metas) {
+        if (del_pred.version() == version.first && del_pred->has_delete_predicate()) {
             return true;
         }
     }

--- a/be/src/olap/tablet_meta.h
+++ b/be/src/olap/tablet_meta.h
@@ -169,10 +169,7 @@ public:
     RowsetMetaSharedPtr acquire_rs_meta_by_version(const Version& version) const;
     void delete_stale_rs_meta_by_version(const Version& version);
     RowsetMetaSharedPtr acquire_stale_rs_meta_by_version(const Version& version) const;
-
-    void add_delete_predicate(const DeletePredicatePB& delete_predicate, int64_t version);
-    void remove_delete_predicate_by_version(const Version& version);
-    const std::vector<DeletePredicatePB>& delete_predicates() const;
+    const std::vector<RowsetMetaSharedPtr> delete_predicates() const;
     bool version_for_delete_predicate(const Version& version);
 
     std::string full_name() const;
@@ -241,8 +238,6 @@ private:
     // These stale rowsets meta are been removed when rowsets' pathVersion is expired,
     // this policy is judged and computed by TimestampedVersionTracker.
     std::vector<RowsetMetaSharedPtr> _stale_rs_metas;
-
-    std::vector<DeletePredicatePB> _del_predicates;
     bool _in_restore_mode = false;
     RowsetTypePB _preferred_rowset_type = BETA_ROWSET;
 

--- a/be/src/vec/exec/scan/new_olap_scanner.cpp
+++ b/be/src/vec/exec/scan/new_olap_scanner.cpp
@@ -172,8 +172,8 @@ Status NewOlapScanner::_init_tablet_reader_params(
     std::copy(function_filters.cbegin(), function_filters.cend(),
               std::inserter(_tablet_reader_params.function_filters,
                             _tablet_reader_params.function_filters.begin()));
-
-    std::copy(_tablet->delete_predicates().cbegin(), _tablet->delete_predicates().cend(),
+    auto& delete_preds = _tablet->delete_predicates();
+    std::copy(delete_preds.cbegin(), delete_preds.cend(),
               std::inserter(_tablet_reader_params.delete_predicates,
                             _tablet_reader_params.delete_predicates.begin()));
 

--- a/be/src/vec/exec/volap_scanner.cpp
+++ b/be/src/vec/exec/volap_scanner.cpp
@@ -199,7 +199,7 @@ Status VOlapScanner::_init_tablet_reader_params(
 
     // Merge the columns in delete predicate that not in latest schema in to current tablet schema
     for (auto& del_pred_rs : _tablet_reader_params.delete_predicates) {
-        _tablet_schema->merge_dropped_columns(_tablet->tablet_schema(del_pred_rs.version()));
+        _tablet_schema->merge_dropped_columns(_tablet->tablet_schema(del_pred_rs->version()));
     }
 
     // Range

--- a/be/src/vec/exec/volap_scanner.cpp
+++ b/be/src/vec/exec/volap_scanner.cpp
@@ -198,9 +198,8 @@ Status VOlapScanner::_init_tablet_reader_params(
                             _tablet_reader_params.delete_predicates.begin()));
 
     // Merge the columns in delete predicate that not in latest schema in to current tablet schema
-    for (auto& del_pred_pb : _tablet_reader_params.delete_predicates) {
-        _tablet_schema->merge_dropped_columns(
-                _tablet->tablet_schema(Version(del_pred_pb.version(), del_pred_pb.version())));
+    for (auto& del_pred_rs : _tablet_reader_params.delete_predicates) {
+        _tablet_schema->merge_dropped_columns(_tablet->tablet_schema(del_pred_rs.version()));
     }
 
     // Range

--- a/be/src/vec/exec/volap_scanner.cpp
+++ b/be/src/vec/exec/volap_scanner.cpp
@@ -192,8 +192,8 @@ Status VOlapScanner::_init_tablet_reader_params(
     std::copy(function_filters.cbegin(), function_filters.cend(),
               std::inserter(_tablet_reader_params.function_filters,
                             _tablet_reader_params.function_filters.begin()));
-
-    std::copy(_tablet->delete_predicates().cbegin(), _tablet->delete_predicates().cend(),
+    auto& delete_preds = _tablet->delete_predicates();
+    std::copy(delete_preds.cbegin(), delete_preds.cend(),
               std::inserter(_tablet_reader_params.delete_predicates,
                             _tablet_reader_params.delete_predicates.begin()));
 

--- a/be/test/olap/cumulative_compaction_policy_test.cpp
+++ b/be/test/olap/cumulative_compaction_policy_test.cpp
@@ -194,7 +194,8 @@ TEST_F(TestNumBasedCumulativeCompactionPolicy, pick_candidate_rowsets) {
     _tablet->calculate_cumulative_point();
 
     std::vector<RowsetSharedPtr> candidate_rowsets;
-    _tablet->pick_candidate_rowsets_to_cumulative_compaction(&candidate_rowsets);
+    std::shared_lock rdlock(_tablet->get_header_lock());
+    _tablet->pick_candidate_rowsets_to_cumulative_compaction(&candidate_rowsets, rdlock);
 
     EXPECT_EQ(2, candidate_rowsets.size());
 }
@@ -214,7 +215,8 @@ TEST_F(TestNumBasedCumulativeCompactionPolicy, pick_input_rowsets_normal) {
     NumBasedCumulativeCompactionPolicy policy;
     std::vector<RowsetSharedPtr> candidate_rowsets;
 
-    _tablet->pick_candidate_rowsets_to_cumulative_compaction(&candidate_rowsets);
+    std::shared_lock rdlock(_tablet->get_header_lock());
+    _tablet->pick_candidate_rowsets_to_cumulative_compaction(&candidate_rowsets, rdlock);
 
     std::vector<RowsetSharedPtr> input_rowsets;
     Version last_delete_version {-1, -1};
@@ -243,7 +245,8 @@ TEST_F(TestNumBasedCumulativeCompactionPolicy, pick_input_rowsets_delete) {
     NumBasedCumulativeCompactionPolicy policy;
     std::vector<RowsetSharedPtr> candidate_rowsets;
 
-    _tablet->pick_candidate_rowsets_to_cumulative_compaction(&candidate_rowsets);
+    std::shared_lock rdlock(_tablet->get_header_lock());
+    _tablet->pick_candidate_rowsets_to_cumulative_compaction(&candidate_rowsets, rdlock);
 
     std::vector<RowsetSharedPtr> input_rowsets;
     Version last_delete_version {-1, -1};
@@ -633,7 +636,8 @@ TEST_F(TestSizeBasedCumulativeCompactionPolicy, pick_candidate_rowsets) {
     _tablet->calculate_cumulative_point();
 
     std::vector<RowsetSharedPtr> candidate_rowsets;
-    _tablet->pick_candidate_rowsets_to_cumulative_compaction(&candidate_rowsets);
+    std::shared_lock rdlock(_tablet->get_header_lock());
+    _tablet->pick_candidate_rowsets_to_cumulative_compaction(&candidate_rowsets, rdlock);
 
     EXPECT_EQ(3, candidate_rowsets.size());
 }
@@ -651,7 +655,8 @@ TEST_F(TestSizeBasedCumulativeCompactionPolicy, pick_candidate_rowsets_big_base)
     _tablet->calculate_cumulative_point();
 
     std::vector<RowsetSharedPtr> candidate_rowsets;
-    _tablet->pick_candidate_rowsets_to_cumulative_compaction(&candidate_rowsets);
+    std::shared_lock rdlock(_tablet->get_header_lock());
+    _tablet->pick_candidate_rowsets_to_cumulative_compaction(&candidate_rowsets, rdlock);
 
     EXPECT_EQ(3, candidate_rowsets.size());
 }
@@ -670,7 +675,8 @@ TEST_F(TestSizeBasedCumulativeCompactionPolicy, pick_input_rowsets_normal) {
 
     std::vector<RowsetSharedPtr> candidate_rowsets;
 
-    _tablet->pick_candidate_rowsets_to_cumulative_compaction(&candidate_rowsets);
+    std::shared_lock rdlock(_tablet->get_header_lock());
+    _tablet->pick_candidate_rowsets_to_cumulative_compaction(&candidate_rowsets, rdlock);
 
     std::vector<RowsetSharedPtr> input_rowsets;
     Version last_delete_version {-1, -1};
@@ -699,7 +705,8 @@ TEST_F(TestSizeBasedCumulativeCompactionPolicy, pick_input_rowsets_big_base) {
 
     std::vector<RowsetSharedPtr> candidate_rowsets;
 
-    _tablet->pick_candidate_rowsets_to_cumulative_compaction(&candidate_rowsets);
+    std::shared_lock rdlock(_tablet->get_header_lock());
+    _tablet->pick_candidate_rowsets_to_cumulative_compaction(&candidate_rowsets, rdlock);
 
     std::vector<RowsetSharedPtr> input_rowsets;
     Version last_delete_version {-1, -1};
@@ -728,7 +735,8 @@ TEST_F(TestSizeBasedCumulativeCompactionPolicy, pick_input_rowsets_promotion) {
 
     std::vector<RowsetSharedPtr> candidate_rowsets;
 
-    _tablet->pick_candidate_rowsets_to_cumulative_compaction(&candidate_rowsets);
+    std::shared_lock rdlock(_tablet->get_header_lock());
+    _tablet->pick_candidate_rowsets_to_cumulative_compaction(&candidate_rowsets, rdlock);
 
     std::vector<RowsetSharedPtr> input_rowsets;
     Version last_delete_version {-1, -1};
@@ -757,7 +765,8 @@ TEST_F(TestSizeBasedCumulativeCompactionPolicy, pick_input_rowsets_not_same_leve
 
     std::vector<RowsetSharedPtr> candidate_rowsets;
 
-    _tablet->pick_candidate_rowsets_to_cumulative_compaction(&candidate_rowsets);
+    std::shared_lock rdlock(_tablet->get_header_lock());
+    _tablet->pick_candidate_rowsets_to_cumulative_compaction(&candidate_rowsets, rdlock);
 
     std::vector<RowsetSharedPtr> input_rowsets;
     Version last_delete_version {-1, -1};
@@ -786,7 +795,8 @@ TEST_F(TestSizeBasedCumulativeCompactionPolicy, pick_input_rowsets_empty) {
 
     std::vector<RowsetSharedPtr> candidate_rowsets;
 
-    _tablet->pick_candidate_rowsets_to_cumulative_compaction(&candidate_rowsets);
+    std::shared_lock rdlock(_tablet->get_header_lock());
+    _tablet->pick_candidate_rowsets_to_cumulative_compaction(&candidate_rowsets, rdlock);
 
     std::vector<RowsetSharedPtr> input_rowsets;
     Version last_delete_version {-1, -1};
@@ -815,7 +825,8 @@ TEST_F(TestSizeBasedCumulativeCompactionPolicy, pick_input_rowsets_not_reach_min
 
     std::vector<RowsetSharedPtr> candidate_rowsets;
 
-    _tablet->pick_candidate_rowsets_to_cumulative_compaction(&candidate_rowsets);
+    std::shared_lock rdlock(_tablet->get_header_lock());
+    _tablet->pick_candidate_rowsets_to_cumulative_compaction(&candidate_rowsets, rdlock);
 
     std::vector<RowsetSharedPtr> input_rowsets;
     Version last_delete_version {-1, -1};
@@ -844,7 +855,8 @@ TEST_F(TestSizeBasedCumulativeCompactionPolicy, pick_input_rowsets_delete) {
 
     std::vector<RowsetSharedPtr> candidate_rowsets;
 
-    _tablet->pick_candidate_rowsets_to_cumulative_compaction(&candidate_rowsets);
+    std::shared_lock rdlock(_tablet->get_header_lock());
+    _tablet->pick_candidate_rowsets_to_cumulative_compaction(&candidate_rowsets, rdlock);
 
     std::vector<RowsetSharedPtr> input_rowsets;
     Version last_delete_version {-1, -1};

--- a/be/test/olap/delete_handler_test.cpp
+++ b/be/test/olap/delete_handler_test.cpp
@@ -968,7 +968,7 @@ TEST_F(TestDeleteHandler, InitSuccess) {
     add_delete_predicate(del_pred_4, 5);
 
     // Get delete conditions which version <= 5
-    res = _delete_handler.init(tablet, tablet->tablet_schema(), tablet->delete_predicates(), 5);
+    res = _delete_handler.init(tablet->tablet_schema(), tablet->delete_predicates(), 5);
     EXPECT_EQ(Status::OK(), res);
     _delete_handler.finalize();
 }
@@ -1000,7 +1000,7 @@ TEST_F(TestDeleteHandler, FilterDataSubconditions) {
     add_delete_predicate(del_pred, 2);
 
     // 指定版本号为10以载入Header中的所有过滤条件(在这个case中，只有过滤条件1)
-    res = _delete_handler.init(tablet, tablet->tablet_schema(), tablet->delete_predicates(), 4);
+    res = _delete_handler.init(tablet->tablet_schema(), tablet->delete_predicates(), 4);
     EXPECT_EQ(Status::OK(), res);
 
     // 构造一行测试数据
@@ -1084,7 +1084,7 @@ TEST_F(TestDeleteHandler, FilterDataConditions) {
     add_delete_predicate(del_pred_3, 4);
 
     // 指定版本号为4以载入meta中的所有过滤条件(在这个case中，只有过滤条件1)
-    res = _delete_handler.init(tablet, tablet->tablet_schema(), tablet->delete_predicates(), 4);
+    res = _delete_handler.init(tablet->tablet_schema(), tablet->delete_predicates(), 4);
     EXPECT_EQ(Status::OK(), res);
 
     std::vector<string> data_str;
@@ -1146,7 +1146,7 @@ TEST_F(TestDeleteHandler, FilterDataVersion) {
     add_delete_predicate(del_pred_2, 4);
 
     // 指定版本号为4以载入meta中的所有过滤条件(过滤条件1，过滤条件2)
-    res = _delete_handler.init(tablet, tablet->tablet_schema(), tablet->delete_predicates(), 4);
+    res = _delete_handler.init(tablet->tablet_schema(), tablet->delete_predicates(), 4);
     EXPECT_EQ(Status::OK(), res);
 
     // 构造一行测试数据

--- a/gensrc/proto/olap_file.proto
+++ b/gensrc/proto/olap_file.proto
@@ -149,7 +149,7 @@ enum KeysType {
 }
 
 message DeletePredicatePB {
-    required int32 version = 1;
+    required int32 version = 1; // This field is useless, but could not removed, not depend on it
     repeated string sub_predicates = 2;
     repeated InPredicatePB in_predicates = 3;
 }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #12155 

## Problem summary

Delete Predicates is acquired in a header lock and then the lock is released. When open the scanner, it will init the delete handler using these delete predicates and could not find related schema then core.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

