### PR TITLE
[feature](file scanner)Get column type from parquet schema.

### DIFF
--- a/be/src/vec/exec/format/generic_reader.h
+++ b/be/src/vec/exec/format/generic_reader.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include "common/status.h"
+#include "runtime/types.h"
 
 namespace doris::vectorized {
 

--- a/be/src/vec/exec/format/parquet/schema_desc.h
+++ b/be/src/vec/exec/format/parquet/schema_desc.h
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#include <gen_cpp/parquet_types.h>
+
 #include <unordered_map>
 #include <vector>
 
@@ -75,6 +77,10 @@ private:
 
     Status parse_node_field(const std::vector<tparquet::SchemaElement>& t_schemas, size_t curr_pos,
                             FieldSchema* node_field);
+
+    TypeDescriptor convert_to_doris_type(tparquet::LogicalType logicalType);
+
+    TypeDescriptor convert_to_doris_type(tparquet::ConvertedType::type convertedType);
 
 public:
     FieldDescriptor() = default;

--- a/be/src/vec/exec/format/parquet/vparquet_reader.cpp
+++ b/be/src/vec/exec/format/parquet/vparquet_reader.cpp
@@ -103,36 +103,11 @@ Status ParquetReader::_init_read_columns(const std::vector<SlotDescriptor*>& tup
 std::unordered_map<std::string, TypeDescriptor> ParquetReader::get_name_to_type() {
     std::unordered_map<std::string, TypeDescriptor> map;
     auto schema_desc = _file_metadata->schema();
-    for (auto& it : _map_column) {
-        TypeDescriptor type;
-        if (it.first == "p_partkey") {
-            type.type = TYPE_INT;
-        } else if (it.first == "p_name") {
-            type.type = TYPE_VARCHAR;
-            type.len = 55;
-        } else if (it.first == "p_mfgr") {
-            type.type = TYPE_VARCHAR;
-            type.len = 25;
-        } else if (it.first == "p_brand") {
-            type.type = TYPE_VARCHAR;
-            type.len = 10;
-        } else if (it.first == "p_type") {
-            type.type = TYPE_VARCHAR;
-            type.len = 25;
-        } else if (it.first == "p_size") {
-            type.type = TYPE_INT;
-        } else if (it.first == "p_container") {
-            type.type = TYPE_VARCHAR;
-            type.len = 10;
-        } else if (it.first == "p_retailprice") {
-            type.type = TYPE_DECIMALV2;
-            type.precision = 27;
-            type.scale = 9;
-        } else if (it.first == "p_comment") {
-            type.type = TYPE_VARCHAR;
-            type.len = 23;
-        }
-        map.emplace(it.first, type);
+    std::unordered_set<std::string> column_names;
+    schema_desc.get_column_names(&column_names);
+    for (auto name : column_names) {
+        auto field = schema_desc.get_column(name);
+        map.emplace(name, field->type);
     }
     return map;
 }


### PR DESCRIPTION
# Proposed changes

Get schema from parquet reader. The new VFileScanner need to get file schema (column name to type map) from parquet file while processing load job, this pr is to set the type information for parquet columns. 

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

