### PR TITLE
[fix](Nereids) subquery predicate's slot appears in having's output by mistake

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/ResolveHaving.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/ResolveHaving.java
@@ -178,12 +178,8 @@ public class ResolveHaving extends OneAnalysisRuleFactory {
         ).collect(Collectors.toList());
         LogicalFilter<LogicalAggregate<Plan>> filter = new LogicalFilter<>(newPredicates,
                 aggregate.withGroupByAndOutput(aggregate.getGroupByExpressions(), newOutputExpressions));
-        return resolver.getNewOutputSlots().isEmpty()
-                ? filter
-                : new LogicalProject<>(
-                        aggregate.getOutputExpressions().stream().map(NamedExpression::toSlot)
-                                .collect(Collectors.toList()),
-                        filter
-                );
+        List<NamedExpression> projections = aggregate.getOutputExpressions().stream()
+                .map(NamedExpression::toSlot).collect(Collectors.toList());
+        return new LogicalProject<>(projections, filter);
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/parser/HavingClauseTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/parser/HavingClauseTest.java
@@ -89,11 +89,12 @@ public class HavingClauseTest extends AnalyzeCheckTestBase implements PatternMat
         );
         PlanChecker.from(connectContext).analyze(sql)
                 .matchesFromRoot(
-                    logicalFilter(
-                        logicalAggregate(
-                            logicalOlapScan()
-                        ).when(FieldChecker.check("outputExpressions", Lists.newArrayList(a1)))
-                    ).when(FieldChecker.check("predicates", new GreaterThan(a1, new TinyIntLiteral((byte) 0)))));
+                    logicalProject(
+                        logicalFilter(
+                            logicalAggregate(
+                                logicalOlapScan()
+                            ).when(FieldChecker.check("outputExpressions", Lists.newArrayList(a1)))
+                        ).when(FieldChecker.check("predicates", new GreaterThan(a1, new TinyIntLiteral((byte) 0))))));
         NamedExpressionUtil.clear();
 
         sql = "SELECT a1 as value FROM t1 GROUP BY a1 HAVING a1 > 0";
@@ -105,22 +106,24 @@ public class HavingClauseTest extends AnalyzeCheckTestBase implements PatternMat
         PlanChecker.from(connectContext).analyze(sql)
                 .applyBottomUp(new ExpressionRewrite(TypeCoercion.INSTANCE))
                 .matchesFromRoot(
-                    logicalFilter(
-                        logicalAggregate(
-                            logicalOlapScan()
-                        ).when(FieldChecker.check("outputExpressions", Lists.newArrayList(value)))
-                    ).when(FieldChecker.check("predicates", new GreaterThan(value.toSlot(), new TinyIntLiteral((byte) 0)))));
+                    logicalProject(
+                        logicalFilter(
+                            logicalAggregate(
+                                logicalOlapScan()
+                            ).when(FieldChecker.check("outputExpressions", Lists.newArrayList(value)))
+                        ).when(FieldChecker.check("predicates", new GreaterThan(value.toSlot(), new TinyIntLiteral((byte) 0))))));
         NamedExpressionUtil.clear();
 
         sql = "SELECT a1 as value FROM t1 GROUP BY a1 HAVING value > 0";
         PlanChecker.from(connectContext).analyze(sql)
                 .applyBottomUp(new ExpressionRewrite(TypeCoercion.INSTANCE))
                 .matchesFromRoot(
-                    logicalFilter(
-                        logicalAggregate(
-                            logicalOlapScan()
-                        ).when(FieldChecker.check("outputExpressions", Lists.newArrayList(value)))
-                    ).when(FieldChecker.check("predicates", new GreaterThan(value.toSlot(), new TinyIntLiteral((byte) 0)))));
+                    logicalProject(
+                        logicalFilter(
+                            logicalAggregate(
+                                logicalOlapScan()
+                            ).when(FieldChecker.check("outputExpressions", Lists.newArrayList(value)))
+                        ).when(FieldChecker.check("predicates", new GreaterThan(value.toSlot(), new TinyIntLiteral((byte) 0))))));
         NamedExpressionUtil.clear();
 
         sql = "SELECT SUM(a2) FROM t1 GROUP BY a1 HAVING a1 > 0";
@@ -173,11 +176,12 @@ public class HavingClauseTest extends AnalyzeCheckTestBase implements PatternMat
         sumA2 = new Alias(new ExprId(3), new Sum(a2), "SUM(a2)");
         PlanChecker.from(connectContext).analyze(sql)
                 .matchesFromRoot(
-                    logicalFilter(
-                        logicalAggregate(
-                            logicalOlapScan()
-                        ).when(FieldChecker.check("outputExpressions", Lists.newArrayList(a1, sumA2)))
-                    ).when(FieldChecker.check("predicates", new GreaterThan(sumA2.toSlot(), new TinyIntLiteral((byte) 0)))));
+                    logicalProject(
+                        logicalFilter(
+                            logicalAggregate(
+                                logicalOlapScan()
+                            ).when(FieldChecker.check("outputExpressions", Lists.newArrayList(a1, sumA2)))
+                        ).when(FieldChecker.check("predicates", new GreaterThan(sumA2.toSlot(), new TinyIntLiteral((byte) 0))))));
         NamedExpressionUtil.clear();
 
         sql = "SELECT a1, SUM(a2) as value FROM t1 GROUP BY a1 HAVING SUM(a2) > 0";
@@ -192,21 +196,23 @@ public class HavingClauseTest extends AnalyzeCheckTestBase implements PatternMat
         Alias value = new Alias(new ExprId(0), new Sum(a2), "value");
         PlanChecker.from(connectContext).analyze(sql)
                 .matchesFromRoot(
-                    logicalFilter(
-                        logicalAggregate(
-                            logicalOlapScan()
-                        ).when(FieldChecker.check("outputExpressions", Lists.newArrayList(a1, value)))
-                    ).when(FieldChecker.check("predicates", new GreaterThan(value.toSlot(), new TinyIntLiteral((byte) 0)))));
+                    logicalProject(
+                        logicalFilter(
+                            logicalAggregate(
+                                logicalOlapScan()
+                            ).when(FieldChecker.check("outputExpressions", Lists.newArrayList(a1, value)))
+                        ).when(FieldChecker.check("predicates", new GreaterThan(value.toSlot(), new TinyIntLiteral((byte) 0))))));
         NamedExpressionUtil.clear();
 
         sql = "SELECT a1, SUM(a2) as value FROM t1 GROUP BY a1 HAVING value > 0";
         PlanChecker.from(connectContext).analyze(sql)
                 .matchesFromRoot(
-                    logicalFilter(
-                        logicalAggregate(
-                            logicalOlapScan()
-                        ).when(FieldChecker.check("outputExpressions", Lists.newArrayList(a1, value)))
-                    ).when(FieldChecker.check("predicates", new GreaterThan(value.toSlot(), new TinyIntLiteral((byte) 0)))));
+                    logicalProject(
+                        logicalFilter(
+                            logicalAggregate(
+                                logicalOlapScan()
+                            ).when(FieldChecker.check("outputExpressions", Lists.newArrayList(a1, value)))
+                        ).when(FieldChecker.check("predicates", new GreaterThan(value.toSlot(), new TinyIntLiteral((byte) 0))))));
         NamedExpressionUtil.clear();
 
         sql = "SELECT a1, SUM(a2) FROM t1 GROUP BY a1 HAVING MIN(pk) > 0";
@@ -239,11 +245,12 @@ public class HavingClauseTest extends AnalyzeCheckTestBase implements PatternMat
         Alias sumA1A2 = new Alias(new ExprId(3), new Sum(new Add(a1, a2)), "SUM((a1 + a2))");
         PlanChecker.from(connectContext).analyze(sql)
                 .matchesFromRoot(
-                    logicalFilter(
-                        logicalAggregate(
-                            logicalOlapScan()
-                        ).when(FieldChecker.check("outputExpressions", Lists.newArrayList(a1, sumA1A2)))
-                    ).when(FieldChecker.check("predicates", new GreaterThan(sumA1A2.toSlot(), new TinyIntLiteral((byte) 0)))));
+                    logicalProject(
+                        logicalFilter(
+                            logicalAggregate(
+                                logicalOlapScan()
+                            ).when(FieldChecker.check("outputExpressions", Lists.newArrayList(a1, sumA1A2)))
+                        ).when(FieldChecker.check("predicates", new GreaterThan(sumA1A2.toSlot(), new TinyIntLiteral((byte) 0))))));
         NamedExpressionUtil.clear();
 
         sql = "SELECT a1, SUM(a1 + a2) FROM t1 GROUP BY a1 HAVING SUM(a1 + a2 + 3) > 0";


### PR DESCRIPTION
# Proposed changes

## Problem summary

when uncorrelated subquery in having predicates, having's output will appears one slot from subquery by mistake. This PR fix it by always add a project on the top of having.

Co-authored-by: mch_ucchi <organic_chemistry@foxmail.com>

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

