### PR TITLE
[typo](docs)The table_function calling reset() function should set _eos to false

### DIFF
--- a/be/src/exprs/table_function/table_function.h
+++ b/be/src/exprs/table_function/table_function.h
@@ -115,7 +115,7 @@ protected:
     // true if there is no more data can be read from this function.
     bool _eos = false;
     // true means the function result set from current row is empty(eg, source value is null or empty).
-    // so that when calling reset(), we can do nothing and keep eos as true.
+    // so that when calling reset(), we can do nothing and keep eos as false.
     bool _is_current_empty = false;
     // the position of current cursor
     int64_t _cur_offset = 0;


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

We should modify the code comment to set _eos to _false.

## Checklist(Required)


1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
3. Has document been added or modified:
    - [x] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

