### PR TITLE
[improvement](new-scan) graceful quit scanner scheduler

### DIFF
--- a/be/src/vec/exec/scan/scanner_scheduler.h
+++ b/be/src/vec/exec/scan/scanner_scheduler.h
@@ -40,13 +40,6 @@ namespace doris::vectorized {
 //     Each Scanner will act as a producer, read a group of blocks and put them into
 //     the corresponding block queue.
 //     The corresponding ScanNode will act as a consumer to consume blocks from the block queue.
-
-using ContextMap = phmap::parallel_flat_hash_map<
-        std::string, std::shared_ptr<ScannerContext>, phmap::priv::hash_default_hash<std::string>,
-        phmap::priv::hash_default_eq<std::string>,
-        std::allocator<std::pair<const std::string, std::shared_ptr<ScannerContext>>>, 12,
-        std::mutex>;
-
 class Env;
 class ScannerScheduler {
 public:
@@ -82,13 +75,12 @@ private:
     // execution thread pool
     // _local_scan_thread_pool is for local scan task(typically, olap scanner)
     // _remote_scan_thread_pool is for remote scan task(cold data on s3, hdfs, etc.)
-    PriorityThreadPool* _local_scan_thread_pool;
-    PriorityThreadPool* _remote_scan_thread_pool;
+    std::unique_ptr<PriorityThreadPool> _local_scan_thread_pool;
+    std::unique_ptr<PriorityThreadPool> _remote_scan_thread_pool;
 
     // true is the scheduler is closed.
     std::atomic_bool _is_closed = {false};
-
-    ContextMap _context_map;
+    bool _is_init = false;
 };
 
 } // namespace doris::vectorized


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

Now, BE process can quit by using `kill -15`

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

