### PR TITLE
[Bugfix](primary-key) fix calc delete bitmap bug in concurrent memtable flush

### DIFF
--- a/be/src/olap/delta_writer.h
+++ b/be/src/olap/delta_writer.h
@@ -168,7 +168,7 @@ private:
     PSuccessSlaveTabletNodeIds _success_slave_node_ids;
     std::shared_mutex _slave_node_lock;
 
-    DeleteBitmapPtr _delete_bitmap;
+    DeleteBitmapPtr _delete_bitmap = nullptr;
     // current rowset_ids, used to do diff in publish_version
     RowsetIdUnorderedSet _rowset_ids;
 };

--- a/be/src/olap/memtable_flush_executor.cpp
+++ b/be/src/olap/memtable_flush_executor.cpp
@@ -133,9 +133,10 @@ void MemTableFlushExecutor::init(const std::vector<DataDir*>& data_dirs) {
 
 // NOTE: we use SERIAL mode here to ensure all mem-tables from one tablet are flushed in order.
 Status MemTableFlushExecutor::create_flush_token(std::unique_ptr<FlushToken>* flush_token,
-                                                 RowsetTypePB rowset_type, bool is_high_priority) {
+                                                 RowsetTypePB rowset_type, bool should_serial,
+                                                 bool is_high_priority) {
     if (!is_high_priority) {
-        if (rowset_type == BETA_ROWSET) {
+        if (rowset_type == BETA_ROWSET && !should_serial) {
             // beta rowset can be flush in CONCURRENT, because each memtable using a new segment writer.
             flush_token->reset(
                     new FlushToken(_flush_pool->new_token(ThreadPool::ExecutionMode::CONCURRENT)));
@@ -145,7 +146,7 @@ Status MemTableFlushExecutor::create_flush_token(std::unique_ptr<FlushToken>* fl
                     new FlushToken(_flush_pool->new_token(ThreadPool::ExecutionMode::SERIAL)));
         }
     } else {
-        if (rowset_type == BETA_ROWSET) {
+        if (rowset_type == BETA_ROWSET && !should_serial) {
             // beta rowset can be flush in CONCURRENT, because each memtable using a new segment writer.
             flush_token->reset(new FlushToken(
                     _high_prio_flush_pool->new_token(ThreadPool::ExecutionMode::CONCURRENT)));

--- a/be/src/olap/memtable_flush_executor.h
+++ b/be/src/olap/memtable_flush_executor.h
@@ -107,7 +107,7 @@ public:
     void init(const std::vector<DataDir*>& data_dirs);
 
     Status create_flush_token(std::unique_ptr<FlushToken>* flush_token, RowsetTypePB rowset_type,
-                              bool is_high_priority);
+                              bool should_serial, bool is_high_priority);
 
 private:
     std::unique_ptr<ThreadPool> _flush_pool;


### PR DESCRIPTION

# Proposed changes

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

