### PR TITLE
[fix](array-type) forbid to create materialized view for array column

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/alter/MaterializedViewHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/MaterializedViewHandler.java
@@ -505,6 +505,12 @@ public class MaterializedViewHandler extends AlterHandler {
         if (KeysType.UNIQUE_KEYS == olapTable.getKeysType() && olapTable.hasSequenceCol()) {
             newMVColumns.add(new Column(olapTable.getSequenceCol()));
         }
+        // if the column is array type, we forbid to create materialized view
+        for (Column column : newMVColumns) {
+            if (column.getDataType() == PrimitiveType.ARRAY) {
+                throw new DdlException("The array column[" + column + "] not support to create materialized view");
+            }
+        }
 
         if (olapTable.getEnableLightSchemaChange()) {
             int nextColUniqueId = Column.COLUMN_UNIQUE_ID_INIT_VALUE + 1;

--- a/regression-test/suites/rollup_p0/test_materialized_view_array.groovy
+++ b/regression-test/suites/rollup_p0/test_materialized_view_array.groovy
@@ -1,0 +1,77 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+suite("test_materialized_view_array", "rollup") {
+    def tableName = "tbl_test_materialized_view_array"
+
+    def create_test_table = {testTable ->
+        // multi-line sql
+        sql "ADMIN SET FRONTEND CONFIG ('enable_array_type' = 'true')"
+        
+        def result1 = sql """
+            CREATE TABLE IF NOT EXISTS ${tableName} (
+              `k1` int(11) NULL,
+              `k2` array<smallint(6)> NULL,
+              `k3` array<int(11)> NULL,
+              `k4` array<bigint(20)> NULL,
+              `k5` array<char(20)> NULL,
+              `k6` array<varchar(50)> NULL,
+              `k7` array<date> NULL,
+              `k8` array<datetime> NULL,
+              `k9` array<float> NULL,
+              `k10` array<double> NULL,
+              `k11` array<decimal(20, 6)> NULL,
+              `k12` array<boolean> NULL,
+              `k13` array<text> NULL
+            ) ENGINE=OLAP
+            DUPLICATE KEY(`k1`)
+            COMMENT 'OLAP'
+            DISTRIBUTED BY HASH(`k1`) BUCKETS 1
+            PROPERTIES (
+            "replication_allocation" = "tag.location.default: 1",
+            "in_memory" = "false",
+            "storage_format" = "V2",
+            "disable_auto_compaction" = "false"
+            )
+            """
+        
+        // DDL/DML return 1 row and 3 column, the only value is update row count
+        assertTrue(result1.size() == 1)
+        assertTrue(result1[0].size() == 1)
+        assertTrue(result1[0][0] == 0, "Create table should update 0 rows")
+        
+        // insert 1 row to check whether the table is ok
+        def result2 = sql """ INSERT INTO ${tableName} VALUES (100, [1, 2, 3], [32767, 32768, 32769], [65534, 65535, 65536], 
+                        ['a', 'b', 'c'], ["hello", "world"], ['2022-07-13'], ['2022-07-13 12:30:00'], [0.33, 0.67], [3.1415926, 0.878787878],
+                        [4, 5.5, 6.67], [true, false], ['happy life'])
+                        """
+        assertTrue(result2.size() == 1)
+        assertTrue(result2[0].size() == 1)
+        assertTrue(result2[0][0] == 1, "Insert should update 1 rows")
+    }
+
+    try {
+        sql "DROP TABLE IF EXISTS ${tableName}"
+        
+        create_test_table.call(tableName)
+        test {
+            sql "CREATE MATERIALIZED VIEW idx AS select k1, k2, k3, k4, k5 from ${tableName}"
+            exception "errCode = 2, detailMessage = The array column[`k2` array<smallint(6)> NULL] not support to create materialized view"
+        }
+    } finally {
+        try_sql("DROP TABLE IF EXISTS ${tableName}")
+    }
+}


### PR DESCRIPTION
# Proposed changes
1. this pr is used to  forbid to create materialized view for array column.
2. before the change,  if you create the  materialized view for array column, it will report success and be will core dump.
3. after the change, if you create the  materialized view for array column, the FE will report error:
MySQL [example_db]> CREATE MATERIALIZED VIEW idx AS select k1, k2 from mv_tb;
ERROR 1105 (HY000): errCode = 2, detailMessage = The array column[`k2` array<tinyint(4)> NULL] not support to create materialized view

Issue Number: #7570

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
5. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
6. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

