### PR TITLE
[Bug](remote) Fix BE crash because of call the future's get method twice

### DIFF
--- a/be/src/io/cache/sub_file_cache.cpp
+++ b/be/src/io/cache/sub_file_cache.cpp
@@ -174,8 +174,9 @@ Status SubFileCache::_generate_cache_reader(size_t offset, size_t req_size) {
         } else {
             return Status::InternalError("Failed to get download cache thread token");
         }
-        if (!future.get().ok()) {
-            return future.get();
+        auto st = future.get();
+        if (!st.ok()) {
+            return st;
         }
     }
     io::FileReaderSPtr cache_reader;

--- a/be/src/io/cache/whole_file_cache.cpp
+++ b/be/src/io/cache/whole_file_cache.cpp
@@ -125,8 +125,9 @@ Status WholeFileCache::_generate_cache_reader(size_t offset, size_t req_size) {
         } else {
             return Status::InternalError("Failed to get download cache thread token");
         }
-        if (!future.get().ok()) {
-            return future.get();
+        auto st = future.get();
+        if (!st.ok()) {
+            return st;
         }
     }
     RETURN_IF_ERROR(io::global_local_filesystem()->open_file(cache_file, &_cache_file_reader));


### PR DESCRIPTION
# Proposed changes

Issue Number: close #12355

## Problem summary

call the future's get method once and save it.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

