### PR TITLE
[feature-wip](unique-key-merge-on-write) update delete bitmap when increamental clone

### DIFF
--- a/be/src/olap/memtable.cpp
+++ b/be/src/olap/memtable.cpp
@@ -413,8 +413,9 @@ Status MemTable::_generate_delete_bitmap() {
     RETURN_IF_ERROR(beta_rowset->load_segment(beta_rowset->num_segments() - 1, &segment));
     segments.push_back(segment);
     std::shared_lock meta_rlock(_tablet->get_header_lock());
+    int64_t end_version = _tablet->max_version_unlocked().second;
     RETURN_IF_ERROR(_tablet->calc_delete_bitmap(beta_rowset->rowset_id(), segments, &_rowset_ids,
-                                                _delete_bitmap));
+                                                _delete_bitmap, end_version));
     return Status::OK();
 }
 

--- a/be/src/olap/rowset/rowset_tree.cpp
+++ b/be/src/olap/rowset/rowset_tree.cpp
@@ -200,7 +200,6 @@ void RowsetTree::FindRowsetsWithKeyInRange(
         const Slice& encoded_key, const RowsetIdUnorderedSet* rowset_ids,
         vector<std::pair<RowsetSharedPtr, int32_t>>* rowsets) const {
     DCHECK(initted_);
-    DCHECK(rowset_ids != nullptr);
 
     // Query the interval tree to efficiently find rowsets with known bounds
     // whose ranges overlap the probe key.
@@ -209,7 +208,7 @@ void RowsetTree::FindRowsetsWithKeyInRange(
     tree_->FindContainingPoint(encoded_key, &from_tree);
     rowsets->reserve(rowsets->size() + from_tree.size());
     for (RowsetWithBounds* rs : from_tree) {
-        if (rowset_ids->find(rs->rowset->rowset_id()) != rowset_ids->end()) {
+        if (!rowset_ids || rowset_ids->find(rs->rowset->rowset_id()) != rowset_ids->end()) {
             rowsets->emplace_back(rs->rowset, rs->segment_id);
         }
     }

--- a/be/src/olap/tablet.h
+++ b/be/src/olap/tablet.h
@@ -329,8 +329,10 @@ public:
     Status calc_delete_bitmap(RowsetId rowset_id,
                               const std::vector<segment_v2::SegmentSharedPtr>& segments,
                               const RowsetIdUnorderedSet* specified_rowset_ids,
-                              DeleteBitmapPtr delete_bitmap, bool check_pre_segments = false);
+                              DeleteBitmapPtr delete_bitmap, int64_t version,
+                              bool check_pre_segments = false);
 
+    Status update_delete_bitmap_without_lock(const RowsetSharedPtr& rowset);
     Status update_delete_bitmap(const RowsetSharedPtr& rowset, DeleteBitmapPtr delete_bitmap,
                                 const RowsetIdUnorderedSet& pre_rowset_ids);
     RowsetIdUnorderedSet all_rs_id() const;

--- a/be/src/olap/task/engine_clone_task.cpp
+++ b/be/src/olap/task/engine_clone_task.cpp
@@ -456,6 +456,7 @@ Status EngineCloneTask::_finish_clone(Tablet* tablet, const std::string& clone_d
             tablet->get_cumulative_compaction_lock());
     tablet->set_clone_occurred(true);
     std::lock_guard<std::mutex> push_lock(tablet->get_push_lock());
+    std::lock_guard<std::mutex> rwlock(tablet->get_rowset_update_lock());
     std::lock_guard<std::shared_mutex> wrlock(tablet->get_header_lock());
     // check clone dir existed
     if (!FileUtils::check_exist(clone_dir)) {


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

Full clone will copy all delete bitmap from src tablet. Incremental clone can't copy the delete bitmap from src table because of compaction. So we should calculate the delete bitmap using incremental rowset data.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

