### PR TITLE
[fix](Nereids) column prune generate empty project list on join's child

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/logical/PruneAggChildColumns.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/logical/PruneAggChildColumns.java
@@ -26,6 +26,7 @@ import org.apache.doris.nereids.trees.expressions.SlotReference;
 import org.apache.doris.nereids.trees.plans.GroupPlan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalAggregate;
 import org.apache.doris.nereids.trees.plans.logical.LogicalProject;
+import org.apache.doris.nereids.util.ExpressionUtils;
 
 import com.google.common.collect.ImmutableList;
 
@@ -56,7 +57,7 @@ public class PruneAggChildColumns extends OneRewriteRuleFactory {
         return RuleType.COLUMN_PRUNE_AGGREGATION_CHILD.build(logicalAggregate().then(agg -> {
             List<Slot> childOutput = agg.child().getOutput();
             if (isAggregateWithConstant(agg)) {
-                Slot slot = selectMinimumColumn(childOutput);
+                Slot slot = ExpressionUtils.selectMinimumColumn(childOutput);
                 if (childOutput.size() == 1 && childOutput.get(0).equals(slot)) {
                     return agg;
                 }
@@ -85,18 +86,5 @@ public class PruneAggChildColumns extends OneRewriteRuleFactory {
             }
         }
         return true;
-    }
-
-    private Slot selectMinimumColumn(List<Slot> outputList) {
-        Slot minSlot = null;
-        for (Slot slot : outputList) {
-            if (minSlot == null) {
-                minSlot = slot;
-            } else {
-                int slotDataTypeWidth = slot.getDataType().width();
-                minSlot = minSlot.getDataType().width() > slotDataTypeWidth ? slot : minSlot;
-            }
-        }
-        return minSlot;
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/logical/PruneJoinChildrenColumns.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/logical/PruneJoinChildrenColumns.java
@@ -81,7 +81,7 @@ public class PruneJoinChildrenColumns
             leftInputs.add(ExpressionUtils.selectMinimumColumn(joinPlan.left().getOutput()));
         }
         if (rightInputs.isEmpty()) {
-            rightInputs.add(ExpressionUtils.selectMinimumColumn(joinPlan.left().getOutput()));
+            rightInputs.add(ExpressionUtils.selectMinimumColumn(joinPlan.right().getOutput()));
         }
 
         Plan leftPlan = joinPlan.left();

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/logical/PruneJoinChildrenColumns.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/logical/PruneJoinChildrenColumns.java
@@ -25,6 +25,7 @@ import org.apache.doris.nereids.trees.plans.GroupPlan;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalJoin;
 import org.apache.doris.nereids.trees.plans.logical.LogicalProject;
+import org.apache.doris.nereids.util.ExpressionUtils;
 
 import com.google.common.collect.ImmutableList;
 
@@ -75,6 +76,13 @@ public class PruneJoinChildrenColumns
                 .filter(r -> exprIds.contains(r.getExprId())).collect(Collectors.toList());
         List<NamedExpression> rightInputs = joinPlan.right().getOutput().stream()
                 .filter(r -> exprIds.contains(r.getExprId())).collect(Collectors.toList());
+
+        if (leftInputs.isEmpty()) {
+            leftInputs.add(ExpressionUtils.selectMinimumColumn(joinPlan.left().getOutput()));
+        }
+        if (rightInputs.isEmpty()) {
+            rightInputs.add(ExpressionUtils.selectMinimumColumn(joinPlan.left().getOutput()));
+        }
 
         Plan leftPlan = joinPlan.left();
         Plan rightPlan = joinPlan.right();

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/util/ExpressionUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/util/ExpressionUtils.java
@@ -21,6 +21,7 @@ import org.apache.doris.nereids.trees.expressions.And;
 import org.apache.doris.nereids.trees.expressions.CompoundPredicate;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.Or;
+import org.apache.doris.nereids.trees.expressions.Slot;
 import org.apache.doris.nereids.trees.expressions.SlotReference;
 import org.apache.doris.nereids.trees.expressions.literal.BooleanLiteral;
 
@@ -141,5 +142,21 @@ public class ExpressionUtils {
             }
         }
         return false;
+    }
+
+    /**
+     * Choose the minimum slot from input parameter.
+     */
+    public static Slot selectMinimumColumn(List<Slot> slots) {
+        Slot minSlot = null;
+        for (Slot slot : slots) {
+            if (minSlot == null) {
+                minSlot = slot;
+            } else {
+                int slotDataTypeWidth = slot.getDataType().width();
+                minSlot = minSlot.getDataType().width() > slotDataTypeWidth ? slot : minSlot;
+            }
+        }
+        return minSlot;
     }
 }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

When we do cross join and project on it only has one side of its child, we will generate a empty project on its child and lead be core dump. This PR fix this problem.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [x] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

