### PR TITLE
[Improvement](string) apply AVX512 for memcmp and memcpy

### DIFF
--- a/be/src/vec/common/memcpy_small.h
+++ b/be/src/vec/common/memcpy_small.h
@@ -22,7 +22,41 @@
 
 #include <string.h>
 
-#if defined(__SSE2__) || defined(__aarch64__)
+#if defined(__AVX512F__) && !defined(MEMORY_SANITIZER)
+#include <immintrin.h>
+
+namespace detail {
+inline void memcpy_small_allow_read_write_overflow15_impl(char* __restrict dst,
+                                                          const char* __restrict src, ssize_t n) {
+    while (n > 0) {
+        if (n >= 64) {
+            /// Load and store 512-bits of integer data from memory into dst. mem_addr
+            _mm512_storeu_si512(reinterpret_cast<__m512i*>(dst),
+                                _mm512_loadu_si512(reinterpret_cast<const __m512i*>(src)));
+
+            dst += 64;
+            src += 64;
+            n -= 64;
+        } else if (n >= 32) {
+            _mm256_storeu_si256(reinterpret_cast<__m256i*>(dst),
+                                _mm256_loadu_si256(reinterpret_cast<const __m256i*>(src)));
+
+            dst += 32;
+            src += 32;
+            n -= 32;
+        } else {
+            _mm_storeu_si128(reinterpret_cast<__m128i*>(dst),
+                             _mm_loadu_si128(reinterpret_cast<const __m128i*>(src)));
+
+            dst += 16;
+            src += 16;
+            n -= 16;
+        }
+    }
+}
+} // namespace detail
+
+#elif defined(__SSE2__) || defined(__aarch64__)
 #ifdef __SSE2__
 #include <emmintrin.h>
 #elif __aarch64__


### PR DESCRIPTION
# Proposed changes

Inspired by [Clickhouse #33706](https://github.com/ClickHouse/ClickHouse/pull/33706) [Clickhouse #35983](https://github.com/ClickHouse/ClickHouse/pull/35983)

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

