### PR TITLE
[branch-1.1-lts](cherry-pick) fix wrong result of tablet health stmt …

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/proc/TabletHealthProcDir.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/proc/TabletHealthProcDir.java
@@ -285,11 +285,11 @@ public class TabletHealthProcDir implements ProcDirInterface {
                 this.colocateMismatchNum += other.colocateMismatchNum;
                 this.colocateRedundantNum += other.colocateRedundantNum;
                 this.needFurtherRepairNum += other.needFurtherRepairNum;
-                this.unrecoverableNum += unrecoverableNum;
-                this.replicaCompactionTooSlowNum += replicaCompactionTooSlowNum;
-                this.inconsistentNum += inconsistentNum;
-                this.oversizeNum += oversizeNum;
-                this.cloningNum += cloningNum;
+                this.unrecoverableNum += other.unrecoverableNum;
+                this.replicaCompactionTooSlowNum += other.replicaCompactionTooSlowNum;
+                this.inconsistentNum += other.inconsistentNum;
+                this.oversizeNum += other.oversizeNum;
+                this.cloningNum += other.cloningNum;
                 return this;
             } else if (other.summary) {
                 return other.reduce(this);


### PR DESCRIPTION
…(#13010)

# Proposed changes

Issue Number: close #13010

## Problem summary

This problem has been fixed in master branch, but not in branch-1.1-lts. 
We will use branch-1.1-lts in production env so we need to fix this problem.
See #13010 

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] **No** 
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] **No**
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] **No**
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] **No**
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] **No**

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

