### PR TITLE
[fix](transfer_thread) fix the loss of notification.

### DIFF
--- a/be/src/vec/exec/volap_scan_node.cpp
+++ b/be/src/vec/exec/volap_scan_node.cpp
@@ -376,7 +376,10 @@ void VOlapScanNode::transfer_thread(RuntimeState* state) {
     }
 
     VLOG_CRITICAL << "TransferThread finish.";
-    _transfer_done = true;
+    {
+        std::unique_lock<std::mutex> l(_blocks_lock);
+        _transfer_done = true;
+    }
     _block_added_cv.notify_all();
     {
         std::unique_lock<std::mutex> l(_scan_blocks_lock);


### PR DESCRIPTION
# Proposed changes

## Problem summary

In the VOlapScanNode:: transfer_thread (), the __transfer_done_ should be locked for modification before calling the cv.notify_all(). Otherwise,  the thread of VOlapScanNode::get_next() may not know the __transfer_done_ has been modified, and lose the notification before calling cv.wait_for(), which will cause the thread to wait for 1s. We can find that OlapScanNode has locked the __transfer_done_ in the same way.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [X] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [X] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [X] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [X] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [X] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

