### PR TITLE
[Enhancement](spark-load) enable spark-load implicitly cast to bitmap

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/CastExpr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/CastExpr.java
@@ -142,11 +142,6 @@ public class CastExpr extends Expr {
                 || toType.isDateType())) {
             return true;
         }
-
-        // Disable casting operation of hll/bitmap/quantile_state
-        if (fromType.isObjectStored() || toType.isObjectStored()) {
-            return true;
-        }
         // Disable no-op casting
         return fromType.equals(toType);
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/SparkLoadJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/SparkLoadJob.java
@@ -956,7 +956,7 @@ public class SparkLoadJob extends BulkLoadJob {
                 // which lead to spark load not work when you import bitmap data
                 // so here we open a back door for spark load, which can support implicitly convert to bitmap type
                 if (dstType == PrimitiveType.BITMAP) {
-                    return new CastExpr(slotDesc.getType(), expr);
+                    return new CastExpr(slotDesc.getType(), expr, true);
                 } else {
                     return expr.castTo(slotDesc.getType());
                 }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

This PR(#8881) disables the HLL / bitmap implicit conversion, causing spark load to fail when importing bitmap type data
so i want to open back door for spark load ,allow implicit convert to bitmap


 **errCode = 2, detailMessage = type not match, originType=VARCHAR(*), targeType=BITMAP**

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

