### PR TITLE
[Bug](mem-tracker) fix core dump when use_mmap_allocate_chunk=true

### DIFF
--- a/be/src/runtime/memory/system_allocator.cpp
+++ b/be/src/runtime/memory/system_allocator.cpp
@@ -44,8 +44,6 @@ void SystemAllocator::free(uint8_t* ptr, size_t length) {
             char buf[64];
             LOG(ERROR) << "fail to free memory via munmap, errno=" << errno
                        << ", errmsg=" << strerror_r(errno, buf, 64);
-        } else {
-            RELEASE_THREAD_MEM_TRACKER(length);
         }
     } else {
         ::free(ptr);


### PR DESCRIPTION
# Proposed changes

```cpp
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /mnt/disk1/pxl/doris/be/src/common/signal_handler.h:420
 1# 0x00007FA30179E400 in /lib64/libc.so.6
 2# gsignal in /lib64/libc.so.6
 3# abort in /lib64/libc.so.6
 4# 0x000055D186FEFFD9 in /mnt/disk1/pxl/doris/output/be/lib/doris_be
 5# TCMallocImplementation::GetAllocatedSize(void const*) at src/tcmalloc.cc:1700
 6# delete_hook(void const*) at /mnt/disk1/pxl/doris/be/src/runtime/memory/tcmalloc_hook.h:56
 7# MallocHook::InvokeDeleteHookSlow(void const*) at src/malloc_hook.cc:505
 8# tcmalloc::invoke_hooks_and_free(void*) at src/tcmalloc.cc:1753
 9# StringHashTable<StringHashMapSubMaps<char*, Allocator<true, true> > >::~StringHashTable() at /mnt/disk1/pxl/doris/be/src/vec/common/hash_table/string_hash_table.h:454
10# doris::vectorized::AggregationNode::~AggregationNode() at /mnt/disk1/pxl/doris/be/src/vec/exec/vaggregation_node.cpp:119
11# doris::vectorized::AggregationNode::~AggregationNode() at /mnt/disk1/pxl/doris/be/src/vec/exec/vaggregation_node.cpp:119
12# doris::RuntimeState::~RuntimeState() at /mnt/disk1/pxl/doris/be/src/runtime/runtime_state.cpp:164
13# doris::PlanFragmentExecutor::~PlanFragmentExecutor() at /mnt/disk1/pxl/doris/be/src/runtime/plan_fragment_executor.cpp:75
14# doris::FragmentExecState::~FragmentExecState() at /mnt/disk1/pxl/doris/be/src/runtime/fragment_mgr.cpp:81
15# std::_Sp_counted_ptr<doris::FragmentExecState*, (__gnu_cxx::_Lock_policy)2>::_M_dispose() at /mnt/disk1/pxl/ldb/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:348
16# std::_Function_handler<void (), doris::FragmentMgr::exec_plan_fragment(doris::TExecPlanFragmentParams const&, std::function<void (doris::PlanFragmentExecutor*)>)::$_3>::_M_manager(std::_Any_data&, std::_Any_data const&, std::_Manager_operation) at /mnt/disk1/pxl/ldb/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:283
17# doris::FunctionRunnable::~FunctionRunnable() at /mnt/disk1/pxl/doris/be/src/util/threadpool.cpp:41
18# doris::ThreadPool::dispatch_thread() at /mnt/disk1/pxl/doris/be/src/util/threadpool.cpp:548
19# doris::Thread::supervise_thread(void*) at /mnt/disk1/pxl/doris/be/src/util/thread.cpp:426
20# start_thread in /lib64/libpthread.so.0
21# clone in /lib64/libc.so.6
```

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

