### PR TITLE
[Opt](hash) Speed up insert from dict data map and not datetime

### DIFF
--- a/be/src/vec/columns/column_complex.h
+++ b/be/src/vec/columns/column_complex.h
@@ -188,16 +188,17 @@ public:
         // TODO add hash function
     }
 
-    virtual void update_hashes_with_value(std::vector<SipHash>& hashes,
-                                          const uint8_t* __restrict null_data = nullptr) const override {
-        // TODO add hash function
+    virtual void update_hashes_with_value(
+            std::vector<SipHash>& hashes,
+            const uint8_t* __restrict null_data = nullptr) const override {
+            // TODO add hash function
     };
 
-    virtual void update_hashes_with_value(uint64_t* __restrict hashes,
-                                          const uint8_t* __restrict null_data = nullptr) const override {
+    virtual void update_hashes_with_value(
+            uint64_t* __restrict hashes,
+            const uint8_t* __restrict null_data = nullptr) const override {
         // TODO add hash function
     }
-
 
     [[noreturn]] int compare_at(size_t n, size_t m, const IColumn& rhs,
                                 int nan_direction_hint) const override {

--- a/be/src/vec/columns/column_complex.h
+++ b/be/src/vec/columns/column_complex.h
@@ -188,6 +188,17 @@ public:
         // TODO add hash function
     }
 
+    virtual void update_hashes_with_value(std::vector<SipHash>& hashes,
+                                          const uint8_t* __restrict null_data = nullptr) const override {
+        // TODO add hash function
+    };
+
+    virtual void update_hashes_with_value(uint64_t* __restrict hashes,
+                                          const uint8_t* __restrict null_data = nullptr) const override {
+        // TODO add hash function
+    }
+
+
     [[noreturn]] int compare_at(size_t n, size_t m, const IColumn& rhs,
                                 int nan_direction_hint) const override {
         LOG(FATAL) << "compare_at not implemented";

--- a/be/src/vec/columns/column_string.h
+++ b/be/src/vec/columns/column_string.h
@@ -199,25 +199,24 @@ public:
 
     void insert_many_dict_data(const int32_t* data_array, size_t start_index, const StringRef* dict,
                                size_t num, uint32_t /*dict_num*/) override {
-        size_t new_size = 0;
+        size_t offset_size = offsets.size();
+        size_t old_size = chars.size();
+        size_t new_size = old_size;
+        offsets.resize(offsets.size() + num);
+
         for (size_t i = start_index; i < start_index + num; i++) {
             int32_t codeword = data_array[i];
             new_size += dict[codeword].size;
+            offsets[offset_size + i] = new_size;
         }
 
-        const size_t old_size = chars.size();
-        chars.resize(old_size + new_size);
+        chars.resize(new_size);
 
-        Char* data = chars.data();
-        size_t offset = old_size;
         for (size_t i = start_index; i < start_index + num; i++) {
             int32_t codeword = data_array[i];
-            uint32_t len = dict[codeword].size;
-            if (len) {
-                memcpy(data + offset, dict[codeword].data, len);
-                offset += len;
-            }
-            offsets.push_back(offset);
+            auto& src = dict[codeword];
+            memcpy(chars.data() + old_size, src.data, src.size);
+            old_size += src.size;
         }
     }
 

--- a/be/src/vec/columns/column_string.h
+++ b/be/src/vec/columns/column_string.h
@@ -204,8 +204,8 @@ public:
         size_t new_size = old_size;
         offsets.resize(offsets.size() + num);
 
-        for (size_t i = start_index; i < start_index + num; i++) {
-            int32_t codeword = data_array[i];
+        for (size_t i = 0; i < num; i++) {
+            int32_t codeword = data_array[i + start_index];
             new_size += dict[codeword].size;
             offsets[offset_size + i] = new_size;
         }

--- a/be/src/vec/columns/column_vector.h
+++ b/be/src/vec/columns/column_vector.h
@@ -198,14 +198,14 @@ public:
         use by date, datetime, basic type
     */
     void insert_many_fix_len_data(const char* data_ptr, size_t num) override {
-        if constexpr (std::is_same_v<T, vectorized::Int128>) {
+        if constexpr (!std::is_same_v<T, vectorized::Int64>) {
             insert_many_in_copy_way(data_ptr, num);
         } else if (IColumn::is_date) {
             insert_date_column(data_ptr, num);
         } else if (IColumn::is_date_time) {
             insert_datetime_column(data_ptr, num);
         } else {
-            insert_many_default_type(data_ptr, num);
+            insert_many_in_copy_way(data_ptr, num);
         }
     }
 


### PR DESCRIPTION
# Proposed changes

Speed up dict data read and not datetime. same target #12636

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

