### PR TITLE
[fix](Nereids) GroupExpression never be optimize if it run with exploration job

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/cascades/OptimizeGroupExpressionJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/cascades/OptimizeGroupExpressionJob.java
@@ -20,9 +20,7 @@ package org.apache.doris.nereids.jobs.cascades;
 import org.apache.doris.nereids.jobs.Job;
 import org.apache.doris.nereids.jobs.JobContext;
 import org.apache.doris.nereids.jobs.JobType;
-import org.apache.doris.nereids.memo.Group;
 import org.apache.doris.nereids.memo.GroupExpression;
-import org.apache.doris.nereids.pattern.Pattern;
 import org.apache.doris.nereids.rules.Rule;
 
 import java.util.ArrayList;
@@ -51,16 +49,6 @@ public class OptimizeGroupExpressionJob extends Job {
 
         for (Rule rule : validRules) {
             pushJob(new ApplyRuleJob(groupExpression, rule, context));
-
-            // If child_pattern has any more children (i.e non-leaf), then we will explore the
-            // child before applying the rule. (assumes task pool is effectively a stack)
-            for (int i = 0; i < rule.getPattern().children().size(); ++i) {
-                Pattern childPattern = rule.getPattern().child(i);
-                if (childPattern.arity() > 0 && !childPattern.isGroup()) {
-                    Group child = groupExpression.child(i);
-                    pushJob(new ExploreGroupJob(child, context));
-                }
-            }
         }
     }
 }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

Exploration job only do explore, but never call optimize. So the GroupExpression explored by exploration only job will never do implementation.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

