### PR TITLE
[fix](bloom filter) wrong result of bloom filter for is not null

### DIFF
--- a/be/src/olap/olap_cond.h
+++ b/be/src/olap/olap_cond.h
@@ -82,7 +82,10 @@ public:
     bool eval(const BloomFilter& bf) const;
     bool eval(const segment_v2::BloomFilter* bf) const;
 
-    bool can_do_bloom_filter() const { return op == OP_EQ || op == OP_IN || op == OP_IS; }
+    bool can_do_bloom_filter() const {
+        return op == OP_EQ || op == OP_IN
+            || (op == OP_IS && operand_field->is_null());
+    }
 
     CondOp op = OP_NULL;
     // valid when op is not OP_IN and OP_NOT_IN


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary
How to reproduce:
```
-- DDL
drop TABLE if exists `t`;

CREATE TABLE `t` (
  `a` varchar(150) NULL
) ENGINE=OLAP
AGGREGATE KEY(`a`)
DISTRIBUTED BY HASH(`a`) BUCKETS 1
PROPERTIES (
"replication_allocation" = "tag.location.default: 1",
"bloom_filter_columns" = "a",
"in_memory" = "false",
"storage_format" = "V2"
);

INSERT INTO t values (null), ('b');

select count(1) from t; // result is 2
select count(1) count_not_null from t WHERE  a is not null; // expected result should be 1, but actually is 0
select count(1) count_null from t WHERE  a is null; // result is 1
```


Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

