### PR TITLE
[fix](string) allocate memory according to actual size instead of max…

### DIFF
--- a/be/src/olap/wrapper_field.cpp
+++ b/be/src/olap/wrapper_field.cpp
@@ -52,11 +52,7 @@ WrapperField* WrapperField::create(const TabletColumn& column, uint32_t len) {
         variable_len =
                 std::max(len, static_cast<uint32_t>(column.length() - sizeof(VarcharLengthType)));
     } else if (column.type() == OLAP_FIELD_TYPE_STRING) {
-        // column.length is the serialized varchar length
-        // the first sizeof(StringLengthType) bytes is the length of varchar
-        // variable_len is the real length of varchar
-        variable_len =
-                std::max(len, static_cast<uint32_t>(column.length() - sizeof(StringLengthType)));
+        variable_len = len;
     } else {
         variable_len = column.length();
     }


### PR DESCRIPTION
… size

String column lengh is 2GB, if we allocate memory according to column length, string would consume a lot of memory. It also misleads memory tracker.

# Proposed changes

Issue Number: close #13110

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

