### PR TITLE
[enhancement](Nereids) add all necessary PhysicalDistribute on Join's child and update cost model

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/NereidsPlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/NereidsPlanner.java
@@ -194,7 +194,7 @@ public class NereidsPlanner extends Planner {
         }
 
         // TODO: set (logical and physical)properties/statistics/... for physicalPlan.
-        return ((PhysicalPlan) plan).withPhysicalProperties(physicalProperties);
+        return ((PhysicalPlan) plan).withPhysicalProperties(groupExpression.getOutputProperties(physicalProperties));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/cost/CostCalculator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/cost/CostCalculator.java
@@ -71,7 +71,6 @@ public class CostCalculator {
 
         @Override
         public CostEstimate visitPhysicalProject(PhysicalProject<? extends Plan> physicalProject, PlanContext context) {
-            StatsDeriveResult statistics = context.getStatisticsWithCheck();
             return CostEstimate.ofCpu(1);
         }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/cost/CostCalculator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/cost/CostCalculator.java
@@ -17,9 +17,12 @@
 
 package org.apache.doris.nereids.cost;
 
-import org.apache.doris.common.Id;
 import org.apache.doris.nereids.PlanContext;
 import org.apache.doris.nereids.memo.GroupExpression;
+import org.apache.doris.nereids.properties.DistributionSpec;
+import org.apache.doris.nereids.properties.DistributionSpecGather;
+import org.apache.doris.nereids.properties.DistributionSpecHash;
+import org.apache.doris.nereids.properties.DistributionSpecReplicated;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalAggregate;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalDistribute;
@@ -35,13 +38,12 @@ import org.apache.doris.statistics.StatsDeriveResult;
 
 import com.google.common.base.Preconditions;
 
-import java.util.List;
-
 /**
  * Calculate the cost of a plan.
  * Inspired by Presto.
  */
 public class CostCalculator {
+
     /**
      * Constructor.
      */
@@ -106,19 +108,43 @@ public class CostCalculator {
             return new CostEstimate(
                     childStatistics.computeSize(),
                     statistics.computeSize(),
-                    childStatistics.computeSize());
+                    0);
         }
 
         @Override
         public CostEstimate visitPhysicalDistribute(
                 PhysicalDistribute<? extends Plan> distribute, PlanContext context) {
-            StatsDeriveResult statistics = context.getStatisticsWithCheck();
             StatsDeriveResult childStatistics = context.getChildStatistics(0);
+            DistributionSpec spec = distribute.getDistributionSpec();
+            // shuffle
+            if (spec instanceof DistributionSpecHash) {
+                return new CostEstimate(
+                        childStatistics.computeSize(),
+                        0,
+                        childStatistics.computeSize());
+            }
 
+            // replicate
+            if (spec instanceof DistributionSpecReplicated) {
+                return new CostEstimate(
+                        0,
+                        0,
+                        childStatistics.computeSize());
+            }
+
+            // gather
+            if (spec instanceof DistributionSpecGather) {
+                return new CostEstimate(
+                        childStatistics.computeSize(),
+                        0,
+                        childStatistics.computeSize());
+            }
+
+            // any
             return new CostEstimate(
                     childStatistics.computeSize(),
-                    statistics.computeSize(),
-                    childStatistics.computeSize());
+                    0,
+                    0);
         }
 
         @Override
@@ -158,22 +184,10 @@ public class CostCalculator {
 
             StatsDeriveResult leftStatistics = context.getChildStatistics(0);
             StatsDeriveResult rightStatistics = context.getChildStatistics(1);
-            List<Id> leftIds = context.getChildOutputIds(0);
-            List<Id> rightIds = context.getChildOutputIds(1);
 
-            // TODO: handle some case
-            // handle cross join, onClause is empty .....
-            if (nestedLoopJoin.getJoinType().isCrossJoin()) {
-                return new CostEstimate(
-                        leftStatistics.computeColumnSize(leftIds) + rightStatistics.computeColumnSize(rightIds),
-                        rightStatistics.computeColumnSize(rightIds),
-                        0);
-            }
-
-            // TODO: network 0?
             return new CostEstimate(
-                    (leftStatistics.computeColumnSize(leftIds) + rightStatistics.computeColumnSize(rightIds)) / 2,
-                    rightStatistics.computeColumnSize(rightIds),
+                    leftStatistics.computeSize() * rightStatistics.computeSize(),
+                    rightStatistics.computeSize(),
                     0);
         }
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/cost/CostCalculator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/cost/CostCalculator.java
@@ -72,7 +72,7 @@ public class CostCalculator {
         @Override
         public CostEstimate visitPhysicalProject(PhysicalProject<? extends Plan> physicalProject, PlanContext context) {
             StatsDeriveResult statistics = context.getStatisticsWithCheck();
-            return CostEstimate.ofCpu(statistics.computeSize());
+            return CostEstimate.ofCpu(1);
         }
 
         @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/cost/CostCalculator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/cost/CostCalculator.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.nereids.cost;
 
+import org.apache.doris.common.Id;
 import org.apache.doris.nereids.PlanContext;
 import org.apache.doris.nereids.memo.GroupExpression;
 import org.apache.doris.nereids.properties.DistributionSpec;
@@ -38,6 +39,8 @@ import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.statistics.StatsDeriveResult;
 
 import com.google.common.base.Preconditions;
+
+import java.util.List;
 
 /**
  * Calculate the cost of a plan.

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/cascades/CostAndEnforcerJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/cascades/CostAndEnforcerJob.java
@@ -117,7 +117,8 @@ public class CostAndEnforcerJob extends Job implements Cloneable {
         for (; requestPropertiesIndex < requestChildrenPropertiesList.size(); requestPropertiesIndex++) {
             // Get one from List<request property to children>
             // like: [ Properties {"", ANY}, Properties {"", BROADCAST} ],
-            List<PhysicalProperties> requestChildrenProperties = requestChildrenPropertiesList.get(requestPropertiesIndex);
+            List<PhysicalProperties> requestChildrenProperties
+                    = requestChildrenPropertiesList.get(requestPropertiesIndex);
 
             // Calculate cost
             if (curChildIndex == 0 && prevChildIndex == -1) {
@@ -171,7 +172,9 @@ public class CostAndEnforcerJob extends Job implements Cloneable {
 
                 // to ensure distributionSpec has been added sufficiently.
                 ChildrenPropertiesRegulator regulator = new ChildrenPropertiesRegulator(
-                        lowestCostChildren, childrenOutputProperties, context);
+                        groupExpression, lowestCostChildren, childrenOutputProperties, context);
+                double enforceCost = regulator.adjustChildrenProperties();
+                curTotalCost += enforceCost;
 
                 // Not need to do pruning here because it has been done when we get the
                 // best expr from the child group

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/cascades/CostAndEnforcerJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/cascades/CostAndEnforcerJob.java
@@ -171,8 +171,8 @@ public class CostAndEnforcerJob extends Job implements Cloneable {
             if (curChildIndex == groupExpression.arity()) {
 
                 // to ensure distributionSpec has been added sufficiently.
-                ChildrenPropertiesRegulator regulator = new ChildrenPropertiesRegulator(
-                        groupExpression, lowestCostChildren, childrenOutputProperties, context);
+                ChildrenPropertiesRegulator regulator = new ChildrenPropertiesRegulator(groupExpression,
+                        lowestCostChildren, childrenOutputProperties, requestChildrenProperties, context);
                 double enforceCost = regulator.adjustChildrenProperties();
                 curTotalCost += enforceCost;
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Group.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Group.java
@@ -198,6 +198,9 @@ public class Group {
         return null;
     }
 
+    /**
+     * replace best plan with new properties
+     */
     public void replaceBestPlan(PhysicalProperties oldProperty, PhysicalProperties newProperty, double cost) {
         Pair<Double, GroupExpression> pair = lowestCostPlans.get(oldProperty);
         GroupExpression lowestGroupExpr = pair.second;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Group.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Group.java
@@ -180,9 +180,10 @@ public class Group {
     /**
      * Set or update lowestCostPlans: properties --> Pair.of(cost, expression)
      */
-    public void setBestPlan(GroupExpression expression, double cost, PhysicalProperties properties) {
+    public void setBestPlan(GroupExpression expression, double cost,
+            PhysicalProperties properties, boolean forceUpdate) {
         if (lowestCostPlans.containsKey(properties)) {
-            if (lowestCostPlans.get(properties).first >= cost) {
+            if (lowestCostPlans.get(properties).first >= cost || forceUpdate) {
                 lowestCostPlans.put(properties, Pair.of(cost, expression));
             }
         } else {
@@ -200,7 +201,8 @@ public class Group {
     public void replaceBestPlan(PhysicalProperties oldProperty, PhysicalProperties newProperty, double cost) {
         Pair<Double, GroupExpression> pair = lowestCostPlans.get(oldProperty);
         GroupExpression lowestGroupExpr = pair.second;
-        lowestGroupExpr.updateLowestCostTable(newProperty, lowestGroupExpr.getInputPropertiesList(oldProperty), cost);
+        lowestGroupExpr.updateLowestCostTable(newProperty,
+                lowestGroupExpr.getInputPropertiesList(oldProperty), cost, false);
         lowestCostPlans.remove(oldProperty);
         lowestCostPlans.put(newProperty, pair);
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Group.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Group.java
@@ -180,10 +180,9 @@ public class Group {
     /**
      * Set or update lowestCostPlans: properties --> Pair.of(cost, expression)
      */
-    public void setBestPlan(GroupExpression expression, double cost,
-            PhysicalProperties properties, boolean forceUpdate) {
+    public void setBestPlan(GroupExpression expression, double cost, PhysicalProperties properties) {
         if (lowestCostPlans.containsKey(properties)) {
-            if (lowestCostPlans.get(properties).first >= cost || forceUpdate) {
+            if (lowestCostPlans.get(properties).first >= cost) {
                 lowestCostPlans.put(properties, Pair.of(cost, expression));
             }
         } else {
@@ -205,7 +204,7 @@ public class Group {
         Pair<Double, GroupExpression> pair = lowestCostPlans.get(oldProperty);
         GroupExpression lowestGroupExpr = pair.second;
         lowestGroupExpr.updateLowestCostTable(newProperty,
-                lowestGroupExpr.getInputPropertiesList(oldProperty), cost, false);
+                lowestGroupExpr.getInputPropertiesList(oldProperty), cost);
         lowestCostPlans.remove(oldProperty);
         lowestCostPlans.put(newProperty, pair);
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/GroupExpression.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/GroupExpression.java
@@ -171,9 +171,9 @@ public class GroupExpression {
     public boolean updateLowestCostTable(
             PhysicalProperties outputProperties,
             List<PhysicalProperties> childrenInputProperties,
-            double cost) {
+            double cost, boolean forceUpdate) {
         if (lowestCostTable.containsKey(outputProperties)) {
-            if (lowestCostTable.get(outputProperties).first > cost) {
+            if (lowestCostTable.get(outputProperties).first > cost || forceUpdate) {
                 lowestCostTable.put(outputProperties, Pair.of(cost, childrenInputProperties));
                 return true;
             } else {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/GroupExpression.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/GroupExpression.java
@@ -168,12 +168,10 @@ public class GroupExpression {
     /**
      * Add a (outputProperties) -> (cost, childrenInputProperties) in lowestCostTable.
      */
-    public boolean updateLowestCostTable(
-            PhysicalProperties outputProperties,
-            List<PhysicalProperties> childrenInputProperties,
-            double cost, boolean forceUpdate) {
+    public boolean updateLowestCostTable(PhysicalProperties outputProperties,
+            List<PhysicalProperties> childrenInputProperties, double cost) {
         if (lowestCostTable.containsKey(outputProperties)) {
-            if (lowestCostTable.get(outputProperties).first > cost || forceUpdate) {
+            if (lowestCostTable.get(outputProperties).first > cost) {
                 lowestCostTable.put(outputProperties, Pair.of(cost, childrenInputProperties));
                 return true;
             } else {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/ChildOutputPropertyDeriver.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/ChildOutputPropertyDeriver.java
@@ -145,12 +145,6 @@ public class ChildOutputPropertyDeriver extends PlanVisitor<PhysicalProperties, 
         // broadcast
         if (rightOutputProperty.getDistributionSpec() instanceof DistributionSpecReplicated) {
             DistributionSpec parentDistributionSpec = leftOutputProperty.getDistributionSpec();
-            if (leftOutputProperty.getDistributionSpec() instanceof DistributionSpecHash) {
-                DistributionSpecHash leftHash = (DistributionSpecHash) leftOutputProperty.getDistributionSpec();
-                List<ExprId> rightHashEqualSlots = JoinUtils.getOnClauseUsedSlots(hashJoin).second;
-                DistributionSpecHash rightHash = new DistributionSpecHash(rightHashEqualSlots, ShuffleType.BUCKETED);
-                parentDistributionSpec = DistributionSpecHash.merge(leftHash, rightHash);
-            }
             return new PhysicalProperties(parentDistributionSpec);
         }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/ChildOutputPropertyDeriver.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/ChildOutputPropertyDeriver.java
@@ -82,7 +82,8 @@ public class ChildOutputPropertyDeriver extends PlanVisitor<PhysicalProperties, 
                         .map(SlotReference.class::cast)
                         .map(SlotReference::getExprId)
                         .collect(Collectors.toList());
-                return PhysicalProperties.createHash(new DistributionSpecHash(columns, ShuffleType.BUCKETED));
+                // TODO: change ENFORCED back to bucketed, when coordinator could process bucket on agg correctly.
+                return PhysicalProperties.createHash(new DistributionSpecHash(columns, ShuffleType.ENFORCED));
             case DISTINCT_GLOBAL:
             default:
                 throw new RuntimeException("Could not derive output properties for agg phase: " + agg.getAggPhase());

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/ChildrenPropertiesRegulator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/ChildrenPropertiesRegulator.java
@@ -103,16 +103,15 @@ public class ChildrenPropertiesRegulator extends PlanVisitor<Double, Void> {
             if (JoinUtils.couldColocateJoin(leftHashSpec, rightHashSpec)) {
                 return enforceCost;
             }
-            enforceCost += updateChildEnforceAndCost(rightChild, rightOutput,
-                    rightHashSpec, rightLowest.first);
-            rightHashSpec.withShuffleType(ShuffleType.ENFORCED);
         }
 
         // check right hand must distribute
         if (rightHashSpec.getShuffleType() != ShuffleType.ENFORCED) {
             enforceCost += updateChildEnforceAndCost(rightChild, rightOutput,
                     rightHashSpec, rightLowest.first);
-            rightHashSpec.withShuffleType(ShuffleType.ENFORCED);
+            childrenProperties.set(1, new PhysicalProperties(
+                    rightHashSpec.withShuffleType(ShuffleType.ENFORCED),
+                    childrenProperties.get(1).getOrderSpec()));
         }
 
         // check bucket shuffle join
@@ -122,6 +121,9 @@ public class ChildrenPropertiesRegulator extends PlanVisitor<Double, Void> {
             }
             enforceCost += updateChildEnforceAndCost(leftChild, leftOutput,
                     leftHashSpec, leftLowest.first);
+            childrenProperties.set(0, new PhysicalProperties(
+                    leftHashSpec.withShuffleType(ShuffleType.ENFORCED),
+                    childrenProperties.get(0).getOrderSpec()));
         }
         return enforceCost;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/ChildrenPropertiesRegulator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/ChildrenPropertiesRegulator.java
@@ -1,0 +1,134 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.properties;
+
+import org.apache.doris.common.Pair;
+import org.apache.doris.nereids.PlanContext;
+import org.apache.doris.nereids.cost.CostCalculator;
+import org.apache.doris.nereids.jobs.JobContext;
+import org.apache.doris.nereids.memo.GroupExpression;
+import org.apache.doris.nereids.properties.DistributionSpecHash.ShuffleType;
+import org.apache.doris.nereids.trees.plans.Plan;
+import org.apache.doris.nereids.trees.plans.physical.PhysicalHashJoin;
+import org.apache.doris.nereids.trees.plans.visitor.PlanVisitor;
+import org.apache.doris.nereids.util.JoinUtils;
+import org.apache.doris.qe.ConnectContext;
+
+import com.alibaba.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+
+import java.util.List;
+
+public class ChildrenPropertiesRegulator extends PlanVisitor<Double, PlanContext> {
+
+    private final List<GroupExpression> children;
+    private final List<PhysicalProperties> childrenProperties;
+    private final JobContext jobContext;
+    private double enforceCost = 0.0;
+
+    public ChildrenPropertiesRegulator(List<GroupExpression> children,
+            List<PhysicalProperties> childrenProperties, JobContext jobContext) {
+        this.children = children;
+        this.childrenProperties = childrenProperties;
+        this.jobContext = jobContext;
+    }
+
+    @Override
+    public Double visit(Plan plan, PlanContext context) {
+        return null;
+    }
+
+    @Override
+    public Double visitPhysicalHashJoin(PhysicalHashJoin<? extends Plan, ? extends Plan> hashJoin,
+            PlanContext context) {
+        Preconditions.checkArgument(children.size() == 2);
+        Preconditions.checkArgument(childrenProperties.size() == 2);
+        DistributionSpec leftDistributionSpec = childrenProperties.get(0).getDistributionSpec();
+        DistributionSpec rightDistributionSpec = childrenProperties.get(1).getDistributionSpec();
+
+        // broadcast do not need regular
+        if (rightDistributionSpec instanceof DistributionSpecReplicated) {
+            return enforceCost;
+        }
+
+        // shuffle
+        if (!(leftDistributionSpec instanceof DistributionSpecHash)
+                || !(rightDistributionSpec instanceof DistributionSpecHash)) {
+            throw new RuntimeException("should not come here");
+        }
+
+        DistributionSpecHash leftHashSpec = (DistributionSpecHash) leftDistributionSpec;
+        DistributionSpecHash rightHashSpec = (DistributionSpecHash) rightDistributionSpec;
+
+        GroupExpression leftChild = children.get(0);
+        final Pair<Double, List<PhysicalProperties>> leftLowest
+                = leftChild.getLowestCostTable().get(PhysicalProperties.ANY);
+        PhysicalProperties leftOutput = leftChild.getOutputProperties(PhysicalProperties.ANY);
+
+        GroupExpression rightChild = children.get(1);
+        final Pair<Double, List<PhysicalProperties>> rightLowest
+                = rightChild.getLowestCostTable().get(PhysicalProperties.ANY);
+        PhysicalProperties rightOutput = rightChild.getOutputProperties(PhysicalProperties.ANY);
+
+        // check colocate join
+        if (leftHashSpec.getShuffleType() == ShuffleType.NATURAL
+                && rightHashSpec.getShuffleType() == ShuffleType.NATURAL) {
+            if (JoinUtils.couldColocateJoin(leftHashSpec, rightHashSpec)) {
+                return enforceCost;
+            }
+            enforceCost += updateChildEnforceAndCost(rightChild, rightOutput,
+                    rightHashSpec, rightLowest.first);
+            rightHashSpec.withShuffleType(ShuffleType.ENFORCED);
+        }
+
+        // check right hand must distribute
+        if (rightHashSpec.getShuffleType() != ShuffleType.ENFORCED) {
+            enforceCost += updateChildEnforceAndCost(rightChild, rightOutput,
+                    rightHashSpec, rightLowest.first);
+            rightHashSpec.withShuffleType(ShuffleType.ENFORCED);
+        }
+
+        // check bucket shuffle join
+        if (leftHashSpec.getShuffleType() != ShuffleType.ENFORCED) {
+            if (ConnectContext.get().getSessionVariable().isEnableBucketShuffleJoin()) {
+                return enforceCost;
+            }
+            enforceCost += updateChildEnforceAndCost(leftChild, leftOutput,
+                    leftHashSpec, leftLowest.first);
+        }
+        return enforceCost;
+    }
+
+    private double updateChildEnforceAndCost(GroupExpression child, PhysicalProperties childOutput,
+            DistributionSpecHash required, double currentCost) {
+        DistributionSpec outputDistributionSpec;
+        outputDistributionSpec = required.withShuffleType(ShuffleType.ENFORCED);
+
+        PhysicalProperties newOutputProperty = new PhysicalProperties(outputDistributionSpec);
+        GroupExpression enforcer = outputDistributionSpec.addEnforcer(child.getOwnerGroup());
+        jobContext.getCascadesContext().getMemo().addEnforcerPlan(enforcer, child.getOwnerGroup());
+        double enforceCost = CostCalculator.calculateCost(enforcer);
+
+        if (enforcer.updateLowestCostTable(newOutputProperty,
+                Lists.newArrayList(childOutput), enforceCost + currentCost, true)) {
+            enforcer.putOutputPropertiesMap(newOutputProperty, newOutputProperty);
+        }
+        child.getOwnerGroup().setBestPlan(enforcer, enforceCost + currentCost, newOutputProperty, true);
+        return enforceCost;
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/ChildrenPropertiesRegulator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/ChildrenPropertiesRegulator.java
@@ -137,10 +137,10 @@ public class ChildrenPropertiesRegulator extends PlanVisitor<Double, Void> {
         double enforceCost = CostCalculator.calculateCost(enforcer);
 
         if (enforcer.updateLowestCostTable(newOutputProperty,
-                Lists.newArrayList(childOutput), enforceCost + currentCost, true)) {
+                Lists.newArrayList(childOutput), enforceCost + currentCost)) {
             enforcer.putOutputPropertiesMap(newOutputProperty, newOutputProperty);
         }
-        child.getOwnerGroup().setBestPlan(enforcer, enforceCost + currentCost, newOutputProperty, true);
+        child.getOwnerGroup().setBestPlan(enforcer, enforceCost + currentCost, newOutputProperty);
         return enforceCost;
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/DistributionSpecHash.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/DistributionSpecHash.java
@@ -237,8 +237,8 @@ public class DistributionSpecHash extends DistributionSpec {
     public enum ShuffleType {
         // require, need to satisfy the distribution spec by aggregation way.
         AGGREGATE,
-        // require, must add a enforce on child node.
-        FORCE_SHUFFLE,
+        // require, need to satisfy the distribution spec by join way.
+        JOIN,
         // output, for olap scan node and colocate join
         NATURAL,
         // output, for all join except colocate join
@@ -246,13 +246,5 @@ public class DistributionSpecHash extends DistributionSpec {
         // output, all distribute enforce
         ENFORCED,
         ;
-
-        public boolean forbiddenEnforce() {
-            return this == NATURAL || this == BUCKETED;
-        }
-
-        public boolean mustEnforce() {
-            return this == FORCE_SHUFFLE;
-        }
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/EnforceMissingPropertiesHelper.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/EnforceMissingPropertiesHelper.java
@@ -47,23 +47,24 @@ public class EnforceMissingPropertiesHelper {
     /**
      * Enforce missing property.
      */
-    public PhysicalProperties enforceProperty(PhysicalProperties output, PhysicalProperties request) {
+    public PhysicalProperties enforceProperty(PhysicalProperties output,
+            PhysicalProperties request, boolean mustEnforceDistribution) {
         boolean isSatisfyOrder = output.getOrderSpec().satisfy(request.getOrderSpec());
         boolean isSatisfyDistribution = output.getDistributionSpec().satisfy(request.getDistributionSpec());
 
         if (!isSatisfyDistribution && !isSatisfyOrder) {
             return enforceSortAndDistribution(output, request);
-        } else if (isSatisfyDistribution && isSatisfyOrder) {
-            return output;
-        } else if (!isSatisfyDistribution) {
+        } else if (!isSatisfyDistribution || mustEnforceDistribution) {
             if (!request.getOrderSpec().getOrderKeys().isEmpty()) {
                 // After redistribute data , original order request may be wrong.
                 return enforceDistributionButMeetSort(output, request);
             }
             return enforceDistribution(output);
-        } else {
+        } else if (!isSatisfyOrder) {
             // Order don't satisfy.
             return enforceLocalSort(output);
+        } else {
+            return output;
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/EnforceMissingPropertiesHelper.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/EnforceMissingPropertiesHelper.java
@@ -141,9 +141,9 @@ public class EnforceMissingPropertiesHelper {
         curTotalCost += CostCalculator.calculateCost(enforcer);
 
         if (enforcer.updateLowestCostTable(newOutputProperty,
-                Lists.newArrayList(oldOutputProperty), curTotalCost, false)) {
+                Lists.newArrayList(oldOutputProperty), curTotalCost)) {
             enforcer.putOutputPropertiesMap(newOutputProperty, newOutputProperty);
         }
-        groupExpression.getOwnerGroup().setBestPlan(enforcer, curTotalCost, newOutputProperty, false);
+        groupExpression.getOwnerGroup().setBestPlan(enforcer, curTotalCost, newOutputProperty);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/RequestPropertyDeriver.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/RequestPropertyDeriver.java
@@ -129,7 +129,19 @@ public class RequestPropertyDeriver extends PlanVisitor<Void, PlanContext> {
         // for shuffle join
         if (JoinUtils.couldShuffle(hashJoin)) {
             Pair<List<ExprId>, List<ExprId>> onClauseUsedSlots = JoinUtils.getOnClauseUsedSlots(hashJoin);
-            // other shuffle join
+            // colocate join
+            addToRequestPropertyToChildren(
+                    PhysicalProperties.createHash(
+                            new DistributionSpecHash(onClauseUsedSlots.first, ShuffleType.NATURAL)),
+                    PhysicalProperties.createHash(
+                            new DistributionSpecHash(onClauseUsedSlots.second, ShuffleType.NATURAL)));
+            // bucket shuffle join
+            addToRequestPropertyToChildren(
+                    PhysicalProperties.createHash(
+                            new DistributionSpecHash(onClauseUsedSlots.first, ShuffleType.BUCKET)),
+                    PhysicalProperties.createHash(
+                            new DistributionSpecHash(onClauseUsedSlots.second, ShuffleType.JOIN)));
+            // shuffle join
             addToRequestPropertyToChildren(
                     PhysicalProperties.createHash(
                             new DistributionSpecHash(onClauseUsedSlots.first, ShuffleType.JOIN)),

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/RequestPropertyDeriver.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/RequestPropertyDeriver.java
@@ -130,6 +130,7 @@ public class RequestPropertyDeriver extends PlanVisitor<Void, PlanContext> {
         if (JoinUtils.couldShuffle(hashJoin)) {
             Pair<List<ExprId>, List<ExprId>> onClauseUsedSlots = JoinUtils.getOnClauseUsedSlots(hashJoin);
             // colocate join
+            // TODO need to check whether colocate join is illegal.
             addToRequestPropertyToChildren(
                     PhysicalProperties.createHash(
                             new DistributionSpecHash(onClauseUsedSlots.first, ShuffleType.NATURAL)),

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/RequestPropertyDeriver.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/RequestPropertyDeriver.java
@@ -129,25 +129,12 @@ public class RequestPropertyDeriver extends PlanVisitor<Void, PlanContext> {
         // for shuffle join
         if (JoinUtils.couldShuffle(hashJoin)) {
             Pair<List<ExprId>, List<ExprId>> onClauseUsedSlots = JoinUtils.getOnClauseUsedSlots(hashJoin);
-            // colocate join
-            // TODO need to check whether colocate join is illegal.
-            addToRequestPropertyToChildren(
-                    PhysicalProperties.createHash(
-                            new DistributionSpecHash(onClauseUsedSlots.first, ShuffleType.NATURAL)),
-                    PhysicalProperties.createHash(
-                            new DistributionSpecHash(onClauseUsedSlots.second, ShuffleType.NATURAL)));
-            // bucket shuffle join
-            addToRequestPropertyToChildren(
-                    PhysicalProperties.createHash(
-                            new DistributionSpecHash(onClauseUsedSlots.first, ShuffleType.BUCKETED)),
-                    PhysicalProperties.createHash(
-                            new DistributionSpecHash(onClauseUsedSlots.second, ShuffleType.FORCE_SHUFFLE)));
             // shuffle join
             addToRequestPropertyToChildren(
                     PhysicalProperties.createHash(
-                            new DistributionSpecHash(onClauseUsedSlots.first, ShuffleType.FORCE_SHUFFLE)),
+                            new DistributionSpecHash(onClauseUsedSlots.first, ShuffleType.JOIN)),
                     PhysicalProperties.createHash(
-                            new DistributionSpecHash(onClauseUsedSlots.second, ShuffleType.FORCE_SHUFFLE)));
+                            new DistributionSpecHash(onClauseUsedSlots.second, ShuffleType.JOIN)));
         }
 
         // for broadcast join

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/RequestPropertyDeriver.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/RequestPropertyDeriver.java
@@ -138,15 +138,15 @@ public class RequestPropertyDeriver extends PlanVisitor<Void, PlanContext> {
             // bucket shuffle join
             addToRequestPropertyToChildren(
                     PhysicalProperties.createHash(
-                            new DistributionSpecHash(onClauseUsedSlots.first, ShuffleType.BUCKET)),
+                            new DistributionSpecHash(onClauseUsedSlots.first, ShuffleType.BUCKETED)),
                     PhysicalProperties.createHash(
-                            new DistributionSpecHash(onClauseUsedSlots.second, ShuffleType.JOIN)));
+                            new DistributionSpecHash(onClauseUsedSlots.second, ShuffleType.FORCE_SHUFFLE)));
             // shuffle join
             addToRequestPropertyToChildren(
                     PhysicalProperties.createHash(
-                            new DistributionSpecHash(onClauseUsedSlots.first, ShuffleType.JOIN)),
+                            new DistributionSpecHash(onClauseUsedSlots.first, ShuffleType.FORCE_SHUFFLE)),
                     PhysicalProperties.createHash(
-                            new DistributionSpecHash(onClauseUsedSlots.second, ShuffleType.JOIN)));
+                            new DistributionSpecHash(onClauseUsedSlots.second, ShuffleType.FORCE_SHUFFLE)));
         }
 
         // for broadcast join

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/visitor/PlanVisitor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/visitor/PlanVisitor.java
@@ -39,6 +39,7 @@ import org.apache.doris.nereids.trees.plans.logical.LogicalSelectHint;
 import org.apache.doris.nereids.trees.plans.logical.LogicalSort;
 import org.apache.doris.nereids.trees.plans.logical.LogicalSubQueryAlias;
 import org.apache.doris.nereids.trees.plans.logical.LogicalTopN;
+import org.apache.doris.nereids.trees.plans.physical.AbstractPhysicalJoin;
 import org.apache.doris.nereids.trees.plans.physical.AbstractPhysicalSort;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalAggregate;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalAssertNumRows;
@@ -198,13 +199,17 @@ public abstract class PlanVisitor<R, C> {
         return visit(limit, context);
     }
 
+    public R visitAbstractPhysicalJoin(AbstractPhysicalJoin<? extends Plan, ? extends Plan> join, C context) {
+        return visit(join, context);
+    }
+
     public R visitPhysicalHashJoin(PhysicalHashJoin<? extends Plan, ? extends Plan> hashJoin, C context) {
-        return visit(hashJoin, context);
+        return visitAbstractPhysicalJoin(hashJoin, context);
     }
 
     public R visitPhysicalNestedLoopJoin(
             PhysicalNestedLoopJoin<? extends Plan, ? extends Plan> nestedLoopJoin, C context) {
-        return visit(nestedLoopJoin, context);
+        return visitAbstractPhysicalJoin(nestedLoopJoin, context);
     }
 
     public R visitPhysicalProject(PhysicalProject<? extends Plan> project, C context) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/util/JoinUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/util/JoinUtils.java
@@ -220,7 +220,7 @@ public class JoinUtils {
      */
     public static boolean shouldColocateJoin(AbstractPhysicalJoin<PhysicalPlan, PhysicalPlan> join) {
         if (ConnectContext.get() == null
-                ||ConnectContext.get().getSessionVariable().isDisableColocatePlan()) {
+                || ConnectContext.get().getSessionVariable().isDisableColocatePlan()) {
             return false;
         }
         DistributionSpec joinDistributionSpec = join.getPhysicalProperties().getDistributionSpec();
@@ -244,7 +244,7 @@ public class JoinUtils {
      */
     public static boolean shouldBucketShuffleJoin(AbstractPhysicalJoin<PhysicalPlan, PhysicalPlan> join) {
         if (ConnectContext.get() == null
-                ||!ConnectContext.get().getSessionVariable().isEnableBucketShuffleJoin()) {
+                || !ConnectContext.get().getSessionVariable().isEnableBucketShuffleJoin()) {
             return false;
         }
         DistributionSpec joinDistributionSpec = join.getPhysicalProperties().getDistributionSpec();
@@ -276,7 +276,7 @@ public class JoinUtils {
      */
     public static boolean couldColocateJoin(DistributionSpecHash leftHashSpec, DistributionSpecHash rightHashSpec) {
         if (ConnectContext.get() == null
-                ||ConnectContext.get().getSessionVariable().isDisableColocatePlan()) {
+                || ConnectContext.get().getSessionVariable().isDisableColocatePlan()) {
             return false;
         }
         if (leftHashSpec.getShuffleType() != ShuffleType.NATURAL

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/util/JoinUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/util/JoinUtils.java
@@ -269,6 +269,9 @@ public class JoinUtils {
         return joinDistributionSpec.satisfy(leftDistributionSpec);
     }
 
+    /**
+     * could do colocate join with left and right child distribution spec.
+     */
     public static boolean couldColocateJoin(DistributionSpecHash leftHashSpec, DistributionSpecHash rightHashSpec) {
         if (ConnectContext.get().getSessionVariable().isDisableColocatePlan()) {
             return false;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/util/JoinUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/util/JoinUtils.java
@@ -262,7 +262,7 @@ public class JoinUtils {
         // when we plan a bucket shuffle join, the left should not add a distribution enforce.
         // so its shuffle type should be NATURAL(olap scan node or result of colocate join / bucket shuffle join with
         // left child's shuffle type is also NATURAL), or be BUCKETED(result of join / agg).
-        if (leftHash.getShuffleType() != ShuffleType.BUCKETED || leftHash.getShuffleType() != ShuffleType.NATURAL) {
+        if (leftHash.getShuffleType() != ShuffleType.BUCKETED && leftHash.getShuffleType() != ShuffleType.NATURAL) {
             return false;
         }
         // there must use left as required and join as source.

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/util/JoinUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/util/JoinUtils.java
@@ -254,6 +254,13 @@ public class JoinUtils {
                 || !(rightDistributionSpec instanceof DistributionSpecHash)) {
             return false;
         }
+        DistributionSpecHash leftHash = (DistributionSpecHash) leftDistributionSpec;
+        // when we plan a bucket shuffle join, the left should not add a distribution enforce.
+        // so its shuffle type should be NATURAL(olap scan node or result of colocate join / bucket shuffle join with
+        // left child's shuffle type is also NATURAL), or be BUCKETED(result of join / agg).
+        if (leftHash.getShuffleType() != ShuffleType.BUCKETED || leftHash.getShuffleType() != ShuffleType.NATURAL) {
+            return false;
+        }
         // there must use left as required and join as source.
         // Because after property derive upper node's properties is contains lower node
         // if their properties are satisfy.

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/util/JoinUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/util/JoinUtils.java
@@ -219,7 +219,8 @@ public class JoinUtils {
      * return true if we should do colocate join when translate plan.
      */
     public static boolean shouldColocateJoin(AbstractPhysicalJoin<PhysicalPlan, PhysicalPlan> join) {
-        if (ConnectContext.get().getSessionVariable().isDisableColocatePlan()) {
+        if (ConnectContext.get() == null
+                ||ConnectContext.get().getSessionVariable().isDisableColocatePlan()) {
             return false;
         }
         DistributionSpec joinDistributionSpec = join.getPhysicalProperties().getDistributionSpec();
@@ -242,7 +243,8 @@ public class JoinUtils {
      * return true if we should do bucket shuffle join when translate plan.
      */
     public static boolean shouldBucketShuffleJoin(AbstractPhysicalJoin<PhysicalPlan, PhysicalPlan> join) {
-        if (!ConnectContext.get().getSessionVariable().isEnableBucketShuffleJoin()) {
+        if (ConnectContext.get() == null
+                ||!ConnectContext.get().getSessionVariable().isEnableBucketShuffleJoin()) {
             return false;
         }
         DistributionSpec joinDistributionSpec = join.getPhysicalProperties().getDistributionSpec();
@@ -273,7 +275,8 @@ public class JoinUtils {
      * could do colocate join with left and right child distribution spec.
      */
     public static boolean couldColocateJoin(DistributionSpecHash leftHashSpec, DistributionSpecHash rightHashSpec) {
-        if (ConnectContext.get().getSessionVariable().isDisableColocatePlan()) {
+        if (ConnectContext.get() == null
+                ||ConnectContext.get().getSessionVariable().isDisableColocatePlan()) {
             return false;
         }
         if (leftHashSpec.getShuffleType() != ShuffleType.NATURAL

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/postprocess/RuntimeFilterTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/postprocess/RuntimeFilterTest.java
@@ -29,13 +29,11 @@ import org.apache.doris.nereids.trees.plans.physical.RuntimeFilter;
 import org.apache.doris.nereids.util.PlanChecker;
 
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.Optional;
 
-@Disabled("disable this case until it do not relay on NereidsPlanner")
 public class RuntimeFilterTest extends SSBTestBase {
 
     @Override

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/postprocess/RuntimeFilterTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/postprocess/RuntimeFilterTest.java
@@ -29,11 +29,13 @@ import org.apache.doris.nereids.trees.plans.physical.RuntimeFilter;
 import org.apache.doris.nereids.util.PlanChecker;
 
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.Optional;
 
+@Disabled("disable this case until it do not relay on NereidsPlanner")
 public class RuntimeFilterTest extends SSBTestBase {
 
     @Override

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/properties/ChildOutputPropertyDeriverTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/properties/ChildOutputPropertyDeriverTest.java
@@ -182,7 +182,7 @@ public class ChildOutputPropertyDeriverTest {
         DistributionSpecHash actual = (DistributionSpecHash) result.getDistributionSpec();
         Assertions.assertEquals(ShuffleType.NATURAL, actual.getShuffleType());
         // check merged
-        Assertions.assertEquals(3, actual.getExprIdToEquivalenceSet().size());
+        Assertions.assertEquals(2, actual.getExprIdToEquivalenceSet().size());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/properties/ChildOutputPropertyDeriverTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/properties/ChildOutputPropertyDeriverTest.java
@@ -220,7 +220,7 @@ public class ChildOutputPropertyDeriverTest {
         Assertions.assertTrue(result.getOrderSpec().getOrderKeys().isEmpty());
         Assertions.assertTrue(result.getDistributionSpec() instanceof DistributionSpecHash);
         DistributionSpecHash actual = (DistributionSpecHash) result.getDistributionSpec();
-        Assertions.assertEquals(ShuffleType.JOIN, actual.getShuffleType());
+        Assertions.assertEquals(ShuffleType.FORCE_SHUFFLE, actual.getShuffleType());
         // check merged
         Assertions.assertEquals(3, actual.getExprIdToEquivalenceSet().size());
     }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/properties/ChildOutputPropertyDeriverTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/properties/ChildOutputPropertyDeriverTest.java
@@ -220,7 +220,7 @@ public class ChildOutputPropertyDeriverTest {
         Assertions.assertTrue(result.getOrderSpec().getOrderKeys().isEmpty());
         Assertions.assertTrue(result.getDistributionSpec() instanceof DistributionSpecHash);
         DistributionSpecHash actual = (DistributionSpecHash) result.getDistributionSpec();
-        Assertions.assertEquals(ShuffleType.FORCE_SHUFFLE, actual.getShuffleType());
+        Assertions.assertEquals(ShuffleType.JOIN, actual.getShuffleType());
         // check merged
         Assertions.assertEquals(3, actual.getExprIdToEquivalenceSet().size());
     }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/properties/ChildOutputPropertyDeriverTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/properties/ChildOutputPropertyDeriverTest.java
@@ -308,7 +308,7 @@ public class ChildOutputPropertyDeriverTest {
         Assertions.assertTrue(result.getOrderSpec().getOrderKeys().isEmpty());
         Assertions.assertTrue(result.getDistributionSpec() instanceof DistributionSpecHash);
         DistributionSpecHash actual = (DistributionSpecHash) result.getDistributionSpec();
-        Assertions.assertEquals(ShuffleType.BUCKETED, actual.getShuffleType());
+        Assertions.assertEquals(ShuffleType.ENFORCED, actual.getShuffleType());
         Assertions.assertEquals(Lists.newArrayList(partition).stream()
                         .map(SlotReference::getExprId).collect(Collectors.toList()),
                 actual.getOrderedShuffledColumns());

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/properties/ChildOutputPropertyDeriverTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/properties/ChildOutputPropertyDeriverTest.java
@@ -41,6 +41,7 @@ import org.apache.doris.nereids.trees.plans.physical.PhysicalTopN;
 import org.apache.doris.nereids.types.BigIntType;
 import org.apache.doris.nereids.types.IntegerType;
 import org.apache.doris.nereids.util.JoinUtils;
+import org.apache.doris.qe.ConnectContext;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
@@ -78,6 +79,13 @@ public class ChildOutputPropertyDeriverTest {
             @Mock
             ColocateTableIndex getCurrentColocateIndex() {
                 return colocateTableIndex;
+            }
+        };
+
+        new MockUp<ConnectContext>() {
+            @Mock
+            ConnectContext get() {
+                return new ConnectContext();
             }
         };
     }
@@ -199,7 +207,7 @@ public class ChildOutputPropertyDeriverTest {
         leftMap.put(new ExprId(1), 0);
         PhysicalProperties left = new PhysicalProperties(new DistributionSpecHash(
                 Lists.newArrayList(new ExprId(0)),
-                ShuffleType.NATURAL,
+                ShuffleType.ENFORCED,
                 0,
                 Sets.newHashSet(0L),
                 ImmutableList.of(Sets.newHashSet(new ExprId(0), new ExprId(1))),
@@ -208,7 +216,7 @@ public class ChildOutputPropertyDeriverTest {
 
         PhysicalProperties right = new PhysicalProperties(new DistributionSpecHash(
                 Lists.newArrayList(new ExprId(2)),
-                ShuffleType.NATURAL,
+                ShuffleType.ENFORCED,
                 1,
                 Sets.newHashSet(1L)
         ));
@@ -220,7 +228,7 @@ public class ChildOutputPropertyDeriverTest {
         Assertions.assertTrue(result.getOrderSpec().getOrderKeys().isEmpty());
         Assertions.assertTrue(result.getDistributionSpec() instanceof DistributionSpecHash);
         DistributionSpecHash actual = (DistributionSpecHash) result.getDistributionSpec();
-        Assertions.assertEquals(ShuffleType.JOIN, actual.getShuffleType());
+        Assertions.assertEquals(ShuffleType.BUCKETED, actual.getShuffleType());
         // check merged
         Assertions.assertEquals(3, actual.getExprIdToEquivalenceSet().size());
     }
@@ -300,7 +308,7 @@ public class ChildOutputPropertyDeriverTest {
         Assertions.assertTrue(result.getOrderSpec().getOrderKeys().isEmpty());
         Assertions.assertTrue(result.getDistributionSpec() instanceof DistributionSpecHash);
         DistributionSpecHash actual = (DistributionSpecHash) result.getDistributionSpec();
-        Assertions.assertEquals(ShuffleType.AGGREGATE, actual.getShuffleType());
+        Assertions.assertEquals(ShuffleType.BUCKETED, actual.getShuffleType());
         Assertions.assertEquals(Lists.newArrayList(partition).stream()
                         .map(SlotReference::getExprId).collect(Collectors.toList()),
                 actual.getOrderedShuffledColumns());

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/properties/DistributionSpecHashTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/properties/DistributionSpecHashTest.java
@@ -53,7 +53,7 @@ public class DistributionSpecHashTest {
         joinMap.put(new ExprId(5), 1);
         DistributionSpecHash join = new DistributionSpecHash(
                 Lists.newArrayList(new ExprId(1), new ExprId(5)),
-                ShuffleType.JOIN,
+                ShuffleType.FORCE_SHUFFLE,
                 1,
                 Sets.newHashSet(1L),
                 Lists.newArrayList(Sets.newHashSet(new ExprId(1), new ExprId(4)), Sets.newHashSet(new ExprId(3), new ExprId(5))),
@@ -82,9 +82,9 @@ public class DistributionSpecHashTest {
     @Test
     public void testSatisfyAny() {
         DistributionSpec required = DistributionSpecAny.INSTANCE;
-        DistributionSpecHash join = new DistributionSpecHash(Lists.newArrayList(), ShuffleType.JOIN);
+        DistributionSpecHash join = new DistributionSpecHash(Lists.newArrayList(), ShuffleType.FORCE_SHUFFLE);
         DistributionSpecHash aggregate = new DistributionSpecHash(Lists.newArrayList(), ShuffleType.AGGREGATE);
-        DistributionSpecHash enforce = new DistributionSpecHash(Lists.newArrayList(), ShuffleType.ENFORCE);
+        DistributionSpecHash enforce = new DistributionSpecHash(Lists.newArrayList(), ShuffleType.ENFORCED);
         DistributionSpecHash natural = new DistributionSpecHash(Lists.newArrayList(), ShuffleType.NATURAL);
 
         Assertions.assertTrue(join.satisfy(required));
@@ -95,9 +95,9 @@ public class DistributionSpecHashTest {
 
     @Test
     public void testNotSatisfyOther() {
-        DistributionSpecHash join = new DistributionSpecHash(Lists.newArrayList(), ShuffleType.JOIN);
+        DistributionSpecHash join = new DistributionSpecHash(Lists.newArrayList(), ShuffleType.FORCE_SHUFFLE);
         DistributionSpecHash aggregate = new DistributionSpecHash(Lists.newArrayList(), ShuffleType.AGGREGATE);
-        DistributionSpecHash enforce = new DistributionSpecHash(Lists.newArrayList(), ShuffleType.ENFORCE);
+        DistributionSpecHash enforce = new DistributionSpecHash(Lists.newArrayList(), ShuffleType.ENFORCED);
         DistributionSpecHash natural = new DistributionSpecHash(Lists.newArrayList(), ShuffleType.NATURAL);
 
         DistributionSpec gather = DistributionSpecGather.INSTANCE;
@@ -155,7 +155,7 @@ public class DistributionSpecHashTest {
 
         DistributionSpecHash join = new DistributionSpecHash(
                 Lists.newArrayList(new ExprId(1), new ExprId(2)),
-                ShuffleType.JOIN,
+                ShuffleType.FORCE_SHUFFLE,
                 1,
                 Sets.newHashSet(1L),
                 Lists.newArrayList(Sets.newHashSet(new ExprId(1)), Sets.newHashSet(new ExprId(2))),
@@ -164,7 +164,7 @@ public class DistributionSpecHashTest {
 
         DistributionSpecHash enforce = new DistributionSpecHash(
                 Lists.newArrayList(new ExprId(1), new ExprId(2)),
-                ShuffleType.ENFORCE,
+                ShuffleType.ENFORCED,
                 1,
                 Sets.newHashSet(1L),
                 Lists.newArrayList(Sets.newHashSet(new ExprId(1)), Sets.newHashSet(new ExprId(2))),
@@ -201,7 +201,7 @@ public class DistributionSpecHashTest {
         join1Map.put(new ExprId(3), 1);
         DistributionSpecHash join1 = new DistributionSpecHash(
                 Lists.newArrayList(new ExprId(0), new ExprId(2)),
-                ShuffleType.JOIN,
+                ShuffleType.FORCE_SHUFFLE,
                 0,
                 Sets.newHashSet(0L),
                 Lists.newArrayList(Sets.newHashSet(new ExprId(0), new ExprId(1)), Sets.newHashSet(new ExprId(2), new ExprId(3))),
@@ -213,7 +213,7 @@ public class DistributionSpecHashTest {
         join2Map.put(new ExprId(2), 1);
         DistributionSpecHash join2 = new DistributionSpecHash(
                 Lists.newArrayList(new ExprId(1), new ExprId(2)),
-                ShuffleType.JOIN,
+                ShuffleType.FORCE_SHUFFLE,
                 1,
                 Sets.newHashSet(1L),
                 Lists.newArrayList(Sets.newHashSet(new ExprId(1)), Sets.newHashSet(new ExprId(2))),
@@ -225,7 +225,7 @@ public class DistributionSpecHashTest {
         join3Map.put(new ExprId(1), 1);
         DistributionSpecHash join3 = new DistributionSpecHash(
                 Lists.newArrayList(new ExprId(2), new ExprId(1)),
-                ShuffleType.JOIN,
+                ShuffleType.FORCE_SHUFFLE,
                 1,
                 Sets.newHashSet(1L),
                 Lists.newArrayList(Sets.newHashSet(new ExprId(2)), Sets.newHashSet(new ExprId(1))),
@@ -243,7 +243,7 @@ public class DistributionSpecHashTest {
 
         DistributionSpecHash enforce = new DistributionSpecHash(
                 Lists.newArrayList(new ExprId(1), new ExprId(2)),
-                ShuffleType.ENFORCE,
+                ShuffleType.ENFORCED,
                 1,
                 Sets.newHashSet(1L),
                 Lists.newArrayList(Sets.newHashSet(new ExprId(1)), Sets.newHashSet(new ExprId(2))),
@@ -338,7 +338,7 @@ public class DistributionSpecHashTest {
 
         DistributionSpecHash enforce = new DistributionSpecHash(
                 Lists.newArrayList(new ExprId(1), new ExprId(2)),
-                ShuffleType.ENFORCE,
+                ShuffleType.ENFORCED,
                 1,
                 Sets.newHashSet(1L),
                 Lists.newArrayList(Sets.newHashSet(new ExprId(1)), Sets.newHashSet(new ExprId(2))),
@@ -347,7 +347,7 @@ public class DistributionSpecHashTest {
 
         DistributionSpecHash join = new DistributionSpecHash(
                 Lists.newArrayList(new ExprId(1), new ExprId(2)),
-                ShuffleType.JOIN,
+                ShuffleType.FORCE_SHUFFLE,
                 1,
                 Sets.newHashSet(1L),
                 Lists.newArrayList(Sets.newHashSet(new ExprId(1)), Sets.newHashSet(new ExprId(2))),
@@ -381,7 +381,7 @@ public class DistributionSpecHashTest {
         enforce1Map.put(new ExprId(3), 1);
         DistributionSpecHash enforce1 = new DistributionSpecHash(
                 Lists.newArrayList(new ExprId(0), new ExprId(2)),
-                ShuffleType.ENFORCE,
+                ShuffleType.ENFORCED,
                 0,
                 Sets.newHashSet(0L),
                 Lists.newArrayList(Sets.newHashSet(new ExprId(0), new ExprId(1)), Sets.newHashSet(new ExprId(2), new ExprId(3))),
@@ -393,7 +393,7 @@ public class DistributionSpecHashTest {
         enforce2Map.put(new ExprId(2), 1);
         DistributionSpecHash enforce2 = new DistributionSpecHash(
                 Lists.newArrayList(new ExprId(1), new ExprId(2)),
-                ShuffleType.ENFORCE,
+                ShuffleType.ENFORCED,
                 1,
                 Sets.newHashSet(1L),
                 Lists.newArrayList(Sets.newHashSet(new ExprId(1)), Sets.newHashSet(new ExprId(2))),
@@ -405,7 +405,7 @@ public class DistributionSpecHashTest {
         enforce3Map.put(new ExprId(1), 1);
         DistributionSpecHash enforce3 = new DistributionSpecHash(
                 Lists.newArrayList(new ExprId(2), new ExprId(1)),
-                ShuffleType.ENFORCE,
+                ShuffleType.ENFORCED,
                 1,
                 Sets.newHashSet(1L),
                 Lists.newArrayList(Sets.newHashSet(new ExprId(2)), Sets.newHashSet(new ExprId(1))),
@@ -414,7 +414,7 @@ public class DistributionSpecHashTest {
 
         DistributionSpecHash join = new DistributionSpecHash(
                 Lists.newArrayList(new ExprId(1), new ExprId(2)),
-                ShuffleType.JOIN,
+                ShuffleType.FORCE_SHUFFLE,
                 1,
                 Sets.newHashSet(1L),
                 Lists.newArrayList(Sets.newHashSet(new ExprId(1)), Sets.newHashSet(new ExprId(2))),
@@ -459,7 +459,7 @@ public class DistributionSpecHashTest {
         enforce1Map.put(new ExprId(2), 2);
         DistributionSpecHash enforce1 = new DistributionSpecHash(
                 Lists.newArrayList(new ExprId(0), new ExprId(1), new ExprId(2)),
-                ShuffleType.ENFORCE,
+                ShuffleType.ENFORCED,
                 0,
                 Sets.newHashSet(0L),
                 Lists.newArrayList(Sets.newHashSet(new ExprId(0)), Sets.newHashSet(new ExprId(1)), Sets.newHashSet(new ExprId(2))),
@@ -471,7 +471,7 @@ public class DistributionSpecHashTest {
         enforce2Map.put(new ExprId(1), 1);
         DistributionSpecHash enforce2 = new DistributionSpecHash(
                 Lists.newArrayList(new ExprId(0), new ExprId(1)),
-                ShuffleType.ENFORCE,
+                ShuffleType.ENFORCED,
                 1,
                 Sets.newHashSet(1L),
                 Lists.newArrayList(Sets.newHashSet(new ExprId(0)), Sets.newHashSet(new ExprId(1))),

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/properties/DistributionSpecHashTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/properties/DistributionSpecHashTest.java
@@ -53,7 +53,7 @@ public class DistributionSpecHashTest {
         joinMap.put(new ExprId(5), 1);
         DistributionSpecHash join = new DistributionSpecHash(
                 Lists.newArrayList(new ExprId(1), new ExprId(5)),
-                ShuffleType.FORCE_SHUFFLE,
+                ShuffleType.JOIN,
                 1,
                 Sets.newHashSet(1L),
                 Lists.newArrayList(Sets.newHashSet(new ExprId(1), new ExprId(4)), Sets.newHashSet(new ExprId(3), new ExprId(5))),
@@ -82,7 +82,7 @@ public class DistributionSpecHashTest {
     @Test
     public void testSatisfyAny() {
         DistributionSpec required = DistributionSpecAny.INSTANCE;
-        DistributionSpecHash join = new DistributionSpecHash(Lists.newArrayList(), ShuffleType.FORCE_SHUFFLE);
+        DistributionSpecHash join = new DistributionSpecHash(Lists.newArrayList(), ShuffleType.JOIN);
         DistributionSpecHash aggregate = new DistributionSpecHash(Lists.newArrayList(), ShuffleType.AGGREGATE);
         DistributionSpecHash enforce = new DistributionSpecHash(Lists.newArrayList(), ShuffleType.ENFORCED);
         DistributionSpecHash natural = new DistributionSpecHash(Lists.newArrayList(), ShuffleType.NATURAL);
@@ -95,7 +95,7 @@ public class DistributionSpecHashTest {
 
     @Test
     public void testNotSatisfyOther() {
-        DistributionSpecHash join = new DistributionSpecHash(Lists.newArrayList(), ShuffleType.FORCE_SHUFFLE);
+        DistributionSpecHash join = new DistributionSpecHash(Lists.newArrayList(), ShuffleType.JOIN);
         DistributionSpecHash aggregate = new DistributionSpecHash(Lists.newArrayList(), ShuffleType.AGGREGATE);
         DistributionSpecHash enforce = new DistributionSpecHash(Lists.newArrayList(), ShuffleType.ENFORCED);
         DistributionSpecHash natural = new DistributionSpecHash(Lists.newArrayList(), ShuffleType.NATURAL);
@@ -155,7 +155,7 @@ public class DistributionSpecHashTest {
 
         DistributionSpecHash join = new DistributionSpecHash(
                 Lists.newArrayList(new ExprId(1), new ExprId(2)),
-                ShuffleType.FORCE_SHUFFLE,
+                ShuffleType.JOIN,
                 1,
                 Sets.newHashSet(1L),
                 Lists.newArrayList(Sets.newHashSet(new ExprId(1)), Sets.newHashSet(new ExprId(2))),
@@ -201,7 +201,7 @@ public class DistributionSpecHashTest {
         join1Map.put(new ExprId(3), 1);
         DistributionSpecHash join1 = new DistributionSpecHash(
                 Lists.newArrayList(new ExprId(0), new ExprId(2)),
-                ShuffleType.FORCE_SHUFFLE,
+                ShuffleType.JOIN,
                 0,
                 Sets.newHashSet(0L),
                 Lists.newArrayList(Sets.newHashSet(new ExprId(0), new ExprId(1)), Sets.newHashSet(new ExprId(2), new ExprId(3))),
@@ -213,7 +213,7 @@ public class DistributionSpecHashTest {
         join2Map.put(new ExprId(2), 1);
         DistributionSpecHash join2 = new DistributionSpecHash(
                 Lists.newArrayList(new ExprId(1), new ExprId(2)),
-                ShuffleType.FORCE_SHUFFLE,
+                ShuffleType.JOIN,
                 1,
                 Sets.newHashSet(1L),
                 Lists.newArrayList(Sets.newHashSet(new ExprId(1)), Sets.newHashSet(new ExprId(2))),
@@ -225,7 +225,7 @@ public class DistributionSpecHashTest {
         join3Map.put(new ExprId(1), 1);
         DistributionSpecHash join3 = new DistributionSpecHash(
                 Lists.newArrayList(new ExprId(2), new ExprId(1)),
-                ShuffleType.FORCE_SHUFFLE,
+                ShuffleType.JOIN,
                 1,
                 Sets.newHashSet(1L),
                 Lists.newArrayList(Sets.newHashSet(new ExprId(2)), Sets.newHashSet(new ExprId(1))),
@@ -347,7 +347,7 @@ public class DistributionSpecHashTest {
 
         DistributionSpecHash join = new DistributionSpecHash(
                 Lists.newArrayList(new ExprId(1), new ExprId(2)),
-                ShuffleType.FORCE_SHUFFLE,
+                ShuffleType.JOIN,
                 1,
                 Sets.newHashSet(1L),
                 Lists.newArrayList(Sets.newHashSet(new ExprId(1)), Sets.newHashSet(new ExprId(2))),
@@ -414,7 +414,7 @@ public class DistributionSpecHashTest {
 
         DistributionSpecHash join = new DistributionSpecHash(
                 Lists.newArrayList(new ExprId(1), new ExprId(2)),
-                ShuffleType.FORCE_SHUFFLE,
+                ShuffleType.JOIN,
                 1,
                 Sets.newHashSet(1L),
                 Lists.newArrayList(Sets.newHashSet(new ExprId(1)), Sets.newHashSet(new ExprId(2))),

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/properties/DistributionSpecHashTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/properties/DistributionSpecHashTest.java
@@ -187,9 +187,9 @@ public class DistributionSpecHashTest {
         // require slots is not contained by target
         Assertions.assertFalse(natural2.satisfy(natural1));
         // other shuffle type with same order
-        Assertions.assertTrue(join.satisfy(natural2));
-        Assertions.assertTrue(aggregate.satisfy(natural2));
-        Assertions.assertTrue(enforce.satisfy(natural2));
+        Assertions.assertFalse(join.satisfy(natural2));
+        Assertions.assertFalse(aggregate.satisfy(natural2));
+        Assertions.assertFalse(enforce.satisfy(natural2));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/properties/DistributionSpecTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/properties/DistributionSpecTest.java
@@ -30,7 +30,7 @@ public class DistributionSpecTest {
         DistributionSpec replicated = DistributionSpecReplicated.INSTANCE;
         DistributionSpec any = DistributionSpecAny.INSTANCE;
         DistributionSpec gather = DistributionSpecGather.INSTANCE;
-        DistributionSpec hash = new DistributionSpecHash(Lists.newArrayList(), ShuffleType.JOIN);
+        DistributionSpec hash = new DistributionSpecHash(Lists.newArrayList(), ShuffleType.FORCE_SHUFFLE);
 
         Assertions.assertTrue(replicated.satisfy(any));
         Assertions.assertTrue(gather.satisfy(any));

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/properties/DistributionSpecTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/properties/DistributionSpecTest.java
@@ -30,7 +30,7 @@ public class DistributionSpecTest {
         DistributionSpec replicated = DistributionSpecReplicated.INSTANCE;
         DistributionSpec any = DistributionSpecAny.INSTANCE;
         DistributionSpec gather = DistributionSpecGather.INSTANCE;
-        DistributionSpec hash = new DistributionSpecHash(Lists.newArrayList(), ShuffleType.FORCE_SHUFFLE);
+        DistributionSpec hash = new DistributionSpecHash(Lists.newArrayList(), ShuffleType.JOIN);
 
         Assertions.assertTrue(replicated.satisfy(any));
         Assertions.assertTrue(gather.satisfy(any));

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/properties/RequestPropertyDeriverTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/properties/RequestPropertyDeriverTest.java
@@ -129,11 +129,11 @@ public class RequestPropertyDeriverTest {
                 = requestPropertyDeriver.getRequestChildrenPropertyList(groupExpression);
 
         List<List<PhysicalProperties>> expected = Lists.newArrayList();
+        expected.add(Lists.newArrayList(PhysicalProperties.ANY, PhysicalProperties.REPLICATED));
         expected.add(Lists.newArrayList(
                 new PhysicalProperties(new DistributionSpecHash(Lists.newArrayList(new ExprId(0)), ShuffleType.JOIN)),
                 new PhysicalProperties(new DistributionSpecHash(Lists.newArrayList(new ExprId(1)), ShuffleType.JOIN))
         ));
-        expected.add(Lists.newArrayList(PhysicalProperties.ANY, PhysicalProperties.REPLICATED));
         Assertions.assertEquals(expected, actual);
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/properties/RequestPropertyDeriverTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/properties/RequestPropertyDeriverTest.java
@@ -104,8 +104,8 @@ public class RequestPropertyDeriverTest {
 
         List<List<PhysicalProperties>> expected = Lists.newArrayList();
         expected.add(Lists.newArrayList(
-                new PhysicalProperties(new DistributionSpecHash(Lists.newArrayList(new ExprId(0)), ShuffleType.JOIN)),
-                new PhysicalProperties(new DistributionSpecHash(Lists.newArrayList(new ExprId(1)), ShuffleType.JOIN))
+                new PhysicalProperties(new DistributionSpecHash(Lists.newArrayList(new ExprId(0)), ShuffleType.FORCE_SHUFFLE)),
+                new PhysicalProperties(new DistributionSpecHash(Lists.newArrayList(new ExprId(1)), ShuffleType.FORCE_SHUFFLE))
         ));
         Assertions.assertEquals(expected, actual);
     }
@@ -130,8 +130,8 @@ public class RequestPropertyDeriverTest {
 
         List<List<PhysicalProperties>> expected = Lists.newArrayList();
         expected.add(Lists.newArrayList(
-                new PhysicalProperties(new DistributionSpecHash(Lists.newArrayList(new ExprId(0)), ShuffleType.JOIN)),
-                new PhysicalProperties(new DistributionSpecHash(Lists.newArrayList(new ExprId(1)), ShuffleType.JOIN))
+                new PhysicalProperties(new DistributionSpecHash(Lists.newArrayList(new ExprId(0)), ShuffleType.FORCE_SHUFFLE)),
+                new PhysicalProperties(new DistributionSpecHash(Lists.newArrayList(new ExprId(1)), ShuffleType.FORCE_SHUFFLE))
         ));
         expected.add(Lists.newArrayList(PhysicalProperties.ANY, PhysicalProperties.REPLICATED));
         Assertions.assertEquals(expected, actual);

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/properties/RequestPropertyDeriverTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/properties/RequestPropertyDeriverTest.java
@@ -104,8 +104,8 @@ public class RequestPropertyDeriverTest {
 
         List<List<PhysicalProperties>> expected = Lists.newArrayList();
         expected.add(Lists.newArrayList(
-                new PhysicalProperties(new DistributionSpecHash(Lists.newArrayList(new ExprId(0)), ShuffleType.FORCE_SHUFFLE)),
-                new PhysicalProperties(new DistributionSpecHash(Lists.newArrayList(new ExprId(1)), ShuffleType.FORCE_SHUFFLE))
+                new PhysicalProperties(new DistributionSpecHash(Lists.newArrayList(new ExprId(0)), ShuffleType.JOIN)),
+                new PhysicalProperties(new DistributionSpecHash(Lists.newArrayList(new ExprId(1)), ShuffleType.JOIN))
         ));
         Assertions.assertEquals(expected, actual);
     }
@@ -130,8 +130,8 @@ public class RequestPropertyDeriverTest {
 
         List<List<PhysicalProperties>> expected = Lists.newArrayList();
         expected.add(Lists.newArrayList(
-                new PhysicalProperties(new DistributionSpecHash(Lists.newArrayList(new ExprId(0)), ShuffleType.FORCE_SHUFFLE)),
-                new PhysicalProperties(new DistributionSpecHash(Lists.newArrayList(new ExprId(1)), ShuffleType.FORCE_SHUFFLE))
+                new PhysicalProperties(new DistributionSpecHash(Lists.newArrayList(new ExprId(0)), ShuffleType.JOIN)),
+                new PhysicalProperties(new DistributionSpecHash(Lists.newArrayList(new ExprId(1)), ShuffleType.JOIN))
         ));
         expected.add(Lists.newArrayList(PhysicalProperties.ANY, PhysicalProperties.REPLICATED));
         Assertions.assertEquals(expected, actual);

--- a/regression-test/suites/tpch_sf1_p1/tpch_sf1/nereids/q1.groovy
+++ b/regression-test/suites/tpch_sf1_p1/tpch_sf1/nereids/q1.groovy
@@ -25,10 +25,7 @@ suite("tpch_sf1_q1_nereids") {
     sql "use ${realDb}"
 
     sql 'set enable_nereids_planner=true'
-
-    sql 'set disable_colocate_plan=true'
-
-    sql 'set enable_bucket_shuffle_join=false'
+    sql 'set enable_fallback_to_original_planner=false'
 
     qt_select """
     select

--- a/regression-test/suites/tpch_sf1_p1/tpch_sf1/nereids/q10.groovy
+++ b/regression-test/suites/tpch_sf1_p1/tpch_sf1/nereids/q10.groovy
@@ -25,9 +25,8 @@ suite("tpch_sf1_q10_nereids") {
     sql "use ${realDb}"
 
     sql 'set enable_nereids_planner=true'
-    sql 'set disable_colocate_plan=true'
+    sql 'set enable_fallback_to_original_planner=false'
 
-    sql 'set enable_bucket_shuffle_join=false'
     qt_select """
     select
         c_custkey,

--- a/regression-test/suites/tpch_sf1_p1/tpch_sf1/nereids/q11.groovy
+++ b/regression-test/suites/tpch_sf1_p1/tpch_sf1/nereids/q11.groovy
@@ -25,9 +25,8 @@ suite("tpch_sf1_q11_nereids") {
     sql "use ${realDb}"
 
     sql 'set enable_nereids_planner=true'
-    sql 'set disable_colocate_plan=true'
+    sql 'set enable_fallback_to_original_planner=false'
 
-    sql 'set enable_bucket_shuffle_join=false'
     qt_select """
     select
         ps_partkey,

--- a/regression-test/suites/tpch_sf1_p1/tpch_sf1/nereids/q12.groovy
+++ b/regression-test/suites/tpch_sf1_p1/tpch_sf1/nereids/q12.groovy
@@ -25,9 +25,8 @@ suite("tpch_sf1_q12_nereids") {
     sql "use ${realDb}"
 
     sql 'set enable_nereids_planner=true'
-    sql 'set disable_colocate_plan=true'
+    sql 'set enable_fallback_to_original_planner=false'
 
-    sql 'set enable_bucket_shuffle_join=false'
     qt_select """
     select
         l_shipmode,

--- a/regression-test/suites/tpch_sf1_p1/tpch_sf1/nereids/q13.groovy
+++ b/regression-test/suites/tpch_sf1_p1/tpch_sf1/nereids/q13.groovy
@@ -25,9 +25,8 @@ suite("tpch_sf1_q13_nereids") {
     sql "use ${realDb}"
 
     sql 'set enable_nereids_planner=true'
-    sql 'set disable_colocate_plan=true'
+    sql 'set enable_fallback_to_original_planner=false'
 
-    sql 'set enable_bucket_shuffle_join=false'
     qt_select """
     select
         c_count,

--- a/regression-test/suites/tpch_sf1_p1/tpch_sf1/nereids/q14.groovy
+++ b/regression-test/suites/tpch_sf1_p1/tpch_sf1/nereids/q14.groovy
@@ -25,9 +25,7 @@ suite("tpch_sf1_q14_nereids") {
     sql "use ${realDb}"
 
     sql 'set enable_nereids_planner=true'
-    sql 'set disable_colocate_plan=true'
-
-    sql 'set enable_bucket_shuffle_join=false'
+    sql 'set enable_fallback_to_original_planner=false'
 
     qt_select """
 select

--- a/regression-test/suites/tpch_sf1_p1/tpch_sf1/nereids/q15.groovy
+++ b/regression-test/suites/tpch_sf1_p1/tpch_sf1/nereids/q15.groovy
@@ -25,9 +25,7 @@ suite("tpch_sf1_q15_nereids") {
     sql "use ${realDb}"
 
     sql 'set enable_nereids_planner=true'
-    sql 'set disable_colocate_plan=true'
 
-    sql 'set enable_bucket_shuffle_join=false'
     sql  """
     drop view if exists revenue0;
     """
@@ -45,6 +43,8 @@ suite("tpch_sf1_q15_nereids") {
     group by
         l_suppkey;
     """
+
+    sql 'set enable_fallback_to_original_planner=false'
 
     qt_select """
     select

--- a/regression-test/suites/tpch_sf1_p1/tpch_sf1/nereids/q16.groovy
+++ b/regression-test/suites/tpch_sf1_p1/tpch_sf1/nereids/q16.groovy
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-suite("tpch_sf1_q15_nereids") {
+suite("tpch_sf1_q16_nereids") {
     String realDb = context.config.getDbNameByFile(context.file)
     // get parent directory's group
     realDb = realDb.substring(0, realDb.lastIndexOf("_"))
@@ -25,9 +25,7 @@ suite("tpch_sf1_q15_nereids") {
     sql "use ${realDb}"
 
     sql 'set enable_nereids_planner=true'
-    sql 'set disable_colocate_plan=true'
-
-    sql 'set enable_bucket_shuffle_join=false'
+    sql 'set enable_fallback_to_original_planner=false'
 
     qt_select """
 select

--- a/regression-test/suites/tpch_sf1_p1/tpch_sf1/nereids/q17.groovy
+++ b/regression-test/suites/tpch_sf1_p1/tpch_sf1/nereids/q17.groovy
@@ -25,9 +25,7 @@ suite("tpch_sf1_q17_nereids") {
     sql "use ${realDb}"
 
     sql 'set enable_nereids_planner=true'
-    sql 'set disable_colocate_plan=true'
-
-    sql 'set enable_bucket_shuffle_join=false'
+    sql 'set enable_fallback_to_original_planner=false'
 
     qt_select """
     select
@@ -53,7 +51,7 @@ suite("tpch_sf1_q17_nereids") {
     select /*+SET_VAR(exec_mem_limit=8589934592, parallel_fragment_exec_instance_num=1, enable_vectorized_engine=true, batch_size=4096, disable_join_reorder=false, enable_cost_based_join_reorder=true, enable_projection=true) */
         sum(l_extendedprice) / 7.0 as avg_yearly
     from
-        lineitem join [broadcast]
+        lineitem join
         part p1 on p1.p_partkey = l_partkey
     where
         p1.p_brand = 'Brand#23'
@@ -62,7 +60,7 @@ suite("tpch_sf1_q17_nereids") {
             select
                 0.2 * avg(l_quantity)
             from
-                lineitem join [broadcast]
+                lineitem join
                 part p2 on p2.p_partkey = l_partkey
             where
                 l_partkey = p1.p_partkey

--- a/regression-test/suites/tpch_sf1_p1/tpch_sf1/nereids/q18.groovy
+++ b/regression-test/suites/tpch_sf1_p1/tpch_sf1/nereids/q18.groovy
@@ -25,46 +25,45 @@ suite("tpch_sf1_q18_nereids") {
     sql "use ${realDb}"
 
     sql 'set enable_nereids_planner=true'
-    sql 'set disable_colocate_plan=true'
+    sql 'set enable_fallback_to_original_planner=false'
 
-    sql 'set enable_bucket_shuffle_join=false'
-    qt_select """
-select
-    c_name,
-    c_custkey,
-    o_orderkey,
-    o_orderdate,
-    o_totalprice,
-    sum(l_quantity)
-from
-    customer,
-    orders,
-    lineitem
-where
-    o_orderkey in (
-        select
-            l_orderkey
-        from
-            lineitem
-        group by
-            l_orderkey having
-                sum(l_quantity) > 300
-    )
-    and c_custkey = o_custkey
-    and o_orderkey = l_orderkey
-group by
-    c_name,
-    c_custkey,
-    o_orderkey,
-    o_orderdate,
-    o_totalprice
-order by
-    o_totalprice desc,
-    o_orderdate
-limit 100;
-    """
+//     qt_select """
+// select
+//     c_name,
+//     c_custkey,
+//     o_orderkey,
+//     o_orderdate,
+//     o_totalprice,
+//     sum(l_quantity)
+// from
+//     customer,
+//     orders,
+//     lineitem
+// where
+//     o_orderkey in (
+//         select
+//             l_orderkey
+//         from
+//             lineitem
+//         group by
+//             l_orderkey having
+//                 sum(l_quantity) > 300
+//     )
+//     and c_custkey = o_custkey
+//     and o_orderkey = l_orderkey
+// group by
+//     c_name,
+//     c_custkey,
+//     o_orderkey,
+//     o_orderdate,
+//     o_totalprice
+// order by
+//     o_totalprice desc,
+//     o_orderdate
+// limit 100;
+//     """
 
-    qt_select """
+     qt_select """
 select /*+SET_VAR(exec_mem_limit=8589934592, parallel_fragment_exec_instance_num=16, enable_vectorized_engine=true, batch_size=4096, disable_join_reorder=true, enable_cost_based_join_reorder=true, enable_projection=true) */
     c_name,
     c_custkey,
@@ -103,7 +102,7 @@ order by
     t3.o_totalprice desc,
     t3.o_orderdate
 limit 100;
-
-    """
-
+ 
+     """
 }
+

--- a/regression-test/suites/tpch_sf1_p1/tpch_sf1/nereids/q19.groovy
+++ b/regression-test/suites/tpch_sf1_p1/tpch_sf1/nereids/q19.groovy
@@ -25,9 +25,8 @@ suite("tpch_sf1_q19_nereids") {
     sql "use ${realDb}"
 
     sql 'set enable_nereids_planner=true'
-    sql 'set disable_colocate_plan=true'
+    sql 'set enable_fallback_to_original_planner=false'
 
-    sql 'set enable_bucket_shuffle_join=false'
     qt_select """
 select
     sum(l_extendedprice* (1 - l_discount)) as revenue

--- a/regression-test/suites/tpch_sf1_p1/tpch_sf1/nereids/q20.groovy
+++ b/regression-test/suites/tpch_sf1_p1/tpch_sf1/nereids/q20.groovy
@@ -25,9 +25,8 @@ suite("tpch_sf1_q20_nereids") {
     sql "use ${realDb}"
 
     sql 'set enable_nereids_planner=true'
-    sql 'set disable_colocate_plan=true'
+    sql 'set enable_fallback_to_original_planner=false'
 
-    sql 'set enable_bucket_shuffle_join=false'
     qt_select """
 select
     s_name,

--- a/regression-test/suites/tpch_sf1_p1/tpch_sf1/nereids/q21.groovy
+++ b/regression-test/suites/tpch_sf1_p1/tpch_sf1/nereids/q21.groovy
@@ -25,9 +25,8 @@ suite("tpch_sf1_q21_nereids") {
     sql "use ${realDb}"
 
     sql 'set enable_nereids_planner=true'
-    sql 'set disable_colocate_plan=true'
+    sql 'set enable_fallback_to_original_planner=false'
 
-    sql 'set enable_bucket_shuffle_join=false'
     qt_select """
 select
     s_name,

--- a/regression-test/suites/tpch_sf1_p1/tpch_sf1/nereids/q22.groovy
+++ b/regression-test/suites/tpch_sf1_p1/tpch_sf1/nereids/q22.groovy
@@ -25,9 +25,8 @@ suite("tpch_sf1_q22_nereids") {
     sql "use ${realDb}"
 
     sql 'set enable_nereids_planner=true'
-    sql 'set disable_colocate_plan=true'
+    sql 'set enable_fallback_to_original_planner=false'
 
-    sql 'set enable_bucket_shuffle_join=false'
     qt_select """
 select
     cntrycode,

--- a/regression-test/suites/tpch_sf1_p1/tpch_sf1/nereids/q3.groovy
+++ b/regression-test/suites/tpch_sf1_p1/tpch_sf1/nereids/q3.groovy
@@ -25,8 +25,7 @@ suite("tpch_sf1_q3_nereids") {
     sql "use ${realDb}"
 
     sql 'set enable_nereids_planner=true'
-    sql 'set disable_colocate_plan=true'
-    sql 'set enable_bucket_shuffle_join=false'
+    sql 'set enable_fallback_to_original_planner=false'
 
     qt_select """
     select

--- a/regression-test/suites/tpch_sf1_p1/tpch_sf1/nereids/q4.groovy
+++ b/regression-test/suites/tpch_sf1_p1/tpch_sf1/nereids/q4.groovy
@@ -25,9 +25,7 @@ suite("tpch_sf1_q4_nereids") {
     sql "use ${realDb}"
 
     sql 'set enable_nereids_planner=true'
-    sql 'set disable_colocate_plan=true'
-
-    sql 'set enable_bucket_shuffle_join=false'
+    sql 'set enable_fallback_to_original_planner=false'
 
     qt_select """
     select

--- a/regression-test/suites/tpch_sf1_p1/tpch_sf1/nereids/q5.groovy
+++ b/regression-test/suites/tpch_sf1_p1/tpch_sf1/nereids/q5.groovy
@@ -25,9 +25,8 @@ suite("tpch_sf1_q5_nereids") {
     sql "use ${realDb}"
 
     sql 'set enable_nereids_planner=true'
-    sql 'set disable_colocate_plan=true'
+    sql 'set enable_fallback_to_original_planner=false'
 
-    sql 'set enable_bucket_shuffle_join=false'
     qt_select """
     select
         n_name,

--- a/regression-test/suites/tpch_sf1_p1/tpch_sf1/nereids/q6.groovy
+++ b/regression-test/suites/tpch_sf1_p1/tpch_sf1/nereids/q6.groovy
@@ -25,9 +25,8 @@ suite("tpch_sf1_q6_nereids") {
     sql "use ${realDb}"
 
     sql 'set enable_nereids_planner=true'
-    sql 'set disable_colocate_plan=true'
+    sql 'set enable_fallback_to_original_planner=false'
 
-    sql 'set enable_bucket_shuffle_join=false'
     qt_select """
     select
         sum(l_extendedprice * l_discount) as revenue

--- a/regression-test/suites/tpch_sf1_p1/tpch_sf1/nereids/q7.groovy
+++ b/regression-test/suites/tpch_sf1_p1/tpch_sf1/nereids/q7.groovy
@@ -25,9 +25,8 @@ suite("tpch_sf1_q7_nereids") {
     sql "use ${realDb}"
 
     sql 'set enable_nereids_planner=true'
-    sql 'set disable_colocate_plan=true'
+    sql 'set enable_fallback_to_original_planner=false'
 
-    sql 'set enable_bucket_shuffle_join=false'
     qt_select """
     select
         supp_nation,

--- a/regression-test/suites/tpch_sf1_p1/tpch_sf1/nereids/q8.groovy
+++ b/regression-test/suites/tpch_sf1_p1/tpch_sf1/nereids/q8.groovy
@@ -25,10 +25,7 @@ suite("tpch_sf1_q8_nereids") {
     sql "use ${realDb}"
 
     sql 'set enable_nereids_planner=true'
-
-    sql 'set disable_colocate_plan=true'
-
-    sql 'set enable_bucket_shuffle_join=false'
+    sql 'set enable_fallback_to_original_planner=false'
 
     qt_select """
 select

--- a/regression-test/suites/tpch_sf1_p1/tpch_sf1/nereids/q9.groovy
+++ b/regression-test/suites/tpch_sf1_p1/tpch_sf1/nereids/q9.groovy
@@ -25,9 +25,8 @@ suite("tpch_sf1_q9_nereids") {
     sql "use ${realDb}"
 
     sql 'set enable_nereids_planner=true'
-    sql 'set disable_colocate_plan=true'
+    sql 'set enable_fallback_to_original_planner=false'
 
-    sql 'set enable_bucket_shuffle_join=false'
     qt_select """
     select
         nation,
@@ -76,10 +75,10 @@ suite("tpch_sf1_q9_nereids") {
                 l_extendedprice * (1 - l_discount) - ps_supplycost * l_quantity as amount
             from
                 lineitem join orders on o_orderkey = l_orderkey
-                join[shuffle] part on p_partkey = l_partkey
-                join[shuffle] partsupp on ps_partkey = l_partkey
-                join[shuffle] supplier on s_suppkey = l_suppkey
-                join[broadcast] nation on s_nationkey = n_nationkey
+                join part on p_partkey = l_partkey
+                join partsupp on ps_partkey = l_partkey
+                join supplier on s_suppkey = l_suppkey
+                join nation on s_nationkey = n_nationkey
             where
                 ps_suppkey = l_suppkey and 
                 p_name like '%green%'


### PR DESCRIPTION
# Proposed changes

In an earlier PR #11976 , we add shuffle join and bucket shuffle support. But if join's right child's distribution spec satisfied join's require, we do not add distribute on right child. Instead of, do it in plan translator.
It is hard to calculate accurate cost in this way, since we some distribute cost do not calculated.
In this PR, we introduce a new shuffle type BUCKET, and change the way of add enforce to ensure all necessary distribute will be added in cost and enforcer job.

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

