### PR TITLE
[fix](memtracker) Remove mem tracker record mem pool actual memory usage

### DIFF
--- a/be/src/runtime/exec_env_init.cpp
+++ b/be/src/runtime/exec_env_init.cpp
@@ -216,7 +216,6 @@ Status ExecEnv::_init_mem_tracker() {
         init_hook();
     }
 #endif
-
     _allocator_cache_mem_tracker = std::make_shared<MemTracker>("Tc/JemallocAllocatorCache");
     _query_pool_mem_tracker =
             std::make_shared<MemTrackerLimiter>(-1, "QueryPool", _process_mem_tracker);

--- a/be/src/runtime/mem_pool.cpp
+++ b/be/src/runtime/mem_pool.cpp
@@ -45,7 +45,6 @@ MemPool::MemPool(MemTracker* mem_tracker)
           next_chunk_size_(INITIAL_CHUNK_SIZE),
           total_allocated_bytes_(0),
           total_reserved_bytes_(0),
-          peak_allocated_bytes_(0),
           _mem_tracker(mem_tracker) {}
 
 MemPool::MemPool()
@@ -53,7 +52,6 @@ MemPool::MemPool()
           next_chunk_size_(INITIAL_CHUNK_SIZE),
           total_allocated_bytes_(0),
           total_reserved_bytes_(0),
-          peak_allocated_bytes_(0),
           _mem_tracker(nullptr) {}
 
 MemPool::ChunkInfo::ChunkInfo(const Chunk& chunk_) : chunk(chunk_), allocated_bytes(0) {
@@ -66,8 +64,6 @@ MemPool::~MemPool() {
         total_bytes_released += chunk.chunk.size;
         ChunkAllocator::instance()->free(chunk.chunk);
     }
-    THREAD_MEM_TRACKER_TRANSFER_FROM(total_bytes_released - peak_allocated_bytes_,
-                                     ExecEnv::GetInstance()->orphan_mem_tracker_raw());
     if (_mem_tracker) _mem_tracker->release(total_bytes_released);
     DorisMetrics::instance()->memory_pool_bytes_total->increment(-total_bytes_released);
 }
@@ -88,15 +84,12 @@ void MemPool::free_all() {
         total_bytes_released += chunk.chunk.size;
         ChunkAllocator::instance()->free(chunk.chunk);
     }
-    THREAD_MEM_TRACKER_TRANSFER_FROM(total_bytes_released - peak_allocated_bytes_,
-                                     ExecEnv::GetInstance()->orphan_mem_tracker_raw());
     if (_mem_tracker) _mem_tracker->release(total_bytes_released);
     chunks_.clear();
     next_chunk_size_ = INITIAL_CHUNK_SIZE;
     current_chunk_idx_ = -1;
     total_allocated_bytes_ = 0;
     total_reserved_bytes_ = 0;
-    peak_allocated_bytes_ = 0;
 
     DorisMetrics::instance()->memory_pool_bytes_total->increment(-total_bytes_released);
 }
@@ -150,7 +143,6 @@ Status MemPool::find_chunk(size_t min_size, bool check_limits) {
     // Allocate a new chunk. Return early if allocate fails.
     Chunk chunk;
     RETURN_IF_ERROR(ChunkAllocator::instance()->allocate(chunk_size, &chunk));
-    THREAD_MEM_TRACKER_TRANSFER_TO(chunk_size, ExecEnv::GetInstance()->orphan_mem_tracker_raw());
     if (_mem_tracker) _mem_tracker->consume(chunk_size);
     ASAN_POISON_MEMORY_REGION(chunk.data, chunk_size);
     // Put it before the first free chunk. If no free chunks, it goes at the end.
@@ -221,8 +213,6 @@ void MemPool::acquire_data(MemPool* src, bool keep_current) {
         src->total_allocated_bytes_ = 0;
     }
 
-    reset_peak();
-
     if (!keep_current) src->free_all();
     DCHECK(src->check_integrity(false));
     DCHECK(check_integrity(false));
@@ -243,7 +233,6 @@ void MemPool::exchange_data(MemPool* other) {
     std::swap(next_chunk_size_, other->next_chunk_size_);
     std::swap(total_allocated_bytes_, other->total_allocated_bytes_);
     std::swap(total_reserved_bytes_, other->total_reserved_bytes_);
-    std::swap(peak_allocated_bytes_, other->peak_allocated_bytes_);
     std::swap(chunks_, other->chunks_);
 }
 

--- a/be/src/runtime/memory/mem_tracker.cpp
+++ b/be/src/runtime/memory/mem_tracker.cpp
@@ -61,11 +61,8 @@ MemTracker::MemTracker(const std::string& label, RuntimeProfile* profile) {
     DCHECK(thread_context()->_thread_mem_tracker_mgr->limiter_mem_tracker_raw() != nullptr);
     MemTrackerLimiter* parent =
             thread_context()->_thread_mem_tracker_mgr->limiter_mem_tracker_raw();
-    _label = fmt::format("[Observer] {} | {}", label,
-                         parent->label() == "Orphan" ? "Process" : parent->label());
-    _bind_group_num = parent->label() == "Orphan"
-                              ? ExecEnv::GetInstance()->process_mem_tracker()->group_num()
-                              : parent->group_num();
+    _label = fmt::format("[Observer] {} | {}", label, parent->label());
+    _bind_group_num = parent->group_num();
     {
         std::lock_guard<std::mutex> l(mem_tracker_pool[_bind_group_num].group_lock);
         _tracker_group_it = mem_tracker_pool[_bind_group_num].trackers.insert(

--- a/be/src/runtime/memory/mem_tracker_limiter.cpp
+++ b/be/src/runtime/memory/mem_tracker_limiter.cpp
@@ -78,7 +78,7 @@ MemTrackerLimiter::~MemTrackerLimiter() {
     DCHECK(remain_child_count() == 0 || _label == "Process");
     // In order to ensure `consumption of all limiter trackers` + `orphan tracker consumption` = `process tracker consumption`
     // in real time. Merge its consumption into orphan when parent is process, to avoid repetition.
-    if ((_parent && _parent->label() == "Process")) {
+    if (_parent && _parent->label() == "Process") {
         ExecEnv::GetInstance()->orphan_mem_tracker_raw()->cache_consume_local(
                 _consumption->current_value());
     }
@@ -89,11 +89,7 @@ MemTrackerLimiter::~MemTrackerLimiter() {
         _all_ancestors.clear();
         _all_ancestors.push_back(ExecEnv::GetInstance()->orphan_mem_tracker_raw());
     }
-    for (auto& tracker : _all_ancestors) {
-        if (tracker->label() != "Process") {
-            tracker->_consumption->add(_untracked_mem);
-        }
-    }
+    consume_local(_untracked_mem);
     if (_parent) {
         std::lock_guard<std::mutex> l(_parent->_child_tracker_limiter_lock);
         if (_child_tracker_it != _parent->_child_tracker_limiters.end()) {

--- a/be/src/runtime/memory/mem_tracker_limiter.h
+++ b/be/src/runtime/memory/mem_tracker_limiter.h
@@ -181,6 +181,8 @@ private:
     WARN_UNUSED_RESULT
     bool try_consume(int64_t bytes, std::string& failed_msg);
 
+    void consume_local(int64_t bytes);
+
     // When the accumulated untracked memory value exceeds the upper limit,
     // the current value is returned and set to 0.
     // Thread safety.
@@ -273,15 +275,18 @@ inline int64_t MemTrackerLimiter::add_untracked_mem(int64_t bytes) {
     return 0;
 }
 
+inline void MemTrackerLimiter::consume_local(int64_t bytes) {
+    if (bytes == 0) return;
+    for (auto& tracker : _all_ancestors) {
+        if (tracker->label() == "Process") return;
+        tracker->_consumption->add(bytes);
+    }
+}
+
 inline void MemTrackerLimiter::cache_consume_local(int64_t bytes) {
     if (bytes == 0) return;
     int64_t consume_bytes = add_untracked_mem(bytes);
-    if (consume_bytes != 0) {
-        for (auto& tracker : _all_ancestors) {
-            if (tracker->label() == "Process") return;
-            tracker->_consumption->add(consume_bytes);
-        }
-    }
+    consume_local(consume_bytes);
 }
 
 inline bool MemTrackerLimiter::try_consume(int64_t bytes, std::string& failed_msg) {


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

In order to avoid different mem tracker consumption values of multiple queries/loads, and the difference between the virtual memory of alloc and the physical memory actually increased by the process.

The memory alloc in PODArray and mempool will not be recorded in the query/load mem tracker immediately, but will be gradually recorded in the mem tracker during the memory usage.

But mem pool allocates memory from chunk allocator. If this chunk is used after the second time, it may have used physical memory. The above mechanism will cause the load channel memory statistics to be less than the actual value.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [x] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

