### PR TITLE
[branch-1.1-lts](cherry-pick) Refactor load channel mem tracker to improve accuracy

### DIFF
--- a/be/src/runtime/memory/mem_tracker_limiter.h
+++ b/be/src/runtime/memory/mem_tracker_limiter.h
@@ -130,6 +130,7 @@ public:
     }
 
     void enable_print_log_usage() { _print_log_usage = true; }
+    void enable_reset_zero() { _reset_zero = true; }
 
     // Logs the usage of this tracker limiter and optionally its children (recursively).
     // If 'logged_consumption' is non-nullptr, sets the consumption value logged.
@@ -251,6 +252,11 @@ private:
     std::atomic_size_t _had_child_count = 0;
 
     bool _print_log_usage = false;
+    // mem hook record tracker cannot guarantee that the final consumption is 0,
+    // nor can it guarantee that the memory alloc and free are recorded in a one-to-one correspondence.
+    // In some cases, in order to avoid the cumulative error of the upper global tracker,
+    // the consumption of the current tracker is reset to zero.
+    bool _reset_zero = false;
 };
 
 inline void MemTrackerLimiter::consume(int64_t bytes) {

--- a/be/src/runtime/memory/mem_tracker_task_pool.cpp
+++ b/be/src/runtime/memory/mem_tracker_task_pool.cpp
@@ -89,14 +89,12 @@ void MemTrackerTaskPool::logout_task_mem_tracker() {
             //  between the two trackers.
             // At present, it is impossible to effectively locate which memory consume and release on different trackers,
             // so query memory leaks cannot be found.
-            //
-            // In order to ensure that the query pool mem tracker is the sum of all currently running query mem trackers,
-            // the effect of the ended query mem tracker on the query pool mem tracker should be cleared, that is,
-            // the negative number of the current value of consume.
-            it->second->parent()->cache_consume_local(-it->second->consumption());
             LOG(INFO) << fmt::format(
-                    "Deregister query/load memory tracker, queryId={}, Limit={}, PeakUsed={}",
-                    it->first, it->second->limit(), it->second->peak_consumption());
+                    "Deregister query/load memory tracker, queryId={}, Limit={}, CurrUsed={}, "
+                    "PeakUsed={}",
+                    it->first, PrettyPrinter::print(it->second->limit(), TUnit::BYTES),
+                    PrettyPrinter::print(it->second->consumption(), TUnit::BYTES),
+                    PrettyPrinter::print(it->second->peak_consumption(), TUnit::BYTES));
             expired_task_ids.emplace_back(it->first);
         }
     }

--- a/be/src/runtime/runtime_state.cpp
+++ b/be/src/runtime/runtime_state.cpp
@@ -230,6 +230,7 @@ Status RuntimeState::init_mem_trackers(const TUniqueId& query_id) {
         DCHECK(false);
         _new_query_mem_tracker = ExecEnv::GetInstance()->query_pool_mem_tracker();
     }
+    _new_query_mem_tracker->enable_reset_zero();
 
     _new_instance_mem_tracker = std::make_shared<MemTrackerLimiter>(
             -1, "RuntimeState:instance:" + print_id(_fragment_instance_id),

--- a/be/src/util/mem_info.cpp
+++ b/be/src/util/mem_info.cpp
@@ -40,12 +40,14 @@ int64_t MemInfo::_s_mem_limit = -1;
 std::string MemInfo::_s_mem_limit_str = "";
 int64_t MemInfo::_s_hard_mem_limit = -1;
 size_t MemInfo::_s_allocator_physical_mem = 0;
+size_t MemInfo::_s_pageheap_unmapped_bytes = 0;
 size_t MemInfo::_s_tcmalloc_pageheap_free_bytes = 0;
 size_t MemInfo::_s_tcmalloc_central_bytes = 0;
 size_t MemInfo::_s_tcmalloc_transfer_bytes = 0;
 size_t MemInfo::_s_tcmalloc_thread_bytes = 0;
 size_t MemInfo::_s_allocator_cache_mem = 0;
 std::string MemInfo::_s_allocator_cache_mem_str = "";
+size_t MemInfo::_s_virtual_memory_used = 0;
 
 void MemInfo::init() {
     // Read from /proc/meminfo

--- a/be/src/util/mem_info.h
+++ b/be/src/util/mem_info.h
@@ -42,6 +42,7 @@ public:
     }
 
     static inline size_t current_mem() { return _s_allocator_physical_mem; }
+    static inline size_t allocator_virtual_mem() { return _s_virtual_memory_used; }
     static inline size_t allocator_cache_mem() { return _s_allocator_cache_mem; }
     static inline std::string allocator_cache_mem_str() { return _s_allocator_cache_mem_str; }
 
@@ -50,6 +51,8 @@ public:
     static inline void refresh_allocator_mem() {
         MallocExtension::instance()->GetNumericProperty("generic.total_physical_bytes",
                                                         &_s_allocator_physical_mem);
+        MallocExtension::instance()->GetNumericProperty("tcmalloc.pageheap_unmapped_bytes",
+                                                        &_s_pageheap_unmapped_bytes);
         MallocExtension::instance()->GetNumericProperty("tcmalloc.pageheap_free_bytes",
                                                         &_s_tcmalloc_pageheap_free_bytes);
         MallocExtension::instance()->GetNumericProperty("tcmalloc.central_cache_free_bytes",
@@ -61,6 +64,7 @@ public:
         _s_allocator_cache_mem = _s_tcmalloc_pageheap_free_bytes + _s_tcmalloc_central_bytes +
                                  _s_tcmalloc_transfer_bytes + _s_tcmalloc_thread_bytes;
         _s_allocator_cache_mem_str = PrettyPrinter::print(_s_allocator_cache_mem, TUnit::BYTES);
+        _s_virtual_memory_used = _s_allocator_physical_mem + _s_pageheap_unmapped_bytes;
     }
 
     static inline int64_t mem_limit() {
@@ -82,12 +86,14 @@ private:
     static std::string _s_mem_limit_str;
     static int64_t _s_hard_mem_limit;
     static size_t _s_allocator_physical_mem;
+    static size_t _s_pageheap_unmapped_bytes;
     static size_t _s_tcmalloc_pageheap_free_bytes;
     static size_t _s_tcmalloc_central_bytes;
     static size_t _s_tcmalloc_transfer_bytes;
     static size_t _s_tcmalloc_thread_bytes;
     static size_t _s_allocator_cache_mem;
     static std::string _s_allocator_cache_mem_str;
+    static size_t _s_virtual_memory_used;
 };
 
 } // namespace doris


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

cherry-pick: #12791
Because load_channel => memtable is still the old mem tracker on 1.1-lts, the content of the new Hook mem tracker has no pick

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

