### PR TITLE
[enhancement](Nereids) let BinaryArithmetic's dataType and nullable match with BE

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/Mod.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/Mod.java
@@ -18,6 +18,7 @@
 package org.apache.doris.nereids.trees.expressions;
 
 import org.apache.doris.analysis.ArithmeticExpr.Operator;
+import org.apache.doris.nereids.exceptions.UnboundException;
 import org.apache.doris.nereids.trees.expressions.visitor.ExpressionVisitor;
 import org.apache.doris.nereids.types.coercion.AbstractDataType;
 import org.apache.doris.nereids.types.coercion.NumericType;
@@ -39,6 +40,11 @@ public class Mod extends BinaryArithmetic {
     public Expression withChildren(List<Expression> children) {
         Preconditions.checkArgument(children.size() == 2);
         return new Mod(children.get(0), children.get(1));
+    }
+
+    @Override
+    public boolean nullable() throws UnboundException {
+        return true;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/Multiply.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/Multiply.java
@@ -19,6 +19,7 @@ package org.apache.doris.nereids.trees.expressions;
 
 import org.apache.doris.analysis.ArithmeticExpr.Operator;
 import org.apache.doris.nereids.trees.expressions.visitor.ExpressionVisitor;
+import org.apache.doris.nereids.types.DataType;
 import org.apache.doris.nereids.types.coercion.AbstractDataType;
 import org.apache.doris.nereids.types.coercion.NumericType;
 
@@ -39,6 +40,11 @@ public class Multiply extends BinaryArithmetic {
     public Expression withChildren(List<Expression> children) {
         Preconditions.checkArgument(children.size() == 2);
         return new Multiply(children.get(0), children.get(1));
+    }
+
+    @Override
+    public DataType getDataType() {
+        return left().getDataType().promotion();
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/Subtract.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/Subtract.java
@@ -19,6 +19,7 @@ package org.apache.doris.nereids.trees.expressions;
 
 import org.apache.doris.analysis.ArithmeticExpr.Operator;
 import org.apache.doris.nereids.trees.expressions.visitor.ExpressionVisitor;
+import org.apache.doris.nereids.types.DataType;
 import org.apache.doris.nereids.types.coercion.AbstractDataType;
 import org.apache.doris.nereids.types.coercion.NumericType;
 
@@ -39,6 +40,11 @@ public class Subtract extends BinaryArithmetic {
     public Expression withChildren(List<Expression> children) {
         Preconditions.checkArgument(children.size() == 2);
         return new Subtract(children.get(0), children.get(1));
+    }
+
+    @Override
+    public DataType getDataType() {
+        return left().getDataType().promotion();
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/ExecutableFunctions.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/ExecutableFunctions.java
@@ -80,22 +80,22 @@ public class ExecutableFunctions {
         return new DecimalLiteral(result);
     }
 
-    @ExecFunction(name = "subtract", argTypes = {"TINYINT", "TINYINT"}, returnType = "TINYINT")
-    public static TinyIntLiteral subtractTinyint(TinyIntLiteral first, TinyIntLiteral second) {
-        byte result = (byte) Math.subtractExact(first.getValue(), second.getValue());
-        return new TinyIntLiteral(result);
-    }
-
-    @ExecFunction(name = "subtract", argTypes = {"SMALLINT", "SMALLINT"}, returnType = "SMALLINT")
-    public static SmallIntLiteral subtractSmallint(SmallIntLiteral first, SmallIntLiteral second) {
+    @ExecFunction(name = "subtract", argTypes = {"TINYINT", "TINYINT"}, returnType = "SMALLINT")
+    public static SmallIntLiteral subtractTinyint(TinyIntLiteral first, TinyIntLiteral second) {
         short result = (short) Math.subtractExact(first.getValue(), second.getValue());
         return new SmallIntLiteral(result);
     }
 
-    @ExecFunction(name = "subtract", argTypes = {"INT", "INT"}, returnType = "INT")
-    public static IntegerLiteral subtractInt(IntegerLiteral first, IntegerLiteral second) {
+    @ExecFunction(name = "subtract", argTypes = {"SMALLINT", "SMALLINT"}, returnType = "INT")
+    public static IntegerLiteral subtractSmallint(SmallIntLiteral first, SmallIntLiteral second) {
         int result = Math.subtractExact(first.getValue(), second.getValue());
         return new IntegerLiteral(result);
+    }
+
+    @ExecFunction(name = "subtract", argTypes = {"INT", "INT"}, returnType = "BIGINT")
+    public static BigIntLiteral subtractInt(IntegerLiteral first, IntegerLiteral second) {
+        long result = Math.subtractExact(first.getValue(), second.getValue());
+        return new BigIntLiteral(result);
     }
 
     @ExecFunction(name = "subtract", argTypes = {"BIGINT", "BIGINT"}, returnType = "BIGINT")
@@ -116,22 +116,22 @@ public class ExecutableFunctions {
         return new DecimalLiteral(result);
     }
 
-    @ExecFunction(name = "multiply", argTypes = {"TINYINT", "TINYINT"}, returnType = "TINYINT")
-    public static TinyIntLiteral multiplyTinyint(TinyIntLiteral first, TinyIntLiteral second) {
-        byte result = (byte) Math.multiplyExact(first.getValue(), second.getValue());
-        return new TinyIntLiteral(result);
-    }
-
-    @ExecFunction(name = "multiply", argTypes = {"SMALLINT", "SMALLINT"}, returnType = "SMALLINT")
-    public static SmallIntLiteral multiplySmallint(SmallIntLiteral first, SmallIntLiteral second) {
+    @ExecFunction(name = "multiply", argTypes = {"TINYINT", "TINYINT"}, returnType = "SMALLINT")
+    public static SmallIntLiteral multiplyTinyint(TinyIntLiteral first, TinyIntLiteral second) {
         short result = (short) Math.multiplyExact(first.getValue(), second.getValue());
         return new SmallIntLiteral(result);
     }
 
-    @ExecFunction(name = "multiply", argTypes = {"INT", "INT"}, returnType = "INT")
-    public static IntegerLiteral multiplyInt(IntegerLiteral first, IntegerLiteral second) {
+    @ExecFunction(name = "multiply", argTypes = {"SMALLINT", "SMALLINT"}, returnType = "INT")
+    public static IntegerLiteral multiplySmallint(SmallIntLiteral first, SmallIntLiteral second) {
         int result = Math.multiplyExact(first.getValue(), second.getValue());
         return new IntegerLiteral(result);
+    }
+
+    @ExecFunction(name = "multiply", argTypes = {"INT", "INT"}, returnType = "BIGINT")
+    public static BigIntLiteral multiplyInt(IntegerLiteral first, IntegerLiteral second) {
+        long result = Math.multiplyExact(first.getValue(), second.getValue());
+        return new BigIntLiteral(result);
     }
 
     @ExecFunction(name = "multiply", argTypes = {"BIGINT", "BIGINT"}, returnType = "BIGINT")

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/parser/HavingClauseTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/parser/HavingClauseTest.java
@@ -257,7 +257,7 @@ public class HavingClauseTest extends AnalyzeCheckTestBase implements PatternMat
         NamedExpressionUtil.clear();
 
         sql = "SELECT a1, SUM(a1 + a2) FROM t1 GROUP BY a1 HAVING SUM(a1 + a2 + 3) > 0";
-        Alias sumA1A23 = new Alias(new ExprId(4), new Sum(new Add(new Add(a1, a2), new SmallIntLiteral((byte) 3))),
+        Alias sumA1A23 = new Alias(new ExprId(4), new Sum(new Add(new Add(a1, a2), new SmallIntLiteral((short) 3))),
                 "sum(((a1 + a2) + 3))");
         PlanChecker.from(connectContext).analyze(sql)
                 .matchesFromRoot(

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/rewrite/FoldConstantTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/rewrite/FoldConstantTest.java
@@ -172,10 +172,9 @@ public class FoldConstantTest {
     public void testArithmeticFold() {
         executor = new ExpressionRuleExecutor(ImmutableList.of(TypeCoercion.INSTANCE, FoldConstantRuleOnFE.INSTANCE));
         assertRewrite("1 + 1", Literal.of((short) 2));
-        assertRewrite("1 - 1", Literal.of((byte) 0));
+        assertRewrite("1 - 1", Literal.of((short) 0));
         assertRewrite("100 + 100", Literal.of((short) 200));
-        assertRewrite("1 - 2", Literal.of((byte) -1));
-
+        assertRewrite("1 - 2", Literal.of((short) -1));
         assertRewrite("1 - 2 > 1", "false");
         assertRewrite("1 - 2 + 1 > 1 + 1 - 100", "true");
         assertRewrite("10 * 2 / 1 + 1 > (1 + 1) - 100", "true");


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

Do type promotion for BinaryArithmetic:
- Add
- Subtract
- Multiply

Do always nullable for:
- Mod

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

