### PR TITLE
[enhancement](memory) Default Jemalloc as generic memory allocator

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -267,7 +267,7 @@ if [[ -z "${USE_MEM_TRACKER}" ]]; then
     USE_MEM_TRACKER='ON'
 fi
 if [[ -z "${USE_JEMALLOC}" ]]; then
-    USE_JEMALLOC='OFF'
+    USE_JEMALLOC='ON'
 fi
 if [[ -z "${STRICT_MEMORY_USE}" ]]; then
     STRICT_MEMORY_USE='OFF'


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

`gperftools/tcmalloc`[https://github.com/gperftools/gperftools] is outdated, there are no new features for many years, only fix bugs. doris is currently used by default.

`google/tcmalloc`[https://github.com/google/tcmalloc], very active recently, has many new features, and is expected to perform better than jemalloc, but there is currently no stable version.
Moreover, the compilation dependencies are complex and difficult to integrate, and are incompatible with `gperftools/tcmalloc`, and there are few reference documents.

`jemalloc`[https://github.com/jemalloc/jemalloc] performs better than `gperftools/tcmalloc` under high concurrency, and is mature and stable, looking forward to being the default memory allocator.
  Tested in Doris: https://github.com/apache/doris/pull/12496

## Checklist(Required)

1. Does it affect the original behavior: 
    - [x] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

