### PR TITLE
[fix](compile) Fix compile error '<unknown>' may be used uninitialized in PODArray::insert_prepare

### DIFF
--- a/be/src/vec/common/pod_array.h
+++ b/be/src/vec/common/pod_array.h
@@ -450,7 +450,20 @@ public:
     /// Do not insert into the array a piece of itself. Because with the resize, the iterators on themselves can be invalidated.
     template <typename It1, typename It2, typename... TAllocatorParams>
     void insert(It1 from_begin, It2 from_end, TAllocatorParams&&... allocator_params) {
+// `place` in IAggregateFunctionHelper::streaming_agg_serialize is initialized by placement new, in IAggregateFunctionHelper::create.
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wuninitialized"
+#elif defined(__GNUC__) || defined(__GNUG__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
         insert_prepare(from_begin, from_end, std::forward<TAllocatorParams>(allocator_params)...);
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(__GNUC__) || defined(__GNUG__)
+#pragma GCC diagnostic pop
+#endif
         insert_assume_reserved(from_begin, from_end);
     }
 


### PR DESCRIPTION
## Problem summary

`place` in `IAggregateFunctionHelper::streaming_agg_serialize` is initialized by placement new, in `IAggregateFunctionHelper::create`.

The error appeared after #12168, but this did not modify the `IAggregateFunctionHelper` `PODArray` related logic. After testing, I found that this error occurs after modifying `limiter_mem_tracker().get()` in `thread_context.h : THREAD_MEM_TRACKER_TRANSFER_FROM` to `limiter_mem_tracker_raw()`.

Perhaps this affects the compilation behavior? Like inline? If you understand c++ compilation, welcome to answer.

error:
```
In member function 'void doris::vectorized::PODArray<T, initial_bytes, TAllocator, pad_right_, pad_left_>::insert(It1, It2, TAllocatorParams&& ...) [with It1 = const char*; It2 = const char*; TAllocatorParams = {}; T = unsigned char; long unsigned int initial_bytes = 4096; TAllocator = Allocator<false>; long unsigned int pad_right_ = 15; long unsigned int pad_left_ = 16]',
    inlined from 'virtual void doris::vectorized::VectorBufferWriter::write(const char*, int)' at /doris/core/be/src/vec/common/string_buffer.hpp:47:21,
    inlined from 'void doris::vectorized::write_pod_binary(const Type&, doris::vectorized::BufferWritable&) [with Type = short int]' at /doris/core/be/src/vec/io/io_helper.h:98:14,
    inlined from 'void doris::vectorized::write_binary(const Type&, doris::vectorized::BufferWritable&) [with Type = short int]' at /doris/core/be/src/vec/io/io_helper.h:143:21,
    inlined from 'void doris::vectorized::AggregateFunctionSumData<T>::write(doris::vectorized::BufferWritable&) const [with T = short int]' at /doris/core/be/src/vec/aggregate_functions/aggregate_function_sum.h:39:57,
    inlined from 'void doris::vectorized::AggregateFunctionSum<T, TResult, Data>::serialize(doris::vectorized::ConstAggregateDataPtr, doris::vectorized::BufferWritable&) const [with T = short int; TResult = short int; Data = doris::vectorized::AggregateFunctionSumData<short int>]' at /doris/core/be/src/vec/aggregate_functions/aggregate_function_sum.h:91:32,
    inlined from 'void doris::vectorized::IAggregateFunctionHelper<Derived>::streaming_agg_serialize(const doris::vectorized::IColumn**, doris::vectorized::BufferWritable&, size_t, doris::vectorized::Arena*) const [with Derived = doris::vectorized::AggregateFunctionSum<short int, short int, doris::vectorized::AggregateFunctionSumData<short int> >]' at /doris/core/be/src/vec/aggregate_functions/aggregate_function.h:315:57,
    inlined from 'void doris::vectorized::IAggregateFunctionHelper<Derived>::streaming_agg_serialize_to_column(const doris::vectorized::IColumn**, doris::vectorized::MutableColumnPtr&, size_t, doris::vectorized::Arena*) const [with Derived = doris::vectorized::AggregateFunctionSum<short int, short int, doris::vectorized::AggregateFunctionSumData<short int> >]' at /doris/core/be/src/vec/aggregate_functions/aggregate_function.h:324:32:
/doris/core/be/src/vec/common/pod_array.h:453:23: error: '<unknown>' may be used uninitialized [-Werror=maybe-uninitialized]
  453 |         insert_prepare(from_begin, from_end, std::forward<TAllocatorParams>(allocator_params)...);
      |         ~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/doris/core/be/src/vec/common/pod_array.h: In member function 'void doris::vectorized::IAggregateFunctionHelper<Derived>::streaming_agg_serialize_to_column(const doris::vectorized::IColumn**, doris::vectorized::MutableColumnPtr&, size_t, doris::vectorized::Arena*) const [with Derived = doris::vectorized::AggregateFunctionSum<short int, short int, doris::vectorized::AggregateFunctionSumData<short int> >]':
/doris/core/be/src/vec/common/pod_array.h:443:10: note: by argument 3 of type 'const char*' to 'void doris::vectorized::PODArray<T, initial_bytes, TAllocator, pad_right_, pad_left_>::insert_prepare(It1, It2, TAllocatorParams&& ...) [with It1 = const char*; It2 = const char*; TAllocatorParams = {}; T = unsigned char; long unsigned int initial_bytes = 4096; TAllocator = Allocator<false>; long unsigned int pad_right_ = 15; long unsigned int pad_left_ = 16]' declared here
  443 |     void insert_prepare(It1 from_begin, It2 from_end, TAllocatorParams&&... allocator_params) {
      |          ^~~~~~~~~~~~~~
```

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [x] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

