### PR TITLE
[Opt](Vectorized) Support push down no grouping agg

### DIFF
--- a/be/src/olap/iterators.h
+++ b/be/src/olap/iterators.h
@@ -77,6 +77,7 @@ public:
     std::vector<ColumnPredicate*> column_predicates;
     std::unordered_map<int32_t, std::shared_ptr<AndBlockColumnPredicate>> col_id_to_predicates;
     std::unordered_map<int32_t, std::vector<const ColumnPredicate*>> col_id_to_del_predicates;
+    TPushAggOp::type push_down_agg_type_opt = TPushAggOp::NONE;
 
     // REQUIRED (null is not allowed)
     OlapReaderStatistics* stats = nullptr;

--- a/be/src/olap/reader.h
+++ b/be/src/olap/reader.h
@@ -91,6 +91,7 @@ public:
         // use only in vec exec engine
         std::vector<uint32_t>* origin_return_columns = nullptr;
         std::unordered_set<uint32_t>* tablet_columns_convert_to_null_set = nullptr;
+        TPushAggOp::type push_down_agg_type_opt = TPushAggOp::NONE;
 
         // used for comapction to record row ids
         bool record_rowids = false;

--- a/be/src/olap/rowset/beta_rowset_reader.cpp
+++ b/be/src/olap/rowset/beta_rowset_reader.cpp
@@ -49,6 +49,7 @@ Status BetaRowsetReader::init(RowsetReaderContext* read_context) {
     // convert RowsetReaderContext to StorageReadOptions
     StorageReadOptions read_options;
     read_options.stats = _stats;
+    read_options.push_down_agg_type_opt = _context->push_down_agg_type_opt;
     if (read_context->lower_bound_keys != nullptr) {
         for (int i = 0; i < read_context->lower_bound_keys->size(); ++i) {
             read_options.key_ranges.emplace_back(&read_context->lower_bound_keys->at(i),

--- a/be/src/olap/rowset/rowset_reader_context.h
+++ b/be/src/olap/rowset/rowset_reader_context.h
@@ -41,6 +41,7 @@ struct RowsetReaderContext {
     std::vector<uint32_t>* read_orderby_key_columns = nullptr;
     // projection columns: the set of columns rowset reader should return
     const std::vector<uint32_t>* return_columns = nullptr;
+    TPushAggOp::type push_down_agg_type_opt = TPushAggOp::NONE;
     // column name -> column predicate
     // adding column_name for predicate to make use of column selectivity
     const std::vector<ColumnPredicate*>* predicates = nullptr;

--- a/be/src/olap/rowset/segment_v2/column_reader.cpp
+++ b/be/src/olap/rowset/segment_v2/column_reader.cpp
@@ -191,13 +191,12 @@ Status ColumnReader::next_batch_of_zone_map(size_t* n, vectorized::MutableColumn
         }
     }
 
-
     auto size = *n - 1;
     if (min_value->is_null()) {
         assert_cast<vectorized::ColumnNullable&>(*dst).insert_null_elements(size);
     } else {
         if (is_string) {
-            auto sv = (StringValue*) min_value->cell_ptr();
+            auto sv = (StringValue*)min_value->cell_ptr();
             dst->insert_many_data(sv->ptr, sv->len, size);
         } else {
             // TODO: the work may cause performance problem, opt latter

--- a/be/src/olap/rowset/segment_v2/column_reader.h
+++ b/be/src/olap/rowset/segment_v2/column_reader.h
@@ -125,6 +125,8 @@ public:
     // Return true if segment zone map is absent or `cond' could be satisfied, false otherwise.
     bool match_condition(const AndBlockColumnPredicate* col_predicates) const;
 
+    Status next_batch_of_zone_map(size_t* n, vectorized::MutableColumnPtr& dst) const;
+
     // get row ranges with zone map
     // - cond_column is user's query predicate
     // - delete_condition is a delete predicate of one version
@@ -256,6 +258,10 @@ public:
         return Status::NotSupported("next_batch not implement");
     }
 
+    virtual Status next_batch_of_zone_map(size_t* n, vectorized::MutableColumnPtr& dst) {
+        return Status::NotSupported("next_batch_of_zone_map not implement");
+    }
+
     virtual Status read_by_rowids(const rowid_t* rowids, const size_t count,
                                   vectorized::MutableColumnPtr& dst) {
         return Status::NotSupported("read_by_rowids not implement");
@@ -298,6 +304,8 @@ public:
     Status next_batch(size_t* n, ColumnBlockView* dst, bool* has_null) override;
 
     Status next_batch(size_t* n, vectorized::MutableColumnPtr& dst, bool* has_null) override;
+
+    Status next_batch_of_zone_map(size_t* n, vectorized::MutableColumnPtr& dst) override;
 
     Status read_by_rowids(const rowid_t* rowids, const size_t count,
                           vectorized::MutableColumnPtr& dst) override;
@@ -446,6 +454,10 @@ public:
     Status next_batch(size_t* n, ColumnBlockView* dst, bool* has_null) override;
 
     Status next_batch(size_t* n, vectorized::MutableColumnPtr& dst, bool* has_null) override;
+
+    Status next_batch_of_zone_map(size_t* n, vectorized::MutableColumnPtr& dst) override {
+        return next_batch(n, dst);
+    }
 
     Status read_by_rowids(const rowid_t* rowids, const size_t count,
                           vectorized::MutableColumnPtr& dst) override;

--- a/be/src/olap/rowset/segment_v2/segment.cpp
+++ b/be/src/olap/rowset/segment_v2/segment.cpp
@@ -35,7 +35,6 @@
 #include "olap/tablet_schema.h"
 #include "util/crc32c.h"
 #include "util/slice.h" // Slice
-
 #include "vec/olap/vgeneric_iterators.h"
 
 namespace doris {
@@ -102,7 +101,8 @@ Status Segment::new_iterator(const Schema& schema, const StorageReadOptions& rea
     }
 
     RETURN_IF_ERROR(load_index());
-    if (read_options.col_id_to_del_predicates.empty() && read_options.push_down_agg_type_opt != TPushAggOp::NONE) {
+    if (read_options.col_id_to_del_predicates.empty() &&
+        read_options.push_down_agg_type_opt != TPushAggOp::NONE) {
         iter->reset(vectorized::new_vstatistics_iterator(this->shared_from_this(), schema));
     } else {
         iter->reset(new SegmentIterator(this->shared_from_this(), schema));

--- a/be/src/olap/rowset/segment_v2/segment.cpp
+++ b/be/src/olap/rowset/segment_v2/segment.cpp
@@ -36,6 +36,8 @@
 #include "util/crc32c.h"
 #include "util/slice.h" // Slice
 
+#include "vec/olap/vgeneric_iterators.h"
+
 namespace doris {
 namespace segment_v2 {
 
@@ -100,7 +102,11 @@ Status Segment::new_iterator(const Schema& schema, const StorageReadOptions& rea
     }
 
     RETURN_IF_ERROR(load_index());
-    iter->reset(new SegmentIterator(this->shared_from_this(), schema));
+    if (read_options.col_id_to_del_predicates.empty() && read_options.push_down_agg_type_opt != TPushAggOp::NONE) {
+        iter->reset(vectorized::new_vstatistics_iterator(this->shared_from_this(), schema));
+    } else {
+        iter->reset(new SegmentIterator(this->shared_from_this(), schema));
+    }
     iter->get()->init(read_options);
     return Status::OK();
 }

--- a/be/src/olap/rowset/segment_v2/segment_iterator.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.cpp
@@ -22,7 +22,6 @@
 #include <utility>
 
 #include "common/status.h"
-#include "gutil/strings/substitute.h"
 #include "olap/column_predicate.h"
 #include "olap/olap_common.h"
 #include "olap/row_block2.h"

--- a/be/src/olap/rowset/segment_v2/segment_iterator.h
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.h
@@ -145,8 +145,8 @@ private:
 
     std::shared_ptr<Segment> _segment;
     const Schema& _schema;
-    // _column_iterators.size() == _schema.num_columns()
-    // map<unique_id, ColumnIterator*> _column_iterators/_bitmap_index_iterators;
+    // _column_iterators_map.size() == _schema.num_columns()
+    // map<unique_id, ColumnIterator*> _column_iterators_map/_bitmap_index_iterators;
     // can use _schema get unique_id by cid
     std::map<int32_t, ColumnIterator*> _column_iterators;
     std::map<int32_t, BitmapIndexIterator*> _bitmap_index_iterators;

--- a/be/src/vec/exec/scan/new_olap_scanner.cpp
+++ b/be/src/vec/exec/scan/new_olap_scanner.cpp
@@ -157,6 +157,8 @@ Status NewOlapScanner::_init_tablet_reader_params(
                 real_parent->_olap_scan_node.__isset.push_down_agg_type_opt;
     }
 
+	RETURN_IF_ERROR(_init_return_columns(!_tablet_reader_params.direct_mode));
+
     _tablet_reader_params.tablet = _tablet;
     _tablet_reader_params.tablet_schema = _tablet_schema;
     _tablet_reader_params.reader_type = READER_QUERY;

--- a/be/src/vec/exec/scan/new_olap_scanner.cpp
+++ b/be/src/vec/exec/scan/new_olap_scanner.cpp
@@ -147,20 +147,21 @@ Status NewOlapScanner::_init_tablet_reader_params(
                       ->rowset()
                       ->rowset_meta()
                       ->is_segments_overlapping());
-
+    auto real_parent = reinterpret_cast<NewOlapScanNode*>(_parent);
     if (_state->skip_storage_engine_merge()) {
         _tablet_reader_params.direct_mode = true;
         _aggregation = true;
     } else {
-        _tablet_reader_params.direct_mode = _aggregation || single_version;
+        _tablet_reader_params.direct_mode = _aggregation || single_version ||
+                                     real_parent->_olap_scan_node.__isset.push_down_agg_type_opt;
     }
-
-    RETURN_IF_ERROR(_init_return_columns(!_tablet_reader_params.direct_mode));
 
     _tablet_reader_params.tablet = _tablet;
     _tablet_reader_params.tablet_schema = _tablet_schema;
     _tablet_reader_params.reader_type = READER_QUERY;
     _tablet_reader_params.aggregation = _aggregation;
+    if (real_parent->_olap_scan_node.__isset.push_down_agg_type_opt)
+        _tablet_reader_params.push_down_agg_type_opt = real_parent->_olap_scan_node.push_down_agg_type_opt;
     _tablet_reader_params.version = Version(0, _version);
 
     // Condition

--- a/be/src/vec/exec/scan/new_olap_scanner.cpp
+++ b/be/src/vec/exec/scan/new_olap_scanner.cpp
@@ -152,8 +152,9 @@ Status NewOlapScanner::_init_tablet_reader_params(
         _tablet_reader_params.direct_mode = true;
         _aggregation = true;
     } else {
-        _tablet_reader_params.direct_mode = _aggregation || single_version ||
-                                     real_parent->_olap_scan_node.__isset.push_down_agg_type_opt;
+        _tablet_reader_params.direct_mode =
+                _aggregation || single_version ||
+                real_parent->_olap_scan_node.__isset.push_down_agg_type_opt;
     }
 
     _tablet_reader_params.tablet = _tablet;
@@ -161,7 +162,8 @@ Status NewOlapScanner::_init_tablet_reader_params(
     _tablet_reader_params.reader_type = READER_QUERY;
     _tablet_reader_params.aggregation = _aggregation;
     if (real_parent->_olap_scan_node.__isset.push_down_agg_type_opt)
-        _tablet_reader_params.push_down_agg_type_opt = real_parent->_olap_scan_node.push_down_agg_type_opt;
+        _tablet_reader_params.push_down_agg_type_opt =
+                real_parent->_olap_scan_node.push_down_agg_type_opt;
     _tablet_reader_params.version = Version(0, _version);
 
     // Condition

--- a/be/src/vec/exec/scan/new_olap_scanner.cpp
+++ b/be/src/vec/exec/scan/new_olap_scanner.cpp
@@ -157,7 +157,7 @@ Status NewOlapScanner::_init_tablet_reader_params(
                 real_parent->_olap_scan_node.__isset.push_down_agg_type_opt;
     }
 
-	RETURN_IF_ERROR(_init_return_columns(!_tablet_reader_params.direct_mode));
+    RETURN_IF_ERROR(_init_return_columns(!_tablet_reader_params.direct_mode));
 
     _tablet_reader_params.tablet = _tablet;
     _tablet_reader_params.tablet_schema = _tablet_schema;

--- a/be/src/vec/exec/volap_scanner.cpp
+++ b/be/src/vec/exec/volap_scanner.cpp
@@ -185,7 +185,8 @@ Status VOlapScanner::_init_tablet_reader_params(
     _tablet_reader_params.reader_type = READER_QUERY;
     _tablet_reader_params.aggregation = _aggregation;
     if (_parent->_olap_scan_node.__isset.push_down_agg_type_opt)
-        _tablet_reader_params.push_down_agg_type_opt = _parent->_olap_scan_node.push_down_agg_type_opt;
+        _tablet_reader_params.push_down_agg_type_opt =
+                _parent->_olap_scan_node.push_down_agg_type_opt;
     _tablet_reader_params.version = Version(0, _version);
 
     // Condition

--- a/be/src/vec/exec/volap_scanner.cpp
+++ b/be/src/vec/exec/volap_scanner.cpp
@@ -178,15 +178,14 @@ Status VOlapScanner::_init_tablet_reader_params(
         _tablet_reader_params.direct_mode = _aggregation || single_version ||
                                             _parent->_olap_scan_node.__isset.push_down_agg_type_opt;
     }
-    if (_parent->_olap_scan_node.__isset.push_down_agg_type_opt)
-        _push_down_agg_type_opt = _parent->_olap_scan_node.push_down_agg_type_opt;
-
     RETURN_IF_ERROR(_init_return_columns(!_tablet_reader_params.direct_mode));
 
     _tablet_reader_params.tablet = _tablet;
     _tablet_reader_params.tablet_schema = _tablet_schema;
     _tablet_reader_params.reader_type = READER_QUERY;
     _tablet_reader_params.aggregation = _aggregation;
+    if (_parent->_olap_scan_node.__isset.push_down_agg_type_opt)
+        _tablet_reader_params.push_down_agg_type_opt = _parent->_olap_scan_node.push_down_agg_type_opt;
     _tablet_reader_params.version = Version(0, _version);
 
     // Condition
@@ -231,7 +230,6 @@ Status VOlapScanner::_init_tablet_reader_params(
 
     _tablet_reader_params.origin_return_columns = &_return_columns;
     _tablet_reader_params.tablet_columns_convert_to_null_set = &_tablet_columns_convert_to_null_set;
-    _tablet_reader_params.push_down_agg_type_opt= _push_down_agg_type_opt;
 
     if (_tablet_reader_params.direct_mode) {
         _tablet_reader_params.return_columns = _return_columns;

--- a/be/src/vec/exec/volap_scanner.h
+++ b/be/src/vec/exec/volap_scanner.h
@@ -127,7 +127,6 @@ private:
 
     std::vector<uint32_t> _return_columns;
     std::unordered_set<uint32_t> _tablet_columns_convert_to_null_set;
-    TPushAggOp::type _push_down_agg_type_opt = TPushAggOp::NONE;
 
     // time costed and row returned statistics
     int64_t _num_rows_read = 0;

--- a/be/src/vec/exec/volap_scanner.h
+++ b/be/src/vec/exec/volap_scanner.h
@@ -127,6 +127,7 @@ private:
 
     std::vector<uint32_t> _return_columns;
     std::unordered_set<uint32_t> _tablet_columns_convert_to_null_set;
+    TPushAggOp::type _push_down_agg_type_opt = TPushAggOp::NONE;
 
     // time costed and row returned statistics
     int64_t _num_rows_read = 0;

--- a/be/src/vec/olap/block_reader.cpp
+++ b/be/src/vec/olap/block_reader.cpp
@@ -49,6 +49,7 @@ Status BlockReader::_init_collect_iter(const ReaderParams& read_params,
 
     _reader_context.batch_size = _batch_size;
     _reader_context.is_vec = true;
+    _reader_context.push_down_agg_type_opt = read_params.push_down_agg_type_opt;
     for (auto& rs_reader : rs_readers) {
         RETURN_NOT_OK(rs_reader->init(&_reader_context));
         Status res = _vcollect_iter.add_child(rs_reader);

--- a/be/src/vec/olap/vgeneric_iterators.cpp
+++ b/be/src/vec/olap/vgeneric_iterators.cpp
@@ -133,13 +133,13 @@ public:
                 auto cid = _schema.column_id(i);
                 auto unique_id = _schema.column(cid)->unique_id();
                 if (_column_iterators_map.count(unique_id) < 1) {
-                    RETURN_IF_ERROR(_segment->new_column_iterator(opts.tablet_schema->column(cid),
-                                                                  &_column_iterators_map[unique_id]));
+                    RETURN_IF_ERROR(_segment->new_column_iterator(
+                            opts.tablet_schema->column(cid), &_column_iterators_map[unique_id]));
                 }
                 _column_iterators.push_back(_column_iterators_map[unique_id]);
             }
 
-            _target_rows =  _push_down_agg_type_opt == TPushAggOp::MINMAX ? 2 : _segment->num_rows();
+            _target_rows = _push_down_agg_type_opt == TPushAggOp::MINMAX ? 2 : _segment->num_rows();
             _init = true;
         }
 
@@ -152,8 +152,9 @@ public:
             block->clear_column_data();
             auto columns = block->mutate_columns();
 
-            size_t size = _push_down_agg_type_opt == TPushAggOp::MINMAX ?
-                 2 : std::min(_target_rows - _output_rows, MAX_ROW_SIZE_IN_COUNT);
+            size_t size = _push_down_agg_type_opt == TPushAggOp::MINMAX
+                                  ? 2
+                                  : std::min(_target_rows - _output_rows, MAX_ROW_SIZE_IN_COUNT);
             if (_push_down_agg_type_opt == TPushAggOp::COUNT) {
                 size = std::min(_target_rows - _output_rows, MAX_ROW_SIZE_IN_COUNT);
                 for (int i = 0; i < block->columns(); ++i) {

--- a/be/src/vec/olap/vgeneric_iterators.h
+++ b/be/src/vec/olap/vgeneric_iterators.h
@@ -43,6 +43,8 @@ RowwiseIterator* new_union_iterator(std::vector<RowwiseIterator*>& inputs);
 // Client should delete returned iterator.
 RowwiseIterator* new_auto_increment_iterator(const Schema& schema, size_t num_rows);
 
+RowwiseIterator* new_vstatistics_iterator(std::shared_ptr<Segment> segment, const Schema& schema);
+
 } // namespace vectorized
 
 } // namespace doris

--- a/be/src/vec/olap/vgeneric_iterators.h
+++ b/be/src/vec/olap/vgeneric_iterators.h
@@ -19,6 +19,10 @@
 
 namespace doris {
 
+namespace segment_v2 {
+class Segment;
+}
+
 namespace vectorized {
 
 // Create a merge iterator for input iterators. Merge iterator will merge

--- a/be/test/vec/exec/vgeneric_iterators_test.cpp
+++ b/be/test/vec/exec/vgeneric_iterators_test.cpp
@@ -1,4 +1,3 @@
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/PrimitiveType.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/PrimitiveType.java
@@ -1068,6 +1068,10 @@ public enum PrimitiveType {
         return this == ARRAY;
     }
 
+    public boolean isComplexType() {
+        return this == HLL || this == BITMAP;
+    }
+
     public boolean isStringType() {
         return (this == VARCHAR || this == CHAR || this == HLL || this == STRING);
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/OlapScanNode.java
@@ -65,6 +65,7 @@ import org.apache.doris.thrift.TPaloScanRange;
 import org.apache.doris.thrift.TPlanNode;
 import org.apache.doris.thrift.TPlanNodeType;
 import org.apache.doris.thrift.TPrimitiveType;
+import org.apache.doris.thrift.TPushAggOp;
 import org.apache.doris.thrift.TScanRange;
 import org.apache.doris.thrift.TScanRangeLocation;
 import org.apache.doris.thrift.TScanRangeLocations;
@@ -153,6 +154,8 @@ public class OlapScanNode extends ScanNode {
     // It's limit for scanner instead of scanNode so we add a new limit.
     private long sortLimit = -1;
 
+    private TPushAggOp pushDownAggNoGroupingOp = null;
+
     // List of tablets will be scanned by current olap_scan_node
     private ArrayList<Long> scanTabletIds = Lists.newArrayList();
 
@@ -173,6 +176,10 @@ public class OlapScanNode extends ScanNode {
         this.isPreAggregation = isPreAggregation;
         this.reasonOfPreAggregation = this.reasonOfPreAggregation == null ? reason :
                                       this.reasonOfPreAggregation + " " + reason;
+    }
+
+    public void setPushDownAggNoGrouping(TPushAggOp pushDownAggNoGroupingOp) {
+        this.pushDownAggNoGroupingOp = pushDownAggNoGroupingOp;
     }
 
     public boolean isPreAggregation() {
@@ -923,6 +930,10 @@ public class OlapScanNode extends ScanNode {
         msg.olap_scan_node.setKeyType(olapTable.getKeysType().toThrift());
         msg.olap_scan_node.setTableName(olapTable.getName());
         msg.olap_scan_node.setEnableUniqueKeyMergeOnWrite(olapTable.getEnableUniqueKeyMergeOnWrite());
+
+        if (pushDownAggNoGroupingOp != null) {
+            msg.olap_scan_node.setPushDownAggTypeOpt(pushDownAggNoGroupingOp);
+        }
     }
 
     // export some tablets

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/SingleNodePlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/SingleNodePlanner.java
@@ -414,7 +414,13 @@ public class SingleNodePlanner {
                 String functionName = aggExpr.getFnName().getFunction();
                 if (!functionName.equalsIgnoreCase("MAX")
                         && !functionName.equalsIgnoreCase("MIN")
-                        && (!functionName.equalsIgnoreCase("COUNT") && type != KeysType.DUP_KEYS)) {
+                        && !functionName.equalsIgnoreCase("COUNT")) {
+                    aggExprValidate = false;
+                    break;
+                }
+
+                if (functionName.equalsIgnoreCase("COUNT")
+                        && type != KeysType.DUP_KEYS) {
                     aggExprValidate = false;
                     break;
                 }

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/SingleNodePlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/SingleNodePlanner.java
@@ -56,8 +56,10 @@ import org.apache.doris.catalog.AggregateType;
 import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.FunctionSet;
 import org.apache.doris.catalog.JdbcTable;
+import org.apache.doris.catalog.KeysType;
 import org.apache.doris.catalog.MysqlTable;
 import org.apache.doris.catalog.OdbcTable;
+import org.apache.doris.catalog.PrimitiveType;
 import org.apache.doris.catalog.Table;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.FeConstants;
@@ -66,7 +68,9 @@ import org.apache.doris.common.Reference;
 import org.apache.doris.common.UserException;
 import org.apache.doris.common.util.VectorizedUtil;
 import org.apache.doris.planner.external.ExternalFileScanNode;
+import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.thrift.TNullSide;
+import org.apache.doris.thrift.TPushAggOp;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Predicate;
@@ -360,6 +364,136 @@ public class SingleNodePlanner {
         selectNode.init(analyzer);
         Preconditions.checkState(selectNode.hasValidStats());
         return selectNode;
+    }
+
+    private TPushAggOp freshTPushAggOpByName(String functionName, TPushAggOp originAggOp) {
+        TPushAggOp newPushAggOp = null;
+        if (functionName.equalsIgnoreCase("COUNT")) {
+            newPushAggOp = TPushAggOp.COUNT;
+        } else {
+            newPushAggOp = TPushAggOp.MINMAX;
+        }
+
+        if (originAggOp == null || newPushAggOp == originAggOp) {
+            return newPushAggOp;
+        }
+        return TPushAggOp.MIX;
+    }
+
+    private void pushDownAggNoGrouping(AggregateInfo aggInfo, SelectStmt selectStmt, Analyzer analyzer, PlanNode root) {
+        do {
+            // TODO: Support other scan node in the future
+            if (!(root instanceof OlapScanNode)) {
+                break;
+            }
+
+            KeysType type = ((OlapScanNode) root).getOlapTable().getKeysType();
+            if (type == KeysType.UNIQUE_KEYS || type == KeysType.PRIMARY_KEYS) {
+                break;
+            }
+
+            // TODO: Support muti table in the future
+            if (selectStmt.getTableRefs().size() != 1) {
+                break;
+            }
+
+            // No not support group by and where clause
+            if (null == aggInfo || !aggInfo.getGroupingExprs().isEmpty()) {
+                break;
+            }
+            List<Expr> allConjuncts = analyzer.getAllConjuncts(selectStmt.getTableRefs().get(0).getId());
+            if (allConjuncts != null) {
+                break;
+            }
+
+            List<FunctionCallExpr> aggExprs = aggInfo.getAggregateExprs();
+            boolean aggExprValidate = true;
+            TPushAggOp aggOp = null;
+            for (FunctionCallExpr aggExpr : aggExprs) {
+                // Only support `min`, `max`, `count` and `count` only effective in dup table
+                String functionName = aggExpr.getFnName().getFunction();
+                if (!functionName.equalsIgnoreCase("MAX")
+                        && !functionName.equalsIgnoreCase("MIN")
+                        && (!functionName.equalsIgnoreCase("COUNT") && type != KeysType.DUP_KEYS)) {
+                    aggExprValidate = false;
+                    break;
+                }
+
+                aggOp = freshTPushAggOpByName(functionName, aggOp);
+
+                if (aggExpr.getChildren().size() > 1) {
+                    aggExprValidate = false;
+                    break;
+                }
+
+                boolean returnColumnValidate = true;
+                if (aggExpr.getChildren().size() == 1) {
+                    List<Column> returnColumns = Lists.newArrayList();
+                    if (!(aggExpr.getChild(0) instanceof SlotRef)) {
+                        Expr child = aggExpr.getChild(0);
+                        if ((child instanceof CastExpr) && (child.getChild(0) instanceof SlotRef)) {
+                            if (child.getType().isNumericType()
+                                    && child.getChild(0).getType().isNumericType()) {
+                                returnColumns.add(((SlotRef) child.getChild(0)).getDesc().getColumn());
+                            } else {
+                                aggExprValidate = false;
+                                break;
+                            }
+                        } else {
+                            aggExprValidate = false;
+                            break;
+                        }
+                    } else {
+                        returnColumns.add(((SlotRef) aggExpr.getChild(0)).getDesc().getColumn());
+                    }
+
+
+                    // check return columns
+                    Column firstColumn = returnColumns.get(0);
+                    for (Column col : returnColumns) {
+                        // TODO(zc): Here column is null is too bad
+                        // Only column of Inline-view will be null
+                        if (col == null) {
+                            continue;
+                        }
+
+                        if (type == KeysType.AGG_KEYS) {
+                            if (!col.isKey() && !col.getName().equals(firstColumn.getName())) {
+                                returnColumnValidate = false;
+                                break;
+                            }
+                        }
+
+                        PrimitiveType colType = col.getDataType();
+                        if (colType.isArrayType() || colType.isComplexType()
+                                || colType == PrimitiveType.STRING) {
+                            returnColumnValidate = false;
+                            break;
+                        }
+
+                        // The zone map max length of CharFamily is 512, do not
+                        // over the length: https://github.com/apache/doris/pull/6293
+                        if (colType.isCharFamily() && aggOp != TPushAggOp.COUNT
+                                && col.getType().getLength() > 512) {
+                            returnColumnValidate = false;
+                            break;
+                        }
+                    }
+                }
+
+                if (!returnColumnValidate) {
+                    aggExprValidate = false;
+                    break;
+                }
+            }
+
+            if (!aggExprValidate) {
+                break;
+            }
+
+            OlapScanNode olapNode = (OlapScanNode) root;
+            olapNode.setPushDownAggNoGrouping(aggOp);
+        } while (false);
     }
 
     private void turnOffPreAgg(AggregateInfo aggInfo, SelectStmt selectStmt, Analyzer analyzer, PlanNode root) {
@@ -998,6 +1132,10 @@ public class SingleNodePlanner {
                 materializeTableResultForCrossJoinOrCountStar(ref, analyzer);
                 PlanNode plan = createTableRefNode(analyzer, ref, selectStmt);
                 turnOffPreAgg(aggInfo, selectStmt, analyzer, plan);
+                if (VectorizedUtil.isVectorized()
+                        && ConnectContext.get().getSessionVariable().enablePushDownNoGroupAgg) {
+                    pushDownAggNoGrouping(aggInfo, selectStmt, analyzer, plan);
+                }
 
                 if (plan instanceof OlapScanNode) {
                     OlapScanNode olapNode = (OlapScanNode) plan;
@@ -1026,6 +1164,10 @@ public class SingleNodePlanner {
             // selectStmt.seondSubstituteInlineViewExprs(analyzer.getChangeResSmap());
 
             turnOffPreAgg(aggInfo, selectStmt, analyzer, root);
+            if (VectorizedUtil.isVectorized()
+                    && ConnectContext.get().getSessionVariable().enablePushDownNoGroupAgg) {
+                pushDownAggNoGrouping(aggInfo, selectStmt, analyzer, root);
+            }
 
             if (root instanceof OlapScanNode) {
                 OlapScanNode olapNode = (OlapScanNode) root;

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -221,6 +221,8 @@ public class SessionVariable implements Serializable, Writable {
 
     public static final String ENABLE_NEW_SHUFFLE_HASH_METHOD = "enable_new_shuffle_hash_method";
 
+    public static final String ENABLE_PUSH_DOWN_NO_GROUP_AGG = "enable_push_down_no_group_agg";
+
     // session origin value
     public Map<Field, String> sessionOriginValue = new HashMap<Field, String>();
     // check stmt is or not [select /*+ SET_VAR(...)*/ ...]
@@ -563,7 +565,10 @@ public class SessionVariable implements Serializable, Writable {
     public boolean enableFallbackToOriginalPlanner = true;
 
     @VariableMgr.VarAttr(name = ENABLE_NEW_SHUFFLE_HASH_METHOD)
-    public boolean enableNewShffleHashMethod = true;
+    public boolean enableNewShuffleHashMethod = true;
+
+    @VariableMgr.VarAttr(name = ENABLE_PUSH_DOWN_NO_GROUP_AGG)
+    public boolean enablePushDownNoGroupAgg = true;
 
     public String getBlockEncryptionMode() {
         return blockEncryptionMode;
@@ -958,6 +963,10 @@ public class SessionVariable implements Serializable, Writable {
         this.enableVectorizedEngine = enableVectorizedEngine;
     }
 
+    public boolean enablePushDownNoGroupAgg() {
+        return enablePushDownNoGroupAgg;
+    }
+
     public boolean getEnableFunctionPushdown() {
         return this.enableFunctionPushdown;
     }
@@ -1170,7 +1179,7 @@ public class SessionVariable implements Serializable, Writable {
         tResult.setEnableFunctionPushdown(enableFunctionPushdown);
         tResult.setFragmentTransmissionCompressionCodec(fragmentTransmissionCompressionCodec);
         tResult.setEnableLocalExchange(enableLocalExchange);
-        tResult.setEnableNewShuffleHashMethod(enableNewShffleHashMethod);
+        tResult.setEnableNewShuffleHashMethod(enableNewShuffleHashMethod);
 
         tResult.setSkipStorageEngineMerge(skipStorageEngineMerge);
 

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -463,6 +463,13 @@ struct TSortInfo {
   4: optional list<Exprs.TExpr> sort_tuple_slot_exprs
 }
 
+enum TPushAggOp {
+	NONE = 0,
+	MINMAX = 1,
+	COUNT = 2,
+	MIX = 3
+}
+
 struct TOlapScanNode {
   1: required Types.TTupleId tuple_id
   2: required list<string> key_column_name
@@ -477,6 +484,7 @@ struct TOlapScanNode {
   // It's limit for scanner instead of scanNode so we add a new limit.
   10: optional i64 sort_limit
   11: optional bool enable_unique_key_merge_on_write
+  12: optional TPushAggOp push_down_agg_type_opt
 }
 
 struct TEqJoinCondition {


### PR DESCRIPTION
# Proposed changes

Use the segment static to speed up some not grouping agg query：`min`, `max`, `count`

Here need to a new SegmentIter call `StatisticsIter` to do the work.

lineorder : 60kw line num

query             Before             After
count(*)         0.5s                0.02s
min                0.4s                0.01s
max               0.4s                 0.01s

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

