### PR TITLE
[dev-1.1.2](parquet-reader) fix dead log of parquet reader prefetch thread

### DIFF
--- a/be/src/exec/parquet_reader.cpp
+++ b/be/src/exec/parquet_reader.cpp
@@ -103,8 +103,7 @@ Status ParquetReaderWrap::init_parquet_reader(const std::vector<SlotDescriptor*>
 
         RETURN_IF_ERROR(column_indices(tuple_slot_descs));
 
-        std::thread thread(&ParquetReaderWrap::prefetch_batch, this, &thread_status);
-        thread.detach();
+        _prefetch_thread = std::thread(&ParquetReaderWrap::prefetch_batch, this);
 
         // read batch
         RETURN_IF_ERROR(read_next_batch());
@@ -134,7 +133,9 @@ void ParquetReaderWrap::close() {
     // must wait the pre_fetch thread finish.
     // because it may still use ParquetReader to read data, which may cause
     // heap-after-use bug.
-    thread_status.get_future().get();
+    if (_prefetch_thread.joinable()) {
+        _prefetch_thread.join();
+    }
     arrow::Status st = _parquet->Close();
     if (!st.ok()) {
         LOG(WARNING) << "close parquet file error: " << st.ToString();
@@ -541,7 +542,7 @@ Status ParquetReaderWrap::read(Tuple* tuple, const std::vector<SlotDescriptor*>&
     return read_record_batch(tuple_slot_descs, eof);
 }
 
-void ParquetReaderWrap::prefetch_batch(std::promise<Status>* status) {
+void ParquetReaderWrap::prefetch_batch() {
     auto insert_batch = [this](const auto& batch) {
         std::unique_lock<std::mutex> lock(_mtx);
         while (!_closed && _queue.size() == _max_queue_size) {
@@ -572,8 +573,6 @@ void ParquetReaderWrap::prefetch_batch(std::promise<Status>* status) {
         std::for_each(batches.begin(), batches.end(), insert_batch);
         current_group++;
     }
-    // the status' value is meaningless, just for notifying that thread is done.
-    status->set_value(Status::OK());
 }
 
 Status ParquetReaderWrap::read_next_batch() {

--- a/be/src/exec/parquet_reader.h
+++ b/be/src/exec/parquet_reader.h
@@ -104,7 +104,7 @@ private:
                             int32_t* wbtyes);
 
 private:
-    void prefetch_batch(std::promise<Status>* status);
+    void prefetch_batch();
     Status read_next_batch();
 
 private:
@@ -137,7 +137,7 @@ private:
     std::list<std::shared_ptr<arrow::RecordBatch>> _queue;
     const size_t _max_queue_size = config::parquet_reader_max_buffer_size;
 
-    std::promise<Status> thread_status;
+    std::thread _prefetch_thread;
 };
 
 } // namespace doris


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

If something wrong before the prefetch thread start, the parquet readers' close() method
will be blocked on waiting thread_status's future.
This bug only exist in dev-1.1.2

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

