### PR TITLE
[fix](new-scan) fix potential wrong cancel when sql has limit

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -852,7 +852,7 @@ CONF_Int32(doris_remote_scanner_thread_pool_queue_size, "10240");
 
 // If set to true, the new scan node framework will be used.
 // This config should be removed when the new scan node is ready.
-CONF_Bool(enable_new_scan_node, "false");
+CONF_Bool(enable_new_scan_node, "true");
 
 #ifdef BE_TEST
 // test s3

--- a/be/src/vec/exec/scan/scanner_scheduler.cpp
+++ b/be/src/vec/exec/scan/scanner_scheduler.cpp
@@ -205,26 +205,30 @@ void ScannerScheduler::_scanner_scan(ScannerScheduler* scheduler, ScannerContext
     bool get_free_block = true;
     int num_rows_in_block = 0;
 
+    // Only set to true when ctx->done() return true.
+    // Use this flag because we need distinguish eos from `should_stop`.
+    // If eos is true, we still need to return blocks,
+    // but is should_stop is true, no need to return blocks
+    bool should_stop = false;
     // Has to wait at least one full block, or it will cause a lot of schedule task in priority
     // queue, it will affect query latency and query concurrency for example ssb 3.3.
     while (!eos && raw_bytes_read < raw_bytes_threshold &&
            ((raw_rows_read < raw_rows_threshold && get_free_block) ||
             num_rows_in_block < state->batch_size())) {
         if (UNLIKELY(ctx->done())) {
-            eos = true;
-            status = Status::Cancelled("Cancelled");
-            LOG(INFO) << "Scan thread cancelled, cause query done, maybe reach limit.";
+            // No need to set status on error here.
+            // Because done() maybe caused by "should_stop"
+            should_stop = true;
             break;
         }
 
         auto block = ctx->get_free_block(&get_free_block);
         status = scanner->get_block(state, block, &eos);
-        VLOG_ROW << "VOlapScanNode input rows: " << block->rows();
+        VLOG_ROW << "VOlapScanNode input rows: " << block->rows() << ", eos: " << eos;
         if (!status.ok()) {
             LOG(WARNING) << "Scan thread read VOlapScanner failed: " << status.to_string();
             // Add block ptr in blocks, prevent mem leak in read failed
             blocks.push_back(block);
-            eos = true;
             break;
         }
 
@@ -249,11 +253,14 @@ void ScannerScheduler::_scanner_scan(ScannerScheduler* scheduler, ScannerContext
         ctx->set_status_on_error(status);
         eos = true;
         std::for_each(blocks.begin(), blocks.end(), std::default_delete<vectorized::Block>());
+    } else if (should_stop) {
+        // No need to return blocks because of should_stop, just delete them
+        std::for_each(blocks.begin(), blocks.end(), std::default_delete<vectorized::Block>());
     } else if (!blocks.empty()) {
         ctx->append_blocks_to_queue(blocks);
     }
 
-    if (eos) {
+    if (eos || should_stop) {
         scanner->mark_to_need_to_close();
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/AdminCopyTabletStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/AdminCopyTabletStmt.java
@@ -75,6 +75,9 @@ public class AdminCopyTabletStmt extends ShowStmt {
             ErrorReport.reportAnalysisException(ErrorCode.ERR_SPECIFIC_ACCESS_DENIED_ERROR, "NODE");
         }
 
+        if (properties == null) {
+            return;
+        }
         try {
             Iterator<Map.Entry<String, String>> iter = properties.entrySet().iterator();
             while (iter.hasNext()) {


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

One scanner maybe stopped by other scanners earlier, which cause data lose.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

