### PR TITLE
[fix](statistics) remove statistical task multiple times in one loop cycle

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticsTaskScheduler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticsTaskScheduler.java
@@ -68,7 +68,6 @@ public class StatisticsTaskScheduler extends MasterDaemon {
             Map<Long, List<Map<Long, Future<StatisticsTaskResult>>>> resultMap = Maps.newLinkedHashMap();
 
             for (StatisticsTask task : tasks) {
-                queue.remove();
                 long jobId = task.getJobId();
 
                 if (checkJobIsValid(jobId)) {
@@ -100,7 +99,7 @@ public class StatisticsTaskScheduler extends MasterDaemon {
         List<StatisticsTask> tasks = Lists.newArrayList();
         int i = Config.cbo_concurrency_statistics_task_num;
         while (i > 0) {
-            StatisticsTask task = queue.peek();
+            StatisticsTask task = queue.poll();
             if (task == null) {
                 break;
             }


### PR DESCRIPTION
# Proposed changes

There is a problem with StatisticsTaskScheduler. The `peek()` method obtains a reference to the same task object, but the for-loop executes multiple removes.

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

