### PR TITLE
[fix](new-scann) scanner may be marked close twice

### DIFF
--- a/be/src/vec/exec/scan/scanner_context.cpp
+++ b/be/src/vec/exec/scan/scanner_context.cpp
@@ -220,7 +220,8 @@ void ScannerContext::push_back_scanner_and_reschedule(VScanner* scanner) {
     // before we call the following if() block.
     // So we need "scanner->set_counted_down()" to avoid "_num_unfinished_scanners" being decreased twice by
     // same scanner.
-    if (scanner->need_to_close() && scanner->set_counted_down() && (--_num_unfinished_scanners) == 0) {
+    if (scanner->need_to_close() && scanner->set_counted_down() &&
+        (--_num_unfinished_scanners) == 0) {
         _is_finished = true;
         _blocks_queue_added_cv.notify_one();
     }

--- a/be/src/vec/exec/scan/scanner_context.cpp
+++ b/be/src/vec/exec/scan/scanner_context.cpp
@@ -214,7 +214,13 @@ void ScannerContext::push_back_scanner_and_reschedule(VScanner* scanner) {
     _num_running_scanners--;
     _num_scheduling_ctx++;
     _state->exec_env()->scanner_scheduler()->submit(this);
-    if (scanner->need_to_close() && (--_num_unfinished_scanners) == 0) {
+
+    // Notice that after calling "_scanners.push_front(scanner)", there may be other ctx in scheduler
+    // to schedule that scanner right away, and in that schedule run, the scanner may be marked as closed
+    // before we call the following if() block.
+    // So we need "scanner->set_counted_down()" to avoid "_num_unfinished_scanners" being decreased twice by
+    // same scanner.
+    if (scanner->need_to_close() && scanner->set_counted_down() && (--_num_unfinished_scanners) == 0) {
         _is_finished = true;
         _blocks_queue_added_cv.notify_one();
     }

--- a/be/src/vec/exec/scan/vscanner.h
+++ b/be/src/vec/exec/scan/vscanner.h
@@ -93,6 +93,16 @@ public:
         _conjunct_ctxs = conjunct_ctxs;
     }
 
+    // return false if _is_counted_down is already true,
+    // otherwise, set _is_counted_down to true and return true.
+    bool set_counted_down() {
+        if (_is_counted_down) {
+            return false;
+        }
+        _is_counted_down = true;
+        return true;
+    }
+
 protected:
     void _discard_conjuncts() {
         if (_vconjunct_ctx) {
@@ -151,6 +161,8 @@ protected:
     std::vector<ExprContext*> _conjunct_ctxs;
 
     bool _is_load = false;
+    // set to true after decrease the "_num_unfinished_scanners" in scanner context
+    bool _is_counted_down = false;
 };
 
 } // namespace doris::vectorized


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

See comment in code for details.
This bug will cause some scanners to exit early, resulting in missing query results.
Hard to reproduce.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

