### PR TITLE
[Improvement](Nereids) Restrict the condition to apply `MergeConsecutiveLimits` rule.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/logical/MergeConsecutiveLimits.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/logical/MergeConsecutiveLimits.java
@@ -24,8 +24,6 @@ import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.algebra.Limit;
 import org.apache.doris.nereids.trees.plans.logical.LogicalLimit;
 
-import java.util.List;
-
 /**
  * This rule aims to merge consecutive limits.
  * <pre>

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/logical/MergeConsecutiveLimits.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/logical/MergeConsecutiveLimits.java
@@ -47,11 +47,10 @@ public class MergeConsecutiveLimits extends OneRewriteRuleFactory {
     public Rule build() {
         return logicalLimit(logicalLimit()).whenNot(Limit::hasValidOffset).then(upperLimit -> {
             LogicalLimit<? extends Plan> bottomLimit = upperLimit.child();
-            List<Plan> children = bottomLimit.children();
             return new LogicalLimit<>(
                     Math.min(upperLimit.getLimit(), bottomLimit.getLimit()),
                     bottomLimit.getOffset(),
-                    children.get(0)
+                    bottomLimit.child()
             );
         }).toRule(RuleType.MERGE_CONSECUTIVE_LIMITS);
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/logical/MergeConsecutiveLimits.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/logical/MergeConsecutiveLimits.java
@@ -21,27 +21,31 @@ import org.apache.doris.nereids.rules.Rule;
 import org.apache.doris.nereids.rules.RuleType;
 import org.apache.doris.nereids.rules.rewrite.OneRewriteRuleFactory;
 import org.apache.doris.nereids.trees.plans.Plan;
+import org.apache.doris.nereids.trees.plans.algebra.Limit;
 import org.apache.doris.nereids.trees.plans.logical.LogicalLimit;
 
 import java.util.List;
 
 /**
- * this rule aims to merge consecutive limits.
- *   LIMIT1(limit=10, offset=4)
+ * This rule aims to merge consecutive limits.
+ * <pre>
+ * input plan:
+ *   LIMIT1(limit=10, offset=0)
  *     |
  *   LIMIT2(limit=3, offset=5)
  *
- *   transformed to
- *    LIMITl(limit=3, offset=5)
- *   where
- *   LIMIT.limit = min(LIMIT1.limit, LIMIT2.limit)
- *   LIMIT.offset = LIMIT2.offset
- *   LIMIT1.offset is ignored
+ * output plan:
+ *    LIMIT(limit=3, offset=5)
+ *
+ * merged limit = min(LIMIT1.limit, LIMIT2.limit)
+ * merged offset = LIMIT2.offset
+ * </pre>
+ * Note that the top limit should not have valid offset info.
  */
 public class MergeConsecutiveLimits extends OneRewriteRuleFactory {
     @Override
     public Rule build() {
-        return logicalLimit(logicalLimit()).then(upperLimit -> {
+        return logicalLimit(logicalLimit()).whenNot(Limit::hasValidOffset).then(upperLimit -> {
             LogicalLimit<? extends Plan> bottomLimit = upperLimit.child();
             List<Plan> children = bottomLimit.children();
             return new LogicalLimit<>(

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/logical/MergeConsecutiveLimitsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/logical/MergeConsecutiveLimitsTest.java
@@ -34,7 +34,7 @@ public class MergeConsecutiveLimitsTest {
     public void testMergeConsecutiveLimits() {
         LogicalLimit limit3 = new LogicalLimit<>(3, 5, new UnboundRelation(Lists.newArrayList("db", "t")));
         LogicalLimit limit2 = new LogicalLimit<>(2, 0, limit3);
-        LogicalLimit limit1 = new LogicalLimit<>(10, 2, limit2);
+        LogicalLimit limit1 = new LogicalLimit<>(10, 0, limit2);
 
         CascadesContext context = MemoTestUtils.createCascadesContext(limit1);
         List<Rule> rules = Lists.newArrayList(new MergeConsecutiveLimits().build());


### PR DESCRIPTION

# Proposed changes

This PR added a condition check for `MergeConsecutiveLimits` rule: the input upper limit should not have valid offset info.

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

