### PR TITLE
[bugfix](be thread) not call rpc during cancel to hang bthread

### DIFF
--- a/be/src/runtime/fragment_mgr.cpp
+++ b/be/src/runtime/fragment_mgr.cpp
@@ -658,9 +658,11 @@ Status FragmentMgr::exec_plan_fragment(const TExecPlanFragmentParams& params, Fi
             std::lock_guard<std::mutex> lock(_lock);
             _fragment_map.erase(params.params.fragment_instance_id);
         }
-        exec_state->cancel();
-        return Status::InternalError("Put planfragment to thread pool failed. err = {}, BE: {}",
-                                     st.get_error_msg(), BackendOptions::get_localhost());
+        exec_state->cancel(PPlanFragmentCancelReason::INTERNAL_ERROR,
+                           "Put planfragment to thread pool failed");
+        return Status::InternalError(
+                strings::Substitute("Put planfragment to thread pool failed. err = {}, BE: {}",
+                                    st.get_error_msg(), BackendOptions::get_localhost()));
     }
 
     return Status::OK();

--- a/be/src/runtime/fragment_mgr.cpp
+++ b/be/src/runtime/fragment_mgr.cpp
@@ -248,9 +248,7 @@ Status FragmentExecState::execute() {
 
 Status FragmentExecState::cancel(const PPlanFragmentCancelReason& reason, const std::string& msg) {
     if (!_cancelled) {
-        _cancelled = true;
         std::lock_guard<std::mutex> l(_status_lock);
-        RETURN_IF_ERROR(_exec_status);
         if (reason == PPlanFragmentCancelReason::LIMIT_REACH) {
             _executor.set_is_report_on_cancel(false);
         }
@@ -258,6 +256,7 @@ Status FragmentExecState::cancel(const PPlanFragmentCancelReason& reason, const 
         if (_pipe != nullptr) {
             _pipe->cancel(PPlanFragmentCancelReason_Name(reason));
         }
+        _cancelled = true;
     }
     return Status::OK();
 }

--- a/be/src/runtime/fragment_mgr.cpp
+++ b/be/src/runtime/fragment_mgr.cpp
@@ -661,7 +661,7 @@ Status FragmentMgr::exec_plan_fragment(const TExecPlanFragmentParams& params, Fi
         exec_state->cancel(PPlanFragmentCancelReason::INTERNAL_ERROR,
                            "Put planfragment to thread pool failed");
         return Status::InternalError(
-                strings::Substitute("Put planfragment to thread pool failed. err = {}, BE: {}",
+                strings::Substitute("Put planfragment to thread pool failed. err = $0, BE: $1",
                                     st.get_error_msg(), BackendOptions::get_localhost()));
     }
 

--- a/be/src/runtime/plan_fragment_executor.cpp
+++ b/be/src/runtime/plan_fragment_executor.cpp
@@ -33,8 +33,8 @@
 #include "runtime/mem_tracker.h"
 #include "runtime/result_buffer_mgr.h"
 #include "runtime/result_queue_mgr.h"
-#include "runtime/runtime_filter_mgr.h"
 #include "runtime/row_batch.h"
+#include "runtime/runtime_filter_mgr.h"
 #include "runtime/thread_context.h"
 #include "util/container_util.hpp"
 #include "util/cpu_info.h"
@@ -646,10 +646,8 @@ void PlanFragmentExecutor::cancel(const PPlanFragmentCancelReason& reason, const
         env->stream_mgr()->cancel(id);
         env->result_mgr()->cancel(id);
     }
-}
-
-void PlanFragmentExecutor::set_abort() {
-    update_status(Status::Aborted("Execution aborted before start"));
+    // Cancel the result queue manager used by spark doris connector
+    _exec_env->result_queue_mgr()->update_queue_status(id, Status::Aborted(msg));
 }
 
 const RowDescriptor& PlanFragmentExecutor::row_desc() {

--- a/be/src/runtime/plan_fragment_executor.h
+++ b/be/src/runtime/plan_fragment_executor.h
@@ -121,11 +121,6 @@ public:
     // in open()/get_next().
     void close();
 
-    // Abort this execution. Must be called if we skip running open().
-    // It will let DataSink node closed with error status, to avoid use resources which created in open() phase.
-    // DataSink node should distinguish Aborted status from other error status.
-    void set_abort();
-
     // Initiate cancellation. Must not be called until after prepare() returned.
     void cancel(const PPlanFragmentCancelReason& reason = PPlanFragmentCancelReason::INTERNAL_ERROR,
                 const std::string& msg = "");

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -296,6 +296,8 @@ void PInternalServiceImpl<T>::tablet_writer_cancel(google::protobuf::RpcControll
 template <typename T>
 Status PInternalServiceImpl<T>::_exec_plan_fragment(const std::string& ser_request,
                                                  PFragmentRequestVersion version, bool compact) {
+    // Could not parse fragment id from string here, just print a log to indicate that BE received a request
+    LOG(INFO) << "received a plan fragment request";
     if (version == PFragmentRequestVersion::VERSION_1) {
         // VERSION_1 should be removed in v1.2
         TExecPlanFragmentParams t_request;
@@ -344,6 +346,8 @@ void PInternalServiceImpl<T>::cancel_plan_fragment(google::protobuf::RpcControll
     }
     if (!st.ok()) {
         LOG(WARNING) << "cancel plan fragment failed, errmsg=" << st.get_error_msg();
+    } else {
+        LOG(INFO) << "cancel fragment, fragment_instance_id=" << print_id(tid) << " successfully.";
     }
     st.to_protobuf(result->mutable_status());
 }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

When exec plan fragment failed to submit the executor to thread pool, be will try to cancel the executor and call update status to send FE the error msg. But it is in bthread, it will occupy the thread during call thrift rpc to fe. Other brpc request send to be will hang.

And also the cancel logic will check the exec status variable, but the variable maybe set by reporting thread and cancel will skip the later logic. Should remove check status logic.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

