### PR TITLE
[compaction](http_action) enable be run manual compaction concurrently

### DIFF
--- a/be/src/http/action/compaction_action.cpp
+++ b/be/src/http/action/compaction_action.cpp
@@ -38,9 +38,6 @@ namespace doris {
 
 const static std::string HEADER_JSON = "application/json";
 
-bool CompactionAction::_is_compaction_running = false;
-std::mutex CompactionAction::_compaction_running_mutex;
-
 Status CompactionAction::_check_param(HttpRequest* req, uint64_t* tablet_id) {
     std::string req_tablet_id = req->param(TABLET_ID_KEY);
     if (req_tablet_id == "") {
@@ -94,18 +91,7 @@ Status CompactionAction::_handle_run_compaction(HttpRequest* req, std::string* j
         return _execute_compaction_callback(tablet, compaction_type);
     });
     std::future<Status> future_obj = task.get_future();
-
-    {
-        // 3.1 check is there compaction running
-        std::lock_guard<std::mutex> lock(_compaction_running_mutex);
-        if (_is_compaction_running) {
-            return Status::TooManyTasks("Manual compaction task is running");
-        } else {
-            // 3.2 execute the compaction task and set compaction task running
-            _is_compaction_running = true;
-            std::thread(std::move(task)).detach();
-        }
-    }
+    std::thread(std::move(task)).detach();
 
     // 4. wait for result for 2 seconds by async
     std::future_status status = future_obj.wait_for(std::chrono::seconds(2));
@@ -234,9 +220,6 @@ Status CompactionAction::_execute_compaction_callback(TabletSharedPtr tablet,
             }
         }
     }
-
-    std::lock_guard<std::mutex> lock(_compaction_running_mutex);
-    _is_compaction_running = false;
 
     timer.stop();
     LOG(INFO) << "Manual compaction task finish, status=" << res

--- a/be/src/http/action/compaction_action.h
+++ b/be/src/http/action/compaction_action.h
@@ -63,11 +63,6 @@ private:
 
 private:
     CompactionActionType _type;
-
-    /// running check mutex
-    static std::mutex _compaction_running_mutex;
-    /// whether there is manual compaction running
-    static bool _is_compaction_running;
 };
 
 } // end namespace doris


### PR DESCRIPTION
In some case, we need to run manual compaction via http interface concurrently, we remove the mutex and tablet's compaction lock is enough to prevent concurrent compaction in tablet.

# Proposed changes

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

