### PR TITLE
[Docs] Add python env for Mac M1

### DIFF
--- a/docs/en/community/developer-guide/fe-idea-dev.md
+++ b/docs/en/community/developer-guide/fe-idea-dev.md
@@ -76,6 +76,12 @@ under the License.
    ```
    mvn clean install -DskipTests
    ```
+
+   If it's MAC M1, run following command
+
+   ```
+   mvn clean install -DskipTests -Dos.arch=x86_64
+   ```
    
    You can also use IDE embedded GUI tools to run maven command to generate sources
 
@@ -84,7 +90,13 @@ under the License.
 If you are developing on the OS which lack of support to run `shell script` and `make` such as Windows, a workround here 
 is generate codes in Linux and copy them back. Using Docker should also be an option.
 
-5. If a help document has not been generated, go to the docs directory and run`sh build_help_zip.sh`，
+5. If it's MAC M1, python may not be found, so create a soft link from python3 to python: 
+
+   ```
+   ln -s /usr/bin/python3 /usr/bin/python
+   ```
+
+6. If a help document has not been generated, go to the docs directory and run`sh build_help_zip.sh`，
    Then copy help-resource.zip from build to fe/fe-core/target/classes
 
 ## 2. Debug

--- a/docs/zh-CN/community/developer-guide/fe-idea-dev.md
+++ b/docs/zh-CN/community/developer-guide/fe-idea-dev.md
@@ -68,6 +68,14 @@ JDK1.8+, IntelliJ IDEA
 
     ```
     cd fe && mvn clean install -DskipTests
+
+    ```
+
+    如果是mac m1版，则执行：
+
+    ```
+    cd fe && mvn clean install -DskipTests -Dos.arch=x86_64
+
     ```
 
 或者通过图形界面运行 maven 命令生成
@@ -76,7 +84,14 @@ JDK1.8+, IntelliJ IDEA
 
 如果使用windows环境可能会有make命令和sh脚本无法执行的情况 可以通过拷贝linux上的 `fe/fe-core/target/generated-sources` 目录拷贝到相应的目录的方式实现，也可以通过docker 镜像挂载本地目录之后，在docker 内部生成自动生成代码，可以参照编译一节
 
-5. 如果还未生成过help文档，需要跳转到docs目录，执行`sh build_help_zip.sh`，
+5. 如果是 mac m1 版，可能会找不到 python，则创建一个 python3 到 python 的软链：
+
+    ```
+    ln -s /usr/bin/python3 /usr/bin/python
+    ```
+
+
+6. 如果还未生成过help文档，需要跳转到docs目录，执行`sh build_help_zip.sh`，
    然后将build中的help-resource.zip拷贝到fe/fe-core/target/classes中
 
 ## 2.调试


### PR DESCRIPTION
For Mac M1, the default is python3 instead of python. When FE compiles, there will be an error that python cannot be found. This PR complements this part of the description.



