### PR TITLE
[fix](jsonreader) teach jsonreader to release memory

### DIFF
--- a/be/src/exec/json_scanner.cpp
+++ b/be/src/exec/json_scanner.cpp
@@ -346,7 +346,7 @@ Status JsonReader::_parse_json_doc(size_t* size, bool* eof) {
         return Status::OK();
     }
 
-    // clear memory here. 
+    // clear memory here.
     _origin_json_doc.GetAllocator().Clear();
     bool has_parse_error = false;
     // parse jsondata to JsonDoc

--- a/be/src/exec/json_scanner.cpp
+++ b/be/src/exec/json_scanner.cpp
@@ -247,6 +247,9 @@ JsonReader::JsonReader(RuntimeState* state, ScannerCounter* counter, RuntimeProf
           _strip_outer_array(strip_outer_array),
           _num_as_string(num_as_string),
           _fuzzy_parse(fuzzy_parse),
+          _value_allocator(_value_buffer, sizeof(_value_buffer)),
+          _parse_allocator(_parse_buffer, sizeof(_parse_buffer)),
+          _origin_json_doc(&_value_allocator, sizeof(_parse_buffer), &_parse_allocator),
           _json_doc(nullptr),
           _scanner_eof(scanner_eof) {
     _bytes_read_counter = ADD_COUNTER(_profile, "BytesRead", TUnit::BYTES);
@@ -343,6 +346,8 @@ Status JsonReader::_parse_json_doc(size_t* size, bool* eof) {
         return Status::OK();
     }
 
+    // clear memory here. 
+    _origin_json_doc.GetAllocator().Clear();
     bool has_parse_error = false;
     // parse jsondata to JsonDoc
 

--- a/be/src/exec/json_scanner.h
+++ b/be/src/exec/json_scanner.h
@@ -182,10 +182,11 @@ protected:
     char _parse_buffer[512 * 1024];
 
     typedef rapidjson::GenericDocument<rapidjson::UTF8<>, rapidjson::MemoryPoolAllocator<>,
-                                       rapidjson::MemoryPoolAllocator<> > Document;
+                                       rapidjson::MemoryPoolAllocator<>>
+            Document;
     rapidjson::MemoryPoolAllocator<> _value_allocator;
     rapidjson::MemoryPoolAllocator<> _parse_allocator;
-    Document _origin_json_doc; // origin json document object from parsed json string
+    Document _origin_json_doc;   // origin json document object from parsed json string
     rapidjson::Value* _json_doc; // _json_doc equals _final_json_doc iff not set `json_root`
     std::unordered_map<std::string, int> _name_map;
 

--- a/be/src/exec/json_scanner.h
+++ b/be/src/exec/json_scanner.h
@@ -178,7 +178,14 @@ protected:
     std::vector<std::vector<JsonPath>> _parsed_jsonpaths;
     std::vector<JsonPath> _parsed_json_root;
 
-    rapidjson::Document _origin_json_doc; // origin json document object from parsed json string
+    char _value_buffer[4 * 1024 * 1024];
+    char _parse_buffer[512 * 1024];
+
+    typedef rapidjson::GenericDocument<rapidjson::UTF8<>, rapidjson::MemoryPoolAllocator<>,
+                                       rapidjson::MemoryPoolAllocator<> > Document;
+    rapidjson::MemoryPoolAllocator<> _value_allocator;
+    rapidjson::MemoryPoolAllocator<> _parse_allocator;
+    Document _origin_json_doc; // origin json document object from parsed json string
     rapidjson::Value* _json_doc; // _json_doc equals _final_json_doc iff not set `json_root`
     std::unordered_map<std::string, int> _name_map;
 


### PR DESCRIPTION
Allocator of rapidjson does not release memory, this fix use allocator with local buffer and call Clear to release memory allocated beyond local buffer.

# Proposed changes

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

