### PR TITLE
[feature](config)Add hide config to hide config in webserver for safety.

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -879,6 +879,10 @@ CONF_mBool(enable_new_load_scan_node, "false");
 // Temp config. True to use new file scanner. Will remove after fully test.
 CONF_mBool(enable_new_file_scanner, "false");
 
+// Hide webserver page for safety.
+// Hide the be config page for webserver.
+CONF_Bool(hide_webserver_config_page, "false");
+
 #ifdef BE_TEST
 // test s3
 CONF_String(test_s3_resource, "resource");

--- a/be/src/http/default_path_handlers.cpp
+++ b/be/src/http/default_path_handlers.cpp
@@ -349,7 +349,10 @@ void cpu_handler(const WebPageHandler::ArgumentMap& args, std::stringstream* out
 void add_default_path_handlers(WebPageHandler* web_page_handler) {
     // TODO(yingchun): logs_handler is not implemented yet, so not show it on navigate bar
     web_page_handler->register_page("/logs", "Logs", logs_handler, false /* is_on_nav_bar */);
-    web_page_handler->register_page("/varz", "Configs", config_handler, true /* is_on_nav_bar */);
+    if (!config::hide_webserver_config_page) {
+        web_page_handler->register_page("/varz", "Configs", config_handler,
+                                        true /* is_on_nav_bar */);
+    }
     web_page_handler->register_page("/memz", "Memory", mem_usage_handler, true /* is_on_nav_bar */);
     web_page_handler->register_page(
             "/mem_tracker", "MemTracker",


### PR DESCRIPTION
# Proposed changes

Issue Number: close #13254

## Problem summary

Webserver on BE has no authorization verification. Anyone can get the config for be.
It is not safe for online system.
So I need to add a parameter to hide the config.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

