### PR TITLE
[fix](Nereids) plan broadcast join for right semi join by mistake

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/JoinType.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/JoinType.java
@@ -92,8 +92,8 @@ public enum JoinType {
         return this == INNER_JOIN;
     }
 
-    public final boolean isReturnUnmatchedRightJoin() {
-        return this == RIGHT_OUTER_JOIN || this == RIGHT_ANTI_JOIN || this == FULL_OUTER_JOIN;
+    public final boolean isRightJoin() {
+        return this == RIGHT_OUTER_JOIN || this == RIGHT_ANTI_JOIN || this == RIGHT_SEMI_JOIN;
     }
 
     public final boolean isFullOuterJoin() {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/util/JoinUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/util/JoinUtils.java
@@ -57,7 +57,7 @@ public class JoinUtils {
     }
 
     public static boolean couldBroadcast(Join join) {
-        return !(join.getJoinType().isReturnUnmatchedRightJoin());
+        return !(join.getJoinType().isRightJoin() || join.getJoinType().isFullOuterJoin());
     }
 
     private static final class JoinSlotCoverageChecker {


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

we plan broadcast join for right semi join by mistake. This could cause wrong answer since we cannot prevent two partitions return the same line of right relation.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

