### PR TITLE
[feature](quick-compaciton) enable  quick compaction  by default

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -821,7 +821,7 @@ CONF_mInt32(bloom_filter_predicate_check_row_num, "1000");
 CONF_Bool(enable_decimalv3, "false");
 
 //whether turn on quick compaction feature
-CONF_Bool(enable_quick_compaction, "false");
+CONF_Bool(enable_quick_compaction, "true");
 // For continuous versions that rows less than quick_compaction_max_rows will  trigger compaction quickly
 CONF_Int32(quick_compaction_max_rows, "1000");
 // min compaction versions


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

i think the quick compaction enabled by default is more beneficial for the system

more details see  issue(#9804)

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

