### PR TITLE
[fix](agg)count function should return 0 for null value

### DIFF
--- a/be/src/vec/aggregate_functions/aggregate_function_count.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_count.h
@@ -189,7 +189,11 @@ public:
                                            const size_t num_rows, Arena* arena) const override {
         auto& col = assert_cast<ColumnUInt64&>(*dst);
         col.resize(num_rows);
-        col.get_data().assign(num_rows, 1UL);
+        auto& data = col.get_data();
+        const ColumnNullable& input_col = assert_cast<const ColumnNullable&>(*columns[0]);
+        for (size_t i = 0; i < num_rows; i++) {
+            data[i] = !input_col.is_null_at(i);
+        }
     }
 
     void deserialize_and_merge_from_column(AggregateDataPtr __restrict place, const IColumn& column,


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

count(null) should return 0 instead of 1, the streaming_agg_serialize_to_column function didn't handle if the input value is null, this pr fix it.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

