### PR TITLE
[fix](exec) Avoid query thread block on wait_for_start

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -859,6 +859,13 @@ CONF_Bool(enable_new_scan_node, "true");
 // limit the queue of pending batches which will be sent by a single nodechannel
 CONF_mInt64(nodechannel_pending_queue_max_bytes, "67108864");
 
+// Max waiting time to wait the "plan fragment start" rpc.
+// If timeout, the fragment will be cancelled.
+// This parameter is usually only used when the FE loses connection,
+// and the BE can automatically cancel the relevant fragment after the timeout,
+// so as to avoid occupying the execution thread for a long time.
+CONF_mInt32(max_fragment_start_wait_time_seconds, "30");
+
 #ifdef BE_TEST
 // test s3
 CONF_String(test_s3_resource, "resource");
@@ -869,7 +876,6 @@ CONF_String(test_s3_region, "region");
 CONF_String(test_s3_bucket, "bucket");
 CONF_String(test_s3_prefix, "prefix");
 #endif
-
 } // namespace config
 
 } // namespace doris

--- a/be/src/runtime/fragment_mgr.cpp
+++ b/be/src/runtime/fragment_mgr.cpp
@@ -239,9 +239,11 @@ Status FragmentExecState::execute() {
             return cancel(PPlanFragmentCancelReason::INTERNAL_ERROR, "wait fragment start timeout");
         }
     }
+#ifndef BE_TEST
     if (_executor.runtime_state()->is_cancelled()) {
         return Status::Cancelled("cancelled before execution");
     }
+#endif
     int64_t duration_ns = 0;
     {
         SCOPED_RAW_TIMER(&duration_ns);

--- a/be/src/runtime/plan_fragment_executor.cpp
+++ b/be/src/runtime/plan_fragment_executor.cpp
@@ -628,6 +628,8 @@ void PlanFragmentExecutor::cancel(const PPlanFragmentCancelReason& reason, const
     _cancel_reason = reason;
     _cancel_msg = msg;
     _runtime_state->set_is_cancelled(true);
+    // To notify wait_for_start()
+    _runtime_state->get_query_fragments_ctx()->set_ready_to_execute(true);
 
     // must close stream_mgr to avoid dead lock in Exchange Node
     auto env = _runtime_state->exec_env();
@@ -638,10 +640,8 @@ void PlanFragmentExecutor::cancel(const PPlanFragmentCancelReason& reason, const
         env->stream_mgr()->cancel(id);
         env->result_mgr()->cancel(id);
     }
-}
-
-void PlanFragmentExecutor::set_abort() {
-    update_status(Status::Aborted("Execution aborted before start"));
+    // Cancel the result queue manager used by spark doris connector
+    _exec_env->result_queue_mgr()->update_queue_status(id, Status::Aborted(msg));
 }
 
 const RowDescriptor& PlanFragmentExecutor::row_desc() {

--- a/be/src/runtime/plan_fragment_executor.h
+++ b/be/src/runtime/plan_fragment_executor.h
@@ -123,11 +123,6 @@ public:
     // in open()/get_next().
     void close();
 
-    // Abort this execution. Must be called if we skip running open().
-    // It will let DataSink node closed with error status, to avoid use resources which created in open() phase.
-    // DataSink node should distinguish Aborted status from other error status.
-    void set_abort();
-
     // Initiate cancellation. Must not be called until after prepare() returned.
     void cancel(const PPlanFragmentCancelReason& reason = PPlanFragmentCancelReason::INTERNAL_ERROR,
                 const std::string& msg = "");

--- a/be/src/util/doris_metrics.h
+++ b/be/src/util/doris_metrics.h
@@ -200,6 +200,7 @@ public:
     UIntGauge* send_batch_thread_pool_queue_size;
     UIntGauge* download_cache_thread_pool_thread_num;
     UIntGauge* download_cache_thread_pool_queue_size;
+    UIntGauge* fragment_thread_pool_queue_size;
 
     // Upload metrics
     UIntGauge* upload_total_byte;

--- a/be/src/vec/exec/volap_scan_node.cpp
+++ b/be/src/vec/exec/volap_scan_node.cpp
@@ -474,8 +474,8 @@ void VOlapScanNode::scanner_thread(VOlapScanner* scanner) {
             num_rows_in_block < _runtime_state->batch_size())) {
         if (UNLIKELY(_transfer_done)) {
             eos = true;
-            status = Status::Cancelled("Cancelled");
-            LOG(INFO) << "Scan thread cancelled, cause query done, maybe reach limit.";
+            status = Status::Cancelled(
+                    "Scan thread cancelled, cause query done, maybe reach limit.");
             break;
         }
 
@@ -1082,7 +1082,6 @@ Status VOlapScanNode::get_next(RuntimeState* state, Block* block, bool* eos) {
 
             _block_consumed_cv.notify_all();
             *eos = true;
-            LOG(INFO) << "VOlapScanNode ReachedLimit.";
         } else {
             *eos = false;
         }

--- a/be/test/runtime/fragment_mgr_test.cpp
+++ b/be/test/runtime/fragment_mgr_test.cpp
@@ -28,7 +28,6 @@ namespace doris {
 
 static Status s_prepare_status;
 static Status s_open_status;
-static int s_abort_cnt;
 // Mock used for this unittest
 PlanFragmentExecutor::PlanFragmentExecutor(ExecEnv* exec_env,
                                            const report_status_callback& report_status_cb)
@@ -47,11 +46,6 @@ Status PlanFragmentExecutor::open() {
 }
 
 void PlanFragmentExecutor::cancel(const PPlanFragmentCancelReason& reason, const std::string& msg) {
-}
-
-void PlanFragmentExecutor::set_abort() {
-    LOG(INFO) << "Plan Aborted";
-    s_abort_cnt++;
 }
 
 void PlanFragmentExecutor::close() {}
@@ -128,7 +122,6 @@ TEST_F(FragmentMgrTest, OfferPoolFailed) {
     config::fragment_pool_thread_num_min = 1;
     config::fragment_pool_thread_num_max = 1;
     config::fragment_pool_queue_size = 0;
-    s_abort_cnt = 0;
     FragmentMgr mgr(nullptr);
 
     TExecPlanFragmentParams params;
@@ -145,7 +138,6 @@ TEST_F(FragmentMgrTest, OfferPoolFailed) {
         params.params.fragment_instance_id.__set_lo(200);
         EXPECT_FALSE(mgr.exec_plan_fragment(params).ok());
     }
-    EXPECT_EQ(3, s_abort_cnt);
 }
 
 } // namespace doris

--- a/docs/sidebars.json
+++ b/docs/sidebars.json
@@ -860,7 +860,6 @@
                        "admin-manual/maint-monitor/multi-tenant",
                        "admin-manual/maint-monitor/tablet-local-debug",
                        "admin-manual/maint-monitor/tablet-restore-tool",
-                       "admin-manual/maint-monitor/monitor-metrics/metrics",
                        "admin-manual/maint-monitor/metadata-operation"
                     ]
                 },

--- a/docs/zh-CN/docs/admin-manual/maint-monitor/monitor-metrics/metrics.md
+++ b/docs/zh-CN/docs/admin-manual/maint-monitor/monitor-metrics/metrics.md
@@ -275,6 +275,7 @@ curl http://be_host:webserver_port/metrics?type=json
 |`doris_be_upload_total_byte`| | | 字节 | 冷热分离功能，上传到远端存储成功的rowset数据量累计值| |
 |`doris_be_load_bytes`| | 字节|通过 tablet sink 发送的数量累计 | 可观测导入数据量 | P0 |
 |`doris_be_load_rows`| | Num | 通过 tablet sink 发送的行数累计| 可观测导入数据量 | P0 |
+|`fragment_thread_pool_queue_size`| | Num | 当前查询执行线程池等待队列的长度 | 如果大于零，则说明查询线程已耗尽，查询会出现堆积 | P0 |
 
 ### 机器监控
 


### PR DESCRIPTION
# Proposed changes

Issue Number: close #12412

## Problem summary

1. When FE send cancel rpc to BE, it does not notify the `wait_for_start()` thread, so that the fragment will be blocked and occupy the execution thread.
2. Add a max wait time for `wait_for_start()` thread. So that it will not block forever.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
3. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
4. Has document been added or modified:
    - [x] Yes
    - [ ] No
    - [ ] No Need
5. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
6. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

