### PR TITLE
[Bug](DOE): Doe query due to be crash.

### DIFF
--- a/be/src/exec/es_http_scan_node.cpp
+++ b/be/src/exec/es_http_scan_node.cpp
@@ -48,7 +48,7 @@ EsHttpScanNode::EsHttpScanNode(ObjectPool* pool, const TPlanNode& tnode, const D
 EsHttpScanNode::~EsHttpScanNode() {}
 
 Status EsHttpScanNode::init(const TPlanNode& tnode, RuntimeState* state) {
-    RETURN_IF_ERROR(ScanNode::init(tnode));
+    RETURN_IF_ERROR(ScanNode::init(tnode, state));
 
     // use TEsScanNode
     _properties = tnode.es_scan_node.properties;

--- a/be/src/vec/exec/ves_http_scan_node.cpp
+++ b/be/src/vec/exec/ves_http_scan_node.cpp
@@ -42,7 +42,7 @@ VEsHttpScanNode::VEsHttpScanNode(ObjectPool* pool, const TPlanNode& tnode,
           _wait_scanner_timer(nullptr) {}
 
 Status VEsHttpScanNode::init(const TPlanNode& tnode, RuntimeState* state) {
-    RETURN_IF_ERROR(ScanNode::init(tnode));
+    RETURN_IF_ERROR(ScanNode::init(tnode, state));
 
     // use TEsScanNode
     _properties = tnode.es_scan_node.properties;


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

Doe query due to be crash.
```
*** SIGSEGV address not mapped to object (@0x484) received by PID 126017 (TID 0x7f74f7a17700) from PID 1156; stack trace: ***
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /root/incubator-doris/be/src/common/signal_handler.h:420
 1# 0x00007F75ED105400 in /lib64/libc.so.6
 2# doris::ExecNode::init(doris::TPlanNode const&, doris::RuntimeState*) at /root/incubator-doris/be/src/exec/exec_node.cpp:191
 3# doris::vectorized::VEsHttpScanNode::init(doris::TPlanNode const&, doris::RuntimeState*) at /root/incubator-doris/be/src/vec/exec/ves_http_scan_node.cpp:45
 4# doris::ExecNode::create_tree_helper(doris::RuntimeState*, doris::ObjectPool*, std::vector<doris::TPlanNode, std::allocator<doris::TPlanNode> > const&, doris::DescriptorTbl const&, doris::ExecNode*, int*, doris::ExecNode**) at /root/incubator-doris/be/src/exec/exec_node.cpp:377
 5# doris::ExecNode::create_tree(doris::RuntimeState*, doris::ObjectPool*, doris::TPlan const&, doris::DescriptorTbl const&, doris::ExecNode**) at /root/incubator-doris/be/src/exec/exec_node.cpp:332
 6# doris::PlanFragmentExecutor::prepare(doris::TExecPlanFragmentParams const&, doris::QueryFragmentsCtx*) at /root/incubator-doris/be/src/runtime/plan_fragment_executor.cpp:139
 7# doris::FragmentExecState::prepare(doris::TExecPlanFragmentParams const&) at /root/incubator-doris/be/src/runtime/fragment_mgr.cpp:233
 8# doris::FragmentMgr::exec_plan_fragment(doris::TExecPlanFragmentParams const&, std::function<void (doris::PlanFragmentExecutor*)>) at /root/incubator-doris/be/src/runtime/fragment_mgr.cpp:697
 9# doris::FragmentMgr::exec_plan_fragment(doris::TExecPlanFragmentParams const&) at /root/incubator-doris/be/src/runtime/fragment_mgr.cpp:552
10# doris::PInternalServiceImpl::_exec_plan_fragment(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, doris::PFragmentRequestVersion, bool) at /root/incubator-doris/be/src/service/internal_service.cpp:380
11# doris::PInternalServiceImpl::exec_plan_fragment(google::protobuf::RpcController*, doris::PExecPlanFragmentRequest const*, doris::PExecPlanFragmentResult*, google::protobuf::Closure*) at /root/incubator-doris/be/src/service/internal_service.cpp:197
12# brpc::policy::ProcessHttpRequest(brpc::InputMessageBase*) at /var/local/doris/thirdparty/src/incubator-brpc-1.2.0/src/brpc/policy/http_rpc_protocol.cpp:1542
13# brpc::ProcessInputMessage(void*) at /var/local/doris/thirdparty/src/incubator-brpc-1.2.0/src/brpc/input_messenger.cpp:149
14# brpc::InputMessenger::OnNewMessages(brpc::Socket*) at /var/local/doris/thirdparty/src/incubator-brpc-1.2.0/src/brpc/input_messenger.cpp:347
15# brpc::Socket::ProcessEvent(void*) at /var/local/doris/thirdparty/src/incubator-brpc-1.2.0/src/brpc/socket.cpp:1020
16# bthread::TaskGroup::task_runner(long) at /var/local/doris/thirdparty/src/incubator-brpc-1.2.0/src/bthread/task_group.cpp:301
17# bthread_make_fcontext in /opt/rongqian_li/be/lib/doris_be
```

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

