### PR TITLE
[fix](streamload&sink) release and allocate memory in the same tracker

### DIFF
--- a/be/src/exec/tablet_sink.cpp
+++ b/be/src/exec/tablet_sink.cpp
@@ -184,6 +184,7 @@ Status NodeChannel::open_wait() {
     // add batch closure
     _add_batch_closure = ReusableClosure<PTabletWriterAddBatchResult>::create();
     _add_batch_closure->addFailedHandler([this](bool is_last_rpc) {
+        SCOPED_ATTACH_TASK(_state);
         std::lock_guard<std::mutex> l(this->_closed_lock);
         if (this->_is_closed) {
             // if the node channel is closed, no need to call `mark_as_failed`,
@@ -206,6 +207,7 @@ Status NodeChannel::open_wait() {
 
     _add_batch_closure->addSuccessHandler([this](const PTabletWriterAddBatchResult& result,
                                                  bool is_last_rpc) {
+        SCOPED_ATTACH_TASK(_state);
         std::lock_guard<std::mutex> l(this->_closed_lock);
         if (this->_is_closed) {
             // if the node channel is closed, no need to call the following logic,
@@ -567,12 +569,19 @@ void NodeChannel::try_send_batch(RuntimeState* state) {
                 brpc_url + "/PInternalServiceImpl/tablet_writer_add_batch_by_http";
         _add_batch_closure->cntl.http_request().set_method(brpc::HTTP_METHOD_POST);
         _add_batch_closure->cntl.http_request().set_content_type("application/json");
-        _brpc_http_stub->tablet_writer_add_batch_by_http(
-                &_add_batch_closure->cntl, NULL, &_add_batch_closure->result, _add_batch_closure);
+        {
+            SCOPED_ATTACH_TASK(ExecEnv::GetInstance()->orphan_mem_tracker());
+            _brpc_http_stub->tablet_writer_add_batch_by_http(&_add_batch_closure->cntl, NULL,
+                                                             &_add_batch_closure->result,
+                                                             _add_batch_closure);
+        }
     } else {
         _add_batch_closure->cntl.http_request().Clear();
-        _stub->tablet_writer_add_batch(&_add_batch_closure->cntl, &request,
-                                       &_add_batch_closure->result, _add_batch_closure);
+        {
+            SCOPED_ATTACH_TASK(ExecEnv::GetInstance()->orphan_mem_tracker());
+            _stub->tablet_writer_add_batch(&_add_batch_closure->cntl, &request,
+                                           &_add_batch_closure->result, _add_batch_closure);
+        }
     }
     _next_packet_seq++;
 }

--- a/be/src/exec/tablet_sink.h
+++ b/be/src/exec/tablet_sink.h
@@ -95,6 +95,8 @@ public:
     ~ReusableClosure() {
         // shouldn't delete when Run() is calling or going to be called, wait for current Run() done.
         join();
+        SCOPED_ATTACH_TASK(ExecEnv::GetInstance()->orphan_mem_tracker());
+        cntl.Reset();
     }
 
     static ReusableClosure<T>* create() { return new ReusableClosure<T>(); }
@@ -121,6 +123,7 @@ public:
 
     // plz follow this order: reset() -> set_in_flight() -> send brpc batch
     void reset() {
+        SCOPED_ATTACH_TASK(ExecEnv::GetInstance()->orphan_mem_tracker());
         cntl.Reset();
         cid = cntl.call_id();
         watch.reset();

--- a/be/src/runtime/thread_context.h
+++ b/be/src/runtime/thread_context.h
@@ -134,10 +134,6 @@ public:
     void attach_task(const TaskType& type, const std::string& task_id,
                      const TUniqueId& fragment_instance_id,
                      const std::shared_ptr<MemTrackerLimiter>& mem_tracker) {
-        DCHECK((_type == TaskType::UNKNOWN || _type == TaskType::BRPC) && _task_id == "")
-                << ",new tracker label: " << mem_tracker->label() << ",old tracker label: "
-                << _thread_mem_tracker_mgr->limiter_mem_tracker_raw()->label();
-        DCHECK(type != TaskType::UNKNOWN);
         _type = type;
         _task_id = task_id;
         _fragment_instance_id = fragment_instance_id;

--- a/be/src/vec/common/pod_array.h
+++ b/be/src/vec/common/pod_array.h
@@ -160,13 +160,15 @@ protected:
                                        ExecEnv::GetInstance()->orphan_mem_tracker_raw());
 
         ptrdiff_t end_diff = c_end - c_start;
+        ptrdiff_t peak_diff = c_end_peak - c_start;
 
         c_start = reinterpret_cast<char*>(TAllocator::realloc(
                           c_start - pad_left, allocated_bytes(), bytes,
                           std::forward<TAllocatorParams>(allocator_params)...)) +
                   pad_left;
 
-        c_end = c_end_peak = c_start + end_diff;
+        c_end = c_start + end_diff;
+        c_end_peak = c_start + peak_diff;
         c_end_of_storage = c_start + bytes - pad_right - pad_left;
     }
 
@@ -503,9 +505,11 @@ public:
         auto swap_stack_heap = [this](PODArray& arr1, PODArray& arr2) {
             size_t stack_size = arr1.size();
             size_t stack_allocated = arr1.allocated_bytes();
+            size_t stack_peak_used = arr1.c_end_peak - arr1.c_start;
 
             size_t heap_size = arr2.size();
             size_t heap_allocated = arr2.allocated_bytes();
+            size_t heap_peak_used = arr2.c_end_peak - arr2.c_start;
 
             /// Keep track of the stack content we have to copy.
             char* stack_c_start = arr1.c_start;
@@ -514,13 +518,19 @@ public:
             arr1.c_start = arr2.c_start;
             arr1.c_end_of_storage = arr1.c_start + heap_allocated - arr1.pad_right;
             arr1.c_end = arr1.c_start + this->byte_size(heap_size);
-            arr1.c_end_peak = arr2.c_end_peak;
+            arr1.c_end_peak = arr1.c_end;
+            THREAD_MEM_TRACKER_TRANSFER_FROM(arr1.c_end_peak - arr1.c_start - heap_peak_used,
+                                             ExecEnv::GetInstance()->orphan_mem_tracker_raw());
+
 
             /// Allocate stack space for arr2.
             arr2.alloc(stack_allocated);
             /// Copy the stack content.
             memcpy(arr2.c_start, stack_c_start, this->byte_size(stack_size));
             arr2.c_end = arr2.c_end_peak = arr2.c_start + this->byte_size(stack_size);
+            THREAD_MEM_TRACKER_TRANSFER_FROM(arr2.c_end_peak - arr2.c_start - stack_peak_used,
+                                             ExecEnv::GetInstance()->orphan_mem_tracker_raw());
+
         };
 
         auto do_move = [this](PODArray& src, PODArray& dest) {
@@ -529,6 +539,11 @@ public:
                 dest.alloc(src.allocated_bytes());
                 memcpy(dest.c_start, src.c_start, this->byte_size(src.size()));
                 dest.c_end = dest.c_end_peak = dest.c_start + (src.c_end - src.c_start);
+                THREAD_MEM_TRACKER_TRANSFER_FROM(dest.c_end_peak - dest.c_start,
+                                                 ExecEnv::GetInstance()->orphan_mem_tracker_raw());
+ 
+                THREAD_MEM_TRACKER_TRANSFER_FROM(src.c_end_of_storage - src.c_end_peak,
+                                                 ExecEnv::GetInstance()->orphan_mem_tracker_raw());
 
                 src.c_start = Base::null;
                 src.c_end = Base::null;


### PR DESCRIPTION
1. HttpServer threads allocate bytebuffer and put them into streamload pipe, but scanner thread release them with query tracker.

2. We can assume brpc allocate memory in doris thread.

Above problems leads to wrong result of memtracker.

# Proposed changes

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

