### PR TITLE
[Opt](vectorized) Speed up bucket shuffle join hash compute

### DIFF
--- a/be/src/exec/tablet_info.cpp
+++ b/be/src/exec/tablet_info.cpp
@@ -220,10 +220,7 @@ Status OlapTablePartitionParam::init() {
                 if (slot != nullptr) {
                     hash_val = RawValue::zlib_crc32(slot, slot_desc->type(), hash_val);
                 } else {
-                    //nullptr is treat as 0 when hash
-                    static const int INT_VALUE = 0;
-                    static const TypeDescriptor INT_TYPE(TYPE_INT);
-                    hash_val = RawValue::zlib_crc32(&INT_VALUE, INT_TYPE, hash_val);
+                    hash_val = HashUtil::zlib_crc_hash_null(hash_val);
                 }
             }
             return hash_val % num_buckets;
@@ -492,16 +489,13 @@ Status VOlapTablePartitionParam::init() {
             uint32_t hash_val = 0;
             for (int i = 0; i < _distributed_slot_locs.size(); ++i) {
                 auto slot_desc = _slots[_distributed_slot_locs[i]];
-                auto column = key->first->get_by_position(_distributed_slot_locs[i]).column;
+                auto& column = key->first->get_by_position(_distributed_slot_locs[i]).column;
                 auto val = column->get_data_at(key->second);
                 if (val.data != nullptr) {
                     hash_val = RawValue::zlib_crc32(val.data, val.size, slot_desc->type().type,
                                                     hash_val);
                 } else {
-                    // NULL is treat as 0 when hash
-                    static const int INT_VALUE = 0;
-                    static const TypeDescriptor INT_TYPE(TYPE_INT);
-                    hash_val = RawValue::zlib_crc32(&INT_VALUE, INT_TYPE, hash_val);
+                    hash_val = HashUtil::zlib_crc_hash_null(hash_val);
                 }
             }
             return hash_val % num_buckets;

--- a/be/src/runtime/data_stream_sender.cpp
+++ b/be/src/runtime/data_stream_sender.cpp
@@ -626,10 +626,7 @@ Status DataStreamSender::process_distribute(RuntimeState* state, TupleRow* row,
         if (partition_val != nullptr) {
             hash_val = RawValue::zlib_crc32(partition_val, ctx->root()->type(), hash_val);
         } else {
-            //nullptr is treat as 0 when hash
-            static const int INT_VALUE = 0;
-            static const TypeDescriptor INT_TYPE(TYPE_INT);
-            hash_val = RawValue::zlib_crc32(&INT_VALUE, INT_TYPE, hash_val);
+            hash_val = HashUtil::zlib_crc_hash_null(hash_val);
         }
     }
     hash_val %= part->distributed_bucket();

--- a/be/src/runtime/define_primitive_type.h
+++ b/be/src/runtime/define_primitive_type.h
@@ -1,0 +1,58 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+namespace doris {
+enum PrimitiveType {
+    INVALID_TYPE = 0,
+    TYPE_NULL,     /* 1 */
+    TYPE_BOOLEAN,  /* 2 */
+    TYPE_TINYINT,  /* 3 */
+    TYPE_SMALLINT, /* 4 */
+    TYPE_INT,      /* 5 */
+    TYPE_BIGINT,   /* 6 */
+    TYPE_LARGEINT, /* 7 */
+    TYPE_FLOAT,    /* 8 */
+    TYPE_DOUBLE,   /* 9 */
+    TYPE_VARCHAR,  /* 10 */
+    TYPE_DATE,     /* 11 */
+    TYPE_DATETIME, /* 12 */
+    TYPE_BINARY,
+    /* 13 */                     // Not implemented
+    TYPE_DECIMAL [[deprecated]], /* 14 */
+    TYPE_CHAR,                   /* 15 */
+
+    TYPE_STRUCT,    /* 16 */
+    TYPE_ARRAY,     /* 17 */
+    TYPE_MAP,       /* 18 */
+    TYPE_HLL,       /* 19 */
+    TYPE_DECIMALV2, /* 20 */
+
+    TYPE_TIME,           /* 21 */
+    TYPE_OBJECT,         /* 22 */
+    TYPE_STRING,         /* 23 */
+    TYPE_QUANTILE_STATE, /* 24 */
+    TYPE_DATEV2,         /* 25 */
+    TYPE_DATETIMEV2,     /* 26 */
+    TYPE_TIMEV2,         /* 27 */
+    TYPE_DECIMAL32,      /* 28 */
+    TYPE_DECIMAL64,      /* 29 */
+    TYPE_DECIMAL128,     /* 30 */
+};
+
+}

--- a/be/src/runtime/primitive_type.h
+++ b/be/src/runtime/primitive_type.h
@@ -19,6 +19,7 @@
 
 #include <string>
 
+#include "runtime/define_primitive_type.h"
 #include "vec/columns/column_decimal.h"
 #include "vec/columns/columns_number.h"
 #include "vec/core/types.h"
@@ -32,43 +33,6 @@ class ColumnString;
 class DateTimeValue;
 class DecimalV2Value;
 struct StringValue;
-
-enum PrimitiveType {
-    INVALID_TYPE = 0,
-    TYPE_NULL,     /* 1 */
-    TYPE_BOOLEAN,  /* 2 */
-    TYPE_TINYINT,  /* 3 */
-    TYPE_SMALLINT, /* 4 */
-    TYPE_INT,      /* 5 */
-    TYPE_BIGINT,   /* 6 */
-    TYPE_LARGEINT, /* 7 */
-    TYPE_FLOAT,    /* 8 */
-    TYPE_DOUBLE,   /* 9 */
-    TYPE_VARCHAR,  /* 10 */
-    TYPE_DATE,     /* 11 */
-    TYPE_DATETIME, /* 12 */
-    TYPE_BINARY,
-    /* 13 */                     // Not implemented
-    TYPE_DECIMAL [[deprecated]], /* 14 */
-    TYPE_CHAR,                   /* 15 */
-
-    TYPE_STRUCT,    /* 16 */
-    TYPE_ARRAY,     /* 17 */
-    TYPE_MAP,       /* 18 */
-    TYPE_HLL,       /* 19 */
-    TYPE_DECIMALV2, /* 20 */
-
-    TYPE_TIME,           /* 21 */
-    TYPE_OBJECT,         /* 22 */
-    TYPE_STRING,         /* 23 */
-    TYPE_QUANTILE_STATE, /* 24 */
-    TYPE_DATEV2,         /* 25 */
-    TYPE_DATETIMEV2,     /* 26 */
-    TYPE_TIMEV2,         /* 27 */
-    TYPE_DECIMAL32,      /* 28 */
-    TYPE_DECIMAL64,      /* 29 */
-    TYPE_DECIMAL128,     /* 30 */
-};
 
 PrimitiveType convert_type_to_primitive(FunctionContext::Type type);
 

--- a/be/src/runtime/raw_value.h
+++ b/be/src/runtime/raw_value.h
@@ -442,8 +442,10 @@ inline uint32_t RawValue::zlib_crc32(const void* v, const TypeDescriptor& type, 
     case TYPE_SMALLINT:
         return HashUtil::zlib_crc_hash(v, 2, seed);
     case TYPE_INT:
+    case TYPE_DATEV2:
         return HashUtil::zlib_crc_hash(v, 4, seed);
     case TYPE_BIGINT:
+    case TYPE_DATETIMEV2:
         return HashUtil::zlib_crc_hash(v, 8, seed);
     case TYPE_LARGEINT:
         return HashUtil::zlib_crc_hash(v, 16, seed);
@@ -456,21 +458,6 @@ inline uint32_t RawValue::zlib_crc32(const void* v, const TypeDescriptor& type, 
         const DateTimeValue* date_val = (const DateTimeValue*)v;
         char buf[64];
         int len = date_val->to_buffer(buf);
-        return HashUtil::zlib_crc_hash(buf, len, seed);
-    }
-    case TYPE_DATEV2: {
-        const vectorized::DateV2Value<doris::vectorized::DateV2ValueType>* date_v2_val =
-                (const vectorized::DateV2Value<doris::vectorized::DateV2ValueType>*)v;
-        char buf[64];
-        int len = date_v2_val->to_buffer(buf);
-        return HashUtil::zlib_crc_hash(buf, len, seed);
-    }
-
-    case TYPE_DATETIMEV2: {
-        const vectorized::DateV2Value<doris::vectorized::DateTimeV2ValueType>* date_v2_val =
-                (const vectorized::DateV2Value<doris::vectorized::DateTimeV2ValueType>*)v;
-        char buf[64];
-        int len = date_v2_val->to_buffer(buf);
         return HashUtil::zlib_crc_hash(buf, len, seed);
     }
 

--- a/be/src/runtime/raw_value.h
+++ b/be/src/runtime/raw_value.h
@@ -443,11 +443,14 @@ inline uint32_t RawValue::zlib_crc32(const void* v, const TypeDescriptor& type, 
         return HashUtil::zlib_crc_hash(v, 2, seed);
     case TYPE_INT:
     case TYPE_DATEV2:
+    case TYPE_DECIMAL32:
         return HashUtil::zlib_crc_hash(v, 4, seed);
     case TYPE_BIGINT:
     case TYPE_DATETIMEV2:
+    case TYPE_DECIMAL64:
         return HashUtil::zlib_crc_hash(v, 8, seed);
     case TYPE_LARGEINT:
+    case TYPE_DECIMAL128:
         return HashUtil::zlib_crc_hash(v, 16, seed);
     case TYPE_FLOAT:
         return HashUtil::zlib_crc_hash(v, 4, seed);
@@ -468,13 +471,6 @@ inline uint32_t RawValue::zlib_crc32(const void* v, const TypeDescriptor& type, 
         seed = HashUtil::zlib_crc_hash(&int_val, sizeof(int_val), seed);
         return HashUtil::zlib_crc_hash(&frac_val, sizeof(frac_val), seed);
     }
-
-    case TYPE_DECIMAL32:
-        return HashUtil::zlib_crc_hash(v, 4, seed);
-    case TYPE_DECIMAL64:
-        return HashUtil::zlib_crc_hash(v, 8, seed);
-    case TYPE_DECIMAL128:
-        return HashUtil::zlib_crc_hash(v, 16, seed);
     default:
         DCHECK(false) << "invalid type: " << type;
         return 0;

--- a/be/src/util/hash_util.hpp
+++ b/be/src/util/hash_util.hpp
@@ -47,6 +47,13 @@ public:
     static uint32_t zlib_crc_hash(const void* data, int32_t bytes, uint32_t hash) {
         return crc32(hash, (const unsigned char*)data, bytes);
     }
+
+    static uint32_t zlib_crc_hash_null(uint32_t hash) {
+        // null is treat as 0 when hash
+        static const int INT_VALUE = 0;
+        return crc32(hash, (const unsigned char*)(&INT_VALUE), 4);
+    }
+
 #if defined(__SSE4_2__) || defined(__aarch64__)
     // Compute the Crc32 hash for data using SSE4 instructions.  The input hash parameter is
     // the current hash/seed value.

--- a/be/src/vec/columns/column_const.cpp
+++ b/be/src/vec/columns/column_const.cpp
@@ -20,6 +20,7 @@
 
 #include "vec/columns/column_const.h"
 
+#include "runtime/raw_value.h"
 #include "vec/columns/columns_common.h"
 #include "vec/common/pod_array.h"
 #include "vec/common/sip_hash.h"
@@ -99,6 +100,23 @@ void ColumnConst::update_hashes_with_value(std::vector<SipHash>& hashes,
     } else {
         for (auto& hash : hashes) {
             hash.update(real_data.data, real_data.size);
+        }
+    }
+}
+
+void ColumnConst::update_crcs_with_value(std::vector<uint32_t>& hashes, doris::PrimitiveType type,
+                                         const uint8_t* __restrict null_data) const {
+    DCHECK(null_data == nullptr);
+    DCHECK(hashes.size() == size());
+    auto real_data = data->get_data_at(0);
+    if (real_data.data == nullptr) {
+        for (int i = 0; i < hashes.size(); ++i) {
+            hashes[i] = HashUtil::zlib_crc_hash_null(hashes[i]);
+        }
+    } else {
+        for (int i = 0; i < hashes.size(); ++i) {
+            hashes[i] = RawValue::zlib_crc32(real_data.data, real_data.size, TypeDescriptor {type},
+                                             hashes[i]);
         }
     }
 }

--- a/be/src/vec/columns/column_const.h
+++ b/be/src/vec/columns/column_const.h
@@ -135,6 +135,9 @@ public:
     void update_hashes_with_value(std::vector<SipHash>& hashes,
                                   const uint8_t* __restrict null_data) const override;
 
+    void update_crcs_with_value(std::vector<uint32_t>& hashes, PrimitiveType type,
+                                const uint8_t* __restrict null_data) const override;
+
     ColumnPtr filter(const Filter& filt, ssize_t result_size_hint) const override;
     ColumnPtr replicate(const Offsets& offsets) const override;
     void replicate(const uint32_t* counts, size_t target_size, IColumn& column) const override;

--- a/be/src/vec/columns/column_decimal.cpp
+++ b/be/src/vec/columns/column_decimal.cpp
@@ -128,6 +128,39 @@ void ColumnDecimal<T>::update_hashes_with_value(std::vector<SipHash>& hashes,
 }
 
 template <typename T>
+void ColumnDecimal<T>::update_crcs_with_value(std::vector<uint32_t>& hashes, PrimitiveType type,
+                                              const uint8_t* __restrict null_data) const {
+    auto s = hashes.size();
+    DCHECK(s == size());
+
+    if constexpr (!std::is_same_v<T, Decimal128>) {
+        DO_CRC_HASHES_FUNCTION_COLUMN_IMPL()
+    } else {
+        if (type == TYPE_DECIMALV2) {
+            auto decimalv2_do_crc = [&](size_t i) {
+                const DecimalV2Value& dec_val = (const DecimalV2Value&)data[i];
+                int64_t int_val = dec_val.int_value();
+                int32_t frac_val = dec_val.frac_value();
+                hashes[i] = HashUtil::zlib_crc_hash(&int_val, sizeof(int_val), hashes[i]);
+                hashes[i] = HashUtil::zlib_crc_hash(&frac_val, sizeof(frac_val), hashes[i]);
+            };
+
+            if (null_data == nullptr) {
+                for (size_t i = 0; i < s; i++) {
+                    decimalv2_do_crc(i);
+                }
+            } else {
+                for (size_t i = 0; i < s; i++) {
+                    if (null_data[i] == 0) decimalv2_do_crc(i);
+                }
+            }
+        } else {
+            DO_CRC_HASHES_FUNCTION_COLUMN_IMPL()
+        }
+    }
+}
+
+template <typename T>
 void ColumnDecimal<T>::get_permutation(bool reverse, size_t limit, int,
                                        IColumn::Permutation& res) const {
 #if 1 /// TODO: perf test

--- a/be/src/vec/columns/column_decimal.h
+++ b/be/src/vec/columns/column_decimal.h
@@ -156,6 +156,8 @@ public:
     void update_hash_with_value(size_t n, SipHash& hash) const override;
     void update_hashes_with_value(std::vector<SipHash>& hash,
                                   const uint8_t* __restrict null_data) const override;
+    void update_crcs_with_value(std::vector<uint32_t>& hashes, PrimitiveType type,
+                                const uint8_t* __restrict null_data) const override;
 
     int compare_at(size_t n, size_t m, const IColumn& rhs_, int nan_direction_hint) const override;
     void get_permutation(bool reverse, size_t limit, int nan_direction_hint,

--- a/be/src/vec/columns/column_nullable.cpp
+++ b/be/src/vec/columns/column_nullable.cpp
@@ -75,7 +75,7 @@ void ColumnNullable::update_crcs_with_value(std::vector<uint32_t>& hashes,
     auto s = hashes.size();
     DCHECK(s == size());
     auto* __restrict real_null_data = assert_cast<const ColumnUInt8&>(*null_map).get_data().data();
-    if (doris::simd::count_zero_num(reinterpret_cast<const int8_t*>(real_null_data), s) == s) {
+    if (!has_null()) {
         nested_column->update_crcs_with_value(hashes, type, nullptr);
     } else {
         for (int i = 0; i < s; ++i) {

--- a/be/src/vec/columns/column_nullable.cpp
+++ b/be/src/vec/columns/column_nullable.cpp
@@ -68,6 +68,25 @@ void ColumnNullable::update_hashes_with_value(std::vector<SipHash>& hashes,
     }
 }
 
+void ColumnNullable::update_crcs_with_value(std::vector<uint32_t>& hashes,
+                                            doris::PrimitiveType type,
+                                            const uint8_t* __restrict null_data) const {
+    DCHECK(null_data == nullptr);
+    auto s = hashes.size();
+    DCHECK(s == size());
+    auto* __restrict real_null_data = assert_cast<const ColumnUInt8&>(*null_map).get_data().data();
+    if (doris::simd::count_zero_num(reinterpret_cast<const int8_t*>(real_null_data), s) == s) {
+        nested_column->update_crcs_with_value(hashes, type, nullptr);
+    } else {
+        for (int i = 0; i < s; ++i) {
+            if (real_null_data[i] != 0) {
+                hashes[i] = HashUtil::zlib_crc_hash_null(hashes[i]);
+            }
+        }
+        nested_column->update_crcs_with_value(hashes, type, real_null_data);
+    }
+}
+
 MutableColumnPtr ColumnNullable::clone_resized(size_t new_size) const {
     MutableColumnPtr new_nested_col = get_nested_column().clone_resized(new_size);
     auto new_null_map = ColumnUInt8::create();

--- a/be/src/vec/columns/column_nullable.h
+++ b/be/src/vec/columns/column_nullable.h
@@ -161,6 +161,8 @@ public:
     void update_hash_with_value(size_t n, SipHash& hash) const override;
     void update_hashes_with_value(std::vector<SipHash>& hashes,
                                   const uint8_t* __restrict null_data) const override;
+    void update_crcs_with_value(std::vector<uint32_t>& hash, PrimitiveType type,
+                                const uint8_t* __restrict null_data) const override;
     void get_extremes(Field& min, Field& max) const override;
 
     MutableColumns scatter(ColumnIndex num_columns, const Selector& selector) const override {

--- a/be/src/vec/columns/column_string.h
+++ b/be/src/vec/columns/column_string.h
@@ -327,31 +327,19 @@ public:
 
     void get_extremes(Field& min, Field& max) const override;
 
-    bool can_be_inside_nullable() const override {
-        return true;
-    }
+    bool can_be_inside_nullable() const override { return true; }
 
-    bool is_column_string() const override {
-        return true;
-    }
+    bool is_column_string() const override { return true; }
 
     bool structure_equals(const IColumn& rhs) const override {
         return typeid(rhs) == typeid(ColumnString);
     }
 
-    Chars& get_chars() {
-        return chars;
-    }
-    const Chars& get_chars() const {
-        return chars;
-    }
+    Chars& get_chars() { return chars; }
+    const Chars& get_chars() const { return chars; }
 
-    Offsets& get_offsets() {
-        return offsets;
-    }
-    const Offsets& get_offsets() const {
-        return offsets;
-    }
+    Offsets& get_offsets() { return offsets; }
+    const Offsets& get_offsets() const { return offsets; }
 
     void clear() override {
         chars.clear();

--- a/be/src/vec/columns/column_string.h
+++ b/be/src/vec/columns/column_string.h
@@ -256,6 +256,9 @@ public:
         SIP_HASHES_FUNCTION_COLUMN_IMPL();
     }
 
+    void update_crcs_with_value(std::vector<uint32_t>& hashes, PrimitiveType type,
+                                const uint8_t* __restrict null_data) const override;
+
     void insert_range_from(const IColumn& src, size_t start, size_t length) override;
 
     void insert_indices_from(const IColumn& src, const int* indices_begin,
@@ -324,19 +327,31 @@ public:
 
     void get_extremes(Field& min, Field& max) const override;
 
-    bool can_be_inside_nullable() const override { return true; }
+    bool can_be_inside_nullable() const override {
+        return true;
+    }
 
-    bool is_column_string() const override { return true; }
+    bool is_column_string() const override {
+        return true;
+    }
 
     bool structure_equals(const IColumn& rhs) const override {
         return typeid(rhs) == typeid(ColumnString);
     }
 
-    Chars& get_chars() { return chars; }
-    const Chars& get_chars() const { return chars; }
+    Chars& get_chars() {
+        return chars;
+    }
+    const Chars& get_chars() const {
+        return chars;
+    }
 
-    Offsets& get_offsets() { return offsets; }
-    const Offsets& get_offsets() const { return offsets; }
+    Offsets& get_offsets() {
+        return offsets;
+    }
+    const Offsets& get_offsets() const {
+        return offsets;
+    }
 
     void clear() override {
         chars.clear();

--- a/be/src/vec/columns/column_vector.h
+++ b/be/src/vec/columns/column_vector.h
@@ -250,6 +250,9 @@ public:
     void update_hashes_with_value(std::vector<SipHash>& hashes,
                                   const uint8_t* __restrict null_data) const override;
 
+    void update_crcs_with_value(std::vector<uint32_t>& hashes, PrimitiveType type,
+                                const uint8_t* __restrict null_data) const override;
+
     size_t byte_size() const override { return data.size() * sizeof(data[0]); }
 
     size_t allocated_bytes() const override { return data.allocated_bytes(); }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/DateLiteral.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/DateLiteral.java
@@ -40,6 +40,7 @@ import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
 import java.time.Year;
@@ -495,14 +496,27 @@ public class DateLiteral extends LiteralExpr {
     // Date column and Datetime column's hash value is not same.
     @Override
     public ByteBuffer getHashValue(PrimitiveType type) {
-        // This hash value should be computed using new String since precision is introduced to datetime.
-        // But it is hard to keep compatibility. So I don't change this function here.
-        String value = convertToString(type);
         ByteBuffer buffer;
-        try {
-            buffer = ByteBuffer.wrap(value.getBytes("UTF-8"));
-        } catch (Exception e) {
-            throw new RuntimeException(e);
+        if (type == PrimitiveType.DATEV2) {
+            int value = (int) ((year << 9) | (month << 5) | day);
+            buffer = ByteBuffer.allocate(4);
+            buffer.order(ByteOrder.LITTLE_ENDIAN);
+            buffer.putInt(value);
+        } else if (type == PrimitiveType.DATETIMEV2) {
+            long value =  (year << 50) | (month << 46) | (day << 41) | (hour << 36)
+                    | (minute << 30) | (second << 24) | microsecond;
+            buffer = ByteBuffer.allocate(8);
+            buffer.order(ByteOrder.LITTLE_ENDIAN);
+            buffer.putLong(value);
+        } else {
+            // This hash value should be computed using new String since precision is introduced to datetime.
+            // But it is hard to keep compatibility. So I don't change this function here.
+            String value = convertToString(type);
+            try {
+                buffer = ByteBuffer.wrap(value.getBytes("UTF-8"));
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
         }
         return buffer;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/DecimalLiteral.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/DecimalLiteral.java
@@ -159,9 +159,6 @@ public class DecimalLiteral extends LiteralExpr {
                 buffer.putLong(value.longValue());
                 break;
             case DECIMALV2:
-            case DECIMAL32:
-            case DECIMAL64:
-            case DECIMAL128:
                 buffer = ByteBuffer.allocate(12);
                 buffer.order(ByteOrder.LITTLE_ENDIAN);
 
@@ -170,6 +167,19 @@ public class DecimalLiteral extends LiteralExpr {
                 buffer.putLong(integerValue);
                 buffer.putInt(fracValue);
                 break;
+            case DECIMAL32:
+                buffer = ByteBuffer.allocate(4);
+                buffer.order(ByteOrder.LITTLE_ENDIAN);
+                buffer.putInt(value.unscaledValue().intValue());
+                break;
+            case DECIMAL64:
+                buffer = ByteBuffer.allocate(8);
+                buffer.order(ByteOrder.LITTLE_ENDIAN);
+                buffer.putLong(value.unscaledValue().longValue());
+                break;
+            case DECIMAL128:
+                LargeIntLiteral tmp = new LargeIntLiteral(value.unscaledValue());
+                return tmp.getHashValue(type);
             default:
                 return super.getHashValue(type);
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/LargeIntLiteral.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/LargeIntLiteral.java
@@ -62,6 +62,12 @@ public class LargeIntLiteral extends LiteralExpr {
         analysisDone();
     }
 
+    public LargeIntLiteral(BigInteger v) {
+        super();
+        type = Type.LARGEINT;
+        value = v;
+    }
+
     public LargeIntLiteral(String value) throws AnalysisException {
         super();
         BigInteger bigInt;


### PR DESCRIPTION
# Proposed changes

Do same opt work as #12334 in crc32 hash compute to speed up hash compute 

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

