### PR TITLE
[refractor](vectorized) refractor some insert_xxx functions

### DIFF
--- a/be/src/vec/columns/column_vector.h
+++ b/be/src/vec/columns/column_vector.h
@@ -126,22 +126,19 @@ private:
                            vectorized::ColumnVector<T>* res_ptr) {
         auto& res_data = res_ptr->data;
         DCHECK(res_data.empty());
-        res_data.reserve(sel_size);
-        T* t = (T*)res_data.get_end_ptr();
+        res_data.resize(sel_size);
         for (size_t i = 0; i < sel_size; i++) {
-            t[i] = T(data[sel[i]]);
+            res_data[i] = T(data[sel[i]]);
         }
-        res_data.set_end_ptr(t + sel_size);
     }
 
     void insert_many_default_type(const char* data_ptr, size_t num) {
+        auto old_size = data.size();
+        data.resize(old_size + num);
         T* input_val_ptr = (T*)data_ptr;
-        T* res_val_ptr = (T*)data.get_end_ptr();
         for (int i = 0; i < num; i++) {
-            res_val_ptr[i] = input_val_ptr[i];
+            data[old_size + i] = input_val_ptr[i];
         }
-        res_val_ptr += num;
-        data.set_end_ptr(res_val_ptr);
     }
 
 public:
@@ -163,10 +160,9 @@ public:
 
     // note(wb) type of data_ptr element should be same with current column_vector's T
     void insert_many_in_copy_way(const char* data_ptr, size_t num) {
-        char* res_ptr = (char*)data.get_end_ptr();
-        memcpy(res_ptr, data_ptr, num * sizeof(T));
-        res_ptr += num * sizeof(T);
-        data.set_end_ptr(res_ptr);
+        auto old_size = data.size();
+        data.resize(old_size + num);
+        memcpy(data.data() + old_size, data_ptr, num * sizeof(T));
     }
 
     void insert_date_column(const char* data_ptr, size_t num) {

--- a/be/src/vec/columns/predicate_column.h
+++ b/be/src/vec/columns/predicate_column.h
@@ -134,17 +134,15 @@ private:
     }
 
     void insert_many_default_type(const char* data_ptr, size_t num) {
-        T* res_val_ptr = (T*)data.get_end_ptr();
-        memcpy(res_val_ptr, data_ptr, num * sizeof(T));
-        res_val_ptr += num;
-        data.set_end_ptr(res_val_ptr);
+        auto old_size = data.size();
+        data.resize(old_size + num);
+        memcpy(data.data() + old_size, data_ptr, num * sizeof(T));
     }
 
     void insert_many_in_copy_way(const char* data_ptr, size_t num) {
-        char* res_ptr = (char*)data.get_end_ptr();
-        memcpy(res_ptr, data_ptr, num * sizeof(T));
-        res_ptr += num * sizeof(T);
-        data.set_end_ptr(res_ptr);
+        auto old_size = data.size();
+        data.resize(old_size + num);
+        memcpy(data.data() + old_size, data_ptr, num * sizeof(T));
     }
 
 public:


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary
As mentioned in https://github.com/apache/doris/pull/13074, there will be some problem in `ColumnVector<int>::insert_many_in_copy_way`.

Column::insert_xxx functions will append some data, they should `reserve` or `resize` before append data.


## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

