### PR TITLE
[feature-wip](parquet-reader) bug fix, create compress codec before parsing dictionary

### DIFF
--- a/be/src/vec/exec/file_hdfs_scanner.h
+++ b/be/src/vec/exec/file_hdfs_scanner.h
@@ -48,7 +48,7 @@ protected:
     void _init_profiles(RuntimeProfile* profile) override;
 
 private:
-    Status _get_next_reader(int _next_range);
+    Status _get_next_reader();
 
 private:
     std::shared_ptr<ParquetReader> _reader;

--- a/be/src/vec/exec/format/parquet/parquet_common.h
+++ b/be/src/vec/exec/format/parquet/parquet_common.h
@@ -113,7 +113,7 @@ public:
 
     virtual Status skip_values(size_t num_values) = 0;
 
-    virtual Status set_dict(std::unique_ptr<uint8_t[]>& dict, size_t dict_size) {
+    virtual Status set_dict(std::unique_ptr<uint8_t[]>& dict, int32_t length, size_t num_values) {
         return Status::NotSupported("set_dict is not supported");
     }
 
@@ -159,7 +159,7 @@ public:
 
     Status skip_values(size_t num_values) override;
 
-    Status set_dict(std::unique_ptr<uint8_t[]>& dict, size_t dict_size) override;
+    Status set_dict(std::unique_ptr<uint8_t[]>& dict, int32_t length, size_t num_values) override;
 
     void set_data(Slice* data) override;
 
@@ -344,7 +344,7 @@ public:
 
     void set_data(Slice* data) override;
 
-    Status set_dict(std::unique_ptr<uint8_t[]>& dict, size_t dict_size) override;
+    Status set_dict(std::unique_ptr<uint8_t[]>& dict, int32_t length, size_t num_values) override;
 
 protected:
     template <typename DecimalPrimitiveType>

--- a/be/src/vec/exec/format/parquet/vparquet_page_reader.cpp
+++ b/be/src/vec/exec/format/parquet/vparquet_page_reader.cpp
@@ -69,7 +69,7 @@ Status PageReader::skip_page() {
     return Status::OK();
 }
 
-Status PageReader::get_page_date(Slice& slice) {
+Status PageReader::get_page_data(Slice& slice) {
     if (_offset == _next_header_offset) {
         return Status::InternalError("Should call next_page() to generate page header");
     }

--- a/be/src/vec/exec/format/parquet/vparquet_page_reader.h
+++ b/be/src/vec/exec/format/parquet/vparquet_page_reader.h
@@ -40,7 +40,7 @@ public:
 
     const tparquet::PageHeader* get_page_header() const { return &_cur_page_header; }
 
-    Status get_page_date(Slice& slice);
+    Status get_page_data(Slice& slice);
 
     void seek_to_page(int64_t page_header_offset) {
         _offset = page_header_offset;

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/HiveMetaStoreClientHelper.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/HiveMetaStoreClientHelper.java
@@ -813,6 +813,12 @@ public class HiveMetaStoreClientHelper {
             default:
                 break;
         }
+        if (lowerCaseType.startsWith("array")) {
+            if (lowerCaseType.indexOf("<") == 5 && lowerCaseType.lastIndexOf(">") == lowerCaseType.length() - 1) {
+                Type innerType = hiveTypeToDorisType(lowerCaseType.substring(6, lowerCaseType.length() - 1));
+                return ArrayType.create(innerType, true);
+            }
+        }
         if (lowerCaseType.startsWith("char")) {
             ScalarType type = ScalarType.createType(PrimitiveType.CHAR);
             Matcher match = digitPattern.matcher(lowerCaseType);


### PR DESCRIPTION
# Proposed changes

## Fix five bugs:
1. Parquet dictionary data may be compressed, but `ColumnChunkReader` try to parse dictionary data before creating compression codec, causing unexpected data errors.
2. `FE` doesn't resolve array type
3. `ParquetFileHdfsScanner`  doesn't fill partition values when the table is partitioned
4. `ParquetFileHdfsScanner` set `_scanner_eof = true` when a scan range is empty, causing the end of the scanner, and resulting in data loss
5. typographical error in `PageReader`

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
6. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
7. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
8. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
9. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

