### PR TITLE
[enhancement](memory) Trigger load channel flush based on process physical memory to avoid OOM

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -72,7 +72,7 @@ CONF_Int64(tc_max_total_thread_cache_bytes, "1073741824");
 // defaults to bytes if no unit is given"
 // must larger than 0. and if larger than physical memory size,
 // it will be set to physical memory size.
-CONF_String(mem_limit, "90%");
+CONF_String(mem_limit, "80%");
 
 // the port heartbeat service used
 CONF_Int32(heartbeat_service_port, "9050");

--- a/be/src/runtime/bufferpool/buffer_allocator.cc
+++ b/be/src/runtime/bufferpool/buffer_allocator.cc
@@ -368,7 +368,8 @@ int64_t BufferPool::BufferAllocator::ScavengeBuffers(bool slow_but_sure, int cur
     if (slow_but_sure && bytes_found < target_bytes) {
         bytes_found +=
                 DecreaseBytesRemaining(target_bytes - bytes_found, true, &system_bytes_remaining_);
-        DCHECK_EQ(bytes_found, target_bytes) << DebugString();
+        // Deadlock in arena_locks in BufferPool::BufferAllocator::ScavengeBuffers and _lock in DebugString
+        // DCHECK_EQ(bytes_found, target_bytes) << DebugString();
     }
     return bytes_found;
 }

--- a/be/src/runtime/load_channel_mgr.cpp
+++ b/be/src/runtime/load_channel_mgr.cpp
@@ -69,8 +69,9 @@ LoadChannelMgr::~LoadChannelMgr() {
 
 Status LoadChannelMgr::init(int64_t process_mem_limit) {
     int64_t load_mgr_mem_limit = calc_process_max_load_memory(process_mem_limit);
-    _load_process_soft_mem_limit =
-            load_mgr_mem_limit * config::load_process_soft_mem_limit_percent / 100;
+    _load_soft_mem_limit = load_mgr_mem_limit * config::load_process_soft_mem_limit_percent / 100;
+    _process_soft_mem_limit =
+            ExecEnv::GetInstance()->process_mem_tracker()->limit() * config::soft_mem_limit_frac;
     _mem_tracker = std::make_shared<MemTrackerLimiter>(load_mgr_mem_limit, "LoadChannelMgr");
     REGISTER_HOOK_METRIC(load_channel_mem_consumption,
                          [this]() { return _mem_tracker->consumption(); });

--- a/be/src/runtime/memory/mem_tracker_limiter.h
+++ b/be/src/runtime/memory/mem_tracker_limiter.h
@@ -75,9 +75,7 @@ public:
         // but it may not actually alloc physical memory, which is not expected in mem hook fail.
         //
         // TODO: In order to ensure no OOM, currently reserve 200M, and then use the free mem in /proc/meminfo to ensure no OOM.
-        if (PerfCounters::get_vm_rss() - static_cast<int64_t>(MemInfo::allocator_cache_mem()) +
-                            bytes >=
-                    MemInfo::mem_limit() ||
+        if (MemInfo::proc_mem_no_allocator_cache() + bytes >= MemInfo::mem_limit() ||
             PerfCounters::get_vm_rss() + bytes >= MemInfo::hard_mem_limit()) {
             return true;
         }

--- a/be/src/service/doris_main.cpp
+++ b/be/src/service/doris_main.cpp
@@ -493,12 +493,11 @@ int main(int argc, char** argv) {
 #if defined(LEAK_SANITIZER)
         __lsan_do_leak_check();
 #endif
-
+        doris::PerfCounters::refresh_proc_status();
 #if !defined(ADDRESS_SANITIZER) && !defined(LEAK_SANITIZER) && !defined(THREAD_SANITIZER) && \
         !defined(USE_JEMALLOC)
         doris::MemInfo::refresh_allocator_mem();
 #endif
-        doris::PerfCounters::refresh_proc_status();
         int64_t allocator_cache_mem_diff =
                 doris::MemInfo::allocator_cache_mem() -
                 doris::ExecEnv::GetInstance()->allocator_cache_mem_tracker()->consumption();

--- a/be/src/util/mem_info.cpp
+++ b/be/src/util/mem_info.cpp
@@ -51,6 +51,7 @@ size_t MemInfo::_s_tcmalloc_thread_bytes = 0;
 size_t MemInfo::_s_allocator_cache_mem = 0;
 std::string MemInfo::_s_allocator_cache_mem_str = "";
 size_t MemInfo::_s_virtual_memory_used = 0;
+int64_t MemInfo::_s_proc_mem_no_allocator_cache = -1;
 
 void MemInfo::init() {
     // Read from /proc/meminfo
@@ -99,7 +100,7 @@ void MemInfo::init() {
     bool is_percent = true;
     _s_mem_limit = ParseUtil::parse_mem_spec(config::mem_limit, -1, _s_physical_mem, &is_percent);
     _s_mem_limit_str = PrettyPrinter::print(_s_mem_limit, TUnit::BYTES);
-    _s_hard_mem_limit = _s_physical_mem - std::min(209715200L, _s_physical_mem / 10); // 200M
+    _s_hard_mem_limit = _s_physical_mem - std::max(209715200L, _s_physical_mem / 10); // 200M
 
     LOG(INFO) << "Physical Memory: " << PrettyPrinter::print(_s_physical_mem, TUnit::BYTES);
     _s_initialized = true;

--- a/be/src/util/mem_info.h
+++ b/be/src/util/mem_info.h
@@ -25,6 +25,7 @@
 #include <string>
 
 #include "common/logging.h"
+#include "util/perf_counters.h"
 #include "util/pretty_printer.h"
 
 namespace doris {
@@ -49,6 +50,7 @@ public:
     static inline size_t allocator_virtual_mem() { return _s_virtual_memory_used; }
     static inline size_t allocator_cache_mem() { return _s_allocator_cache_mem; }
     static inline std::string allocator_cache_mem_str() { return _s_allocator_cache_mem_str; }
+    static inline int64_t proc_mem_no_allocator_cache() { return _s_proc_mem_no_allocator_cache; }
 
     // Tcmalloc property `generic.total_physical_bytes` records the total length of the virtual memory
     // obtained by the process malloc, not the physical memory actually used by the process in the OS.
@@ -69,6 +71,8 @@ public:
                                  _s_tcmalloc_transfer_bytes + _s_tcmalloc_thread_bytes;
         _s_allocator_cache_mem_str = PrettyPrinter::print(_s_allocator_cache_mem, TUnit::BYTES);
         _s_virtual_memory_used = _s_allocator_physical_mem + _s_pageheap_unmapped_bytes;
+        _s_proc_mem_no_allocator_cache =
+                PerfCounters::get_vm_rss() - static_cast<int64_t>(_s_allocator_cache_mem);
     }
 
     static inline int64_t mem_limit() {
@@ -98,6 +102,7 @@ private:
     static size_t _s_allocator_cache_mem;
     static std::string _s_allocator_cache_mem_str;
     static size_t _s_virtual_memory_used;
+    static int64_t _s_proc_mem_no_allocator_cache;
 };
 
 } // namespace doris

--- a/docs/en/docs/admin-manual/config/be-config.md
+++ b/docs/en/docs/admin-manual/config/be-config.md
@@ -844,7 +844,7 @@ The number of sliced tablets, plan the layout of the tablet, and avoid too many 
 
 * Type: string
 * Description: Limit the percentage of the server's maximum memory used by the BE process. It is used to prevent BE memory from occupying to many the machine's memory. This parameter must be greater than 0. When the percentage is greater than 100%, the value will default to 100%.
-* Default value: 90%
+* Default value: 80%
 
 ### `memory_limitation_per_thread_for_schema_change`
 

--- a/docs/zh-CN/docs/admin-manual/config/be-config.md
+++ b/docs/zh-CN/docs/admin-manual/config/be-config.md
@@ -845,7 +845,7 @@ txn 管理器中每个 txn_partition_map 的最大 txns 数，这是一种自我
 
 * 类型：string
 * 描述：限制BE进程使用服务器最大内存百分比。用于防止BE内存挤占太多的机器内存，该参数必须大于0，当百分大于100%之后，该值会默认为100%。
-* 默认值：90%
+* 默认值：80%
 
 ### `memory_limitation_per_thread_for_schema_change`
 


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

1. When the physical memory of the process reaches 90% of the mem limit, trigger the load channel mgr to flush
2. The default value of be.conf `mem_limit` is changed from 90% to 80%, and stability is the priority.
3. Fix deadlock in arena_locks in BufferPool::BufferAllocator::ScavengeBuffers and _lock in DebugString

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
5. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
6. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

