### PR TITLE
[config](datev2) set `enable_date_conversion = true` by default

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/Config.java
@@ -1726,7 +1726,7 @@ public class Config extends ConfigBase {
      * If set to TRUE, FE will convert date/datetime to datev2/datetimev2(0) automatically.
      */
     @ConfField(mutable = true, masterOnly = true)
-    public static boolean enable_date_conversion = false;
+    public static boolean enable_date_conversion = true;
 
     @ConfField(mutable = false, masterOnly = true)
     public static boolean enable_multi_tags = false;


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

