### PR TITLE
[fix](memory) Fix buffer pool deadlock

### DIFF
--- a/be/src/runtime/bufferpool/buffer_allocator.cc
+++ b/be/src/runtime/bufferpool/buffer_allocator.cc
@@ -724,7 +724,7 @@ int64_t BufferPool::FreeBufferArena::GetNumCleanPages() {
 }
 
 std::string BufferPool::FreeBufferArena::DebugString() {
-    std::lock_guard<SpinLock> al(lock_);
+    // std::lock_guard<SpinLock> al(lock_);
     std::stringstream ss;
     ss << "<FreeBufferArena> " << this << "\n";
     for (int i = 0; i < NumBufferSizes(); ++i) {
@@ -734,8 +734,8 @@ std::string BufferPool::FreeBufferArena::DebugString() {
            << " free buffers: " << lists.num_free_buffers.load(std::memory_order_acquire)
            << " low water mark: " << lists.low_water_mark
            << " clean pages: " << lists.num_clean_pages.load(std::memory_order_acquire) << " ";
-        lists.clean_pages.iterate(
-                std::bind<bool>(Page::DebugStringCallback, &ss, std::placeholders::_1));
+        // lists.clean_pages.iterate(
+        //         std::bind<bool>(Page::DebugStringCallback, &ss, std::placeholders::_1));
         ss << "\n";
     }
     return ss.str();


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

Deadlock in arena_locks in `BufferPool::BufferAllocator::ScavengeBuffers` and `_lock` in `DebugString`

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

