### PR TITLE
[Enhancement](array-type) Add readable information in subquery for array type

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/Subquery.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/Subquery.java
@@ -109,7 +109,9 @@ public class Subquery extends Expr {
         ArrayList<Expr> stmtResultExprs = stmt.getResultExprs();
         if (stmtResultExprs.size() == 1) {
             type = stmtResultExprs.get(0).getType();
-            Preconditions.checkState(!type.isComplexType());
+            if (type.isComplexType()) {
+                throw new AnalysisException("A subquery should not return Array/Map/Struct type: " + toSql());
+            }
         } else {
             type = createStructTypeFromExprList();
         }


### PR DESCRIPTION
# Proposed changes

```
Before:
mysql> select k1 from test_array_tbl_1 where c_array in (select c_array from test_array_tbl_2);
ERROR 1105 (HY000): errCode = 2, detailMessage = Unexpected exception: null

After:
mysql> select k1 from test_array_tbl_1 where c_array in (select c_array from test_array_tbl_2);
ERROR 1105 (HY000): errCode = 2, detailMessage = A subquery should not return Array/Map/Struct type: (SELECT `c_array` AS `c_array` FROM `default_cluster:array_test`.`test_array_tbl_2`)
```

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

