### PR TITLE
[enhancement](array-type) output more readable message for array type

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/BinaryPredicate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/BinaryPredicate.java
@@ -330,6 +330,9 @@ public class BinaryPredicate extends Predicate implements Writable {
             if (e.getType().getPrimitiveType() == PrimitiveType.BITMAP) {
                 throw new AnalysisException("Bitmap type dose not support operand: " + toSql());
             }
+            if (e.getType().isArrayType()) {
+                throw new AnalysisException("Array type dose not support operand: " + toSql());
+            }
         }
 
         if (canCompareDate(getChild(0).getType().getPrimitiveType(), getChild(1).getType().getPrimitiveType())) {

--- a/regression-test/suites/query_p0/sql_functions/array_functions/test_array_functions_with_where.groovy
+++ b/regression-test/suites/query_p0/sql_functions/array_functions/test_array_functions_with_where.groovy
@@ -46,4 +46,10 @@ suite("test_array_functions_with_where") {
     qt_select "SELECT k1, size(k2) FROM ${tableName} WHERE element_at(k2, 1)=1 ORDER BY k1"
     qt_select "SELECT k1, size(k2) FROM ${tableName} WHERE arrays_overlap(k2, k4) ORDER BY k1"
     qt_select "SELECT k1, size(k2) FROM ${tableName} WHERE cardinality(k2)>0 ORDER BY k1, size(k2)"
+
+    test {
+        sql "select k1, size(k2) FROM ${tableName} WHERE k2 = []"
+        // check exception message contains
+        exception "Array type dose not support operand"
+    }
 }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary
Array type do not support directly operand '=', '>', '<' and so on.
The pr make the output error message more readable.

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [x] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

