### PR TITLE
[Opt](vec) opt runtime filter for TPCH Q22

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -817,7 +817,7 @@ CONF_mInt32(parquet_column_max_buffer_mb, "8");
 
 // When the rows number reached this limit, will check the filter rate the of bloomfilter
 // if it is lower than a specific threshold, the predicate will be disabled.
-CONF_mInt32(bloom_filter_predicate_check_row_num, "1000");
+CONF_mInt32(bloom_filter_predicate_check_row_num, "20480");
 
 CONF_Bool(enable_decimalv3, "false");
 

--- a/be/src/exprs/bloomfilter_predicate.cpp
+++ b/be/src/exprs/bloomfilter_predicate.cpp
@@ -77,7 +77,7 @@ BooleanVal BloomFilterPredicate::get_boolean_val(ExprContext* ctx, TupleRow* row
     }
     _filtered_rows++;
 
-    if (!_has_calculate_filter && _scan_rows % _loop_size == 0) {
+    if (!_has_calculate_filter && _scan_rows >= config::bloom_filter_predicate_check_row_num) {
         double rate = (double)_filtered_rows / _scan_rows;
         if (rate < _expect_filter_rate) {
             _always_true = true;

--- a/be/src/exprs/bloomfilter_predicate.h
+++ b/be/src/exprs/bloomfilter_predicate.h
@@ -435,9 +435,7 @@ private:
 
     std::shared_ptr<BloomFilterFuncBase> _filter;
     bool _has_calculate_filter = false;
-    // loop size must be power of 2
-    constexpr static int64_t _loop_size = 8192;
     // if filter rate less than this, bloom filter will set always true
-    constexpr static double _expect_filter_rate = 0.2;
+    constexpr static double _expect_filter_rate = 0.5;
 };
 } // namespace doris

--- a/be/src/exprs/bloomfilter_predicate.h
+++ b/be/src/exprs/bloomfilter_predicate.h
@@ -436,6 +436,6 @@ private:
     std::shared_ptr<BloomFilterFuncBase> _filter;
     bool _has_calculate_filter = false;
     // if filter rate less than this, bloom filter will set always true
-    constexpr static double _expect_filter_rate = 0.5;
+    constexpr static double _expect_filter_rate = 0.4;
 };
 } // namespace doris

--- a/be/src/vec/exprs/vruntimefilter_wrapper.cpp
+++ b/be/src/vec/exprs/vruntimefilter_wrapper.cpp
@@ -92,13 +92,7 @@ Status VRuntimeFilterWrapper::execute(VExprContext* context, Block* block, int* 
             return Status::InternalError("Invalid type for runtime filters!");
         }
 
-        if ((!_has_calculate_filter) && (_scan_rows.load() >= THRESHOLD_TO_CALCULATE_RATE)) {
-            double rate = (double)_filtered_rows / _scan_rows;
-            if (rate < EXPECTED_FILTER_RATE) {
-                _always_true = true;
-            }
-            _has_calculate_filter = true;
-        }
+        calculate_filter(_filtered_rows, _scan_rows, _has_calculate_filter, _always_true);
         return Status::OK();
     }
 }

--- a/be/src/vec/exprs/vruntimefilter_wrapper.h
+++ b/be/src/vec/exprs/vruntimefilter_wrapper.h
@@ -46,6 +46,20 @@ public:
 
     const VExpr* get_impl() const override { return _impl; }
 
+    // if filter rate less than this, bloom filter will set always true
+    constexpr static double EXPECTED_FILTER_RATE = 0.4;
+
+    static void calculate_filter(int64_t filter_rows, int64_t scan_rows, bool& has_calculate,
+                                 bool& always_true) {
+        if ((!has_calculate) && (scan_rows > config::bloom_filter_predicate_check_row_num)) {
+            if (filter_rows / (scan_rows * 1.0) <
+                vectorized::VRuntimeFilterWrapper::EXPECTED_FILTER_RATE) {
+                always_true = true;
+            }
+            has_calculate = true;
+        }
+    }
+
 private:
     VExpr* _impl;
 
@@ -55,10 +69,6 @@ private:
     std::atomic<int64_t> _scan_rows;
 
     bool _has_calculate_filter = false;
-    // loop size must be power of 2
-    constexpr static int64_t THRESHOLD_TO_CALCULATE_RATE = 8192;
-    // if filter rate less than this, bloom filter will set always true
-    constexpr static double EXPECTED_FILTER_RATE = 0.2;
 
     std::string _expr_name;
 };

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/RuntimeFilterGenerator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/RuntimeFilterGenerator.java
@@ -20,6 +20,7 @@ package org.apache.doris.planner;
 import org.apache.doris.analysis.Analyzer;
 import org.apache.doris.analysis.Expr;
 import org.apache.doris.analysis.ExprSubstitutionMap;
+import org.apache.doris.analysis.JoinOperator;
 import org.apache.doris.analysis.SlotDescriptor;
 import org.apache.doris.analysis.SlotId;
 import org.apache.doris.analysis.SlotRef;
@@ -221,7 +222,7 @@ public final class RuntimeFilterGenerator {
             // from the ON clause.
             if (!joinNode.getJoinOp().isLeftOuterJoin()
                     && !joinNode.getJoinOp().isFullOuterJoin()
-                    && !joinNode.getJoinOp().isAntiJoin()) {
+                    && !joinNode.getJoinOp().equals(JoinOperator.LEFT_ANTI_JOIN)) {
                 joinConjuncts.addAll(joinNode.getEqJoinConjuncts());
             }
 

--- a/tools/tpch-tools/queries/q14.sql
+++ b/tools/tpch-tools/queries/q14.sql
@@ -17,7 +17,7 @@
 
 -- Modified
 
-select /*+SET_VAR(exec_mem_limit=8589934592, parallel_fragment_exec_instance_num=8, enable_vectorized_engine=true, batch_size=4096, disable_join_reorder=true, enable_cost_based_join_reorder=true, enable_projection=true) */
+select /*+SET_VAR(exec_mem_limit=8589934592, parallel_fragment_exec_instance_num=8, enable_vectorized_engine=true, batch_size=4096, disable_join_reorder=true, enable_cost_based_join_reorder=true, enable_projection=true, runtime_filter_mode=OFF) */
     100.00 * sum(case
         when p_type like 'PROMO%'
             then l_extendedprice * (1 - l_discount)

--- a/tools/tpch-tools/queries/q22.sql
+++ b/tools/tpch-tools/queries/q22.sql
@@ -15,38 +15,29 @@
 -- specific language governing permissions and limitations
 -- under the License.
 
-select /*+SET_VAR(exec_mem_limit=8589934592, parallel_fragment_exec_instance_num=16, enable_vectorized_engine=true, batch_size=4096, disable_join_reorder=false, enable_cost_based_join_reorder=true, enable_projection=true) */
-    cntrycode,
-    count(*) as numcust,
-    sum(c_acctbal) as totacctbal
-from
-    (
-        select
-            substring(c_phone, 1, 2) as cntrycode,
-            c_acctbal
-        from
-            customer
-        where
-            substring(c_phone, 1, 2) in
-                ('13', '31', '23', '29', '30', '18', '17')
-            and c_acctbal > (
-                select
-                    avg(c_acctbal)
+with tmp as (select
+                    avg(c_acctbal) as av
                 from
                     customer
                 where
                     c_acctbal > 0.00
                     and substring(c_phone, 1, 2) in
-                        ('13', '31', '23', '29', '30', '18', '17')
-            )
-            and not exists (
-                select
-                    *
-                from
-                    orders
-                where
-                    o_custkey = c_custkey
-            )
+                        ('13', '31', '23', '29', '30', '18', '17'))
+
+select /*+SET_VAR(exec_mem_limit=8589934592, parallel_fragment_exec_instance_num=16, enable_vectorized_engine=true, batch_size=4096, disable_join_reorder=false, enable_cost_based_join_reorder=true, enable_projection=true,runtime_bloom_filter_size=4194304) */
+    cntrycode,
+    count(*) as numcust,
+    sum(c_acctbal) as totacctbal
+from
+    (
+	select
+            substring(c_phone, 1, 2) as cntrycode,
+            c_acctbal
+        from
+             orders right anti join customer c on  o_custkey = c.c_custkey join tmp on c.c_acctbal > tmp.av
+        where
+            substring(c_phone, 1, 2) in
+                ('13', '31', '23', '29', '30', '18', '17')
     ) as custsale
 group by
     cntrycode


### PR DESCRIPTION
1. Support Right Anti Join to generate runtime filter
2. Union the always true logic of runtime filter
3. Rewrite the Q22 and Q14 of TPCH

# Proposed changes

After do the opt

the tpch q22

before : 5.5s
after : 3.5s

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

