### PR TITLE
[feature-wip](MTMV) Support showing and dropping materialized view for multiple tables

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/alter/Alter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/Alter.java
@@ -28,6 +28,7 @@ import org.apache.doris.analysis.CreateMaterializedViewStmt;
 import org.apache.doris.analysis.CreateMultiTableMaterializedViewStmt;
 import org.apache.doris.analysis.DropMaterializedViewStmt;
 import org.apache.doris.analysis.DropPartitionClause;
+import org.apache.doris.analysis.DropTableStmt;
 import org.apache.doris.analysis.ModifyColumnCommentClause;
 import org.apache.doris.analysis.ModifyDistributionClause;
 import org.apache.doris.analysis.ModifyEngineClause;
@@ -131,17 +132,27 @@ public class Alter {
     }
 
     public void processDropMaterializedView(DropMaterializedViewStmt stmt) throws DdlException, MetaNotFoundException {
-        if (stmt.getTableName() == null) {
+        if (!stmt.isForMTMV() && stmt.getTableName() == null) {
             throw new DdlException("Drop materialized view without table name is unsupported : " + stmt.toSql());
         }
+        TableName tableName = !stmt.isForMTMV() ? stmt.getTableName() : stmt.getMTMVName();
+
         // check db
-        String dbName = stmt.getTableName().getDb();
+        String dbName = tableName.getDb();
         Database db = Env.getCurrentInternalCatalog().getDbOrDdlException(dbName);
 
-        String tableName = stmt.getTableName().getTbl();
-        OlapTable olapTable = (OlapTable) db.getTableOrMetaException(tableName, TableType.OLAP);
+        String name = tableName.getTbl();
+        OlapTable olapTable = (OlapTable) db.getTableOrMetaException(name,
+                !stmt.isForMTMV() ? TableType.OLAP : TableType.MATERIALIZED_VIEW);
+
         // drop materialized view
-        ((MaterializedViewHandler) materializedViewHandler).processDropMaterializedView(stmt, db, olapTable);
+        if (!stmt.isForMTMV()) {
+            ((MaterializedViewHandler) materializedViewHandler).processDropMaterializedView(stmt, db, olapTable);
+        } else {
+            DropTableStmt dropTableStmt = new DropTableStmt(stmt.isIfExists(), stmt.getMTMVName(), false);
+            dropTableStmt.setMaterializedView(true);
+            Env.getCurrentInternalCatalog().dropTable(dropTableStmt);
+        }
     }
 
     public void processRefreshMaterializedView(RefreshMaterializedViewStmt stmt) throws DdlException {

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateMultiTableMaterializedViewStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateMultiTableMaterializedViewStmt.java
@@ -18,6 +18,7 @@
 package org.apache.doris.analysis;
 
 import org.apache.doris.analysis.ColumnDef.DefaultValue;
+import org.apache.doris.analysis.MVRefreshInfo.BuildMode;
 import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.Database;
 import org.apache.doris.catalog.Env;
@@ -38,17 +39,17 @@ import java.util.stream.Collectors;
 
 public class CreateMultiTableMaterializedViewStmt extends CreateTableStmt {
     private final String mvName;
-    private final MVRefreshInfo.BuildMode buildMethod;
+    private final MVRefreshInfo.BuildMode buildMode;
     private final MVRefreshInfo refreshInfo;
     private final QueryStmt queryStmt;
     private Database database;
     private final Map<String, OlapTable> olapTables = Maps.newHashMap();
 
-    public CreateMultiTableMaterializedViewStmt(String mvName, MVRefreshInfo.BuildMode buildMethod,
+    public CreateMultiTableMaterializedViewStmt(String mvName, MVRefreshInfo.BuildMode buildMode,
             MVRefreshInfo refreshInfo, KeysDesc keyDesc, PartitionDesc partitionDesc, DistributionDesc distributionDesc,
             Map<String, String> properties, QueryStmt queryStmt) {
         this.mvName = mvName;
-        this.buildMethod = buildMethod;
+        this.buildMode = buildMode;
         this.refreshInfo = refreshInfo;
         this.queryStmt = queryStmt;
 
@@ -142,7 +143,7 @@ public class CreateMultiTableMaterializedViewStmt extends CreateTableStmt {
     @Override
     public String toSql() {
         StringBuilder sb = new StringBuilder();
-        sb.append("CREATE MATERIALIZED VIEW ").append(mvName).append(" BUILD ON ").append(buildMethod.toString());
+        sb.append("CREATE MATERIALIZED VIEW ").append(mvName).append(" BUILD ").append(buildMode.toString());
         if (refreshInfo != null) {
             sb.append(" ").append(refreshInfo.toString());
         }
@@ -179,5 +180,9 @@ public class CreateMultiTableMaterializedViewStmt extends CreateTableStmt {
 
     public QueryStmt getQueryStmt() {
         return queryStmt;
+    }
+
+    public BuildMode getBuildMode() {
+        return buildMode;
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/DropTableStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/DropTableStmt.java
@@ -33,6 +33,7 @@ public class DropTableStmt extends DdlStmt {
     private final TableName tableName;
     private final boolean isView;
     private boolean forceDrop;
+    private boolean isMaterializedView;
 
     public DropTableStmt(boolean ifExists, TableName tableName, boolean forceDrop) {
         this.ifExists = ifExists;
@@ -66,6 +67,14 @@ public class DropTableStmt extends DdlStmt {
 
     public boolean isForceDrop() {
         return this.forceDrop;
+    }
+
+    public void setMaterializedView(boolean value) {
+        isMaterializedView = value;
+    }
+
+    public boolean isMaterializedView() {
+        return isMaterializedView;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/MVRefreshInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/MVRefreshInfo.java
@@ -85,7 +85,7 @@ public class MVRefreshInfo {
         DEMAND, COMMIT, INTERVAL
     }
 
-    enum BuildMode {
+    public enum BuildMode {
         IMMEDIATE, DEFERRED
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowCreateTableStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowCreateTableStmt.java
@@ -43,6 +43,12 @@ public class ShowCreateTableStmt extends ShowStmt {
                     .addColumn(new Column("collation_connection", ScalarType.createVarchar(30)))
                     .build();
 
+    private static final ShowResultSetMetaData MATERIALIZED_VIEW_META_DATA =
+            ShowResultSetMetaData.builder()
+                    .addColumn(new Column("Materialized View", ScalarType.createVarchar(20)))
+                    .addColumn(new Column("Create Materialized View", ScalarType.createVarchar(30)))
+                    .build();
+
     private TableName tbl;
     private boolean isView;
 
@@ -54,6 +60,7 @@ public class ShowCreateTableStmt extends ShowStmt {
         this.tbl = tbl;
         this.isView = isView;
     }
+
 
     public String getCtl() {
         return tbl.getCtl();
@@ -73,6 +80,10 @@ public class ShowCreateTableStmt extends ShowStmt {
 
     public static ShowResultSetMetaData getViewMetaData() {
         return VIEW_META_DATA;
+    }
+
+    public static ShowResultSetMetaData getMaterializedViewMetaData() {
+        return MATERIALIZED_VIEW_META_DATA;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/MaterializedView.java
@@ -18,6 +18,7 @@
 package org.apache.doris.catalog;
 
 import org.apache.doris.analysis.MVRefreshInfo;
+import org.apache.doris.analysis.MVRefreshInfo.BuildMode;
 import org.apache.doris.catalog.OlapTableFactory.MaterializedViewParams;
 import org.apache.doris.common.io.Text;
 import org.apache.doris.persist.gson.GsonUtils;
@@ -29,6 +30,8 @@ import java.io.DataOutput;
 import java.io.IOException;
 
 public class MaterializedView extends OlapTable {
+    @SerializedName("buildMode")
+    private BuildMode buildMode;
     @SerializedName("refreshInfo")
     private MVRefreshInfo refreshInfo;
     @SerializedName("query")
@@ -49,8 +52,13 @@ public class MaterializedView extends OlapTable {
                 params.distributionInfo
         );
         type = TableType.MATERIALIZED_VIEW;
+        buildMode = params.buildMode;
         refreshInfo = params.mvRefreshInfo;
         query = params.queryStmt.toSql();
+    }
+
+    public BuildMode getBuildMode() {
+        return buildMode;
     }
 
     public MVRefreshInfo getRefreshInfo() {

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTableFactory.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTableFactory.java
@@ -21,6 +21,7 @@ import org.apache.doris.analysis.CreateMultiTableMaterializedViewStmt;
 import org.apache.doris.analysis.CreateTableStmt;
 import org.apache.doris.analysis.DdlStmt;
 import org.apache.doris.analysis.MVRefreshInfo;
+import org.apache.doris.analysis.MVRefreshInfo.BuildMode;
 import org.apache.doris.analysis.QueryStmt;
 import org.apache.doris.catalog.TableIf.TableType;
 
@@ -44,6 +45,7 @@ public class OlapTableFactory {
     }
 
     public static class MaterializedViewParams extends BuildParams {
+        public MVRefreshInfo.BuildMode buildMode;
         public MVRefreshInfo mvRefreshInfo;
         public QueryStmt queryStmt;
     }
@@ -135,6 +137,12 @@ public class OlapTableFactory {
         return this;
     }
 
+    private OlapTableFactory withBuildMode(BuildMode buildMode) {
+        MaterializedViewParams materializedViewParams = (MaterializedViewParams) params;
+        materializedViewParams.buildMode = buildMode;
+        return this;
+    }
+
     public OlapTableFactory withRefreshInfo(MVRefreshInfo mvRefreshInfo) {
         Preconditions.checkState(params instanceof MaterializedViewParams, "Invalid argument for "
                 + params.getClass().getSimpleName());
@@ -150,7 +158,8 @@ public class OlapTableFactory {
             return withIndexes(new TableIndexes(createOlapTableStmt.getIndexes()));
         } else {
             CreateMultiTableMaterializedViewStmt createMVStmt = (CreateMultiTableMaterializedViewStmt) stmt;
-            return withRefreshInfo(createMVStmt.getRefreshInfo())
+            return withBuildMode(createMVStmt.getBuildMode())
+                    .withRefreshInfo(createMVStmt.getRefreshInfo())
                     .withQueryStmt(createMVStmt.getQueryStmt());
         }
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
@@ -86,6 +86,7 @@ import org.apache.doris.catalog.MaterializedIndex;
 import org.apache.doris.catalog.MaterializedIndex.IndexExtState;
 import org.apache.doris.catalog.MaterializedIndex.IndexState;
 import org.apache.doris.catalog.MaterializedIndexMeta;
+import org.apache.doris.catalog.MaterializedView;
 import org.apache.doris.catalog.MetaIdGenerator.IdGeneratorBuffer;
 import org.apache.doris.catalog.MysqlTable;
 import org.apache.doris.catalog.OdbcTable;
@@ -825,7 +826,7 @@ public class InternalCatalog implements CatalogIf<Database> {
                     ErrorReport.reportDdlException(ErrorCode.ERR_WRONG_OBJECT, dbName, tableName, "VIEW");
                 }
             } else {
-                if (table instanceof View) {
+                if (table instanceof View || (!stmt.isMaterializedView() && table instanceof MaterializedView)) {
                     ErrorReport.reportDdlException(ErrorCode.ERR_WRONG_OBJECT, dbName, tableName, "TABLE");
                 }
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ShowExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ShowExecutor.java
@@ -878,7 +878,9 @@ public class ShowExecutor {
                                                         showStmt.getTable(), "VIEW");
                 }
                 rows.add(Lists.newArrayList(table.getName(), createTableStmt.get(0)));
-                resultSet = new ShowResultSet(showStmt.getMetaData(), rows);
+                resultSet = table.getType() != TableType.MATERIALIZED_VIEW
+                        ? new ShowResultSet(showStmt.getMetaData(), rows)
+                        : new ShowResultSet(ShowCreateTableStmt.getMaterializedViewMetaData(), rows);
             }
         } catch (MetaNotFoundException e) {
             throw new AnalysisException(e.getMessage());


### PR DESCRIPTION
# Proposed changes

Support showing and dropping materialized view for multiple tables

## Use case

```shell
mysql> CREATE TABLE t1 (pk INT, v1 INT SUM) AGGREGATE KEY (pk) DISTRIBUTED BY hash (pk) PROPERTIES ('replication_num' = '1');
Query OK, 0 rows affected (0.05 sec)

mysql> CREATE TABLE t2 (pk INT, v2 INT SUM) AGGREGATE KEY (pk) DISTRIBUTED BY hash (pk) PROPERTIES ('replication_num' = '1');
Query OK, 0 rows affected (0.01 sec)

mysql> CREATE MATERIALIZED VIEW mv BUILD IMMEDIATE REFRESH COMPLETE KEY (mv_pk) DISTRIBUTED BY HASH (mv_pk) PROPERTIES ('replication_num' = '1') AS SELECT t1.pk as mv_pk FROM t1, t2 WHERE t1.pk = t2.pk;
Query OK, 0 rows affected (0.02 sec)

mysql> SHOW TABLES;
+---------------+
| Tables_in_dev |
+---------------+
| mv            |
| t1            |
| t2            |
+---------------+
3 rows in set (0.00 sec)

mysql> SHOW CREATE TABLE mv;
+-------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Materialized View | Create Materialized View                                                                                                                                                                                                                                                                                                                                                                                        |
+-------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| mv                | CREATE MATERIALIZED VIEW `mv`
BUILD IMMEDIATE REFRESH COMPLETE ON DEMAND
KEY(`mv_pk`)
DISTRIBUTED BY HASH(`mv_pk`) BUCKETS 10
PROPERTIES (
"replication_allocation" = "tag.location.default: 1",
"in_memory" = "false",
"storage_format" = "V2",
"disable_auto_compaction" = "false"
)
AS SELECT `t1`.`pk` AS `mv_pk` FROM `default_cluster:dev`.`t1` , `default_cluster:dev`.`t2` WHERE `t1`.`pk` = `t2`.`pk`; |
+-------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
1 row in set (0.01 sec)

mysql> DROP MATERIALIZED VIEW mv;
Query OK, 0 rows affected (0.01 sec)

```

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [x] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

