### PR TITLE
[fix](Nereids)lowest cost plan map do not be merged when do group merge

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Group.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Group.java
@@ -46,7 +46,7 @@ import java.util.stream.Collectors;
  */
 public class Group {
     private final GroupId groupId;
-    private final IdentityHashMap<GroupExpression, Void> parentExpressions = new IdentityHashMap();
+    private final IdentityHashMap<GroupExpression, Void> parentExpressions = new IdentityHashMap<>();
 
     private final List<GroupExpression> logicalExpressions = Lists.newArrayList();
     private final List<GroupExpression> physicalExpressions = Lists.newArrayList();
@@ -301,6 +301,7 @@ public class Group {
 
     /**
      * remove the reference to parent groupExpression
+     *
      * @param parent group expression
      * @return parentExpressions's num
      */
@@ -382,6 +383,7 @@ public class Group {
     /**
      * move the ownerGroup of all logical expressions to target group
      * if this.equals(target), do nothing.
+     *
      * @param target the new owner group of expressions
      */
     public void moveLogicalExpressionOwnership(Group target) {
@@ -397,6 +399,7 @@ public class Group {
     /**
      * move the ownerGroup of all physical expressions to target group
      * if this.equals(target), do nothing.
+     *
      * @param target the new owner group of expressions
      */
     public void movePhysicalExpressionOwnership(Group target) {
@@ -409,4 +412,31 @@ public class Group {
         physicalExpressions.clear();
     }
 
+    /**
+     * move the ownerGroup of all lowestCostPlans to target group
+     * if this.equals(target), do nothing.
+     *
+     * @param target the new owner group of expressions
+     */
+    public void moveLowestCostPlansOwnership(Group target) {
+        if (equals(target)) {
+            return;
+        }
+        lowestCostPlans.forEach((physicalProperties, costAndGroupExpr) -> {
+            GroupExpression bestGroupExpression = costAndGroupExpr.second;
+            // change into target group.
+            if (bestGroupExpression.getOwnerGroup() == this) {
+                bestGroupExpression.setOwnerGroup(target);
+                bestGroupExpression.children().set(0, target);
+            }
+            if (!target.lowestCostPlans.containsKey(physicalProperties)) {
+                target.lowestCostPlans.put(physicalProperties, costAndGroupExpr);
+            } else {
+                if (costAndGroupExpr.first < target.lowestCostPlans.get(physicalProperties).first) {
+                    target.lowestCostPlans.put(physicalProperties, costAndGroupExpr);
+                }
+            }
+        });
+        lowestCostPlans.clear();
+    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Memo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Memo.java
@@ -341,8 +341,10 @@ public class Memo {
             }
         }
         if (!source.equals(destination)) {
+            // TODO: stats and other
             source.moveLogicalExpressionOwnership(destination);
             source.movePhysicalExpressionOwnership(destination);
+            source.moveLowestCostPlansOwnership(destination);
             groups.remove(source.getGroupId());
         }
         return destination;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/StatsCalculator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/StatsCalculator.java
@@ -307,7 +307,7 @@ public class StatsCalculator extends DefaultPlanVisitor<StatsDeriveResult, Void>
                 // TODO: just a trick here, need to do real project on column stats
                 return new AbstractMap.SimpleEntry<>(projection.toSlot(), childColumnStats.get(slotReferences.get(0)));
             }
-        }).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+        }).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (item1, item2) -> item1));
         statsDeriveResult.setSlotToColumnStats(columnsStats);
         return statsDeriveResult;
     }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/memo/MemoCopyInTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/memo/MemoCopyInTest.java
@@ -17,73 +17,64 @@
 
 package org.apache.doris.nereids.memo;
 
-import org.apache.doris.nereids.analyzer.UnboundRelation;
-import org.apache.doris.nereids.trees.expressions.literal.BooleanLiteral;
 import org.apache.doris.nereids.trees.plans.JoinType;
-import org.apache.doris.nereids.trees.plans.logical.LogicalFilter;
 import org.apache.doris.nereids.trees.plans.logical.LogicalJoin;
+import org.apache.doris.nereids.trees.plans.logical.LogicalOlapScan;
 import org.apache.doris.nereids.util.MemoTestUtils;
 import org.apache.doris.nereids.util.PatternMatchSupported;
 import org.apache.doris.nereids.util.PlanChecker;
+import org.apache.doris.nereids.util.PlanConstructor;
 
-import com.google.common.collect.Lists;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class MemoCopyInTest implements PatternMatchSupported {
+    LogicalJoin<LogicalOlapScan, LogicalOlapScan> logicalJoinAB = new LogicalJoin<>(JoinType.INNER_JOIN,
+            PlanConstructor.newLogicalOlapScan(0, "A", 0), PlanConstructor.newLogicalOlapScan(1, "B", 0));
+    LogicalJoin<LogicalJoin<LogicalOlapScan, LogicalOlapScan>, LogicalOlapScan> logicalJoinABC = new LogicalJoin<>(
+            JoinType.INNER_JOIN, logicalJoinAB, PlanConstructor.newLogicalOlapScan(2, "C", 0));
+
     /**
      * Original:
-     * Group 0: UnboundRelation C
-     * Group 1: UnboundRelation B
-     * Group 2: UnboundRelation A
+     * Group 0: LogicalOlapScan C
+     * Group 1: LogicalOlapScan B
+     * Group 2: LogicalOlapScan A
      * Group 3: Join(Group 1, Group 2)
      * Group 4: Join(Group 0, Group 3)
-     * Group 5: Filter(Group 4)
      * <p>
      * Then:
      * Copy In Join(Group 2, Group 1) into Group 3
      * <p>
      * Expected:
-     * Group 0: UnboundRelation C
-     * Group 1: UnboundRelation B
-     * Group 2: UnboundRelation A
-     * Group 3: Join(Group 1, Group 2), Join(Group 1, Group 2)
+     * Group 0: LogicalOlapScan C
+     * Group 1: LogicalOlapScan B
+     * Group 2: LogicalOlapScan A
+     * Group 3: Join(Group 1, Group 2), Join(Group 2, Group 1)
      * Group 4: Join(Group 0, Group 3)
-     * Group 5: Filter(Group 4)
      */
     @Test
-    public void testMergeGroup() {
-        UnboundRelation unboundRelationA = new UnboundRelation(Lists.newArrayList("A"));
-        UnboundRelation unboundRelationB = new UnboundRelation(Lists.newArrayList("B"));
-        UnboundRelation unboundRelationC = new UnboundRelation(Lists.newArrayList("C"));
-        LogicalJoin<UnboundRelation, UnboundRelation> logicalJoinBA = new LogicalJoin<>(JoinType.INNER_JOIN,
-                unboundRelationB, unboundRelationA);
-        LogicalJoin<UnboundRelation, LogicalJoin<UnboundRelation, UnboundRelation>> logicalJoinCBA = new LogicalJoin<>(
-                JoinType.INNER_JOIN, unboundRelationC, logicalJoinBA);
-        LogicalFilter<LogicalJoin<UnboundRelation, LogicalJoin<UnboundRelation, UnboundRelation>>> logicalFilter
-                = new LogicalFilter<>(new BooleanLiteral(true), logicalJoinCBA);
-
-        PlanChecker.from(MemoTestUtils.createConnectContext(), logicalFilter)
-                .checkGroupNum(6)
+    public void testInsertSameGroup() {
+        PlanChecker.from(MemoTestUtils.createConnectContext(), logicalJoinABC)
                 .transform(
                         // swap join's children
-                        logicalJoin(unboundRelation(), unboundRelation()).then(joinBA ->
+                        logicalJoin(logicalOlapScan(), logicalOlapScan()).then(joinBA ->
                                 new LogicalJoin<>(JoinType.INNER_JOIN, joinBA.right(), joinBA.left())
                         ))
-                .checkGroupNum(6)
-                .checkGroupExpressionNum(7)
+                .checkGroupNum(5)
+                .checkGroupExpressionNum(6)
                 .checkMemo(memo -> {
                     Group root = memo.getRoot();
                     Assertions.assertEquals(1, root.getLogicalExpressions().size());
-                    GroupExpression filter = root.getLogicalExpression();
-                    GroupExpression joinCBA = filter.child(0).getLogicalExpression();
-                    Assertions.assertEquals(1, joinCBA.child(0).getLogicalExpressions().size());
-                    Assertions.assertEquals(2, joinCBA.child(1).getLogicalExpressions().size());
-                    GroupExpression joinBA = joinCBA.child(1).getLogicalExpressions().get(0);
-                    GroupExpression joinAB = joinCBA.child(1).getLogicalExpressions().get(1);
+                    GroupExpression joinABC = root.getLogicalExpression();
+                    Assertions.assertEquals(2, joinABC.child(0).getLogicalExpressions().size());
+                    Assertions.assertEquals(1, joinABC.child(1).getLogicalExpressions().size());
+                    GroupExpression joinAB = joinABC.child(0).getLogicalExpressions().get(0);
+                    GroupExpression joinBA = joinABC.child(0).getLogicalExpressions().get(1);
                     Assertions.assertTrue(joinAB.getPlan() instanceof LogicalJoin);
                     Assertions.assertTrue(joinBA.getPlan() instanceof LogicalJoin);
                 });
 
     }
+
+    // TODO: test mergeGroup().
 }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

fix bug:
- merge same slot stats in calculate project stats.
- merge lowestPlan when merge group

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

