### PR TITLE
[bugfix](odbc) escape identifiers for sqlserver and postgresql

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/OdbcTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/OdbcTable.java
@@ -76,10 +76,22 @@ public class OdbcTable extends Table {
         return "`" + name + "`";
     }
 
+    private static String mssqlProperName(String name) {
+        return "[" + name + "]";
+    }
+
+    private static String psqlProperName(String name) {
+        return "\"" + name + "\"";
+    }
+
     public static String databaseProperName(TOdbcTableType tableType, String name) {
         switch (tableType) {
             case MYSQL:
                 return mysqlProperName(name);
+            case SQLSERVER:
+                return mssqlProperName(name);
+            case POSTGRESQL:
+                return psqlProperName(name);
             default:
                 return name;
         }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

Delimited identifier format for sqlserver and postgresql is different from MySQL.
Sqlserver use brackets ([ ]) and postgresql use double quotes("").

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

