### PR TITLE
[BugFix](VExprContext) capture error status to prevent incorrect func call which causes coredump

### DIFF
--- a/be/src/vec/exprs/vexpr_context.cpp
+++ b/be/src/vec/exprs/vexpr_context.cpp
@@ -118,7 +118,7 @@ Status VExprContext::filter_block(VExprContext* vexpr_ctx, Block* block, int col
         return Status::OK();
     }
     int result_column_id = -1;
-    vexpr_ctx->execute(block, &result_column_id);
+    RETURN_IF_ERROR(vexpr_ctx->execute(block, &result_column_id));
     return Block::filter_block(block, result_column_id, column_to_keep);
 }
 


### PR DESCRIPTION
# Proposed changes

Issue Number: close #12778

## Problem summary

Use macro `return if error` to capture error status to prevent incorrect forward func call.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [x] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

