### PR TITLE
[fix](doc) remove the ambiguity in the description of the operating instructions document

### DIFF
--- a/docs/en/docs/sql-manual/sql-reference/Data-Manipulation-Statements/Manipulation/DELETE.md
+++ b/docs/en/docs/sql-manual/sql-reference/Data-Manipulation-Statements/Manipulation/DELETE.md
@@ -47,7 +47,7 @@ column_name1 op { value | value_list } [ AND column_name2 op { value | value_lis
 illustrate:
 
 1. The optional types of op include: =, >, <, >=, <=, !=, in, not in
-2. Only conditions on the key column can be specified.
+2. Only conditions on the key column can be specified when using AGGREGATE (UNIQUE) model.
 3. When the selected key column does not exist in a rollup, delete cannot be performed.
 4. Conditions can only have an "and" relationship. If you want to achieve an "or" relationship, you need to write the conditions in two DELETE statements.
 5. If it is a partitioned table, you can specify a partition. If not specified, and the session variable delete_without_partition is true, it will be applied to all partitions. If it is a single-partition table, it can be left unspecified.

--- a/docs/zh-CN/docs/sql-manual/sql-reference/Data-Manipulation-Statements/Manipulation/DELETE.md
+++ b/docs/zh-CN/docs/sql-manual/sql-reference/Data-Manipulation-Statements/Manipulation/DELETE.md
@@ -46,9 +46,9 @@ column_name1 op { value | value_list } [ AND column_name2 op { value | value_lis
 说明：
 
 1. op 的可选类型包括：=, >, <, >=, <=, !=, in, not in
-2.  只能指定 key 列上的条件。
-3.  当选定的 key 列不存在于某个 rollup 中时，无法进行 delete。
-4.  条件之间只能是“与”的关系。若希望达成“或”的关系，需要将条件分写在两个 DELETE 语句中。
+2. 使用聚合类的表模型（AGGREGATE、UNIQUE）只能指定 key 列上的条件。
+3. 当选定的 key 列不存在于某个 rollup 中时，无法进行 delete。
+4. 条件之间只能是“与”的关系。若希望达成“或”的关系，需要将条件分写在两个 DELETE 语句中。
 5. 如果为分区表，可以指定分区，如不指定，且会话变量 delete_without_partition 为 true，则会应用到所有分区。如果是单分区表，可以不指定。
 
 注意：


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

Remove the ambiguity in the description of the operating instructions document

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

