### PR TITLE
[enhancement](array-type) avoid abuse of Offset and Offset64

### DIFF
--- a/be/src/vec/columns/column.h
+++ b/be/src/vec/columns/column.h
@@ -46,7 +46,18 @@ private:
     /// If you want to copy column for modification, look at 'mutate' method.
     virtual MutablePtr clone() const = 0;
 
+protected:
+    // 64bit offsets now only Array type used, so we make it protected
+    // to avoid use IColumn::Offset64 directly.
+    // please use ColumnArray::Offset64 instead if we need.
+    using Offset64 = UInt64;
+    using Offsets64 = PaddedPODArray<Offset64>;
+
 public:
+    // 32bit offsets for string
+    using Offset = UInt32;
+    using Offsets = PaddedPODArray<Offset>;
+
     /// Name of a Column. It is used in info messages.
     virtual std::string get_name() const { return get_family_name(); }
 
@@ -339,14 +350,6 @@ public:
       */
     virtual void get_permutation(bool reverse, size_t limit, int nan_direction_hint,
                                  Permutation& res) const = 0;
-
-    // 32bit offsets for string
-    using Offset = UInt32;
-    using Offsets = PaddedPODArray<Offset>;
-
-    // 64bit offsets for array
-    using Offset64 = UInt64;
-    using Offsets64 = PaddedPODArray<Offset64>;
 
     /** Copies each element according offsets parameter.
       * (i-th element should be copied offsets[i] - offsets[i - 1] times.)

--- a/be/src/vec/columns/column_array.cpp
+++ b/be/src/vec/columns/column_array.cpp
@@ -386,10 +386,10 @@ ColumnPtr ColumnArray::filter_string(const Filter& filt, ssize_t result_size_hin
     }
 
     Offset64 prev_src_offset = 0;
-    Offset prev_src_string_offset = 0;
+    IColumn::Offset prev_src_string_offset = 0;
 
     Offset64 prev_res_offset = 0;
-    Offset prev_res_string_offset = 0;
+    IColumn::Offset prev_res_string_offset = 0;
 
     for (size_t i = 0; i < col_size; ++i) {
         /// Number of rows in the array.
@@ -496,7 +496,7 @@ void ColumnArray::insert_indices_from(const IColumn& src, const int* indices_beg
     }
 }
 
-ColumnPtr ColumnArray::replicate(const Offsets& replicate_offsets) const {
+ColumnPtr ColumnArray::replicate(const IColumn::Offsets& replicate_offsets) const {
     if (replicate_offsets.empty()) return clone_empty();
 
     // keep ColumnUInt8 for ColumnNullable::null_map
@@ -527,7 +527,7 @@ void ColumnArray::replicate(const uint32_t* counts, size_t target_size, IColumn&
         return;
     }
 
-    Offsets replicate_offsets(col_size);
+    IColumn::Offsets replicate_offsets(col_size);
     size_t cur_offset = 0;
     for (size_t i = 0; i < col_size; ++i) {
         cur_offset += counts[i];
@@ -553,7 +553,7 @@ void ColumnArray::replicate(const uint32_t* counts, size_t target_size, IColumn&
 }
 
 template <typename T>
-ColumnPtr ColumnArray::replicate_number(const Offsets& replicate_offsets) const {
+ColumnPtr ColumnArray::replicate_number(const IColumn::Offsets& replicate_offsets) const {
     size_t col_size = size();
     if (col_size != replicate_offsets.size())
         LOG(FATAL) << "Size of offsets doesn't match size of column.";
@@ -575,7 +575,7 @@ ColumnPtr ColumnArray::replicate_number(const Offsets& replicate_offsets) const 
     res_data.reserve(data->size() / col_size * replicate_offsets.back());
     res_offsets.reserve(replicate_offsets.back());
 
-    Offset prev_replicate_offset = 0;
+    IColumn::Offset prev_replicate_offset = 0;
     Offset64 prev_data_offset = 0;
     Offset64 current_new_offset = 0;
 
@@ -601,7 +601,7 @@ ColumnPtr ColumnArray::replicate_number(const Offsets& replicate_offsets) const 
     return res;
 }
 
-ColumnPtr ColumnArray::replicate_string(const Offsets& replicate_offsets) const {
+ColumnPtr ColumnArray::replicate_string(const IColumn::Offsets& replicate_offsets) const {
     size_t col_size = size();
     if (col_size != replicate_offsets.size())
         LOG(FATAL) << "Size of offsets doesn't match size of column.";
@@ -625,13 +625,13 @@ ColumnPtr ColumnArray::replicate_string(const Offsets& replicate_offsets) const 
     res_string_offsets.reserve(src_string_offsets.size() / col_size * replicate_offsets.back());
     res_offsets.reserve(replicate_offsets.back());
 
-    Offset prev_replicate_offset = 0;
+    IColumn::Offset prev_replicate_offset = 0;
 
     Offset64 prev_src_offset = 0;
-    Offset prev_src_string_offset = 0;
+    IColumn::Offset prev_src_string_offset = 0;
 
     Offset64 current_res_offset = 0;
-    Offset current_res_string_offset = 0;
+    IColumn::Offset current_res_string_offset = 0;
 
     for (size_t i = 0; i < col_size; ++i) {
         /// How many times to replicate the array.
@@ -675,7 +675,7 @@ ColumnPtr ColumnArray::replicate_string(const Offsets& replicate_offsets) const 
     return res;
 }
 
-ColumnPtr ColumnArray::replicate_const(const Offsets& replicate_offsets) const {
+ColumnPtr ColumnArray::replicate_const(const IColumn::Offsets& replicate_offsets) const {
     size_t col_size = size();
     if (col_size != replicate_offsets.size())
         LOG(FATAL) << "Size of offsets doesn't match size of column.";
@@ -688,7 +688,7 @@ ColumnPtr ColumnArray::replicate_const(const Offsets& replicate_offsets) const {
     auto& res_offsets = res_column_offsets->get_data();
     res_offsets.reserve(replicate_offsets.back());
 
-    Offset prev_replicate_offset = 0;
+    IColumn::Offset prev_replicate_offset = 0;
     Offset64 prev_data_offset = 0;
     Offset64 current_new_offset = 0;
 
@@ -709,7 +709,7 @@ ColumnPtr ColumnArray::replicate_const(const Offsets& replicate_offsets) const {
                                std::move(res_column_offsets));
 }
 
-ColumnPtr ColumnArray::replicate_generic(const Offsets& replicate_offsets) const {
+ColumnPtr ColumnArray::replicate_generic(const IColumn::Offsets& replicate_offsets) const {
     size_t col_size = size();
     if (col_size != replicate_offsets.size())
         LOG(FATAL) << "Size of offsets doesn't match size of column.";
@@ -730,7 +730,7 @@ ColumnPtr ColumnArray::replicate_generic(const Offsets& replicate_offsets) const
     return res;
 }
 
-ColumnPtr ColumnArray::replicate_nullable(const Offsets& replicate_offsets) const {
+ColumnPtr ColumnArray::replicate_nullable(const IColumn::Offsets& replicate_offsets) const {
     const ColumnNullable& nullable = assert_cast<const ColumnNullable&>(*data);
 
     /// Make temporary arrays for each components of Nullable. Then replicate them independently and collect back to result.

--- a/be/src/vec/columns/column_array.h
+++ b/be/src/vec/columns/column_array.h
@@ -46,6 +46,18 @@ private:
     ColumnArray(const ColumnArray&) = default;
 
 public:
+    // offsets of array is 64bit wise
+    using Offset64 = IColumn::Offset64;
+    using Offsets64 = IColumn::Offsets64;
+
+private:
+    // please use IColumn::Offset if we really need 32bit offset, otherwise use ColumnArray::Offset64
+    using Offset [[deprecated("ColumnArray::Offset64 for Array, IColumn::Offset for String")]] =
+            Offset64;
+    using Offsets [[deprecated("ColumnArray::Offsets64 for Array, IColumn::Offsets for String")]] =
+            Offsets64;
+
+public:
     /** Create immutable column using immutable arguments. This arguments may be shared with other columns.
       * Use IColumn::mutate in order to make mutable column and mutate shared nested columns.
       */
@@ -104,7 +116,7 @@ public:
     size_t byte_size() const override;
     size_t allocated_bytes() const override;
     void protect() override;
-    ColumnPtr replicate(const Offsets& replicate_offsets) const override;
+    ColumnPtr replicate(const IColumn::Offsets& replicate_offsets) const override;
     void replicate(const uint32_t* counts, size_t target_size, IColumn& column) const override;
     ColumnPtr convert_to_full_column_if_const() const override;
     void get_extremes(Field& min, Field& max) const override {
@@ -171,22 +183,22 @@ private:
 
     /// Multiply values if the nested column is ColumnVector<T>.
     template <typename T>
-    ColumnPtr replicate_number(const Offsets& replicate_offsets) const;
+    ColumnPtr replicate_number(const IColumn::Offsets& replicate_offsets) const;
 
     /// Multiply the values if the nested column is ColumnString. The code is too complicated.
-    ColumnPtr replicate_string(const Offsets& replicate_offsets) const;
+    ColumnPtr replicate_string(const IColumn::Offsets& replicate_offsets) const;
 
     /** Non-constant arrays of constant values are quite rare.
       * Most functions can not work with them, and does not create such columns as a result.
       * An exception is the function `replicate` (see FunctionsMiscellaneous.h), which has service meaning for the implementation of lambda functions.
       * Only for its sake is the implementation of the `replicate` method for ColumnArray(ColumnConst).
       */
-    ColumnPtr replicate_const(const Offsets& replicate_offsets) const;
+    ColumnPtr replicate_const(const IColumn::Offsets& replicate_offsets) const;
 
     /** The following is done by simply replicating of nested columns.
       */
-    ColumnPtr replicate_nullable(const Offsets& replicate_offsets) const;
-    ColumnPtr replicate_generic(const Offsets& replicate_offsets) const;
+    ColumnPtr replicate_nullable(const IColumn::Offsets& replicate_offsets) const;
+    ColumnPtr replicate_generic(const IColumn::Offsets& replicate_offsets) const;
 
     /// Specializations for the filter function.
     template <typename T>

--- a/be/src/vec/columns/columns_common.cpp
+++ b/be/src/vec/columns/columns_common.cpp
@@ -27,6 +27,7 @@
 
 #include "util/simd/bits.h"
 #include "vec/columns/column.h"
+#include "vec/columns/column_array.h"
 #include "vec/columns/column_vector.h"
 #include "vec/columns/columns_common.h"
 
@@ -256,25 +257,25 @@ void filter_arrays_impl_only_data(const PaddedPODArray<T>& src_elems,
             const IColumn::Filter&, ssize_t);
 
 INSTANTIATE(UInt8, IColumn::Offset)
-INSTANTIATE(UInt8, IColumn::Offset64)
+INSTANTIATE(UInt8, ColumnArray::Offset64)
 INSTANTIATE(UInt16, IColumn::Offset)
-INSTANTIATE(UInt16, IColumn::Offset64)
+INSTANTIATE(UInt16, ColumnArray::Offset64)
 INSTANTIATE(UInt32, IColumn::Offset)
-INSTANTIATE(UInt32, IColumn::Offset64)
+INSTANTIATE(UInt32, ColumnArray::Offset64)
 INSTANTIATE(UInt64, IColumn::Offset)
-INSTANTIATE(UInt64, IColumn::Offset64)
+INSTANTIATE(UInt64, ColumnArray::Offset64)
 INSTANTIATE(Int8, IColumn::Offset)
-INSTANTIATE(Int8, IColumn::Offset64)
+INSTANTIATE(Int8, ColumnArray::Offset64)
 INSTANTIATE(Int16, IColumn::Offset)
-INSTANTIATE(Int16, IColumn::Offset64)
+INSTANTIATE(Int16, ColumnArray::Offset64)
 INSTANTIATE(Int32, IColumn::Offset)
-INSTANTIATE(Int32, IColumn::Offset64)
+INSTANTIATE(Int32, ColumnArray::Offset64)
 INSTANTIATE(Int64, IColumn::Offset)
-INSTANTIATE(Int64, IColumn::Offset64)
+INSTANTIATE(Int64, ColumnArray::Offset64)
 INSTANTIATE(Float32, IColumn::Offset)
-INSTANTIATE(Float32, IColumn::Offset64)
+INSTANTIATE(Float32, ColumnArray::Offset64)
 INSTANTIATE(Float64, IColumn::Offset)
-INSTANTIATE(Float64, IColumn::Offset64)
+INSTANTIATE(Float64, ColumnArray::Offset64)
 
 #undef INSTANTIATE
 

--- a/be/src/vec/data_types/data_type_array.cpp
+++ b/be/src/vec/data_types/data_type_array.cpp
@@ -58,7 +58,7 @@ size_t DataTypeArray::get_number_of_dimensions() const {
 int64_t DataTypeArray::get_uncompressed_serialized_bytes(const IColumn& column) const {
     auto ptr = column.convert_to_full_column_if_const();
     const auto& data_column = assert_cast<const ColumnArray&>(*ptr.get());
-    return sizeof(IColumn::Offset64) * (column.size() + 1) +
+    return sizeof(ColumnArray::Offset64) * (column.size() + 1) +
            get_nested_type()->get_uncompressed_serialized_bytes(data_column.get_data());
 }
 
@@ -67,11 +67,11 @@ char* DataTypeArray::serialize(const IColumn& column, char* buf) const {
     const auto& data_column = assert_cast<const ColumnArray&>(*ptr.get());
 
     // row num
-    *reinterpret_cast<IColumn::Offset64*>(buf) = column.size();
-    buf += sizeof(IColumn::Offset64);
+    *reinterpret_cast<ColumnArray::Offset64*>(buf) = column.size();
+    buf += sizeof(ColumnArray::Offset64);
     // offsets
-    memcpy(buf, data_column.get_offsets().data(), column.size() * sizeof(IColumn::Offset64));
-    buf += column.size() * sizeof(IColumn::Offset64);
+    memcpy(buf, data_column.get_offsets().data(), column.size() * sizeof(ColumnArray::Offset64));
+    buf += column.size() * sizeof(ColumnArray::Offset64);
     // children
     return get_nested_type()->serialize(data_column.get_data(), buf);
 }
@@ -81,12 +81,12 @@ const char* DataTypeArray::deserialize(const char* buf, IColumn* column) const {
     auto& offsets = data_column->get_offsets();
 
     // row num
-    IColumn::Offset64 row_num = *reinterpret_cast<const IColumn::Offset64*>(buf);
-    buf += sizeof(IColumn::Offset64);
+    ColumnArray::Offset64 row_num = *reinterpret_cast<const ColumnArray::Offset64*>(buf);
+    buf += sizeof(ColumnArray::Offset64);
     // offsets
     offsets.resize(row_num);
-    memcpy(offsets.data(), buf, sizeof(IColumn::Offset64) * row_num);
-    buf += sizeof(IColumn::Offset64) * row_num;
+    memcpy(offsets.data(), buf, sizeof(ColumnArray::Offset64) * row_num);
+    buf += sizeof(ColumnArray::Offset64) * row_num;
     // children
     return get_nested_type()->deserialize(buf, data_column->get_data_ptr()->assume_mutable());
 }

--- a/be/test/vec/core/block_test.cpp
+++ b/be/test/vec/core/block_test.cpp
@@ -196,10 +196,10 @@ void block_to_pb(
 }
 
 void fill_block_with_array_int(vectorized::Block& block) {
-    auto off_column = vectorized::ColumnVector<vectorized::IColumn::Offset64>::create();
+    auto off_column = vectorized::ColumnVector<vectorized::ColumnArray::Offset64>::create();
     auto data_column = vectorized::ColumnVector<int32_t>::create();
     // init column array with [[1,2,3],[],[4],[5,6]]
-    std::vector<vectorized::IColumn::Offset64> offs = {0, 3, 3, 4, 6};
+    std::vector<vectorized::ColumnArray::Offset64> offs = {0, 3, 3, 4, 6};
     std::vector<int32_t> vals = {1, 2, 3, 4, 5, 6};
     for (size_t i = 1; i < offs.size(); ++i) {
         off_column->insert_data((const char*)(&offs[i]), 0);
@@ -218,10 +218,10 @@ void fill_block_with_array_int(vectorized::Block& block) {
 }
 
 void fill_block_with_array_string(vectorized::Block& block) {
-    auto off_column = vectorized::ColumnVector<vectorized::IColumn::Offset64>::create();
+    auto off_column = vectorized::ColumnVector<vectorized::ColumnArray::Offset64>::create();
     auto data_column = vectorized::ColumnString::create();
     // init column array with [["abc","de"],["fg"],[], [""]];
-    std::vector<vectorized::IColumn::Offset64> offs = {0, 2, 3, 3, 4};
+    std::vector<vectorized::ColumnArray::Offset64> offs = {0, 2, 3, 3, 4};
     std::vector<std::string> vals = {"abc", "de", "fg", ""};
     for (size_t i = 1; i < offs.size(); ++i) {
         off_column->insert_data((const char*)(&offs[i]), 0);

--- a/be/test/vec/core/column_array_test.cpp
+++ b/be/test/vec/core/column_array_test.cpp
@@ -28,7 +28,7 @@
 
 namespace doris::vectorized {
 
-void check_array_offsets(const IColumn& arr, const std::vector<IColumn::Offset64>& offs) {
+void check_array_offsets(const IColumn& arr, const std::vector<ColumnArray::Offset64>& offs) {
     auto arr_col = check_and_get_column<ColumnArray>(arr);
     ASSERT_EQ(arr_col->size(), offs.size());
     for (size_t i = 0; i < arr_col->size(); ++i) {
@@ -57,10 +57,10 @@ void check_array_data(const IColumn& arr, const std::vector<std::string>& data) 
 }
 
 TEST(ColumnArrayTest, IntArrayTest) {
-    auto off_column = ColumnVector<IColumn::Offset64>::create();
+    auto off_column = ColumnVector<ColumnArray::Offset64>::create();
     auto data_column = ColumnVector<int32_t>::create();
     // init column array with [[1,2,3],[],[4]]
-    std::vector<IColumn::Offset64> offs = {0, 3, 3, 4};
+    std::vector<ColumnArray::Offset64> offs = {0, 3, 3, 4};
     std::vector<int32_t> vals = {1, 2, 3, 4};
     for (size_t i = 1; i < offs.size(); ++i) {
         off_column->insert_data((const char*)(&offs[i]), 0);
@@ -82,10 +82,10 @@ TEST(ColumnArrayTest, IntArrayTest) {
 }
 
 TEST(ColumnArrayTest, StringArrayTest) {
-    auto off_column = ColumnVector<IColumn::Offset64>::create();
+    auto off_column = ColumnVector<ColumnArray::Offset64>::create();
     auto data_column = ColumnString::create();
     // init column array with [["abc","d"],["ef"],[], [""]];
-    std::vector<IColumn::Offset64> offs = {0, 2, 3, 3, 4};
+    std::vector<ColumnArray::Offset64> offs = {0, 2, 3, 3, 4};
     std::vector<std::string> vals = {"abc", "d", "ef", ""};
     for (size_t i = 1; i < offs.size(); ++i) {
         off_column->insert_data((const char*)(&offs[i]), 0);
@@ -107,10 +107,10 @@ TEST(ColumnArrayTest, StringArrayTest) {
 }
 
 TEST(ColumnArrayTest, IntArrayPermuteTest) {
-    auto off_column = ColumnVector<IColumn::Offset64>::create();
+    auto off_column = ColumnVector<ColumnArray::Offset64>::create();
     auto data_column = ColumnVector<int32_t>::create();
     // init column array with [[1,2,3],[],[4],[5,6]]
-    std::vector<IColumn::Offset64> offs = {0, 3, 3, 4, 6};
+    std::vector<ColumnArray::Offset64> offs = {0, 3, 3, 4, 6};
     std::vector<int32_t> vals = {1, 2, 3, 4, 5, 6};
     for (size_t i = 1; i < offs.size(); ++i) {
         off_column->insert_data((const char*)(&offs[i]), 0);
@@ -133,10 +133,10 @@ TEST(ColumnArrayTest, IntArrayPermuteTest) {
 }
 
 TEST(ColumnArrayTest, StringArrayPermuteTest) {
-    auto off_column = ColumnVector<IColumn::Offset64>::create();
+    auto off_column = ColumnVector<ColumnArray::Offset64>::create();
     auto data_column = ColumnString::create();
     // init column array with [["abc","d"],["ef"],[], [""]];
-    std::vector<IColumn::Offset64> offs = {0, 2, 3, 3, 4};
+    std::vector<ColumnArray::Offset64> offs = {0, 2, 3, 3, 4};
     std::vector<std::string> vals = {"abc", "d", "ef", ""};
     for (size_t i = 1; i < offs.size(); ++i) {
         off_column->insert_data((const char*)(&offs[i]), 0);
@@ -159,10 +159,10 @@ TEST(ColumnArrayTest, StringArrayPermuteTest) {
 }
 
 TEST(ColumnArrayTest, EmptyArrayPermuteTest) {
-    auto off_column = ColumnVector<IColumn::Offset64>::create();
+    auto off_column = ColumnVector<ColumnArray::Offset64>::create();
     auto data_column = ColumnVector<int32_t>::create();
     // init column array with [[],[],[],[]]
-    std::vector<IColumn::Offset64> offs = {0, 0, 0, 0, 0};
+    std::vector<ColumnArray::Offset64> offs = {0, 0, 0, 0, 0};
     std::vector<int32_t> vals = {};
     for (size_t i = 1; i < offs.size(); ++i) {
         off_column->insert_data((const char*)(&offs[i]), 0);
@@ -185,10 +185,10 @@ TEST(ColumnArrayTest, EmptyArrayPermuteTest) {
 }
 
 TEST(ColumnArrayTest, IntArrayReplicateTest) {
-    auto off_column = ColumnVector<IColumn::Offset64>::create();
+    auto off_column = ColumnVector<ColumnArray::Offset64>::create();
     auto data_column = ColumnVector<int32_t>::create();
     // init column array with [[1,2,3],[],[4],[5,6]]
-    std::vector<IColumn::Offset64> offs = {0, 3, 3, 4, 6};
+    std::vector<ColumnArray::Offset64> offs = {0, 3, 3, 4, 6};
     std::vector<int32_t> vals = {1, 2, 3, 4, 5, 6};
     for (size_t i = 1; i < offs.size(); ++i) {
         off_column->insert_data((const char*)(&offs[i]), 0);
@@ -209,10 +209,10 @@ TEST(ColumnArrayTest, IntArrayReplicateTest) {
 }
 
 TEST(ColumnArrayTest, StringArrayReplicateTest) {
-    auto off_column = ColumnVector<IColumn::Offset64>::create();
+    auto off_column = ColumnVector<ColumnArray::Offset64>::create();
     auto data_column = ColumnString::create();
     // init column array with [["abc","d"],["ef"],[], [""]];
-    std::vector<IColumn::Offset64> offs = {0, 2, 3, 3, 4};
+    std::vector<ColumnArray::Offset64> offs = {0, 2, 3, 3, 4};
     std::vector<std::string> vals = {"abc", "d", "ef", ""};
     for (size_t i = 1; i < offs.size(); ++i) {
         off_column->insert_data((const char*)(&offs[i]), 0);

--- a/be/test/vec/utils/arrow_column_to_doris_column_test.cpp
+++ b/be/test/vec/utils/arrow_column_to_doris_column_test.cpp
@@ -613,7 +613,7 @@ TEST(ArrowColumnToDorisColumnTest, test_binary) {
 
 template <typename ArrowValueType, bool is_nullable = false>
 static inline std::shared_ptr<arrow::Array> create_array_array(
-        std::vector<IColumn::Offset64>& vec_offsets, std::vector<bool>& null_map,
+        std::vector<ColumnArray::Offset64>& vec_offsets, std::vector<bool>& null_map,
         std::shared_ptr<arrow::DataType> value_type, std::shared_ptr<arrow::Array> values,
         size_t& counter) {
     using offset_type = typename arrow::ListType::offset_type;
@@ -646,7 +646,7 @@ static inline std::shared_ptr<arrow::Array> create_array_array(
 
 template <typename ArrowType, bool is_nullable>
 void test_arrow_to_array_column(ColumnWithTypeAndName& column,
-                                std::vector<IColumn::Offset64>& vec_offsets,
+                                std::vector<ColumnArray::Offset64>& vec_offsets,
                                 std::vector<bool>& null_map,
                                 std::shared_ptr<arrow::DataType> value_type,
                                 std::shared_ptr<arrow::Array> values, const std::string& value,
@@ -698,7 +698,7 @@ void test_arrow_to_array_column(ColumnWithTypeAndName& column,
 
 template <typename ArrowType, bool is_nullable>
 void test_array(const std::vector<std::string>& test_cases, size_t num_elements,
-                std::vector<IColumn::Offset64>& vec_offsets, std::vector<bool>& null_map,
+                std::vector<ColumnArray::Offset64>& vec_offsets, std::vector<bool>& null_map,
                 std::shared_ptr<arrow::DataType> value_type) {
     TypeDescriptor type(TYPE_ARRAY);
     type.children.push_back(TYPE_VARCHAR);
@@ -724,7 +724,7 @@ void test_array(const std::vector<std::string>& test_cases, size_t num_elements,
 TEST(ArrowColumnToDorisColumnTest, test_array) {
     std::vector<std::string> test_cases = {"1.2345678", "-12.34567890", "99999999999.99999999",
                                            "-99999999999.99999999"};
-    std::vector<IColumn::Offset64> vec_offsets = {0, 3, 3, 4, 6, 6, 64};
+    std::vector<ColumnArray::Offset64> vec_offsets = {0, 3, 3, 4, 6, 6, 64};
     std::vector<bool> null_map = {false, true, false, false, false, false};
     test_array<arrow::BinaryType, false>(test_cases, 64, vec_offsets, null_map,
                                          arrow::list(arrow::binary()));


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

Describe your changes.

We already separate Array Offset64 and String Offset(32bit) in PR: https://github.com/apache/doris/pull/12341

Now we limit: Offset inside IColumn, Offset64 only inside ColumnArray, to avoid abuse of them.
If we use the wrong one, it will compile failed.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

