### PR TITLE
[feature-wip](new-scan) refactor some interface about predicate push down in scan node

### DIFF
--- a/be/src/vec/exec/scan/new_olap_scan_node.cpp
+++ b/be/src/vec/exec/scan/new_olap_scan_node.cpp
@@ -182,7 +182,8 @@ Status NewOlapScanNode::_build_key_ranges_and_filters() {
 
     // Append value ranges in "_not_in_value_ranges"
     for (auto& range : _not_in_value_ranges) {
-        std::visit([&](auto&& the_range) { the_range.to_in_condition(_olap_filters, false); }, range);
+        std::visit([&](auto&& the_range) { the_range.to_in_condition(_olap_filters, false); },
+                   range);
     }
 
     _runtime_profile->add_info_string("PushDownPredicates", olap_filters_to_string(_olap_filters));

--- a/be/src/vec/exec/scan/new_olap_scan_node.h
+++ b/be/src/vec/exec/scan/new_olap_scan_node.h
@@ -38,17 +38,17 @@ protected:
     Status _process_conjuncts() override;
     bool _is_key_column(const std::string& col_name) override;
 
-    bool _should_push_down_binary_predicate(
-            VectorizedFnCall* fn_call, VExprContext* expr_ctx, StringRef* constant_val,
-            int* slot_ref_child,
-            const std::function<bool(const std::string&)>& fn_checker) override;
+    PushDownType _should_push_down_function_filter(VectorizedFnCall* fn_call,
+                                                   VExprContext* expr_ctx, StringVal* constant_str,
+                                                   doris_udf::FunctionContext** fn_ctx) override;
 
-    bool _should_push_down_in_predicate(VInPredicate* in_pred, VExprContext* expr_ctx,
-                                        bool is_not_in) override;
+    PushDownType _should_push_down_bloom_filter() override {
+        return PushDownType::ACCEPTABLE;
+    }
 
-    bool _should_push_down_function_filter(VectorizedFnCall* fn_call, VExprContext* expr_ctx,
-                                           StringVal* constant_str,
-                                           doris_udf::FunctionContext** fn_ctx) override;
+    PushDownType _should_push_down_is_null_predicate() override {
+        return PushDownType::ACCEPTABLE;
+    }
 
     Status _init_scanners(std::list<VScanner*>* scanners) override;
 

--- a/be/src/vec/exec/scan/new_olap_scan_node.h
+++ b/be/src/vec/exec/scan/new_olap_scan_node.h
@@ -42,13 +42,9 @@ protected:
                                                    VExprContext* expr_ctx, StringVal* constant_str,
                                                    doris_udf::FunctionContext** fn_ctx) override;
 
-    PushDownType _should_push_down_bloom_filter() override {
-        return PushDownType::ACCEPTABLE;
-    }
+    PushDownType _should_push_down_bloom_filter() override { return PushDownType::ACCEPTABLE; }
 
-    PushDownType _should_push_down_is_null_predicate() override {
-        return PushDownType::ACCEPTABLE;
-    }
+    PushDownType _should_push_down_is_null_predicate() override { return PushDownType::ACCEPTABLE; }
 
     Status _init_scanners(std::list<VScanner*>* scanners) override;
 


### PR DESCRIPTION
# Proposed changes

This PR introduce a new enum type `PushDownType`:
```
enum class PushDownType {
        // The predicate can not be pushed down to data source
        UNACCEPTABLE,
        // The predicate can be pushed down to data source
        // and the data source can fully evaludate it
        ACCEPTABLE,
        // The predicate can be pushed down to data source
        // but the data source can not fully evaluate it.
        PARTIAL_ACCEPTABLE
    };
```

And derived class of VScanNode can override following method to determine whether to accept
a bianry/in/bloom filter/is null predicate:

```
PushDownType _should_push_down_binary_predicate();
PushDownType _should_push_down_in_predicate();
PushDownType _should_push_down_function_filter();
PushDownType _should_push_down_bloom_filter();
PushDownType _should_push_down_is_null_predicate();
```

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

