### PR TITLE
[fix](column-const) Avoid return ColumnConst for vliteral

### DIFF
--- a/be/src/vec/exprs/vliteral.cpp
+++ b/be/src/vec/exprs/vliteral.cpp
@@ -182,7 +182,10 @@ void VLiteral::init(const TExprNode& node) {
         }
         }
     }
-    _column_ptr = _data_type->create_column_const(1, field);
+    // Here we avoid to be a ColumnConst column
+    // ColumnConst has many calling methods that behave inconsistently and is prone to errors.
+    // TODO: rethink about how to use ColumnConst correctly.
+    _column_ptr = _data_type->create_column_const(1, field)->convert_to_full_column_if_const();
 }
 
 Status VLiteral::execute(VExprContext* context, vectorized::Block* block, int* result_column_id) {


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

ColumnConst is hard to use and very error-prone.
eg,
the `remove_nullable()` method will not remove the `nullable` of inner column data of ColumnConst.
And `is_nullable()` method is comment out in ColumnConst with unknown reason.

So this PR, I change the default behavior of `vliteral`, to not return ColumnConst.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

