### PR TITLE
[fix](like)prevent null pointer by unimplemented like_vec functions

### DIFF
--- a/be/src/olap/like_column_predicate.cpp
+++ b/be/src/olap/like_column_predicate.cpp
@@ -88,7 +88,7 @@ uint16_t LikeColumnPredicate<is_vectorized>::evaluate(const vectorized::IColumn&
                         continue;
                     }
 
-                    StringValue cell_value = nested_col_ptr->get_value(data_array[idx]);
+                    StringValue cell_value = nested_col_ptr->get_shrink_value(data_array[idx]);
                     unsigned char flag = 0;
                     (_state->function)(const_cast<vectorized::LikeSearchState*>(&_like_state),
                                        cell_value, pattern, &flag);
@@ -123,7 +123,7 @@ uint16_t LikeColumnPredicate<is_vectorized>::evaluate(const vectorized::IColumn&
                         StringValue values[size];
                         unsigned char flags[size];
                         for (uint16_t i = 0; i != size; i++) {
-                            values[i] = nested_col_ptr->get_value(data_array[sel[i]]);
+                            values[i] = nested_col_ptr->get_shrink_value(data_array[sel[i]]);
                         }
                         (_state->function_vec_dict)(
                                 const_cast<vectorized::LikeSearchState*>(&_like_state), pattern,

--- a/be/src/olap/like_column_predicate.cpp
+++ b/be/src/olap/like_column_predicate.cpp
@@ -115,45 +115,78 @@ uint16_t LikeColumnPredicate<is_vectorized>::evaluate(const vectorized::IColumn&
             }
         } else {
             if (column.is_column_dictionary()) {
-                if (LIKELY(_like_state.search_string_sv.len > 0)) {
+                if (_state->function_vec_dict) {
+                    if (LIKELY(_like_state.search_string_sv.len > 0)) {
+                        auto* nested_col_ptr = vectorized::check_and_get_column<
+                                vectorized::ColumnDictionary<vectorized::Int32>>(column);
+                        auto& data_array = nested_col_ptr->get_data();
+                        StringValue values[size];
+                        unsigned char flags[size];
+                        for (uint16_t i = 0; i != size; i++) {
+                            values[i] = nested_col_ptr->get_value(data_array[sel[i]]);
+                        }
+                        (_state->function_vec_dict)(
+                                const_cast<vectorized::LikeSearchState*>(&_like_state), pattern,
+                                values, size, flags);
+
+                        for (uint16_t i = 0; i != size; i++) {
+                            uint16_t idx = sel[i];
+                            sel[new_size] = idx;
+                            new_size += _opposite ^ flags[i];
+                        }
+                    } else {
+                        for (uint16_t i = 0; i != size; i++) {
+                            uint16_t idx = sel[i];
+                            sel[new_size] = idx;
+                            new_size += _opposite ^ true;
+                        }
+                    }
+                } else {
                     auto* nested_col_ptr = vectorized::check_and_get_column<
                             vectorized::ColumnDictionary<vectorized::Int32>>(column);
                     auto& data_array = nested_col_ptr->get_data();
-                    StringValue values[size];
-                    unsigned char flags[size];
-                    for (uint16_t i = 0; i != size; i++) {
-                        values[i] = nested_col_ptr->get_value(data_array[sel[i]]);
-                    }
-                    (_state->function_vec_dict)(
-                            const_cast<vectorized::LikeSearchState*>(&_like_state), pattern, values,
-                            size, flags);
-
                     for (uint16_t i = 0; i != size; i++) {
                         uint16_t idx = sel[i];
                         sel[new_size] = idx;
-                        new_size += _opposite ^ flags[i];
-                    }
-                } else {
-                    for (uint16_t i = 0; i != size; i++) {
-                        uint16_t idx = sel[i];
-                        sel[new_size] = idx;
-                        new_size += _opposite ^ true;
+                        StringValue cell_value = nested_col_ptr->get_value(data_array[idx]);
+                        unsigned char flag = 0;
+                        (_state->function)(const_cast<vectorized::LikeSearchState*>(&_like_state),
+                                           cell_value, pattern, &flag);
+                        new_size += _opposite ^ flag;
                     }
                 }
             } else {
-                if (LIKELY(_like_state.search_string_sv.len > 0)) {
+                if (_state->function_vec) {
+                    if (LIKELY(_like_state.search_string_sv.len > 0)) {
+                        auto* data_array =
+                                vectorized::check_and_get_column<
+                                        vectorized::PredicateColumnType<TYPE_STRING>>(column)
+                                        ->get_data()
+                                        .data();
+
+                        (_state->function_vec)(
+                                const_cast<vectorized::LikeSearchState*>(&_like_state), pattern,
+                                data_array, sel, size, _opposite, &new_size);
+                    } else {
+                        for (uint16_t i = 0; i < size; i++) {
+                            uint16_t idx = sel[i];
+                            sel[new_size] = idx;
+                            new_size += _opposite ^ true;
+                        }
+                    }
+                } else {
                     auto* data_array = vectorized::check_and_get_column<
                                                vectorized::PredicateColumnType<TYPE_STRING>>(column)
                                                ->get_data()
                                                .data();
 
-                    (_state->function_vec)(const_cast<vectorized::LikeSearchState*>(&_like_state),
-                                           pattern, data_array, sel, size, _opposite, &new_size);
-                } else {
-                    for (uint16_t i = 0; i < size; i++) {
+                    for (uint16_t i = 0; i != size; i++) {
                         uint16_t idx = sel[i];
                         sel[new_size] = idx;
-                        new_size += _opposite ^ true;
+                        unsigned char flag = 0;
+                        (_state->function)(const_cast<vectorized::LikeSearchState*>(&_like_state),
+                                           data_array[idx], pattern, &flag);
+                        new_size += _opposite ^ flag;
                     }
                 }
             }

--- a/be/src/olap/like_column_predicate.h
+++ b/be/src/olap/like_column_predicate.h
@@ -118,31 +118,53 @@ private:
                 }
             } else {
                 if (column.is_column_dictionary()) {
-                    if (LIKELY(_like_state.search_string_sv.len > 0)) {
-                        auto* nested_col_ptr = vectorized::check_and_get_column<
-                                vectorized::ColumnDictionary<vectorized::Int32>>(column);
-                        auto& data_array = nested_col_ptr->get_data();
-                        StringValue values[size];
-                        unsigned char temp_flags[size];
-                        for (uint16_t i = 0; i != size; i++) {
-                            values[i] = nested_col_ptr->get_value(data_array[i]);
-                        }
-                        (_state->function_vec_dict)(
-                                const_cast<vectorized::LikeSearchState*>(&_like_state), pattern,
-                                values, size, temp_flags);
-                        for (uint16_t i = 0; i < size; i++) {
-                            if constexpr (is_and) {
-                                flags[i] &= _opposite ^ temp_flags[i];
-                            } else {
-                                flags[i] = _opposite ^ temp_flags[i];
+                    if (_state->function_vec_dict) {
+                        if (LIKELY(_like_state.search_string_sv.len > 0)) {
+                            auto* nested_col_ptr = vectorized::check_and_get_column<
+                                    vectorized::ColumnDictionary<vectorized::Int32>>(column);
+                            auto& data_array = nested_col_ptr->get_data();
+                            StringValue values[size];
+                            unsigned char temp_flags[size];
+                            for (uint16_t i = 0; i != size; i++) {
+                                values[i] = nested_col_ptr->get_value(data_array[i]);
+                            }
+                            (_state->function_vec_dict)(
+                                    const_cast<vectorized::LikeSearchState*>(&_like_state), pattern,
+                                    values, size, temp_flags);
+                            for (uint16_t i = 0; i < size; i++) {
+                                if constexpr (is_and) {
+                                    flags[i] &= _opposite ^ temp_flags[i];
+                                } else {
+                                    flags[i] = _opposite ^ temp_flags[i];
+                                }
+                            }
+                        } else {
+                            for (uint16_t i = 0; i < size; i++) {
+                                if constexpr (is_and) {
+                                    flags[i] &= _opposite ^ true;
+                                } else {
+                                    flags[i] = _opposite ^ true;
+                                }
                             }
                         }
                     } else {
+                        auto* nested_col_ptr = vectorized::check_and_get_column<
+                                vectorized::ColumnDictionary<vectorized::Int32>>(column);
+                        auto& data_array = nested_col_ptr->get_data();
                         for (uint16_t i = 0; i < size; i++) {
+                            StringValue cell_value = nested_col_ptr->get_value(data_array[i]);
                             if constexpr (is_and) {
-                                flags[i] &= _opposite ^ true;
+                                unsigned char flag = 0;
+                                (_state->function)(
+                                        const_cast<vectorized::LikeSearchState*>(&_like_state),
+                                        cell_value, pattern, &flag);
+                                flags[i] &= _opposite ^ flag;
                             } else {
-                                flags[i] = _opposite ^ true;
+                                unsigned char flag = 0;
+                                (_state->function)(
+                                        const_cast<vectorized::LikeSearchState*>(&_like_state),
+                                        cell_value, pattern, &flag);
+                                flags[i] = _opposite ^ flag;
                             }
                         }
                     }

--- a/be/src/olap/like_column_predicate.h
+++ b/be/src/olap/like_column_predicate.h
@@ -98,7 +98,7 @@ private:
                             continue;
                         }
 
-                        StringValue cell_value = nested_col_ptr->get_value(data_array[i]);
+                        StringValue cell_value = nested_col_ptr->get_shrink_value(data_array[i]);
                         if constexpr (is_and) {
                             unsigned char flag = 0;
                             (_state->function)(
@@ -126,7 +126,7 @@ private:
                             StringValue values[size];
                             unsigned char temp_flags[size];
                             for (uint16_t i = 0; i != size; i++) {
-                                values[i] = nested_col_ptr->get_value(data_array[i]);
+                                values[i] = nested_col_ptr->get_shrink_value(data_array[i]);
                             }
                             (_state->function_vec_dict)(
                                     const_cast<vectorized::LikeSearchState*>(&_like_state), pattern,

--- a/be/src/vec/columns/column_dictionary.h
+++ b/be/src/vec/columns/column_dictionary.h
@@ -279,6 +279,14 @@ public:
 
     inline const StringValue& get_value(value_type code) const { return _dict.get_value(code); }
 
+    inline StringValue get_shrink_value(value_type code) const {
+        StringValue result = _dict.get_value(code);
+        if (_type == OLAP_FIELD_TYPE_CHAR) {
+            result.len = strnlen(result.ptr, result.len);
+        }
+        return result;
+    }
+
     class Dictionary {
     public:
         Dictionary() = default;


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

currently only constant_substring_fn is fully vectorized, other functions should keep the old behavior by checking function_vec_dict and function_vec is nullptr or not

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

