### PR TITLE
[fix](remote)Fix bug for Segment::open() in case: config::file_cache_type

### DIFF
--- a/be/src/olap/rowset/segment_v2/segment.cpp
+++ b/be/src/olap/rowset/segment_v2/segment.cpp
@@ -25,6 +25,7 @@
 #include "common/config.h"
 #include "common/logging.h" // LOG
 #include "io/cache/file_cache_manager.h"
+#include "io/fs/file_system.h"
 #include "olap/rowset/segment_v2/column_reader.h" // ColumnReader
 #include "olap/rowset/segment_v2/empty_segment_iterator.h"
 #include "olap/rowset/segment_v2/page_io.h"
@@ -46,6 +47,15 @@ Status Segment::open(io::FileSystem* fs, const std::string& path, const std::str
     std::shared_ptr<Segment> segment(new Segment(segment_id, tablet_schema));
     io::FileReaderSPtr file_reader;
     RETURN_IF_ERROR(fs->open_file(path, &file_reader));
+    if (fs->type() != io::FileSystemType::LOCAL && !config::file_cache_type.empty()) {
+        io::FileCachePtr cache_reader = FileCacheManager::instance()->new_file_cache(
+                cache_path, config::file_cache_alive_time_sec, file_reader,
+                config::file_cache_type);
+        segment->_file_reader = cache_reader;
+        FileCacheManager::instance()->add_file_cache(cache_path, cache_reader);
+    } else {
+        segment->_file_reader = std::move(file_reader);
+    }
     if (config::file_cache_type.empty()) {
         segment->_file_reader = std::move(file_reader);
     } else {

--- a/be/src/olap/rowset/segment_v2/segment.cpp
+++ b/be/src/olap/rowset/segment_v2/segment.cpp
@@ -56,15 +56,6 @@ Status Segment::open(io::FileSystem* fs, const std::string& path, const std::str
     } else {
         segment->_file_reader = std::move(file_reader);
     }
-    if (config::file_cache_type.empty()) {
-        segment->_file_reader = std::move(file_reader);
-    } else {
-        io::FileCachePtr cache_reader = FileCacheManager::instance()->new_file_cache(
-                cache_path, config::file_cache_alive_time_sec, file_reader,
-                config::file_cache_type);
-        segment->_file_reader = cache_reader;
-        FileCacheManager::instance()->add_file_cache(cache_path, cache_reader);
-    }
     RETURN_IF_ERROR(segment->_open());
     *output = std::move(segment);
     return Status::OK();


### PR DESCRIPTION
# Proposed changes

Issue Number: close #12247

## Problem summary

When config::file_cache_type is not empty, select * from TableInHDD will cause an error.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

