### PR TITLE
[enhancement](workflow) Enable the shellcheck workflow to comment the PRs

### DIFF
--- a/.github/actions/patches/action-sh-checker.patch
+++ b/.github/actions/patches/action-sh-checker.patch
@@ -1,0 +1,13 @@
+diff --git a/entrypoint.sh b/entrypoint.sh
+index d3399e3..5c8ee7b 100755
+--- a/entrypoint.sh
++++ b/entrypoint.sh
+@@ -202,7 +202,7 @@ if ((CHECKBASHISMS_ENABLE == 1)); then
+ fi
+ 
+ if ((shellcheck_code != 0 || shfmt_code != 0)); then
+-	if [ "$GITHUB_EVENT_NAME" == "pull_request" ] && ((SH_CHECKER_COMMENT == 1)); then
++	if [[ "$GITHUB_EVENT_NAME" == "pull_request" || "$GITHUB_EVENT_NAME" == "pull_request_target" ]] && ((SH_CHECKER_COMMENT == 1)); then
+ 		_comment_on_github "$shellcheck_error" "$shfmt_error"
+ 	fi
+ fi

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -17,7 +17,7 @@
 
 name: ShellCheck
 
-on: [push, pull_request]
+on: [push, pull_request_target]
 
 jobs:
   shellcheck:
@@ -25,9 +25,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout ${{ github.ref }} ( ${{ github.sha }} )
+        if: ${{ github.event_name != 'pull_request_target' }}
         uses: actions/checkout@v3
         with:
           submodules: recursive
+
+      - name: Checkout ${{ github.ref }} ( ${{ github.event.pull_request.head.sha }} )
+        if: ${{ github.event_name == 'pull_request_target' }}
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          submodules: recursive
+
+      - name: Patch
+        run: |
+          pushd .github/actions/action-sh-checker >/dev/null
+          git apply ../patches/action-sh-checker.patch
+          popd >/dev/null
 
       - name: Run ShellCheck
         uses: ./.github/actions/action-sh-checker


### PR DESCRIPTION
# Proposed changes

Change the trigger condition from `pull_request` to `pull_request_target`.

## Problem summary

> Due to the dangers inherent to automatic processing of PRs, GitHub’s standard pull_request workflow trigger by default prevents write permissions and secrets access to the target repository. However, in some scenarios such access is needed to properly process the PR. To this end the pull_request_target workflow trigger was introduced.

According to the article [Keeping your GitHub Actions and workflows secure](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/) , the trigger condition in `shellcheck.yml` which is `pull_request` can't comment the PR due to the lack of write permissions of the workflow.

Despite the `ShellCheck` workflow checkouts the source, but it doesn't build and test the source code. I think it is safe to change the trigger condition from `pull_request` to `pull_request_target` which can make the workflow have write permissions to comment the PR.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

