### PR TITLE
[fix](be_ut) fix hll_test, vexpr_test and lru_cache_test failure

### DIFF
--- a/be/src/olap/lru_cache.h
+++ b/be/src/olap/lru_cache.h
@@ -361,7 +361,7 @@ private:
     uint64_t _hit_count = 0;    // 命中cache的总次数
 };
 
-static const int kNumShardBits = 10;
+static const int kNumShardBits = 4;
 static const int kNumShards = 1 << kNumShardBits;
 
 class ShardedLRUCache : public Cache {

--- a/be/test/olap/hll_test.cpp
+++ b/be/test/olap/hll_test.cpp
@@ -34,7 +34,7 @@ static uint64_t hash(uint64_t value) {
 }
 //  keep logic same with java version in fe when you change hll_test.cpp,see HllTest.java
 TEST_F(TestHll, Normal) {
-    uint8_t buf[HLL_REGISTERS_COUNT + 1];
+    uint8_t buf[HLL_REGISTERS_COUNT + 1] = {0};
 
     // empty
     {

--- a/be/test/olap/lru_cache_test.cpp
+++ b/be/test/olap/lru_cache_test.cpp
@@ -71,7 +71,7 @@ public:
     // there is 16 shards in ShardedLRUCache
     // And the LRUHandle size is about 100B. So the cache size should big enough
     // to run the UT.
-    static const int kCacheSize = 1000 * 16;
+    static const int kCacheSize = 1000 * 1024l;
     std::vector<int> _deleted_keys;
     std::vector<int> _deleted_values;
     Cache* _cache;
@@ -231,37 +231,37 @@ static void insert_LRUCache(LRUCache& cache, const CacheKey& key, int value,
 
 TEST_F(CacheTest, Usage) {
     LRUCache cache(LRUCacheType::SIZE);
-    cache.set_capacity(1050);
+    cache.set_capacity(1200);
 
-    // The lru usage is handle_size + charge = 96 - 1 = 95
-    // 95 + 3 means handle_size + key size
+    // The lru usage is handle_size + charge = 104 - 1 = 103
+    // 103 + 3 means handle_size + key size
     CacheKey key1("100");
     insert_LRUCache(cache, key1, 100, CachePriority::NORMAL);
-    ASSERT_EQ(198, cache.get_usage()); // 100 + 95 + 3
+    ASSERT_EQ(206, cache.get_usage());
 
     CacheKey key2("200");
     insert_LRUCache(cache, key2, 200, CachePriority::DURABLE);
-    ASSERT_EQ(496, cache.get_usage()); // 198 + 200 + 95 + 3
+    ASSERT_EQ(512, cache.get_usage());
 
     CacheKey key3("300");
     insert_LRUCache(cache, key3, 300, CachePriority::NORMAL);
-    ASSERT_EQ(894, cache.get_usage()); // 496 + 300 + 95 + 3
+    ASSERT_EQ(918, cache.get_usage());
 
     CacheKey key4("400");
     insert_LRUCache(cache, key4, 400, CachePriority::NORMAL);
-    ASSERT_EQ(796, cache.get_usage()); // 894 + 400 + 95 + 3 - (300 + 100 + (95 + 3) * 2)
+    ASSERT_EQ(812, cache.get_usage());
 
     CacheKey key5("500");
     insert_LRUCache(cache, key5, 500, CachePriority::NORMAL);
-    ASSERT_EQ(896, cache.get_usage()); // 796 + 500 + 95 + 3 - (400 + 95 +3)
+    ASSERT_EQ(912, cache.get_usage());
 
     CacheKey key6("600");
     insert_LRUCache(cache, key6, 600, CachePriority::NORMAL);
-    ASSERT_EQ(996, cache.get_usage()); // 896 + 600 + 95 +3 - (500 + 95 + 3)
+    ASSERT_EQ(1012, cache.get_usage());
 
     CacheKey key7("950");
     insert_LRUCache(cache, key7, 950, CachePriority::DURABLE);
-    ASSERT_EQ(1048, cache.get_usage()); // 996 + 950 + 95 +3 - (200 + 600 + (95 + 3) * 2)
+    ASSERT_EQ(1056, cache.get_usage());
 }
 
 TEST_F(CacheTest, Prune) {

--- a/be/test/olap/lru_cache_test.cpp
+++ b/be/test/olap/lru_cache_test.cpp
@@ -71,7 +71,7 @@ public:
     // there is 16 shards in ShardedLRUCache
     // And the LRUHandle size is about 100B. So the cache size should big enough
     // to run the UT.
-    static const int kCacheSize = 1000 * 1024l;
+    static const int kCacheSize = 1000 * 16;
     std::vector<int> _deleted_keys;
     std::vector<int> _deleted_values;
     Cache* _cache;

--- a/be/test/vec/exprs/vexpr_test.cpp
+++ b/be/test/vec/exprs/vexpr_test.cpp
@@ -79,12 +79,7 @@ TEST(TEST_VEXPR, ABSTEST) {
     auto block = row_batch.convert_to_vec_block();
     int ts = -1;
     context->execute(&block, &ts);
-
-    FunctionContext* fun_ct = context->fn_context(0);
     context->close(&runtime_stat);
-    if(fun_ct) {
-        delete fun_ct;
-    }
 }
 
 TEST(TEST_VEXPR, ABSTEST2) {
@@ -130,12 +125,7 @@ TEST(TEST_VEXPR, ABSTEST2) {
     auto block = row_batch.convert_to_vec_block();
     int ts = -1;
     context->execute(&block, &ts);
-
-    FunctionContext* fun_ct = context->fn_context(0);
     context->close(&runtime_stat);
-    if(fun_ct) {
-        delete fun_ct;
-    }
 }
 
 namespace doris {


### PR DESCRIPTION
1. fix the hll test do not init the array
2. vexpr test double delete function context
3. fix lru cache UT test

# Proposed changes

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

