### PR TITLE
(storage) Level1Iterator should release iterators in heap

### DIFF
--- a/be/src/vec/olap/vcollect_iterator.h
+++ b/be/src/vec/olap/vcollect_iterator.h
@@ -42,6 +42,7 @@ struct IteratorRowRef {
 
 class VCollectIterator {
 public:
+    VCollectIterator();
     // Hold reader point to get reader params
     ~VCollectIterator();
 
@@ -122,7 +123,7 @@ private:
     class Level0Iterator : public LevelIterator {
     public:
         Level0Iterator(RowsetReaderSharedPtr rs_reader, TabletReader* reader);
-        ~Level0Iterator() {}
+        virtual ~Level0Iterator() {}
 
         OLAPStatus init() override;
 
@@ -154,7 +155,7 @@ private:
 
         OLAPStatus next(Block* block) override;
 
-        ~Level1Iterator();
+        virtual ~Level1Iterator();
 
     private:
         inline OLAPStatus _merge_next(IteratorRowRef* ref);


### PR DESCRIPTION
When there is a query with limit, e.g. select * from limit 1, scanners are closed by FragmentExecutor, then some scanners do not run to eof and mem leaks happen.

We have to release iterators in the heap.

# Proposed changes

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

