### PR TITLE
[fix](regression p0) fix regression p0 test qt_window_hang2 always failed because of timeout

### DIFF
--- a/regression-test/suites/query_p0/sql_functions/window_functions/test_window_function.groovy
+++ b/regression-test/suites/query_p0/sql_functions/window_functions/test_window_function.groovy
@@ -492,7 +492,7 @@ suite("test_window_function") {
         }
     }
 
-    sql """ admin set frontend config("remote_fragment_exec_timeout_ms"="60000"); """
+    sql """ admin set frontend config("remote_fragment_exec_timeout_ms"="300000"); """
 
     qt_window_hang2"""select A.${k1}, A.wj - B.dyk + 1 as num from 
         (select ${k1}, wj from ${line} as W1) as A join 


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

