### PR TITLE
[fix](storage) Level1Iterator should release iterators in heap

### DIFF
--- a/be/src/vec/olap/vcollect_iterator.h
+++ b/be/src/vec/olap/vcollect_iterator.h
@@ -36,8 +36,9 @@ namespace vectorized {
 
 class VCollectIterator {
 public:
+    VCollectIterator();
     // Hold reader point to get reader params
-    ~VCollectIterator() = default;
+    ~VCollectIterator(); 
 
     void init(TabletReader* reader, bool force_merge, bool is_reverse);
 


### PR DESCRIPTION
When there is a query with limit, e.g. select * from limit 1, scanners are closed by FragmentExecutor, then some scanners do not run to eof and mem leaks happen.

We have to release iterators in the heap.

# Proposed changes

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

