### PR TITLE
[Bug](date)(1.1-lts) Fix wrong type in TimestampArithmeticExpr

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/TimestampArithmeticExpr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/TimestampArithmeticExpr.java
@@ -213,8 +213,21 @@ public class TimestampArithmeticExpr extends Expr {
                     (op == ArithmeticExpr.Operator.ADD) ? "ADD" : "SUB");
         }
 
-        fn = getBuiltinFunction(analyzer, funcOpName.toLowerCase(),
-                collectChildReturnTypes(), Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
+        Type[] childrenTypes = collectChildReturnTypes();
+        fn = getBuiltinFunction(funcOpName.toLowerCase(), childrenTypes,
+                Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
+        Preconditions.checkArgument(fn != null);
+        Type[] argTypes = fn.getArgs();
+        if (argTypes.length > 0) {
+            // Implicitly cast all the children to match the function if necessary
+            for (int i = 0; i < childrenTypes.length; ++i) {
+                // For varargs, we must compare with the last type in callArgs.argTypes.
+                int ix = Math.min(argTypes.length - 1, i);
+                if (!childrenTypes[i].matchesType(argTypes[ix]) && !(
+                        childrenTypes[i].isDateType() && argTypes[ix].isDateType())) {
+                    uncheckedCastChild(argTypes[ix], i);
+                }
+            }
         LOG.debug("fn is {} name is {}", fn, funcOpName);
     }
 


### PR DESCRIPTION
# Proposed changes

Cherry pick from #12727

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

