### PR TITLE
[chore](thirdparty) Support third-party incremental build

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -230,6 +230,10 @@ if [[ ! -f "${DORIS_THIRDPARTY}/installed/lib/libbacktrace.a" ]]; then
     rm -rf "${DORIS_THIRDPARTY}/installed"
     "${DORIS_THIRDPARTY}/build-thirdparty.sh" -j "${PARALLEL}"
 fi
+# For soft upgrade, to minimize complaints of build issues, enable it by default in the future
+if [[ "${ENABLE_INCREMENTAL_THIRD_PARTY_BUILD}" == "1" ]]; then
+    "${DORIS_THIRDPARTY}/build-thirdparty.sh" -j "${PARALLEL}"
+fi
 
 if [[ "${CLEAN}" -eq 1 && "${BUILD_BE}" -eq 0 && "${BUILD_FE}" -eq 0 && "${BUILD_SPARK_DPP}" -eq 0 ]]; then
     clean_gensrc

--- a/build.sh
+++ b/build.sh
@@ -231,7 +231,10 @@ if [[ ! -f "${DORIS_THIRDPARTY}/installed/lib/libbacktrace.a" ]]; then
     "${DORIS_THIRDPARTY}/build-thirdparty.sh" -j "${PARALLEL}"
 fi
 # For soft upgrade, to minimize complaints of build issues, enable it by default in the future
-if [[ "${ENABLE_INCREMENTAL_THIRD_PARTY_BUILD}" == "1" ]]; then
+if [[ -z "${ENABLE_INCREMENTAL_THIRD_PARTY_BUILD}" ]]; then
+    ENABLE_INCREMENTAL_THIRD_PARTY_BUILD="OFF"
+fi
+if [[ "${ENABLE_INCREMENTAL_THIRD_PARTY_BUILD}" == "ON" ]]; then
     "${DORIS_THIRDPARTY}/build-thirdparty.sh" -j "${PARALLEL}"
 fi
 

--- a/thirdparty/build-thirdparty.sh
+++ b/thirdparty/build-thirdparty.sh
@@ -1420,21 +1420,21 @@ build_xxhash() {
 
 # Choose what to compile
 if [[ -d ${TP_INSTALL_DIR} && "${DEPS}" != "" ]]; then
-    for i in $(echo ${DEPS}); do
-        build_${i}
+    for i in $(echo "${DEPS}"); do
+        "build_${i}"
     done
     echo "Built specified dependencies: ${DEPS}"
     exit
 fi
 
 if [[ -f version.txt ]]; then
-    CUR_VERSION=$(cat version.txt | grep -v "#")
+    CUR_VERSION=$(grep -v "#" version.txt)
 else
     CUR_VERSION="y"
 fi
 
 if [[ -f ${TP_INSTALL_DIR}/version.txt ]]; then
-    INSTALLED_VERSION=$(cat ${TP_INSTALL_DIR}/version.txt | grep -v "#")
+    INSTALLED_VERSION=$(grep -v "#" "${TP_INSTALL_DIR}/version.txt")
 else
     INSTALLED_VERSION="x"
 fi
@@ -1446,27 +1446,27 @@ fi
 
 # Incremental build
 if [[ -f version.txt && -f ${TP_INSTALL_DIR}/version.txt && ${BUILD_ALL} -eq 0 ]]; then
-    CUR_VERSION=$(cat version.txt | grep -v "#" | awk '{print $1; exit}')
-    INSTALLED_VERSION=$(cat ${TP_INSTALL_DIR}/version.txt | grep -v "#" | awk '{print $1; exit}')
+    CUR_VERSION=$(grep -v "#" version.txt | awk '{print $1; exit}')
+    INSTALLED_VERSION=$(grep -v "#" "${TP_INSTALL_DIR}/version.txt" | awk '{print $1; exit}')
     if [[ "${INSTALLED_VERSION}" -gt "${CUR_VERSION}" ]]; then
         echo "Installed dependencies are up to date, if you want to downgrade, use -a or -d option to rebuild"
         exit
     fi
-    VER_DIFF=$((${CUR_VERSION} - ${INSTALLED_VERSION}))
+    VER_DIFF=$((CUR_VERSION - INSTALLED_VERSION))
     if [[ ${VER_DIFF} -lt 2 ]]; then
         INC_BUILD_DEPS=""
         CNT=0
-        for i in $(cat version.txt | grep -v "#"); do
+        for i in $(grep -v "#" version.txt); do
             if [[ ${CNT} -lt 2 ]]; then
-                CNT=$((${CNT} + 1))
+                CNT=$((CNT + 1))
                 continue
             fi
             INC_BUILD_DEPS="${INC_BUILD_DEPS} ${i}"
-            build_${i}
+            "build_${i}"
         done
         if [[ "${INC_BUILD_DEPS}" != "" ]]; then
             echo "Incremental build done:${INC_BUILD_DEPS}"
-            cp -f version.txt ${TP_INSTALL_DIR}/version.txt
+            cp -f version.txt "${TP_INSTALL_DIR}/version.txt"
             exit
         else
             echo "Continue to full build"
@@ -1481,10 +1481,10 @@ fi
 echo "Full build dependencies"
 if [[ ${BUILD_ALL} -eq 1 ]]; then
     # Remove all except source code
-    rm -rf ${TP_INSTALL_DIR}/include
-    rm -rf ${TP_INSTALL_DIR}/lib
-    rm -rf ${TP_INSTALL_DIR}/lib64
-    rm -rf ${TP_INSTALL_DIR}/gperftools
+    rm -rf "${TP_INSTALL_DIR}/include"
+    rm -rf "${TP_INSTALL_DIR}/lib"
+    rm -rf "${TP_INSTALL_DIR}/lib64"
+    rm -rf "${TP_INSTALL_DIR}/gperftools"
 fi
 
 build_libunixodbc

--- a/thirdparty/build-thirdparty.sh
+++ b/thirdparty/build-thirdparty.sh
@@ -1420,7 +1420,7 @@ build_xxhash() {
 
 # Choose what to compile
 if [[ -d ${TP_INSTALL_DIR} && "${DEPS}" != "" ]]; then
-    for i in `echo ${DEPS}`; do
+    for i in $(echo ${DEPS}); do
         build_${i}
     done
     echo "Built specified dependencies: ${DEPS}"
@@ -1428,13 +1428,13 @@ if [[ -d ${TP_INSTALL_DIR} && "${DEPS}" != "" ]]; then
 fi
 
 if [[ -f version.txt ]]; then
-    CUR_VERSION=`cat version.txt | grep -v "#"`
+    CUR_VERSION=$(cat version.txt | grep -v "#")
 else
     CUR_VERSION="y"
 fi
 
 if [[ -f ${TP_INSTALL_DIR}/version.txt ]]; then
-    INSTALLED_VERSION=`cat ${TP_INSTALL_DIR}/version.txt | grep -v "#"`
+    INSTALLED_VERSION=$(cat ${TP_INSTALL_DIR}/version.txt | grep -v "#")
 else
     INSTALLED_VERSION="x"
 fi
@@ -1446,19 +1446,19 @@ fi
 
 # Incremental build
 if [[ -f version.txt && -f ${TP_INSTALL_DIR}/version.txt && ${BUILD_ALL} -eq 0 ]]; then
-    CUR_VERSION=`cat version.txt | grep -v "#" | awk '{print $1; exit}'`
-    INSTALLED_VERSION=`cat ${TP_INSTALL_DIR}/version.txt | grep -v "#" | awk '{print $1; exit}'`
+    CUR_VERSION=$(cat version.txt | grep -v "#" | awk '{print $1; exit}')
+    INSTALLED_VERSION=$(cat ${TP_INSTALL_DIR}/version.txt | grep -v "#" | awk '{print $1; exit}')
     if [[ "${INSTALLED_VERSION}" -gt "${CUR_VERSION}" ]]; then
         echo "Installed dependencies are up to date, if you want to downgrade, use -a or -d option to rebuild"
         exit
     fi
-    VER_DIFF=$[${CUR_VERSION} - ${INSTALLED_VERSION}]
+    VER_DIFF=$((${CUR_VERSION} - ${INSTALLED_VERSION}))
     if [[ ${VER_DIFF} -lt 2 ]]; then
         INC_BUILD_DEPS=""
         CNT=0
-        for i in `cat version.txt | grep -v "#"`; do
+        for i in $(cat version.txt | grep -v "#"); do
             if [[ ${CNT} -lt 2 ]]; then
-                CNT=$[${CNT} + 1]
+                CNT=$((${CNT} + 1))
                 continue
             fi
             INC_BUILD_DEPS="${INC_BUILD_DEPS} ${i}"
@@ -1544,7 +1544,7 @@ build_xxhash
 
 # Full build done
 if [[ -f version.txt ]]; then
-    cp -f version.txt  ${TP_INSTALL_DIR}/version.txt
+    cp -f version.txt ${TP_INSTALL_DIR}/version.txt
 fi
 
 echo "Finished to build all thirdparties"

--- a/thirdparty/version.txt
+++ b/thirdparty/version.txt
@@ -1,0 +1,26 @@
+# This file records the version info of thirdparty,
+# the format is white space separated, and defined as following:
+#
+# ${verison_num} ${date} ${dep1} ${dep2} ${dep3} ...
+# 
+# e.g.
+# 1 20220917 lz4 curl tcmalloc
+#
+# where
+# ${version_num} is a monotonic consecutive integer indicates how many
+# times the third-party is upgraded.
+# ${depx} is the dependency updated, if you want a full rebuild when
+# updating third-party, specify no ${depx}, say,
+#
+# ${version_num} ${date}
+# 
+# e.g.
+# 1 20220917
+#
+# Once all third-parties are installed, build-thirdparty.sh will copy
+# version.txt to "installed" folder, and it will check version.txt for
+# incremental or full build automatically.
+#
+# **Note that no empty lines are allowed in this file.**
+#
+1 20220917 jemalloc arrow xxhash


### PR DESCRIPTION
It's a pain that third-party cannot be built partially and incrementally. This commit adds several build options to kill the pain.

to build specified dependencies
```
./build-third-party.sh -d "curl lz4 jemalloc"
```

automatic incremental build, a version file `version.txt` is added to complete this functionality. Check version.txt for more details.
```
./build-third-party.sh
```

to force rebuild all dependencies
```
./build-third-party.sh -a
```

Also, to enable automatic third-party incremental build support in `build.sh`, set the env. var.
```
export ENABLE_INCREMENTAL_THIRD_PARTY_BUILD=1
```

This may be enabled by default in the future.
