### PR TITLE
[fix](memory) Fix BE OOM when load -238 fail

### DIFF
--- a/be/src/runtime/load_channel.cpp
+++ b/be/src/runtime/load_channel.cpp
@@ -92,28 +92,6 @@ Status LoadChannel::_get_tablets_channel(std::shared_ptr<TabletsChannel>& channe
     return Status::OK();
 }
 
-void LoadChannel::handle_mem_exceed_limit(bool force) {
-    // lock so that only one thread can check mem limit
-    std::lock_guard<std::mutex> l(_lock);
-    if (!(force || _mem_tracker->limit_exceeded())) {
-        return;
-    }
-
-    if (!force) {
-        LOG(INFO) << "reducing memory of " << *this << " because its mem consumption "
-                  << _mem_tracker->consumption() << " has exceeded limit " << _mem_tracker->limit();
-    }
-
-    std::shared_ptr<TabletsChannel> channel;
-    if (_find_largest_consumption_channel(&channel)) {
-        channel->reduce_mem_usage(_mem_tracker->limit());
-    } else {
-        // should not happen, add log to observe
-        LOG(WARNING) << "fail to find suitable tablets-channel when memory exceed. "
-                     << "load_id=" << _load_id;
-    }
-}
-
 // lock should be held when calling this method
 bool LoadChannel::_find_largest_consumption_channel(std::shared_ptr<TabletsChannel>* channel) {
     int64_t max_consume = 0;

--- a/be/src/runtime/load_channel_mgr.h
+++ b/be/src/runtime/load_channel_mgr.h
@@ -66,7 +66,8 @@ private:
     void _finish_load_channel(UniqueId load_id);
     // check if the total load mem consumption exceeds limit.
     // If yes, it will pick a load channel to try to reduce memory consumption.
-    void _handle_mem_exceed_limit();
+    template <typename TabletWriterAddResult>
+    Status _handle_mem_exceed_limit(TabletWriterAddResult* response);
 
     Status _start_bg_worker();
 
@@ -125,7 +126,7 @@ Status LoadChannelMgr::add_batch(const TabletWriterAddRequest& request,
         // 2. check if mem consumption exceed limit
         // If this is a high priority load task, do not handle this.
         // because this may block for a while, which may lead to rpc timeout.
-        _handle_mem_exceed_limit();
+        RETURN_IF_ERROR(_handle_mem_exceed_limit(response));
     }
 
     // 3. add batch to load channel
@@ -138,6 +139,40 @@ Status LoadChannelMgr::add_batch(const TabletWriterAddRequest& request,
         _finish_load_channel(load_id);
     }
     return Status::OK();
+}
+
+template <typename TabletWriterAddResult>
+Status LoadChannelMgr::_handle_mem_exceed_limit(TabletWriterAddResult* response) {
+    // lock so that only one thread can check mem limit
+    std::lock_guard<std::mutex> l(_lock);
+    if (!_mem_tracker->limit_exceeded()) {
+        return Status::OK();
+    }
+
+    int64_t max_consume = 0;
+    std::shared_ptr<LoadChannel> channel;
+    for (auto& kv : _load_channels) {
+        if (kv.second->is_high_priority()) {
+            // do not select high priority channel to reduce memory
+            // to avoid blocking them.
+            continue;
+        }
+        if (kv.second->mem_consumption() > max_consume) {
+            max_consume = kv.second->mem_consumption();
+            channel = kv.second;
+        }
+    }
+    if (max_consume == 0) {
+        // should not happen, add log to observe
+        LOG(WARNING) << "failed to find suitable load channel when total load mem limit exceed";
+        return Status::OK();
+    }
+    DCHECK(channel.get() != nullptr);
+
+    // force reduce mem limit of the selected channel
+    LOG(INFO) << "reducing memory of " << *channel << " because total load mem consumption "
+              << _mem_tracker->consumption() << " has exceeded limit " << _mem_tracker->limit();
+    return channel->handle_mem_exceed_limit(true, response);
 }
 
 } // namespace doris

--- a/be/src/runtime/tablets_channel.cpp
+++ b/be/src/runtime/tablets_channel.cpp
@@ -194,7 +194,8 @@ void TabletsChannel::_close_wait(DeltaWriter* writer,
     }
 }
 
-Status TabletsChannel::reduce_mem_usage(int64_t mem_limit) {
+template <typename TabletWriterAddResult>
+Status TabletsChannel::reduce_mem_usage(int64_t mem_limit, TabletWriterAddResult* response) {
     std::lock_guard<std::mutex> l(_lock);
     if (_state == kFinished) {
         // TabletsChannel is closed without LoadChannel's lock,
@@ -237,8 +238,22 @@ Status TabletsChannel::reduce_mem_usage(int64_t mem_limit) {
         }
     }
     VLOG_CRITICAL << "flush " << counter << " memtables to reduce memory: " << sum;
+    google::protobuf::RepeatedPtrField<PTabletError>* tablet_errors =
+            response->mutable_tablet_errors();
     for (int i = 0; i < counter; i++) {
-        writers[i]->flush_memtable_and_wait(false);
+        Status st = writers[i]->flush_memtable_and_wait(false);
+        if (!st.ok()) {
+            auto err_msg = strings::Substitute(
+                    "tablet writer failed to reduce mem consumption by flushing memtable, "
+                    "tablet_id=$0, txn_id=$1, err=$2, errcode=$3, msg:$4",
+                    writers[i]->tablet_id(), _txn_id, st.code(), st.precise_code(),
+                    st.get_error_msg());
+            LOG(WARNING) << err_msg;
+            PTabletError* error = tablet_errors->Add();
+            error->set_tablet_id(writers[i]->tablet_id());
+            error->set_msg(err_msg);
+            _broken_tablets.insert(writers[i]->tablet_id());
+        }
     }
 
     for (int i = 0; i < counter; i++) {
@@ -402,4 +417,8 @@ TabletsChannel::add_batch<PTabletWriterAddBatchRequest, PTabletWriterAddBatchRes
 template Status
 TabletsChannel::add_batch<PTabletWriterAddBlockRequest, PTabletWriterAddBlockResult>(
         PTabletWriterAddBlockRequest const&, PTabletWriterAddBlockResult*);
+template Status TabletsChannel::reduce_mem_usage<PTabletWriterAddBatchResult>(
+        int64_t, PTabletWriterAddBatchResult*);
+template Status TabletsChannel::reduce_mem_usage<PTabletWriterAddBlockResult>(
+        int64_t, PTabletWriterAddBlockResult*);
 } // namespace doris

--- a/be/src/runtime/tablets_channel.cpp
+++ b/be/src/runtime/tablets_channel.cpp
@@ -257,6 +257,10 @@ Status TabletsChannel::reduce_mem_usage(int64_t mem_limit, TabletWriterAddResult
     }
 
     for (int i = 0; i < counter; i++) {
+        if (_broken_tablets.find(writers[i]->tablet_id()) != _broken_tablets.end()) {
+            // skip broken tablets
+            continue;
+        }
         Status st = writers[i]->wait_flush();
         if (!st.ok()) {
             return Status::InternalError(

--- a/be/src/runtime/tablets_channel.h
+++ b/be/src/runtime/tablets_channel.h
@@ -92,7 +92,8 @@ public:
     // eg. flush the largest memtable immediately.
     // return Status::OK if mem is reduced.
     // no-op when this channel has been closed or cancelled
-    Status reduce_mem_usage(int64_t mem_limit);
+    template <typename TabletWriterAddResult>
+    Status reduce_mem_usage(int64_t mem_limit, TabletWriterAddResult* response);
 
     int64_t mem_consumption() const { return _mem_tracker->consumption(); }
 

--- a/be/src/service/doris_main.cpp
+++ b/be/src/service/doris_main.cpp
@@ -504,6 +504,8 @@ int main(int argc, char** argv) {
         // this will cause coredump for ASAN build when running regression test,
         // disable temporarily.
         doris::ExecEnv::GetInstance()->task_pool_mem_tracker_registry()->logout_task_mem_tracker();
+        // The process tracker print log usage interval is 1s to avoid a large number of tasks being
+        // canceled when the process exceeds the mem limit, resulting in too many duplicate logs.
         doris::ExecEnv::GetInstance()->process_mem_tracker_raw()->enable_print_log_usage();
         sleep(1);
     }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #12661

## Problem summary

When the flush is triggered when the load channel exceeds the mem limit, if the flush fails, an error message is returned and the load is terminated.

Usually flush failure is -238 error code. Because the memtable is frequently flushed after the load channel exceeds the mem limit, the number of segments exceeds the max value.

Before fix:
![image](https://user-images.githubusercontent.com/13197424/190564895-17f93550-e630-4c62-a7af-2e03de571112.png)

After fix:
![image](https://user-images.githubusercontent.com/13197424/190564839-5fef5e57-a80e-437c-a911-78862e188e97.png)


## Checklist(Required)

1. Does it affect the original behavior: 
    - [x] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

