### PR TITLE
[Bugfix](string_functions) fix heap-buffer-overflow on find_in_set

### DIFF
--- a/be/src/exprs/string_functions.cpp
+++ b/be/src/exprs/string_functions.cpp
@@ -710,7 +710,7 @@ IntVal StringFunctions::find_in_set(FunctionContext* context, const StringVal& s
     do {
         end = start;
         // Position end.
-        while (str_set.ptr[end] != ',' && end < str_set.len) {
+        while (end < str_set.len && str_set.ptr[end] != ',') {
             ++end;
         }
         StringValue token(reinterpret_cast<char*>(str_set.ptr) + start, end - start);


### PR DESCRIPTION
# Proposed changes

Issue Number: close #12612 

## Problem summary

 fix heap-buffer-overflow on find_in_set

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

