### PR TITLE
[fix](Nereids) throw IndexOutOfBoundsException in DistributionSpecHash#equalsSatisfy

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/DistributionSpecHash.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/DistributionSpecHash.java
@@ -168,14 +168,6 @@ public class DistributionSpecHash extends DistributionSpec {
             return containsSatisfy(requiredHash.getOrderedShuffledColumns());
         }
 
-        // if (requiredHash.shuffleType == ShuffleType.JOIN) {
-        //     return equalsSatisfy(requiredHash.getOrderedShuffledColumns());
-        // }
-        //
-        // if (!this.shuffleType.equals(requiredHash.shuffleType)) {
-        //     return false;
-        // }
-
         return equalsSatisfy(requiredHash.getOrderedShuffledColumns());
     }
 
@@ -190,6 +182,9 @@ public class DistributionSpecHash extends DistributionSpec {
     }
 
     private boolean equalsSatisfy(List<ExprId> required) {
+        if (equivalenceExprIds.size() != required.size()) {
+            return false;
+        }
         for (int i = 0; i < required.size(); i++) {
             if (!equivalenceExprIds.get(i).contains(required.get(i))) {
                 return false;

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/properties/DistributionSpecHashTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/properties/DistributionSpecHashTest.java
@@ -450,4 +450,35 @@ public class DistributionSpecHashTest {
         Assertions.assertTrue(aggregate.satisfy(enforce2));
         Assertions.assertTrue(natural.satisfy(enforce2));
     }
+
+    @Test
+    public void testHashEqualSatisfyWithDifferentLength() {
+        Map<ExprId, Integer> enforce1Map = Maps.newHashMap();
+        enforce1Map.put(new ExprId(0), 0);
+        enforce1Map.put(new ExprId(1), 1);
+        enforce1Map.put(new ExprId(2), 2);
+        DistributionSpecHash enforce1 = new DistributionSpecHash(
+                Lists.newArrayList(new ExprId(0), new ExprId(1), new ExprId(2)),
+                ShuffleType.ENFORCE,
+                0,
+                Sets.newHashSet(0L),
+                Lists.newArrayList(Sets.newHashSet(new ExprId(0)), Sets.newHashSet(new ExprId(1)), Sets.newHashSet(new ExprId(2))),
+                enforce1Map
+        );
+
+        Map<ExprId, Integer> enforce2Map = Maps.newHashMap();
+        enforce2Map.put(new ExprId(0), 0);
+        enforce2Map.put(new ExprId(1), 1);
+        DistributionSpecHash enforce2 = new DistributionSpecHash(
+                Lists.newArrayList(new ExprId(0), new ExprId(1)),
+                ShuffleType.ENFORCE,
+                1,
+                Sets.newHashSet(1L),
+                Lists.newArrayList(Sets.newHashSet(new ExprId(0)), Sets.newHashSet(new ExprId(1))),
+                enforce2Map
+        );
+
+        Assertions.assertFalse(enforce1.satisfy(enforce2));
+        Assertions.assertFalse(enforce2.satisfy(enforce1));
+    }
 }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

In earlier PR #11976 , we changed DistributionSpecHash#equalsSatisfy, and forgot to check whether the length of both side are same.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [x] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

