### PR TITLE
[enhancement](like)pass data to like function in block not in row

### DIFF
--- a/be/src/olap/like_column_predicate.cpp
+++ b/be/src/olap/like_column_predicate.cpp
@@ -115,31 +115,46 @@ uint16_t LikeColumnPredicate<is_vectorized>::evaluate(const vectorized::IColumn&
             }
         } else {
             if (column.is_column_dictionary()) {
-                auto* nested_col_ptr = vectorized::check_and_get_column<
-                        vectorized::ColumnDictionary<vectorized::Int32>>(column);
-                auto& data_array = nested_col_ptr->get_data();
-                for (uint16_t i = 0; i != size; i++) {
-                    uint16_t idx = sel[i];
-                    sel[new_size] = idx;
-                    StringValue cell_value = nested_col_ptr->get_value(data_array[idx]);
-                    unsigned char flag = 0;
-                    (_state->function)(const_cast<vectorized::LikeSearchState*>(&_like_state),
-                                       cell_value, pattern, &flag);
-                    new_size += _opposite ^ flag;
+                if (LIKELY(_like_state.search_string_sv.len > 0)) {
+                    auto* nested_col_ptr = vectorized::check_and_get_column<
+                            vectorized::ColumnDictionary<vectorized::Int32>>(column);
+                    auto& data_array = nested_col_ptr->get_data();
+                    StringValue values[size];
+                    unsigned char flags[size];
+                    for (uint16_t i = 0; i != size; i++) {
+                        values[i] = nested_col_ptr->get_value(data_array[sel[i]]);
+                    }
+                    (_state->function_vec_dict)(
+                            const_cast<vectorized::LikeSearchState*>(&_like_state), pattern, values,
+                            size, flags);
+
+                    for (uint16_t i = 0; i != size; i++) {
+                        uint16_t idx = sel[i];
+                        sel[new_size] = idx;
+                        new_size += _opposite ^ flags[i];
+                    }
+                } else {
+                    for (uint16_t i = 0; i != size; i++) {
+                        uint16_t idx = sel[i];
+                        sel[new_size] = idx;
+                        new_size += _opposite ^ true;
+                    }
                 }
             } else {
-                auto* data_array = vectorized::check_and_get_column<
-                                           vectorized::PredicateColumnType<TYPE_STRING>>(column)
-                                           ->get_data()
-                                           .data();
+                if (LIKELY(_like_state.search_string_sv.len > 0)) {
+                    auto* data_array = vectorized::check_and_get_column<
+                                               vectorized::PredicateColumnType<TYPE_STRING>>(column)
+                                               ->get_data()
+                                               .data();
 
-                for (uint16_t i = 0; i != size; i++) {
-                    uint16_t idx = sel[i];
-                    sel[new_size] = idx;
-                    unsigned char flag = 0;
-                    (_state->function)(const_cast<vectorized::LikeSearchState*>(&_like_state),
-                                       data_array[idx], pattern, &flag);
-                    new_size += _opposite ^ flag;
+                    (_state->function_vec)(const_cast<vectorized::LikeSearchState*>(&_like_state),
+                                           pattern, data_array, sel, size, _opposite, &new_size);
+                } else {
+                    for (uint16_t i = 0; i < size; i++) {
+                        uint16_t idx = sel[i];
+                        sel[new_size] = idx;
+                        new_size += _opposite ^ true;
+                    }
                 }
             }
         }

--- a/be/src/olap/like_column_predicate.h
+++ b/be/src/olap/like_column_predicate.h
@@ -118,23 +118,32 @@ private:
                 }
             } else {
                 if (column.is_column_dictionary()) {
-                    auto* nested_col_ptr = vectorized::check_and_get_column<
-                            vectorized::ColumnDictionary<vectorized::Int32>>(column);
-                    auto& data_array = nested_col_ptr->get_data();
-                    for (uint16_t i = 0; i < size; i++) {
-                        StringValue cell_value = nested_col_ptr->get_value(data_array[i]);
-                        if constexpr (is_and) {
-                            unsigned char flag = 0;
-                            (_state->function)(
-                                    const_cast<vectorized::LikeSearchState*>(&_like_state),
-                                    cell_value, pattern, &flag);
-                            flags[i] &= _opposite ^ flag;
-                        } else {
-                            unsigned char flag = 0;
-                            (_state->function)(
-                                    const_cast<vectorized::LikeSearchState*>(&_like_state),
-                                    cell_value, pattern, &flag);
-                            flags[i] = _opposite ^ flag;
+                    if (LIKELY(_like_state.search_string_sv.len > 0)) {
+                        auto* nested_col_ptr = vectorized::check_and_get_column<
+                                vectorized::ColumnDictionary<vectorized::Int32>>(column);
+                        auto& data_array = nested_col_ptr->get_data();
+                        StringValue values[size];
+                        unsigned char temp_flags[size];
+                        for (uint16_t i = 0; i != size; i++) {
+                            values[i] = nested_col_ptr->get_value(data_array[i]);
+                        }
+                        (_state->function_vec_dict)(
+                                const_cast<vectorized::LikeSearchState*>(&_like_state), pattern,
+                                values, size, temp_flags);
+                        for (uint16_t i = 0; i < size; i++) {
+                            if constexpr (is_and) {
+                                flags[i] &= _opposite ^ temp_flags[i];
+                            } else {
+                                flags[i] = _opposite ^ temp_flags[i];
+                            }
+                        }
+                    } else {
+                        for (uint16_t i = 0; i < size; i++) {
+                            if constexpr (is_and) {
+                                flags[i] &= _opposite ^ true;
+                            } else {
+                                flags[i] = _opposite ^ true;
+                            }
                         }
                     }
                 } else {

--- a/be/src/vec/functions/like.h
+++ b/be/src/vec/functions/like.h
@@ -96,12 +96,21 @@ struct LikeSearchState {
     }
 };
 
-using LikeFn = std::function<doris::Status(LikeSearchState* state, const StringValue&,
-                                           const StringValue&, unsigned char*)>;
+using LikeFn = std::function<doris::Status(LikeSearchState*, const StringValue&, const StringValue&,
+                                           unsigned char*)>;
+
+using LikeFnVec =
+        std::function<doris::Status(LikeSearchState*, const StringValue&, const StringValue*,
+                                    uint16_t*, uint16_t, bool, uint16_t*)>;
+
+using LikeFnVecDict = std::function<doris::Status(LikeSearchState*, const StringValue&,
+                                                  const StringValue*, uint16_t, unsigned char*)>;
 
 struct LikeState {
     LikeSearchState search_state;
     LikeFn function;
+    LikeFnVec function_vec;
+    LikeFnVecDict function_vec_dict;
 };
 
 class FunctionLikeBase : public IFunction {
@@ -136,6 +145,14 @@ protected:
 
     static Status constant_substring_fn(LikeSearchState* state, const StringValue& val,
                                         const StringValue& pattern, unsigned char* result);
+
+    static Status constant_substring_fn_vec(LikeSearchState* state, const StringValue& pattern,
+                                            const StringValue* values, uint16_t* sel, uint16_t size,
+                                            bool opposite, uint16_t* new_size);
+
+    static Status constant_substring_fn_vec_dict(LikeSearchState* state, const StringValue& pattern,
+                                                 const StringValue* values, uint16_t size,
+                                                 unsigned char* result);
 
     static Status constant_regex_fn(LikeSearchState* state, const StringValue& val,
                                     const StringValue& pattern, unsigned char* result);


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary
The like predicate process data in block perform better than in row. Currently, only not null column is optimized, nullable column will be handled later.

`SELECT COUNT(*) FROM hits WHERE URL LIKE '%google%';`
before: ~680ms
after:    ~570ms

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

