### PR TITLE
[Improvement](like function) avoid to convert const column to full column

### DIFF
--- a/be/src/vec/functions/like.h
+++ b/be/src/vec/functions/like.h
@@ -134,6 +134,16 @@ protected:
                          ColumnUInt8::Container& result, const LikeFn& function,
                          LikeSearchState* search_state);
 
+    Status vector_const(const ColumnString::Chars& values,
+                        const ColumnString::Offsets& value_offsets, const StringRef* pattern_val,
+                        ColumnUInt8::Container& result, const LikeFn& function,
+                        LikeSearchState* search_state);
+
+    Status execute_substring(const ColumnString::Chars& values,
+                             const ColumnString::Offsets& value_offsets,
+                             ColumnUInt8::Container& result, const LikeFn& function,
+                             LikeSearchState* search_state);
+
     static Status constant_starts_with_fn(LikeSearchState* state, const StringValue& val,
                                           const StringValue& pattern, unsigned char* result);
 


### PR DESCRIPTION
# Proposed changes

Test on TPCH Q14

baseline:
![image](https://user-images.githubusercontent.com/37700562/194745679-037a2f6c-48a7-4497-bf02-0ef4b1b1098c.png)

patched:
![image](https://user-images.githubusercontent.com/37700562/194745687-7a88fe97-8c51-475f-9ec8-f57073b8393b.png)


## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

