### PR TITLE
[regression](Nereids) temporary remove test case 'tpch q21' until we fix it

### DIFF
--- a/regression-test/suites/tpch_sf1_p1/tpch_sf1/nereids/q21.groovy
+++ b/regression-test/suites/tpch_sf1_p1/tpch_sf1/nereids/q21.groovy
@@ -69,41 +69,5 @@ order by
     s_name
 limit 100;
     """
-
-    qt_select """
-select /*+SET_VAR(exec_mem_limit=8589934592, parallel_fragment_exec_instance_num=16, enable_vectorized_engine=true, batch_size=4096, disable_join_reorder=true, enable_cost_based_join_reorder=true, enable_projection=true) */
-s_name, count(*) as numwait
-from orders join
-(
-  select * from
-  lineitem l2 right semi join
-  (
-    select * from
-    lineitem l3 right anti join
-    (
-      select * from
-      lineitem l1 join
-      (
-        select * from
-        supplier join nation
-        where s_nationkey = n_nationkey
-          and n_name = 'SAUDI ARABIA'
-      ) t1
-      where t1.s_suppkey = l1.l_suppkey and l1.l_receiptdate > l1.l_commitdate
-    ) t2
-    on l3.l_orderkey = t2.l_orderkey and l3.l_suppkey <> t2.l_suppkey and l3.l_receiptdate > l3.l_commitdate
-  ) t3
-  on l2.l_orderkey = t3.l_orderkey and l2.l_suppkey <> t3.l_suppkey
-) t4
-on o_orderkey = t4.l_orderkey and o_orderstatus = 'F'
-group by
-    t4.s_name
-order by
-    numwait desc,
-    t4.s_name
-limit 100;
-
-
-    """
-
 }
+


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

NPE thrown when we run regression test tpc-h q21 on Nereids

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

