### PR TITLE
[improvement](runtime) log status via to_string

### DIFF
--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -663,7 +663,7 @@ void TaskWorkerPool::_push_worker_thread_callback() {
             task_status.__set_status_code(TStatusCode::OK);
             finish_task_request.__set_finish_tablet_infos(tablet_infos);
         } else {
-            LOG(WARNING) << "push failed, error_code: " << status
+            LOG(WARNING) << "push failed, error_code: " << status.to_string()
                          << ", signature: " << agent_task_req.signature;
             error_msgs.push_back("push failed");
             task_status.__set_status_code(TStatusCode::RUNTIME_ERROR);
@@ -1595,7 +1595,7 @@ void TaskWorkerPool::_handle_report(TReportRequest& request, ReportType type) {
     Status status = _master_client->report(request, &result);
     bool is_report_success = false;
     if (!status.ok()) {
-        LOG(WARNING) << "report " << TYPE_STRING(type) << " failed. status: " << status
+        LOG(WARNING) << "report " << TYPE_STRING(type) << " failed. status: " << status.to_string()
                      << ", master host: " << _master_info.network_address.hostname
                      << ", port:" << _master_info.network_address.port;
     } else if (result.status.status_code != TStatusCode::OK) {

--- a/be/src/runtime/fragment_mgr.cpp
+++ b/be/src/runtime/fragment_mgr.cpp
@@ -290,7 +290,7 @@ void FragmentExecState::coordinator_callback(const Status& status, RuntimeProfil
     FrontendServiceConnection coord(_exec_env->frontend_client_cache(), _coord_addr, &coord_status);
     if (!coord_status.ok()) {
         std::stringstream ss;
-        ss << "couldn't get a client for " << _coord_addr << ", reason: " << coord_status;
+        ss << "couldn't get a client for " << _coord_addr << ", reason: " << coord_status.to_string();
         LOG(WARNING) << "query_id: " << _query_id << ", " << ss.str();
         update_status(Status::InternalError(ss.str()));
         return;


### PR DESCRIPTION
Status is treated as bool when we log it via operator << due to Status::bool() method.

# Proposed changes

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

