### PR TITLE
[feature](nereids) implement uncheckedCast method in VarcharLiteral

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/VarcharLiteral.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/VarcharLiteral.java
@@ -19,7 +19,10 @@ package org.apache.doris.nereids.trees.expressions.literal;
 
 import org.apache.doris.analysis.LiteralExpr;
 import org.apache.doris.analysis.StringLiteral;
+import org.apache.doris.nereids.exceptions.AnalysisException;
+import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.visitor.ExpressionVisitor;
+import org.apache.doris.nereids.types.DataType;
 import org.apache.doris.nereids.types.VarcharType;
 
 import com.google.common.base.Preconditions;
@@ -27,7 +30,8 @@ import com.google.common.base.Preconditions;
 import java.util.Objects;
 
 /**
- * varchar type literal
+ * Varchar type literal, in theory,
+ * the difference from StringLiteral is that VarcharLiteral keeps the length information.
  */
 public class VarcharLiteral extends Literal {
 
@@ -62,5 +66,29 @@ public class VarcharLiteral extends Literal {
     @Override
     public String toString() {
         return "'" + value + "'";
+    }
+
+    // Temporary way to process type coercion in TimestampArithmetic, should be replaced by TypeCoercion rule.
+    @Override
+    protected Expression uncheckedCastTo(DataType targetType) throws AnalysisException {
+        if (getDataType().equals(targetType)) {
+            return this;
+        }
+        if (targetType.isDateType()) {
+            return convertToDate(targetType);
+        } else if (targetType.isIntType()) {
+            return new IntegerLiteral(Integer.parseInt(value));
+        }
+        return this;
+    }
+
+    private DateLiteral convertToDate(DataType targetType) throws AnalysisException {
+        DateLiteral dateLiteral = null;
+        if (targetType.isDate()) {
+            dateLiteral = new DateLiteral(value);
+        } else if (targetType.isDateTime()) {
+            dateLiteral = new DateTimeLiteral(value);
+        }
+        return dateLiteral;
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/util/AnalyzeFunctionTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/util/AnalyzeFunctionTest.java
@@ -1,0 +1,52 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.util;
+
+import org.apache.doris.nereids.parser.NereidsParser;
+import org.apache.doris.nereids.trees.expressions.literal.VarcharLiteral;
+import org.apache.doris.nereids.trees.plans.logical.LogicalFilter;
+import org.apache.doris.nereids.trees.plans.logical.LogicalPlan;
+import org.apache.doris.utframe.TestWithFeService;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+public class AnalyzeFunctionTest extends TestWithFeService {
+
+    private final NereidsParser parser = new NereidsParser();
+
+    @Override
+    protected void runBeforeAll() throws Exception {
+        createDatabase("test");
+        connectContext.setDatabase("default_cluster:test");
+        createTables("CREATE TABLE t1 (col1 date, col2 int) DISTRIBUTED BY HASH(col2)\n" + "BUCKETS 1\n" + "PROPERTIES(\n"
+                + "    \"replication_num\"=\"1\"\n" + ");");
+    }
+
+    @Test
+    public void testTimeArithmExpr() {
+        String sql = "SELECT * FROM t1 WHERE col1 < date '1994-01-01' + interval '1' year";
+        LogicalPlan logicalPlan = (LogicalPlan) PlanChecker.from(connectContext)
+                .analyze(sql).getCascadesContext().getMemo().copyOut();
+        Assertions.assertTrue(logicalPlan
+                .<Set<LogicalFilter>>collect(LogicalFilter.class::isInstance)
+                .stream().map(f -> f.getPredicates()).noneMatch(VarcharLiteral.class::isInstance));
+    }
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/util/PlanChecker.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/util/PlanChecker.java
@@ -241,4 +241,8 @@ public class PlanChecker {
     public static PlanChecker from(CascadesContext cascadesContext) {
         return new PlanChecker(cascadesContext);
     }
+
+    public CascadesContext getCascadesContext() {
+        return cascadesContext;
+    }
 }


### PR DESCRIPTION
# Proposed changes

Issue Number: noissue

## Problem summary

Implement uncheckedCast on varchar Literal for a temp way to let TimestampArithmetic work.
We should remove these code and do implicit cast in TypeCoercion rule in future.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

