### PR TITLE
[fix](alter-load) fix bug that tablet version may be wrong when doing alter and load

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeJobV2.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeJobV2.java
@@ -426,7 +426,7 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
 
                         if (indexColumnMap.containsKey(SchemaChangeHandler.SHADOW_NAME_PRFIX + column.getName())) {
                             Column newColumn = indexColumnMap
-                                    .get(SchemaChangeHandler.SHADOW_NAME_PRFIX + column.getName());
+   r                                 .get(SchemaChangeHandler.SHADOW_NAME_PRFIX + column.getName());
                             if (newColumn.getType() != column.getType()) {
                                 try {
                                     SlotRef slot = new SlotRef(destSlotDesc);

--- a/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeJobV2.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeJobV2.java
@@ -426,7 +426,7 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
 
                         if (indexColumnMap.containsKey(SchemaChangeHandler.SHADOW_NAME_PRFIX + column.getName())) {
                             Column newColumn = indexColumnMap
-   r                                 .get(SchemaChangeHandler.SHADOW_NAME_PRFIX + column.getName());
+                                    .get(SchemaChangeHandler.SHADOW_NAME_PRFIX + column.getName());
                             if (newColumn.getType() != column.getType()) {
                                 try {
                                     SlotRef slot = new SlotRef(destSlotDesc);

--- a/fe/fe-core/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/Config.java
@@ -753,6 +753,7 @@ public class Config extends ConfigBase {
      * this config has been replaced by async_loading_load_task_pool_size,
      * it will be removed in the future.
      */
+    @Deprecated
     @ConfField(mutable = false, masterOnly = true)
     public static int async_load_task_pool_size = 10;
 

--- a/fe/fe-core/src/main/java/org/apache/doris/load/LoadChecker.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/LoadChecker.java
@@ -300,7 +300,7 @@ public class LoadChecker extends MasterDaemon {
 
         // yiguolei: for real time load we use full finished replicas
         Set<Long> fullTablets = job.getFullTablets();
-        if (state.isRunning()) {
+        if (!state.getTransactionStatus().isFinalStatus()) {
             job.setProgress(fullTablets.size() * 100 / jobTotalTablets.size());
         } else {
             job.setProgress(100);

--- a/fe/fe-core/src/main/java/org/apache/doris/system/Diagnoser.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/system/Diagnoser.java
@@ -144,6 +144,9 @@ public class Diagnoser {
                 versionErr.append("Replica on backend " + replica.getBackendId() + "'s version ("
                         + replica.getVersion() + ") does not equal"
                         + " to partition visible version (" + partition.getVisibleVersion() + ")");
+            } else if (replica.getLastFailedVersion() != -1) {
+                versionErr.append("Replica on backend " + replica.getBackendId() + "'s last failed version is "
+                        + replica.getLastFailedVersion());
             }
             // status
             if (!replica.isAlive()) {

--- a/fe/fe-core/src/main/java/org/apache/doris/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/transaction/DatabaseTransactionMgr.java
@@ -1600,7 +1600,7 @@ public class DatabaseTransactionMgr {
         try {
             for (Map.Entry<Long, TransactionState> entry : idToRunningTransactionState.entrySet()) {
                 if (entry.getValue().getDbId() != dbId || !isIntersectionNotEmpty(entry.getValue().getTableIdList(),
-                        tableIdList) || !entry.getValue().isRunning()) {
+                        tableIdList) || entry.getValue().getTransactionStatus().isFinalStatus()) {
                     continue;
                 }
                 if (entry.getKey() <= endTransactionId) {

--- a/fe/fe-core/src/main/java/org/apache/doris/transaction/TransactionState.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/transaction/TransactionState.java
@@ -287,11 +287,6 @@ public class TransactionState implements Writable {
         this.errorReplicas = newErrorReplicas;
     }
 
-    public boolean isRunning() {
-        return transactionStatus == TransactionStatus.PREPARE
-                || transactionStatus == TransactionStatus.COMMITTED;
-    }
-
     public void addPublishVersionTask(Long backendId, PublishVersionTask task) {
         this.publishVersionTasks.put(backendId, task);
     }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #13071

## Problem summary

the `isRunning()` method of `TransactionState` is missing `PRE_COMMITTED` status.
Which cause wrong judgment of `isPreviousTransactionsFinished`

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

