### PR TITLE
[Bug](libjvm) reorder initialization of JNI

### DIFF
--- a/be/src/service/doris_main.cpp
+++ b/be/src/service/doris_main.cpp
@@ -369,6 +369,7 @@ int main(int argc, char** argv) {
     // add logger for thrift internal
     apache::thrift::GlobalOutput.setOutputFunction(doris::thrift_output);
 
+    Status status = Status::OK();
 #ifdef LIBJVM
     // Init jni
     status = doris::JniUtil::Init();
@@ -418,7 +419,7 @@ int main(int argc, char** argv) {
     doris::ThriftServer* be_server = nullptr;
     EXIT_IF_ERROR(
             doris::BackendService::create_service(exec_env, doris::config::be_port, &be_server));
-    Status status = be_server->start();
+    status = be_server->start();
     if (!status.ok()) {
         LOG(ERROR) << "Doris Be server did not start correctly, exiting";
         doris::shutdown_logging();

--- a/be/src/service/doris_main.cpp
+++ b/be/src/service/doris_main.cpp
@@ -369,6 +369,16 @@ int main(int argc, char** argv) {
     // add logger for thrift internal
     apache::thrift::GlobalOutput.setOutputFunction(doris::thrift_output);
 
+#ifdef LIBJVM
+    // Init jni
+    status = doris::JniUtil::Init();
+    if (!status.ok()) {
+        LOG(WARNING) << "Failed to initialize JNI: " << status.get_error_msg();
+        doris::shutdown_logging();
+        exit(1);
+    }
+#endif
+
     doris::Daemon daemon;
     daemon.init(argc, argv, paths);
     daemon.start();
@@ -478,16 +488,6 @@ int main(int argc, char** argv) {
         doris::shutdown_logging();
         exit(1);
     }
-
-#ifdef LIBJVM
-    // 6. init jni
-    status = doris::JniUtil::Init();
-    if (!status.ok()) {
-        LOG(WARNING) << "Failed to initialize JNI: " << status.get_error_msg();
-        doris::shutdown_logging();
-        exit(1);
-    }
-#endif
 
     while (!doris::k_doris_exit) {
 #if defined(LEAK_SANITIZER)


### PR DESCRIPTION
# Proposed changes

Issue Number: close #13164

When we send signal 15 to Doris BE, JVM will exist and do some clean-up jobs. According to my analysis, I think this signal processing by JVM will overwrite Doris's one. So I just move JNI initialization front of BE daemon initialization.

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

