### PR TITLE
[fix](outerjoin)output full column for tupleIsNull predicate

### DIFF
--- a/be/src/vec/exec/join/vhash_join_node.cpp
+++ b/be/src/vec/exec/join/vhash_join_node.cpp
@@ -202,6 +202,9 @@ struct ProcessHashTableProbe {
                                 ->get_null_map_column()
                                 .insert_join_nullmap(_build_block_rows.data(),
                                                      _build_block_rows.data() + size);
+                        reinterpret_cast<ColumnNullable*>(mcol[i + column_offset].get())
+                                ->get_nested_column()
+                                .resize(size);
                     } else {
                         mcol[i + column_offset]->resize(size);
                     }
@@ -274,6 +277,9 @@ struct ProcessHashTableProbe {
                                 ->get_null_map_column()
                                 .insert_join_nullmap(_build_block_rows.data(),
                                                      _build_block_rows.data() + size);
+                        reinterpret_cast<ColumnNullable*>(mcol[i + column_offset].get())
+                                ->get_nested_column()
+                                .resize(size);
                     } else {
                         mcol[i + column_offset]->resize(size);
                     }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

we need output full column for tuple is null predicate instead of only the nullmap sub column

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

