### PR TITLE
[Bug](replace function) fix be infinite loop and oom when use replace with an empty old str

### DIFF
--- a/be/src/vec/functions/function_string.h
+++ b/be/src/vec/functions/function_string.h
@@ -1470,6 +1470,9 @@ public:
 
 private:
     std::string replace(std::string str, std::string_view old_str, std::string_view new_str) {
+        if (old_str.empty()) {
+            return str;
+        }
         std::string::size_type pos = 0;
         std::string::size_type oldLen = old_str.size();
         std::string::size_type newLen = new_str.size();

--- a/regression-test/data/query_p0/sql_functions/string_functions/test_string_function.out
+++ b/regression-test/data/query_p0/sql_functions/string_functions/test_string_function.out
@@ -201,6 +201,9 @@ aaa
 https://doris.apache.org
 
 -- !sql --
+https://doris.apache.org:9090
+
+-- !sql --
 olleh
 
 -- !sql --

--- a/regression-test/suites/query_p0/sql_functions/string_functions/test_string_function.groovy
+++ b/regression-test/suites/query_p0/sql_functions/string_functions/test_string_function.groovy
@@ -107,6 +107,7 @@ suite("test_string_function") {
     qt_sql "SELECT repeat(null,1);"
 
     qt_sql "select replace(\"https://doris.apache.org:9090\", \":9090\", \"\");"
+    qt_sql "select replace(\"https://doris.apache.org:9090\", \"\", \"new_str\");"
 
     qt_sql "SELECT REVERSE('hello');"
 


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

The former logic in replace function didn't check whether the input old str is empty or not. The `string.find` function of cpp stl would return pos 0, which would result in an endless string replace logic loop, and end up with OOM.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [x] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [x] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

