### PR TITLE
[enhancement](string column)copy string continuous

### DIFF
--- a/be/src/olap/rowset/segment_v2/page_io.cpp
+++ b/be/src/olap/rowset/segment_v2/page_io.cpp
@@ -34,7 +34,7 @@ namespace doris {
 namespace segment_v2 {
 
 using strings::Substitute;
-
+enum { PAGE_PADDING_SIZE = 16 };
 Status PageIO::compress_page_body(BlockCompressionCodec* codec, double min_space_saving,
                                   const std::vector<Slice>& body, OwnedSlice* compressed_body) {
     size_t uncompressed_size = Slice::compute_total_size(body);
@@ -132,7 +132,7 @@ Status PageIO::read_and_decompress_page(const PageReadOptions& opts, PageHandle*
     }
 
     // hold compressed page at first, reset to decompressed page later
-    std::unique_ptr<char[]> page(new char[page_size]);
+    std::unique_ptr<char[]> page(new char[page_size + PAGE_PADDING_SIZE]);
     Slice page_slice(page.get(), page_size);
     {
         SCOPED_RAW_TIMER(&opts.stats->io_ns);
@@ -167,7 +167,7 @@ Status PageIO::read_and_decompress_page(const PageReadOptions& opts, PageHandle*
         }
         SCOPED_RAW_TIMER(&opts.stats->decompress_ns);
         std::unique_ptr<char[]> decompressed_page(
-                new char[footer->uncompressed_size() + footer_size + 4]);
+                new char[footer->uncompressed_size() + footer_size + 4 + PAGE_PADDING_SIZE]);
 
         // decompress page body
         Slice compressed_body(page_slice.data, body_size);


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

Some query read string columns continuously, but the string will be copied to ColumnString one by one from page. There are two improvement in this PR:
1. Resize the chars using the avg size of 100 string rows.
2. Calculate the max continuous rows and copy using a single memcpy command.

I also add a padding size in page, so that we could using overflow memcpy in the future.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
4. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
5. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
6. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
7. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

