### PR TITLE
[fix](Nereids)get NPE and group not be optimized when add REWRITE rule to Cascades Optimizer

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/cascades/ApplyRuleJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/cascades/ApplyRuleJob.java
@@ -66,7 +66,7 @@ public class ApplyRuleJob extends Job {
             for (Plan newPlan : newPlans) {
                 CopyInResult result = context.getCascadesContext()
                         .getMemo()
-                        .copyIn(newPlan, groupExpression.getOwnerGroup(), rule.isRewrite());
+                        .copyIn(newPlan, groupExpression.getOwnerGroup(), false);
                 if (!result.generateNewExpression) {
                     continue;
                 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/RulePromise.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/RulePromise.java
@@ -19,12 +19,13 @@ package org.apache.doris.nereids.rules;
 
 /**
  * Promise of rule, The value with a large promise has a higher priority.
+ * NOTICE: we must ensure that the promise of the IMPLEMENT is greater than the promise of the others.
  */
 public enum RulePromise {
+    ANALYSIS,
+    REWRITE,
     EXPLORE,
     IMPLEMENT,
-    REWRITE,
-    ANALYSIS,
 
     // just for check plan in UT
     PLAN_CHECK


### PR DESCRIPTION
## Problem summary

Fix some bugs when add REWRITE rule to Cascades Optimizer
- all rule should set as not rewrite rule when use them in Cascades Optimizer
- IMPLEMENT rule promise should large than others since we should do exploration first.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [x] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

