### PR TITLE
[improvement](index) Support bitmap index can be applied with compound predicate when enable vectorized engine query

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -867,6 +867,9 @@ CONF_Bool(enable_fuzzy_mode, "false");
 
 CONF_Int32(pipeline_executor_size, "0");
 
+// Temp config. True to use optimization for bitmap_index apply OR predicate.  Will remove after fully test.
+CONF_Bool(enable_index_apply_or_predicates, "false");
+
 #ifdef BE_TEST
 // test s3
 CONF_String(test_s3_resource, "resource");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -867,8 +867,9 @@ CONF_Bool(enable_fuzzy_mode, "false");
 
 CONF_Int32(pipeline_executor_size, "0");
 
-// Temp config. True to use optimization for bitmap_index apply compound predicate.  Will remove after fully test.
-CONF_Bool(enable_index_apply_compound_predicates, "false");
+// Temp config. True to use optimization for bitmap_index apply predicate except leaf node of the and node.
+// Will remove after fully test.
+CONF_Bool(enable_index_apply_preds_except_leafnode_of_andnode, "false");
 
 #ifdef BE_TEST
 // test s3

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -867,8 +867,8 @@ CONF_Bool(enable_fuzzy_mode, "false");
 
 CONF_Int32(pipeline_executor_size, "0");
 
-// Temp config. True to use optimization for bitmap_index apply OR predicate.  Will remove after fully test.
-CONF_Bool(enable_index_apply_or_predicates, "false");
+// Temp config. True to use optimization for bitmap_index apply compound predicate.  Will remove after fully test.
+CONF_Bool(enable_index_apply_compound_predicates, "false");
 
 #ifdef BE_TEST
 // test s3

--- a/be/src/exec/olap_common.h
+++ b/be/src/exec/olap_common.h
@@ -98,9 +98,9 @@ public:
 
     Status add_compound_value(SQLFilterOp op, CppType value);
 
-    bool is_fixed_value_range() const;
-
     bool is_in_compound_value_range() const;
+
+    bool is_fixed_value_range() const;
 
     bool is_scope_value_range() const;
 
@@ -551,8 +551,7 @@ bool ColumnValueRange<primitive_type>::is_empty_value_range() const {
         return true;
     }
 
-    return (!is_fixed_value_range() && !is_scope_value_range() && !contain_null() &&
-            !is_in_compound_value_range());
+    return (!is_fixed_value_range() && !is_scope_value_range() && !contain_null());
 }
 
 template <PrimitiveType primitive_type>

--- a/be/src/exec/olap_common.h
+++ b/be/src/exec/olap_common.h
@@ -258,7 +258,8 @@ public:
             } else if (value.first == FILTER_LESS_OR_EQUAL) {
                 condition.__set_condition_op("<=");
             }
-            condition.condition_values.push_back(cast_to_string<primitive_type, CppType>(value.second, _scale));
+            condition.condition_values.push_back(
+                    cast_to_string<primitive_type, CppType>(value.second, _scale));
             if (condition.condition_values.size() != 0) {
                 filters.push_back(condition);
             }
@@ -318,8 +319,8 @@ public:
         range.add_range(op, *value);
     }
 
-     static void add_compound_value_range(ColumnValueRange<primitive_type>& range, SQLFilterOp op, 
-                                    CppType* value) {
+    static void add_compound_value_range(ColumnValueRange<primitive_type>& range, SQLFilterOp op,
+                                         CppType* value) {
         range.add_compound_value(op, *value);
     }
 
@@ -373,7 +374,8 @@ private:
                                                   primitive_type == PrimitiveType::TYPE_DATETIME ||
                                                   primitive_type == PrimitiveType::TYPE_DATETIMEV2;
 
-    std::set<std::pair<SQLFilterOp, CppType>> _boundary_values; // range boundary value in CompoundPredicate
+    // range boundary value in CompoundPredicate
+    std::set<std::pair<SQLFilterOp, CppType>> _boundary_values;
     TCompoundType::type _compound_type = TCompoundType::UNKNOWN;
 };
 
@@ -554,10 +556,8 @@ bool ColumnValueRange<primitive_type>::is_empty_value_range() const {
         return true;
     }
 
-    return (!is_fixed_value_range() && 
-                !is_scope_value_range() && 
-                !contain_null() &&
-                !is_boundary_value_range());
+    return (!is_fixed_value_range() && !is_scope_value_range() && !contain_null() &&
+            !is_boundary_value_range());
 }
 
 template <PrimitiveType primitive_type>

--- a/be/src/olap/column_predicate.h
+++ b/be/src/olap/column_predicate.h
@@ -31,6 +31,10 @@ namespace doris {
 
 class Schema;
 
+struct PredicateParams {
+    std::string value;
+};
+
 enum class PredicateType {
     UNKNOWN = 0,
     EQ = 1,
@@ -113,7 +117,9 @@ struct PredicateTypeTraits {
 class ColumnPredicate {
 public:
     explicit ColumnPredicate(uint32_t column_id, bool opposite = false)
-            : _column_id(column_id), _opposite(opposite) {}
+            : _column_id(column_id), _opposite(opposite) {
+        _predicate_params = std::make_shared<PredicateParams>();
+    }
 
     virtual ~ColumnPredicate() = default;
 
@@ -163,12 +169,44 @@ public:
                ", opposite=" + (_opposite ? "true" : "false");
     }
 
+    std::shared_ptr<PredicateParams> predicate_params() { return _predicate_params; }
+    const std::string pred_type_string(PredicateType type) {
+        switch (type) {
+        case PredicateType::EQ:
+            return "eq";
+        case PredicateType::NE:
+            return "ne";
+        case PredicateType::LT:
+            return "lt";
+        case PredicateType::LE:
+            return "le";
+        case PredicateType::GT:
+            return "gt";
+        case PredicateType::GE:
+            return "ge";
+        case PredicateType::IN_LIST:
+            return "in_list";
+        case PredicateType::NOT_IN_LIST:
+            return "not_in_list";
+        case PredicateType::IS_NULL:
+            return "is_null";
+        case PredicateType::IS_NOT_NULL:
+            return "is_not_null";
+        case PredicateType::BF:
+            return "bf";
+        default:
+            return "unknown";
+        }
+
+    }
+
 protected:
     virtual std::string _debug_string() const = 0;
 
     uint32_t _column_id;
     // TODO: the value is only in delete condition, better be template value
     bool _opposite;
+    std::shared_ptr<PredicateParams> _predicate_params;
 };
 
 } //namespace doris

--- a/be/src/olap/column_predicate.h
+++ b/be/src/olap/column_predicate.h
@@ -197,7 +197,6 @@ public:
         default:
             return "unknown";
         }
-
     }
 
 protected:

--- a/be/src/olap/iterators.h
+++ b/be/src/olap/iterators.h
@@ -25,6 +25,7 @@
 #include "olap/olap_common.h"
 #include "olap/tablet_schema.h"
 #include "vec/core/block.h"
+#include "vec/exprs/vexpr.h"
 
 namespace doris {
 
@@ -82,7 +83,6 @@ public:
     // used to fiter rows in row block
     std::vector<ColumnPredicate*> column_predicates;
     std::vector<ColumnPredicate*> all_compound_column_predicates;
-    std::vector<std::pair<bool, std::vector<ColumnPredicate*>>> in_or_compound_column_predicates;
     std::unordered_map<int32_t, std::shared_ptr<AndBlockColumnPredicate>> col_id_to_predicates;
     std::unordered_map<int32_t, std::vector<const ColumnPredicate*>> col_id_to_del_predicates;
     TPushAggOp::type push_down_agg_type_opt = TPushAggOp::NONE;
@@ -98,8 +98,8 @@ public:
     bool read_orderby_key_reverse = false;
     // columns for orderby keys
     std::vector<uint32_t>* read_orderby_key_columns = nullptr;
-
     IOContext io_ctx;
+    vectorized::VExpr* remaining_vconjunct_root = nullptr;
 };
 
 class RowwiseIterator {

--- a/be/src/olap/iterators.h
+++ b/be/src/olap/iterators.h
@@ -82,7 +82,7 @@ public:
     // reader's column predicate, nullptr if not existed
     // used to fiter rows in row block
     std::vector<ColumnPredicate*> column_predicates;
-    std::vector<ColumnPredicate*> all_compound_column_predicates;
+    std::vector<ColumnPredicate*> column_predicates_except_leafnode_of_andnode;
     std::unordered_map<int32_t, std::shared_ptr<AndBlockColumnPredicate>> col_id_to_predicates;
     std::unordered_map<int32_t, std::vector<const ColumnPredicate*>> col_id_to_del_predicates;
     TPushAggOp::type push_down_agg_type_opt = TPushAggOp::NONE;

--- a/be/src/olap/iterators.h
+++ b/be/src/olap/iterators.h
@@ -81,6 +81,8 @@ public:
     // reader's column predicate, nullptr if not existed
     // used to fiter rows in row block
     std::vector<ColumnPredicate*> column_predicates;
+    std::vector<ColumnPredicate*> all_compound_column_predicates;
+    std::vector<std::pair<bool, std::vector<ColumnPredicate*>>> in_or_compound_column_predicates;
     std::unordered_map<int32_t, std::shared_ptr<AndBlockColumnPredicate>> col_id_to_predicates;
     std::unordered_map<int32_t, std::vector<const ColumnPredicate*>> col_id_to_del_predicates;
     TPushAggOp::type push_down_agg_type_opt = TPushAggOp::NONE;

--- a/be/src/olap/reader.cpp
+++ b/be/src/olap/reader.cpp
@@ -85,6 +85,9 @@ TabletReader::~TabletReader() {
     for (auto pred : _value_col_predicates) {
         delete pred;
     }
+    for (auto pred : _all_compound_col_predicates) {
+        delete pred;
+    }
 }
 
 Status TabletReader::init(const ReaderParams& read_params) {
@@ -200,6 +203,8 @@ Status TabletReader::_capture_rs_readers(const ReaderParams& read_params,
     _reader_context.read_orderby_key_columns =
             _orderby_key_columns.size() > 0 ? &_orderby_key_columns : nullptr;
     _reader_context.predicates = &_col_predicates;
+    _reader_context.all_compound_predicates = &_all_compound_col_predicates;
+    _reader_context.in_or_compound_predicates = &_in_or_compound_col_predicates;
     _reader_context.value_predicates = &_value_col_predicates;
     _reader_context.lower_bound_keys = &_keys_param.start_keys;
     _reader_context.is_lower_keys_included = &_is_lower_keys_included;
@@ -234,6 +239,7 @@ Status TabletReader::_init_params(const ReaderParams& read_params) {
     _reader_context.runtime_state = read_params.runtime_state;
 
     _init_conditions_param(read_params);
+    _init_compound_conditions_param(read_params);
 
     Status res = _init_delete_condition(read_params);
     if (!res.ok()) {
@@ -465,6 +471,49 @@ void TabletReader::_init_conditions_param(const ReaderParams& read_params) {
     // Function filter push down to storage engine
     for (const auto& filter : read_params.function_filters) {
         _col_predicates.emplace_back(_parse_to_predicate(filter));
+    }
+}
+
+bool TabletReader::_all_conditions_in_or_compound(
+                const std::vector<std::pair<bool, std::vector<TCondition>>>& compound_column_conditions) {
+    if (compound_column_conditions.empty()) {
+        return false;
+    }
+
+    for (auto& condition : compound_column_conditions) {
+        std::vector<TCondition> t_conditions = condition.second;
+        for (auto child_condition : t_conditions) {
+            if (child_condition.compound_type != TCompoundType::OR) {
+                return false;
+            }
+        }
+    }
+
+    return true;
+}
+
+void TabletReader::_init_compound_conditions_param(const ReaderParams& read_params) {
+    bool all_conditions_in_or_compound = _all_conditions_in_or_compound(read_params.compound_conditions);
+
+    for (const auto& iter : read_params.compound_conditions) {
+        bool not_compound = iter.first;
+        auto conditions_per_conjunct = iter.second;
+        std::vector<ColumnPredicate*> predicate_per_conjunct;
+        for (const auto& condition : conditions_per_conjunct) {
+            TCondition tmp_cond = condition;
+            auto condition_col_uid = _tablet_schema->column(tmp_cond.column_name).unique_id();
+            tmp_cond.__set_column_unique_id(condition_col_uid);
+            ColumnPredicate* predicate = parse_to_predicate(_tablet_schema, tmp_cond, _predicate_mem_pool.get());
+            if (predicate != nullptr) {
+                _all_compound_col_predicates.push_back(predicate);
+                if (all_conditions_in_or_compound) {
+                    predicate_per_conjunct.push_back(predicate);
+                }
+            }
+        }
+        if (!predicate_per_conjunct.empty()) {
+            _in_or_compound_col_predicates.push_back(std::make_pair(not_compound, predicate_per_conjunct));
+        }
     }
 }
 

--- a/be/src/olap/reader.cpp
+++ b/be/src/olap/reader.cpp
@@ -474,7 +474,8 @@ void TabletReader::_init_conditions_param(const ReaderParams& read_params) {
     }
 }
 
-void TabletReader::_init_conditions_param_except_leafnode_of_andnode(const ReaderParams& read_params) {
+void TabletReader::_init_conditions_param_except_leafnode_of_andnode(
+        const ReaderParams& read_params) {
     for (const auto& condition : read_params.conditions_except_leafnode_of_andnode) {
         TCondition tmp_cond = condition;
         auto condition_col_uid = _tablet_schema->column(tmp_cond.column_name).unique_id();

--- a/be/src/olap/reader.cpp
+++ b/be/src/olap/reader.cpp
@@ -85,7 +85,7 @@ TabletReader::~TabletReader() {
     for (auto pred : _value_col_predicates) {
         delete pred;
     }
-    for (auto pred : _all_compound_col_predicates) {
+    for (auto pred : _col_preds_except_leafnode_of_andnode) {
         delete pred;
     }
 }
@@ -203,7 +203,7 @@ Status TabletReader::_capture_rs_readers(const ReaderParams& read_params,
     _reader_context.read_orderby_key_columns =
             _orderby_key_columns.size() > 0 ? &_orderby_key_columns : nullptr;
     _reader_context.predicates = &_col_predicates;
-    _reader_context.all_compound_predicates = &_all_compound_col_predicates;
+    _reader_context.predicates_except_leafnode_of_andnode = &_col_preds_except_leafnode_of_andnode;
     _reader_context.value_predicates = &_value_col_predicates;
     _reader_context.lower_bound_keys = &_keys_param.start_keys;
     _reader_context.is_lower_keys_included = &_is_lower_keys_included;
@@ -239,7 +239,7 @@ Status TabletReader::_init_params(const ReaderParams& read_params) {
     _reader_context.runtime_state = read_params.runtime_state;
 
     _init_conditions_param(read_params);
-    _init_compound_conditions_param(read_params);
+    _init_conditions_param_except_leafnode_of_andnode(read_params);
 
     Status res = _init_delete_condition(read_params);
     if (!res.ok()) {
@@ -474,19 +474,17 @@ void TabletReader::_init_conditions_param(const ReaderParams& read_params) {
     }
 }
 
-void TabletReader::_init_compound_conditions_param(const ReaderParams& read_params) {
-    for (const auto& conditions_per_conjunct : read_params.compound_conditions) {
-        for (const auto& condition : conditions_per_conjunct) {
-            TCondition tmp_cond = condition;
-            auto condition_col_uid = _tablet_schema->column(tmp_cond.column_name).unique_id();
-            tmp_cond.__set_column_unique_id(condition_col_uid);
-            ColumnPredicate* predicate =
-                    parse_to_predicate(_tablet_schema, tmp_cond, _predicate_mem_pool.get());
-            if (predicate != nullptr) {
-                auto predicate_params = predicate->predicate_params();
-                predicate_params->value = condition.condition_values[0];
-                _all_compound_col_predicates.push_back(predicate);
-            }
+void TabletReader::_init_conditions_param_except_leafnode_of_andnode(const ReaderParams& read_params) {
+    for (const auto& condition : read_params.conditions_except_leafnode_of_andnode) {
+        TCondition tmp_cond = condition;
+        auto condition_col_uid = _tablet_schema->column(tmp_cond.column_name).unique_id();
+        tmp_cond.__set_column_unique_id(condition_col_uid);
+        ColumnPredicate* predicate =
+                parse_to_predicate(_tablet_schema, tmp_cond, _predicate_mem_pool.get());
+        if (predicate != nullptr) {
+            auto predicate_params = predicate->predicate_params();
+            predicate_params->value = condition.condition_values[0];
+            _col_preds_except_leafnode_of_andnode.push_back(predicate);
         }
     }
 }

--- a/be/src/olap/reader.cpp
+++ b/be/src/olap/reader.cpp
@@ -505,6 +505,8 @@ void TabletReader::_init_compound_conditions_param(const ReaderParams& read_para
             tmp_cond.__set_column_unique_id(condition_col_uid);
             ColumnPredicate* predicate = parse_to_predicate(_tablet_schema, tmp_cond, _predicate_mem_pool.get());
             if (predicate != nullptr) {
+                auto predicate_params = predicate->predicate_params();
+                predicate_params->value = condition.condition_values[0];
                 _all_compound_col_predicates.push_back(predicate);
                 if (all_conditions_in_or_compound) {
                     predicate_per_conjunct.push_back(predicate);

--- a/be/src/olap/reader.cpp
+++ b/be/src/olap/reader.cpp
@@ -480,7 +480,8 @@ void TabletReader::_init_compound_conditions_param(const ReaderParams& read_para
             TCondition tmp_cond = condition;
             auto condition_col_uid = _tablet_schema->column(tmp_cond.column_name).unique_id();
             tmp_cond.__set_column_unique_id(condition_col_uid);
-            ColumnPredicate* predicate = parse_to_predicate(_tablet_schema, tmp_cond, _predicate_mem_pool.get());
+            ColumnPredicate* predicate =
+                    parse_to_predicate(_tablet_schema, tmp_cond, _predicate_mem_pool.get());
             if (predicate != nullptr) {
                 auto predicate_params = predicate->predicate_params();
                 predicate_params->value = condition.condition_values[0];

--- a/be/src/olap/reader.h
+++ b/be/src/olap/reader.h
@@ -39,6 +39,7 @@ class RuntimeState;
 namespace vectorized {
 class VCollectIterator;
 class Block;
+class VExpr;
 } // namespace vectorized
 
 class TabletReader {
@@ -75,7 +76,7 @@ public:
         std::vector<std::pair<string, std::shared_ptr<BloomFilterFuncBase>>> bloom_filters;
         std::vector<std::pair<string, std::shared_ptr<BitmapFilterFuncBase>>> bitmap_filters;
         std::vector<std::pair<string, std::shared_ptr<HybridSetBase>>> in_filters;
-        std::vector<std::pair<bool, std::vector<TCondition>>> compound_conditions;
+        std::vector<std::vector<TCondition>> compound_conditions;
         std::vector<FunctionFilter> function_filters;
         std::vector<RowsetMetaSharedPtr> delete_predicates;
 
@@ -91,6 +92,7 @@ public:
         std::vector<uint32_t>* origin_return_columns = nullptr;
         std::unordered_set<uint32_t>* tablet_columns_convert_to_null_set = nullptr;
         TPushAggOp::type push_down_agg_type_opt = TPushAggOp::NONE;
+        vectorized::VExpr* remaining_vconjunct_root= nullptr;
 
         // used for compaction to record row ids
         bool record_rowids = false;
@@ -167,9 +169,6 @@ protected:
 
     void _init_compound_conditions_param(const ReaderParams& read_params);
 
-    bool _all_conditions_in_or_compound(
-                const std::vector<std::pair<bool, std::vector<TCondition>>>& compound_column_conditions);
-
     ColumnPredicate* _parse_to_predicate(
             const std::pair<std::string, std::shared_ptr<BloomFilterFuncBase>>& bloom_filter);
 
@@ -205,7 +204,6 @@ protected:
     std::vector<bool> _is_upper_keys_included;
     std::vector<ColumnPredicate*> _col_predicates;
     std::vector<ColumnPredicate*> _all_compound_col_predicates;
-    std::vector<std::pair<bool, std::vector<ColumnPredicate*>>> _in_or_compound_col_predicates;
     std::vector<ColumnPredicate*> _value_col_predicates;
     DeleteHandler _delete_handler;
 

--- a/be/src/olap/reader.h
+++ b/be/src/olap/reader.h
@@ -75,6 +75,7 @@ public:
         std::vector<std::pair<string, std::shared_ptr<BloomFilterFuncBase>>> bloom_filters;
         std::vector<std::pair<string, std::shared_ptr<BitmapFilterFuncBase>>> bitmap_filters;
         std::vector<std::pair<string, std::shared_ptr<HybridSetBase>>> in_filters;
+        std::vector<std::pair<bool, std::vector<TCondition>>> compound_conditions;
         std::vector<FunctionFilter> function_filters;
         std::vector<RowsetMetaSharedPtr> delete_predicates;
 
@@ -164,6 +165,11 @@ protected:
 
     void _init_conditions_param(const ReaderParams& read_params);
 
+    void _init_compound_conditions_param(const ReaderParams& read_params);
+
+    bool _all_conditions_in_or_compound(
+                const std::vector<std::pair<bool, std::vector<TCondition>>>& compound_column_conditions);
+
     ColumnPredicate* _parse_to_predicate(
             const std::pair<std::string, std::shared_ptr<BloomFilterFuncBase>>& bloom_filter);
 
@@ -198,6 +204,8 @@ protected:
     std::vector<bool> _is_lower_keys_included;
     std::vector<bool> _is_upper_keys_included;
     std::vector<ColumnPredicate*> _col_predicates;
+    std::vector<ColumnPredicate*> _all_compound_col_predicates;
+    std::vector<std::pair<bool, std::vector<ColumnPredicate*>>> _in_or_compound_col_predicates;
     std::vector<ColumnPredicate*> _value_col_predicates;
     DeleteHandler _delete_handler;
 

--- a/be/src/olap/reader.h
+++ b/be/src/olap/reader.h
@@ -92,7 +92,7 @@ public:
         std::vector<uint32_t>* origin_return_columns = nullptr;
         std::unordered_set<uint32_t>* tablet_columns_convert_to_null_set = nullptr;
         TPushAggOp::type push_down_agg_type_opt = TPushAggOp::NONE;
-        vectorized::VExpr* remaining_vconjunct_root= nullptr;
+        vectorized::VExpr* remaining_vconjunct_root = nullptr;
 
         // used for compaction to record row ids
         bool record_rowids = false;

--- a/be/src/olap/reader.h
+++ b/be/src/olap/reader.h
@@ -76,7 +76,7 @@ public:
         std::vector<std::pair<string, std::shared_ptr<BloomFilterFuncBase>>> bloom_filters;
         std::vector<std::pair<string, std::shared_ptr<BitmapFilterFuncBase>>> bitmap_filters;
         std::vector<std::pair<string, std::shared_ptr<HybridSetBase>>> in_filters;
-        std::vector<std::vector<TCondition>> compound_conditions;
+        std::vector<TCondition> conditions_except_leafnode_of_andnode;
         std::vector<FunctionFilter> function_filters;
         std::vector<RowsetMetaSharedPtr> delete_predicates;
 
@@ -167,7 +167,7 @@ protected:
 
     void _init_conditions_param(const ReaderParams& read_params);
 
-    void _init_compound_conditions_param(const ReaderParams& read_params);
+    void _init_conditions_param_except_leafnode_of_andnode(const ReaderParams& read_params);
 
     ColumnPredicate* _parse_to_predicate(
             const std::pair<std::string, std::shared_ptr<BloomFilterFuncBase>>& bloom_filter);
@@ -203,7 +203,7 @@ protected:
     std::vector<bool> _is_lower_keys_included;
     std::vector<bool> _is_upper_keys_included;
     std::vector<ColumnPredicate*> _col_predicates;
-    std::vector<ColumnPredicate*> _all_compound_col_predicates;
+    std::vector<ColumnPredicate*> _col_preds_except_leafnode_of_andnode;
     std::vector<ColumnPredicate*> _value_col_predicates;
     DeleteHandler _delete_handler;
 

--- a/be/src/olap/rowset/beta_rowset_reader.cpp
+++ b/be/src/olap/rowset/beta_rowset_reader.cpp
@@ -105,7 +105,7 @@ Status BetaRowsetReader::get_segment_iterators(RowsetReaderContext* read_context
                     single_column_block_predicate);
         }
     }
-    
+
     if (read_context->all_compound_predicates != nullptr) {
         _read_options.all_compound_column_predicates.insert(
                 _read_options.all_compound_column_predicates.end(),

--- a/be/src/olap/rowset/beta_rowset_reader.cpp
+++ b/be/src/olap/rowset/beta_rowset_reader.cpp
@@ -107,8 +107,8 @@ Status BetaRowsetReader::get_segment_iterators(RowsetReaderContext* read_context
     }
     
     if (read_context->all_compound_predicates != nullptr) {
-        read_options.all_compound_column_predicates.insert(
-                read_options.all_compound_column_predicates.end(),
+        _read_options.all_compound_column_predicates.insert(
+                _read_options.all_compound_column_predicates.end(),
                 read_context->all_compound_predicates->begin(),
                 read_context->all_compound_predicates->end());
     }

--- a/be/src/olap/rowset/beta_rowset_reader.cpp
+++ b/be/src/olap/rowset/beta_rowset_reader.cpp
@@ -104,6 +104,21 @@ Status BetaRowsetReader::get_segment_iterators(RowsetReaderContext* read_context
                     single_column_block_predicate);
         }
     }
+    
+    if (read_context->all_compound_predicates != nullptr) {
+        read_options.all_compound_column_predicates.insert(
+                read_options.all_compound_column_predicates.end(),
+                read_context->all_compound_predicates->begin(),
+                read_context->all_compound_predicates->end());
+    }
+    
+    if (read_context->in_or_compound_predicates != nullptr) {
+        read_options.in_or_compound_column_predicates.insert(
+                read_options.in_or_compound_column_predicates.end(),
+                read_context->in_or_compound_predicates->begin(),
+                read_context->in_or_compound_predicates->end());
+    }
+
     // Take a delete-bitmap for each segment, the bitmap contains all deletes
     // until the max read version, which is read_context->version.second
     if (read_context->delete_bitmap != nullptr) {

--- a/be/src/olap/rowset/beta_rowset_reader.cpp
+++ b/be/src/olap/rowset/beta_rowset_reader.cpp
@@ -106,11 +106,11 @@ Status BetaRowsetReader::get_segment_iterators(RowsetReaderContext* read_context
         }
     }
 
-    if (read_context->all_compound_predicates != nullptr) {
-        _read_options.all_compound_column_predicates.insert(
-                _read_options.all_compound_column_predicates.end(),
-                read_context->all_compound_predicates->begin(),
-                read_context->all_compound_predicates->end());
+    if (read_context->predicates_except_leafnode_of_andnode != nullptr) {
+        _read_options.column_predicates_except_leafnode_of_andnode.insert(
+                _read_options.column_predicates_except_leafnode_of_andnode.end(),
+                read_context->predicates_except_leafnode_of_andnode->begin(),
+                read_context->predicates_except_leafnode_of_andnode->end());
     }
 
     // Take a delete-bitmap for each segment, the bitmap contains all deletes

--- a/be/src/olap/rowset/beta_rowset_reader.cpp
+++ b/be/src/olap/rowset/beta_rowset_reader.cpp
@@ -57,6 +57,7 @@ Status BetaRowsetReader::get_segment_iterators(RowsetReaderContext* read_context
     // convert RowsetReaderContext to StorageReadOptions
     _read_options.stats = _stats;
     _read_options.push_down_agg_type_opt = _context->push_down_agg_type_opt;
+    _read_options.remaining_vconjunct_root = _context->remaining_vconjunct_root;
     if (read_context->lower_bound_keys != nullptr) {
         for (int i = 0; i < read_context->lower_bound_keys->size(); ++i) {
             _read_options.key_ranges.emplace_back(&read_context->lower_bound_keys->at(i),
@@ -110,13 +111,6 @@ Status BetaRowsetReader::get_segment_iterators(RowsetReaderContext* read_context
                 read_options.all_compound_column_predicates.end(),
                 read_context->all_compound_predicates->begin(),
                 read_context->all_compound_predicates->end());
-    }
-    
-    if (read_context->in_or_compound_predicates != nullptr) {
-        read_options.in_or_compound_column_predicates.insert(
-                read_options.in_or_compound_column_predicates.end(),
-                read_context->in_or_compound_predicates->begin(),
-                read_context->in_or_compound_predicates->end());
     }
 
     // Take a delete-bitmap for each segment, the bitmap contains all deletes

--- a/be/src/olap/rowset/rowset_reader_context.h
+++ b/be/src/olap/rowset/rowset_reader_context.h
@@ -45,6 +45,8 @@ struct RowsetReaderContext {
     // column name -> column predicate
     // adding column_name for predicate to make use of column selectivity
     const std::vector<ColumnPredicate*>* predicates = nullptr;
+    const std::vector<ColumnPredicate*>* all_compound_predicates = nullptr;
+    const std::vector<std::pair<bool, std::vector<ColumnPredicate*>>>* in_or_compound_predicates = nullptr;
     // value column predicate in UNIQUE table
     const std::vector<ColumnPredicate*>* value_predicates = nullptr;
     const std::vector<RowCursor>* lower_bound_keys = nullptr;

--- a/be/src/olap/rowset/rowset_reader_context.h
+++ b/be/src/olap/rowset/rowset_reader_context.h
@@ -21,6 +21,7 @@
 #include "olap/column_predicate.h"
 #include "olap/olap_common.h"
 #include "runtime/runtime_state.h"
+#include "vec/exprs/vexpr.h"
 
 namespace doris {
 
@@ -46,7 +47,6 @@ struct RowsetReaderContext {
     // adding column_name for predicate to make use of column selectivity
     const std::vector<ColumnPredicate*>* predicates = nullptr;
     const std::vector<ColumnPredicate*>* all_compound_predicates = nullptr;
-    const std::vector<std::pair<bool, std::vector<ColumnPredicate*>>>* in_or_compound_predicates = nullptr;
     // value column predicate in UNIQUE table
     const std::vector<ColumnPredicate*>* value_predicates = nullptr;
     const std::vector<RowCursor>* lower_bound_keys = nullptr;
@@ -56,6 +56,7 @@ struct RowsetReaderContext {
     const DeleteHandler* delete_handler = nullptr;
     OlapReaderStatistics* stats = nullptr;
     RuntimeState* runtime_state = nullptr;
+    vectorized::VExpr* remaining_vconjunct_root = nullptr;
     bool use_page_cache = false;
     int sequence_id_idx = -1;
     int batch_size = 1024;

--- a/be/src/olap/rowset/rowset_reader_context.h
+++ b/be/src/olap/rowset/rowset_reader_context.h
@@ -46,7 +46,7 @@ struct RowsetReaderContext {
     // column name -> column predicate
     // adding column_name for predicate to make use of column selectivity
     const std::vector<ColumnPredicate*>* predicates = nullptr;
-    const std::vector<ColumnPredicate*>* all_compound_predicates = nullptr;
+    const std::vector<ColumnPredicate*>* predicates_except_leafnode_of_andnode = nullptr;
     // value column predicate in UNIQUE table
     const std::vector<ColumnPredicate*>* value_predicates = nullptr;
     const std::vector<RowCursor>* lower_bound_keys = nullptr;

--- a/be/src/olap/rowset/segment_v2/segment.cpp
+++ b/be/src/olap/rowset/segment_v2/segment.cpp
@@ -92,15 +92,6 @@ Status Segment::_open() {
 
 Status Segment::new_iterator(const Schema& schema, const StorageReadOptions& read_options,
                              std::unique_ptr<RowwiseIterator>* iter) {
-    auto cond_in_compound_query = [&](int32_t column_id) -> auto{
-        for (auto pred : read_options.all_compound_column_predicates) {
-            if (pred->column_id() == column_id) {
-                return true;
-            }
-        }
-        return false;
-    };
-
     read_options.stats->total_segment_number++;
     // trying to prune the current segment by segment-level zone map
     for (auto& entry : read_options.col_id_to_predicates) {
@@ -110,8 +101,7 @@ Status Segment::new_iterator(const Schema& schema, const StorageReadOptions& rea
             continue;
         }
         int32_t uid = read_options.tablet_schema->column(column_id).unique_id();
-        if (_column_readers.count(uid) < 1 || !_column_readers.at(uid)->has_zone_map() ||
-            cond_in_compound_query(column_id)) {
+        if (_column_readers.count(uid) < 1 || !_column_readers.at(uid)->has_zone_map()) {
             continue;
         }
         if (read_options.col_id_to_predicates.count(column_id) > 0 &&

--- a/be/src/olap/rowset/segment_v2/segment.cpp
+++ b/be/src/olap/rowset/segment_v2/segment.cpp
@@ -92,7 +92,7 @@ Status Segment::_open() {
 
 Status Segment::new_iterator(const Schema& schema, const StorageReadOptions& read_options,
                              std::unique_ptr<RowwiseIterator>* iter) {
-    auto cond_in_compound_query = [&](int32_t column_id) -> auto {
+    auto cond_in_compound_query = [&](int32_t column_id) -> auto{
         for (auto pred : read_options.all_compound_column_predicates) {
             if (pred->column_id() == column_id) {
                 return true;
@@ -110,9 +110,8 @@ Status Segment::new_iterator(const Schema& schema, const StorageReadOptions& rea
             continue;
         }
         int32_t uid = read_options.tablet_schema->column(column_id).unique_id();
-        if (_column_readers.count(uid) < 1 || 
-                !_column_readers.at(uid)->has_zone_map() ||
-                cond_in_compound_query(column_id)) {
+        if (_column_readers.count(uid) < 1 || !_column_readers.at(uid)->has_zone_map() ||
+            cond_in_compound_query(column_id)) {
             continue;
         }
         if (read_options.col_id_to_predicates.count(column_id) > 0 &&

--- a/be/src/olap/rowset/segment_v2/segment_iterator.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.cpp
@@ -420,15 +420,15 @@ Status SegmentIterator::_execute_all_compound_predicates(vectorized::VExpr* expr
     if (node_type == TExprNodeType::SLOT_REF) {
         _column_predicate_info->column_name = expr->expr_name();
     } else if (_is_literal_node(node_type)) {
-        auto v_literal_expr =  dynamic_cast<doris::vectorized::VLiteral*>(expr);
+        auto v_literal_expr = dynamic_cast<doris::vectorized::VLiteral*>(expr);
         _column_predicate_info->query_value = v_literal_expr->value();
     } else if (node_type == TExprNodeType::BINARY_PRED) {
         _column_predicate_info->query_op = expr->fn().name.function_name;
         // get child condition result in compound condtions
         auto column_sign = _gen_predicate_sign(_column_predicate_info.get());
         _column_predicate_info.reset(new ColumnPredicateInfo());
-        if (_rowid_result_for_index.count(column_sign) > 0 
-                && _rowid_result_for_index[column_sign].first) {
+        if (_rowid_result_for_index.count(column_sign) > 0 &&
+            _rowid_result_for_index[column_sign].first) {
             auto apply_reuslt = _rowid_result_for_index[column_sign].second;
             _compound_predicate_execute_result.push_back(apply_reuslt);
         }
@@ -447,7 +447,8 @@ Status SegmentIterator::_execute_compound_fn(const std::string& function_name) {
         if (size < 2) {
             return Status::InternalError("execute and logic compute error.");
         }
-        _compound_predicate_execute_result.at(size - 2) &= _compound_predicate_execute_result.at(size - 1);
+        _compound_predicate_execute_result.at(size - 2) &=
+                _compound_predicate_execute_result.at(size - 1);
         _compound_predicate_execute_result.pop_back();
         return Status::OK();
     };
@@ -457,7 +458,8 @@ Status SegmentIterator::_execute_compound_fn(const std::string& function_name) {
         if (size < 2) {
             return Status::InternalError("execute or logic compute error.");
         }
-        _compound_predicate_execute_result.at(size - 2) |= _compound_predicate_execute_result.at(size - 1);
+        _compound_predicate_execute_result.at(size - 2) |=
+                _compound_predicate_execute_result.at(size - 1);
         _compound_predicate_execute_result.pop_back();
         return Status::OK();
     };
@@ -502,17 +504,18 @@ bool SegmentIterator::_check_apply_by_bitmap_index(ColumnPredicate* pred) {
     return true;
 }
 
-Status SegmentIterator::_apply_bitmap_index_in_compound(ColumnPredicate* pred, roaring::Roaring* output_result) {
+Status SegmentIterator::_apply_bitmap_index_in_compound(ColumnPredicate* pred,
+                                                        roaring::Roaring* output_result) {
     int32_t unique_id = _schema.unique_id(pred->column_id());
     RETURN_IF_ERROR(pred->evaluate(_bitmap_index_iterators[unique_id], _segment->num_rows(),
-                                       output_result));
+                                   output_result));
     return Status::OK();
 }
 
 Status SegmentIterator::_apply_index_in_compound() {
     for (auto pred : _all_compound_col_predicates) {
         auto pred_type = pred->type();
-        bool is_support_in_compound = 
+        bool is_support_in_compound =
                 pred_type == PredicateType::EQ || pred_type == PredicateType::NE ||
                 pred_type == PredicateType::LT || pred_type == PredicateType::LE ||
                 pred_type == PredicateType::GT || pred_type == PredicateType::GE;
@@ -537,8 +540,7 @@ Status SegmentIterator::_apply_index_in_compound() {
         }
 
         std::string pred_sign = _gen_predicate_sign(pred);
-        _rowid_result_for_index.emplace(
-                std::make_pair(pred_sign, std::make_pair(true, bitmap)));
+        _rowid_result_for_index.emplace(std::make_pair(pred_sign, std::make_pair(true, bitmap)));
     }
 
     return Status::OK();
@@ -1309,7 +1311,7 @@ void SegmentIterator::_output_index_return_column(vectorized::Block* block) {
     if (block->rows() == 0) {
         return;
     }
-    
+
     for (auto column_sign : _rowid_result_for_index) {
         block->insert({vectorized::ColumnUInt8::create(),
                        std::make_shared<vectorized::DataTypeUInt8>(), column_sign.first});
@@ -1321,9 +1323,9 @@ void SegmentIterator::_output_index_return_column(vectorized::Block* block) {
     }
 }
 
-void SegmentIterator::_build_index_return_column(vectorized::Block* block, 
-                                    const std::string& index_result_column_sign,
-                                    const roaring::Roaring& index_result) {
+void SegmentIterator::_build_index_return_column(vectorized::Block* block,
+                                                 const std::string& index_result_column_sign,
+                                                 const roaring::Roaring& index_result) {
     auto index_result_column = vectorized::ColumnUInt8::create();
     vectorized::ColumnUInt8::Container& vec_match_pred = index_result_column->get_data();
     vec_match_pred.resize(block->rows());

--- a/be/src/olap/rowset/segment_v2/segment_iterator.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.cpp
@@ -449,6 +449,7 @@ Status SegmentIterator::_execute_compound_fn(const std::string& function_name) {
         }
         _compound_predicate_execute_result.at(size - 2) &= _compound_predicate_execute_result.at(size - 1);
         _compound_predicate_execute_result.pop_back();
+        return Status::OK();
     };
 
     auto or_execute_result = [&]() {
@@ -458,6 +459,7 @@ Status SegmentIterator::_execute_compound_fn(const std::string& function_name) {
         }
         _compound_predicate_execute_result.at(size - 2) |= _compound_predicate_execute_result.at(size - 1);
         _compound_predicate_execute_result.pop_back();
+        return Status::OK();
     };
 
     auto not_execute_result = [&]() {
@@ -468,14 +470,15 @@ Status SegmentIterator::_execute_compound_fn(const std::string& function_name) {
         roaring::Roaring tmp = _row_bitmap;
         tmp -= _compound_predicate_execute_result.at(size - 1);
         _compound_predicate_execute_result.at(size - 1) = tmp;
+        return Status::OK();
     };
 
     if (function_name == "and") {
-        and_execute_result();
+        RETURN_IF_ERROR(and_execute_result());
     } else if (function_name == "or") {
-        or_execute_result();
+        RETURN_IF_ERROR(or_execute_result());
     } else if (function_name == "not") {
-        not_execute_result();
+        RETURN_IF_ERROR(not_execute_result());
     }
     return Status::OK();
 }
@@ -512,8 +515,7 @@ Status SegmentIterator::_apply_index_in_compound() {
         bool is_support_in_compound = 
                 pred_type == PredicateType::EQ || pred_type == PredicateType::NE ||
                 pred_type == PredicateType::LT || pred_type == PredicateType::LE ||
-                pred_type == PredicateType::GT || pred_type == PredicateType::GE ||
-                pred_type == PredicateType::MATCH;
+                pred_type == PredicateType::GT || pred_type == PredicateType::GE;
         if (!is_support_in_compound) {
             continue;
         }

--- a/be/src/olap/rowset/segment_v2/segment_iterator.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.cpp
@@ -356,7 +356,7 @@ Status SegmentIterator::_get_row_ranges_from_conditions(RowRanges* condition_row
 Status SegmentIterator::_apply_bitmap_index() {
     SCOPED_RAW_TIMER(&_opts.stats->bitmap_index_filter_timer);
     size_t input_rows = _row_bitmap.cardinality();
-    if (!_in_or_compound_col_predicates.empty()) {
+    if (config::enable_index_apply_or_predicates && !_in_or_compound_col_predicates.empty()) {
         RETURN_IF_ERROR(_execute_all_or_compound_predicates());
     }
 

--- a/be/src/olap/rowset/segment_v2/segment_iterator.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.cpp
@@ -487,8 +487,8 @@ bool SegmentIterator::_check_apply_by_bitmap_index(ColumnPredicate* pred) {
     return true;
 }
 
-Status SegmentIterator::_apply_bitmap_index_except_leafnode_of_andnode(ColumnPredicate* pred,
-                                                        roaring::Roaring* output_result) {
+Status SegmentIterator::_apply_bitmap_index_except_leafnode_of_andnode(
+        ColumnPredicate* pred, roaring::Roaring* output_result) {
     int32_t unique_id = _schema.unique_id(pred->column_id());
     RETURN_IF_ERROR(pred->evaluate(_bitmap_index_iterators[unique_id], _segment->num_rows(),
                                    output_result));
@@ -498,10 +498,9 @@ Status SegmentIterator::_apply_bitmap_index_except_leafnode_of_andnode(ColumnPre
 Status SegmentIterator::_apply_index_except_leafnode_of_andnode() {
     for (auto pred : _col_preds_except_leafnode_of_andnode) {
         auto pred_type = pred->type();
-        bool is_support =
-                pred_type == PredicateType::EQ || pred_type == PredicateType::NE ||
-                pred_type == PredicateType::LT || pred_type == PredicateType::LE ||
-                pred_type == PredicateType::GT || pred_type == PredicateType::GE;
+        bool is_support = pred_type == PredicateType::EQ || pred_type == PredicateType::NE ||
+                          pred_type == PredicateType::LT || pred_type == PredicateType::LE ||
+                          pred_type == PredicateType::GT || pred_type == PredicateType::GE;
         if (!is_support) {
             continue;
         }
@@ -523,7 +522,8 @@ Status SegmentIterator::_apply_index_except_leafnode_of_andnode() {
         }
 
         std::string pred_result_sign = _gen_predicate_sign(pred);
-        _rowid_result_for_index.emplace(std::make_pair(pred_result_sign, std::make_pair(true, bitmap)));
+        _rowid_result_for_index.emplace(
+                std::make_pair(pred_result_sign, std::make_pair(true, bitmap)));
     }
 
     return Status::OK();
@@ -536,7 +536,7 @@ std::string SegmentIterator::_gen_predicate_sign(ColumnPredicate* predicate) {
     auto pred_type = predicate->type();
     auto predicate_params = predicate->predicate_params();
     pred_result_sign = column_desc->name() + "_" + predicate->pred_type_string(pred_type) + "_" +
-                predicate_params->value;
+                       predicate_params->value;
 
     return pred_result_sign;
 }
@@ -544,7 +544,7 @@ std::string SegmentIterator::_gen_predicate_sign(ColumnPredicate* predicate) {
 std::string SegmentIterator::_gen_predicate_sign(ColumnPredicateInfo* predicate_info) {
     std::string pred_result_sign;
     pred_result_sign = predicate_info->column_name + "_" + predicate_info->query_op + "_" +
-                predicate_info->query_value;
+                       predicate_info->query_value;
     return pred_result_sign;
 }
 

--- a/be/src/olap/rowset/segment_v2/segment_iterator.h
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.h
@@ -124,7 +124,8 @@ private:
     Status _apply_bitmap_index();
 
     Status _apply_index_except_leafnode_of_andnode();
-    Status _apply_bitmap_index_except_leafnode_of_andnode(ColumnPredicate* pred, roaring::Roaring* output_result);
+    Status _apply_bitmap_index_except_leafnode_of_andnode(ColumnPredicate* pred,
+                                                          roaring::Roaring* output_result);
 
     bool _can_filter_by_preds_except_leafnode_of_andnode();
     Status _execute_predicates_except_leafnode_of_andnode(vectorized::VExpr* expr);
@@ -188,11 +189,10 @@ private:
     std::string _gen_predicate_sign(ColumnPredicateInfo* predicate_info);
 
     void _build_index_result_column(uint16_t* sel_rowid_idx, uint16_t select_size,
-                                    vectorized::Block* block,
-                                    const std::string& pred_result_sign,
+                                    vectorized::Block* block, const std::string& pred_result_sign,
                                     const roaring::Roaring& index_result);
     void _output_index_result_column(uint16_t* sel_rowid_idx, uint16_t select_size,
-                                            vectorized::Block* block);
+                                     vectorized::Block* block);
 
 private:
     class BitmapRangeIterator;

--- a/be/src/olap/rowset/segment_v2/segment_iterator.h
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.h
@@ -49,7 +49,7 @@ class BitmapIndexReader;
 class ColumnIterator;
 
 struct ColumnPredicateInfo {
-    ColumnPredicateInfo() {};
+    ColumnPredicateInfo() = default;
     std::string column_name;
     std::string query_value;
     std::string query_op;

--- a/be/src/olap/rowset/segment_v2/segment_iterator.h
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.h
@@ -114,6 +114,9 @@ private:
     Status _get_row_ranges_by_column_conditions();
     Status _get_row_ranges_from_conditions(RowRanges* condition_row_ranges);
     Status _apply_bitmap_index();
+    Status _apply_index_in_compound(
+            const std::vector<ColumnPredicate*>& predicates, roaring::Roaring* output_bitmap);
+    Status _execute_all_or_compound_predicates();
 
     void _init_lazy_materialization();
     void _vec_init_lazy_materialization();
@@ -221,6 +224,8 @@ private:
     StorageReadOptions _opts;
     // make a copy of `_opts.column_predicates` in order to make local changes
     std::vector<ColumnPredicate*> _col_predicates;
+    std::vector<ColumnPredicate*> _all_compound_col_predicates;
+    std::vector<std::pair<bool, std::vector<ColumnPredicate*>>> _in_or_compound_col_predicates;
 
     // row schema of the key to seek
     // only used in `_get_row_ranges_by_keys`

--- a/be/src/olap/rowset/segment_v2/segment_iterator.h
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.h
@@ -187,7 +187,8 @@ private:
     std::string _gen_predicate_sign(ColumnPredicate* predicate);
     std::string _gen_predicate_sign(ColumnPredicateInfo* predicate_info);
 
-    void _build_index_return_column(vectorized::Block* block, const std::string& index_result_column_sign,
+    void _build_index_return_column(vectorized::Block* block,
+                                    const std::string& index_result_column_sign,
                                     const roaring::Roaring& index_result);
 
     void _output_index_return_column(vectorized::Block* block);

--- a/be/src/olap/rowset/segment_v2/segment_iterator.h
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.h
@@ -169,6 +169,14 @@ private:
 
     void _update_max_row(const vectorized::Block* block);
 
+    std::string _gen_predicate_sign(ColumnPredicate* predicate);
+
+    void _build_index_return_column(vectorized::Block* block, const std::string& index_result_column_sign,
+                                    const roaring::Roaring& index_result);
+
+    void _output_index_return_column(vectorized::Block* block);
+
+private:
     class BitmapRangeIterator;
     class BackwardBitmapRangeIterator;
 
@@ -181,6 +189,9 @@ private:
     std::map<int32_t, BitmapIndexIterator*> _bitmap_index_iterators;
     // after init(), `_row_bitmap` contains all rowid to scan
     roaring::Roaring _row_bitmap;
+    // "column_name+operator+value-> <in_compound_query, rowid_result>
+    std::unordered_map<std::string, std::pair<bool, roaring::Roaring> > _rowid_result_for_index;
+    std::vector<roaring::Roaring> _split_row_bitmaps;
     // an iterator for `_row_bitmap` that can be used to extract row range to scan
     std::unique_ptr<BitmapRangeIterator> _range_iter;
     // the next rowid to read

--- a/be/src/vec/exec/scan/new_olap_scan_node.cpp
+++ b/be/src/vec/exec/scan/new_olap_scan_node.cpp
@@ -237,14 +237,15 @@ Status NewOlapScanNode::_build_key_ranges_and_filters() {
             std::vector<TCondition> conditions;
             for (auto& iter : _compound_value_ranges[i]) {
                 std::vector<TCondition> filters;
-                std::visit([&](auto&& range) { 
-                    if (range.is_boundary_value_range()) {
-                        range.to_boundary_condition(filters); 
-                    } else {
-                        range.to_olap_filter(filters);
-                    }
-
-                }, iter);
+                std::visit(
+                        [&](auto&& range) {
+                            if (range.is_boundary_value_range()) {
+                                range.to_boundary_condition(filters);
+                            } else {
+                                range.to_olap_filter(filters);
+                            }
+                        },
+                        iter);
 
                 for (const auto& filter : filters) {
                     conditions.push_back(filter);
@@ -255,7 +256,7 @@ Status NewOlapScanNode::_build_key_ranges_and_filters() {
                 _compound_filters.emplace_back(conditions);
             }
         }
-        
+
         // Append value ranges in "_not_in_value_ranges"
         for (auto& range : _not_in_value_ranges) {
             std::visit([&](auto&& the_range) { the_range.to_in_condition(_olap_filters, false); },
@@ -408,7 +409,7 @@ Status NewOlapScanNode::_init_scanners(std::list<VScanner*>* scanners) {
             NewOlapScanner* scanner = new NewOlapScanner(
                     _state, this, _limit_per_scanner, _olap_scan_node.is_preaggregation,
                     _need_agg_finalize, *scan_range, _scanner_profile.get());
-            
+
             scanner->set_compound_filters(_compound_filters);
             // add scanner to pool before doing prepare.
             // so that scanner can be automatically deconstructed if prepare failed.

--- a/be/src/vec/exec/scan/new_olap_scan_node.cpp
+++ b/be/src/vec/exec/scan/new_olap_scan_node.cpp
@@ -229,14 +229,13 @@ Status NewOlapScanNode::_build_key_ranges_and_filters() {
             std::visit([&](auto&& range) { range.to_olap_filter(filters); }, iter.second);
 
             for (const auto& filter : filters) {
-                _olap_filters.push_back(filter);
+                _olap_filters.push_back(std::move(filter));
             }
         }
 
         for (auto i = 0; i < _compound_value_ranges.size(); ++i) {
-            bool not_compound = _compound_value_ranges[i].first;
             std::vector<TCondition> conditions;
-            for (auto& iter : _compound_value_ranges[i].second) {
+            for (auto& iter : _compound_value_ranges[i]) {
                 std::vector<TCondition> filters;
                 std::visit([&](auto&& range) { 
                     if (range.is_boundary_value_range()) {
@@ -253,7 +252,7 @@ Status NewOlapScanNode::_build_key_ranges_and_filters() {
             }
 
             if (!conditions.empty()) {
-                _compound_filters.emplace_back(std::make_pair(not_compound, conditions));
+                _compound_filters.emplace_back(conditions);
             }
         }
         

--- a/be/src/vec/exec/scan/new_olap_scan_node.cpp
+++ b/be/src/vec/exec/scan/new_olap_scan_node.cpp
@@ -229,7 +229,7 @@ Status NewOlapScanNode::_build_key_ranges_and_filters() {
             std::visit([&](auto&& range) { range.to_olap_filter(filters); }, iter.second);
 
             for (const auto& filter : filters) {
-                _olap_filters.push_back(std::move(filter));
+                _olap_filters.push_back(filter);
             }
         }
 
@@ -247,7 +247,7 @@ Status NewOlapScanNode::_build_key_ranges_and_filters() {
                 }, iter);
 
                 for (const auto& filter : filters) {
-                    conditions.push_back(std::move(filter));
+                    conditions.push_back(filter);
                 }
             }
 

--- a/be/src/vec/exec/scan/new_olap_scan_node.cpp
+++ b/be/src/vec/exec/scan/new_olap_scan_node.cpp
@@ -233,6 +233,30 @@ Status NewOlapScanNode::_build_key_ranges_and_filters() {
             }
         }
 
+        for (auto i = 0; i < _compound_value_ranges.size(); ++i) {
+            bool not_compound = _compound_value_ranges[i].first;
+            std::vector<TCondition> conditions;
+            for (auto& iter : _compound_value_ranges[i].second) {
+                std::vector<TCondition> filters;
+                std::visit([&](auto&& range) { 
+                    if (range.is_boundary_value_range()) {
+                        range.to_boundary_condition(filters); 
+                    } else {
+                        range.to_olap_filter(filters);
+                    }
+
+                }, iter);
+
+                for (const auto& filter : filters) {
+                    conditions.push_back(std::move(filter));
+                }
+            }
+
+            if (!conditions.empty()) {
+                _compound_filters.emplace_back(std::make_pair(not_compound, conditions));
+            }
+        }
+        
         // Append value ranges in "_not_in_value_ranges"
         for (auto& range : _not_in_value_ranges) {
             std::visit([&](auto&& the_range) { the_range.to_in_condition(_olap_filters, false); },
@@ -385,6 +409,8 @@ Status NewOlapScanNode::_init_scanners(std::list<VScanner*>* scanners) {
             NewOlapScanner* scanner = new NewOlapScanner(
                     _state, this, _limit_per_scanner, _olap_scan_node.is_preaggregation,
                     _need_agg_finalize, *scan_range, _scanner_profile.get());
+            
+            scanner->set_compound_filters(_compound_filters);
             // add scanner to pool before doing prepare.
             // so that scanner can be automatically deconstructed if prepare failed.
             _scanner_pool.add(scanner);

--- a/be/src/vec/exec/scan/new_olap_scan_node.cpp
+++ b/be/src/vec/exec/scan/new_olap_scan_node.cpp
@@ -233,27 +233,17 @@ Status NewOlapScanNode::_build_key_ranges_and_filters() {
             }
         }
 
-        for (auto i = 0; i < _compound_value_ranges.size(); ++i) {
-            std::vector<TCondition> conditions;
-            for (auto& iter : _compound_value_ranges[i]) {
-                std::vector<TCondition> filters;
-                std::visit(
-                        [&](auto&& range) {
-                            if (range.is_boundary_value_range()) {
-                                range.to_boundary_condition(filters);
-                            } else {
-                                range.to_olap_filter(filters);
-                            }
-                        },
-                        iter);
-
-                for (const auto& filter : filters) {
-                    conditions.push_back(filter);
-                }
-            }
-
-            if (!conditions.empty()) {
-                _compound_filters.emplace_back(conditions);
+        for (auto& iter : _compound_value_ranges) {
+            std::vector<TCondition> filters;
+            std::visit(
+                    [&](auto&& range) {
+                        if (range.is_in_compound_value_range()) {
+                            range.to_condition_in_compound(filters);
+                        }
+                    },
+                    iter);
+            for (const auto& filter : filters) {
+                _compound_filters.push_back(filter);
             }
         }
 

--- a/be/src/vec/exec/scan/new_olap_scan_node.h
+++ b/be/src/vec/exec/scan/new_olap_scan_node.h
@@ -65,8 +65,8 @@ private:
     std::vector<std::unique_ptr<TPaloScanRange>> _scan_ranges;
     OlapScanKeys _scan_keys;
     std::vector<TCondition> _olap_filters;
-    // compound filters in every conjunct, like: "(a or b) and (c or d)", (a or b) in conjuct[0], (c or d) in conjuct[1]
-    std::vector<std::vector<TCondition>> _compound_filters;
+    // _compound_filters store conditions in the one compound relationship in conjunct expr tree, like: "(a or b) and (c or d)", conditions for a,b,c,d will be stored
+    std::vector<TCondition> _compound_filters;
 
 private:
     std::unique_ptr<RuntimeProfile> _segment_profile;

--- a/be/src/vec/exec/scan/new_olap_scan_node.h
+++ b/be/src/vec/exec/scan/new_olap_scan_node.h
@@ -66,7 +66,7 @@ private:
     OlapScanKeys _scan_keys;
     std::vector<TCondition> _olap_filters;
     // compound filters in every conjunct, like: "(a or b) and (c or d)", (a or b) in conjuct[0], (c or d) in conjuct[1]
-    std::vector<std::pair<bool, std::vector<TCondition>>> _compound_filters;
+    std::vector<std::vector<TCondition>> _compound_filters;
 
 private:
     std::unique_ptr<RuntimeProfile> _segment_profile;

--- a/be/src/vec/exec/scan/new_olap_scan_node.h
+++ b/be/src/vec/exec/scan/new_olap_scan_node.h
@@ -65,7 +65,8 @@ private:
     std::vector<std::unique_ptr<TPaloScanRange>> _scan_ranges;
     OlapScanKeys _scan_keys;
     std::vector<TCondition> _olap_filters;
-    // _compound_filters store conditions in the one compound relationship in conjunct expr tree, like: "(a or b) and (c or d)", conditions for a,b,c,d will be stored
+    // _compound_filters store conditions in the one compound relationship in conjunct expr tree except leaf node of `and` node,
+    // such as: "(a or b) and (c or d)", conditions for a,b,c,d will be stored
     std::vector<TCondition> _compound_filters;
 
 private:

--- a/be/src/vec/exec/scan/new_olap_scan_node.h
+++ b/be/src/vec/exec/scan/new_olap_scan_node.h
@@ -65,6 +65,8 @@ private:
     std::vector<std::unique_ptr<TPaloScanRange>> _scan_ranges;
     OlapScanKeys _scan_keys;
     std::vector<TCondition> _olap_filters;
+    // compound filters in every conjunct, like: "(a or b) and (c or d)", (a or b) in conjuct[0], (c or d) in conjuct[1]
+    std::vector<std::pair<bool, std::vector<TCondition>>> _compound_filters;
 
 private:
     std::unique_ptr<RuntimeProfile> _segment_profile;

--- a/be/src/vec/exec/scan/new_olap_scanner.cpp
+++ b/be/src/vec/exec/scan/new_olap_scanner.cpp
@@ -127,8 +127,7 @@ Status NewOlapScanner::open(RuntimeState* state) {
     return Status::OK();
 }
 
-void NewOlapScanner::set_compound_filters(
-        const std::vector<TCondition>& compound_filters) {
+void NewOlapScanner::set_compound_filters(const std::vector<TCondition>& compound_filters) {
     _compound_filters = compound_filters;
 }
 

--- a/be/src/vec/exec/scan/new_olap_scanner.cpp
+++ b/be/src/vec/exec/scan/new_olap_scanner.cpp
@@ -128,7 +128,7 @@ Status NewOlapScanner::open(RuntimeState* state) {
 }
 
 void NewOlapScanner::set_compound_filters(
-        const std::vector<std::pair<bool, std::vector<TCondition>>>& compound_filters) {
+        const std::vector<std::vector<TCondition>>& compound_filters) {
     _compound_filters = compound_filters;
 }
 
@@ -173,6 +173,7 @@ Status NewOlapScanner::_init_tablet_reader_params(
                 real_parent->_olap_scan_node.push_down_agg_type_opt;
     }
     _tablet_reader_params.version = Version(0, _version);
+    _tablet_reader_params.remaining_vconjunct_root = (_vconjunct_ctx == nullptr) ? nullptr : _vconjunct_ctx->root();
 
     // Condition
     for (auto& filter : filters) {

--- a/be/src/vec/exec/scan/new_olap_scanner.cpp
+++ b/be/src/vec/exec/scan/new_olap_scanner.cpp
@@ -128,7 +128,7 @@ Status NewOlapScanner::open(RuntimeState* state) {
 }
 
 void NewOlapScanner::set_compound_filters(
-        const std::vector<std::vector<TCondition>>& compound_filters) {
+        const std::vector<TCondition>& compound_filters) {
     _compound_filters = compound_filters;
 }
 
@@ -182,8 +182,8 @@ Status NewOlapScanner::_init_tablet_reader_params(
     }
 
     std::copy(_compound_filters.cbegin(), _compound_filters.cend(),
-              std::inserter(_tablet_reader_params.compound_conditions,
-                            _tablet_reader_params.compound_conditions.begin()));
+              std::inserter(_tablet_reader_params.conditions_except_leafnode_of_andnode,
+                            _tablet_reader_params.conditions_except_leafnode_of_andnode.begin()));
 
     std::copy(filter_predicates.bloom_filters.cbegin(), filter_predicates.bloom_filters.cend(),
               std::inserter(_tablet_reader_params.bloom_filters,

--- a/be/src/vec/exec/scan/new_olap_scanner.cpp
+++ b/be/src/vec/exec/scan/new_olap_scanner.cpp
@@ -127,6 +127,11 @@ Status NewOlapScanner::open(RuntimeState* state) {
     return Status::OK();
 }
 
+void NewOlapScanner::set_compound_filters(
+        const std::vector<std::pair<bool, std::vector<TCondition>>>& compound_filters) {
+    _compound_filters = compound_filters;
+}
+
 // it will be called under tablet read lock because capture rs readers need
 Status NewOlapScanner::_init_tablet_reader_params(
         const std::vector<OlapScanRange*>& key_ranges, const std::vector<TCondition>& filters,
@@ -173,6 +178,11 @@ Status NewOlapScanner::_init_tablet_reader_params(
     for (auto& filter : filters) {
         _tablet_reader_params.conditions.push_back(filter);
     }
+
+    std::copy(_compound_filters.cbegin(), _compound_filters.cend(),
+            std::inserter(_tablet_reader_params.compound_conditions,
+                        _tablet_reader_params.compound_conditions.begin()));
+
     std::copy(filter_predicates.bloom_filters.cbegin(), filter_predicates.bloom_filters.cend(),
               std::inserter(_tablet_reader_params.bloom_filters,
                             _tablet_reader_params.bloom_filters.begin()));

--- a/be/src/vec/exec/scan/new_olap_scanner.cpp
+++ b/be/src/vec/exec/scan/new_olap_scanner.cpp
@@ -173,7 +173,8 @@ Status NewOlapScanner::_init_tablet_reader_params(
                 real_parent->_olap_scan_node.push_down_agg_type_opt;
     }
     _tablet_reader_params.version = Version(0, _version);
-    _tablet_reader_params.remaining_vconjunct_root = (_vconjunct_ctx == nullptr) ? nullptr : _vconjunct_ctx->root();
+    _tablet_reader_params.remaining_vconjunct_root =
+            (_vconjunct_ctx == nullptr) ? nullptr : _vconjunct_ctx->root();
 
     // Condition
     for (auto& filter : filters) {
@@ -181,8 +182,8 @@ Status NewOlapScanner::_init_tablet_reader_params(
     }
 
     std::copy(_compound_filters.cbegin(), _compound_filters.cend(),
-            std::inserter(_tablet_reader_params.compound_conditions,
-                        _tablet_reader_params.compound_conditions.begin()));
+              std::inserter(_tablet_reader_params.compound_conditions,
+                            _tablet_reader_params.compound_conditions.begin()));
 
     std::copy(filter_predicates.bloom_filters.cbegin(), filter_predicates.bloom_filters.cend(),
               std::inserter(_tablet_reader_params.bloom_filters,

--- a/be/src/vec/exec/scan/new_olap_scanner.h
+++ b/be/src/vec/exec/scan/new_olap_scanner.h
@@ -49,7 +49,7 @@ public:
 
     const std::string& scan_disk() const { return _tablet->data_dir()->path(); }
 
-    void set_compound_filters(const std::vector<std::pair<bool, std::vector<TCondition>>>& compound_filters);
+    void set_compound_filters(const std::vector<std::vector<TCondition>>& compound_filters);
 
 protected:
     Status _get_block_impl(RuntimeState* state, Block* block, bool* eos) override;
@@ -77,7 +77,7 @@ private:
 
     std::vector<uint32_t> _return_columns;
     std::unordered_set<uint32_t> _tablet_columns_convert_to_null_set;
-    std::vector<std::pair<bool, std::vector<TCondition>>> _compound_filters;
+    std::vector<std::vector<TCondition>> _compound_filters;
 
     // ========= profiles ==========
     int64_t _compressed_bytes_read = 0;

--- a/be/src/vec/exec/scan/new_olap_scanner.h
+++ b/be/src/vec/exec/scan/new_olap_scanner.h
@@ -49,7 +49,7 @@ public:
 
     const std::string& scan_disk() const { return _tablet->data_dir()->path(); }
 
-    void set_compound_filters(const std::vector<std::vector<TCondition>>& compound_filters);
+    void set_compound_filters(const std::vector<TCondition>& compound_filters);
 
 protected:
     Status _get_block_impl(RuntimeState* state, Block* block, bool* eos) override;
@@ -77,7 +77,7 @@ private:
 
     std::vector<uint32_t> _return_columns;
     std::unordered_set<uint32_t> _tablet_columns_convert_to_null_set;
-    std::vector<std::vector<TCondition>> _compound_filters;
+    std::vector<TCondition> _compound_filters;
 
     // ========= profiles ==========
     int64_t _compressed_bytes_read = 0;

--- a/be/src/vec/exec/scan/new_olap_scanner.h
+++ b/be/src/vec/exec/scan/new_olap_scanner.h
@@ -49,6 +49,8 @@ public:
 
     const std::string& scan_disk() const { return _tablet->data_dir()->path(); }
 
+    void set_compound_filters(const std::vector<std::pair<bool, std::vector<TCondition>>>& compound_filters);
+
 protected:
     Status _get_block_impl(RuntimeState* state, Block* block, bool* eos) override;
     void _update_counters_before_close() override;
@@ -75,6 +77,7 @@ private:
 
     std::vector<uint32_t> _return_columns;
     std::unordered_set<uint32_t> _tablet_columns_convert_to_null_set;
+    std::vector<std::pair<bool, std::vector<TCondition>>> _compound_filters;
 
     // ========= profiles ==========
     int64_t _compressed_bytes_read = 0;

--- a/be/src/vec/exec/scan/vscan_node.cpp
+++ b/be/src/vec/exec/scan/vscan_node.cpp
@@ -507,16 +507,11 @@ Status VScanNode::_normalize_predicate(VExpr* conjunct_expr_root, VExpr** output
             }
 
             if (pdt == PushDownType::UNACCEPTABLE && is_compound_predicate) {
-                auto fn_name = cur_expr->fn().name.function_name;
-                bool not_compound = false;
-                if (fn_name == "not") {
-                    not_compound = true;
-                }
                 std::vector<ColumnValueRangeType> column_value_rangs;
                 _normalize_compound_predicate(cur_expr, *(_vconjunct_ctx_ptr.get()), 
                                 &pdt, &column_value_rangs,
                                 in_predicate_checker, eq_predicate_checker);
-                _compound_value_ranges.push_back(std::make_pair(not_compound, column_value_rangs));
+                _compound_value_ranges.push_back(column_value_rangs);
             }
 
             if (pdt == PushDownType::ACCEPTABLE && _is_key_column(slot->col_name())) {

--- a/be/src/vec/exec/scan/vscan_node.cpp
+++ b/be/src/vec/exec/scan/vscan_node.cpp
@@ -926,7 +926,6 @@ Status VScanNode::_normalize_compound_predicate(
         const std::function<bool(const std::vector<VExpr*>&, const VSlotRef**, VExpr**)>&
                 eq_predicate_checker) {
     if (TExprNodeType::COMPOUND_PRED == expr->node_type()) {
-        DCHECK(expr->children().size() == 2);
         auto compound_fn_name = expr->fn().name.function_name;
         auto children_num = expr->children().size();
         for (auto i = 0; i < children_num; ++i) {

--- a/be/src/vec/exec/scan/vscan_node.cpp
+++ b/be/src/vec/exec/scan/vscan_node.cpp
@@ -512,6 +512,8 @@ Status VScanNode::_normalize_predicate(VExpr* conjunct_expr_root, VExpr** output
                                 &pdt, &column_value_rangs,
                                 in_predicate_checker, eq_predicate_checker);
                 _compound_value_ranges.push_back(column_value_rangs);
+                *output_expr = conjunct_expr_root; // remaining in conjunct tree
+                return Status::OK();
             }
 
             if (pdt == PushDownType::ACCEPTABLE && _is_key_column(slot->col_name())) {

--- a/be/src/vec/exec/scan/vscan_node.cpp
+++ b/be/src/vec/exec/scan/vscan_node.cpp
@@ -975,15 +975,18 @@ Status VScanNode::_normalize_binary_in_compound_predicate(
 
         StringRef value;
         int slot_ref_child = -1;
-        PushDownType eq_pdt =
-                _should_push_down_binary_predicate(reinterpret_cast<VectorizedFnCall*>(expr),
-                                                   expr_ctx, &value, &slot_ref_child, eq_checker);
-        PushDownType ne_pdt =
-                _should_push_down_binary_predicate(reinterpret_cast<VectorizedFnCall*>(expr),
-                                                   expr_ctx, &value, &slot_ref_child, ne_checker);
-        PushDownType noneq_pdt = _should_push_down_binary_predicate(reinterpret_cast<VectorizedFnCall*>(expr), 
-                                                    expr_ctx, &value, &slot_ref_child, noneq_checker);
-
+        PushDownType eq_pdt;
+        PushDownType ne_pdt;
+        PushDownType noneq_pdt;
+        RETURN_IF_ERROR(_should_push_down_binary_predicate(
+                reinterpret_cast<VectorizedFnCall*>(expr), expr_ctx, &value, &slot_ref_child,
+                eq_checker, eq_pdt));
+        RETURN_IF_ERROR(_should_push_down_binary_predicate(
+                reinterpret_cast<VectorizedFnCall*>(expr), expr_ctx, &value, &slot_ref_child,
+                ne_checker, ne_pdt));
+        RETURN_IF_ERROR(_should_push_down_binary_predicate(
+                reinterpret_cast<VectorizedFnCall*>(expr), expr_ctx, &value, &slot_ref_child,
+                noneq_checker, noneq_pdt));
         if (eq_pdt == PushDownType::UNACCEPTABLE 
                 && ne_pdt == PushDownType::UNACCEPTABLE
                 && noneq_pdt == PushDownType::UNACCEPTABLE) {

--- a/be/src/vec/exec/scan/vscan_node.h
+++ b/be/src/vec/exec/scan/vscan_node.h
@@ -217,6 +217,7 @@ protected:
     // column -> ColumnValueRange
     std::unordered_map<std::string, ColumnValueRangeType> _colname_to_value_range;
     // We use _colname_to_value_range to store a column and its corresponding value ranges.
+    std::vector<std::pair<bool, std::vector<ColumnValueRangeType>>> _compound_value_ranges;
     // But if a col is with value range, eg: 1 < col < 10, which is "!is_fixed_range",
     // in this case we can not merge "1 < col < 10" with "col not in (2)".
     // So we have to save "col not in (2)" to another structure: "_not_in_value_ranges".
@@ -308,6 +309,21 @@ private:
     Status _normalize_noneq_binary_predicate(vectorized::VExpr* expr, VExprContext* expr_ctx,
                                              SlotDescriptor* slot, ColumnValueRange<T>& range,
                                              PushDownType* pdt);
+
+    Status _normalize_compound_predicate(vectorized::VExpr* expr, 
+                    VExprContext* expr_ctx, 
+                    PushDownType* pdt,
+                    std::vector<ColumnValueRangeType>* column_value_rangs,
+                    const std::function<bool(const std::vector<VExpr*>&, const VSlotRef**, VExpr**)>& in_predicate_checker,
+                    const std::function<bool(const std::vector<VExpr*>&, const VSlotRef**, VExpr**)>& eq_predicate_checker);
+
+    template <PrimitiveType T>
+    Status _normalize_binary_in_compound_predicate(
+                vectorized::VExpr* expr, VExprContext* expr_ctx,
+                SlotDescriptor* slot, ColumnValueRange<T>& range,
+                PushDownType* pdt, const TCompoundType::type& compound_type);
+
+    TCompoundType::type _get_compound_type_by_fn_name(const std::string& fn_name);
 
     template <PrimitiveType T>
     Status _normalize_is_null_predicate(vectorized::VExpr* expr, VExprContext* expr_ctx,

--- a/be/src/vec/exec/scan/vscan_node.h
+++ b/be/src/vec/exec/scan/vscan_node.h
@@ -216,9 +216,8 @@ protected:
             _slot_id_to_value_range;
     // column -> ColumnValueRange
     std::unordered_map<std::string, ColumnValueRangeType> _colname_to_value_range;
-    // We use _colname_to_value_range to store a column and its corresponding value ranges.
-
-    std::vector<std::pair<bool, std::vector<ColumnValueRangeType>>> _compound_value_ranges;
+    std::vector<std::vector<ColumnValueRangeType>> _compound_value_ranges;
+    // We use _colname_to_value_range to store a column and its conresponding value ranges.
     // But if a col is with value range, eg: 1 < col < 10, which is "!is_fixed_range",
     // in this case we can not merge "1 < col < 10" with "col not in (2)".
     // So we have to save "col not in (2)" to another structure: "_not_in_value_ranges".

--- a/be/src/vec/exec/scan/vscan_node.h
+++ b/be/src/vec/exec/scan/vscan_node.h
@@ -310,18 +310,19 @@ private:
                                              SlotDescriptor* slot, ColumnValueRange<T>& range,
                                              PushDownType* pdt);
 
-    Status _normalize_compound_predicate(vectorized::VExpr* expr, 
-                    VExprContext* expr_ctx, 
-                    PushDownType* pdt,
-                    std::vector<ColumnValueRangeType>* column_value_rangs,
-                    const std::function<bool(const std::vector<VExpr*>&, const VSlotRef**, VExpr**)>& in_predicate_checker,
-                    const std::function<bool(const std::vector<VExpr*>&, const VSlotRef**, VExpr**)>& eq_predicate_checker);
+    Status _normalize_compound_predicate(
+            vectorized::VExpr* expr, VExprContext* expr_ctx, PushDownType* pdt,
+            std::vector<ColumnValueRangeType>* column_value_rangs,
+            const std::function<bool(const std::vector<VExpr*>&, const VSlotRef**, VExpr**)>&
+                    in_predicate_checker,
+            const std::function<bool(const std::vector<VExpr*>&, const VSlotRef**, VExpr**)>&
+                    eq_predicate_checker);
 
     template <PrimitiveType T>
-    Status _normalize_binary_in_compound_predicate(
-                vectorized::VExpr* expr, VExprContext* expr_ctx,
-                SlotDescriptor* slot, ColumnValueRange<T>& range,
-                PushDownType* pdt, const TCompoundType::type& compound_type);
+    Status _normalize_binary_in_compound_predicate(vectorized::VExpr* expr, VExprContext* expr_ctx,
+                                                   SlotDescriptor* slot, ColumnValueRange<T>& range,
+                                                   PushDownType* pdt,
+                                                   const TCompoundType::type& compound_type);
 
     TCompoundType::type _get_compound_type_by_fn_name(const std::string& fn_name);
 

--- a/be/src/vec/exec/scan/vscan_node.h
+++ b/be/src/vec/exec/scan/vscan_node.h
@@ -217,6 +217,7 @@ protected:
     // column -> ColumnValueRange
     std::unordered_map<std::string, ColumnValueRangeType> _colname_to_value_range;
     // We use _colname_to_value_range to store a column and its corresponding value ranges.
+
     std::vector<std::pair<bool, std::vector<ColumnValueRangeType>>> _compound_value_ranges;
     // But if a col is with value range, eg: 1 < col < 10, which is "!is_fixed_range",
     // in this case we can not merge "1 < col < 10" with "col not in (2)".

--- a/be/src/vec/exprs/vectorized_fn_call.cpp
+++ b/be/src/vec/exprs/vectorized_fn_call.cpp
@@ -106,7 +106,7 @@ doris::Status VectorizedFnCall::execute(VExprContext* context, doris::vectorized
     block->insert({nullptr, _data_type, _expr_name});
     if (_function->can_fast_execute()) {
         bool ok = fast_execute(context->fn_context(_fn_context_index), *block, arguments,
-                                       num_columns_without_result, block->rows());
+                               num_columns_without_result, block->rows());
         if (ok) {
             *result_column_id = num_columns_without_result;
             return Status::OK();
@@ -119,8 +119,9 @@ doris::Status VectorizedFnCall::execute(VExprContext* context, doris::vectorized
     return Status::OK();
 }
 
-bool VectorizedFnCall::fast_execute(FunctionContext* context, Block& block, const ColumnNumbers& arguments,
-                           size_t result, size_t input_rows_count) {
+bool VectorizedFnCall::fast_execute(FunctionContext* context, Block& block,
+                                    const ColumnNumbers& arguments, size_t result,
+                                    size_t input_rows_count) {
     auto column_with_name = block.get_by_position(arguments[1]);
     auto query_value = column_with_name.to_string(0);
     std::string column_name = block.get_by_position(arguments[0]).name;
@@ -128,8 +129,9 @@ bool VectorizedFnCall::fast_execute(FunctionContext* context, Block& block, cons
     if (!block.has(result_column_name)) {
         return false;
     }
-    
-    auto result_column = block.get_by_name(result_column_name).column->convert_to_full_column_if_const();
+
+    auto result_column =
+            block.get_by_name(result_column_name).column->convert_to_full_column_if_const();
     block.replace_by_position(result, std::move(result_column));
     return true;
 }

--- a/be/src/vec/exprs/vectorized_fn_call.cpp
+++ b/be/src/vec/exprs/vectorized_fn_call.cpp
@@ -119,11 +119,11 @@ doris::Status VectorizedFnCall::execute(VExprContext* context, doris::vectorized
     return Status::OK();
 }
 
+// fast_execute can direct copy expr filter result which build by apply index in segment_iterator
 bool VectorizedFnCall::fast_execute(FunctionContext* context, Block& block,
                                     const ColumnNumbers& arguments, size_t result,
                                     size_t input_rows_count) {
-    auto column_with_name = block.get_by_position(arguments[1]);
-    auto query_value = column_with_name.to_string(0);
+    auto query_value = block.get_by_position(arguments[1]).to_string(0);
     std::string column_name = block.get_by_position(arguments[0]).name;
     auto result_column_name = column_name + "_" + _function->get_name() + "_" + query_value;
     if (!block.has(result_column_name)) {

--- a/be/src/vec/exprs/vectorized_fn_call.cpp
+++ b/be/src/vec/exprs/vectorized_fn_call.cpp
@@ -104,10 +104,34 @@ doris::Status VectorizedFnCall::execute(VExprContext* context, doris::vectorized
     size_t num_columns_without_result = block->columns();
     // prepare a column to save result
     block->insert({nullptr, _data_type, _expr_name});
+    if (_function->can_fast_execute()) {
+        bool ok = fast_execute(context->fn_context(_fn_context_index), *block, arguments,
+                                       num_columns_without_result, block->rows());
+        if (ok) {
+            *result_column_id = num_columns_without_result;
+            return Status::OK();
+        }
+    }
+
     RETURN_IF_ERROR(_function->execute(context->fn_context(_fn_context_index), *block, arguments,
                                        num_columns_without_result, block->rows(), false));
     *result_column_id = num_columns_without_result;
     return Status::OK();
+}
+
+bool VectorizedFnCall::fast_execute(FunctionContext* context, Block& block, const ColumnNumbers& arguments,
+                           size_t result, size_t input_rows_count) {
+    auto column_with_name = block.get_by_position(arguments[1]);
+    auto query_value = column_with_name.to_string(0);
+    std::string column_name = block.get_by_position(arguments[0]).name;
+    auto result_column_name = column_name + "_" + _function->get_name() + "_" + query_value;
+    if (!block.has(result_column_name)) {
+        return false;
+    }
+    
+    auto result_column = block.get_by_name(result_column_name).column->convert_to_full_column_if_const();
+    block.replace_by_position(result, std::move(result_column));
+    return true;
 }
 
 const std::string& VectorizedFnCall::expr_name() const {

--- a/be/src/vec/exprs/vectorized_fn_call.h
+++ b/be/src/vec/exprs/vectorized_fn_call.h
@@ -36,7 +36,7 @@ public:
     static std::string debug_string(const std::vector<VectorizedFnCall*>& exprs);
 
     bool fast_execute(FunctionContext* context, Block& block, const ColumnNumbers& arguments,
-                           size_t result, size_t input_rows_count);
+                      size_t result, size_t input_rows_count);
 
 private:
     FunctionBasePtr _function;

--- a/be/src/vec/exprs/vectorized_fn_call.h
+++ b/be/src/vec/exprs/vectorized_fn_call.h
@@ -35,6 +35,9 @@ public:
     std::string debug_string() const override;
     static std::string debug_string(const std::vector<VectorizedFnCall*>& exprs);
 
+    bool fast_execute(FunctionContext* context, Block& block, const ColumnNumbers& arguments,
+                           size_t result, size_t input_rows_count);
+
 private:
     FunctionBasePtr _function;
     std::string _expr_name;

--- a/be/src/vec/exprs/vliteral.cpp
+++ b/be/src/vec/exprs/vliteral.cpp
@@ -191,11 +191,8 @@ Status VLiteral::execute(VExprContext* context, vectorized::Block* block, int* r
     return Status::OK();
 }
 
-std::string VLiteral::debug_string() const {
+std::string VLiteral::value() const {
     std::stringstream out;
-    out << "VLiteral (name = " << _expr_name;
-    out << ", type = " << _data_type->get_name();
-    out << ", value = (";
     for (size_t i = 0; i < _column_ptr->size(); i++) {
         if (i != 0) {
             out << ", ";
@@ -283,8 +280,17 @@ std::string VLiteral::debug_string() const {
             }
         }
     }
+    return out.str();
+}
+
+std::string VLiteral::debug_string() const {
+    std::stringstream out;
+    out << "VLiteral (name = " << _expr_name;
+    out << ", type = " << _data_type->get_name();
+    out << ", value = (" << value();
     out << "))";
     return out.str();
 }
+
 } // namespace vectorized
 } // namespace doris

--- a/be/src/vec/exprs/vliteral.h
+++ b/be/src/vec/exprs/vliteral.h
@@ -37,6 +37,8 @@ public:
     VExpr* clone(doris::ObjectPool* pool) const override { return pool->add(new VLiteral(*this)); }
     std::string debug_string() const override;
 
+    std::string value() const;
+
 protected:
     ColumnPtr _column_ptr;
     std::string _expr_name;

--- a/be/src/vec/functions/function.h
+++ b/be/src/vec/functions/function.h
@@ -529,10 +529,10 @@ public:
 
     bool is_deterministic() const override { return function->is_deterministic(); }
 
-    bool can_fast_execute() const override { 
-        return function->get_name() == "eq" || function->get_name() == "ne"
-                || function->get_name() == "lt" || function->get_name() == "gt"
-                || function->get_name() == "le" || function->get_name() == "ge"; 
+    bool can_fast_execute() const override {
+        return function->get_name() == "eq" || function->get_name() == "ne" ||
+               function->get_name() == "lt" || function->get_name() == "gt" ||
+               function->get_name() == "le" || function->get_name() == "ge";
     }
 
     bool is_deterministic_in_scope_of_query() const override {

--- a/be/src/vec/functions/function.h
+++ b/be/src/vec/functions/function.h
@@ -144,6 +144,8 @@ public:
 
     virtual bool is_stateful() const { return false; }
 
+    virtual bool can_fast_execute() const { return false; }
+
     /** Should we evaluate this function while constant folding, if arguments are constants?
       * Usually this is true. Notable counterexample is function 'sleep'.
       * If we will call it during query analysis, we will sleep extra amount of time.
@@ -526,6 +528,12 @@ public:
     }
 
     bool is_deterministic() const override { return function->is_deterministic(); }
+
+    bool can_fast_execute() const override { 
+        return function->get_name() == "eq" || function->get_name() == "ne"
+                || function->get_name() == "lt" || function->get_name() == "gt"
+                || function->get_name() == "le" || function->get_name() == "ge"; 
+    }
 
     bool is_deterministic_in_scope_of_query() const override {
         return function->is_deterministic_in_scope_of_query();

--- a/gensrc/thrift/PaloInternalService.thrift
+++ b/gensrc/thrift/PaloInternalService.thrift
@@ -521,6 +521,13 @@ struct TFetchDataResult {
     4: optional Status.TStatus status
 }
 
+enum TCompoundType {
+    UNKNOWN = 0,
+    AND = 1,
+    OR = 2,
+    NOT = 3,
+}
+
 struct TCondition {
     1:  required string column_name
     2:  required string condition_op
@@ -528,6 +535,7 @@ struct TCondition {
     // In delete condition, the different column may have same column name, need
     // using unique id to distinguish them
     4:  optional i32 column_unique_id
+    5:  optional TCompoundType compound_type = TCompoundType.UNKNOWN
 }
 
 struct TExportStatusResult {

--- a/gensrc/thrift/PaloInternalService.thrift
+++ b/gensrc/thrift/PaloInternalService.thrift
@@ -521,13 +521,6 @@ struct TFetchDataResult {
     4: optional Status.TStatus status
 }
 
-enum TCompoundType {
-    UNKNOWN = 0,
-    AND = 1,
-    OR = 2,
-    NOT = 3,
-}
-
 struct TCondition {
     1:  required string column_name
     2:  required string condition_op
@@ -535,7 +528,6 @@ struct TCondition {
     // In delete condition, the different column may have same column name, need
     // using unique id to distinguish them
     4:  optional i32 column_unique_id
-    5:  optional TCompoundType compound_type = TCompoundType.UNKNOWN
 }
 
 struct TExportStatusResult {


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary
Current bitmap index only can apply pushed down predicates which in AND conditions. When predicates in OR conditions and other complex compound conditions, it will not be pushed down to the storage layer, this leads to read more data.

Based on that situation, this pr will do:
1. this pr in order to support bitmap index apply compound predicates, query sql like:
```
select * from tb where a > 'hello' or b < 100;
select * from tb where a > 'hello' or b < 100 or c > 'ok';
select * from tb where (a > 'hello' or b <100) and (a < 'world' or b > 200);
select * from tb where (not a> 'hello') or b < 100;
...
```
above sql，column `a` and `b` and `c` has created bitmap_index.

2. this optimization can reduce reading data by index
3. set config `enable_index_apply_preds_except_leafnode_of_andnode` to use this optimization

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
4. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
5. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
6. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
7. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

