### PR TITLE
[Opt](vectorized) Use new way to do hash shffle to speed up query

### DIFF
--- a/be/src/util/hash_util.hpp
+++ b/be/src/util/hash_util.hpp
@@ -33,6 +33,7 @@
 #elif __aarch64__
 #include <sse2neon.h>
 #endif
+#include <xxh3.h>
 #include <zlib.h>
 
 #include "gen_cpp/Types_types.h"
@@ -362,6 +363,18 @@ public:
     static inline void hash_combine(std::size_t& seed, const T& v) {
         std::hash<T> hasher;
         seed ^= hasher(v) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+    }
+
+    // xxHash function for a byte array.  For convenience, a 64-bit seed is also
+    // hashed into the result.  The mapping may change from time to time.
+    static xxh_u64 xxHash64WithSeed(const char* s, size_t len, xxh_u64 seed) {
+        return XXH3_64bits_withSeed(s, len, seed);
+    }
+
+    // same to the up function, just for null value
+    static xxh_u64 xxHash64NullWithSeed(xxh_u64 seed) {
+        static const int INT_VALUE = 0;
+        return XXH3_64bits_withSeed(reinterpret_cast<const char*>(&INT_VALUE), sizeof(int), seed);
     }
 };
 

--- a/be/src/vec/columns/column.h
+++ b/be/src/vec/columns/column.h
@@ -328,23 +328,36 @@ public:
         LOG(FATAL) << "deserialize_vec_with_null_map not supported";
     }
 
+    /// TODO: SipHash is slower than city or xx hash, rethink we should have a new interface
     /// Update state of hash function with value of n-th element.
     /// On subsequent calls of this method for sequence of column values of arbitrary types,
     ///  passed bytes to hash must identify sequence of values unambiguously.
-    virtual void update_hash_with_value(size_t n, SipHash& hash) const = 0;
+    virtual void update_hash_with_value(size_t n, SipHash& hash) const {
+        LOG(FATAL) << "update_hash_with_value siphash not supported";
+    }
 
     /// Update state of hash function with value of n elements to avoid the virtual function call
     /// null_data to mark whether need to do hash compute, null_data == nullptr
     /// means all element need to do hash function, else only *null_data != 0 need to do hash func
-    virtual void update_hashes_with_value(std::vector<SipHash>& hash,
+    /// do xxHash here, faster than other hash method
+    virtual void update_hashes_with_value(std::vector<SipHash>& hashes,
                                           const uint8_t* __restrict null_data = nullptr) const {
-        LOG(FATAL) << "update_hashes_with_value not supported";
+        LOG(FATAL) << "update_hashes_with_value siphash not supported";
+    };
+
+    /// Update state of hash function with value of n elements to avoid the virtual function call
+    /// null_data to mark whether need to do hash compute, null_data == nullptr
+    /// means all element need to do hash function, else only *null_data != 0 need to do hash func
+    /// do xxHash here, faster than other sip hash
+    virtual void update_hashes_with_value(uint64_t* __restrict hashes,
+                                          const uint8_t* __restrict null_data = nullptr) const {
+        LOG(FATAL) << "update_hashes_with_value xxhash not supported";
     };
 
     /// Update state of crc32 hash function with value of n elements to avoid the virtual function call
     /// null_data to mark whether need to do hash compute, null_data == nullptr
     /// means all element need to do hash function, else only *null_data != 0 need to do hash func
-    virtual void update_crcs_with_value(std::vector<uint32_t>& hash, PrimitiveType type,
+    virtual void update_crcs_with_value(std::vector<uint64_t>& hash, PrimitiveType type,
                                         const uint8_t* __restrict null_data = nullptr) const {
         LOG(FATAL) << "update_crcs_with_value not supported";
     };

--- a/be/src/vec/columns/column_array.cpp
+++ b/be/src/vec/columns/column_array.cpp
@@ -226,11 +226,6 @@ void ColumnArray::update_hash_with_value(size_t n, SipHash& hash) const {
     for (size_t i = 0; i < array_size; ++i) get_data().update_hash_with_value(offset + i, hash);
 }
 
-void ColumnArray::update_hashes_with_value(std::vector<SipHash>& hashes,
-                                           const uint8_t* __restrict null_data) const {
-    SIP_HASHES_FUNCTION_COLUMN_IMPL();
-}
-
 void ColumnArray::insert(const Field& x) {
     const Array& array = doris::vectorized::get<const Array&>(x);
     size_t size = array.size();

--- a/be/src/vec/columns/column_array.h
+++ b/be/src/vec/columns/column_array.h
@@ -98,8 +98,6 @@ public:
     StringRef serialize_value_into_arena(size_t n, Arena& arena, char const*& begin) const override;
     const char* deserialize_and_insert_from_arena(const char* pos) override;
     void update_hash_with_value(size_t n, SipHash& hash) const override;
-    void update_hashes_with_value(std::vector<SipHash>& hashes,
-                                  const uint8_t* __restrict null_data) const override;
     void insert_range_from(const IColumn& src, size_t start, size_t length) override;
     void insert(const Field& x) override;
     void insert_from(const IColumn& src_, size_t n) override;

--- a/be/src/vec/columns/column_complex.h
+++ b/be/src/vec/columns/column_complex.h
@@ -188,11 +188,6 @@ public:
         // TODO add hash function
     }
 
-    void update_hashes_with_value(std::vector<SipHash>& hash,
-                                  const uint8_t* __restrict null_data) const override {
-        // TODO add hash function
-    }
-
     [[noreturn]] int compare_at(size_t n, size_t m, const IColumn& rhs,
                                 int nan_direction_hint) const override {
         LOG(FATAL) << "compare_at not implemented";

--- a/be/src/vec/columns/column_const.cpp
+++ b/be/src/vec/columns/column_const.cpp
@@ -104,7 +104,7 @@ void ColumnConst::update_hashes_with_value(std::vector<SipHash>& hashes,
     }
 }
 
-void ColumnConst::update_crcs_with_value(std::vector<uint32_t>& hashes, doris::PrimitiveType type,
+void ColumnConst::update_crcs_with_value(std::vector<uint64_t>& hashes, doris::PrimitiveType type,
                                          const uint8_t* __restrict null_data) const {
     DCHECK(null_data == nullptr);
     DCHECK(hashes.size() == size());
@@ -117,6 +117,22 @@ void ColumnConst::update_crcs_with_value(std::vector<uint32_t>& hashes, doris::P
         for (int i = 0; i < hashes.size(); ++i) {
             hashes[i] = RawValue::zlib_crc32(real_data.data, real_data.size, TypeDescriptor {type},
                                              hashes[i]);
+        }
+    }
+}
+
+void ColumnConst::update_hashes_with_value(uint64_t* __restrict hashes,
+                                           const uint8_t* __restrict null_data) const {
+    DCHECK(null_data == nullptr);
+    auto real_data = data->get_data_at(0);
+    auto real_size = size();
+    if (real_data.data == nullptr) {
+        for (int i = 0; i < real_size; ++i) {
+            hashes[i] = HashUtil::xxHash64NullWithSeed(hashes[i]);
+        }
+    } else {
+        for (int i = 0; i < real_size; ++i) {
+            hashes[i] = HashUtil::xxHash64WithSeed(real_data.data, real_data.size, hashes[i]);
         }
     }
 }

--- a/be/src/vec/columns/column_const.h
+++ b/be/src/vec/columns/column_const.h
@@ -135,8 +135,11 @@ public:
     void update_hashes_with_value(std::vector<SipHash>& hashes,
                                   const uint8_t* __restrict null_data) const override;
 
-    void update_crcs_with_value(std::vector<uint32_t>& hashes, PrimitiveType type,
+    void update_crcs_with_value(std::vector<uint64_t>& hashes, PrimitiveType type,
                                 const uint8_t* __restrict null_data) const override;
+
+    void update_hashes_with_value(uint64_t* __restrict hashes,
+                                  const uint8_t* __restrict null_data) const override;
 
     ColumnPtr filter(const Filter& filt, ssize_t result_size_hint) const override;
     ColumnPtr replicate(const Offsets& offsets) const override;

--- a/be/src/vec/columns/column_decimal.cpp
+++ b/be/src/vec/columns/column_decimal.cpp
@@ -128,7 +128,7 @@ void ColumnDecimal<T>::update_hashes_with_value(std::vector<SipHash>& hashes,
 }
 
 template <typename T>
-void ColumnDecimal<T>::update_crcs_with_value(std::vector<uint32_t>& hashes, PrimitiveType type,
+void ColumnDecimal<T>::update_crcs_with_value(std::vector<uint64_t>& hashes, PrimitiveType type,
                                               const uint8_t* __restrict null_data) const {
     auto s = hashes.size();
     DCHECK(s == size());
@@ -157,6 +157,16 @@ void ColumnDecimal<T>::update_crcs_with_value(std::vector<uint32_t>& hashes, Pri
         } else {
             DO_CRC_HASHES_FUNCTION_COLUMN_IMPL()
         }
+    }
+}
+
+template <typename T>
+void ColumnDecimal<T>::update_hashes_with_value(uint64_t* __restrict hashes,
+                                                const uint8_t* __restrict null_data) const {
+    auto s = size();
+    for (int i = 0; i < s; i++) {
+        hashes[i] = HashUtil::xxHash64WithSeed(reinterpret_cast<const char*>(&data[i]), sizeof(T),
+                                               hashes[i]);
     }
 }
 

--- a/be/src/vec/columns/column_decimal.h
+++ b/be/src/vec/columns/column_decimal.h
@@ -154,9 +154,11 @@ public:
                                        const uint8_t* null_map) override;
 
     void update_hash_with_value(size_t n, SipHash& hash) const override;
-    void update_hashes_with_value(std::vector<SipHash>& hash,
+    void update_hashes_with_value(std::vector<SipHash>& hashes,
                                   const uint8_t* __restrict null_data) const override;
-    void update_crcs_with_value(std::vector<uint32_t>& hashes, PrimitiveType type,
+    void update_hashes_with_value(uint64_t* __restrict hashes,
+                                  const uint8_t* __restrict null_data) const override;
+    void update_crcs_with_value(std::vector<uint64_t>& hashes, PrimitiveType type,
                                 const uint8_t* __restrict null_data) const override;
 
     int compare_at(size_t n, size_t m, const IColumn& rhs_, int nan_direction_hint) const override;

--- a/be/src/vec/columns/column_dummy.h
+++ b/be/src/vec/columns/column_dummy.h
@@ -72,11 +72,6 @@ public:
         return pos;
     }
 
-    void update_hash_with_value(size_t /*n*/, SipHash& /*hash*/) const override {}
-
-    void update_hashes_with_value(std::vector<SipHash>& hashes,
-                                  const uint8_t* __restrict null_data) const override {};
-
     void insert_from(const IColumn&, size_t) override { ++s; }
 
     void insert_range_from(const IColumn& /*src*/, size_t /*start*/, size_t length) override {

--- a/be/src/vec/columns/column_nullable.cpp
+++ b/be/src/vec/columns/column_nullable.cpp
@@ -25,7 +25,6 @@
 #include "vec/common/arena.h"
 #include "vec/common/assert_cast.h"
 #include "vec/common/nan_utils.h"
-#include "vec/common/sip_hash.h"
 #include "vec/common/typeid_cast.h"
 #include "vec/core/sort_block.h"
 
@@ -73,7 +72,7 @@ void ColumnNullable::update_hashes_with_value(std::vector<SipHash>& hashes,
     }
 }
 
-void ColumnNullable::update_crcs_with_value(std::vector<uint32_t>& hashes,
+void ColumnNullable::update_crcs_with_value(std::vector<uint64_t>& hashes,
                                             doris::PrimitiveType type,
                                             const uint8_t* __restrict null_data) const {
     DCHECK(null_data == nullptr);
@@ -89,6 +88,21 @@ void ColumnNullable::update_crcs_with_value(std::vector<uint32_t>& hashes,
             }
         }
         nested_column->update_crcs_with_value(hashes, type, real_null_data);
+    }
+}
+
+void ColumnNullable::update_hashes_with_value(uint64_t* __restrict hashes,
+                                              const uint8_t* __restrict null_data) const {
+    DCHECK(null_data == nullptr);
+    auto s = size();
+    auto* __restrict real_null_data = assert_cast<const ColumnUInt8&>(*null_map).get_data().data();
+    if (doris::simd::count_zero_num(reinterpret_cast<const int8_t*>(real_null_data), s) == s) {
+        nested_column->update_hashes_with_value(hashes, nullptr);
+    } else {
+        for (int i = 0; i < s; ++i) {
+            if (real_null_data[i] != 0) hashes[i] = HashUtil::xxHash64NullWithSeed(hashes[i]);
+        }
+        nested_column->update_hashes_with_value(hashes, real_null_data);
     }
 }
 

--- a/be/src/vec/columns/column_nullable.h
+++ b/be/src/vec/columns/column_nullable.h
@@ -163,8 +163,10 @@ public:
     void update_hash_with_value(size_t n, SipHash& hash) const override;
     void update_hashes_with_value(std::vector<SipHash>& hashes,
                                   const uint8_t* __restrict null_data) const override;
-    void update_crcs_with_value(std::vector<uint32_t>& hash, PrimitiveType type,
+    void update_crcs_with_value(std::vector<uint64_t>& hash, PrimitiveType type,
                                 const uint8_t* __restrict null_data) const override;
+    void update_hashes_with_value(uint64_t* __restrict hashes,
+                                  const uint8_t* __restrict null_data) const override;
     void get_extremes(Field& min, Field& max) const override;
 
     MutableColumns scatter(ColumnIndex num_columns, const Selector& selector) const override {

--- a/be/src/vec/columns/column_string.cpp
+++ b/be/src/vec/columns/column_string.cpp
@@ -116,7 +116,7 @@ void ColumnString::insert_indices_from(const IColumn& src, const int* indices_be
     }
 }
 
-void ColumnString::update_crcs_with_value(std::vector<uint32_t>& hashes, doris::PrimitiveType type,
+void ColumnString::update_crcs_with_value(std::vector<uint64_t>& hashes, doris::PrimitiveType type,
                                           const uint8_t* __restrict null_data) const {
     auto s = hashes.size();
     DCHECK(s == size());

--- a/be/src/vec/columns/column_string.h
+++ b/be/src/vec/columns/column_string.h
@@ -258,8 +258,19 @@ public:
         SIP_HASHES_FUNCTION_COLUMN_IMPL();
     }
 
-    void update_crcs_with_value(std::vector<uint32_t>& hashes, PrimitiveType type,
+    void update_crcs_with_value(std::vector<uint64_t>& hashes, PrimitiveType type,
                                 const uint8_t* __restrict null_data) const override;
+
+    void update_hashes_with_value(uint64_t* __restrict hashes,
+                                  const uint8_t* __restrict null_data) const override {
+        auto s = size();
+        for (int i = 0; i < s; i++) {
+            size_t string_size = size_at(i);
+            size_t offset = offset_at(i);
+            hashes[i] = HashUtil::xxHash64WithSeed(reinterpret_cast<const char*>(&chars[offset]),
+                                                   string_size, hashes[i]);
+        }
+    }
 
     void insert_range_from(const IColumn& src, size_t start, size_t length) override;
 
@@ -329,19 +340,31 @@ public:
 
     void get_extremes(Field& min, Field& max) const override;
 
-    bool can_be_inside_nullable() const override { return true; }
+    bool can_be_inside_nullable() const override {
+        return true;
+    }
 
-    bool is_column_string() const override { return true; }
+    bool is_column_string() const override {
+        return true;
+    }
 
     bool structure_equals(const IColumn& rhs) const override {
         return typeid(rhs) == typeid(ColumnString);
     }
 
-    Chars& get_chars() { return chars; }
-    const Chars& get_chars() const { return chars; }
+    Chars& get_chars() {
+        return chars;
+    }
+    const Chars& get_chars() const {
+        return chars;
+    }
 
-    Offsets& get_offsets() { return offsets; }
-    const Offsets& get_offsets() const { return offsets; }
+    Offsets& get_offsets() {
+        return offsets;
+    }
+    const Offsets& get_offsets() const {
+        return offsets;
+    }
 
     void clear() override {
         chars.clear();

--- a/be/src/vec/columns/column_string.h
+++ b/be/src/vec/columns/column_string.h
@@ -340,31 +340,19 @@ public:
 
     void get_extremes(Field& min, Field& max) const override;
 
-    bool can_be_inside_nullable() const override {
-        return true;
-    }
+    bool can_be_inside_nullable() const override { return true; }
 
-    bool is_column_string() const override {
-        return true;
-    }
+    bool is_column_string() const override { return true; }
 
     bool structure_equals(const IColumn& rhs) const override {
         return typeid(rhs) == typeid(ColumnString);
     }
 
-    Chars& get_chars() {
-        return chars;
-    }
-    const Chars& get_chars() const {
-        return chars;
-    }
+    Chars& get_chars() { return chars; }
+    const Chars& get_chars() const { return chars; }
 
-    Offsets& get_offsets() {
-        return offsets;
-    }
-    const Offsets& get_offsets() const {
-        return offsets;
-    }
+    Offsets& get_offsets() { return offsets; }
+    const Offsets& get_offsets() const { return offsets; }
 
     void clear() override {
         chars.clear();

--- a/be/src/vec/columns/column_vector.cpp
+++ b/be/src/vec/columns/column_vector.cpp
@@ -112,6 +112,16 @@ void ColumnVector<T>::update_hashes_with_value(std::vector<SipHash>& hashes,
 }
 
 template <typename T>
+void ColumnVector<T>::update_hashes_with_value(uint64_t* __restrict hashes,
+                                               const uint8_t* __restrict null_data) const {
+    auto s = size();
+    for (int i = 0; i < s; i++) {
+        hashes[i] = HashUtil::xxHash64WithSeed(reinterpret_cast<const char*>(&data[i]), sizeof(T),
+                                               hashes[i]);
+    }
+}
+
+template <typename T>
 void ColumnVector<T>::sort_column(const ColumnSorter* sorter, EqualFlags& flags,
                                   IColumn::Permutation& perms, EqualRange& range,
                                   bool last_column) const {
@@ -119,7 +129,7 @@ void ColumnVector<T>::sort_column(const ColumnSorter* sorter, EqualFlags& flags,
 }
 
 template <typename T>
-void ColumnVector<T>::update_crcs_with_value(std::vector<uint32_t>& hashes, PrimitiveType type,
+void ColumnVector<T>::update_crcs_with_value(std::vector<uint64_t>& hashes, PrimitiveType type,
                                              const uint8_t* __restrict null_data) const {
     auto s = hashes.size();
     DCHECK(s == size());

--- a/be/src/vec/columns/column_vector.h
+++ b/be/src/vec/columns/column_vector.h
@@ -250,8 +250,11 @@ public:
     void update_hashes_with_value(std::vector<SipHash>& hashes,
                                   const uint8_t* __restrict null_data) const override;
 
-    void update_crcs_with_value(std::vector<uint32_t>& hashes, PrimitiveType type,
+    void update_crcs_with_value(std::vector<uint64_t>& hashes, PrimitiveType type,
                                 const uint8_t* __restrict null_data) const override;
+
+    void update_hashes_with_value(uint64_t* __restrict hashes,
+                                  const uint8_t* __restrict null_data) const override;
 
     size_t byte_size() const override { return data.size() * sizeof(data[0]); }
 

--- a/be/src/vec/sink/vdata_stream_sender.h
+++ b/be/src/vec/sink/vdata_stream_sender.h
@@ -91,7 +91,7 @@ protected:
     }
 
     template <typename Channels>
-    Status channel_add_rows(Channels& channels, int num_channels, uint64_t* hash_vals, int rows,
+    Status channel_add_rows(Channels& channels, int num_channels, uint64_t* channel_ids, int rows,
                             Block* block);
 
     struct hash_128 {
@@ -320,11 +320,12 @@ private:
 
 template <typename Channels>
 Status VDataStreamSender::channel_add_rows(Channels& channels, int num_channels,
-                                           uint64_t* __restrict hash_vals, int rows, Block* block) {
+                                           uint64_t* __restrict channel_ids, int rows,
+                                           Block* block) {
     std::vector<int> channel2rows[num_channels];
 
     for (int i = 0; i < rows; i++) {
-        channel2rows[hash_vals[i]].emplace_back(i);
+        channel2rows[channel_ids[i]].emplace_back(i);
     }
 
     for (int i = 0; i < num_channels; ++i) {

--- a/be/src/vec/sink/vdata_stream_sender.h
+++ b/be/src/vec/sink/vdata_stream_sender.h
@@ -90,9 +90,9 @@ protected:
         return Status::OK();
     }
 
-    template <typename Channels, typename HashVals>
-    Status channel_add_rows(Channels& channels, int num_channels, const HashVals& hash_vals,
-                            int rows, Block* block);
+    template <typename Channels>
+    Status channel_add_rows(Channels& channels, int num_channels, uint64_t* hash_vals, int rows,
+                            Block* block);
 
     struct hash_128 {
         uint64_t high;
@@ -156,6 +156,8 @@ protected:
     std::string _compressed_data_buffer;
 
     segment_v2::CompressionTypePB _compression_type;
+
+    bool _new_shuffle_hash_method = false;
 };
 
 // TODO: support local exechange
@@ -316,14 +318,13 @@ private:
     bool _enable_local_exchange = false;
 };
 
-template <typename Channels, typename HashVals>
+template <typename Channels>
 Status VDataStreamSender::channel_add_rows(Channels& channels, int num_channels,
-                                           const HashVals& hash_vals, int rows, Block* block) {
+                                           uint64_t* __restrict hash_vals, int rows, Block* block) {
     std::vector<int> channel2rows[num_channels];
 
     for (int i = 0; i < rows; i++) {
-        auto cid = hash_vals[i] % num_channels;
-        channel2rows[cid].emplace_back(i);
+        channel2rows[hash_vals[i]].emplace_back(i);
     }
 
     for (int i = 0; i < num_channels; ++i) {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -217,6 +217,8 @@ public class SessionVariable implements Serializable, Writable {
 
     public static final String SKIP_DELETE_PREDICATE = "skip_delete_predicate";
 
+    public static final String ENABLE_NEW_SHUFFLE_HASH_METHOD = "enable_new_shuffle_hash_method";
+
     // session origin value
     public Map<Field, String> sessionOriginValue = new HashMap<Field, String>();
     // check stmt is or not [select /*+ SET_VAR(...)*/ ...]
@@ -555,6 +557,8 @@ public class SessionVariable implements Serializable, Writable {
     @VariableMgr.VarAttr(name = ENABLE_FALLBACK_TO_ORIGINAL_PLANNER)
     public boolean enableFallbackToOriginalPlanner = true;
 
+    @VariableMgr.VarAttr(name = ENABLE_NEW_SHUFFLE_HASH_METHOD)
+    public boolean enableNewShffleHashMethod = true;
 
     public String getBlockEncryptionMode() {
         return blockEncryptionMode;
@@ -1153,6 +1157,7 @@ public class SessionVariable implements Serializable, Writable {
         tResult.setEnableFunctionPushdown(enableFunctionPushdown);
         tResult.setFragmentTransmissionCompressionCodec(fragmentTransmissionCompressionCodec);
         tResult.setEnableLocalExchange(enableLocalExchange);
+        tResult.setEnableNewShuffleHashMethod(enableNewShffleHashMethod);
 
         tResult.setSkipStorageEngineMerge(skipStorageEngineMerge);
 

--- a/gensrc/thrift/PaloInternalService.thrift
+++ b/gensrc/thrift/PaloInternalService.thrift
@@ -175,6 +175,8 @@ struct TQueryOptions {
 
   // For debug purpose, skip delete predicates when reading data
   49: optional bool skip_delete_predicate = false
+
+  50: optional bool enable_new_shuffle_hash_method = true
 }
     
 


### PR DESCRIPTION
# Proposed changes

Use new hash method to do shuffle hash compute to speed up query

Time cost:
origin      new
1082ms  665ms

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [x] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [x] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

