### PR TITLE
[chore](release build) copy license and notice file to output folder and strip debug info from meta tool

### DIFF
--- a/be/src/tools/CMakeLists.txt
+++ b/be/src/tools/CMakeLists.txt
@@ -35,13 +35,9 @@ target_link_libraries(meta_tool
 install(DIRECTORY DESTINATION ${OUTPUT_DIR}/lib/)
 install(TARGETS meta_tool DESTINATION ${OUTPUT_DIR}/lib/)
 
-if (${STRIP_DEBUG_INFO} STREQUAL "ON")
-    add_custom_command(TARGET meta_tool POST_BUILD
-        COMMAND ${CMAKE_OBJCOPY} --only-keep-debug $<TARGET_FILE:meta_tool> $<TARGET_FILE:meta_tool>.dbg
-        COMMAND ${CMAKE_STRIP} --strip-debug --strip-unneeded $<TARGET_FILE:meta_tool>
-        COMMAND ${CMAKE_OBJCOPY} --add-gnu-debuglink=$<TARGET_FILE:meta_tool>.dbg $<TARGET_FILE:meta_tool>
-        )
-
-    install(DIRECTORY DESTINATION ${OUTPUT_DIR}/lib/debug_info/)
-    install(FILES $<TARGET_FILE:meta_tool>.dbg DESTINATION ${OUTPUT_DIR}/lib/debug_info/)
-endif()
+# Meta tool never need debug info
+add_custom_command(TARGET meta_tool POST_BUILD
+    COMMAND ${CMAKE_OBJCOPY} --only-keep-debug $<TARGET_FILE:meta_tool> $<TARGET_FILE:meta_tool>.dbg
+    COMMAND ${CMAKE_STRIP} --strip-debug --strip-unneeded $<TARGET_FILE:meta_tool>
+    COMMAND ${CMAKE_OBJCOPY} --add-gnu-debuglink=$<TARGET_FILE:meta_tool>.dbg $<TARGET_FILE:meta_tool>
+    )

--- a/build.sh
+++ b/build.sh
@@ -99,9 +99,9 @@ clean_fe() {
 
 # Copy the common files like licenses, notice.txt to output folder
 function copy_common_files() {
-    cp -r -p ${DORIS_HOME}/NOTICE.txt "$1/"
-    cp -r -p ${DORIS_HOME}/dist/LICENSE-dist.txt "$1/"
-    cp -r -p ${DORIS_HOME}/dist/licenses "$1/"
+    cp -r -p "${DORIS_HOME}/NOTICE.txt" "$1/"
+    cp -r -p "${DORIS_HOME}/dist/LICENSE-dist.txt" "$1/"
+    cp -r -p "${DORIS_HOME}/dist/licenses" "$1/"
 }
 
 if ! OPTS="$(getopt \
@@ -453,7 +453,7 @@ if [[ "${BUILD_FE}" -eq 1 ]]; then
     cp -r -p "${DORIS_HOME}/webroot/static" "${DORIS_OUTPUT}/fe/webroot"/
 
     cp -r -p "${DORIS_THIRDPARTY}/installed/webroot"/* "${DORIS_OUTPUT}/fe/webroot/static"/
-    copy_common_files ${DORIS_OUTPUT}/fe/
+    copy_common_files "${DORIS_OUTPUT}/fe/"
     mkdir -p "${DORIS_OUTPUT}/fe/log"
     mkdir -p "${DORIS_OUTPUT}/fe/doris-meta"
 fi
@@ -499,7 +499,7 @@ if [[ "${BUILD_BE}" -eq 1 ]]; then
     fi
 
     cp -r -p "${DORIS_THIRDPARTY}/installed/webroot"/* "${DORIS_OUTPUT}/be/www"/
-    copy_common_files ${DORIS_OUTPUT}/be/
+    copy_common_files "${DORIS_OUTPUT}/be/"
     mkdir -p "${DORIS_OUTPUT}/be/log"
     mkdir -p "${DORIS_OUTPUT}/be/storage"
 fi
@@ -511,7 +511,7 @@ if [[ "${BUILD_BROKER}" -eq 1 ]]; then
     ./build.sh
     rm -rf "${DORIS_OUTPUT}/apache_hdfs_broker"/*
     cp -r -p "${DORIS_HOME}/fs_brokers/apache_hdfs_broker/output/apache_hdfs_broker"/* "${DORIS_OUTPUT}/apache_hdfs_broker"/
-    copy_common_files ${DORIS_OUTPUT}/apache_hdfs_broker/
+    copy_common_files "${DORIS_OUTPUT}/apache_hdfs_broker/"
     cd "${DORIS_HOME}"
 fi
 

--- a/build.sh
+++ b/build.sh
@@ -97,6 +97,13 @@ clean_fe() {
     popd
 }
 
+# Copy the common files like licenses, notice.txt to output folder
+function copy_common_files() {
+    cp -r -p ${DORIS_HOME}/NOTICE.txt "$1/"
+    cp -r -p ${DORIS_HOME}/dist/LICENSE-dist.txt "$1/"
+    cp -r -p ${DORIS_HOME}/dist/licenses "$1/"
+}
+
 if ! OPTS="$(getopt \
     -n "$0" \
     -o '' \
@@ -446,6 +453,7 @@ if [[ "${BUILD_FE}" -eq 1 ]]; then
     cp -r -p "${DORIS_HOME}/webroot/static" "${DORIS_OUTPUT}/fe/webroot"/
 
     cp -r -p "${DORIS_THIRDPARTY}/installed/webroot"/* "${DORIS_OUTPUT}/fe/webroot/static"/
+    copy_common_files ${DORIS_OUTPUT}/fe/
     mkdir -p "${DORIS_OUTPUT}/fe/log"
     mkdir -p "${DORIS_OUTPUT}/fe/doris-meta"
 fi
@@ -491,6 +499,7 @@ if [[ "${BUILD_BE}" -eq 1 ]]; then
     fi
 
     cp -r -p "${DORIS_THIRDPARTY}/installed/webroot"/* "${DORIS_OUTPUT}/be/www"/
+    copy_common_files ${DORIS_OUTPUT}/be/
     mkdir -p "${DORIS_OUTPUT}/be/log"
     mkdir -p "${DORIS_OUTPUT}/be/storage"
 fi
@@ -502,6 +511,7 @@ if [[ "${BUILD_BROKER}" -eq 1 ]]; then
     ./build.sh
     rm -rf "${DORIS_OUTPUT}/apache_hdfs_broker"/*
     cp -r -p "${DORIS_HOME}/fs_brokers/apache_hdfs_broker/output/apache_hdfs_broker"/* "${DORIS_OUTPUT}/apache_hdfs_broker"/
+    copy_common_files ${DORIS_OUTPUT}/apache_hdfs_broker/
     cd "${DORIS_HOME}"
 fi
 


### PR DESCRIPTION

# Proposed changes

When build a doris release, the release manager need do a lot of works and sometimes he or she may forget something. And sometimes the release maybe not fully tested because the release is build manually by the release manager and the env maybe wrong. In this PR do follow things:

1. add licenses and notices file to our binary folder as default so that the release manager do not need copy them manually.
2. strip debug info from meta tool by default since debug info is useless for meta tool.

After this we could get the binary from github pipeline in the future and the binary is fully tested and it is more stable.

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
4. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
5. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
6. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
7. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

