### PR TITLE
[fix](nereids) type coercion on case-when is not correct

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/CaseWhen.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/CaseWhen.java
@@ -65,7 +65,11 @@ public class CaseWhen extends Expression {
     }
 
     public List<DataType> dataTypesForCoercion() {
-        return whenClauses.stream().map(WhenClause::getDataType).collect(Collectors.toList());
+        List<DataType> result = whenClauses.stream().map(WhenClause::getDataType).collect(Collectors.toList());
+        if (defaultValue.isPresent()) {
+            result.add(defaultValue.get().getDataType());
+        }
+        return result;
     }
 
     public <R, C> R accept(ExpressionVisitor<R, C> visitor, C context) {


### PR DESCRIPTION
# Proposed changes
`case when n_nationkey > 1 then n_regionkey else 0`
The `else 0`  part need type cast, that is `else cast (0 as int)`

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

