### PR TITLE
(enhancement)(cache) Add remote segment cache statistics to profile

### DIFF
--- a/be/src/io/cache/file_cache.cpp
+++ b/be/src/io/cache/file_cache.cpp
@@ -83,5 +83,11 @@ Status FileCache::download_cache_to_local(const Path& cache_file, const Path& ca
     return Status::OK();
 }
 
+Status FileCache::init_cache_stats(bool is_query, OlapReaderStatistics* stats) {
+    _is_query = is_query;
+    _stats = stats;
+    return Status::OK();
+}
+
 } // namespace io
 } // namespace doris

--- a/be/src/io/cache/file_cache.h
+++ b/be/src/io/cache/file_cache.h
@@ -49,6 +49,12 @@ public:
     Status download_cache_to_local(const Path& cache_file, const Path& cache_done_file,
                                    io::FileReaderSPtr remote_file_reader, size_t req_size,
                                    size_t offset = 0);
+
+    Status init_cache_stats(bool is_query, OlapReaderStatistics* stats);
+
+protected:
+    bool _is_query = false;
+    OlapReaderStatistics* _stats = nullptr;
 };
 
 using FileCachePtr = std::shared_ptr<FileCache>;

--- a/be/src/io/cache/sub_file_cache.cpp
+++ b/be/src/io/cache/sub_file_cache.cpp
@@ -117,6 +117,9 @@ Status SubFileCache::read_at(size_t offset, Slice result, size_t* bytes_read) {
             }
             *bytes_read += sub_bytes_read;
             _last_match_times[*iter] = time(nullptr);
+            if (_is_query) {
+                _stats->read_segments_num += 1;
+            }
         }
     }
     return Status::OK();
@@ -163,6 +166,9 @@ Status SubFileCache::_generate_cache_reader(size_t offset, size_t req_size) {
                             download_cache_to_local(cache_file, cache_done_file,
                                                     _remote_file_reader, req_size, offset),
                             "Download cache from remote to local failed.");
+                    if (_is_query) {
+                        _stats->download_segments_num += 1;
+                    }
                     return Status::OK();
                 };
                 download_st.set_value(func());

--- a/be/src/io/cache/whole_file_cache.cpp
+++ b/be/src/io/cache/whole_file_cache.cpp
@@ -113,6 +113,9 @@ Status WholeFileCache::_generate_cache_reader(size_t offset, size_t req_size) {
                             download_cache_to_local(cache_file, cache_done_file,
                                                     _remote_file_reader, req_size),
                             "Download cache from remote to local failed.");
+                    if (_is_query) {
+                        _stats->download_segments_num += 1;
+                    }
                     return Status::OK();
                 };
                 download_st.set_value(func());
@@ -133,6 +136,9 @@ Status WholeFileCache::_generate_cache_reader(size_t offset, size_t req_size) {
     RETURN_IF_ERROR(io::global_local_filesystem()->open_file(cache_file, &_cache_file_reader));
     _cache_file_size = _cache_file_reader->size();
     _last_match_time = time(nullptr);
+    if (_is_query) {
+        _stats->read_segments_num += 1;
+    }
     LOG(INFO) << "Create cache file from remote file successfully: "
               << _remote_file_reader->path().native() << " -> " << cache_file.native();
     return Status::OK();

--- a/be/src/io/fs/file_reader.h
+++ b/be/src/io/fs/file_reader.h
@@ -25,6 +25,7 @@
 #include "util/slice.h"
 
 namespace doris {
+struct OlapReaderStatistics;
 namespace io {
 
 class FileReader {
@@ -43,6 +44,10 @@ public:
     virtual size_t size() const = 0;
 
     virtual bool closed() const = 0;
+
+    virtual Status init_cache_stats(bool is_query, OlapReaderStatistics* stats) {
+        return Status::NotSupported("not support");
+    }
 };
 
 using FileReaderSPtr = std::shared_ptr<FileReader>;

--- a/be/src/olap/olap_common.h
+++ b/be/src/olap/olap_common.h
@@ -337,6 +337,9 @@ struct OlapReaderStatistics {
     // usage example:
     //               SCOPED_RAW_TIMER(&_stats->general_debug_ns[1]);
     int64_t general_debug_ns[GENERAL_DEBUG_COUNT] = {};
+
+    int64_t read_segments_num = 0;
+    int64_t download_segments_num = 0;
 };
 
 using ColumnId = uint32_t;

--- a/be/src/olap/rowset/beta_rowset.cpp
+++ b/be/src/olap/rowset/beta_rowset.cpp
@@ -90,7 +90,8 @@ Status BetaRowset::do_load(bool /*use_cache*/) {
     return Status::OK();
 }
 
-Status BetaRowset::load_segments(std::vector<segment_v2::SegmentSharedPtr>* segments) {
+Status BetaRowset::load_segments(std::vector<segment_v2::SegmentSharedPtr>* segments, bool is_query,
+                                 OlapReaderStatistics* stats) {
     auto fs = _rowset_meta->fs();
     if (!fs || _schema == nullptr) {
         return Status::OLAPInternalError(OLAP_ERR_INIT_FAILED);
@@ -99,7 +100,8 @@ Status BetaRowset::load_segments(std::vector<segment_v2::SegmentSharedPtr>* segm
         auto seg_path = segment_file_path(seg_id);
         auto cache_path = segment_cache_path(seg_id);
         std::shared_ptr<segment_v2::Segment> segment;
-        auto s = segment_v2::Segment::open(fs, seg_path, cache_path, seg_id, _schema, &segment);
+        auto s = segment_v2::Segment::open(fs, seg_path, cache_path, seg_id, _schema, &segment,
+                                           is_query, stats);
         if (!s.ok()) {
             LOG(WARNING) << "failed to open segment. " << seg_path << " under rowset "
                          << unique_id() << " : " << s.to_string();

--- a/be/src/olap/rowset/beta_rowset.h
+++ b/be/src/olap/rowset/beta_rowset.h
@@ -79,7 +79,8 @@ public:
 
     bool check_file_exist() override;
 
-    Status load_segments(std::vector<segment_v2::SegmentSharedPtr>* segments);
+    Status load_segments(std::vector<segment_v2::SegmentSharedPtr>* segments, bool is_query = false,
+                         OlapReaderStatistics* stats = nullptr);
 
     Status load_segment(int64_t seg_id, segment_v2::SegmentSharedPtr* segment);
 

--- a/be/src/olap/rowset/beta_rowset_reader.cpp
+++ b/be/src/olap/rowset/beta_rowset_reader.cpp
@@ -151,8 +151,8 @@ Status BetaRowsetReader::init(RowsetReaderContext* read_context) {
 
     // load segments
     RETURN_NOT_OK(SegmentLoader::instance()->load_segments(
-            _rowset, &_segment_cache_handle,
-            read_context->reader_type == ReaderType::READER_QUERY));
+            _rowset, &_segment_cache_handle, read_context->reader_type == ReaderType::READER_QUERY,
+            true, read_options.stats));
 
     // create iterator for each segment
     std::vector<std::unique_ptr<RowwiseIterator>> seg_iterators;

--- a/be/src/olap/rowset/segment_v2/segment.cpp
+++ b/be/src/olap/rowset/segment_v2/segment.cpp
@@ -43,7 +43,7 @@ using io::FileCacheManager;
 
 Status Segment::open(io::FileSystem* fs, const std::string& path, const std::string& cache_path,
                      uint32_t segment_id, TabletSchemaSPtr tablet_schema,
-                     std::shared_ptr<Segment>* output) {
+                     std::shared_ptr<Segment>* output, bool is_query, OlapReaderStatistics* stats) {
     std::shared_ptr<Segment> segment(new Segment(segment_id, tablet_schema));
     io::FileReaderSPtr file_reader;
     RETURN_IF_ERROR(fs->open_file(path, &file_reader));
@@ -52,6 +52,7 @@ Status Segment::open(io::FileSystem* fs, const std::string& path, const std::str
                 cache_path, config::file_cache_alive_time_sec, file_reader,
                 config::file_cache_type);
         segment->_file_reader = cache_reader;
+        cache_reader->init_cache_stats(is_query, stats);
         FileCacheManager::instance()->add_file_cache(cache_path, cache_reader);
     } else {
         segment->_file_reader = std::move(file_reader);

--- a/be/src/olap/rowset/segment_v2/segment.h
+++ b/be/src/olap/rowset/segment_v2/segment.h
@@ -107,8 +107,6 @@ public:
         return _footer.primary_key_index_meta().max_key();
     };
 
-    io::FileReaderSPtr get_file_reader() { return _file_reader; }
-
 private:
     DISALLOW_COPY_AND_ASSIGN(Segment);
     Segment(uint32_t segment_id, TabletSchemaSPtr tablet_schema);

--- a/be/src/olap/rowset/segment_v2/segment.h
+++ b/be/src/olap/rowset/segment_v2/segment.h
@@ -63,7 +63,8 @@ class Segment : public std::enable_shared_from_this<Segment> {
 public:
     static Status open(io::FileSystem* fs, const std::string& path, const std::string& cache_path,
                        uint32_t segment_id, TabletSchemaSPtr tablet_schema,
-                       std::shared_ptr<Segment>* output);
+                       std::shared_ptr<Segment>* output, bool is_query = false,
+                       OlapReaderStatistics* stats = nullptr);
 
     ~Segment();
 
@@ -105,6 +106,8 @@ public:
         DCHECK(_tablet_schema->keys_type() == UNIQUE_KEYS && _footer.has_primary_key_index_meta());
         return _footer.primary_key_index_meta().max_key();
     };
+
+    io::FileReaderSPtr get_file_reader() { return _file_reader; }
 
 private:
     DISALLOW_COPY_AND_ASSIGN(Segment);

--- a/be/src/olap/segment_loader.cpp
+++ b/be/src/olap/segment_loader.cpp
@@ -58,7 +58,8 @@ void SegmentLoader::_insert(const SegmentLoader::CacheKey& key, SegmentLoader::C
 }
 
 Status SegmentLoader::load_segments(const BetaRowsetSharedPtr& rowset,
-                                    SegmentCacheHandle* cache_handle, bool use_cache) {
+                                    SegmentCacheHandle* cache_handle, bool use_cache, bool is_query,
+                                    OlapReaderStatistics* stats) {
     SegmentLoader::CacheKey cache_key(rowset->rowset_id());
     if (_lookup(cache_key, cache_handle)) {
         cache_handle->owned = false;
@@ -67,7 +68,7 @@ Status SegmentLoader::load_segments(const BetaRowsetSharedPtr& rowset,
     cache_handle->owned = !use_cache;
 
     std::vector<segment_v2::SegmentSharedPtr> segments;
-    RETURN_NOT_OK(rowset->load_segments(&segments));
+    RETURN_NOT_OK(rowset->load_segments(&segments, is_query, stats));
 
     if (use_cache) {
         // memory of SegmentLoader::CacheValue will be handled by SegmentLoader

--- a/be/src/olap/segment_loader.h
+++ b/be/src/olap/segment_loader.h
@@ -83,7 +83,8 @@ public:
     // Load segments of "rowset", return the "cache_handle" which contains segments.
     // If use_cache is true, it will be loaded from _cache.
     Status load_segments(const BetaRowsetSharedPtr& rowset, SegmentCacheHandle* cache_handle,
-                         bool use_cache = false);
+                         bool use_cache = false, bool is_query = false,
+                         OlapReaderStatistics* stats = nullptr);
 
     // Try to prune the segment cache if expired.
     Status prune();

--- a/be/src/runtime/plan_fragment_executor.h
+++ b/be/src/runtime/plan_fragment_executor.h
@@ -199,6 +199,10 @@ private:
 
     RuntimeProfile::Counter* _fragment_cpu_timer;
 
+    RuntimeProfile::Counter* _fragment_read_segment_cache_files_num_counter;
+    RuntimeProfile::Counter* _fragment_download_segment_cache_files_num_counter;
+    RuntimeProfile::Counter* _fragment_hit_segment_cache_files_num_counter;
+
     // It is shared with BufferControlBlock and will be called in two different
     // threads. But their calls are all at different time, there is no problem of
     // multithreaded access.

--- a/be/src/vec/exec/volap_scan_node.cpp
+++ b/be/src/vec/exec/volap_scan_node.cpp
@@ -187,6 +187,12 @@ void VOlapScanNode::_init_counter(RuntimeState* state) {
     // time of node to wait for batch/block queue
     _olap_wait_batch_queue_timer = ADD_TIMER(_runtime_profile, "BatchQueueWaitTime");
 
+    _read_segments_num_counter = ADD_COUNTER(_runtime_profile, "ReadSegmentsNum", TUnit::UNIT);
+    _download_segments_num_counter =
+            ADD_COUNTER(_runtime_profile, "DownloadSegmentsNum", TUnit::UNIT);
+    _hit_cache_segments_num_counter =
+            ADD_COUNTER(_runtime_profile, "HitCacheSegmentsNum", TUnit::UNIT);
+
     // for the purpose of debugging or profiling
     for (int i = 0; i < GENERAL_DEBUG_COUNT; ++i) {
         char name[64];

--- a/be/src/vec/exec/volap_scan_node.h
+++ b/be/src/vec/exec/volap_scan_node.h
@@ -64,6 +64,14 @@ public:
 
     std::string get_name() override;
 
+    RuntimeProfile::Counter* get_read_segments_num_counter() { return _read_segments_num_counter; }
+    RuntimeProfile::Counter* get_download_segments_num_counter() {
+        return _download_segments_num_counter;
+    }
+    RuntimeProfile::Counter* get_hit_cache_segments_num_counter() {
+        return _hit_cache_segments_num_counter;
+    }
+
 private:
     // In order to ensure the accuracy of the query result
     // only key column conjuncts will be remove as idle conjunct
@@ -319,6 +327,10 @@ private:
 
     // for debugging or profiling, record any info as you want
     RuntimeProfile::Counter* _general_debug_timer[GENERAL_DEBUG_COUNT] = {};
+
+    RuntimeProfile::Counter* _read_segments_num_counter = nullptr;
+    RuntimeProfile::Counter* _download_segments_num_counter = nullptr;
+    RuntimeProfile::Counter* _hit_cache_segments_num_counter = nullptr;
 
     std::vector<Block*> _scan_blocks;
     std::vector<Block*> _materialized_blocks;

--- a/be/src/vec/exec/volap_scanner.cpp
+++ b/be/src/vec/exec/volap_scanner.cpp
@@ -465,6 +465,12 @@ void VOlapScanner::update_counter() {
     COUNTER_UPDATE(_parent->_filtered_segment_counter, stats.filtered_segment_number);
     COUNTER_UPDATE(_parent->_total_segment_counter, stats.total_segment_number);
 
+    COUNTER_UPDATE(_parent->_read_segments_num_counter, stats.read_segments_num);
+    COUNTER_UPDATE(_parent->_download_segments_num_counter, stats.download_segments_num);
+
+    COUNTER_UPDATE(_parent->_hit_cache_segments_num_counter,
+                   stats.read_segments_num - stats.download_segments_num);
+
     DorisMetrics::instance()->query_scan_bytes->increment(_compressed_bytes_read);
     DorisMetrics::instance()->query_scan_rows->increment(_raw_rows_read);
 

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
@@ -30,6 +30,7 @@ import org.apache.doris.common.Status;
 import org.apache.doris.common.UserException;
 import org.apache.doris.common.telemetry.ScopedSpan;
 import org.apache.doris.common.telemetry.Telemetry;
+import org.apache.doris.common.util.Counter;
 import org.apache.doris.common.util.DebugUtil;
 import org.apache.doris.common.util.ListUtil;
 import org.apache.doris.common.util.ProfileWriter;
@@ -405,6 +406,22 @@ public class Coordinator {
 
     public List<TErrorTabletInfo> getErrorTabletInfos() {
         return errorTabletInfos;
+    }
+
+    public long getSegmentCacheFilesStatistics(String key) {
+        long resultNum = 0L;
+        for (int i = 0; i < fragmentProfile.size(); ++i) {
+            Map<String, RuntimeProfile> instanceMap = fragmentProfile.get(i).getChildMap();
+            for (RuntimeProfile instanceProfile : instanceMap.values()) {
+                Map<String, Counter> counterMap = instanceProfile.getCounterMap();
+                if (!counterMap.isEmpty()) {
+                    if (counterMap.containsKey(key)) {
+                        resultNum += counterMap.get(key).getValue();
+                    }
+                }
+            }
+        }
+        return resultNum;
     }
 
     // Initialize


### PR DESCRIPTION
# Proposed changes

Issue Number: close #12598

## Problem summary

Add some segment cache statistics, for example:
```
Query:
    Summary:
          -  Start  Time:  2022-09-14  15:18:27
          -  End  Time:  2022-09-14  15:18:28
          -  Total:  1s339ms
          -  Query  State:  EOF
          -  Query  ID:  3042c4b738594677-b8e267fb3d97ea93
          -  Query  Type:  Query
          -  Doris  Version:  trunk
          -  User:  root
          -  Default  Db:  default_cluster:test
          -  Sql  Statement:  select  *  from  table_s3
          -  Is  Cached:  No
          -  Trace  ID:  
        Execution  Summary:
              -  Analysis  Time:  17.768ms
              -  Plan  Time:  75.774ms
              -  Schedule  Time:  845.839ms
              -  Wait  and  Fetch  Result  Time:  379.989ms
        Segment  Cache  Statistics:
              -  ReadSegmentCacheFilesNum:  11					// New Add
              -  DownloadSegmentCacheFilesNum:  3				// New Add
              -  HitSegmentCacheFilesNum:  8					// New Add
              -  HitSegmentCacheFilesPercent:  72.73%				// New Add
    Execution  Profile  3042c4b738594677-b8e267fb3d97ea93:(Active:  1s340ms,  %  non-child:  100.00%)
        Fragment  0:
            Instance  3042c4b738594677-b8e267fb3d97ea95  (host=TNetworkAddress(hostname:)):(Active:  377.112ms,  %  non-child:  0.07%)
                  -  FragmentCpuTime:  1.196ms
                  -  FragmentDownloadSegmentCacheFileNum:  0			// New Add
                  -  FragmentHitSegmentCacheFileNum:  0				// New Add
                  -  FragmentReadSegmentCacheFileNum:  0			// New Add
                  -  MemoryLimit:  2.00  GB
                  -  PeakMemoryUsage:  0.00  
                  -  RowsProduced:  11
                BlockMgr:
                      -  ...
                VDataBufferSender  (dst_fragment_instance_id=3042c4b738594677--471d9804c268156b):
                      -  ...
                VEXCHANGE_NODE  (id=1):(Active:  376.140ms,  %  non-child:  28.06%)
                      -  ...
        Fragment  1:
            Instance  3042c4b738594677-b8e267fb3d97ea94  (host=TNetworkAddress(hostname:)):(Active:  377.266ms,  %  non-child:  0.08%)
                  -  FragmentCpuTime:  1.150ms
                  -  FragmentDownloadSegmentCacheFileNum:  3			// New Add
                  -  FragmentHitSegmentCacheFileNum:  8				// New Add
                  -  FragmentReadSegmentCacheFileNum:  11			// New Add
                  -  MemoryLimit:  2.00  GB
                  -  PeakMemoryUsage:  6.81  MB
                  -  RowsProduced:  11
                BlockMgr:
                      -  ...
                VDataStreamSender  (dst_id=1,  dst_fragments=[{"3042c4b738594677-b8e267fb3d97ea95"}]):(Active:  400.700us,  %  non-child:  0.03%)
                      -  ... 
                VOLAP_SCAN_NODE  (id=0):(Active:  375.735ms,  %  non-child:  28.03%)
                      -  ...
                      -  DownloadSegmentsNum:  3				// New Add
                      -  HitCacheSegmentsNum:  8				// New Add
                      -  ... 
                      -  ReadSegmentsNum:  11					// New Add
                      -  ...
                    VOlapScanner(table_s3):
                          -  ...
                        SegmentIterator:
                              -  ...
```

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

