### PR TITLE
[Bug](NodeChannel) Fix OOM caused by pending queue in sink send (#12359)

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -854,6 +854,9 @@ CONF_Int32(doris_remote_scanner_thread_pool_queue_size, "10240");
 // This config should be removed when the new scan node is ready.
 CONF_Bool(enable_new_scan_node, "true");
 
+// limit the queue of pending batches which will be sent by a single nodechannel
+CONF_mInt64(nodechannel_pending_queue_max_bytes, "67108864");
+
 #ifdef BE_TEST
 // test s3
 CONF_String(test_s3_resource, "resource");

--- a/be/src/exec/tablet_sink.cpp
+++ b/be/src/exec/tablet_sink.cpp
@@ -113,7 +113,6 @@ Status NodeChannel::init(RuntimeState* state) {
 
     _rpc_timeout_ms = state->query_options().query_timeout * 1000;
     _timeout_watch.start();
-    _max_pending_batches_bytes = _parent->_load_mem_limit / 20; //TODO: session variable percent
 
     return Status::OK();
 }
@@ -317,6 +316,10 @@ Status NodeChannel::add_row(Tuple* input_tuple, int64_t tablet_id) {
             //To simplify the add_row logic, postpone adding batch into req until the time of sending req
             _pending_batches.emplace(std::move(_cur_batch), _cur_add_batch_request);
             _pending_batches_num++;
+            VLOG_DEBUG << "OlapTableSink:" << _parent << " NodeChannel:" << this
+                       << " pending_batches_bytes:" << _pending_batches_bytes
+                       << " jobid:" << std::to_string(_state->load_job_id())
+                       << " tabletid:" << tablet_id << " loadinfo:" << _load_info;
         }
 
         _cur_batch.reset(new RowBatch(*_row_desc, _batch_size));

--- a/be/src/exec/tablet_sink.h
+++ b/be/src/exec/tablet_sink.h
@@ -286,7 +286,7 @@ protected:
 
     // limit _pending_batches size
     std::atomic<size_t> _pending_batches_bytes {0};
-    size_t _max_pending_batches_bytes {10 * 1024 * 1024};
+    size_t _max_pending_batches_bytes {(size_t)config::nodechannel_pending_queue_max_bytes};
     std::mutex _pending_batches_lock;          // reuse for vectorized
     std::atomic<int> _pending_batches_num {0}; // reuse for vectorized
 

--- a/be/src/vec/sink/vtablet_sink.cpp
+++ b/be/src/vec/sink/vtablet_sink.cpp
@@ -201,6 +201,10 @@ Status VNodeChannel::add_block(vectorized::Block* block,
             _pending_batches_bytes += _cur_mutable_block->allocated_bytes();
             _pending_blocks.emplace(std::move(_cur_mutable_block), _cur_add_block_request);
             _pending_batches_num++;
+            VLOG_DEBUG << "VOlapTableSink:" << _parent << " VNodeChannel:" << this
+                       << " pending_batches_bytes:" << _pending_batches_bytes
+                       << " jobid:" << std::to_string(_state->load_job_id())
+                       << " loadinfo:" << _load_info;
         }
 
         _cur_mutable_block.reset(new vectorized::MutableBlock({_tuple_desc}));


### PR DESCRIPTION
Each NodeChannel has its own queue, with size up to 1/20 exec_mem_limit.
User will crash into OOM if set exec_mem_limit high. This commit uses
fixed number to control the total max memory used by NodeChannels.

Signed-off-by: freemandealer <freeman.zhang1992@gmail.com>

# Proposed changes

Issue Number: close #12359

## Problem summary
FIx OOM caused by pending queues

## Checklist(Required)

1. Does it affect the original behavior: 
    - [x] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments
performance test result:

Before:
streamload 100 concurrent job  |    13-27s   finish time    | 14.2% memory consumption
s3load        100 concurrent job   |    4-9min     | 55%

After:
streamload 100 concurrent job  |    5-20s       | 21% memory consumption
s3load        100 concurrent job   |    5-7m30s | 40%


If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

