### PR TITLE
[fix](array-type) array_sort function with empty input

### DIFF
--- a/be/src/vec/functions/array/function_array_sort.h
+++ b/be/src/vec/functions/array/function_array_sort.h
@@ -107,7 +107,7 @@ private:
                               const ColumnArray::Offset& curr_offset,
                               const SrcDataType* src_data_concrete, const IColumn& src_column,
                               const NullMapType* src_null_map, IColumn::Permutation& permutation) {
-        for (ColumnArray::Offset j = prev_offset; j < curr_offset - 1; ++j) {
+        for (ColumnArray::Offset j = prev_offset; j + 1 < curr_offset; ++j) {
             if (src_null_map && (*src_null_map)[j]) {
                 continue;
             }

--- a/regression-test/data/query_p0/sql_functions/array_functions/test_array_functions_by_literal.out
+++ b/regression-test/data/query_p0/sql_functions/array_functions/test_array_functions_by_literal.out
@@ -186,6 +186,9 @@ false
 [0, 1, 1]
 
 -- !sql --
+[]
+
+-- !sql --
 false
 
 -- !sql --

--- a/regression-test/suites/query_p0/sql_functions/array_functions/test_array_functions_by_literal.groovy
+++ b/regression-test/suites/query_p0/sql_functions/array_functions/test_array_functions_by_literal.groovy
@@ -97,6 +97,7 @@ suite("test_array_functions_by_literal") {
     qt_sql "select array_sort(['a','b','c'])"
     qt_sql "select array_sort(['c','b','a'])"
     qt_sql "select array_sort([true, false, true])"
+    qt_sql "select array_sort([])"
 
     // array_overlap function
     qt_sql "select arrays_overlap([1,2,3], [4,5,6])"


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

array_sort with empty array as input, will got error.
because compare use UInt64, `(uint64_t)0 < (uint64_t)0 - 1` is true.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [x] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

