### PR TITLE
[Enhancement](debugging) Add more debug info for clang build

### DIFF
--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -456,7 +456,7 @@ if (COMPILER_GCC)
 endif ()
 
 if (COMPILER_CLANG)
-    add_compile_options (-fcolor-diagnostics)
+    add_compile_options(-fcolor-diagnostics -fno-limit-debug-info)
     if(MAKE_TEST STREQUAL "OFF")
         add_compile_options(-Qunused-arguments)
     endif()


### PR DESCRIPTION
# Proposed changes

Issue Number: close #12843

Add a compile option for clang: `-fno-limit-debug-info`

## Problem summary

Currently, If we use clang to build the project, we can't view the contents of some objects (e.g. `std::string` objects) in gdb. It is inconvenient for us to debug the program due to the frequency of these objects is high.

More information can be refered to [Cannot view std::string when compiled with clang](https://stackoverflow.com/questions/41745527/cannot-view-stdstring-when-compiled-with-clang).

### Example

**source code: test.cc**
```cpp
#include <iostream>
#include <string>

int main() {
    std::string s = "Hello, world!";
    std::cout << s << std::endl;
    return 0;
}

```

**Debugging with GDB**
```gdb
(gdb) l
1       #include <iostream>
2       #include <string>
3
4       int main() {
5           std::string s = "Hello, world!";
6           std::cout << s << std::endl;
7           return 0;
8       }
(gdb) b 6
Breakpoint 1 at 0x14e0e: file test.cc, line 6.
(gdb) r
Starting program: /ssd2/lingcong/misc/clang/test

Breakpoint 1, main () at test.cc:6
6           std::cout << s << std::endl;
```

### Before

```shell
clang++ -g test.cc -o test
```

```gdb
(gdb) p s
$1 = <incomplete type>
(gdb) p s.c_str()
Couldn't find method std::string::c_str
(gdb)
```

### After

```shell
clang++ -fno-limit-debug-info -g test.cc -o test
```

```gdb
(gdb) p s
$1 = {static npos = 18446744073709551615, _M_dataplus = {<std::allocator<char>> = {<__gnu_cxx::new_allocator<char>> = {<No data fields>}, <No data fields>},
    _M_p = 0x7fffffffe358 "Hello, world!"}, _M_string_length = 13, {_M_local_buf = "Hello, world!\000\000", _M_allocated_capacity = 8583909746840200520}}
(gdb) p s.c_str()
$2 = 0x7fffffffe358 "Hello, world!"
(gdb)
```

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

