### PR TITLE
[Fix](meta): fix colocate group meta error

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Catalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Catalog.java
@@ -2174,6 +2174,7 @@ public class Catalog {
     }
 
     public long saveColocateTableIndex(CountingDataOutputStream dos, long checksum) throws IOException {
+        Catalog.getCurrentColocateIndex().correctMetaDataOfDistributionCols();
         Catalog.getCurrentColocateIndex().write(dos);
         return checksum;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/ScalarType.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/ScalarType.java
@@ -450,7 +450,9 @@ public class ScalarType extends Type {
 
     // add scalar infix to override with getPrecision
     public int getScalarScale() { return scale; }
+    public void setScalarScale(int scale) { this.scale = scale; }
     public int getScalarPrecision() { return precision; }
+    public void setScalarPrecision(int precision) { this.precision = precision; }
 
     public String getScalarPrecisionStr() {
         return precisionStr;


### PR DESCRIPTION
# Proposed changes

Issue Number: close #12788 

## Problem summary
From version 1.1.1, the types of distributed columns in colocate table are with length and precision info, which are defaut value,may be -1 or 0, in the elder version.

There are two solutions to solve this problem
1. temporary incomplete solution: skip the length and precision meta-check of varchar and decimal in colocate tables.
2. long term solution: incorrect the meta data when fe do checkpoint to completely fix the meta error.


Describe your changes.
We choosed solution 2 in this pr.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
3. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
5. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
6. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

