### PR TITLE
[enhancement](memtracker) Print query memory usage log every second when `memory_verbose_track` is enabled

### DIFF
--- a/be/src/runtime/memory/mem_tracker_task_pool.cpp
+++ b/be/src/runtime/memory/mem_tracker_task_pool.cpp
@@ -109,7 +109,7 @@ void MemTrackerTaskPool::logout_task_mem_tracker() {
                     PrettyPrinter::print(it->second->peak_consumption(), TUnit::BYTES));
             expired_task_ids.emplace_back(it->first);
         } else if (config::memory_verbose_track) {
-            it->second->print_log_usage("routine");
+            it->second->print_log_usage("query routine");
             it->second->enable_print_log_usage();
         }
     }

--- a/be/src/runtime/memory/mem_tracker_task_pool.cpp
+++ b/be/src/runtime/memory/mem_tracker_task_pool.cpp
@@ -108,6 +108,9 @@ void MemTrackerTaskPool::logout_task_mem_tracker() {
                     PrettyPrinter::print(it->second->consumption(), TUnit::BYTES),
                     PrettyPrinter::print(it->second->peak_consumption(), TUnit::BYTES));
             expired_task_ids.emplace_back(it->first);
+        } else if (config::memory_verbose_track) {
+            it->second->print_log_usage("routine");
+            it->second->enable_print_log_usage();
         }
     }
     for (auto tid : expired_task_ids) {

--- a/be/src/runtime/memory/thread_mem_tracker_mgr.h
+++ b/be/src/runtime/memory/thread_mem_tracker_mgr.h
@@ -96,6 +96,7 @@ public:
         return _limiter_tracker_raw;
     }
 
+    bool check_limit() { return _check_limit; }
     void set_check_limit(bool check_limit) { _check_limit = check_limit; }
     void set_check_attach(bool check_attach) { _check_attach = check_attach; }
 

--- a/be/src/runtime/thread_context.h
+++ b/be/src/runtime/thread_context.h
@@ -241,12 +241,16 @@ private:
 class StopCheckThreadMemTrackerLimit {
 public:
     explicit StopCheckThreadMemTrackerLimit() {
+        _pre = thread_context()->_thread_mem_tracker_mgr->check_limit();
         thread_context()->_thread_mem_tracker_mgr->set_check_limit(false);
     }
 
     ~StopCheckThreadMemTrackerLimit() {
-        thread_context()->_thread_mem_tracker_mgr->set_check_limit(true);
+        thread_context()->_thread_mem_tracker_mgr->set_check_limit(_pre);
     }
+
+private:
+    bool _pre;
 };
 
 // The following macros are used to fix the tracking accuracy of caches etc.

--- a/be/src/service/doris_main.cpp
+++ b/be/src/service/doris_main.cpp
@@ -514,7 +514,7 @@ int main(int argc, char** argv) {
         // canceled when the process exceeds the mem limit, resulting in too many duplicate logs.
         doris::ExecEnv::GetInstance()->process_mem_tracker()->enable_print_log_usage();
         if (doris::config::memory_verbose_track) {
-            doris::ExecEnv::GetInstance()->process_mem_tracker()->print_log_usage("routine");
+            doris::ExecEnv::GetInstance()->process_mem_tracker()->print_log_usage("main routine");
             doris::ExecEnv::GetInstance()->process_mem_tracker()->enable_print_log_usage();
         }
         sleep(1);

--- a/be/src/service/doris_main.cpp
+++ b/be/src/service/doris_main.cpp
@@ -513,6 +513,10 @@ int main(int argc, char** argv) {
         // The process tracker print log usage interval is 1s to avoid a large number of tasks being
         // canceled when the process exceeds the mem limit, resulting in too many duplicate logs.
         doris::ExecEnv::GetInstance()->process_mem_tracker()->enable_print_log_usage();
+        if (doris::config::memory_verbose_track) {
+            doris::ExecEnv::GetInstance()->process_mem_tracker()->print_log_usage("routine");
+            doris::ExecEnv::GetInstance()->process_mem_tracker()->enable_print_log_usage();
+        }
         sleep(1);
     }
 


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

1、When `memory_verbose_track` is enabled, Print query mem tracker and process mem tracker  every second.
2、Fix thread mem tracker check limit hidden risk.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

