### PR TITLE
[improve](Nereids): Add all slots used by onClause in project 

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/join/InnerJoinLAsscom.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/join/InnerJoinLAsscom.java
@@ -20,6 +20,9 @@ package org.apache.doris.nereids.rules.exploration.join;
 import org.apache.doris.nereids.rules.Rule;
 import org.apache.doris.nereids.rules.RuleType;
 import org.apache.doris.nereids.rules.exploration.OneExplorationRuleFactory;
+import org.apache.doris.nereids.trees.plans.GroupPlan;
+import org.apache.doris.nereids.trees.plans.Plan;
+import org.apache.doris.nereids.trees.plans.logical.LogicalJoin;
 
 /**
  * Rule for change inner join LAsscom (associative and commutive).
@@ -37,7 +40,7 @@ public class InnerJoinLAsscom extends OneExplorationRuleFactory {
     @Override
     public Rule build() {
         return innerLogicalJoin(innerLogicalJoin(), group())
-                .when(topJoin -> JoinLAsscomHelper.checkInner(topJoin, topJoin.left()))
+                .when(topJoin -> check(topJoin, topJoin.left()))
                 .then(topJoin -> {
                     JoinLAsscomHelper helper = new JoinLAsscomHelper(topJoin, topJoin.left());
                     if (!helper.initJoinOnCondition()) {
@@ -45,5 +48,11 @@ public class InnerJoinLAsscom extends OneExplorationRuleFactory {
                     }
                     return helper.newTopJoin();
                 }).toRule(RuleType.LOGICAL_INNER_JOIN_LASSCOM);
+    }
+
+    public static boolean check(LogicalJoin<? extends Plan, GroupPlan> topJoin,
+            LogicalJoin<GroupPlan, GroupPlan> bottomJoin) {
+        return !bottomJoin.getJoinReorderContext().hasCommuteZigZag()
+                && !topJoin.getJoinReorderContext().hasLAsscom();
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/join/InnerJoinLAsscomProject.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/join/InnerJoinLAsscomProject.java
@@ -39,10 +39,10 @@ public class InnerJoinLAsscomProject extends OneExplorationRuleFactory {
     @Override
     public Rule build() {
         return innerLogicalJoin(logicalProject(innerLogicalJoin()), group())
-                .when(topJoin -> JoinLAsscomHelper.checkInner(topJoin, topJoin.left().child()))
+                .when(topJoin -> InnerJoinLAsscom.check(topJoin, topJoin.left().child()))
                 .then(topJoin -> {
                     JoinLAsscomHelper helper = new JoinLAsscomHelper(topJoin, topJoin.left().child());
-                    helper.initAllProject(topJoin.left());
+                    helper.initProject(topJoin.left());
                     if (!helper.initJoinOnCondition()) {
                         return null;
                     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/join/JoinCommuteHelper.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/join/JoinCommuteHelper.java
@@ -17,10 +17,9 @@
 
 package org.apache.doris.nereids.rules.exploration.join;
 
-import org.apache.doris.nereids.trees.expressions.SlotReference;
+import org.apache.doris.nereids.trees.expressions.Slot;
 import org.apache.doris.nereids.trees.plans.GroupPlan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalJoin;
-import org.apache.doris.nereids.util.Utils;
 
 import java.util.List;
 
@@ -47,7 +46,7 @@ class JoinCommuteHelper {
 
     private static boolean containJoin(GroupPlan groupPlan) {
         // TODO: tmp way to judge containJoin
-        List<SlotReference> output = Utils.getOutputSlotReference(groupPlan);
-        return !output.stream().map(SlotReference::getQualifier).allMatch(output.get(0).getQualifier()::equals);
+        List<Slot> output = groupPlan.getOutput();
+        return !output.stream().map(Slot::getQualifier).allMatch(output.get(0).getQualifier()::equals);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/join/OuterJoinLAsscomProject.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/join/OuterJoinLAsscomProject.java
@@ -40,12 +40,12 @@ public class OuterJoinLAsscomProject extends OneExplorationRuleFactory {
     @Override
     public Rule build() {
         return logicalJoin(logicalProject(logicalJoin()), group())
-                .when(topJoin -> JoinLAsscomHelper.checkOuter(topJoin, topJoin.left().child()))
+                .when(topJoin -> OuterJoinLAsscom.check(topJoin, topJoin.left().child()))
                 .when(join -> OuterJoinLAsscom.VALID_TYPE_PAIR_SET.contains(
                         Pair.of(join.left().child().getJoinType(), join.getJoinType())))
                 .then(topJoin -> {
                     JoinLAsscomHelper helper = new JoinLAsscomHelper(topJoin, topJoin.left().child());
-                    helper.initAllProject(topJoin.left());
+                    helper.initProject(topJoin.left());
                     if (!helper.initJoinOnCondition()) {
                         return null;
                     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/implementation/LogicalOlapScanToPhysicalOlapScan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/implementation/LogicalOlapScanToPhysicalOlapScan.java
@@ -27,10 +27,9 @@ import org.apache.doris.nereids.properties.DistributionSpecHash.ShuffleType;
 import org.apache.doris.nereids.rules.Rule;
 import org.apache.doris.nereids.rules.RuleType;
 import org.apache.doris.nereids.trees.expressions.ExprId;
-import org.apache.doris.nereids.trees.expressions.SlotReference;
+import org.apache.doris.nereids.trees.expressions.Slot;
 import org.apache.doris.nereids.trees.plans.logical.LogicalOlapScan;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalOlapScan;
-import org.apache.doris.nereids.util.Utils;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
@@ -63,7 +62,7 @@ public class LogicalOlapScanToPhysicalOlapScan extends OneImplementationRuleFact
         if (distributionInfo instanceof HashDistributionInfo) {
             HashDistributionInfo hashDistributionInfo = (HashDistributionInfo) distributionInfo;
 
-            List<SlotReference> output = Utils.getOutputSlotReference(olapScan);
+            List<Slot> output = olapScan.getOutput();
             List<ExprId> hashColumns = Lists.newArrayList();
             List<Column> schemaColumns = olapScan.getTable().getFullSchema();
             for (int i = 0; i < schemaColumns.size(); i++) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/util/Utils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/util/Utils.java
@@ -21,7 +21,6 @@ import org.apache.doris.nereids.exceptions.AnalysisException;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.SlotReference;
 import org.apache.doris.nereids.trees.expressions.shape.BinaryExpression;
-import org.apache.doris.nereids.trees.plans.Plan;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
@@ -114,15 +113,6 @@ public class Utils {
             return false;
         }
         return new HashSet<>(one).containsAll(other) && new HashSet<>(other).containsAll(one);
-    }
-
-    /**
-     * Get SlotReference from output of plam.
-     * Warning, plan must have bound, because exists Slot Cast to SlotReference.
-     */
-    public static List<SlotReference> getOutputSlotReference(Plan plan) {
-        return plan.getOutput().stream().map(SlotReference.class::cast)
-                .collect(Collectors.toList());
     }
 
     /**


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

1. Add all slots used by onClause in project

```
(A & B) & C like
join(hash conjuncts: C.t2 = A.t2)
|---project(A.t2)
|   +---join(hash conjuncts: A.t1 = B.t1)
|       +---A
|       +---B
+---C

transform to (A & C) & B
join(hash conjuncts: A.t1 = B.t1)
|---project(A.t2)
|   +---join(hash conjuncts: C.t2 = A.t2)
|       +---A
|       +---C
+---B
```

But projection just include `A.t2`, can't find `A.t1`, we should add slots used by onClause when projection exist.

2. fix join reorder mark

Add mark `LAsscom` when apply `LAsscom`

3. remove slotReference

use `Slot` instead of `SlotReference` to avoid cast.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [x] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

