### PR TITLE
[schema change](fix) fix coredump of schema change

### DIFF
--- a/be/src/vec/olap/olap_data_convertor.cpp
+++ b/be/src/vec/olap/olap_data_convertor.cpp
@@ -160,6 +160,7 @@ void OlapBlockDataConvertor::OlapColumnDataConvertorBase::set_source_column(
 void OlapBlockDataConvertor::OlapColumnDataConvertorBase::clear_source_column() {
     // just to reduce the source column's ref count to 1
     _typed_column.column = nullptr;
+    _nullmap = nullptr;
 }
 
 // This should be called only in SegmentWriter. If you want to access nullmap in Convertor,


### PR DESCRIPTION
When schema change and compaction is executing simutaneously, both nullable and not nullable data can be read for the same column, need to reset _nullmap for each Block when converting Block data, or else Column cast will be wrong.

# Proposed changes

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

