### PR TITLE
[Improvement](load) accelerate tablet sink

### DIFF
--- a/be/src/exec/tablet_sink.h
+++ b/be/src/exec/tablet_sink.h
@@ -185,8 +185,8 @@ public:
     Status add_row(Tuple* tuple, int64_t tablet_id);
 
     virtual Status add_block(vectorized::Block* block,
-                             const vectorized::IColumn::Selector& selector,
-                             const std::vector<int64_t>& tablet_ids) {
+                             const std::pair<std::unique_ptr<vectorized::IColumn::Selector>,
+                                             std::vector<int64_t>>& payload) {
         LOG(FATAL) << "add block to NodeChannel not supported";
         return Status::OK();
     }

--- a/be/src/exec/tablet_sink.h
+++ b/be/src/exec/tablet_sink.h
@@ -183,8 +183,11 @@ public:
     virtual Status open_wait();
 
     Status add_row(Tuple* tuple, int64_t tablet_id);
-    virtual Status add_row(const BlockRow& block_row, int64_t tablet_id) {
-        LOG(FATAL) << "add block row to NodeChannel not supported";
+
+    virtual Status add_block(vectorized::Block* block,
+                             const vectorized::IColumn::Selector& selector,
+                             const std::vector<int64_t>& tablet_ids) {
+        LOG(FATAL) << "add block to NodeChannel not supported";
         return Status::OK();
     }
 

--- a/be/src/vec/columns/column.h
+++ b/be/src/vec/columns/column.h
@@ -361,6 +361,8 @@ public:
     virtual std::vector<MutablePtr> scatter(ColumnIndex num_columns,
                                             const Selector& selector) const = 0;
 
+    virtual void append_data_by_selector(MutablePtr& res, const Selector& selector) const = 0;
+
     /// Insert data from several other columns according to source mask (used in vertical merge).
     /// For now it is a helper to de-virtualize calls to insert*() functions inside gather loop
     /// (descendants should call gatherer_stream.gather(*this) to implement this function.)
@@ -530,6 +532,9 @@ protected:
     /// In derived classes (that use final keyword), implement scatter method as call to scatter_impl.
     template <typename Derived>
     std::vector<MutablePtr> scatter_impl(ColumnIndex num_columns, const Selector& selector) const;
+
+    template <typename Derived>
+    void append_data_by_selector_impl(MutablePtr& res, const Selector& selector) const;
 };
 
 using ColumnPtr = IColumn::Ptr;

--- a/be/src/vec/columns/column_array.h
+++ b/be/src/vec/columns/column_array.h
@@ -136,6 +136,11 @@ public:
         return scatter_impl<ColumnArray>(num_columns, selector);
     }
 
+    void append_data_by_selector(MutableColumnPtr& res,
+                                 const IColumn::Selector& selector) const override {
+        return append_data_by_selector_impl<ColumnArray>(res, selector);
+    }
+
     void for_each_subcolumn(ColumnCallback callback) override {
         callback(offsets);
         callback(data);

--- a/be/src/vec/columns/column_complex.h
+++ b/be/src/vec/columns/column_complex.h
@@ -230,6 +230,11 @@ public:
         LOG(FATAL) << "scatter not implemented";
     }
 
+    void append_data_by_selector(MutableColumnPtr& res,
+                                 const IColumn::Selector& selector) const override {
+        LOG(FATAL) << "append_data_by_selector is not supported!";
+    }
+
     void replace_column_data(const IColumn& rhs, size_t row, size_t self_row = 0) override {
         DCHECK(size() > self_row);
         data[self_row] = static_cast<const Self&>(rhs).data[row];

--- a/be/src/vec/columns/column_complex.h
+++ b/be/src/vec/columns/column_complex.h
@@ -232,7 +232,7 @@ public:
 
     void append_data_by_selector(MutableColumnPtr& res,
                                  const IColumn::Selector& selector) const override {
-        LOG(FATAL) << "append_data_by_selector is not supported!";
+        this->template append_data_by_selector_impl<ColumnComplexType<T>>(res, selector);
     }
 
     void replace_column_data(const IColumn& rhs, size_t row, size_t self_row = 0) override {

--- a/be/src/vec/columns/column_const.h
+++ b/be/src/vec/columns/column_const.h
@@ -165,6 +165,11 @@ public:
 
     MutableColumns scatter(ColumnIndex num_columns, const Selector& selector) const override;
 
+    void append_data_by_selector(MutableColumnPtr& res,
+                                 const IColumn::Selector& selector) const override {
+        LOG(FATAL) << "append_data_by_selector is not supported in ColumnConst!";
+    }
+
     void get_extremes(Field& min, Field& max) const override { data->get_extremes(min, max); }
 
     void for_each_subcolumn(ColumnCallback callback) override { callback(data); }

--- a/be/src/vec/columns/column_decimal.h
+++ b/be/src/vec/columns/column_decimal.h
@@ -194,6 +194,11 @@ public:
         return this->template scatter_impl<Self>(num_columns, selector);
     }
 
+    void append_data_by_selector(MutableColumnPtr& res,
+                                 const IColumn::Selector& selector) const override {
+        this->template append_data_by_selector_impl<Self>(res, selector);
+    }
+
     //    void gather(ColumnGathererStream & gatherer_stream) override;
 
     bool structure_equals(const IColumn& rhs) const override {

--- a/be/src/vec/columns/column_dictionary.h
+++ b/be/src/vec/columns/column_dictionary.h
@@ -185,6 +185,11 @@ public:
         LOG(FATAL) << "scatter not supported in ColumnDictionary";
     }
 
+    void append_data_by_selector(MutableColumnPtr& res,
+                                 const IColumn::Selector& selector) const override {
+        LOG(FATAL) << "append_data_by_selector is not supported in ColumnDictionary!";
+    }
+
     Status filter_by_selector(const uint16_t* sel, size_t sel_size, IColumn* col_ptr) override {
         auto* res_col = reinterpret_cast<vectorized::ColumnString*>(col_ptr);
         for (size_t i = 0; i < sel_size; i++) {

--- a/be/src/vec/columns/column_dummy.h
+++ b/be/src/vec/columns/column_dummy.h
@@ -125,6 +125,20 @@ public:
         return res;
     }
 
+    void append_data_by_selector(MutableColumnPtr& res,
+                                 const IColumn::Selector& selector) const override {
+        size_t num_rows = size();
+
+        if (num_rows < selector.size()) {
+            LOG(FATAL) << fmt::format("Size of selector: {}, is larger than size of column:{}",
+                                      selector.size(), num_rows);
+        }
+
+        res->reserve(num_rows);
+
+        for (size_t i = 0; i < selector.size(); ++i) res->insert_from(*this, selector[i]);
+    }
+
     void get_extremes(Field&, Field&) const override {}
 
     void addSize(size_t delta) { s += delta; }

--- a/be/src/vec/columns/column_fixed_length_object.h
+++ b/be/src/vec/columns/column_fixed_length_object.h
@@ -165,6 +165,11 @@ public:
         LOG(FATAL) << "scatter not supported";
     }
 
+    void append_data_by_selector(MutableColumnPtr& res,
+                                 const IColumn::Selector& selector) const override {
+        LOG(FATAL) << "append_data_by_selector is not supported!";
+    }
+
     void get_extremes(Field& min, Field& max) const override {
         LOG(FATAL) << "get_extremes not supported";
     }

--- a/be/src/vec/columns/column_impl.h
+++ b/be/src/vec/columns/column_impl.h
@@ -59,4 +59,19 @@ std::vector<IColumn::MutablePtr> IColumn::scatter_impl(ColumnIndex num_columns,
     return columns;
 }
 
+template <typename Derived>
+void IColumn::append_data_by_selector_impl(MutablePtr& res, const Selector& selector) const {
+    size_t num_rows = size();
+
+    if (num_rows < selector.size()) {
+        LOG(FATAL) << fmt::format("Size of selector: {}, is larger than size of column:{}",
+                                  selector.size(), num_rows);
+    }
+
+    res->reserve(num_rows);
+
+    for (size_t i = 0; i < selector.size(); ++i)
+        static_cast<Derived&>(*res).insert_from(*this, selector[i]);
+}
+
 } // namespace doris::vectorized

--- a/be/src/vec/columns/column_nullable.h
+++ b/be/src/vec/columns/column_nullable.h
@@ -165,6 +165,11 @@ public:
         return scatter_impl<ColumnNullable>(num_columns, selector);
     }
 
+    void append_data_by_selector(MutableColumnPtr& res,
+                                 const IColumn::Selector& selector) const override {
+        append_data_by_selector_impl<ColumnNullable>(res, selector);
+    }
+
     //    void gather(ColumnGathererStream & gatherer_stream) override;
 
     void for_each_subcolumn(ColumnCallback callback) override {

--- a/be/src/vec/columns/column_string.h
+++ b/be/src/vec/columns/column_string.h
@@ -302,6 +302,11 @@ public:
         return scatter_impl<ColumnString>(num_columns, selector);
     }
 
+    void append_data_by_selector(MutableColumnPtr& res,
+                                 const IColumn::Selector& selector) const override {
+        append_data_by_selector_impl<ColumnString>(res, selector);
+    }
+
     //    void gather(ColumnGathererStream & gatherer_stream) override;
 
     void reserve(size_t n) override;

--- a/be/src/vec/columns/column_vector.h
+++ b/be/src/vec/columns/column_vector.h
@@ -342,6 +342,11 @@ public:
         return this->template scatter_impl<Self>(num_columns, selector);
     }
 
+    void append_data_by_selector(MutableColumnPtr& res,
+                                 const IColumn::Selector& selector) const override {
+        this->template append_data_by_selector_impl<Self>(res, selector);
+    }
+
     //    void gather(ColumnGathererStream & gatherer_stream) override;
 
     bool can_be_inside_nullable() const override { return true; }

--- a/be/src/vec/columns/predicate_column.h
+++ b/be/src/vec/columns/predicate_column.h
@@ -397,6 +397,11 @@ public:
         LOG(FATAL) << "scatter not supported in PredicateColumnType";
     }
 
+    void append_data_by_selector(MutableColumnPtr& res,
+                                 const IColumn::Selector& selector) const override {
+        LOG(FATAL) << "append_data_by_selector is not supported in PredicateColumnType!";
+    }
+
     Status filter_by_selector(const uint16_t* sel, size_t sel_size, IColumn* col_ptr) override {
         if constexpr (std::is_same_v<T, StringValue>) {
             insert_string_to_res_column(sel, sel_size,

--- a/be/src/vec/core/block.cpp
+++ b/be/src/vec/core/block.cpp
@@ -640,6 +640,14 @@ Block Block::copy_block(const std::vector<int>& column_offset) const {
     return columns_with_type_and_name;
 }
 
+void Block::append_block_by_selector(MutableColumns& columns,
+                                     const IColumn::Selector& selector) const {
+    DCHECK(data.size() == columns.size());
+    for (size_t i = 0; i < data.size(); i++) {
+        data[i].column->append_data_by_selector(columns[i], selector);
+    }
+}
+
 Status Block::filter_block(Block* block, int filter_column_id, int column_to_keep) {
     ColumnPtr filter_column = block->get_by_position(filter_column_id).column;
     if (auto* nullable_column = check_and_get_column<ColumnNullable>(*filter_column)) {

--- a/be/src/vec/core/block.h
+++ b/be/src/vec/core/block.h
@@ -257,6 +257,8 @@ public:
     // copy a new block by the offset column
     Block copy_block(const std::vector<int>& column_offset) const;
 
+    void append_block_by_selector(MutableColumns& columns, const IColumn::Selector& selector) const;
+
     static void filter_block_internal(Block* block, const IColumn::Filter& filter,
                                       uint32_t column_to_keep);
 

--- a/be/src/vec/sink/vtablet_sink.h
+++ b/be/src/vec/sink/vtablet_sink.h
@@ -38,7 +38,8 @@ public:
 
     Status open_wait() override;
 
-    Status add_row(const BlockRow& block_row, int64_t tablet_id) override;
+    Status add_block(vectorized::Block* block, const vectorized::IColumn::Selector& selector,
+                     const std::vector<int64_t>& tablet_ids) override;
 
     int try_send_and_fetch_status(RuntimeState* state,
                                   std::unique_ptr<ThreadPoolToken>& thread_pool_token) override;

--- a/be/src/vec/sink/vtablet_sink.h
+++ b/be/src/vec/sink/vtablet_sink.h
@@ -38,8 +38,9 @@ public:
 
     Status open_wait() override;
 
-    Status add_block(vectorized::Block* block, const vectorized::IColumn::Selector& selector,
-                     const std::vector<int64_t>& tablet_ids) override;
+    Status add_block(vectorized::Block* block,
+                     const std::pair<std::unique_ptr<vectorized::IColumn::Selector>,
+                                     std::vector<int64_t>>& payload) override;
 
     int try_send_and_fetch_status(RuntimeState* state,
                                   std::unique_ptr<ThreadPoolToken>& thread_pool_token) override;


### PR DESCRIPTION
# Proposed changes

Issue Number: close #12289

## Problem summary

In tablets sink, we determine the channel which should be used to send data. Currently, this process is **row by row** and we construct a block by this pattern also. To achieve more performance, this PR aims to construct a new block **batch-at-once** by a vector of row ids.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

