### PR TITLE
[fix](nereids) bug: tpch-q12  meets "invalid PrimitiveType" error

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/Predicate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/Predicate.java
@@ -32,11 +32,13 @@ public abstract class Predicate extends Expr {
 
     public Predicate() {
         super();
+        type = Type.BOOLEAN;
         this.isEqJoinConjunct = false;
     }
 
     protected Predicate(Predicate other) {
         super(other);
+        type = other.type;
         isEqJoinConjunct = other.isEqJoinConjunct;
     }
 
@@ -50,7 +52,6 @@ public abstract class Predicate extends Expr {
 
     @Override
     protected void analyzeImpl(Analyzer analyzer) throws AnalysisException {
-        type = Type.BOOLEAN;
         // values: true/false/null
         numDistinctValues = 3;
     }


### PR DESCRIPTION
# Proposed changes
In old planner, Predicate set its type in analyzeImpl(). However, function analyzeImpl() is in old planner path, but not in nereids path. And hence the `type` is invalid.

Because all `predicate` has type `bool`, we set its type in constructor.

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

