### PR TITLE
[Bug](array-type) Fix cast null to array make be core

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/CastExpr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/CastExpr.java
@@ -291,7 +291,7 @@ public class CastExpr extends Expr {
         // it is necessary to check if it is castable before creating fn.
         // char type will fail in canCastTo, so for compatibility, only the cast of array type is checked here.
         if (type.isArrayType() || childType.isArrayType()) {
-            if (!Type.canCastTo(childType, type)) {
+            if (childType.isNull() || !Type.canCastTo(childType, type)) {
                 throw new AnalysisException("Invalid type cast of " + getChild(0).toSql()
                         + " from " + childType + " to " + type);
             }

--- a/regression-test/suites/query_p0/sql_functions/cast_function/test_cast_array_functions_by_literal.groovy
+++ b/regression-test/suites/query_p0/sql_functions/cast_function/test_cast_array_functions_by_literal.groovy
@@ -53,6 +53,12 @@ suite("test_cast_array_functions_by_literal") {
     }
 
     test {
+        sql "select cast(NULL as array<int>)"
+        // check exception message contains
+        exception "errCode = 2,"
+    }
+
+    test {
         sql "select cast(1 as array<int>)"
         // check exception message contains
         exception "errCode = 2,"


### PR DESCRIPTION
# Proposed changes

Doris do not support explicitly cast NULL_TYPE to ANY type .

```
mysql> select cast(NULL as int);
ERROR 1105 (HY000): errCode = 2, detailMessage = Invalid type cast of NULL from NULL_TYPE to INT
```

So we should also forbid user from casting NULL_TYPE to ARRAY type.

This commit will produce the following effect:

```
mysql> select cast(NULL as array<int>);
ERROR 1105 (HY000): errCode = 2, detailMessage = Invalid type cast of NULL from NULL_TYPE to ARRAY<INT(11)>
```

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [x] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

