### PR TITLE
[feature-wip](parquet-reader)  refactor some arguments for parquet reader

### DIFF
--- a/be/src/vec/exec/file_hdfs_scanner.cpp
+++ b/be/src/vec/exec/file_hdfs_scanner.cpp
@@ -38,7 +38,7 @@ Status ParquetFileHdfsScanner::open() {
         return Status::OK();
     }
     RETURN_IF_ERROR(_get_next_reader());
-    return Status();
+    return Status::OK();
 }
 
 void ParquetFileHdfsScanner::_init_profiles(RuntimeProfile* profile) {}
@@ -70,12 +70,18 @@ Status ParquetFileHdfsScanner::_get_next_reader() {
     std::unique_ptr<FileReader> file_reader;
     RETURN_IF_ERROR(FileFactory::create_file_reader(_state->exec_env(), _profile, _params, range,
                                                     file_reader));
-    _reader.reset(new ParquetReader(
-            file_reader.release(), _file_slot_descs.size(), _state->query_options().batch_size,
-            range.start_offset, range.size, const_cast<cctz::time_zone*>(&_state->timezone_obj())));
     auto tuple_desc = _state->desc_tbl().get_tuple_descriptor(_tupleId);
-    Status status =
-            _reader->init_reader(tuple_desc, _file_slot_descs, _conjunct_ctxs, _state->timezone());
+    if (tuple_desc->slots().empty()) {
+        return Status::EndOfFile("No Parquet column need load");
+    }
+    std::vector<std::string> column_names;
+    for (int i = 0; i < _file_slot_descs.size(); i++) {
+        column_names.push_back(_file_slot_descs[i]->col_name());
+    }
+    _reader.reset(new ParquetReader(
+            file_reader.release(), column_names, _state->query_options().batch_size,
+            range.start_offset, range.size, const_cast<cctz::time_zone*>(&_state->timezone_obj())));
+    Status status = _reader->init_reader(_conjunct_ctxs);
     if (!status.ok()) {
         if (status.is_end_of_file()) {
             return _get_next_reader();

--- a/be/src/vec/exec/format/parquet/schema_desc.h
+++ b/be/src/vec/exec/format/parquet/schema_desc.h
@@ -104,6 +104,8 @@ public:
     void get_column_names(std::unordered_set<std::string>* names) const;
 
     std::string debug_string() const;
+
+    int32_t size() const { return _fields.size(); };
 };
 
 } // namespace doris::vectorized

--- a/be/src/vec/exec/format/parquet/vparquet_column_reader.cpp
+++ b/be/src/vec/exec/format/parquet/vparquet_column_reader.cpp
@@ -37,13 +37,13 @@ Status ParquetColumnReader::create(FileReader* file, FieldSchema* field,
     }
     if (field->type.type == TYPE_ARRAY) {
         tparquet::ColumnChunk chunk = row_group.columns[field->children[0].physical_column_index];
-        ArrayColumnReader* array_reader = new ArrayColumnReader(column, ctz);
+        ArrayColumnReader* array_reader = new ArrayColumnReader(ctz);
         array_reader->init_column_metadata(chunk);
         RETURN_IF_ERROR(array_reader->init(file, field, &chunk, row_ranges));
         reader.reset(array_reader);
     } else {
         tparquet::ColumnChunk chunk = row_group.columns[field->physical_column_index];
-        ScalarColumnReader* scalar_reader = new ScalarColumnReader(column, ctz);
+        ScalarColumnReader* scalar_reader = new ScalarColumnReader(ctz);
         scalar_reader->init_column_metadata(chunk);
         RETURN_IF_ERROR(scalar_reader->init(file, field, &chunk, row_ranges));
         reader.reset(scalar_reader);

--- a/be/src/vec/exec/format/parquet/vparquet_column_reader.h
+++ b/be/src/vec/exec/format/parquet/vparquet_column_reader.h
@@ -49,8 +49,7 @@ private:
 
 class ParquetColumnReader {
 public:
-    ParquetColumnReader(const ParquetReadColumn& column, cctz::time_zone* ctz)
-            : _column(column), _ctz(ctz) {};
+    ParquetColumnReader(cctz::time_zone* ctz) : _ctz(ctz) {};
     virtual ~ParquetColumnReader() {
         if (_stream_reader != nullptr) {
             delete _stream_reader;
@@ -70,7 +69,6 @@ protected:
     void _generate_read_ranges(int64_t start_index, int64_t end_index,
                                std::list<RowRange>& read_ranges);
 
-    const ParquetReadColumn& _column;
     BufferedFileStreamReader* _stream_reader;
     std::unique_ptr<ParquetColumnMetadata> _metadata;
     std::vector<RowRange> _row_ranges;
@@ -83,8 +81,7 @@ protected:
 
 class ScalarColumnReader : public ParquetColumnReader {
 public:
-    ScalarColumnReader(const ParquetReadColumn& column, cctz::time_zone* ctz)
-            : ParquetColumnReader(column, ctz) {};
+    ScalarColumnReader(cctz::time_zone* ctz) : ParquetColumnReader(ctz) {};
     ~ScalarColumnReader() override { close(); };
     Status init(FileReader* file, FieldSchema* field, tparquet::ColumnChunk* chunk,
                 std::vector<RowRange>& row_ranges);
@@ -97,8 +94,7 @@ public:
 
 class ArrayColumnReader : public ParquetColumnReader {
 public:
-    ArrayColumnReader(const ParquetReadColumn& column, cctz::time_zone* ctz)
-            : ParquetColumnReader(column, ctz) {};
+    ArrayColumnReader(cctz::time_zone* ctz) : ParquetColumnReader(ctz) {};
     ~ArrayColumnReader() override { close(); };
     Status init(FileReader* file, FieldSchema* field, tparquet::ColumnChunk* chunk,
                 std::vector<RowRange>& row_ranges);

--- a/be/src/vec/exec/format/parquet/vparquet_file_metadata.cpp
+++ b/be/src/vec/exec/format/parquet/vparquet_file_metadata.cpp
@@ -23,13 +23,7 @@
 
 namespace doris::vectorized {
 
-FileMetaData::FileMetaData(tparquet::FileMetaData& metadata) : _metadata(metadata) {
-    _num_rows = metadata.num_rows;
-    _num_groups = metadata.row_groups.size();
-    if (_num_groups != 0) {
-        _num_columns = metadata.row_groups[0].columns.size();
-    }
-}
+FileMetaData::FileMetaData(tparquet::FileMetaData& metadata) : _metadata(metadata) {}
 
 Status FileMetaData::init_schema() {
     if (_metadata.schema[0].num_children <= 0) {
@@ -39,7 +33,7 @@ Status FileMetaData::init_schema() {
     return Status();
 }
 
-tparquet::FileMetaData& FileMetaData::to_thrift_metadata() {
+const tparquet::FileMetaData& FileMetaData::to_thrift() {
     return _metadata;
 }
 
@@ -47,8 +41,6 @@ std::string FileMetaData::debug_string() const {
     std::stringstream out;
     out << "Parquet Metadata(";
     out << "; version=" << _metadata.version;
-    out << "; num row groups=" << _num_groups;
-    out << "; num rows=" << _num_rows;
     out << ")";
     return out.str();
 }

--- a/be/src/vec/exec/format/parquet/vparquet_file_metadata.h
+++ b/be/src/vec/exec/format/parquet/vparquet_file_metadata.h
@@ -27,18 +27,12 @@ public:
     FileMetaData(tparquet::FileMetaData& metadata);
     ~FileMetaData() = default;
     Status init_schema();
-    tparquet::FileMetaData& to_thrift_metadata();
-    int32_t num_row_groups() const { return _num_groups; }
-    int32_t num_columns() const { return _num_columns; };
-    int32_t num_rows() const { return _num_rows; };
-    FieldDescriptor schema() const { return _schema; };
+    const FieldDescriptor& schema() const { return _schema; };
+    const tparquet::FileMetaData& to_thrift();
     std::string debug_string() const;
 
 private:
     tparquet::FileMetaData _metadata;
-    int32_t _num_groups = 0;
-    int32_t _num_columns = 0;
-    int64_t _num_rows = 0;
     FieldDescriptor _schema;
 };
 

--- a/be/src/vec/exec/format/parquet/vparquet_group_reader.cpp
+++ b/be/src/vec/exec/format/parquet/vparquet_group_reader.cpp
@@ -24,7 +24,7 @@ namespace doris::vectorized {
 
 RowGroupReader::RowGroupReader(doris::FileReader* file_reader,
                                const std::vector<ParquetReadColumn>& read_columns,
-                               const int32_t row_group_id, tparquet::RowGroup& row_group,
+                               const int32_t row_group_id, const tparquet::RowGroup& row_group,
                                cctz::time_zone* ctz)
         : _file_reader(file_reader),
           _read_columns(read_columns),
@@ -47,9 +47,7 @@ Status RowGroupReader::_init_column_readers(
         const FieldDescriptor& schema, std::vector<RowRange>& row_ranges,
         std::unordered_map<int, tparquet::OffsetIndex>& col_offsets) {
     for (auto& read_col : _read_columns) {
-        SlotDescriptor* slot_desc = read_col._slot_desc;
-        TypeDescriptor col_type = slot_desc->type();
-        auto field = const_cast<FieldSchema*>(schema.get_column(slot_desc->col_name()));
+        auto field = const_cast<FieldSchema*>(schema.get_column(read_col._file_slot_name));
         std::unique_ptr<ParquetColumnReader> reader;
         RETURN_IF_ERROR(ParquetColumnReader::create(_file_reader, field, read_col, _row_group_meta,
                                                     row_ranges, _ctz, reader));
@@ -62,8 +60,7 @@ Status RowGroupReader::_init_column_readers(
             VLOG_DEBUG << "Init row group reader failed";
             return Status::Corruption("Init row group reader failed");
         }
-
-        _column_readers[slot_desc->id()] = std::move(reader);
+        _column_readers[read_col._file_slot_name] = std::move(reader);
     }
     return Status::OK();
 }
@@ -73,15 +70,14 @@ Status RowGroupReader::next_batch(Block* block, size_t batch_size, bool* _batch_
     bool has_eof = false;
     int col_idx = 0;
     for (auto& read_col : _read_columns) {
-        auto slot_desc = read_col._slot_desc;
-        auto& column_with_type_and_name = block->get_by_name(slot_desc->col_name());
+        auto& column_with_type_and_name = block->get_by_name(read_col._file_slot_name);
         auto& column_ptr = column_with_type_and_name.column;
         auto& column_type = column_with_type_and_name.type;
         size_t col_read_rows = 0;
         bool col_eof = false;
         while (!col_eof && col_read_rows < batch_size) {
             size_t loop_rows = 0;
-            RETURN_IF_ERROR(_column_readers[slot_desc->id()]->read_column_data(
+            RETURN_IF_ERROR(_column_readers[read_col._file_slot_name]->read_column_data(
                     column_ptr, column_type, batch_size - col_read_rows, &loop_rows, &col_eof));
             col_read_rows += loop_rows;
         }

--- a/be/src/vec/exec/format/parquet/vparquet_group_reader.h
+++ b/be/src/vec/exec/format/parquet/vparquet_group_reader.h
@@ -33,7 +33,7 @@ class RowGroupReader {
 public:
     RowGroupReader(doris::FileReader* file_reader,
                    const std::vector<ParquetReadColumn>& read_columns, const int32_t _row_group_id,
-                   tparquet::RowGroup& row_group, cctz::time_zone* ctz);
+                   const tparquet::RowGroup& row_group, cctz::time_zone* ctz);
     ~RowGroupReader();
     Status init(const FieldDescriptor& schema, std::vector<RowRange>& row_ranges,
                 std::unordered_map<int, tparquet::OffsetIndex>& col_offsets);
@@ -45,10 +45,10 @@ private:
 
 private:
     doris::FileReader* _file_reader;
-    std::unordered_map<int32_t, std::unique_ptr<ParquetColumnReader>> _column_readers;
+    std::unordered_map<std::string, std::unique_ptr<ParquetColumnReader>> _column_readers;
     const std::vector<ParquetReadColumn>& _read_columns;
     const int32_t _row_group_id;
-    tparquet::RowGroup& _row_group_meta;
+    const tparquet::RowGroup& _row_group_meta;
     int64_t _read_rows = 0;
     cctz::time_zone* _ctz;
 };

--- a/be/src/vec/exec/format/parquet/vparquet_reader.cpp
+++ b/be/src/vec/exec/format/parquet/vparquet_reader.cpp
@@ -20,17 +20,15 @@
 #include "parquet_thrift_util.h"
 
 namespace doris::vectorized {
-ParquetReader::ParquetReader(FileReader* file_reader, int32_t num_of_columns_from_file,
+ParquetReader::ParquetReader(FileReader* file_reader, const std::vector<std::string>& column_names,
                              size_t batch_size, int64_t range_start_offset, int64_t range_size,
                              cctz::time_zone* ctz)
-        : _num_of_columns_from_file(num_of_columns_from_file),
+        : _file_reader(file_reader),
           _batch_size(batch_size),
           _range_start_offset(range_start_offset),
           _range_size(range_size),
-          _ctz(ctz) {
-    _file_reader = file_reader;
-    _total_groups = 0;
-    _current_row_group_id = 0;
+          _ctz(ctz),
+          _column_names(column_names) {
     //        _statistics = std::make_shared<Statistics>();
 }
 
@@ -42,59 +40,40 @@ void ParquetReader::close() {
     for (auto& conjuncts : _slot_conjuncts) {
         conjuncts.second.clear();
     }
-    // todo: use context instead of these structures
-    _row_group_readers.clear();
-    _read_row_groups.clear();
-    _candidate_row_ranges.clear();
-    _slot_conjuncts.clear();
     _file_reader->close();
-    _col_offsets.clear();
     delete _file_reader;
 }
 
-Status ParquetReader::init_reader(const TupleDescriptor* tuple_desc,
-                                  const std::vector<SlotDescriptor*>& tuple_slot_descs,
-                                  std::vector<ExprContext*>& conjunct_ctxs,
-                                  const std::string& timezone) {
+Status ParquetReader::init_reader(std::vector<ExprContext*>& conjunct_ctxs) {
     _file_reader->open();
-    _tuple_desc = tuple_desc;
-    if (_tuple_desc->slots().size() == 0) {
-        return Status::EndOfFile("No Parquet column need load");
-    }
     RETURN_IF_ERROR(parse_thrift_footer(_file_reader, _file_metadata));
-    _t_metadata = &_file_metadata->to_thrift_metadata();
-    _total_groups = _file_metadata->num_row_groups();
+    _t_metadata = &_file_metadata->to_thrift();
+    _total_groups = _t_metadata->row_groups.size();
     if (_total_groups == 0) {
         return Status::EndOfFile("Empty Parquet File");
     }
     auto schema_desc = _file_metadata->schema();
-    for (int i = 0; i < _file_metadata->num_columns(); ++i) {
+    for (int i = 0; i < schema_desc.size(); ++i) {
         VLOG_DEBUG << schema_desc.debug_string();
         // Get the Column Reader for the boolean column
         _map_column.emplace(schema_desc.get_column(i)->name, i);
     }
-    RETURN_IF_ERROR(_init_read_columns(tuple_slot_descs));
+    RETURN_IF_ERROR(_init_read_columns());
     RETURN_IF_ERROR(_init_row_group_readers(conjunct_ctxs));
     return Status::OK();
 }
 
-Status ParquetReader::_init_read_columns(const std::vector<SlotDescriptor*>& tuple_slot_descs) {
-    DCHECK(_num_of_columns_from_file <= tuple_slot_descs.size());
+Status ParquetReader::_init_read_columns() {
     _include_column_ids.clear();
-    for (int i = 0; i < _num_of_columns_from_file; i++) {
-        auto slot_desc = tuple_slot_descs.at(i);
+    for (auto& file_col_name : _column_names) {
         // Get the Column Reader for the boolean column
-        auto iter = _map_column.find(slot_desc->col_name());
+        auto iter = _map_column.find(file_col_name);
         auto parquet_col_id = iter->second;
         if (iter != _map_column.end()) {
             _include_column_ids.emplace_back(parquet_col_id);
-            ParquetReadColumn column(parquet_col_id, slot_desc);
-            _read_columns.emplace_back(column);
+            _read_columns.emplace_back(parquet_col_id, file_col_name);
         } else {
-            std::stringstream str_error;
-            str_error << "Invalid Column Name:" << slot_desc->col_name();
-            VLOG_DEBUG << str_error.str();
-            return Status::InvalidArgument(str_error.str());
+            continue;
         }
     }
     return Status::OK();
@@ -172,8 +151,9 @@ Status ParquetReader::_init_row_group_readers(const std::vector<ExprContext*>& c
         std::shared_ptr<RowGroupReader> row_group_reader;
         row_group_reader.reset(
                 new RowGroupReader(_file_reader, _read_columns, row_group_id, row_group, _ctz));
-        RETURN_IF_ERROR(_process_page_index(row_group));
-        RETURN_IF_ERROR(row_group_reader->init(_file_metadata->schema(), _candidate_row_ranges,
+        std::vector<RowRange> candidate_row_ranges;
+        RETURN_IF_ERROR(_process_page_index(row_group, candidate_row_ranges));
+        RETURN_IF_ERROR(row_group_reader->init(_file_metadata->schema(), candidate_row_ranges,
                                                _col_offsets));
         _row_group_readers.emplace_back(row_group_reader);
     }
@@ -184,12 +164,9 @@ Status ParquetReader::_init_row_group_readers(const std::vector<ExprContext*>& c
 }
 
 void ParquetReader::_init_conjuncts(const std::vector<ExprContext*>& conjunct_ctxs) {
-    if (_tuple_desc->slots().empty()) {
-        return;
-    }
     std::unordered_set<int> parquet_col_ids(_include_column_ids.begin(), _include_column_ids.end());
-    for (int i = 0; i < _tuple_desc->slots().size(); i++) {
-        auto col_iter = _map_column.find(_tuple_desc->slots()[i]->col_name());
+    for (auto& col_name : _column_names) {
+        auto col_iter = _map_column.find(col_name);
         if (col_iter == _map_column.end()) {
             continue;
         }
@@ -206,26 +183,21 @@ void ParquetReader::_init_conjuncts(const std::vector<ExprContext*>& conjunct_ct
             if (TExprNodeType::SLOT_REF != raw_slot->node_type()) {
                 continue;
             }
-            SlotRef* slot_ref = (SlotRef*)raw_slot;
-            SlotId conjunct_slot_id = slot_ref->slot_id();
-            if (conjunct_slot_id == _tuple_desc->slots()[i]->id()) {
-                // Get conjuncts by conjunct_slot_id
-                auto iter = _slot_conjuncts.find(parquet_col_id);
-                if (_slot_conjuncts.end() == iter) {
-                    std::vector<ExprContext*> conjuncts;
-                    conjuncts.emplace_back(conjunct_ctxs[conj_idx]);
-                    _slot_conjuncts.emplace(std::make_pair(parquet_col_id, conjuncts));
-                } else {
-                    std::vector<ExprContext*> conjuncts = iter->second;
-                    conjuncts.emplace_back(conjunct_ctxs[conj_idx]);
-                }
+            auto iter = _slot_conjuncts.find(parquet_col_id);
+            if (_slot_conjuncts.end() == iter) {
+                std::vector<ExprContext*> conjuncts;
+                conjuncts.emplace_back(conjunct_ctxs[conj_idx]);
+                _slot_conjuncts.emplace(std::make_pair(parquet_col_id, conjuncts));
+            } else {
+                std::vector<ExprContext*> conjuncts = iter->second;
+                conjuncts.emplace_back(conjunct_ctxs[conj_idx]);
             }
         }
     }
 }
 
 Status ParquetReader::_filter_row_groups() {
-    if (_total_groups == 0 || _file_metadata->num_rows() == 0 || _range_size < 0) {
+    if (_total_groups == 0 || _t_metadata->num_rows == 0 || _range_size < 0) {
         return Status::EndOfFile("No row group need read");
     }
     for (int32_t row_group_idx = 0; row_group_idx < _total_groups; row_group_idx++) {
@@ -256,20 +228,22 @@ bool ParquetReader::_is_misaligned_range_group(const tparquet::RowGroup& row_gro
     return false;
 }
 
-bool ParquetReader::_has_page_index(std::vector<tparquet::ColumnChunk>& columns) {
-    _page_index.reset(new PageIndex());
-    return _page_index->check_and_get_page_index_ranges(columns);
+bool ParquetReader::_has_page_index(const std::vector<tparquet::ColumnChunk>& columns,
+                                    PageIndex& page_index) {
+    return page_index.check_and_get_page_index_ranges(columns);
 }
 
-Status ParquetReader::_process_page_index(tparquet::RowGroup& row_group) {
-    if (!_has_page_index(row_group.columns)) {
+Status ParquetReader::_process_page_index(const tparquet::RowGroup& row_group,
+                                          std::vector<RowRange>& candidate_row_ranges) {
+    PageIndex page_index;
+    if (!_has_page_index(row_group.columns, page_index)) {
         return Status::OK();
     }
-    int64_t buffer_size = _page_index->_column_index_size + _page_index->_offset_index_size;
+    int64_t buffer_size = page_index._column_index_size + page_index._offset_index_size;
     uint8_t buff[buffer_size];
     int64_t bytes_read = 0;
     RETURN_IF_ERROR(
-            _file_reader->readat(_page_index->_column_index_start, buffer_size, &bytes_read, buff));
+            _file_reader->readat(page_index._column_index_start, buffer_size, &bytes_read, buff));
 
     std::vector<RowRange> skipped_row_ranges;
     for (auto& read_col : _read_columns) {
@@ -279,23 +253,23 @@ Status ParquetReader::_process_page_index(tparquet::RowGroup& row_group) {
         }
         auto& chunk = row_group.columns[read_col._parquet_col_id];
         tparquet::ColumnIndex column_index;
-        RETURN_IF_ERROR(_page_index->parse_column_index(chunk, buff, &column_index));
+        RETURN_IF_ERROR(page_index.parse_column_index(chunk, buff, &column_index));
         const int num_of_pages = column_index.null_pages.size();
         if (num_of_pages <= 0) {
             break;
         }
         auto& conjuncts = conjunct_iter->second;
         std::vector<int> skipped_page_range;
-        _page_index->collect_skipped_page_range(&column_index, conjuncts, skipped_page_range);
+        page_index.collect_skipped_page_range(&column_index, conjuncts, skipped_page_range);
         if (skipped_page_range.empty()) {
             return Status::OK();
         }
         tparquet::OffsetIndex offset_index;
-        RETURN_IF_ERROR(_page_index->parse_offset_index(chunk, buff, buffer_size, &offset_index));
+        RETURN_IF_ERROR(page_index.parse_offset_index(chunk, buff, buffer_size, &offset_index));
         for (int page_id : skipped_page_range) {
             RowRange skipped_row_range;
-            _page_index->create_skipped_row_range(offset_index, row_group.num_rows, page_id,
-                                                  &skipped_row_range);
+            page_index.create_skipped_row_range(offset_index, row_group.num_rows, page_id,
+                                                &skipped_row_range);
             // use the union row range
             skipped_row_ranges.emplace_back(skipped_row_range);
         }
@@ -310,18 +284,20 @@ Status ParquetReader::_process_page_index(tparquet::RowGroup& row_group) {
                   return std::tie(lhs.first_row, lhs.last_row) <
                          std::tie(rhs.first_row, rhs.last_row);
               });
-    int skip_end = -1;
+    int skip_end = 0;
     for (auto& skip_range : skipped_row_ranges) {
-        VLOG_DEBUG << skip_range.first_row << " " << skip_range.last_row << " | ";
-        if (skip_end + 1 >= skip_range.first_row) {
+        if (skip_end >= skip_range.first_row) {
             if (skip_end < skip_range.last_row) {
                 skip_end = skip_range.last_row;
             }
         } else {
             // read row with candidate ranges rather than skipped ranges
-            _candidate_row_ranges.push_back({skip_end + 1, skip_range.first_row - 1});
+            candidate_row_ranges.push_back({skip_end, skip_range.first_row});
             skip_end = skip_range.last_row;
         }
+    }
+    if (skip_end != row_group.num_rows) {
+        candidate_row_ranges.push_back({skip_end, row_group.num_rows});
     }
     return Status::OK();
 }
@@ -341,8 +317,7 @@ Status ParquetReader::_process_column_stat_filter(const std::vector<tparquet::Co
     // It will not filter if head_group_offset equals tail_group_offset
     std::unordered_set<int> _parquet_column_ids(_include_column_ids.begin(),
                                                 _include_column_ids.end());
-    for (SlotId slot_id = 0; slot_id < _tuple_desc->slots().size(); slot_id++) {
-        const std::string& col_name = _tuple_desc->slots()[slot_id]->col_name();
+    for (auto& col_name : _column_names) {
         auto col_iter = _map_column.find(col_name);
         if (col_iter == _map_column.end()) {
             continue;

--- a/be/src/vec/exec/format/parquet/vparquet_reader.h
+++ b/be/src/vec/exec/format/parquet/vparquet_reader.h
@@ -55,29 +55,26 @@ struct RowRange {
 
 class ParquetReadColumn {
 public:
-    friend class ParquetReader;
-    friend class RowGroupReader;
-    ParquetReadColumn(int parquet_col_id, SlotDescriptor* slot_desc)
-            : _parquet_col_id(parquet_col_id), _slot_desc(slot_desc) {};
+    ParquetReadColumn(int parquet_col_id, const std::string& file_slot_name)
+            : _parquet_col_id(parquet_col_id), _file_slot_name(file_slot_name) {};
     ~ParquetReadColumn() = default;
 
 private:
+    friend class ParquetReader;
+    friend class RowGroupReader;
     int _parquet_col_id;
-    SlotDescriptor* _slot_desc;
-    //    int64_t start_offset;
-    //    int64_t chunk_size;
+    const std::string& _file_slot_name;
 };
 
 class ParquetReader : public GenericReader {
 public:
-    ParquetReader(FileReader* file_reader, int32_t num_of_columns_from_file, size_t batch_size,
-                  int64_t range_start_offset, int64_t range_size, cctz::time_zone* ctz);
+    ParquetReader(FileReader* file_reader, const std::vector<std::string>& column_names,
+                  size_t batch_size, int64_t range_start_offset, int64_t range_size,
+                  cctz::time_zone* ctz);
 
     virtual ~ParquetReader();
 
-    Status init_reader(const TupleDescriptor* tuple_desc,
-                       const std::vector<SlotDescriptor*>& tuple_slot_descs,
-                       std::vector<ExprContext*>& conjunct_ctxs, const std::string& timezone);
+    Status init_reader(std::vector<ExprContext*>& conjunct_ctxs);
 
     Status get_next_block(Block* block, bool* eof) override;
 
@@ -90,12 +87,13 @@ public:
 
 private:
     bool _next_row_group_reader();
-    Status _init_read_columns(const std::vector<SlotDescriptor*>& tuple_slot_descs);
+    Status _init_read_columns();
     Status _init_row_group_readers(const std::vector<ExprContext*>& conjunct_ctxs);
     void _init_conjuncts(const std::vector<ExprContext*>& conjunct_ctxs);
     // Page Index Filter
-    bool _has_page_index(std::vector<tparquet::ColumnChunk>& columns);
-    Status _process_page_index(tparquet::RowGroup& row_group);
+    bool _has_page_index(const std::vector<tparquet::ColumnChunk>& columns, PageIndex& page_index);
+    Status _process_page_index(const tparquet::RowGroup& row_group,
+                               std::vector<RowRange>& candidate_row_ranges);
 
     // Row Group Filter
     bool _is_misaligned_range_group(const tparquet::RowGroup& row_group);
@@ -118,14 +116,11 @@ private:
 private:
     FileReader* _file_reader;
     std::shared_ptr<FileMetaData> _file_metadata;
-    tparquet::FileMetaData* _t_metadata;
-    std::unique_ptr<PageIndex> _page_index;
+    const tparquet::FileMetaData* _t_metadata;
     std::list<std::shared_ptr<RowGroupReader>> _row_group_readers;
     std::shared_ptr<RowGroupReader> _current_group_reader;
     int32_t _total_groups; // num of groups(stripes) of a parquet(orc) file
-    int32_t _current_row_group_id;
     //        std::shared_ptr<Statistics> _statistics;
-    const int32_t _num_of_columns_from_file;
     std::map<std::string, int> _map_column; // column-name <---> column-index
     std::unordered_map<int, std::vector<ExprContext*>> _slot_conjuncts;
     std::vector<int> _include_column_ids; // columns that need to get from file
@@ -136,9 +131,8 @@ private:
     int64_t _range_start_offset;
     int64_t _range_size;
     cctz::time_zone* _ctz;
-    std::vector<RowRange> _candidate_row_ranges;
-    std::unordered_map<int, tparquet::OffsetIndex> _col_offsets;
 
-    const TupleDescriptor* _tuple_desc; // get all slot info
+    std::unordered_map<int, tparquet::OffsetIndex> _col_offsets;
+    const std::vector<std::string> _column_names;
 };
 } // namespace doris::vectorized

--- a/be/src/vec/exec/scan/vfile_scanner.cpp
+++ b/be/src/vec/exec/scan/vfile_scanner.cpp
@@ -333,13 +333,15 @@ Status VFileScanner::_get_next_reader() {
 
         switch (_params.format_type) {
         case TFileFormatType::FORMAT_PARQUET:
-            _cur_reader = new ParquetReader(file_reader.release(), _file_slot_descs.size(),
+            std::vector<std::string> column_names;
+            for (int i = 0; i < _file_slot_descs.size(); i++) {
+                column_names.push_back(_file_slot_descs[i]->col_name());
+            }
+            _cur_reader = new ParquetReader(file_reader.release(), column_names,
                                             _state->query_options().batch_size, range.start_offset,
                                             range.size,
                                             const_cast<cctz::time_zone*>(&_state->timezone_obj()));
-            RETURN_IF_ERROR(((ParquetReader*)_cur_reader)
-                                    ->init_reader(_output_tuple_desc, _file_slot_descs,
-                                                  _conjunct_ctxs, _state->timezone()));
+            RETURN_IF_ERROR(((ParquetReader*)_cur_reader)->init_reader(_conjunct_ctxs));
             break;
         default:
             std::stringstream error_msg;

--- a/be/src/vec/exec/scan/vfile_scanner.cpp
+++ b/be/src/vec/exec/scan/vfile_scanner.cpp
@@ -330,10 +330,9 @@ Status VFileScanner::_get_next_reader() {
             file_reader->close();
             continue;
         }
-
+        std::vector<std::string> column_names;
         switch (_params.format_type) {
         case TFileFormatType::FORMAT_PARQUET:
-            std::vector<std::string> column_names;
             for (int i = 0; i < _file_slot_descs.size(); i++) {
                 column_names.push_back(_file_slot_descs[i]->col_name());
             }

--- a/be/test/vec/exec/parquet/parquet_reader_test.cpp
+++ b/be/test/vec/exec/parquet/parquet_reader_test.cpp
@@ -95,14 +95,18 @@ TEST_F(ParquetReaderTest, normal) {
 
     cctz::time_zone ctz;
     TimezoneUtils::find_cctz_time_zone(TimezoneUtils::default_time_zone, ctz);
-    auto p_reader = new ParquetReader(reader, slot_descs.size(), 1024, 0, 1000, &ctz);
+    auto tuple_desc = desc_tbl->get_tuple_descriptor(0);
+    std::vector<std::string> column_names;
+    for (int i = 0; i < slot_descs.size(); i++) {
+        column_names.push_back(slot_descs[i]->col_name());
+    }
+    auto p_reader = new ParquetReader(reader, column_names, 1024, 0, 1000, &ctz);
     RuntimeState runtime_state((TQueryGlobals()));
     runtime_state.set_desc_tbl(desc_tbl);
     runtime_state.init_instance_mem_tracker();
 
-    auto tuple_desc = desc_tbl->get_tuple_descriptor(0);
     std::vector<ExprContext*> conjunct_ctxs = std::vector<ExprContext*>();
-    p_reader->init_reader(tuple_desc, slot_descs, conjunct_ctxs, runtime_state.timezone());
+    p_reader->init_reader(conjunct_ctxs);
     Block* block = new Block();
     for (const auto& slot_desc : tuple_desc->slots()) {
         auto data_type =

--- a/be/test/vec/exec/parquet/parquet_thrift_test.cpp
+++ b/be/test/vec/exec/parquet/parquet_thrift_test.cpp
@@ -55,7 +55,6 @@ TEST_F(ParquetThriftReaderTest, normal) {
     parse_thrift_footer(&reader, meta_data);
     tparquet::FileMetaData t_metadata = meta_data->to_thrift();
 
-    LOG(WARNING) << "num columns: " << meta_data->num_columns();
     LOG(WARNING) << "=====================================";
     for (auto value : t_metadata.row_groups) {
         LOG(WARNING) << "row group num_rows: " << value.num_rows;

--- a/be/test/vec/exec/parquet/parquet_thrift_test.cpp
+++ b/be/test/vec/exec/parquet/parquet_thrift_test.cpp
@@ -51,12 +51,11 @@ TEST_F(ParquetThriftReaderTest, normal) {
     auto st = reader.open();
     EXPECT_TRUE(st.ok());
 
-    std::shared_ptr<FileMetaData> metaData;
-    parse_thrift_footer(&reader, metaData);
-    tparquet::FileMetaData t_metadata = metaData->to_thrift_metadata();
+    std::shared_ptr<FileMetaData> meta_data;
+    parse_thrift_footer(&reader, meta_data);
+    tparquet::FileMetaData t_metadata = meta_data->to_thrift();
 
-    LOG(WARNING) << "num row groups: " << metaData->num_row_groups();
-    LOG(WARNING) << "num columns: " << metaData->num_columns();
+    LOG(WARNING) << "num columns: " << meta_data->num_columns();
     LOG(WARNING) << "=====================================";
     for (auto value : t_metadata.row_groups) {
         LOG(WARNING) << "row group num_rows: " << value.num_rows;
@@ -83,9 +82,9 @@ TEST_F(ParquetThriftReaderTest, complex_nested_file) {
     auto st = reader.open();
     EXPECT_TRUE(st.ok());
 
-    std::shared_ptr<FileMetaData> metaData;
-    parse_thrift_footer(&reader, metaData);
-    tparquet::FileMetaData t_metadata = metaData->to_thrift_metadata();
+    std::shared_ptr<FileMetaData> metadata;
+    parse_thrift_footer(&reader, metadata);
+    tparquet::FileMetaData t_metadata = metadata->to_thrift();
     FieldDescriptor schemaDescriptor;
     schemaDescriptor.parse_from_thrift(t_metadata.schema);
 
@@ -272,9 +271,9 @@ static void read_parquet_data_and_check(const std::string& parquet_file,
 
     std::unique_ptr<vectorized::Block> block;
     create_block(block);
-    std::shared_ptr<FileMetaData> metaData;
-    parse_thrift_footer(&reader, metaData);
-    tparquet::FileMetaData t_metadata = metaData->to_thrift_metadata();
+    std::shared_ptr<FileMetaData> metadata;
+    parse_thrift_footer(&reader, metadata);
+    tparquet::FileMetaData t_metadata = metadata->to_thrift();
     FieldDescriptor schema_descriptor;
     schema_descriptor.parse_from_thrift(t_metadata.schema);
     level_t defs[rows];
@@ -382,9 +381,8 @@ TEST_F(ParquetThriftReaderTest, group_reader) {
 
     std::vector<ParquetReadColumn> read_columns;
     for (const auto& slot : tuple_slots) {
-        read_columns.emplace_back(ParquetReadColumn(7, slot));
+        read_columns.emplace_back(ParquetReadColumn(7, slot->col_name()));
     }
-
     LocalFileReader file_reader("./be/test/exec/test_data/parquet_scanner/type-decoder.parquet", 0);
     auto st = file_reader.open();
     EXPECT_TRUE(st.ok());
@@ -392,7 +390,7 @@ TEST_F(ParquetThriftReaderTest, group_reader) {
     // prepare metadata
     std::shared_ptr<FileMetaData> meta_data;
     parse_thrift_footer(&file_reader, meta_data);
-    tparquet::FileMetaData t_metadata = meta_data->to_thrift_metadata();
+    tparquet::FileMetaData t_metadata = meta_data->to_thrift();
 
     cctz::time_zone ctz;
     TimezoneUtils::find_cctz_time_zone(TimezoneUtils::default_time_zone, ctz);


### PR DESCRIPTION
# Proposed changes

refactor some arguments for parquet reader 
1、 Add new parquet context to wrap reader arguments
2、Reduced some arguments for function call

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

