### PR TITLE
[fix](Nereids)cast StringType to DateType failed when bind TimestampArithmetic function

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/BindFunction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/BindFunction.java
@@ -35,6 +35,7 @@ import org.apache.doris.nereids.trees.expressions.visitor.DefaultExpressionRewri
 import org.apache.doris.nereids.trees.plans.logical.LogicalFilter;
 import org.apache.doris.nereids.trees.plans.logical.LogicalProject;
 import org.apache.doris.nereids.types.DateTimeType;
+import org.apache.doris.nereids.types.DateType;
 import org.apache.doris.nereids.types.IntegerType;
 
 import com.google.common.collect.ImmutableList;
@@ -143,7 +144,7 @@ public class BindFunction implements AnalysisRuleFactory {
 
         @Override
         public Expression visitTimestampArithmetic(TimestampArithmetic arithmetic, Void context) {
-            String funcOpName = null;
+            String funcOpName;
             if (arithmetic.getFuncName() == null) {
                 funcOpName = String.format("%sS_%s", arithmetic.getTimeUnit(),
                         (arithmetic.getOp() == Operator.ADD) ? "ADD" : "SUB");
@@ -154,11 +155,18 @@ public class BindFunction implements AnalysisRuleFactory {
             Expression left = arithmetic.left();
             Expression right = arithmetic.right();
 
-            if (!arithmetic.left().getDataType().isDateType()) {
-                left = arithmetic.left().castTo(DateTimeType.INSTANCE);
+            if (!left.getDataType().isDateType()) {
+                try {
+                    left = left.castTo(DateTimeType.INSTANCE);
+                } catch (Exception e) {
+                    // ignore
+                }
+                if (!left.getDataType().isDateType() && arithmetic.getTimeUnit().isDateTimeUnit()) {
+                    left = arithmetic.left().castTo(DateType.INSTANCE);
+                }
             }
-            if (!arithmetic.right().getDataType().isIntType()) {
-                right = arithmetic.right().castTo(IntegerType.INSTANCE);
+            if (!right.getDataType().isIntType()) {
+                right = right.castTo(IntegerType.INSTANCE);
             }
             return arithmetic.withFuncName(funcOpName).withChildren(ImmutableList.of(left, right));
         }


### PR DESCRIPTION
## Problem summary

When bind TimestampArithmetic, we always want to cast left child to DateTimeType. But sometimes, we need to cast it to DateType, this PR fix this problem.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

