### PR TITLE
[fix](log)Audit log status is incorrect

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectProcessor.java
@@ -54,6 +54,7 @@ import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 
 import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.iceberg.catalog.Catalog;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -158,7 +159,11 @@ public class ConnectProcessor {
                 ctx.getAuditEventBuilder().setStmt(origStmt);
             }
         }
-
+        if(!Catalog.getCurrentCatalog().isMaster()) {
+            if(ctx.executor.isForwardToMaster()) {
+                ctx.getAuditEventBuilder().setState(ctx.executor.getProxyStatus());
+            }
+        }
         Catalog.getCurrentAuditEventProcessor().handleAuditEvent(ctx.getAuditEventBuilder().build());
     }
 
@@ -506,6 +511,7 @@ public class ConnectProcessor {
         }
         result.setMaxJournalId(Catalog.getCurrentCatalog().getMaxJournalId().longValue());
         result.setPacket(getResultPacket());
+        result.setStatus(ctx.getState().toString());
         if (executor != null && executor.getProxyResultSet() != null) {
             result.setResultSet(executor.getProxyResultSet().tothrift());
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/MasterOpExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/MasterOpExecutor.java
@@ -141,6 +141,12 @@ public class MasterOpExecutor {
         }
     }
 
+    public String getProxyStatus() {
+        if (result == null) {
+            return null;
+        }
+        return result.getStatus();
+    }
     
     public ShowResultSet getProxyResultSet() {
         if (result == null) {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/MasterOpExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/MasterOpExecutor.java
@@ -143,7 +143,10 @@ public class MasterOpExecutor {
 
     public String getProxyStatus() {
         if (result == null) {
-            return null;
+            return QueryState.MysqlStateType.UNKNOWN.name();
+        }
+        if (result.isSetStatus()) {
+            return QueryState.MysqlStateType.UNKNOWN.name();
         }
         return result.getStatus();
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/MasterOpExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/MasterOpExecutor.java
@@ -145,7 +145,7 @@ public class MasterOpExecutor {
         if (result == null) {
             return QueryState.MysqlStateType.UNKNOWN.name();
         }
-        if (result.isSetStatus()) {
+        if (!result.isSetStatus()) {
             return QueryState.MysqlStateType.UNKNOWN.name();
         }
         return result.getStatus();

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/QueryState.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/QueryState.java
@@ -29,7 +29,8 @@ public class QueryState {
         NOOP,   // send nothing to remote
         OK,     // send OK packet to remote
         EOF,    // send EOF packet to remote
-        ERR     // send ERROR packet to remote
+        ERR,     // send ERROR packet to remote
+        UNKNOWN  // send UNKNOWN packet to remote
     }
 
     public enum ErrType {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -298,7 +298,7 @@ public class StmtExecutor implements ProfileWriter {
 
     public String getProxyStatus() {
         if (masterOpExecutor == null) {
-            return null;
+            return QueryState.MysqlStateType.UNKNOWN.name();
         }
         return masterOpExecutor.getProxyStatus();
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -296,6 +296,13 @@ public class StmtExecutor implements ProfileWriter {
         }
     }
 
+    public String getProxyStatus() {
+        if (masterOpExecutor == null) {
+            return null;
+        }
+        return masterOpExecutor.getProxyStatus();
+    }
+
     public boolean isQueryStmt() {
         return parsedStmt != null && parsedStmt instanceof QueryStmt;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
@@ -667,6 +667,7 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         context.setCurrentConnectedFEIp(clientAddr.getHostname());
         ConnectProcessor processor = new ConnectProcessor(context);
         TMasterOpResult result = processor.proxyExecute(params);
+        context.getState().setError(result.getStatus());
         ConnectContext.remove();
         return result;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
@@ -667,7 +667,11 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         context.setCurrentConnectedFEIp(clientAddr.getHostname());
         ConnectProcessor processor = new ConnectProcessor(context);
         TMasterOpResult result = processor.proxyExecute(params);
-        context.getState().setError(result.getStatus());
+        if ("ERR".equalsIgnoreCase(result.getStatus())) {
+            context.getState().setError(result.getStatus());
+        } else {
+            context.getState().setOk();
+        }
         ConnectContext.remove();
         return result;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
@@ -51,6 +51,7 @@ import org.apache.doris.plugin.AuditEvent.EventType;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.ConnectProcessor;
 import org.apache.doris.qe.QeProcessorImpl;
+import org.apache.doris.qe.QueryState;
 import org.apache.doris.qe.VariableMgr;
 import org.apache.doris.system.Frontend;
 import org.apache.doris.system.SystemInfoService;
@@ -667,7 +668,8 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         context.setCurrentConnectedFEIp(clientAddr.getHostname());
         ConnectProcessor processor = new ConnectProcessor(context);
         TMasterOpResult result = processor.proxyExecute(params);
-        if ("ERR".equalsIgnoreCase(result.getStatus())) {
+
+        if (QueryState.MysqlStateType.ERR.name().equalsIgnoreCase(result.getStatus())) {
             context.getState().setError(result.getStatus());
         } else {
             context.getState().setOk();

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -479,6 +479,7 @@ struct TMasterOpResult {
     2: required binary packet;
     3: optional TShowResultSet resultSet;
     4: optional Types.TUniqueId queryId;
+    5: optional string status;
 }
 
 struct TLoadCheckRequest {


### PR DESCRIPTION
Audit log status is incorrect
1. If it is an operation that needs to be forwarded to the master, the sql execution fails, but the status of the non-master audit log record operation is OK, but the master records ERR
2. The above operation also caused duplicate records, who should operate the records

The revised scheme is:
1. Who operates who records
2. If it is forward to master, the status of the operation is transmitted to the client through RPC to ensure the correctness of the status record

# Proposed changes

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

