### PR TITLE
 [feature-wip](statistics) template for building internal query SQL statements

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/util/InternalSqlTemplate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/util/InternalSqlTemplate.java
@@ -1,0 +1,295 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.statistics.util;
+
+import org.apache.doris.common.InvalidFormatException;
+
+import com.google.common.collect.Sets;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Template for building internal query SQL statements.
+ * e.g.:
+ *   - "SELECT ${column} FROM ${table}"
+ *   - ${column} and ${table} will be replaced with the actual executed table and column.
+ */
+public class InternalSqlTemplate {
+    /** -------------------------- for statistics begin -------------------------- */
+    public static final String MIN_VALUE_SQL = "SELECT MIN(${column}) AS min_value FROM ${table};";
+    public static final String PARTITION_MIN_VALUE_SQL = "SELECT MIN(${column}) AS min_value"
+            + " FROM ${table} PARTITION (${partition});";
+
+    public static final String MAX_VALUE_SQL = "SELECT MAX(${column}) AS max_value FROM ${table};";
+    public static final String PARTITION_MAX_VALUE_SQL = "SELECT MAX(${column}) AS max_value FROM"
+            + " ${table} PARTITION (${partition});";
+
+    public static final String NDV_VALUE_SQL = "SELECT NDV(${column}) AS ndv FROM ${table};";
+    public static final String PARTITION_NDV_VALUE_SQL = "SELECT NDV(${column}) AS ndv FROM"
+            + " ${table} PARTITION (${partition});";
+
+    public static final String MIN_MAX_NDV_VALUE_SQL = "SELECT MIN(${column}) AS min_value, MAX(${column})"
+            + " AS max_value, NDV(${column}) AS ndv FROM ${table};";
+    public static final String PARTITION_MIN_MAX_NDV_VALUE_SQL = "SELECT MIN(${column}) AS min_value,"
+            + " MAX(${column}) AS max_value, NDV(${column}) AS ndv FROM ${table} PARTITION (${partition});";
+
+    public static final String ROW_COUNT_SQL = "SELECT COUNT(1) AS row_count FROM ${table};";
+    public static final String PARTITION_ROW_COUNT_SQL = "SELECT COUNT(1) AS row_count FROM ${table} PARTITION"
+            + " (${partition});";
+
+    public static final String MAX_SIZE_SQL = "SELECT MAX(LENGTH(${column})) AS max_size FROM ${table};";
+    public static final String PARTITION_MAX_SIZE_SQL = "SELECT MAX(LENGTH(${column})) AS max_size FROM"
+            + " ${table} PARTITION (${partition});";
+
+    public static final String AVG_SIZE_SQL = "SELECT AVG(LENGTH(${column})) AS avg_size FROM ${table};";
+    public static final String PARTITION_AVG_SIZE_SQL = "SELECT AVG(LENGTH(${column})) AS avg_size"
+            + " FROM ${table} PARTITION (${partition});";
+
+    public static final String MAX_AVG_SIZE_SQL = "SELECT MAX(LENGTH(${column})) AS max_size,"
+            + " AVG(LENGTH(${column})) AS avg_size FROM ${table};";
+    public static final String PARTITION_MAX_AVG_SIZE_SQL = "SELECT MAX(LENGTH(${column}))"
+            + " AS max_size, AVG(LENGTH(${column})) AS avg_size FROM ${table} PARTITION (${partition});";
+
+    public static final String NUM_NULLS_SQL = "SELECT COUNT(1) AS num_nulls FROM ${table}"
+            + " WHERE ${column} IS NULL;";
+    public static final String PARTITION_NUM_NULLS_SQL = "SELECT COUNT(1) AS num_nulls FROM"
+            + " ${table} PARTITION (${partition}) WHERE ${column} IS NULL;";
+    /** ---------------------------- for statistics end ---------------------------- */
+
+    private static final Logger LOG = LogManager.getLogger(InternalSqlTemplate.class);
+
+    private static final Pattern PATTERN = Pattern.compile("\\$\\{\\w+\\}");
+
+    /**
+     * Concatenate SQL statements based on templates and parameters. e.g.:
+     * template and parameters:
+     *  'SELECT ${col} FROM ${table} WHERE id = ${id};',
+     *   parameters: {col=colName, table=tableName, id=1}
+     *   result sql: 'SELECT colName FROM tableName WHERE id = 1;
+     * <p>
+     *
+     * @param template sql template
+     * @param params   k,v parameter, if without parameter, params should be null
+     * @return SQL statement with parameters concatenated
+     */
+    public static String processTemplate(String template, Map<String, String> params) {
+        Matcher matcher = PATTERN.matcher(template);
+        StringBuffer sb = new StringBuffer();
+
+        while (matcher.find()) {
+            String param = matcher.group();
+            String value = params.get(param.substring(2, param.length() - 1));
+            matcher.appendReplacement(sb, value == null ? "" : value);
+        }
+
+        matcher.appendTail(sb);
+        LOG.debug("Template:{}, params: {}, SQL: {}", template, params, sb.toString());
+
+        return sb.toString();
+    }
+
+    public static String buildStatsMinValueSql(Map<String, String> params) throws InvalidFormatException {
+        Set<String> requiredParams = getTemplateParams(MIN_VALUE_SQL);
+        if (checkParams(requiredParams, params)) {
+            return processTemplate(MIN_VALUE_SQL, params);
+        } else {
+            throw new InvalidFormatException("Wrong parameter format. need params: " + requiredParams);
+        }
+    }
+
+    public static String buildStatsPartitionMinValueSql(Map<String, String> params) throws InvalidFormatException {
+        Set<String> requiredParams = getTemplateParams(PARTITION_MIN_VALUE_SQL);
+        if (checkParams(requiredParams, params)) {
+            return processTemplate(PARTITION_MIN_VALUE_SQL, params);
+        } else {
+            throw new InvalidFormatException("Wrong parameter format. need params: " + requiredParams);
+        }
+    }
+
+    public static String buildStatsMaxValueSql(Map<String, String> params) throws InvalidFormatException {
+        Set<String> requiredParams = getTemplateParams(MAX_VALUE_SQL);
+        if (checkParams(requiredParams, params)) {
+            return processTemplate(MAX_VALUE_SQL, params);
+        } else {
+            throw new InvalidFormatException("Wrong parameter format. need params: " + requiredParams);
+        }
+    }
+
+    public static String buildStatsPartitionMaxValueSql(Map<String, String> params) throws InvalidFormatException {
+        Set<String> requiredParams = getTemplateParams(PARTITION_MAX_VALUE_SQL);
+        if (checkParams(requiredParams, params)) {
+            return processTemplate(PARTITION_MAX_VALUE_SQL, params);
+        } else {
+            throw new InvalidFormatException("Wrong parameter format. need params: " + requiredParams);
+        }
+    }
+
+    public static String buildStatsNdvValueSql(Map<String, String> params) throws InvalidFormatException {
+        Set<String> requiredParams = getTemplateParams(NDV_VALUE_SQL);
+        if (checkParams(requiredParams, params)) {
+            return processTemplate(NDV_VALUE_SQL, params);
+        } else {
+            throw new InvalidFormatException("Wrong parameter format. need params: " + requiredParams);
+        }
+    }
+
+    public static String buildStatsPartitionNdvValueSql(Map<String, String> params) throws InvalidFormatException {
+        Set<String> requiredParams = getTemplateParams(PARTITION_NDV_VALUE_SQL);
+        if (checkParams(requiredParams, params)) {
+            return processTemplate(PARTITION_NDV_VALUE_SQL, params);
+        } else {
+            throw new InvalidFormatException("Wrong parameter format. need params: " + requiredParams);
+        }
+    }
+
+    public static String buildStatsMinMaxNdvValueSql(Map<String, String> params) throws InvalidFormatException {
+        Set<String> requiredParams = getTemplateParams(MIN_MAX_NDV_VALUE_SQL);
+        if (checkParams(requiredParams, params)) {
+            return processTemplate(MIN_MAX_NDV_VALUE_SQL, params);
+        } else {
+            throw new InvalidFormatException("Wrong parameter format. need params: " + requiredParams);
+        }
+    }
+
+    public static String buildStatsPartitionMinMaxNdvValueSql(Map<String, String> params)
+            throws InvalidFormatException {
+        Set<String> requiredParams = getTemplateParams(PARTITION_MIN_MAX_NDV_VALUE_SQL);
+        if (checkParams(requiredParams, params)) {
+            return processTemplate(PARTITION_MIN_MAX_NDV_VALUE_SQL, params);
+        } else {
+            throw new InvalidFormatException("Wrong parameter format. need params: " + requiredParams);
+        }
+    }
+
+    public static String buildStatsRowCountSql(Map<String, String> params) throws InvalidFormatException {
+        Set<String> requiredParams = getTemplateParams(ROW_COUNT_SQL);
+        if (checkParams(requiredParams, params)) {
+            return processTemplate(ROW_COUNT_SQL, params);
+        } else {
+            throw new InvalidFormatException("Wrong parameter format. need params: " + requiredParams);
+        }
+    }
+
+    public static String buildStatsPartitionRowCountSql(Map<String, String> params) throws InvalidFormatException {
+        Set<String> requiredParams = getTemplateParams(PARTITION_ROW_COUNT_SQL);
+        if (checkParams(requiredParams, params)) {
+            return processTemplate(PARTITION_ROW_COUNT_SQL, params);
+        } else {
+            throw new InvalidFormatException("Wrong parameter format. need params: " + requiredParams);
+        }
+    }
+
+    public static String buildStatsMaxSizeSql(Map<String, String> params) throws InvalidFormatException {
+        Set<String> requiredParams = getTemplateParams(MAX_SIZE_SQL);
+        if (checkParams(requiredParams, params)) {
+            return processTemplate(MAX_SIZE_SQL, params);
+        } else {
+            throw new InvalidFormatException("Wrong parameter format. need params: " + requiredParams);
+        }
+    }
+
+    public static String buildStatsPartitionMaxSizeSql(Map<String, String> params) throws InvalidFormatException {
+        Set<String> requiredParams = getTemplateParams(PARTITION_MAX_SIZE_SQL);
+        if (checkParams(requiredParams, params)) {
+            return processTemplate(PARTITION_MAX_SIZE_SQL, params);
+        } else {
+            throw new InvalidFormatException("Wrong parameter format. need params: " + requiredParams);
+        }
+    }
+
+    public static String buildStatsAvgSizeSql(Map<String, String> params) throws InvalidFormatException {
+        Set<String> requiredParams = getTemplateParams(AVG_SIZE_SQL);
+        if (checkParams(requiredParams, params)) {
+            return processTemplate(AVG_SIZE_SQL, params);
+        } else {
+            throw new InvalidFormatException("Wrong parameter format. need params: " + requiredParams);
+        }
+    }
+
+    public static String buildStatsPartitionAvgSizeSql(Map<String, String> params) throws InvalidFormatException {
+        Set<String> requiredParams = getTemplateParams(PARTITION_AVG_SIZE_SQL);
+        if (checkParams(requiredParams, params)) {
+            return processTemplate(PARTITION_AVG_SIZE_SQL, params);
+        } else {
+            throw new InvalidFormatException("Wrong parameter format. need params: " + requiredParams);
+        }
+    }
+
+    public static String buildStatsMaxAvgSizeSql(Map<String, String> params) throws InvalidFormatException {
+        Set<String> requiredParams = getTemplateParams(MAX_AVG_SIZE_SQL);
+        if (checkParams(requiredParams, params)) {
+            return processTemplate(MAX_AVG_SIZE_SQL, params);
+        } else {
+            throw new InvalidFormatException("Wrong parameter format. need params: " + requiredParams);
+        }
+    }
+
+    public static String buildStatsPartitionMaxAvgSizeSql(Map<String, String> params) throws InvalidFormatException {
+        Set<String> requiredParams = getTemplateParams(PARTITION_MAX_AVG_SIZE_SQL);
+        if (checkParams(requiredParams, params)) {
+            return processTemplate(PARTITION_MAX_AVG_SIZE_SQL, params);
+        } else {
+            throw new InvalidFormatException("Wrong parameter format. need params: " + requiredParams);
+        }
+    }
+
+    public static String buildStatsNumNullsSql(Map<String, String> params) throws InvalidFormatException {
+        Set<String> requiredParams = getTemplateParams(NUM_NULLS_SQL);
+        if (checkParams(requiredParams, params)) {
+            return processTemplate(NUM_NULLS_SQL, params);
+        } else {
+            throw new InvalidFormatException("Wrong parameter format. need params: " + requiredParams);
+        }
+    }
+
+    public static String buildStatsPartitionNumNullsSql(Map<String, String> params) throws InvalidFormatException {
+        Set<String> requiredParams = getTemplateParams(PARTITION_NUM_NULLS_SQL);
+        if (checkParams(requiredParams, params)) {
+            return processTemplate(PARTITION_NUM_NULLS_SQL, params);
+        } else {
+            throw new InvalidFormatException("Wrong parameter format. need params: " + requiredParams);
+        }
+    }
+
+    private static Set<String> getTemplateParams(String template) {
+        Matcher matcher = PATTERN.matcher(template);
+        Set<String> requiredParams = Sets.newHashSet();
+
+        while (matcher.find()) {
+            String param = matcher.group();
+            String value = param.substring(2, param.length() - 1);
+            requiredParams.add(value);
+        }
+
+        return requiredParams;
+    }
+
+    private static boolean checkParams(Set<String> requiredParams, Map<String, String> params) {
+        if (params != null && !params.isEmpty()) {
+            Set<String> paramsSet = params.keySet();
+            return paramsSet.containsAll(requiredParams);
+        } else {
+            return requiredParams == null;
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/statistics/util/InternalSqlTemplateTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/statistics/util/InternalSqlTemplateTest.java
@@ -1,0 +1,546 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.statistics.util;
+
+import org.apache.doris.common.InvalidFormatException;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class InternalSqlTemplateTest {
+
+    @Test
+    public void testProcessTemplate() {
+        // Setup
+        String template = "SELECT * FROM ${table} WHERE id = ${id};";
+        String expectSQL = "SELECT * FROM table0 WHERE id = 123;";
+
+        Map<String, String> params = new HashMap<>();
+        params.put("table", "table0");
+        params.put("id", "123");
+
+        // Run the test
+        String result = InternalSqlTemplate.processTemplate(template, params);
+
+        // Verify the results
+        Assert.assertEquals(expectSQL, result);
+    }
+
+    @Test
+    public void testBuildStatsMinValueSql() throws Exception {
+        // Setup
+        String expectSQL = "SELECT MIN(column0) AS min_value FROM table0;";
+
+        Map<String, String> params = new HashMap<>();
+        params.put("table", "table0");
+        params.put("column", "column0");
+
+        // Run the test
+        String result = InternalSqlTemplate.buildStatsMinValueSql(params);
+
+        // Verify the results
+        Assert.assertEquals(expectSQL, result);
+    }
+
+    @Test
+    public void testBuildStatsMinValueSql_ThrowsInvalidFormatException() {
+        // Setup
+        Map<String, String> params = new HashMap<>();
+        params.put("xxx", "table0");
+
+        // Run the test
+        Assert.assertThrows(InvalidFormatException.class,
+                () -> InternalSqlTemplate.buildStatsMinValueSql(params));
+    }
+
+    @Test
+    public void testBuildStatsPartitionMinValueSql() throws Exception {
+        // Setup
+        String expectSQL = "SELECT MIN(column0) AS min_value"
+                + " FROM table0 PARTITION (partition0);";
+
+        Map<String, String> params = new HashMap<>();
+        params.put("table", "table0");
+        params.put("column", "column0");
+        params.put("partition", "partition0");
+
+        // Run the test
+        String result = InternalSqlTemplate.buildStatsPartitionMinValueSql(params);
+
+        // Verify the results
+        Assert.assertEquals(expectSQL, result);
+    }
+
+    @Test
+    public void testBuildStatsPartitionMinValueSql_ThrowsInvalidFormatException() {
+        // Setup
+        Map<String, String> params = new HashMap<>();
+        params.put("xxx", "table0");
+
+        // Run the test
+        Assert.assertThrows(InvalidFormatException.class,
+                () -> InternalSqlTemplate.buildStatsPartitionMinValueSql(params));
+    }
+
+    @Test
+    public void testBuildStatsMaxValueSql() throws Exception {
+        // Setup
+        String expectSQL = "SELECT MAX(column0) AS max_value FROM table0;";
+
+        Map<String, String> params = new HashMap<>();
+        params.put("table", "table0");
+        params.put("column", "column0");
+
+        // Run the test
+        String result = InternalSqlTemplate.buildStatsMaxValueSql(params);
+
+        // Verify the results
+        Assert.assertEquals(expectSQL, result);
+    }
+
+    @Test
+    public void testBuildStatsMaxValueSql_ThrowsInvalidFormatException() {
+        // Setup
+        Map<String, String> params = new HashMap<>();
+        params.put("xxx", "table0");
+
+        // Run the test
+        Assert.assertThrows(InvalidFormatException.class,
+                () -> InternalSqlTemplate.buildStatsMaxValueSql(params));
+    }
+
+    @Test
+    public void testBuildStatsPartitionMaxValueSql() throws Exception {
+        // Setup
+        String expectSQL = "SELECT MAX(column0) AS max_value FROM"
+                + " table0 PARTITION (partition0);";
+
+        Map<String, String> params = new HashMap<>();
+        params.put("table", "table0");
+        params.put("column", "column0");
+        params.put("partition", "partition0");
+
+        // Run the test
+        String result = InternalSqlTemplate.buildStatsPartitionMaxValueSql(params);
+
+        // Verify the results
+        Assert.assertEquals(expectSQL, result);
+    }
+
+    @Test
+    public void testBuildStatsPartitionMaxValueSql_ThrowsInvalidFormatException() {
+        // Setup
+        Map<String, String> params = new HashMap<>();
+        params.put("xxx", "table0");
+
+        // Run the test
+        Assert.assertThrows(InvalidFormatException.class,
+                () -> InternalSqlTemplate.buildStatsPartitionMaxValueSql(params));
+    }
+
+    @Test
+    public void testBuildStatsNdvValueSql() throws Exception {
+        // Setup
+        String expectSQL = "SELECT NDV(column0) AS ndv FROM table0;";
+
+        Map<String, String> params = new HashMap<>();
+        params.put("table", "table0");
+        params.put("column", "column0");
+
+        // Run the test
+        String result = InternalSqlTemplate.buildStatsNdvValueSql(params);
+
+        // Verify the results
+        Assert.assertEquals(expectSQL, result);
+    }
+
+    @Test
+    public void testBuildStatsNdvValueSql_ThrowsInvalidFormatException() {
+        // Setup
+        Map<String, String> params = new HashMap<>();
+        params.put("xxx", "table0");
+
+        // Run the test
+        Assert.assertThrows(InvalidFormatException.class,
+                () -> InternalSqlTemplate.buildStatsNdvValueSql(params));
+    }
+
+    @Test
+    public void testBuildStatsPartitionNdvValueSql() throws Exception {
+        // Setup
+        String expectSQL = "SELECT NDV(column0) AS ndv FROM table0 PARTITION (partition0);";
+
+        Map<String, String> params = new HashMap<>();
+        params.put("table", "table0");
+        params.put("column", "column0");
+        params.put("partition", "partition0");
+
+        // Run the test
+        String result = InternalSqlTemplate.buildStatsPartitionNdvValueSql(params);
+
+        // Verify the results
+        Assert.assertEquals(expectSQL, result);
+    }
+
+    @Test
+    public void testBuildStatsPartitionNdvValueSql_ThrowsInvalidFormatException() {
+        // Setup
+        Map<String, String> params = new HashMap<>();
+        params.put("xxx", "table0");
+
+        // Run the test
+        Assert.assertThrows(InvalidFormatException.class,
+                () -> InternalSqlTemplate.buildStatsPartitionNdvValueSql(params));
+    }
+
+    @Test
+    public void testBuildStatsMinMaxNdvValueSql() throws Exception {
+        // Setup
+        String expectSQL = "SELECT MIN(column0) AS min_value, MAX(column0) AS max_value, "
+                + "NDV(column0) AS ndv FROM table0;";
+
+        Map<String, String> params = new HashMap<>();
+        params.put("table", "table0");
+        params.put("column", "column0");
+
+        // Run the test
+        String result = InternalSqlTemplate.buildStatsMinMaxNdvValueSql(params);
+
+        // Verify the results
+        Assert.assertEquals(expectSQL, result);
+    }
+
+    @Test
+    public void testBuildStatsMinMaxNdvValueSql_ThrowsInvalidFormatException() {
+        // Setup
+        Map<String, String> params = new HashMap<>();
+        params.put("xxx", "table0");
+
+        // Run the test
+        Assert.assertThrows(InvalidFormatException.class,
+                () -> InternalSqlTemplate.buildStatsMinMaxNdvValueSql(params));
+    }
+
+    @Test
+    public void testBuildStatsPartitionMinMaxNdvValueSql() throws Exception {
+        // Setup
+        String expectSQL = "SELECT MIN(column0) AS min_value, MAX(column0) AS max_value, "
+                + "NDV(column0) AS ndv FROM table0 PARTITION (partition0);";
+
+        Map<String, String> params = new HashMap<>();
+        params.put("table", "table0");
+        params.put("column", "column0");
+        params.put("partition", "partition0");
+
+        // Run the test
+        String result = InternalSqlTemplate.buildStatsPartitionMinMaxNdvValueSql(params);
+
+        // Verify the results
+        Assert.assertEquals(expectSQL, result);
+    }
+
+    @Test
+    public void testBuildStatsPartitionMinMaxNdvValueSql_ThrowsInvalidFormatException() {
+        // Setup
+        Map<String, String> params = new HashMap<>();
+        params.put("xxx", "table0");
+
+        // Run the test
+        Assert.assertThrows(InvalidFormatException.class,
+                () -> InternalSqlTemplate.buildStatsPartitionMinMaxNdvValueSql(params));
+    }
+
+    @Test
+    public void testBuildStatsRowCountSql() throws Exception {
+        // Setup
+        String expectSQL = "SELECT COUNT(1) AS row_count FROM table0;";
+
+        Map<String, String> params = new HashMap<>();
+        params.put("table", "table0");
+        params.put("column", "column0");
+
+        // Run the test
+        String result = InternalSqlTemplate.buildStatsRowCountSql(params);
+
+        // Verify the results
+        Assert.assertEquals(expectSQL, result);
+    }
+
+    @Test
+    public void testBuildStatsRowCountSql_ThrowsInvalidFormatException() {
+        // Setup
+        Map<String, String> params = new HashMap<>();
+        params.put("xxx", "table0");
+
+        // Run the test
+        Assert.assertThrows(InvalidFormatException.class,
+                () -> InternalSqlTemplate.buildStatsRowCountSql(params));
+    }
+
+    @Test
+    public void testBuildStatsPartitionRowCountSql() throws Exception {
+        // Setup
+        String expectSQL = "SELECT COUNT(1) AS row_count FROM table0 PARTITION (partition0);";
+
+        Map<String, String> params = new HashMap<>();
+        params.put("table", "table0");
+        params.put("partition", "partition0");
+
+        // Run the test
+        String result = InternalSqlTemplate.buildStatsPartitionRowCountSql(params);
+
+        // Verify the results
+        Assert.assertEquals(expectSQL, result);
+    }
+
+    @Test
+    public void testBuildStatsPartitionRowCountSql_ThrowsInvalidFormatException() {
+        // Setup
+        Map<String, String> params = new HashMap<>();
+        params.put("xxx", "table0");
+
+        // Run the test
+        Assert.assertThrows(InvalidFormatException.class,
+                () -> InternalSqlTemplate.buildStatsPartitionRowCountSql(params));
+    }
+
+    @Test
+    public void testBuildStatsMaxSizeSql() throws Exception {
+        // Setup
+        String expectSQL = "SELECT MAX(LENGTH(column0)) AS max_size FROM table0;";
+
+        Map<String, String> params = new HashMap<>();
+        params.put("table", "table0");
+        params.put("column", "column0");
+
+        // Run the test
+        String result = InternalSqlTemplate.buildStatsMaxSizeSql(params);
+
+        // Verify the results
+        Assert.assertEquals(expectSQL, result);
+    }
+
+    @Test
+    public void testBuildStatsMaxSizeSql_ThrowsInvalidFormatException() {
+        // Setup
+        Map<String, String> params = new HashMap<>();
+        params.put("xxx", "table0");
+
+        // Run the test
+        Assert.assertThrows(InvalidFormatException.class,
+                () -> InternalSqlTemplate.buildStatsMaxSizeSql(params));
+    }
+
+    @Test
+    public void testBuildStatsPartitionMaxSizeSql() throws Exception {
+        // Setup
+        String expectSQL = "SELECT MAX(LENGTH(column0)) AS max_size FROM table0 PARTITION (partition0);";
+
+        Map<String, String> params = new HashMap<>();
+        params.put("table", "table0");
+        params.put("column", "column0");
+        params.put("partition", "partition0");
+
+        // Run the test
+        String result = InternalSqlTemplate.buildStatsPartitionMaxSizeSql(params);
+
+        // Verify the results
+        Assert.assertEquals(expectSQL, result);
+    }
+
+    @Test
+    public void testBuildStatsPartitionMaxSizeSql_ThrowsInvalidFormatException() {
+        // Setup
+        Map<String, String> params = new HashMap<>();
+        params.put("xxx", "table0");
+
+        // Run the test
+        Assert.assertThrows(InvalidFormatException.class,
+                () -> InternalSqlTemplate.buildStatsPartitionMaxSizeSql(params));
+    }
+
+    @Test
+    public void testBuildStatsAvgSizeSql() throws Exception {
+        // Setup
+        String expectSQL = "SELECT AVG(LENGTH(column0)) AS avg_size FROM table0;";
+
+        Map<String, String> params = new HashMap<>();
+        params.put("table", "table0");
+        params.put("column", "column0");
+
+        // Run the test
+        String result = InternalSqlTemplate.buildStatsAvgSizeSql(params);
+
+        // Verify the results
+        Assert.assertEquals(expectSQL, result);
+    }
+
+    @Test
+    public void testBuildStatsAvgSizeSql_ThrowsInvalidFormatException() {
+        // Setup
+        Map<String, String> params = new HashMap<>();
+        params.put("xxx", "table0");
+
+        // Run the test
+        Assert.assertThrows(InvalidFormatException.class,
+                () -> InternalSqlTemplate.buildStatsAvgSizeSql(params));
+    }
+
+    @Test
+    public void testBuildStatsPartitionAvgSizeSql() throws Exception {
+        // Setup
+        String expectSQL = "SELECT AVG(LENGTH(column0)) AS avg_size FROM table0 PARTITION (partition0);";
+
+        Map<String, String> params = new HashMap<>();
+        params.put("table", "table0");
+        params.put("column", "column0");
+        params.put("partition", "partition0");
+
+        // Run the test
+        String result = InternalSqlTemplate.buildStatsPartitionAvgSizeSql(params);
+
+        // Verify the results
+        Assert.assertEquals(expectSQL, result);
+    }
+
+    @Test
+    public void testBuildStatsPartitionAvgSizeSql_ThrowsInvalidFormatException() {
+        // Setup
+        Map<String, String> params = new HashMap<>();
+        params.put("xxx", "table0");
+
+        // Run the test
+        Assert.assertThrows(InvalidFormatException.class,
+                () -> InternalSqlTemplate.buildStatsPartitionAvgSizeSql(params));
+    }
+
+    @Test
+    public void testBuildStatsMaxAvgSizeSql() throws Exception {
+        // Setup
+        String expectSQL = "SELECT MAX(LENGTH(column0)) AS max_size, "
+                + "AVG(LENGTH(column0)) AS avg_size FROM table0;";
+
+        Map<String, String> params = new HashMap<>();
+        params.put("table", "table0");
+        params.put("column", "column0");
+
+        // Run the test
+        String result = InternalSqlTemplate.buildStatsMaxAvgSizeSql(params);
+
+        // Verify the results
+        Assert.assertEquals(expectSQL, result);
+    }
+
+    @Test
+    public void testBuildStatsMaxAvgSizeSql_ThrowsInvalidFormatException() {
+        // Setup
+        Map<String, String> params = new HashMap<>();
+        params.put("xxx", "table0");
+
+        // Run the test
+        Assert.assertThrows(InvalidFormatException.class,
+                () -> InternalSqlTemplate.buildStatsMaxAvgSizeSql(params));
+    }
+
+    @Test
+    public void testBuildStatsPartitionMaxAvgSizeSql() throws Exception {
+        // Setup
+        String expectSQL = "SELECT MAX(LENGTH(column0)) AS max_size, "
+                + "AVG(LENGTH(column0)) AS avg_size FROM table0 PARTITION (partition0);";
+
+        Map<String, String> params = new HashMap<>();
+        params.put("table", "table0");
+        params.put("column", "column0");
+        params.put("partition", "partition0");
+
+        // Run the test
+        String result = InternalSqlTemplate.buildStatsPartitionMaxAvgSizeSql(params);
+
+        // Verify the results
+        Assert.assertEquals(expectSQL, result);
+    }
+
+    @Test
+    public void testBuildStatsPartitionMaxAvgSizeSql_ThrowsInvalidFormatException() {
+        // Setup
+        Map<String, String> params = new HashMap<>();
+        params.put("xxx", "table0");
+
+        // Run the test
+        Assert.assertThrows(InvalidFormatException.class,
+                () -> InternalSqlTemplate.buildStatsPartitionMaxAvgSizeSql(params));
+    }
+
+    @Test
+    public void testBuildStatsNumNullsSql() throws Exception {
+        // Setup
+        String expectSQL = "SELECT COUNT(1) AS num_nulls FROM table0 WHERE column0 IS NULL;";
+
+        Map<String, String> params = new HashMap<>();
+        params.put("table", "table0");
+        params.put("column", "column0");
+
+        // Run the test
+        String result = InternalSqlTemplate.buildStatsNumNullsSql(params);
+
+        // Verify the results
+        Assert.assertEquals(expectSQL, result);
+    }
+
+    @Test
+    public void testBuildStatsNumNullsSql_ThrowsInvalidFormatException() {
+        // Setup
+        Map<String, String> params = new HashMap<>();
+        params.put("xxx", "table0");
+
+        // Run the test
+        Assert.assertThrows(InvalidFormatException.class,
+                () -> InternalSqlTemplate.buildStatsNumNullsSql(params));
+    }
+
+    @Test
+    public void testBuildStatsPartitionNumNullsSql() throws Exception {
+        // Setup
+        String expectSQL = "SELECT COUNT(1) AS num_nulls FROM table0 PARTITION (partition0) WHERE column0 IS NULL;";
+
+        Map<String, String> params = new HashMap<>();
+        params.put("table", "table0");
+        params.put("column", "column0");
+        params.put("partition", "partition0");
+
+        // Run the test
+        String result = InternalSqlTemplate.buildStatsPartitionNumNullsSql(params);
+
+        // Verify the results
+        Assert.assertEquals(expectSQL, result);
+    }
+
+    @Test
+    public void testBuildStatsPartitionNumNullsSql_ThrowsInvalidFormatException() {
+        // Setup
+        Map<String, String> params = new HashMap<>();
+        params.put("xxx", "table0");
+
+        // Run the test
+        Assert.assertThrows(InvalidFormatException.class,
+                () -> InternalSqlTemplate.buildStatsPartitionNumNullsSql(params));
+    }
+}


### PR DESCRIPTION
# Proposed changes

Template for building internal query SQL statements，it mainly used for statistics module. After the template is defined, the executable statement will be built after the given parameters.

For example, template and parameters:
- template: `SELECT ${col} FROM ${table} WHERE id = ${id};`,
- parameters:  `{col=colName, table=tableName, id=1}`
- result sql:  `SELECT colName FROM tableName WHERE id = 1;`

usage:
```
String template = "SELECT * FROM ${table} WHERE id = ${id};";
Map<String, String> params = new HashMap<>();
params.put("table", "table0");
params.put("id", "123");

// result: SELECT * FROM table0 WHERE id = 123;
String result = InternalSqlTemplate.processTemplate(template, params);
```

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [x] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

