### PR TITLE
[improvement](memory) disable page cache and chunk allocator, optimize memory allocate size

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -440,6 +440,9 @@ CONF_Bool(disable_mem_pools, "false");
 // but will acquire more free memory which can not be used by other modules.
 CONF_mString(chunk_reserved_bytes_limit, "10%");
 
+// 1024, The minimum chunk allocator size (in bytes)
+CONF_Int32(min_chunk_reserved_bytes, "1024");
+
 // Whether using chunk allocator to cache memory chunk
 CONF_Bool(disable_chunk_allocator, "true");
 // Disable Chunk Allocator in Vectorized Allocator, this will reduce memory cache.

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -239,7 +239,7 @@ CONF_Int32(storage_page_cache_shard_size, "16");
 // all storage page cache will be divided into data_page_cache and index_page_cache
 CONF_Int32(index_page_cache_percentage, "10");
 // whether to disable page cache feature in storage
-CONF_Bool(disable_storage_page_cache, "false");
+CONF_Bool(disable_storage_page_cache, "true");
 
 CONF_Bool(enable_storage_vectorization, "true");
 
@@ -439,14 +439,20 @@ CONF_Bool(disable_mem_pools, "false");
 // increase this variable can improve performance,
 // but will acquire more free memory which can not be used by other modules.
 CONF_mString(chunk_reserved_bytes_limit, "10%");
-// 1024, The minimum chunk allocator size (in bytes)
-CONF_Int32(min_chunk_reserved_bytes, "1024");
+
+// Whether using chunk allocator to cache memory chunk
+CONF_Bool(disable_chunk_allocator, "true");
 // Disable Chunk Allocator in Vectorized Allocator, this will reduce memory cache.
 // For high concurrent queries, using Chunk Allocator with vectorized Allocator can reduce the impact
 // of gperftools tcmalloc central lock.
 // Jemalloc or google tcmalloc have core cache, Chunk Allocator may no longer be needed after replacing
 // gperftools tcmalloc.
-CONF_mBool(disable_chunk_allocator_in_vec, "false");
+CONF_mBool(disable_chunk_allocator_in_vec, "true");
+
+// Both MemPool and vectorized engine's podarray allocator, vectorized engine's arena will try to allocate memory as power of two.
+// But if the memory is very large then power of two is also very large. This config means if the allocated memory's size is larger
+// than this limit then all allocators will not use RoundUpToPowerOfTwo to allocate memory.
+CONF_mInt64(memory_linear_growth_threshold, "134217728"); // 128Mb
 
 // The probing algorithm of partitioned hash table.
 // Enable quadratic probing hash table

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -440,9 +440,6 @@ CONF_Bool(disable_mem_pools, "false");
 // but will acquire more free memory which can not be used by other modules.
 CONF_mString(chunk_reserved_bytes_limit, "10%");
 
-// 1024, The minimum chunk allocator size (in bytes)
-CONF_Int32(min_chunk_reserved_bytes, "1024");
-
 // Whether using chunk allocator to cache memory chunk
 CONF_Bool(disable_chunk_allocator, "true");
 // Disable Chunk Allocator in Vectorized Allocator, this will reduce memory cache.

--- a/be/src/runtime/exec_env_init.cpp
+++ b/be/src/runtime/exec_env_init.cpp
@@ -305,13 +305,6 @@ Status ExecEnv::_init_mem_tracker() {
     RETURN_IF_ERROR(_disk_io_mgr->init(global_memory_limit_bytes));
     RETURN_IF_ERROR(_tmp_file_mgr->init());
 
-    // 5. init chunk allocator
-    if (!BitUtil::IsPowerOf2(config::min_chunk_reserved_bytes)) {
-        ss << "Config min_chunk_reserved_bytes must be a power-of-two: "
-           << config::min_chunk_reserved_bytes;
-        return Status::InternalError(ss.str());
-    }
-
     int64_t chunk_reserved_bytes_limit =
             ParseUtil::parse_mem_spec(config::chunk_reserved_bytes_limit, global_memory_limit_bytes,
                                       MemInfo::physical_mem(), &is_percent);
@@ -321,8 +314,8 @@ Status ExecEnv::_init_mem_tracker() {
            << config::chunk_reserved_bytes_limit;
         return Status::InternalError(ss.str());
     }
-    chunk_reserved_bytes_limit =
-            BitUtil::RoundDown(chunk_reserved_bytes_limit, config::min_chunk_reserved_bytes);
+    // Has to round to multiple of page size(4096 bytes), chunk allocator will also check this
+    chunk_reserved_bytes_limit = BitUtil::RoundDown(chunk_reserved_bytes_limit, 4096);
     ChunkAllocator::init_instance(chunk_reserved_bytes_limit);
     LOG(INFO) << "Chunk allocator memory limit: "
               << PrettyPrinter::print(chunk_reserved_bytes_limit, TUnit::BYTES)

--- a/be/src/runtime/exec_env_init.cpp
+++ b/be/src/runtime/exec_env_init.cpp
@@ -185,8 +185,6 @@ Status ExecEnv::_init(const std::vector<StorePath>& store_paths) {
 }
 
 Status ExecEnv::_init_mem_tracker() {
-    LOG(INFO) << "Physical memory is: "
-              << PrettyPrinter::print(MemInfo::physical_mem(), TUnit::BYTES);
     // 1. init global memory limit.
     int64_t global_memory_limit_bytes = 0;
     bool is_percent = false;
@@ -308,6 +306,12 @@ Status ExecEnv::_init_mem_tracker() {
     RETURN_IF_ERROR(_tmp_file_mgr->init());
 
     // 5. init chunk allocator
+    if (!BitUtil::IsPowerOf2(config::min_chunk_reserved_bytes)) {
+        ss << "Config min_chunk_reserved_bytes must be a power-of-two: "
+           << config::min_chunk_reserved_bytes;
+        return Status::InternalError(ss.str());
+    }
+
     int64_t chunk_reserved_bytes_limit =
             ParseUtil::parse_mem_spec(config::chunk_reserved_bytes_limit, global_memory_limit_bytes,
                                       MemInfo::physical_mem(), &is_percent);
@@ -317,6 +321,8 @@ Status ExecEnv::_init_mem_tracker() {
            << config::chunk_reserved_bytes_limit;
         return Status::InternalError(ss.str());
     }
+    chunk_reserved_bytes_limit =
+            BitUtil::RoundDown(chunk_reserved_bytes_limit, config::min_chunk_reserved_bytes);
     ChunkAllocator::init_instance(chunk_reserved_bytes_limit);
     LOG(INFO) << "Chunk allocator memory limit: "
               << PrettyPrinter::print(chunk_reserved_bytes_limit, TUnit::BYTES)

--- a/be/src/runtime/mem_pool.cpp
+++ b/be/src/runtime/mem_pool.cpp
@@ -131,8 +131,9 @@ Status MemPool::find_chunk(size_t min_size, bool check_limits) {
         DCHECK_GE(next_chunk_size_, INITIAL_CHUNK_SIZE);
         chunk_size = std::max<size_t>(min_size, next_chunk_size_);
     }
-
-    chunk_size = BitUtil::RoundUpToPowerOfTwo(chunk_size);
+    if (chunk_size < config::memory_linear_growth_threshold) {
+        chunk_size = BitUtil::RoundUpToPowerOfTwo(chunk_size);
+    }
     if (check_limits &&
         !thread_context()->_thread_mem_tracker_mgr->limiter_mem_tracker_raw()->check_limit(
                 chunk_size)) {

--- a/be/src/runtime/mem_pool.cpp
+++ b/be/src/runtime/mem_pool.cpp
@@ -119,21 +119,9 @@ Status MemPool::find_chunk(size_t min_size, bool check_limits) {
     }
 
     // Didn't find a big enough free chunk - need to allocate new chunk.
-    size_t chunk_size = 0;
     DCHECK_LE(next_chunk_size_, MAX_CHUNK_SIZE);
-
-    if (config::disable_mem_pools) {
-        // Disable pooling by sizing the chunk to fit only this allocation.
-        // Make sure the alignment guarantees are respected.
-        // This will generate too many small chunks.
-        chunk_size = std::max<size_t>(min_size, alignof(max_align_t));
-    } else {
-        DCHECK_GE(next_chunk_size_, INITIAL_CHUNK_SIZE);
-        chunk_size = std::max<size_t>(min_size, next_chunk_size_);
-    }
-    if (chunk_size < config::memory_linear_growth_threshold) {
-        chunk_size = BitUtil::RoundUpToPowerOfTwo(chunk_size);
-    }
+    DCHECK_GE(next_chunk_size_, INITIAL_CHUNK_SIZE);
+    size_t chunk_size = BitUtil::RoundUpToPowerOfTwo(std::max<size_t>(min_size, next_chunk_size_));
     if (check_limits &&
         !thread_context()->_thread_mem_tracker_mgr->limiter_mem_tracker_raw()->check_limit(
                 chunk_size)) {

--- a/be/src/runtime/mem_pool.h
+++ b/be/src/runtime/mem_pool.h
@@ -231,9 +231,9 @@ private:
         // I refers to https://github.com/mcgov/asan_alignment_example.
 
         ChunkInfo& info = chunks_[current_chunk_idx_];
-        int64_t aligned_allocated_bytes =
-                BitUtil::RoundUpToPowerOf2(info.allocated_bytes + DEFAULT_PADDING_SIZE, alignment);
-        if (aligned_allocated_bytes + size <= info.chunk.size) {
+        int64_t aligned_allocated_bytes = BitUtil::RoundUpToMultiplyOfFactor(
+                info.allocated_bytes + DEFAULT_PADDING_SIZE, alignment);
+        if (aligned_allocated_bytes + size + DEFAULT_PADDING_SIZE <= info.chunk.size) {
             // Ensure the requested alignment is respected.
             int64_t padding = aligned_allocated_bytes - info.allocated_bytes;
             uint8_t* result = info.chunk.data + aligned_allocated_bytes;

--- a/be/src/runtime/memory/chunk_allocator.cpp
+++ b/be/src/runtime/memory/chunk_allocator.cpp
@@ -154,35 +154,37 @@ ChunkAllocator::ChunkAllocator(size_t reserve_limit)
 Status ChunkAllocator::allocate(size_t size, Chunk* chunk) {
     CHECK((size > 0 && (size & (size - 1)) == 0));
 
-    // fast path: allocate from current core arena
-    int core_id = CpuInfo::get_current_core();
-    chunk->size = size;
-    chunk->core_id = core_id;
+    if (!config::disable_chunk_allocator) {
+        // fast path: allocate from current core arena
+        int core_id = CpuInfo::get_current_core();
+        chunk->size = size;
+        chunk->core_id = core_id;
 
-    if (_arenas[core_id]->pop_free_chunk(size, &chunk->data)) {
-        DCHECK_GE(_reserved_bytes, 0);
-        _reserved_bytes.fetch_sub(size);
-        chunk_pool_local_core_alloc_count->increment(1);
-        // transfer the memory ownership of allocate from ChunkAllocator::tracker to the tls tracker.
-        THREAD_MEM_TRACKER_TRANSFER_FROM(size, _mem_tracker.get());
-        return Status::OK();
-    }
-    // Second path: try to allocate from other core's arena
-    // When the reserved bytes is greater than the limit, the chunk is stolen from other arena.
-    // Otherwise, it is allocated from the system first, which can reserve enough memory as soon as possible.
-    // After that, allocate from current core arena as much as possible.
-    if (_reserved_bytes > _steal_arena_limit) {
-        ++core_id;
-        for (int i = 1; i < _arenas.size(); ++i, ++core_id) {
-            if (_arenas[core_id % _arenas.size()]->pop_free_chunk(size, &chunk->data)) {
-                DCHECK_GE(_reserved_bytes, 0);
-                _reserved_bytes.fetch_sub(size);
-                chunk_pool_other_core_alloc_count->increment(1);
-                // reset chunk's core_id to other
-                chunk->core_id = core_id % _arenas.size();
-                // transfer the memory ownership of allocate from ChunkAllocator::tracker to the tls tracker.
-                THREAD_MEM_TRACKER_TRANSFER_FROM(size, _mem_tracker.get());
-                return Status::OK();
+        if (_arenas[core_id]->pop_free_chunk(size, &chunk->data)) {
+            DCHECK_GE(_reserved_bytes, 0);
+            _reserved_bytes.fetch_sub(size);
+            chunk_pool_local_core_alloc_count->increment(1);
+            // transfer the memory ownership of allocate from ChunkAllocator::tracker to the tls tracker.
+            THREAD_MEM_TRACKER_TRANSFER_FROM(size, _mem_tracker.get());
+            return Status::OK();
+        }
+        // Second path: try to allocate from other core's arena
+        // When the reserved bytes is greater than the limit, the chunk is stolen from other arena.
+        // Otherwise, it is allocated from the system first, which can reserve enough memory as soon as possible.
+        // After that, allocate from current core arena as much as possible.
+        if (_reserved_bytes > _steal_arena_limit) {
+            ++core_id;
+            for (int i = 1; i < _arenas.size(); ++i, ++core_id) {
+                if (_arenas[core_id % _arenas.size()]->pop_free_chunk(size, &chunk->data)) {
+                    DCHECK_GE(_reserved_bytes, 0);
+                    _reserved_bytes.fetch_sub(size);
+                    chunk_pool_other_core_alloc_count->increment(1);
+                    // reset chunk's core_id to other
+                    chunk->core_id = core_id % _arenas.size();
+                    // transfer the memory ownership of allocate from ChunkAllocator::tracker to the tls tracker.
+                    THREAD_MEM_TRACKER_TRANSFER_FROM(size, _mem_tracker.get());
+                    return Status::OK();
+                }
             }
         }
     }
@@ -204,7 +206,7 @@ Status ChunkAllocator::allocate(size_t size, Chunk* chunk) {
 void ChunkAllocator::free(const Chunk& chunk) {
     DCHECK(chunk.core_id != -1);
     CHECK((chunk.size & (chunk.size - 1)) == 0);
-    if (config::disable_mem_pools) {
+    if (config::disable_chunk_allocator) {
         SystemAllocator::free(chunk.data, chunk.size);
         return;
     }

--- a/be/src/runtime/memory/chunk_allocator.cpp
+++ b/be/src/runtime/memory/chunk_allocator.cpp
@@ -154,12 +154,11 @@ ChunkAllocator::ChunkAllocator(size_t reserve_limit)
 Status ChunkAllocator::allocate(size_t size, Chunk* chunk) {
     CHECK((size > 0 && (size & (size - 1)) == 0));
 
+    int core_id = CpuInfo::get_current_core();
+    chunk->core_id = core_id;
+    chunk->size = size;
     if (!config::disable_chunk_allocator) {
         // fast path: allocate from current core arena
-        int core_id = CpuInfo::get_current_core();
-        chunk->size = size;
-        chunk->core_id = core_id;
-
         if (_arenas[core_id]->pop_free_chunk(size, &chunk->data)) {
             DCHECK_GE(_reserved_bytes, 0);
             _reserved_bytes.fetch_sub(size);

--- a/be/src/util/bit_util.h
+++ b/be/src/util/bit_util.h
@@ -43,6 +43,8 @@ public:
         return value / divisor + (value % divisor != 0);
     }
 
+    static inline size_t round_up_to_page_size(size_t s) { return (s + 4096 - 1) / 4096 * 4096; }
+
     // Returns 'value' rounded up to the nearest multiple of 'factor'
     static inline int64_t round_up(int64_t value, int64_t factor) {
         return (value + (factor - 1)) / factor * factor;
@@ -304,8 +306,12 @@ public:
     }
 
     /// Returns 'value' rounded up to the nearest multiple of 'factor' when factor is
-    /// a power of two
-    static inline int64_t RoundUpToPowerOf2(int64_t value, int64_t factor) {
+    /// a power of two, for example
+    /// Factor has to be a power of two
+    /// factor = 16, value = 10 --> result = 16
+    /// factor = 16, value = 17 --> result = 32
+    /// factor = 16, value = 33 --> result = 48
+    static inline int64_t RoundUpToMultiplyOfFactor(int64_t value, int64_t factor) {
         DCHECK((factor > 0) && ((factor & (factor - 1)) == 0));
         return (value + (factor - 1)) & ~(factor - 1);
     }

--- a/be/src/vec/common/arena.h
+++ b/be/src/vec/common/arena.h
@@ -127,11 +127,16 @@ private:
 
 public:
     Arena(size_t initial_size_ = 4096, size_t growth_factor_ = 2,
-          size_t linear_growth_threshold_ = 128 * 1024 * 1024)
+          size_t linear_growth_threshold_ = -1)
             : growth_factor(growth_factor_),
-              linear_growth_threshold(linear_growth_threshold_),
               head(new Chunk(initial_size_, nullptr)),
-              size_in_bytes(head->size()) {}
+              size_in_bytes(head->size()) {
+        if (linear_growth_threshold_ < 0) {
+            linear_growth_threshold = config::memory_linear_growth_threshold;
+        } else {
+            linear_growth_threshold = linear_growth_threshold_;
+        }
+    }
 
     ~Arena() { delete head; }
 

--- a/be/src/vec/common/pod_array.h
+++ b/be/src/vec/common/pod_array.h
@@ -238,50 +238,45 @@ public:
             realloc(minimum_memory_for_elements(n),
                     std::forward<TAllocatorParams>(allocator_params)...);
     }
-}
 
-template <typename... TAllocatorParams>
-void resize(size_t n, TAllocatorParams&&... allocator_params) {
-    reserve(n, std::forward<TAllocatorParams>(allocator_params)...);
-    resize_assume_reserved(n);
-}
+    template <typename... TAllocatorParams>
+    void resize(size_t n, TAllocatorParams&&... allocator_params) {
+        reserve(n, std::forward<TAllocatorParams>(allocator_params)...);
+        resize_assume_reserved(n);
+    }
 
-void resize_assume_reserved(const size_t n) {
-    c_end = c_start + byte_size(n);
-    reset_peak();
-}
+    void resize_assume_reserved(const size_t n) {
+        c_end = c_start + byte_size(n);
+        reset_peak();
+    }
 
-const char* raw_data() const {
-    return c_start;
-}
+    const char* raw_data() const { return c_start; }
 
-template <typename... TAllocatorParams>
-void push_back_raw(const char* ptr, TAllocatorParams&&... allocator_params) {
-    if (UNLIKELY(c_end == c_end_of_storage))
-        reserve_for_next_size(std::forward<TAllocatorParams>(allocator_params)...);
+    template <typename... TAllocatorParams>
+    void push_back_raw(const char* ptr, TAllocatorParams&&... allocator_params) {
+        if (UNLIKELY(c_end == c_end_of_storage))
+            reserve_for_next_size(std::forward<TAllocatorParams>(allocator_params)...);
 
-    memcpy(c_end, ptr, ELEMENT_SIZE);
-    c_end += byte_size(1);
-    reset_peak();
-}
+        memcpy(c_end, ptr, ELEMENT_SIZE);
+        c_end += byte_size(1);
+        reset_peak();
+    }
 
-void protect() {
+    void protect() {
 #ifndef NDEBUG
-    protect_impl(PROT_READ);
-    mprotected = true;
+        protect_impl(PROT_READ);
+        mprotected = true;
 #endif
-}
+    }
 
-void unprotect() {
+    void unprotect() {
 #ifndef NDEBUG
-    if (mprotected) protect_impl(PROT_WRITE);
-    mprotected = false;
+        if (mprotected) protect_impl(PROT_WRITE);
+        mprotected = false;
 #endif
-}
+    }
 
-~PODArrayBase() {
-    dealloc();
-}
+    ~PODArrayBase() { dealloc(); }
 };
 
 template <typename T, size_t initial_bytes, typename TAllocator, size_t pad_right_,


### PR DESCRIPTION


# Proposed changes
1. disable page cache by default
2. disable chunk allocator by default
3. not use chunk allocator for vectorized allocator by default
4. add a new config memory_linear_growth_threshold = 128Mb, not allocate memory by RoundUpToPowerOf2 if the allocated size is larger than this threshold. This config is added to MemPool, ChunkAllocator, PodArray, Arena.

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
5. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
6. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
7. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
8. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

