### PR TITLE
[refactor](column) remove confused field

### DIFF
--- a/fe/fe-core/src/main/cup/sql_parser.cup
+++ b/fe/fe-core/src/main/cup/sql_parser.cup
@@ -4837,12 +4837,10 @@ type ::=
   {: RESULT = ScalarType.createStringType(); :}
   | KW_VARCHAR LPAREN INTEGER_LITERAL:len RPAREN
   {: ScalarType type = ScalarType.createVarcharType(len.intValue());
-     type.setAssignedStrLenInColDefinition();
      RESULT = type;
   :}
   | KW_VARCHAR LPAREN ident_or_text:lenStr RPAREN
   {: ScalarType type = ScalarType.createVarcharType(lenStr);
-     type.setAssignedStrLenInColDefinition();
      RESULT = type;
   :}
   | KW_VARCHAR
@@ -4857,12 +4855,10 @@ type ::=
   {: RESULT = new StructType(fields); :}
   | KW_CHAR LPAREN INTEGER_LITERAL:len RPAREN
   {: ScalarType type = ScalarType.createCharType(len.intValue());
-     type.setAssignedStrLenInColDefinition();
      RESULT = type;
   :}
   | KW_CHAR LPAREN ident_or_text:lenStr RPAREN
   {: ScalarType type = ScalarType.createCharType(lenStr);
-     type.setAssignedStrLenInColDefinition();
      RESULT = type;
   :}
   | KW_CHAR
@@ -4889,7 +4885,6 @@ type ::=
   {: RESULT = ScalarType.createDecimalV3Type(precision, scale); :}
   | KW_HLL
   {: ScalarType type = ScalarType.createHllType();
-     type.setAssignedStrLenInColDefinition();
      RESULT = type;
   :}
   | KW_ALL

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/CastExpr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/CastExpr.java
@@ -342,8 +342,7 @@ public class CastExpr extends Expr {
         // of cast is decided by child.
         if (targetTypeDef.getType().isScalarType()) {
             final ScalarType targetType = (ScalarType) targetTypeDef.getType();
-            if (!(targetType.getPrimitiveType().isStringType()
-                    && !targetType.isAssignedStrLenInColDefinition())) {
+            if (!(targetType.getPrimitiveType().isStringType() && !targetType.isLengthSet())) {
                 targetTypeDef.analyze(analyzer);
             }
         } else {

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ColumnDef.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ColumnDef.java
@@ -205,8 +205,7 @@ public class ColumnDef {
         // When string type length is not assigned, it need to be assigned to 1.
         if (typeDef.getType().isScalarType()) {
             final ScalarType targetType = (ScalarType) typeDef.getType();
-            if (targetType.getPrimitiveType().isStringType()
-                    && !targetType.isAssignedStrLenInColDefinition()) {
+            if (targetType.getPrimitiveType().isStringType() && !targetType.isLengthSet()) {
                 targetType.setLength(1);
             }
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/TypeDef.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/TypeDef.java
@@ -129,8 +129,7 @@ public class TypeDef implements ParseNode {
             throw new AnalysisException("Array unsupported sub-type: " + type.toSql());
         }
 
-        if (type.getPrimitiveType().isStringType()
-                && !type.isAssignedStrLenInColDefinition()) {
+        if (type.getPrimitiveType().isStringType() && !type.isLengthSet()) {
             type.setLength(1);
         }
         analyze(type);

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/ScalarType.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/ScalarType.java
@@ -87,8 +87,6 @@ public class ScalarType extends Type {
     // Only used for type CHAR.
     @SerializedName(value = "len")
     private int len = -1;
-    @SerializedName(value = "isAssignedStrLenInColDefinition")
-    private boolean isAssignedStrLenInColDefinition = false;
 
     // Only used if type is DECIMAL. -1 (for both) is used to represent a
     // decimal with any precision and scale.
@@ -660,12 +658,8 @@ public class ScalarType extends Type {
         this.len = len;
     }
 
-    public boolean isAssignedStrLenInColDefinition() {
-        return isAssignedStrLenInColDefinition;
-    }
-
-    public void setAssignedStrLenInColDefinition() {
-        this.isAssignedStrLenInColDefinition = true;
+    public boolean isLengthSet() {
+        return getPrimitiveType() == PrimitiveType.HLL || len > 0 || !Strings.isNullOrEmpty(lenStr);
     }
 
     // add scalar infix to override with getPrecision


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

`isAssignedStrLenInColDefinition` is confused and not necessary at all,
we can just use `len` and `lenStr` to check whether the length of string type is set.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

