### PR TITLE
[performance improvement](Spark Load) SparkDpp processRDDAggregate performance improvement

### DIFF
--- a/fe/spark-dpp/src/main/java/org/apache/doris/load/loadv2/dpp/SparkDpp.java
+++ b/fe/spark-dpp/src/main/java/org/apache/doris/load/loadv2/dpp/SparkDpp.java
@@ -138,12 +138,8 @@ public final class SparkDpp implements java.io.Serializable {
             RollupTreeNode curNode, SparkRDDAggregator[] sparkRDDAggregators) throws SparkDppException {
         final boolean isDuplicateTable = !StringUtils.equalsIgnoreCase(curNode.indexMeta.indexType, "AGGREGATE")
                 && !StringUtils.equalsIgnoreCase(curNode.indexMeta.indexType, "UNIQUE");
-
         // Aggregate/UNIQUE table
         if (!isDuplicateTable) {
-            // TODO(wb) set the reduce concurrency by statistic instead of hard code 200
-            int aggregateConcurrency = 200;
-
             int idx = 0;
             for (int i = 0; i < curNode.indexMeta.columns.size(); i++) {
                 if (!curNode.indexMeta.columns.get(i).isKey) {
@@ -155,14 +151,14 @@ public final class SparkDpp implements java.io.Serializable {
             if (curNode.indexMeta.isBaseIndex) {
                 JavaPairRDD<List<Object>, Object[]> result = currentPairRDD.mapToPair(
                         new EncodeBaseAggregateTableFunction(sparkRDDAggregators))
-                        .reduceByKey(new AggregateReduceFunction(sparkRDDAggregators), aggregateConcurrency);
+                        .reduceByKey(new AggregateReduceFunction(sparkRDDAggregators));
                 return result;
             } else {
                 JavaPairRDD<List<Object>, Object[]> result = currentPairRDD
                         .mapToPair(new EncodeRollupAggregateTableFunction(
                                 getColumnIndexInParentRollup(curNode.keyColumnNames, curNode.valueColumnNames,
                                         curNode.parent.keyColumnNames, curNode.parent.valueColumnNames)))
-                        .reduceByKey(new AggregateReduceFunction(sparkRDDAggregators), aggregateConcurrency);
+                        .reduceByKey(new AggregateReduceFunction(sparkRDDAggregators));
                 return result;
             }
         // Duplicate Table


### PR DESCRIPTION
…rformance improvement

# Proposed changes

Issue Number: close #12185 

## Problem summary

### 变更位置

- 删除如图所示的 aggregateConcurrency
- reduceByKey 删除指定的分区数，使用 Stage 1 的分区数来进行计算

![image](https://user-images.githubusercontent.com/8758438/187402399-e4296f4f-8140-4642-9bbf-a8bc434737f3.png)

### 性能比对

#### 【修改前】reduceByKey 中传入写死的 200 限制了分区数

- Stage 2 处理数据时间 1 小时 30 分

![spark 执行过程性能瓶颈描述](https://user-images.githubusercontent.com/8758438/187393221-b0eefcb9-3913-49c9-a5c0-d45e9fbbd4bc.png)

![image](https://user-images.githubusercontent.com/8758438/187398925-6111b419-54e2-45f8-9ebc-899d5c669177.png)

####【修改后】reduceByKey 过程使用前置节点的分区数

- Stage 2 处理数据时间 1.8 分

![优化后效果截图](https://user-images.githubusercontent.com/8758438/187396454-461dc61e-1490-4ddc-b5f9-d4fbd0129cac.png)

![image](https://user-images.githubusercontent.com/8758438/187399488-157cbca7-88cd-4d28-97e6-7142c8229d68.png)


## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

