### PR TITLE
[bugfix](join) fix coredump when build block size is 0

### DIFF
--- a/be/src/vec/exec/join/vhash_join_node.cpp
+++ b/be/src/vec/exec/join/vhash_join_node.cpp
@@ -200,9 +200,9 @@ struct ProcessHashTableProbe {
                     }
                 }
             } else {
-                bool need_nullable_convert[column_length];
+                bool need_nullable_convert[column_length] = {false};
                 for (int i = 0; i < column_length; ++i) {
-                    if (output_slot_flags[i]) {
+                    if (output_slot_flags[i] && !_build_blocks.empty()) {
                         need_nullable_convert[i] =
                                 probe_all &&
                                 !_build_blocks[0].get_by_position(i).column->is_nullable();


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

```
WARNING: Logging before InitGoogleLogging() is written to STDERR
I0919 11:28:12.714655  4271 env.cpp:46] Env init successfully.
*** Aborted at 1663558219 (unix time) try "date -d @1663558219" if you are using GNU date ***
*** SIGSEGV unkown detail explain (@0x0) received by PID 4271 (TID 0x7ff098311700) from PID 0; stack trace: ***
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /root/doris/be/src/common/signal_handler.h:420
 1# 0x00007FF0DC129400 in /lib64/libc.so.6
 2# COW<doris::vectorized::IColumn>::intrusive_ptr<doris::vectorized::IColumn const>::operator->() const at /root/doris/be/src/vec/common/cow.h:210
 3# void doris::vectorized::ProcessHashTableProbe<doris::vectorized::SerializedHashTableContext, std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type)1>, false>::build_side_output_column<false>(std::vector<COW<doris::vectorized::IColumn>::mutable_ptr<doris::vectorized::IColumn>, std::allocator<COW<doris::vectorized::IColumn>::mutable_ptr<doris::vectorized::IColumn> > >&, int, int, std::vector<bool, std::allocator<bool> > const&, int) at /root/doris/be/src/vec/exec/join/vhash_join_node.cpp:208
 4# doris::vectorized::ProcessHashTableProbe<doris::vectorized::SerializedHashTableContext, std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type)1>, false>::do_process(doris::vectorized::SerializedHashTableContext&, doris::vectorized::PODArray<unsigned char, 4096ul, Allocator<false, false>, 15ul, 16ul> const*, doris::vectorized::MutableBlock&, doris::vectorized::Block*) at /root/doris/be/src/vec/exec/join/vhash_join_node.cpp:399
 5# auto doris::vectorized::HashJoinNode::get_next(doris::RuntimeState*, doris::vectorized::Block*, bool*)::{lambda(auto:1&&, auto:2&&, auto:3, auto:4)#2}::operator()<doris::vectorized::SerializedHashTableContext&, std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type)1>&, std::integral_constant<bool, false>, std::integral_constant<bool, false> >(doris::vectorized::SerializedHashTableContext&, std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type)1>&, std::integral_constant<bool, false>, std::integral_constant<bool, false>) const at /root/doris/be/src/vec/exec/join/vhash_join_node.cpp:955
 6# void std::__invoke_impl<void, doris::vectorized::HashJoinNode::get_next(doris::RuntimeState*, doris::vectorized::Block*, bool*)::{lambda(auto:1&&, auto:2&&, auto:3, auto:4)#2}, doris::vectorized::SerializedHashTableContext&, std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type)1>&, std::integral_constant<bool, false>, std::integral_constant<bool, false> >(std::__invoke_other, doris::vectorized::HashJoinNode::get_next(doris::RuntimeState*, doris::vectorized::Block*, bool*)::{lambda(auto:1&&, auto:2&&, auto:3, auto:4)#2}&&, doris::vectorized::SerializedHashTableContext&, std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type)1>&, std::integral_constant<bool, false>&&, std::integral_constant<bool, false>&&) at /var/local/ldb-toolchain/include/c++/11/bits/invoke.h:61
 7# std::__invoke_result<doris::vectorized::HashJoinNode::get_next(doris::RuntimeState*, doris::vectorized::Block*, bool*)::{lambda(auto:1&&, auto:2&&, auto:3, auto:4)#2}, doris::vectorized::SerializedHashTableContext&, std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type)1>&, std::integral_constant<bool, false>, std::integral_constant<bool, false> >::type std::__invoke<doris::vectorized::HashJoinNode::get_next(doris::RuntimeState*, doris::vectorized::Block*, bool*)::{lambda(auto:1&&, auto:2&&, auto:3, auto:4)#2}, doris::vectorized::SerializedHashTableContext&, std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type)1>&, std::integral_constant<bool, false>, std::integral_constant<bool, false> >(doris::vectorized::HashJoinNode::get_next(doris::RuntimeState*, doris::vectorized::Block*, bool*)::{lambda(auto:1&&, auto:2&&, auto:3, auto:4)#2}&&, doris::vectorized::SerializedHashTableContext&, std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type)1>&, std::integral_constant<bool, false>&&, std::integral_constant<bool, false>&&) at /var/local/ldb-toolchain/include/c++/11/bits/invoke.h:97
 8# std::__detail::__variant::__gen_vtable_impl<std::__detail::__variant::_Multi_array<std::__detail::__variant::__deduce_visit_result<void> (*)(doris::vectorized::HashJoinNode::get_next(doris::RuntimeState*, doris::vectorized::Block*, bool*)::{lambda(auto:1&&, auto:2&&, auto:3, auto:4)#2}&&, std::variant<std::monostate, doris::vectorized::SerializedHashTableContext, doris::vectorized::PrimaryTypeHashTableContext<unsigned char>, doris::vectorized::PrimaryTypeHashTableContext<unsigned short>, doris::vectorized::PrimaryTypeHashTableContext<unsigned int>, doris::vectorized::PrimaryTypeHashTableContext<unsigned long>, doris::vectorized::PrimaryTypeHashTableContext<doris::vectorized::UInt128>, doris::vectorized::PrimaryTypeHashTableContext<doris::vectorized::UInt256>, doris::vectorized::FixedKeyHashTableContext<unsigned long, true>, doris::vectorized::FixedKeyHashTableContext<unsigned long, false>, doris::vectorized::FixedKeyHashTableContext<doris::vectorized::UInt128, true>, doris::vectorized::FixedKeyHashTableContext<doris::vectorized::UInt128, false>, doris::vectorized::FixedKeyHashTableContext<doris::vectorized::UInt256, true>, doris::vectorized::FixedKeyHashTableContext<doris::vectorized::UInt256, false> >&, std::variant<std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type)0>, std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type)2>, std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type)8>, std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type)1>, std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type)4>, std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type)3>, std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type)5>, std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type)7>, std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type)9>, std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type)10> >&, std::variant<std::integral_constant<bool, false>, std::integral_constant<bool, true> >&&, std::variant<std::integral_constant<bool, false>, std::integral_constant<bool, true> >&&)>, std::integer_sequence<unsigned long, 1ul, 3ul, 0ul, 0ul> >::__visit_invoke(doris::vectorized::HashJoinNode::get_next(doris::RuntimeState*, doris::vectorized::Block*, bool*)::{lambda(auto:1&&, auto:2&&, auto:3, auto:4)#2}&&, std::variant<std::monostate, doris::vectorized::SerializedHashTableContext, doris::vectorized::PrimaryTypeHashTableContext<unsigned char>, doris::vectorized::PrimaryTypeHashTableContext<unsigned short>, doris::vectorized::PrimaryTypeHashTableContext<unsigned int>, doris::vectorized::PrimaryTypeHashTableContext<unsigned long>, doris::vectorized::PrimaryTypeHashTableContext<doris::vectorized::UInt128>, doris::vectorized::PrimaryTypeHashTableContext<doris::vectorized::UInt256>, doris::vectorized::FixedKeyHashTableContext<unsigned long, true>, doris::vectorized::FixedKeyHashTableContext<unsigned long, false>, doris::vectorized::FixedKeyHashTableContext<doris::vectorized::UInt128, true>, doris::vectorized::FixedKeyHashTableContext<doris::vectorized::UInt128, false>, doris::vectorized::FixedKeyHashTableContext<doris::vectorized::UInt256, true>, doris::vectorized::FixedKeyHashTableContext<doris::vectorized::UInt256, false> >&, std::variant<std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type)0>, std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type)2>, std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type)8>, std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type)1>, std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type)4>, std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type)3>, std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type)5>, std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type)7>, std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type)9>, std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type)10> >&, std::variant<std::integral_constant<bool, false>, std::integral_constant<bool, true> >&&, std::variant<std::integral_constant<bool, false>, std::integral_constant<bool, true> >&&) at /var/local/ldb-toolchain/include/c++/11/variant:1015
 9# decltype(auto) std::__do_visit<std::__detail::__variant::__deduce_visit_result<void>, doris::vectorized::HashJoinNode::get_next(doris::RuntimeState*, doris::vectorized::Block*, bool*)::{lambda(auto:1&&, auto:2&&, auto:3, auto:4)#2}, std::variant<std::monostate, doris::vectorized::SerializedHashTableContext, doris::vectorized::PrimaryTypeHashTableContext<unsigned char>, doris::vectorized::PrimaryTypeHashTableContext<unsigned short>, doris::vectorized::PrimaryTypeHashTableContext<unsigned int>, doris::vectorized::PrimaryTypeHashTableContext<unsigned long>, doris::vectorized::PrimaryTypeHashTableContext<doris::vectorized::UInt128>, doris::vectorized::PrimaryTypeHashTableContext<doris::vectorized::UInt256>, doris::vectorized::FixedKeyHashTableContext<unsigned long, true>, doris::vectorized::FixedKeyHashTableContext<unsigned long, false>, doris::vectorized::FixedKeyHashTableContext<doris::vectorized::UInt128, true>, doris::vectorized::FixedKeyHashTableContext<doris::vectorized::UInt128, false>, doris::vectorized::FixedKeyHashTableContext<doris::vectorized::UInt256, true>, doris::vectorized::FixedKeyHashTableContext<doris::vectorized::UInt256, false> >&, std::variant<std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type)0>, std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type)2>, std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type)8>, std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type)1>, std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type)4>, std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type)3>, std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type)5>, std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type)7>, std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type)9>, std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type)10> >&, std::variant<std::integral_constant<bool, false>, std::integral_constant<bool, true> >, std::variant<std::integral_constant<bool, false>, std::integral_constant<bool, true> > >(doris::vectorized::HashJoinNode::get_next(doris::RuntimeState*, doris::vectorized::Block*, bool*)::{lambda(auto:1&&, auto:2&&, auto:3, auto:4)#2}&&, std::variant<std::monostate, doris::vectorized::SerializedHashTableContext, doris::vectorized::PrimaryTypeHashTableContext<unsigned char>, doris::vectorized::PrimaryTypeHashTableContext<unsigned short>, doris::vectorized::PrimaryTypeHashTableContext<unsigned int>, doris::vectorized::PrimaryTypeHashTableContext<unsigned long>, doris::vectorized::PrimaryTypeHashTableContext<doris::vectorized::UInt128>, doris::vectorized::PrimaryTypeHashTableContext<doris::vectorized::UInt256>, doris::vectorized::FixedKeyHashTableContext<unsigned long, true>, doris::vectorized::FixedKeyHashTableContext<unsigned long, false>, doris::vectorized::FixedKeyHashTableContext<doris::vectorized::UInt128, true>, doris::vectorized::FixedKeyHashTableContext<doris::vectorized::UInt128, false>, doris::vectorized::FixedKeyHashTableContext<doris::vectorized::UInt256, true>, doris::vectorized::FixedKeyHashTableContext<doris::vectorized::UInt256, false> >&, std::variant<std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type)0>, std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type)2>, std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type)8>, std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type)1>, std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type)4>, std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type)3>, std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type)5>, std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type)7>, std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type)9>, std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type)10> >&, std::variant<std::integral_constant<bool, false>, std::integral_constant<bool, true> >&&, std::variant<std::integral_constant<bool, false>, std::integral_constant<bool, true> >&&) at /var/local/ldb-toolchain/include/c++/11/variant:1715
10# decltype(auto) std::visit<doris::vectorized::HashJoinNode::get_next(doris::RuntimeState*, doris::vectorized::Block*, bool*)::{lambda(auto:1&&, auto:2&&, auto:3, auto:4)#2}, std::variant<std::monostate, doris::vectorized::SerializedHashTableContext, doris::vectorized::PrimaryTypeHashTableContext<unsigned char>, doris::vectorized::PrimaryTypeHashTableContext<unsigned short>, doris::vectorized::PrimaryTypeHashTableContext<unsigned int>, doris::vectorized::PrimaryTypeHashTableContext<unsigned long>, doris::vectorized::PrimaryTypeHashTableContext<doris::vectorized::UInt128>, doris::vectorized::PrimaryTypeHashTableContext<doris::vectorized::UInt256>, doris::vectorized::FixedKeyHashTableContext<unsigned long, true>, doris::vectorized::FixedKeyHashTableContext<unsigned long, false>, doris::vectorized::FixedKeyHashTableContext<doris::vectorized::UInt128, true>, doris::vectorized::FixedKeyHashTableContext<doris::vectorized::UInt128, false>, doris::vectorized::FixedKeyHashTableContext<doris::vectorized::UInt256, true>, doris::vectorized::FixedKeyHashTableContext<doris::vectorized::UInt256, false> >&, std::variant<std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type)0>, std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type)2>, std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type)8>, std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type)1>, std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type)4>, std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type)3>, std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type)5>, std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type)7>, std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type)9>, std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type)10> >&, std::variant<std::integral_constant<bool, false>, std::integral_constant<bool, true> >, std::variant<std::integral_constant<bool, false>, std::integral_constant<bool, true> > >(doris::vectorized::HashJoinNode::get_next(doris::RuntimeState*, doris::vectorized::Block*, bool*)::{lambda(auto:1&&, auto:2&&, auto:3, auto:4)#2}&&, std::variant<std::monostate, doris::vectorized::SerializedHashTableContext, doris::vectorized::PrimaryTypeHashTableContext<unsigned char>, doris::vectorized::PrimaryTypeHashTableContext<unsigned short>, doris::vectorized::PrimaryTypeHashTableContext<unsigned int>, doris::vectorized::PrimaryTypeHashTableContext<unsigned long>, doris::vectorized::PrimaryTypeHashTableContext<doris::vectorized::UInt128>, doris::vectorized::PrimaryTypeHashTableContext<doris::vectorized::UInt256>, doris::vectorized::FixedKeyHashTableContext<unsigned long, true>, doris::vectorized::FixedKeyHashTableContext<unsigned long, false>, doris::vectorized::FixedKeyHashTableContext<doris::vectorized::UInt128, true>, doris::vectorized::FixedKeyHashTableContext<doris::vectorized::UInt128, false>, doris::vectorized::FixedKeyHashTableContext<doris::vectorized::UInt256, true>, doris::vectorized::FixedKeyHashTableContext<doris::vectorized::UInt256, false> >&, std::variant<std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type)0>, std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type)2>, std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type)8>, std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type)1>, std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type)4>, std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type)3>, std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type)5>, std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type)7>, std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type)9>, std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type)10> >&, std::variant<std::integral_constant<bool, false>, std::integral_constant<bool, true> >&&, std::variant<std::integral_constant<bool, false>, std::integral_constant<bool, true> >&&) at /var/local/ldb-toolchain/include/c++/11/variant:1771
11# doris::vectorized::HashJoinNode::get_next(doris::RuntimeState*, doris::vectorized::Block*, bool*) at /root/doris/be/src/vec/exec/join/vhash_join_node.cpp:946
12# doris::vectorized::AggregationNode::get_next(doris::RuntimeState*, doris::vectorized::Block*, bool*) at /root/doris/be/src/vec/exec/vaggregation_node.cpp:395
13# doris::PlanFragmentExecutor::get_vectorized_internal(doris::vectorized::Block**) at /root/doris/be/src/runtime/plan_fragment_executor.cpp:352
14# doris::PlanFragmentExecutor::open_vectorized_internal() at /root/doris/be/src/runtime/plan_fragment_executor.cpp:301
15# doris::PlanFragmentExecutor::open() at /root/doris/be/src/runtime/plan_fragment_executor.cpp:259
16# doris::FragmentExecState::execute() at /root/doris/be/src/runtime/fragment_mgr.cpp:242
17# doris::FragmentMgr::_exec_actual(std::shared_ptr<doris::FragmentExecState>, std::function<void (doris::PlanFragmentExecutor*)>) at /root/doris/be/src/runtime/fragment_mgr.cpp:482
18# void std::__invoke_impl<void, void (doris::FragmentMgr::*&)(std::shared_ptr<doris::FragmentExecState>, std::function<void (doris::PlanFragmentExecutor*)>), doris::FragmentMgr*&, std::shared_ptr<doris::FragmentExecState>&, std::function<void (doris::PlanFragmentExecutor*)>&>(std::__invoke_memfun_deref, void (doris::FragmentMgr::*&)(std::shared_ptr<doris::FragmentExecState>, std::function<void (doris::PlanFragmentExecutor*)>), doris::FragmentMgr*&, std::shared_ptr<doris::FragmentExecState>&, std::function<void (doris::PlanFragmentExecutor*)>&) in /opt/hadoop/ssddata/doris/be/lib/doris_be
19# std::enable_if<is_invocable_r_v<void, void (doris::FragmentMgr::*&)(std::shared_ptr<doris::FragmentExecState>, std::function<void (doris::PlanFragmentExecutor*)>), doris::FragmentMgr*&, std::shared_ptr<doris::FragmentExecState>&, std::function<void (doris::PlanFragmentExecutor*)>&>, void>::type std::__invoke_r<void, void (doris::FragmentMgr::*&)(std::shared_ptr<doris::FragmentExecState>, std::function<void (doris::PlanFragmentExecutor*)>), doris::FragmentMgr*&, std::shared_ptr<doris::FragmentExecState>&, std::function<void (doris::PlanFragmentExecutor*)>&>(void (doris::FragmentMgr::*&)(std::shared_ptr<doris::FragmentExecState>, std::function<void (doris::PlanFragmentExecutor*)>), doris::FragmentMgr*&, std::shared_ptr<doris::FragmentExecState>&, std::function<void (doris::PlanFragmentExecutor*)>&) in /opt/hadoop/ssddata/doris/be/lib/doris_be
20# void std::_Bind_result<void, void (doris::FragmentMgr::*(doris::FragmentMgr*, std::shared_ptr<doris::FragmentExecState>, std::function<void (doris::PlanFragmentExecutor*)>))(std::shared_ptr<doris::FragmentExecState>, std::function<void (doris::PlanFragmentExecutor*)>)>::__call<void, , 0ul, 1ul, 2ul>(std::tuple<>&&, std::_Index_tuple<0ul, 1ul, 2ul>) in /opt/hadoop/ssddata/doris/be/lib/doris_be
21# void std::_Bind_result<void, void (doris::FragmentMgr::*(doris::FragmentMgr*, std::shared_ptr<doris::FragmentExecState>, std::function<void (doris::PlanFragmentExecutor*)>))(std::shared_ptr<doris::FragmentExecState>, std::function<void (doris::PlanFragmentExecutor*)>)>::operator()<>() at /var/local/ldb-toolchain/include/c++/11/functional:631
22# void std::__invoke_impl<void, std::_Bind_result<void, void (doris::FragmentMgr::*(doris::FragmentMgr*, std::shared_ptr<doris::FragmentExecState>, std::function<void (doris::PlanFragmentExecutor*)>))(std::shared_ptr<doris::FragmentExecState>, std::function<void (doris::PlanFragmentExecutor*)>)>&>(std::__invoke_other, std::_Bind_result<void, void (doris::FragmentMgr::*(doris::FragmentMgr*, std::shared_ptr<doris::FragmentExecState>, std::function<void (doris::PlanFragmentExecutor*)>))(std::shared_ptr<doris::FragmentExecState>, std::function<void (doris::PlanFragmentExecutor*)>)>&) in /opt/hadoop/ssddata/doris/be/lib/doris_be
23# std::enable_if<is_invocable_r_v<void, std::_Bind_result<void, void (doris::FragmentMgr::*(doris::FragmentMgr*, std::shared_ptr<doris::FragmentExecState>, std::function<void (doris::PlanFragmentExecutor*)>))(std::shared_ptr<doris::FragmentExecState>, std::function<void (doris::PlanFragmentExecutor*)>)>&>, void>::type std::__invoke_r<void, std::_Bind_result<void, void (doris::FragmentMgr::*(doris::FragmentMgr*, std::shared_ptr<doris::FragmentExecState>, std::function<void (doris::PlanFragmentExecutor*)>))(std::shared_ptr<doris::FragmentExecState>, std::function<void (doris::PlanFragmentExecutor*)>)>&>(std::_Bind_result<void, void (doris::FragmentMgr::*(doris::FragmentMgr*, std::shared_ptr<doris::FragmentExecState>, std::function<void (doris::PlanFragmentExecutor*)>))(std::shared_ptr<doris::FragmentExecState>, std::function<void (doris::PlanFragmentExecutor*)>)>&) in /opt/hadoop/ssddata/doris/be/lib/doris_be
24# std::_Function_handler<void (), std::_Bind_result<void, void (doris::FragmentMgr::*(doris::FragmentMgr*, std::shared_ptr<doris::FragmentExecState>, std::function<void (doris::PlanFragmentExecutor*)>))(std::shared_ptr<doris::FragmentExecState>, std::function<void (doris::PlanFragmentExecutor*)>)> >::_M_invoke(std::_Any_data const&) at /var/local/ldb-toolchain/include/c++/11/bits/std_function.h:292
25# std::function<void ()>::operator()() const at /var/local/ldb-toolchain/include/c++/11/bits/std_function.h:560
26# doris::FunctionRunnable::run() at /root/doris/be/src/util/threadpool.cpp:42
27# doris::ThreadPool::dispatch_thread() at /root/doris/be/src/util/threadpool.cpp:578
28# void std::__invoke_impl<void, void (doris::ThreadPool::*&)(), doris::ThreadPool*&>(std::__invoke_memfun_deref, void (doris::ThreadPool::*&)(), doris::ThreadPool*&) at /var/local/ldb-toolchain/include/c++/11/bits/invoke.h:74
29# std::__invoke_result<void (doris::ThreadPool::*&)(), doris::ThreadPool*&>::type std::__invoke<void (doris::ThreadPool::*&)(), doris::ThreadPool*&>(void (doris::ThreadPool::*&)(), doris::ThreadPool*&) at /var/local/ldb-toolchain/include/c++/11/bits/invoke.h:97
30# void std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>::__call<void, , 0ul>(std::tuple<>&&, std::_Index_tuple<0ul>) at /var/local/ldb-toolchain/include/c++/11/functional:422
31# void std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>::operator()<, void>() at /var/local/ldb-toolchain/include/c++/11/functional:505
32# void std::__invoke_impl<void, std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>&>(std::__invoke_other, std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>&) at /var/local/ldb-toolchain/include/c++/11/bits/invoke.h:61
33# std::enable_if<is_invocable_r_v<void, std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>&>, void>::type std::__invoke_r<void, std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>&>(std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>&) at /var/local/ldb-toolchain/include/c++/11/bits/invoke.h:117
34# std::_Function_handler<void (), std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()> >::_M_invoke(std::_Any_data const&) at /var/local/ldb-toolchain/include/c++/11/bits/std_function.h:292
35# std::function<void ()>::operator()() const at /var/local/ldb-toolchain/include/c++/11/bits/std_function.h:560
36# doris::Thread::supervise_thread(void*) at /root/doris/be/src/util/thread.cpp:407
37# start_thread in /lib64/libpthread.so.0
38# __clone in /lib64/libc.so.6
```


## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

