### PR TITLE
[fix](Nereids) Add exchange node check between local and global agg

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslator.java
@@ -200,7 +200,13 @@ public class PhysicalPlanTranslator extends DefaultPlanVisitor<PlanFragment, Pla
             outputTupleDesc = generateTupleDesc(slotList, null, context);
         } else {
             // In the distinct agg scenario, global shares local's desc
-            AggregationNode localAggNode = (AggregationNode) inputPlanFragment.getPlanRoot().getChild(0);
+            AggregationNode localAggNode;
+            if (inputPlanFragment.getPlanRoot() instanceof ExchangeNode) {
+                localAggNode = (AggregationNode) inputPlanFragment.getPlanRoot().getChild(0);
+            } else {
+                // If the group by expr hits the partition key, there may be no exchange node
+                localAggNode = (AggregationNode) inputPlanFragment.getPlanRoot();
+            }
             outputTupleDesc = localAggNode.getAggInfo().getOutputTupleDesc();
         }
 

--- a/regression-test/data/nereids_syntax_p0/function.out
+++ b/regression-test/data/nereids_syntax_p0/function.out
@@ -16,6 +16,11 @@
 1
 1
 
+-- !distinct_count_group_by_distributed_key --
+1312	1
+1309	1
+1303	1
+
 -- !avg --
 5.0	2356811.0
 

--- a/regression-test/data/nereids_syntax_p0/function.out
+++ b/regression-test/data/nereids_syntax_p0/function.out
@@ -17,9 +17,9 @@
 1
 
 -- !distinct_count_group_by_distributed_key --
-1312	1
-1309	1
 1303	1
+1309	1
+1312	1
 
 -- !avg --
 5.0	2356811.0

--- a/regression-test/suites/nereids_syntax_p0/function.groovy
+++ b/regression-test/suites/nereids_syntax_p0/function.groovy
@@ -45,6 +45,10 @@ suite("function") {
         SELECT count(distinct c_custkey + 1) AS custdist FROM customer group by c_city;
     """
 
+    order_qt_distinct_count_group_by_distributed_key """
+        SELECT c_custkey, count(distinct c_custkey + 1) AS custdist FROM customer group by c_custkey;
+    """
+
     order_qt_avg """
         SELECT avg(lo_tax), avg(lo_extendedprice) AS avg_extendedprice FROM lineorder;
     """


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

### table schema
CREATE TABLE `t1` (
  `k1` int(11) NULL,
  `v1` int(11) NULL
) ENGINE=OLAP
DUPLICATE KEY(`k1`, `v1`)
COMMENT 'OLAP'
DISTRIBUTED BY HASH(`k1`) BUCKETS 3

### query
select k1,count(distinct v1+1) from t1 group by k1;

### error
java.lang.ClassCastException: org.apache.doris.planner.OlapScanNode cannot be cast to org.apache.doris.planner.AggregationNode

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [x] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

