### PR TITLE
[improvement](new-scan) avoid too many scanner context scheduling

### DIFF
--- a/be/src/vec/exec/scan/scanner_context.h
+++ b/be/src/vec/exec/scan/scanner_context.h
@@ -136,7 +136,6 @@ private:
         return _cur_bytes_in_queue < _max_bytes_in_queue / 2;
     }
 
-
 private:
     RuntimeState* _state;
     VScanNode* _parent;

--- a/be/src/vec/exec/scan/scanner_context.h
+++ b/be/src/vec/exec/scan/scanner_context.h
@@ -78,7 +78,7 @@ public:
 
     // When a scanner complete a scan, this method will be called
     // to return the scanner to the list for next scheduling.
-    void push_back_scanner_and_reschedule(ScannerScheduler* scheduler, VScanner* scanner);
+    void push_back_scanner_and_reschedule(VScanner* scanner);
 
     bool set_status_on_error(const Status& status);
 
@@ -110,7 +110,7 @@ public:
         _ctx_finish_cv.notify_one();
     }
 
-    bool get_next_batch_of_scanners(std::list<VScanner*>* current_run);
+    void get_next_batch_of_scanners(std::list<VScanner*>* current_run);
 
     void clear_and_join();
 
@@ -131,6 +131,11 @@ public:
 
 private:
     Status _close_and_clear_scanners();
+
+    inline bool _has_enough_space_in_blocks_queue() {
+        return _cur_bytes_in_queue < _max_bytes_in_queue / 2;
+    }
+
 
 private:
     RuntimeState* _state;

--- a/be/src/vec/exec/scan/scanner_scheduler.cpp
+++ b/be/src/vec/exec/scan/scanner_scheduler.cpp
@@ -98,17 +98,15 @@ void ScannerScheduler::_schedule_scanners(ScannerContext* ctx) {
     }
 
     std::list<VScanner*> this_run;
-    bool res = ctx->get_next_batch_of_scanners(&this_run);
+    ctx->get_next_batch_of_scanners(&this_run);
     if (this_run.empty()) {
-        if (!res) {
-            // This means we failed to choose scanners this time, and there may be no other scanners running.
-            // So we need to submit this ctx back to queue to be scheduled next time.
-            submit(ctx);
-        } else {
-            // No need to push back this ctx to reschedule
-            // There will be running scanners to push it back.
-            ctx->update_num_running(0, -1);
-        }
+        // There will be 2 cases when this_run is empty:
+        // 1. The blocks queue reaches limit.
+        //      The consumer will continue scheduling the ctx.
+        // 2. All scanners are running.
+        //      There running scanner will schedule the ctx after they are finished.
+        // So here we just return to stop scheduling ctx.
+        ctx->update_num_running(0, -1);
         return;
     }
 
@@ -264,7 +262,7 @@ void ScannerScheduler::_scanner_scan(ScannerScheduler* scheduler, ScannerContext
         scanner->mark_to_need_to_close();
     }
 
-    ctx->push_back_scanner_and_reschedule(scheduler, scanner);
+    ctx->push_back_scanner_and_reschedule(scanner);
 }
 
 } // namespace doris::vectorized

--- a/regression-test/suites/rollup/test_materialized_view_date.groovy
+++ b/regression-test/suites/rollup/test_materialized_view_date.groovy
@@ -51,6 +51,7 @@ suite("test_materialized_view_date", "rollup") {
             }
         }
     }
+    Thread.sleep(2)
     max_try_secs = 60
     sql "CREATE materialized VIEW amt_max2 AS SELECT store_id, max(sale_datetime1) FROM ${tbName1} GROUP BY store_id;"
     while (max_try_secs--) {
@@ -65,6 +66,7 @@ suite("test_materialized_view_date", "rollup") {
             }
         }
     }
+    Thread.sleep(2)
     max_try_secs = 60
     sql "CREATE materialized VIEW amt_max3 AS SELECT store_id, max(sale_datetime2) FROM ${tbName1} GROUP BY store_id;"
     while (max_try_secs--) {
@@ -79,6 +81,7 @@ suite("test_materialized_view_date", "rollup") {
             }
         }
     }
+    Thread.sleep(2)
     max_try_secs = 60
     sql "CREATE materialized VIEW amt_max4 AS SELECT store_id, max(sale_datetime3) FROM ${tbName1} GROUP BY store_id;"
     while (max_try_secs--) {


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

When select large number of data from a table, the profile will show that:
```
- ScannerCtxSchedCount: 2.82664M(2826640)
```

But there is only 8 times of `ScannerSchedCount`, most of them are busy running.
After improvement, the `ScannerCtxSchedCount` will be reduced to only 10.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

