### PR TITLE
[feature-wip](multi-catalog) optimize parquet profile & add null map timer

### DIFF
--- a/be/src/util/runtime_profile.h
+++ b/be/src/util/runtime_profile.h
@@ -45,6 +45,7 @@ namespace doris {
 
 #define ADD_COUNTER(profile, name, type) (profile)->add_counter(name, type)
 #define ADD_TIMER(profile, name) (profile)->add_counter(name, TUnit::TIME_NS)
+#define ADD_CHILD_COUNTER(profile, name, type, parent) (profile)->add_counter(name, type, parent)
 #define ADD_CHILD_TIMER(profile, name, parent) (profile)->add_counter(name, TUnit::TIME_NS, parent)
 #define SCOPED_TIMER(c) ScopedTimer<MonotonicStopWatch> MACRO_CONCAT(SCOPED_TIMER, __COUNTER__)(c)
 #define SCOPED_CPU_TIMER(c) \

--- a/be/src/vec/exec/format/parquet/parquet_common.h
+++ b/be/src/vec/exec/format/parquet/parquet_common.h
@@ -336,7 +336,7 @@ Status FixLengthDecoder::_decode_binary_decimal(MutableColumnPtr& doris_column,
         value = BigEndian::ToHost128(value);
         if (scale_params.scale_type == DecimalScaleParams::SCALE_UP) {
             value *= scale_params.scale_factor;
-        } else if (scale_params.scale_type == DecimalScaleParams::SCALE_UP) {
+        } else if (scale_params.scale_type == DecimalScaleParams::SCALE_DOWN) {
             value /= scale_params.scale_factor;
         }
         auto& v = reinterpret_cast<DecimalPrimitiveType&>(column_data[origin_size + i]);
@@ -361,7 +361,7 @@ Status FixLengthDecoder::_decode_primitive_decimal(MutableColumnPtr& doris_colum
         Int128 value = *reinterpret_cast<DecimalPhysicalType*>(buf_start);
         if (scale_params.scale_type == DecimalScaleParams::SCALE_UP) {
             value *= scale_params.scale_factor;
-        } else if (scale_params.scale_type == DecimalScaleParams::SCALE_UP) {
+        } else if (scale_params.scale_type == DecimalScaleParams::SCALE_DOWN) {
             value /= scale_params.scale_factor;
         }
         auto& v = reinterpret_cast<DecimalPrimitiveType&>(column_data[origin_size + i]);
@@ -430,7 +430,7 @@ Status ByteArrayDecoder::_decode_binary_decimal(MutableColumnPtr& doris_column,
         value = BigEndian::ToHost128(value);
         if (scale_params.scale_type == DecimalScaleParams::SCALE_UP) {
             value *= scale_params.scale_factor;
-        } else if (scale_params.scale_type == DecimalScaleParams::SCALE_UP) {
+        } else if (scale_params.scale_type == DecimalScaleParams::SCALE_DOWN) {
             value /= scale_params.scale_factor;
         }
         auto& v = reinterpret_cast<DecimalPrimitiveType&>(column_data[origin_size + i]);

--- a/be/src/vec/exec/format/parquet/vparquet_column_reader.cpp
+++ b/be/src/vec/exec/format/parquet/vparquet_column_reader.cpp
@@ -126,7 +126,10 @@ Status ScalarColumnReader::_read_values(size_t num_values, ColumnPtr& doris_colu
     MutableColumnPtr data_column = nullable_column->get_nested_column_ptr();
     NullMap& map_data_column = nullable_column->get_null_map_data();
     auto origin_size = map_data_column.size();
-    map_data_column.resize(origin_size + num_values);
+    {
+        SCOPED_RAW_TIMER(&_decode_null_map_time);
+        map_data_column.resize(origin_size + num_values);
+    }
 
     if (_chunk_reader->max_def_level() > 0) {
         LevelDecoder& def_decoder = _chunk_reader->def_level_decoder();
@@ -136,8 +139,11 @@ Status ScalarColumnReader::_read_values(size_t num_values, ColumnPtr& doris_colu
             size_t loop_read = def_decoder.get_next_run(&def_level, num_values - has_read);
             bool is_null = def_level == 0;
             // fill NullMap
-            for (int i = 0; i < loop_read; ++i) {
-                map_data_column[origin_size + has_read + i] = (UInt8)is_null;
+            {
+                SCOPED_RAW_TIMER(&_decode_null_map_time);
+                for (int i = 0; i < loop_read; ++i) {
+                    map_data_column[origin_size + has_read + i] = (UInt8)is_null;
+                }
             }
             // decode data
             if (is_null) {
@@ -298,11 +304,14 @@ Status ArrayColumnReader::read_column_data(ColumnPtr& doris_column, DataTypePtr&
             size_t scan_values =
                     element_offsets[offset_index + scan_rows] - element_offsets[offset_index];
             // null array, should ignore the last offset in element_offsets
-            auto origin_size = map_data_column.size();
-            map_data_column.resize(origin_size + scan_rows);
-            for (int i = offset_index; i < offset_index + scan_rows; ++i) {
-                map_data_column[origin_size + i] =
-                        (UInt8)(definitions[element_offsets[i]] == _NULL_ARRAY);
+            {
+                SCOPED_RAW_TIMER(&_decode_null_map_time);
+                auto origin_size = map_data_column.size();
+                map_data_column.resize(origin_size + scan_rows);
+                for (int i = offset_index; i < offset_index + scan_rows; ++i) {
+                    map_data_column[origin_size + i] =
+                            (UInt8)(definitions[element_offsets[i]] == _NULL_ARRAY);
+                }
             }
             // fill array offset, should skip a value when parsing null array
             _fill_array_offset(data_column, element_offsets, offset_index, scan_rows);
@@ -344,23 +353,26 @@ Status ArrayColumnReader::_load_nested_column(ColumnPtr& doris_column, DataTypeP
     level_t* definitions = _def_levels_buf.get();
     auto* nullable_column = reinterpret_cast<vectorized::ColumnNullable*>(
             (*std::move(doris_column)).mutate().get());
-    NullMap& map_data_column = nullable_column->get_null_map_data();
     MutableColumnPtr data_column = nullable_column->get_nested_column_ptr();
-    size_t null_map_size = 0;
-    for (int i = _def_offset; i < _def_offset + read_values; ++i) {
-        // should skip _EMPTY_ARRAY and _NULL_ARRAY
-        if (definitions[i] == _CONCRETE_ELEMENT || definitions[i] == _NULL_ELEMENT) {
-            null_map_size++;
+    {
+        SCOPED_RAW_TIMER(&_decode_null_map_time);
+        NullMap& map_data_column = nullable_column->get_null_map_data();
+        size_t null_map_size = 0;
+        for (int i = _def_offset; i < _def_offset + read_values; ++i) {
+            // should skip _EMPTY_ARRAY and _NULL_ARRAY
+            if (definitions[i] == _CONCRETE_ELEMENT || definitions[i] == _NULL_ELEMENT) {
+                null_map_size++;
+            }
         }
-    }
-    auto origin_size = map_data_column.size();
-    map_data_column.resize(origin_size + null_map_size);
-    size_t null_map_idx = origin_size;
-    for (int i = _def_offset; i < _def_offset + read_values; ++i) {
-        if (definitions[i] == _CONCRETE_ELEMENT) {
-            map_data_column[null_map_idx++] = (UInt8) false;
-        } else if (definitions[i] == _NULL_ELEMENT) {
-            map_data_column[null_map_idx++] = (UInt8) true;
+        auto origin_size = map_data_column.size();
+        map_data_column.resize(origin_size + null_map_size);
+        size_t null_map_idx = origin_size;
+        for (int i = _def_offset; i < _def_offset + read_values; ++i) {
+            if (definitions[i] == _CONCRETE_ELEMENT) {
+                map_data_column[null_map_idx++] = (UInt8) false;
+            } else if (definitions[i] == _NULL_ELEMENT) {
+                map_data_column[null_map_idx++] = (UInt8) true;
+            }
         }
     }
     // column with null values

--- a/be/src/vec/exec/format/parquet/vparquet_column_reader.h
+++ b/be/src/vec/exec/format/parquet/vparquet_column_reader.h
@@ -55,9 +55,11 @@ public:
                   decode_header_time(0),
                   decode_value_time(0),
                   decode_dict_time(0),
-                  decode_level_time(0) {}
+                  decode_level_time(0),
+                  decode_null_map_time(0) {}
 
-        Statistics(BufferedStreamReader::Statistics& fs, ColumnChunkReader::Statistics& cs)
+        Statistics(BufferedStreamReader::Statistics& fs, ColumnChunkReader::Statistics& cs,
+                   int64_t null_map_time)
                 : read_time(fs.read_time),
                   read_calls(fs.read_calls),
                   read_bytes(fs.read_bytes),
@@ -66,7 +68,8 @@ public:
                   decode_header_time(cs.decode_header_time),
                   decode_value_time(cs.decode_value_time),
                   decode_dict_time(cs.decode_dict_time),
-                  decode_level_time(cs.decode_level_time) {}
+                  decode_level_time(cs.decode_level_time),
+                  decode_null_map_time(null_map_time) {}
 
         int64_t read_time;
         int64_t read_calls;
@@ -77,6 +80,7 @@ public:
         int64_t decode_value_time;
         int64_t decode_dict_time;
         int64_t decode_level_time;
+        int64_t decode_null_map_time;
 
         void merge(Statistics& statistics) {
             read_time += statistics.read_time;
@@ -88,6 +92,7 @@ public:
             decode_value_time += statistics.decode_value_time;
             decode_dict_time += statistics.decode_dict_time;
             decode_level_time += statistics.decode_level_time;
+            decode_null_map_time += statistics.decode_null_map_time;
         }
     };
 
@@ -107,7 +112,8 @@ public:
     void init_column_metadata(const tparquet::ColumnChunk& chunk);
     void add_offset_index(tparquet::OffsetIndex* offset_index) { _offset_index = offset_index; }
     Statistics statistics() {
-        return Statistics(_stream_reader->statistics(), _chunk_reader->statistics());
+        return Statistics(_stream_reader->statistics(), _chunk_reader->statistics(),
+                          _decode_null_map_time);
     }
     virtual void close() = 0;
 
@@ -123,6 +129,7 @@ protected:
     tparquet::OffsetIndex* _offset_index;
     int64_t _current_row_index = 0;
     int _row_range_index = 0;
+    int64_t _decode_null_map_time = 0;
 };
 
 class ScalarColumnReader : public ParquetColumnReader {

--- a/be/src/vec/exec/format/parquet/vparquet_reader.cpp
+++ b/be/src/vec/exec/format/parquet/vparquet_reader.cpp
@@ -46,30 +46,43 @@ ParquetReader::~ParquetReader() {
 
 void ParquetReader::_init_profile() {
     if (_profile != nullptr) {
+        static const char* const parquetProfile = "ParquetReader";
+        ADD_TIMER(_profile, parquetProfile);
+
         _parquet_profile.filtered_row_groups =
-                ADD_COUNTER(_profile, "ParquetFilteredGroups", TUnit::UNIT);
+                ADD_CHILD_COUNTER(_profile, "FilteredGroups", TUnit::UNIT, parquetProfile);
         _parquet_profile.to_read_row_groups =
-                ADD_COUNTER(_profile, "ParquetReadGroups", TUnit::UNIT);
+                ADD_CHILD_COUNTER(_profile, "ReadGroups", TUnit::UNIT, parquetProfile);
         _parquet_profile.filtered_group_rows =
-                ADD_COUNTER(_profile, "ParquetFilteredRowsByGroup", TUnit::UNIT);
+                ADD_CHILD_COUNTER(_profile, "FilteredRowsByGroup", TUnit::UNIT, parquetProfile);
         _parquet_profile.filtered_page_rows =
-                ADD_COUNTER(_profile, "ParquetFilteredRowsByPage", TUnit::UNIT);
+                ADD_CHILD_COUNTER(_profile, "FilteredRowsByPage", TUnit::UNIT, parquetProfile);
         _parquet_profile.filtered_bytes =
-                ADD_COUNTER(_profile, "ParquetFilteredBytes", TUnit::BYTES);
-        _parquet_profile.to_read_bytes = ADD_COUNTER(_profile, "ParquetReadBytes", TUnit::BYTES);
-        _parquet_profile.column_read_time = ADD_TIMER(_profile, "ParquetColumnReadTime");
-        _parquet_profile.parse_meta_time = ADD_TIMER(_profile, "ParquetParseMetaTime");
+                ADD_CHILD_COUNTER(_profile, "FilteredBytes", TUnit::BYTES, parquetProfile);
+        _parquet_profile.to_read_bytes =
+                ADD_CHILD_COUNTER(_profile, "ReadBytes", TUnit::BYTES, parquetProfile);
+        _parquet_profile.column_read_time =
+                ADD_CHILD_TIMER(_profile, "ColumnReadTime", parquetProfile);
+        _parquet_profile.parse_meta_time =
+                ADD_CHILD_TIMER(_profile, "ParseMetaTime", parquetProfile);
 
         _parquet_profile.file_read_time = ADD_TIMER(_profile, "FileReadTime");
         _parquet_profile.file_read_calls = ADD_COUNTER(_profile, "FileReadCalls", TUnit::UNIT);
         _parquet_profile.file_read_bytes = ADD_COUNTER(_profile, "FileReadBytes", TUnit::BYTES);
-        _parquet_profile.decompress_time = ADD_TIMER(_profile, "ParquetDecompressTime");
+        _parquet_profile.decompress_time =
+                ADD_CHILD_TIMER(_profile, "DecompressTime", parquetProfile);
         _parquet_profile.decompress_cnt =
-                ADD_COUNTER(_profile, "ParquetDecompressCount", TUnit::UNIT);
-        _parquet_profile.decode_header_time = ADD_TIMER(_profile, "ParquetDecodeHeaderTime");
-        _parquet_profile.decode_value_time = ADD_TIMER(_profile, "ParquetDecodeValueTime");
-        _parquet_profile.decode_dict_time = ADD_TIMER(_profile, "ParquetDecodeDictTime");
-        _parquet_profile.decode_level_time = ADD_TIMER(_profile, "ParquetDecodeLevelTime");
+                ADD_CHILD_COUNTER(_profile, "DecompressCount", TUnit::UNIT, parquetProfile);
+        _parquet_profile.decode_header_time =
+                ADD_CHILD_TIMER(_profile, "DecodeHeaderTime", parquetProfile);
+        _parquet_profile.decode_value_time =
+                ADD_CHILD_TIMER(_profile, "DecodeValueTime", parquetProfile);
+        _parquet_profile.decode_dict_time =
+                ADD_CHILD_TIMER(_profile, "DecodeDictTime", parquetProfile);
+        _parquet_profile.decode_level_time =
+                ADD_CHILD_TIMER(_profile, "DecodeLevelTime", parquetProfile);
+        _parquet_profile.decode_null_map_time =
+                ADD_CHILD_TIMER(_profile, "DecodeNullMapTime", parquetProfile);
     }
 }
 
@@ -97,6 +110,8 @@ void ParquetReader::close() {
             COUNTER_UPDATE(_parquet_profile.decode_dict_time, _column_statistics.decode_dict_time);
             COUNTER_UPDATE(_parquet_profile.decode_level_time,
                            _column_statistics.decode_level_time);
+            COUNTER_UPDATE(_parquet_profile.decode_null_map_time,
+                           _column_statistics.decode_null_map_time);
         }
         _closed = true;
     }

--- a/be/src/vec/exec/format/parquet/vparquet_reader.h
+++ b/be/src/vec/exec/format/parquet/vparquet_reader.h
@@ -93,6 +93,7 @@ private:
         RuntimeProfile::Counter* decode_value_time;
         RuntimeProfile::Counter* decode_dict_time;
         RuntimeProfile::Counter* decode_level_time;
+        RuntimeProfile::Counter* decode_null_map_time;
     };
 
     void _init_profile();


### PR DESCRIPTION
# Proposed changes

Use indentation to make `ParquetReader`'s profile more readable
Add `ParquetReader.DecodeNullMapTime` to show the time of parsing `NullMap` for `NullableColumn`

```
VFILE_SCAN_NODE  (id=0):(Active:  279.62ms,  %  non-child:  85.83%)
    -  FileReadBytes:  2.36  MB
    -  FileReadCalls:  20
    -  FileReadTime:  5.686ms
    -  MaxScannerThreadNum:  1
    -  NewlyCreateFreeBlocksNum:  125
    -  NumScanners:  1
    -  ParquetReader:  0ns
        -  ColumnReadTime:  259.946ms
        -  DecodeDictTime:  0ns
        -  DecodeHeaderTime:  437.707us
        -  DecodeLevelTime:  30.101us
        -  DecodeNullMapTime:  53.295ms
        -  DecodeValueTime:  62.607ms
        -  DecompressCount:  511
        -  DecompressTime:  1.159ms
        -  FilteredBytes:  0.00  
        -  FilteredGroups:  0
        -  FilteredRowsByGroup:  0
        -  FilteredRowsByPage:  0
        -  ParseMetaTime:  22.517ms
        -  ReadBytes:  2.36  MB
        -  ReadGroups:  20
```

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

