### PR TITLE
[fix](nereids) fix dead loop in unnesting subquery rule

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/logical/ApplyPullFilterOnAgg.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/logical/ApplyPullFilterOnAgg.java
@@ -68,6 +68,11 @@ public class ApplyPullFilterOnAgg extends OneRewriteRuleFactory {
             List<Expression> correlatedPredicate = split.get(true);
             List<Expression> unCorrelatedPredicate = split.get(false);
 
+            // the representative has experienced the rule and added the correlated predicate to the apply node
+            if (correlatedPredicate.isEmpty()) {
+                return apply;
+            }
+
             LogicalFilter<GroupPlan> newUnCorrelatedFilter = null;
             if (!unCorrelatedPredicate.isEmpty()) {
                 newUnCorrelatedFilter = new LogicalFilter<>(ExpressionUtils.and(unCorrelatedPredicate),


### PR DESCRIPTION
# Proposed changes

introduced by this pr #11454

## Problem summary

When the filter under agg in the subquery contains both association and non-association, repeatedly executing ApplyPullFilterOnAgg will cause an infinite loop.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

