### PR TITLE
[fix](config)Update user_define_tables.sh

### DIFF
--- a/extension/mysql_to_doris/user_define_tables.sh
+++ b/extension/mysql_to_doris/user_define_tables.sh
@@ -68,7 +68,7 @@ rm -rf ./user_files/tables1.sql
 mv ./user_files/tables2.sql ./user_files/tables.sql
 #start transform tables struct
 sed -i '/ENGINE=/a) ENGINE=ODBC\n COMMENT "ODBC"\nPROPERTIES (\n"host" = "ApacheDorisHostIp",\n"port" = "3306",\n"user" = "root",\n"password" = "ApacheDorisHostPassword",\n"database" = "ApacheDorisDataBases",\n"table" = "ApacheDorisTables",\n"driver" = "MySQL",\n"odbc_type" = "mysql");' ./user_files/tables.sql
-sed -i "s/\"driver\" = \"MySQL\"/\"driver\" = \"$doris_odbc_name\"/g" ./files/tables.sql
+sed -i "s/\"driver\" = \"MySQL\"/\"driver\" = \"$doris_odbc_name\"/g" ./user_files/tables.sql
 #delete match line
 sed -i '/ENGINT=/d' ./user_files/tables.sql
 sed -i '/PRIMARY KEY/d' ./user_files/tables.sql


### PR DESCRIPTION
# Proposed changes

Issue Number: close #12541

## Problem summary
For the mysql to doris extension, the user defined tables shell should create sqls to the path user_files.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [x] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

