### PR TITLE
[feature-wip](CN Node)Support compute only node in doris

### DIFF
--- a/be/src/agent/heartbeat_server.cpp
+++ b/be/src/agent/heartbeat_server.cpp
@@ -80,6 +80,7 @@ void HeartbeatServer::heartbeat(THeartbeatResult& heartbeat_result,
         heartbeat_result.backend_info.__set_brpc_port(config::brpc_port);
         heartbeat_result.backend_info.__set_version(get_short_version());
         heartbeat_result.backend_info.__set_be_start_time(_be_epoch);
+        heartbeat_result.backend_info.__set_be_node_type(config::be_node_type);
     }
 }
 

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -879,6 +879,8 @@ CONF_mBool(enable_new_load_scan_node, "false");
 // Temp config. True to use new file scanner. Will remove after fully test.
 CONF_mBool(enable_new_file_scanner, "false");
 
+CONF_mString(be_node_type, "be");
+
 #ifdef BE_TEST
 // test s3
 CONF_String(test_s3_resource, "resource");

--- a/docs/en/docs/sql-manual/sql-reference/Show-Statements/SHOW-BACKENDS.md
+++ b/docs/en/docs/sql-manual/sql-reference/Show-Statements/SHOW-BACKENDS.md
@@ -52,6 +52,7 @@ illustrate:
        10. UsedPct Indicates the percentage of disk used.
        11. ErrMsg is used to display the error message when the heartbeat fails.
        12. Status is used to display some status information of BE in JSON format, including the time information of the last time BE reported its tablet.
+       13. NodeType is used to display the type of Backend node. Now there are two types: BE and CN. BE Node represent the origin Backend node and CN Node represent the compute only node.
 
 ### Example
 

--- a/docs/zh-CN/docs/sql-manual/sql-reference/Show-Statements/SHOW-BACKENDS.md
+++ b/docs/zh-CN/docs/sql-manual/sql-reference/Show-Statements/SHOW-BACKENDS.md
@@ -52,6 +52,7 @@ SHOW BACKENDS
        10. UsedPct 表示磁盘已使用量百分比。
        11. ErrMsg 用于显示心跳失败时的错误信息。
        12. Status 用于以 JSON 格式显示BE的一些状态信息, 目前包括最后一次BE汇报其tablet的时间信息。
+       13. NodeType用于展示节点类型, 现在有两种类型: BE代表原来的节点类型, CN代表只做计算的节点类型.
 
 ### Example
 

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
@@ -1434,7 +1434,7 @@ public class OlapTable extends Table {
                 Map<Tag, List<Long>> tag2beIds = Maps.newHashMap();
                 for (long beId : replicaBackendIds) {
                     Backend be = infoService.getBackend(beId);
-                    if (be == null) {
+                    if (be == null || !be.isHybridNode()) {
                         continue;
                     }
                     short num = currentReplicaAlloc.getOrDefault(be.getLocationTag(), (short) 0);
@@ -1896,7 +1896,7 @@ public class OlapTable extends Table {
                     Map<Tag, Short> curMap = Maps.newHashMap();
                     for (Replica replica : tablet.getReplicas()) {
                         Backend be = infoService.getBackend(replica.getBackendId());
-                        if (be == null) {
+                        if (be == null || !be.isHybridNode()) {
                             continue;
                         }
                         short num = curMap.getOrDefault(be.getLocationTag(), (short) 0);

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Tablet.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Tablet.java
@@ -430,7 +430,7 @@ public class Tablet extends MetaObject implements Writable {
         for (Replica replica : replicas) {
             Backend backend = systemInfoService.getBackend(replica.getBackendId());
             if (backend == null || !backend.isAlive() || !replica.isAlive() || !hosts.add(backend.getHost())
-                    || replica.tooSlow()) {
+                    || replica.tooSlow() || !backend.isHybridNode()) {
                 // this replica is not alive,
                 // or if this replica is on same host with another replica, we also treat it as 'dead',
                 // so that Tablet Scheduler will create a new replica on different host.

--- a/fe/fe-core/src/main/java/org/apache/doris/clone/ClusterLoadStatistic.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/ClusterLoadStatistic.java
@@ -90,6 +90,10 @@ public class ClusterLoadStatistic {
                 // So balance will be blocked.
                 continue;
             }
+            // only hybrid node have tablet statistic
+            if (!backend.isHybridNode()) {
+                continue;
+            }
             BackendLoadStatistic beStatistic = new BackendLoadStatistic(backend.getId(), backend.getOwnerClusterName(),
                     backend.getLocationTag(), infoService, invertedIndex);
             try {

--- a/fe/fe-core/src/main/java/org/apache/doris/clone/ColocateTableCheckerAndBalancer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/ColocateTableCheckerAndBalancer.java
@@ -588,6 +588,8 @@ public class ColocateTableCheckerAndBalancer extends MasterDaemon {
         Backend be = infoService.getBackend(backendId);
         if (be == null) {
             return false;
+        } else if (!be.isHybridNode()) {
+            return false;
         } else if (!be.getLocationTag().equals(tag) || excludedBeIds.contains(be.getId())) {
             return false;
         } else if (!be.isScheduleAvailable()) {

--- a/fe/fe-core/src/main/java/org/apache/doris/clone/TabletScheduler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/TabletScheduler.java
@@ -713,7 +713,8 @@ public class TabletScheduler extends MasterDaemon {
         Map<Tag, Short> currentAllocMap = Maps.newHashMap();
         for (Replica replica : replicas) {
             Backend be = infoService.getBackend(replica.getBackendId());
-            if (be != null && be.isScheduleAvailable() && replica.isAlive() && !replica.tooSlow()) {
+            if (be != null && be.isScheduleAvailable() && replica.isAlive() && !replica.tooSlow()
+                    && be.isHybridNode()) {
                 Short num = currentAllocMap.getOrDefault(be.getLocationTag(), (short) 0);
                 currentAllocMap.put(be.getLocationTag(), (short) (num + 1));
             }
@@ -979,7 +980,7 @@ public class TabletScheduler extends MasterDaemon {
         Map<Tag, Short> allocMap = tabletCtx.getReplicaAlloc().getAllocMap();
         for (Replica replica : replicas) {
             Backend be = infoService.getBackend(replica.getBackendId());
-            if (!allocMap.containsKey(be.getLocationTag())) {
+            if (be.isHybridNode() && !allocMap.containsKey(be.getLocationTag())) {
                 deleteReplicaInternal(tabletCtx, replica, "not in valid tag", force);
                 return true;
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/Config.java
@@ -1792,4 +1792,7 @@ public class Config extends ConfigBase {
 
     @ConfField(mutable = false)
     public static int statistic_task_scheduler_execution_interval_ms = 60 * 1000;
+
+    @ConfField(mutable = true, masterOnly = false)
+    public static int backend_num_for_federation = 3;
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/common/proc/BackendsProcDir.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/proc/BackendsProcDir.java
@@ -52,6 +52,7 @@ public class BackendsProcDir implements ProcDirInterface {
             .add("SystemDecommissioned").add("ClusterDecommissioned").add("TabletNum")
             .add("DataUsedCapacity").add("AvailCapacity").add("TotalCapacity").add("UsedPct")
             .add("MaxDiskUsedPct").add("RemoteUsedCapacity").add("Tag").add("ErrMsg").add("Version").add("Status")
+            .add("NodeType")
             .build();
 
     public static final int HOSTNAME_INDEX = 3;
@@ -178,6 +179,9 @@ public class BackendsProcDir implements ProcDirInterface {
             backendInfo.add(backend.getVersion());
             // status
             backendInfo.add(new Gson().toJson(backend.getBackendStatus()));
+
+            // node type, show the value only when backend is alive.
+            backendInfo.add(backend.isAlive() ? backend.getNodeTypeTag().value : "");
 
             comparableBackendInfos.add(backendInfo);
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/common/proc/ClusterLoadStatByTag.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/proc/ClusterLoadStatByTag.java
@@ -71,7 +71,7 @@ public class ClusterLoadStatByTag implements ProcDirInterface {
         List<Long> beIds = Env.getCurrentSystemInfo().getBackendIds(false);
         for (long beId : beIds) {
             Backend be = Env.getCurrentSystemInfo().getBackend(beId);
-            if (be != null) {
+            if (be != null && be.isHybridNode()) {
                 tags.add(be.getLocationTag());
             }
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/BrokerScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/BrokerScanNode.java
@@ -429,15 +429,10 @@ public class BrokerScanNode extends LoadScanNode {
         // broker scan node is used for query or load
         BeSelectionPolicy policy = new BeSelectionPolicy.Builder().needQueryAvailable().needLoadAvailable()
                 .addTags(tags).build();
-        for (Backend be : Env.getCurrentSystemInfo().getIdToBackend().values()) {
-            if (policy.isMatch(be)) {
-                backends.add(be);
-            }
-        }
+        backends.addAll(policy.getCandidateBackends(Env.getCurrentSystemInfo().getIdToBackend().values()));
         if (backends.isEmpty()) {
             throw new UserException("No available backends");
         }
-        Collections.shuffle(backends, random);
     }
 
     private TFileFormatType formatType(String fileFormat, String path) throws UserException {

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/OlapScanNode.java
@@ -642,6 +642,9 @@ public class OlapScanNode extends ScanNode {
                     errs.add(replica.getId() + "'s backend " + replica.getBackendId() + " does not exist or not alive");
                     continue;
                 }
+                if (!backend.isHybridNode()) {
+                    continue;
+                }
                 if (needCheckTags && !allowedTags.isEmpty() && !allowedTags.contains(backend.getLocationTag())) {
                     String err = String.format(
                             "Replica on backend %d with tag %s," + " which is not in user's resource tags: %s",

--- a/fe/fe-core/src/main/java/org/apache/doris/resource/Tag.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/resource/Tag.java
@@ -55,6 +55,7 @@ public class Tag implements Writable {
     public static final String TYPE_ROLE = "role";
     public static final String TYPE_FUNCTION = "function";
     public static final String TYPE_LOCATION = "location";
+    public static final String TYPE_NODE_TYPE = "node_type";
 
     public static final String VALUE_FRONTEND = "frontend";
     public static final String VALUE_BACKEND = "backend";
@@ -65,6 +66,7 @@ public class Tag implements Writable {
     public static final String VALUE_DEFAULT_CLUSTER = "default_cluster";
     public static final String VALUE_DEFAULT_TAG = "default";
     public static final String VALUE_INVALID_TAG = "invalid";
+    public static final String VALUE_NODE_TYPE_TAG = "be";
 
     public static final ImmutableSet<String> RESERVED_TAG_TYPE = ImmutableSet.of(
             TYPE_ROLE, TYPE_FUNCTION, TYPE_LOCATION);
@@ -74,10 +76,12 @@ public class Tag implements Writable {
     private static final String TAG_REGEX = "^[a-zA-Z][a-zA-Z0-9_]{0,32}$";
 
     public static final Tag DEFAULT_BACKEND_TAG;
+    public static final Tag DEFAULT_NODE_TYPE_TAG;
     public static final Tag INVALID_TAG;
 
     static {
         DEFAULT_BACKEND_TAG = new Tag(TYPE_LOCATION, VALUE_DEFAULT_TAG);
+        DEFAULT_NODE_TYPE_TAG = new Tag(TYPE_NODE_TYPE, VALUE_NODE_TYPE_TAG);
         INVALID_TAG = new Tag(TYPE_LOCATION, VALUE_INVALID_TAG);
     }
 
@@ -100,6 +104,11 @@ public class Tag implements Writable {
 
     public static Tag createNotCheck(String type, String value) {
         return new Tag(type, value);
+    }
+
+    // only support be and cn node type tag for be.
+    public static boolean validNodeTypeTag(String value) {
+        return value != null && (value.equals("be") || value.equals("cn"));
     }
 
     public String toKey() {

--- a/fe/fe-core/src/main/java/org/apache/doris/system/Backend.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/system/Backend.java
@@ -123,6 +123,9 @@ public class Backend implements Writable {
     // creating this everytime we get it.
     @SerializedName(value = "locationTag", alternate = {"tag"})
     private Tag locationTag = Tag.DEFAULT_BACKEND_TAG;
+
+    private Tag nodeTypeTag = Tag.DEFAULT_NODE_TYPE_TAG;
+
     // tag type -> tag value.
     // A backend can only be assigned to one tag type, and each type can only have one value.
     @SerializedName("tagMap")
@@ -679,6 +682,12 @@ public class Backend implements Writable {
                 this.brpcPort = hbResponse.getBrpcPort();
             }
 
+            if (!this.getNodeTypeTag().value.equals(hbResponse.getBeNodeType()) && Tag.validNodeTypeTag(
+                    hbResponse.getBeNodeType())) {
+                isChanged = true;
+                this.nodeTypeTag = Tag.createNotCheck(Tag.TYPE_NODE_TYPE, hbResponse.getBeNodeType());
+            }
+
             this.lastUpdateMs = hbResponse.getHbTime();
             if (!isAlive.get()) {
                 isChanged = true;
@@ -742,10 +751,25 @@ public class Backend implements Writable {
         return locationTag;
     }
 
+    public Tag getNodeTypeTag() {
+        return nodeTypeTag;
+    }
+
+    public boolean isHybridNode() {
+        return nodeTypeTag.value.equals("be");
+    }
+
+    public boolean isComputeNode() {
+        return nodeTypeTag.value.equals("cn");
+    }
+
     public void setTagMap(Map<String, String> tagMap) {
         Preconditions.checkState(tagMap.containsKey(Tag.TYPE_LOCATION));
         this.tagMap = tagMap;
         this.locationTag = Tag.createNotCheck(Tag.TYPE_LOCATION, tagMap.get(Tag.TYPE_LOCATION));
+        if (tagMap.containsKey(Tag.TYPE_NODE_TYPE) && Tag.validNodeTypeTag(tagMap.get(Tag.TYPE_NODE_TYPE))) {
+            this.nodeTypeTag = Tag.createNotCheck(Tag.TYPE_NODE_TYPE, tagMap.get(Tag.TYPE_NODE_TYPE));
+        }
     }
 
     public Map<String, String> getTagMap() {

--- a/fe/fe-core/src/main/java/org/apache/doris/system/BackendHbResponse.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/system/BackendHbResponse.java
@@ -34,6 +34,7 @@ public class BackendHbResponse extends HeartbeatResponse implements Writable {
     private long beStartTime;
     private String host;
     private String version = "";
+    private String beNodeType = "be";
 
     public BackendHbResponse() {
         super(HeartbeatResponse.Type.BACKEND);
@@ -50,6 +51,20 @@ public class BackendHbResponse extends HeartbeatResponse implements Writable {
         this.hbTime = hbTime;
         this.beStartTime = beStartTime;
         this.version = version;
+    }
+
+    public BackendHbResponse(long beId, int bePort, int httpPort, int brpcPort,
+            long hbTime, long beStartTime, String version, String beNodeType) {
+        super(HeartbeatResponse.Type.BACKEND);
+        this.beId = beId;
+        this.status = HbStatus.OK;
+        this.bePort = bePort;
+        this.httpPort = httpPort;
+        this.brpcPort = brpcPort;
+        this.hbTime = hbTime;
+        this.beStartTime = beStartTime;
+        this.version = version;
+        this.beNodeType = beNodeType;
     }
 
     public BackendHbResponse(long beId, String errMsg) {
@@ -89,6 +104,10 @@ public class BackendHbResponse extends HeartbeatResponse implements Writable {
 
     public String getVersion() {
         return version;
+    }
+
+    public String getBeNodeType() {
+        return beNodeType;
     }
 
     public static BackendHbResponse read(DataInput in) throws IOException {

--- a/fe/fe-core/src/main/java/org/apache/doris/system/BeSelectionPolicy.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/system/BeSelectionPolicy.java
@@ -20,9 +20,14 @@ package org.apache.doris.system;
 import org.apache.doris.resource.Tag;
 import org.apache.doris.thrift.TStorageMedium;
 
+import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.Sets;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Selection policy for building BE nodes
@@ -40,6 +45,9 @@ public class BeSelectionPolicy {
     public boolean checkDiskUsage = false;
     // If set to false, do not select backends on same host.
     public boolean allowOnSameHost = false;
+
+    public boolean preferComputeNode = false;
+    public int candidateNum = Integer.MAX_VALUE;
 
     private BeSelectionPolicy() {
 
@@ -92,12 +100,27 @@ public class BeSelectionPolicy {
             return this;
         }
 
+        public Builder preferComputeNode() {
+            policy.preferComputeNode = true;
+            return this;
+        }
+
+        public Builder assignCandidateNum(int candidateNum) {
+            policy.candidateNum = candidateNum;
+            return this;
+        }
+
         public BeSelectionPolicy build() {
             return policy;
         }
     }
 
-    public boolean isMatch(Backend backend) {
+    private boolean isMatch(Backend backend) {
+        // Compute node is only used when preferComputeNode is set.
+        if (!preferComputeNode && backend.isComputeNode()) {
+            return false;
+        }
+
         if (needScheduleAvailable && !backend.isScheduleAvailable() || needQueryAvailable && !backend.isQueryAvailable()
                 || needLoadAvailable && !backend.isLoadAvailable() || !resourceTags.isEmpty() && !resourceTags.contains(
                 backend.getLocationTag()) || storageMedium != null && !backend.hasSpecifiedStorageMedium(
@@ -116,6 +139,41 @@ public class BeSelectionPolicy {
         return true;
     }
 
+    public List<Backend> getCandidateBackends(ImmutableCollection<Backend> backends) {
+        List<Backend> filterBackends = backends.stream().filter(this::isMatch).collect(Collectors.toList());
+        Collections.shuffle(filterBackends);
+        List<Backend> candidates = new ArrayList<>();
+        if (preferComputeNode) {
+            int num = 0;
+            // pick compute node first
+            for (Backend backend : filterBackends) {
+                if (backend.isComputeNode()) {
+                    if (num >= candidateNum) {
+                        break;
+                    }
+                    candidates.add(backend);
+                    num++;
+                }
+            }
+            // fill with some hybrid node.
+            if (num < candidateNum) {
+                for (Backend backend : filterBackends) {
+                    if (backend.isHybridNode()) {
+                        if (num >= candidateNum) {
+                            break;
+                        }
+                        candidates.add(backend);
+                        num++;
+                    }
+                }
+            }
+        } else {
+            candidates.addAll(filterBackends);
+        }
+
+        return candidates;
+    }
+
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();
@@ -128,4 +186,5 @@ public class BeSelectionPolicy {
         sb.append(storageMedium);
         return sb.toString();
     }
+
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/system/HeartbeatMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/system/HeartbeatMgr.java
@@ -253,8 +253,12 @@ public class HeartbeatMgr extends MasterDaemon {
                     long beStartTime = tBackendInfo.isSetBeStartTime()
                             ? tBackendInfo.getBeStartTime() : System.currentTimeMillis();
                     // backend.updateOnce(bePort, httpPort, beRpcPort, brpcPort);
+                    String nodeType = "be";
+                    if (tBackendInfo.isSetBeNodeType()) {
+                        nodeType = tBackendInfo.getBeNodeType();
+                    }
                     return new BackendHbResponse(backendId, bePort, httpPort, brpcPort,
-                            System.currentTimeMillis(), beStartTime, version);
+                            System.currentTimeMillis(), beStartTime, version, nodeType);
                 } else {
                     return new BackendHbResponse(backendId, backend.getHost(),
                             result.getStatus().getErrorMsgs().isEmpty()

--- a/fe/fe-core/src/main/java/org/apache/doris/system/SystemInfoService.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/system/SystemInfoService.java
@@ -781,8 +781,7 @@ public class SystemInfoService {
      */
     public List<Long> selectBackendIdsByPolicy(BeSelectionPolicy policy, int number) {
         Preconditions.checkArgument(number >= -1);
-        List<Backend> candidates =
-                idToBackendRef.values().stream().filter(policy::isMatch).collect(Collectors.toList());
+        List<Backend> candidates = policy.getCandidateBackends(idToBackendRef.values());
         if ((number != -1 && candidates.size() < number) || candidates.isEmpty()) {
             LOG.debug("Not match policy: {}. candidates num: {}, expected: {}", policy, candidates.size(), number);
             return Lists.newArrayList();
@@ -1162,7 +1161,8 @@ public class SystemInfoService {
     public void checkReplicaAllocation(String cluster, ReplicaAllocation replicaAlloc) throws DdlException {
         List<Backend> backends = getClusterBackends(cluster);
         for (Map.Entry<Tag, Short> entry : replicaAlloc.getAllocMap().entrySet()) {
-            if (backends.stream().filter(b -> b.getLocationTag().equals(entry.getKey())).count() < entry.getValue()) {
+            if (backends.stream().filter(Backend::isHybridNode).filter(b -> b.getLocationTag().equals(entry.getKey()))
+                    .count() < entry.getValue()) {
                 throw new DdlException(
                         "Failed to find enough host with tag(" + entry.getKey() + ") in all backends. need: "
                                 + entry.getValue());
@@ -1174,6 +1174,9 @@ public class SystemInfoService {
         List<Backend> bes = getClusterBackends(clusterName);
         Set<Tag> tags = Sets.newHashSet();
         for (Backend be : bes) {
+            if (be == null || !be.isHybridNode()) {
+                continue;
+            }
             tags.add(be.getLocationTag());
         }
         return tags;
@@ -1181,6 +1184,7 @@ public class SystemInfoService {
 
     public List<Backend> getBackendsByTagInCluster(String clusterName, Tag tag) {
         List<Backend> bes = getClusterBackends(clusterName);
-        return bes.stream().filter(b -> b.getLocationTag().equals(tag)).collect(Collectors.toList());
+        return bes.stream().filter(Backend::isHybridNode).filter(b -> b.getLocationTag().equals(tag))
+            .collect(Collectors.toList());
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/clone/ClusterLoadStatisticsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/clone/ClusterLoadStatisticsTest.java
@@ -42,6 +42,7 @@ public class ClusterLoadStatisticsTest {
     private Backend be1;
     private Backend be2;
     private Backend be3;
+    private Backend be4;
 
     private Env env;
     private SystemInfoService systemInfoService;
@@ -119,10 +120,27 @@ public class ClusterLoadStatisticsTest {
         be3.setAlive(true);
         be3.setOwnerClusterName(SystemInfoService.DEFAULT_CLUSTER);
 
+        // compute node
+        be4 = new Backend(10004, "192.168.0.4", 9053);
+        disks = Maps.newHashMap();
+        diskInfo1 = new DiskInfo("/path1");
+        diskInfo1.setTotalCapacityB(4000000);
+        diskInfo1.setAvailableCapacityB(100000);
+        diskInfo1.setDataUsedCapacityB(80000);
+        disks.put(diskInfo1.getRootPath(), diskInfo1);
+
+        be4.setDisks(ImmutableMap.copyOf(disks));
+        be4.setAlive(true);
+        be4.setOwnerClusterName(SystemInfoService.DEFAULT_CLUSTER);
+        Map<String, String> tagMap = Tag.DEFAULT_BACKEND_TAG.toMap();
+        tagMap.put(Tag.TYPE_NODE_TYPE, "cn");
+        be4.setTagMap(tagMap);
+
         systemInfoService = new SystemInfoService();
         systemInfoService.addBackend(be1);
         systemInfoService.addBackend(be2);
         systemInfoService.addBackend(be3);
+        systemInfoService.addBackend(be4);
 
         // tablet
         invertedIndex = new TabletInvertedIndex();

--- a/fe/fe-core/src/test/java/org/apache/doris/clone/ColocateTableCheckerAndBalancerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/clone/ColocateTableCheckerAndBalancerTest.java
@@ -349,6 +349,9 @@ public class ColocateTableCheckerAndBalancerTest {
                 myBackend2.getLocationTag();
                 result = Tag.DEFAULT_BACKEND_TAG;
                 minTimes = 0;
+                myBackend2.isHybridNode();
+                result = true;
+                minTimes = 0;
 
                 // backend3 not available, and dead for a long time
                 infoService.getBackend(3L);
@@ -365,6 +368,9 @@ public class ColocateTableCheckerAndBalancerTest {
                 minTimes = 0;
                 myBackend3.getLocationTag();
                 result = Tag.DEFAULT_BACKEND_TAG;
+                minTimes = 0;
+                myBackend3.isHybridNode();
+                result = true;
                 minTimes = 0;
 
                 // backend4 not available, and dead for a short time
@@ -383,6 +389,9 @@ public class ColocateTableCheckerAndBalancerTest {
                 myBackend4.getLocationTag();
                 result = Tag.DEFAULT_BACKEND_TAG;
                 minTimes = 0;
+                myBackend4.isHybridNode();
+                result = true;
+                minTimes = 0;
 
                 // backend5 not available, and in decommission
                 infoService.getBackend(5L);
@@ -399,6 +408,9 @@ public class ColocateTableCheckerAndBalancerTest {
                 minTimes = 0;
                 myBackend5.getLocationTag();
                 result = Tag.DEFAULT_BACKEND_TAG;
+                minTimes = 0;
+                myBackend5.isHybridNode();
+                result = true;
                 minTimes = 0;
 
                 colocateTableIndex.getBackendsByGroup(groupId, tag);
@@ -420,7 +432,8 @@ public class ColocateTableCheckerAndBalancerTest {
                                       @Mocked Backend myBackend4,
                                       @Mocked Backend myBackend5,
                                       @Mocked Backend myBackend6,
-                                      @Mocked Backend myBackend7) throws AnalysisException {
+                                      @Mocked Backend myBackend7,
+                                      @Mocked Backend myBackend8) throws AnalysisException {
         List<Long> clusterBackendIds = Lists.newArrayList(1L, 2L, 3L, 4L, 5L);
         new Expectations() {
             {
@@ -442,6 +455,9 @@ public class ColocateTableCheckerAndBalancerTest {
                 myBackend2.getLocationTag();
                 result = Tag.DEFAULT_BACKEND_TAG;
                 minTimes = 0;
+                myBackend2.isHybridNode();
+                result = true;
+                minTimes = 0;
 
                 // backend3 not available, and dead for a long time
                 infoService.getBackend(3L);
@@ -458,6 +474,9 @@ public class ColocateTableCheckerAndBalancerTest {
                 minTimes = 0;
                 myBackend3.getLocationTag();
                 result = Tag.DEFAULT_BACKEND_TAG;
+                minTimes = 0;
+                myBackend3.isHybridNode();
+                result = true;
                 minTimes = 0;
 
                 // backend4 available, not alive but dead for a short time
@@ -476,6 +495,9 @@ public class ColocateTableCheckerAndBalancerTest {
                 myBackend4.getLocationTag();
                 result = Tag.DEFAULT_BACKEND_TAG;
                 minTimes = 0;
+                myBackend4.isHybridNode();
+                result = true;
+                minTimes = 0;
 
                 // backend5 not available, and in decommission
                 infoService.getBackend(5L);
@@ -492,6 +514,9 @@ public class ColocateTableCheckerAndBalancerTest {
                 minTimes = 0;
                 myBackend5.getLocationTag();
                 result = Tag.DEFAULT_BACKEND_TAG;
+                minTimes = 0;
+                myBackend5.isHybridNode();
+                result = true;
                 minTimes = 0;
 
                 // backend6 is available, but with different tag
@@ -510,6 +535,9 @@ public class ColocateTableCheckerAndBalancerTest {
                 myBackend6.getLocationTag();
                 result = Tag.create(Tag.TYPE_LOCATION, "new_loc");
                 minTimes = 0;
+                myBackend6.isHybridNode();
+                result = true;
+                minTimes = 0;
 
                 // backend7 is available, but in exclude sets
                 infoService.getBackend(5L);
@@ -527,8 +555,31 @@ public class ColocateTableCheckerAndBalancerTest {
                 myBackend7.getLocationTag();
                 result = Tag.DEFAULT_BACKEND_TAG;
                 minTimes = 0;
+                myBackend7.isHybridNode();
+                result = true;
+                minTimes = 0;
                 myBackend7.getId();
                 result = 999L;
+                minTimes = 0;
+
+                // backend8 is available, it's a compute node.
+                infoService.getBackend(5L);
+                result = myBackend8;
+                minTimes = 0;
+                myBackend8.isScheduleAvailable();
+                result = false;
+                minTimes = 0;
+                myBackend8.isAlive();
+                result = true;
+                minTimes = 0;
+                myBackend8.isDecommissioned();
+                result = false;
+                minTimes = 0;
+                myBackend8.getLocationTag();
+                result = Tag.DEFAULT_BACKEND_TAG;
+                minTimes = 0;
+                myBackend8.isHybridNode();
+                result = false;
                 minTimes = 0;
             }
         };

--- a/fe/fe-core/src/test/java/org/apache/doris/system/SystemInfoServiceTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/system/SystemInfoServiceTest.java
@@ -222,6 +222,57 @@ public class SystemInfoServiceTest {
     }
 
     @Test
+    public void testComputeNodeBackendSelect() throws Exception {
+        // only one compute node
+        Tag taga = Tag.create(Tag.TYPE_LOCATION, "taga");
+        addBackend(20001, "192.168.2.1", 9051);
+        Backend be1 = infoService.getBackend(20001);
+        setComputeNode(be1, taga);
+        be1.setAlive(true);
+        addDisk(be1, "path1", TStorageMedium.HDD, 200 * 1024 * 1024L, 100 * 1024 * 1024L);
+        BeSelectionPolicy policy01 = new BeSelectionPolicy.Builder().addTags(Sets.newHashSet(taga))
+                .setStorageMedium(TStorageMedium.HDD).build();
+        Assert.assertEquals(0, infoService.selectBackendIdsByPolicy(policy01, 1).size());
+
+        BeSelectionPolicy policy02 = new BeSelectionPolicy.Builder().addTags(Sets.newHashSet(taga))
+                .setStorageMedium(TStorageMedium.HDD).preferComputeNode().build();
+        Assert.assertEquals(1, infoService.selectBackendIdsByPolicy(policy02, 1).size());
+
+        BeSelectionPolicy policy03 = new BeSelectionPolicy.Builder().addTags(Sets.newHashSet(taga))
+                .setStorageMedium(TStorageMedium.HDD).preferComputeNode().assignCandidateNum(0).build();
+        Assert.assertEquals(0, infoService.selectBackendIdsByPolicy(policy03, 1).size());
+
+        BeSelectionPolicy policy04 = new BeSelectionPolicy.Builder().addTags(Sets.newHashSet(taga))
+                .setStorageMedium(TStorageMedium.HDD).preferComputeNode().assignCandidateNum(1).build();
+        Assert.assertEquals(1, infoService.selectBackendIdsByPolicy(policy04, 1).size());
+
+        // one compute node and two hybrid node
+        addBackend(20002, "192.168.2.2", 9051);
+        Backend be2 = infoService.getBackend(20002);
+        be2.setTagMap(taga.toMap());
+        be2.setAlive(true);
+        addDisk(be2, "path1", TStorageMedium.HDD, 200 * 1024 * 1024L, 100 * 1024 * 1024L);
+
+        addBackend(20003, "192.168.2.3", 9051);
+        Backend be3 = infoService.getBackend(20003);
+        be3.setTagMap(taga.toMap());
+        be3.setAlive(true);
+        addDisk(be3, "path1", TStorageMedium.HDD, 200 * 1024 * 1024L, 100 * 1024 * 1024L);
+
+        BeSelectionPolicy policy05 = new BeSelectionPolicy.Builder().addTags(Sets.newHashSet(taga))
+                .setStorageMedium(TStorageMedium.HDD).build();
+        Assert.assertEquals(0, infoService.selectBackendIdsByPolicy(policy05, 3).size());
+
+        BeSelectionPolicy policy06 = new BeSelectionPolicy.Builder().addTags(Sets.newHashSet(taga))
+                .setStorageMedium(TStorageMedium.HDD).preferComputeNode().assignCandidateNum(2).build();
+        Assert.assertEquals(2, infoService.selectBackendIdsByPolicy(policy06, 2).size());
+
+        BeSelectionPolicy policy07 = new BeSelectionPolicy.Builder().addTags(Sets.newHashSet(taga))
+                .setStorageMedium(TStorageMedium.HDD).preferComputeNode().assignCandidateNum(3).build();
+        Assert.assertEquals(3, infoService.selectBackendIdsByPolicy(policy07, 3).size());
+    }
+
+    @Test
     public void testSelectBackendIdsForReplicaCreation() throws Exception {
         addBackend(10001, "192.168.1.1", 9050);
         Backend be1 = infoService.getBackend(10001);
@@ -243,6 +294,12 @@ public class SystemInfoServiceTest {
         Backend be5 = infoService.getBackend(10005);
         addDisk(be5, "path1", TStorageMedium.HDD, 200 * 1024 * 1024L, 150 * 1024 * 1024L);
         be5.setAlive(true);
+        // no effect with compute node
+        addBackend(10006, "192.168.1.6", 9050);
+        Backend be6 = infoService.getBackend(10006);
+        addDisk(be6, "path1", TStorageMedium.HDD, 200 * 1024 * 1024L, 150 * 1024 * 1024L);
+        be6.setAlive(true);
+        setComputeNode(be6, Tag.DEFAULT_BACKEND_TAG);
 
         ReplicaAllocation replicaAlloc = ReplicaAllocation.DEFAULT_ALLOCATION;
         // also check if the random selection logic can evenly distribute the replica.
@@ -270,5 +327,11 @@ public class SystemInfoServiceTest {
         Map<String, DiskInfo> map = Maps.newHashMap();
         map.put(diskInfo1.getRootPath(), diskInfo1);
         be.setDisks(ImmutableMap.copyOf(map));
+    }
+
+    private void setComputeNode(Backend be, Tag tag) {
+        Map<String, String> tagMap = tag.toMap();
+        tagMap.put(Tag.TYPE_NODE_TYPE, "cn");
+        be.setTagMap(tagMap);
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/utframe/DemoMultiBackendsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/utframe/DemoMultiBackendsTest.java
@@ -200,6 +200,8 @@ public class DemoMultiBackendsTest {
         Assert.assertEquals(BackendsProcDir.TITLE_NAMES.size(), result.getColumnNames().size());
         Assert.assertEquals("{\"location\" : \"default\"}", result.getRows().get(0).get(20));
         Assert.assertEquals("{\"lastSuccessReportTabletsTime\":\"N/A\",\"lastStreamLoadTime\":-1,\"isQueryDisabled\":false,\"isLoadDisabled\":false}",
+                result.getRows().get(0).get(BackendsProcDir.TITLE_NAMES.size() - 2));
+        Assert.assertEquals("be",
                 result.getRows().get(0).get(BackendsProcDir.TITLE_NAMES.size() - 1));
     }
 

--- a/gensrc/thrift/HeartbeatService.thrift
+++ b/gensrc/thrift/HeartbeatService.thrift
@@ -43,6 +43,7 @@ struct TBackendInfo {
     4: optional Types.TPort brpc_port
     5: optional string version
     6: optional i64 be_start_time
+    7: optional string be_node_type
 }
 
 struct THeartbeatResult {


### PR DESCRIPTION
# Proposed changes

Issue Number: https://github.com/apache/doris/issues/13144

## Problem summary

Describe your changes.
Introduce the node type to doris, and the table creation and tablet scheduler will control the storage only assign to the BE nodes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [x] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [x] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [x] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

