### PR TITLE
[feature-wip](unique-key-merge-on-write) fix that versions of multiple replicas are inconsistent when rebalance

### DIFF
--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -61,7 +61,7 @@ DEFINE_GAUGE_METRIC_PROTOTYPE_2ARG(agent_task_queue_size, MetricUnit::NOUNIT);
 
 const uint32_t TASK_FINISH_MAX_RETRY = 3;
 const uint32_t PUBLISH_VERSION_MAX_RETRY = 3;
-const int64_t PUBLISH_TIMEOUT = 10;
+const int64_t PUBLISH_TIMEOUT_SEC = 10;
 
 std::atomic_ulong TaskWorkerPool::_s_report_version(time(nullptr) * 10000);
 std::mutex TaskWorkerPool::_s_task_signatures_lock;
@@ -693,7 +693,7 @@ void TaskWorkerPool::_publish_version_worker_thread_callback() {
                 break;
             } else if (status.precise_code() == OLAP_ERR_PUBLISH_VERSION_NOT_CONTINUOUS) {
                 int64_t time_elapsed = time(nullptr) - agent_task_req.recv_time;
-                if (time_elapsed > PUBLISH_TIMEOUT) {
+                if (time_elapsed > PUBLISH_TIMEOUT_SEC) {
                     LOG(INFO) << "task elapsed " << time_elapsed
                               << " seconds since it is inserted to queue, it is timeout";
                     is_task_timeout = true;

--- a/be/src/olap/task/engine_publish_version_task.cpp
+++ b/be/src/olap/task/engine_publish_version_task.cpp
@@ -62,12 +62,8 @@ Status EnginePublishVersionTask::finish() {
     VLOG_NOTICE << "begin to process publish version. transaction_id=" << transaction_id;
 
     // each partition
-    bool meet_version_not_continuous = false;
     std::atomic<int64_t> total_task_num(0);
     for (auto& par_ver_info : _publish_version_req.partition_version_infos) {
-        if (meet_version_not_continuous) {
-            break;
-        }
         int64_t partition_id = par_ver_info.partition_id;
         // get all partition related tablets and check whether the tablet have the related version
         std::set<TabletInfo> partition_related_tablet_infos;
@@ -87,9 +83,6 @@ Status EnginePublishVersionTask::finish() {
 
         // each tablet
         for (auto& tablet_rs : tablet_related_rs) {
-            if (meet_version_not_continuous) {
-                break;
-            }
             TabletInfo tablet_info = tablet_rs.first;
             RowsetSharedPtr rowset = tablet_rs.second;
             VLOG_CRITICAL << "begin to publish version on tablet. "
@@ -131,8 +124,14 @@ Status EnginePublishVersionTask::finish() {
                                    "version="
                                 << max_version.second << ", publish_version=" << version.first
                                 << " tablet_id=" << tablet->tablet_id();
-                    meet_version_not_continuous = true;
-                    res = Status::OLAPInternalError(OLAP_ERR_PUBLISH_VERSION_NOT_CONTINUOUS);
+                    // If a tablet migrates out and back, the previously failed
+                    // publish task may retry on the new tablet, so check
+                    // whether the version exists. if not exist, then set
+                    // publish failed
+                    if (!tablet->check_version_exist(version)) {
+                        add_error_tablet_id(tablet_info.tablet_id);
+                        res = Status::OLAPInternalError(OLAP_ERR_PUBLISH_VERSION_NOT_CONTINUOUS);
+                    }
                     continue;
                 }
             }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

unique key with merge-on-write version is not continuous when publish transaction，return an error message to FE. FE will retry this publish transaction.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

