### PR TITLE
[Bug](nereids) Fix UT when run test cases in package

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/NamedExpressionUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/NamedExpressionUtil.java
@@ -22,7 +22,6 @@ import org.apache.doris.common.IdGenerator;
 import com.google.common.annotations.VisibleForTesting;
 
 import java.lang.reflect.Field;
-import java.lang.reflect.Modifier;
 
 /**
  * The util of named expression.
@@ -42,11 +41,8 @@ public class NamedExpressionUtil {
      */
     @VisibleForTesting
     public static void clear() throws Exception {
-        Field f = NamedExpressionUtil.class.getDeclaredField("ID_GENERATOR");
-        f.setAccessible(true);
-        Field mf = Field.class.getDeclaredField("modifiers");
-        mf.setAccessible(true);
-        mf.setInt(f, f.getModifiers() & ~Modifier.FINAL);
-        f.set(NamedExpressionUtil.class, ExprId.createGenerator());
+        Field nextId = ID_GENERATOR.getClass().getSuperclass().getDeclaredField("nextId");
+        nextId.setAccessible(true);
+        nextId.setInt(ID_GENERATOR, 0);
     }
 }


### PR DESCRIPTION
# Proposed changes

`NamedExpressionUtil::clear` should reset the `nextId` rather than create a new `IdGenerator<ExprId>` because the old one may be referenced by other objects and it may cause some cases start in a dirty environment when we run test cases in package.

Issue Number: close https://github.com/apache/doris/issues/12631

## Problem summary

If we run the nereids test cases in package in Intellij IDEA, we will see some cases fail.

See #12631 .

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

