### PR TITLE
[chore](build) Fix compilation errors reported by clang-15

### DIFF
--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -437,11 +437,7 @@ set(CUSTUM_LINKER_COMMAND "ld")
 # TODO: mold will link fail on thirdparty brpc now, waiting for investigation.
 # TRY_TO_CHANGE_LINKER("mold" "mold")
 
-# TODO: brpc will link fail on clang-15, need fix in the future.
-if (COMPILER_GCC OR CLANG_VERSION_MAJOR VERSION_LESS 15)
-    TRY_TO_CHANGE_LINKER("lld" "LLD")
-endif()
-
+TRY_TO_CHANGE_LINKER("lld" "LLD")
 TRY_TO_CHANGE_LINKER("gold" "GNU gold")
 if (NOT CUSTUM_LINKER_COMMAND STREQUAL "ld")
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fuse-ld=${CUSTUM_LINKER_COMMAND}")

--- a/be/src/geo/CMakeLists.txt
+++ b/be/src/geo/CMakeLists.txt
@@ -29,6 +29,7 @@ add_library(Geo STATIC
     ${GENSRC_DIR}/geo/wkt_lex.l.cpp
     ${GENSRC_DIR}/geo/wkt_yacc.y.cpp
 )
+target_compile_options(Geo PRIVATE -Wno-unused-but-set-variable)
 
 add_custom_command(
     OUTPUT ${GENSRC_DIR}/geo/wkt_lex.l.cpp ${GENSRC_DIR}/geo/wkt_lex.l.h

--- a/be/src/olap/rowset/CMakeLists.txt
+++ b/be/src/olap/rowset/CMakeLists.txt
@@ -30,5 +30,3 @@ add_library(Rowset STATIC
     beta_rowset_reader.cpp
     beta_rowset_writer.cpp
     rowset_tree.cpp)
-
-target_compile_options(Rowset PUBLIC)


### PR DESCRIPTION
# Proposed changes

Add a compile flag `-Wno-unused-but-set-variable` to build `libGeo.a` .

## Problem summary

Fix the following error.

```shell
/Programs/doris/be/../gensrc/build//geo/wkt_yacc.y.cpp:1153:9: error: variable 'wkt_nerrs' set but not used [-Werror,-Wunused-but-set-variable]
    int yynerrs;
        ^
/Programs/doris/gensrc/build/geo/wkt_yacc.y.cpp:72:25: note: expanded from macro 'yynerrs'
#define yynerrs         wkt_nerrs
                        ^
1 error generated.
```

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

