### PR TITLE
[optimization](array-type) optimize error prompts when sql parser rep…

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectProcessor.java
@@ -357,6 +357,8 @@ public class ConnectProcessor {
             } else {
                 throw new AnalysisException(errorMessage, e);
             }
+        } catch (ArrayStoreException e) {
+            throw new AnalysisException("Sql parser can't convert the result to array, please check your sql.", e);
         } catch (Exception e) {
             // TODO(lingbin): we catch 'Exception' to prevent unexpected error,
             // should be removed this try-catch clause future.


### PR DESCRIPTION
1. this pr is used to optimize error prompts when sql parser report error.
2. before the change, we run the sql will report the common error.
MySQL [example_db]> select [id, c_array] from test_array_nest;
ERROR 1105 (HY000): errCode = 2, detailMessage = Internal Error, maybe syntax error or this is a bug

3. after the change, we run the sql will report the detail error message.
MySQL [example_db]> select [id, c_array] from test_array_nest;
ERROR 1105 (HY000): errCode = 2, detailMessage = Sql parser can't convert the result to array, please check your sql.

4. the detail error stack is as below:
2022-09-27 10:49:46,675 DEBUG (mysql-nio-pool-0|308) [ConnectProcessor.parse():344] the originStmts are: select [id, c_array] from test_array_nest
2022-09-27 10:49:46,675 WARN (mysql-nio-pool-0|308) [ConnectProcessor.handleQuery():307] Process one query failed because.
org.apache.doris.common.AnalysisException: errCode = 2, detailMessage = Sql parser can't convert the result to array, please check your sql.
        at org.apache.doris.qe.ConnectProcessor.parse(ConnectProcessor.java:361) ~[doris-fe.jar:1.0-SNAPSHOT]
        at org.apache.doris.qe.ConnectProcessor.handleQuery(ConnectProcessor.java:275) ~[doris-fe.jar:1.0-SNAPSHOT]
        at org.apache.doris.qe.ConnectProcessor.dispatch(ConnectProcessor.java:432) ~[doris-fe.jar:1.0-SNAPSHOT]
        at org.apache.doris.qe.ConnectProcessor.processOnce(ConnectProcessor.java:662) ~[doris-fe.jar:1.0-SNAPSHOT]
        at org.apache.doris.mysql.nio.ReadListener.lambda$handleEvent$0(ReadListener.java:52) ~[doris-fe.jar:1.0-SNAPSHOT]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) ~[?:1.8.0_242]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) ~[?:1.8.0_242]
        at java.lang.Thread.run(Thread.java:748) ~[?:1.8.0_242]
Caused by: java.lang.ArrayStoreException
        at java.util.ArrayList.toArray(ArrayList.java:411) ~[?:1.8.0_242]
        at org.apache.doris.analysis.CUP$SqlParser$actions.case912(SqlParser.java:23695) ~[doris-fe.jar:1.0-SNAPSHOT]
        at org.apache.doris.analysis.CUP$SqlParser$actions.CUP$SqlParser$do_action(SqlParser.java:6531) ~[doris-fe.jar:1.0-SNAPSHOT]
        at org.apache.doris.analysis.SqlParser.do_action(SqlParser.java:2182) ~[doris-fe.jar:1.0-SNAPSHOT]
        at java_cup.runtime.lr_parser.parse(lr_parser.java:584) ~[jflex-1.4.3.jar:?]
        at org.apache.doris.common.util.SqlParserUtils.getMultiStmts(SqlParserUtils.java:60) ~[doris-fe.jar:1.0-SNAPSHOT]
        at org.apache.doris.qe.ConnectProcessor.parse(ConnectProcessor.java:349) ~[doris-fe.jar:1.0-SNAPSHOT]
        ... 7 more

# Proposed changes

Issue Number: #7570

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
6. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
7. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
8. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
9. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

