### PR TITLE
[fix](tcmalloc)Revert tc limit

### DIFF
--- a/bin/start_be.sh
+++ b/bin/start_be.sh
@@ -117,39 +117,6 @@ fi
 export ASAN_OPTIONS=symbolize=1:abort_on_error=1:disable_coredump=0:unmap_shadow_on_exit=1
 export UBSAN_OPTIONS=print_stacktrace=1
 
-## set TCMALLOC_HEAP_LIMIT_MB to limit memory used by tcmalloc
-set_tcmalloc_heap_limit() {
-    total_mem_mb=$(free -m | grep Mem | awk '{print $2}')
-    mem_limit_str=$(grep ^mem_limit "${DORIS_HOME}"/conf/be.conf)
-    digits_unit=${mem_limit_str##*=}
-    digits_unit="${digits_unit#"${digits_unit%%[![:space:]]*}"}"
-    digits_unit="${digits_unit%"${digits_unit##*[![:space:]]}"}"
-    digits=${digits_unit%%[^[:digit:]]*}
-    unit=${digits_unit##*[[:digit:] ]}
-
-    mem_limit_mb=0
-    case ${unit} in
-    t | T) mem_limit_mb=$((digits * 1024 * 1024)) ;;
-    g | G) mem_limit_mb=$((digits * 1024)) ;;
-    m | M) mem_limit_mb=$((digits)) ;;
-    k | K) mem_limit_mb=$((digits / 1024)) ;;
-    %) mem_limit_mb=$((total_mem_mb * digits / 100)) ;;
-    *) mem_limit_mb=$((digits / 1024 / 1024 / 1024)) ;;
-    esac
-
-    if [[ "${mem_limit_mb}" -eq 0 ]]; then
-        mem_limit_mb=$((total_mem_mb * 80 / 100))
-    fi
-
-    if [[ "${mem_limit_mb}" -gt "${total_mem_mb}" ]]; then
-        echo "mem_limit is larger than whole memory of the server. ${mem_limit_mb} > ${total_mem_mb}."
-        return 1
-    fi
-    export TCMALLOC_HEAP_LIMIT_MB=${mem_limit_mb}
-}
-
-set_tcmalloc_heap_limit || exit 1
-
 if [ ${RUN_DAEMON} -eq 1 ]; then
     nohup $LIMIT ${DORIS_HOME}/lib/doris_be "$@" >> $LOG_DIR/be.out 2>&1 < /dev/null &
 else


### PR DESCRIPTION
…emory consumption of tcmalloc (#12981)"

This reverts commit 675166711a84e060365c822260866d89f0d11a01.

Now, doris allocates a lot memory which is not used, in most cases it just consumes virtual memory but not physical memory. Then it is easy to fail query with TCMALLOC_HEAP_LIMIT_MB set.

We revert the patch and add it back after we resolve all not used virtual memory issues.

# Proposed changes

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

