### PR TITLE
[ResourceTag](tag) Unified tag format verification

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/PropertyAnalyzer.java
@@ -653,7 +653,8 @@ public class PropertyAnalyzer {
                 continue;
             }
             String val = entry.getValue().replaceAll(" ", "");
-            tagMap.put(keyParts[1], val);
+            Tag tag = Tag.create(keyParts[1], val);
+            tagMap.put(tag.type, tag.value);
             iter.remove();
         }
         if (tagMap.isEmpty() && defaultValue != null) {

--- a/fe/fe-core/src/main/java/org/apache/doris/resource/Tag.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/resource/Tag.java
@@ -71,7 +71,9 @@ public class Tag implements Writable {
     public static final ImmutableSet<String> RESERVED_TAG_VALUES = ImmutableSet.of(
             VALUE_FRONTEND, VALUE_BACKEND, VALUE_BROKER, VALUE_REMOTE_STORAGE, VALUE_STORE, VALUE_COMPUTATION,
             VALUE_DEFAULT_CLUSTER);
-    private static final String TAG_REGEX = "^[a-zA-Z][a-zA-Z0-9_]{0,32}$";
+    private static final String TAG_TYPE_REGEX = "^[a-z][a-z0-9_]{0,32}$";
+    private static final String TAG_VALUE_REGEX = "^[a-zA-Z][a-zA-Z0-9_]{0,32}$";
+
 
     public static final Tag DEFAULT_BACKEND_TAG;
     public static final Tag INVALID_TAG;
@@ -87,13 +89,16 @@ public class Tag implements Writable {
     public String value;
 
     private Tag(String type, String val) {
-        this.type = type.toLowerCase();
-        this.value = val.toLowerCase();
+        this.type = type;
+        this.value = val;
     }
 
     public static Tag create(String type, String value) throws AnalysisException {
-        if (!type.matches(TAG_REGEX) || !value.matches(TAG_REGEX)) {
-            throw new AnalysisException("Invalid tag format: " + type + ":" + value);
+        if (!type.matches(TAG_TYPE_REGEX)) {
+            throw new AnalysisException("Invalid tag type format: " + type);
+        }
+        if (!value.matches(TAG_VALUE_REGEX)) {
+            throw new AnalysisException("Invalid tag value format: " + value);
         }
         return new Tag(type, value);
     }

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/ReplicaAllocationTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/ReplicaAllocationTest.java
@@ -123,7 +123,7 @@ public class ReplicaAllocationTest {
 
         properties.clear();
         properties.put(PropertyAnalyzer.PROPERTIES_REPLICATION_ALLOCATION, "tag.location.12321:1");
-        ExceptionChecker.expectThrowsWithMsg(AnalysisException.class, "Invalid tag value format: location:12321",
+        ExceptionChecker.expectThrowsWithMsg(AnalysisException.class, "Invalid tag value format: 12321",
                 () -> PropertyAnalyzer.analyzeReplicaAllocation(properties, ""));
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/ReplicaAllocationTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/ReplicaAllocationTest.java
@@ -123,7 +123,7 @@ public class ReplicaAllocationTest {
 
         properties.clear();
         properties.put(PropertyAnalyzer.PROPERTIES_REPLICATION_ALLOCATION, "tag.location.12321:1");
-        ExceptionChecker.expectThrowsWithMsg(AnalysisException.class, "Invalid tag format: location:12321",
+        ExceptionChecker.expectThrowsWithMsg(AnalysisException.class, "Invalid tag value format: location:12321",
                 () -> PropertyAnalyzer.analyzeReplicaAllocation(properties, ""));
     }
 


### PR DESCRIPTION
# Proposed changes

previous pr is #13063

## Problem summary

Unified tag format verification, after #13063 tag support uppercase,  but tag format verify is different at add backends and modify backends

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

