### PR TITLE
[fix](memtracker) Fix memory leak by calling `boost::stacktrace` in mem hook

### DIFF
--- a/be/src/runtime/memory/mem_tracker_limiter.cpp
+++ b/be/src/runtime/memory/mem_tracker_limiter.cpp
@@ -213,7 +213,8 @@ void MemTrackerLimiter::print_log_usage(const std::string& msg) {
         } else {
             detail += "\n" + log_usage();
         }
-        detail += "\n" + boost::stacktrace::to_string(boost::stacktrace::stacktrace());
+        // TODO: memory leak by calling `boost::stacktrace` in mem hook
+        // detail += "\n" + boost::stacktrace::to_string(boost::stacktrace::stacktrace());
         LOG(WARNING) << detail;
         _print_log_usage = false;
     }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

After the consume mem tracker exceeds the mem limit in the mem hook, the boost stacktrace will be printed. A query/load will only be printed once, and the process tracker will only be printed once per second.

After the process memory reaches the upper limit, the boost stacktrace will be printed every second. The observed phenomena are as follows:
1. After query/load is canceled, the memory increases instantly;
2. tcmalloc profile total physical memory is less than perf process memory;
3. The process mem tracker is smaller than the perf process memory;

## Checklist(Required)

1. Does it affect the original behavior: 
    - [x] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
5. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
6. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

