### PR TITLE
[fix](planner) Add default execution interval time for stats framework

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/Config.java
@@ -1785,4 +1785,10 @@ public class Config extends ConfigBase {
      */
     @ConfField(mutable = true, masterOnly = true)
     public static int be_exec_version = max_be_exec_version;
+
+    @ConfField(mutable = false)
+    public static int statistic_job_scheduler_execution_interval_ms = 60 * 60 * 1000;
+
+    @ConfField(mutable = false)
+    public static int statistic_task_scheduler_execution_interval_ms = 60 * 60 * 1000;
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticsJobScheduler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticsJobScheduler.java
@@ -78,7 +78,8 @@ public class StatisticsJobScheduler extends MasterDaemon {
             = Queues.newLinkedBlockingQueue(Config.cbo_max_statistics_job_num);
 
     public StatisticsJobScheduler() {
-        super("Statistics job scheduler", 0);
+        super("Statistics job scheduler",
+                Config.statistic_job_scheduler_execution_interval_ms);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticsTaskScheduler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticsTaskScheduler.java
@@ -52,7 +52,8 @@ public class StatisticsTaskScheduler extends MasterDaemon {
     private final Queue<StatisticsTask> queue = Queues.newLinkedBlockingQueue();
 
     public StatisticsTaskScheduler() {
-        super("Statistics task scheduler", 0);
+        super("Statistics task scheduler",
+                Config.statistic_task_scheduler_execution_interval_ms);
     }
 
     @Override


### PR DESCRIPTION
# Proposed changes

Issue Number: noissue

## Problem summary

Set a default execution interval for stats collection related threads.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

