### PR TITLE
[feature-wip](parquet-reader) add detail profile for parquet reader

### DIFF
--- a/be/src/io/buffered_reader.h
+++ b/be/src/io/buffered_reader.h
@@ -87,6 +87,12 @@ private:
  */
 class BufferedStreamReader {
 public:
+    struct Statistics {
+        int64_t read_time = 0;
+        int64_t read_calls = 0;
+        int64_t read_bytes = 0;
+    };
+
     /**
      * Return the address of underlying buffer that locates the start of data between [offset, offset + bytes_to_read)
      * @param buf the buffer address to save the start address of data
@@ -98,7 +104,11 @@ public:
      * Save the data address to slice.data, and the slice.size is the bytes to read.
      */
     virtual Status read_bytes(Slice& slice, uint64_t offset) = 0;
+    Statistics& statistics() { return _statistics; }
     virtual ~BufferedStreamReader() = default;
+
+protected:
+    Statistics _statistics;
 };
 
 class BufferedFileStreamReader : public BufferedStreamReader {

--- a/be/src/io/hdfs_file_reader.cpp
+++ b/be/src/io/hdfs_file_reader.cpp
@@ -145,9 +145,9 @@ Status HdfsFileReader::readat(int64_t position, int64_t nbytes, int64_t* bytes_r
     }
 
     int64_t has_read = 0;
+    char* cast_out = reinterpret_cast<char*>(out);
     while (has_read < nbytes) {
-        int64_t loop_read = hdfsRead(_hdfs_fs, _hdfs_file, reinterpret_cast<char*>(out) + has_read,
-                                     nbytes - has_read);
+        int64_t loop_read = hdfsRead(_hdfs_fs, _hdfs_file, cast_out + has_read, nbytes - has_read);
         if (loop_read < 0) {
             return Status::InternalError(
                     "Read hdfs file failed. (BE: {}) namenode:{}, path:{}, err: {}",

--- a/be/src/vec/exec/format/parquet/parquet_common.h
+++ b/be/src/vec/exec/format/parquet/parquet_common.h
@@ -38,6 +38,22 @@ namespace doris::vectorized {
 
 using level_t = int16_t;
 
+struct RowRange {
+    RowRange() {}
+    RowRange(int64_t first, int64_t last) : first_row(first), last_row(last) {}
+
+    int64_t first_row;
+    int64_t last_row;
+};
+
+struct ParquetReadColumn {
+    ParquetReadColumn(int parquet_col_id, const std::string& file_slot_name)
+            : _parquet_col_id(parquet_col_id), _file_slot_name(file_slot_name) {};
+
+    int _parquet_col_id;
+    const std::string& _file_slot_name;
+};
+
 struct ParquetInt96 {
     uint64_t lo; // time of nanoseconds in a day
     uint32_t hi; // days from julian epoch

--- a/be/src/vec/exec/format/parquet/vparquet_column_chunk_reader.cpp
+++ b/be/src/vec/exec/format/parquet/vparquet_column_chunk_reader.cpp
@@ -58,10 +58,7 @@ Status ColumnChunkReader::next_page() {
     if (UNLIKELY(_remaining_num_values != 0)) {
         return Status::Corruption("Should skip current page");
     }
-    {
-        SCOPED_RAW_TIMER(&_statistics.decode_header_time);
-        RETURN_IF_ERROR(_page_reader->next_page_header());
-    }
+    RETURN_IF_ERROR(_page_reader->next_page_header());
     if (_page_reader->get_page_header()->type == tparquet::PageType::DICTIONARY_PAGE) {
         // the first page maybe directory page even if _metadata.__isset.dictionary_page_offset == false,
         // so we should parse the directory page in next_page()

--- a/be/src/vec/exec/format/parquet/vparquet_column_chunk_reader.cpp
+++ b/be/src/vec/exec/format/parquet/vparquet_column_chunk_reader.cpp
@@ -58,7 +58,10 @@ Status ColumnChunkReader::next_page() {
     if (UNLIKELY(_remaining_num_values != 0)) {
         return Status::Corruption("Should skip current page");
     }
-    RETURN_IF_ERROR(_page_reader->next_page_header());
+    {
+        SCOPED_RAW_TIMER(&_statistics.decode_header_time);
+        RETURN_IF_ERROR(_page_reader->next_page_header());
+    }
     if (_page_reader->get_page_header()->type == tparquet::PageType::DICTIONARY_PAGE) {
         // the first page maybe directory page even if _metadata.__isset.dictionary_page_offset == false,
         // so we should parse the directory page in next_page()
@@ -86,6 +89,8 @@ Status ColumnChunkReader::load_page_data() {
         // check decompressed buffer size
         _reserve_decompress_buf(uncompressed_size);
         _page_data = Slice(_decompress_buf.get(), uncompressed_size);
+        SCOPED_RAW_TIMER(&_statistics.decompress_time);
+        _statistics.decompress_cnt++;
         RETURN_IF_ERROR(_block_compress_codec->decompress(compressed_data, &_page_data));
     } else {
         RETURN_IF_ERROR(_page_reader->get_page_data(_page_data));
@@ -93,11 +98,13 @@ Status ColumnChunkReader::load_page_data() {
 
     // Initialize repetition level and definition level. Skip when level = 0, which means required field.
     if (_max_rep_level > 0) {
+        SCOPED_RAW_TIMER(&_statistics.decode_level_time);
         RETURN_IF_ERROR(_rep_level_decoder.init(&_page_data,
                                                 header.data_page_header.repetition_level_encoding,
                                                 _max_rep_level, _remaining_num_values));
     }
     if (_max_def_level > 0) {
+        SCOPED_RAW_TIMER(&_statistics.decode_level_time);
         RETURN_IF_ERROR(_def_level_decoder.init(&_page_data,
                                                 header.data_page_header.definition_level_encoding,
                                                 _max_def_level, _remaining_num_values));
@@ -132,6 +139,7 @@ Status ColumnChunkReader::load_page_data() {
 Status ColumnChunkReader::_decode_dict_page() {
     const tparquet::PageHeader& header = *_page_reader->get_page_header();
     DCHECK_EQ(tparquet::PageType::DICTIONARY_PAGE, header.type);
+    SCOPED_RAW_TIMER(&_statistics.decode_dict_time);
 
     // Using the PLAIN_DICTIONARY enum value is deprecated in the Parquet 2.0 specification.
     // Prefer using RLE_DICTIONARY in a data page and PLAIN in a dictionary page for Parquet 2.0+ files.
@@ -187,6 +195,7 @@ Status ColumnChunkReader::skip_values(size_t num_values, bool skip_data) {
     }
     _remaining_num_values -= num_values;
     if (skip_data) {
+        SCOPED_RAW_TIMER(&_statistics.decode_value_time);
         return _page_decoder->skip_values(num_values);
     } else {
         return Status::OK();
@@ -194,6 +203,7 @@ Status ColumnChunkReader::skip_values(size_t num_values, bool skip_data) {
 }
 
 void ColumnChunkReader::insert_null_values(ColumnPtr& doris_column, size_t num_values) {
+    SCOPED_RAW_TIMER(&_statistics.decode_value_time);
     DCHECK_GE(_remaining_num_values, num_values);
     CHECK(doris_column->is_nullable());
     auto* nullable_column = reinterpret_cast<vectorized::ColumnNullable*>(
@@ -206,6 +216,7 @@ void ColumnChunkReader::insert_null_values(ColumnPtr& doris_column, size_t num_v
 }
 
 void ColumnChunkReader::insert_null_values(MutableColumnPtr& doris_column, size_t num_values) {
+    SCOPED_RAW_TIMER(&_statistics.decode_value_time);
     for (int i = 0; i < num_values; ++i) {
         doris_column->insert_default();
     }
@@ -227,6 +238,7 @@ Status ColumnChunkReader::decode_values(ColumnPtr& doris_column, DataTypePtr& da
     if (UNLIKELY(_remaining_num_values < num_values)) {
         return Status::IOError("Decode too many values in current page");
     }
+    SCOPED_RAW_TIMER(&_statistics.decode_value_time);
     _remaining_num_values -= num_values;
     return _page_decoder->decode_values(doris_column, data_type, num_values);
 }
@@ -236,6 +248,7 @@ Status ColumnChunkReader::decode_values(MutableColumnPtr& doris_column, DataType
     if (UNLIKELY(_remaining_num_values < num_values)) {
         return Status::IOError("Decode too many values in current page");
     }
+    SCOPED_RAW_TIMER(&_statistics.decode_value_time);
     _remaining_num_values -= num_values;
     return _page_decoder->decode_values(doris_column, data_type, num_values);
 }

--- a/be/src/vec/exec/format/parquet/vparquet_column_chunk_reader.h
+++ b/be/src/vec/exec/format/parquet/vparquet_column_chunk_reader.h
@@ -29,8 +29,6 @@
 #include "parquet_common.h"
 #include "schema_desc.h"
 #include "util/block_compression.h"
-#include "vec/columns/column_array.h"
-#include "vec/columns/column_nullable.h"
 #include "vparquet_page_reader.h"
 
 namespace doris::vectorized {
@@ -57,6 +55,15 @@ namespace doris::vectorized {
  */
 class ColumnChunkReader {
 public:
+    struct Statistics {
+        int64_t decompress_time = 0;
+        int64_t decompress_cnt = 0;
+        int64_t decode_header_time = 0;
+        int64_t decode_value_time = 0;
+        int64_t decode_dict_time = 0;
+        int64_t decode_level_time = 0;
+    };
+
     ColumnChunkReader(BufferedStreamReader* reader, tparquet::ColumnChunk* column_chunk,
                       FieldSchema* field_schema, cctz::time_zone* ctz);
     ~ColumnChunkReader() = default;
@@ -96,7 +103,7 @@ public:
     // Load page data into the underlying container,
     // and initialize the repetition and definition level decoder for current page data.
     Status load_page_data();
-    Status load_page_date_idempotent() {
+    Status load_page_data_idempotent() {
         if (_state == DATA_LOADED) {
             return Status::OK();
         }
@@ -131,6 +138,8 @@ public:
     // Get page decoder
     Decoder* get_page_decoder() { return _page_decoder; }
 
+    Statistics& statistics() { return _statistics; }
+
 private:
     enum ColumnChunkReaderState { NOT_INIT, INITIALIZED, HEADER_PARSED, DATA_LOADED };
 
@@ -161,6 +170,7 @@ private:
     // Map: encoding -> Decoder
     // Plain or Dictionary encoding. If the dictionary grows too big, the encoding will fall back to the plain encoding
     std::unordered_map<int, std::unique_ptr<Decoder>> _decoders;
+    Statistics _statistics;
 };
 
 } // namespace doris::vectorized

--- a/be/src/vec/exec/format/parquet/vparquet_column_chunk_reader.h
+++ b/be/src/vec/exec/format/parquet/vparquet_column_chunk_reader.h
@@ -138,7 +138,10 @@ public:
     // Get page decoder
     Decoder* get_page_decoder() { return _page_decoder; }
 
-    Statistics& statistics() { return _statistics; }
+    Statistics& statistics() {
+        _statistics.decode_header_time = _page_reader->statistics().decode_header_time;
+        return _statistics;
+    }
 
 private:
     enum ColumnChunkReaderState { NOT_INIT, INITIALIZED, HEADER_PARSED, DATA_LOADED };

--- a/be/src/vec/exec/format/parquet/vparquet_column_reader.cpp
+++ b/be/src/vec/exec/format/parquet/vparquet_column_reader.cpp
@@ -176,7 +176,7 @@ Status ScalarColumnReader::read_column_data(ColumnPtr& doris_column, DataTypePtr
         *read_rows = 0;
     } else {
         // load page data to decode or skip values
-        RETURN_IF_ERROR(_chunk_reader->load_page_date_idempotent());
+        RETURN_IF_ERROR(_chunk_reader->load_page_data_idempotent());
         size_t has_read = 0;
         for (auto& range : read_ranges) {
             // generate the skipped values

--- a/be/src/vec/exec/format/parquet/vparquet_group_reader.cpp
+++ b/be/src/vec/exec/format/parquet/vparquet_group_reader.cpp
@@ -52,7 +52,7 @@ Status RowGroupReader::init(const FieldDescriptor& schema, std::vector<RowRange>
             reader->add_offset_index(&oi);
         }
         if (reader == nullptr) {
-            VLOG_DEBUG << "Init row group reader failed";
+            VLOG_DEBUG << "Init row group(" << _row_group_id << ") reader failed";
             return Status::Corruption("Init row group reader failed");
         }
         _column_readers[read_col._file_slot_name] = std::move(reader);

--- a/be/src/vec/exec/format/parquet/vparquet_group_reader.cpp
+++ b/be/src/vec/exec/format/parquet/vparquet_group_reader.cpp
@@ -38,14 +38,6 @@ RowGroupReader::~RowGroupReader() {
 
 Status RowGroupReader::init(const FieldDescriptor& schema, std::vector<RowRange>& row_ranges,
                             std::unordered_map<int, tparquet::OffsetIndex>& col_offsets) {
-    VLOG_DEBUG << "Row group id: " << _row_group_id;
-    RETURN_IF_ERROR(_init_column_readers(schema, row_ranges, col_offsets));
-    return Status::OK();
-}
-
-Status RowGroupReader::_init_column_readers(
-        const FieldDescriptor& schema, std::vector<RowRange>& row_ranges,
-        std::unordered_map<int, tparquet::OffsetIndex>& col_offsets) {
     const size_t MAX_GROUP_BUF_SIZE = config::parquet_rowgroup_max_buffer_mb << 20;
     const size_t MAX_COLUMN_BUF_SIZE = config::parquet_column_max_buffer_mb << 20;
     size_t max_buf_size = std::min(MAX_COLUMN_BUF_SIZE, MAX_GROUP_BUF_SIZE / _read_columns.size());
@@ -98,6 +90,15 @@ Status RowGroupReader::next_batch(Block* block, size_t batch_size, bool* _batch_
     *_batch_eof = has_eof;
     // use data fill utils read column data to column ptr
     return Status::OK();
+}
+
+ParquetColumnReader::Statistics RowGroupReader::statistics() {
+    ParquetColumnReader::Statistics st;
+    for (auto& reader : _column_readers) {
+        auto ost = reader.second->statistics();
+        st.merge(ost);
+    }
+    return st;
 }
 
 } // namespace doris::vectorized

--- a/be/src/vec/exec/format/parquet/vparquet_group_reader.h
+++ b/be/src/vec/exec/format/parquet/vparquet_group_reader.h
@@ -17,17 +17,11 @@
 #pragma once
 #include <common/status.h>
 
-#include "exprs/expr_context.h"
 #include "io/file_reader.h"
 #include "vec/core/block.h"
 #include "vparquet_column_reader.h"
-#include "vparquet_file_metadata.h"
-#include "vparquet_reader.h"
 
 namespace doris::vectorized {
-class ParquetReadColumn;
-class ParquetColumnReader;
-struct RowRange;
 
 class RowGroupReader {
 public:
@@ -39,9 +33,7 @@ public:
                 std::unordered_map<int, tparquet::OffsetIndex>& col_offsets);
     Status next_batch(Block* block, size_t batch_size, bool* _batch_eof);
 
-private:
-    Status _init_column_readers(const FieldDescriptor& schema, std::vector<RowRange>& row_ranges,
-                                std::unordered_map<int, tparquet::OffsetIndex>& col_offsets);
+    ParquetColumnReader::Statistics statistics();
 
 private:
     doris::FileReader* _file_reader;

--- a/be/src/vec/exec/format/parquet/vparquet_page_index.h
+++ b/be/src/vec/exec/format/parquet/vparquet_page_index.h
@@ -19,11 +19,10 @@
 #include <common/status.h>
 #include <gen_cpp/parquet_types.h>
 
-#include "vparquet_reader.h"
+#include "exec/olap_common.h"
+#include "parquet_common.h"
 
 namespace doris::vectorized {
-class ParquetReader;
-struct RowRange;
 
 class PageIndex {
 public:

--- a/be/src/vec/exec/format/parquet/vparquet_page_reader.cpp
+++ b/be/src/vec/exec/format/parquet/vparquet_page_reader.cpp
@@ -48,6 +48,7 @@ Status PageReader::next_page_header() {
         header_size = std::min(header_size, max_size);
         RETURN_IF_ERROR(_reader->read_bytes(&page_header_buf, _offset, header_size));
         real_header_size = header_size;
+        SCOPED_RAW_TIMER(&_statistics.decode_header_time);
         auto st =
                 deserialize_thrift_msg(page_header_buf, &real_header_size, true, &_cur_page_header);
         if (st.ok()) {

--- a/be/src/vec/exec/format/parquet/vparquet_page_reader.h
+++ b/be/src/vec/exec/format/parquet/vparquet_page_reader.h
@@ -28,6 +28,10 @@ namespace doris::vectorized {
  */
 class PageReader {
 public:
+    struct Statistics {
+        int64_t decode_header_time;
+    };
+
     PageReader(BufferedStreamReader* reader, uint64_t offset, uint64_t length);
     ~PageReader() = default;
 
@@ -41,6 +45,8 @@ public:
 
     Status get_page_data(Slice& slice);
 
+    Statistics& statistics() { return _statistics; }
+
     void seek_to_page(int64_t page_header_offset) {
         _offset = page_header_offset;
         _next_header_offset = page_header_offset;
@@ -52,6 +58,7 @@ private:
 
     BufferedStreamReader* _reader;
     tparquet::PageHeader _cur_page_header;
+    Statistics _statistics;
     PageReaderState _state = INITIALIZED;
 
     uint64_t _offset = 0;

--- a/be/src/vec/exec/format/parquet/vparquet_reader.h
+++ b/be/src/vec/exec/format/parquet/vparquet_reader.h
@@ -29,55 +29,34 @@
 #include "io/file_reader.h"
 #include "vec/core/block.h"
 #include "vec/exec/format/generic_reader.h"
+#include "vparquet_column_reader.h"
 #include "vparquet_file_metadata.h"
 #include "vparquet_group_reader.h"
 #include "vparquet_page_index.h"
 
 namespace doris::vectorized {
 
-struct ParquetStatistics {
-    int32_t filtered_row_groups = 0;
-    int32_t read_row_groups = 0;
-    int64_t filtered_group_rows = 0;
-    int64_t filtered_page_rows = 0;
-    int64_t read_rows = 0;
-    int64_t filtered_bytes = 0;
-    int64_t read_bytes = 0;
-};
-
-class RowGroupReader;
-class PageIndex;
-
-struct RowRange {
-    RowRange() {}
-    RowRange(int64_t first, int64_t last) : first_row(first), last_row(last) {}
-    int64_t first_row;
-    int64_t last_row;
-};
-
-class ParquetReadColumn {
-public:
-    ParquetReadColumn(int parquet_col_id, const std::string& file_slot_name)
-            : _parquet_col_id(parquet_col_id), _file_slot_name(file_slot_name) {};
-    ~ParquetReadColumn() = default;
-
-private:
-    friend class ParquetReader;
-    friend class RowGroupReader;
-    int _parquet_col_id;
-    const std::string& _file_slot_name;
-};
-
 class ParquetReader : public GenericReader {
 public:
-    ParquetReader(RuntimeProfile* profile, FileReader* file_reader,
-                  const TFileScanRangeParams& params, const TFileRangeDesc& range,
-                  const std::vector<std::string>& column_names, size_t batch_size,
-                  cctz::time_zone* ctz);
+    struct Statistics {
+        int32_t filtered_row_groups = 0;
+        int32_t read_row_groups = 0;
+        int64_t filtered_group_rows = 0;
+        int64_t filtered_page_rows = 0;
+        int64_t read_rows = 0;
+        int64_t filtered_bytes = 0;
+        int64_t read_bytes = 0;
+        int64_t column_read_time = 0;
+        int64_t parse_meta_time = 0;
+    };
+
+    ParquetReader(RuntimeProfile* profile, const TFileScanRangeParams& params,
+                  const TFileRangeDesc& range, const std::vector<std::string>& column_names,
+                  size_t batch_size, cctz::time_zone* ctz);
 
     virtual ~ParquetReader();
     // for test
-    void set_file_reader(FileReader* file_reader) { _file_reader = file_reader; }
+    void set_file_reader(FileReader* file_reader) { _file_reader.reset(file_reader); }
 
     Status init_reader(
             std::unordered_map<std::string, ColumnValueRangeType>* colname_to_value_range);
@@ -92,9 +71,31 @@ public:
     Status get_columns(std::unordered_map<std::string, TypeDescriptor>* name_to_type,
                        std::unordered_set<std::string>* missing_cols) override;
 
-    ParquetStatistics& statistics() { return _statistics; }
+    Statistics& statistics() { return _statistics; }
 
 private:
+    struct ParquetProfile {
+        RuntimeProfile::Counter* filtered_row_groups;
+        RuntimeProfile::Counter* to_read_row_groups;
+        RuntimeProfile::Counter* filtered_group_rows;
+        RuntimeProfile::Counter* filtered_page_rows;
+        RuntimeProfile::Counter* filtered_bytes;
+        RuntimeProfile::Counter* to_read_bytes;
+        RuntimeProfile::Counter* column_read_time;
+        RuntimeProfile::Counter* parse_meta_time;
+
+        RuntimeProfile::Counter* file_read_time;
+        RuntimeProfile::Counter* file_read_calls;
+        RuntimeProfile::Counter* file_read_bytes;
+        RuntimeProfile::Counter* decompress_time;
+        RuntimeProfile::Counter* decompress_cnt;
+        RuntimeProfile::Counter* decode_header_time;
+        RuntimeProfile::Counter* decode_value_time;
+        RuntimeProfile::Counter* decode_dict_time;
+        RuntimeProfile::Counter* decode_level_time;
+    };
+
+    void _init_profile();
     bool _next_row_group_reader();
     Status _init_read_columns();
     Status _init_row_group_readers();
@@ -117,10 +118,9 @@ private:
 
 private:
     RuntimeProfile* _profile;
-    // file reader is passed from file scanner, and owned by this parquet reader.
-    FileReader* _file_reader = nullptr;
-    //    const TFileScanRangeParams& _scan_params;
-    //    const TFileRangeDesc& _scan_range;
+    const TFileScanRangeParams& _scan_params;
+    const TFileRangeDesc& _scan_range;
+    std::unique_ptr<FileReader> _file_reader = nullptr;
 
     std::shared_ptr<FileMetaData> _file_metadata;
     const tparquet::FileMetaData* _t_metadata;
@@ -141,15 +141,9 @@ private:
     const std::vector<std::string> _column_names;
 
     std::vector<std::string> _missing_cols;
-    ParquetStatistics _statistics;
+    Statistics _statistics;
+    ParquetColumnReader::Statistics _column_statistics;
+    ParquetProfile _parquet_profile;
     bool _closed = false;
-
-    // parquet profile
-    RuntimeProfile::Counter* _filtered_row_groups;
-    RuntimeProfile::Counter* _to_read_row_groups;
-    RuntimeProfile::Counter* _filtered_group_rows;
-    RuntimeProfile::Counter* _filtered_page_rows;
-    RuntimeProfile::Counter* _filtered_bytes;
-    RuntimeProfile::Counter* _to_read_bytes;
 };
 } // namespace doris::vectorized

--- a/be/test/vec/exec/parquet/parquet_thrift_test.cpp
+++ b/be/test/vec/exec/parquet/parquet_thrift_test.cpp
@@ -36,6 +36,7 @@
 #include "vec/exec/format/parquet/vparquet_column_chunk_reader.h"
 #include "vec/exec/format/parquet/vparquet_column_reader.h"
 #include "vec/exec/format/parquet/vparquet_file_metadata.h"
+#include "vec/exec/format/parquet/vparquet_group_reader.h"
 
 namespace doris {
 namespace vectorized {


### PR DESCRIPTION
# Proposed changes

Add more detail profile for ParquetReader:
ParquetColumnReadTime: the total time of reading parquet columns
ParquetDecodeDictTime: time to parse dictionary page
ParquetDecodeHeaderTime: time to parse page header
ParquetDecodeLevelTime: time to parse page's definition/repetition level
ParquetDecodeValueTime: time to decode page data into doris column
ParquetDecompressCount: counter of decompressing page data
ParquetDecompressTime:  time to decompress page data
ParquetParseMetaTime: time to parse parquet meta data
```
 ┌──────────────────────────────────────────┐
 │[0: VFILE_SCAN_NODE]                      │
 │(Active: 1s476ms, non-child: 88.00)       │
 │  - Counters:                             │
 │      - FileReadBytes: 73.60 MB           │
 │      - FileReadCalls: 10                 │
 │      - FileReadTime: 866.685ms           │
 │      - MaxScannerThreadNum: 1            │
 │      - NewlyCreateFreeBlocksNum: 93      │
 │      - NumScanners: 1                    │
 │      - ParquetColumnReadTime: 1s503ms    │
 │      - ParquetDecodeDictTime: 0ns        │
 │      - ParquetDecodeHeaderTime: 868.392ms│
 │      - ParquetDecodeLevelTime: 144.826us │
 │      - ParquetDecodeValueTime: 403.950ms │
 │      - ParquetDecompressCount: 305       │
 │      - ParquetDecompressTime: 154.345ms  │
 │      - ParquetFilteredBytes: 0.00        │
 │      - ParquetFilteredGroups: 0          │
 │      - ParquetFilteredRowsByGroup: 0     │
 │      - ParquetFilteredRowsByPage: 0      │
 │      - ParquetParseMetaTime: 119.999ms   │
 │      - ParquetReadBytes: 73.60 MB        │
 │      - ParquetReadGroups: 10             │
 │      - PeakMemoryUsage: 0.00             │
 │      - PreAllocFreeBlocksNum: 17         │
 │      - RowsRead: 6.001215M (6001215)     │
 │      - RowsReturned: 6.001215M (6001215) │
 │      - RowsReturnedRate: 4.064708M /sec  │
 │      - ScannerBatchWaitTime: 1s469ms     │
 │      - ScannerCtxSchedCount: 0           │
 │      - ScannerSchedCount: 0              │
 │      - ScannerWorkerWaitTime: 0ns        │
 │      - TotalReadThroughput: 0            │
 └──────────────────────────────────────────┘
```

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

