### PR TITLE
[feature](nereids) add stats min/maxValue support for Date/CHAR/VARCHAR

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/ColumnStat.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/ColumnStat.java
@@ -34,6 +34,7 @@ import org.apache.doris.common.util.Util;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
@@ -259,13 +260,11 @@ public class ColumnStat {
                     return Double.parseDouble(columnValue);
                 case DATE:
                 case DATEV2:
-                    DateTimeFormatter timeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
-                    return LocalDateTime
-                            .parse(columnValue, timeFormatter)
+                    return LocalDate.parse(columnValue).atStartOfDay()
                             .atZone(ZoneId.systemDefault()).toInstant().getEpochSecond();
                 case DATETIMEV2:
                 case DATETIME:
-                    timeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+                    DateTimeFormatter timeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
                     return LocalDateTime
                             .parse(columnValue, timeFormatter)
                             .atZone(ZoneId.systemDefault()).toInstant().getEpochSecond();

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/ColumnStat.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/ColumnStat.java
@@ -291,11 +291,12 @@ public class ColumnStat {
         int pos = 0;
         int len = Math.min(s.length(), 8);
         while (pos < len) {
-            v += ((long) s.charAt(pos)) << ((7-pos)*8);
-            pos ++;
+            v += ((long) s.charAt(pos)) << ((7 - pos) * 8);
+            pos++;
         }
         return (double) v;
     }
+
     public ColumnStat copy() {
         return new ColumnStat(this);
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/ColumnStat.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/ColumnStat.java
@@ -271,6 +271,7 @@ public class ColumnStat {
                             .atZone(ZoneId.systemDefault()).toInstant().getEpochSecond();
                 case CHAR:
                 case VARCHAR:
+                    return convertStringToDouble(columnValue);
                 case HLL:
                 case BITMAP:
                 case ARRAY:
@@ -285,6 +286,16 @@ public class ColumnStat {
 
     }
 
+    private double convertStringToDouble(String s) {
+        long v = 0;
+        int pos = 0;
+        int len = Math.min(s.length(), 8);
+        while (pos < len) {
+            v += ((long) s.charAt(pos)) << ((7-pos)*8);
+            pos ++;
+        }
+        return (double) v;
+    }
     public ColumnStat copy() {
         return new ColumnStat(this);
     }


### PR DESCRIPTION
# Proposed changes
1. enable varchar/char type set min/max value.
    take first 8 chars as long, and convert to double.
2. fix bug when set min/max value for date and datav2

@Kikyou1997  @jackwener  please review

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

