### PR TITLE
[feature](nereids) print more friendly join info in `explain`

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/SlotRef.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/SlotRef.java
@@ -211,7 +211,7 @@ public class SlotRef extends Expr {
             if (ConnectContext.get() != null
                     && ConnectContext.get().getSessionVariable() != null
                     && ConnectContext.get().getSessionVariable().isEnableNereidsPlanner()) {
-                return label + "[#" + desc.getId().asInt() + "]";
+                return label + "[T" + desc.getParent().getId().asInt() + "." + desc.getId().asInt() + "]";
             } else {
                 return label;
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/HashJoinNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/HashJoinNode.java
@@ -1135,6 +1135,16 @@ public class HashJoinNode extends PlanNode {
             }
             output.append("\n");
         }
+        output.append(detailPrefix).append("nereids output slot ids: ");
+        for (Expr e : vSrcToOutputSMap.getLhs()) {
+            if (e instanceof SlotRef) {
+                SlotRef s = (SlotRef) e;
+                output.append("t")
+                        .append(s.getDesc().getParent().getId())
+                        .append(".").append(s.getSlotId()).append(" ");
+            }
+        }
+        output.append("\n");
         if (hashOutputSlotIds != null) {
             output.append(detailPrefix).append("hash output slot ids: ");
             for (SlotId slotId : hashOutputSlotIds) {
@@ -1142,6 +1152,11 @@ public class HashJoinNode extends PlanNode {
             }
             output.append("\n");
         }
+        output.append(detailPrefix).append("input tuple ids: ");
+        for (TupleId tid : tblRefIds) {
+            output.append(tid.asInt()).append(" ");
+        }
+        output.append("\n");
         return output.toString();
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/PlanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/PlanNode.java
@@ -482,7 +482,7 @@ public abstract class PlanNode extends TreeNode<PlanNode> implements PlanStats {
         }
         // Output Tuple Ids only when explain plan level is set to verbose
         if (detailLevel.equals(TExplainLevel.VERBOSE)) {
-            expBuilder.append(detailPrefix + "tuple ids: ");
+            expBuilder.append(detailPrefix + "output tuple ids: ");
             for (TupleId tupleId : tupleIds) {
                 String nullIndicator = nullableTupleIds.contains(tupleId) ? "N" : "";
                 expBuilder.append(tupleId.asInt() + nullIndicator + " ");


### PR DESCRIPTION
# Proposed changes
This pr alleviates the effort to detect "slot and tuple miss-match" issues.
```
|   2:VHASH JOIN                                                                |
|   |  join op: RIGHT ANTI JOIN(COLOCATE[])[]                                   |
|   |  equal join conjunct: l_orderkey[#35] = l_orderkey[#16]                   |
|   |  other join predicates: l_suppkey[#36] != l_suppkey[#39]                  |
|   |  cardinality=-1                                                           |
|   |  vec output tuple id: 5                                                   |
|   |  vIntermediate tuple ids: 4                                               |
|   |  tuple ids: 0                                                             |
|   |                       
```
1. According to this fragment, It is painful to verify that slot#36 resides in tuple 4. 
2. Join output slots are not listed, we add `nereids output slot ids`
3. `tuple ids` is output tuple ids, rename to `output tuple ids`. Infact `output tuple ids` means the slot in ` vec output tuple id` comes from `output tuple ids`. 
4. add `input tuple ids` for join node.

the new version becomes
```
|   2:VHASH JOIN                                                                |
|   |  join op: RIGHT ANTI JOIN(COLOCATE[])[]                                   |
|   |  equal join conjunct: l_orderkey[T3.35] = l_orderkey[T1.16]               |
|   |  other join predicates: l_suppkey[T3.36] != l_suppkey[T4.39]              |
|   |  cardinality=-1                                                           |
|   |  vec output tuple id: 5                                                   |
|   |  vIntermediate tuple ids: 4                                               |
|   |  nereids output slot ids: t4.38                                           |
|   |  input tuple ids: 2 0                                                     |
|   |  output tuple ids: 0   
```
We can quickly detect that ` l_suppkey[T3.36] ` is wrong.

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
6. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
7. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
8. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
9. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

