### PR TITLE
[feature-wip](parquet-reader) optimize the performance of column conversion

### DIFF
--- a/be/src/vec/exec/format/parquet/parquet_pred_cmp.h
+++ b/be/src/vec/exec/format/parquet/parquet_pred_cmp.h
@@ -97,9 +97,7 @@ static bool _eval_in_val(PrimitiveType conjunct_type, std::vector<void*> in_pred
     }
     case TYPE_STRING:
     case TYPE_VARCHAR:
-    case TYPE_CHAR:
-    case TYPE_DATE:
-    case TYPE_DATETIME: {
+    case TYPE_CHAR: {
         std::vector<const char*> in_values;
         for (auto val : in_pred_values) {
             const char* value = ((std::string*)val)->data();
@@ -157,9 +155,7 @@ static bool _eval_eq(PrimitiveType conjunct_type, void* value, const char* min_b
     }
     case TYPE_STRING:
     case TYPE_VARCHAR:
-    case TYPE_CHAR:
-    case TYPE_DATE:
-    case TYPE_DATETIME: {
+    case TYPE_CHAR: {
         const char* conjunct_value = ((std::string*)value)->data();
         if (strcmp(conjunct_value, min_bytes) < 0 || strcmp(conjunct_value, max_bytes) > 0) {
             return true;
@@ -206,10 +202,7 @@ static bool _eval_gt(PrimitiveType conjunct_type, void* value, const char* max_b
     }
     case TYPE_STRING:
     case TYPE_VARCHAR:
-    case TYPE_CHAR:
-    case TYPE_DATE:
-    case TYPE_DATETIME: {
-        //            case TYPE_TIME:
+    case TYPE_CHAR: {
         const char* conjunct_value = ((std::string*)value)->data();
         if (strcmp(max_bytes, conjunct_value) <= 0) {
             return true;
@@ -256,10 +249,7 @@ static bool _eval_ge(PrimitiveType conjunct_type, void* value, const char* max_b
     }
     case TYPE_STRING:
     case TYPE_VARCHAR:
-    case TYPE_CHAR:
-    case TYPE_DATE:
-    case TYPE_DATETIME: {
-        //            case TYPE_TIME:
+    case TYPE_CHAR: {
         const char* conjunct_value = ((std::string*)value)->data();
         if (strcmp(max_bytes, conjunct_value) < 0) {
             return true;
@@ -306,10 +296,7 @@ static bool _eval_lt(PrimitiveType conjunct_type, void* value, const char* min_b
     }
     case TYPE_STRING:
     case TYPE_VARCHAR:
-    case TYPE_CHAR:
-    case TYPE_DATE:
-    case TYPE_DATETIME: {
-        //            case TYPE_TIME:
+    case TYPE_CHAR: {
         const char* conjunct_value = ((std::string*)value)->data();
         if (strcmp(min_bytes, conjunct_value) >= 0) {
             return true;
@@ -356,10 +343,7 @@ static bool _eval_le(PrimitiveType conjunct_type, void* value, const char* min_b
     }
     case TYPE_STRING:
     case TYPE_VARCHAR:
-    case TYPE_CHAR:
-    case TYPE_DATE:
-    case TYPE_DATETIME: {
-        //            case TYPE_TIME:
+    case TYPE_CHAR: {
         const char* conjunct_value = ((std::string*)value)->data();
         if (strcmp(min_bytes, conjunct_value) > 0) {
             return true;

--- a/be/src/vec/exec/format/parquet/vparquet_column_chunk_reader.cpp
+++ b/be/src/vec/exec/format/parquet/vparquet_column_chunk_reader.cpp
@@ -214,9 +214,7 @@ void ColumnChunkReader::insert_null_values(ColumnPtr& doris_column, size_t num_v
 
 void ColumnChunkReader::insert_null_values(MutableColumnPtr& doris_column, size_t num_values) {
     SCOPED_RAW_TIMER(&_statistics.decode_value_time);
-    for (int i = 0; i < num_values; ++i) {
-        doris_column->insert_default();
-    }
+    doris_column->insert_many_defaults(num_values);
     _remaining_num_values -= num_values;
 }
 


### PR DESCRIPTION
# Proposed changes

Convert Parquet column into doris column via batch method.
In the previous implementation, only numeric types can be converted in batches, and other types can only be inserted one by one. This process will generate repeated virtual function calls and container expansion.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

