### PR TITLE
[chore](build release) remove doris home and user info from doris_be --version output

### DIFF
--- a/gensrc/script/gen_build_version.sh
+++ b/gensrc/script/gen_build_version.sh
@@ -58,21 +58,15 @@ if [[ -z "${DORIS_TEST_BINARY_DIR}" ]]; then
 fi
 
 cd "${DORIS_HOME}"
-if [[ -d '.svn' ]]; then
-    revision=$(svn info | sed -n -e 's/Last Changed Rev: \(.*\)/\1/p')
-    short_revision="${revision}"
-    url=$(svn info | sed -n -e 's/^URL: \(.*\)/\1/p')
-    if echo "${url}" | grep '\/tags\/' >/dev/null; then
-        build_version="$(echo "${url}" | sed 's/.*_\([0-9-]\+\)_PD_BL.*/\1/g' | sed 's/-/\./g')"
-    fi
-elif [[ -d '.git' ]]; then
+
+if [[ -d '.git' ]]; then
     revision="$(git log -1 --pretty=format:"%H")"
     short_revision="$(git log -1 --pretty=format:"%h")"
-    url="git://${hostname}${DORIS_HOME}"
+    url="git://${hostname}"
 else
     revision="Unknown"
     short_revision="${revision}"
-    url="file://${DORIS_HOME}"
+    url="file://${hostname}"
 fi
 
 cd "${cwd}"
@@ -80,7 +74,7 @@ cd "${cwd}"
 build_hash="${url}@${revision}"
 build_short_hash="${short_revision}"
 build_time="${date}"
-build_info="${user}@${hostname}"
+build_info="${hostname}"
 
 if [[ -z "${JAVA_HOME}" ]]; then
     java_cmd="$(which java)"

--- a/gensrc/script/gen_build_version.sh
+++ b/gensrc/script/gen_build_version.sh
@@ -38,7 +38,6 @@ build_version="${build_version_prefix}-${build_version_major}.${build_version_mi
 unset LANG
 unset LC_CTYPE
 
-user="$(whoami)"
 date="$(date +"%a, %d %b %Y %H:%M:%S %Z")"
 hostname="$(hostname)"
 


### PR DESCRIPTION
# Proposed changes

There will be personal info in doris_be --version, like this:

doris-0.0.0-trunk RELEASE (build git://hk-dev01/mnt/disk2/ygl/code/github/apache-doris/be/../@8b7d928af26318f71098f1be2ab03ed83b1955fd)
Built on Wed, 12 Oct 2022 18:36:44 CST by ygl@hk-dev01

Since we always not need this info, commit id is enough, I remove these redundant info, the new result is like this:

doris-0.0.0-trunk RELEASE (build git://hk-dev01@8b7d928af26318f71098f1be2ab03ed83b1955fd)
Built on Thu, 13 Oct 2022 15:03:01 CST by hk-dev01

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

