### PR TITLE
[fix](memtracker) Fix open query profile to print the complete mem limit exceed log

### DIFF
--- a/be/src/runtime/memory/mem_tracker_limiter.cpp
+++ b/be/src/runtime/memory/mem_tracker_limiter.cpp
@@ -151,8 +151,8 @@ bool MemTrackerLimiter::gc_memory(int64_t max_consumption) {
 Status MemTrackerLimiter::try_gc_memory(int64_t bytes) {
     if (UNLIKELY(gc_memory(_limit - bytes))) {
         return Status::MemoryLimitExceeded(fmt::format(
-                "failed_alloc_size={}B, exceeded_tracker={}, limit={}B, peak_used={}B, "
-                "current_used={}B",
+                "failed_alloc_size={} B, exceeded_tracker={}, limit={} B, peak_used={} B, "
+                "current_used={} B",
                 bytes, label(), _limit, _consumption->value(), _consumption->current_value()));
     }
     VLOG_NOTICE << "GC succeeded, TryConsume bytes=" << bytes
@@ -281,8 +281,8 @@ Status MemTrackerLimiter::mem_limit_exceeded(const std::string& msg,
     MemTrackerLimiter* print_log_usage_tracker = nullptr;
     if (exceeded_tracker != nullptr) {
         detail += fmt::format(
-                "failed_alloc_size={}B, exceeded_tracker={}, limit={}B, peak_used={}B, "
-                "current_used={}B>, executing_msg:<{}>",
+                "failed_alloc_size={} B, exceeded_tracker={}, limit={} B, peak_used={} B, "
+                "current_used={} B>, executing_msg:<{}>",
                 PrettyPrinter::print(failed_allocation_size, TUnit::BYTES),
                 exceeded_tracker->label(), exceeded_tracker->limit(),
                 exceeded_tracker->peak_consumption(), exceeded_tracker->consumption(), msg);
@@ -292,8 +292,8 @@ Status MemTrackerLimiter::mem_limit_exceeded(const std::string& msg,
     } else if (max_consumption_tracker != nullptr) {
         // must after check_sys_mem_info false
         detail += fmt::format(
-                "failed_alloc_size={}B, max_consumption_tracker={}, limit={}B, peak_used={}B, "
-                "current_used={}B>, executing_msg:<{}>",
+                "failed_alloc_size={} B, max_consumption_tracker={}, limit={} B, peak_used={} B, "
+                "current_used={} B>, executing_msg:<{}>",
                 PrettyPrinter::print(failed_allocation_size, TUnit::BYTES),
                 max_consumption_tracker->label(), max_consumption_tracker->limit(),
                 max_consumption_tracker->peak_consumption(), max_consumption_tracker->consumption(),

--- a/be/src/runtime/memory/mem_tracker_limiter.h
+++ b/be/src/runtime/memory/mem_tracker_limiter.h
@@ -71,7 +71,7 @@ public:
         // for fast, expect MemInfo::initialized() to be true.
         if (PerfCounters::get_vm_rss() + bytes >= MemInfo::mem_limit()) {
             auto st = Status::MemoryLimitExceeded(
-                    "process memory used {} exceed limit {}, failed_alloc_size={}",
+                    "process memory used {} B, exceed limit {} B, failed_alloc_size={} B",
                     PerfCounters::get_vm_rss(), MemInfo::mem_limit(), bytes);
             ExecEnv::GetInstance()->process_mem_tracker_raw()->print_log_usage(st.get_error_msg());
             return st;
@@ -229,7 +229,7 @@ private:
     // The number of child trackers that have been added.
     std::atomic_size_t _had_child_count = 0;
 
-    bool _print_log_usage = true;
+    bool _print_log_usage = false;
 
     // Lock to protect gc_memory(). This prevents many GCs from occurring at once.
     std::mutex _gc_lock;

--- a/be/src/runtime/runtime_state.cpp
+++ b/be/src/runtime/runtime_state.cpp
@@ -231,6 +231,11 @@ Status RuntimeState::init_mem_trackers(const TUniqueId& query_id) {
             -1, "RuntimeState:instance:" + print_id(_fragment_instance_id), _query_mem_tracker,
             &_profile);
 
+    if (_query_options.is_report_success) {
+        _query_mem_tracker->enable_print_log_usage();
+        _instance_mem_tracker->enable_print_log_usage();
+    }
+
     return Status::OK();
 }
 


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

print mem limit exceed log depends on `enable_profile=1`

## Checklist(Required)

1. Does it affect the original behavior: 
    - [x] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

