### PR TITLE
[feature](Nereids) Support function registry

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/BuiltinFunctions.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/BuiltinFunctions.java
@@ -50,4 +50,8 @@ public class BuiltinFunctions implements FunctionHelper {
             agg(Min.class),
             agg(Sum.class)
     );
+
+    public static final BuiltinFunctions INSTANCE = new BuiltinFunctions();
+
+    private BuiltinFunctions() {}
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/BuiltinFunctions.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/BuiltinFunctions.java
@@ -1,0 +1,53 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.catalog;
+
+import org.apache.doris.nereids.trees.expressions.functions.Avg;
+import org.apache.doris.nereids.trees.expressions.functions.Count;
+import org.apache.doris.nereids.trees.expressions.functions.Max;
+import org.apache.doris.nereids.trees.expressions.functions.Min;
+import org.apache.doris.nereids.trees.expressions.functions.Substring;
+import org.apache.doris.nereids.trees.expressions.functions.Sum;
+import org.apache.doris.nereids.trees.expressions.functions.WeekOfYear;
+import org.apache.doris.nereids.trees.expressions.functions.Year;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+
+/**
+ * Built-in functions.
+ *
+ * Note: Please ensure that this class only has some lists and no procedural code.
+ *       It helps to be clear and concise.
+ */
+public class BuiltinFunctions implements FunctionHelper {
+    public final List<ScalarFunc> scalarFunctions = ImmutableList.of(
+            scalar(Substring.class, "substr", "substring"),
+            scalar(WeekOfYear.class),
+            scalar(Year.class)
+    );
+
+    public final ImmutableList<AggregateFunc> aggregateFunctions = ImmutableList.of(
+            agg(Avg.class),
+            agg(Count.class),
+            agg(Max.class),
+            agg(Min.class),
+            agg(Sum.class)
+    );
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/BuiltinFunctions.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/BuiltinFunctions.java
@@ -53,5 +53,6 @@ public class BuiltinFunctions implements FunctionHelper {
 
     public static final BuiltinFunctions INSTANCE = new BuiltinFunctions();
 
+    // Note: Do not add any code here!
     private BuiltinFunctions() {}
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
@@ -375,6 +375,9 @@ public class Env {
     private CatalogRecycleBin recycleBin;
     private FunctionSet functionSet;
 
+    // for nereids
+    private FunctionRegistry functionRegistry;
+
     private MetaReplayState metaReplayState;
 
     private BrokerMgr brokerMgr;
@@ -554,6 +557,8 @@ public class Env {
         this.recycleBin = new CatalogRecycleBin();
         this.functionSet = new FunctionSet();
         this.functionSet.init();
+
+        this.functionRegistry = new FunctionRegistry();
 
         this.metaReplayState = new MetaReplayState();
 
@@ -4304,6 +4309,10 @@ public class Env {
             throw new DdlException("Failed to create view[" + tableName + "].");
         }
         LOG.info("successfully create view[" + tableName + "-" + newView.getId() + "]");
+    }
+
+    public FunctionRegistry getFunctionRegistry() {
+        return functionRegistry;
     }
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/FunctionHelper.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/FunctionHelper.java
@@ -1,0 +1,109 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.catalog;
+
+import org.apache.doris.nereids.trees.expressions.functions.AggregateFunction;
+import org.apache.doris.nereids.trees.expressions.functions.BoundFunction;
+import org.apache.doris.nereids.trees.expressions.functions.FunctionBuilder;
+import org.apache.doris.nereids.trees.expressions.functions.ScalarFunction;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+public interface FunctionHelper {
+    /**
+     * put functions into the target map, which the key is the function name,
+     * and value is FunctionBuilder is converted from NamedFunc.
+     * @param name2FuncBuilders target Map
+     * @param functions the NamedFunc list to be put into the target map
+     */
+    static void addFunctions(Map<String, List<FunctionBuilder>> name2FuncBuilders,
+            List<? extends NamedFunc<? extends BoundFunction>> functions) {
+        for (NamedFunc<? extends BoundFunction> func : functions) {
+            for (String name : func.names) {
+                if (name2FuncBuilders.containsKey(name)) {
+                    throw new IllegalStateException("Function '" + name + "' already exists in function registry");
+                }
+
+                name2FuncBuilders.put(name, func.functionBuilders);
+            }
+        }
+    }
+
+    default ScalarFunc scalar(Class<? extends ScalarFunction> functionClass) {
+        String functionName = functionClass.getSimpleName();
+        return scalar(functionClass, functionName);
+    }
+
+    /**
+     * Resolve ScalaFunction class, convert to FunctionBuilder and wrap to ScalarFunc
+     * @param functionClass the ScalaFunction class
+     * @return ScalaFunc which contains the functionName and the FunctionBuilder
+     */
+    default ScalarFunc scalar(Class<? extends ScalarFunction> functionClass, String... functionNames) {
+        return new ScalarFunc(functionClass, functionNames);
+    }
+
+    default AggregateFunc agg(Class<? extends AggregateFunction> functionClass) {
+        String functionName = functionClass.getSimpleName();
+        return new AggregateFunc(functionClass, functionName);
+    }
+
+    /**
+     * Resolve AggregateFunction class, convert to FunctionBuilder and wrap to AggregateFunc
+     * @param functionClass the AggregateFunction class
+     * @return AggregateFunc which contains the functionName and the AggregateFunc
+     */
+    default AggregateFunc agg(Class<? extends AggregateFunction> functionClass, String... functionNames) {
+        return new AggregateFunc(functionClass, functionNames);
+    }
+
+    /**
+     * use this class to prevent the wrong type from being registered, and support multi function names
+     * like substring and substr.
+     */
+    class NamedFunc<T extends BoundFunction> {
+        public final List<String> names;
+        public final Class<? extends T> functionClass;
+
+        public final List<FunctionBuilder> functionBuilders;
+
+        public NamedFunc(Class<? extends T> functionClass, String... names) {
+            this.functionClass = functionClass;
+            this.names = Arrays.stream(names)
+                    .map(String::toLowerCase)
+                    .collect(ImmutableList.toImmutableList());
+            this.functionBuilders = FunctionBuilder.resolve(functionClass);
+        }
+    }
+
+    class ScalarFunc extends NamedFunc<ScalarFunction> {
+        public ScalarFunc(Class<? extends ScalarFunction> functionClass, String... names) {
+            super(functionClass, names);
+        }
+    }
+
+    class AggregateFunc extends NamedFunc<AggregateFunction> {
+        public AggregateFunc(Class<? extends AggregateFunction> functionClass, String... names) {
+            super(functionClass, names);
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/FunctionRegistry.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/FunctionRegistry.java
@@ -17,49 +17,160 @@
 
 package org.apache.doris.catalog;
 
+import org.apache.doris.nereids.annotation.Developing;
+import org.apache.doris.nereids.exceptions.AnalysisException;
+import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.functions.AggregateFunction;
-import org.apache.doris.nereids.trees.expressions.functions.BoundFunction;
-import org.apache.doris.nereids.trees.expressions.functions.ScalarFunction;
 import org.apache.doris.nereids.trees.expressions.functions.Avg;
+import org.apache.doris.nereids.trees.expressions.functions.BoundFunction;
 import org.apache.doris.nereids.trees.expressions.functions.Count;
+import org.apache.doris.nereids.trees.expressions.functions.FunctionBuilder;
 import org.apache.doris.nereids.trees.expressions.functions.Max;
 import org.apache.doris.nereids.trees.expressions.functions.Min;
+import org.apache.doris.nereids.trees.expressions.functions.ScalarFunction;
 import org.apache.doris.nereids.trees.expressions.functions.Substring;
 import org.apache.doris.nereids.trees.expressions.functions.Sum;
 import org.apache.doris.nereids.trees.expressions.functions.WeekOfYear;
 import org.apache.doris.nereids.trees.expressions.functions.Year;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 
+import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+import javax.annotation.concurrent.ThreadSafe;
 
 /**
  * New function registry for nereids.
+ *
+ * this class is developing for more functions.
  */
+@Developing
+@ThreadSafe
 public class FunctionRegistry {
-    public static final List<Named<ScalarFunction>> SCALAR_FUNCTIONS = ImmutableList.of(
-            Substring.class,
-            WeekOfYear.class,
-            Year.class
+    public static final List<ScalarFunc> SCALAR_FUNCTIONS = ImmutableList.of(
+            scalar(Substring.class, "substr", "substring"),
+            scalar(WeekOfYear.class),
+            scalar(Year.class)
     );
 
-    public static final ImmutableList<Named<AggregateFunction>> AGGREGATE_FUNCTIONS = ImmutableList.of(
-            Avg.class,
-            Count.class,
-            Max.class,
-            Min.class,
-            Sum.class
+    public static final ImmutableList<AggregateFunc> AGGREGATE_FUNCTIONS = ImmutableList.of(
+            agg(Avg.class),
+            agg(Count.class),
+            agg(Max.class),
+            agg(Min.class),
+            agg(Sum.class)
     );
 
-    private static final
+    private final Map<String, List<FunctionBuilder>> name2Builders;
 
-    private static class Named<T extends BoundFunction> {
-        public final String name;
-        public final Class<T> functionClass;
+    public FunctionRegistry() {
+        name2Builders = new ConcurrentHashMap<>();
+        addFunctions(name2Builders, SCALAR_FUNCTIONS);
+        addFunctions(name2Builders, AGGREGATE_FUNCTIONS);
+        afterRegisterBuiltinFunctions(name2Builders);
+    }
 
-        public Named(String name, Class<T> functionClass) {
-            this.name = name;
+    // this function is used to test.
+    // for example, you can create child class of FunctionRegistry and clear builtin functions or add more functions
+    // in this method
+    @VisibleForTesting
+    protected void afterRegisterBuiltinFunctions(Map<String, List<FunctionBuilder>> name2Builders) {}
+
+    // currently we only find function by name and arity
+    public FunctionBuilder findFunctionBuilder(String name, List<Expression> arguments) {
+        int arity = arguments.size();
+        List<FunctionBuilder> functionBuilders = name2Builders.get(name.toLowerCase());
+        if (functionBuilders.isEmpty()) {
+            throw new AnalysisException("Can not found function '" + name + "'");
+        }
+
+        List<FunctionBuilder> candidateBuilders = functionBuilders.stream()
+                .filter(functionBuilder -> functionBuilder.arity == arity)
+                .collect(Collectors.toList());
+        if (candidateBuilders.isEmpty()) {
+            String candidateHints = getCandidateHint(name, candidateBuilders);
+            throw new AnalysisException("Can not found function '" + name
+                    + "' which has " + arity + " arity. Candidate functions are: " + candidateHints);
+        }
+
+        if (candidateBuilders.size() > 1) {
+            String candidateHints = getCandidateHint(name, candidateBuilders);
+            // NereidsPlanner not supported override function by the same arity, should we support it?
+
+            throw new AnalysisException("Function '" + name + "' is ambiguous: " + candidateHints);
+        }
+        return candidateBuilders.get(0);
+    }
+
+    private void addFunctions(Map<String, List<FunctionBuilder>> name2FuncBuilders,
+            List<? extends NamedFunc<? extends BoundFunction>> funcs) {
+        for (NamedFunc<? extends BoundFunction> func : funcs) {
+            for (String name : func.names) {
+                if (name2FuncBuilders.containsKey(name)) {
+                    throw new IllegalStateException("Function '" + name + "' already exists in function registry");
+                }
+
+                name2FuncBuilders.put(name, func.functionBuilders);
+            }
+        }
+    }
+
+    public String getCandidateHint(String name, List<FunctionBuilder> candidateBuilders) {
+        return candidateBuilders.stream()
+                .map(builder -> name + builder.toString())
+                .collect(Collectors.joining(", "));
+    }
+
+    public static final ScalarFunc scalar(Class<? extends ScalarFunction> functionClass) {
+        String functionName = functionClass.getSimpleName();
+        return scalar(functionClass, functionName);
+    }
+
+    public static final ScalarFunc scalar(Class<? extends ScalarFunction> functionClass, String... functionNames) {
+        return new ScalarFunc(functionClass, functionNames);
+    }
+
+    public static final AggregateFunc agg(Class<? extends AggregateFunction> functionClass) {
+        String functionName = functionClass.getSimpleName();
+        return new AggregateFunc(functionClass, functionName);
+    }
+
+    private static final AggregateFunc agg(Class<? extends AggregateFunction> functionClass, String... functionNames) {
+        return new AggregateFunc(functionClass, functionNames);
+    }
+
+    /**
+     * use this class to prevent the wrong type from being registered, and support multi function names
+     * like substring and substr.
+     */
+    public static class NamedFunc<T extends BoundFunction> {
+        public final List<String> names;
+        public final Class<? extends T> functionClass;
+
+        public final List<FunctionBuilder> functionBuilders;
+
+        public NamedFunc(Class<? extends T> functionClass, String... names) {
             this.functionClass = functionClass;
+            this.names = Arrays.stream(names)
+                    .map(String::toLowerCase)
+                    .collect(ImmutableList.toImmutableList());
+            this.functionBuilders = FunctionBuilder.resolve(functionClass);
+        }
+    }
+
+    public static class ScalarFunc extends NamedFunc<ScalarFunction> {
+        public ScalarFunc(Class<? extends ScalarFunction> functionClass, String... names) {
+            super(functionClass, names);
+        }
+    }
+
+    public static class AggregateFunc extends NamedFunc<AggregateFunction> {
+        public AggregateFunc(Class<? extends AggregateFunction> functionClass, String... names) {
+            super(functionClass, names);
         }
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/FunctionRegistry.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/FunctionRegistry.java
@@ -84,7 +84,7 @@ public class FunctionRegistry {
     public FunctionBuilder findFunctionBuilder(String name, List<Expression> arguments) {
         int arity = arguments.size();
         List<FunctionBuilder> functionBuilders = name2Builders.get(name.toLowerCase());
-        if (functionBuilders.isEmpty()) {
+        if (functionBuilders == null || functionBuilders.isEmpty()) {
             throw new AnalysisException("Can not found function '" + name + "'");
         }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/FunctionRegistry.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/FunctionRegistry.java
@@ -42,7 +42,7 @@ public class FunctionRegistry {
 
     public FunctionRegistry() {
         name2Builders = new ConcurrentHashMap<>();
-        addBuiltinFunctions(name2Builders);
+        registerBuiltinFunctions(name2Builders);
         afterRegisterBuiltinFunctions(name2Builders);
     }
 
@@ -78,7 +78,7 @@ public class FunctionRegistry {
         return candidateBuilders.get(0);
     }
 
-    private void addBuiltinFunctions(Map<String, List<FunctionBuilder>> name2Builders) {
+    private void registerBuiltinFunctions(Map<String, List<FunctionBuilder>> name2Builders) {
         BuiltinFunctions builtinFunctions = new BuiltinFunctions();
         FunctionHelper.addFunctions(name2Builders, builtinFunctions.scalarFunctions);
         FunctionHelper.addFunctions(name2Builders, builtinFunctions.aggregateFunctions);

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/FunctionRegistry.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/FunctionRegistry.java
@@ -20,23 +20,10 @@ package org.apache.doris.catalog;
 import org.apache.doris.nereids.annotation.Developing;
 import org.apache.doris.nereids.exceptions.AnalysisException;
 import org.apache.doris.nereids.trees.expressions.Expression;
-import org.apache.doris.nereids.trees.expressions.functions.AggregateFunction;
-import org.apache.doris.nereids.trees.expressions.functions.Avg;
-import org.apache.doris.nereids.trees.expressions.functions.BoundFunction;
-import org.apache.doris.nereids.trees.expressions.functions.Count;
 import org.apache.doris.nereids.trees.expressions.functions.FunctionBuilder;
-import org.apache.doris.nereids.trees.expressions.functions.Max;
-import org.apache.doris.nereids.trees.expressions.functions.Min;
-import org.apache.doris.nereids.trees.expressions.functions.ScalarFunction;
-import org.apache.doris.nereids.trees.expressions.functions.Substring;
-import org.apache.doris.nereids.trees.expressions.functions.Sum;
-import org.apache.doris.nereids.trees.expressions.functions.WeekOfYear;
-import org.apache.doris.nereids.trees.expressions.functions.Year;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableList;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -51,26 +38,11 @@ import javax.annotation.concurrent.ThreadSafe;
 @Developing
 @ThreadSafe
 public class FunctionRegistry {
-    public static final List<ScalarFunc> SCALAR_FUNCTIONS = ImmutableList.of(
-            scalar(Substring.class, "substr", "substring"),
-            scalar(WeekOfYear.class),
-            scalar(Year.class)
-    );
-
-    public static final ImmutableList<AggregateFunc> AGGREGATE_FUNCTIONS = ImmutableList.of(
-            agg(Avg.class),
-            agg(Count.class),
-            agg(Max.class),
-            agg(Min.class),
-            agg(Sum.class)
-    );
-
     private final Map<String, List<FunctionBuilder>> name2Builders;
 
     public FunctionRegistry() {
         name2Builders = new ConcurrentHashMap<>();
-        addFunctions(name2Builders, SCALAR_FUNCTIONS);
-        addFunctions(name2Builders, AGGREGATE_FUNCTIONS);
+        addBuiltinFunctions(name2Builders);
         afterRegisterBuiltinFunctions(name2Builders);
     }
 
@@ -106,71 +78,15 @@ public class FunctionRegistry {
         return candidateBuilders.get(0);
     }
 
-    private void addFunctions(Map<String, List<FunctionBuilder>> name2FuncBuilders,
-            List<? extends NamedFunc<? extends BoundFunction>> funcs) {
-        for (NamedFunc<? extends BoundFunction> func : funcs) {
-            for (String name : func.names) {
-                if (name2FuncBuilders.containsKey(name)) {
-                    throw new IllegalStateException("Function '" + name + "' already exists in function registry");
-                }
-
-                name2FuncBuilders.put(name, func.functionBuilders);
-            }
-        }
+    private void addBuiltinFunctions(Map<String, List<FunctionBuilder>> name2Builders) {
+        BuiltinFunctions builtinFunctions = new BuiltinFunctions();
+        FunctionHelper.addFunctions(name2Builders, builtinFunctions.scalarFunctions);
+        FunctionHelper.addFunctions(name2Builders, builtinFunctions.aggregateFunctions);
     }
 
     public String getCandidateHint(String name, List<FunctionBuilder> candidateBuilders) {
         return candidateBuilders.stream()
                 .map(builder -> name + builder.toString())
                 .collect(Collectors.joining(", "));
-    }
-
-    public static final ScalarFunc scalar(Class<? extends ScalarFunction> functionClass) {
-        String functionName = functionClass.getSimpleName();
-        return scalar(functionClass, functionName);
-    }
-
-    public static final ScalarFunc scalar(Class<? extends ScalarFunction> functionClass, String... functionNames) {
-        return new ScalarFunc(functionClass, functionNames);
-    }
-
-    public static final AggregateFunc agg(Class<? extends AggregateFunction> functionClass) {
-        String functionName = functionClass.getSimpleName();
-        return new AggregateFunc(functionClass, functionName);
-    }
-
-    private static final AggregateFunc agg(Class<? extends AggregateFunction> functionClass, String... functionNames) {
-        return new AggregateFunc(functionClass, functionNames);
-    }
-
-    /**
-     * use this class to prevent the wrong type from being registered, and support multi function names
-     * like substring and substr.
-     */
-    public static class NamedFunc<T extends BoundFunction> {
-        public final List<String> names;
-        public final Class<? extends T> functionClass;
-
-        public final List<FunctionBuilder> functionBuilders;
-
-        public NamedFunc(Class<? extends T> functionClass, String... names) {
-            this.functionClass = functionClass;
-            this.names = Arrays.stream(names)
-                    .map(String::toLowerCase)
-                    .collect(ImmutableList.toImmutableList());
-            this.functionBuilders = FunctionBuilder.resolve(functionClass);
-        }
-    }
-
-    public static class ScalarFunc extends NamedFunc<ScalarFunction> {
-        public ScalarFunc(Class<? extends ScalarFunction> functionClass, String... names) {
-            super(functionClass, names);
-        }
-    }
-
-    public static class AggregateFunc extends NamedFunc<AggregateFunction> {
-        public AggregateFunc(Class<? extends AggregateFunction> functionClass, String... names) {
-            super(functionClass, names);
-        }
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/FunctionRegistry.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/FunctionRegistry.java
@@ -79,9 +79,8 @@ public class FunctionRegistry {
     }
 
     private void registerBuiltinFunctions(Map<String, List<FunctionBuilder>> name2Builders) {
-        BuiltinFunctions builtinFunctions = new BuiltinFunctions();
-        FunctionHelper.addFunctions(name2Builders, builtinFunctions.scalarFunctions);
-        FunctionHelper.addFunctions(name2Builders, builtinFunctions.aggregateFunctions);
+        FunctionHelper.addFunctions(name2Builders, BuiltinFunctions.INSTANCE.scalarFunctions);
+        FunctionHelper.addFunctions(name2Builders, BuiltinFunctions.INSTANCE.aggregateFunctions);
     }
 
     public String getCandidateHint(String name, List<FunctionBuilder> candidateBuilders) {

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/FunctionRegistry.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/FunctionRegistry.java
@@ -1,0 +1,65 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.catalog;
+
+import org.apache.doris.nereids.trees.expressions.functions.AggregateFunction;
+import org.apache.doris.nereids.trees.expressions.functions.BoundFunction;
+import org.apache.doris.nereids.trees.expressions.functions.ScalarFunction;
+import org.apache.doris.nereids.trees.expressions.functions.Avg;
+import org.apache.doris.nereids.trees.expressions.functions.Count;
+import org.apache.doris.nereids.trees.expressions.functions.Max;
+import org.apache.doris.nereids.trees.expressions.functions.Min;
+import org.apache.doris.nereids.trees.expressions.functions.Substring;
+import org.apache.doris.nereids.trees.expressions.functions.Sum;
+import org.apache.doris.nereids.trees.expressions.functions.WeekOfYear;
+import org.apache.doris.nereids.trees.expressions.functions.Year;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+
+/**
+ * New function registry for nereids.
+ */
+public class FunctionRegistry {
+    public static final List<Named<ScalarFunction>> SCALAR_FUNCTIONS = ImmutableList.of(
+            Substring.class,
+            WeekOfYear.class,
+            Year.class
+    );
+
+    public static final ImmutableList<Named<AggregateFunction>> AGGREGATE_FUNCTIONS = ImmutableList.of(
+            Avg.class,
+            Count.class,
+            Max.class,
+            Min.class,
+            Sum.class
+    );
+
+    private static final
+
+    private static class Named<T extends BoundFunction> {
+        public final String name;
+        public final Class<T> functionClass;
+
+        public Named(String name, Class<T> functionClass) {
+            this.name = name;
+            this.functionClass = functionClass;
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/AggregateFunction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/AggregateFunction.java
@@ -21,7 +21,9 @@ import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.visitor.ExpressionVisitor;
 import org.apache.doris.nereids.types.DataType;
 
-/** AggregateFunction. */
+/**
+ * The function which consume arguments in lots of rows and product one value.
+ */
 public abstract class AggregateFunction extends BoundFunction {
 
     private DataType intermediate;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/FunctionBuilder.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/FunctionBuilder.java
@@ -1,0 +1,90 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.trees.expressions.functions;
+
+import org.apache.doris.nereids.trees.expressions.Expression;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+/**
+ * This class used to resolve a concrete BoundFunction's class and build BoundFunction by a list of Expressions.
+ */
+public class FunctionBuilder {
+    public final int arity;
+
+    // Concrete BoundFunction's constructor
+    private final Constructor<BoundFunction> builderMethod;
+
+    public FunctionBuilder(Constructor<BoundFunction> builderMethod) {
+        this.builderMethod = Objects.requireNonNull(builderMethod, "builderMethod can not be null");
+        this.arity = builderMethod.getParameterCount();
+    }
+
+    /**
+     * build a BoundFunction by function name and arguments.
+     * @param name function name which in the sql expression
+     * @param arguments the function's argument expressions
+     * @return the concrete bound function instance
+     */
+    public BoundFunction build(String name, List<Expression> arguments) {
+        try {
+            return builderMethod.newInstance(arguments.toArray(new Expression[0]));
+        } catch (Throwable t) {
+            String argString = arguments.stream()
+                    .map(arg -> arg == null ? "null" : arg.toSql())
+                    .collect(Collectors.joining(", ", "(", ")"));
+            throw new IllegalStateException("Can not build function: '" + name
+                    + "', expression: " + name + argString, t);
+        }
+    }
+
+    @Override
+    public String toString() {
+        return Arrays.stream(builderMethod.getParameterTypes())
+                .map(type -> type.getSimpleName())
+                .collect(Collectors.joining(", ", "(", ")"));
+    }
+
+    /**
+     * resolve a Concrete boundFunction's class and convert the constructors to FunctionBuilder
+     * @param functionClass a class which is the child class of BoundFunction and can not be abstract class
+     * @return list of FunctionBuilder which contains the constructor
+     */
+    public static List<FunctionBuilder> resolve(Class<? extends BoundFunction> functionClass) {
+        Preconditions.checkArgument(!Modifier.isAbstract(functionClass.getModifiers()),
+                "Can not resolve bind function which is abstract class: "
+                        + functionClass.getSimpleName());
+        return Arrays.stream(functionClass.getConstructors())
+                .filter(constructor -> Modifier.isPublic(constructor.getModifiers()))
+                .filter(constructor ->
+                        // all arguments must be Expression
+                        Arrays.stream(functionClass.getTypeParameters())
+                                .allMatch(Expression.class::isInstance)
+                )
+                .map(constructor -> new FunctionBuilder((Constructor<BoundFunction>) constructor))
+                .collect(ImmutableList.toImmutableList());
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/ScalarFunction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/ScalarFunction.java
@@ -19,6 +19,9 @@ package org.apache.doris.nereids.trees.expressions.functions;
 
 import org.apache.doris.nereids.trees.expressions.Expression;
 
+/**
+ * The function which consume zero or more arguments in a row and product one value.
+ */
 public abstract class ScalarFunction extends BoundFunction {
     public ScalarFunction(String name, Expression... arguments) {
         super(name, arguments);

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/ScalarFunction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/ScalarFunction.java
@@ -1,0 +1,26 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.trees.expressions.functions;
+
+import org.apache.doris.nereids.trees.expressions.Expression;
+
+public abstract class ScalarFunction extends BoundFunction {
+    public ScalarFunction(String name, Expression... arguments) {
+        super(name, arguments);
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/Substring.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/Substring.java
@@ -35,7 +35,7 @@ import java.util.List;
 /**
  * substring function.
  */
-public class Substring extends BoundFunction implements TernaryExpression, ImplicitCastInputTypes {
+public class Substring extends ScalarFunction implements TernaryExpression, ImplicitCastInputTypes {
 
     // used in interface expectedInputTypes to avoid new list in each time it be called
     private static final List<AbstractDataType> EXPECTED_INPUT_TYPES = ImmutableList.of(

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/Substring.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/Substring.java
@@ -19,7 +19,6 @@ package org.apache.doris.nereids.trees.expressions.functions;
 
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.literal.IntegerLiteral;
-import org.apache.doris.nereids.trees.expressions.shape.TernaryExpression;
 import org.apache.doris.nereids.trees.expressions.typecoercion.ImplicitCastInputTypes;
 import org.apache.doris.nereids.types.DataType;
 import org.apache.doris.nereids.types.IntegerType;
@@ -31,11 +30,12 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
+import java.util.Optional;
 
 /**
  * substring function.
  */
-public class Substring extends ScalarFunction implements TernaryExpression, ImplicitCastInputTypes {
+public class Substring extends ScalarFunction implements ImplicitCastInputTypes {
 
     // used in interface expectedInputTypes to avoid new list in each time it be called
     private static final List<AbstractDataType> EXPECTED_INPUT_TYPES = ImmutableList.of(
@@ -49,10 +49,10 @@ public class Substring extends ScalarFunction implements TernaryExpression, Impl
     }
 
     public Substring(Expression str, Expression pos) {
-        super("substring", str, pos, new IntegerLiteral(Integer.MAX_VALUE));
+        super("substring", str, pos);
     }
 
-    public Expression getTarget() {
+    public Expression getSource() {
         return child(0);
     }
 
@@ -60,21 +60,22 @@ public class Substring extends ScalarFunction implements TernaryExpression, Impl
         return child(1);
     }
 
-    public Expression getLength() {
-        return child(2);
+    public Optional<Expression> getLength() {
+        return arity() == 3 ? Optional.of(child(2)) : Optional.empty();
     }
 
     @Override
     public DataType getDataType() {
-        if (getLength() instanceof IntegerLiteral) {
-            return VarcharType.createVarcharType(((IntegerLiteral) getLength()).getValue());
+        Optional<Expression> length = getLength();
+        if (length.isPresent() && length.get() instanceof IntegerLiteral) {
+            return VarcharType.createVarcharType(((IntegerLiteral) length.get()).getValue());
         }
         return VarcharType.SYSTEM_DEFAULT;
     }
 
     @Override
     public boolean nullable() {
-        return first().nullable();
+        return children().stream().anyMatch(Expression::nullable);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/WeekOfYear.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/WeekOfYear.java
@@ -34,7 +34,7 @@ import java.util.List;
 /**
  * weekOfYear function
  */
-public class WeekOfYear extends BoundFunction implements UnaryExpression, ImplicitCastInputTypes {
+public class WeekOfYear extends ScalarFunction implements UnaryExpression, ImplicitCastInputTypes {
 
     private static final List<AbstractDataType> EXPECTED_INPUT_TYPES = ImmutableList.of(
             new TypeCollection(DateTimeType.INSTANCE)

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/Year.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/Year.java
@@ -35,7 +35,7 @@ import java.util.List;
 /**
  * year function.
  */
-public class Year extends BoundFunction implements UnaryExpression, ImplicitCastInputTypes {
+public class Year extends ScalarFunction implements UnaryExpression, ImplicitCastInputTypes {
 
     // used in interface expectedInputTypes to avoid new list in each time it be called
     private static final List<AbstractDataType> EXPECTED_INPUT_TYPES = ImmutableList.of(

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/analysis/FunctionRegistryTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/analysis/FunctionRegistryTest.java
@@ -1,0 +1,132 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.rules.analysis;
+
+import org.apache.doris.catalog.FunctionRegistry;
+import org.apache.doris.nereids.exceptions.AnalysisException;
+import org.apache.doris.nereids.trees.expressions.Expression;
+import org.apache.doris.nereids.trees.expressions.functions.BoundFunction;
+import org.apache.doris.nereids.trees.expressions.functions.FunctionBuilder;
+import org.apache.doris.nereids.trees.expressions.functions.Substring;
+import org.apache.doris.nereids.trees.expressions.functions.Year;
+import org.apache.doris.nereids.trees.expressions.literal.Literal;
+import org.apache.doris.nereids.trees.expressions.shape.UnaryExpression;
+import org.apache.doris.nereids.util.MemoTestUtils;
+import org.apache.doris.nereids.util.PatternMatchSupported;
+import org.apache.doris.nereids.util.PlanChecker;
+import org.apache.doris.qe.ConnectContext;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+// this ut will add more test case later
+public class FunctionRegistryTest implements PatternMatchSupported {
+    private ConnectContext connectContext = MemoTestUtils.createConnectContext();
+
+    @Test
+    public void testDefaultFunctionNameIsClassName() {
+        // we register Year by the code in FunctionRegistry: scalar(Year.class).
+        // and default class name should be year.
+        PlanChecker.from(connectContext)
+                .analyze("select year('2021-01-01')")
+                .matchesFromRoot(
+                        logicalOneRowRelation().when(r -> {
+                            Year year = (Year) r.getProjects().get(0).child(0);
+                            Assertions.assertEquals("2021-01-01",
+                                    ((Literal) year.getArguments().get(0)).getValue());
+                            return true;
+                        })
+                );
+    }
+
+    @Test
+    public void testMultiName() {
+        // the substring function has 2 names:
+        // 1. substring
+        // 2. substr
+        PlanChecker.from(connectContext)
+                .analyze("select substring('abc', 1, 2), substr(substring('abcdefg', 4, 3), 1, 2)")
+                .matchesFromRoot(
+                        logicalOneRowRelation().when(r -> {
+                            Substring firstSubstring = (Substring) r.getProjects().get(0).child(0);
+                            Assertions.assertEquals("abc", ((Literal) firstSubstring.getSource()).getValue());
+                            Assertions.assertEquals((byte) 1, ((Literal) firstSubstring.getPosition()).getValue());
+                            Assertions.assertEquals((byte) 2, ((Literal) firstSubstring.getLength().get()).getValue());
+
+                            Substring secondSubstring = (Substring) r.getProjects().get(1).child(0);
+                            Assertions.assertTrue(secondSubstring.getSource() instanceof Substring);
+                            Assertions.assertEquals((byte) 1, ((Literal) secondSubstring.getPosition()).getValue());
+                            Assertions.assertEquals((byte) 2, ((Literal) secondSubstring.getLength().get()).getValue());
+                            return true;
+                        })
+                );
+    }
+
+    @Test
+    public void testOverrideArity() {
+        // the substring function has 2 override functions:
+        // 1. substring(string, position)
+        // 2. substring(string, position, length)
+        PlanChecker.from(connectContext)
+                .analyze("select substr('abc', 1), substring('def', 2, 3)")
+                .matchesFromRoot(
+                        logicalOneRowRelation().when(r -> {
+                            Substring firstSubstring = (Substring) r.getProjects().get(0).child(0);
+                            Assertions.assertEquals("abc", ((Literal) firstSubstring.getSource()).getValue());
+                            Assertions.assertEquals((byte) 1, ((Literal) firstSubstring.getPosition()).getValue());
+                            // default length is max int
+                            Assertions.assertFalse(firstSubstring.getLength().isPresent());
+
+                            Substring secondSubstring = (Substring) r.getProjects().get(1).child(0);
+                            Assertions.assertEquals("def", ((Literal) secondSubstring.getSource()).getValue());
+                            Assertions.assertEquals((byte) 2, ((Literal) secondSubstring.getPosition()).getValue());
+                            Assertions.assertEquals((byte) 3, ((Literal) secondSubstring.getLength().get()).getValue());
+                            return true;
+                        })
+                );
+    }
+
+    @Test
+    public void testOverrideDifferenceTypes() {
+        FunctionRegistry functionRegistry = new FunctionRegistry() {
+            @Override
+            protected void afterRegisterBuiltinFunctions(Map<String, List<FunctionBuilder>> name2builders) {
+                name2builders.put("abc", FunctionBuilder.resolve(Abc.class));
+            }
+        };
+
+        // currently we can not support the override same arity function with difference types
+        Assertions.assertThrowsExactly(AnalysisException.class, () -> {
+            functionRegistry.findFunctionBuilder("abc", ImmutableList.of(Literal.of(1)));
+        });
+    }
+
+    private static class Abc extends BoundFunction implements UnaryExpression {
+        public Abc(Expression a1) {
+            super("abc", a1);
+        }
+
+        public Abc(Literal a1) {
+            super("abc", a1);
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/analysis/FunctionRegistryTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/analysis/FunctionRegistryTest.java
@@ -93,7 +93,6 @@ public class FunctionRegistryTest implements PatternMatchSupported {
                             Substring firstSubstring = (Substring) r.getProjects().get(0).child(0);
                             Assertions.assertEquals("abc", ((Literal) firstSubstring.getSource()).getValue());
                             Assertions.assertEquals((byte) 1, ((Literal) firstSubstring.getPosition()).getValue());
-                            // default length is max int
                             Assertions.assertFalse(firstSubstring.getLength().isPresent());
 
                             Substring secondSubstring = (Substring) r.getProjects().get(1).child(0);


### PR DESCRIPTION
# Proposed changes

Support function registry.

The classes:
- BuiltinFunctions: contains the built-in functions list
- FunctionRegistry: used to register scalar functions and aggregate functions, it can find the function by name
- FunctionBuilder: used to resolve a BoundFunction class, extract the constructor, and build to a BoundFunction by arguments(`List<Expression>`)

Register example: you can add built-in functions in the list for simplicity

```java
public class BuiltinFunctions implements FunctionHelper {
    public final List<ScalarFunc> scalarFunctions = ImmutableList.of(
            scalar(Substring.class, "substr", "substring"),
            scalar(WeekOfYear.class),
            scalar(Year.class)
    );

    public final ImmutableList<AggregateFunc> aggregateFunctions = ImmutableList.of(
            agg(Avg.class),
            agg(Count.class),
            agg(Max.class),
            agg(Min.class),
            agg(Sum.class)
    );
}
```

Note:
- Currently, we only support register scalar functions add aggregate functions, we will support register table functions.
- Currently, we only support resolve function by function name and difference arity, but can not resolve the same arity override function, e.g. `some_function(Expression)` and `some_function(Literal)`


## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [x] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No