### PR TITLE
[fix](inpredicate)always use PredicateColumn<TYPE_STRING> for CHAR, VARCHAR and STRING type

### DIFF
--- a/be/src/olap/comparison_predicate.h
+++ b/be/src/olap/comparison_predicate.h
@@ -552,7 +552,8 @@ private:
             }
         } else {
             auto* data_array =
-                    vectorized::check_and_get_column<vectorized::PredicateColumnType<EvalType>>(column)
+                    vectorized::check_and_get_column<vectorized::PredicateColumnType<EvalType>>(
+                            column)
                             ->get_data()
                             .data();
 

--- a/be/src/olap/comparison_predicate.h
+++ b/be/src/olap/comparison_predicate.h
@@ -552,7 +552,7 @@ private:
             }
         } else {
             auto* data_array =
-                    vectorized::check_and_get_column<vectorized::PredicateColumnType<Type>>(column)
+                    vectorized::check_and_get_column<vectorized::PredicateColumnType<EvalType>>(column)
                             ->get_data()
                             .data();
 
@@ -561,6 +561,10 @@ private:
     }
 
     T _value;
+    static constexpr PrimitiveType EvalType = (Type == TYPE_CHAR ? TYPE_STRING : Type);
 };
+
+template <PrimitiveType Type, PredicateType PT>
+constexpr PrimitiveType ComparisonPredicateBase<Type, PT>::EvalType;
 
 } //namespace doris

--- a/be/src/olap/in_list_predicate.h
+++ b/be/src/olap/in_list_predicate.h
@@ -375,7 +375,8 @@ private:
             }
         } else {
             auto* nested_col_ptr =
-                    vectorized::check_and_get_column<vectorized::PredicateColumnType<EvalType>>(column);
+                    vectorized::check_and_get_column<vectorized::PredicateColumnType<EvalType>>(
+                            column);
             auto& data_array = nested_col_ptr->get_data();
 
             for (uint16_t i = 0; i < size; i++) {

--- a/be/src/olap/in_list_predicate.h
+++ b/be/src/olap/in_list_predicate.h
@@ -375,7 +375,7 @@ private:
             }
         } else {
             auto* nested_col_ptr =
-                    vectorized::check_and_get_column<vectorized::PredicateColumnType<Type>>(column);
+                    vectorized::check_and_get_column<vectorized::PredicateColumnType<EvalType>>(column);
             auto& data_array = nested_col_ptr->get_data();
 
             for (uint16_t i = 0; i < size; i++) {
@@ -410,6 +410,10 @@ private:
     mutable std::vector<vectorized::UInt8> _value_in_dict_flags;
     T _min_value;
     T _max_value;
+    static constexpr PrimitiveType EvalType = (Type == TYPE_CHAR ? TYPE_STRING : Type);
 };
+
+template <PrimitiveType Type, PredicateType PT>
+constexpr PrimitiveType InListPredicateBase<Type, PT>::EvalType;
 
 } //namespace doris


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

The predicate column type for char, varchar and string is PredicateColumnType<TYPE_STRING>, so _base_evaluate method should convert the input column to PredicateColumnType<TYPE_STRING> always.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

