### PR TITLE
[Bug](compile) fix a be clang compile error

### DIFF
--- a/be/src/util/bit_packing.inline.h
+++ b/be/src/util/bit_packing.inline.h
@@ -35,6 +35,13 @@ inline int64_t BitPacking::NumValuesToUnpack(int bit_width, int64_t in_bytes, in
     }
 }
 
+constexpr uint64_t GetMask(int num_bits) {
+    if (num_bits >= 64) {
+        return ~0L;
+    }
+    return (1ULL << num_bits) - 1;
+}
+
 template <typename T>
 constexpr bool IsSupportedUnpackingType() {
     return std::is_same<T, uint8_t>::value || std::is_same<T, uint16_t>::value ||
@@ -176,7 +183,7 @@ inline uint64_t ALWAYS_INLINE UnpackValue(const uint8_t* __restrict__ in_buf) {
     static_assert(WORDS_TO_READ <= 3, "At most three 32-bit words need to be loaded.");
 
     constexpr int FIRST_BIT_OFFSET = FIRST_BIT_IDX - FIRST_WORD_IDX * 32;
-    constexpr uint64_t mask = BIT_WIDTH == 64 ? ~0L : (1UL << BIT_WIDTH) - 1;
+    constexpr uint64_t mask = GetMask(BIT_WIDTH);
     const uint32_t* const in = reinterpret_cast<const uint32_t*>(in_buf);
 
     // Avoid reading past the end of the buffer. We can safely read 64 bits if we know that


### PR DESCRIPTION
# Proposed changes

Fix a clang compile error.

Clang compiler report:
```
left shift count >= width of type
```

This compile error is from #11637 

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

