### PR TITLE
[fix](array-type) ARRAY is not supported in bloomfilter index

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/PropertyAnalyzer.java
@@ -380,7 +380,8 @@ public class PropertyAnalyzer {
                         // tinyint/float/double columns don't support
                         // key columns and none/replace aggregate non-key columns support
                         if (type == PrimitiveType.TINYINT || type == PrimitiveType.FLOAT
-                                || type == PrimitiveType.DOUBLE || type == PrimitiveType.BOOLEAN) {
+                                || type == PrimitiveType.DOUBLE || type == PrimitiveType.BOOLEAN
+                                || type.isArrayType()) {
                             throw new AnalysisException(type + " is not supported in bloom filter index. "
                                     + "invalid column: " + bfColumn);
                         } else if (keysType != KeysType.AGG_KEYS || column.isKey()) {

--- a/regression-test/suites/bloom_filter_p0/test_bloom_filter.groovy
+++ b/regression-test/suites/bloom_filter_p0/test_bloom_filter.groovy
@@ -17,4 +17,37 @@
 suite("test_bloom_filter") {
     // todo: test bloom filter, such alter table bloom filter, create table with bloom filter
     sql "SHOW ALTER TABLE COLUMN"
+
+    // bloom filter index for ARRAY column
+    def test_tb = "test_array_bloom_filter_tb"
+    sql "ADMIN SET FRONTEND CONFIG ('enable_array_type' = 'true')"
+    sql """DROP TABLE IF EXISTS ${test_tb}"""
+    test {
+        sql """CREATE TABLE ${test_tb} (
+                `k1` int(11) NOT NULL,
+                `a1` array<boolean> NOT NULL
+                ) ENGINE=OLAP
+                DUPLICATE KEY(`k1`)
+                DISTRIBUTED BY HASH(`k1`) BUCKETS 5
+                PROPERTIES (
+                    "replication_num" = "1",
+                    "bloom_filter_columns" = "k1,a1"
+            )"""
+        exception "not supported in bloom filter index"
+    }
+
+    sql """CREATE TABLE ${test_tb} (
+            `k1` int(11) NOT NULL,
+            `a1` array<boolean> NOT NULL
+            ) ENGINE=OLAP
+            DUPLICATE KEY(`k1`)
+            DISTRIBUTED BY HASH(`k1`) BUCKETS 5
+            PROPERTIES (
+                "replication_num" = "1",
+                "bloom_filter_columns" = "k1"
+        )"""
+    test {
+        sql """ALTER TABLE ${test_tb} SET("bloom_filter_columns" = "k1,a1")"""
+        exception "not supported in bloom filter index"
+    }
 }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

Describe your changes.
Array column do no support bloom filter index, return error while create or add bloom filter:

1. create table case:
`CREATE TABLE  test_array_alter_test_array_bloom_filter_tb ( k1 int NOT NULL, a1 array<boolean> NOT NULL, a2 array<tinyint> NOT NULL, a3 array<smallint> NOT NULL, a4 array<int> NOT NULL, a5 array<bigint> NOT NULL, a6 array<largeint> NOT NULL, a7 array<decimal(27, 7)> NOT NULL, a8 array<float> NOT NULL, a9 array<double> NOT NULL, a10 array<date> NOT NULL, a11 array<datetime> NOT NULL, a12 array<char(20)> NOT NULL, a13 array<varchar(50)> NOT NULL, a14 array<string> NOT NULL ) DUPLICATE KEY(k1) DISTRIBUTED BY HASH(k1) BUCKETS 5 PROPERTIES ( "bloom_filter_columns"="k1,a2" );`
ERROR 1105 (HY000): errCode = 2, detailMessage = errCode = 2, detailMessage = ARRAY is not supported in bloom filter index. invalid column: a2

2. alter table case:
`alter table test_array_alter_test_array_bloom_filter_tb set ("bloom_filter_columns"="k1,a1");`
ERROR 1105 (HY000): errCode = 2, detailMessage = errCode = 2, detailMessage = ARRAY is not supported in bloom filter index. invalid column: a1

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

