### PR TITLE
[enhancement](regression-test) add sync for unique table debug test

### DIFF
--- a/regression-test/suites/data_model_p0/unique/test_unique_table_debug_data.groovy
+++ b/regression-test/suites/data_model_p0/unique/test_unique_table_debug_data.groovy
@@ -46,6 +46,7 @@ suite("test_unique_table_debug_data") {
     sql "insert into ${tbName} values(1,1),(2,1);"
     sql "insert into ${tbName} values(1,11),(2,11);"
     sql "insert into ${tbName} values(3,1);"
+    sql "sync"
 
     qt_select_init "select * from ${tbName} order by a, b"
 
@@ -70,10 +71,12 @@ suite("test_unique_table_debug_data") {
 
         time 10000 // limit inflight 10s
     }
+    sql "sync"
     qt_select_batch_delete "select * from ${tbName} order by a, b"
 
     // delete rows with a = 2:
     sql "delete from ${tbName} where a = 2;"
+    sql "sync"
     qt_select_sql_delete "select * from ${tbName} order by a, b"
 
     // enable skip_delete_predicate, rows deleted with delete statement is returned:


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

To avoid accidental result errors, add sync for for unique table debug test.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

