### PR TITLE
[fix](new-scan) try to fix invalid call to nullptr slot

### DIFF
--- a/be/src/vec/exec/scan/vscan_node.cpp
+++ b/be/src/vec/exec/scan/vscan_node.cpp
@@ -437,6 +437,7 @@ VExpr* VScanNode::_normalize_predicate(VExpr* conjunct_expr_root) {
                         },
                         *range);
             }
+            LOG(WARNING) << "MYTEST" << slot->debug_string();
             if (pdt == PushDownType::ACCEPTABLE && slot != nullptr &&
                 _is_key_column(slot->col_name())) {
                 return nullptr;

--- a/be/src/vec/exec/scan/vscan_node.cpp
+++ b/be/src/vec/exec/scan/vscan_node.cpp
@@ -437,7 +437,8 @@ VExpr* VScanNode::_normalize_predicate(VExpr* conjunct_expr_root) {
                         },
                         *range);
             }
-            if (pdt == PushDownType::ACCEPTABLE && _is_key_column(slot->col_name())) {
+            if (pdt == PushDownType::ACCEPTABLE && slot != nullptr &&
+                _is_key_column(slot->col_name())) {
                 return nullptr;
             } else {
                 // for PARTIAL_ACCEPTABLE and UNACCEPTABLE, do not remove expr from the tree

--- a/be/src/vec/exec/scan/vscan_node.cpp
+++ b/be/src/vec/exec/scan/vscan_node.cpp
@@ -272,11 +272,11 @@ Status VScanNode::_append_rf_into_conjuncts(std::vector<VExpr*>& vexprs) {
     RETURN_IF_ERROR(new_vconjunct_ctx_ptr->prepare(_state, _row_descriptor));
     RETURN_IF_ERROR(new_vconjunct_ctx_ptr->open(_state));
     if (_vconjunct_ctx_ptr) {
-        (*(_vconjunct_ctx_ptr))->mark_as_stale();
+        (*_vconjunct_ctx_ptr)->mark_as_stale();
         _stale_vexpr_ctxs.push_back(std::move(_vconjunct_ctx_ptr));
     }
     _vconjunct_ctx_ptr.reset(new doris::vectorized::VExprContext*);
-    *(_vconjunct_ctx_ptr) = new_vconjunct_ctx_ptr;
+    *_vconjunct_ctx_ptr = new_vconjunct_ctx_ptr;
     return Status::OK();
 }
 
@@ -353,7 +353,7 @@ Status VScanNode::_normalize_conjuncts() {
             if (new_root) {
                 (*_vconjunct_ctx_ptr)->set_root(new_root);
             } else {
-                (*(_vconjunct_ctx_ptr))->mark_as_stale();
+                (*_vconjunct_ctx_ptr)->mark_as_stale();
                 _stale_vexpr_ctxs.push_back(std::move(_vconjunct_ctx_ptr));
                 _vconjunct_ctx_ptr.reset(nullptr);
             }
@@ -408,7 +408,7 @@ VExpr* VScanNode::_normalize_predicate(VExpr* conjunct_expr_root) {
             SlotDescriptor* slot = nullptr;
             ColumnValueRangeType* range = nullptr;
             PushDownType pdt = PushDownType::UNACCEPTABLE;
-            _eval_const_conjuncts(cur_expr, *(_vconjunct_ctx_ptr), &pdt);
+            _eval_const_conjuncts(cur_expr, *_vconjunct_ctx_ptr, &pdt);
             if (pdt == PushDownType::UNACCEPTABLE &&
                 (_is_predicate_acting_on_slot(cur_expr, in_predicate_checker, &slot, &range) ||
                  _is_predicate_acting_on_slot(cur_expr, eq_predicate_checker, &slot, &range))) {

--- a/be/src/vec/exec/scan/vscan_node.cpp
+++ b/be/src/vec/exec/scan/vscan_node.cpp
@@ -272,11 +272,11 @@ Status VScanNode::_append_rf_into_conjuncts(std::vector<VExpr*>& vexprs) {
     RETURN_IF_ERROR(new_vconjunct_ctx_ptr->prepare(_state, _row_descriptor));
     RETURN_IF_ERROR(new_vconjunct_ctx_ptr->open(_state));
     if (_vconjunct_ctx_ptr) {
-        (*(_vconjunct_ctx_ptr.get()))->mark_as_stale();
+        (*(_vconjunct_ctx_ptr))->mark_as_stale();
         _stale_vexpr_ctxs.push_back(std::move(_vconjunct_ctx_ptr));
     }
     _vconjunct_ctx_ptr.reset(new doris::vectorized::VExprContext*);
-    *(_vconjunct_ctx_ptr.get()) = new_vconjunct_ctx_ptr;
+    *(_vconjunct_ctx_ptr) = new_vconjunct_ctx_ptr;
     return Status::OK();
 }
 
@@ -353,7 +353,7 @@ Status VScanNode::_normalize_conjuncts() {
             if (new_root) {
                 (*_vconjunct_ctx_ptr)->set_root(new_root);
             } else {
-                (*(_vconjunct_ctx_ptr.get()))->mark_as_stale();
+                (*(_vconjunct_ctx_ptr))->mark_as_stale();
                 _stale_vexpr_ctxs.push_back(std::move(_vconjunct_ctx_ptr));
                 _vconjunct_ctx_ptr.reset(nullptr);
             }
@@ -405,10 +405,10 @@ VExpr* VScanNode::_normalize_predicate(VExpr* conjunct_expr_root) {
             auto impl = conjunct_expr_root->get_impl();
             // If impl is not null, which means this a conjuncts from runtime filter.
             VExpr* cur_expr = impl ? const_cast<VExpr*>(impl) : conjunct_expr_root;
-            SlotDescriptor* slot;
+            SlotDescriptor* slot = nullptr;
             ColumnValueRangeType* range = nullptr;
             PushDownType pdt = PushDownType::UNACCEPTABLE;
-            _eval_const_conjuncts(cur_expr, *(_vconjunct_ctx_ptr.get()), &pdt);
+            _eval_const_conjuncts(cur_expr, *(_vconjunct_ctx_ptr), &pdt);
             if (pdt == PushDownType::UNACCEPTABLE &&
                 (_is_predicate_acting_on_slot(cur_expr, in_predicate_checker, &slot, &range) ||
                  _is_predicate_acting_on_slot(cur_expr, eq_predicate_checker, &slot, &range))) {
@@ -437,7 +437,6 @@ VExpr* VScanNode::_normalize_predicate(VExpr* conjunct_expr_root) {
                         },
                         *range);
             }
-            LOG(WARNING) << "MYTEST" << slot->debug_string();
             if (pdt == PushDownType::ACCEPTABLE && slot != nullptr &&
                 _is_key_column(slot->col_name())) {
                 return nullptr;


### PR DESCRIPTION
# Proposed changes

In some case, slot will not be initialized, so we should do not call `slot->name()`

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

