### PR TITLE
[fix](Nereids)statistics calculator for Project and Aggregate lost some columns

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/StatsCalculator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/StatsCalculator.java
@@ -284,8 +284,8 @@ public class StatsCalculator extends DefaultPlanVisitor<StatsDeriveResult, Void>
     // TODO: do real project on column stats
     private StatsDeriveResult computeProject(Project project) {
         List<NamedExpression> projections = project.getProjects();
-        Map<Slot, ColumnStats> childColumnStats = groupExpression.getCopyOfChildStats(0).getSlotToColumnStats();
         StatsDeriveResult statsDeriveResult = groupExpression.getCopyOfChildStats(0);
+        Map<Slot, ColumnStats> childColumnStats = statsDeriveResult.getSlotToColumnStats();
         Map<Slot, ColumnStats> columnsStats = projections.stream().map(projection -> {
             List<SlotReference> slotReferences = projection.collect(SlotReference.class::isInstance);
             if (slotReferences.isEmpty()) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/StatsCalculator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/StatsCalculator.java
@@ -285,17 +285,13 @@ public class StatsCalculator extends DefaultPlanVisitor<StatsDeriveResult, Void>
     private StatsDeriveResult computeProject(Project project) {
         List<NamedExpression> projections = project.getProjects();
         Map<Slot, ColumnStats> childColumnStats = groupExpression.getCopyOfChildStats(0).getSlotToColumnStats();
-        StatsDeriveResult statsDeriveResult = new StatsDeriveResult(groupExpression.getCopyOfChildStats(0));
+        StatsDeriveResult statsDeriveResult = groupExpression.getCopyOfChildStats(0);
         Map<Slot, ColumnStats> columnsStats = projections.stream().map(projection -> {
             List<SlotReference> slotReferences = projection.collect(SlotReference.class::isInstance);
             if (slotReferences.isEmpty()) {
-                ColumnStats columnStats = new ColumnStats();
-                columnStats.setAvgSize(1);
-                columnStats.setMaxSize(1);
-                columnStats.setNdv(1);
-                columnStats.setNumNulls(0);
-                return new AbstractMap.SimpleEntry<>(projection.toSlot(), columnStats);
+                return new AbstractMap.SimpleEntry<>(projection.toSlot(), ColumnStats.createDefaultColumnStats());
             } else {
+                // TODO: just a trick here, need to do real project on column stats
                 return new AbstractMap.SimpleEntry<>(projection.toSlot(), childColumnStats.get(slotReferences.get(0)));
             }
         }).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/SlotReference.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/SlotReference.java
@@ -116,16 +116,13 @@ public class SlotReference extends Slot {
             return false;
         }
         SlotReference that = (SlotReference) o;
-        return nullable == that.nullable
-                && dataType.equals(that.dataType)
-                && exprId.equals(that.exprId)
-                && name.equals(that.name)
-                && qualifier.equals(that.qualifier);
+        return exprId.equals(that.exprId);
+
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(exprId, name, qualifier, nullable);
+        return Objects.hash(exprId);
     }
 
     public Column getColumn() {

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/ColumnStats.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/ColumnStats.java
@@ -76,6 +76,15 @@ public class ColumnStats {
     private LiteralExpr minValue;
     private LiteralExpr maxValue;
 
+    public static ColumnStats createDefaultColumnStats() {
+        ColumnStats columnStats = new ColumnStats();
+        columnStats.setAvgSize(1);
+        columnStats.setMaxSize(1);
+        columnStats.setNdv(1);
+        columnStats.setNumNulls(0);
+        return columnStats;
+    }
+
     public ColumnStats(ColumnStats other) {
         this.ndv = other.ndv;
         this.avgSize = other.avgSize;

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/PlanEqualsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/PlanEqualsTest.java
@@ -95,8 +95,8 @@ public class PlanEqualsTest {
         Assertions.assertEquals(expected, actual);
 
         LogicalJoin<Plan, Plan> unexpected = new LogicalJoin<>(JoinType.INNER_JOIN, Lists.newArrayList(new EqualTo(
-                new SlotReference(new ExprId(2),"a", BigIntType.INSTANCE, false, Lists.newArrayList()),
-                new SlotReference(new ExprId(3),"b", BigIntType.INSTANCE, true, Lists.newArrayList()))),
+                new SlotReference(new ExprId(2), "a", BigIntType.INSTANCE, false, Lists.newArrayList()),
+                new SlotReference(new ExprId(3), "b", BigIntType.INSTANCE, true, Lists.newArrayList()))),
                 Optional.empty(), left, right);
         Assertions.assertNotEquals(unexpected, actual);
     }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/PlanEqualsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/PlanEqualsTest.java
@@ -65,7 +65,7 @@ public class PlanEqualsTest {
         Assertions.assertEquals(expected, actual);
 
         LogicalAggregate<Plan> unexpected = new LogicalAggregate<>(Lists.newArrayList(), ImmutableList.of(
-                new SlotReference(new ExprId(0), "b", BigIntType.INSTANCE, true, Lists.newArrayList())),
+                new SlotReference(new ExprId(1), "b", BigIntType.INSTANCE, true, Lists.newArrayList())),
                 child);
         Assertions.assertNotEquals(unexpected, actual);
     }
@@ -95,8 +95,8 @@ public class PlanEqualsTest {
         Assertions.assertEquals(expected, actual);
 
         LogicalJoin<Plan, Plan> unexpected = new LogicalJoin<>(JoinType.INNER_JOIN, Lists.newArrayList(new EqualTo(
-                new SlotReference("a", BigIntType.INSTANCE, false, Lists.newArrayList()),
-                new SlotReference("b", BigIntType.INSTANCE, true, Lists.newArrayList()))),
+                new SlotReference(new ExprId(2),"a", BigIntType.INSTANCE, false, Lists.newArrayList()),
+                new SlotReference(new ExprId(3),"b", BigIntType.INSTANCE, true, Lists.newArrayList()))),
                 Optional.empty(), left, right);
         Assertions.assertNotEquals(unexpected, actual);
     }
@@ -151,7 +151,7 @@ public class PlanEqualsTest {
 
         LogicalSort<Plan> unexpected = new LogicalSort<>(
                 ImmutableList.of(new OrderKey(
-                        new SlotReference(new ExprId(1), "a", BigIntType.INSTANCE, true, Lists.newArrayList()), true,
+                        new SlotReference(new ExprId(2), "a", BigIntType.INSTANCE, true, Lists.newArrayList()), true,
                         true)),
                 child);
         Assertions.assertNotEquals(unexpected, actual);
@@ -211,8 +211,8 @@ public class PlanEqualsTest {
 
         PhysicalHashJoin<Plan, Plan> unexpected = new PhysicalHashJoin<>(JoinType.INNER_JOIN,
                 Lists.newArrayList(new EqualTo(
-                        new SlotReference("a", BigIntType.INSTANCE, false, Lists.newArrayList()),
-                        new SlotReference("b", BigIntType.INSTANCE, true, Lists.newArrayList()))),
+                        new SlotReference(new ExprId(2), "a", BigIntType.INSTANCE, false, Lists.newArrayList()),
+                        new SlotReference(new ExprId(3), "b", BigIntType.INSTANCE, true, Lists.newArrayList()))),
                 Optional.empty(), logicalProperties, left, right);
         Assertions.assertNotEquals(unexpected, actual);
     }
@@ -288,7 +288,7 @@ public class PlanEqualsTest {
 
         PhysicalQuickSort<Plan> unexpected = new PhysicalQuickSort<>(
                 ImmutableList.of(new OrderKey(
-                        new SlotReference(new ExprId(1), "a", BigIntType.INSTANCE, true, Lists.newArrayList()), true,
+                        new SlotReference(new ExprId(2), "a", BigIntType.INSTANCE, true, Lists.newArrayList()), true,
                         true)),
                 logicalProperties,
                 child);


### PR DESCRIPTION
## Problem summary

There are some bugs in Nereids' StatsCalculator.
- Project: return child column stats directly, so its parents cannot find column stats from project's slot.
- Aggregate: do not return column that is `Alias`, its parents cannot find some column stats from Aggregate's slot.
- All: use `SlotReference` as key of column to stats map. So we need change SlotReference's `equals` and `hashCode` method to just using `ExprId` as we discussed.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

