### PR TITLE
[Enhancement](statistics) optimize the default configuration related to statistics, etc.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/clone/ColocateTableCheckerAndBalancer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/ColocateTableCheckerAndBalancer.java
@@ -41,13 +41,13 @@ import org.apache.doris.system.Backend;
 import org.apache.doris.system.SystemInfoService;
 
 import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.common.collect.Table;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.parquet.Strings;
 
 import java.util.List;
 import java.util.Map;

--- a/fe/fe-core/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/Config.java
@@ -1639,7 +1639,7 @@ public class Config extends ConfigBase {
      */
     // TODO change it to mutable true
     @ConfField(mutable = false, masterOnly = true)
-    public static int cbo_concurrency_statistics_task_num = 1;
+    public static int cbo_concurrency_statistics_task_num = 10;
     /*
      * default sample percentage
      * The value from 0 ~ 100. The 100 means no sampling and fetch all data.
@@ -1788,8 +1788,8 @@ public class Config extends ConfigBase {
     public static int be_exec_version = max_be_exec_version;
 
     @ConfField(mutable = false)
-    public static int statistic_job_scheduler_execution_interval_ms = 60 * 60 * 1000;
+    public static int statistic_job_scheduler_execution_interval_ms = 60 * 1000;
 
     @ConfField(mutable = false)
-    public static int statistic_task_scheduler_execution_interval_ms = 60 * 60 * 1000;
+    public static int statistic_task_scheduler_execution_interval_ms = 60 * 1000;
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/policy/PolicyMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/policy/PolicyMgr.java
@@ -33,13 +33,13 @@ import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.ShowResultSet;
 
 import com.google.common.base.Joiner;
+import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.gson.annotations.SerializedName;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.parquet.Strings;
 
 import java.io.DataInput;
 import java.io.DataOutput;

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticsJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticsJob.java
@@ -35,6 +35,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.text.SimpleDateFormat;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -338,10 +339,15 @@ public class StatisticsJob {
             }
         }
 
+        // exclude invalid info
+        if (scope.isEmpty()) {
+            return Collections.emptyList();
+        }
+
         result.add(StringUtils.join(scope.toArray(), ","));
         result.add(finishedTaskNum + "/" + totalTaskNum);
 
-        if (totalTaskNum == finishedTaskNum) {
+        if (totalTaskNum > 0 && totalTaskNum == finishedTaskNum) {
             result.add("FINISHED");
         } else {
             result.add(jobState.toString());

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticsJobManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticsJobManager.java
@@ -158,6 +158,9 @@ public class StatisticsJobManager {
                 }
                 if (jobState == null || jobState == statisticsJob.getJobState()) {
                     List<Comparable> showInfo = statisticsJob.getShowInfo(null);
+                    if (showInfo == null || showInfo.isEmpty()) {
+                        continue;
+                    }
                     results.add(showInfo);
                 }
             }
@@ -176,6 +179,9 @@ public class StatisticsJobManager {
                         set.retainAll(tblIds);
                         for (long tblId : set) {
                             List<Comparable> showInfo = statisticsJob.getShowInfo(tblId);
+                            if (showInfo == null || showInfo.isEmpty()) {
+                                continue;
+                            }
                             results.add(showInfo);
                         }
                     }

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticsJobScheduler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticsJobScheduler.java
@@ -147,15 +147,15 @@ public class StatisticsJobScheduler extends MasterDaemon {
 
         for (Long tblId : tblIds) {
             Optional<Table> optionalTbl = db.getTable(tblId);
-            if (!optionalTbl.isPresent()) {
-                LOG.warn("Table(id={}) not found in the database {}", tblId, db.getFullName());
-                continue;
-            }
-            Table table = optionalTbl.get();
-            if (!table.isPartitioned()) {
-                getStatsTaskByTable(job, tblId);
+            if (optionalTbl.isPresent()) {
+                Table table = optionalTbl.get();
+                if (!table.isPartitioned()) {
+                    getStatsTaskByTable(job, tblId);
+                } else {
+                    getStatsTaskByPartition(job, tblId);
+                }
             } else {
-                getStatsTaskByPartition(job, tblId);
+                LOG.warn("Table(id={}) not found in the database {}", tblId, db.getFullName());
             }
         }
     }
@@ -170,6 +170,11 @@ public class StatisticsJobScheduler extends MasterDaemon {
     private void getStatsTaskByTable(StatisticsJob job, long tableId) throws DdlException {
         Database db = Env.getCurrentInternalCatalog().getDbOrDdlException(job.getDbId());
         OlapTable table = (OlapTable) db.getTableOrDdlException(tableId);
+
+        if (table.getDataSize() == 0) {
+            LOG.info("Do not collect statistics for empty table {}", table.getName());
+            return;
+        }
 
         Map<Long, List<String>> tblIdToColName = job.getTableIdToColumnName();
         List<String> colNames = tblIdToColName.get(tableId);
@@ -202,7 +207,7 @@ public class StatisticsJobScheduler extends MasterDaemon {
         for (String colName : colNames) {
             Column column = table.getColumn(colName);
             if (column == null) {
-                LOG.info("column {} not found in table {}", colName, table.getName());
+                LOG.info("Column {} not found in table {}", colName, table.getName());
                 continue;
             }
             Type colType = column.getType();
@@ -323,6 +328,11 @@ public class StatisticsJobScheduler extends MasterDaemon {
             Partition partition = table.getPartition(partitionName);
             if (partition == null) {
                 LOG.info("Partition {} not found in the table {}", partitionName, table.getName());
+                continue;
+            }
+            if (partition.getDataSize() == 0) {
+                LOG.info("Do not collect statistics for empty partition {} in the table {}",
+                        partitionName, table.getName());
                 continue;
             }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticsTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticsTask.java
@@ -135,7 +135,7 @@ public abstract class StatisticsTask implements Callable<StatisticsTaskResult> {
             throw new DdlException(errorMsg + taskState + " to " + newState);
         }
 
-        LOG.info("Statistics job(id={}) state changed from {} to {}", id, taskState, newState);
+        LOG.info("Statistics task(id={}) state changed from {} to {}", id, taskState, newState);
         taskState = newState;
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/statistics/StatisticsJobSchedulerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/statistics/StatisticsJobSchedulerTest.java
@@ -71,10 +71,12 @@ public class StatisticsJobSchedulerTest {
         // Setup
         Column col1 = new Column("c1", PrimitiveType.STRING);
         Column col2 = new Column("c2", PrimitiveType.INT);
-        OlapTable tbl1 = new OlapTable(0L, "tbl1", Arrays.asList(col1, col2), KeysType.AGG_KEYS,
-                new PartitionInfo(), new HashDistributionInfo());
-        OlapTable tbl2 = new OlapTable(1L, "tbl2", Arrays.asList(col1, col2), KeysType.DUP_KEYS,
-                new PartitionInfo(), new HashDistributionInfo());
+
+        OlapTable tbl1 = new OlapTable(0L, "tbl1", Arrays.asList(col1, col2),
+                KeysType.AGG_KEYS, new PartitionInfo(), new HashDistributionInfo());
+        OlapTable tbl2 = new OlapTable(1L, "tbl2", Arrays.asList(col1, col2),
+                KeysType.DUP_KEYS, new PartitionInfo(), new HashDistributionInfo());
+
         Database database = new Database(0L, "db");
         database.createTable(tbl1);
         database.createTable(tbl2);
@@ -92,6 +94,13 @@ public class StatisticsJobSchedulerTest {
             @Mock
             public List<Long> getBackendIds(boolean needAlive) {
                 return Collections.singletonList(1L);
+            }
+        };
+
+        new MockUp<OlapTable>(OlapTable.class) {
+            @Mock
+            public long getDataSize() {
+                return 1L;
             }
         };
 


### PR DESCRIPTION
# Proposed changes

This pr is mainly to optimize statistical tasks. Includes the following:
1. No longer generate statistics tasks for empty tables, and move the logic of skipping empty partitions to the process of task generation.
2. Adjusted the default configuration related to statistics to improve the efficiency of statistics collection, parameters include `cbo_concurrency_statistics_task_num`,`statistic_job_scheduler_execution_interval_ms`  and `statistic_task_scheduler_execution_interval_ms`.
3. Optimize the display of statistical tasks.
4. In addition, some `org.apache.parquet.Strings` packages are changed to `com.google.common.base.Strings` to avoid the exception that Strings cannot be found in local debug.

etc.

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [x] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

