### PR TITLE
[fix](Nereids)get NPE from finalize TimestampArithmeticExpr that generated by ExpressionTranslator

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/TimestampArithmeticExpr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/TimestampArithmeticExpr.java
@@ -92,8 +92,8 @@ public class TimestampArithmeticExpr extends Expr {
      * C'tor for function-call like arithmetic, e.g., 'date_add(a, interval b year)'.
      *
      * @param funcName timestamp arithmetic function name, used for all function except ADD and SUBTRACT.
-     * @param e1 left child of this function
-     * @param e2 right child of this function
+     * @param e1 non interval literal child of this function
+     * @param e2 interval literal child of this function
      * @param timeUnitIdent interval time unit, could be 'year', 'month', 'day', 'hour', 'minute', 'second'.
      * @param dataType the return data type of this expression.
      */
@@ -114,8 +114,8 @@ public class TimestampArithmeticExpr extends Expr {
      * to the time value (even in the interval-first case).
      *
      * @param op operator of this function either ADD or SUBTRACT.
-     * @param e1 left child of this function
-     * @param e2 right child of this function
+     * @param e1 non interval literal child of this function
+     * @param e2 interval literal child of this function
      * @param timeUnitIdent interval time unit, could be 'year', 'month', 'day', 'hour', 'minute', 'second'.
      * @param intervalFirst true if the left child is interval literal
      * @param dataType the return data type of this expression.

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/TimestampArithmeticExpr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/TimestampArithmeticExpr.java
@@ -36,6 +36,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 
 /**
@@ -89,11 +90,17 @@ public class TimestampArithmeticExpr extends Expr {
     /**
      * used for Nereids ONLY.
      * C'tor for function-call like arithmetic, e.g., 'date_add(a, interval b year)'.
+     *
+     * @param funcName timestamp arithmetic function name, used for all function except ADD and SUBTRACT.
+     * @param e1 left child of this function
+     * @param e2 right child of this function
+     * @param timeUnitIdent interval time unit, could be 'year', 'month', 'day', 'hour', 'minute', 'second'.
+     * @param dataType the return data type of this expression.
      */
     public TimestampArithmeticExpr(String funcName, Expr e1, Expr e2, String timeUnitIdent, Type dataType) {
         this.funcName = funcName;
         this.timeUnitIdent = timeUnitIdent;
-        this.timeUnit = TIME_UNITS_MAP.get(timeUnitIdent);
+        this.timeUnit = TIME_UNITS_MAP.get(timeUnitIdent.toUpperCase(Locale.ROOT));
         this.intervalFirst = false;
         children.add(e1);
         children.add(e2);
@@ -105,6 +112,13 @@ public class TimestampArithmeticExpr extends Expr {
      * C'tor for non-function-call like arithmetic, e.g., 'a + interval b year'.
      * e1 always refers to the timestamp to be added/subtracted from, and e2
      * to the time value (even in the interval-first case).
+     *
+     * @param op operator of this function either ADD or SUBTRACT.
+     * @param e1 left child of this function
+     * @param e2 right child of this function
+     * @param timeUnitIdent interval time unit, could be 'year', 'month', 'day', 'hour', 'minute', 'second'.
+     * @param intervalFirst true if the left child is interval literal
+     * @param dataType the return data type of this expression.
      */
     public TimestampArithmeticExpr(ArithmeticExpr.Operator op, Expr e1, Expr e2,
             String timeUnitIdent, boolean intervalFirst, Type dataType) {
@@ -112,7 +126,7 @@ public class TimestampArithmeticExpr extends Expr {
         this.funcName = null;
         this.op = op;
         this.timeUnitIdent = timeUnitIdent;
-        this.timeUnit = TIME_UNITS_MAP.get(timeUnitIdent);
+        this.timeUnit = TIME_UNITS_MAP.get(timeUnitIdent.toUpperCase(Locale.ROOT));
         this.intervalFirst = intervalFirst;
         children.add(e1);
         children.add(e2);

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/ExpressionTranslator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/ExpressionTranslator.java
@@ -266,7 +266,14 @@ public class ExpressionTranslator extends DefaultExpressionVisitor<Expr, PlanTra
 
     @Override
     public Expr visitTimestampArithmetic(TimestampArithmetic arithmetic, PlanTranslatorContext context) {
-        return new TimestampArithmeticExpr(arithmetic.getFuncName(), arithmetic.left().accept(this, context),
-                arithmetic.right().accept(this, context), arithmetic.getTimeUnit().toString());
+        if (arithmetic.getFuncName() == null) {
+            return new TimestampArithmeticExpr(arithmetic.getOp(), arithmetic.left().accept(this, context),
+                    arithmetic.right().accept(this, context), arithmetic.getTimeUnit().toString(),
+                    arithmetic.isIntervalFirst(), arithmetic.getDataType().toCatalogDataType());
+        } else {
+            return new TimestampArithmeticExpr(arithmetic.getFuncName(), arithmetic.left().accept(this, context),
+                    arithmetic.right().accept(this, context), arithmetic.getTimeUnit().toString(),
+                    arithmetic.getDataType().toCatalogDataType());
+        }
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/TimestampArithmetic.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/TimestampArithmetic.java
@@ -24,6 +24,7 @@ import org.apache.doris.nereids.trees.expressions.shape.BinaryExpression;
 import org.apache.doris.nereids.trees.expressions.visitor.ExpressionVisitor;
 import org.apache.doris.nereids.types.DataType;
 import org.apache.doris.nereids.types.DateTimeType;
+import org.apache.doris.nereids.types.DateType;
 
 import com.google.common.base.Preconditions;
 import org.apache.logging.log4j.LogManager;
@@ -84,7 +85,15 @@ public class TimestampArithmetic extends Expression implements BinaryExpression 
 
     @Override
     public DataType getDataType() throws UnboundException {
-        return DateTimeType.INSTANCE;
+        int dateChildIndex = 0;
+        if (intervalFirst) {
+            dateChildIndex = 1;
+        }
+        if (child(dateChildIndex).getDataType() instanceof DateTimeType || timeUnit.isDateTimeUnit()) {
+            return DateTimeType.INSTANCE;
+        } else {
+            return DateType.INSTANCE;
+        }
     }
 
     public String getFuncName() {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/IntervalLiteral.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/IntervalLiteral.java
@@ -51,17 +51,25 @@ public class IntervalLiteral extends Expression {
      * Supported time unit.
      */
     public enum TimeUnit {
-        YEAR("YEAR"),                               // YEARS
-        MONTH("MONTH"),                             // MONTHS
-        WEEK("WEEK"),                               // WEEKS
-        DAY("DAY"),                                 // DAYS
-        HOUR("HOUR"),                               // HOURS
-        MINUTE("MINUTE"),                           // MINUTES
-        SECOND("SECOND");                            // SECONDS
+        YEAR("YEAR", false),
+        MONTH("MONTH", false),
+        WEEK("WEEK", false),
+        DAY("DAY", false),
+        HOUR("HOUR", true),
+        MINUTE("MINUTE", true),
+        SECOND("SECOND", true);
+
         private final String description;
 
-        TimeUnit(String description) {
+        private final boolean isDateTimeUnit;
+
+        TimeUnit(String description, boolean isDateTimeUnit) {
             this.description = description;
+            this.isDateTimeUnit = isDateTimeUnit;
+        }
+
+        public boolean isDateTimeUnit() {
+            return isDateTimeUnit;
         }
 
         @Override


### PR DESCRIPTION
# Proposed changes

This PR:
- refactor getDataType in TimestampArithmetic
- set TimeUnit correctly when translate TimestampArithmetic to TimestampArithmeticExpr

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

