### PR TITLE
[fix](streamload&sink) release and allocate memory in the same tracker

### DIFF
--- a/be/src/exec/tablet_sink.cpp
+++ b/be/src/exec/tablet_sink.cpp
@@ -580,12 +580,18 @@ void NodeChannel::try_send_batch(RuntimeState* state) {
                 brpc_url + "/PInternalServiceImpl/tablet_writer_add_batch_by_http";
         _add_batch_closure->cntl.http_request().set_method(brpc::HTTP_METHOD_POST);
         _add_batch_closure->cntl.http_request().set_content_type("application/json");
-        _brpc_http_stub->tablet_writer_add_batch_by_http(
-                &_add_batch_closure->cntl, NULL, &_add_batch_closure->result, _add_batch_closure);
+        {
+            SCOPED_ATTACH_TASK(ExecEnv::GetInstance()->orphan_mem_tracker());
+            _brpc_http_stub->tablet_writer_add_batch_by_http(
+                    &_add_batch_closure->cntl, NULL, &_add_batch_closure->result, _add_batch_closure);
+        }
     } else {
         _add_batch_closure->cntl.http_request().Clear();
-        _stub->tablet_writer_add_batch(&_add_batch_closure->cntl, &request,
-                                       &_add_batch_closure->result, _add_batch_closure);
+        {
+            SCOPED_ATTACH_TASK(ExecEnv::GetInstance()->orphan_mem_tracker());
+            _stub->tablet_writer_add_batch(&_add_batch_closure->cntl, &request,
+                                           &_add_batch_closure->result, _add_batch_closure);
+        }
     }
     _next_packet_seq++;
 }

--- a/be/src/exec/tablet_sink.cpp
+++ b/be/src/exec/tablet_sink.cpp
@@ -196,6 +196,7 @@ Status NodeChannel::open_wait() {
         // add batch closure
         _add_batch_closure = ReusableClosure<PTabletWriterAddBatchResult>::create();
         _add_batch_closure->addFailedHandler([this](bool is_last_rpc) {
+            SCOPED_ATTACH_TASK(_state);
             std::lock_guard<std::mutex> l(this->_closed_lock);
             if (this->_is_closed) {
                 // if the node channel is closed, no need to call `mark_as_failed`,
@@ -217,6 +218,7 @@ Status NodeChannel::open_wait() {
 
         _add_batch_closure->addSuccessHandler([this](const PTabletWriterAddBatchResult& result,
                                                      bool is_last_rpc) {
+            SCOPED_ATTACH_TASK(_state);
             std::lock_guard<std::mutex> l(this->_closed_lock);
             if (this->_is_closed) {
                 // if the node channel is closed, no need to call the following logic,

--- a/be/src/exec/tablet_sink.cpp
+++ b/be/src/exec/tablet_sink.cpp
@@ -582,8 +582,9 @@ void NodeChannel::try_send_batch(RuntimeState* state) {
         _add_batch_closure->cntl.http_request().set_content_type("application/json");
         {
             SCOPED_ATTACH_TASK(ExecEnv::GetInstance()->orphan_mem_tracker());
-            _brpc_http_stub->tablet_writer_add_batch_by_http(
-                    &_add_batch_closure->cntl, NULL, &_add_batch_closure->result, _add_batch_closure);
+            _brpc_http_stub->tablet_writer_add_batch_by_http(&_add_batch_closure->cntl, NULL,
+                                                             &_add_batch_closure->result,
+                                                             _add_batch_closure);
         }
     } else {
         _add_batch_closure->cntl.http_request().Clear();

--- a/be/src/exec/tablet_sink.h
+++ b/be/src/exec/tablet_sink.h
@@ -96,6 +96,8 @@ public:
     ~ReusableClosure() override {
         // shouldn't delete when Run() is calling or going to be called, wait for current Run() done.
         join();
+        SCOPED_ATTACH_TASK(ExecEnv::GetInstance()->orphan_mem_tracker());
+        cntl.Reset();
     }
 
     static ReusableClosure<T>* create() { return new ReusableClosure<T>(); }
@@ -122,6 +124,7 @@ public:
 
     // plz follow this order: reset() -> set_in_flight() -> send brpc batch
     void reset() {
+        SCOPED_ATTACH_TASK(ExecEnv::GetInstance()->orphan_mem_tracker());
         cntl.Reset();
         cid = cntl.call_id();
     }

--- a/be/src/runtime/stream_load/stream_load_pipe.h
+++ b/be/src/runtime/stream_load/stream_load_pipe.h
@@ -26,12 +26,14 @@
 #include "runtime/message_body_sink.h"
 #include "util/bit_util.h"
 #include "util/byte_buffer.h"
+#include "runtime/thread_context.h"
 
 namespace doris {
 
 const size_t kMaxPipeBufferedBytes = 4 * 1024 * 1024;
 // StreamLoadPipe use to transfer data from producer to consumer
 // Data in pip is stored in chunks.
+
 class StreamLoadPipe : public MessageBodySink, public FileReader {
 public:
     StreamLoadPipe(size_t max_buffered_bytes = kMaxPipeBufferedBytes,
@@ -43,7 +45,11 @@ public:
               _min_chunk_size(min_chunk_size),
               _total_length(total_length),
               _use_proto(use_proto) {}
-    virtual ~StreamLoadPipe() {}
+
+    virtual ~StreamLoadPipe() {
+        SCOPED_ATTACH_TASK(ExecEnv::GetInstance()->orphan_mem_tracker());
+        while (!_buf_queue.empty()) _buf_queue.pop_front();
+    }
 
     Status open() override { return Status::OK(); }
 
@@ -113,6 +119,7 @@ public:
     }
 
     Status read(uint8_t* data, int64_t data_size, int64_t* bytes_read, bool* eof) override {
+        SCOPED_ATTACH_TASK(ExecEnv::GetInstance()->orphan_mem_tracker());
         *bytes_read = 0;
         while (*bytes_read < data_size) {
             std::unique_lock<std::mutex> l(_lock);
@@ -209,7 +216,6 @@ private:
         *length = buf->remaining();
         data->reset(new uint8_t[*length]);
         buf->get_bytes((char*)(data->get()), *length);
-
         _buf_queue.pop_front();
         _buffered_bytes -= buf->limit;
         if (_use_proto) {

--- a/be/src/runtime/stream_load/stream_load_pipe.h
+++ b/be/src/runtime/stream_load/stream_load_pipe.h
@@ -24,9 +24,9 @@
 #include "gen_cpp/internal_service.pb.h"
 #include "io/file_reader.h"
 #include "runtime/message_body_sink.h"
+#include "runtime/thread_context.h"
 #include "util/bit_util.h"
 #include "util/byte_buffer.h"
-#include "runtime/thread_context.h"
 
 namespace doris {
 

--- a/be/src/runtime/thread_context.h
+++ b/be/src/runtime/thread_context.h
@@ -134,12 +134,6 @@ public:
     void attach_task(const TaskType& type, const std::string& task_id,
                      const TUniqueId& fragment_instance_id,
                      const std::shared_ptr<MemTrackerLimiter>& mem_tracker) {
-#ifndef BE_TEST
-        DCHECK((_type == TaskType::UNKNOWN || _type == TaskType::BRPC) && _task_id == "")
-                << ",new tracker label: " << mem_tracker->label() << ",old tracker label: "
-                << _thread_mem_tracker_mgr->limiter_mem_tracker_raw()->label();
-#endif
-        DCHECK(type != TaskType::UNKNOWN);
         _type = type;
         _task_id = task_id;
         _fragment_instance_id = fragment_instance_id;

--- a/be/src/vec/common/pod_array.h
+++ b/be/src/vec/common/pod_array.h
@@ -534,7 +534,7 @@ public:
             arr1.c_end = arr1.c_start + this->byte_size(heap_size);
             arr1.c_end_peak = arr1.c_end;
             THREAD_MEM_TRACKER_TRANSFER_FROM(arr1.c_end_peak - arr1.c_start - heap_peak_used,
-                                         ExecEnv::GetInstance()->orphan_mem_tracker_raw());
+                                             ExecEnv::GetInstance()->orphan_mem_tracker_raw());
 
             /// Allocate stack space for arr2.
             arr2.alloc(stack_allocated);
@@ -542,7 +542,7 @@ public:
             memcpy(arr2.c_start, stack_c_start, this->byte_size(stack_size));
             arr2.c_end = arr2.c_end_peak = arr2.c_start + this->byte_size(stack_size);
             THREAD_MEM_TRACKER_TRANSFER_FROM(arr2.c_end_peak - arr2.c_start - stack_peak_used,
-                                         ExecEnv::GetInstance()->orphan_mem_tracker_raw());
+                                             ExecEnv::GetInstance()->orphan_mem_tracker_raw());
         };
 
         auto do_move = [this](PODArray& src, PODArray& dest) {
@@ -552,10 +552,10 @@ public:
                 memcpy(dest.c_start, src.c_start, this->byte_size(src.size()));
                 dest.c_end = dest.c_end_peak = dest.c_start + (src.c_end - src.c_start);
                 THREAD_MEM_TRACKER_TRANSFER_FROM(dest.c_end_peak - dest.c_start,
-                                             ExecEnv::GetInstance()->orphan_mem_tracker_raw());
+                                                 ExecEnv::GetInstance()->orphan_mem_tracker_raw());
 
                 THREAD_MEM_TRACKER_TRANSFER_FROM(src.c_end_of_storage - src.c_end_peak,
-                                         ExecEnv::GetInstance()->orphan_mem_tracker_raw());
+                                                 ExecEnv::GetInstance()->orphan_mem_tracker_raw());
                 src.c_start = Base::null;
                 src.c_end = Base::null;
                 src.c_end_of_storage = Base::null;

--- a/be/src/vec/sink/vtablet_sink.cpp
+++ b/be/src/vec/sink/vtablet_sink.cpp
@@ -361,9 +361,9 @@ void VNodeChannel::try_send_block(RuntimeState* state) {
     } else {
         _add_block_closure->cntl.http_request().Clear();
         {
-             SCOPED_ATTACH_TASK(ExecEnv::GetInstance()->orphan_mem_tracker());
-             _stub->tablet_writer_add_block(&_add_block_closure->cntl, &request,
-                                            &_add_block_closure->result, _add_block_closure);
+            SCOPED_ATTACH_TASK(ExecEnv::GetInstance()->orphan_mem_tracker());
+            _stub->tablet_writer_add_block(&_add_block_closure->cntl, &request,
+                                           &_add_block_closure->result, _add_block_closure);
         }
     }
 

--- a/be/src/vec/sink/vtablet_sink.cpp
+++ b/be/src/vec/sink/vtablet_sink.cpp
@@ -354,15 +354,16 @@ void VNodeChannel::try_send_block(RuntimeState* state) {
 
         {
             SCOPED_ATTACH_TASK(ExecEnv::GetInstance()->orphan_mem_tracker());
-            _brpc_http_stub->tablet_writer_add_block_by_http(
-                    &_add_block_closure->cntl, NULL, &_add_block_closure->result, _add_block_closure);
+            _brpc_http_stub->tablet_writer_add_block_by_http(&_add_block_closure->cntl, NULL,
+                                                             &_add_block_closure->result,
+                                                             _add_block_closure);
         }
     } else {
         _add_block_closure->cntl.http_request().Clear();
         {
              SCOPED_ATTACH_TASK(ExecEnv::GetInstance()->orphan_mem_tracker());
              _stub->tablet_writer_add_block(&_add_block_closure->cntl, &request,
-                                           &_add_block_closure->result, _add_block_closure);
+                                            &_add_block_closure->result, _add_block_closure);
         }
     }
 

--- a/be/src/vec/sink/vtablet_sink.cpp
+++ b/be/src/vec/sink/vtablet_sink.cpp
@@ -80,6 +80,7 @@ Status VNodeChannel::open_wait() {
     // add block closure
     _add_block_closure = ReusableClosure<PTabletWriterAddBlockResult>::create();
     _add_block_closure->addFailedHandler([this](bool is_last_rpc) {
+        SCOPED_ATTACH_TASK(_state);
         std::lock_guard<std::mutex> l(this->_closed_lock);
         if (this->_is_closed) {
             // if the node channel is closed, no need to call `mark_as_failed`,
@@ -101,6 +102,7 @@ Status VNodeChannel::open_wait() {
 
     _add_block_closure->addSuccessHandler([this](const PTabletWriterAddBlockResult& result,
                                                  bool is_last_rpc) {
+        SCOPED_ATTACH_TASK(_state);
         std::lock_guard<std::mutex> l(this->_closed_lock);
         if (this->_is_closed) {
             // if the node channel is closed, no need to call the following logic,
@@ -349,11 +351,15 @@ void VNodeChannel::try_send_block(RuntimeState* state) {
                 brpc_url + "/PInternalServiceImpl/tablet_writer_add_block_by_http";
         _add_block_closure->cntl.http_request().set_method(brpc::HTTP_METHOD_POST);
         _add_block_closure->cntl.http_request().set_content_type("application/json");
+
+        SCOPED_ATTACH_TASK(ExecEnv::GetInstance()->orphan_mem_tracker());
         _brpc_http_stub->tablet_writer_add_block_by_http(
                 &_add_block_closure->cntl, NULL, &_add_block_closure->result, _add_block_closure);
     } else {
         _add_block_closure->cntl.http_request().Clear();
-        _stub->tablet_writer_add_block(&_add_block_closure->cntl, &request,
+
+        SCOPED_ATTACH_TASK(ExecEnv::GetInstance()->orphan_mem_tracker());
+         _stub->tablet_writer_add_block(&_add_block_closure->cntl, &request,
                                        &_add_block_closure->result, _add_block_closure);
     }
 

--- a/be/src/vec/sink/vtablet_sink.cpp
+++ b/be/src/vec/sink/vtablet_sink.cpp
@@ -352,15 +352,18 @@ void VNodeChannel::try_send_block(RuntimeState* state) {
         _add_block_closure->cntl.http_request().set_method(brpc::HTTP_METHOD_POST);
         _add_block_closure->cntl.http_request().set_content_type("application/json");
 
-        SCOPED_ATTACH_TASK(ExecEnv::GetInstance()->orphan_mem_tracker());
-        _brpc_http_stub->tablet_writer_add_block_by_http(
-                &_add_block_closure->cntl, NULL, &_add_block_closure->result, _add_block_closure);
+        {
+            SCOPED_ATTACH_TASK(ExecEnv::GetInstance()->orphan_mem_tracker());
+            _brpc_http_stub->tablet_writer_add_block_by_http(
+                    &_add_block_closure->cntl, NULL, &_add_block_closure->result, _add_block_closure);
+        }
     } else {
         _add_block_closure->cntl.http_request().Clear();
-
-        SCOPED_ATTACH_TASK(ExecEnv::GetInstance()->orphan_mem_tracker());
-         _stub->tablet_writer_add_block(&_add_block_closure->cntl, &request,
-                                       &_add_block_closure->result, _add_block_closure);
+        {
+             SCOPED_ATTACH_TASK(ExecEnv::GetInstance()->orphan_mem_tracker());
+             _stub->tablet_writer_add_block(&_add_block_closure->cntl, &request,
+                                           &_add_block_closure->result, _add_block_closure);
+        }
     }
 
     _next_packet_seq++;


### PR DESCRIPTION
1. HttpServer threads allocate bytebuffer and put them into streamload pipe, but scanner thread release them with query tracker.

2. We can assume brpc allocate memory in doris thread.

Above problems leads to wrong result of memtracker.

# Proposed changes

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

