### PR TITLE
[fix](log)Audit log status is incorrect

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectProcessor.java
@@ -221,7 +221,11 @@ public class ConnectProcessor {
                 ctx.getAuditEventBuilder().setStmt(origStmt);
             }
         }
-
+        if(!Env.getCurrentEnv().isMaster()){
+            if(ctx.executor.isForwardToMaster()) {
+                ctx.getAuditEventBuilder().setState (ctx.executor.getProxyStatus());
+            }
+        }
         Env.getCurrentAuditEventProcessor().handleAuditEvent(ctx.getAuditEventBuilder().build());
     }
 
@@ -623,6 +627,7 @@ public class ConnectProcessor {
         }
         result.setMaxJournalId(Env.getCurrentEnv().getMaxJournalId());
         result.setPacket(getResultPacket());
+        result.setStatus(ctx.getState().toString());
         if (executor != null && executor.getProxyResultSet() != null) {
             result.setResultSet(executor.getProxyResultSet().tothrift());
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectProcessor.java
@@ -221,8 +221,8 @@ public class ConnectProcessor {
                 ctx.getAuditEventBuilder().setStmt(origStmt);
             }
         }
-        if(!Env.getCurrentEnv().isMaster()){
-            if(ctx.executor.isForwardToMaster()) {
+        if (!Env.getCurrentEnv().isMaster()) {
+            if (ctx.executor.isForwardToMaster()) {
                 ctx.getAuditEventBuilder().setState (ctx.executor.getProxyStatus());
             }
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectProcessor.java
@@ -223,7 +223,7 @@ public class ConnectProcessor {
         }
         if (!Env.getCurrentEnv().isMaster()) {
             if (ctx.executor.isForwardToMaster()) {
-                ctx.getAuditEventBuilder().setState (ctx.executor.getProxyStatus());
+                ctx.getAuditEventBuilder().setState(ctx.executor.getProxyStatus());
             }
         }
         Env.getCurrentAuditEventProcessor().handleAuditEvent(ctx.getAuditEventBuilder().build());

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/MasterOpExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/MasterOpExecutor.java
@@ -169,7 +169,7 @@ public class MasterOpExecutor {
         if (result == null) {
             return QueryState.MysqlStateType.UNKNOWN.name();
         }
-        if (result.isStatus()) {
+        if (result.isSetStatus()) {
             return QueryState.MysqlStateType.UNKNOWN.name();
         } else {
             return result.getStatus();

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/MasterOpExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/MasterOpExecutor.java
@@ -165,6 +165,12 @@ public class MasterOpExecutor {
         }
     }
 
+    public String getProxyStatus() {
+        if (result == null) {
+            return null;
+        }
+        return result.getStatus();
+    }
 
     public ShowResultSet getProxyResultSet() {
         if (result == null) {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/MasterOpExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/MasterOpExecutor.java
@@ -169,7 +169,7 @@ public class MasterOpExecutor {
         if (result == null) {
             return QueryState.MysqlStateType.UNKNOWN.name();
         }
-        if (result.isSetStatus()) {
+        if (!result.isSetStatus()) {
             return QueryState.MysqlStateType.UNKNOWN.name();
         } else {
             return result.getStatus();

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/MasterOpExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/MasterOpExecutor.java
@@ -167,9 +167,13 @@ public class MasterOpExecutor {
 
     public String getProxyStatus() {
         if (result == null) {
-            return null;
+            return QueryState.MysqlStateType.UNKNOWN.name();
         }
-        return result.getStatus();
+        if (result.isStatus()) {
+            return QueryState.MysqlStateType.UNKNOWN.name();
+        } else {
+            return result.getStatus();
+        }
     }
 
     public ShowResultSet getProxyResultSet() {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/QueryState.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/QueryState.java
@@ -29,7 +29,8 @@ public class QueryState {
         NOOP,   // send nothing to remote
         OK,     // send OK packet to remote
         EOF,    // send EOF packet to remote
-        ERR     // send ERROR packet to remote
+        ERR,     // send ERROR packet to remote
+        UNKNOWN  // send UNKNOWN packet to remote
     }
 
     public enum ErrType {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -346,7 +346,7 @@ public class StmtExecutor implements ProfileWriter {
 
     public String getProxyStatus() {
         if (masterOpExecutor == null) {
-            return null;
+            return MysqlStateType.UNKNOWN.name();
         }
         return masterOpExecutor.getProxyStatus();
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -346,10 +346,11 @@ public class StmtExecutor implements ProfileWriter {
 
     public String getProxyStatus() {
         if (masterOpExecutor == null) {
-           return null;
+            return null;
         }
         return masterOpExecutor.getProxyStatus();
     }
+
     public boolean isQueryStmt() {
         return parsedStmt != null && parsedStmt instanceof QueryStmt;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -337,7 +337,7 @@ public class StmtExecutor implements ProfileWriter {
     }
 
     public ShowResultSet getShowResultSet() {
-        if(masterOpExecutor == null) {
+        if (masterOpExecutor == null) {
             return null;
         } else {
             return masterOpExecutor.getProxyResultSet();
@@ -345,7 +345,7 @@ public class StmtExecutor implements ProfileWriter {
     }
 
     public String getProxyStatus() {
-        if(masterOpExecutor == null) {
+        if (masterOpExecutor == null) {
            return null;
         }
         return masterOpExecutor.getProxyStatus();

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -337,13 +337,19 @@ public class StmtExecutor implements ProfileWriter {
     }
 
     public ShowResultSet getShowResultSet() {
-        if (masterOpExecutor == null) {
+        if(masterOpExecutor == null) {
             return null;
         } else {
             return masterOpExecutor.getProxyResultSet();
         }
     }
 
+    public String getProxyStatus() {
+        if(masterOpExecutor == null) {
+           return null;
+        }
+        return masterOpExecutor.getProxyStatus();
+    }
     public boolean isQueryStmt() {
         return parsedStmt != null && parsedStmt instanceof QueryStmt;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
@@ -53,6 +53,7 @@ import org.apache.doris.policy.StoragePolicy;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.ConnectProcessor;
 import org.apache.doris.qe.QeProcessorImpl;
+import org.apache.doris.qe.QueryState;
 import org.apache.doris.qe.VariableMgr;
 import org.apache.doris.system.Frontend;
 import org.apache.doris.system.SystemInfoService;
@@ -501,7 +502,7 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         context.setCurrentConnectedFEIp(clientAddr.getHostname());
         ConnectProcessor processor = new ConnectProcessor(context);
         TMasterOpResult result = processor.proxyExecute(params);
-        if ("ERR".equalsIgnoreCase(result.getStatus())) {
+        if (QueryState.MysqlStateType.ERR.name().equalsIgnoreCase(result.getStatus())) {
             context.getState().setError(result.getStatus());
         } else {
             context.getState().setOk();

--- a/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
@@ -501,7 +501,11 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         context.setCurrentConnectedFEIp(clientAddr.getHostname());
         ConnectProcessor processor = new ConnectProcessor(context);
         TMasterOpResult result = processor.proxyExecute(params);
-        context.getState().setError(result.getStatus());
+        if ("ERR".equalsIgnoreCase(result.getStatus())) {
+            context.getState().setError(result.getStatus());
+        } else {
+            context.getState().setOk();
+        }
         ConnectContext.remove();
         return result;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
@@ -501,6 +501,7 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         context.setCurrentConnectedFEIp(clientAddr.getHostname());
         ConnectProcessor processor = new ConnectProcessor(context);
         TMasterOpResult result = processor.proxyExecute(params);
+        context.getState().setError(result.getStatus());
         ConnectContext.remove();
         return result;
     }

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -459,6 +459,7 @@ struct TMasterOpResult {
     2: required binary packet;
     3: optional TShowResultSet resultSet;
     4: optional Types.TUniqueId queryId;
+    5: optional string status;
 }
 
 struct TUpdateExportTaskStatusRequest {


### PR DESCRIPTION
# Proposed changes

If it is an operation that needs to be forwarded to the master, the sql execution fails, but the status of the non-master audit log record operation is OK, but the master records ERR
The above operation also caused duplicate records, who should operate the records
The revised scheme is:

Who operates who records
If it is forward to master, the status of the operation is transmitted to the client through RPC to ensure the correctness of the status record

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

