### PR TITLE
[fix](compile)compile error when use clang on aarch64 platform

### DIFF
--- a/be/src/geo/geo_types.cpp
+++ b/be/src/geo/geo_types.cpp
@@ -52,7 +52,7 @@ void print_s2point(std::ostream& os, const S2Point& point) {
 }
 
 static inline bool is_valid_lng_lat(double lng, double lat) {
-    return abs(lng) <= 180 && abs(lat) <= 90;
+    return std::abs(lng) <= 180 && std::abs(lat) <= 90;
 }
 
 // Return GEO_PARSE_OK, if and only if this can be converted to a valid S2Point

--- a/be/src/glibc-compatibility/memcpy/memcpy_aarch64.cpp
+++ b/be/src/glibc-compatibility/memcpy/memcpy_aarch64.cpp
@@ -22,11 +22,6 @@ static inline __attribute__((always_inline)) __m128i _mm_loadu_si128(const __m12
     return vreinterpretq_m128i_s32(vld1q_s32((const int32_t *) p));
 }
 
-static inline __attribute__((always_inline)) __m128i _mm_load_si128(const __m128i *p)
-{
-    return vreinterpretq_m128i_s32(vld1q_s32((const int32_t *) p));
-}
-
 /** Custom memcpy implementation for ClickHouse.
   * It has the following benefits over using glibc's implementation:
   * 1. Avoiding dependency on specific version of glibc's symbol, like memcpy@@GLIBC_2.14 for portability.


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

1. get unused function on `_mm_load_si128` in file `be/src/glibc-compatibility/memcpy/memcpy_aarch64.cpp`
2. get ambiguous function used on `abs` in file `be/src/geo/geo_types.cpp:55`

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
3. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
5. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
6. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

