### PR TITLE
[fix](auditloader plugin): fix bug for AuditLoaderPlugin that stmt ap…

### DIFF
--- a/fe_plugins/auditloader/src/main/java/org/apache/doris/plugin/audit/AuditLoaderPlugin.java
+++ b/fe_plugins/auditloader/src/main/java/org/apache/doris/plugin/audit/AuditLoaderPlugin.java
@@ -163,7 +163,7 @@ public class AuditLoaderPlugin extends Plugin implements AuditPlugin {
         auditBuffer.append(event.peakMemoryBytes).append("\t");
         // trim the query to avoid too long
         // use `getBytes().length` to get real byte length
-        String stmt = truncateByBytes(event.stmt).replace("\t", " ");
+        String stmt = truncateByBytes(event.stmt).replace("\n", " ").replace("\t", " ");
         LOG.debug("receive audit event with stmt: {}", stmt);
         auditBuffer.append(stmt).append("\n");
     }


### PR DESCRIPTION
…pears truncated when stmt contains '\n'. (#12584)

# Proposed changes

Issue Number: close #12584 #12381

## Problem summary

You can find the problem details in issue [#12584](https://github.com/apache/doris/issues/12584)

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] No
2. Has unit tests been added:
    - [ ] No Need
3. Has document been added or modified:
    - [ ] No
4. Does it need to update dependencies:
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

