### PR TITLE
[feature](nereids) dump physical tree and memo 

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/NereidsPlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/NereidsPlanner.java
@@ -40,9 +40,13 @@ import org.apache.doris.planner.PlanFragment;
 import org.apache.doris.planner.Planner;
 import org.apache.doris.planner.RuntimeFilter;
 import org.apache.doris.planner.ScanNode;
+import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.qe.SessionVariable;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -52,6 +56,7 @@ import java.util.stream.Collectors;
  * Planner to do query plan in Nereids.
  */
 public class NereidsPlanner extends Planner {
+    public static final Logger LOG = LogManager.getLogger(NereidsPlanner.class);
 
     private CascadesContext cascadesContext;
     private final StatementContext statementContext;
@@ -72,6 +77,14 @@ public class NereidsPlanner extends Planner {
         PhysicalPlan physicalPlan = plan(logicalPlanAdapter.getLogicalPlan(), PhysicalProperties.ANY);
         PhysicalPlanTranslator physicalPlanTranslator = new PhysicalPlanTranslator();
         PlanTranslatorContext planTranslatorContext = new PlanTranslatorContext(cascadesContext);
+        if (ConnectContext.get().getSessionVariable().isEnableNereidsDebug()) {
+            String tree = physicalPlan.treeString();
+            System.out.println(tree);
+            LOG.info(tree);
+            String memo = cascadesContext.getMemo().toString();
+            System.out.println(memo);
+            LOG.info(memo);
+        }
         PlanFragment root = physicalPlanTranslator.translatePlan(physicalPlan, planTranslatorContext);
 
         scanNodeList = planTranslatorContext.getScanNodes();

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/NereidsPlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/NereidsPlanner.java
@@ -76,7 +76,7 @@ public class NereidsPlanner extends Planner {
         PhysicalPlan physicalPlan = plan(logicalPlanAdapter.getLogicalPlan(), PhysicalProperties.ANY);
         PhysicalPlanTranslator physicalPlanTranslator = new PhysicalPlanTranslator();
         PlanTranslatorContext planTranslatorContext = new PlanTranslatorContext(cascadesContext);
-        if (ConnectContext.get().getSessionVariable().isEnableNereidsDebug()) {
+        if (ConnectContext.get().getSessionVariable().isEnableNereidsTrace()) {
             String tree = physicalPlan.treeString();
             System.out.println(tree);
             LOG.info(tree);

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/NereidsPlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/NereidsPlanner.java
@@ -76,8 +76,7 @@ public class NereidsPlanner extends Planner {
         PhysicalPlan physicalPlan = plan(logicalPlanAdapter.getLogicalPlan(), PhysicalProperties.ANY);
         PhysicalPlanTranslator physicalPlanTranslator = new PhysicalPlanTranslator();
         PlanTranslatorContext planTranslatorContext = new PlanTranslatorContext(cascadesContext);
-        if (ConnectContext.get().get
-        ().isEnableNereidsDebug()) {
+        if (ConnectContext.get().getSessionVariable().isEnableNereidsDebug()) {
             String tree = physicalPlan.treeString();
             System.out.println(tree);
             LOG.info(tree);

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/NereidsPlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/NereidsPlanner.java
@@ -41,7 +41,6 @@ import org.apache.doris.planner.Planner;
 import org.apache.doris.planner.RuntimeFilter;
 import org.apache.doris.planner.ScanNode;
 import org.apache.doris.qe.ConnectContext;
-import org.apache.doris.qe.SessionVariable;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
@@ -77,7 +76,8 @@ public class NereidsPlanner extends Planner {
         PhysicalPlan physicalPlan = plan(logicalPlanAdapter.getLogicalPlan(), PhysicalProperties.ANY);
         PhysicalPlanTranslator physicalPlanTranslator = new PhysicalPlanTranslator();
         PlanTranslatorContext planTranslatorContext = new PlanTranslatorContext(cascadesContext);
-        if (ConnectContext.get().getSessionVariable().isEnableNereidsDebug()) {
+        if (ConnectContext.get().get
+        ().isEnableNereidsDebug()) {
             String tree = physicalPlan.treeString();
             System.out.println(tree);
             LOG.info(tree);

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/GroupExpression.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/GroupExpression.java
@@ -229,11 +229,11 @@ public class GroupExpression {
     public String toString() {
         StringBuilder builder = new StringBuilder();
         builder.append(ownerGroup.getGroupId())
-                .append("(plan=" + plan.toString() + ") children:[");
+                .append("(plan=" + plan.toString() + ") children=[");
         for (Group group : children) {
             builder.append(group.getGroupId()).append(" ");
         }
-        builder.append("]");
+        builder.append("] stats=");
         builder.append(ownerGroup.getStatistics());
         return builder.toString();
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/GroupExpression.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/GroupExpression.java
@@ -227,6 +227,14 @@ public class GroupExpression {
 
     @Override
     public String toString() {
-        return "GroupExpression(plan=" + plan.toString() + ")";
+        StringBuilder builder = new StringBuilder();
+        builder.append(ownerGroup.getGroupId())
+                .append("(plan=" + plan.toString() + ") children:[");
+        for (Group group : children) {
+            builder.append(group.getGroupId()).append(" ");
+        }
+        builder.append("]");
+        builder.append(ownerGroup.getStatistics());
+        return builder.toString();
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Memo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Memo.java
@@ -560,7 +560,7 @@ public class Memo {
         for (Group group : groups.values()) {
             builder.append(group.toString()).append("\n");
             for (GroupExpression groupExpression : group.getPhysicalExpressions()) {
-                builder.append(groupExpression.toString()).append("\n");
+                builder.append("  ").append(groupExpression.toString()).append("\n");
             }
         }
         return builder.toString();

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Memo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Memo.java
@@ -552,4 +552,17 @@ public class Memo {
             }
         }
     }
+
+    @Override
+    public String toString() {
+        StringBuilder builder = new StringBuilder();
+        builder.append("root:").append(getRoot()).append("\n");
+        for (Group group : groups.values()) {
+            builder.append(group.toString()).append("\n");
+            for (GroupExpression groupExpression : group.getPhysicalExpressions()) {
+                builder.append(groupExpression.toString()).append("\n");
+            }
+        }
+        return builder.toString();
+    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/DistributionSpec.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/DistributionSpec.java
@@ -51,7 +51,7 @@ public abstract class DistributionSpec {
 
     @Override
     public String toString() {
-        return this.getClass().toString();
+        return this.getClass().getSimpleName();
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalDistribute.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalDistribute.java
@@ -64,9 +64,7 @@ public class PhysicalDistribute<CHILD_TYPE extends Plan> extends PhysicalUnary<C
         if (statsDeriveResult != null) {
             return Utils.toSqlString("PhysicalDistribute",
                     "distributionSpec", distributionSpec,
-                    "estimateRows", statsDeriveResult.getRowCount(),
-                    "isReduced", statsDeriveResult.isReduced,
-                    "width", statsDeriveResult.width
+                    "stats", statsDeriveResult.toString()
             );
         }
         return Utils.toSqlString("PhysicalDistribute",

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalDistribute.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalDistribute.java
@@ -61,14 +61,9 @@ public class PhysicalDistribute<CHILD_TYPE extends Plan> extends PhysicalUnary<C
 
     @Override
     public String toString() {
-        if (statsDeriveResult != null) {
-            return Utils.toSqlString("PhysicalDistribute",
-                    "distributionSpec", distributionSpec,
-                    "stats", statsDeriveResult.toString()
-            );
-        }
         return Utils.toSqlString("PhysicalDistribute",
-                "distributionSpec", distributionSpec
+                "distributionSpec", distributionSpec,
+                "stats", statsDeriveResult
         );
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalDistribute.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalDistribute.java
@@ -61,9 +61,16 @@ public class PhysicalDistribute<CHILD_TYPE extends Plan> extends PhysicalUnary<C
 
     @Override
     public String toString() {
+        if (statsDeriveResult != null) {
+            return Utils.toSqlString("PhysicalDistribute",
+                    "distributionSpec", distributionSpec,
+                    "estimateRows", statsDeriveResult.getRowCount(),
+                    "isReduced", statsDeriveResult.isReduced,
+                    "width", statsDeriveResult.width
+            );
+        }
         return Utils.toSqlString("PhysicalDistribute",
-                "distributionSpec", distributionSpec,
-                "level", statsDeriveResult.width
+                "distributionSpec", distributionSpec
         );
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalFilter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalFilter.java
@@ -66,14 +66,9 @@ public class PhysicalFilter<CHILD_TYPE extends Plan> extends PhysicalUnary<CHILD
 
     @Override
     public String toString() {
-        if (statsDeriveResult != null) {
-            return Utils.toSqlString("PhysicalFilter",
-                    "predicates", predicates,
-                    "stats", statsDeriveResult.toString()
-            );
-        }
         return Utils.toSqlString("PhysicalFilter",
-                "predicates", predicates
+                "predicates", predicates,
+                "stats", statsDeriveResult
         );
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalFilter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalFilter.java
@@ -69,9 +69,7 @@ public class PhysicalFilter<CHILD_TYPE extends Plan> extends PhysicalUnary<CHILD
         if (statsDeriveResult != null) {
             return Utils.toSqlString("PhysicalFilter",
                     "predicates", predicates,
-                    "estimateRows", statsDeriveResult.getRowCount(),
-                    "isReduced", statsDeriveResult.isReduced,
-                    "width", statsDeriveResult.width
+                    "stats", statsDeriveResult.toString()
             );
         }
         return Utils.toSqlString("PhysicalFilter",

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalFilter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalFilter.java
@@ -66,6 +66,14 @@ public class PhysicalFilter<CHILD_TYPE extends Plan> extends PhysicalUnary<CHILD
 
     @Override
     public String toString() {
+        if (statsDeriveResult != null) {
+            return Utils.toSqlString("PhysicalFilter",
+                    "predicates", predicates,
+                    "estimateRows", statsDeriveResult.getRowCount(),
+                    "isReduced", statsDeriveResult.isReduced,
+                    "width", statsDeriveResult.width
+            );
+        }
         return Utils.toSqlString("PhysicalFilter",
                 "predicates", predicates
         );

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalHashJoin.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalHashJoin.java
@@ -93,9 +93,7 @@ public class PhysicalHashJoin<
                     "type", joinType,
                     "hashJoinCondition", hashJoinConjuncts,
                     "otherJoinCondition", otherJoinCondition,
-                    "estimateRows", statsDeriveResult.getRowCount(),
-                    "isReduced", statsDeriveResult.isReduced,
-                    "width", statsDeriveResult.width
+                    "stats", statsDeriveResult.toString()
             );
         }
         return Utils.toSqlString("PhysicalHashJoin",

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalHashJoin.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalHashJoin.java
@@ -88,18 +88,11 @@ public class PhysicalHashJoin<
 
     @Override
     public String toString() {
-        if (statsDeriveResult != null) {
-            return Utils.toSqlString("PhysicalHashJoin",
-                    "type", joinType,
-                    "hashJoinCondition", hashJoinConjuncts,
-                    "otherJoinCondition", otherJoinCondition,
-                    "stats", statsDeriveResult.toString()
-            );
-        }
         return Utils.toSqlString("PhysicalHashJoin",
                 "type", joinType,
                 "hashJoinCondition", hashJoinConjuncts,
-                "otherJoinCondition", otherJoinCondition);
+                "otherJoinCondition", otherJoinCondition,
+                "stats", statsDeriveResult);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalHashJoin.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalHashJoin.java
@@ -88,6 +88,16 @@ public class PhysicalHashJoin<
 
     @Override
     public String toString() {
+        if (statsDeriveResult != null) {
+            return Utils.toSqlString("PhysicalHashJoin",
+                    "type", joinType,
+                    "hashJoinCondition", hashJoinConjuncts,
+                    "otherJoinCondition", otherJoinCondition,
+                    "estimateRows", statsDeriveResult.getRowCount(),
+                    "isReduced", statsDeriveResult.isReduced,
+                    "width", statsDeriveResult.width
+            );
+        }
         return Utils.toSqlString("PhysicalHashJoin",
                 "type", joinType,
                 "hashJoinCondition", hashJoinConjuncts,

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -200,7 +200,7 @@ public class SessionVariable implements Serializable, Writable {
     public static final String ENABLE_NEREIDS_RUNTIME_FILTER = "enable_nereids_runtime_filter";
 
     public static final String NEREIDS_STAR_SCHEMA_SUPPORT = "nereids_star_schema_support";
-    public static final String ENABLE_NEREIDS_DEBUG = "enable_nereids_debug";
+    public static final String ENABLE_NEREIDS_TRACE = "enable_nereids_trace";
     public static final String ENABLE_NEREIDS_REORDER_TO_ELIMINATE_CROSS_JOIN =
             "enable_nereids_reorder_to_eliminate_cross_join";
 
@@ -526,8 +526,8 @@ public class SessionVariable implements Serializable, Writable {
     @VariableMgr.VarAttr(name = NEREIDS_STAR_SCHEMA_SUPPORT)
     private boolean nereidsStarSchemaSupport = true;
 
-    @VariableMgr.VarAttr(name = ENABLE_NEREIDS_DEBUG)
-    private boolean enableNereidsDebug = true;
+    @VariableMgr.VarAttr(name = ENABLE_NEREIDS_TRACE)
+    private boolean enableNereidsTrace = true;
 
     @VariableMgr.VarAttr(name = ENABLE_NEREIDS_RUNTIME_FILTER)
     private boolean enableNereidsRuntimeFilter = true;
@@ -1119,8 +1119,8 @@ public class SessionVariable implements Serializable, Writable {
         return isEnableNereidsPlanner() && nereidsStarSchemaSupport;
     }
 
-    public boolean isEnableNereidsDebug() {
-        return isEnableNereidsPlanner() && enableNereidsDebug;
+    public boolean isEnableNereidsTrace() {
+        return isEnableNereidsPlanner() && enableNereidsTrace;
     }
 
     public boolean isEnableNereidsRuntimeFilter() {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -200,6 +200,7 @@ public class SessionVariable implements Serializable, Writable {
     public static final String ENABLE_NEREIDS_RUNTIME_FILTER = "enable_nereids_runtime_filter";
 
     public static final String NEREIDS_STAR_SCHEMA_SUPPORT = "nereids_star_schema_support";
+    public static final String ENABLE_NEREIDS_DEBUG = "enable_nereids_debug";
     public static final String ENABLE_NEREIDS_REORDER_TO_ELIMINATE_CROSS_JOIN =
             "enable_nereids_reorder_to_eliminate_cross_join";
 
@@ -524,6 +525,10 @@ public class SessionVariable implements Serializable, Writable {
 
     @VariableMgr.VarAttr(name = NEREIDS_STAR_SCHEMA_SUPPORT)
     private boolean nereidsStarSchemaSupport = true;
+
+    @VariableMgr.VarAttr(name = ENABLE_NEREIDS_DEBUG)
+    private boolean enableNereidsDebug = true;
+
     @VariableMgr.VarAttr(name = ENABLE_NEREIDS_RUNTIME_FILTER)
     private boolean enableNereidsRuntimeFilter = true;
 
@@ -1112,6 +1117,10 @@ public class SessionVariable implements Serializable, Writable {
 
     public boolean isNereidsStarSchemaSupport() {
         return isEnableNereidsPlanner() && nereidsStarSchemaSupport;
+    }
+
+    public boolean isEnableNereidsDebug() {
+        return isEnableNereidsPlanner() && enableNereidsDebug;
     }
 
     public boolean isEnableNereidsRuntimeFilter() {

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/StatsDeriveResult.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/StatsDeriveResult.java
@@ -150,9 +150,9 @@ public class StatsDeriveResult {
     @Override
     public String toString() {
         StringBuilder builder = new StringBuilder();
-        builder.append(" stats=(rows:").append(rowCount)
-                .append(" isReduced:").append(isReduced)
-                .append(" width:").append(width).append(")");
+        builder.append("(rows=").append(rowCount)
+                .append(", isReduced=").append(isReduced)
+                .append(", width=").append(width).append(")");
         return builder.toString();
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/StatsDeriveResult.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/StatsDeriveResult.java
@@ -146,4 +146,13 @@ public class StatsDeriveResult {
     public StatsDeriveResult copy() {
         return new StatsDeriveResult(this);
     }
+
+    @Override
+    public String toString() {
+        StringBuilder builder = new StringBuilder();
+        builder.append(" stats=(rows:").append(rowCount)
+                .append(" isReduced:").append(isReduced)
+                .append(" width:").append(width).append(")");
+        return builder.toString();
+    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/StatsDeriveResult.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/StatsDeriveResult.java
@@ -155,4 +155,12 @@ public class StatsDeriveResult {
                 .append(", width=").append(width).append(")");
         return builder.toString();
     }
+
+    public static String toString(StatsDeriveResult stats) {
+        if (stats == null) {
+            return "null";
+        } else {
+            return stats.toString();
+        }
+    }
 }


### PR DESCRIPTION
# Proposed changes

dump memo info and physical plan in stdout and log
set `enable_nereids_trace` variable true/false to open/close this dump.

following is a fragment of memo:
```
Group[GroupId#8]
GroupId#8(plan=PhysicalHashJoin ( type=INNER_JOIN, hashJoinCondition=[(r_regionkey#250 = n_regionkey#255)], otherJoinCondition=Optional.empty, stats=null )) children=[GroupId#6 GroupId#7 ] stats=(rows=25, isReduced=false, width=2)
GroupId#8(plan=PhysicalHashJoin ( type=INNER_JOIN, hashJoinCondition=[(r_regionkey#250 = n_regionkey#255)], otherJoinCondition=Optional.empty, stats=null )) children=[GroupId#7 GroupId#6 ] stats=(rows=25, isReduced=false, width=2)
```

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

