### PR TITLE
[fix](spark-load) no need to filter row group when doing spark load

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -819,7 +819,6 @@ CONF_Int32(object_pool_buffer_size, "100");
 
 // ParquetReaderWrap prefetch buffer size
 CONF_Int32(parquet_reader_max_buffer_size, "50");
-CONF_Bool(parquet_predicate_push_down, "true");
 // Max size of parquet page header in bytes
 CONF_mInt32(parquet_header_max_size_mb, "1");
 // Max buffer size for parquet row group

--- a/be/src/exec/arrow/arrow_reader.cpp
+++ b/be/src/exec/arrow/arrow_reader.cpp
@@ -98,7 +98,7 @@ int ArrowReaderWrap::get_column_index(std::string column_name) {
     }
 }
 
-Status ArrowReaderWrap::get_next_block(vectorized::Block* block, bool* eof) {
+Status ArrowReaderWrap::get_next_block(vectorized::Block* block, size_t* read_row, bool* eof) {
     size_t rows = 0;
     bool tmp_eof = false;
     do {
@@ -107,7 +107,7 @@ Status ArrowReaderWrap::get_next_block(vectorized::Block* block, bool* eof) {
             // We need to make sure the eof is set to true iff block is empty.
             if (tmp_eof) {
                 *eof = (rows == 0);
-                return Status::OK();
+                break;
             }
         }
 
@@ -129,6 +129,7 @@ Status ArrowReaderWrap::get_next_block(vectorized::Block* block, bool* eof) {
         rows += num_elements;
         _arrow_batch_cur_idx += num_elements;
     } while (!tmp_eof && rows < _state->batch_size());
+    *read_row = rows;
     return Status::OK();
 }
 

--- a/be/src/exec/arrow/arrow_reader.h
+++ b/be/src/exec/arrow/arrow_reader.h
@@ -92,7 +92,7 @@ public:
         return Status::NotSupported("Not Implemented read");
     }
     // for vec
-    Status get_next_block(vectorized::Block* block, bool* eof) override;
+    Status get_next_block(vectorized::Block* block, size_t* read_row, bool* eof) override;
     // This method should be deprecated once the old scanner is removed.
     // And user should use "get_next_block" instead.
     Status next_batch(std::shared_ptr<arrow::RecordBatch>* batch, bool* eof);

--- a/be/src/exec/arrow/parquet_reader.cpp
+++ b/be/src/exec/arrow/parquet_reader.cpp
@@ -100,7 +100,8 @@ Status ParquetReaderWrap::init_reader(const TupleDescriptor* tuple_desc,
         _timezone = timezone;
 
         RETURN_IF_ERROR(column_indices());
-        if (config::parquet_predicate_push_down && tuple_desc != nullptr) {
+        _need_filter_row_group = (tuple_desc != nullptr);
+        if (_need_filter_row_group) {
             int64_t file_size = 0;
             size(&file_size);
             _row_group_reader.reset(new RowGroupReader(_range_start_offset, _range_size,
@@ -551,7 +552,7 @@ void ParquetReaderWrap::read_batches(arrow::RecordBatchVector& batches, int curr
 }
 
 bool ParquetReaderWrap::filter_row_group(int current_group) {
-    if (config::parquet_predicate_push_down) {
+    if (_need_filter_row_group) {
         auto filter_group_set = _row_group_reader->filter_groups();
         if (filter_group_set.end() != filter_group_set.find(current_group)) {
             // find filter group, skip

--- a/be/src/exec/arrow/parquet_reader.cpp
+++ b/be/src/exec/arrow/parquet_reader.cpp
@@ -100,7 +100,7 @@ Status ParquetReaderWrap::init_reader(const TupleDescriptor* tuple_desc,
         _timezone = timezone;
 
         RETURN_IF_ERROR(column_indices());
-        if (config::parquet_predicate_push_down) {
+        if (config::parquet_predicate_push_down && tuple_desc != nullptr) {
             int64_t file_size = 0;
             size(&file_size);
             _row_group_reader.reset(new RowGroupReader(_range_start_offset, _range_size,

--- a/be/src/exec/arrow/parquet_reader.h
+++ b/be/src/exec/arrow/parquet_reader.h
@@ -101,6 +101,7 @@ private:
     std::string _timezone;
     int64_t _range_start_offset;
     int64_t _range_size;
+    bool _need_filter_row_group = false;
 
 private:
     std::unique_ptr<doris::RowGroupReader> _row_group_reader;

--- a/be/src/exec/base_scanner.h
+++ b/be/src/exec/base_scanner.h
@@ -153,7 +153,7 @@ protected:
     int _num_of_columns_from_file;
 
     // slot_ids for parquet predicate push down are in tuple desc
-    TupleId _tupleId;
+    TupleId _tupleId = -1;
     std::vector<ExprContext*> _conjunct_ctxs;
 
 private:

--- a/be/src/vec/exec/format/generic_reader.h
+++ b/be/src/vec/exec/format/generic_reader.h
@@ -28,7 +28,7 @@ class Block;
 // a set of blocks with specified schema,
 class GenericReader {
 public:
-    virtual Status get_next_block(Block* block, bool* eof) = 0;
+    virtual Status get_next_block(Block* block, size_t* read_rows, bool* eof) = 0;
     virtual std::unordered_map<std::string, TypeDescriptor> get_name_to_type() {
         std::unordered_map<std::string, TypeDescriptor> map;
         return map;

--- a/be/src/vec/exec/format/parquet/vparquet_group_reader.cpp
+++ b/be/src/vec/exec/format/parquet/vparquet_group_reader.cpp
@@ -60,7 +60,8 @@ Status RowGroupReader::init(const FieldDescriptor& schema, std::vector<RowRange>
     return Status::OK();
 }
 
-Status RowGroupReader::next_batch(Block* block, size_t batch_size, size_t* read_rows, bool* _batch_eof) {
+Status RowGroupReader::next_batch(Block* block, size_t batch_size, size_t* read_rows,
+                                  bool* _batch_eof) {
     size_t batch_read_rows = 0;
     bool has_eof = false;
     int col_idx = 0;

--- a/be/src/vec/exec/format/parquet/vparquet_group_reader.cpp
+++ b/be/src/vec/exec/format/parquet/vparquet_group_reader.cpp
@@ -60,7 +60,7 @@ Status RowGroupReader::init(const FieldDescriptor& schema, std::vector<RowRange>
     return Status::OK();
 }
 
-Status RowGroupReader::next_batch(Block* block, size_t batch_size, bool* _batch_eof) {
+Status RowGroupReader::next_batch(Block* block, size_t batch_size, size_t* read_rows, bool* _batch_eof) {
     size_t batch_read_rows = 0;
     bool has_eof = false;
     int col_idx = 0;
@@ -86,6 +86,7 @@ Status RowGroupReader::next_batch(Block* block, size_t batch_size, bool* _batch_
         has_eof = col_eof;
         col_idx++;
     }
+    *read_rows = batch_read_rows;
     _read_rows += batch_read_rows;
     *_batch_eof = has_eof;
     // use data fill utils read column data to column ptr

--- a/be/src/vec/exec/format/parquet/vparquet_group_reader.h
+++ b/be/src/vec/exec/format/parquet/vparquet_group_reader.h
@@ -31,7 +31,7 @@ public:
     ~RowGroupReader();
     Status init(const FieldDescriptor& schema, std::vector<RowRange>& row_ranges,
                 std::unordered_map<int, tparquet::OffsetIndex>& col_offsets);
-    Status next_batch(Block* block, size_t batch_size, bool* _batch_eof);
+    Status next_batch(Block* block, size_t batch_size, size_t* read_rows, bool* _batch_eof);
 
     ParquetColumnReader::Statistics statistics();
 

--- a/be/src/vec/exec/format/parquet/vparquet_reader.cpp
+++ b/be/src/vec/exec/format/parquet/vparquet_reader.cpp
@@ -177,7 +177,7 @@ Status ParquetReader::get_columns(std::unordered_map<std::string, TypeDescriptor
     return Status::OK();
 }
 
-Status ParquetReader::get_next_block(Block* block, bool* eof) {
+Status ParquetReader::get_next_block(Block* block, size_t* read_rows, bool* eof) {
     int32_t num_of_readers = _row_group_readers.size();
     DCHECK(num_of_readers <= _read_row_groups.size());
     if (_read_row_groups.empty()) {
@@ -187,7 +187,7 @@ Status ParquetReader::get_next_block(Block* block, bool* eof) {
     bool _batch_eof = false;
     {
         SCOPED_RAW_TIMER(&_statistics.column_read_time);
-        RETURN_IF_ERROR(_current_group_reader->next_batch(block, _batch_size, &_batch_eof));
+        RETURN_IF_ERROR(_current_group_reader->next_batch(block, _batch_size, read_rows, &_batch_eof));
     }
     if (_batch_eof) {
         auto column_st = _current_group_reader->statistics();

--- a/be/src/vec/exec/format/parquet/vparquet_reader.cpp
+++ b/be/src/vec/exec/format/parquet/vparquet_reader.cpp
@@ -187,7 +187,8 @@ Status ParquetReader::get_next_block(Block* block, size_t* read_rows, bool* eof)
     bool _batch_eof = false;
     {
         SCOPED_RAW_TIMER(&_statistics.column_read_time);
-        RETURN_IF_ERROR(_current_group_reader->next_batch(block, _batch_size, read_rows, &_batch_eof));
+        RETURN_IF_ERROR(
+                _current_group_reader->next_batch(block, _batch_size, read_rows, &_batch_eof));
     }
     if (_batch_eof) {
         auto column_st = _current_group_reader->statistics();

--- a/be/src/vec/exec/format/parquet/vparquet_reader.h
+++ b/be/src/vec/exec/format/parquet/vparquet_reader.h
@@ -61,7 +61,7 @@ public:
     Status init_reader(
             std::unordered_map<std::string, ColumnValueRangeType>* colname_to_value_range);
 
-    Status get_next_block(Block* block, bool* eof) override;
+    Status get_next_block(Block* block, size_t* read_rows, bool* eof) override;
 
     void close();
 

--- a/be/src/vec/exec/scan/vfile_scanner.cpp
+++ b/be/src/vec/exec/scan/vfile_scanner.cpp
@@ -136,10 +136,11 @@ Status VFileScanner::_get_block_impl(RuntimeState* state, Block* block, bool* eo
             SCOPED_TIMER(_get_block_timer);
             // Read next block.
             // Some of column in block may not be filled (column not exist in file)
-            RETURN_IF_ERROR(_cur_reader->get_next_block(_src_block_ptr, &read_rows, &_cur_reader_eof));
+            RETURN_IF_ERROR(
+                    _cur_reader->get_next_block(_src_block_ptr, &read_rows, &_cur_reader_eof));
         }
 
-        if (read_rows  > 0) {
+        if (read_rows > 0) {
             // Convert the src block columns type to string in-place.
             RETURN_IF_ERROR(_cast_to_input_block(block));
             // Fill rows in src block with partition columns from path. (e.g. Hive partition columns)

--- a/be/test/vec/exec/parquet/parquet_reader_test.cpp
+++ b/be/test/vec/exec/parquet/parquet_reader_test.cpp
@@ -122,7 +122,8 @@ TEST_F(ParquetReaderTest, normal) {
                 ColumnWithTypeAndName(std::move(data_column), data_type, slot_desc->col_name()));
     }
     bool eof = false;
-    p_reader->get_next_block(block, &eof);
+    size_t read_row = 0;
+    p_reader->get_next_block(block, &read_row, &eof);
     for (auto& col : block->get_columns_with_type_and_name()) {
         ASSERT_EQ(col.column->size(), 10);
     }

--- a/be/test/vec/exec/parquet/parquet_thrift_test.cpp
+++ b/be/test/vec/exec/parquet/parquet_thrift_test.cpp
@@ -411,7 +411,8 @@ TEST_F(ParquetThriftReaderTest, group_reader) {
                 ColumnWithTypeAndName(std::move(data_column), data_type, slot_desc->col_name()));
     }
     bool batch_eof = false;
-    auto stb = row_group_reader->next_batch(&block, 1024, &batch_eof);
+    size_t read_rows = 0;
+    auto stb = row_group_reader->next_batch(&block, 1024, &read_rows, &batch_eof);
     EXPECT_TRUE(stb.ok());
 
     LocalFileReader result("./be/test/exec/test_data/parquet_scanner/group-reader.txt", 0);

--- a/regression-test/conf/regression-conf.groovy
+++ b/regression-test/conf/regression-conf.groovy
@@ -63,3 +63,5 @@ brokerName = "broker_name"
 
 // broker load test config
 enableBrokerLoad=false
+ak=""
+sk=""

--- a/regression-test/suites/load_p0/broker_load/test_broker_load.groovy
+++ b/regression-test/suites/load_p0/broker_load/test_broker_load.groovy
@@ -60,6 +60,20 @@ suite("test_broker_load", "p0") {
     ]
     def where_exprs = ["", "", "", "", "", "", "", "", "", "", "", "where p_partkey>10", ""]
 
+    def etl_info = ["unselected.rows=0; dpp.abnorm.ALL=0; dpp.norm.ALL=200000",
+                    "unselected.rows=0; dpp.abnorm.ALL=0; dpp.norm.ALL=200000",
+                    "unselected.rows=0; dpp.abnorm.ALL=0; dpp.norm.ALL=200000",
+                    "unselected.rows=0; dpp.abnorm.ALL=0; dpp.norm.ALL=200000",
+                    "unselected.rows=0; dpp.abnorm.ALL=0; dpp.norm.ALL=200000",
+                    "unselected.rows=0; dpp.abnorm.ALL=0; dpp.norm.ALL=200000",
+                    "unselected.rows=0; dpp.abnorm.ALL=0; dpp.norm.ALL=200000",
+                    "unselected.rows=0; dpp.abnorm.ALL=0; dpp.norm.ALL=200000",
+                    "unselected.rows=0; dpp.abnorm.ALL=0; dpp.norm.ALL=200000",
+                    "unselected.rows=0; dpp.abnorm.ALL=0; dpp.norm.ALL=200000",
+                    "unselected.rows=0; dpp.abnorm.ALL=0; dpp.norm.ALL=200000",
+                    "unselected.rows=163703; dpp.abnorm.ALL=0; dpp.norm.ALL=36294",
+                    "unselected.rows=0; dpp.abnorm.ALL=0; dpp.norm.ALL=200000"]
+
     String ak = getS3AK()
     String sk = getS3SK()
     String enabled = context.config.otherConfigs.get("enableBrokerLoad")
@@ -126,12 +140,14 @@ suite("test_broker_load", "p0") {
                 i++
             }
 
+            i = 0
             for (String label in uuids) {
                 max_try_milli_secs = 600000
                 while (max_try_milli_secs > 0) {
-                    String[][] result = sql """ show load where label="$label"; """
+                    String[][] result = sql """ show load where label="$label" order by createtime desc limit 1; """
                     if (result[0][2].equals("FINISHED")) {
                         logger.info("Load FINISHED " + label)
+                        assertTrue(etl_info[i] == result[0][5], "expected: " + etl_info[i] + ", actual: " + result[0][5])
                         break;
                     }
                     if (result[0][2].equals("CANCELLED")) {
@@ -143,6 +159,7 @@ suite("test_broker_load", "p0") {
                         assertTrue(1 == 2, "Load Timeout.")
                     }
                 }
+                i++
             }
         } finally {
             for (String table in tables) {


### PR DESCRIPTION
# Proposed changes

Issue Number: close #13115

## Problem summary

1. Fix issue #13115 
2. Modify the method of `get_next_block` or `GenericReader`, to return "read_rows" explicitly.
    Some columns in block may not be filled in reader, if the first column is not filled, use `block->rows()` can not return real row numbers.
4. Add more checks for broker load test cases.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
5. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
6. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
7. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
8. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

