### PR TITLE
[Enhancement](DOE): Doe support object/nested use string

### DIFF
--- a/be/src/http/http_client.cpp
+++ b/be/src/http/http_client.cpp
@@ -162,7 +162,7 @@ Status HttpClient::execute(const std::function<bool(const void* data, size_t len
     _callback = &callback;
     auto code = curl_easy_perform(_curl);
     if (code != CURLE_OK) {
-        LOG(WARNING) << "fail to execute HTTP client, errmsg=" << _to_errmsg(code);
+        LOG(WARNING) << "fail to execute HTTP client, errmsg=" << _to_errmsg(code) << " trace=" << get_stack_trace();
         return Status::InternalError(_to_errmsg(code));
     }
     return Status::OK();

--- a/be/src/http/http_client.cpp
+++ b/be/src/http/http_client.cpp
@@ -16,9 +16,9 @@
 // under the License.
 
 #include "http/http_client.h"
-#include "util/stack_util.h"
 
 #include "common/config.h"
+#include "util/stack_util.h"
 
 namespace doris {
 
@@ -163,7 +163,8 @@ Status HttpClient::execute(const std::function<bool(const void* data, size_t len
     _callback = &callback;
     auto code = curl_easy_perform(_curl);
     if (code != CURLE_OK) {
-        LOG(WARNING) << "fail to execute HTTP client, errmsg=" << _to_errmsg(code) << " trace=" << get_stack_trace();
+        LOG(WARNING) << "fail to execute HTTP client, errmsg=" << _to_errmsg(code)
+                     << " trace=" << get_stack_trace();
         return Status::InternalError(_to_errmsg(code));
     }
     return Status::OK();

--- a/be/src/http/http_client.cpp
+++ b/be/src/http/http_client.cpp
@@ -16,6 +16,7 @@
 // under the License.
 
 #include "http/http_client.h"
+#include "util/stack_util.h"
 
 #include "common/config.h"
 

--- a/be/src/http/http_client.cpp
+++ b/be/src/http/http_client.cpp
@@ -164,7 +164,7 @@ Status HttpClient::execute(const std::function<bool(const void* data, size_t len
     auto code = curl_easy_perform(_curl);
     if (code != CURLE_OK) {
         LOG(WARNING) << "fail to execute HTTP client, errmsg=" << _to_errmsg(code)
-                     << " trace=" << get_stack_trace();
+                     << ", trace=" << get_stack_trace();
         return Status::InternalError(_to_errmsg(code));
     }
     return Status::OK();

--- a/fe/fe-core/src/main/java/org/apache/doris/external/elasticsearch/EsUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/external/elasticsearch/EsUtil.java
@@ -37,6 +37,7 @@ import org.apache.doris.analysis.RangePartitionDesc;
 import org.apache.doris.analysis.SlotRef;
 import org.apache.doris.catalog.ArrayType;
 import org.apache.doris.catalog.Column;
+import org.apache.doris.catalog.ScalarType;
 import org.apache.doris.catalog.Type;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.DdlException;
@@ -359,7 +360,7 @@ public class EsUtil {
         for (String key : keys) {
             JSONObject field = (JSONObject) mappingProps.get(key);
             Type type;
-            // Complex types are not currently supported.
+            // Complex types are treating as String types for now.
             if (field.containsKey("type")) {
                 type = toDorisType(field.get("type").toString());
             } else {
@@ -405,7 +406,7 @@ public class EsUtil {
             case "scaled_float":
                 return Type.DOUBLE;
             case "date":
-                return Type.DATE;
+                return ScalarType.getDefaultDateType(Type.DATE);
             case "keyword":
             case "text":
             case "ip":

--- a/fe/fe-core/src/main/java/org/apache/doris/external/elasticsearch/EsUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/external/elasticsearch/EsUtil.java
@@ -358,22 +358,23 @@ public class EsUtil {
         List<Column> columns = new ArrayList<>();
         for (String key : keys) {
             JSONObject field = (JSONObject) mappingProps.get(key);
+            Type type;
             // Complex types are not currently supported.
             if (field.containsKey("type")) {
-                Type type = toDorisType(field.get("type").toString());
-                if (!type.isInvalid()) {
-                    Column column = new Column();
-                    column.setName(key);
-                    column.setIsKey(true);
-                    column.setIsAllowNull(true);
-                    if (arrayFields.contains(key)) {
-                        column.setType(ArrayType.create(type, true));
-                    } else {
-                        column.setType(type);
-                    }
-                    columns.add(column);
-                }
+                type = toDorisType(field.get("type").toString());
+            } else {
+                type = Type.STRING;
             }
+            Column column = new Column();
+            column.setName(key);
+            column.setIsKey(true);
+            column.setIsAllowNull(true);
+            if (arrayFields.contains(key)) {
+                column.setType(ArrayType.create(type, true));
+            } else {
+                column.setType(type);
+            }
+            columns.add(column);
         }
         return columns;
     }
@@ -403,16 +404,15 @@ public class EsUtil {
             case "double":
             case "scaled_float":
                 return Type.DOUBLE;
+            case "date":
+                return Type.DATE;
             case "keyword":
             case "text":
             case "ip":
             case "nested":
             case "object":
-                return Type.STRING;
-            case "date":
-                return Type.DATE;
             default:
-                return Type.INVALID;
+                return Type.STRING;
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/external/elasticsearch/MappingPhase.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/external/elasticsearch/MappingPhase.java
@@ -119,6 +119,8 @@ public class MappingPhase implements SearchPhase {
                 if (!docValue) {
                     return;
                 }
+            } else {
+                return;
             }
             docValueField = colName;
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/external/elasticsearch/MappingPhase.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/external/elasticsearch/MappingPhase.java
@@ -119,7 +119,7 @@ public class MappingPhase implements SearchPhase {
                 if (!docValue) {
                     return;
                 }
-            } else {
+            } else if (fieldType == null) {
                 return;
             }
             docValueField = colName;

--- a/fe/fe-core/src/main/java/org/apache/doris/external/elasticsearch/MappingPhase.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/external/elasticsearch/MappingPhase.java
@@ -119,7 +119,8 @@ public class MappingPhase implements SearchPhase {
                 if (!docValue) {
                     return;
                 }
-            } else if (fieldType == null) {
+            } else if (fieldType == null || "nested".equals(fieldType)) {
+                // The object field has no type, and nested not support doc value.
                 return;
             }
             docValueField = colName;

--- a/fe/fe-core/src/test/java/org/apache/doris/external/elasticsearch/EsUtilTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/external/elasticsearch/EsUtilTest.java
@@ -120,6 +120,7 @@ public class EsUtilTest extends EsTestCase {
         Assertions.assertEquals("k3.keyword", searchContext1.docValueFieldsContext().get("k3"));
         Assertions.assertEquals("k1", searchContext1.docValueFieldsContext().get("k1"));
         Assertions.assertEquals("k2", searchContext1.docValueFieldsContext().get("k2"));
+        Assertions.assertEquals(null, searchContext1.docValueFieldsContext().get("k4"));
 
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/external/elasticsearch/EsUtilTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/external/elasticsearch/EsUtilTest.java
@@ -74,9 +74,15 @@ public class EsUtilTest extends EsTestCase {
         Column k1 = new Column("k1", PrimitiveType.BIGINT);
         Column k2 = new Column("k2", PrimitiveType.VARCHAR);
         Column k3 = new Column("k3", PrimitiveType.VARCHAR);
+        Column k4 = new Column("k4", PrimitiveType.VARCHAR);
+        Column k5 = new Column("k5", PrimitiveType.VARCHAR);
+        Column k6 = new Column("k6", PrimitiveType.DATE);
         columns.add(k1);
         columns.add(k2);
         columns.add(k3);
+        columns.add(k4);
+        columns.add(k5);
+        columns.add(k6);
     }
 
     @Test
@@ -120,7 +126,8 @@ public class EsUtilTest extends EsTestCase {
         Assertions.assertEquals("k3.keyword", searchContext1.docValueFieldsContext().get("k3"));
         Assertions.assertEquals("k1", searchContext1.docValueFieldsContext().get("k1"));
         Assertions.assertEquals("k2", searchContext1.docValueFieldsContext().get("k2"));
-        Assertions.assertEquals(null, searchContext1.docValueFieldsContext().get("k4"));
+        Assertions.assertNull(searchContext1.docValueFieldsContext().get("k4"));
+        Assertions.assertNull(searchContext1.docValueFieldsContext().get("k5"));
 
     }
 

--- a/fe/fe-core/src/test/resources/data/es/test_index_mapping.json
+++ b/fe/fe-core/src/test/resources/data/es/test_index_mapping.json
@@ -16,6 +16,22 @@
                 "type": "keyword"
               }
             }
+          },
+          "k4": {
+            "properties": {
+              "child1": {
+                "type": "text",
+                "fields": {
+                  "keyword": {
+                    "type": "keyword",
+                    "ignore_above": 256
+                  }
+                }
+              },
+              "child2": {
+                "type": "long"
+              }
+            }
           }
         }
       }

--- a/fe/fe-core/src/test/resources/data/es/test_index_mapping.json
+++ b/fe/fe-core/src/test/resources/data/es/test_index_mapping.json
@@ -32,6 +32,20 @@
                 "type": "long"
               }
             }
+          },
+          "k5": {
+            "type": "nested",
+            "properties": {
+              "child3": {
+                "type": "keyword"
+              },
+              "child4": {
+                "type": "keyword"
+              }
+            }
+          },
+          "k6": {
+            "type": "date"
           }
         }
       }

--- a/fe/fe-core/src/test/resources/data/es/test_index_mapping_after_7x.json
+++ b/fe/fe-core/src/test/resources/data/es/test_index_mapping_after_7x.json
@@ -15,6 +15,36 @@
               "type": "keyword"
             }
           }
+        },
+        "k4": {
+          "properties": {
+            "child1": {
+              "type": "text",
+              "fields": {
+                "keyword": {
+                  "type": "keyword",
+                  "ignore_above": 256
+                }
+              }
+            },
+            "child2": {
+              "type": "long"
+            }
+          }
+        },
+        "k5": {
+          "type": "nested",
+          "properties": {
+            "child3": {
+              "type": "keyword"
+            },
+            "child4": {
+              "type": "keyword"
+            }
+          }
+        },
+        "k6": {
+          "type": "date"
         }
       }
     }

--- a/fe/fe-core/src/test/resources/data/es/test_index_mapping_field_mult_analyzer.json
+++ b/fe/fe-core/src/test/resources/data/es/test_index_mapping_field_mult_analyzer.json
@@ -16,6 +16,36 @@
               "analyzer": "ik_max_word"
             }
           }
+        },
+        "k4": {
+          "properties": {
+            "child1": {
+              "type": "text",
+              "fields": {
+                "keyword": {
+                  "type": "keyword",
+                  "ignore_above": 256
+                }
+              }
+            },
+            "child2": {
+              "type": "long"
+            }
+          }
+        },
+        "k5": {
+          "type": "nested",
+          "properties": {
+            "child3": {
+              "type": "keyword"
+            },
+            "child4": {
+              "type": "keyword"
+            }
+          }
+        },
+        "k6": {
+          "type": "date"
         }
       }
     }


### PR DESCRIPTION
# Proposed changes

Issue Number: close https://github.com/apache/doris/issues/12387

## Problem summary

Doe support object/nested use string
1. doc_value logic modify, ignore object/nested
2. auto create table mapping object/nested to string type.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [x] Yes
    - [ ] No
    - [ ] I don't know
3. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
5. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
6. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

