### PR TITLE
[fix](Broker Load)fix bug when load data using broker with md5sum()/sm3sum()

### DIFF
--- a/be/src/exprs/encryption_functions.cpp
+++ b/be/src/exprs/encryption_functions.cpp
@@ -181,7 +181,7 @@ StringVal EncryptionFunctions::md5sum(FunctionContext* ctx, int num_args, const 
     for (int i = 0; i < num_args; ++i) {
         const StringVal& arg = args[i];
         if (arg.is_null) {
-            continue;
+            return StringVal::null();
         }
         digest.update(arg.ptr, arg.len);
     }
@@ -204,7 +204,7 @@ StringVal EncryptionFunctions::sm3sum(FunctionContext* ctx, int num_args, const 
     for (int i = 0; i < num_args; ++i) {
         const StringVal& arg = args[i];
         if (arg.is_null) {
-            continue;
+            return StringVal::null();
         }
         digest.update(arg.ptr, arg.len);
     }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #12989

## Problem summary

You can find the problem details in issue https://github.com/apache/doris/issues/12989

## Checklist(Required)

1. Does it affect the original behavior: 
    - [x] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

