### PR TITLE
[fix](parquet) fix write error data as parquet format.

### DIFF
--- a/be/src/exec/parquet_writer.h
+++ b/be/src/exec/parquet_writer.h
@@ -120,6 +120,9 @@ public:
     int64_t written_len();
 
 private:
+    template<typename T>
+    void write_int32_column(int index, T* item);
+
     std::shared_ptr<ParquetOutputStream> _outstream;
     std::shared_ptr<parquet::WriterProperties> _properties;
     std::shared_ptr<parquet::schema::GroupNode> _schema;

--- a/be/src/exec/parquet_writer.h
+++ b/be/src/exec/parquet_writer.h
@@ -120,7 +120,7 @@ public:
     int64_t written_len();
 
 private:
-    template<typename T>
+    template <typename T>
     void write_int32_column(int index, T* item);
 
     std::shared_ptr<ParquetOutputStream> _outstream;


### PR DESCRIPTION
Fix incorrect data conversion when writing tiny int and small int data to parquet files in non-vectorized engine.

# Proposed changes

Issue Number: close #12861

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

