### PR TITLE
[Improvement](multi-catalog)Support refresh external catalog.

### DIFF
--- a/fe/fe-core/src/main/cup/sql_parser.cup
+++ b/fe/fe-core/src/main/cup/sql_parser.cup
@@ -1127,6 +1127,10 @@ refresh_stmt ::=
     {:
         RESULT = new RefreshDbStmt(db);
     :}
+    | KW_REFRESH KW_DATABASE ident:ctl DOT ident:db
+    {:
+        RESULT = new RefreshDbStmt(ctl, db);
+    :}
     | KW_REFRESH KW_MATERIALIZED KW_VIEW table_name:mv
     {:
         RESULT = new RefreshMaterializedViewStmt(mv, MVRefreshInfo.RefreshMethod.COMPLETE);

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/RefreshDbStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/RefreshDbStmt.java
@@ -57,6 +57,9 @@ public class RefreshDbStmt extends DdlStmt {
     @Override
     public void analyze(Analyzer analyzer) throws AnalysisException, UserException {
         super.analyze(analyzer);
+        if (Strings.isNullOrEmpty(catalogName)) {
+            catalogName = ConnectContext.get().getCurrentCatalog().getName();
+        }
         if (Strings.isNullOrEmpty(dbName)) {
             ErrorReport.reportAnalysisException(ErrorCode.ERR_WRONG_DB_NAME, dbName);
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/RefreshDbStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/RefreshDbStmt.java
@@ -34,14 +34,24 @@ import org.apache.logging.log4j.Logger;
 public class RefreshDbStmt extends DdlStmt {
     private static final Logger LOG = LogManager.getLogger(RefreshDbStmt.class);
 
+    private String catalogName;
     private String dbName;
 
     public RefreshDbStmt(String dbName) {
         this.dbName = dbName;
     }
 
+    public RefreshDbStmt(String catalogName, String dbName) {
+        this.catalogName = catalogName;
+        this.dbName = dbName;
+    }
+
     public String getDbName() {
         return dbName;
+    }
+
+    public String getCatalogName() {
+        return catalogName;
     }
 
     @Override
@@ -74,7 +84,11 @@ public class RefreshDbStmt extends DdlStmt {
     @Override
     public String toSql() {
         StringBuilder sb = new StringBuilder();
-        sb.append("REFRESH DATABASE ").append("`").append(dbName).append("`");
+        sb.append("REFRESH DATABASE ");
+        if (catalogName != null) {
+            sb.append("`").append(catalogName).append("`.");
+        }
+        sb.append("`").append(dbName).append("`");
         return sb.toString();
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/RefreshTableStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/RefreshTableStmt.java
@@ -18,11 +18,9 @@
 package org.apache.doris.analysis;
 
 import org.apache.doris.catalog.Env;
-import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.ErrorReport;
 import org.apache.doris.common.UserException;
-import org.apache.doris.common.util.Util;
 import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.qe.ConnectContext;
 
@@ -38,6 +36,10 @@ public class RefreshTableStmt extends DdlStmt {
         this.tableName = tableName;
     }
 
+    public String getCtl() {
+        return tableName.getCtl();
+    }
+
     public String getDbName() {
         return tableName.getDb();
     }
@@ -51,11 +53,9 @@ public class RefreshTableStmt extends DdlStmt {
     }
 
     @Override
-    public void analyze(Analyzer analyzer) throws AnalysisException, UserException {
+    public void analyze(Analyzer analyzer) throws UserException {
         super.analyze(analyzer);
         tableName.analyze(analyzer);
-        // disallow external catalog
-        Util.prohibitExternalCatalog(tableName.getCtl(), this.getClass().getSimpleName());
 
         // check access
         if (!Env.getCurrentEnv().getAuth().checkTblPriv(ConnectContext.get(), tableName.getDb(),

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/RefreshManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/RefreshManager.java
@@ -22,12 +22,12 @@ import org.apache.doris.analysis.DropTableStmt;
 import org.apache.doris.analysis.RefreshDbStmt;
 import org.apache.doris.analysis.RefreshTableStmt;
 import org.apache.doris.analysis.TableName;
-import org.apache.doris.catalog.external.HMSExternalDatabase;
-import org.apache.doris.catalog.external.HMSExternalTable;
+import org.apache.doris.catalog.external.ExternalDatabase;
+import org.apache.doris.catalog.external.ExternalTable;
 import org.apache.doris.common.DdlException;
 import org.apache.doris.common.UserException;
 import org.apache.doris.datasource.CatalogIf;
-import org.apache.doris.datasource.HMSExternalCatalog;
+import org.apache.doris.datasource.ExternalCatalog;
 import org.apache.doris.datasource.InternalCatalog;
 
 import org.apache.logging.log4j.LogManager;
@@ -108,15 +108,15 @@ public class RefreshManager {
     }
 
     private void refreshExternalCtlDb(String dbName, CatalogIf catalog) throws DdlException {
-        if (!(catalog instanceof HMSExternalCatalog)) {
-            throw new DdlException("Only support refresh HMSExternalCatalog Database");
+        if (!(catalog instanceof ExternalCatalog)) {
+            throw new DdlException("Only support refresh ExternalCatalog Database");
         }
 
         DatabaseIf db = catalog.getDbNullable(dbName);
         if (db == null) {
             throw new DdlException("Database " + dbName + " does not exist in catalog " + catalog.getName());
         }
-        ((HMSExternalDatabase) db).setUnInitialized();
+        ((ExternalDatabase) db).setUnInitialized();
     }
 
     private void refreshInternalCtlIcebergTable(RefreshTableStmt stmt, Env env) throws UserException {
@@ -143,8 +143,8 @@ public class RefreshManager {
     }
 
     private void refreshExternalCtlTable(String dbName, String tableName, CatalogIf catalog) throws DdlException {
-        if (!(catalog instanceof HMSExternalCatalog)) {
-            throw new DdlException("Only support refresh HMSExternalCatalog Tables");
+        if (!(catalog instanceof ExternalCatalog)) {
+            throw new DdlException("Only support refresh ExternalCatalog Tables");
         }
         DatabaseIf db = catalog.getDbNullable(dbName);
         if (db == null) {
@@ -155,6 +155,6 @@ public class RefreshManager {
         if (table == null) {
             throw new DdlException("Table " + tableName + " does not exist in db " + dbName);
         }
-        ((HMSExternalTable) table).setUnInitialized();
+        ((ExternalTable) table).setUnInitialized();
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/RefreshManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/RefreshManager.java
@@ -22,8 +22,13 @@ import org.apache.doris.analysis.DropTableStmt;
 import org.apache.doris.analysis.RefreshDbStmt;
 import org.apache.doris.analysis.RefreshTableStmt;
 import org.apache.doris.analysis.TableName;
+import org.apache.doris.catalog.external.HMSExternalDatabase;
+import org.apache.doris.catalog.external.HMSExternalTable;
 import org.apache.doris.common.DdlException;
 import org.apache.doris.common.UserException;
+import org.apache.doris.datasource.CatalogIf;
+import org.apache.doris.datasource.HMSExternalCatalog;
+import org.apache.doris.datasource.InternalCatalog;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -35,38 +40,48 @@ public class RefreshManager {
     private static final Logger LOG = LogManager.getLogger(RefreshManager.class);
 
     public void handleRefreshTable(RefreshTableStmt stmt) throws UserException {
+        String catalogName = stmt.getCtl();
         String dbName = stmt.getDbName();
         String tableName = stmt.getTblName();
         Env env = Env.getCurrentEnv();
 
-        // 0. check table type
-        Database db = env.getInternalCatalog().getDbOrDdlException(dbName);
-        Table table = db.getTableNullable(tableName);
-        if (!(table instanceof IcebergTable)) {
-            throw new DdlException("Only support refresh Iceberg table.");
+        CatalogIf catalog = catalogName != null ? env.getCatalogMgr().getCatalog(catalogName) : env.getCurrentCatalog();
+
+        if (catalog == null) {
+            throw new DdlException("Catalog " + catalogName + " doesn't exist.");
         }
 
-        // 1. get iceberg properties
-        Map<String, String> icebergProperties = ((IcebergTable) table).getIcebergProperties();
-        icebergProperties.put(IcebergProperty.ICEBERG_TABLE, ((IcebergTable) table).getIcebergTbl());
-        icebergProperties.put(IcebergProperty.ICEBERG_DATABASE, ((IcebergTable) table).getIcebergDb());
-
-        // 2. drop old table
-        DropTableStmt dropTableStmt = new DropTableStmt(true, stmt.getTableName(), true);
-        env.dropTable(dropTableStmt);
-
-        // 3. create new table
-        CreateTableStmt createTableStmt = new CreateTableStmt(true, true,
-                stmt.getTableName(), "ICEBERG", icebergProperties, "");
-        env.createTable(createTableStmt);
-
+        if (catalog.getName().equals(InternalCatalog.INTERNAL_CATALOG_NAME)) {
+            // Process internal catalog iceberg external table refresh.
+            refreshInternalCtlIcebergTable(stmt, env);
+        } else {
+            // Process external catalog table refresh
+            refreshExternalCtlTable(dbName, tableName, catalog);
+        }
         LOG.info("Successfully refresh table: {} from db: {}", tableName, dbName);
     }
 
     public void handleRefreshDb(RefreshDbStmt stmt) throws DdlException {
+        String catalogName = stmt.getCatalogName();
         String dbName = stmt.getDbName();
         Env env = Env.getCurrentEnv();
+        CatalogIf catalog = catalogName != null ? env.getCatalogMgr().getCatalog(catalogName) : env.getCurrentCatalog();
 
+        if (catalog == null) {
+            throw new DdlException("Catalog " + catalogName + " doesn't exist.");
+        }
+
+        if (catalog.getName().equals(InternalCatalog.INTERNAL_CATALOG_NAME)) {
+            // Process internal catalog iceberg external db refresh.
+            refreshInternalCtlIcebergDb(dbName, env);
+        } else {
+            // Process external catalog db refresh
+            refreshExternalCtlDb(dbName, catalog);
+        }
+        LOG.info("Successfully refresh db: {}", dbName);
+    }
+
+    private void refreshInternalCtlIcebergDb(String dbName, Env env) throws DdlException {
         Database db = env.getInternalCatalog().getDbOrDdlException(dbName);
 
         // 0. build iceberg property
@@ -90,7 +105,56 @@ public class RefreshManager {
 
         // 3. register iceberg database to recreate iceberg table
         env.getIcebergTableCreationRecordMgr().registerDb(db);
+    }
 
-        LOG.info("Successfully refresh db: {}", dbName);
+    private void refreshExternalCtlDb(String dbName, CatalogIf catalog) throws DdlException {
+        if (!(catalog instanceof HMSExternalCatalog)) {
+            throw new DdlException("Only support refresh HMSExternalCatalog Database");
+        }
+
+        DatabaseIf db = catalog.getDbNullable(dbName);
+        if (db == null) {
+            throw new DdlException("Database " + dbName + " does not exist in catalog " + catalog.getName());
+        }
+        ((HMSExternalDatabase) db).setUnInitialized();
+    }
+
+    private void refreshInternalCtlIcebergTable(RefreshTableStmt stmt, Env env) throws UserException {
+        // 0. check table type
+        Database db = env.getInternalCatalog().getDbOrDdlException(stmt.getDbName());
+        Table table = db.getTableNullable(stmt.getTblName());
+        if (!(table instanceof IcebergTable)) {
+            throw new DdlException("Only support refresh Iceberg table.");
+        }
+
+        // 1. get iceberg properties
+        Map<String, String> icebergProperties = ((IcebergTable) table).getIcebergProperties();
+        icebergProperties.put(IcebergProperty.ICEBERG_TABLE, ((IcebergTable) table).getIcebergTbl());
+        icebergProperties.put(IcebergProperty.ICEBERG_DATABASE, ((IcebergTable) table).getIcebergDb());
+
+        // 2. drop old table
+        DropTableStmt dropTableStmt = new DropTableStmt(true, stmt.getTableName(), true);
+        env.dropTable(dropTableStmt);
+
+        // 3. create new table
+        CreateTableStmt createTableStmt = new CreateTableStmt(true, true,
+                stmt.getTableName(), "ICEBERG", icebergProperties, "");
+        env.createTable(createTableStmt);
+    }
+
+    private void refreshExternalCtlTable(String dbName, String tableName, CatalogIf catalog) throws DdlException {
+        if (!(catalog instanceof HMSExternalCatalog)) {
+            throw new DdlException("Only support refresh HMSExternalCatalog Tables");
+        }
+        DatabaseIf db = catalog.getDbNullable(dbName);
+        if (db == null) {
+            throw new DdlException("Database " + dbName + " does not exist in catalog " + catalog.getName());
+        }
+
+        TableIf table = db.getTableNullable(tableName);
+        if (table == null) {
+            throw new DdlException("Table " + tableName + " does not exist in db " + dbName);
+        }
+        ((HMSExternalTable) table).setUnInitialized();
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/external/EsExternalDatabase.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/external/EsExternalDatabase.java
@@ -51,17 +51,36 @@ public class EsExternalDatabase extends ExternalDatabase<EsExternalTable> {
      */
     public EsExternalDatabase(ExternalCatalog extCatalog, long id, String name) {
         super(extCatalog, id, name);
-        init();
+    }
+
+    private synchronized void makeSureInitialized() {
+        if (!initialized) {
+            init();
+            initialized = true;
+        }
     }
 
     private void init() {
         List<String> tableNames = extCatalog.listTableNames(null, name);
         if (tableNames != null) {
+            Map<String, Long> tmpTableNameToId = Maps.newConcurrentMap();
+            Map<Long, EsExternalTable> tmpIdToTbl = Maps.newHashMap();
             for (String tableName : tableNames) {
-                long tblId = Env.getCurrentEnv().getNextId();
-                tableNameToId.put(tableName, tblId);
-                idToTbl.put(tblId, new EsExternalTable(tblId, tableName, name, (EsExternalCatalog) extCatalog));
+                long tblId;
+                if (tableNameToId.containsKey(tableName)) {
+                    tblId = tableNameToId.get(tableName);
+                    tmpTableNameToId.put(tableName, tblId);
+                    EsExternalTable table = idToTbl.get(tblId);
+                    table.setUnInitialized();
+                    tmpIdToTbl.put(tblId, table);
+                } else {
+                    tblId = Env.getCurrentEnv().getNextId();
+                    tmpTableNameToId.put(tableName, tblId);
+                    tmpIdToTbl.put(tblId, new EsExternalTable(tblId, tableName, name, (EsExternalCatalog) extCatalog));
+                }
             }
+            tableNameToId = tmpTableNameToId;
+            idToTbl = tmpIdToTbl;
         }
     }
 
@@ -73,11 +92,13 @@ public class EsExternalDatabase extends ExternalDatabase<EsExternalTable> {
 
     @Override
     public List<EsExternalTable> getTables() {
+        makeSureInitialized();
         return new ArrayList<>(idToTbl.values());
     }
 
     @Override
     public EsExternalTable getTableNullable(String tableName) {
+        makeSureInitialized();
         if (!tableNameToId.containsKey(tableName)) {
             return null;
         }
@@ -86,6 +107,7 @@ public class EsExternalDatabase extends ExternalDatabase<EsExternalTable> {
 
     @Override
     public EsExternalTable getTableNullable(long tableId) {
+        makeSureInitialized();
         return idToTbl.get(tableId);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/external/EsExternalTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/external/EsExternalTable.java
@@ -39,7 +39,6 @@ public class EsExternalTable extends ExternalTable {
 
     private final EsExternalCatalog catalog;
     private final String dbName;
-    private boolean initialized = false;
     private EsTable esTable;
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/external/ExternalDatabase.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/external/ExternalDatabase.java
@@ -48,6 +48,7 @@ public class ExternalDatabase<T extends ExternalTable> implements DatabaseIf<T> 
     protected String name;
     protected ExternalCatalog extCatalog;
     protected DatabaseProperty dbProperties;
+    protected boolean initialized = false;
 
     /**
      * Create external database.
@@ -60,6 +61,10 @@ public class ExternalDatabase<T extends ExternalTable> implements DatabaseIf<T> 
         this.extCatalog = extCatalog;
         this.id = id;
         this.name = name;
+    }
+
+    public synchronized void setUnInitialized() {
+        this.initialized = false;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/external/ExternalTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/external/ExternalTable.java
@@ -45,6 +45,7 @@ public class ExternalTable implements TableIf {
     protected ReentrantReadWriteLock rwLock = new ReentrantReadWriteLock(true);
     protected TableType type = null;
     protected volatile List<Column> fullSchema = null;
+    protected boolean initialized = false;
 
     /**
      * Create external table.
@@ -72,6 +73,11 @@ public class ExternalTable implements TableIf {
 
     public boolean isView() {
         return false;
+    }
+
+    public synchronized void setUnInitialized() {
+        this.initialized = false;
+        this.fullSchema = null;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/external/HMSExternalDatabase.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/external/HMSExternalDatabase.java
@@ -88,7 +88,7 @@ public class HMSExternalDatabase extends ExternalDatabase<HMSExternalTable> {
         }
     }
 
-    public void setUnInitialized() {
+    public synchronized void setUnInitialized() {
         this.initialized = false;
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/external/HMSExternalDatabase.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/external/HMSExternalDatabase.java
@@ -43,7 +43,6 @@ public class HMSExternalDatabase extends ExternalDatabase<HMSExternalTable> {
     // Cache of table name to table id.
     private Map<String, Long> tableNameToId = Maps.newConcurrentMap();
     private Map<Long, HMSExternalTable> idToTbl = Maps.newHashMap();
-    private boolean initialized = false;
 
     /**
      * Create HMS external database.
@@ -70,7 +69,7 @@ public class HMSExternalDatabase extends ExternalDatabase<HMSExternalTable> {
             Map<Long, HMSExternalTable> tmpIdToTbl = Maps.newHashMap();
             for (String tableName : tableNames) {
                 long tblId;
-                if (tableNameToId != null && tableNameToId.containsKey(tableName)) {
+                if (tableNameToId.containsKey(tableName)) {
                     tblId = tableNameToId.get(tableName);
                     tmpTableNameToId.put(tableName, tblId);
                     HMSExternalTable table = idToTbl.get(tblId);
@@ -86,10 +85,6 @@ public class HMSExternalDatabase extends ExternalDatabase<HMSExternalTable> {
             tableNameToId = tmpTableNameToId;
             idToTbl = tmpIdToTbl;
         }
-    }
-
-    public synchronized void setUnInitialized() {
-        this.initialized = false;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/external/HMSExternalTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/external/HMSExternalTable.java
@@ -51,7 +51,6 @@ public class HMSExternalTable extends ExternalTable {
 
     private volatile org.apache.hadoop.hive.metastore.api.Table remoteTable = null;
     private DLAType dlaType = DLAType.UNKNOWN;
-    private boolean initialized = false;
 
     public enum DLAType {
         UNKNOWN, HIVE, HUDI, ICEBERG
@@ -169,11 +168,6 @@ public class HMSExternalTable extends ExternalTable {
                 }
             }
         }
-    }
-
-    public synchronized void setUnInitialized() {
-        this.initialized = false;
-        this.fullSchema = null;
     }
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/external/HMSExternalTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/external/HMSExternalTable.java
@@ -171,6 +171,11 @@ public class HMSExternalTable extends ExternalTable {
         }
     }
 
+    public void setUnInitialized() {
+        this.initialized = false;
+        this.fullSchema = null;
+    }
+
     /**
      * Get the related remote hive metastore table.
      */

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/external/HMSExternalTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/external/HMSExternalTable.java
@@ -171,7 +171,7 @@ public class HMSExternalTable extends ExternalTable {
         }
     }
 
-    public void setUnInitialized() {
+    public synchronized void setUnInitialized() {
         this.initialized = false;
         this.fullSchema = null;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/EsExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/EsExternalCatalog.java
@@ -151,12 +151,16 @@ public class EsExternalCatalog extends ExternalCatalog {
         } catch (DdlException e) {
             LOG.warn("validate error", e);
         }
-        dbNameToId = Maps.newConcurrentMap();
-        idToDb = Maps.newConcurrentMap();
         this.esRestClient = new EsRestClient(this.nodes, this.username, this.password, this.enableSsl);
-        long defaultDbId = Env.getCurrentEnv().getNextId();
-        dbNameToId.put(DEFAULT_DB, defaultDbId);
-        idToDb.put(defaultDbId, new EsExternalDatabase(this, defaultDbId, DEFAULT_DB));
+        if (dbNameToId != null && dbNameToId.containsKey(DEFAULT_DB)) {
+            idToDb.get(dbNameToId.get(DEFAULT_DB)).setUnInitialized();
+        } else {
+            dbNameToId = Maps.newConcurrentMap();
+            idToDb = Maps.newConcurrentMap();
+            long defaultDbId = Env.getCurrentEnv().getNextId();
+            dbNameToId.put(DEFAULT_DB, defaultDbId);
+            idToDb.put(defaultDbId, new EsExternalDatabase(this, defaultDbId, DEFAULT_DB));
+        }
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/HMSExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/HMSExternalCatalog.java
@@ -84,7 +84,7 @@ public class HMSExternalCatalog extends ExternalCatalog {
         }
         for (String dbName : allDatabases) {
             long dbId;
-            if (dbNameToId != null && dbNameToId.containsKey(dbName)) {
+            if (dbNameToId.containsKey(dbName)) {
                 dbId = dbNameToId.get(dbName);
                 tmpDbNameToId.put(dbName, dbId);
                 HMSExternalDatabase db = idToDb.get(dbId);

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/HMSExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/HMSExternalCatalog.java
@@ -62,7 +62,6 @@ public class HMSExternalCatalog extends ExternalCatalog {
     }
 
     private void init() {
-        // Must set here. Because after replay from image, these 2 map will become null again.
         Map<String, Long> tmpDbNameToId = Maps.newConcurrentMap();
         Map<Long, HMSExternalDatabase> tmpIdToDb = Maps.newConcurrentMap();
         HiveConf hiveConf = new HiveConf();

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/HMSExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/HMSExternalCatalog.java
@@ -42,8 +42,8 @@ public class HMSExternalCatalog extends ExternalCatalog {
     private static final Logger LOG = LogManager.getLogger(HMSExternalCatalog.class);
 
     // Cache of db name to db id.
-    private Map<String, Long> dbNameToId;
-    private Map<Long, HMSExternalDatabase> idToDb;
+    private Map<String, Long> dbNameToId = Maps.newConcurrentMap();
+    private Map<Long, HMSExternalDatabase> idToDb = Maps.newConcurrentMap();
     protected HiveMetaStoreClient client;
 
     /**
@@ -63,8 +63,8 @@ public class HMSExternalCatalog extends ExternalCatalog {
 
     private void init() {
         // Must set here. Because after replay from image, these 2 map will become null again.
-        dbNameToId = Maps.newConcurrentMap();
-        idToDb = Maps.newConcurrentMap();
+        Map<String, Long> tmpDbNameToId = Maps.newConcurrentMap();
+        Map<Long, HMSExternalDatabase> tmpIdToDb = Maps.newConcurrentMap();
         HiveConf hiveConf = new HiveConf();
         hiveConf.setVar(HiveConf.ConfVars.METASTOREURIS, getHiveMetastoreUris());
         try {
@@ -84,10 +84,21 @@ public class HMSExternalCatalog extends ExternalCatalog {
             return;
         }
         for (String dbName : allDatabases) {
-            long dbId = Env.getCurrentEnv().getNextId();
-            dbNameToId.put(dbName, dbId);
-            idToDb.put(dbId, new HMSExternalDatabase(this, dbId, dbName));
+            long dbId;
+            if (dbNameToId != null && dbNameToId.containsKey(dbName)) {
+                dbId = dbNameToId.get(dbName);
+                tmpDbNameToId.put(dbName, dbId);
+                HMSExternalDatabase db = idToDb.get(dbId);
+                db.setUnInitialized();
+                tmpIdToDb.put(dbId, db);
+            } else {
+                dbId = Env.getCurrentEnv().getNextId();
+                tmpDbNameToId.put(dbName, dbId);
+                tmpIdToDb.put(dbId, new HMSExternalDatabase(this, dbId, dbName));
+            }
         }
+        dbNameToId = tmpDbNameToId;
+        idToDb = tmpIdToDb;
     }
 
     /**


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

Support manually refresh external catalog metadata.
1. refresh catalog external_catalog_name
2. refresh database catalog.db OR refresh database db (current catalog)
3. refresh table catalog.db.table OR refresh table db.table (current catalog) OR refresh table table_name (current db)

And the refresh operations above keep the database and table ids unchanged.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
5. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
6. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
7. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
8. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

