### PR TITLE
[feature](Nereids) let nullable of Year, weekOfYear and Divide be the same as implementation in BE

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/Divide.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/Divide.java
@@ -18,6 +18,7 @@
 package org.apache.doris.nereids.trees.expressions;
 
 import org.apache.doris.analysis.ArithmeticExpr.Operator;
+import org.apache.doris.nereids.exceptions.UnboundException;
 import org.apache.doris.nereids.trees.expressions.visitor.ExpressionVisitor;
 import org.apache.doris.nereids.types.coercion.AbstractDataType;
 import org.apache.doris.nereids.types.coercion.NumericType;
@@ -49,5 +50,11 @@ public class Divide extends BinaryArithmetic {
     @Override
     public AbstractDataType inputType() {
         return NumericType.INSTANCE;
+    }
+
+    // Divide is implemented as a scalar function which return type is always nullable.
+    @Override
+    public boolean nullable() throws UnboundException {
+        return true;
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/WeekOfYear.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/WeekOfYear.java
@@ -49,9 +49,10 @@ public class WeekOfYear extends BoundFunction implements UnaryExpression, Implic
         return IntegerType.INSTANCE;
     }
 
+    // Follow the return type of origin definition in the FunctionSet.
     @Override
     public boolean nullable() {
-        return child().nullable();
+        return true;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/Year.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/Year.java
@@ -51,9 +51,10 @@ public class Year extends BoundFunction implements UnaryExpression, ImplicitCast
         return IntegerType.INSTANCE;
     }
 
+    // Follow the return type of origin definition in the FunctionSet.
     @Override
     public boolean nullable() {
-        return child().nullable();
+        return true;
     }
 
     @Override


### PR DESCRIPTION
# Proposed changes

Issue Number: noissue
## Problem summary

These function/expression should always be nullable, so just return true in the overwrite method.
- Year
- weekOfYear
- Divide

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

