### PR TITLE
[improvement](planner) unset common fields to reduce plan thrift size

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ExprSubstitutionMap.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ExprSubstitutionMap.java
@@ -294,17 +294,19 @@ public final class ExprSubstitutionMap {
      * and that all rhs exprs are analyzed.
      */
     private void verify() {
-        for (int i = 0; i < lhs.size(); ++i) {
-            for (int j = i + 1; j < lhs.size(); ++j) {
-                if (lhs.get(i).equals(lhs.get(j))) {
-                    if (LOG.isTraceEnabled()) {
-                        LOG.trace("verify: smap=" + this.debugString());
+        if (LOG.isDebugEnabled()) {
+            for (int i = 0; i < lhs.size(); ++i) {
+                for (int j = i + 1; j < lhs.size(); ++j) {
+                    if (lhs.get(i).equals(lhs.get(j))) {
+                        if (LOG.isTraceEnabled()) {
+                            LOG.trace("verify: smap=" + this.debugString());
+                        }
+                        // TODO(zc): partition by k1, order by k1, there is failed.
+                        // Preconditions.checkState(false);
                     }
-                    // TODO(zc): partition by k1, order by k1, there is failed.
-                    // Preconditions.checkState(false);
                 }
+                Preconditions.checkState(!checkAnalyzed || rhs.get(i).isAnalyzed());
             }
-            Preconditions.checkState(!checkAnalyzed || rhs.get(i).isAnalyzed());
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ExprSubstitutionMap.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ExprSubstitutionMap.java
@@ -294,6 +294,8 @@ public final class ExprSubstitutionMap {
      * and that all rhs exprs are analyzed.
      */
     private void verify() {
+        // This method is very very time consuming, especially when planning large complex query.
+        // So disable it by default.
         if (LOG.isDebugEnabled()) {
             for (int i = 0; i < lhs.size(); ++i) {
                 for (int j = i + 1; j < lhs.size(); ++j) {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
@@ -154,7 +154,7 @@ public class Coordinator {
 
     // copied from TQueryExecRequest; constant across all fragments
     private final TDescriptorTable descTable;
-    
+
     // Why do we use query global?
     // When `NOW()` function is in sql, we need only one now(),
     // but, we execute `NOW()` distributed.

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
@@ -154,9 +154,7 @@ public class Coordinator {
 
     // copied from TQueryExecRequest; constant across all fragments
     private final TDescriptorTable descTable;
-
-    private final Set<Long> alreadySentBackendIds = Sets.newHashSet();
-
+    
     // Why do we use query global?
     // When `NOW()` function is in sql, we need only one now(),
     // but, we execute `NOW()` distributed.
@@ -396,7 +394,6 @@ public class Coordinator {
             }
             this.exportFiles.clear();
             this.needCheckBackendExecStates.clear();
-            this.alreadySentBackendIds.clear();
         } finally {
             lock.unlock();
         }
@@ -748,9 +745,6 @@ public class Coordinator {
             } finally {
                 pair.first.scopedSpan.endSpan();
             }
-
-            // succeed to send the plan fragment, update the "alreadySentBackendIds"
-            alreadySentBackendIds.add(pair.first.beId);
         }
     }
 
@@ -2081,15 +2075,11 @@ public class Coordinator {
          * This information can be obtained from the cache of BE.
          */
         public void unsetFields() {
-            if (alreadySentBackendIds.contains(backend.getId())) {
-                this.rpcParams.unsetDescTbl();
-                this.rpcParams.unsetCoord();
-                this.rpcParams.unsetQueryGlobals();
-                this.rpcParams.unsetResourceInfo();
-                this.rpcParams.setIsSimplifiedParam(true);
-            } else {
-                this.rpcParams.setIsSimplifiedParam(false);
-            }
+            this.rpcParams.unsetDescTbl();
+            this.rpcParams.unsetCoord();
+            this.rpcParams.unsetQueryGlobals();
+            this.rpcParams.unsetResourceInfo();
+            this.rpcParams.setIsSimplifiedParam(true);
         }
 
         // update profile.


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

1.
For query with 1656 `union`, the plan thrift size will be reduced from 400MB+ to 2MB.
This optimization is introduced from #4904, but lost after #9720

2.
Disable `ExprSubstitutionMap.verify` when debug is disable.
So that the plan time of query  with 1656 `union` will be reduced from 20s to 2s

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

