### PR TITLE
[feature-wip](parquet-reader) filter rows by page index

### DIFF
--- a/be/src/vec/exec/format/parquet/level_decoder.h
+++ b/be/src/vec/exec/format/parquet/level_decoder.h
@@ -35,18 +35,12 @@ public:
     Status init(Slice* slice, tparquet::Encoding::type encoding, level_t max_level,
                 uint32_t num_levels);
 
-    bool has_levels() const { return _num_levels > 0; }
+    inline bool has_levels() const { return _num_levels > 0; }
 
     size_t get_levels(level_t* levels, size_t n);
 
-    size_t next_repeated_count() {
-        DCHECK_EQ(_encoding, tparquet::Encoding::RLE);
-        return _rle_decoder.repeated_count();
-    }
-
-    level_t get_repeated_value(size_t count) {
-        DCHECK_EQ(_encoding, tparquet::Encoding::RLE);
-        return _rle_decoder.get_repeated_value(count);
+    inline size_t get_next_run(level_t* val, size_t max_run) {
+        return _rle_decoder.GetNextRun(val, max_run);
     }
 
 private:

--- a/be/src/vec/exec/format/parquet/vparquet_column_chunk_reader.cpp
+++ b/be/src/vec/exec/format/parquet/vparquet_column_chunk_reader.cpp
@@ -46,10 +46,17 @@ Status ColumnChunkReader::init() {
         // seek to the first data page
         _page_reader->seek_to_page(_metadata.data_page_offset);
     }
+    _state = INITIALIZED;
     return Status::OK();
 }
 
 Status ColumnChunkReader::next_page() {
+    if (UNLIKELY(_state == NOT_INIT)) {
+        return Status::Corruption("Should initialize chunk reader");
+    }
+    if (UNLIKELY(_remaining_num_values != 0)) {
+        return Status::Corruption("Should skip current page");
+    }
     RETURN_IF_ERROR(_page_reader->next_page_header());
     if (_page_reader->get_page_header()->type == tparquet::PageType::DICTIONARY_PAGE) {
         // the first page maybe directory page even if _metadata.__isset.dictionary_page_offset == false,
@@ -59,11 +66,15 @@ Status ColumnChunkReader::next_page() {
         return next_page();
     } else {
         _remaining_num_values = _page_reader->get_page_header()->data_page_header.num_values;
+        _state = HEADER_PARSED;
         return Status::OK();
     }
 }
 
 Status ColumnChunkReader::load_page_data() {
+    if (UNLIKELY(_state != HEADER_PARSED)) {
+        return Status::Corruption("Should parse page header");
+    }
     const auto& header = *_page_reader->get_page_header();
     // int32_t compressed_size = header.compressed_page_size;
     int32_t uncompressed_size = header.uncompressed_page_size;
@@ -113,6 +124,7 @@ Status ColumnChunkReader::load_page_data() {
     // Reset page data for each page
     _page_decoder->set_data(&_page_data);
 
+    _state = DATA_LOADED;
     return Status::OK();
 }
 

--- a/be/src/vec/exec/format/parquet/vparquet_column_chunk_reader.h
+++ b/be/src/vec/exec/format/parquet/vparquet_column_chunk_reader.h
@@ -69,14 +69,25 @@ public:
 
     // Seek to the specific page, page_header_offset must be the start offset of the page header.
     void seek_to_page(int64_t page_header_offset) {
+        _remaining_num_values = 0;
         _page_reader->seek_to_page(page_header_offset);
+        _state = INITIALIZED;
     }
 
     // Seek to next page. Only read and parse the page header.
     Status next_page();
 
     // Skip current page(will not read and parse) if the page is filtered by predicates.
-    Status skip_page() { return _page_reader->skip_page(); }
+    Status skip_page() {
+        _remaining_num_values = 0;
+        if (_state == HEADER_PARSED) {
+            return _page_reader->skip_page();
+        }
+        if (_state != DATA_LOADED) {
+            return Status::Corruption("Should parse page header to skip page");
+        }
+        return Status::OK();
+    }
     // Skip some values(will not read and parse) in current page if the values are filtered by predicates.
     // when skip_data = false, the underlying decoder will not skip data,
     // only used when maintaining the consistency of _remaining_num_values.
@@ -85,6 +96,12 @@ public:
     // Load page data into the underlying container,
     // and initialize the repetition and definition level decoder for current page data.
     Status load_page_data();
+    Status load_page_date_idempotent() {
+        if (_state == DATA_LOADED) {
+            return Status::OK();
+        }
+        return load_page_data();
+    }
     // The remaining number of values in current page(including null values). Decreased when reading or skipping.
     uint32_t remaining_num_values() const { return _remaining_num_values; };
     // null values are generated from definition levels
@@ -115,10 +132,13 @@ public:
     Decoder* get_page_decoder() { return _page_decoder; }
 
 private:
+    enum ColumnChunkReaderState { NOT_INIT, INITIALIZED, HEADER_PARSED, DATA_LOADED };
+
     Status _decode_dict_page();
     void _reserve_decompress_buf(size_t size);
     int32_t _get_type_length();
 
+    ColumnChunkReaderState _state = NOT_INIT;
     FieldSchema* _field_schema;
     level_t _max_rep_level;
     level_t _max_def_level;

--- a/be/src/vec/exec/format/parquet/vparquet_column_reader.h
+++ b/be/src/vec/exec/format/parquet/vparquet_column_reader.h
@@ -67,8 +67,8 @@ public:
     virtual void close() = 0;
 
 protected:
-    void _skipped_pages();
-    void _reserve_def_levels_buf(size_t size);
+    void _generate_read_ranges(int64_t start_index, int64_t end_index,
+                               std::list<RowRange>& read_ranges);
 
     const ParquetReadColumn& _column;
     BufferedFileStreamReader* _stream_reader;
@@ -76,9 +76,9 @@ protected:
     std::vector<RowRange> _row_ranges;
     cctz::time_zone* _ctz;
     std::unique_ptr<ColumnChunkReader> _chunk_reader;
-    std::unique_ptr<level_t[]> _def_levels_buf = nullptr;
-    size_t _def_levels_buf_size = 0;
     tparquet::OffsetIndex* _offset_index;
+    int64_t _current_row_index = 0;
+    int _row_range_index = 0;
 };
 
 class ScalarColumnReader : public ParquetColumnReader {
@@ -90,6 +90,8 @@ public:
                 std::vector<RowRange>& row_ranges);
     Status read_column_data(ColumnPtr& doris_column, DataTypePtr& type, size_t batch_size,
                             size_t* read_rows, bool* eof) override;
+    Status _skip_values(size_t num_values);
+    Status _read_values(size_t num_values, ColumnPtr& doris_column, DataTypePtr& type);
     void close() override;
 };
 
@@ -105,12 +107,19 @@ public:
     void close() override;
 
 private:
+    void _reserve_def_levels_buf(size_t size);
     void _init_rep_levels_buf();
     void _load_rep_levels();
     Status _load_nested_column(ColumnPtr& doris_column, DataTypePtr& type, size_t read_values);
     Status _generate_array_offset(std::vector<size_t>& element_offsets, size_t pre_batch_size,
                                   size_t* real_batch_size, size_t* num_values);
-    void _fill_array_offset(MutableColumnPtr& doris_column, std::vector<size_t>& element_offsets);
+    void _fill_array_offset(MutableColumnPtr& doris_column, std::vector<size_t>& element_offsets,
+                            int offset_index, size_t num_rows);
+    Status _skip_values(size_t num_values);
+
+    std::unique_ptr<level_t[]> _def_levels_buf = nullptr;
+    size_t _def_levels_buf_size = 0;
+    size_t _def_offset = 0;
 
     std::unique_ptr<level_t[]> _rep_levels_buf = nullptr;
     size_t _rep_levels_buf_size = 0;

--- a/be/src/vec/exec/format/parquet/vparquet_page_reader.h
+++ b/be/src/vec/exec/format/parquet/vparquet_page_reader.h
@@ -28,7 +28,6 @@ namespace doris::vectorized {
  */
 class PageReader {
 public:
-public:
     PageReader(BufferedStreamReader* reader, uint64_t offset, uint64_t length);
     ~PageReader() = default;
 
@@ -45,11 +44,15 @@ public:
     void seek_to_page(int64_t page_header_offset) {
         _offset = page_header_offset;
         _next_header_offset = page_header_offset;
+        _state = INITIALIZED;
     }
 
 private:
+    enum PageReaderState { INITIALIZED, HEADER_PARSED };
+
     BufferedStreamReader* _reader;
     tparquet::PageHeader _cur_page_header;
+    PageReaderState _state = INITIALIZED;
 
     uint64_t _offset = 0;
     uint64_t _next_header_offset = 0;

--- a/be/src/vec/exec/format/parquet/vparquet_reader.h
+++ b/be/src/vec/exec/format/parquet/vparquet_reader.h
@@ -47,6 +47,8 @@ class RowGroupReader;
 class PageIndex;
 
 struct RowRange {
+    RowRange() {}
+    RowRange(int64_t first, int64_t last) : first_row(first), last_row(last) {}
     int64_t first_row;
     int64_t last_row;
 };


### PR DESCRIPTION
# Proposed changes

[Parquet v1.11+ supports page skipping](https://github.com/apache/parquet-format/blob/master/PageIndex.md), which helps the scanner reduce the amount of data scanned, decompressed, decoded, and insertion. According to the performance FlameGraph, decompression takes up 20% cpu time. If a page can be filtered as a whole, the page can not be decompressed.

However, the row numbers between pages are not aligned. Columns containing predicates can be filtered by page granularity, but other columns need to be skipped within pages, so non predicate columns can only save the decoding and insertion time.

Array column needs the repetition level to align with other columns, so the array column can only save the decoding and insertion time.

## Explore
`OffsetIndex` in the column metadata can locate the page position. Theoretically, a page can be completely skipped, including the time of reading from HDFS. However, the average size of a page is around 500KB. Skipping a page requires calling the `skip`. The performance of `skip` is low when it is called frequently, and may not be better than continuous reading of large blocks of data (such as 4MB).

If multiple consecutive pages are filtered, `skip` reading can be performed according to`OffsetIndex`. However, for the convenience of programming and readability, the data of all pages are loaded and filtered in turn.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

