### PR TITLE
[feature-wip](parquet-reader) create file reader for each column to avoid time consuming of hdfsSeek

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -809,6 +809,8 @@ CONF_Int32(object_pool_buffer_size, "100");
 CONF_Int32(parquet_reader_max_buffer_size, "50");
 CONF_Bool(parquet_predicate_push_down, "true");
 CONF_Int32(parquet_header_max_size, "8388608");
+CONF_Int32(parquet_file_buffer_size, "2097152");
+CONF_Int32(parquet_group_pooled_reader, "100");
 CONF_Bool(parquet_reader_using_internal, "false");
 
 // When the rows number reached this limit, will check the filter rate the of bloomfilter

--- a/be/src/io/buffered_reader.h
+++ b/be/src/io/buffered_reader.h
@@ -115,12 +115,9 @@ private:
     uint64_t _file_start_offset;
     uint64_t _file_end_offset;
 
-    int64_t _file_position = -1;
     uint64_t _buf_start_offset = 0;
     uint64_t _buf_end_offset = 0;
     size_t _buf_size = 0;
-
-    Status seek(uint64_t position);
 };
 
 } // namespace doris

--- a/be/src/io/file_factory.h
+++ b/be/src/io/file_factory.h
@@ -58,6 +58,10 @@ public:
                                      const TFileRangeDesc& range,
                                      std::shared_ptr<FileReader>& file_reader);
 
+    static Status create_file_reader(const TFileScanRangeParams& params,
+                                     const TFileRangeDesc& range,
+                                     std::unique_ptr<FileReader>& file_reader);
+
     static TFileType::type convert_storage_type(TStorageBackendType::type type) {
         switch (type) {
         case TStorageBackendType::LOCAL:

--- a/be/src/io/hdfs_file_reader.cpp
+++ b/be/src/io/hdfs_file_reader.cpp
@@ -147,6 +147,7 @@ Status HdfsFileReader::readat(int64_t position, int64_t nbytes, int64_t* bytes_r
                                          BackendOptions::get_localhost(), _namenode, _path,
                                          hdfsGetLastError());
         }
+        _current_offset = position;
     }
 
     *bytes_read = hdfsRead(_hdfs_fs, _hdfs_file, out, nbytes);
@@ -191,6 +192,7 @@ Status HdfsFileReader::seek(int64_t position) {
         return Status::InternalError("Seek to offset failed. (BE: {}) offset={}, err: {}",
                                      BackendOptions::get_localhost(), position, hdfsGetLastError());
     }
+    _current_offset = position;
     return Status::OK();
 }
 

--- a/be/src/vec/exec/file_hdfs_scanner.cpp
+++ b/be/src/vec/exec/file_hdfs_scanner.cpp
@@ -17,8 +17,6 @@
 
 #include "file_hdfs_scanner.h"
 
-#include "io/file_factory.h"
-
 namespace doris::vectorized {
 
 ParquetFileHdfsScanner::ParquetFileHdfsScanner(RuntimeState* state, RuntimeProfile* profile,
@@ -67,12 +65,9 @@ Status ParquetFileHdfsScanner::_get_next_reader() {
         return Status::OK();
     }
     const TFileRangeDesc& range = _ranges[_next_range++];
-    std::unique_ptr<FileReader> file_reader;
-    RETURN_IF_ERROR(FileFactory::create_file_reader(_state->exec_env(), _profile, _params, range,
-                                                    file_reader));
-    _reader.reset(new ParquetReader(
-            file_reader.release(), _file_slot_descs.size(), _state->query_options().batch_size,
-            range.start_offset, range.size, const_cast<cctz::time_zone*>(&_state->timezone_obj())));
+    _reader.reset(new ParquetReader(_profile, _params, range, _file_slot_descs.size(),
+                                    _state->query_options().batch_size,
+                                    const_cast<cctz::time_zone*>(&_state->timezone_obj())));
     auto tuple_desc = _state->desc_tbl().get_tuple_descriptor(_tupleId);
     Status status =
             _reader->init_reader(tuple_desc, _file_slot_descs, _conjunct_ctxs, _state->timezone());

--- a/be/src/vec/exec/format/parquet/vparquet_page_reader.cpp
+++ b/be/src/vec/exec/format/parquet/vparquet_page_reader.cpp
@@ -23,8 +23,6 @@
 
 namespace doris::vectorized {
 
-static constexpr size_t initPageHeaderSize = 128;
-
 PageReader::PageReader(BufferedStreamReader* reader, uint64_t offset, uint64_t length)
         : _reader(reader), _start_offset(offset), _end_offset(offset + length) {}
 
@@ -38,7 +36,7 @@ Status PageReader::next_page_header() {
 
     const uint8_t* page_header_buf = nullptr;
     size_t max_size = _end_offset - _offset;
-    size_t header_size = std::min(initPageHeaderSize, max_size);
+    size_t header_size = 128;
     uint32_t real_header_size = 0;
     while (true) {
         header_size = std::min(header_size, max_size);


### PR DESCRIPTION
# Proposed changes

## Problem summary
`ParquetReader` spends a lot time on hdfsSeek:
![image](https://user-images.githubusercontent.com/19337507/189920276-1a185c72-424b-4815-8dcc-05051cba237c.png)
There are two reasons why the hdfs reader frequently trigger the seek function:
1.  The `readAt` and `seek` function of `HdfsFileReader` don't reset the right file position after reading or seeking.
2.  `ParquetColumnReader`s of a row group reuse the same `HdfsFileReader`, the file position must seek to the each column when reading a page.
### Solution
1. Fix the bug of file position of `HdfsFileReader`
2. Create a new file reader for the column. To prevent too many connections to hdfs, build a file readers pool, the column will reuse the previous file reader when the pool if full
### Effect
The end-to-end query time of TPCH-Q1 has been reduced from 48s to 18s. The hdfsSeek disappears on the flame diagram:
![image](https://user-images.githubusercontent.com/19337507/189923778-1532cff8-269f-4ffd-b230-ae03ff9b8fee.png)



## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
4. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
5. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
6. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
7. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

