### PR TITLE
[ResourceTag](tagname) support upper case in tag name

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/resource/Tag.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/resource/Tag.java
@@ -71,7 +71,7 @@ public class Tag implements Writable {
     public static final ImmutableSet<String> RESERVED_TAG_VALUES = ImmutableSet.of(
             VALUE_FRONTEND, VALUE_BACKEND, VALUE_BROKER, VALUE_REMOTE_STORAGE, VALUE_STORE, VALUE_COMPUTATION,
             VALUE_DEFAULT_CLUSTER);
-    private static final String TAG_REGEX = "^[a-z][a-z0-9_]{0,32}$";
+    private static final String TAG_REGEX = "^[a-zA-Z][a-zA-Z0-9_]{0,32}$";
 
     public static final Tag DEFAULT_BACKEND_TAG;
     public static final Tag INVALID_TAG;

--- a/fe/fe-core/src/test/java/org/apache/doris/resource/TagTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/resource/TagTest.java
@@ -40,6 +40,8 @@ public class TagTest {
     @Test
     public void testTagName3() throws AnalysisException {
         Tag.create("unknown", "test1");
+        Tag.create("unknown", "Test1");
+        Tag.create("unknown", "tTest1");
     }
 
     @Test


### PR DESCRIPTION
## Problem summary

support upper case in tag name

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

