### PR TITLE
[fix](like)the dictionary column should call get_shrink_value to get correct string value

### DIFF
--- a/be/src/olap/like_column_predicate.cpp
+++ b/be/src/olap/like_column_predicate.cpp
@@ -148,7 +148,7 @@ uint16_t LikeColumnPredicate<is_vectorized>::evaluate(const vectorized::IColumn&
                     for (uint16_t i = 0; i != size; i++) {
                         uint16_t idx = sel[i];
                         sel[new_size] = idx;
-                        StringValue cell_value = nested_col_ptr->get_value(data_array[idx]);
+                        StringValue cell_value = nested_col_ptr->get_shrink_value(data_array[idx]);
                         unsigned char flag = 0;
                         (_state->function)(const_cast<vectorized::LikeSearchState*>(&_like_state),
                                            cell_value, pattern, &flag);

--- a/be/src/olap/like_column_predicate.h
+++ b/be/src/olap/like_column_predicate.h
@@ -152,7 +152,8 @@ private:
                                 vectorized::ColumnDictionary<vectorized::Int32>>(column);
                         auto& data_array = nested_col_ptr->get_data();
                         for (uint16_t i = 0; i < size; i++) {
-                            StringValue cell_value = nested_col_ptr->get_shrink_value(data_array[i]);
+                            StringValue cell_value =
+                                    nested_col_ptr->get_shrink_value(data_array[i]);
                             if constexpr (is_and) {
                                 unsigned char flag = 0;
                                 (_state->function)(

--- a/be/src/olap/like_column_predicate.h
+++ b/be/src/olap/like_column_predicate.h
@@ -152,7 +152,7 @@ private:
                                 vectorized::ColumnDictionary<vectorized::Int32>>(column);
                         auto& data_array = nested_col_ptr->get_data();
                         for (uint16_t i = 0; i < size; i++) {
-                            StringValue cell_value = nested_col_ptr->get_value(data_array[i]);
+                            StringValue cell_value = nested_col_ptr->get_shrink_value(data_array[i]);
                             if constexpr (is_and) {
                                 unsigned char flag = 0;
                                 (_state->function)(


### PR DESCRIPTION

# Proposed changes

Issue Number: close #xxx

## Problem summary

call get_shrink_value to get correct string value for CHAR type

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

