### PR TITLE
[Improvement](predicate) Replace for-loop by memcpy

### DIFF
--- a/be/src/vec/columns/predicate_column.h
+++ b/be/src/vec/columns/predicate_column.h
@@ -133,13 +133,9 @@ private:
         }
     }
 
-    // note(wb): Write data one by one has a slight performance improvement than memcpy directly
     void insert_many_default_type(const char* data_ptr, size_t num) {
-        T* input_val_ptr = (T*)data_ptr;
         T* res_val_ptr = (T*)data.get_end_ptr();
-        for (int i = 0; i < num; i++) {
-            res_val_ptr[i] = input_val_ptr[i];
-        }
+        memcpy(res_val_ptr, data_ptr, num * sizeof(T));
         res_val_ptr += num;
         data.set_end_ptr(res_val_ptr);
     }


### PR DESCRIPTION
# Proposed changes

This PR replace for-loop by memcpy.
I did two experiments.

Experiment 1

Run ckbench q20 and print a flame graph. Compare proportion of this function time to the total time.

I got:
for-loop:1.74%
memcpy:0.013%

Experiment 2

Run `SELECT JavaEnable FROM hits`. 9900w+ rows returned and JavaEnable is SMALL INT.
Compare the BlockLoadTime.
I got: 
for-loop:1s225ms
memcpy:805.603ms

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

