### PR TITLE
[enhancement](nereids) use Literal promotion to avoid unnecessary cast

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/types/DataType.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/types/DataType.java
@@ -20,6 +20,11 @@ package org.apache.doris.nereids.types;
 import org.apache.doris.catalog.ScalarType;
 import org.apache.doris.catalog.Type;
 import org.apache.doris.nereids.exceptions.AnalysisException;
+import org.apache.doris.nereids.trees.expressions.literal.BigIntLiteral;
+import org.apache.doris.nereids.trees.expressions.literal.DoubleLiteral;
+import org.apache.doris.nereids.trees.expressions.literal.IntegerLiteral;
+import org.apache.doris.nereids.trees.expressions.literal.Literal;
+import org.apache.doris.nereids.trees.expressions.literal.SmallIntLiteral;
 import org.apache.doris.nereids.types.coercion.AbstractDataType;
 import org.apache.doris.nereids.types.coercion.CharacterType;
 import org.apache.doris.nereids.types.coercion.NumericType;
@@ -48,6 +53,26 @@ public abstract class DataType implements AbstractDataType {
             .put(IntegerType.class, () -> BigIntType.INSTANCE)
             .put(FloatType.class, () -> DoubleType.INSTANCE)
             .build();
+
+    /**
+     * create a specific Literal for a given dataType
+     */
+    public static Literal promoteNumberLiteral(Object value, DataType dataType) {
+        if (! (value instanceof Number)) {
+            return null;
+        }
+
+        if (dataType.equals(SmallIntType.INSTANCE)) {
+            return new SmallIntLiteral(((Number) value).shortValue());
+        } else if (dataType.equals(IntegerType.INSTANCE)) {
+            return new IntegerLiteral(((Number) value).intValue());
+        } else if (dataType.equals(BigIntType.INSTANCE)) {
+            return new BigIntLiteral(((Number) value).longValue());
+        } else if (dataType.equals(DoubleType.INSTANCE)) {
+            return new DoubleLiteral(((Number) value).doubleValue());
+        }
+        return null;
+    }
 
     /**
      * Convert data type in Doris catalog to data type in Nereids.

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/util/TypeCoercionUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/util/TypeCoercionUtils.java
@@ -291,11 +291,15 @@ public class TypeCoercionUtils {
             return input;
         } else {
             if (input instanceof Literal) {
-                DataType newType = input.getDataType();
-                while (!newType.equals(dataType) && newType != null) {
-                    newType = newType.promotion();
+                DataType type = input.getDataType();
+                while (!type.equals(dataType)) {
+                    DataType promoted = type.promotion();
+                    if (type.equals(promoted)) {
+                        break;
+                    }
+                    type = promoted;
                 }
-                if (newType != null) {
+                if (type.equals(dataType)) {
                     Literal promoted = DataType.promoteNumberLiteral(((Literal) input).getValue(), dataType);
                     if (promoted != null) {
                         return promoted;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/util/TypeCoercionUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/util/TypeCoercionUtils.java
@@ -20,6 +20,7 @@ package org.apache.doris.nereids.util;
 import org.apache.doris.nereids.annotation.Developing;
 import org.apache.doris.nereids.trees.expressions.Cast;
 import org.apache.doris.nereids.trees.expressions.Expression;
+import org.apache.doris.nereids.trees.expressions.literal.Literal;
 import org.apache.doris.nereids.types.BigIntType;
 import org.apache.doris.nereids.types.BooleanType;
 import org.apache.doris.nereids.types.DataType;
@@ -289,6 +290,19 @@ public class TypeCoercionUtils {
         if (input.getDataType().equals(dataType)) {
             return input;
         } else {
+            if (input instanceof Literal) {
+                DataType newType = input.getDataType();
+                while (!newType.equals(dataType) && newType != null) {
+                    newType = newType.promotion();
+                }
+                if (newType != null) {
+                    Literal promoted = DataType.promoteNumberLiteral(((Literal) input).getValue(), dataType);
+                    if (promoted != null) {
+                        return promoted;
+                    }
+
+                }
+            }
             return new Cast(input, dataType);
         }
     }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/rewrite/TypeCoercionTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/rewrite/TypeCoercionTest.java
@@ -39,7 +39,6 @@ import org.apache.doris.nereids.trees.expressions.literal.IntegerLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.SmallIntLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.StringLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.TinyIntLiteral;
-import org.apache.doris.nereids.types.BigIntType;
 import org.apache.doris.nereids.types.DecimalType;
 import org.apache.doris.nereids.types.DoubleType;
 import org.apache.doris.nereids.types.IntegerType;
@@ -177,7 +176,7 @@ public class TypeCoercionTest {
     @Test
     public void testBinaryOperator() {
         Expression actual = new Divide(new SmallIntLiteral((short) 1), new BigIntLiteral(10L));
-        Expression expected = new Divide(new Cast(new SmallIntLiteral((short) 1), BigIntType.INSTANCE),
+        Expression expected = new Divide(new BigIntLiteral(1L),
                 new BigIntLiteral(10L));
         assertRewrite(expected, actual);
     }


### PR DESCRIPTION
# Proposed changes
Instead of add a cast function on literal, we directly change the literal type. This change could save cast execution time and memory.
For example:
`case when l_orderkey > 0 then ...`
`0` is a TinyIntLiteral. 
before this pr: `case when l_orderkey > cast (TinyIntLiteral(0) as int)` 
with this pr:  `case when l_orderkey > IntegerLiteral(0) ` 

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

