### PR TITLE
[fix](broker-load) fix npe when executing broker load

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/planner/BrokerScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/BrokerScanNode.java
@@ -283,9 +283,11 @@ public class BrokerScanNode extends LoadScanNode {
         }
 
         if (targetTable != null) {
+            List<Integer> srcSlotIds = Lists.newArrayList();
             Load.initColumns(targetTable, columnDescs, context.fileGroup.getColumnToHadoopFunction(), context.exprMap,
-                    analyzer, context.srcTupleDescriptor, context.slotDescByName, context.params.getSrcSlotIds(),
+                    analyzer, context.srcTupleDescriptor, context.slotDescByName, srcSlotIds,
                     formatType(context.fileGroup.getFileFormat(), ""), null, VectorizedUtil.isVectorized());
+            context.params.setSrcSlotIds(srcSlotIds);
         }
     }
 


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

This bug is introduced from #12275 
the srcSlotIds should be created before using, otherwise, NPE will be thrown.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

