### PR TITLE
[fix](array-type) check value valid while insert data into array column

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ArrayLiteral.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ArrayLiteral.java
@@ -156,4 +156,11 @@ public class ArrayLiteral extends LiteralExpr {
         literal.setType(targetType);
         return literal;
     }
+
+    @Override
+    public void checkValueValid() throws AnalysisException {
+        for (Expr e : children) {
+            e.checkValueValid();
+        }
+    }
 }

--- a/regression-test/suites/insert_p0/test_array_insert_overflow.groovy
+++ b/regression-test/suites/insert_p0/test_array_insert_overflow.groovy
@@ -1,0 +1,47 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_array_insert_overflow") {
+    def testTable = "test_array_insert_overflow"
+    sql "ADMIN SET FRONTEND CONFIG ('enable_array_type' = 'true')"
+    sql """ set enable_vectorized_engine = true """
+
+    sql """
+            CREATE TABLE IF NOT EXISTS ${testTable} (
+              `k1` INT(11) NULL COMMENT "",
+              `k2` ARRAY<INT> NULL COMMENT ""
+            ) ENGINE=OLAP
+            DUPLICATE KEY(`k1`)
+            DISTRIBUTED BY HASH(`k1`) BUCKETS 1
+            PROPERTIES (
+            "replication_allocation" = "tag.location.default: 1",
+            "storage_format" = "V2"
+            )
+    """
+    
+    test {
+        sql "insert into ${testTable} values (1005, [-2147483649])"
+        // check exception message contains
+        exception "Number out of range"
+    }
+
+    test {
+        sql "insert into ${testTable} values (1006, [-9223372036854775809])"
+        // check exception message contains
+        exception "Number out of range"
+    }
+}


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

We should prevent insert while value overflow.

1. create table:
`CREATE TABLE test_array_load_test_array_int_insert_db.test_array_load_test_array_int_insert_tb ( k1 int NULL, k2 array<int> NULL ) DUPLICATE KEY(k1) DISTRIBUTED BY HASH(k1) BUCKETS 5`

2. try insert data less than INT_MIN.
`insert into test_array_load_test_array_int_insert_tb values (1005, [-2147483649])`

Before this pr, the insert will success, but the value it not correct.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

