### PR TITLE
[fix](nereids) NormalizeAggregate rule cause FE inifite loop

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalAggregate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalAggregate.java
@@ -160,12 +160,14 @@ public class LogicalAggregate<CHILD_TYPE extends Plan> extends LogicalUnary<CHIL
         LogicalAggregate that = (LogicalAggregate) o;
         return Objects.equals(groupByExpressions, that.groupByExpressions)
                 && Objects.equals(outputExpressions, that.outputExpressions)
-                && aggPhase == that.aggPhase;
+                && aggPhase == that.aggPhase
+                && disassembled == that.disassembled
+                && normalized == that.normalized;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(groupByExpressions, outputExpressions, aggPhase);
+        return Objects.hash(groupByExpressions, outputExpressions, aggPhase, normalized, disassembled);
     }
 
     @Override

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/PlanEqualsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/PlanEqualsTest.java
@@ -68,6 +68,21 @@ public class PlanEqualsTest {
                 new SlotReference(new ExprId(1), "b", BigIntType.INSTANCE, true, Lists.newArrayList())),
                 child);
         Assertions.assertNotEquals(unexpected, actual);
+
+        unexpected = new LogicalAggregate<>(Lists.newArrayList(), ImmutableList.of(
+                new SlotReference(new ExprId(1), "b", BigIntType.INSTANCE, true, Lists.newArrayList())),
+                true, false, AggPhase.GLOBAL, child);
+        Assertions.assertNotEquals(unexpected, actual);
+
+        unexpected = new LogicalAggregate<>(Lists.newArrayList(), ImmutableList.of(
+                new SlotReference(new ExprId(1), "b", BigIntType.INSTANCE, true, Lists.newArrayList())),
+                false, true, AggPhase.GLOBAL, child);
+        Assertions.assertNotEquals(unexpected, actual);
+
+        unexpected = new LogicalAggregate<>(Lists.newArrayList(), ImmutableList.of(
+                new SlotReference(new ExprId(1), "b", BigIntType.INSTANCE, true, Lists.newArrayList())),
+                false, false, AggPhase.LOCAL, child);
+        Assertions.assertNotEquals(unexpected, actual);
     }
 
     @Test


### PR DESCRIPTION
# Proposed changes
After applying NormalizeAggregate rule, owner groups of all aggregate children are removed.
The root cause is the new aggregate node is regarded as the old aggregate node, because LogicalAggregate.equals() does not take some attributes ("normalized", "disassembled") into account.

test sql: revised version of TPCH Q16 
```
select    
    p_brand,
    p_type,
    p_size
from
    partsupp,
    part
where
    p_partkey = ps_partkey
    and p_brand <> 'Brand#45'
    and p_type not like 'MEDIUM POLISHED%'
    and p_size in (49, 14, 23, 45, 19, 3, 36, 9)
    and ps_suppkey not in (
        select
            s_suppkey
        from
            supplier
        where
            s_comment like '%Customer%Complaints%'
    )
group by
    p_brand,
    p_type,
    p_size
order by
    p_brand,
    p_type,
    p_size;
```
Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

