### PR TITLE
[feature](nereids) merge push down and remove redundant operator rules into one batch

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/batch/RewriteJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/batch/RewriteJob.java
@@ -62,17 +62,17 @@ public class RewriteJob extends BatchRulesJob {
                 .addAll(new ConvertApplyToJoinJob(cascadesContext).rulesJob)
                 .add(topDownBatch(ImmutableList.of(new ExpressionNormalization())))
                 .add(topDownBatch(ImmutableList.of(new NormalizeAggregate())))
-                .add(topDownBatch(ImmutableList.of(new ReorderJoin())))
+                 .add(topDownBatch(ImmutableList.of(new ReorderJoin())))
                 .add(topDownBatch(ImmutableList.of(new FindHashConditionForJoin())))
-                .add(topDownBatch(ImmutableList.of(new PushPredicateThroughJoin())))
                 .add(topDownBatch(ImmutableList.of(new NormalizeAggregate())))
                 .add(topDownBatch(ImmutableList.of(new ColumnPruning())))
+                .add(topDownBatch(ImmutableList.of(new PushPredicateThroughJoin(),
+                        new PushdownProjectThroughLimit(),
+                        new PushdownFilterThroughProject(),
+                        new MergeConsecutiveProjects(),
+                        new MergeConsecutiveFilters(),
+                        new MergeConsecutiveLimits())))
                 .add(topDownBatch(ImmutableList.of(new AggregateDisassemble())))
-                .add(topDownBatch(ImmutableList.of(new PushdownProjectThroughLimit())))
-                .add(topDownBatch(ImmutableList.of(new PushdownFilterThroughProject())))
-                .add(bottomUpBatch(ImmutableList.of(new MergeConsecutiveProjects())))
-                .add(topDownBatch(ImmutableList.of(new MergeConsecutiveFilters())))
-                .add(bottomUpBatch(ImmutableList.of(new MergeConsecutiveLimits())))
                 .add(topDownBatch(ImmutableList.of(new EliminateLimit())))
                 .add(topDownBatch(ImmutableList.of(new EliminateFilter())))
                 .add(topDownBatch(ImmutableList.of(new PruneOlapScanPartition())))

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -195,6 +195,8 @@ public class SessionVariable implements Serializable, Writable {
 
     public static final String ENABLE_NEREIDS_PLANNER = "enable_nereids_planner";
 
+    public static final String ENABLE_FALLBACK_TO_ORIGINAL_PLANNER = "enable_fallback_to_original_planner";
+
     public static final String ENABLE_NEREIDS_REORDER_TO_ELIMINATE_CROSS_JOIN =
             "enable_nereids_reorder_to_eliminate_cross_join";
 
@@ -534,6 +536,7 @@ public class SessionVariable implements Serializable, Writable {
     @VariableMgr.VarAttr(name = ENABLE_LOCAL_EXCHANGE)
     public boolean enableLocalExchange = false;
 
+
     /**
      * For debugg purpose, dont' merge unique key and agg key when reading data.
      */
@@ -545,6 +548,13 @@ public class SessionVariable implements Serializable, Writable {
      */
     @VariableMgr.VarAttr(name = SKIP_DELETE_PREDICATE)
     public boolean skipDeletePredicate = false;
+
+    // This variable is used to avoid FE fallback to the original parser. When we execute SQL in regression tests
+    // for nereids, fallback will cause the Doris return the correct result although the syntax is unsupported
+    // in nereids for some mistaken modification. You should set it on the
+    @VariableMgr.VarAttr(name = ENABLE_FALLBACK_TO_ORIGINAL_PLANNER)
+    public boolean enableFallbackToOriginalPlanner = true;
+
 
     public String getBlockEncryptionMode() {
         return blockEncryptionMode;

--- a/regression-test/suites/nereids_syntax_p0/agg_with_const.groovy
+++ b/regression-test/suites/nereids_syntax_p0/agg_with_const.groovy
@@ -17,6 +17,9 @@
 
 suite("agg_with_const") {
 
+    sql "SET enable_vectorized_engine=true"
+    sql "SET enable_nereids_planner=true"
+
     sql """
         DROP TABLE IF EXISTS t1
        """
@@ -32,6 +35,8 @@ suite("agg_with_const") {
     sql """
     insert into t1 values(1994, 1994, 1995)
     """
+
+    sql "SET enable_fallback_to_original_planner=false"
 
     qt_select """
         select count(2) + 1, sum(2) + sum(col1) from t1

--- a/regression-test/suites/nereids_syntax_p0/empty_relation.groovy
+++ b/regression-test/suites/nereids_syntax_p0/empty_relation.groovy
@@ -19,6 +19,7 @@ suite("empty_relation") {
     // enable nereids and vectorized engine
     sql "SET enable_vectorized_engine=true"
     sql "SET enable_nereids_planner=true"
+    sql "SET enable_fallback_to_original_planner=false"
 
     test {
         sql "select *, substring(s_name, 1, 2) from supplier limit 0"

--- a/regression-test/suites/nereids_syntax_p0/explain.groovy
+++ b/regression-test/suites/nereids_syntax_p0/explain.groovy
@@ -24,6 +24,8 @@ suite("explain") {
         SET enable_nereids_planner=true
     """
 
+    sql "SET enable_fallback_to_original_planner=false"
+
     explain {
         sql("select count(2) + 1, sum(2) + sum(lo_suppkey) from lineorder")
         contains "projections: lo_suppkey"

--- a/regression-test/suites/nereids_syntax_p0/function.groovy
+++ b/regression-test/suites/nereids_syntax_p0/function.groovy
@@ -23,6 +23,7 @@ suite("function") {
     sql """
         SET enable_nereids_planner=true
     """
+    sql "SET enable_fallback_to_original_planner=false"
 
     order_qt_max """
         SELECT max(lo_discount), max(lo_extendedprice) AS max_extendedprice FROM lineorder;

--- a/regression-test/suites/nereids_syntax_p0/having.groovy
+++ b/regression-test/suites/nereids_syntax_p0/having.groovy
@@ -43,6 +43,7 @@ suite("test_nereids_having") {
             (3, 3, 9)
     """
 
+    sql "SET enable_fallback_to_original_planner=false"
 
     order_qt_select "SELECT a1 as value FROM t1 GROUP BY a1 HAVING a1 > 0";
     order_qt_select "SELECT a1 as value FROM t1 GROUP BY a1 HAVING value > 0";

--- a/regression-test/suites/nereids_syntax_p0/inpredicate.groovy
+++ b/regression-test/suites/nereids_syntax_p0/inpredicate.groovy
@@ -24,6 +24,8 @@ suite("inpredicate") {
         SET enable_nereids_planner=true
     """
 
+    sql "SET enable_fallback_to_original_planner=false"
+
     order_qt_in_predicate_1 """
         SELECT * FROM supplier WHERE s_suppkey in (1, 2, 3);
     """

--- a/regression-test/suites/nereids_syntax_p0/join.groovy
+++ b/regression-test/suites/nereids_syntax_p0/join.groovy
@@ -24,6 +24,8 @@ suite("join") {
         SET enable_nereids_planner=true
     """
 
+    sql "SET enable_fallback_to_original_planner=false"
+
     order_qt_inner_join_1 """
         SELECT * FROM lineorder JOIN supplier ON lineorder.lo_suppkey = supplier.s_suppkey
     """

--- a/regression-test/suites/nereids_syntax_p0/one_row_relation.groovy
+++ b/regression-test/suites/nereids_syntax_p0/one_row_relation.groovy
@@ -19,6 +19,7 @@ suite("one_row_relation") {
     // enable nereids and vectorized engine
     sql "SET enable_vectorized_engine=true"
     sql "SET enable_nereids_planner=true"
+    sql "SET enable_fallback_to_original_planner=false"
 
     test {
         sql "select 100, 'abc', substring('abc', 1, 2), substring(substring('abcdefg', 4, 3), 1, 2)"

--- a/regression-test/suites/nereids_syntax_p0/rollup.groovy
+++ b/regression-test/suites/nereids_syntax_p0/rollup.groovy
@@ -67,6 +67,8 @@ suite("rollup") {
 
     sql "set enable_nereids_planner=true"
 
+    sql "SET enable_fallback_to_original_planner=false"
+
     explain {
         sql("select k2, sum(v1) from rollup_t1 group by k2")
         contains("rollup_t1(r1)")

--- a/regression-test/suites/nereids_syntax_p0/sub_query_alias.groovy
+++ b/regression-test/suites/nereids_syntax_p0/sub_query_alias.groovy
@@ -24,6 +24,8 @@ suite("sub_query_alias") {
         SET enable_nereids_planner=true
     """
 
+    sql "SET enable_fallback_to_original_planner=false"
+
     qt_select_1 """
         select t.c_custkey, t.lo_custkey 
         from (

--- a/regression-test/suites/nereids_syntax_p0/sub_query_correlated.groovy
+++ b/regression-test/suites/nereids_syntax_p0/sub_query_correlated.groovy
@@ -89,6 +89,8 @@ suite ("sub_query_correlated") {
         insert into subquery4 values (5,4), (5,2), (8,3), (5,4), (6,7), (8,9)
     """
 
+    sql "SET enable_fallback_to_original_planner=false"
+
     //------------------Correlated-----------------
     qt_scalar_less_than_corr """
         select * from subquery1 where subquery1.k1 < (select sum(subquery3.k3) from subquery3 where subquery3.v2 = subquery1.k2) order by k1

--- a/regression-test/suites/nereids_syntax_p0/view.groovy
+++ b/regression-test/suites/nereids_syntax_p0/view.groovy
@@ -46,6 +46,8 @@ suite("view") {
         on v1.c_custkey = t.lo_custkey;
     """
 
+    sql "SET enable_fallback_to_original_planner=false"
+
     qt_select_1 """
         select * 
         from v1


### PR DESCRIPTION
# Proposed changes

Issue Number: noissue

## Problem summary

1. For some related rules, we need to iterate thems many times together to get the expected plan.
2. Add session variables to avoid fallback to stale planner when running regression tests of nereids for piggyback.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
3. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
4. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
5. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
6. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

