### PR TITLE
[Fix](Load) fix bug that last line of data lost for stream load

### DIFF
--- a/be/src/exec/plain_text_line_reader.cpp
+++ b/be/src/exec/plain_text_line_reader.cpp
@@ -200,9 +200,7 @@ Status PlainTextLineReader::read_line(const uint8_t** ptr, size_t* size, bool* e
             // for multi bytes delimiter we cannot set offset to avoid incomplete
             // delimiter
             // read from file reader
-            if (_line_delimiter_length == 1) {
-                offset = output_buf_read_remaining();
-            }
+            offset = output_buf_read_remaining();
             extend_output_buf();
             if ((_input_buf_limit > _input_buf_pos) && _more_input_bytes == 0) {
                 // we still have data in input which is not decompressed.

--- a/regression-test/data/load_p0/stream_load/test_line_delimiter.csv
+++ b/regression-test/data/load_p0/stream_load/test_line_delimiter.csv
@@ -1,0 +1,1 @@
+1|aaweizuo2|bbweizuo3|cc


### PR DESCRIPTION

# Proposed changes

Issue Number: close #13064 

## Problem summary

Last line of data lost for stream load when line delimiter is more than one character.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No
