### PR TITLE
[fix](colocation) fix decommission failure with 2 BEs and colocation table

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/alter/SystemHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/SystemHandler.java
@@ -96,7 +96,7 @@ public class SystemHandler extends AlterHandler {
             }
 
             LOG.info("backend {} lefts {} replicas to decommission: {}", beId, backendTabletIds.size(),
-                    backendTabletIds.size() <= 20 ? backendTabletIds : "too many");
+                    backendTabletIds.subList(0, Math.min(10, backendTabletIds.size())));
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/clone/ColocateTableCheckerAndBalancer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/ColocateTableCheckerAndBalancer.java
@@ -385,6 +385,7 @@ public class ColocateTableCheckerAndBalancer extends MasterDaemon {
                 if (!seqIndexes.isEmpty()) {
                     srcBeId = beId;
                     hasUnavailableBe = true;
+                    LOG.info("find unavailable backend {} in colocate group: {}", beId, groupId);
                     break;
                 }
             }
@@ -394,7 +395,7 @@ public class ColocateTableCheckerAndBalancer extends MasterDaemon {
                             unavailableBeIds, statistic, flatBackendsPerBucketSeq);
 
             // if there is only one available backend and no unavailable bucketId to relocate, end the outer loop
-            if (backendWithReplicaNum.size() <= 1) {
+            if (backendWithReplicaNum.size() <= 1 && !hasUnavailableBe) {
                 break;
             }
 


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

This PR fix:
1. 2 Backends.
2. Create tables with colocation group, 1 replica.
3. Decommission one of Backends.
4. The tablet on decommissioned Backend is not reduced.

This is a bug of ColocateTableCheckerAndBalancer.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
6. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
7. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
8. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
9. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

