### PR TITLE
[fix](planner) fix orthogonal_bitmap_union_count planner : wrong PREAGGREGATION

### DIFF
--- a/docs/en/docs/sql-manual/sql-reference/Database-Administration-Statements/ADMIN-COPY-TABLET.md
+++ b/docs/en/docs/sql-manual/sql-reference/Database-Administration-Statements/ADMIN-COPY-TABLET.md
@@ -1,6 +1,6 @@
 ---
 {
-    "title": "ADMIN-COPY-TABLET"
+    "title": "ADMIN-COPY-TABLET",
     "language": "en"
 }
 ---

--- a/docs/zh-CN/docs/sql-manual/sql-reference/Database-Administration-Statements/ADMIN-COPY-TABLET.md
+++ b/docs/zh-CN/docs/sql-manual/sql-reference/Database-Administration-Statements/ADMIN-COPY-TABLET.md
@@ -1,6 +1,6 @@
 ---
 {
-    "title": "ADMIN-COPY-TABLET"
+    "title": "ADMIN-COPY-TABLET",
     "language": "zh-CN"
 }
 ---

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/SingleNodePlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/SingleNodePlanner.java
@@ -587,7 +587,8 @@ public class SingleNodePlanner {
                             break;
                         }
                     } else if (aggExpr.getFnName().getFunction().equalsIgnoreCase(FunctionSet.BITMAP_UNION)
-                            || aggExpr.getFnName().getFunction().equalsIgnoreCase(FunctionSet.BITMAP_UNION_COUNT)) {
+                            || aggExpr.getFnName().getFunction().equalsIgnoreCase(FunctionSet.BITMAP_UNION_COUNT)
+                            || aggExpr.getFnName().getFunction().equalsIgnoreCase(FunctionSet.ORTHOGONAL_BITMAP_UNION_COUNT)) {
                         if (col.getAggregationType() != AggregateType.BITMAP_UNION) {
                             turnOffReason =
                                     "Aggregate Operator not match: BITMAP_UNION <--> " + col.getAggregationType();


### PR DESCRIPTION
# Proposed changes


## Problem summary

Execution plan display when using orthogonal_bitmap_union_count function:

PREAGGREGATION: OFF

Reason: Invalid Aggregate Operator: orthogonal_bitmap_union_count

The correct plan is: PREAGGREGATION: ON
![image](https://user-images.githubusercontent.com/35155212/190051445-4f905213-6fe8-45db-963a-4ef943dd0240.png)

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [x] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

