### PR TITLE
[fix](DynamicPartition) Not check max_dynamic_partition_num when disable DynamicPartition

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/DynamicPartitionUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/DynamicPartitionUtil.java
@@ -558,7 +558,8 @@ public class DynamicPartitionUtil {
                 expectCreatePartitionNum = end - start;
             }
         }
-        if (hasEnd && (expectCreatePartitionNum > Config.max_dynamic_partition_num)) {
+        if (hasEnd && (expectCreatePartitionNum > Config.max_dynamic_partition_num)
+                && Boolean.parseBoolean(analyzedProperties.getOrDefault(DynamicPartitionProperty.ENABLE, "true"))) {
             throw new DdlException("Too many dynamic partitions: "
                     + expectCreatePartitionNum + ". Limit: " + Config.max_dynamic_partition_num);
         }


### PR DESCRIPTION
# Proposed changes

Disable max_dynamic_partition_num check when disable DynamicPartition by `ALTER TABLE tbl_name SET ("dynamic_partition.enable" = "false")`,  when  `max_dynamic_partition_num` changed to larger and then changed to a lower value, the actual  dynamic partition num may larger than `max_dynamic_partition_num`, and cannot disable DynamicPartition

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

