### PR TITLE
[Bug](array_type) Forbid adding array key columns

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ColumnDef.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ColumnDef.java
@@ -265,6 +265,10 @@ public class ColumnDef {
         }
 
         if (type.getPrimitiveType() == PrimitiveType.ARRAY) {
+            if (isKey()) {
+                throw new AnalysisException("Array can only be used in the non-key column of"
+                    + " the duplicate table at present.");
+            }
             if (defaultValue.isSet && defaultValue != DefaultValue.NULL_DEFAULT_VALUE) {
                 throw new AnalysisException("Array type column default value only support null");
             }


### PR DESCRIPTION
# Proposed changes

```
mysql> desc array_test;
+-----------+----------------+------+-------+---------+-------+
| Field     | Type           | Null | Key   | Default | Extra |
+-----------+----------------+------+-------+---------+-------+
| id        | INT            | Yes  | true  | NULL    |       |
| c_array   | ARRAY<INT(11)> | Yes  | false | NULL    | NONE  |
+-----------+----------------+------+-------+---------+-------+

Before:
mysql> ALTER TABLE array_test ADD COLUMN add_arr_key array<int> key NULL DEFAULT NULL;
Query OK, 0 rows affected (0.00 sec)

After:
mysql> ALTER TABLE array_test ADD COLUMN c_array array<int> key NULL DEFAULT NULL;
ERROR 1105 (HY000): errCode = 2, detailMessage = Array can only be used in the non-key column of the duplicate table at present.

mysql> ALTER TABLE array_test MODIFY COLUMN c_array array<int> key NULL DEFAULT NULL;
ERROR 1105 (HY000): errCode = 2, detailMessage = Array can only be used in the non-key column of the duplicate table at present.
```

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

