### PR TITLE
[enhancement](Nereids) add type coercion between decimal and integral

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/util/TypeCoercionUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/util/TypeCoercionUtils.java
@@ -143,6 +143,10 @@ public class TypeCoercionUtils {
         if (leftType instanceof NullType && rightType instanceof DecimalType) {
             return true;
         }
+        if (leftType instanceof DecimalType && rightType instanceof IntegralType
+                || leftType instanceof IntegralType && rightType instanceof DecimalType) {
+            return true;
+        }
         // TODO: add decimal promotion support
         if (!(leftType instanceof DecimalType) && !(rightType instanceof DecimalType) && !leftType.equals(rightType)) {
             return true;
@@ -189,6 +193,10 @@ public class TypeCoercionUtils {
             }
         } else if (left instanceof CharacterType || right instanceof CharacterType) {
             tightestCommonType = StringType.INSTANCE;
+        } else if (left instanceof DecimalType && right instanceof IntegralType) {
+            tightestCommonType = DecimalType.widerDecimalType((DecimalType) left, DecimalType.forType(right));
+        } else if (left instanceof IntegralType && right instanceof DecimalType) {
+            tightestCommonType = DecimalType.widerDecimalType((DecimalType) right, DecimalType.forType(left));
         }
         return Optional.ofNullable(tightestCommonType);
     }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/util/TypeCoercionUtilsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/util/TypeCoercionUtilsTest.java
@@ -110,8 +110,8 @@ public class TypeCoercionUtilsTest {
         Assertions.assertTrue(TypeCoercionUtils.canHandleTypeCoercion(decimalType, nullType));
         Assertions.assertTrue(TypeCoercionUtils.canHandleTypeCoercion(nullType, decimalType));
         Assertions.assertTrue(TypeCoercionUtils.canHandleTypeCoercion(smallIntType, integerType));
-        Assertions.assertFalse(TypeCoercionUtils.canHandleTypeCoercion(integerType, decimalType));
-        Assertions.assertFalse(TypeCoercionUtils.canHandleTypeCoercion(decimalType, integerType));
+        Assertions.assertTrue(TypeCoercionUtils.canHandleTypeCoercion(integerType, decimalType));
+        Assertions.assertTrue(TypeCoercionUtils.canHandleTypeCoercion(decimalType, integerType));
         Assertions.assertFalse(TypeCoercionUtils.canHandleTypeCoercion(integerType, integerType));
     }
 


### PR DESCRIPTION
# Proposed changes

Issue Number: noissue
## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

