### PR TITLE
[fix](array-type) fix get_data_at for zero element array

### DIFF
--- a/be/src/vec/columns/column_array.cpp
+++ b/be/src/vec/columns/column_array.cpp
@@ -150,9 +150,11 @@ StringRef ColumnArray::get_data_at(size_t n) const {
       * For arrays of strings and arrays of arrays, the resulting chunk of memory may not be one-to-one correspondence with the elements,
       *  since it contains only the data laid in succession, but not the offsets.
       */
-
     size_t offset_of_first_elem = offset_at(n);
-    StringRef first = get_data().get_data_at(offset_of_first_elem);
+    StringRef first;
+    if (offset_of_first_elem < get_data().size()) {
+        first = get_data().get_data_at(offset_of_first_elem);
+    }
 
     size_t array_size = size_at(n);
     if (array_size == 0) {

--- a/be/src/vec/exprs/vliteral.cpp
+++ b/be/src/vec/exprs/vliteral.cpp
@@ -197,8 +197,8 @@ std::string VLiteral::debug_string() const {
     out << "VLiteral (name = " << _expr_name;
     out << ", type = " << _data_type->get_name();
     out << ", value = ";
-    if (_column_ptr.get()->size() > 0) {
-        StringRef ref = _column_ptr.get()->get_data_at(0);
+    if (_column_ptr->size() > 0) {
+        StringRef ref = _column_ptr->get_data_at(0);
         if (ref.data == nullptr) {
             out << "null";
         } else {


### PR DESCRIPTION
# Proposed changes

Issue Number: close #13119

## Problem summary

Describe your changes.
We should get data ptr after check element size.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

