### PR TITLE
[enhancement](chore)add single space separator rule to fe check style

### DIFF
--- a/fe/check/checkstyle/checkstyle.xml
+++ b/fe/check/checkstyle/checkstyle.xml
@@ -391,6 +391,7 @@ under the License.
             <property name="tokens" value="METHOD_REF"/>
             <property name="option" value="nl"/>
         </module>
+        <module name="SingleSpaceSeparator"/>
         <module name="WhitespaceAfter">
             <property name="tokens"
                       value="COMMA, SEMI, TYPECAST, LITERAL_IF, LITERAL_ELSE,

--- a/fe/check/checkstyle/suppressions.xml
+++ b/fe/check/checkstyle/suppressions.xml
@@ -47,6 +47,7 @@ under the License.
     <!-- other -->
     <suppress files="org[\\/]apache[\\/]doris[\\/](?!nereids)[^\\/]+[\\/]|PaloFe\.java" checks="DeclarationOrder" />
     <suppress files="org[\\/]apache[\\/]doris[\\/](?!nereids)[^\\/]+[\\/]|PaloFe\.java" checks="OverloadMethodsDeclarationOrder" />
+    <suppress files="org[\\/]apache[\\/]doris[\\/](?!nereids)[^\\/]+[\\/]|PaloFe\.java" checks="SingleSpaceSeparator" />
     <suppress files="org[\\/]apache[\\/]doris[\\/](?!nereids)[^\\/]+[\\/]|PaloFe\.java" checks="VariableDeclarationUsageDistance" />
 
     <!-- exclude rules for special files -->

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/analyzer/UnboundFunction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/analyzer/UnboundFunction.java
@@ -64,13 +64,13 @@ public class UnboundFunction extends Expression implements Unbound {
         String params = children.stream()
                 .map(Expression::toSql)
                 .collect(Collectors.joining(", "));
-        return name + "(" + (isDistinct ? "DISTINCT " : "")  + params + ")";
+        return name + "(" + (isDistinct ? "DISTINCT " : "") + params + ")";
     }
 
     @Override
     public String toString() {
         String params = Joiner.on(", ").join(children);
-        return "'" + name + "(" + (isDistinct ? "DISTINCT " : "")  + params + ")";
+        return "'" + name + "(" + (isDistinct ? "DISTINCT " : "") + params + ")";
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/ExpressionTranslator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/ExpressionTranslator.java
@@ -265,7 +265,7 @@ public class ExpressionTranslator extends DefaultExpressionVisitor<Expr, PlanTra
 
     @Override
     public Expr visitBinaryArithmetic(BinaryArithmetic binaryArithmetic, PlanTranslatorContext context) {
-        ArithmeticExpr arithmeticExpr =  new ArithmeticExpr(binaryArithmetic.getLegacyOperator(),
+        ArithmeticExpr arithmeticExpr = new ArithmeticExpr(binaryArithmetic.getLegacyOperator(),
                 binaryArithmetic.child(0).accept(this, context),
                 binaryArithmetic.child(1).accept(this, context));
         return arithmeticExpr;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslator.java
@@ -356,7 +356,7 @@ public class PhysicalPlanTranslator extends DefaultPlanVisitor<PlanFragment, Pla
 
         TupleDescriptor leftChildOutputTupleDesc = leftPlanRoot.getOutputTupleDesc();
         TupleDescriptor leftTuple =
-                leftChildOutputTupleDesc != null ? leftChildOutputTupleDesc :  context.getTupleDesc(leftPlanRoot);
+                leftChildOutputTupleDesc != null ? leftChildOutputTupleDesc : context.getTupleDesc(leftPlanRoot);
         TupleDescriptor rightChildOutputTupleDesc = rightPlanRoot.getOutputTupleDesc();
         TupleDescriptor rightTuple =
                 rightChildOutputTupleDesc != null ? rightChildOutputTupleDesc : context.getTupleDesc(rightPlanRoot);

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/pattern/generator/LogicalLeafPatternGenerator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/pattern/generator/LogicalLeafPatternGenerator.java
@@ -32,7 +32,7 @@ public class LogicalLeafPatternGenerator extends PatternGenerator {
 
     @Override
     public String genericType() {
-        return  "<" + opType.name + ">";
+        return "<" + opType.name + ">";
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/pattern/generator/PatternGenerator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/pattern/generator/PatternGenerator.java
@@ -275,7 +275,7 @@ public abstract class PatternGenerator {
                 childrenPattern = ", " + childrenPattern;
             }
 
-            String pattern =  "default " + methodGeneric + "\n"
+            String pattern = "default " + methodGeneric + "\n"
                     + "PatternDescriptor" + genericParam + "\n"
                     + "        " + patterName + "(" + methodParam + ") {\n"
                     + "    return new PatternDescriptor" + genericParam + "(\n"

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rewrite/rules/SimplifyNotExprRule.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rewrite/rules/SimplifyNotExprRule.java
@@ -51,7 +51,7 @@ public class SimplifyNotExprRule extends AbstractExpressionRewriteRule {
         Expression child = not.child();
         if (child instanceof ComparisonPredicate) {
             ComparisonPredicate cp = (ComparisonPredicate) not.child();
-            Expression left =  rewrite(cp.left(), context);
+            Expression left = rewrite(cp.left(), context);
             Expression right = rewrite(cp.right(), context);
 
             // TODO: visit concrete class instead of `instanceof`.
@@ -59,7 +59,7 @@ public class SimplifyNotExprRule extends AbstractExpressionRewriteRule {
                 return new LessThanEqual(left, right);
             } else if (child instanceof GreaterThanEqual) {
                 return new LessThan(left, right);
-            } else  if (child instanceof LessThan) {
+            } else if (child instanceof LessThan) {
                 return new GreaterThanEqual(left, right);
             } else if (child instanceof LessThanEqual) {
                 return new GreaterThan(left, right);
@@ -68,7 +68,7 @@ public class SimplifyNotExprRule extends AbstractExpressionRewriteRule {
             }
         } else if (child instanceof CompoundPredicate) {
             CompoundPredicate cp = (CompoundPredicate) not.child();
-            Expression left =  rewrite(new Not(cp.left()), context);
+            Expression left = rewrite(new Not(cp.left()), context);
             Expression right = rewrite(new Not(cp.right()), context);
             return cp.flip(left, right);
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/logical/MergeConsecutiveFilters.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/logical/MergeConsecutiveFilters.java
@@ -42,7 +42,7 @@ import org.apache.doris.nereids.util.ExpressionUtils;
  *                   |
  *                 scan
  */
-public class MergeConsecutiveFilters  extends OneRewriteRuleFactory {
+public class MergeConsecutiveFilters extends OneRewriteRuleFactory {
     @Override
     public Rule build() {
         return logicalFilter(logicalFilter()).then(filter -> {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/WeekOfYear.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/WeekOfYear.java
@@ -34,7 +34,7 @@ import java.util.List;
 /**
  * weekOfYear function
  */
-public class WeekOfYear  extends BoundFunction implements UnaryExpression, ImplicitCastInputTypes {
+public class WeekOfYear extends BoundFunction implements UnaryExpression, ImplicitCastInputTypes {
 
     private static final List<AbstractDataType> EXPECTED_INPUT_TYPES = ImmutableList.of(
             new TypeCollection(DateTimeType.INSTANCE)

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/util/JoinUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/util/JoinUtils.java
@@ -102,7 +102,7 @@ public class JoinUtils {
          * @return true if the equal can be used as hash join condition
          */
         boolean isHashJoinCondition(EqualTo equalTo) {
-            List<SlotReference> equalLeft =  equalTo.left().collect(SlotReference.class::isInstance);
+            List<SlotReference> equalLeft = equalTo.left().collect(SlotReference.class::isInstance);
             if (equalLeft.isEmpty()) {
                 return false;
             }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/rewrite/ExpressionRewriteTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/rewrite/ExpressionRewriteTest.java
@@ -121,17 +121,17 @@ public class ExpressionRewriteTest {
         assertRewrite("(a and b) or ((d and c) and (d and e))", "(a and b) or (d and c and e)");
         assertRewrite("(a or b) and ((d or c) or (d or e))", "(a or b) and (d or c or e)");
 
-        assertRewrite("(a and b) or (a and b and c)",  "a and b");
-        assertRewrite("(a or b) and (a or b or c)",  "a or b");
+        assertRewrite("(a and b) or (a and b and c)", "a and b");
+        assertRewrite("(a or b) and (a or b or c)", "a or b");
 
-        assertRewrite("a and true",  "a");
-        assertRewrite("a or false",  "a");
+        assertRewrite("a and true", "a");
+        assertRewrite("a or false", "a");
 
-        assertRewrite("a and false",  "false");
-        assertRewrite("a or true",  "true");
+        assertRewrite("a and false", "false");
+        assertRewrite("a or true", "true");
 
-        assertRewrite("a or false or false or false",  "a");
-        assertRewrite("a and true and true and true",  "a");
+        assertRewrite("a or false or false or false", "a");
+        assertRewrite("a and true and true and true", "a");
 
         assertRewrite("(a and b) or a ", "a");
         assertRewrite("(a or b) and a ", "a");

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/util/AnalyzeWhereSubqueryTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/util/AnalyzeWhereSubqueryTest.java
@@ -362,7 +362,7 @@ public class AnalyzeWhereSubqueryTest extends TestWithFeService implements Patte
                                                         ImmutableList.of("default_cluster:test", "t7")), "aa")
                                         )))
                                 ).when(FieldChecker.check("outputExpressions", ImmutableList.of(
-                                        new Alias(new ExprId(8), new Max(new SlotReference(new ExprId(0), "aa",  BigIntType.INSTANCE, true,
+                                        new Alias(new ExprId(8), new Max(new SlotReference(new ExprId(0), "aa", BigIntType.INSTANCE, true,
                                                 ImmutableList.of("t2"))), "max(aa)")
                                 )))
                                         .when(FieldChecker.check("groupByExpressions", ImmutableList.of()))
@@ -414,7 +414,7 @@ public class AnalyzeWhereSubqueryTest extends TestWithFeService implements Patte
                                 logicalAggregate(
                                         logicalProject()
                                 ).when(FieldChecker.check("outputExpressions", ImmutableList.of(
-                                        new Alias(new ExprId(8), new Max(new SlotReference(new ExprId(0), "aa",  BigIntType.INSTANCE, true,
+                                        new Alias(new ExprId(8), new Max(new SlotReference(new ExprId(0), "aa", BigIntType.INSTANCE, true,
                                                 ImmutableList.of("t2"))), "max(aa)"),
                                         new SlotReference(new ExprId(7), "v2", BigIntType.INSTANCE, true,
                                                 ImmutableList.of("default_cluster:test", "t7")))))


### PR DESCRIPTION
# Proposed changes

Some times, our code use more than one space as separator by mistake. This PR add a CheckStyle rule SingleSpaceSeparator to check that for Nereids.

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

