### PR TITLE
[enhancement](explain) compress descriptor table explain string

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/DescriptorTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/DescriptorTable.java
@@ -227,7 +227,9 @@ public class DescriptorTable {
         StringBuilder out = new StringBuilder();
         out.append("\nTuples:\n");
         for (TupleDescriptor desc : tupleDescs.values()) {
-            out.append(desc.getExplainString() + "\n");
+            if (desc.isMaterialized()) {
+                out.append(desc.getExplainString() + "\n");
+            }
         }
         return out.toString();
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/SlotDescriptor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/SlotDescriptor.java
@@ -328,19 +328,9 @@ public class SlotDescriptor {
         StringBuilder builder = new StringBuilder();
         String colStr = (column == null ? "null" : column.getName());
         String typeStr = (type == null ? "null" : type.toString());
-        String parentTupleId = (parent == null) ? "null" : parent.getId().toString();
-        builder.append(prefix).append("SlotDescriptor{").append("id=").append(id).append(", col=").append(colStr)
-                .append(", type=").append(typeStr).append("}\n");
-
-        prefix += "  ";
-        builder.append(prefix).append("parent=").append(parentTupleId).append("\n");
-        builder.append(prefix).append("materialized=").append(isMaterialized).append("\n");
-        builder.append(prefix).append("byteSize=").append(byteSize).append("\n");
-        builder.append(prefix).append("byteOffset=").append(byteOffset).append("\n");
-        builder.append(prefix).append("nullIndicatorByte=").append(nullIndicatorByte).append("\n");
-        builder.append(prefix).append("nullIndicatorBit=").append(nullIndicatorBit).append("\n");
-        builder.append(prefix).append("nullable=").append(isNullable).append("\n");
-        builder.append(prefix).append("slotIdx=").append(slotIdx).append("\n");
+        builder.append(prefix).append("SlotDescriptor{")
+                .append("id=").append(id).append(", col=").append(colStr).append(", type=").append(typeStr)
+                .append(", nullable=").append(isNullable).append(", slotIdx=").append(slotIdx).append("}\n");
         return builder.toString();
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/SlotDescriptor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/SlotDescriptor.java
@@ -330,7 +330,7 @@ public class SlotDescriptor {
         String typeStr = (type == null ? "null" : type.toString());
         builder.append(prefix).append("SlotDescriptor{")
                 .append("id=").append(id).append(", col=").append(colStr).append(", type=").append(typeStr)
-                .append(", nullable=").append(isNullable).append(", slotIdx=").append(slotIdx).append("}\n");
+                .append(", nullable=").append(isNullable).append(", slotIdx=").append(slotIdx).append("}");
         return builder.toString();
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/SlotDescriptor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/SlotDescriptor.java
@@ -330,7 +330,7 @@ public class SlotDescriptor {
         String typeStr = (type == null ? "null" : type.toString());
         builder.append(prefix).append("SlotDescriptor{")
                 .append("id=").append(id).append(", col=").append(colStr).append(", type=").append(typeStr)
-                .append(", nullable=").append(isNullable).append(", slotIdx=").append(slotIdx).append("}");
+                .append(", nullable=").append(isNullable).append("}");
         return builder.toString();
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/TupleDescriptor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/TupleDescriptor.java
@@ -406,13 +406,12 @@ public class TupleDescriptor {
 
         builder.append(MoreObjects.toStringHelper(this)
                 .add("id", id.asInt())
-                .add("tbl", tblStr)
-                .add("byteSize", byteSize)
-                .add("materialized", isMaterialized)
-                .toString());
+                .add("tbl", tblStr));
         builder.append("\n");
         for (SlotDescriptor slot : slots) {
-            builder.append(slot.getExplainString(prefix)).append("\n");
+            if (slot.isMaterialized()) {
+                builder.append(slot.getExplainString(prefix)).append("\n");
+            }
         }
         return builder.toString();
     }


### PR DESCRIPTION
# Proposed changes

1. compress slot descriptor explain string to one row
2. remove unmaterialized tuple descriptor and slot descriptor

current descriptor table explain string is like this:
```
TupleDescriptor{id=2, tbl=lineitem}
  SlotDescriptor{id=1, col=l_extendedprice, type=DECIMAL(15,2), nullable=false}
  SlotDescriptor{id=2, col=l_discount, type=DECIMAL(15,2), nullable=false}
  SlotDescriptor{id=5, col=l_partkey, type=INT, nullable=false}
  SlotDescriptor{id=7, col=l_suppkey, type=INT, nullable=false}
  SlotDescriptor{id=8, col=l_orderkey, type=BIGINT, nullable=false}
```

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
4. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
5. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
6. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
7. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

