### PR TITLE
[fix] a slot id is bounded on a wrong tuple id, if cross join has a hash join as child

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/planner/HashJoinNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/HashJoinNode.java
@@ -377,7 +377,9 @@ public class HashJoinNode extends PlanNode {
         int leftNullableNumber = 0;
         int rightNullableNumber = 0;
         if (copyLeft) {
-            for (TupleDescriptor leftTupleDesc : analyzer.getDescTbl().getTupleDesc(getChild(0).getOutputTblRefIds())) {
+            List<TupleId> srcTupleIds = getChild(0) instanceof CrossJoinNode ? getChild(0).getOutputTupleIds()
+                    : getChild(0).getOutputTblRefIds();
+            for (TupleDescriptor leftTupleDesc : analyzer.getDescTbl().getTupleDesc(srcTupleIds)) {
                 // if the child is cross join node, the only way to get the correct nullable info of its output slots
                 // is to check if the output tuple ids are outer joined or not.
                 // then pass this nullable info to hash join node will be correct.
@@ -401,8 +403,10 @@ public class HashJoinNode extends PlanNode {
             }
         }
         if (copyRight) {
+            List<TupleId> srcTupleIds = getChild(1) instanceof CrossJoinNode ? getChild(1).getOutputTupleIds()
+                    : getChild(1).getOutputTblRefIds();
             for (TupleDescriptor rightTupleDesc :
-                    analyzer.getDescTbl().getTupleDesc(getChild(1).getOutputTblRefIds())) {
+                    analyzer.getDescTbl().getTupleDesc(srcTupleIds)) {
                 boolean needSetToNullable =
                         getChild(1) instanceof CrossJoinNode && analyzer.isOuterJoined(rightTupleDesc.getId());
                 for (SlotDescriptor rightSlotDesc : rightTupleDesc.getSlots()) {


### PR DESCRIPTION
# Proposed changes
pick from
https://github.com/apache/doris/pull/12156

To produce this bug, please refer to regression test case: correctness/test_crossjoin_inlineview_slot
the plan is

```
RightJoin
   |
   |-->ANY
   |-->CrossJoin
              |-->HashJoin
              |-->ANY
```
The root cause is RightJoin use a slot which is from the child of HashJoin。
All slot referred from HashJoin should be bounded on HashJoin.vOutputTupleIds, not the HashJoin.InputTupleIds.

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

