### PR TITLE
[fix](frontend)  fix notify update storage policy agent task null exception

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/policy/StoragePolicy.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/policy/StoragePolicy.java
@@ -181,11 +181,8 @@ public class StoragePolicy extends Policy {
         }
         if (props.containsKey(COOLDOWN_TTL)) {
             hasCooldownTtl = true;
-            if (Integer.parseInt(props.get(COOLDOWN_TTL)) < 0) {
-                throw new AnalysisException("cooldown_ttl must >= 0.");
-            }
-            this.cooldownTtl = props.get(COOLDOWN_TTL);
-            this.cooldownTtlMs = getMsByCooldownTtl(this.cooldownTtl);
+            // second
+            this.cooldownTtl = String.valueOf(getMsByCooldownTtl(props.get(COOLDOWN_TTL)) / 1000);
         }
         if (hasCooldownDatetime && hasCooldownTtl) {
             throw new AnalysisException(COOLDOWN_DATETIME + " and " + COOLDOWN_TTL + " can't be set together.");

--- a/fe/fe-core/src/main/java/org/apache/doris/task/AgentBatchTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/task/AgentBatchTask.java
@@ -33,6 +33,7 @@ import org.apache.doris.thrift.TCompactionReq;
 import org.apache.doris.thrift.TCreateTabletReq;
 import org.apache.doris.thrift.TDownloadReq;
 import org.apache.doris.thrift.TDropTabletReq;
+import org.apache.doris.thrift.TGetStoragePolicy;
 import org.apache.doris.thrift.TMoveDirReq;
 import org.apache.doris.thrift.TNetworkAddress;
 import org.apache.doris.thrift.TPublishVersionRequest;
@@ -347,6 +348,15 @@ public class AgentBatchTask implements Runnable {
                     LOG.debug(request.toString());
                 }
                 tAgentTaskRequest.setCompactionReq(request);
+                return tAgentTaskRequest;
+            }
+            case NOTIFY_UPDATE_STORAGE_POLICY: {
+                NotifyUpdateStoragePolicyTask notifyUpdateStoragePolicyTask = (NotifyUpdateStoragePolicyTask) task;
+                TGetStoragePolicy request = notifyUpdateStoragePolicyTask.toThrift();
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug(request.toString());
+                }
+                tAgentTaskRequest.setUpdatePolicy(request);
                 return tAgentTaskRequest;
             }
             default:


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [x] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No


Fix cold_heat_separation regression case java.lang.NullPointerException

such as
```
2022-09-08 01:09:39,705 WARN (agent-task-pool-5|289) [AgentBatchTask.run():176] task exec error. backend[10003]
java.lang.NullPointerException: null
	at org.apache.doris.thrift.BackendService$submit_tasks_args$submit_tasks_argsStandardScheme.write(BackendService.java:6456) ~[spark-dpp-1.0-SNAPSHOT.jar:1.0-SNAPSHOT]
	at org.apache.doris.thrift.BackendService$submit_tasks_args$submit_tasks_argsStandardScheme.write(BackendService.java:6404) ~[spark-dpp-1.0-SNAPSHOT.jar:1.0-SNAPSHOT]
	at org.apache.doris.thrift.BackendService$submit_tasks_args.write(BackendService.java:6358) ~[spark-dpp-1.0-SNAPSHOT.jar:1.0-SNAPSHOT]
	at org.apache.thrift.TServiceClient.sendBase(TServiceClient.java:71) ~[spark-dpp-1.0-SNAPSHOT.jar:1.0-SNAPSHOT]
	at org.apache.thrift.TServiceClient.sendBase(TServiceClient.java:62) ~[spark-dpp-1.0-SNAPSHOT.jar:1.0-SNAPSHOT]
	at org.apache.doris.thrift.BackendService$Client.sendSubmitTasks(BackendService.java:227) ~[spark-dpp-1.0-SNAPSHOT.jar:1.0-SNAPSHOT]
	at org.apache.doris.thrift.BackendService$Client.submitTasks(BackendService.java:219) ~[spark-dpp-1.0-SNAPSHOT.jar:1.0-SNAPSHOT]
	at org.apache.doris.task.AgentBatchTask.run(AgentBatchTask.java:167) ~[doris-fe.jar:1.0-SNAPSHOT]
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515) ~[?:?]
	at java.util.concurrent.FutureTask.run(FutureTask.java:264) ~[?:?]


