### PR TITLE
[chore](regression-test) add default group(p0) for regression-test

### DIFF
--- a/regression-test/data/query_p0/sql_functions/window_functions/test_window_function.out
+++ b/regression-test/data/query_p0/sql_functions/window_functions/test_window_function.out
@@ -411,6 +411,7 @@ USA	Pete	Hello
 9223372036854775807	2
 
 -- !window_error1 --
+\N	\N
 -9223372036854775807	true
 -9223372036854775807	true
 -11011907	false
@@ -426,7 +427,6 @@ USA	Pete	Hello
 11011920	true
 9223372036854775807	false
 9223372036854775807	false
-\N	\N
 
 -- !window_error2 --
 \N	\N

--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/Config.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/Config.groovy
@@ -162,6 +162,12 @@ class Config {
                 .findAll({d -> d != null && d.length() > 0})
                 .toSet()
 
+        if (!config.suiteWildcard && !config.groups && !config.directories && !config.excludeSuiteWildcard
+            && !config.excludeGroupSet && !config.excludeDirectorySet) {
+            log.info("no suites/directories/groups specified, set groups to p0".toString())
+            config.groups = ["p0"].toSet()
+        }
+
         config.feHttpAddress = cmd.getOptionValue(feHttpAddressOpt, config.feHttpAddress)
         try {
             Inet4Address host = Inet4Address.getByName(config.feHttpAddress.split(":")[0]) as Inet4Address

--- a/regression-test/suites/query_p0/sql_functions/window_functions/test_window_function.groovy
+++ b/regression-test/suites/query_p0/sql_functions/window_functions/test_window_function.groovy
@@ -397,7 +397,7 @@ suite("test_window_function") {
             assertTrue(exception != null)
         }
     }
-    qt_window_error1"""select ${k1}, first_value(${k2}) over (partition by ${k1}) from baseall"""
+    qt_window_error1"""select ${k1}, first_value(${k2}) over (partition by ${k1}) from baseall order by ${k1}"""
     qt_window_error2"""select ${k1}, first_value(${k2}) over (order by ${k3}) from baseall"""
     qt_window_error3"""select ${k1}, max(${k2}) over (order by ${k3}) from baseall"""
     test {

--- a/regression-test/suites/tpch_unique_sql_zstd_p0/load.groovy
+++ b/regression-test/suites/tpch_unique_sql_zstd_p0/load.groovy
@@ -54,7 +54,7 @@ suite("load") {
 
             // relate to ${DORIS_HOME}/regression-test/data/demo/streamload_input.csv.
             // also, you can stream load a http stream, e.g. http://xxx/some.csv
-            file """${context.sf1DataPath}/tpch/sf0.1/${tableName}.tbl.gz"""
+            file """${context.sf1DataPath}/regression/tpch/sf0.1/${tableName}.tbl.gz"""
 
             time 10000 // limit inflight 10s
 


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary

It's difficult to run all groups of regression-test successfully on local env, so make `run-regression-test.sh` just run p0 by default.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

