### PR TITLE
[enhancement](memory) Print memory usage log when memory allocation fails

### DIFF
--- a/be/src/runtime/memory/system_allocator.cpp
+++ b/be/src/runtime/memory/system_allocator.cpp
@@ -43,8 +43,10 @@ uint8_t* SystemAllocator::allocate_via_malloc(size_t length) {
     int res = posix_memalign(&ptr, PAGE_SIZE, length);
     if (res != 0) {
         char buf[64];
-        LOG(ERROR) << "fail to allocate mem via posix_memalign, res=" << res
-                   << ", errmsg=" << strerror_r(res, buf, 64);
+        auto err = fmt::format("fail to allocate mem via posix_memalign, res={}, errmsg={}.", res,
+                               strerror_r(res, buf, 64));
+        ExecEnv::GetInstance()->process_mem_tracker()->print_log_usage(err);
+        LOG(ERROR) << err;
         return nullptr;
     }
     return (uint8_t*)ptr;

--- a/be/src/vec/common/allocator.h
+++ b/be/src/vec/common/allocator.h
@@ -129,7 +129,9 @@ public:
             buf = mmap(get_mmap_hint(), size, PROT_READ | PROT_WRITE, mmap_flags, -1, 0);
             if (MAP_FAILED == buf) {
                 RELEASE_THREAD_MEM_TRACKER(size);
-                doris::vectorized::throwFromErrno(fmt::format("Allocator: Cannot mmap {}.", size),
+                auto err = fmt::format("Allocator: Cannot mmap {}.", size);
+                ExecEnv::GetInstance()->process_mem_tracker()->print_log_usage(err);
+                doris::vectorized::throwFromErrno(err,
                                                   doris::TStatusCode::VEC_CANNOT_ALLOCATE_MEMORY);
             }
 
@@ -137,9 +139,10 @@ public:
         } else if (!doris::config::disable_chunk_allocator_in_vec && size >= CHUNK_THRESHOLD) {
             doris::Chunk chunk;
             if (!doris::ChunkAllocator::instance()->allocate_align(size, &chunk)) {
-                doris::vectorized::throwFromErrno(
-                        fmt::format("Allocator: Cannot allocate chunk {}.", size),
-                        doris::TStatusCode::VEC_CANNOT_ALLOCATE_MEMORY);
+                auto err = fmt::format("Allocator: Cannot allocate chunk {}.", size);
+                ExecEnv::GetInstance()->process_mem_tracker()->print_log_usage(err);
+                doris::vectorized::throwFromErrno(err,
+                                                  doris::TStatusCode::VEC_CANNOT_ALLOCATE_MEMORY);
             }
             buf = chunk.data;
             if constexpr (clear_memory) memset(buf, 0, chunk.size);
@@ -150,18 +153,22 @@ public:
                 else
                     buf = ::malloc(size);
 
-                if (nullptr == buf)
+                if (nullptr == buf) {
+                    auto err = fmt::format("Allocator: Cannot malloc {}.", size);
+                    ExecEnv::GetInstance()->process_mem_tracker()->print_log_usage(err);
                     doris::vectorized::throwFromErrno(
-                            fmt::format("Allocator: Cannot malloc {}.", size),
-                            doris::TStatusCode::VEC_CANNOT_ALLOCATE_MEMORY);
+                            err, doris::TStatusCode::VEC_CANNOT_ALLOCATE_MEMORY);
+                }
             } else {
                 buf = nullptr;
                 int res = posix_memalign(&buf, alignment, size);
 
-                if (0 != res)
+                if (0 != res) {
+                    auto err = fmt::format("Cannot allocate memory (posix_memalign) {}.", size);
+                    ExecEnv::GetInstance()->process_mem_tracker()->print_log_usage(err);
                     doris::vectorized::throwFromErrno(
-                            fmt::format("Cannot allocate memory (posix_memalign) {}.", size),
-                            doris::TStatusCode::VEC_CANNOT_ALLOCATE_MEMORY, res);
+                            err, doris::TStatusCode::VEC_CANNOT_ALLOCATE_MEMORY, res);
+                }
 
                 if constexpr (clear_memory) memset(buf, 0, size);
             }
@@ -173,8 +180,9 @@ public:
     void free(void* buf, size_t size) {
         if (size >= MMAP_THRESHOLD) {
             if (0 != munmap(buf, size)) {
-                doris::vectorized::throwFromErrno(fmt::format("Allocator: Cannot munmap {}.", size),
-                                                  doris::TStatusCode::VEC_CANNOT_MUNMAP);
+                auto err = fmt::format("Allocator: Cannot munmap {}.", size);
+                ExecEnv::GetInstance()->process_mem_tracker()->print_log_usage(err);
+                doris::vectorized::throwFromErrno(err, doris::TStatusCode::VEC_CANNOT_MUNMAP);
             } else {
                 RELEASE_THREAD_MEM_TRACKER(size);
             }
@@ -199,11 +207,13 @@ public:
                    alignment <= MALLOC_MIN_ALIGNMENT) {
             /// Resize malloc'd memory region with no special alignment requirement.
             void* new_buf = ::realloc(buf, new_size);
-            if (nullptr == new_buf)
-                doris::vectorized::throwFromErrno("Allocator: Cannot realloc from " +
-                                                          std::to_string(old_size) + " to " +
-                                                          std::to_string(new_size) + ".",
+            if (nullptr == new_buf) {
+                auto err =
+                        fmt::format("Allocator: Cannot realloc from {} to {}.", old_size, new_size);
+                ExecEnv::GetInstance()->process_mem_tracker()->print_log_usage(err);
+                doris::vectorized::throwFromErrno(err,
                                                   doris::TStatusCode::VEC_CANNOT_ALLOCATE_MEMORY);
+            }
 
             buf = new_buf;
             if constexpr (clear_memory)
@@ -218,10 +228,10 @@ public:
                                     mmap_flags, -1, 0);
             if (MAP_FAILED == buf) {
                 RELEASE_THREAD_MEM_TRACKER(new_size - old_size);
-                doris::vectorized::throwFromErrno("Allocator: Cannot mremap memory chunk from " +
-                                                          std::to_string(old_size) + " to " +
-                                                          std::to_string(new_size) + ".",
-                                                  doris::TStatusCode::VEC_CANNOT_MREMAP);
+                auto err = fmt::format("Allocator: Cannot mremap memory chunk from {} to {}.",
+                                       old_size, new_size);
+                ExecEnv::GetInstance()->process_mem_tracker()->print_log_usage(err);
+                doris::vectorized::throwFromErrno(err, doris::TStatusCode::VEC_CANNOT_MREMAP);
             }
 
             /// No need for zero-fill, because mmap guarantees it.

--- a/be/src/vec/common/allocator.h
+++ b/be/src/vec/common/allocator.h
@@ -130,7 +130,7 @@ public:
             if (MAP_FAILED == buf) {
                 RELEASE_THREAD_MEM_TRACKER(size);
                 auto err = fmt::format("Allocator: Cannot mmap {}.", size);
-                ExecEnv::GetInstance()->process_mem_tracker()->print_log_usage(err);
+                doris::ExecEnv::GetInstance()->process_mem_tracker()->print_log_usage(err);
                 doris::vectorized::throwFromErrno(err,
                                                   doris::TStatusCode::VEC_CANNOT_ALLOCATE_MEMORY);
             }
@@ -140,7 +140,7 @@ public:
             doris::Chunk chunk;
             if (!doris::ChunkAllocator::instance()->allocate_align(size, &chunk)) {
                 auto err = fmt::format("Allocator: Cannot allocate chunk {}.", size);
-                ExecEnv::GetInstance()->process_mem_tracker()->print_log_usage(err);
+                doris::ExecEnv::GetInstance()->process_mem_tracker()->print_log_usage(err);
                 doris::vectorized::throwFromErrno(err,
                                                   doris::TStatusCode::VEC_CANNOT_ALLOCATE_MEMORY);
             }
@@ -155,7 +155,7 @@ public:
 
                 if (nullptr == buf) {
                     auto err = fmt::format("Allocator: Cannot malloc {}.", size);
-                    ExecEnv::GetInstance()->process_mem_tracker()->print_log_usage(err);
+                    doris::ExecEnv::GetInstance()->process_mem_tracker()->print_log_usage(err);
                     doris::vectorized::throwFromErrno(
                             err, doris::TStatusCode::VEC_CANNOT_ALLOCATE_MEMORY);
                 }
@@ -165,7 +165,7 @@ public:
 
                 if (0 != res) {
                     auto err = fmt::format("Cannot allocate memory (posix_memalign) {}.", size);
-                    ExecEnv::GetInstance()->process_mem_tracker()->print_log_usage(err);
+                    doris::ExecEnv::GetInstance()->process_mem_tracker()->print_log_usage(err);
                     doris::vectorized::throwFromErrno(
                             err, doris::TStatusCode::VEC_CANNOT_ALLOCATE_MEMORY, res);
                 }
@@ -181,7 +181,7 @@ public:
         if (size >= MMAP_THRESHOLD) {
             if (0 != munmap(buf, size)) {
                 auto err = fmt::format("Allocator: Cannot munmap {}.", size);
-                ExecEnv::GetInstance()->process_mem_tracker()->print_log_usage(err);
+                doris::ExecEnv::GetInstance()->process_mem_tracker()->print_log_usage(err);
                 doris::vectorized::throwFromErrno(err, doris::TStatusCode::VEC_CANNOT_MUNMAP);
             } else {
                 RELEASE_THREAD_MEM_TRACKER(size);
@@ -210,7 +210,7 @@ public:
             if (nullptr == new_buf) {
                 auto err =
                         fmt::format("Allocator: Cannot realloc from {} to {}.", old_size, new_size);
-                ExecEnv::GetInstance()->process_mem_tracker()->print_log_usage(err);
+                doris::ExecEnv::GetInstance()->process_mem_tracker()->print_log_usage(err);
                 doris::vectorized::throwFromErrno(err,
                                                   doris::TStatusCode::VEC_CANNOT_ALLOCATE_MEMORY);
             }
@@ -230,7 +230,7 @@ public:
                 RELEASE_THREAD_MEM_TRACKER(new_size - old_size);
                 auto err = fmt::format("Allocator: Cannot mremap memory chunk from {} to {}.",
                                        old_size, new_size);
-                ExecEnv::GetInstance()->process_mem_tracker()->print_log_usage(err);
+                doris::ExecEnv::GetInstance()->process_mem_tracker()->print_log_usage(err);
                 doris::vectorized::throwFromErrno(err, doris::TStatusCode::VEC_CANNOT_MREMAP);
             }
 


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

When memory allocation fails, print the process mem tracker and the children two levels below

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

