### PR TITLE
[fix](nereids)fix NPE at runtime filter translator when runtime filter's target is null.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/RuntimeFilterTranslator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/RuntimeFilterTranslator.java
@@ -74,6 +74,10 @@ public class RuntimeFilterTranslator {
     public void createLegacyRuntimeFilter(RuntimeFilter filter, HashJoinNode node, PlanTranslatorContext ctx) {
         SlotRef src = ctx.findSlotRef(filter.getSrcExpr().getExprId());
         SlotRef target = context.getExprIdToOlapScanNodeSlotRef().get(filter.getTargetExpr().getExprId());
+        if (target == null) {
+            context.addTargetNullRFCount();
+            return;
+        }
         org.apache.doris.planner.RuntimeFilter origFilter
                 = org.apache.doris.planner.RuntimeFilter.fromNereidsRuntimeFilter(
                 filter.getId(), node, src, filter.getExprOrder(), target,

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/RuntimeFilterContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/RuntimeFilterContext.java
@@ -71,6 +71,8 @@ public class RuntimeFilterContext {
 
     private final FilterSizeLimits limits;
 
+    private int targetNullRFCount = 0;
+
     public RuntimeFilterContext(SessionVariable sessionVariable) {
         this.sessionVariable = sessionVariable;
         this.limits = new FilterSizeLimits(sessionVariable);
@@ -177,5 +179,14 @@ public class RuntimeFilterContext {
             expr = aliasChildToSelf.get(expr.toSlot());
         } while (expr != null);
         return builder.build();
+    }
+
+    public void addTargetNullRFCount() {
+        targetNullRFCount++;
+    }
+
+    @VisibleForTesting
+    public int getTargetNullRFCount() {
+        return targetNullRFCount;
     }
 }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

fix NPE at runtime filter translator caused by some runtime filter's target is null when slotReference transfers to SlotRef of OlapScanNode.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [x] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

