### PR TITLE
[feature-wip](unique-key-merge-on-write) fix calculate delete bitmap when flush memtable

### DIFF
--- a/be/src/olap/delta_writer.cpp
+++ b/be/src/olap/delta_writer.cpp
@@ -106,6 +106,7 @@ Status DeltaWriter::init() {
     if (_tablet->enable_unique_key_merge_on_write()) {
         std::lock_guard<std::shared_mutex> lck(_tablet->get_header_lock());
         _rowset_ids = _tablet->all_rs_id();
+        _cur_max_version = _tablet->max_version_unlocked().second;
     }
 
     _mem_tracker = std::make_shared<MemTrackerLimiter>(
@@ -289,7 +290,7 @@ void DeltaWriter::_reset_mem_table() {
     }
     _mem_table.reset(new MemTable(_tablet, _schema.get(), _tablet_schema.get(), _req.slots,
                                   _req.tuple_desc, _rowset_writer.get(), _delete_bitmap,
-                                  _rowset_ids, _is_vec));
+                                  _rowset_ids, _cur_max_version, _is_vec));
 }
 
 Status DeltaWriter::close() {

--- a/be/src/olap/delta_writer.h
+++ b/be/src/olap/delta_writer.h
@@ -171,6 +171,8 @@ private:
     DeleteBitmapPtr _delete_bitmap = nullptr;
     // current rowset_ids, used to do diff in publish_version
     RowsetIdUnorderedSet _rowset_ids;
+    // current max version, used to calculate delete bitmap
+    int64_t _cur_max_version;
 };
 
 } // namespace doris

--- a/be/src/olap/memtable.h
+++ b/be/src/olap/memtable.h
@@ -44,7 +44,8 @@ public:
     MemTable(TabletSharedPtr tablet, Schema* schema, const TabletSchema* tablet_schema,
              const std::vector<SlotDescriptor*>* slot_descs, TupleDescriptor* tuple_desc,
              RowsetWriter* rowset_writer, DeleteBitmapPtr delete_bitmap,
-             const RowsetIdUnorderedSet& rowset_ids, bool support_vec = false);
+             const RowsetIdUnorderedSet& rowset_ids, int64_t cur_max_version,
+             bool support_vec = false);
     ~MemTable();
 
     int64_t tablet_id() const { return _tablet->tablet_id(); }
@@ -210,6 +211,7 @@ private:
 
     DeleteBitmapPtr _delete_bitmap;
     RowsetIdUnorderedSet _rowset_ids;
+    int64_t _cur_max_version;
 }; // class MemTable
 
 inline std::ostream& operator<<(std::ostream& os, const MemTable& table) {


### PR DESCRIPTION

# Proposed changes

Issue Number: close #xxx

## Problem summary

Multiple memtable should use the same version when calculate delete bitmap.  Otherwise, updating the delete bitmap of the same segment with different versions will cause the delete bitmap on the segment to be overwritten.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

