### PR TITLE
[Bug](parquet) fix parquet write setting property is not effective

### DIFF
--- a/be/src/runtime/file_result_writer.cpp
+++ b/be/src/runtime/file_result_writer.cpp
@@ -231,6 +231,7 @@ Status FileResultWriter::append_row_batch(const RowBatch* batch) {
 Status FileResultWriter::_write_parquet_file(const RowBatch& batch) {
     RETURN_IF_ERROR(_parquet_writer->write(batch));
     // split file if exceed limit
+    _current_written_bytes = _parquet_writer->written_len();
     return _create_new_file_if_exceed_size();
 }
 
@@ -407,7 +408,6 @@ Status FileResultWriter::_create_new_file_if_exceed_size() {
 Status FileResultWriter::_close_file_writer(bool done, bool only_close) {
     if (_parquet_writer != nullptr) {
         _parquet_writer->close();
-        _current_written_bytes = _parquet_writer->written_len();
         COUNTER_UPDATE(_written_data_bytes, _current_written_bytes);
         delete _parquet_writer;
         _parquet_writer = nullptr;

--- a/be/src/vec/runtime/vfile_result_writer.cpp
+++ b/be/src/vec/runtime/vfile_result_writer.cpp
@@ -210,6 +210,7 @@ Status VFileResultWriter::append_block(Block& block) {
 Status VFileResultWriter::_write_parquet_file(const Block& block) {
     RETURN_IF_ERROR(_vparquet_writer->write(block));
     // split file if exceed limit
+    _current_written_bytes = _vparquet_writer->written_len();
     return _create_new_file_if_exceed_size();
 }
 
@@ -416,7 +417,6 @@ Status VFileResultWriter::_create_new_file_if_exceed_size() {
 Status VFileResultWriter::_close_file_writer(bool done) {
     if (_vparquet_writer) {
         _vparquet_writer->close();
-        _current_written_bytes = _vparquet_writer->written_len();
         COUNTER_UPDATE(_written_data_bytes, _current_written_bytes);
         _vparquet_writer.reset(nullptr);
     } else if (_file_writer_impl) {

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/OutFileClause.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/OutFileClause.java
@@ -144,7 +144,7 @@ public class OutFileClause {
     private static final String PARQUET_COMPRESSION = "compression";
     private TParquetCompressionType parquetCompressionType = TParquetCompressionType.UNCOMPRESSED;
     private static final String PARQUET_DISABLE_DICTIONARY = "disable_dictionary";
-    private boolean parquetDisableDictionary = true;
+    private boolean parquetDisableDictionary = false;
     private static final String PARQUET_VERSION = "version";
     private static TParquetVersion parquetVersion = TParquetVersion.PARQUET_1_0;
 


### PR DESCRIPTION
# Proposed changes
outfile export as parquet format, and have set "max_file_size"="128MB"
But finally write all data into one file not as CSV split file

<img width="937" alt="Snipaste_2022-09-23_16-33-59" src="https://user-images.githubusercontent.com/87313068/191922147-127422a0-612c-4cca-b31e-9f66ed50d450.png">
## Problem summary

Describe your changes.

## Checklist(Required)
1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

