### PR TITLE
[Improvement](crchash) Use wider built-in CRC hash function

### DIFF
--- a/be/src/util/hash_util.hpp
+++ b/be/src/util/hash_util.hpp
@@ -63,9 +63,7 @@ public:
         return res;
     }
 
-    static inline uint64_t shift_mix(uint64_t val) {
-        return val ^ (val >> 47);
-    }
+    static inline uint64_t shift_mix(uint64_t val) { return val ^ (val >> 47); }
 
     static inline size_t hash_less_than8(const char* data, size_t size) {
         static constexpr uint64_t k2 = 0x9ae16a3b2f90404fULL;

--- a/regression-test/suites/correctness_p0/test_case_when.groovy
+++ b/regression-test/suites/correctness_p0/test_case_when.groovy
@@ -62,7 +62,8 @@ suite("test_case_when") {
             where dt = '2019-01-01'
             and merchant_id in (45010002, 45010003)
             and channel_id = '00'
-            group by hour_time, station_type; 
+            group by hour_time, station_type
+            order by date_hour;
     """
 
     qt_select_agg """


### PR DESCRIPTION
# Proposed changes

Baseline:
![image](https://user-images.githubusercontent.com/37700562/191476856-1f1bf4c8-cc8c-455a-938c-ad877a98be6a.png)

Optimized:
![image](https://user-images.githubusercontent.com/37700562/191476926-2b67c652-b447-48a5-86f2-e1a366f677a5.png)

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

