### PR TITLE
[Enhancement](sparkload) cast the src slot types of bitmap columns to bitmap in spark load

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/SparkLoadJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/SparkLoadJob.java
@@ -903,10 +903,18 @@ public class SparkLoadJob extends BulkLoadJob {
             Map<String, SlotDescriptor> srcSlotDescByName = Maps.newHashMap();
             for (Column column : columns) {
                 SlotDescriptor srcSlotDesc = descTable.addSlotDescriptor(srcTupleDesc);
-                srcSlotDesc.setType(ScalarType.createType(PrimitiveType.VARCHAR));
                 srcSlotDesc.setIsMaterialized(true);
                 srcSlotDesc.setIsNullable(true);
-                srcSlotDesc.setColumn(new Column(column.getName(), PrimitiveType.VARCHAR));
+
+                if (column.getDataType() == PrimitiveType.BITMAP) {
+                    // cast to bitmap when the target column type is bitmap
+                    srcSlotDesc.setType(ScalarType.createType(PrimitiveType.BITMAP));
+                    srcSlotDesc.setColumn(new Column(column.getName(), PrimitiveType.BITMAP));
+                } else {
+                    srcSlotDesc.setType(ScalarType.createType(PrimitiveType.VARCHAR));
+                    srcSlotDesc.setColumn(new Column(column.getName(), PrimitiveType.VARCHAR));
+                }
+
                 params.addToSrcSlotIds(srcSlotDesc.getId().asInt());
                 srcSlotDescByName.put(column.getName(), srcSlotDesc);
             }


### PR DESCRIPTION
# Proposed changes
Cast the src slot types of bitmap columns to bitmap in spark load
## Problem summary
In the current spark load implementation, the types of source data, that BE reads from the Broker, are all set to `varchar`.
However, the two types of `varchar` and `bitmap` are not compatible anymore after version 1.1.0, which will cause spark load failure.

An example of spark load error message:
```
detailMessage = type not match, originType=VARCHAR(*), targeType=BITMAP
```

Describe your changes.

Set the src type of the bitmap columns from `varchar` to `bitmap`when fe pushtasks.
## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

