### PR TITLE
[feature-wip](multi-catalog) Support flatten catalog

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/BaseTableRef.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/BaseTableRef.java
@@ -66,7 +66,6 @@ public class BaseTableRef extends TableRef {
      */
     @Override
     public void analyze(Analyzer analyzer) throws UserException {
-        name = analyzer.getFqTableName(name);
         name.analyze(analyzer);
         desc = analyzer.registerTableRef(this);
         isAnalyzed = true;  // true that we have assigned desc

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateTableStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateTableStmt.java
@@ -94,10 +94,7 @@ public class CreateTableStmt extends DdlStmt {
         engineNames.add("jdbc");
     }
 
-    public CreateTableStmt() {
-        // for persist
-        tableName = new TableName();
-        columnDefs = Lists.newArrayList();
+    protected CreateTableStmt() {
     }
 
     public CreateTableStmt(boolean ifNotExists,

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/InlineViewRef.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/InlineViewRef.java
@@ -192,8 +192,8 @@ public class InlineViewRef extends TableRef {
 
         queryStmt.getMaterializedTupleIds(materializedTupleIds);
         if (view != null && !hasExplicitAlias() && !view.isLocalView()) {
-            name = analyzer.getFqTableName(name);
-            aliases = new String[] { name.toString(), view.getName() };
+            name.analyze(analyzer);
+            aliases = new String[] {name.toString(), view.getName()};
         }
         //TODO(chenhao16): fix TableName in Db.Table style
         // name.analyze(analyzer);

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/SelectStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/SelectStmt.java
@@ -304,15 +304,14 @@ public class SelectStmt extends QueryStmt {
                         tblFuncRef.getTableFunction().getTable());
             } else {
                 TableName tblName = tblRef.getName();
-                // Must anylyze first to get real catalog/db/table name
-                tblName.analyze(analyzer);
-                String dbName = tblName.getDb();
                 String tableName = tblName.getTbl();
-                if (isViewTableRef(tblName.toString(), parentViewNameSet)) {
+                if (isViewTableRef(tableName, parentViewNameSet)) {
                     continue;
                 }
+
+                tblName.analyze(analyzer);
                 DatabaseIf db = analyzer.getEnv().getCatalogMgr()
-                        .getCatalogOrAnalysisException(tblName.getCtl()).getDbOrAnalysisException(dbName);
+                        .getCatalogOrAnalysisException(tblName.getCtl()).getDbOrAnalysisException(tblName.getDb());
                 TableIf table = db.getTableOrAnalysisException(tableName);
 
                 if (expandView && (table instanceof View)) {
@@ -324,7 +323,7 @@ public class SelectStmt extends QueryStmt {
                             .checkTblPriv(ConnectContext.get(), tblName, PrivPredicate.SELECT)) {
                         ErrorReport.reportAnalysisException(ErrorCode.ERR_TABLEACCESS_DENIED_ERROR, "SELECT",
                                 ConnectContext.get().getQualifiedUser(), ConnectContext.get().getRemoteIP(),
-                                dbName + ": " + tableName);
+                                tblName.toSql());
                     }
                     tableMap.put(table.getId(), table);
                 }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/SelectStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/SelectStmt.java
@@ -304,6 +304,7 @@ public class SelectStmt extends QueryStmt {
                         tblFuncRef.getTableFunction().getTable());
             } else {
                 TableName tblName = tblRef.getName();
+                // Must anylyze first to get real catalog/db/table name
                 tblName.analyze(analyzer);
                 String dbName = tblName.getDb();
                 String tableName = tblName.getTbl();

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/SlotRef.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/SlotRef.java
@@ -432,8 +432,7 @@ public class SlotRef extends Expr {
 
     public void readFields(DataInput in) throws IOException {
         if (in.readBoolean()) {
-            tblName = new TableName();
-            tblName.readFields(in);
+            tblName = TableName.read(in);
         }
         col = Text.readString(in);
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/TableName.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/TableName.java
@@ -51,6 +51,7 @@ public class TableName implements Writable {
     @SerializedName(value = "db")
     private String db;
     private Level level;
+    private boolean isAnalyzed = false;
 
     private TableName() {
 
@@ -91,6 +92,9 @@ public class TableName implements Writable {
     // 3. ctl.db.tbl: Will use sepcific ctalog and db
     // 4. __ctl__db.tbl: If flattenCatalog is enabled, parse and use specific catalog and db
     public void analyze(Analyzer analyzer) throws AnalysisException {
+        if (isAnalyzed) {
+            return;
+        }
         if (level == Level.NONE) {
             throw new AnalysisException("Empty table name");
         }
@@ -112,6 +116,7 @@ public class TableName implements Writable {
         if (ctl.equals(InternalCatalog.INTERNAL_CATALOG_NAME)) {
             db = ClusterNamespace.getFullName(analyzer.getClusterName(), db);
         }
+        isAnalyzed = true;
     }
 
     public String getCtl() {

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/TableName.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/TableName.java
@@ -60,9 +60,9 @@ public class TableName implements Writable {
 
     private enum Level {
         NONE,
-        ONE,
-        TWO,
-        THREE
+        ONE,    // tbl
+        TWO,    // db.tbl
+        THREE   // ctl.db.tbl
     }
 
     public TableName(String ctl, String db, String tbl) {
@@ -91,7 +91,7 @@ public class TableName implements Writable {
     // 1. tbl: Will use default catalog and db
     // 2. db.tbl: Will use default catalog and specific db
     // 3. ctl.db.tbl: Will use sepcific ctalog and db
-    // 4. __ctl__db.tbl: If flattenCatalog is enabled, parse and use specific catalog and db
+    // 4. __ctl__db.tbl: flattened catalog_db, parse and use specific catalog and db
     public void analyze(Analyzer analyzer) throws AnalysisException {
         if (isAnalyzed) {
             return;

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/TableName.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/TableName.java
@@ -21,6 +21,7 @@
 package org.apache.doris.analysis;
 
 import org.apache.doris.catalog.Env;
+import org.apache.doris.catalog.InfoSchemaDb;
 import org.apache.doris.cluster.ClusterNamespace;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.ErrorCode;
@@ -113,6 +114,12 @@ public class TableName implements Writable {
                 ErrorReport.reportAnalysisException(ErrorCode.ERR_NO_DB_ERROR);
             }
         }
+
+        if (db.equalsIgnoreCase(InfoSchemaDb.DATABASE_NAME)) {
+            // There is only one information_schema db which exit in internal catalog.
+            ctl = InternalCatalog.INTERNAL_CATALOG_NAME;
+        }
+
         if (ctl.equals(InternalCatalog.INTERNAL_CATALOG_NAME)) {
             db = ClusterNamespace.getFullName(analyzer.getClusterName(), db);
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/TableRef.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/TableRef.java
@@ -832,8 +832,7 @@ public class TableRef implements ParseNode, Writable {
     }
 
     public void readFields(DataInput in) throws IOException {
-        name = new TableName();
-        name.readFields(in);
+        name = TableName.read(in);
         if (in.readBoolean()) {
             partitionNames = PartitionNames.read(in);
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/UseStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/UseStmt.java
@@ -79,10 +79,10 @@ public class UseStmt extends StatementBase {
             ErrorReport.reportAnalysisException(ErrorCode.ERR_NO_DB_ERROR);
         }
 
-        // We support 2 formats:
-        // 1. use db: use default catalog in context and the specific db
-        // 2. use catalog.db: use specific catalog and db
-        // 3. use __catalog__db: when flattenCatalog is enabled, parse and use specific catalog and db
+        // We support following formats:
+        // 1. use db: Will use default catalog in context and the specific db
+        // 2. use catalog.db: Will use specific catalog and db
+        // 3. use __catalog__db: flattened catalog_db, will parse and use specific catalog and db
         if (Strings.isNullOrEmpty(catalogName)) {
             Pair<String, String> ctlDb = CatalogFlattenUtils.analyzeFlattenName(database);
             catalogName = ctlDb.first;

--- a/fe/fe-core/src/main/java/org/apache/doris/common/FeNameFormat.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/FeNameFormat.java
@@ -128,6 +128,15 @@ public class FeNameFormat {
         }
     }
 
+    /**
+     * Check catalog's name.
+     * Do not allow "__" in name, because we need to support flattened catalog name like: __catalog__db,
+     * so that we can parse it and extract catalog and database name.
+     *
+     * @param type
+     * @param name
+     * @throws AnalysisException
+     */
     public static void checkCatalogName(String type, String name) throws AnalysisException {
         if (Strings.isNullOrEmpty(name) || !name.matches(COMMON_NAME_REGEX) || name.contains(DOUBLE_UNDERLINE)) {
             ErrorReport.reportAnalysisException(ErrorCode.ERR_WRONG_NAME_FORMAT, type, name);

--- a/fe/fe-core/src/main/java/org/apache/doris/common/FeNameFormat.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/FeNameFormat.java
@@ -34,6 +34,8 @@ public class FeNameFormat {
 
     public static final String FORBIDDEN_PARTITION_NAME = "placeholder_";
 
+    public static final String DOUBLE_UNDERLINE = "__";
+
     public static void checkClusterName(String clusterName) throws AnalysisException {
         if (Strings.isNullOrEmpty(clusterName) || !clusterName.matches(COMMON_NAME_REGEX)) {
             ErrorReport.reportAnalysisException(ErrorCode.ERR_WRONG_CLUSTER_NAME, clusterName);
@@ -122,6 +124,12 @@ public class FeNameFormat {
 
     public static void checkCommonName(String type, String name) throws AnalysisException {
         if (Strings.isNullOrEmpty(name) || !name.matches(COMMON_NAME_REGEX)) {
+            ErrorReport.reportAnalysisException(ErrorCode.ERR_WRONG_NAME_FORMAT, type, name);
+        }
+    }
+
+    public static void checkCatalogName(String type, String name) throws AnalysisException {
+        if (Strings.isNullOrEmpty(name) || !name.matches(COMMON_NAME_REGEX) || name.contains(DOUBLE_UNDERLINE)) {
             ErrorReport.reportAnalysisException(ErrorCode.ERR_WRONG_NAME_FORMAT, type, name);
         }
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/Util.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/Util.java
@@ -489,7 +489,7 @@ public class Util {
         }
 
         if (!catalog.equals(InternalCatalog.INTERNAL_CATALOG_NAME)) {
-            FeNameFormat.checkCommonName("catalog", catalog);
+            FeNameFormat.checkCatalogName("catalog", catalog);
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/CatalogFlattenUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/CatalogFlattenUtils.java
@@ -34,6 +34,7 @@ public class CatalogFlattenUtils {
     public static Pair<String, String> analyzeFlattenName(String name) {
         String[] nameParts = name.split("\\.");
         if (nameParts.length == 1) {
+            // db or __catalog__db
             if (!name.startsWith(FLATTEN_SEPARATOR)) {
                 String ctl = null;
                 if (ConnectContext.get() != null) {
@@ -51,6 +52,7 @@ public class CatalogFlattenUtils {
             String db = name.substring(idx + FLATTEN_SEPARATOR.length());
             return Pair.of(ctl, db);
         } else if (nameParts.length == 2) {
+            // catalog.db
             return Pair.of(nameParts[0], nameParts[1]);
         } else {
             throw new RuntimeException("invalid flatten name: " + name);

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/CatalogFlattenUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/CatalogFlattenUtils.java
@@ -1,0 +1,58 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.datasource;
+
+import org.apache.doris.common.Pair;
+import org.apache.doris.qe.ConnectContext;
+
+import com.google.common.base.Strings;
+
+public class CatalogFlattenUtils {
+    // __catalog_name__db_name
+    public static final String FLATTEN_SEPARATOR = "__";
+
+    public static Pair<String, String> analyzeFlattenName(String name) {
+        if (!name.startsWith(FLATTEN_SEPARATOR)) {
+            String ctl = null;
+            if (ConnectContext.get() != null) {
+                ctl = ConnectContext.get().getDefaultCatalog();
+            }
+            ctl = Strings.isNullOrEmpty(ctl) ? InternalCatalog.INTERNAL_CATALOG_NAME : ctl;
+            return Pair.of(Strings.nullToEmpty(ctl), name);
+        }
+        int idx = name.indexOf(FLATTEN_SEPARATOR, FLATTEN_SEPARATOR.length());
+        if (idx == -1) {
+            throw new RuntimeException("invalid flatten name: " + name);
+        }
+        String ctl = name.substring(FLATTEN_SEPARATOR.length(), idx);
+        String db = name.substring(idx + FLATTEN_SEPARATOR.length());
+        return Pair.of(ctl, db);
+    }
+
+    public static String flatten(String ctl, String db) {
+        return FLATTEN_SEPARATOR + ctl + FLATTEN_SEPARATOR + db;
+    }
+
+    public static boolean isFlattenCatalogEnabled() {
+        ConnectContext connectContext = ConnectContext.get();
+        if (connectContext == null) {
+            return false;
+        }
+        return connectContext.getSessionVariable().flattenCatalog;
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/CatalogFlattenUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/CatalogFlattenUtils.java
@@ -23,25 +23,38 @@ import org.apache.doris.qe.ConnectContext;
 import com.google.common.base.Strings;
 
 public class CatalogFlattenUtils {
-    // __catalog_name__db_name
     public static final String FLATTEN_SEPARATOR = "__";
 
+    /**
+     * @param name 1. db
+     * 2. catalog.db
+     * 3. __catalog__db
+     * @return Pair<catalog, db>
+     */
     public static Pair<String, String> analyzeFlattenName(String name) {
-        if (!name.startsWith(FLATTEN_SEPARATOR)) {
-            String ctl = null;
-            if (ConnectContext.get() != null) {
-                ctl = ConnectContext.get().getDefaultCatalog();
+        String[] nameParts = name.split("\\.");
+        if (nameParts.length == 1) {
+            if (!name.startsWith(FLATTEN_SEPARATOR)) {
+                String ctl = null;
+                if (ConnectContext.get() != null) {
+                    ctl = ConnectContext.get().getDefaultCatalog();
+                }
+                ctl = Strings.isNullOrEmpty(ctl) ? InternalCatalog.INTERNAL_CATALOG_NAME : ctl;
+                return Pair.of(ctl, name);
             }
-            ctl = Strings.isNullOrEmpty(ctl) ? InternalCatalog.INTERNAL_CATALOG_NAME : ctl;
-            return Pair.of(Strings.nullToEmpty(ctl), name);
-        }
-        int idx = name.indexOf(FLATTEN_SEPARATOR, FLATTEN_SEPARATOR.length());
-        if (idx == -1) {
+            int idx = name.indexOf(FLATTEN_SEPARATOR, FLATTEN_SEPARATOR.length());
+            if (idx == -1 || idx == 2) {
+                // idx == 2 means "____"
+                throw new RuntimeException("invalid flatten name: " + name);
+            }
+            String ctl = name.substring(FLATTEN_SEPARATOR.length(), idx);
+            String db = name.substring(idx + FLATTEN_SEPARATOR.length());
+            return Pair.of(ctl, db);
+        } else if (nameParts.length == 2) {
+            return Pair.of(nameParts[0], nameParts[1]);
+        } else {
             throw new RuntimeException("invalid flatten name: " + name);
         }
-        String ctl = name.substring(FLATTEN_SEPARATOR.length(), idx);
-        String db = name.substring(idx + FLATTEN_SEPARATOR.length());
-        return Pair.of(ctl, db);
     }
 
     public static String flatten(String ctl, String db) {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/CatalogFlattenUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/CatalogFlattenUtils.java
@@ -62,12 +62,4 @@ public class CatalogFlattenUtils {
     public static String flatten(String ctl, String db) {
         return FLATTEN_SEPARATOR + ctl + FLATTEN_SEPARATOR + db;
     }
-
-    public static boolean isFlattenCatalogEnabled() {
-        ConnectContext connectContext = ConnectContext.get();
-        if (connectContext == null) {
-            return false;
-        }
-        return connectContext.getSessionVariable().flattenCatalog;
-    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/load/ExportJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/ExportJob.java
@@ -845,8 +845,7 @@ public class ExportJob implements Writable {
             brokerDesc = BrokerDesc.read(in);
         }
 
-        tableName = new TableName();
-        tableName.readFields(in);
+        tableName = TableName.read(in);
         origStmt = OriginStatement.read(in);
         int size = in.readInt();
         for (int i = 0; i < size; i++) {

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/MysqlProto.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/MysqlProto.java
@@ -279,7 +279,7 @@ public class MysqlProto {
             Pair<String, String> ctlDb = CatalogFlattenUtils.analyzeFlattenName(db);
             try {
                 Env.getCurrentEnv().changeCatalog(context, ctlDb.first);
-                String dbFullName = ClusterNamespace.getFullName(context.getClusterName(), db);
+                String dbFullName = ClusterNamespace.getFullName(context.getClusterName(), ctlDb.second);
                 Env.getCurrentEnv().changeDb(context, dbFullName);
             } catch (DdlException e) {
                 context.getState().setError(e.getMysqlErrorCode(), e.getMessage());

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/MysqlProto.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/MysqlProto.java
@@ -25,6 +25,8 @@ import org.apache.doris.common.DdlException;
 import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.ErrorReport;
 import org.apache.doris.common.LdapConfig;
+import org.apache.doris.common.Pair;
+import org.apache.doris.datasource.CatalogFlattenUtils;
 import org.apache.doris.ldap.LdapAuthenticate;
 import org.apache.doris.mysql.privilege.PaloAuth;
 import org.apache.doris.mysql.privilege.UserResource;
@@ -274,7 +276,9 @@ public class MysqlProto {
         // set database
         String db = authPacket.getDb();
         if (!Strings.isNullOrEmpty(db)) {
+            Pair<String, String> ctlDb = CatalogFlattenUtils.analyzeFlattenName(db);
             try {
+                Env.getCurrentEnv().changeCatalog(context, ctlDb.first);
                 String dbFullName = ClusterNamespace.getFullName(context.getClusterName(), db);
                 Env.getCurrentEnv().changeDb(context, dbFullName);
             } catch (DdlException e) {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectProcessor.java
@@ -119,7 +119,6 @@ public class ConnectProcessor {
         }
 
         Pair<String, String> ctlDb = CatalogFlattenUtils.analyzeFlattenName(fullDbName);
-
         String catalogName = ctlDb.first;
         String dbName = ctlDb.second;
         dbName = ClusterNamespace.getFullName(ctx.getClusterName(), dbName);

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectProcessor.java
@@ -41,6 +41,7 @@ import org.apache.doris.common.UserException;
 import org.apache.doris.common.telemetry.Telemetry;
 import org.apache.doris.common.util.DebugUtil;
 import org.apache.doris.common.util.SqlParserUtils;
+import org.apache.doris.datasource.CatalogFlattenUtils;
 import org.apache.doris.datasource.CatalogIf;
 import org.apache.doris.metric.MetricRepo;
 import org.apache.doris.mysql.MysqlChannel;
@@ -116,18 +117,11 @@ public class ConnectProcessor {
             ctx.getState().setError(ErrorCode.ERR_CLUSTER_NAME_NULL, "Please enter cluster");
             return;
         }
-        String catalogName = null;
-        String dbName = null;
-        String[] dbNames = fullDbName.split("\\.");
-        if (dbNames.length == 1) {
-            dbName = fullDbName;
-        } else if (dbNames.length == 2) {
-            catalogName = dbNames[0];
-            dbName = dbNames[1];
-        } else if (dbNames.length > 2) {
-            ctx.getState().setError(ErrorCode.ERR_BAD_DB_ERROR, "Only one dot can be in the name: " + fullDbName);
-            return;
-        }
+
+        Pair<String, String> ctlDb = CatalogFlattenUtils.analyzeFlattenName(fullDbName);
+
+        String catalogName = ctlDb.first;
+        String dbName = ctlDb.second;
         dbName = ClusterNamespace.getFullName(ctx.getClusterName(), dbName);
 
         // check catalog and db exists

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/QueryDetail.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/QueryDetail.java
@@ -17,6 +17,8 @@
 
 package org.apache.doris.qe;
 
+import org.apache.doris.cluster.ClusterNamespace;
+
 public class QueryDetail {
     public enum QueryMemState {
         RUNNING,
@@ -54,12 +56,7 @@ public class QueryDetail {
         this.endTime = endTime;
         this.latency = latency;
         this.state = state;
-        if (database.equals("")) {
-            this.database = "";
-        } else {
-            String[] stringPieces = database.split(":", -1);
-            this.database = stringPieces[1]; // eliminate cluster name
-        }
+        this.database = ClusterNamespace.getNameFromFullName(database);
         this.sql = sql;
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -220,7 +220,7 @@ public class SessionVariable implements Serializable, Writable {
     public static final String SKIP_DELETE_PREDICATE = "skip_delete_predicate";
 
     public static final String ENABLE_NEW_SHUFFLE_HASH_METHOD = "enable_new_shuffle_hash_method";
-    
+
     // session origin value
     public Map<Field, String> sessionOriginValue = new HashMap<Field, String>();
     // check stmt is or not [select /*+ SET_VAR(...)*/ ...]

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -221,6 +221,8 @@ public class SessionVariable implements Serializable, Writable {
 
     public static final String ENABLE_NEW_SHUFFLE_HASH_METHOD = "enable_new_shuffle_hash_method";
 
+    public static final String FLATTEN_CATALOG = "flatten_catalog";
+
     // session origin value
     public Map<Field, String> sessionOriginValue = new HashMap<Field, String>();
     // check stmt is or not [select /*+ SET_VAR(...)*/ ...]
@@ -564,6 +566,9 @@ public class SessionVariable implements Serializable, Writable {
 
     @VariableMgr.VarAttr(name = ENABLE_NEW_SHUFFLE_HASH_METHOD)
     public boolean enableNewShffleHashMethod = true;
+
+    @VariableMgr.VarAttr(name = FLATTEN_CATALOG)
+    public boolean flattenCatalog = false;
 
     public String getBlockEncryptionMode() {
         return blockEncryptionMode;

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -220,9 +220,7 @@ public class SessionVariable implements Serializable, Writable {
     public static final String SKIP_DELETE_PREDICATE = "skip_delete_predicate";
 
     public static final String ENABLE_NEW_SHUFFLE_HASH_METHOD = "enable_new_shuffle_hash_method";
-
-    public static final String FLATTEN_CATALOG = "flatten_catalog";
-
+    
     // session origin value
     public Map<Field, String> sessionOriginValue = new HashMap<Field, String>();
     // check stmt is or not [select /*+ SET_VAR(...)*/ ...]
@@ -566,9 +564,6 @@ public class SessionVariable implements Serializable, Writable {
 
     @VariableMgr.VarAttr(name = ENABLE_NEW_SHUFFLE_HASH_METHOD)
     public boolean enableNewShffleHashMethod = true;
-
-    @VariableMgr.VarAttr(name = FLATTEN_CATALOG)
-    public boolean flattenCatalog = false;
 
     public String getBlockEncryptionMode() {
         return blockEncryptionMode;

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/AccessTestUtil.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/AccessTestUtil.java
@@ -144,18 +144,22 @@ public class AccessTestUtil {
                 }
             };
 
-            CatalogMgr dsMgr = new CatalogMgr();
-            new Expectations(dsMgr) {
+            CatalogMgr catalogMgr = new CatalogMgr();
+            new Expectations(catalogMgr) {
                 {
-                    dsMgr.getCatalog((String) any);
+                    catalogMgr.getCatalog((String) any);
                     minTimes = 0;
                     result = catalog;
 
-                    dsMgr.getCatalogOrException((String) any, (Function) any);
+                    catalogMgr.getCatalogNullable((String) any);
                     minTimes = 0;
                     result = catalog;
 
-                    dsMgr.getCatalogOrAnalysisException((String) any);
+                    catalogMgr.getCatalogOrException((String) any, (Function) any);
+                    minTimes = 0;
+                    result = catalog;
+
+                    catalogMgr.getCatalogOrAnalysisException((String) any);
                     minTimes = 0;
                     result = catalog;
                 }
@@ -200,7 +204,7 @@ public class AccessTestUtil {
 
                     env.getCatalogMgr();
                     minTimes = 0;
-                    result = dsMgr;
+                    result = catalogMgr;
                 }
             };
             return env;

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/CancelAlterStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/CancelAlterStmtTest.java
@@ -25,6 +25,7 @@ import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.UserException;
 import org.apache.doris.datasource.InternalCatalog;
 import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.system.SystemInfoService;
 
 import mockit.Expectations;
 import mockit.Mock;
@@ -59,6 +60,10 @@ public class CancelAlterStmtTest {
                 analyzer.getQualifiedUser();
                 minTimes = 0;
                 result = "testUser";
+
+                analyzer.getClusterName();
+                minTimes = 0;
+                result = SystemInfoService.DEFAULT_CLUSTER;
             }
         };
 
@@ -76,18 +81,18 @@ public class CancelAlterStmtTest {
         FakeEnv.setEnv(env);
         // cancel alter column
         CancelAlterTableStmt stmt = new CancelAlterTableStmt(AlterType.COLUMN,
-                new TableName(InternalCatalog.INTERNAL_CATALOG_NAME, null, "testTbl"));
+                new TableName(InternalCatalog.INTERNAL_CATALOG_NAME, "testDb", "testTbl"));
         stmt.analyze(analyzer);
-        Assert.assertEquals("CANCEL ALTER COLUMN FROM `testDb`.`testTbl`", stmt.toString());
-        Assert.assertEquals("testDb", stmt.getDbName());
+        Assert.assertEquals("CANCEL ALTER COLUMN FROM `default_cluster:testDb`.`testTbl`", stmt.toString());
+        Assert.assertEquals("default_cluster:testDb", stmt.getDbName());
         Assert.assertEquals(AlterType.COLUMN, stmt.getAlterType());
         Assert.assertEquals("testTbl", stmt.getTableName());
 
         stmt = new CancelAlterTableStmt(AlterType.ROLLUP,
-                new TableName(InternalCatalog.INTERNAL_CATALOG_NAME, null, "testTbl"));
+                new TableName(InternalCatalog.INTERNAL_CATALOG_NAME, "testDb", "testTbl"));
         stmt.analyze(analyzer);
-        Assert.assertEquals("CANCEL ALTER ROLLUP FROM `testDb`.`testTbl`", stmt.toString());
-        Assert.assertEquals("testDb", stmt.getDbName());
+        Assert.assertEquals("CANCEL ALTER ROLLUP FROM `default_cluster:testDb`.`testTbl`", stmt.toString());
+        Assert.assertEquals("default_cluster:testDb", stmt.getDbName());
         Assert.assertEquals(AlterType.ROLLUP, stmt.getAlterType());
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/CreateTableStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/CreateTableStmtTest.java
@@ -79,7 +79,7 @@ public class CreateTableStmtTest {
         analyzer = AccessTestUtil.fetchAdminAnalyzer(false);
         // table name
         tblName = new TableName(InternalCatalog.INTERNAL_CATALOG_NAME, "db1", "table1");
-        tblNameNoDb = new TableName(InternalCatalog.INTERNAL_CATALOG_NAME, "", "table1");
+        tblNameNoDb = new TableName("", "", "table1");
         // col
         cols = Lists.newArrayList();
         cols.add(new ColumnDef("col1", new TypeDef(ScalarType.createType(PrimitiveType.INT))));
@@ -190,7 +190,7 @@ public class CreateTableStmtTest {
                 new KeysDesc(KeysType.AGG_KEYS, colsName), null,
                 new HashDistributionDesc(10, Lists.newArrayList("col1")), null, null, "");
         stmt.analyze(analyzer);
-        Assert.assertEquals("testDb", stmt.getDbName());
+        Assert.assertEquals("testCluster:testDb", stmt.getDbName());
         Assert.assertEquals("table1", stmt.getTableName());
         Assert.assertNull(stmt.getPartitionDesc());
         Assert.assertNull(stmt.getProperties());

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/DropTableStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/DropTableStmtTest.java
@@ -47,7 +47,7 @@ public class DropTableStmtTest {
     @Before
     public void setUp() {
         tbl = new TableName(internalCtl, "db1", "table1");
-        noDbTbl = new TableName(internalCtl, "", "table1");
+        noDbTbl = new TableName("", "", "table1");
         analyzer = AccessTestUtil.fetchAdminAnalyzer(true);
 
         new Expectations() {
@@ -94,12 +94,4 @@ public class DropTableStmtTest {
         stmt.analyze(noDbAnalyzer);
         Assert.fail("No Exception throws.");
     }
-
-    @Test(expected = AnalysisException.class)
-    public void testNoTableFail() throws UserException, AnalysisException {
-        DropTableStmt stmt = new DropTableStmt(false, new TableName(internalCtl, "db1", ""), true);
-        stmt.analyze(noDbAnalyzer);
-        Assert.fail("No Exception throws.");
-    }
-
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/ShowIndexStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/ShowIndexStmtTest.java
@@ -47,15 +47,18 @@ public class ShowIndexStmtTest {
 
     @Test
     public void testNormal() throws UserException {
-        ShowIndexStmt stmt = new ShowIndexStmt("testDb", new TableName(internalCtl, "testDb", "testTbl"));
+        ShowIndexStmt stmt = new ShowIndexStmt("testDb", new TableName("", "", "testTbl"));
         stmt.analyze(analyzer);
         Assert.assertEquals("SHOW INDEX FROM `testCluster:testDb`.`testTbl`", stmt.toSql());
-        stmt = new ShowIndexStmt("", new TableName(internalCtl, "", "testTbl"));
+
+        stmt = new ShowIndexStmt("", new TableName(internalCtl, "testDb", "testTbl"));
         stmt.analyze(analyzer);
         Assert.assertEquals("SHOW INDEX FROM `testCluster:testDb`.`testTbl`", stmt.toSql());
+
         stmt = new ShowIndexStmt(null, new TableName(internalCtl, "testDb", "testTbl"));
         stmt.analyze(analyzer);
         Assert.assertEquals("SHOW INDEX FROM `testCluster:testDb`.`testTbl`", stmt.toSql());
+
         stmt = new ShowIndexStmt("testDb", new TableName(internalCtl, "testDb2", "testTbl"));
         stmt.analyze(analyzer);
         Assert.assertEquals("SHOW INDEX FROM `testCluster:testDb`.`testTbl`", stmt.toSql());

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/ShowIndexStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/ShowIndexStmtTest.java
@@ -17,7 +17,6 @@
 
 package org.apache.doris.analysis;
 
-import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.UserException;
 import org.apache.doris.datasource.InternalCatalog;
 import org.apache.doris.mysql.privilege.MockedAuth;
@@ -48,7 +47,7 @@ public class ShowIndexStmtTest {
 
     @Test
     public void testNormal() throws UserException {
-        ShowIndexStmt stmt = new ShowIndexStmt("testDb", new TableName(internalCtl, "", "testTbl"));
+        ShowIndexStmt stmt = new ShowIndexStmt("testDb", new TableName(internalCtl, "testDb", "testTbl"));
         stmt.analyze(analyzer);
         Assert.assertEquals("SHOW INDEX FROM `testCluster:testDb`.`testTbl`", stmt.toSql());
         stmt = new ShowIndexStmt("", new TableName(internalCtl, "", "testTbl"));
@@ -60,11 +59,5 @@ public class ShowIndexStmtTest {
         stmt = new ShowIndexStmt("testDb", new TableName(internalCtl, "testDb2", "testTbl"));
         stmt.analyze(analyzer);
         Assert.assertEquals("SHOW INDEX FROM `testCluster:testDb`.`testTbl`", stmt.toSql());
-    }
-
-    @Test(expected = AnalysisException.class)
-    public void testNoTbl() throws UserException {
-        ShowIndexStmt stmt = new ShowIndexStmt("testDb", new TableName(internalCtl, "", ""));
-        stmt.analyze(analyzer);
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/ShowRollupStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/ShowRollupStmtTest.java
@@ -36,7 +36,7 @@ public class ShowRollupStmtTest {
     @Test
     public void testNormal() throws AnalysisException {
         // use default database
-        ShowRollupStmt stmt = new ShowRollupStmt(new TableName(internalCtl, "", "tbl"), "");
+        ShowRollupStmt stmt = new ShowRollupStmt(new TableName("", "", "tbl"), "");
         stmt.analyze(analyzer);
         Assert.assertEquals("testCluster:testDb", stmt.getDb());
         Assert.assertEquals("tbl", stmt.getTbl());
@@ -55,13 +55,5 @@ public class ShowRollupStmtTest {
         Assert.assertEquals("testCluster:testDb2", stmt.getDb());
         Assert.assertEquals("tbl", stmt.getTbl());
         Assert.assertEquals("SHOW ROLLUP FROM `testCluster:testDb2`.`tbl`", stmt.toString());
-    }
-
-    @Test(expected = AnalysisException.class)
-    public void testNoTbl() throws AnalysisException {
-        // use default database
-        ShowRollupStmt stmt = new ShowRollupStmt(new TableName(internalCtl, "testDb", ""), "");
-        stmt.analyze(analyzer);
-        Assert.fail("No exception throws.");
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/ShowViewStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/ShowViewStmtTest.java
@@ -111,7 +111,7 @@ public class ShowViewStmtTest {
     @Test(expected = UserException.class)
     public void testNoDb() throws Exception {
         ConnectContext ctx = UtFrameUtils.createDefaultCtx();
-        ShowViewStmt stmt = new ShowViewStmt("", new TableName(internalCtl, "", "testTbl"));
+        ShowViewStmt stmt = new ShowViewStmt("", new TableName("", "", "testTbl"));
         stmt.analyze(new Analyzer(ctx.getEnv(), ctx));
         Assert.fail();
     }

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/UseStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/UseStmtTest.java
@@ -48,7 +48,7 @@ public class UseStmtTest {
         UseStmt stmt = new UseStmt("testDb");
         stmt.analyze(analyzer);
 
-        Assert.assertEquals("USE `testCluster:testDb`", stmt.toString());
+        Assert.assertEquals("USE `internal`.`testCluster:testDb`", stmt.toString());
         Assert.assertEquals("testCluster:testDb", stmt.getDatabase());
     }
 
@@ -60,13 +60,12 @@ public class UseStmtTest {
         Assert.fail("No exception throws.");
     }
 
-
     @Test
     public void testFromCatalog() throws UserException, AnalysisException {
         UseStmt stmt = new UseStmt("cn", "testDb");
         stmt.analyze(analyzer);
-        Assert.assertEquals("USE `cn`.`testCluster:testDb`", stmt.toString());
-        Assert.assertEquals("testCluster:testDb", stmt.getDatabase());
+        Assert.assertEquals("USE `cn`.`testDb`", stmt.toString());
+        Assert.assertEquals("testDb", stmt.getDatabase());
         Assert.assertEquals("cn", stmt.getCatalogName());
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/FlattenCatalogTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/FlattenCatalogTest.java
@@ -108,9 +108,13 @@ public class FlattenCatalogTest {
         Assert.assertEquals("db1", res.second);
 
         String name2 = "__db1";
-        ExceptionChecker.expectThrowsWithMsg(RuntimeException.class, "invalid flatten name", ()->{CatalogFlattenUtils.analyzeFlattenName(name2);});
+        ExceptionChecker.expectThrowsWithMsg(RuntimeException.class, "invalid flatten name", () -> {
+            CatalogFlattenUtils.analyzeFlattenName(name2);
+        });
 
         String name3 = "__hive_db1";
-        ExceptionChecker.expectThrowsWithMsg(RuntimeException.class, "invalid flatten name", ()->{CatalogFlattenUtils.analyzeFlattenName(name3);});
+        ExceptionChecker.expectThrowsWithMsg(RuntimeException.class, "invalid flatten name", () -> {
+            CatalogFlattenUtils.analyzeFlattenName(name3);
+        });
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/FlattenCatalogTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/FlattenCatalogTest.java
@@ -1,0 +1,116 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.datasource;
+
+import org.apache.doris.analysis.Analyzer;
+import org.apache.doris.analysis.TableName;
+import org.apache.doris.cluster.ClusterNamespace;
+import org.apache.doris.common.Config;
+import org.apache.doris.common.ExceptionChecker;
+import org.apache.doris.common.FeConstants;
+import org.apache.doris.common.Pair;
+import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.system.SystemInfoService;
+
+import mockit.Expectations;
+import mockit.Mocked;
+import org.junit.Assert;
+import org.junit.jupiter.api.Test;
+
+public class FlattenCatalogTest {
+
+    private static final String CTL = "hive";
+    private static final String DB = "db1";
+    private static final String TBL = "tbl1";
+
+    @Test
+    protected void testTableName(@Mocked Analyzer analyzer) throws Exception {
+        Config.enable_multi_catalog = true;
+        FeConstants.runningUnitTest = true;
+
+        new Expectations() {
+            {
+                analyzer.getDefaultCatalog();
+                minTimes = 0;
+                result = InternalCatalog.INTERNAL_CATALOG_NAME;
+                analyzer.getDefaultDb();
+                minTimes = 0;
+                result = DB;
+                analyzer.getClusterName();
+                minTimes = 0;
+                result = SystemInfoService.DEFAULT_CLUSTER;
+            }
+        };
+
+        // tbl
+        TableName name = new TableName(null, null, TBL);
+        name.analyze(analyzer);
+        Assert.assertEquals(InternalCatalog.INTERNAL_CATALOG_NAME, name.getCtl());
+        Assert.assertEquals(ClusterNamespace.getFullName(SystemInfoService.DEFAULT_CLUSTER, DB), name.getDb());
+        Assert.assertEquals(TBL, name.getTbl());
+
+        // db.tbl
+        name = new TableName(null, DB, TBL);
+        name.analyze(analyzer);
+        Assert.assertEquals(InternalCatalog.INTERNAL_CATALOG_NAME, name.getCtl());
+        Assert.assertEquals(ClusterNamespace.getFullName(SystemInfoService.DEFAULT_CLUSTER, DB), name.getDb());
+        Assert.assertEquals(TBL, name.getTbl());
+
+        name = new TableName(null, CatalogFlattenUtils.flatten(CTL, DB), TBL);
+        name.analyze(analyzer);
+        Assert.assertEquals(CTL, name.getCtl());
+        Assert.assertEquals(DB, name.getDb());
+        Assert.assertEquals(TBL, name.getTbl());
+
+        name = new TableName(CTL, DB, TBL);
+        name.analyze(analyzer);
+        Assert.assertEquals(CTL, name.getCtl());
+        Assert.assertEquals(DB, name.getDb());
+        Assert.assertEquals(TBL, name.getTbl());
+    }
+
+    @Test
+    protected void testFlattenUtil(@Mocked ConnectContext ctx) throws Exception {
+        new Expectations() {
+            {
+                ConnectContext.get();
+                minTimes = 0;
+                result = ctx;
+                ctx.getDefaultCatalog();
+                minTimes = 0;
+                result = InternalCatalog.INTERNAL_CATALOG_NAME;
+            }
+        };
+
+        String name = "db1";
+        Pair<String, String> res = CatalogFlattenUtils.analyzeFlattenName(name);
+        Assert.assertEquals(InternalCatalog.INTERNAL_CATALOG_NAME, res.first);
+        Assert.assertEquals("db1", res.second);
+
+        name = "__hive__db1";
+        res = CatalogFlattenUtils.analyzeFlattenName(name);
+        Assert.assertEquals("hive", res.first);
+        Assert.assertEquals("db1", res.second);
+
+        String name2 = "__db1";
+        ExceptionChecker.expectThrowsWithMsg(RuntimeException.class, "invalid flatten name", ()->{CatalogFlattenUtils.analyzeFlattenName(name2);});
+
+        String name3 = "__hive_db1";
+        ExceptionChecker.expectThrowsWithMsg(RuntimeException.class, "invalid flatten name", ()->{CatalogFlattenUtils.analyzeFlattenName(name3);});
+    }
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/FlattenCatalogTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/FlattenCatalogTest.java
@@ -107,6 +107,11 @@ public class FlattenCatalogTest {
         Assert.assertEquals("hive", res.first);
         Assert.assertEquals("db1", res.second);
 
+        name = "hive.db1";
+        res = CatalogFlattenUtils.analyzeFlattenName(name);
+        Assert.assertEquals("hive", res.first);
+        Assert.assertEquals("db1", res.second);
+
         String name2 = "__db1";
         ExceptionChecker.expectThrowsWithMsg(RuntimeException.class, "invalid flatten name", () -> {
             CatalogFlattenUtils.analyzeFlattenName(name2);

--- a/fe/fe-core/src/test/java/org/apache/doris/mysql/MysqlProtoTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/mysql/MysqlProtoTest.java
@@ -99,6 +99,9 @@ public class MysqlProtoTest {
 
                 env.changeDb((ConnectContext) any, anyString);
                 minTimes = 0;
+
+                env.changeCatalog((ConnectContext) any, anyString);
+                minTimes = 0;
             }
         };
 

--- a/fe/fe-core/src/test/java/org/apache/doris/mysql/privilege/MockedAuth.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/mysql/privilege/MockedAuth.java
@@ -31,7 +31,7 @@ public class MockedAuth {
                 auth.checkGlobalPriv((ConnectContext) any, (PrivPredicate) any);
                 minTimes = 0;
                 result = true;
-                
+
                 auth.checkCtlPriv((ConnectContext) any, anyString, (PrivPredicate) any);
                 minTimes = 0;
                 result = true;

--- a/fe/fe-core/src/test/java/org/apache/doris/mysql/privilege/MockedAuth.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/mysql/privilege/MockedAuth.java
@@ -31,6 +31,10 @@ public class MockedAuth {
                 auth.checkGlobalPriv((ConnectContext) any, (PrivPredicate) any);
                 minTimes = 0;
                 result = true;
+                
+                auth.checkCtlPriv((ConnectContext) any, anyString, (PrivPredicate) any);
+                minTimes = 0;
+                result = true;
 
                 auth.checkDbPriv((ConnectContext) any, anyString, (PrivPredicate) any);
                 minTimes = 0;

--- a/fe/fe-core/src/test/java/org/apache/doris/qe/PartitionCacheTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/qe/PartitionCacheTest.java
@@ -1170,10 +1170,10 @@ public class PartitionCacheTest {
 
             cache.rewriteSelectStmt(null);
             Assert.assertEquals(cache.getNokeyStmt().getWhereClause(), null);
-            Assert.assertEquals(cache.getSqlWithViewStmt(),
-                    "SELECT `origin`.`eventdate` AS `eventdate`, `origin`.`cnt` AS `cnt` FROM (SELECT "
+            Assert.assertEquals("SELECT `origin`.`eventdate` AS `eventdate`, `origin`.`cnt` AS `cnt` FROM (SELECT "
                             + "<slot 4> `eventdate` AS `eventdate`, <slot 5> count(`userid`) AS `cnt` FROM "
-                            + "`testDb`.`view2` GROUP BY `eventdate`) origin|select eventdate, userid FROM appevent");
+                            + "`testCluster:testDb`.`view2` GROUP BY `eventdate`) origin|select eventdate, userid FROM appevent",
+                    cache.getSqlWithViewStmt());
         } catch (Exception e) {
             LOG.warn("ex={}", e);
             Assert.fail(e.getMessage());


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

Doris is now support 3 level schema:
`Catalog -> Database -> Table`

However, when using some MySQL-compatible tools to connect to Doris,
these tools only support two-level (Database -> Table) metadata,
so the database information in the external catalog cannot be displayed.

This PR attempts to make compatibility improvements to this issue.

In normal use, when users need to switch to other catalogs, they can use the switch statement to switch, such as:
`switch hms_catalog;`

and then use the `use` statement to switch the database:
`use db;`

At the same time, we can directly use the following commands to directly switch the catalog and database:
`use __hms_catalog__db;`

Here we use `__` as a special identifier so that the system can identify and parse out the catalog name.
At the same time, we prohibit `__` in the catalog name, so as to ensure that there are no semantic errors.

This change does not require any additional configuration, and Doris will automatically perform the correct
operation based on the name.

I have tested mysql command line tool and dbeaver, which works fine with this feature.

```
$ mysql -h 127.0.0.1 -P 9030 -uroot -D__hive__tpch100;
mysql> show tables;
+-------------------+
| Tables_in_tpch100 |
+-------------------+
| customer          |
| lineitem          |
| nation            |
| orders            |
| part              |
| partsupp          |
| region            |
| supplier          |
+-------------------+
8 rows in set (0.00 sec)
```

The document will be added later with full `multi-catalog` feature.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [x] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [x] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

