### PR TITLE
[Improvement](multi-catalog)Keep db/table id unchaged after call refresh catalog.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/external/HMSExternalTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/external/HMSExternalTable.java
@@ -171,6 +171,11 @@ public class HMSExternalTable extends ExternalTable {
         }
     }
 
+    public void setUnInitialized() {
+        this.initialized = false;
+        this.fullSchema = null;
+    }
+
     /**
      * Get the related remote hive metastore table.
      */

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/HMSExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/HMSExternalCatalog.java
@@ -42,8 +42,8 @@ public class HMSExternalCatalog extends ExternalCatalog {
     private static final Logger LOG = LogManager.getLogger(HMSExternalCatalog.class);
 
     // Cache of db name to db id.
-    private Map<String, Long> dbNameToId;
-    private Map<Long, HMSExternalDatabase> idToDb;
+    private Map<String, Long> dbNameToId = Maps.newConcurrentMap();
+    private Map<Long, HMSExternalDatabase> idToDb = Maps.newConcurrentMap();
     protected HiveMetaStoreClient client;
 
     /**
@@ -63,8 +63,8 @@ public class HMSExternalCatalog extends ExternalCatalog {
 
     private void init() {
         // Must set here. Because after replay from image, these 2 map will become null again.
-        dbNameToId = Maps.newConcurrentMap();
-        idToDb = Maps.newConcurrentMap();
+        Map<String, Long> tmpDbNameToId = Maps.newConcurrentMap();
+        Map<Long, HMSExternalDatabase> tmpIdToDb = Maps.newConcurrentMap();
         HiveConf hiveConf = new HiveConf();
         hiveConf.setVar(HiveConf.ConfVars.METASTOREURIS, getHiveMetastoreUris());
         try {
@@ -84,10 +84,21 @@ public class HMSExternalCatalog extends ExternalCatalog {
             return;
         }
         for (String dbName : allDatabases) {
-            long dbId = Env.getCurrentEnv().getNextId();
-            dbNameToId.put(dbName, dbId);
-            idToDb.put(dbId, new HMSExternalDatabase(this, dbId, dbName));
+            long dbId;
+            if (dbNameToId != null && dbNameToId.containsKey(dbName)) {
+                dbId = dbNameToId.get(dbName);
+                tmpDbNameToId.put(dbName, dbId);
+                HMSExternalDatabase db = idToDb.get(dbId);
+                db.setUnInitialized();
+                tmpIdToDb.put(dbId, db);
+            } else {
+                dbId = Env.getCurrentEnv().getNextId();
+                tmpDbNameToId.put(dbName, dbId);
+                tmpIdToDb.put(dbId, new HMSExternalDatabase(this, dbId, dbName));
+            }
         }
+        dbNameToId = tmpDbNameToId;
+        idToDb = tmpIdToDb;
     }
 
     /**


### PR DESCRIPTION
# Proposed changes

See https://github.com/apache/doris/pull/13363, will close this pr.

## Problem summary

Keep external db/table id unchanged after call refresh catalog command.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

