### PR TITLE
[enhancement](macOS M1) Support building from source on macOS (M1)

### DIFF
--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -122,11 +122,13 @@ set(Boost_DEBUG FALSE)
 set(Boost_USE_MULTITHREADED ON)
 set(BOOST_ROOT ${THIRDPARTY_DIR})
 set(Boost_NO_BOOST_CMAKE OFF)
+set(BOOST_VERSION "1.73.0")
 
 if (NOT APPLE)
-    find_package(Boost 1.73.0 REQUIRED COMPONENTS system date_time)
+    find_package(Boost ${BOOST_VERSION} REQUIRED COMPONENTS system date_time)
 else()
-    find_package(Boost 1.73.0 COMPONENTS system date_time)
+    find_package(Boost ${BOOST_VERSION} COMPONENTS system date_time)
+    find_package(Boost ${BOOST_VERSION} COMPONENTS system container)
 endif()
 
 set(GPERFTOOLS_HOME "${THIRDPARTY_DIR}/gperftools")
@@ -510,7 +512,7 @@ if (USE_MEM_TRACKER)
 endif()
 
 # Compile with jemalloc.
-# Adding the option `USE_JEMALLOC=ON sh build.sh` when compiling can turn on building with jemalloc 
+# Adding the option `USE_JEMALLOC=ON sh build.sh` when compiling can turn on building with jemalloc
 if (USE_JEMALLOC)
     set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -DUSE_JEMALLOC")
 endif()
@@ -742,7 +744,13 @@ set(COMMON_THIRDPARTY
 )
 
 if (OS_MACOSX)
-    set(COMMON_THIRDPARTY ${COMMON_THIRDPARTY} bfd iberty intl)
+    set(COMMON_THIRDPARTY
+        ${COMMON_THIRDPARTY}
+        Boost::container
+        bfd
+        iberty
+        intl
+    )
 endif()
 
 if (${MAKE_TEST} STREQUAL "ON")

--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -538,7 +538,12 @@ if (USE_DWARF)
 endif()
 
 # For CMAKE_BUILD_TYPE=Debug
-set(CXX_FLAGS_DEBUG "${CXX_GCC_FLAGS} -O0")
+if (OS_MACOSX AND ARCH_ARM)
+    # Using -O0 may meet ARM64 branch out of range errors when linking with tcmalloc.
+    set(CXX_FLAGS_DEBUG "${CXX_GCC_FLAGS} -Og")
+else()
+    set(CXX_FLAGS_DEBUG "${CXX_GCC_FLAGS} -O0")
+endif()
 
 # For CMAKE_BUILD_TYPE=Release
 #   -O3: Enable all compiler optimizations

--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -26,7 +26,7 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 if (CMAKE_SYSTEM_PROCESSOR MATCHES "amd64|x86_64")
     set (ARCH_AMD64 1)
 endif ()
-if (CMAKE_SYSTEM_PROCESSOR MATCHES "^(aarch64.*|AARCH64.*)")
+if (CMAKE_SYSTEM_PROCESSOR MATCHES "^(aarch64.*|AARCH64.*|arm64.*)")
     set (ARCH_AARCH64 1)
 endif ()
 if (ARCH_AARCH64 OR CMAKE_SYSTEM_PROCESSOR MATCHES "arm")
@@ -58,8 +58,12 @@ elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif ()
 
 # Set boost/stacktrace use backtrace api to unwind
-add_definitions(-DBOOST_STACKTRACE_USE_BACKTRACE)
-#add_definitions(-DPRINT_ALL_ERR_STATUS_STACKTRACE)
+if (NOT OS_MACOSX)
+    add_definitions(-DBOOST_STACKTRACE_USE_BACKTRACE)
+    #add_definitions(-DPRINT_ALL_ERR_STATUS_STACKTRACE)
+else()
+    add_definitions(-DBOOST_STACKTRACE_USE_NOOP)
+endif()
 
 option(GLIBC_COMPATIBILITY "Enable compatibility with older glibc libraries." ON)
 message(STATUS "GLIBC_COMPATIBILITY is ${GLIBC_COMPATIBILITY}")
@@ -90,11 +94,7 @@ set(SRC_DIR "${BASE_DIR}/src/")
 set(TEST_DIR "${CMAKE_SOURCE_DIR}/test/")
 set(OUTPUT_DIR "${BASE_DIR}/output")
 
-if (APPLE)
-    set(MAKE_TEST "ON")
-else()
-    option(MAKE_TEST "ON for make unit test or OFF for not" OFF)
-endif()
+option(MAKE_TEST "ON for make unit test or OFF for not" OFF)
 message(STATUS "make test: ${MAKE_TEST}")
 option(WITH_MYSQL "Support access MySQL" ON)
 
@@ -325,8 +325,10 @@ set_target_properties(aws-checksums PROPERTIES IMPORTED_LOCATION ${THIRDPARTY_DI
 add_library(aws-c-s3 STATIC IMPORTED)
 set_target_properties(aws-c-s3 PROPERTIES IMPORTED_LOCATION ${THIRDPARTY_DIR}/lib64/libaws-c-s3.a)
 
-add_library(aws-s2n STATIC IMPORTED)
-set_target_properties(aws-s2n PROPERTIES IMPORTED_LOCATION ${THIRDPARTY_DIR}/lib64/libs2n.a)
+if (NOT OS_MACOSX)
+    add_library(aws-s2n STATIC IMPORTED)
+    set_target_properties(aws-s2n PROPERTIES IMPORTED_LOCATION ${THIRDPARTY_DIR}/lib64/libs2n.a)
+endif()
 
 add_library(minizip STATIC IMPORTED)
 set_target_properties(minizip PROPERTIES IMPORTED_LOCATION ${THIRDPARTY_DIR}/lib64/libminizip.a)
@@ -399,6 +401,17 @@ set_target_properties(hdfs3 PROPERTIES IMPORTED_LOCATION ${THIRDPARTY_DIR}/lib/l
 
 find_program(THRIFT_COMPILER thrift ${CMAKE_SOURCE_DIR}/bin)
 
+if (OS_MACOSX)
+    add_library(bfd STATIC IMPORTED)
+    set_target_properties(bfd PROPERTIES IMPORTED_LOCATION "${THIRDPARTY_DIR}/lib/libbfd.a")
+
+    add_library(iberty STATIC IMPORTED)
+    set_target_properties(iberty PROPERTIES IMPORTED_LOCATION "${THIRDPARTY_DIR}/lib/libiberty.a")
+
+    add_library(intl STATIC IMPORTED)
+    set_target_properties(intl PROPERTIES IMPORTED_LOCATION "${THIRDPARTY_DIR}/lib/libintl.a")
+endif()
+
 # Check if functions are supported in this platform. All flags will generated
 # in gensrc/build/common/env_config.h.
 # You can check funcion here which depends on platform. Don't forget add this
@@ -447,7 +460,10 @@ if (NOT CUSTUM_LINKER_COMMAND STREQUAL "ld")
 endif()
 
 if (USE_LIBCPP AND COMPILER_CLANG)
-    set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -stdlib=libc++ -lstdc++")
+    set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -stdlib=libc++")
+    if (NOT OS_MACOSX)
+        set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -lstdc++")
+    endif()
     add_definitions(-DUSE_LIBCPP)
 endif()
 
@@ -597,9 +613,10 @@ if (BUILD_JAVA_UDF)
     endif()
 endif()
 
-set(WL_START_GROUP "-Wl,--start-group")
-set(WL_END_GROUP "-Wl,--end-group")
-
+if (NOT OS_MACOSX)
+    set(WL_START_GROUP "-Wl,--start-group")
+    set(WL_END_GROUP "-Wl,--end-group")
+endif()
 
 set(KRB5_LIBS
     krb5support
@@ -626,6 +643,10 @@ set(AWS_LIBS
     aws-c-mqtt
     aws-sdk-s3-crt)
 
+if (OS_MACOSX)
+    list(REMOVE_ITEM AWS_LIBS aws-s2n)
+endif()
+
 # Set Doris libraries
 set(DORIS_LINK_LIBS
     ${WL_START_GROUP}
@@ -648,7 +669,6 @@ set(DORIS_LINK_LIBS
     Vec
     ${WL_END_GROUP}
 )
-
 
 # COMMON_THIRDPARTY are thirdparty dependencies that can run on all platform
 # When adding new dependencies, If you don’t know if it can run on all platforms,
@@ -716,6 +736,10 @@ set(COMMON_THIRDPARTY
     simdjson
 )
 
+if (OS_MACOSX)
+    set(COMMON_THIRDPARTY ${COMMON_THIRDPARTY} bfd iberty intl)
+endif()
+
 if (${MAKE_TEST} STREQUAL "ON")
     set(COMMON_THIRDPARTY
         ${COMMON_THIRDPARTY}
@@ -731,15 +755,11 @@ set(DORIS_DEPENDENCIES
 )
 
 if(WITH_LZO)
-    set(DORIS_DEPENDENCIES ${DORIS_DEPENDENCIES}
-        lzo
-    )
+    set(DORIS_DEPENDENCIES ${DORIS_DEPENDENCIES} lzo)
 endif()
 
 if (WITH_MYSQL)
-    set(DORIS_DEPENDENCIES ${DORIS_DEPENDENCIES}
-        mysql
-        )
+    set(DORIS_DEPENDENCIES ${DORIS_DEPENDENCIES} mysql)
 endif()
 
 set(DORIS_DEPENDENCIES ${DORIS_DEPENDENCIES} ${WL_END_GROUP})
@@ -748,13 +768,23 @@ message(STATUS "DORIS_DEPENDENCIES is ${DORIS_DEPENDENCIES}")
 
 # Add all external dependencies. They should come after the palo libs.
 # static link gcc's lib
-set(DORIS_LINK_LIBS ${DORIS_LINK_LIBS}
-    ${DORIS_DEPENDENCIES}
-    -static-libstdc++
-    -static-libgcc
-    -lstdc++fs
-    -lresolv
-)
+if (NOT OS_MACOSX)
+    set(DORIS_LINK_LIBS ${DORIS_LINK_LIBS}
+        ${DORIS_DEPENDENCIES}
+        -static-libstdc++
+        -static-libgcc
+        -lstdc++fs
+        -lresolv
+    )
+else()
+    set(DORIS_LINK_LIBS
+        ${DORIS_LINK_LIBS}
+        ${DORIS_DEPENDENCIES}
+        -lapple_nghttp2
+        -lresolv
+        -liconv
+    )
+endif()
 
 if (USE_JEMALLOC)
     set(MALLOCLIB jemalloc)
@@ -793,9 +823,26 @@ if (GLIBC_COMPATIBILITY)
     set(DORIS_LINK_LIBS ${DORIS_LINK_LIBS} glibc-compatibility-explicit glibc-compatibility)
 endif()
 
-set(DORIS_LINK_LIBS ${DORIS_LINK_LIBS}
-    -lrt -l:libbfd.a -liberty -lc -lm -ldl -pthread
-)
+if (NOT OS_MACOSX)
+    set(DORIS_LINK_LIBS ${DORIS_LINK_LIBS}
+        -lrt -l:libbfd.a -liberty -lc -lm -ldl -pthread
+    )
+else()
+    set(DORIS_LINK_LIBS ${DORIS_LINK_LIBS}
+        "-framework CoreFoundation"
+        "-framework CoreGraphics"
+        "-framework CoreText"
+        "-framework Foundation"
+        "-framework SystemConfiguration"
+        "-framework Security"
+    )
+    if (NOT CMAKE_BUILD_TYPE STREQUAL "DEBUG" AND NOT CMAKE_BUILD_TYPE STREQUAL "RELEASE")
+        set(DORIS_LINK_LIBS
+            ${DORIS_LINK_LIBS}
+            "-Wl,-U,_MallocExtension_ReleaseFreeMemory"
+        )
+    endif()
+endif()
 
 # Set libraries for test
 set (TEST_LINK_LIBS ${DORIS_LINK_LIBS}
@@ -805,12 +852,21 @@ set (TEST_LINK_LIBS ${DORIS_LINK_LIBS}
     ${WL_END_GROUP}
 )
 
+if (NOT MAKE_TEST)
+    message(STATUS "Link Flags: ${DORIS_LINK_LIBS}")
+else()
+    message(STATUS "Link Flags: ${TEST_LINK_LIBS}")
+endif()
+
 # Only build static libs
 set(BUILD_SHARED_LIBS OFF)
 
 if (${MAKE_TEST} STREQUAL "ON")
     SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fprofile-arcs -ftest-coverage -DGTEST_USE_OWN_TR1_TUPLE=0")
-    SET(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fprofile-arcs -ftest-coverage -lgcov")
+    SET(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fprofile-arcs -ftest-coverage")
+    if (NOT OS_MACOSX)
+        SET(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -lgcov")
+    endif()
     add_definitions(-DBE_TEST)
 endif ()
 

--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -841,7 +841,7 @@ else()
         "-framework SystemConfiguration"
         "-framework Security"
     )
-    if (NOT CMAKE_BUILD_TYPE STREQUAL "DEBUG" AND NOT CMAKE_BUILD_TYPE STREQUAL "RELEASE")
+    if (USE_JEMALLOC OR (NOT CMAKE_BUILD_TYPE STREQUAL "DEBUG" AND NOT CMAKE_BUILD_TYPE STREQUAL "RELEASE"))
         set(DORIS_LINK_LIBS
             ${DORIS_LINK_LIBS}
             "-Wl,-U,_MallocExtension_ReleaseFreeMemory"

--- a/be/src/agent/CMakeLists.txt
+++ b/be/src/agent/CMakeLists.txt
@@ -20,8 +20,8 @@ set(LIBRARY_OUTPUT_PATH "${BUILD_DIR}/src/agent")
 
 # where to put generated binaries
 set(EXECUTABLE_OUTPUT_PATH "${BUILD_DIR}/src/agent")
-  
-add_library(Agent STATIC
+
+set(AGENT_SOURCES
     agent_server.cpp
     heartbeat_server.cpp
     task_worker_pool.cpp
@@ -30,3 +30,10 @@ add_library(Agent STATIC
     topic_subscriber.cpp
     user_resource_listener.cpp
 )
+
+if (OS_MACOSX)
+    list(REMOVE_ITEM AGENT_SOURCES cgroups_mgr.cpp user_resource_listener.cpp)
+    list(APPEND AGENT_SOURCES cgroups_mgr_mac.cpp)
+endif()
+
+add_library(Agent STATIC ${AGENT_SOURCES})

--- a/be/src/agent/agent_server.cpp
+++ b/be/src/agent/agent_server.cpp
@@ -94,7 +94,7 @@ AgentServer::AgentServer(ExecEnv* exec_env, const TMasterInfo& master_info)
 #undef CREATE_AND_START_POOL
 #undef CREATE_AND_START_THREAD
 
-#ifndef BE_TEST
+#if !defined(BE_TEST) && !defined(__APPLE__)
     // Add subscriber here and register listeners
     TopicListener* user_resource_listener = new UserResourceListener(exec_env, master_info);
     LOG(INFO) << "Register user resource listener";

--- a/be/src/agent/cgroups_mgr_mac.cpp
+++ b/be/src/agent/cgroups_mgr_mac.cpp
@@ -1,0 +1,37 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "agent/cgroups_mgr.h"
+
+namespace doris {
+
+const std::string CgroupsMgr::_s_system_user = "system";
+const std::string CgroupsMgr::_s_system_group = "normal";
+
+std::map<TResourceType::type, std::string> CgroupsMgr::_s_resource_cgroups;
+
+CgroupsMgr::CgroupsMgr(ExecEnv* exec_env, const std::string& root_cgroups_path) {}
+
+CgroupsMgr::~CgroupsMgr() = default;
+
+Status CgroupsMgr::init_cgroups() {
+    return Status::OK();
+}
+
+void CgroupsMgr::apply_cgroup(const std::string& user_name, const std::string& level) {}
+
+} // namespace doris

--- a/be/src/env/env_posix.cpp
+++ b/be/src/env/env_posix.cpp
@@ -82,9 +82,15 @@ static Status io_error(const std::string& context, int err_number) {
 }
 
 static Status do_sync(int fd, const string& filename) {
+#ifdef __APPLE__
+    if (fcntl(fd, F_FULLFSYNC) < 0) {
+        return io_error(filename, errno);
+    }
+#else
     if (fdatasync(fd) < 0) {
         return io_error(filename, errno);
     }
+#endif
     return Status::OK();
 }
 
@@ -306,6 +312,9 @@ public:
     }
 
     Status pre_allocate(uint64_t size) override {
+#ifdef __APPLE__
+        return io_error(_filename, ENOSYS);
+#else
         uint64_t offset = std::max(_filesize, _pre_allocated_size);
         int ret;
         RETRY_ON_EINTR(ret, fallocate(_fd, 0, offset, size));
@@ -320,6 +329,7 @@ public:
         }
         _pre_allocated_size = offset + size;
         return Status::OK();
+#endif
     }
 
     Status close() override {

--- a/be/src/exec/analytic_eval_node.cpp
+++ b/be/src/exec/analytic_eval_node.cpp
@@ -426,7 +426,8 @@ inline void AnalyticEvalNode::try_remove_rows_before_window(int64_t stream_idx) 
     // The start of the window may have been before the current partition, in which case
     // there is no tuple to remove in _window_tuples. Check the index of the row at which
     // tuples from _window_tuples should begin to be removed.
-    int64_t remove_idx = stream_idx - _rows_end_offset + std::min(_rows_start_offset, 0L) - 1;
+    int64_t remove_idx =
+            stream_idx - _rows_end_offset + std::min<int64_t>(_rows_start_offset, 0L) - 1;
 
     if (remove_idx < _curr_partition_idx) {
         return;
@@ -434,7 +435,7 @@ inline void AnalyticEvalNode::try_remove_rows_before_window(int64_t stream_idx) 
 
     VLOG_ROW << id() << " Remove idx=" << remove_idx << " stream_idx=" << stream_idx;
     DCHECK(!_window_tuples.empty()) << debug_state_string(true);
-    DCHECK_EQ(remove_idx + std::max(_rows_start_offset, 0L), _window_tuples.front().first)
+    DCHECK_EQ(remove_idx + std::max<int64_t>(_rows_start_offset, 0L), _window_tuples.front().first)
             << debug_state_string(true);
     TupleRow* remove_row = reinterpret_cast<TupleRow*>(&_window_tuples.front().second);
     AggFnEvaluator::remove(_evaluators, _fn_ctxs, remove_row, _curr_tuple);

--- a/be/src/exec/arrow/parquet_reader.cpp
+++ b/be/src/exec/arrow/parquet_reader.cpp
@@ -22,6 +22,7 @@
 #include <time.h>
 
 #include <algorithm>
+#include <cinttypes>
 #include <mutex>
 #include <thread>
 
@@ -286,7 +287,7 @@ Status ParquetReaderWrap::read(Tuple* tuple, MemPool* mem_pool, bool* eof) {
                     RETURN_IF_ERROR(set_field_null(tuple, slot_desc));
                 } else {
                     int64_t value = int64_array->Value(_current_line_of_batch);
-                    wbytes = sprintf((char*)tmp_buf, "%ld", value);
+                    wbytes = sprintf((char*)tmp_buf, "%" PRId64, value);
                     fill_slot(tuple, slot_desc, mem_pool, tmp_buf, wbytes);
                 }
                 break;
@@ -310,7 +311,7 @@ Status ParquetReaderWrap::read(Tuple* tuple, MemPool* mem_pool, bool* eof) {
                     RETURN_IF_ERROR(set_field_null(tuple, slot_desc));
                 } else {
                     uint64_t value = uint64_array->Value(_current_line_of_batch);
-                    wbytes = sprintf((char*)tmp_buf, "%lu", value);
+                    wbytes = sprintf((char*)tmp_buf, "%" PRIu64, value);
                     fill_slot(tuple, slot_desc, mem_pool, tmp_buf, wbytes);
                 }
                 break;

--- a/be/src/exec/json_scanner.cpp
+++ b/be/src/exec/json_scanner.cpp
@@ -483,10 +483,10 @@ Status JsonReader::_write_data_to_tuple(rapidjson::Value::ConstValueIterator val
             wbytes = sprintf((char*)tmp_buf, "%d", value->GetInt());
             _fill_slot(tuple, desc, tuple_pool, tmp_buf, wbytes);
         } else if (value->IsUint64()) {
-            wbytes = sprintf((char*)tmp_buf, "%lu", value->GetUint64());
+            wbytes = sprintf((char*)tmp_buf, "%" PRIu64, value->GetUint64());
             _fill_slot(tuple, desc, tuple_pool, tmp_buf, wbytes);
         } else if (value->IsInt64()) {
-            wbytes = sprintf((char*)tmp_buf, "%ld", value->GetInt64());
+            wbytes = sprintf((char*)tmp_buf, "%" PRId64, value->GetInt64());
             _fill_slot(tuple, desc, tuple_pool, tmp_buf, wbytes);
         } else {
             wbytes = sprintf((char*)tmp_buf, "%f", value->GetDouble());

--- a/be/src/exec/orc_scanner.cpp
+++ b/be/src/exec/orc_scanner.cpp
@@ -212,7 +212,7 @@ Status ORCScanner::get_next(Tuple* tuple, MemPool* tuple_pool, bool* eof, bool* 
                     case orc::SHORT:
                     case orc::LONG: {
                         int64_t value = ((orc::LongVectorBatch*)cvb)->data[_current_line_of_group];
-                        wbytes = sprintf((char*)tmp_buf, "%ld", value);
+                        wbytes = sprintf((char*)tmp_buf, "%" PRId64, value);
                         str_slot->ptr = reinterpret_cast<char*>(tuple_pool->allocate(wbytes));
                         memcpy(str_slot->ptr, tmp_buf, wbytes);
                         str_slot->len = wbytes;

--- a/be/src/exec/table_connector.cpp
+++ b/be/src/exec/table_connector.cpp
@@ -17,6 +17,8 @@
 
 #include "exec/table_connector.h"
 
+#include <codecvt>
+
 #include "exprs/expr.h"
 #include "runtime/primitive_type.h"
 #include "util/mysql_global.h"

--- a/be/src/exprs/table_function/explode_json_array.cpp
+++ b/be/src/exprs/table_function/explode_json_array.cpp
@@ -77,9 +77,9 @@ int ParsedData::set_output(ExplodeJsonArrayType type, rapidjson::Document& docum
                 } else if (v.IsInt()) {
                     wbytes = sprintf(tmp_buf, "%d", v.GetInt());
                 } else if (v.IsUint64()) {
-                    wbytes = sprintf(tmp_buf, "%lu", v.GetUint64());
+                    wbytes = sprintf(tmp_buf, "%" PRIu64, v.GetUint64());
                 } else if (v.IsInt64()) {
-                    wbytes = sprintf(tmp_buf, "%ld", v.GetInt64());
+                    wbytes = sprintf(tmp_buf, "%" PRId64, v.GetInt64());
                 } else {
                     wbytes = sprintf(tmp_buf, "%f", v.GetDouble());
                 }

--- a/be/src/geo/CMakeLists.txt
+++ b/be/src/geo/CMakeLists.txt
@@ -29,7 +29,9 @@ add_library(Geo STATIC
     ${GENSRC_DIR}/geo/wkt_lex.l.cpp
     ${GENSRC_DIR}/geo/wkt_yacc.y.cpp
 )
-target_compile_options(Geo PRIVATE -Wno-unused-but-set-variable)
+if (COMPILER_GCC OR CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "15.0.0")
+    target_compile_options(Geo PRIVATE -Wno-unused-but-set-variable)
+endif()
 
 add_custom_command(
     OUTPUT ${GENSRC_DIR}/geo/wkt_lex.l.cpp ${GENSRC_DIR}/geo/wkt_lex.l.h

--- a/be/src/gutil/strings/split_internal.h
+++ b/be/src/gutil/strings/split_internal.h
@@ -64,8 +64,14 @@ struct NoFilter {
 // The two-argument constructor is used to split the given text using the given
 // delimiter.
 template <typename Delimiter, typename Predicate = NoFilter>
-class SplitIterator : public std::iterator<std::input_iterator_tag, StringPiece> {
+class SplitIterator {
 public:
+    using iterator_category = std::input_iterator_tag;
+    using value_type = StringPiece;
+    using difference_type = ptrdiff_t;
+    using pointer = StringPiece*;
+    using reference = StringPiece&;
+
     // Two constructors for "end" iterators.
     explicit SplitIterator(Delimiter d) : delimiter_(std::move(d)), predicate_(), is_end_(true) {}
     SplitIterator(Delimiter d, Predicate p)

--- a/be/src/gutil/sysinfo.cc
+++ b/be/src/gutil/sysinfo.cc
@@ -99,6 +99,9 @@ void SleepForMilliseconds(int64_t milliseconds) {
     SleepForNanoseconds(milliseconds * 1000 * 1000);
 }
 
+// ReadIntFromFile is only called on linux and cygwin platforms.
+#if defined(__linux__) || defined(__CYGWIN__) || defined(__CYGWIN32__)
+
 // Helper function estimates cycles/sec by observing cycles elapsed during
 // sleep(). Using small sleep time decreases accuracy significantly.
 static int64 EstimateCyclesPerSecond(const int estimate_time_ms) {
@@ -111,9 +114,6 @@ static int64 EstimateCyclesPerSecond(const int estimate_time_ms) {
     const int64 guess = int64(multiplier * (CycleClock::Now() - start_ticks));
     return guess;
 }
-
-// ReadIntFromFile is only called on linux and cygwin platforms.
-#if defined(__linux__) || defined(__CYGWIN__) || defined(__CYGWIN32__)
 
 // Slurp a file with a single read() call into 'buf'. This is only safe to use on small
 // files in places like /proc where we are guaranteed not to get a partial read.
@@ -233,6 +233,7 @@ static void InitializeSystemInfo() {
     if (already_called) return;
     already_called = true;
 
+#if defined(__linux__) || defined(__CYGWIN__) || defined(__CYGWIN32__)
     bool saw_mhz = false;
 
     if (RunningOnValgrind()) {
@@ -243,7 +244,6 @@ static void InitializeSystemInfo() {
         saw_mhz = true;
     }
 
-#if defined(__linux__) || defined(__CYGWIN__) || defined(__CYGWIN32__)
     char line[1024];
     char* err;
     int freq;

--- a/be/src/gutil/type_traits.h
+++ b/be/src/gutil/type_traits.h
@@ -165,7 +165,7 @@ template <>
 struct is_integral<long> : true_type {};
 template <>
 struct is_integral<unsigned long> : true_type {};
-#ifdef HAVE_LONG_LONG
+#if defined(HAVE_LONG_LONG) && !defined(__APPLE__)
 template <>
 struct is_integral<long long> : true_type {};
 template <>

--- a/be/src/olap/CMakeLists.txt
+++ b/be/src/olap/CMakeLists.txt
@@ -111,3 +111,7 @@ add_library(Olap STATIC
     segment_loader.cpp
     storage_policy_mgr.cpp
 )
+
+if (NOT USE_MEM_TRACKER)
+    target_compile_options(Olap PRIVATE -Wno-unused-lambda-capture)
+endif()

--- a/be/src/olap/base_compaction.cpp
+++ b/be/src/olap/base_compaction.cpp
@@ -49,9 +49,11 @@ Status BaseCompaction::prepare_compact() {
 }
 
 Status BaseCompaction::execute_compact_impl() {
+#ifndef __APPLE__
     if (config::enable_base_compaction_idle_sched) {
         Thread::set_idle_sched();
     }
+#endif
     std::unique_lock<std::mutex> lock(_tablet->get_base_compaction_lock(), std::try_to_lock);
     if (!lock.owns_lock()) {
         LOG(WARNING) << "another base compaction is running. tablet=" << _tablet->full_name();

--- a/be/src/olap/data_dir.cpp
+++ b/be/src/olap/data_dir.cpp
@@ -17,12 +17,15 @@
 
 #include "olap/data_dir.h"
 
+#ifndef __APPLE__
+#include <mntent.h>
+#include <sys/statfs.h>
+#endif
+
 #include <ctype.h>
 #include <gen_cpp/olap_file.pb.h>
-#include <mntent.h>
 #include <stdio.h>
 #include <sys/file.h>
-#include <sys/statfs.h>
 #include <utime.h>
 
 #include <atomic>

--- a/be/src/olap/decimal12.h
+++ b/be/src/olap/decimal12.h
@@ -81,9 +81,9 @@ struct decimal12_t {
         char buf[128] = {'\0'};
 
         if (integer < 0 || fraction < 0) {
-            snprintf(buf, sizeof(buf), "-%lu.%09u", std::abs(integer), std::abs(fraction));
+            snprintf(buf, sizeof(buf), "-%" PRIu64 ".%09u", std::abs(integer), std::abs(fraction));
         } else {
-            snprintf(buf, sizeof(buf), "%lu.%09u", std::abs(integer), std::abs(fraction));
+            snprintf(buf, sizeof(buf), "%" PRIu64 ".%09u", std::abs(integer), std::abs(fraction));
         }
 
         return std::string(buf);
@@ -115,7 +115,7 @@ struct decimal12_t {
                 int32_t f = 0;
                 sscanf(value_string, ".%9d", &f);
             } else {
-                sscanf(value_string, "%18ld.%9d", &i, &f);
+                sscanf(value_string, "%18" PRId64 ".%9d", &i, &f);
             }
             integer = i;
             fraction = f;

--- a/be/src/olap/file_helper.h
+++ b/be/src/olap/file_helper.h
@@ -95,8 +95,11 @@ private:
 
     int _fd;
     off_t _wr_length;
-    const int64_t _cache_threshold = 1 << 19;
     std::string _file_name;
+
+#ifndef __APPLE__
+    const int64_t _cache_threshold = 1 << 19;
+#endif
 };
 
 class FileHandlerWithBuf {

--- a/be/src/olap/options.cpp
+++ b/be/src/olap/options.cpp
@@ -42,7 +42,7 @@ static std::string REMOTE_CACHE_UC = "REMOTE_CACHE";
 // TODO: should be a general util method
 static std::string to_upper(const std::string& str) {
     std::string out = str;
-    std::transform(out.begin(), out.end(), out.begin(), ::toupper);
+    std::transform(out.begin(), out.end(), out.begin(), [](auto c) { return std::toupper(c); });
     return out;
 }
 

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -1252,8 +1252,8 @@ void Tablet::get_compaction_status(std::string* json_result) {
             missing_versions_arr.PushBack(miss_value, missing_versions_arr.GetAllocator());
         }
         rapidjson::Value value;
-        std::string disk_size =
-                PrettyPrinter::print(rowsets[i]->rowset_meta()->total_disk_size(), TUnit::BYTES);
+        std::string disk_size = PrettyPrinter::print(
+                static_cast<uint64_t>(rowsets[i]->rowset_meta()->total_disk_size()), TUnit::BYTES);
         std::string version_str = strings::Substitute(
                 "[$0-$1] $2 $3 $4 $5 $6", ver.first, ver.second, rowsets[i]->num_segments(),
                 (delete_flags[i] ? "DELETE" : "DATA"),
@@ -1273,7 +1273,8 @@ void Tablet::get_compaction_status(std::string* json_result) {
         const Version& ver = stale_rowsets[i]->version();
         rapidjson::Value value;
         std::string disk_size = PrettyPrinter::print(
-                stale_rowsets[i]->rowset_meta()->total_disk_size(), TUnit::BYTES);
+                static_cast<uint64_t>(stale_rowsets[i]->rowset_meta()->total_disk_size()),
+                TUnit::BYTES);
         std::string version_str = strings::Substitute(
                 "[$0-$1] $2 $3 $4", ver.first, ver.second, stale_rowsets[i]->num_segments(),
                 stale_rowsets[i]->rowset_id().to_string(), disk_size);

--- a/be/src/olap/tablet_schema.cpp
+++ b/be/src/olap/tablet_schema.cpp
@@ -32,7 +32,8 @@ namespace doris {
 
 FieldType TabletColumn::get_field_type_by_string(const std::string& type_str) {
     std::string upper_type_str = type_str;
-    std::transform(type_str.begin(), type_str.end(), upper_type_str.begin(), toupper);
+    std::transform(type_str.begin(), type_str.end(), upper_type_str.begin(),
+                   [](auto c) { return std::toupper(c); });
     FieldType type;
 
     if (0 == upper_type_str.compare("TINYINT")) {
@@ -109,7 +110,8 @@ FieldType TabletColumn::get_field_type_by_string(const std::string& type_str) {
 
 FieldAggregationMethod TabletColumn::get_aggregation_type_by_string(const std::string& str) {
     std::string upper_str = str;
-    std::transform(str.begin(), str.end(), upper_str.begin(), toupper);
+    std::transform(str.begin(), str.end(), upper_str.begin(),
+                   [](auto c) { return std::toupper(c); });
     FieldAggregationMethod aggregation_type;
 
     if (0 == upper_str.compare("NONE")) {

--- a/be/src/olap/types.h
+++ b/be/src/olap/types.h
@@ -20,6 +20,7 @@
 #include <math.h>
 #include <stdio.h>
 
+#include <cinttypes>
 #include <limits>
 #include <memory>
 #include <sstream>
@@ -789,7 +790,7 @@ struct FieldTypeTraits<OLAP_FIELD_TYPE_LARGEINT>
         int128_t value = reinterpret_cast<const PackedInt128*>(src)->value;
         if (value >= std::numeric_limits<int64_t>::min() &&
             value <= std::numeric_limits<int64_t>::max()) {
-            snprintf(buf, sizeof(buf), "%ld", (int64_t)value);
+            snprintf(buf, sizeof(buf), "%" PRId64, (int64_t)value);
         } else {
             char* current = buf;
             uint128_t abs_value = value;

--- a/be/src/olap/uint24.h
+++ b/be/src/olap/uint24.h
@@ -64,7 +64,7 @@ public:
     }
 
     uint24_t& operator>>=(const int bits) {
-        *this = static_cast<uint>(*this) >> bits;
+        *this = static_cast<unsigned int>(*this) >> bits;
         return *this;
     }
 

--- a/be/src/olap/utils.h
+++ b/be/src/olap/utils.h
@@ -147,9 +147,9 @@ public:
 };
 
 // iterator offset，用于二分查找
-typedef uint32_t iterator_offset_t;
+using iterator_offset_t = size_t;
 
-class BinarySearchIterator : public std::iterator<std::random_access_iterator_tag, size_t> {
+class BinarySearchIterator : public std::iterator_traits<iterator_offset_t*> {
 public:
     BinarySearchIterator() : _offset(0u) {}
     explicit BinarySearchIterator(iterator_offset_t offset) : _offset(offset) {}

--- a/be/src/runtime/client_cache.h
+++ b/be/src/runtime/client_cache.h
@@ -267,8 +267,8 @@ private:
     // since service type is multiple, we should set thrift server type here for be thrift client
     ThriftServer::ServerType get_thrift_server_type() {
         auto& thrift_server_type = config::thrift_server_type_of_fe;
-        transform(thrift_server_type.begin(), thrift_server_type.end(), thrift_server_type.begin(),
-                  toupper);
+        std::transform(thrift_server_type.begin(), thrift_server_type.end(),
+                       thrift_server_type.begin(), [](auto c) { return std::toupper(c); });
         if (strcmp(typeid(T).name(), "N5doris21FrontendServiceClientE") == 0 &&
             thrift_server_type == "THREADED_SELECTOR") {
             return ThriftServer::ServerType::NON_BLOCKING;

--- a/be/src/runtime/load_path_mgr.cpp
+++ b/be/src/runtime/load_path_mgr.cpp
@@ -63,7 +63,7 @@ Status LoadPathMgr::init() {
     RETURN_IF_ERROR(FileUtils::create_dir(_error_log_dir));
 
     _idx = 0;
-    _reserved_hours = std::max(config::load_data_reserve_hours, 1L);
+    _reserved_hours = std::max<int64_t>(config::load_data_reserve_hours, 1L);
     RETURN_IF_ERROR(Thread::create(
             "LoadPathMgr", "clean_expired_temp_path",
             [this]() {

--- a/be/src/runtime/row_batch.cpp
+++ b/be/src/runtime/row_batch.cpp
@@ -33,6 +33,7 @@
 #include "runtime/string_value.h"
 #include "runtime/thread_context.h"
 #include "runtime/tuple_row.h"
+#include "util/exception.h"
 #include "vec/columns/column_vector.h"
 #include "vec/core/block.h"
 
@@ -285,7 +286,7 @@ Status RowBatch::serialize(PRowBatch* output_batch, size_t* uncompressed_size,
             std::exception_ptr p = std::current_exception();
             LOG(WARNING) << "Try to alloc " << max_compressed_size
                          << " bytes for compression scratch failed. "
-                         << (p ? p.__cxa_exception_type()->name() : "null");
+                         << get_current_exception_type_name(p);
         }
     }
     if (can_compress) {

--- a/be/src/service/doris_main.cpp
+++ b/be/src/service/doris_main.cpp
@@ -17,6 +17,7 @@
 
 #include <errno.h>
 #include <gperftools/malloc_extension.h>
+#include <libgen.h>
 #include <setjmp.h>
 #include <sys/file.h>
 #include <unistd.h>
@@ -181,7 +182,9 @@ void check_required_instructions_impl(volatile InstructionFail& fail) {
 
 #if defined(__ARM_NEON__)
     fail = InstructionFail::ARM_NEON;
+#ifndef __APPLE__
     __asm__ volatile("vadd.i32  q8, q8, q8" : : : "q8");
+#endif
 #endif
 
     fail = InstructionFail::NONE;

--- a/be/src/util/CMakeLists.txt
+++ b/be/src/util/CMakeLists.txt
@@ -113,12 +113,18 @@ set(UTIL_FILES
   telemetry/open_telemetry_scop_wrapper.hpp
   quantile_state.cpp
   jni-util.cpp
+  exception.cpp
 )
 
 if (WITH_MYSQL)
     set(UTIL_FILES ${UTIL_FILES}
         mysql_load_error_hub.cpp
         )
+endif()
+
+if (OS_MACOSX)
+    list(REMOVE_ITEM UTIL_FILES perf_counters.cpp disk_info.cpp)
+    list(APPEND UTIL_FILES perf_counters_mac.cpp disk_info_mac.cpp)
 endif()
 
 add_library(Util STATIC

--- a/be/src/util/bit_stream_utils.h
+++ b/be/src/util/bit_stream_utils.h
@@ -124,7 +124,7 @@ public:
     void Rewind(int num_bits);
 
     // Seek to a specific bit in the buffer
-    void SeekToBit(uint stream_position);
+    void SeekToBit(unsigned int stream_position);
 
     // Maximum byte length of a vlq encoded int
     static const int MAX_VLQ_BYTE_LEN = 5;

--- a/be/src/util/bit_stream_utils.inline.h
+++ b/be/src/util/bit_stream_utils.inline.h
@@ -150,7 +150,7 @@ inline void BitReader::Rewind(int num_bits) {
     memcpy(&buffered_values_, buffer_ + byte_offset_, 8);
 }
 
-inline void BitReader::SeekToBit(uint stream_position) {
+inline void BitReader::SeekToBit(unsigned int stream_position) {
     DCHECK_LE(stream_position, max_bytes_ * 8);
 
     int delta = static_cast<int>(stream_position) - position();

--- a/be/src/util/bit_util.h
+++ b/be/src/util/bit_util.h
@@ -20,7 +20,9 @@
 
 #pragma once
 
+#ifndef __APPLE__
 #include <endian.h>
+#endif
 
 #include "common/compiler_util.h"
 #include "gutil/bits.h"

--- a/be/src/util/core_local.h
+++ b/be/src/util/core_local.h
@@ -124,7 +124,11 @@ public:
 
     size_t size() const { return _size; }
     T* access() const {
+#ifdef __APPLE__
+        size_t cpu_id = 0;
+#else
         size_t cpu_id = sched_getcpu();
+#endif
         if (cpu_id >= _size) {
             cpu_id &= _size - 1;
         }

--- a/be/src/util/crc32c.cpp
+++ b/be/src/util/crc32c.cpp
@@ -228,7 +228,7 @@ uint32_t ExtendImpl(uint32_t crc, const char* buf, size_t size) {
     uint64_t l = crc ^ 0xffffffffu;
 
 // Align n to (1 << m) byte boundary
-#define ALIGN(n, m) ((n + ((1 << m) - 1)) & ~((1 << m) - 1))
+#define CRC_ALIGN(n, m) ((n + ((1 << m) - 1)) & ~((1 << m) - 1))
 
 #define STEP1                      \
     do {                           \
@@ -239,7 +239,7 @@ uint32_t ExtendImpl(uint32_t crc, const char* buf, size_t size) {
     // Point x at first 16-byte aligned byte in string.  This might be
     // just past the end of the string.
     const uintptr_t pval = reinterpret_cast<uintptr_t>(p);
-    const uint8_t* x = reinterpret_cast<const uint8_t*>(ALIGN(pval, 4));
+    const uint8_t* x = reinterpret_cast<const uint8_t*>(CRC_ALIGN(pval, 4));
     if (x <= e) {
         // Process bytes until finished or p is 16-byte aligned
         while (p != x) {
@@ -260,7 +260,7 @@ uint32_t ExtendImpl(uint32_t crc, const char* buf, size_t size) {
         STEP1;
     }
 #undef STEP1
-#undef ALIGN
+#undef CRC_ALIGN
     return static_cast<uint32_t>(l ^ 0xffffffffu);
 }
 

--- a/be/src/util/disk_info_mac.cpp
+++ b/be/src/util/disk_info_mac.cpp
@@ -1,0 +1,163 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <libgen.h>
+#include <sys/mount.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+
+#include <algorithm>
+#include <cstring>
+#include <iterator>
+#include <map>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "disk_info.h"
+#include "file_utils.h"
+
+namespace doris {
+
+bool DiskInfo::_s_initialized;
+std::vector<DiskInfo::Disk> DiskInfo::_s_disks;
+std::map<dev_t, int> DiskInfo::_s_device_id_to_disk_id;
+std::map<std::string, int> DiskInfo::_s_disk_name_to_disk_id;
+int DiskInfo::_s_num_datanode_dirs;
+
+std::vector<std::pair<std::string, std::string>> get_mount_infos() {
+    struct statfs* stfs;
+    auto num = getmntinfo(&stfs, MNT_WAIT);
+
+    std::vector<std::pair<std::string, std::string>> mount_infos;
+    mount_infos.reserve(num);
+    for (int i = 0; i < num; ++i) {
+        auto device = stfs[i].f_mntfromname;
+        auto mount_point = stfs[i].f_mntonname;
+        if (strncmp(device, "/dev/", std::min(strlen("/dev/"), strlen(device))) != 0) {
+            continue;
+        }
+        mount_infos.push_back({device, mount_point});
+    }
+    return mount_infos;
+}
+
+void DiskInfo::get_device_names() {
+    auto mount_infos = get_mount_infos();
+    std::sort(std::begin(mount_infos), std::end(mount_infos),
+              [](const auto& info, const auto& other) {
+                  const auto& mount_point = info.second;
+                  const auto& other_mount_point = info.second;
+                  return mount_point < other_mount_point;
+              });
+
+    std::map<int, int> major_to_disk_id;
+    for (const auto& info : mount_infos) {
+        const auto* device = info.first.c_str();
+        struct stat st;
+        if (stat(device, &st) == 0) {
+            dev_t dev = st.st_rdev;
+            auto it = major_to_disk_id.find(major(dev));
+            int disk_id;
+            if (it == major_to_disk_id.end()) {
+                disk_id = _s_disks.size();
+                major_to_disk_id[major(dev)] = disk_id;
+
+                std::string name = "disk" + std::to_string(disk_id);
+                _s_disks.push_back(Disk(name, disk_id, true));
+                _s_disk_name_to_disk_id[name] = disk_id;
+            } else {
+                disk_id = it->second;
+            }
+            _s_device_id_to_disk_id[dev] = disk_id;
+        }
+    }
+
+    if (_s_disks.empty()) {
+        // If all else fails, return 1
+        LOG(WARNING) << "Could not determine number of disks on this machine.";
+        _s_disks.push_back(Disk("sda", 0));
+    }
+}
+
+void DiskInfo::init() {
+    get_device_names();
+    _s_initialized = true;
+}
+
+int DiskInfo::disk_id(const char* path) {
+    struct stat s;
+    stat(path, &s);
+    std::map<dev_t, int>::iterator it = _s_device_id_to_disk_id.find(s.st_dev);
+
+    if (it == _s_device_id_to_disk_id.end()) {
+        return -1;
+    }
+
+    return it->second;
+}
+
+std::string DiskInfo::debug_string() {
+    DCHECK(_s_initialized);
+    std::stringstream stream;
+    stream << "Disk Info: " << std::endl;
+    stream << "  Num disks " << num_disks() << ": ";
+
+    for (int i = 0; i < _s_disks.size(); ++i) {
+        stream << _s_disks[i].name;
+
+        if (i < num_disks() - 1) {
+            stream << ", ";
+        }
+    }
+
+    stream << std::endl;
+    return stream.str();
+}
+
+Status DiskInfo::get_disk_devices(const std::vector<std::string>& paths,
+                                  std::set<std::string>* devices) {
+    std::vector<std::string> real_paths;
+    for (const auto& path : paths) {
+        std::string p;
+        WARN_IF_ERROR(FileUtils::canonicalize(path, &p),
+                      "canonicalize path " + path + " failed, skip disk monitoring of this path");
+        real_paths.emplace_back(std::move(p));
+    }
+
+    auto mount_infos = get_mount_infos();
+    for (const auto& path : real_paths) {
+        size_t max_mount_size = 0;
+        std::string match_dev;
+        for (const auto& info : mount_infos) {
+            auto mount_point = info.second;
+            size_t mount_size = mount_point.length();
+            if (mount_size < max_mount_size || path.size() < mount_point.size() ||
+                mount_point.compare(0, mount_point.length(), path, 0, mount_point.length()) != 0) {
+                continue;
+            }
+            max_mount_size = mount_size;
+            match_dev = info.first;
+        }
+        if (max_mount_size > 0) {
+            devices->emplace(basename(const_cast<char*>(match_dev.c_str())));
+        }
+    }
+    return Status::OK();
+}
+
+} // namespace doris

--- a/be/src/util/easy_json.cc
+++ b/be/src/util/easy_json.cc
@@ -104,6 +104,13 @@ EasyJson& EasyJson::operator=(EasyJson::ComplexTypeInitializer val) {
     return (*this);
 }
 
+#ifdef __APPLE__
+template <>
+EasyJson& EasyJson::operator=(unsigned long val) {
+    return EasyJson::operator=(static_cast<uint64_t>(val));
+}
+#endif
+
 EasyJson& EasyJson::SetObject() {
     if (!value_->IsObject()) {
         value_->SetObject();

--- a/be/src/util/errno.cpp
+++ b/be/src/util/errno.cpp
@@ -17,7 +17,9 @@
 
 #include "util/errno.h"
 
+#ifndef __APPLE__
 #include <features.h>
+#endif
 
 #include <cstring>
 

--- a/be/src/util/exception.cpp
+++ b/be/src/util/exception.cpp
@@ -1,0 +1,35 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "exception.h"
+
+#ifdef USE_LIBCPP
+#include <cxxabi.h>
+
+#include <typeinfo>
+#endif
+
+const char* get_current_exception_type_name(const std::exception_ptr& exception_ptr) {
+#ifdef USE_LIBCPP
+    int status;
+    return exception_ptr ? abi::__cxa_demangle(abi::__cxa_current_exception_type()->name(), nullptr,
+                                               nullptr, &status)
+                         : "null";
+#else
+    return exception_ptr ? exception_ptr.__cxa_exception_type()->name() : "null";
+#endif
+}

--- a/be/src/util/exception.h
+++ b/be/src/util/exception.h
@@ -1,0 +1,22 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <exception>
+
+const char* get_current_exception_type_name(const std::exception_ptr& exception_ptr);

--- a/be/src/util/lru_cache.hpp
+++ b/be/src/util/lru_cache.hpp
@@ -29,8 +29,14 @@ public:
     typedef typename std::pair<Key, Value> KeyValuePair;
     typedef typename std::list<KeyValuePair>::iterator ListIterator;
 
-    class Iterator : public std::iterator<std::input_iterator_tag, KeyValuePair> {
+    class Iterator {
     public:
+        using iterator_category = std::input_iterator_tag;
+        using value_type = KeyValuePair;
+        using difference_type = ptrdiff_t;
+        using pointer = KeyValuePair*;
+        using reference = KeyValuePair&;
+
         Iterator(typename std::unordered_map<Key, ListIterator>::iterator it) : _it(it) {}
 
         Iterator& operator++() {

--- a/be/src/util/mem_info.h
+++ b/be/src/util/mem_info.h
@@ -69,7 +69,8 @@ public:
                                                         &_s_tcmalloc_thread_bytes);
         _s_allocator_cache_mem = _s_tcmalloc_pageheap_free_bytes + _s_tcmalloc_central_bytes +
                                  _s_tcmalloc_transfer_bytes + _s_tcmalloc_thread_bytes;
-        _s_allocator_cache_mem_str = PrettyPrinter::print(_s_allocator_cache_mem, TUnit::BYTES);
+        _s_allocator_cache_mem_str =
+                PrettyPrinter::print(static_cast<uint64_t>(_s_allocator_cache_mem), TUnit::BYTES);
         _s_virtual_memory_used = _s_allocator_physical_mem + _s_pageheap_unmapped_bytes;
         _s_proc_mem_no_allocator_cache =
                 PerfCounters::get_vm_rss() - static_cast<int64_t>(_s_allocator_cache_mem);

--- a/be/src/util/network_util.cpp
+++ b/be/src/util/network_util.cpp
@@ -30,6 +30,12 @@
 
 #include <sstream>
 
+#ifdef __APPLE__
+#ifndef HOST_NAME_MAX
+#define HOST_NAME_MAX MAXHOSTNAMELEN
+#endif
+#endif
+
 namespace doris {
 
 InetAddress::InetAddress(struct sockaddr* addr) {

--- a/be/src/util/path_trie.hpp
+++ b/be/src/util/path_trie.hpp
@@ -37,6 +37,22 @@ public:
         }
     }
 
+    class Allocator {
+    public:
+        using value_type = T;
+
+        T* allocate(size_t n) { return static_cast<T*>(::operator new(sizeof(T) * n)); }
+
+        template <typename... Args>
+        void construct(T* p, Args&&... args) {
+            new (p) T(std::forward<Args>(args)...);
+        }
+
+        void destroy(T* p) { p->~T(); }
+
+        void deallocate(T* p, size_t n) { ::operator delete(p); }
+    };
+
     class TrieNode {
     public:
         TrieNode(const std::string& key, const std::string& wildcard)
@@ -199,7 +215,7 @@ public:
         std::string _wildcard;
         std::string _named_wildcard;
         std::map<std::string, TrieNode*> _children;
-        std::allocator<T> _allocator;
+        Allocator _allocator;
     };
 
     bool insert(const std::string& path, const T& value) {
@@ -270,7 +286,7 @@ private:
     TrieNode _root;
     T* _root_value;
     char _separator;
-    std::allocator<T> _allocator;
+    Allocator _allocator;
 };
 
 } // namespace doris

--- a/be/src/util/perf_counters_mac.cpp
+++ b/be/src/util/perf_counters_mac.cpp
@@ -1,0 +1,27 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "perf_counters.h"
+
+namespace doris {
+
+int64_t PerfCounters::_vm_rss = 0;
+std::string PerfCounters::_vm_rss_str = "";
+
+void PerfCounters::refresh_proc_status() {}
+
+} // namespace doris

--- a/be/src/util/proto_util.h
+++ b/be/src/util/proto_util.h
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#include "exception.h"
+
 namespace doris {
 
 // When the tuple/block data is greater than 2G, embed the tuple/block data
@@ -122,7 +124,7 @@ inline Status request_embed_attachment(Params* brpc_request, const std::string& 
         std::exception_ptr p = std::current_exception();
         LOG(WARNING) << "Try to alloc " << data_size
                      << " bytes for append data to attachment failed. "
-                     << (p ? p.__cxa_exception_type()->name() : "null");
+                     << get_current_exception_type_name(p);
         return Status::MemoryAllocFailed("request embed attachment failed to memcpy {} bytes",
                                          data_size);
     }
@@ -173,7 +175,7 @@ inline Status attachment_extract_request(const Params* brpc_request, brpc::Contr
         std::exception_ptr p = std::current_exception();
         LOG(WARNING) << "Try to alloc " << data_size
                      << " bytes for extract data from attachment failed. "
-                     << (p ? p.__cxa_exception_type()->name() : "null");
+                     << get_current_exception_type_name(p);
         return Status::MemoryAllocFailed("attachment extract request failed to memcpy {} bytes",
                                          data_size);
     }

--- a/be/src/util/radix_sort.h
+++ b/be/src/util/radix_sort.h
@@ -25,7 +25,10 @@
 
 #pragma once
 
+#ifndef __APPLE__
 #include <malloc.h>
+#endif
+
 #include <string.h>
 
 #include <algorithm>

--- a/be/src/util/runtime_profile.cpp
+++ b/be/src/util/runtime_profile.cpp
@@ -254,7 +254,7 @@ void RuntimeProfile::compute_time_in_profile(int64_t total) {
 
     int64_t local_time = total_time_counter()->value() - total_child_time;
     // Counters have some margin, set to 0 if it was negative.
-    local_time = std::max(0L, local_time);
+    local_time = std::max<int64_t>(0L, local_time);
     _local_time_percent = static_cast<double>(local_time) / total;
     _local_time_percent = std::min(1.0, _local_time_percent) * 100;
 

--- a/be/src/util/system_metrics.cpp
+++ b/be/src/util/system_metrics.cpp
@@ -799,25 +799,25 @@ void SystemMetrics::_update_proc_metrics() {
         char* start_pos = nullptr;
         start_pos = strstr(_line_ptr, "intr ");
         if (start_pos) {
-            sscanf(start_pos, "intr %lu", &inter);
+            sscanf(start_pos, "intr %" PRIu64, &inter);
             _proc_metrics->proc_interrupt->set_value(inter);
         }
 
         start_pos = strstr(_line_ptr, "ctxt ");
         if (start_pos) {
-            sscanf(start_pos, "ctxt %lu", &ctxt);
+            sscanf(start_pos, "ctxt %" PRIu64, &ctxt);
             _proc_metrics->proc_ctxt_switch->set_value(ctxt);
         }
 
         start_pos = strstr(_line_ptr, "procs_running ");
         if (start_pos) {
-            sscanf(start_pos, "procs_running %lu", &procs_r);
+            sscanf(start_pos, "procs_running %" PRIu64, &procs_r);
             _proc_metrics->proc_procs_running->set_value(procs_r);
         }
 
         start_pos = strstr(_line_ptr, "procs_blocked ");
         if (start_pos) {
-            sscanf(start_pos, "procs_blocked %lu", &procs_b);
+            sscanf(start_pos, "procs_blocked %" PRIu64, &procs_b);
             _proc_metrics->proc_procs_blocked->set_value(procs_b);
         }
     }
@@ -847,7 +847,7 @@ void SystemMetrics::get_metrics_from_proc_vmstat() {
     while (getline(&_line_ptr, &_line_buf_size, fp) > 0) {
         uint64_t value;
         char name[64];
-        int num = sscanf(_line_ptr, "%s %lu", name, &value);
+        int num = sscanf(_line_ptr, "%s %" PRIu64, name, &value);
         if (num < 2) {
             continue;
         }

--- a/be/src/util/thread.h
+++ b/be/src/util/thread.h
@@ -20,8 +20,11 @@
 
 #pragma once
 
-#include <pthread.h>
+#ifndef __APPLE__
 #include <syscall.h>
+#endif
+
+#include <pthread.h>
 
 #include <atomic>
 
@@ -89,7 +92,9 @@ public:
 
     static void set_self_name(const std::string& name);
 
+#ifndef __APPLE__
     static void set_idle_sched();
+#endif
 
     ~Thread();
 

--- a/be/src/vec/aggregate_functions/aggregate_function_collect.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_collect.h
@@ -84,7 +84,7 @@ struct AggregateFunctionCollectSetData<StringRef> {
         }
     }
     void read(BufferReadable& buf) {
-        size_t rows;
+        UInt64 rows;
         read_var_uint(rows, buf);
 
         StringRef ref;
@@ -121,7 +121,7 @@ struct AggregateFunctionCollectListData {
         buf.write(data.raw_data(), data.size() * sizeof(ElementType));
     }
     void read(BufferReadable& buf) {
-        size_t rows = 0;
+        UInt64 rows = 0;
         read_var_uint(rows, buf);
         data.resize(rows);
         buf.read(reinterpret_cast<char*>(data.data()), rows * sizeof(ElementType));
@@ -161,13 +161,13 @@ struct AggregateFunctionCollectListData<StringRef> {
 
     void read(BufferReadable& buf) {
         auto& col = assert_cast<ColVecType&>(*data);
-        size_t offs_size = 0;
+        UInt64 offs_size = 0;
         read_var_uint(offs_size, buf);
         col.get_offsets().resize(offs_size);
         buf.read(reinterpret_cast<char*>(col.get_offsets().data()),
                  offs_size * sizeof(IColumn::Offset));
 
-        size_t chars_size = 0;
+        UInt64 chars_size = 0;
         read_var_uint(chars_size, buf);
         col.get_chars().resize(chars_size);
         buf.read(reinterpret_cast<char*>(col.get_chars().data()), chars_size);

--- a/be/src/vec/aggregate_functions/aggregate_function_count.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_count.h
@@ -95,7 +95,7 @@ public:
                                            const size_t num_rows, Arena* arena) const override {
         auto& col = assert_cast<ColumnUInt64&>(*dst);
         col.resize(num_rows);
-        col.get_data().assign(num_rows, 1UL);
+        col.get_data().assign(num_rows, static_cast<UInt64>(1UL));
     }
 
     void deserialize_and_merge_from_column(AggregateDataPtr __restrict place, const IColumn& column,

--- a/be/src/vec/aggregate_functions/aggregate_function_distinct.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_distinct.h
@@ -83,7 +83,7 @@ struct AggregateFunctionDistinctGenericData {
     }
 
     void deserialize(BufferReadable& buf, Arena* arena) {
-        size_t size;
+        UInt64 size;
         read_var_uint(size, buf);
 
         StringRef ref;

--- a/be/src/vec/aggregate_functions/aggregate_function_uniq.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_uniq.h
@@ -177,7 +177,7 @@ public:
     void deserialize_and_merge(AggregateDataPtr __restrict place, BufferReadable& buf,
                                Arena* arena) const override {
         auto& set = this->data(place).set;
-        size_t size;
+        UInt64 size;
         read_var_uint(size, buf);
 
         set.rehash(size + set.size());

--- a/be/src/vec/common/allocator.h
+++ b/be/src/vec/common/allocator.h
@@ -41,6 +41,8 @@
 
 #if !defined(__APPLE__) && !defined(__FreeBSD__)
 #include <malloc.h>
+#else
+#define _DARWIN_C_SOURCE
 #endif
 
 #include <sys/mman.h>

--- a/be/src/vec/common/hash_table/fixed_hash_table.h
+++ b/be/src/vec/common/hash_table/fixed_hash_table.h
@@ -114,9 +114,6 @@ class FixedHashTable : private boost::noncopyable,
     static constexpr size_t NUM_CELLS = 1ULL << (sizeof(Key) * 8);
 
 protected:
-    friend class const_iterator;
-    friend class iterator;
-
     using Self = FixedHashTable;
 
     Cell* buf; /// A piece of memory for all elements.
@@ -340,14 +337,14 @@ public:
     void read(doris::vectorized::BufferReadable& rb) {
         Cell::State::read(rb);
         destroy_elements();
-        size_t m_size;
+        doris::vectorized::UInt64 m_size;
         doris::vectorized::read_var_uint(m_size, rb);
         this->set_size(m_size);
         free();
         alloc();
 
         for (size_t i = 0; i < m_size; ++i) {
-            size_t place_value = 0;
+            doris::vectorized::UInt64 place_value = 0;
             doris::vectorized::read_var_uint(place_value, rb);
             Cell x;
             x.read(rb);

--- a/be/src/vec/common/hash_table/hash_table.h
+++ b/be/src/vec/common/hash_table/hash_table.h
@@ -428,8 +428,6 @@ class HashTable : private boost::noncopyable,
                                              Cell> /// empty base optimization
 {
 protected:
-    friend class const_iterator;
-    friend class iterator;
     friend class Reader;
 
     template <typename, typename, typename, typename, typename, typename, size_t>
@@ -1057,7 +1055,7 @@ public:
         this->clear_get_has_zero();
         m_size = 0;
 
-        size_t new_size = 0;
+        doris::vectorized::UInt64 new_size = 0;
         doris::vectorized::read_var_uint(new_size, rb);
 
         free();

--- a/be/src/vec/common/hash_table/string_hash_table.h
+++ b/be/src/vec/common/hash_table/string_hash_table.h
@@ -234,9 +234,6 @@ protected:
 
     using Cell = typename Ts::cell_type;
 
-    friend class const_iterator;
-    friend class iterator;
-
     template <typename Derived, bool is_const>
     class iterator_base {
         using Container = std::conditional_t<is_const, const Self, Self>;

--- a/be/src/vec/common/pod_array.h
+++ b/be/src/vec/common/pod_array.h
@@ -527,11 +527,14 @@ public:
         auto swap_stack_heap = [this](PODArray& arr1, PODArray& arr2) {
             size_t stack_size = arr1.size();
             size_t stack_allocated = arr1.allocated_bytes();
-            size_t stack_peak_used = arr1.c_end_peak - arr1.c_start;
 
             size_t heap_size = arr2.size();
             size_t heap_allocated = arr2.allocated_bytes();
+
+#ifdef USE_MEM_TRACKER
+            size_t stack_peak_used = arr1.c_end_peak - arr1.c_start;
             size_t heap_peak_used = arr2.c_end_peak - arr2.c_start;
+#endif
 
             /// Keep track of the stack content we have to copy.
             char* stack_c_start = arr1.c_start;

--- a/be/src/vec/core/block.cpp
+++ b/be/src/vec/core/block.cpp
@@ -31,6 +31,7 @@
 #include "runtime/tuple_row.h"
 #include "udf/udf.h"
 #include "util/block_compression.h"
+#include "util/exception.h"
 #include "util/faststring.h"
 #include "util/simd/bits.h"
 #include "vec/columns/column.h"
@@ -714,9 +715,9 @@ Status Block::serialize(PBlock* pblock,
         column_values.resize(content_uncompressed_size);
     } catch (...) {
         std::exception_ptr p = std::current_exception();
-        std::string msg = fmt::format(
-                "Try to alloc {} bytes for pblock column values failed. reason {}",
-                content_uncompressed_size, p ? p.__cxa_exception_type()->name() : "null");
+        std::string msg =
+                fmt::format("Try to alloc {} bytes for pblock column values failed. reason {}",
+                            content_uncompressed_size, get_current_exception_type_name(p));
         LOG(WARNING) << msg;
         return Status::BufferAllocFailed(msg);
     }

--- a/be/src/vec/exec/vjson_scanner.cpp
+++ b/be/src/vec/exec/vjson_scanner.cpp
@@ -331,9 +331,9 @@ Status VJsonReader::_write_data_to_column(rapidjson::Value::ConstValueIterator v
         } else if (value->IsInt()) {
             wbytes = sprintf(tmp_buf, "%d", value->GetInt());
         } else if (value->IsUint64()) {
-            wbytes = sprintf(tmp_buf, "%lu", value->GetUint64());
+            wbytes = sprintf(tmp_buf, "%" PRIu64, value->GetUint64());
         } else if (value->IsInt64()) {
-            wbytes = sprintf(tmp_buf, "%ld", value->GetInt64());
+            wbytes = sprintf(tmp_buf, "%" PRId64, value->GetInt64());
         } else {
             wbytes = sprintf(tmp_buf, "%f", value->GetDouble());
         }

--- a/be/src/vec/functions/array/function_array_sort.h
+++ b/be/src/vec/functions/array/function_array_sort.h
@@ -188,7 +188,7 @@ private:
         ColumnString::Offsets& column_string_offsets = dest_column_string.get_offsets();
         column_string_chars.reserve(src_column.size());
 
-        size_t prev_src_offset = 0;
+        ColumnArray::Offset64 prev_src_offset = 0;
         IColumn::Permutation permutation(src_column.size());
         for (size_t i = 0; i < src_column.size(); ++i) {
             permutation[i] = i;

--- a/be/src/vec/functions/function_string.h
+++ b/be/src/vec/functions/function_string.h
@@ -17,12 +17,20 @@
 
 #pragma once
 
+#ifndef USE_LIBCPP
+#include <memory_resource>
+#define PMR std::pmr
+#else
+#include <boost/container/pmr/monotonic_buffer_resource.hpp>
+#include <boost/container/pmr/vector.hpp>
+#define PMR boost::container::pmr
+#endif
+
 #include <fmt/core.h>
 #include <fmt/format.h>
 #include <fmt/ranges.h>
 
 #include <cstdint>
-#include <memory_resource>
 #include <string_view>
 
 #include "exprs/math_functions.h"
@@ -160,10 +168,10 @@ private:
         res_chars.reserve(chars.size());
 
         std::array<std::byte, 128 * 1024> buf;
-        std::pmr::monotonic_buffer_resource pool {buf.data(), buf.size()};
-        std::pmr::vector<size_t> index {&pool};
+        PMR::monotonic_buffer_resource pool {buf.data(), buf.size()};
+        PMR::vector<size_t> index {&pool};
 
-        std::pmr::vector<std::pair<const unsigned char*, int>> strs(&pool);
+        PMR::vector<std::pair<const unsigned char*, int>> strs(&pool);
         strs.resize(size);
         auto* __restrict data_ptr = chars.data();
         auto* __restrict offset_ptr = offsets.data();

--- a/be/src/vec/io/io_helper.h
+++ b/be/src/vec/io/io_helper.h
@@ -166,7 +166,7 @@ inline void read_float_binary(Type& x, BufferReadable& buf) {
 
 inline void read_string_binary(std::string& s, BufferReadable& buf,
                                size_t MAX_STRING_SIZE = DEFAULT_MAX_STRING_SIZE) {
-    size_t size = 0;
+    UInt64 size = 0;
     read_var_uint(size, buf);
 
     if (size > MAX_STRING_SIZE) {
@@ -179,7 +179,7 @@ inline void read_string_binary(std::string& s, BufferReadable& buf,
 
 inline void read_string_binary(StringRef& s, BufferReadable& buf,
                                size_t MAX_STRING_SIZE = DEFAULT_MAX_STRING_SIZE) {
-    size_t size = 0;
+    UInt64 size = 0;
     read_var_uint(size, buf);
 
     if (size > MAX_STRING_SIZE) {
@@ -190,7 +190,7 @@ inline void read_string_binary(StringRef& s, BufferReadable& buf,
 }
 
 inline StringRef read_string_binary_into(Arena& arena, BufferReadable& buf) {
-    size_t size = 0;
+    UInt64 size = 0;
     read_var_uint(size, buf);
 
     char* data = arena.alloc(size);
@@ -208,7 +208,7 @@ inline void read_json_binary(JsonbField val, BufferReadable& buf,
 template <typename Type>
 void read_vector_binary(std::vector<Type>& v, BufferReadable& buf,
                         size_t MAX_VECTOR_SIZE = DEFAULT_MAX_STRING_SIZE) {
-    size_t size = 0;
+    UInt64 size = 0;
     read_var_uint(size, buf);
 
     if (size > MAX_VECTOR_SIZE) {

--- a/be/test/testutil/test_util.cpp
+++ b/be/test/testutil/test_util.cpp
@@ -17,9 +17,12 @@
 
 #include "testutil/test_util.h"
 
+#ifndef __APPLE__
+#include <linux/limits.h>
+#endif
+
 #include <common/configbase.h>
 #include <libgen.h>
-#include <linux/limits.h>
 #include <strings.h>
 #include <sys/types.h>
 #include <unistd.h>

--- a/bin/stop_be.sh
+++ b/bin/stop_be.sh
@@ -54,7 +54,7 @@ if [[ -f "${pidfile}" ]]; then
         exit 1
     fi
 
-    pidcomm="$(ps -p "${pid}" -o comm=)"
+    pidcomm="$(basename "$(ps -p "${pid}" -o comm=)")"
     # check if pid process is backend process
     if [[ "doris_be" != "${pidcomm}" ]]; then
         echo "ERROR: pid process may not be be. "

--- a/bin/stop_fe.sh
+++ b/bin/stop_fe.sh
@@ -54,7 +54,7 @@ if [[ -f "${pidfile}" ]]; then
         exit 1
     fi
 
-    pidcomm="$(ps -p "${pid}" -o comm=)"
+    pidcomm="$(basename "$(ps -p "${pid}" -o comm=)")"
     # check if pid process is frontend process
     if [[ "java" != "${pidcomm}" ]]; then
         echo "ERROR: pid process may not be fe. "

--- a/build.sh
+++ b/build.sh
@@ -272,10 +272,18 @@ if [[ -z "${STRIP_DEBUG_INFO}" ]]; then
     STRIP_DEBUG_INFO='OFF'
 fi
 if [[ -z "${USE_MEM_TRACKER}" ]]; then
-    USE_MEM_TRACKER='ON'
+    if [[ "$(uname -s)" != 'Darwin' ]]; then
+        USE_MEM_TRACKER='ON'
+    else
+        USE_MEM_TRACKER='OFF'
+    fi
 fi
 if [[ -z "${USE_JEMALLOC}" ]]; then
-    USE_JEMALLOC='ON'
+    if [[ "$(uname -s)" != 'Darwin' ]]; then
+        USE_JEMALLOC='ON'
+    else
+        USE_JEMALLOC='OFF'
+    fi
 fi
 if [[ -z "${STRICT_MEMORY_USE}" ]]; then
     STRICT_MEMORY_USE='OFF'
@@ -485,7 +493,7 @@ if [[ "${BUILD_BE}" -eq 1 ]]; then
 
     # Fix Killed: 9 error on MacOS (arm64).
     # See: https://stackoverflow.com/questions/67378106/mac-m1-cping-binary-over-another-results-in-crash
-    rm "${DORIS_OUTPUT}/be/lib/doris_be"
+    rm -f "${DORIS_OUTPUT}/be/lib/doris_be"
     cp -r -p "${DORIS_HOME}/be/output/lib/doris_be" "${DORIS_OUTPUT}/be/lib"/
 
     # make a soft link palo_be point to doris_be, for forward compatibility

--- a/build.sh
+++ b/build.sh
@@ -249,7 +249,11 @@ if [[ -z "${WITH_MYSQL}" ]]; then
     WITH_MYSQL='OFF'
 fi
 if [[ -z "${GLIBC_COMPATIBILITY}" ]]; then
-    GLIBC_COMPATIBILITY='ON'
+    if [[ "$(uname -s)" != 'Darwin' ]]; then
+        GLIBC_COMPATIBILITY='ON'
+    else
+        GLIBC_COMPATIBILITY='OFF'
+    fi
 fi
 if [[ -z "${USE_AVX2}" ]]; then
     USE_AVX2='ON'
@@ -258,7 +262,11 @@ if [[ -z "${WITH_LZO}" ]]; then
     WITH_LZO='OFF'
 fi
 if [[ -z "${USE_LIBCPP}" ]]; then
-    USE_LIBCPP='OFF'
+    if [[ "$(uname -s)" != 'Darwin' ]]; then
+        USE_LIBCPP='OFF'
+    else
+        USE_LIBCPP='ON'
+    fi
 fi
 if [[ -z "${STRIP_DEBUG_INFO}" ]]; then
     STRIP_DEBUG_INFO='OFF'
@@ -474,6 +482,10 @@ if [[ "${BUILD_BE}" -eq 1 ]]; then
 
     cp -r -p "${DORIS_HOME}/be/output/bin"/* "${DORIS_OUTPUT}/be/bin"/
     cp -r -p "${DORIS_HOME}/be/output/conf"/* "${DORIS_OUTPUT}/be/conf"/
+
+    # Fix Killed: 9 error on MacOS (arm64).
+    # See: https://stackoverflow.com/questions/67378106/mac-m1-cping-binary-over-another-results-in-crash
+    rm "${DORIS_OUTPUT}/be/lib/doris_be"
     cp -r -p "${DORIS_HOME}/be/output/lib/doris_be" "${DORIS_OUTPUT}/be/lib"/
 
     # make a soft link palo_be point to doris_be, for forward compatibility

--- a/env.sh
+++ b/env.sh
@@ -57,7 +57,11 @@ if ! ${PYTHON} --version; then
 fi
 
 if [[ -z "${DORIS_TOOLCHAIN}" ]]; then
-    DORIS_TOOLCHAIN=gcc
+    if [[ "$(uname -s)" == 'Darwin' ]]; then
+        DORIS_TOOLCHAIN=clang
+    else
+        DORIS_TOOLCHAIN=gcc
+    fi
 fi
 
 if [[ "${DORIS_TOOLCHAIN}" == "gcc" ]]; then
@@ -158,6 +162,13 @@ if test -z "${BUILD_THIRDPARTY_WIP:-}"; then
         exit 1
     fi
     export MVN_CMD
+fi
+
+if [[ "$(uname -s)" == 'Darwin' ]]; then
+    if ! command -v libtoolize &>/dev/null && command -v glibtoolize &>/dev/null; then
+        shopt -s expand_aliases
+        alias libtoolize='glibtoolize'
+    fi
 fi
 
 CMAKE_CMD='cmake'

--- a/fs_brokers/apache_hdfs_broker/bin/stop_broker.sh
+++ b/fs_brokers/apache_hdfs_broker/bin/stop_broker.sh
@@ -36,7 +36,7 @@ pidfile="${PID_DIR}/apache_hdfs_broker.pid"
 
 if [[ -f "${pidfile}" ]]; then
     pid="$(cat "${pidfile}")"
-    pidcomm="$(ps -p "${pid}" -o comm=)"
+    pidcomm="$(basename "$(ps -p "${pid}" -o comm=)")"
 
     if [[ "java" != "${pidcomm}" ]]; then
         echo "ERROR: pid process may not broker. "

--- a/run-be-ut.sh
+++ b/run-be-ut.sh
@@ -114,7 +114,7 @@ if [[ "$#" != 1 ]]; then
 fi
 
 CMAKE_BUILD_TYPE="${BUILD_TYPE:-ASAN}"
-CMAKE_BUILD_TYPE="${CMAKE_BUILD_TYPE^^}"
+CMAKE_BUILD_TYPE="$(echo "${CMAKE_BUILD_TYPE}" | awk '{ print(toupper($0)) }')"
 
 echo "Get params:
     PARALLEL            -- ${PARALLEL}
@@ -135,7 +135,19 @@ if [[ ! -d "${CMAKE_BUILD_DIR}" ]]; then
 fi
 
 if [[ -z "${GLIBC_COMPATIBILITY}" ]]; then
-    GLIBC_COMPATIBILITY='ON'
+    if [[ "$(uname -s)" != 'Darwin' ]]; then
+        GLIBC_COMPATIBILITY='ON'
+    else
+        GLIBC_COMPATIBILITY='OFF'
+    fi
+fi
+
+if [[ -z "${USE_LIBCPP}" ]]; then
+    if [[ "$(uname -s)" != 'Darwin' ]]; then
+        USE_LIBCPP='OFF'
+    else
+        USE_LIBCPP='ON'
+    fi
 fi
 
 if [[ -z "${USE_DWARF}" ]]; then
@@ -153,6 +165,7 @@ cd "${CMAKE_BUILD_DIR}"
     -DCMAKE_BUILD_TYPE="${CMAKE_BUILD_TYPE}" \
     -DMAKE_TEST=ON \
     -DGLIBC_COMPATIBILITY="${GLIBC_COMPATIBILITY}" \
+    -DUSE_LIBCPP="${USE_LIBCPP}" \
     -DBUILD_META_TOOL=OFF \
     -DBUILD_BENCHMARK_TOOL="${BUILD_BENCHMARK_TOOL}" \
     -DWITH_MYSQL=OFF \

--- a/thirdparty/build-thirdparty.sh
+++ b/thirdparty/build-thirdparty.sh
@@ -157,7 +157,7 @@ popd
 check_prerequest() {
     local CMD="$1"
     local NAME="$2"
-    if ! ${CMD}; then
+    if ! eval "${CMD}"; then
         echo "${NAME} is missing"
         exit 1
     else
@@ -1027,7 +1027,11 @@ build_bitshuffle() {
             local objcopy="${DORIS_BIN_UTILS}/objcopy"
 
             if [[ ! -f "${nm}" ]]; then nm="$(command -v nm)"; fi
-            if [[ ! -f "${objcopy}" ]]; then objcopy="$(command -v objcopy)"; fi
+            if [[ ! -f "${objcopy}" ]]; then
+                if ! objcopy="$(command -v objcopy)"; then
+                    objcopy="${TP_INSTALL_DIR}/bin/objcopy"
+                fi
+            fi
 
             # Create a mapping file with '<old_sym> <suffixed_sym>' on each line.
             "${nm}" --defined-only --extern-only "${tmp_obj}" | while read -r addr type sym; do
@@ -1196,7 +1200,7 @@ build_aws_sdk() {
     "${CMAKE_CMD}" -G "${GENERATOR}" -B"${BUILD_DIR}" -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX="${TP_INSTALL_DIR}" \
         -DCMAKE_PREFIX_PATH="${TP_INSTALL_DIR}" -DBUILD_SHARED_LIBS=OFF -DENABLE_TESTING=OFF \
         -DCURL_LIBRARY_RELEASE="${TP_INSTALL_DIR}/lib/libcurl.a" -DZLIB_LIBRARY_RELEASE="${TP_INSTALL_DIR}/lib/libz.a" \
-        -DBUILD_ONLY="core;s3;s3-crt;transfer" -DCMAKE_CXX_FLAGS="-Wno-nonnull" -DCPP_STANDARD=17
+        -DBUILD_ONLY="core;s3;s3-crt;transfer" -DCMAKE_CXX_FLAGS="-Wno-nonnull -Wno-deprecated-declarations" -DCPP_STANDARD=17
 
     cd "${BUILD_DIR}"
 
@@ -1256,7 +1260,7 @@ build_xml2() {
 
     export ACLOCAL_PATH='/usr/share/aclocal'
 
-    sh autogen.sh
+    sed '/(libtoolize/,/}/d' autogen.sh | bash
     make distclean
 
     mkdir -p "${BUILD_DIR}"

--- a/thirdparty/vars.sh
+++ b/thirdparty/vars.sh
@@ -103,10 +103,10 @@ SNAPPY_SOURCE=snappy-1.1.8
 SNAPPY_MD5SUM="70e48cba7fecf289153d009791c9977f"
 
 # gperftools
-GPERFTOOLS_DOWNLOAD="https://github.com/gperftools/gperftools/archive/gperftools-2.9.1.tar.gz"
-GPERFTOOLS_NAME=gperftools-2.9.1.tar.gz
-GPERFTOOLS_SOURCE=gperftools-gperftools-2.9.1
-GPERFTOOLS_MD5SUM="e340f1b247ff512119a2db98c1538dc1"
+GPERFTOOLS_DOWNLOAD="https://github.com/gperftools/gperftools/releases/download/gperftools-2.10/gperftools-2.10.tar.gz"
+GPERFTOOLS_NAME=gperftools-2.10.tar.gz
+GPERFTOOLS_SOURCE=gperftools-2.10
+GPERFTOOLS_MD5SUM="62bf6c76ba855ed580de5e139bd2a483"
 
 # zlib
 ZLIB_DOWNLOAD="https://sourceforge.net/projects/libpng/files/zlib/1.2.11/zlib-1.2.11.tar.gz"
@@ -492,3 +492,20 @@ export TP_ARCHIVES=(
     'SSE2NEON'
     'XXHASH'
 )
+
+if [[ "$(uname -s)" == 'Darwin' ]]; then
+    #binutils
+    BINUTILS_DOWNLOAD='https://mirrors.aliyun.com/gnu/binutils/binutils-2.39.tar.gz'
+    BINUTILS_NAME=binutils-2.39.tar.gz
+    BINUTILS_SOURCE=binutils-2.39
+    BINUTILS_MD5SUM='ab6825df57514ec172331e988f55fc10'
+
+    #gettext
+    GETTEXT_DOWNLOAD='https://mirrors.aliyun.com/gnu/gettext/gettext-0.21.tar.gz'
+    GETTEXT_NAME='gettext-0.21.tar.gz'
+    GETTEXT_SOURCE='gettext-0.21'
+    GETTEXT_MD5SUM='28b1cd4c94a74428723ed966c38cf479'
+
+    read -r -a TP_ARCHIVES <<<"${TP_ARCHIVES[*]} BINUTILS GETTEXT"
+    export TP_ARCHIVES
+fi


### PR DESCRIPTION
# Proposed changes

This PR fixed lots of issues when building from source on macOS with Apple M1 chip.

Validation Environment:
**OS:**
macOS Monterey

**Compiler:**
Apple clang version 14.0.0 (clang-1400.0.29.102)
Target: arm64-apple-darwin21.6.0
Thread model: posix
InstalledDir: /Library/Developer/CommandLineTools/usr/bin

## ATTENTION

The job for supporting macOS with Apple M1 chip is too big and there are lots of unresolved issues during runtime:
1. Some errors with memory tracker occur when BE (RELEASE) starts.
2. Some UT cases fail.
...

This PR kicks off the job. Guys who are interested in this job can continue to fix these runtime issues.

## Use case

```shell
./build.sh -j 8 --be --clean
```

## Something else

It takes around _**10+**_ minutes to build BE (with prebuilt third-parties) on macOS with M1 chip. We will improve the  development experience on macOS greatly when we finish the adaptation job.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
6. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
7. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
8. Does it need to update dependencies:
    - [x] Yes (Monterey (macOS 12.x) needs this [commit](https://github.com/gperftools/gperftools/commit/852fb6df031560c5e353b497222b76394190e27d))
    - [ ] No
9. Are there any changes that cannot be rolled back:
    - [ ] Yes
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

