### PR TITLE
[fix](frontend) fix peerDependencies error

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -396,7 +396,7 @@ function build_ui() {
         ui_dist="${CUSTOM_UI_DIST}"
     else
         cd "${DORIS_HOME}/ui"
-        "${NPM}" install
+        "${NPM}" install --legacy-peer-deps
         "${NPM}" run build
     fi
     echo "ui dist: ${ui_dist}"


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

```npm install``` problem with peer dependencies in the latest version of npm (v7+) 
Use ```npm install --legacy-peer-deps``` to fix it.

Reference: https://blog.npmjs.org/post/626173315965468672/npm-v7-series-beta-release-and-semver-major

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ x] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

