### PR TITLE
[fix](lateral_view) fix lateral view explode_split with temp table

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/planner/SingleNodePlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/SingleNodePlanner.java
@@ -1399,6 +1399,7 @@ public class SingleNodePlanner {
                 unionNode.init(analyzer);
                 //set outputSmap to substitute literal in outputExpr
                 unionNode.setWithoutTupleIsNullOutputSmap(inlineViewRef.getSmap());
+                unionNode.setOutputSmap(inlineViewRef.getSmap());
                 if (analyzer.isOuterJoined(inlineViewRef.getId())) {
                     List<Expr> nullableRhs;
                     if (analyzer.isOuterJoinedLeftSide(inlineViewRef.getId())) {

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/TableFunctionNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/TableFunctionNode.java
@@ -107,26 +107,6 @@ public class TableFunctionNode extends PlanNode {
                 dst.getSlotRefsBoundByTupleIds(tupleIds, outputSlotRef);
             }
         }
-        /**
-         * For case: WITH example1  AS ( select  6 AS k1 ,'a,b,c' AS k2) select  k1, e1 from example1
-         *           lateral view explode_split(k2, ',') tmp as  e1;
-         * baseTblResultExprs do not include SlotRef(K1), but resultExprs include it.
-         * So here we travel resultExprs to get correct outputSlotRef.
-         *
-         * TODO: maybe we should make sure baseTblResultExprs include SlotRef(k1),
-         *       after function SelectStmt::resolveInlineViewRefs called.
-         */
-        List<Expr> resultExprs = selectStmt.getResultExprs();
-        for (Expr resultExpr : resultExprs) {
-            // find all slotRef bound by tupleIds in resultExpr
-            resultExpr.getSlotRefsBoundByTupleIds(tupleIds, outputSlotRef);
-
-            // For vec engine while lateral view involves subquery
-            Expr dst = outputSmap.get(resultExpr);
-            if (dst != null) {
-                dst.getSlotRefsBoundByTupleIds(tupleIds, outputSlotRef);
-            }
-        }
         // case2
         List<Expr> remainConjuncts = analyzer.getRemainConjuncts(tupleIds);
         for (Expr expr : remainConjuncts) {

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/TableFunctionNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/TableFunctionNode.java
@@ -107,6 +107,26 @@ public class TableFunctionNode extends PlanNode {
                 dst.getSlotRefsBoundByTupleIds(tupleIds, outputSlotRef);
             }
         }
+        /**
+         * For case: WITH example1  AS ( select  6 AS k1 ,'a,b,c' AS k2) select  k1, e1 from example1
+         *           lateral view explode_split(k2, ',') tmp as  e1;
+         * baseTblResultExprs do not include SlotRef(K1), but resultExprs include it.
+         * So here we travel resultExprs to get correct outputSlotRef.
+         *
+         * TODO: maybe we should make sure baseTblResultExprs include SlotRef(k1),
+         *       after function SelectStmt::resolveInlineViewRefs called.
+         */
+        List<Expr> resultExprs = selectStmt.getResultExprs();
+        for (Expr resultExpr : resultExprs) {
+            // find all slotRef bound by tupleIds in resultExpr
+            resultExpr.getSlotRefsBoundByTupleIds(tupleIds, outputSlotRef);
+
+            // For vec engine while lateral view involves subquery
+            Expr dst = outputSmap.get(resultExpr);
+            if (dst != null) {
+                dst.getSlotRefsBoundByTupleIds(tupleIds, outputSlotRef);
+            }
+        }
         // case2
         List<Expr> remainConjuncts = analyzer.getRemainConjuncts(tupleIds);
         for (Expr expr : remainConjuncts) {

--- a/regression-test/data/query_p0/sql_functions/table_function/explode_split.out
+++ b/regression-test/data/query_p0/sql_functions/table_function/explode_split.out
@@ -16,6 +16,11 @@
 1	a,b,c	c	c
 
 -- !explode_split --
+6	a
+6	b
+6	c
+
+-- !explode_split --
 1	a,b,c	a
 1	a,b,c	b
 1	a,b,c	c
@@ -30,4 +35,9 @@
 1	a,b,c	c	a
 1	a,b,c	c	b
 1	a,b,c	c	c
+
+-- !explode_split --
+6	a
+6	b
+6	c
 

--- a/regression-test/suites/query_p0/sql_functions/table_function/explode_split.groovy
+++ b/regression-test/suites/query_p0/sql_functions/table_function/explode_split.groovy
@@ -29,21 +29,29 @@ suite("explode_split") {
     sql """ INSERT INTO ${tableName} VALUES (1, 'a,b,c') """
 
     // not_vectorized
+    sql """ set enable_vectorized_engine = false """
     qt_explode_split """ select * from ${tableName} 
                         lateral view explode_split(k2, ',') tmp1 as e1 """
 
     qt_explode_split """ select * from ${tableName}
                         lateral view explode_split(k2, ',') tmp1 as e1 
                         lateral view explode_split(k2, ',') tmp2 as e2 """
+
+    qt_explode_split """ WITH example1  AS ( select  6 AS k1 ,'a,b,c' AS k2)
+                         select  k1, e1 from example1
+                         lateral view explode_split(k2, ',') tmp as  e1 """
 
     // vectorized
     sql """ set enable_vectorized_engine = true """
-
     qt_explode_split """ select * from ${tableName} 
                         lateral view explode_split(k2, ',') tmp1 as e1 """
 
     qt_explode_split """ select * from ${tableName}
                         lateral view explode_split(k2, ',') tmp1 as e1 
                         lateral view explode_split(k2, ',') tmp2 as e2 """
+
+    qt_explode_split """ WITH example1  AS ( select  6 AS k1 ,'a,b,c' AS k2)
+                         select  k1, e1 from example1
+                         lateral view explode_split(k2, ',') tmp as  e1 """
 
 }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #12634

## Problem summary

Describe your changes.

Problem describe:
1. follow SQL return wrong result:
`WITH example1  AS ( select  6 AS k1 ,'a,b,c' AS k2) select  k1, e1 from example1  lateral view explode_split(k2, ',') tmp as  e1;`

2. Wrong result:
```
+------+------+
| k1   | e1   |
+------+------+
|    0 | a    |
|    0 | b    |
|    0 | c    |
+------+------+
```
3. Correct result should be:
```
+------+------+
| k1   | e1   |
+------+------+
|    6 | a    |
|    6 | b    |
|    6 | c    |
+------+------+
```

Why?
TableFunctionNode::outputSlotIds do not include column `k1`.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [x] Yes
    - [ ] No
    - [ ] No Need
5. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
6. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
7. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

