### PR TITLE
[improvement](test) cache data from s3 to cacheDataPath

### DIFF
--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/Config.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/Config.groovy
@@ -51,6 +51,7 @@ class Config {
     public String dataPath
     public String realDataPath
     public String sf1DataPath
+    public String cacheDataPath
     public String pluginPath
 
     public String testGroups
@@ -87,7 +88,7 @@ class Config {
 
     Config(String defaultDb, String jdbcUrl, String jdbcUser, String jdbcPassword,
            String feHttpAddress, String feHttpUser, String feHttpPassword, String metaServiceHttpAddress,
-           String suitePath, String dataPath, String realDataPath, String sf1DataPath,
+           String suitePath, String dataPath, String realDataPath, String sf1DataPath, String cacheDataPath,
            String testGroups, String excludeGroups, String testSuites, String excludeSuites,
            String testDirectories, String excludeDirectories, String pluginPath) {
         this.defaultDb = defaultDb
@@ -102,6 +103,7 @@ class Config {
         this.dataPath = dataPath
         this.realDataPath = realDataPath
         this.sf1DataPath = sf1DataPath
+        this.cacheDataPath = cacheDataPath
         this.testGroups = testGroups
         this.excludeGroups = excludeGroups
         this.testSuites = testSuites
@@ -130,6 +132,7 @@ class Config {
         config.dataPath = FileUtils.getCanonicalPath(cmd.getOptionValue(dataOpt, config.dataPath))
         config.realDataPath = FileUtils.getCanonicalPath(cmd.getOptionValue(realDataOpt, config.realDataPath))
         config.sf1DataPath = cmd.getOptionValue(sf1DataOpt, config.sf1DataPath)
+        config.cacheDataPath = cmd.getOptionValue(cacheDataOpt, config.cacheDataPath)
         config.pluginPath = FileUtils.getCanonicalPath(cmd.getOptionValue(pluginOpt, config.pluginPath))
         config.suiteWildcard = cmd.getOptionValue(suiteOpt, config.testSuites)
                 .split(",")
@@ -226,6 +229,7 @@ class Config {
             configToString(obj.dataPath),
             configToString(obj.realDataPath),
             configToString(obj.sf1DataPath),
+            configToString(obj.cacheDataPath),
             configToString(obj.testGroups),
             configToString(obj.excludeGroups),
             configToString(obj.testSuites),
@@ -307,6 +311,11 @@ class Config {
         if (config.sf1DataPath == null) {
             config.sf1DataPath = "regression-test/sf1Data"
             log.info("Set sf1DataPath to '${config.sf1DataPath}' because not specify.".toString())
+        }
+
+        if (config.cacheDataPath == null) {
+            config.cacheDataPath = "regression-test/cacheData"
+            log.info("Set cacheDataPath to '${config.cacheDataPath}' because not specify.".toString())
         }
 
         if (config.pluginPath == null) {

--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/ConfigOptions.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/ConfigOptions.groovy
@@ -40,6 +40,7 @@ class ConfigOptions {
     static Option dataOpt
     static Option realDataOpt
     static Option sf1DataOpt
+    static Option cacheDataOpt
     static Option pluginOpt
     static Option suiteOpt
     static Option excludeSuiteOpt
@@ -139,6 +140,15 @@ class ConfigOptions {
                 .longOpt("sf1DataPath")
                 .desc("the sf1 data path contains data file for ssb_sf1, tpcds_sf1 and tpch_sf1 cases")
                 .build()
+        cacheDataOpt = Option.builder("CD")
+                .argName("cacheDataPath")
+                .required(false)
+                .hasArg(true)
+                .type(String.class)
+                .longOpt("cacheDataPath")
+                .desc("the cache data path caches data for stream load from s3")
+                .build()
+
         pluginOpt = Option.builder("plugin")
                 .argName("pluginPath")
                 .required(false)

--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/action/StreamLoadAction.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/action/StreamLoadAction.groovy
@@ -180,6 +180,32 @@ class StreamLoadAction implements SuiteAction {
         return requestBuilder
     }
 
+    private String cacheHttpFile(CloseableHttpClient client, String url) {
+        def relativePath = url.substring(url.indexOf('/', 9))
+        def file = new File("${context.config.cacheDataPath}/${relativePath}")
+        if (file.exists()) {
+            log.info("Found ${url} in ${file.getAbsolutePath()}");
+            return file.getAbsolutePath()
+        }
+        log.info("Start to cache data from ${url} to ${file.getAbsolutePath()}");
+        CloseableHttpResponse resp = client.execute(RequestBuilder.get(url).build())
+        int code = resp.getStatusLine().getStatusCode()
+        if (code != HttpStatus.SC_OK) {
+            String streamBody = EntityUtils.toString(resp.getEntity())
+            throw new IllegalStateException("Get http stream failed, status code is ${code}, body:\n${streamBody}")
+        }
+
+        file.getParentFile().mkdirs();
+        new File("${context.config.cacheDataPath}/tmp/").mkdir()
+        InputStream httpFileStream = resp.getEntity().getContent()
+        File tmpFile = File.createTempFile("cache", null, new File("${context.config.cacheDataPath}/tmp/"))
+
+        java.nio.file.Files.copy(httpFileStream, tmpFile.toPath(), java.nio.file.StandardCopyOption.REPLACE_EXISTING);
+        java.nio.file.Files.move(tmpFile.toPath(), file.toPath(), java.nio.file.StandardCopyOption.ATOMIC_MOVE);
+        log.info("Cached data from ${url} to ${file.getAbsolutePath()}");
+        return file.getAbsolutePath()
+    }
+
     private HttpEntity prepareHttpEntity(CloseableHttpClient client) {
         HttpEntity entity = null
         if (inputStream != null) {
@@ -194,19 +220,26 @@ class StreamLoadAction implements SuiteAction {
             String fileName = this.file
             if (fileName.startsWith("http://") || fileName.startsWith("https://")) {
                 log.info("Set stream load input: ${fileName}".toString())
-                entity = new InputStreamEntity(httpGetStream(client, fileName))
-            } else { // local file
-                if (!new File(fileName).isAbsolute()) {
-                    fileName = new File(context.dataPath, fileName).getAbsolutePath()
+                def file = new File(context.config.cacheDataPath)
+                file.mkdirs();
+
+                if (file.exists() && file.isDirectory()) {
+                    fileName = cacheHttpFile(client, fileName)
+                } else {
+                    entity = new InputStreamEntity(httpGetStream(client, fileName))
+                    return entity;
                 }
-                def file = new File(fileName)
-                if (!file.exists()) {
-                    log.warn("Stream load input file not exists: ${file}".toString())
-                    throw new IllegalStateException("Stream load input file not exists: ${file}");
-                }
-                log.info("Set stream load input: ${file.canonicalPath}".toString())
-                entity = new FileEntity(file)
             }
+            if (!new File(fileName).isAbsolute()) {
+                fileName = new File(context.dataPath, fileName).getAbsolutePath()
+            }
+            def file = new File(fileName)
+            if (!file.exists()) {
+                log.warn("Stream load input file not exists: ${file}".toString())
+                throw new IllegalStateException("Stream load input file not exists: ${file}");
+            }
+            log.info("Set stream load input: ${file.canonicalPath}".toString())
+            entity = new FileEntity(file)
         }
         return entity
     }


### PR DESCRIPTION
# Proposed changes
Now, regression data is stored in sf1DataPath, which is local or remote. For performance reason, we use local dir for community pipeline, however, we need prepare data for every machine, this process is easy mistake. So we cache data from s3 in local transparently, thus, we just need to config one data source.

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

