### PR TITLE
[fix](BE) fix the stream load error when upgrade BE from 1.1.2 to master

### DIFF
--- a/be/src/exec/olap_scanner.cpp
+++ b/be/src/exec/olap_scanner.cpp
@@ -81,7 +81,8 @@ Status OlapScanner::prepare(
             return Status::InternalError(ss.str());
         }
         _tablet_schema->copy_from(*_tablet->tablet_schema());
-        if (!_parent->_olap_scan_node.columns_desc.empty() &&
+        if (_parent->_olap_scan_node.__isset.columns_desc &&
+            !_parent->_olap_scan_node.columns_desc.empty() &&
             _parent->_olap_scan_node.columns_desc[0].col_unique_id >= 0) {
             _tablet_schema->clear_columns();
             for (const auto& column_desc : _parent->_olap_scan_node.columns_desc) {

--- a/be/src/exec/tablet_info.cpp
+++ b/be/src/exec/tablet_info.cpp
@@ -98,10 +98,12 @@ Status OlapTableSchemaParam::init(const TOlapTableSchemaParam& tschema) {
             }
             index->slots.emplace_back(it->second);
         }
-        for (auto& tcolumn_desc : t_index.columns_desc) {
-            TabletColumn* tc = _obj_pool.add(new TabletColumn());
-            tc->init_from_thrift(tcolumn_desc);
-            index->columns.emplace_back(tc);
+        if (t_index.__isset.columns_desc) {
+            for (auto& tcolumn_desc : t_index.columns_desc) {
+                TabletColumn* tc = _obj_pool.add(new TabletColumn());
+                tc->init_from_thrift(tcolumn_desc);
+                index->columns.emplace_back(tc);
+            }
         }
         _indexes.emplace_back(index);
     }

--- a/be/src/vec/exec/scan/new_olap_scanner.cpp
+++ b/be/src/vec/exec/scan/new_olap_scanner.cpp
@@ -67,7 +67,7 @@ Status NewOlapScanner::prepare(
         _tablet_schema->copy_from(*_tablet->tablet_schema());
 
         TOlapScanNode& olap_scan_node = ((NewOlapScanNode*)_parent)->_olap_scan_node;
-        if (!olap_scan_node.columns_desc.empty() &&
+        if (olap_scan_node.__isset.columns_desc && !olap_scan_node.columns_desc.empty() &&
             olap_scan_node.columns_desc[0].col_unique_id >= 0) {
             // Originally scanner get TabletSchema from tablet object in BE.
             // To support lightweight schema change for adding / dropping columns,

--- a/be/src/vec/exec/volap_scanner.cpp
+++ b/be/src/vec/exec/volap_scanner.cpp
@@ -71,7 +71,8 @@ Status VOlapScanner::prepare(
             return Status::InternalError(ss.str());
         }
         _tablet_schema->copy_from(*_tablet->tablet_schema());
-        if (!_parent->_olap_scan_node.columns_desc.empty() &&
+        if (_parent->_olap_scan_node.__isset.columns_desc &&
+            !_parent->_olap_scan_node.columns_desc.empty() &&
             _parent->_olap_scan_node.columns_desc[0].col_unique_id >= 0) {
             // Originally scanner get TabletSchema from tablet object in BE.
             // To support lightweight schema change for adding / dropping columns,

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/OlapScanNode.java
@@ -913,8 +913,8 @@ public class OlapScanNode extends ScanNode {
         }
 
         msg.node_type = TPlanNodeType.OLAP_SCAN_NODE;
-        msg.olap_scan_node = new TOlapScanNode(desc.getId().asInt(), keyColumnNames, keyColumnTypes, isPreAggregation,
-                columnsDesc);
+        msg.olap_scan_node = new TOlapScanNode(desc.getId().asInt(), keyColumnNames, keyColumnTypes, isPreAggregation);
+        msg.olap_scan_node.setColumnsDesc(columnsDesc);
         if (null != sortColumn) {
             msg.olap_scan_node.setSortColumn(sortColumn);
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/OlapTableSink.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/OlapTableSink.java
@@ -215,7 +215,8 @@ public class OlapTableSink extends DataSink {
                 columnsDesc.add(tColumn);
             }
             TOlapTableIndexSchema indexSchema = new TOlapTableIndexSchema(pair.getKey(), columns,
-                    indexMeta.getSchemaHash(), columnsDesc);
+                    indexMeta.getSchemaHash());
+            indexSchema.setColumnsDesc(columnsDesc);
             schemaParam.addToIndexes(indexSchema);
         }
         return schemaParam;

--- a/gensrc/thrift/Descriptors.thrift
+++ b/gensrc/thrift/Descriptors.thrift
@@ -175,7 +175,7 @@ struct TOlapTableIndexSchema {
     1: required i64 id
     2: required list<string> columns
     3: required i32 schema_hash
-    4: required list<TColumn> columns_desc
+    4: optional list<TColumn> columns_desc
 }
 
 struct TOlapTableSchemaParam {

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -479,7 +479,7 @@ struct TOlapScanNode {
   5: optional string sort_column
   6: optional Types.TKeysType keyType
   7: optional string table_name
-  8: required list<Descriptors.TColumn> columns_desc
+  8: optional list<Descriptors.TColumn> columns_desc
   9: optional TSortInfo sort_info
   // When scan match sort_info, we can push limit into OlapScanNode.
   // It's limit for scanner instead of scanNode so we add a new limit.


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

When upgrade from 1.1.2 to master, we will upgrade BE firstly, the load operator will fail because the field columns_desc is required but FE doesn't upgrade. So change it to be optional.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

