### PR TITLE
[Enhancement](optimize) optimize for function multiply on decimalv2

### DIFF
--- a/be/src/vec/functions/function_binary_arithmetic.h
+++ b/be/src/vec/functions/function_binary_arithmetic.h
@@ -244,15 +244,12 @@ struct DecimalBinaryOperation {
             }
         }
 
-        /// default: use it if no return before
-        for (size_t i = 0; i < size; i++) {
-            c[i] = apply(a[i], b[i]);
-        }
-        if constexpr (std::is_same_v<NativeResultType, DecimalV2Value>) {
+        if constexpr (OpTraits::is_multiply && std::is_same_v<A, Decimal128> &&
+                      std::is_same_v<B, Decimal128>) {
+            Op::vector_vector(a, b, c);
+        } else {
             for (size_t i = 0; i < size; i++) {
-                if (c[i].value() > DecimalV2Value::MAX_DECIMAL_VALUE) {
-                    c[i].value() = DecimalV2Value::MAX_DECIMAL_VALUE;
-                }
+                c[i] = apply(a[i], b[i]);
             }
         }
     }

--- a/be/src/vec/functions/function_binary_arithmetic.h
+++ b/be/src/vec/functions/function_binary_arithmetic.h
@@ -20,6 +20,9 @@
 
 #pragma once
 
+#include <type_traits>
+
+#include "runtime/decimalv2_value.h"
 #include "vec/columns/column_const.h"
 #include "vec/columns/column_decimal.h"
 #include "vec/columns/column_nullable.h"
@@ -242,8 +245,15 @@ struct DecimalBinaryOperation {
         }
 
         /// default: use it if no return before
-        for (size_t i = 0; i < size; ++i) {
+        for (size_t i = 0; i < size; i++) {
             c[i] = apply(a[i], b[i]);
+        }
+        if constexpr (std::is_same_v<NativeResultType, DecimalV2Value>) {
+            for (size_t i = 0; i < size; i++) {
+                if (c[i].value() > DecimalV2Value::MAX_DECIMAL_VALUE) {
+                    c[i].value() = DecimalV2Value::MAX_DECIMAL_VALUE;
+                }
+            }
         }
     }
 

--- a/be/src/vec/functions/multiply.cpp
+++ b/be/src/vec/functions/multiply.cpp
@@ -36,7 +36,7 @@ struct MultiplyImpl {
 
     template <typename Result = DecimalV2Value>
     static inline DecimalV2Value apply(const DecimalV2Value& a, const DecimalV2Value& b) {
-        return DecimalV2Value(a.value() * b.value() / DecimalV2Value::ONE_BILLION);
+        return DecimalV2Value((a.value() * b.value() - 1) / DecimalV2Value::ONE_BILLION + 1);
     }
     /// Apply operation and check overflow. It's used for Deciamal operations. @returns true if overflowed, false otherwise.
     template <typename Result = ResultType>

--- a/be/src/vec/functions/multiply.cpp
+++ b/be/src/vec/functions/multiply.cpp
@@ -35,8 +35,8 @@ struct MultiplyImpl {
     }
 
     template <typename Result = DecimalV2Value>
-    static inline DecimalV2Value apply(DecimalV2Value a, DecimalV2Value b) {
-        return a * b;
+    static inline DecimalV2Value apply(const DecimalV2Value& a, const DecimalV2Value& b) {
+        return DecimalV2Value(a.value() * b.value() / DecimalV2Value::ONE_BILLION);
     }
     /// Apply operation and check overflow. It's used for Deciamal operations. @returns true if overflowed, false otherwise.
     template <typename Result = ResultType>

--- a/be/src/vec/functions/multiply.cpp
+++ b/be/src/vec/functions/multiply.cpp
@@ -48,8 +48,9 @@ struct MultiplyImpl {
         int8 sgn[size];
 
         for (int i = 0; i < size; i++) {
-            sgn[i] = (DecimalV2Value(a[i]).value() >= 0 == DecimalV2Value(b[i]).value() > 0) ? 1
-                                                                                             : -1;
+            sgn[i] = ((DecimalV2Value(a[i]).value() >= 0) == (DecimalV2Value(b[i]).value() >= 0))
+                             ? 1
+                             : -1;
         }
 
         for (int i = 0; i < size; i++) {


### PR DESCRIPTION
# Proposed changes
TPCH Q6 0.8s->0.4s
```sql
select /*+SET_VAR(exec_mem_limit=8589934592, parallel_fragment_exec_instance_num=1, enable_vectorized_engine=true, batch_size=4096, disable_join_reorder=false, enable_cost_based_join_reorder=false, enable_projection=true) */
    sum(l_extendedprice * l_discount) as revenue
from
    lineitem
where
    l_shipdate >= date '1994-01-01'
    and l_shipdate < date '1994-01-01' + interval '1' year
    and l_discount between .06 - 0.01 and .06 + 0.01
    and l_quantity < 24;
```
before: 
<img width="557" alt="图片" src="https://user-images.githubusercontent.com/7939630/192945331-acf4b30a-8495-43ea-bf3d-8bdb7f76991f.png">
after:
<img width="593" alt="图片" src="https://user-images.githubusercontent.com/7939630/192945516-9b2b0674-84ba-4d31-8d3c-3277e59d38f2.png">


## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

