### PR TITLE
[Improvement](statistics) collect statistics in parallel and add test cases

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/ColumnStats.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/ColumnStats.java
@@ -38,7 +38,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Predicate;
 
-
 /**
  * There are the statistics of column.
  * The column stats are mainly used to provide input for the Optimizer's cost model.

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/util/InternalQuery.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/util/InternalQuery.java
@@ -180,13 +180,13 @@ public class InternalQuery {
         }
     }
 
-    private InternalQueryResult fetchResult() throws DdlException {
+    private InternalQueryResult fetchResult() {
         List<String> columns = stmt.getColLabels();
         List<PrimitiveType> types = stmt.getResultExprs().stream()
                 .map(e -> e.getType().getPrimitiveType())
                 .collect(Collectors.toList());
 
-        InternalQueryResult result = new InternalQueryResult(columns, types);
+        InternalQueryResult result = new InternalQueryResult();
         List<ResultRow> resultRows = result.getResultRows();
 
         for (TResultBatch batch : resultBatches) {
@@ -200,7 +200,7 @@ public class InternalQuery {
                     values.add(value);
                 }
 
-                ResultRow resultRow = new ResultRow(values);
+                ResultRow resultRow = new ResultRow(columns, types, values);
                 resultRows.add(resultRow);
             }
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/util/InternalQueryResult.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/util/InternalQueryResult.java
@@ -23,6 +23,7 @@ import org.apache.doris.common.DdlException;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -31,66 +32,51 @@ import java.util.Map;
  * providing some read operations.
  */
 public class InternalQueryResult {
-    private static List<String> mateOfColumns;
-    private static List<PrimitiveType> mateOfTypes;
-
     private final List<ResultRow> resultRows = Lists.newArrayList();
 
-    public InternalQueryResult(List<String> columns, List<PrimitiveType> types) {
-        mateOfColumns = columns;
-        mateOfTypes = types;
+    public InternalQueryResult() {
     }
 
     public List<ResultRow> getResultRows() {
         return resultRows;
     }
 
-    public static List<String> getMateOfColumns() throws DdlException {
-        if (mateOfColumns == null) {
-            throw new DdlException("Failed to get the column names.");
-        }
-        return mateOfColumns;
-    }
-
-    public static List<PrimitiveType> getMateOfTypes() throws DdlException {
-        if (mateOfTypes == null) {
-            throw new DdlException("Failed to get the column types.");
-        }
-        return mateOfTypes;
-    }
-
     public static class ResultRow {
+        private final List<String> columns;
+        private final List<PrimitiveType> types;
         private final List<String> values;
 
         private final Map<String, Integer> columnNameMap = Maps.newHashMap();
         private final Map<Integer, String> columnIndexMap = Maps.newHashMap();
 
-        public ResultRow(List<String> values) throws DdlException {
+        public ResultRow(List<String> columns, List<PrimitiveType> types, List<String> values) {
+            this.columns = columns;
+            this.types = types;
             this.values = values;
             buildColumnNameMap();
             buildColumnIndexMap();
         }
 
-        public List<String> getColumns() throws DdlException {
-            return getMateOfColumns();
+        public List<String> getColumns() {
+            return columns != null ? columns : Collections.emptyList();
         }
 
-        public List<PrimitiveType> getTypes() throws DdlException {
-            return getMateOfTypes();
+        public List<PrimitiveType> getTypes() {
+            return types != null ? types : Collections.emptyList();
         }
 
         public List<String> getValues() {
-            return values != null ? values : Lists.newArrayList();
+            return values != null ? values : Collections.emptyList();
         }
 
-        private void buildColumnNameMap() throws DdlException {
+        private void buildColumnNameMap() {
             List<String> columns = getColumns();
             for (int i = 0; i < columns.size(); i++) {
                 columnNameMap.put(columns.get(i), i);
             }
         }
 
-        private void buildColumnIndexMap() throws DdlException {
+        private void buildColumnIndexMap() {
             List<String> columns = getColumns();
             for (int i = 0; i < columns.size(); i++) {
                 columnIndexMap.put(i, columns.get(i));
@@ -218,24 +204,19 @@ public class InternalQueryResult {
 
         @Override
         public String toString() {
-            try {
-                StringBuilder sb = new StringBuilder();
-                sb.append("ResultRow{ ");
-                if (values != null && values.size() > 0) {
-                    List<String> columns = getColumns();
-                    for (int i = 0; i < values.size(); i++) {
-                        sb.append(columns.get(i));
-                        sb.append(":");
-                        sb.append(values.get(i));
-                        sb.append(" ");
-                    }
+            StringBuilder sb = new StringBuilder();
+            sb.append("ResultRow{ ");
+            if (values != null && values.size() > 0) {
+                List<String> columns = getColumns();
+                for (int i = 0; i < values.size(); i++) {
+                    sb.append(columns.get(i));
+                    sb.append(":");
+                    sb.append(values.get(i));
+                    sb.append(" ");
                 }
-                sb.append("}");
-                return sb.toString();
-            } catch (DdlException ignored) {
-                return "ResultRow{" + "values=" + values + ", columnNameMap="
-                        + columnNameMap + ", columnIndexMap=" + columnIndexMap + '}';
             }
+            sb.append("}");
+            return sb.toString();
         }
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/statistics/StatisticsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/statistics/StatisticsTest.java
@@ -1,0 +1,277 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.statistics;
+
+import org.apache.doris.catalog.PrimitiveType;
+import org.apache.doris.catalog.Type;
+import org.apache.doris.common.AnalysisException;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class StatisticsTest {
+    private Statistics statisticsUnderTest;
+
+    @Before
+    public void setUp() throws Exception {
+        statisticsUnderTest = new Statistics();
+    }
+
+    @Test
+    public void testUpdateTableStats() throws Exception {
+        // Setup
+        Map<StatsType, String> statsTypeToValue = new HashMap<>();
+        statsTypeToValue.put(StatsType.ROW_COUNT, "1000");
+
+        // Run the test
+        statisticsUnderTest.updateTableStats(0L, statsTypeToValue);
+        long rowCount = statisticsUnderTest.getTableStats(0L).getRowCount();
+
+        // Verify the results
+        Assert.assertEquals(rowCount, 1000L);
+    }
+
+    @Test
+    public void testUpdateTableStats_ThrowsAnalysisException() {
+        // Setup
+        Map<StatsType, String> statsTypeToValue = new HashMap<>();
+        statsTypeToValue.put(StatsType.ROW_COUNT, "-100");
+
+        // Run the test
+        Assert.assertThrows(AnalysisException.class,
+                () -> statisticsUnderTest.updateTableStats(0L, statsTypeToValue));
+    }
+
+    @Test
+    public void testUpdatePartitionStats() throws Exception {
+        // Setup
+        Map<StatsType, String> statsTypeToValue = new HashMap<>();
+        statsTypeToValue.put(StatsType.ROW_COUNT, "1000");
+
+        // Run the test
+        statisticsUnderTest.updatePartitionStats(0L, "partitionName", statsTypeToValue);
+        Map<String, PartitionStats> partitionStats = statisticsUnderTest
+                .getPartitionStats(0L, "partitionName");
+        long rowCount = partitionStats.get("partitionName").getRowCount();
+
+        // Verify the results
+        Assert.assertEquals(rowCount, 1000L);
+    }
+
+    @Test
+    public void testUpdatePartitionStats_ThrowsAnalysisException() {
+        // Setup
+        Map<StatsType, String> statsTypeToValue = new HashMap<>();
+        statsTypeToValue.put(StatsType.ROW_COUNT, "-100");
+
+        // Run the test
+        Assert.assertThrows(AnalysisException.class, () -> statisticsUnderTest
+                        .updatePartitionStats(0L, "partitionName", statsTypeToValue));
+    }
+
+    @Test
+    public void testUpdateTableColumnStats() throws Exception {
+        // Setup
+        Type columnType = Type.fromPrimitiveType(PrimitiveType.STRING);
+        Map<StatsType, String> statsTypeToValue = new HashMap<>();
+        statsTypeToValue.put(StatsType.NUM_NULLS, "1000");
+
+        // Run the test
+        statisticsUnderTest.updateColumnStats(0L, "columnName", columnType, statsTypeToValue);
+        Map<String, ColumnStats> columnStats = statisticsUnderTest.getColumnStats(0L);
+        long numNulls = columnStats.get("columnName").getNumNulls();
+
+        // Verify the results
+        Assert.assertEquals(numNulls, 1000L);
+    }
+
+    @Test
+    public void testUpdateTableColumnStats_ThrowsAnalysisException() {
+        // Setup
+        Type columnType = Type.fromPrimitiveType(PrimitiveType.BIGINT);
+        Map<StatsType, String> statsTypeToValue = new HashMap<>();
+        statsTypeToValue.put(StatsType.MAX_VALUE, "ABC");
+
+        // Run the test
+        Assert.assertThrows(AnalysisException.class, () -> statisticsUnderTest
+                .updateColumnStats(0L, "columnName", columnType, statsTypeToValue));
+    }
+
+    @Test
+    public void testUpdatePartitionColumnStats() throws Exception {
+        // Setup
+        Type columnType = Type.fromPrimitiveType(PrimitiveType.STRING);
+        Map<StatsType, String> statsTypeToValue = new HashMap<>();
+        statsTypeToValue.put(StatsType.NUM_NULLS, "1000");
+
+        // Run the test
+        statisticsUnderTest.updateColumnStats(0L, "partitionName",
+                "columnName", columnType, statsTypeToValue);
+        Map<String, ColumnStats> columnStats = statisticsUnderTest
+                .getColumnStats(0L, "partitionName");
+        long numNulls = columnStats.get("columnName").getNumNulls();
+
+        // Verify the results
+        Assert.assertEquals(numNulls, 1000L);
+    }
+
+    @Test
+    public void testUpdatePartitionColumnStats_ThrowsAnalysisException() {
+        // Setup
+        Type columnType = Type.fromPrimitiveType(PrimitiveType.BIGINT);
+        Map<StatsType, String> statsTypeToValue = new HashMap<>();
+        statsTypeToValue.put(StatsType.ROW_COUNT, "ABC");
+
+        // Run the test
+        Assert.assertThrows(AnalysisException.class, () -> statisticsUnderTest.updateColumnStats(
+                0L, "partitionName", "columnName", columnType, statsTypeToValue));
+    }
+
+    @Test
+    public void testGetNotNullTableStats() {
+        // Run the test
+        TableStats result = statisticsUnderTest.getNotNullTableStats(0L);
+
+        // Verify the results
+        Assert.assertNotNull(result);
+    }
+
+    @Test
+    public void testGetTableStats() throws Exception {
+        // Setup
+        Map<StatsType, String> statsTypeToValue = new HashMap<>();
+        statsTypeToValue.put(StatsType.ROW_COUNT, "1000");
+        statisticsUnderTest.updateTableStats(0L, statsTypeToValue);
+
+        // Run the test
+        TableStats result = statisticsUnderTest.getTableStats(0L);
+
+        // Verify the results
+        Assert.assertNotNull(result);
+    }
+
+    @Test
+    public void testGetTableStats_ThrowsAnalysisException() {
+        // Verify the results
+        Assert.assertThrows(AnalysisException.class,
+                () -> statisticsUnderTest.getTableStats(0L));
+    }
+
+    @Test
+    public void testGetNotNullPartitionStats() {
+        // Run the test
+        PartitionStats result = statisticsUnderTest
+                .getNotNullPartitionStats(0L, "partitionName");
+
+        // Verify the results
+        Assert.assertNotNull(result);
+    }
+
+    @Test
+    public void testGetPartitionStats() throws Exception {
+        // Setup
+        Map<StatsType, String> statsTypeToValue = new HashMap<>();
+        statsTypeToValue.put(StatsType.ROW_COUNT, "1000");
+        statisticsUnderTest.updatePartitionStats(0L, "partitionName", statsTypeToValue);
+
+        // Run the test
+        Map<String, PartitionStats> result = statisticsUnderTest.getPartitionStats(0L);
+
+        // Verify the results
+        Assert.assertNotNull(result);
+    }
+
+    @Test
+    public void testGetPartitionStats1_ThrowsAnalysisException() {
+        // Verify the results
+        Assert.assertThrows(AnalysisException.class,
+                () -> statisticsUnderTest.getPartitionStats(0L));
+    }
+
+    @Test
+    public void testGetPartitionStatsWithName() throws Exception {
+        // Setup
+        Map<StatsType, String> statsTypeToValue = new HashMap<>();
+        statsTypeToValue.put(StatsType.ROW_COUNT, "1000");
+        statisticsUnderTest.updatePartitionStats(0L, "partitionName", statsTypeToValue);
+
+        // Run the test
+        Map<String, PartitionStats> result = statisticsUnderTest
+                .getPartitionStats(0L, "partitionName");
+
+        // Verify the results
+        Assert.assertNotNull(result);
+    }
+
+    @Test
+    public void testGetPartitionStatsWithName_ThrowsAnalysisException() {
+        // Run the test
+        Assert.assertThrows(AnalysisException.class, () -> statisticsUnderTest
+                .getPartitionStats(0L, "partitionName"));
+    }
+
+    @Test
+    public void testGetTableColumnStats() throws Exception {
+        // Setup
+        Type columnType = Type.fromPrimitiveType(PrimitiveType.STRING);
+        Map<StatsType, String> statsTypeToValue = new HashMap<>();
+        statsTypeToValue.put(StatsType.NUM_NULLS, "1000");
+        statisticsUnderTest.updateColumnStats(0L, "columnName", columnType, statsTypeToValue);
+
+        // Run the test
+        Map<String, ColumnStats> result = statisticsUnderTest.getColumnStats(0L);
+
+        // Verify the results
+        Assert.assertNotNull(result);
+    }
+
+    @Test
+    public void testGetTableColumnStats_ThrowsAnalysisException() {
+        // Verify the results
+        Assert.assertThrows(AnalysisException.class,
+                () -> statisticsUnderTest.getColumnStats(0L));
+    }
+
+    @Test
+    public void testGetPartitionColumnStats() throws Exception {
+        // Setup
+        Type columnType = Type.fromPrimitiveType(PrimitiveType.STRING);
+        Map<StatsType, String> statsTypeToValue = new HashMap<>();
+        statsTypeToValue.put(StatsType.NUM_NULLS, "1000");
+        statisticsUnderTest.updateColumnStats(0L, "partitionName",
+                "columnName", columnType, statsTypeToValue);
+
+        // Run the test
+        Map<String, ColumnStats> result = statisticsUnderTest
+                .getColumnStats(0L, "partitionName");
+
+        // Verify the results
+        Assert.assertNotNull(result);
+    }
+
+    @Test
+    public void testGetPartitionColumnStats_ThrowsAnalysisException() {
+        // Verify the results
+        Assert.assertThrows(AnalysisException.class, () -> statisticsUnderTest
+                .getColumnStats(0L, "partitionName"));
+    }
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/statistics/util/InternalQueryResultTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/statistics/util/InternalQueryResultTest.java
@@ -39,20 +39,9 @@ public class InternalQueryResultTest {
         List<PrimitiveType> types = Arrays.asList(PrimitiveType.STRING,
                 PrimitiveType.INT, PrimitiveType.FLOAT,
                 PrimitiveType.DOUBLE, PrimitiveType.BIGINT);
-        queryResult = new InternalQueryResult(columns, types);
-        resultRow = new ResultRow(Arrays.asList("s1", "1000", "0.1", "0.0001", "1000000"));
-    }
-
-    @Test
-    public void testGetMateOfColumns() throws Exception {
-        Assert.assertEquals(Arrays.asList("c1", "c2", "c3", "c4", "c5"),
-                InternalQueryResult.getMateOfColumns());
-    }
-
-    @Test
-    public void testGetMateOfTypes() throws Exception {
-        Assert.assertEquals(Arrays.asList(PrimitiveType.STRING, PrimitiveType.INT, PrimitiveType.FLOAT,
-                PrimitiveType.DOUBLE, PrimitiveType.BIGINT), InternalQueryResult.getMateOfTypes());
+        queryResult = new InternalQueryResult();
+        List<String> values = Arrays.asList("s1", "1000", "0.1", "0.0001", "1000000");
+        resultRow = new ResultRow(columns, types, values);
     }
 
     @Test


### PR DESCRIPTION
# Proposed changes

This PR mainly improves some functions of the statistics module(#6370)：
1. when collecting partition statistics, filter empty partitions in advance and do not generate statistical tasks.
2. the old statistical update method may have problems when updating statistics in parallel, which has been solved.
3. optimize internal-query.
3. add test cases related to statistics.
4. modify some comments as prompted by CheckStyle.

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
5. Has unit tests been added:
    - [x] Yes
    - [ ] No
    - [ ] No Need
6. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
7. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
8. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

