### PR TITLE
[feature-wip](CN Node)Support compute node

### DIFF
--- a/be/src/agent/heartbeat_server.cpp
+++ b/be/src/agent/heartbeat_server.cpp
@@ -80,6 +80,7 @@ void HeartbeatServer::heartbeat(THeartbeatResult& heartbeat_result,
         heartbeat_result.backend_info.__set_brpc_port(config::brpc_port);
         heartbeat_result.backend_info.__set_version(get_short_version());
         heartbeat_result.backend_info.__set_be_start_time(_be_epoch);
+        heartbeat_result.backend_info.__set_be_node_role(config::be_node_role);
     }
 }
 

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -857,6 +857,10 @@ CONF_mInt64(nodechannel_pending_queue_max_bytes, "67108864");
 // so as to avoid occupying the execution thread for a long time.
 CONF_mInt32(max_fragment_start_wait_time_seconds, "30");
 
+// Node role tag for backend. Mix role is the default role, and computation role have no
+// any tablet.
+CONF_String(be_node_role, "mix");
+
 // Hide webserver page for safety.
 // Hide the be config page for webserver.
 CONF_Bool(hide_webserver_config_page, "false");

--- a/docs/en/docs/sql-manual/sql-reference/Show-Statements/SHOW-BACKENDS.md
+++ b/docs/en/docs/sql-manual/sql-reference/Show-Statements/SHOW-BACKENDS.md
@@ -52,6 +52,8 @@ illustrate:
        10. UsedPct Indicates the percentage of disk used.
        11. ErrMsg is used to display the error message when the heartbeat fails.
        12. Status is used to display some status information of BE in JSON format, including the time information of the last time BE reported its tablet.
+       13. HeartbeatFailureCounter: The current number of heartbeats that have failed consecutively. If the number exceeds the `max_backend_heartbeat_failure_tolerance_count` configuration, the isAlive will be set to false.
+       14. NodeRole is used to display the role of Backend node. Now there are two roles: mix and computation. Mix node represent the origin Backend node and computation Node represent the compute only node.
 
 ### Example
 

--- a/docs/zh-CN/docs/sql-manual/sql-reference/Show-Statements/SHOW-BACKENDS.md
+++ b/docs/zh-CN/docs/sql-manual/sql-reference/Show-Statements/SHOW-BACKENDS.md
@@ -52,6 +52,8 @@ SHOW BACKENDS
        10. UsedPct 表示磁盘已使用量百分比。
        11. ErrMsg 用于显示心跳失败时的错误信息。
        12. Status 用于以 JSON 格式显示BE的一些状态信息, 目前包括最后一次BE汇报其tablet的时间信息。
+       13. HeartbeatFailureCounter：现在当前连续失败的心跳次数，如果次数超过 `max_backend_heartbeat_failure_tolerance_count` 配置，则 isAlive 字段会置为 false。
+       14. NodeRole用于展示节点角色, 现在有两种类型: Mix代表原来的节点类型, computation代表只做计算的节点类型.
 
 ### Example
 

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
@@ -1434,7 +1434,7 @@ public class OlapTable extends Table {
                 Map<Tag, List<Long>> tag2beIds = Maps.newHashMap();
                 for (long beId : replicaBackendIds) {
                     Backend be = infoService.getBackend(beId);
-                    if (be == null) {
+                    if (be == null || !be.isMixNode()) {
                         continue;
                     }
                     short num = currentReplicaAlloc.getOrDefault(be.getLocationTag(), (short) 0);
@@ -1896,7 +1896,7 @@ public class OlapTable extends Table {
                     Map<Tag, Short> curMap = Maps.newHashMap();
                     for (Replica replica : tablet.getReplicas()) {
                         Backend be = infoService.getBackend(replica.getBackendId());
-                        if (be == null) {
+                        if (be == null || !be.isMixNode()) {
                             continue;
                         }
                         short num = curMap.getOrDefault(be.getLocationTag(), (short) 0);

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Tablet.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Tablet.java
@@ -430,7 +430,7 @@ public class Tablet extends MetaObject implements Writable {
         for (Replica replica : replicas) {
             Backend backend = systemInfoService.getBackend(replica.getBackendId());
             if (backend == null || !backend.isAlive() || !replica.isAlive() || !hosts.add(backend.getHost())
-                    || replica.tooSlow()) {
+                    || replica.tooSlow() || !backend.isMixNode()) {
                 // this replica is not alive,
                 // or if this replica is on same host with another replica, we also treat it as 'dead',
                 // so that Tablet Scheduler will create a new replica on different host.

--- a/fe/fe-core/src/main/java/org/apache/doris/clone/ClusterLoadStatistic.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/ClusterLoadStatistic.java
@@ -90,6 +90,10 @@ public class ClusterLoadStatistic {
                 // So balance will be blocked.
                 continue;
             }
+            // only mix node have tablet statistic
+            if (!backend.isMixNode()) {
+                continue;
+            }
             BackendLoadStatistic beStatistic = new BackendLoadStatistic(backend.getId(), backend.getOwnerClusterName(),
                     backend.getLocationTag(), infoService, invertedIndex);
             try {

--- a/fe/fe-core/src/main/java/org/apache/doris/clone/ColocateTableCheckerAndBalancer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/ColocateTableCheckerAndBalancer.java
@@ -588,6 +588,8 @@ public class ColocateTableCheckerAndBalancer extends MasterDaemon {
         Backend be = infoService.getBackend(backendId);
         if (be == null) {
             return false;
+        } else if (!be.isMixNode()) {
+            return false;
         } else if (!be.getLocationTag().equals(tag) || excludedBeIds.contains(be.getId())) {
             return false;
         } else if (!be.isScheduleAvailable()) {

--- a/fe/fe-core/src/main/java/org/apache/doris/clone/TabletScheduler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/TabletScheduler.java
@@ -713,7 +713,8 @@ public class TabletScheduler extends MasterDaemon {
         Map<Tag, Short> currentAllocMap = Maps.newHashMap();
         for (Replica replica : replicas) {
             Backend be = infoService.getBackend(replica.getBackendId());
-            if (be != null && be.isScheduleAvailable() && replica.isAlive() && !replica.tooSlow()) {
+            if (be != null && be.isScheduleAvailable() && replica.isAlive() && !replica.tooSlow()
+                    && be.isMixNode()) {
                 Short num = currentAllocMap.getOrDefault(be.getLocationTag(), (short) 0);
                 currentAllocMap.put(be.getLocationTag(), (short) (num + 1));
             }
@@ -979,7 +980,7 @@ public class TabletScheduler extends MasterDaemon {
         Map<Tag, Short> allocMap = tabletCtx.getReplicaAlloc().getAllocMap();
         for (Replica replica : replicas) {
             Backend be = infoService.getBackend(replica.getBackendId());
-            if (!allocMap.containsKey(be.getLocationTag())) {
+            if (be.isMixNode() && !allocMap.containsKey(be.getLocationTag())) {
                 deleteReplicaInternal(tabletCtx, replica, "not in valid tag", force);
                 return true;
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/Config.java
@@ -1789,6 +1789,14 @@ public class Config extends ConfigBase {
     public static int statistic_task_scheduler_execution_interval_ms = 60 * 1000;
 
     /**
+     * The candidate of the backend node for federation query such as hive table and es table query.
+     * If the backend of computation role is less than this value, it will acquire some mix backend.
+     * If the computation backend is enough, federation query will only assign to computation backend.
+     */
+    @ConfField(mutable = true, masterOnly = false)
+    public static int backend_num_for_federation = 3;
+
+    /**
      * Max query profile num.
      */
     @ConfField(mutable = true, masterOnly = false)

--- a/fe/fe-core/src/main/java/org/apache/doris/common/proc/BackendsProcDir.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/proc/BackendsProcDir.java
@@ -52,7 +52,7 @@ public class BackendsProcDir implements ProcDirInterface {
             .add("SystemDecommissioned").add("ClusterDecommissioned").add("TabletNum")
             .add("DataUsedCapacity").add("AvailCapacity").add("TotalCapacity").add("UsedPct")
             .add("MaxDiskUsedPct").add("RemoteUsedCapacity").add("Tag").add("ErrMsg").add("Version").add("Status")
-            .add("HeartbeatFailureCounter")
+            .add("HeartbeatFailureCounter").add("NodeRole")
             .build();
 
     public static final int HOSTNAME_INDEX = 3;
@@ -181,6 +181,9 @@ public class BackendsProcDir implements ProcDirInterface {
             backendInfo.add(new Gson().toJson(backend.getBackendStatus()));
             // heartbeat failure counter
             backendInfo.add(backend.getHeartbeatFailureCounter());
+
+            // node role, show the value only when backend is alive.
+            backendInfo.add(backend.isAlive() ? backend.getNodeRoleTag().value : "");
 
             comparableBackendInfos.add(backendInfo);
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/common/proc/ClusterLoadStatByTag.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/proc/ClusterLoadStatByTag.java
@@ -71,7 +71,7 @@ public class ClusterLoadStatByTag implements ProcDirInterface {
         List<Long> beIds = Env.getCurrentSystemInfo().getBackendIds(false);
         for (long beId : beIds) {
             Backend be = Env.getCurrentSystemInfo().getBackend(beId);
-            if (be != null) {
+            if (be != null && be.isMixNode()) {
                 tags.add(be.getLocationTag());
             }
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/BrokerScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/BrokerScanNode.java
@@ -77,7 +77,6 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
-import java.util.Random;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -106,8 +105,6 @@ public class BrokerScanNode extends LoadScanNode {
             return 0;
         }
     }
-
-    private final Random random = new Random(System.currentTimeMillis());
 
     // File groups need to
     private List<TScanRangeLocations> locationsList;
@@ -430,15 +427,10 @@ public class BrokerScanNode extends LoadScanNode {
         // broker scan node is used for query or load
         BeSelectionPolicy policy = new BeSelectionPolicy.Builder().needQueryAvailable().needLoadAvailable()
                 .addTags(tags).build();
-        for (Backend be : Env.getCurrentSystemInfo().getIdToBackend().values()) {
-            if (policy.isMatch(be)) {
-                backends.add(be);
-            }
-        }
+        backends.addAll(policy.getCandidateBackends(Env.getCurrentSystemInfo().getIdToBackend().values()));
         if (backends.isEmpty()) {
             throw new UserException("No available backends");
         }
-        Collections.shuffle(backends, random);
     }
 
     private TFileFormatType formatType(String fileFormat, String path) throws UserException {

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/OlapScanNode.java
@@ -661,6 +661,9 @@ public class OlapScanNode extends ScanNode {
                     errs.add(replica.getId() + "'s backend " + replica.getBackendId() + " does not exist or not alive");
                     continue;
                 }
+                if (!backend.isMixNode()) {
+                    continue;
+                }
                 if (needCheckTags && !allowedTags.isEmpty() && !allowedTags.contains(backend.getLocationTag())) {
                     String err = String.format(
                             "Replica on backend %d with tag %s," + " which is not in user's resource tags: %s",

--- a/fe/fe-core/src/main/java/org/apache/doris/resource/Tag.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/resource/Tag.java
@@ -55,13 +55,13 @@ public class Tag implements Writable {
     public static final String TYPE_ROLE = "role";
     public static final String TYPE_FUNCTION = "function";
     public static final String TYPE_LOCATION = "location";
-
     public static final String VALUE_FRONTEND = "frontend";
     public static final String VALUE_BACKEND = "backend";
     public static final String VALUE_BROKER = "broker";
     public static final String VALUE_REMOTE_STORAGE = "remote_storage";
     public static final String VALUE_STORE = "store";
     public static final String VALUE_COMPUTATION = "computation";
+    public static final String VALUE_MIX = "mix";
     public static final String VALUE_DEFAULT_CLUSTER = "default_cluster";
     public static final String VALUE_DEFAULT_TAG = "default";
     public static final String VALUE_INVALID_TAG = "invalid";
@@ -70,16 +70,18 @@ public class Tag implements Writable {
             TYPE_ROLE, TYPE_FUNCTION, TYPE_LOCATION);
     public static final ImmutableSet<String> RESERVED_TAG_VALUES = ImmutableSet.of(
             VALUE_FRONTEND, VALUE_BACKEND, VALUE_BROKER, VALUE_REMOTE_STORAGE, VALUE_STORE, VALUE_COMPUTATION,
-            VALUE_DEFAULT_CLUSTER);
+            VALUE_MIX, VALUE_DEFAULT_CLUSTER);
     private static final String TAG_TYPE_REGEX = "^[a-z][a-z0-9_]{0,32}$";
     private static final String TAG_VALUE_REGEX = "^[a-zA-Z][a-zA-Z0-9_]{0,32}$";
 
 
     public static final Tag DEFAULT_BACKEND_TAG;
+    public static final Tag DEFAULT_NODE_ROLE_TAG;
     public static final Tag INVALID_TAG;
 
     static {
         DEFAULT_BACKEND_TAG = new Tag(TYPE_LOCATION, VALUE_DEFAULT_TAG);
+        DEFAULT_NODE_ROLE_TAG = new Tag(TYPE_ROLE, VALUE_MIX);
         INVALID_TAG = new Tag(TYPE_LOCATION, VALUE_INVALID_TAG);
     }
 
@@ -105,6 +107,11 @@ public class Tag implements Writable {
 
     public static Tag createNotCheck(String type, String value) {
         return new Tag(type, value);
+    }
+
+    // only support be and cn node role tag for be.
+    public static boolean validNodeRoleTag(String value) {
+        return value != null && (value.equals(VALUE_MIX) || value.equals(VALUE_COMPUTATION));
     }
 
     public String toKey() {

--- a/fe/fe-core/src/main/java/org/apache/doris/system/Backend.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/system/Backend.java
@@ -124,6 +124,10 @@ public class Backend implements Writable {
     // creating this everytime we get it.
     @SerializedName(value = "locationTag", alternate = {"tag"})
     private Tag locationTag = Tag.DEFAULT_BACKEND_TAG;
+
+    @SerializedName("nodeRole")
+    private Tag nodeRoleTag = Tag.DEFAULT_NODE_ROLE_TAG;
+
     // tag type -> tag value.
     // A backend can only be assigned to one tag type, and each type can only have one value.
     @SerializedName("tagMap")
@@ -692,6 +696,12 @@ public class Backend implements Writable {
                 this.brpcPort = hbResponse.getBrpcPort();
             }
 
+            if (!this.getNodeRoleTag().value.equals(hbResponse.getNodeRole()) && Tag.validNodeRoleTag(
+                    hbResponse.getNodeRole())) {
+                isChanged = true;
+                this.nodeRoleTag = Tag.createNotCheck(Tag.TYPE_ROLE, hbResponse.getNodeRole());
+            }
+
             this.lastUpdateMs = hbResponse.getHbTime();
             if (!isAlive.get()) {
                 isChanged = true;
@@ -762,10 +772,25 @@ public class Backend implements Writable {
         return locationTag;
     }
 
+    public Tag getNodeRoleTag() {
+        return nodeRoleTag;
+    }
+
+    public boolean isMixNode() {
+        return nodeRoleTag.value.equals(Tag.VALUE_MIX);
+    }
+
+    public boolean isComputeNode() {
+        return nodeRoleTag.value.equals(Tag.VALUE_COMPUTATION);
+    }
+
     public void setTagMap(Map<String, String> tagMap) {
         Preconditions.checkState(tagMap.containsKey(Tag.TYPE_LOCATION));
         this.tagMap = tagMap;
         this.locationTag = Tag.createNotCheck(Tag.TYPE_LOCATION, tagMap.get(Tag.TYPE_LOCATION));
+        if (tagMap.containsKey(Tag.TYPE_ROLE) && Tag.validNodeRoleTag(tagMap.get(Tag.TYPE_ROLE))) {
+            this.nodeRoleTag = Tag.createNotCheck(Tag.TYPE_ROLE, tagMap.get(Tag.TYPE_ROLE));
+        }
     }
 
     public Map<String, String> getTagMap() {

--- a/fe/fe-core/src/main/java/org/apache/doris/system/BackendHbResponse.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/system/BackendHbResponse.java
@@ -18,6 +18,7 @@
 package org.apache.doris.system;
 
 import org.apache.doris.common.io.Writable;
+import org.apache.doris.resource.Tag;
 
 import java.io.DataInput;
 import java.io.DataOutput;
@@ -34,6 +35,7 @@ public class BackendHbResponse extends HeartbeatResponse implements Writable {
     private long beStartTime;
     private String host;
     private String version = "";
+    private String nodeRole = Tag.VALUE_MIX;
 
     public BackendHbResponse() {
         super(HeartbeatResponse.Type.BACKEND);
@@ -50,6 +52,20 @@ public class BackendHbResponse extends HeartbeatResponse implements Writable {
         this.hbTime = hbTime;
         this.beStartTime = beStartTime;
         this.version = version;
+    }
+
+    public BackendHbResponse(long beId, int bePort, int httpPort, int brpcPort,
+            long hbTime, long beStartTime, String version, String nodeRole) {
+        super(HeartbeatResponse.Type.BACKEND);
+        this.beId = beId;
+        this.status = HbStatus.OK;
+        this.bePort = bePort;
+        this.httpPort = httpPort;
+        this.brpcPort = brpcPort;
+        this.hbTime = hbTime;
+        this.beStartTime = beStartTime;
+        this.version = version;
+        this.nodeRole = nodeRole;
     }
 
     public BackendHbResponse(long beId, String errMsg) {
@@ -89,6 +105,10 @@ public class BackendHbResponse extends HeartbeatResponse implements Writable {
 
     public String getVersion() {
         return version;
+    }
+
+    public String getNodeRole() {
+        return nodeRole;
     }
 
     public static BackendHbResponse read(DataInput in) throws IOException {

--- a/fe/fe-core/src/main/java/org/apache/doris/system/HeartbeatMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/system/HeartbeatMgr.java
@@ -26,6 +26,7 @@ import org.apache.doris.common.ThreadPoolManager;
 import org.apache.doris.common.Version;
 import org.apache.doris.common.util.MasterDaemon;
 import org.apache.doris.persist.HbPackage;
+import org.apache.doris.resource.Tag;
 import org.apache.doris.service.FrontendOptions;
 import org.apache.doris.system.HeartbeatResponse.HbStatus;
 import org.apache.doris.thrift.FrontendService;
@@ -253,8 +254,12 @@ public class HeartbeatMgr extends MasterDaemon {
                     long beStartTime = tBackendInfo.isSetBeStartTime()
                             ? tBackendInfo.getBeStartTime() : System.currentTimeMillis();
                     // backend.updateOnce(bePort, httpPort, beRpcPort, brpcPort);
+                    String nodeRole = Tag.VALUE_MIX;
+                    if (tBackendInfo.isSetBeNodeRole()) {
+                        nodeRole = tBackendInfo.getBeNodeRole();
+                    }
                     return new BackendHbResponse(backendId, bePort, httpPort, brpcPort,
-                            System.currentTimeMillis(), beStartTime, version);
+                            System.currentTimeMillis(), beStartTime, version, nodeRole);
                 } else {
                     return new BackendHbResponse(backendId, backend.getHost(),
                             result.getStatus().getErrorMsgs().isEmpty()

--- a/fe/fe-core/src/test/java/org/apache/doris/clone/ClusterLoadStatisticsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/clone/ClusterLoadStatisticsTest.java
@@ -42,6 +42,7 @@ public class ClusterLoadStatisticsTest {
     private Backend be1;
     private Backend be2;
     private Backend be3;
+    private Backend be4;
 
     private Env env;
     private SystemInfoService systemInfoService;
@@ -119,10 +120,27 @@ public class ClusterLoadStatisticsTest {
         be3.setAlive(true);
         be3.setOwnerClusterName(SystemInfoService.DEFAULT_CLUSTER);
 
+        // compute role node
+        be4 = new Backend(10004, "192.168.0.4", 9053);
+        disks = Maps.newHashMap();
+        diskInfo1 = new DiskInfo("/path1");
+        diskInfo1.setTotalCapacityB(4000000);
+        diskInfo1.setAvailableCapacityB(100000);
+        diskInfo1.setDataUsedCapacityB(80000);
+        disks.put(diskInfo1.getRootPath(), diskInfo1);
+
+        be4.setDisks(ImmutableMap.copyOf(disks));
+        be4.setAlive(true);
+        be4.setOwnerClusterName(SystemInfoService.DEFAULT_CLUSTER);
+        Map<String, String> tagMap = Tag.DEFAULT_BACKEND_TAG.toMap();
+        tagMap.put(Tag.TYPE_ROLE, Tag.VALUE_COMPUTATION);
+        be4.setTagMap(tagMap);
+
         systemInfoService = new SystemInfoService();
         systemInfoService.addBackend(be1);
         systemInfoService.addBackend(be2);
         systemInfoService.addBackend(be3);
+        systemInfoService.addBackend(be4);
 
         // tablet
         invertedIndex = new TabletInvertedIndex();

--- a/fe/fe-core/src/test/java/org/apache/doris/clone/ColocateTableCheckerAndBalancerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/clone/ColocateTableCheckerAndBalancerTest.java
@@ -349,6 +349,9 @@ public class ColocateTableCheckerAndBalancerTest {
                 myBackend2.getLocationTag();
                 result = Tag.DEFAULT_BACKEND_TAG;
                 minTimes = 0;
+                myBackend2.isMixNode();
+                result = true;
+                minTimes = 0;
 
                 // backend3 not available, and dead for a long time
                 infoService.getBackend(3L);
@@ -365,6 +368,9 @@ public class ColocateTableCheckerAndBalancerTest {
                 minTimes = 0;
                 myBackend3.getLocationTag();
                 result = Tag.DEFAULT_BACKEND_TAG;
+                minTimes = 0;
+                myBackend3.isMixNode();
+                result = true;
                 minTimes = 0;
 
                 // backend4 not available, and dead for a short time
@@ -383,6 +389,9 @@ public class ColocateTableCheckerAndBalancerTest {
                 myBackend4.getLocationTag();
                 result = Tag.DEFAULT_BACKEND_TAG;
                 minTimes = 0;
+                myBackend4.isMixNode();
+                result = true;
+                minTimes = 0;
 
                 // backend5 not available, and in decommission
                 infoService.getBackend(5L);
@@ -399,6 +408,9 @@ public class ColocateTableCheckerAndBalancerTest {
                 minTimes = 0;
                 myBackend5.getLocationTag();
                 result = Tag.DEFAULT_BACKEND_TAG;
+                minTimes = 0;
+                myBackend5.isMixNode();
+                result = true;
                 minTimes = 0;
 
                 colocateTableIndex.getBackendsByGroup(groupId, tag);
@@ -420,7 +432,8 @@ public class ColocateTableCheckerAndBalancerTest {
                                       @Mocked Backend myBackend4,
                                       @Mocked Backend myBackend5,
                                       @Mocked Backend myBackend6,
-                                      @Mocked Backend myBackend7) throws AnalysisException {
+                                      @Mocked Backend myBackend7,
+                                      @Mocked Backend myBackend8) throws AnalysisException {
         List<Long> clusterBackendIds = Lists.newArrayList(1L, 2L, 3L, 4L, 5L);
         new Expectations() {
             {
@@ -442,6 +455,9 @@ public class ColocateTableCheckerAndBalancerTest {
                 myBackend2.getLocationTag();
                 result = Tag.DEFAULT_BACKEND_TAG;
                 minTimes = 0;
+                myBackend2.isMixNode();
+                result = true;
+                minTimes = 0;
 
                 // backend3 not available, and dead for a long time
                 infoService.getBackend(3L);
@@ -458,6 +474,9 @@ public class ColocateTableCheckerAndBalancerTest {
                 minTimes = 0;
                 myBackend3.getLocationTag();
                 result = Tag.DEFAULT_BACKEND_TAG;
+                minTimes = 0;
+                myBackend3.isMixNode();
+                result = true;
                 minTimes = 0;
 
                 // backend4 available, not alive but dead for a short time
@@ -476,6 +495,9 @@ public class ColocateTableCheckerAndBalancerTest {
                 myBackend4.getLocationTag();
                 result = Tag.DEFAULT_BACKEND_TAG;
                 minTimes = 0;
+                myBackend4.isMixNode();
+                result = true;
+                minTimes = 0;
 
                 // backend5 not available, and in decommission
                 infoService.getBackend(5L);
@@ -492,6 +514,9 @@ public class ColocateTableCheckerAndBalancerTest {
                 minTimes = 0;
                 myBackend5.getLocationTag();
                 result = Tag.DEFAULT_BACKEND_TAG;
+                minTimes = 0;
+                myBackend5.isMixNode();
+                result = true;
                 minTimes = 0;
 
                 // backend6 is available, but with different tag
@@ -510,6 +535,9 @@ public class ColocateTableCheckerAndBalancerTest {
                 myBackend6.getLocationTag();
                 result = Tag.create(Tag.TYPE_LOCATION, "new_loc");
                 minTimes = 0;
+                myBackend6.isMixNode();
+                result = true;
+                minTimes = 0;
 
                 // backend7 is available, but in exclude sets
                 infoService.getBackend(5L);
@@ -527,8 +555,31 @@ public class ColocateTableCheckerAndBalancerTest {
                 myBackend7.getLocationTag();
                 result = Tag.DEFAULT_BACKEND_TAG;
                 minTimes = 0;
+                myBackend7.isMixNode();
+                result = true;
+                minTimes = 0;
                 myBackend7.getId();
                 result = 999L;
+                minTimes = 0;
+
+                // backend8 is available, it's a compute node.
+                infoService.getBackend(5L);
+                result = myBackend8;
+                minTimes = 0;
+                myBackend8.isScheduleAvailable();
+                result = false;
+                minTimes = 0;
+                myBackend8.isAlive();
+                result = true;
+                minTimes = 0;
+                myBackend8.isDecommissioned();
+                result = false;
+                minTimes = 0;
+                myBackend8.getLocationTag();
+                result = Tag.DEFAULT_BACKEND_TAG;
+                minTimes = 0;
+                myBackend8.isMixNode();
+                result = false;
                 minTimes = 0;
             }
         };

--- a/fe/fe-core/src/test/java/org/apache/doris/utframe/DemoMultiBackendsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/utframe/DemoMultiBackendsTest.java
@@ -38,6 +38,7 @@ import org.apache.doris.planner.PlanFragment;
 import org.apache.doris.planner.Planner;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.StmtExecutor;
+import org.apache.doris.resource.Tag;
 import org.apache.doris.system.Backend;
 import org.apache.doris.system.SystemInfoService;
 import org.apache.doris.thrift.TDisk;
@@ -199,9 +200,10 @@ public class DemoMultiBackendsTest {
         ProcResult result = dir.fetchResult();
         Assert.assertEquals(BackendsProcDir.TITLE_NAMES.size(), result.getColumnNames().size());
         Assert.assertEquals("{\"location\" : \"default\"}", result.getRows().get(0).get(20));
-        Assert.assertEquals(
-                "{\"lastSuccessReportTabletsTime\":\"N/A\",\"lastStreamLoadTime\":-1,\"isQueryDisabled\":false,\"isLoadDisabled\":false}",
-                result.getRows().get(0).get(BackendsProcDir.TITLE_NAMES.size() - 2));
+        Assert.assertEquals("{\"lastSuccessReportTabletsTime\":\"N/A\",\"lastStreamLoadTime\":-1,\"isQueryDisabled\":false,\"isLoadDisabled\":false}",
+                result.getRows().get(0).get(BackendsProcDir.TITLE_NAMES.size() - 3));
+        Assert.assertEquals("0", result.getRows().get(0).get(BackendsProcDir.TITLE_NAMES.size() - 2));
+        Assert.assertEquals(Tag.VALUE_MIX, result.getRows().get(0).get(BackendsProcDir.TITLE_NAMES.size() - 1));
     }
 
     private static void updateReplicaPathHash() {

--- a/gensrc/thrift/HeartbeatService.thrift
+++ b/gensrc/thrift/HeartbeatService.thrift
@@ -43,6 +43,7 @@ struct TBackendInfo {
     4: optional Types.TPort brpc_port
     5: optional string version
     6: optional i64 be_start_time
+    7: optional string be_node_role
 }
 
 struct THeartbeatResult {


### PR DESCRIPTION
# Proposed changes

Issue Number: https://github.com/apache/doris/issues/13144

## Problem summary

Introduce the node role to doris, and the table creation and tablet scheduler will control the storage only assign to the BE nodes.
## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [x] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [x] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

