### PR TITLE
[Bug](predicate) Cover all const predicates in scan node

### DIFF
--- a/be/src/vec/exec/scan/vscan_node.cpp
+++ b/be/src/vec/exec/scan/vscan_node.cpp
@@ -550,7 +550,7 @@ void VScanNode::_eval_const_conjuncts(VExpr* vexpr, VExprContext* expr_ctx, Push
             }
         } else {
             LOG(WARNING) << "Expr[" << vexpr->debug_string()
-                         << "] should return a boolean column but actually is "
+                         << "] should return a const column but actually is "
                          << vexpr->get_const_col(expr_ctx)->column_ptr->get_name();
         }
     }

--- a/be/src/vec/exec/scan/vscan_node.cpp
+++ b/be/src/vec/exec/scan/vscan_node.cpp
@@ -535,9 +535,23 @@ void VScanNode::_eval_const_conjuncts(VExpr* vexpr, VExprContext* expr_ctx, Push
                 *pdt = PushDownType::ACCEPTABLE;
                 _eos = true;
             }
+        } else if (const ColumnVector<UInt8>* bool_column =
+                           check_and_get_column<ColumnVector<UInt8>>(
+                                   vexpr->get_const_col(expr_ctx)->column_ptr)) {
+            // TODO: If `vexpr->is_constant()` is true, a const column is expected here.
+            //  But now we still don't cover all predicates for const expression.
+            //  For example, for query `SELECT col FROM tbl WHERE 'PROMOTION' LIKE 'AAA%'`,
+            //  predicate `like` will return a ColumnVector<UInt8> which contains a single value.
+            DCHECK_EQ(bool_column->size(), 1);
+            constant_val = const_cast<char*>(bool_column->get_data_at(0).data);
+            if (constant_val == nullptr || *reinterpret_cast<bool*>(constant_val) == false) {
+                *pdt = PushDownType::ACCEPTABLE;
+                _eos = true;
+            }
         } else {
             LOG(WARNING) << "Expr[" << vexpr->debug_string()
-                         << "] is a constant but doesn't contain a const column!";
+                         << "] should return a boolean column but actually is "
+                         << vexpr->get_const_col(expr_ctx)->column_ptr->get_name();
         }
     }
 }

--- a/be/src/vec/exec/volap_scan_node.cpp
+++ b/be/src/vec/exec/volap_scan_node.cpp
@@ -1655,6 +1655,9 @@ void VOlapScanNode::eval_const_conjuncts(VExpr* vexpr, VExprContext* expr_ctx, b
             //  But now we still don't cover all predicates for const expression.
             //  For example, for query `SELECT col FROM tbl WHERE 'PROMOTION' LIKE 'AAA%'`,
             //  predicate `like` will return a ColumnVector<UInt8> which contains a single value.
+            LOG(WARNING) << "Expr[" << vexpr->debug_string()
+                         << "] should return a const column but actually is "
+                         << vexpr->get_const_col(expr_ctx)->column_ptr->get_name();
             DCHECK_EQ(bool_column->size(), 1);
             constant_val = const_cast<char*>(bool_column->get_data_at(0).data);
             if (constant_val == nullptr || *reinterpret_cast<bool*>(constant_val) == false) {

--- a/be/src/vec/exec/volap_scan_node.cpp
+++ b/be/src/vec/exec/volap_scan_node.cpp
@@ -1648,9 +1648,23 @@ void VOlapScanNode::eval_const_conjuncts(VExpr* vexpr, VExprContext* expr_ctx, b
                 *push_down = true;
                 _eos = true;
             }
+        } else if (const ColumnVector<UInt8>* bool_column =
+                           check_and_get_column<ColumnVector<UInt8>>(
+                                   vexpr->get_const_col(expr_ctx)->column_ptr)) {
+            // TODO: If `vexpr->is_constant()` is true, a const column is expected here.
+            //  But now we still don't cover all predicates for const expression.
+            //  For example, for query `SELECT col FROM tbl WHERE 'PROMOTION' LIKE 'AAA%'`,
+            //  predicate `like` will return a ColumnVector<UInt8> which contains a single value.
+            DCHECK_EQ(bool_column->size(), 1);
+            constant_val = const_cast<char*>(bool_column->get_data_at(0).data);
+            if (constant_val == nullptr || *reinterpret_cast<bool*>(constant_val) == false) {
+                *push_down = true;
+                _eos = true;
+            }
         } else {
             LOG(WARNING) << "Expr[" << vexpr->debug_string()
-                         << "] is a constant but doesn't contain a const column!";
+                         << "] should return a boolean column but actually is "
+                         << vexpr->get_const_col(expr_ctx)->column_ptr->get_name();
         }
     }
 }

--- a/be/src/vec/functions/like.h
+++ b/be/src/vec/functions/like.h
@@ -121,6 +121,8 @@ public:
         return std::make_shared<DataTypeUInt8>();
     }
 
+    bool use_default_implementation_for_constants() const override { return true; }
+
     Status execute_impl(FunctionContext* context, Block& block, const ColumnNumbers& arguments,
                         size_t result, size_t /*input_rows_count*/) override;
 


### PR DESCRIPTION
# Proposed changes

For an vectorized expression which meets the condition `vexpr->is_constant()`, a const column is expected to return.
But now we still don't cover all predicates for const expression.
For example, for query `SELECT col FROM tbl WHERE 'PROMOTION' LIKE 'AAA%'`, predicate `like` will return a ColumnVector<UInt8> which contains a single value.

This PR want to cover all const predicates in scan node whether it returns a constcolumn or not

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

