### PR TITLE
[feature](Nereids) use one stage aggregation if available

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/TupleDescriptor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/TupleDescriptor.java
@@ -412,9 +412,7 @@ public class TupleDescriptor {
                 .toString());
         builder.append("\n");
         for (SlotDescriptor slot : slots) {
-            if (slot.isMaterialized()) {
-                builder.append(slot.getExplainString(prefix)).append("\n");
-            }
+            builder.append(slot.getExplainString(prefix)).append("\n");
         }
         return builder.toString();
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/TupleDescriptor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/TupleDescriptor.java
@@ -412,7 +412,9 @@ public class TupleDescriptor {
                 .toString());
         builder.append("\n");
         for (SlotDescriptor slot : slots) {
-            builder.append(slot.getExplainString(prefix)).append("\n");
+            if (slot.isMaterialized()) {
+                builder.append(slot.getExplainString(prefix)).append("\n");
+            }
         }
         return builder.toString();
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslator.java
@@ -193,9 +193,8 @@ public class PhysicalPlanTranslator extends DefaultPlanVisitor<PlanFragment, Pla
         // 3. generate output tuple
         List<Slot> slotList = Lists.newArrayList();
         TupleDescriptor outputTupleDesc;
-        if (aggregate.getAggPhase() == AggPhase.LOCAL) {
-            outputTupleDesc = generateTupleDesc(aggregate.getOutput(), null, context);
-        } else if ((aggregate.getAggPhase() == AggPhase.GLOBAL && aggregate.isFinalPhase())
+        if (aggregate.getAggPhase() == AggPhase.LOCAL
+                || (aggregate.getAggPhase() == AggPhase.GLOBAL && aggregate.isFinalPhase())
                 || aggregate.getAggPhase() == AggPhase.DISTINCT_LOCAL) {
             slotList.addAll(groupSlotList);
             slotList.addAll(aggFunctionOutput);

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslator.java
@@ -222,10 +222,12 @@ public class PhysicalPlanTranslator extends DefaultPlanVisitor<PlanFragment, Pla
                 outputTupleDesc, aggregate.getAggPhase().toExec());
         AggregationNode aggregationNode = new AggregationNode(context.nextPlanNodeId(),
                 inputPlanFragment.getPlanRoot(), aggInfo);
+        if (!aggregate.isFinalPhase()) {
+            aggregationNode.unsetNeedsFinalize();
+        }
         PlanFragment currentFragment = inputPlanFragment;
         switch (aggregate.getAggPhase()) {
             case LOCAL:
-                aggregationNode.unsetNeedsFinalize();
                 aggregationNode.setUseStreamingPreagg(aggregate.isUsingStream());
                 aggregationNode.setIntermediateTuple();
                 break;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/batch/NereidsRewriteJobExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/batch/NereidsRewriteJobExecutor.java
@@ -24,7 +24,6 @@ import org.apache.doris.nereids.rules.expression.rewrite.ExpressionNormalization
 import org.apache.doris.nereids.rules.expression.rewrite.ExpressionOptimization;
 import org.apache.doris.nereids.rules.mv.SelectRollupWithAggregate;
 import org.apache.doris.nereids.rules.mv.SelectRollupWithoutAggregate;
-import org.apache.doris.nereids.rules.rewrite.AggregateDisassemble;
 import org.apache.doris.nereids.rules.rewrite.logical.ColumnPruning;
 import org.apache.doris.nereids.rules.rewrite.logical.EliminateFilter;
 import org.apache.doris.nereids.rules.rewrite.logical.EliminateLimit;
@@ -68,7 +67,6 @@ public class NereidsRewriteJobExecutor extends BatchRulesJob {
                 .add(topDownBatch(ImmutableList.of(new ColumnPruning())))
                 .add(topDownBatch(RuleSet.PUSH_DOWN_JOIN_CONDITION_RULES, false))
                 .add(topDownBatch(ImmutableList.of(new FindHashConditionForJoin())))
-                .add(topDownBatch(ImmutableList.of(new AggregateDisassemble())))
                 .add(topDownBatch(ImmutableList.of(new LimitPushDown())))
                 .add(topDownBatch(ImmutableList.of(new EliminateLimit())))
                 .add(topDownBatch(ImmutableList.of(new EliminateFilter())))

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/cascades/CostAndEnforcerJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/cascades/CostAndEnforcerJob.java
@@ -172,6 +172,10 @@ public class CostAndEnforcerJob extends Job implements Cloneable {
                 ChildrenPropertiesRegulator regulator = new ChildrenPropertiesRegulator(groupExpression,
                         lowestCostChildren, requestChildrenProperties, requestChildrenProperties, context);
                 double enforceCost = regulator.adjustChildrenProperties();
+                if (enforceCost < 0) {
+                    // invalid enforce, return.
+                    return;
+                }
                 curTotalCost += enforceCost;
 
                 // Not need to do pruning here because it has been done when we get the

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/RequestPropertyDeriver.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/RequestPropertyDeriver.java
@@ -80,7 +80,7 @@ public class RequestPropertyDeriver extends PlanVisitor<Void, PlanContext> {
     @Override
     public Void visitPhysicalAggregate(PhysicalAggregate<? extends Plan> agg, PlanContext context) {
         // 1. first phase agg just return any
-        if (agg.getAggPhase().isLocal()) {
+        if (agg.getAggPhase().isLocal() && !agg.isFinalPhase()) {
             addToRequestPropertyToChildren(PhysicalProperties.ANY);
             return null;
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/RuleSet.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/RuleSet.java
@@ -37,6 +37,7 @@ import org.apache.doris.nereids.rules.implementation.LogicalOneRowRelationToPhys
 import org.apache.doris.nereids.rules.implementation.LogicalProjectToPhysicalProject;
 import org.apache.doris.nereids.rules.implementation.LogicalSortToPhysicalQuickSort;
 import org.apache.doris.nereids.rules.implementation.LogicalTopNToPhysicalTopN;
+import org.apache.doris.nereids.rules.rewrite.AggregateDisassemble;
 import org.apache.doris.nereids.rules.rewrite.logical.EliminateOuter;
 import org.apache.doris.nereids.rules.rewrite.logical.MergeConsecutiveFilters;
 import org.apache.doris.nereids.rules.rewrite.logical.MergeConsecutiveLimits;
@@ -65,6 +66,7 @@ public class RuleSet {
             .add(SemiJoinLogicalJoinTranspose.LEFT_DEEP)
             .add(SemiJoinLogicalJoinTransposeProject.LEFT_DEEP)
             .add(SemiJoinSemiJoinTranspose.INSTANCE)
+            .add(new AggregateDisassemble())
             .add(new PushdownFilterThroughProject())
             .add(new MergeConsecutiveProjects())
             .build();

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/AggregateDisassemble.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/AggregateDisassemble.java
@@ -67,19 +67,23 @@ import java.util.stream.Collectors;
  *     2. if instance count is 1, shouldn't disassemble the agg plan
  */
 public class AggregateDisassemble extends OneRewriteRuleFactory {
+
     @Override
     public Rule build() {
-        return logicalAggregate().when(agg -> !agg.isDisassembled()).then(aggregate -> {
-            // used in secondDisassemble to transform local expressions into global
-            final Map<Expression, Expression> globalOutputSMap = Maps.newHashMap();
-            // used in secondDisassemble to transform local expressions into global
-            final Map<Expression, Expression> globalGroupBySMap = Maps.newHashMap();
-            Pair<LogicalAggregate, Boolean> ret = firstDisassemble(aggregate, globalOutputSMap, globalGroupBySMap);
-            if (!ret.second) {
-                return ret.first;
-            }
-            return secondDisassemble(ret.first, globalOutputSMap, globalGroupBySMap);
-        }).toRule(RuleType.AGGREGATE_DISASSEMBLE);
+        return logicalAggregate()
+                .whenNot(LogicalAggregate::isDisassembled)
+                .then(aggregate -> {
+                    // used in secondDisassemble to transform local expressions into global
+                    final Map<Expression, Expression> globalOutputSMap = Maps.newHashMap();
+                    // used in secondDisassemble to transform local expressions into global
+                    final Map<Expression, Expression> globalGroupBySMap = Maps.newHashMap();
+                    Pair<LogicalAggregate, Boolean> ret = firstDisassemble(aggregate, globalOutputSMap,
+                            globalGroupBySMap);
+                    if (!ret.second) {
+                        return ret.first;
+                    }
+                    return secondDisassemble(ret.first, globalOutputSMap, globalGroupBySMap);
+                }).toRule(RuleType.AGGREGATE_DISASSEMBLE);
     }
 
     // only support distinct function with group by

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/logical/MergeConsecutiveProjects.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/logical/MergeConsecutiveProjects.java
@@ -83,8 +83,7 @@ public class MergeConsecutiveProjects extends OneRewriteRuleFactory {
                 // case 2:
                 Slot ref = ((SlotReference) expr).withQualifier(Collections.emptyList());
                 if (substitutionMap.containsKey(ref)) {
-                    Alias res = (Alias) substitutionMap.get(ref);
-                    return (res.child() instanceof SlotReference) ? res : res.child();
+                    return substitutionMap.get(ref);
                 }
             } else if (substitutionMap.containsKey(expr)) {
                 return substitutionMap.get(expr).child(0);

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/logical/MergeConsecutiveProjects.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/logical/MergeConsecutiveProjects.java
@@ -56,6 +56,14 @@ public class MergeConsecutiveProjects extends OneRewriteRuleFactory {
     private static class ExpressionReplacer extends DefaultExpressionRewriter<Map<Expression, Expression>> {
         public static final ExpressionReplacer INSTANCE = new ExpressionReplacer();
 
+        public Expression replace(Expression expr, Map<Expression, Expression> substitutionMap) {
+            if (expr instanceof SlotReference) {
+                Slot ref = ((SlotReference) expr).withQualifier(Collections.emptyList());
+                return substitutionMap.getOrDefault(ref, expr);
+            }
+            return visit(expr, substitutionMap);
+        }
+
         /**
          * case 1:
          *          project(alias(c) as d, alias(x) as y)
@@ -83,7 +91,8 @@ public class MergeConsecutiveProjects extends OneRewriteRuleFactory {
                 // case 2:
                 Slot ref = ((SlotReference) expr).withQualifier(Collections.emptyList());
                 if (substitutionMap.containsKey(ref)) {
-                    return substitutionMap.get(ref);
+                    Alias res = (Alias) substitutionMap.get(ref);
+                    return res.child();
                 }
             } else if (substitutionMap.containsKey(expr)) {
                 return substitutionMap.get(expr).child(0);
@@ -105,7 +114,7 @@ public class MergeConsecutiveProjects extends OneRewriteRuleFactory {
                     );
 
             projectExpressions = projectExpressions.stream()
-                    .map(e -> MergeConsecutiveProjects.ExpressionReplacer.INSTANCE.visit(e, childAliasMap))
+                    .map(e -> MergeConsecutiveProjects.ExpressionReplacer.INSTANCE.replace(e, childAliasMap))
                     .map(NamedExpression.class::cast)
                     .collect(Collectors.toList());
             return new LogicalProject<>(projectExpressions, childProject.children().get(0));

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/logical/NormalizeAggregate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/logical/NormalizeAggregate.java
@@ -25,6 +25,7 @@ import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.NamedExpression;
 import org.apache.doris.nereids.trees.expressions.SlotReference;
 import org.apache.doris.nereids.trees.expressions.functions.agg.AggregateFunction;
+import org.apache.doris.nereids.trees.expressions.literal.Literal;
 import org.apache.doris.nereids.trees.plans.logical.LogicalAggregate;
 import org.apache.doris.nereids.trees.plans.logical.LogicalPlan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalProject;
@@ -61,7 +62,7 @@ import java.util.stream.Collectors;
 public class NormalizeAggregate extends OneRewriteRuleFactory {
     @Override
     public Rule build() {
-        return logicalAggregate().when(aggregate -> !aggregate.isNormalized()).then(aggregate -> {
+        return logicalAggregate().whenNot(LogicalAggregate::isNormalized).then(aggregate -> {
             // substitution map used to substitute expression in aggregate's output to use it as top projections
             Map<Expression, Expression> substitutionMap = Maps.newHashMap();
             List<Expression> keys = aggregate.getGroupByExpressions();
@@ -102,25 +103,40 @@ public class NormalizeAggregate extends OneRewriteRuleFactory {
             List<NamedExpression> outputs = aggregate.getOutputExpressions();
             Map<Boolean, List<NamedExpression>> partitionedOutputs = outputs.stream()
                     .collect(Collectors.groupingBy(e -> e.anyMatch(AggregateFunction.class::isInstance)));
+
+            boolean needBottomProjects = partitionedKeys.containsKey(false);
             if (partitionedOutputs.containsKey(true)) {
                 // process expressions that contain aggregate function
                 Set<AggregateFunction> aggregateFunctions = partitionedOutputs.get(true).stream()
                         .flatMap(e -> e.<Set<AggregateFunction>>collect(AggregateFunction.class::isInstance).stream())
                         .collect(Collectors.toSet());
-                newOutputs.addAll(aggregateFunctions.stream()
-                        .map(f -> new Alias(f, f.toSql()))
-                        .peek(a -> substitutionMap.put(a.child(), a.toSlot()))
-                        .collect(Collectors.toList()));
-                // add slot references in aggregate function to bottom projections
-                bottomProjections.addAll(aggregateFunctions.stream()
-                        .flatMap(f -> f.<Set<SlotReference>>collect(SlotReference.class::isInstance).stream())
-                        .map(SlotReference.class::cast)
-                        .collect(Collectors.toSet()));
+
+                // replace all non-slot expression in aggregate functions children.
+                for (AggregateFunction aggregateFunction : aggregateFunctions) {
+                    List<Expression> newChildren = Lists.newArrayList();
+                    for (Expression child : aggregateFunction.getArguments()) {
+                        if (child instanceof SlotReference || child instanceof Literal) {
+                            newChildren.add(child);
+                            if (child instanceof SlotReference) {
+                                bottomProjections.add((SlotReference) child);
+                            }
+                        } else {
+                            needBottomProjects = true;
+                            Alias alias = new Alias(child, child.toSql());
+                            bottomProjections.add(alias);
+                            newChildren.add(alias.toSlot());
+                        }
+                    }
+                    AggregateFunction newFunction = (AggregateFunction) aggregateFunction.withChildren(newChildren);
+                    Alias alias = new Alias(newFunction, newFunction.toSql());
+                    newOutputs.add(alias);
+                    substitutionMap.put(aggregateFunction, alias.toSlot());
+                }
             }
 
             // assemble
             LogicalPlan root = aggregate.child();
-            if (partitionedKeys.containsKey(false)) {
+            if (needBottomProjects) {
                 root = new LogicalProject<>(bottomProjections, root);
             }
             root = new LogicalAggregate<>(newKeys, newOutputs, aggregate.isDisassembled(),

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/Add.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/Add.java
@@ -19,6 +19,7 @@ package org.apache.doris.nereids.trees.expressions;
 
 import org.apache.doris.analysis.ArithmeticExpr.Operator;
 import org.apache.doris.nereids.trees.expressions.visitor.ExpressionVisitor;
+import org.apache.doris.nereids.types.DataType;
 import org.apache.doris.nereids.types.coercion.AbstractDataType;
 import org.apache.doris.nereids.types.coercion.NumericType;
 
@@ -39,6 +40,11 @@ public class Add extends BinaryArithmetic {
     public Expression withChildren(List<Expression> children) {
         Preconditions.checkArgument(children.size() == 2);
         return new Add(children.get(0), children.get(1));
+    }
+
+    @Override
+    public DataType getDataType() {
+        return left().getDataType().promotion();
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/ExecutableFunctions.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/ExecutableFunctions.java
@@ -44,22 +44,22 @@ public class ExecutableFunctions {
      * Executable arithmetic functions
      */
 
-    @ExecFunction(name = "add", argTypes = {"TINYINT", "TINYINT"}, returnType = "TINYINT")
-    public static TinyIntLiteral addTinyint(TinyIntLiteral first, TinyIntLiteral second) {
-        byte result = (byte) Math.addExact(first.getValue(), second.getValue());
-        return new TinyIntLiteral(result);
-    }
-
-    @ExecFunction(name = "add", argTypes = {"SMALLINT", "SMALLINT"}, returnType = "SMALLINT")
-    public static SmallIntLiteral addSmallint(SmallIntLiteral first, SmallIntLiteral second) {
+    @ExecFunction(name = "add", argTypes = {"TINYINT", "TINYINT"}, returnType = "SMALLINT")
+    public static SmallIntLiteral addTinyint(TinyIntLiteral first, TinyIntLiteral second) {
         short result = (short) Math.addExact(first.getValue(), second.getValue());
         return new SmallIntLiteral(result);
     }
 
-    @ExecFunction(name = "add", argTypes = {"INT", "INT"}, returnType = "INT")
-    public static IntegerLiteral addInt(IntegerLiteral first, IntegerLiteral second) {
+    @ExecFunction(name = "add", argTypes = {"SMALLINT", "SMALLINT"}, returnType = "INT")
+    public static IntegerLiteral addSmallint(SmallIntLiteral first, SmallIntLiteral second) {
         int result = Math.addExact(first.getValue(), second.getValue());
         return new IntegerLiteral(result);
+    }
+
+    @ExecFunction(name = "add", argTypes = {"INT", "INT"}, returnType = "BIGINT")
+    public static BigIntLiteral addInt(IntegerLiteral first, IntegerLiteral second) {
+        long result = Math.addExact(first.getValue(), second.getValue());
+        return new BigIntLiteral(result);
     }
 
     @ExecFunction(name = "add", argTypes = {"BIGINT", "BIGINT"}, returnType = "BIGINT")

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalAggregate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalAggregate.java
@@ -60,9 +60,10 @@ public class LogicalAggregate<CHILD_TYPE extends Plan> extends LogicalUnary<CHIL
     private final AggPhase aggPhase;
 
     // use for scenes containing distinct agg
-    // 1. If there are LOCAL and GLOBAL phases, global is the final phase
-    // 2. If there are LOCAL, GLOBAL and DISTINCT_LOCAL phases, DISTINCT_LOCAL is the final phase
-    // 3. If there are LOCAL, GLOBAL, DISTINCT_LOCAL, DISTINCT_GLOBAL phases,
+    // 1. If there is LOCAL only, LOCAL is the final phase
+    // 2. If there are LOCAL and GLOBAL phases, global is the final phase
+    // 3. If there are LOCAL, GLOBAL and DISTINCT_LOCAL phases, DISTINCT_LOCAL is the final phase
+    // 4. If there are LOCAL, GLOBAL, DISTINCT_LOCAL, DISTINCT_GLOBAL phases,
     // DISTINCT_GLOBAL is the final phase
     private final boolean isFinalPhase;
 
@@ -73,7 +74,7 @@ public class LogicalAggregate<CHILD_TYPE extends Plan> extends LogicalUnary<CHIL
             List<Expression> groupByExpressions,
             List<NamedExpression> outputExpressions,
             CHILD_TYPE child) {
-        this(groupByExpressions, outputExpressions, false, false, true, AggPhase.GLOBAL, child);
+        this(groupByExpressions, outputExpressions, false, false, true, AggPhase.LOCAL, child);
     }
 
     public LogicalAggregate(

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/parser/HavingClauseTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/parser/HavingClauseTest.java
@@ -34,6 +34,7 @@ import org.apache.doris.nereids.trees.expressions.functions.agg.Count;
 import org.apache.doris.nereids.trees.expressions.functions.agg.Min;
 import org.apache.doris.nereids.trees.expressions.functions.agg.Sum;
 import org.apache.doris.nereids.trees.expressions.literal.Literal;
+import org.apache.doris.nereids.trees.expressions.literal.SmallIntLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.TinyIntLiteral;
 import org.apache.doris.nereids.types.BigIntType;
 import org.apache.doris.nereids.types.TinyIntType;
@@ -256,7 +257,7 @@ public class HavingClauseTest extends AnalyzeCheckTestBase implements PatternMat
         NamedExpressionUtil.clear();
 
         sql = "SELECT a1, SUM(a1 + a2) FROM t1 GROUP BY a1 HAVING SUM(a1 + a2 + 3) > 0";
-        Alias sumA1A23 = new Alias(new ExprId(4), new Sum(new Add(new Add(a1, a2), new TinyIntLiteral((byte) 3))),
+        Alias sumA1A23 = new Alias(new ExprId(4), new Sum(new Add(new Add(a1, a2), new SmallIntLiteral((byte) 3))),
                 "sum(((a1 + a2) + 3))");
         PlanChecker.from(connectContext).analyze(sql)
                 .matchesFromRoot(
@@ -360,7 +361,7 @@ public class HavingClauseTest extends AnalyzeCheckTestBase implements PatternMat
                 ImmutableList.of("default_cluster:test_having", "t1")
         );
         Alias pk1 = new Alias(new ExprId(7), new Add(pk, Literal.of((byte) 1)), "(pk + 1)");
-        Alias pk11 = new Alias(new ExprId(8), new Add(new Add(pk, Literal.of((byte) 1)), Literal.of((byte) 1)), "((pk + 1) + 1)");
+        Alias pk11 = new Alias(new ExprId(8), new Add(new Add(pk, Literal.of((byte) 1)), Literal.of((short) 1)), "((pk + 1) + 1)");
         Alias pk2 = new Alias(new ExprId(9), new Add(pk, Literal.of((byte) 2)), "(pk + 2)");
         Alias sumA1 = new Alias(new ExprId(10), new Sum(a1), "SUM(a1)");
         Alias countA11 = new Alias(new ExprId(11), new Add(new Count(a1, false), Literal.of(1L)), "(COUNT(a1) + 1)");

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/properties/RequestPropertyDeriverTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/properties/RequestPropertyDeriverTest.java
@@ -150,7 +150,7 @@ public class RequestPropertyDeriverTest {
                 Lists.newArrayList(key),
                 AggPhase.LOCAL,
                 true,
-                true,
+                false,
                 logicalProperties,
                 groupPlan
         );

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/rewrite/FoldConstantTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/rewrite/FoldConstantTest.java
@@ -171,9 +171,9 @@ public class FoldConstantTest {
     @Test
     public void testArithmeticFold() {
         executor = new ExpressionRuleExecutor(ImmutableList.of(TypeCoercion.INSTANCE, FoldConstantRuleOnFE.INSTANCE));
-        assertRewrite("1 + 1", Literal.of((byte) 2));
+        assertRewrite("1 + 1", Literal.of((short) 2));
         assertRewrite("1 - 1", Literal.of((byte) 0));
-        assertRewrite("100 + 100", Literal.of((byte) 200));
+        assertRewrite("100 + 100", Literal.of((short) 200));
         assertRewrite("1 - 2", Literal.of((byte) -1));
 
         assertRewrite("1 - 2 > 1", "false");
@@ -284,9 +284,9 @@ public class FoldConstantTest {
     private void assertRewrite(String expression, String expected) {
         Map<String, Slot> mem = Maps.newHashMap();
         Expression needRewriteExpression = PARSER.parseExpression(expression);
-        needRewriteExpression = replaceUnboundSlot(needRewriteExpression, mem);
+        needRewriteExpression = typeCoercion(replaceUnboundSlot(needRewriteExpression, mem));
         Expression expectedExpression = PARSER.parseExpression(expected);
-        expectedExpression = replaceUnboundSlot(expectedExpression, mem);
+        expectedExpression = typeCoercion(replaceUnboundSlot(expectedExpression, mem));
         Expression rewrittenExpression = executor.rewrite(needRewriteExpression);
         Assertions.assertEquals(expectedExpression, rewrittenExpression);
     }
@@ -318,6 +318,10 @@ public class FoldConstantTest {
             return mem.get(name);
         }
         return hasNewChildren ? expression.withChildren(children) : expression;
+    }
+
+    private Expression typeCoercion(Expression expression) {
+        return TypeCoercion.INSTANCE.visit(expression, null);
     }
 
     private DataType getType(char t) {

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/logical/MergeConsecutiveProjectsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/logical/MergeConsecutiveProjectsTest.java
@@ -89,7 +89,8 @@ public class MergeConsecutiveProjectsTest {
                 relation);
         LogicalProject project2 = new LogicalProject<>(
                 Lists.newArrayList(
-                        new Alias(new Add(aliasRef, new IntegerLiteral(2)), "Y")
+                        new Alias(new Add(aliasRef, new IntegerLiteral(2)), "Y"),
+                        aliasRef
                 ),
                 project1);
 
@@ -100,11 +101,12 @@ public class MergeConsecutiveProjectsTest {
         System.out.println(plan.treeString());
         Assertions.assertTrue(plan instanceof LogicalProject);
         LogicalProject finalProject = (LogicalProject) plan;
-        Add finalExpression = new Add(
+        Add aPlus1Plus2 = new Add(
                 new Add(colA, new IntegerLiteral(1)),
                 new IntegerLiteral(2)
         );
-        Assertions.assertEquals(1, finalProject.getProjects().size());
-        Assertions.assertEquals(((Alias) finalProject.getProjects().get(0)).child(), finalExpression);
+        Assertions.assertEquals(2, finalProject.getProjects().size());
+        Assertions.assertEquals(aPlus1Plus2, ((Alias) finalProject.getProjects().get(0)).child());
+        Assertions.assertEquals(alias, finalProject.getProjects().get(1));
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/logical/NormalizeAggregateTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/logical/NormalizeAggregateTest.java
@@ -23,6 +23,7 @@ import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.Multiply;
 import org.apache.doris.nereids.trees.expressions.NamedExpression;
 import org.apache.doris.nereids.trees.expressions.SlotReference;
+import org.apache.doris.nereids.trees.expressions.functions.agg.AggregateFunction;
 import org.apache.doris.nereids.trees.expressions.functions.agg.Sum;
 import org.apache.doris.nereids.trees.expressions.literal.IntegerLiteral;
 import org.apache.doris.nereids.trees.plans.Plan;
@@ -93,15 +94,17 @@ public class NormalizeAggregateTest implements PatternMatchSupported {
      * +--ScanOlapTable (student.student, output: [id#0, gender#1, name#2, age#3])
      *
      * after rewrite:
-     * LogicalProject ((sum((id * 1))#5 + 2) AS `(sum((id * 1)) + 2)`#4)
-     * +--LogicalAggregate (phase: [GLOBAL], output: [sum((id#0 * 1)) AS `sum((id * 1))`#5], groupBy: [name#2])
-     *    +--ScanOlapTable (student.student, output: [id#0, gender#1, name#2, age#3])
+     * LogicalProject ( projects=[(sum((id * 1))#6 + 2) AS `(sum((id * 1)) + 2)`#4] )
+     * +--LogicalAggregate ( phase=LOCAL, outputExpr=[sum((id * 1)#5) AS `sum((id * 1))`#6], groupByExpr=[name#2] )
+     *    +--LogicalProject ( projects=[name#2, (id#0 * 1) AS `(id * 1)`#5] )
+     *       +--GroupPlan( GroupId#0 )
      */
     @Test
     public void testComplexFuncWithComplexOutputOfFunc() {
         NamedExpression key = rStudent.getOutput().get(2).toSlot();
         List<Expression> groupExpressionList = Lists.newArrayList(key);
-        Expression aggregateFunction = new Sum(new Multiply(rStudent.getOutput().get(0).toSlot(), new IntegerLiteral(1)));
+        Expression multiply = new Multiply(rStudent.getOutput().get(0).toSlot(), new IntegerLiteral(1));
+        Expression aggregateFunction = new Sum(multiply);
         Expression complexOutput = new Add(aggregateFunction, new IntegerLiteral(2));
         Alias output = new Alias(complexOutput, complexOutput.toSql());
         List<NamedExpression> outputExpressionList = Lists.newArrayList(output);
@@ -112,10 +115,14 @@ public class NormalizeAggregateTest implements PatternMatchSupported {
                 .matchesFromRoot(
                         logicalProject(
                                 logicalAggregate(
-                                        logicalOlapScan()
+                                        logicalProject(
+                                            logicalOlapScan()
+                                        ).when(project -> project.getProjects().size() == 2)
+                                                .when(project -> project.getProjects().get(0) instanceof SlotReference)
+                                                .when(project -> project.getProjects().get(1).child(0).equals(multiply))
                                 ).when(FieldChecker.check("groupByExpressions", ImmutableList.of(key)))
                                         .when(aggregate -> aggregate.getOutputExpressions().size() == 1)
-                                        .when(aggregate -> aggregate.getOutputExpressions().get(0).child(0).equals(aggregateFunction))
+                                        .when(aggregate -> aggregate.getOutputExpressions().get(0).child(0) instanceof AggregateFunction)
                         ).when(project -> project.getProjects().size() == 1)
                                 .when(project -> project.getProjects().get(0) instanceof Alias)
                                 .when(project -> project.getProjects().get(0).getExprId().equals(output.getExprId()))

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/PlanToStringTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/PlanToStringTest.java
@@ -57,7 +57,7 @@ public class PlanToStringTest {
                 new SlotReference(new ExprId(0), "a", BigIntType.INSTANCE, true, Lists.newArrayList())), child);
 
         Assertions.assertTrue(plan.toString()
-                .matches("LogicalAggregate \\( phase=GLOBAL, outputExpr=\\[a#\\d+], groupByExpr=\\[] \\)"));
+                .matches("LogicalAggregate \\( phase=LOCAL, outputExpr=\\[a#\\d+], groupByExpr=\\[] \\)"));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/util/AnalyzeWhereSubqueryTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/util/AnalyzeWhereSubqueryTest.java
@@ -25,6 +25,7 @@ import org.apache.doris.nereids.parser.NereidsParser;
 import org.apache.doris.nereids.properties.PhysicalProperties;
 import org.apache.doris.nereids.rules.Rule;
 import org.apache.doris.nereids.rules.RuleSet;
+import org.apache.doris.nereids.rules.rewrite.AggregateDisassemble;
 import org.apache.doris.nereids.rules.rewrite.logical.ApplyPullFilterOnAgg;
 import org.apache.doris.nereids.rules.rewrite.logical.ApplyPullFilterOnProjectUnderAgg;
 import org.apache.doris.nereids.rules.rewrite.logical.ExistsApplyToJoin;
@@ -120,7 +121,7 @@ public class AnalyzeWhereSubqueryTest extends TestWithFeService implements Patte
         new MockUp<RuleSet>() {
             @Mock
             public List<Rule> getExplorationRules() {
-                return Lists.newArrayList();
+                return Lists.newArrayList(new AggregateDisassemble().build());
             }
         };
 


### PR DESCRIPTION
# Proposed changes

Currently, we always disassemble aggregation into two stage: local and global. However, in some case, one stage aggregation is enough, there are two advantage of one stage aggregation.
1. avoid unnecessary exchange.
2. have a chance to do colocate join on the top of aggregation.

This PR move AggregateDisassemble rule from rewrite stage to optimization stage. And choose one stage or two stage aggregation according to cost.

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
4. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
5. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
6. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
7. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

