### PR TITLE
[enhancement](doc) When we use flink doris connector with bounded source, we should using the BATCH mode.

### DIFF
--- a/docs/en/docs/ecosystem/flink-doris-connector.md
+++ b/docs/en/docs/ecosystem/flink-doris-connector.md
@@ -253,6 +253,8 @@ env.fromSource(dorisSource, WatermarkStrategy.noWatermarks(), "doris source").pr
 ```java
 // enable checkpoint
 env.enableCheckpointing(10000);
+// using batch mode for bounded data
+env.setRuntimeMode(RuntimeExecutionMode.BATCH);
 
 DorisSink.Builder<String> builder = DorisSink.builder();
 DorisOptions.Builder dorisBuilder = DorisOptions.builder();
@@ -292,6 +294,8 @@ source.map((MapFunction<Tuple2<String, Integer>, String>) t -> t.f0 + "\t" + t.f
 ```java
 // enable checkpoint
 env.enableCheckpointing(10000);
+// using batch mode for bounded data
+env.setRuntimeMode(RuntimeExecutionMode.BATCH);
 
 //doris sink option
 DorisSink.Builder<RowData> builder = DorisSink.builder();

--- a/docs/zh-CN/docs/ecosystem/flink-doris-connector.md
+++ b/docs/zh-CN/docs/ecosystem/flink-doris-connector.md
@@ -257,6 +257,8 @@ env.fromSource(dorisSource, WatermarkStrategy.noWatermarks(), "doris source").pr
 ```java
 // enable checkpoint
 env.enableCheckpointing(10000);
+// using batch mode for bounded data
+env.setRuntimeMode(RuntimeExecutionMode.BATCH);
 
 DorisSink.Builder<String> builder = DorisSink.builder();
 DorisOptions.Builder dorisBuilder = DorisOptions.builder();
@@ -289,6 +291,8 @@ source.map((MapFunction<Tuple2<String, Integer>, String>) t -> t.f0 + "\t" + t.f
 ```java
 // enable checkpoint
 env.enableCheckpointing(10000);
+// using batch mode for bounded data
+env.setRuntimeMode(RuntimeExecutionMode.BATCH);
 
 //doris sink option
 DorisSink.Builder<RowData> builder = DorisSink.builder();


### PR DESCRIPTION
# Proposed changes
When we using flink to write bounded data into doris, we should using the BATCH RuntimeExecutionMode.

Issue Number: close #12575

## Problem summary
When we using flink to write bounded data into doris, we should using the BATCH RuntimeExecutionMode.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [x] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
3. Has document been added or modified:
    - [x] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

