### PR TITLE
[Enhancement](optimize) optimize for BinaryDictPageDecoder::read_by_rowids

### DIFF
--- a/be/src/olap/rowset/segment_v2/binary_dict_page.cpp
+++ b/be/src/olap/rowset/segment_v2/binary_dict_page.cpp
@@ -287,7 +287,6 @@ Status BinaryDictPageDecoder::read_by_rowids(const rowid_t* rowids, ordinal_t pa
         if (rowids[i] >= limit) {
             break;
         }
-
         data[read_count++] = data_array[rowids[i] - page_first_ordinal];
     }
 

--- a/be/src/olap/rowset/segment_v2/binary_dict_page.cpp
+++ b/be/src/olap/rowset/segment_v2/binary_dict_page.cpp
@@ -268,26 +268,27 @@ Status BinaryDictPageDecoder::read_by_rowids(const rowid_t* rowids, ordinal_t pa
     DCHECK(_parsed);
     DCHECK(_dict_decoder != nullptr) << "dict decoder pointer is nullptr";
 
-    if (PREDICT_FALSE(*n == 0)) {
-        *n = 0;
+    if (*n == 0) {
         return Status::OK();
     }
 
     const auto* data_array = reinterpret_cast<const int32_t*>(_bit_shuffle_ptr->get_data(0));
     auto total = *n;
     size_t read_count = 0;
-    int32_t data[total];
+
+    ordinal_t limit = _bit_shuffle_ptr->_num_elements + page_first_ordinal;
+
     for (size_t i = 0; i < total; ++i) {
-        ordinal_t ord = rowids[i] - page_first_ordinal;
-        if (PREDICT_FALSE(ord >= _bit_shuffle_ptr->_num_elements)) {
+        if (rowids[i] >= limit) {
             break;
         }
 
-        data[read_count++] = data_array[ord];
+        _selector[read_count++] = data_array[rowids[i]];
     }
 
-    if (LIKELY(read_count > 0)) {
-        dst->insert_many_dict_data(data, 0, _dict_word_info, read_count, _dict_decoder->_num_elems);
+    if (read_count > 0) {
+        dst->insert_many_dict_data(_selector, 0, _dict_word_info, read_count,
+                                   _dict_decoder->_num_elems);
     }
     *n = read_count;
     return Status::OK();

--- a/be/src/olap/rowset/segment_v2/binary_dict_page.h
+++ b/be/src/olap/rowset/segment_v2/binary_dict_page.h
@@ -135,8 +135,6 @@ private:
     std::unique_ptr<ColumnVectorBatch> _batch;
 
     StringRef* _dict_word_info = nullptr;
-
-    int32_t _selector[4096];
 };
 
 } // namespace segment_v2

--- a/be/src/olap/rowset/segment_v2/binary_dict_page.h
+++ b/be/src/olap/rowset/segment_v2/binary_dict_page.h
@@ -135,6 +135,8 @@ private:
     std::unique_ptr<ColumnVectorBatch> _batch;
 
     StringRef* _dict_word_info = nullptr;
+
+    int32_t _selector[4096];
 };
 
 } // namespace segment_v2

--- a/be/src/runtime/decimalv2_value.h
+++ b/be/src/runtime/decimalv2_value.h
@@ -86,7 +86,7 @@ public:
     }
     // Construct from olap engine
     DecimalV2Value(int64_t int_value, int64_t frac_value) {
-        from_olap_decimal(int_value, frac_value);
+        _value = static_cast<int128_t>(int_value) * ONE_BILLION + frac_value;
     }
 
     bool from_olap_decimal(int64_t int_value, int64_t frac_value) {

--- a/be/src/vec/columns/column.h
+++ b/be/src/vec/columns/column.h
@@ -231,6 +231,10 @@ public:
         LOG(FATAL) << "Method insert_many_fix_len_data is not supported for " << get_name();
     }
 
+    virtual void insert_many_fix_len_data(const char** address, size_t num) {
+        LOG(FATAL) << "Method insert_many_fix_len_data is not supported for " << get_name();
+    }
+
     // todo(zeno) Use dict_args temp object to cover all arguments
     virtual void insert_many_dict_data(const int32_t* data_array, size_t start_index,
                                        const StringRef* dict, size_t data_num,

--- a/be/src/vec/columns/column_decimal.cpp
+++ b/be/src/vec/columns/column_decimal.cpp
@@ -250,12 +250,12 @@ void ColumnDecimal<T>::insert_many_fix_len_data(const char* data_ptr, size_t num
 template <typename T>
 void ColumnDecimal<T>::insert_many_fix_len_data(const char** address, size_t num) {
     size_t old_size = data.size();
-    data.resize(old_size + num);
+    data.resize_assume_reserved(old_size + num);
     if (this->is_decimalv2_type()) {
         for (int i = 0; i < num; i++) {
             const char* cur_ptr = address[i];
-            data[old_size + i] = (Decimal128)DecimalV2Value(*(int64_t*)(cur_ptr),
-                                                            *(int32_t*)(cur_ptr + sizeof(int64_t)));
+            new (&data[old_size + i])
+                    DecimalV2Value(*(int64_t*)(cur_ptr), *(int32_t*)(cur_ptr + sizeof(int64_t)));
         }
     } else {
         for (int i = 0; i < num; i++) {

--- a/be/src/vec/columns/column_decimal.h
+++ b/be/src/vec/columns/column_decimal.h
@@ -115,6 +115,8 @@ public:
 
     void insert_many_fix_len_data(const char* data_ptr, size_t num) override;
 
+    void insert_many_fix_len_data(const char** address, size_t num) override;
+
     void insert_many_raw_data(const char* pos, size_t num) override {
         size_t old_size = data.size();
         data.resize(old_size + num);

--- a/be/src/vec/columns/column_nullable.h
+++ b/be/src/vec/columns/column_nullable.h
@@ -112,6 +112,11 @@ public:
         get_nested_column().insert_many_fix_len_data(pos, num);
     }
 
+    void insert_many_fix_len_data(const char** address, size_t num) override {
+        get_null_map_column().fill(0, num);
+        get_nested_column().insert_many_fix_len_data(address, num);
+    }
+
     void insert_many_raw_data(const char* pos, size_t num) override {
         get_null_map_column().fill(0, num);
         get_nested_column().insert_many_raw_data(pos, num);

--- a/be/src/vec/columns/column_vector.h
+++ b/be/src/vec/columns/column_vector.h
@@ -21,6 +21,7 @@
 #pragma once
 
 #include <cmath>
+#include <cstddef>
 #include <type_traits>
 
 #include "olap/uint24.h"
@@ -207,6 +208,15 @@ public:
         } else {
             insert_many_in_copy_way(data_ptr, num);
         }
+    }
+
+    void insert_many_fix_len_data(const char** address, size_t num) override {
+        char* res_ptr = (char*)data.get_end_ptr();
+        for (int i = 0; i < num; i++) {
+            ((T*)res_ptr)[i] = *((T*)address[i]);
+        }
+        res_ptr += num * sizeof(T);
+        data.set_end_ptr(res_ptr);
     }
 
     void insert_many_raw_data(const char* pos, size_t num) override {

--- a/be/src/vec/columns/predicate_column.h
+++ b/be/src/vec/columns/predicate_column.h
@@ -252,6 +252,15 @@ public:
         }
     }
 
+    void insert_many_fix_len_data(const char** address, size_t num) override {
+        char* res_ptr = (char*)data.get_end_ptr();
+        for (int i = 0; i < num; i++) {
+            ((T*)res_ptr)[i] = *((T*)address[i]);
+        }
+        res_ptr += num * sizeof(T);
+        data.set_end_ptr(res_ptr);
+    }
+
     void insert_many_dict_data(const int32_t* data_array, size_t start_index, const StringRef* dict,
                                size_t num, uint32_t /*dict_num*/) override {
         if constexpr (std::is_same_v<T, StringValue>) {


### PR DESCRIPTION
# Proposed changes

Move array created on stack to class member to avoid allocate memory every time we call read_by_rowids.

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

