### PR TITLE
[enhancement](Nereids)ban groupPlan() pattern to avoid misuse

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/pattern/generator/PatternGeneratorAnalyzer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/pattern/generator/PatternGeneratorAnalyzer.java
@@ -76,6 +76,7 @@ public class PatternGeneratorAnalyzer {
     private String doGenerate() {
         Map<ClassDeclaration, Set<String>> planClassMap = parentClassMap.entrySet().stream()
                 .filter(kv -> kv.getValue().contains("org.apache.doris.nereids.trees.plans.Plan"))
+                .filter(kv -> !kv.getKey().name.equals("GroupPlan"))
                 .filter(kv -> !Modifier.isAbstract(kv.getKey().modifiers.mod)
                         && kv.getKey() instanceof ClassDeclaration)
                 .collect(Collectors.toMap(kv -> (ClassDeclaration) kv.getKey(), kv -> kv.getValue()));

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/join/JoinLAsscom.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/join/JoinLAsscom.java
@@ -38,7 +38,7 @@ public class JoinLAsscom extends OneExplorationRuleFactory {
      */
     @Override
     public Rule build() {
-        return logicalJoin(logicalJoin(), groupPlan())
+        return logicalJoin(logicalJoin(), group())
             .when(JoinLAsscomHelper::check)
             .when(join -> join.getJoinType().isInnerJoin() || join.getJoinType().isLeftOuterJoin()
                     && (join.left().getJoinType().isInnerJoin() || join.left().getJoinType().isLeftOuterJoin()))

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/join/JoinLAsscomProject.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/join/JoinLAsscomProject.java
@@ -40,7 +40,7 @@ public class JoinLAsscomProject extends OneExplorationRuleFactory {
      */
     @Override
     public Rule build() {
-        return logicalJoin(logicalProject(logicalJoin()), groupPlan())
+        return logicalJoin(logicalProject(logicalJoin()), group())
             .when(JoinLAsscomHelper::check)
             .when(join -> join.getJoinType().isInnerJoin() || join.getJoinType().isLeftOuterJoin()
                     && (join.left().child().getJoinType().isInnerJoin() || join.left().child().getJoinType()


### PR DESCRIPTION
# Proposed changes

`groupPlan()` pattern means to find a `GroupPlan` in memo. Since we have no `GroupPlan` in memo, it is always return nothing.
When we want write a pattern to match any GROUP, we should use `group()`. But pattern `groupPlan` is very confusing, and easy misuse.
So, this PR ban `groupPlan()` pattern ti avoid misuse.

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

