### PR TITLE
[Bugfix](mem) Fix memory limit check may overflow

### DIFF
--- a/be/src/runtime/memory/mem_tracker_limiter.h
+++ b/be/src/runtime/memory/mem_tracker_limiter.h
@@ -78,11 +78,12 @@ public:
                     MemInfo::mem_limit() ||
             PerfCounters::get_vm_rss() + bytes >= MemInfo::hard_mem_limit()) {
             auto st = Status::MemoryLimitExceeded(
-                    "process memory used {}, tc/jemalloc cache {}, exceed limit {}, failed alloc "
+                    "process memory used {}, tc/jemalloc cache {}, exceed limit {}, hard limit {}, "
+                    "failed alloc "
                     "size {}",
                     print_bytes(PerfCounters::get_vm_rss()),
                     print_bytes(MemInfo::allocator_cache_mem()), print_bytes(MemInfo::mem_limit()),
-                    print_bytes(bytes));
+                    print_bytes(MemInfo::hard_mem_limit()), print_bytes(bytes));
             ExecEnv::GetInstance()->process_mem_tracker_raw()->print_log_usage(st.get_error_msg());
             return st;
         }

--- a/be/src/runtime/memory/mem_tracker_limiter.h
+++ b/be/src/runtime/memory/mem_tracker_limiter.h
@@ -74,13 +74,13 @@ public:
         // but it may not actually alloc physical memory, which is not expected in mem hook fail.
         //
         // TODO: In order to ensure no OOM, currently reserve 200M, and then use the free mem in /proc/meminfo to ensure no OOM.
-        if (PerfCounters::get_vm_rss() - MemInfo::allocator_cache_mem() + bytes >=
+        if (PerfCounters::get_vm_rss() - static_cast<int64_t>(MemInfo::allocator_cache_mem()) +
+                            bytes >=
                     MemInfo::mem_limit() ||
             PerfCounters::get_vm_rss() + bytes >= MemInfo::hard_mem_limit()) {
             auto st = Status::MemoryLimitExceeded(
                     "process memory used {}, tc/jemalloc cache {}, exceed limit {}, hard limit {}, "
-                    "failed alloc "
-                    "size {}",
+                    "failed alloc size {}",
                     print_bytes(PerfCounters::get_vm_rss()),
                     print_bytes(MemInfo::allocator_cache_mem()), print_bytes(MemInfo::mem_limit()),
                     print_bytes(MemInfo::hard_mem_limit()), print_bytes(bytes));

--- a/be/src/util/mem_info.cpp
+++ b/be/src/util/mem_info.cpp
@@ -41,12 +41,12 @@ bool MemInfo::_s_initialized = false;
 int64_t MemInfo::_s_physical_mem = -1;
 int64_t MemInfo::_s_mem_limit = -1;
 int64_t MemInfo::_s_hard_mem_limit = -1;
-size_t MemInfo::_s_allocator_physical_mem = 0;
-size_t MemInfo::_s_tcmalloc_pageheap_free_bytes = 0;
-size_t MemInfo::_s_tcmalloc_central_bytes = 0;
-size_t MemInfo::_s_tcmalloc_transfer_bytes = 0;
-size_t MemInfo::_s_tcmalloc_thread_bytes = 0;
-size_t MemInfo::_s_allocator_cache_mem = 0;
+int64_t MemInfo::_s_allocator_physical_mem = -1;
+int64_t MemInfo::_s_tcmalloc_pageheap_free_bytes = -1;
+int64_t MemInfo::_s_tcmalloc_central_bytes = -1;
+int64_t MemInfo::_s_tcmalloc_transfer_bytes = -1;
+int64_t MemInfo::_s_tcmalloc_thread_bytes = -1;
+int64_t MemInfo::_s_allocator_cache_mem = -1;
 
 void MemInfo::init() {
     // Read from /proc/meminfo
@@ -94,7 +94,7 @@ void MemInfo::init() {
 
     bool is_percent = true;
     _s_mem_limit = ParseUtil::parse_mem_spec(config::mem_limit, -1, _s_physical_mem, &is_percent);
-    _s_hard_mem_limit = _s_physical_mem - std::min(209715200.0, _s_physical_mem * 0.1); // 200M
+    _s_hard_mem_limit = _s_physical_mem - std::min(209715200L, _s_physical_mem / 10); // 200M
 
     LOG(INFO) << "Physical Memory: " << PrettyPrinter::print(_s_physical_mem, TUnit::BYTES);
     _s_initialized = true;

--- a/be/src/util/mem_info.cpp
+++ b/be/src/util/mem_info.cpp
@@ -41,12 +41,12 @@ bool MemInfo::_s_initialized = false;
 int64_t MemInfo::_s_physical_mem = -1;
 int64_t MemInfo::_s_mem_limit = -1;
 int64_t MemInfo::_s_hard_mem_limit = -1;
-int64_t MemInfo::_s_allocator_physical_mem = -1;
-int64_t MemInfo::_s_tcmalloc_pageheap_free_bytes = -1;
-int64_t MemInfo::_s_tcmalloc_central_bytes = -1;
-int64_t MemInfo::_s_tcmalloc_transfer_bytes = -1;
-int64_t MemInfo::_s_tcmalloc_thread_bytes = -1;
-int64_t MemInfo::_s_allocator_cache_mem = -1;
+size_t MemInfo::_s_allocator_physical_mem = 0;
+size_t MemInfo::_s_tcmalloc_pageheap_free_bytes = 0;
+size_t MemInfo::_s_tcmalloc_central_bytes = 0;
+size_t MemInfo::_s_tcmalloc_transfer_bytes = 0;
+size_t MemInfo::_s_tcmalloc_thread_bytes = 0;
+size_t MemInfo::_s_allocator_cache_mem = 0;
 
 void MemInfo::init() {
     // Read from /proc/meminfo

--- a/be/src/util/mem_info.h
+++ b/be/src/util/mem_info.h
@@ -44,8 +44,8 @@ public:
         return _s_physical_mem;
     }
 
-    static inline int64_t current_mem() { return _s_allocator_physical_mem; }
-    static inline int64_t allocator_cache_mem() { return _s_allocator_cache_mem; }
+    static inline size_t current_mem() { return _s_allocator_physical_mem; }
+    static inline size_t allocator_cache_mem() { return _s_allocator_cache_mem; }
 
     // Tcmalloc property `generic.total_physical_bytes` records the total length of the virtual memory
     // obtained by the process malloc, not the physical memory actually used by the process in the OS.
@@ -77,12 +77,12 @@ private:
     static int64_t _s_physical_mem;
     static int64_t _s_mem_limit;
     static int64_t _s_hard_mem_limit;
-    static int64_t _s_allocator_physical_mem;
-    static int64_t _s_tcmalloc_pageheap_free_bytes;
-    static int64_t _s_tcmalloc_central_bytes;
-    static int64_t _s_tcmalloc_transfer_bytes;
-    static int64_t _s_tcmalloc_thread_bytes;
-    static int64_t _s_allocator_cache_mem;
+    static size_t _s_allocator_physical_mem;
+    static size_t _s_tcmalloc_pageheap_free_bytes;
+    static size_t _s_tcmalloc_central_bytes;
+    static size_t _s_tcmalloc_transfer_bytes;
+    static size_t _s_tcmalloc_thread_bytes;
+    static size_t _s_allocator_cache_mem;
 };
 
 } // namespace doris

--- a/be/src/util/mem_info.h
+++ b/be/src/util/mem_info.h
@@ -44,8 +44,8 @@ public:
         return _s_physical_mem;
     }
 
-    static inline size_t current_mem() { return _s_allocator_physical_mem; }
-    static inline size_t allocator_cache_mem() { return _s_allocator_cache_mem; }
+    static inline int64_t current_mem() { return _s_allocator_physical_mem; }
+    static inline int64_t allocator_cache_mem() { return _s_allocator_cache_mem; }
 
     // Tcmalloc property `generic.total_physical_bytes` records the total length of the virtual memory
     // obtained by the process malloc, not the physical memory actually used by the process in the OS.
@@ -77,12 +77,12 @@ private:
     static int64_t _s_physical_mem;
     static int64_t _s_mem_limit;
     static int64_t _s_hard_mem_limit;
-    static size_t _s_allocator_physical_mem;
-    static size_t _s_tcmalloc_pageheap_free_bytes;
-    static size_t _s_tcmalloc_central_bytes;
-    static size_t _s_tcmalloc_transfer_bytes;
-    static size_t _s_tcmalloc_thread_bytes;
-    static size_t _s_allocator_cache_mem;
+    static int64_t _s_allocator_physical_mem;
+    static int64_t _s_tcmalloc_pageheap_free_bytes;
+    static int64_t _s_tcmalloc_central_bytes;
+    static int64_t _s_tcmalloc_transfer_bytes;
+    static int64_t _s_tcmalloc_thread_bytes;
+    static int64_t _s_allocator_cache_mem;
 };
 
 } // namespace doris


### PR DESCRIPTION
# Proposed changes

Issue Number: close #12775

## Problem summary

This bug is because the result of subtracting signed and unsigned numbers may overflow if it is negative.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

