### PR TITLE
[improvement](aduit-plugin) Audit logs are missing and refreshed irregularly

### DIFF
--- a/fe_plugins/auditloader/src/main/java/org/apache/doris/plugin/audit/AuditLoaderPlugin.java
+++ b/fe_plugins/auditloader/src/main/java/org/apache/doris/plugin/audit/AuditLoaderPlugin.java
@@ -139,7 +139,7 @@ public class AuditLoaderPlugin extends Plugin implements AuditPlugin {
             // In order to ensure that the system can run normally, here we directly
             // discard the current audit_event. If this problem occurs frequently,
             // improvement can be considered.
-            LOG.error("encounter exception when putting current audit batch, discard current audit event", e);
+            LOG.warn("encounter exception when putting current audit batch, discard current audit event", e);
         }
     }
 

--- a/fe_plugins/auditloader/src/main/java/org/apache/doris/plugin/audit/AuditLoaderPlugin.java
+++ b/fe_plugins/auditloader/src/main/java/org/apache/doris/plugin/audit/AuditLoaderPlugin.java
@@ -58,7 +58,7 @@ public class AuditLoaderPlugin extends Plugin implements AuditPlugin {
     private StringBuilder auditBuffer = new StringBuilder();
     private long lastLoadTime = 0;
 
-    private BlockingQueue<AuditEvent> auditEventQueue = new LinkedBlockingDeque<AuditEvent>(1);
+    private BlockingQueue<AuditEvent> auditEventQueue = new LinkedBlockingDeque<AuditEvent>(10);
     private DorisStreamLoader streamLoader;
     private Thread loadThread;
 
@@ -134,7 +134,7 @@ public class AuditLoaderPlugin extends Plugin implements AuditPlugin {
 
     public void exec(AuditEvent event) {
         try {
-            auditEventQueue.add(event);
+            auditEventQueue.put(event);
         } catch (Exception e) {
             // In order to ensure that the system can run normally, here we directly
             // discard the current audit_event. If this problem occurs frequently,
@@ -270,8 +270,8 @@ public class AuditLoaderPlugin extends Plugin implements AuditPlugin {
                     AuditEvent event = auditEventQueue.poll(5, TimeUnit.SECONDS);
                     if (event != null) {
                         assembleAudit(event);
-                        loadIfNecessary(loader);
                     }
+                    loadIfNecessary(loader);
                 } catch (InterruptedException ie) {
                     LOG.debug("encounter exception when loading current audit batch", ie);
                 } catch (Exception e) {

--- a/fe_plugins/auditloader/src/main/java/org/apache/doris/plugin/audit/AuditLoaderPlugin.java
+++ b/fe_plugins/auditloader/src/main/java/org/apache/doris/plugin/audit/AuditLoaderPlugin.java
@@ -139,7 +139,7 @@ public class AuditLoaderPlugin extends Plugin implements AuditPlugin {
             // In order to ensure that the system can run normally, here we directly
             // discard the current audit_event. If this problem occurs frequently,
             // improvement can be considered.
-            LOG.debug("encounter exception when putting current audit batch, discard current audit event", e);
+            LOG.error("encounter exception when putting current audit batch, discard current audit event", e);
         }
     }
 
@@ -194,7 +194,7 @@ public class AuditLoaderPlugin extends Plugin implements AuditPlugin {
             DorisStreamLoader.LoadResponse response = loader.loadBatch(auditBuffer);
             LOG.debug("audit loader response: {}", response);
         } catch (Exception e) {
-            LOG.debug("encounter exception when putting current audit batch, discard current batch", e);
+            LOG.error("encounter exception when putting current audit batch, discard current batch", e);
         } finally {
             // make a new string builder to receive following events.
             this.auditBuffer = new StringBuilder();


### PR DESCRIPTION
## Problem summary

1.The audit log is sometimes lost. The related logs are as follows：
`encounter exception when putting current audit batch, discard current audit event`
2.The audit log does not take effect according to the time parameters, and must be triggered based on the event

So the following changes were made:
1. Modify the blocking queue length from 1 to 10
2. The add method is modified to put
3. Put the loadIfNecessary method outside

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

