### PR TITLE
[fix](ddl) check view name by table name regex when create

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateViewStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateViewStmt.java
@@ -20,6 +20,7 @@ package org.apache.doris.analysis;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.ErrorReport;
+import org.apache.doris.common.FeNameFormat;
 import org.apache.doris.common.UserException;
 import org.apache.doris.common.util.Util;
 import org.apache.doris.mysql.privilege.PrivPredicate;
@@ -55,6 +56,7 @@ public class CreateViewStmt extends BaseViewStmt {
     @Override
     public void analyze(Analyzer analyzer) throws UserException {
         tableName.analyze(analyzer);
+        FeNameFormat.checkTableName(tableName.getTbl());
         viewDefStmt.setNeedToSql(true);
         // disallow external catalog
         Util.prohibitExternalCatalog(tableName.getCtl(), this.getClass().getSimpleName());

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/CreateViewStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/CreateViewStmtTest.java
@@ -1,0 +1,52 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.analysis;
+
+import org.apache.doris.common.AnalysisException;
+import org.apache.doris.common.ExceptionChecker;
+import org.apache.doris.utframe.TestWithFeService;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * test for CreateTableAsSelectStmt.
+ **/
+public class CreateViewStmtTest extends TestWithFeService {
+
+    @Override
+    protected void runBeforeAll() throws Exception {
+        createDatabase("test");
+        useDatabase("test");
+        String table1 = "create table test.table1 (k1 int, k2 int) distributed by hash(k1) "
+                + "buckets 1 properties('replication_num' = '1')";
+        createTable(table1);
+    }
+
+    @Test
+    public void testQuerySchema() throws Exception {
+        connectContext.setDatabase("default_cluster:test");
+        String createViewStr1 = "create view 1view1 as select k1,k2 from test.table1;";
+        ExceptionChecker.expectThrowsWithMsg(AnalysisException.class,
+                "Incorrect table name '1view1'. Table name regex is '^[a-zA-Z][a-zA-Z0-9_]*$'",
+                () -> parseAndAnalyzeStmt(createViewStr1, connectContext));
+
+        String createViewStr2 = "create view view2 as select k1,k2 from test.table1;";
+        ExceptionChecker.expectThrowsNoException(
+                () -> parseAndAnalyzeStmt(createViewStr2, connectContext));
+    }
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/CreateViewStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/CreateViewStmtTest.java
@@ -24,7 +24,7 @@ import org.apache.doris.utframe.TestWithFeService;
 import org.junit.jupiter.api.Test;
 
 /**
- * test for CreateTableAsSelectStmt.
+ * test for CreateViewStmtTest.
  **/
 public class CreateViewStmtTest extends TestWithFeService {
 
@@ -38,7 +38,7 @@ public class CreateViewStmtTest extends TestWithFeService {
     }
 
     @Test
-    public void testQuerySchema() throws Exception {
+    public void testCreateView() throws Exception {
         connectContext.setDatabase("default_cluster:test");
         String createViewStr1 = "create view 1view1 as select k1,k2 from test.table1;";
         ExceptionChecker.expectThrowsWithMsg(AnalysisException.class,


### PR DESCRIPTION
Signed-off-by: nextdreamblue <zxw520blue1@163.com>

# Proposed changes

Issue Number: close #13242

## Problem summary

add check view name by table name regex when create.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

