### PR TITLE
[Enhancement](metric-type) more readable error message for only metric type

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/SetOperationStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/SetOperationStmt.java
@@ -234,7 +234,7 @@ public class SetOperationStmt extends QueryStmt {
      * set operands are set compatible, adding implicit casts if necessary.
      */
     @Override
-    public void analyze(Analyzer analyzer) throws UserException {
+    public void analyze(Analyzer analyzer) throws AnalysisException, UserException {
         if (isAnalyzed()) {
             return;
         }
@@ -292,13 +292,8 @@ public class SetOperationStmt extends QueryStmt {
         if (!distinctOperands.isEmpty()) {
             // Aggregate produces exactly the same tuple as the original setOp stmt.
             ArrayList<Expr> groupingExprs = Expr.cloneList(resultExprs);
-            try {
-                distinctAggInfo = AggregateInfo.create(
-                        groupingExprs, null, analyzer.getDescTbl().getTupleDesc(tupleId), analyzer);
-            } catch (AnalysisException e) {
-                // Should never happen.
-                throw new IllegalStateException("Error creating agg info in SetOperationStmt.analyze()", e);
-            }
+            distinctAggInfo = AggregateInfo.create(
+                    groupingExprs, null, analyzer.getDescTbl().getTupleDesc(tupleId), analyzer);
         }
 
         setOpsResultExprs = Expr.cloneList(resultExprs);


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

- reproduce step 1: create two table with same schema.

```
CREATE TABLE `t1` (
  `k1` int(11) NULL,
  `k2` bitmap BITMAP_UNION NULL
) ENGINE=OLAP
AGGREGATE KEY(`k1`)
COMMENT 'OLAP'
DISTRIBUTED BY HASH(`k1`) BUCKETS 1
PROPERTIES (
"replication_allocation" = "tag.location.default: 1",
"in_memory" = "false",
"storage_format" = "V2",
"disable_auto_compaction" = "false"
);
```

```
CREATE TABLE `t2` (
  `k1` int(11) NULL,
  `k2` bitmap BITMAP_UNION NULL
) ENGINE=OLAP
AGGREGATE KEY(`k1`)
COMMENT 'OLAP'
DISTRIBUTED BY HASH(`k1`) BUCKETS 1
PROPERTIES (
"replication_allocation" = "tag.location.default: 1",
"in_memory" = "false",
"storage_format" = "V2",
"disable_auto_compaction" = "false"
);
```

- reproduce step 2: Query with union
` select k1,k2 from t1 union select k1,k2 from t2;`

- The error message before:
`ERROR 1105 (HY000): errCode = 2, detailMessage = Unexpected exception: Error creating agg info in SetOperationStmt.analyze()`

- The error message after Enhancement:
`ERROR 1105 (HY000): errCode = 2, detailMessage = Doris hll, bitmap and array column must use with specific function, and don't support filter or group by.please run 'help hll' or 'help bitmap' or 'help array' in your mysql client.
`

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

