### PR TITLE
Replace jvm's garbage collector CMS with G1

### DIFF
--- a/conf/fe.conf
+++ b/conf/fe.conf
@@ -25,7 +25,7 @@
 LOG_DIR = ${DORIS_HOME}/log
 
 DATE = `date +%Y%m%d-%H%M%S`
-JAVA_OPTS="-Xmx8192m -XX:+UseG1GC -XX:MaxTenuringThreshold=7 -XX:MaxGCPauseMillis=200 -XX:InitiatingHeapOccupancyPercent=45 -XX:G1ReservePercent=30 -verbose:gc -XX:+HeapDumpOnOutOfMemoryError -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+PrintGCDateStamps -Xloggc:$DORIS_HOME/log/fe.gc.log.$DATE"
+JAVA_OPTS="-Xmx8192m -XX:+UseMembar -XX:SurvivorRatio=8 -XX:MaxTenuringThreshold=7 -XX:+PrintGCDateStamps -XX:+PrintGCDetails -XX:+UseConcMarkSweepGC -XX:+UseParNewGC -XX:+CMSClassUnloadingEnabled -XX:-CMSParallelRemarkEnabled -XX:CMSInitiatingOccupancyFraction=80 -XX:SoftRefLRUPolicyMSPerMB=0 -Xloggc:$DORIS_HOME/log/fe.gc.log.$DATE"
 # For jdk 9+, this JAVA_OPTS will be used as default JVM options
 JAVA_OPTS_FOR_JDK_9="-Xmx8192m -XX:+UseG1GC -XX:SurvivorRatio=8 -XX:MaxTenuringThreshold=7 -XX:MaxGCPauseMillis=200 -XX:InitiatingHeapOccupancyPercent=45 -XX:G1ReservePercent=30 -verbose:gc -XX:+HeapDumpOnOutOfMemoryError -XX:+PrintGCDetails -Xlog:gc=trace:file=$DORIS_HOME/log/fe.gc.log.$DATE:time:filecount=10,filesize=10M"
 ##

--- a/conf/fe.conf
+++ b/conf/fe.conf
@@ -27,8 +27,7 @@ LOG_DIR = ${DORIS_HOME}/log
 DATE = `date +%Y%m%d-%H%M%S`
 JAVA_OPTS="-Xmx8192m -XX:+UseG1GC -XX:MaxTenuringThreshold=7 -XX:MaxGCPauseMillis=200 -XX:InitiatingHeapOccupancyPercent=45 -XX:G1ReservePercent=30 -verbose:gc -XX:+HeapDumpOnOutOfMemoryError -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+PrintGCDateStamps -Xloggc:$DORIS_HOME/log/fe.gc.log.$DATE"
 # For jdk 9+, this JAVA_OPTS will be used as default JVM options
-JAVA_OPTS_FOR_JDK_9="-Xmx8192m -XX:+UseG1GC -XX:SurvivorRatio=8 -XX:MaxTenuringThreshold=7 -XX:MaxGCPauseMillis=200 -XX:InitiatingHeapOccupancyPercent=45 -XX:G1ReservePercent=30 -verbose:gc -XX:+HeapDumpOnOutOfMemoryError -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+PrintGCDateStamps -Xloggc:$DORIS_HOME/log/fe.gc.log.$DATE:time"
-
+JAVA_OPTS_FOR_JDK_9="-Xmx8192m -XX:+UseG1GC -XX:SurvivorRatio=8 -XX:MaxTenuringThreshold=7 -XX:MaxGCPauseMillis=200 -XX:InitiatingHeapOccupancyPercent=45 -XX:G1ReservePercent=30 -verbose:gc -XX:+HeapDumpOnOutOfMemoryError -XX:+PrintGCDetails -Xlog:gc=trace:file=$DORIS_HOME/log/fe.gc.log.$DATE:time:filecount=10,filesize=10M"
 ##
 ## the lowercase properties are read by main program.
 ##

--- a/conf/fe.conf
+++ b/conf/fe.conf
@@ -25,10 +25,9 @@
 LOG_DIR = ${DORIS_HOME}/log
 
 DATE = `date +%Y%m%d-%H%M%S`
-JAVA_OPTS="-Xmx8192m -XX:+UseMembar -XX:SurvivorRatio=8 -XX:MaxTenuringThreshold=7 -XX:+PrintGCDateStamps -XX:+PrintGCDetails -XX:+UseConcMarkSweepGC -XX:+UseParNewGC -XX:+CMSClassUnloadingEnabled -XX:-CMSParallelRemarkEnabled -XX:CMSInitiatingOccupancyFraction=80 -XX:SoftRefLRUPolicyMSPerMB=0 -Xloggc:$DORIS_HOME/log/fe.gc.log.$DATE"
-
+JAVA_OPTS="-Xmx8192m -XX:+UseG1GC -XX:MaxTenuringThreshold=7 -XX:MaxGCPauseMillis=200 -XX:InitiatingHeapOccupancyPercent=45 -XX:G1ReservePercent=30 -verbose:gc -XX:+HeapDumpOnOutOfMemoryError -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+PrintGCDateStamps -Xloggc:$DORIS_HOME/log/fe.gc.log.$DATE"
 # For jdk 9+, this JAVA_OPTS will be used as default JVM options
-JAVA_OPTS_FOR_JDK_9="-Xmx8192m -XX:SurvivorRatio=8 -XX:MaxTenuringThreshold=7 -XX:+CMSClassUnloadingEnabled -XX:-CMSParallelRemarkEnabled -XX:CMSInitiatingOccupancyFraction=80 -XX:SoftRefLRUPolicyMSPerMB=0 -Xlog:gc*:$DORIS_HOME/log/fe.gc.log.$DATE:time"
+JAVA_OPTS_FOR_JDK_9="-Xmx8192m -XX:+UseG1GC -XX:SurvivorRatio=8 -XX:MaxTenuringThreshold=7 -XX:MaxGCPauseMillis=200 -XX:InitiatingHeapOccupancyPercent=45 -XX:G1ReservePercent=30 -verbose:gc -XX:+HeapDumpOnOutOfMemoryError -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+PrintGCDateStamps -Xloggc:$DORIS_HOME/log/fe.gc.log.$DATE:time"
 
 ##
 ## the lowercase properties are read by main program.

--- a/conf/fe.conf
+++ b/conf/fe.conf
@@ -27,7 +27,7 @@ LOG_DIR = ${DORIS_HOME}/log
 DATE = `date +%Y%m%d-%H%M%S`
 JAVA_OPTS="-Xmx8192m -XX:+UseMembar -XX:SurvivorRatio=8 -XX:MaxTenuringThreshold=7 -XX:+PrintGCDateStamps -XX:+PrintGCDetails -XX:+UseConcMarkSweepGC -XX:+UseParNewGC -XX:+CMSClassUnloadingEnabled -XX:-CMSParallelRemarkEnabled -XX:CMSInitiatingOccupancyFraction=80 -XX:SoftRefLRUPolicyMSPerMB=0 -Xloggc:$DORIS_HOME/log/fe.gc.log.$DATE"
 # For jdk 9+, this JAVA_OPTS will be used as default JVM options
-JAVA_OPTS_FOR_JDK_9="-Xmx8192m -XX:+UseG1GC -XX:SurvivorRatio=8 -XX:MaxTenuringThreshold=7 -XX:MaxGCPauseMillis=200 -XX:InitiatingHeapOccupancyPercent=45 -XX:G1ReservePercent=30 -verbose:gc -XX:+HeapDumpOnOutOfMemoryError -XX:+PrintGCDetails -Xlog:gc=trace:file=$DORIS_HOME/log/fe.gc.log.$DATE:time:filecount=10,filesize=10M"
+JAVA_OPTS_FOR_JDK_9="-Xmx8192m -XX:+UseG1GC -XX:SurvivorRatio=8 -XX:MaxTenuringThreshold=7 -XX:MaxGCPauseMillis=200 -XX:InitiatingHeapOccupancyPercent=45 -XX:G1ReservePercent=30 -verbose:gc -XX:+HeapDumpOnOutOfMemoryError -Xlog:gc=trace:file=$DORIS_HOME/log/fe.gc.log.$DATE:time:filecount=10,filesize=10M"
 ##
 ## the lowercase properties are read by main program.
 ##


### PR DESCRIPTION

Replace jvm's garbage collector CMS with G1
From the test use, the overall performance is better than the CMS

# Proposed changes

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

