### PR TITLE
[enhancement](memory) Jemalloc performance optimization and compatibility with MemTracker

### DIFF
--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -223,7 +223,10 @@ add_library(leveldb STATIC IMPORTED)
 set_target_properties(leveldb PROPERTIES IMPORTED_LOCATION ${THIRDPARTY_DIR}/lib/libleveldb.a)
 
 add_library(jemalloc STATIC IMPORTED)
-set_target_properties(jemalloc PROPERTIES IMPORTED_LOCATION ${THIRDPARTY_DIR}/lib64/libjemalloc.a)
+set_target_properties(jemalloc PROPERTIES IMPORTED_LOCATION ${THIRDPARTY_DIR}/lib/libjemalloc_doris.a)
+
+add_library(jemalloc_arrow STATIC IMPORTED)
+set_target_properties(jemalloc_arrow PROPERTIES IMPORTED_LOCATION ${THIRDPARTY_DIR}/lib64/libjemalloc.a)
 
 add_library(brotlicommon STATIC IMPORTED)
 set_target_properties(brotlicommon PROPERTIES IMPORTED_LOCATION ${THIRDPARTY_DIR}/lib64/libbrotlicommon.a)
@@ -681,6 +684,7 @@ set(COMMON_THIRDPARTY
     roaring
     fmt
     jemalloc
+    jemalloc_arrow
     brotlicommon
     brotlidec
     brotlienc

--- a/be/src/runtime/CMakeLists.txt
+++ b/be/src/runtime/CMakeLists.txt
@@ -115,6 +115,12 @@ if (WITH_MYSQL)
         )
 endif()
 
+if (USE_JEMALLOC)
+    set(RUNTIME_FILES ${RUNTIME_FILES}
+        memory/jemalloc_hook.cpp
+        )
+endif()
+
 add_library(Runtime STATIC
     ${RUNTIME_FILES}
     )

--- a/be/src/runtime/exec_env_init.cpp
+++ b/be/src/runtime/exec_env_init.cpp
@@ -208,7 +208,7 @@ Status ExecEnv::_init_mem_tracker() {
             std::make_shared<MemTrackerLimiter>(global_memory_limit_bytes, "Process");
     _orphan_mem_tracker = std::make_shared<MemTrackerLimiter>(-1, "Orphan", _process_mem_tracker);
     _orphan_mem_tracker_raw = _orphan_mem_tracker.get();
-    thread_context()->_thread_mem_tracker_mgr->init();
+    thread_context()->_thread_mem_tracker_mgr->init_impl();
     thread_context()->_thread_mem_tracker_mgr->set_check_attach(false);
 #if defined(USE_MEM_TRACKER) && !defined(__SANITIZE_ADDRESS__) && !defined(ADDRESS_SANITIZER) && \
         !defined(LEAK_SANITIZER) && !defined(THREAD_SANITIZER) && !defined(USE_JEMALLOC)

--- a/be/src/runtime/memory/jemalloc_hook.cpp
+++ b/be/src/runtime/memory/jemalloc_hook.cpp
@@ -1,0 +1,141 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "jemalloc/jemalloc.h"
+#include "runtime/thread_context.h"
+
+extern "C" {
+void* doris_malloc(size_t size) __THROW {
+    MEM_MALLOC_HOOK(je_nallocx(size, 0));
+    void* ptr = je_malloc(size);
+    if (UNLIKELY(ptr == nullptr)) {
+        MEM_FREE_HOOK(je_nallocx(size, 0));
+    }
+    return ptr;
+}
+
+void doris_free(void* p) __THROW {
+    MEM_FREE_HOOK(je_malloc_usable_size(p));
+    je_free(p);
+}
+
+void* doris_realloc(void* p, size_t size) __THROW {
+    if (UNLIKELY(size == 0)) {
+        return nullptr;
+    }
+    int64_t old_size = je_malloc_usable_size(p);
+    MEM_MALLOC_HOOK(je_nallocx(size, 0) - old_size);
+    void* ptr = je_realloc(p, size);
+    if (UNLIKELY(ptr == nullptr)) {
+        MEM_FREE_HOOK(je_nallocx(size, 0) - old_size);
+    }
+    return ptr;
+}
+
+void* doris_calloc(size_t n, size_t size) __THROW {
+    if (UNLIKELY(size == 0)) {
+        return nullptr;
+    }
+
+    MEM_MALLOC_HOOK(n * size);
+    void* ptr = je_calloc(n, size);
+    if (UNLIKELY(ptr == nullptr)) {
+        MEM_FREE_HOOK(n * size);
+    } else {
+        MEM_FREE_HOOK(je_malloc_usable_size(ptr) - n * size);
+    }
+    return ptr;
+}
+
+void doris_cfree(void* ptr) __THROW {
+    MEM_FREE_HOOK(je_malloc_usable_size(ptr));
+    je_free(ptr);
+}
+
+void* doris_memalign(size_t align, size_t size) __THROW {
+    MEM_MALLOC_HOOK(size);
+    void* ptr = je_aligned_alloc(align, size);
+    if (UNLIKELY(ptr == nullptr)) {
+        MEM_FREE_HOOK(size);
+    } else {
+        MEM_MALLOC_HOOK(je_malloc_usable_size(ptr) - size);
+    }
+    return ptr;
+}
+
+void* doris_aligned_alloc(size_t align, size_t size) __THROW {
+    MEM_MALLOC_HOOK(size);
+    void* ptr = je_aligned_alloc(align, size);
+    if (UNLIKELY(ptr == nullptr)) {
+        MEM_FREE_HOOK(size);
+    } else {
+        MEM_MALLOC_HOOK(je_malloc_usable_size(ptr) - size);
+    }
+    return ptr;
+}
+
+void* doris_valloc(size_t size) __THROW {
+    MEM_MALLOC_HOOK(size);
+    void* ptr = je_valloc(size);
+    if (UNLIKELY(ptr == nullptr)) {
+        MEM_FREE_HOOK(size);
+    } else {
+        MEM_MALLOC_HOOK(je_malloc_usable_size(ptr) - size);
+    }
+    return ptr;
+}
+
+void* doris_pvalloc(size_t size) __THROW {
+    MEM_MALLOC_HOOK(size);
+    void* ptr = je_valloc(size);
+    if (UNLIKELY(ptr == nullptr)) {
+        MEM_FREE_HOOK(size);
+    } else {
+        MEM_MALLOC_HOOK(je_malloc_usable_size(ptr) - size);
+    }
+    return ptr;
+}
+
+int doris_posix_memalign(void** r, size_t align, size_t size) __THROW {
+    MEM_MALLOC_HOOK(size);
+    int ret = je_posix_memalign(r, align, size);
+    if (UNLIKELY(ret != 0)) {
+        MEM_FREE_HOOK(size);
+    } else {
+        MEM_MALLOC_HOOK(je_malloc_usable_size(*r) - size);
+    }
+    return ret;
+}
+
+size_t doris_malloc_usable_size(void* ptr) __THROW {
+    size_t ret = je_malloc_usable_size(ptr);
+    return ret;
+}
+
+#define ALIAS(doris_fn) __attribute__((alias(#doris_fn), used))
+void* malloc(size_t size) __THROW ALIAS(doris_malloc);
+void free(void* p) __THROW ALIAS(doris_free);
+void* realloc(void* p, size_t size) __THROW ALIAS(doris_realloc);
+void* calloc(size_t n, size_t size) __THROW ALIAS(doris_calloc);
+void cfree(void* ptr) __THROW ALIAS(doris_cfree);
+void* memalign(size_t align, size_t size) __THROW ALIAS(doris_memalign);
+void* aligned_alloc(size_t align, size_t size) __THROW ALIAS(doris_aligned_alloc);
+void* valloc(size_t size) __THROW ALIAS(doris_valloc);
+void* pvalloc(size_t size) __THROW ALIAS(doris_pvalloc);
+int posix_memalign(void** r, size_t a, size_t s) __THROW ALIAS(doris_posix_memalign);
+size_t malloc_usable_size(void* ptr) __THROW ALIAS(doris_malloc_usable_size);
+}

--- a/be/src/runtime/memory/tcmalloc_hook.h
+++ b/be/src/runtime/memory/tcmalloc_hook.h
@@ -36,28 +36,11 @@
 //  destructor to control the behavior of consume can lead to unexpected behavior,
 //  like this: if (LIKELY(doris::start_thread_mem_tracker)) {
 void new_hook(const void* ptr, size_t size) {
-    if (doris::btls_key != doris::EMPTY_BTLS_KEY && doris::bthread_context != nullptr) {
-        // Currently in bthread, consume thread context mem tracker in bthread tls.
-        doris::update_bthread_context();
-        doris::bthread_context->_thread_mem_tracker_mgr->consume(tc_nallocx(size, 0));
-    } else if (doris::thread_context_ptr._init) {
-        doris::thread_context_ptr._ptr->_thread_mem_tracker_mgr->consume(tc_nallocx(size, 0));
-    } else {
-        doris::ThreadMemTrackerMgr::consume_no_attach(tc_nallocx(size, 0));
-    }
+    MEM_MALLOC_HOOK(tc_nallocx(size, 0));
 }
 
 void delete_hook(const void* ptr) {
-    if (doris::btls_key != doris::EMPTY_BTLS_KEY && doris::bthread_context != nullptr) {
-        doris::update_bthread_context();
-        doris::bthread_context->_thread_mem_tracker_mgr->consume(
-                -tc_malloc_size(const_cast<void*>(ptr)));
-    } else if (doris::thread_context_ptr._init) {
-        doris::thread_context_ptr._ptr->_thread_mem_tracker_mgr->consume(
-                -tc_malloc_size(const_cast<void*>(ptr)));
-    } else {
-        doris::ThreadMemTrackerMgr::consume_no_attach(-tc_malloc_size(const_cast<void*>(ptr)));
-    }
+    MEM_FREE_HOOK(tc_malloc_size(const_cast<void*>(ptr)));
 }
 
 void init_hook() {

--- a/bin/start_be.sh
+++ b/bin/start_be.sh
@@ -207,6 +207,8 @@ export UBSAN_OPTIONS=print_stacktrace=1
 ## set hdfs conf
 export LIBHDFS3_CONF="${DORIS_HOME}/conf/hdfs-site.xml"
 
+export MALLOC_CONF="percpu_arena:percpu,background_thread:true,metadata_thp:auto,muzzy_decay_ms:30000,dirty_decay_ms:30000,oversize_threshold:0,lg_tcache_max:16"
+
 if [[ "${RUN_DAEMON}" -eq 1 ]]; then
     nohup ${LIMIT:+${LIMIT}} "${DORIS_HOME}/lib/doris_be" "$@" >>"${LOG_DIR}/be.out" 2>&1 </dev/null &
 else


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

1. Before jemalloc was compiled with arrow, it was compiled separately
2. Modify the default parameters of jemalloc to achieve better performance and lower memory usage.
This will significantly improve multi-threading and high concurrency memory performance.
3. Jemalloc compatible mem tracker, which is consistent with the query mem tracker value of tcmalloc

Test commit: Wed Aug 31 1a198b3777ba0c8eb7c2ff31f226a816bcd4a472, 
does not include #12436 Optimize tcmalloc performance, so the test result of tcmalloc may be lower than the latest code.

refer to:
https://github.com/jemalloc/jemalloc/blob/dev/TUNING.md
https://jemalloc.net/jemalloc.3.html
https://github.com/jemalloc/jemalloc/issues/1621
https://github.com/jemalloc/jemalloc/wiki/Getting-Started
https://github.com/jemalloc/jemalloc/issues/2058
https://github.com/jemalloc/jemalloc/issues/2172

## Performance Verification Results
### 1、single msyql client sequential execution
> the sum of the averages of multiple executions of each query
1) Clickbench:

| | sum of time(s) | peak mem(M) | 
| :------| ------: | :------: |
| tcmalloc |  210 | 11927 |
| jemalloc default conf | 203.17 | 20777 |
| jemalloc optimize conf |  194.45 |  13594 |

2) SSB:

| | sum of time(s) | peak mem(M) |
| :------| ------: | :------: |
| tcmalloc |  15.845 |  832 |
| jemalloc default conf | 15.052 |  2920 |
| jemalloc optimize conf | 13.828 |  2091 |

Looking at the flame graph, the time-consuming of submitting sql in a single mysql client is not in memory, so the performance improvement is less.

### 2、jmeter stress test, disable page cache and chunk allocator and mem pool
>  Take the results of the second stress test for each sql, because jemalloc has a cold start, the first stress test is more aggressively cached, and the second stress test starts to get faster.
1) Clickbench,  only q13 + q14

| | sum of time(s) |
| :------| ------: |
| tcmalloc | 82611  |
| jemalloc default conf | 72688 |
| jemalloc optimize conf | 42506 |

the performance of jemalloc is doubled.
2) SSB, only q1.1 - q3.4

| | sum of time(s) |
| :------| ------: |
| tcmalloc | 76760  |
| jemalloc default conf | 73326 |
| jemalloc optimize conf | 57297 |

the performance of jemalloc is improved by 25%.

### 3、jmeter stress test, enable page cache and chunk allocator and mem pool(default conf)
1) Clickbench,  only q13 + q14

| | sum of time(s) |
| :------| ------: |
| tcmalloc | 73616 |
| jemalloc default conf | 62220 |
| jemalloc optimize conf | 39565 |

the performance of jemalloc is improved by 46%.
2) SSB, only q1.1 - q3.4

| | sum of time(s) |
| :------| ------: |
| tcmalloc | 53709 |
| jemalloc default conf | 47790 |
| jemalloc optimize conf | 43297 |

the performance of jemalloc is improved by 19%.

### 4、jmeter stress test, disable  page cache, enable chunk allocator and mem pool
1) Clickbench,  only q13 + q14

| | sum of time(s) |
| :------| ------: |
| tcmalloc | 74949 |
| jemalloc default conf | 61335 |
| jemalloc optimize conf | TODO |

### 5、jmeter stress test, v1.1.1 vs master
sql:
```
with e as (select b.Title,b.measure1,b.measure2 from (select a.Title, sum(case when a.PageCharset = 'windows-1251;charset' then 1 else 0 end) as measure1,sum(case when a.RefererHash in('-296158784638538920', '-6389909303817027441') then cast(a.JavaEnable AS Double) else 0 end) as measure2 from hits  a where CounterID = 62 AND EventDate >= '2013-07-01' AND EventDate <= '2013-07-31' AND DontCountHits = 0 AND IsRefresh = 0 AND Title <> '' group by 1) b) , f as (select avg(e.measure2) as avg1,avg(e.measure1) as avg2,var_samp(e.measure2) as variance1,var_samp(e.measure1) as variance2 from e),g as (select sum((e.measure1-f.avg2)*(e.measure2-f.avg1)) as covariance from e,f) select f.avg2,f.variance1,f.variance2,g.covariance as covariance from f,g;
```
v1.1.1:

| | jmeter thread=10 | jmeter thread=20 | jmeter thread=30 |
| :------| ------: | :------: | :------: |
| tcmalloc | 1095 | 1818  | 2870  |
| jemalloc default conf | 581 | 1171  | 1802  |

master:

| | jmeter thread=8 |
| :------| ------: |
| tcmalloc | 573 |
| jemalloc default conf | 502 |

1. On v1.11, jemalloc improves performance by 55% - double, the more jmeter threads, the greater the bottleneck outside the memory, and the smaller the performance improvement.
2.  jemalloc on the master improves performance by 20%, because the master does a lot of memory reuse.

### 6、jmeter stress test, Try replacing ChunkAllocator with jemalloc in vec
1) Clickbench,  only q13 + q14

| | sum of time(s) |
| :------| ------: |
| jemalloc lg_tcache_max:16 + ChunkAllocator | 39565 |
| jemalloc lg_tcache_max:26 | 40158 |

Size < 4K using jemalloc, 4K < size < 64M using ChunkAllocator, the performance is still a little higher.
TODO, more testing and tuning, looking forward to replacing ChunkAllocator

## Performance Verification Reproduce
### 1、single mysql client sequential execution
be.conf add
```
          `enable_tcmalloc_hook=false`
          `disable_storage_page_cache=true`
          `disable_mem_pools=true`
          `chunk_reserved_bytes_limit=1`
```
1) Clickbench
```
vim tools/clickbench-tools/run-clickbench-queries.sh
    pre_set "set global parallel_fragment_exec_instance_num=1;"
    pre_set "set global exec_mem_limit=20G;
sh tools/clickbench-tools/run-clickbench-queries.sh
```
2) SSB
```
vim tools/ssb-tools/bin/run-ssb-queries.sh
    pre_set "set global parallel_fragment_exec_instance_num=1;"
sh tools/ssb-tools/bin/run-ssb-queries.sh
```

### 2、jmeter stress test, disable page cache and chunk allocator and mem pool
`set global parallel_fragment_exec_instance_num=1;`
be.conf add
```
          `enable_tcmalloc_hook=false`
          `disable_storage_page_cache=true`
          `disable_mem_pools=true`
          `chunk_reserved_bytes_limit=1`
```

jmeter conf
1) Clickbench
```
        <stringProp name="ThreadGroup.num_threads">30</stringProp>
        <stringProp name="ThreadGroup.ramp_time">1</stringProp>
        <boolProp name="ThreadGroup.scheduler">true</boolProp>
        <stringProp name="ThreadGroup.duration">100</stringProp>
        <stringProp name="ThreadGroup.delay">0</stringProp>
```
2) SSB
```
        <stringProp name="ThreadGroup.num_threads">10</stringProp>
        <stringProp name="ThreadGroup.ramp_time">1</stringProp>
        <boolProp name="ThreadGroup.scheduler">true</boolProp>
        <stringProp name="ThreadGroup.duration">30</stringProp>
        <stringProp name="ThreadGroup.delay">0</stringProp>
```

### 3、jmeter stress test, enable page cache and chunk allocator and mem pool
`set global parallel_fragment_exec_instance_num=1;`
be.conf add
```
          `enable_tcmalloc_hook=false`
```

### 4、jmeter stress test, disable  page cache, enable chunk allocator and mem pool
`set global parallel_fragment_exec_instance_num=1;`
be.conf add
```
          `enable_tcmalloc_hook=false`
          `disable_storage_page_cache=true`
```

### 5、jmeter stress test, v1.1.1 vs master
`set global parallel_fragment_exec_instance_num=1;`
be.conf add
```
          `enable_tcmalloc_hook=false`
          `disable_storage_page_cache=true`
          `disable_mem_pools=true`
          `chunk_reserved_bytes_limit=1`
```

## Performance Verification Data
[tcmalloc_vs_jemalloc.zip](https://github.com/apache/doris/files/9531896/tcmalloc_vs_jemalloc.zip)

## Checklist(Required)

1. Does it affect the original behavior: 
    - [x] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [x] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No