### PR TITLE
[Fix](Nereids) Fix exception message when can't bind slot.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/BindSlotReference.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/BindSlotReference.java
@@ -237,21 +237,21 @@ public class BindSlotReference implements AnalysisRuleFactory {
                         .get()
                         .getSlots()));
             }
-            if (!boundedOpt.isPresent()) {
-                throw new AnalysisException("Cannot resolve " + unboundSlot.toString());
-            }
             List<Slot> bounded = boundedOpt.get();
             switch (bounded.size()) {
+                case 0:
+                    throw new AnalysisException(String.format("Cannot find column %s.", unboundSlot.toSql()));
                 case 1:
                     if (!foundInThisScope) {
                         getScope().getOuterScope().get().getCorrelatedSlots().add(bounded.get(0));
                     }
                     return bounded.get(0);
                 default:
-                    throw new AnalysisException(unboundSlot + " is ambiguous： "
-                            + bounded.stream()
-                            .map(Slot::toString)
-                            .collect(Collectors.joining(", ")));
+                    throw new AnalysisException(String.format("%s is ambiguous: %s.",
+                            unboundSlot.toSql(),
+                            bounded.stream()
+                                    .map(Slot::toString)
+                                    .collect(Collectors.joining(", "))));
             }
         }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/analysis/BindSlotReferenceTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/analysis/BindSlotReferenceTest.java
@@ -1,0 +1,66 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.rules.analysis;
+
+import org.apache.doris.nereids.analyzer.UnboundSlot;
+import org.apache.doris.nereids.exceptions.AnalysisException;
+import org.apache.doris.nereids.trees.expressions.NamedExpressionUtil;
+import org.apache.doris.nereids.trees.plans.JoinType;
+import org.apache.doris.nereids.trees.plans.RelationId;
+import org.apache.doris.nereids.trees.plans.logical.LogicalJoin;
+import org.apache.doris.nereids.trees.plans.logical.LogicalOlapScan;
+import org.apache.doris.nereids.trees.plans.logical.LogicalProject;
+import org.apache.doris.nereids.util.MemoTestUtils;
+import org.apache.doris.nereids.util.PlanChecker;
+import org.apache.doris.nereids.util.PlanConstructor;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class BindSlotReferenceTest {
+
+    @BeforeEach
+    public void beforeEach() throws Exception {
+        NamedExpressionUtil.clear();
+    }
+
+    @Test
+    public void testCannotFindSlot() {
+        LogicalProject project = new LogicalProject<>(ImmutableList.of(new UnboundSlot("foo")),
+                new LogicalOlapScan(new RelationId(0), PlanConstructor.student));
+        AnalysisException exception = Assertions.assertThrows(AnalysisException.class,
+                () -> PlanChecker.from(MemoTestUtils.createConnectContext()).analyze(project));
+        Assertions.assertEquals("Cannot find column foo.", exception.getMessage());
+    }
+
+    @Test
+    public void testAmbiguousSlot() {
+        LogicalOlapScan scan1 = new LogicalOlapScan(RelationId.createGenerator().getNextId(), PlanConstructor.student);
+        LogicalOlapScan scan2 = new LogicalOlapScan(RelationId.createGenerator().getNextId(), PlanConstructor.student);
+        LogicalJoin<LogicalOlapScan, LogicalOlapScan> join = new LogicalJoin<>(
+                JoinType.CROSS_JOIN, scan1, scan2);
+        LogicalProject<LogicalJoin<LogicalOlapScan, LogicalOlapScan>> project = new LogicalProject<>(
+                ImmutableList.of(new UnboundSlot("id")), join);
+
+        AnalysisException exception = Assertions.assertThrows(AnalysisException.class,
+                () -> PlanChecker.from(MemoTestUtils.createConnectContext()).analyze(project));
+        Assertions.assertEquals("id is ambiguous: id#8, id#12.", exception.getMessage());
+    }
+}


### PR DESCRIPTION
# Proposed changes
This PR proposes to fix the exception message when failed to bind slot by query refers to the column does not exist in underlying tables. 
For example: `select col from t` and table `t` don't have a column named `col`.
Without this PR, the error message is `col is ambiguous:`
With this PR, the error message is `Cannot find column col.`

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

