### PR TITLE
[feature](Nereids) generate ExprId from 0 for each statement

### DIFF
--- a/fe/fe-core/src/main/antlr4/org/apache/doris/nereids/DorisParser.g4
+++ b/fe/fe-core/src/main/antlr4/org/apache/doris/nereids/DorisParser.g4
@@ -50,8 +50,7 @@ singleStatement
 
 statement
     : query                                                            #statementDefault
-    | (EXPLAIN | DESC | DESCRIBE) level=(VERBOSE | GRAPH)?
-        query                                                          #explain
+    | (EXPLAIN | DESC | DESCRIBE) level=(VERBOSE | GRAPH)? query       #explain
     ;
 
 //  -----------------Query-----------------

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/StatementContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/StatementContext.java
@@ -19,6 +19,7 @@ package org.apache.doris.nereids;
 
 import org.apache.doris.analysis.StatementBase;
 import org.apache.doris.common.IdGenerator;
+import org.apache.doris.nereids.trees.expressions.ExprId;
 import org.apache.doris.nereids.trees.plans.RelationId;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.OriginStatement;
@@ -27,20 +28,35 @@ import org.apache.doris.qe.OriginStatement;
  * Statement context for nereids
  */
 public class StatementContext {
-    private final ConnectContext connectContext;
-    private final OriginStatement originStatement;
 
-    private final IdGenerator<RelationId> idGenerator = RelationId.createGenerator();
+    private ConnectContext connectContext;
+
+    private OriginStatement originStatement;
+
+    private final IdGenerator<ExprId> exprIdGenerator = ExprId.createGenerator();
+
+    private final IdGenerator<RelationId> relationIdGenerator = RelationId.createGenerator();
 
     private StatementBase parsedStatement;
+
+    public StatementContext() {
+    }
 
     public StatementContext(ConnectContext connectContext, OriginStatement originStatement) {
         this.connectContext = connectContext;
         this.originStatement = originStatement;
     }
 
+    public void setConnectContext(ConnectContext connectContext) {
+        this.connectContext = connectContext;
+    }
+
     public ConnectContext getConnectContext() {
         return connectContext;
+    }
+
+    public void setOriginStatement(OriginStatement originStatement) {
+        this.originStatement = originStatement;
     }
 
     public OriginStatement getOriginStatement() {
@@ -51,8 +67,12 @@ public class StatementContext {
         return parsedStatement;
     }
 
-    public RelationId getNextId() {
-        return idGenerator.getNextId();
+    public ExprId getNextExprId() {
+        return exprIdGenerator.getNextId();
+    }
+
+    public RelationId getNextRelationId() {
+        return relationIdGenerator.getNextId();
     }
 
     public void setParsedStatement(StatementBase parsedStatement) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/LogicalPlanAdapter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/LogicalPlanAdapter.java
@@ -22,6 +22,7 @@ import org.apache.doris.analysis.OutFileClause;
 import org.apache.doris.analysis.Queriable;
 import org.apache.doris.analysis.RedirectStatus;
 import org.apache.doris.analysis.StatementBase;
+import org.apache.doris.nereids.StatementContext;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalPlan;
 
@@ -35,12 +36,14 @@ import java.util.List;
  */
 public class LogicalPlanAdapter extends StatementBase implements Queriable {
 
+    private final StatementContext statementContext;
     private final LogicalPlan logicalPlan;
     private List<Expr> resultExprs;
     private ArrayList<String> colLabels;
 
-    public LogicalPlanAdapter(LogicalPlan logicalPlan) {
+    public LogicalPlanAdapter(LogicalPlan logicalPlan, StatementContext statementContext) {
         this.logicalPlan = logicalPlan;
+        this.statementContext = statementContext;
     }
 
     @Override
@@ -62,21 +65,25 @@ public class LogicalPlanAdapter extends StatementBase implements Queriable {
         return null;
     }
 
+    public void setResultExprs(List<Expr> resultExprs) {
+        this.resultExprs = resultExprs;
+    }
+
     @Override
     public List<Expr> getResultExprs() {
         return resultExprs;
+    }
+
+    public void setColLabels(ArrayList<String> colLabels) {
+        this.colLabels = colLabels;
     }
 
     public ArrayList<String> getColLabels() {
         return colLabels;
     }
 
-    public void setResultExprs(List<Expr> resultExprs) {
-        this.resultExprs = resultExprs;
-    }
-
-    public void setColLabels(ArrayList<String> colLabels) {
-        this.colLabels = colLabels;
+    public StatementContext getStatementContext() {
+        return statementContext;
     }
 
     public String toDigest() {
@@ -85,6 +92,6 @@ public class LogicalPlanAdapter extends StatementBase implements Queriable {
     }
 
     public static LogicalPlanAdapter of(Plan plan) {
-        return new LogicalPlanAdapter((LogicalPlan) plan);
+        return new LogicalPlanAdapter((LogicalPlan) plan, null);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/LogicalPlanAdapter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/LogicalPlanAdapter.java
@@ -65,8 +65,8 @@ public class LogicalPlanAdapter extends StatementBase implements Queriable {
         return null;
     }
 
-    public void setResultExprs(List<Expr> resultExprs) {
-        this.resultExprs = resultExprs;
+    public ArrayList<String> getColLabels() {
+        return colLabels;
     }
 
     @Override
@@ -74,12 +74,12 @@ public class LogicalPlanAdapter extends StatementBase implements Queriable {
         return resultExprs;
     }
 
-    public void setColLabels(ArrayList<String> colLabels) {
-        this.colLabels = colLabels;
+    public void setResultExprs(List<Expr> resultExprs) {
+        this.resultExprs = resultExprs;
     }
 
-    public ArrayList<String> getColLabels() {
-        return colLabels;
+    public void setColLabels(ArrayList<String> colLabels) {
+        this.colLabels = colLabels;
     }
 
     public StatementContext getStatementContext() {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslator.java
@@ -163,6 +163,7 @@ public class PhysicalPlanTranslator extends DefaultPlanVisitor<PlanFragment, Pla
             if (e instanceof SlotReference && outputExpressionList.stream().anyMatch(o -> o.anyMatch(e::equals))) {
                 groupSlotList.add((SlotReference) e);
             } else {
+                // TODO: review this, should not
                 groupSlotList.add(new SlotReference(e.toSql(), e.getDataType(), e.nullable(), Collections.emptyList()));
             }
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/LogicalPlanBuilder.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/LogicalPlanBuilder.java
@@ -142,6 +142,7 @@ import org.apache.doris.nereids.trees.plans.logical.LogicalSort;
 import org.apache.doris.nereids.trees.plans.logical.LogicalSubQueryAlias;
 import org.apache.doris.nereids.types.DataType;
 import org.apache.doris.nereids.util.ExpressionUtils;
+import org.apache.doris.qe.ConnectContext;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
@@ -202,6 +203,9 @@ public class LogicalPlanBuilder extends DorisParserBaseVisitor<Object> {
         List<Pair<LogicalPlan, StatementContext>> logicalPlans = Lists.newArrayList();
         for (org.apache.doris.nereids.DorisParser.StatementContext statement : ctx.statement()) {
             statementContext = new StatementContext();
+            if (ConnectContext.get() != null) {
+                ConnectContext.get().setStatementContext(statementContext);
+            }
             logicalPlans.add(Pair.of(
                     ParserUtils.withOrigin(ctx, () -> (LogicalPlan) visit(statement)), statementContext));
         }
@@ -311,7 +315,7 @@ public class LogicalPlanBuilder extends DorisParserBaseVisitor<Object> {
         return ParserUtils.withOrigin(ctx, () -> {
             Expression expression = getExpression(ctx.expression());
             if (ctx.name != null) {
-                return new Alias(statementContext.getNextExprId(), expression, ctx.name.getText());
+                return new Alias(expression, ctx.name.getText());
             } else {
                 return expression;
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/BindRelation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/BindRelation.java
@@ -78,7 +78,7 @@ public class BindRelation extends OneAnalysisRuleFactory {
         Table table = getTable(dbName, nameParts.get(0), cascadesContext.getConnectContext().getEnv());
         // TODO: should generate different Scan sub class according to table's type
         if (table.getType() == TableType.OLAP) {
-            return new LogicalOlapScan(cascadesContext.getStatementContext().getNextId(),
+            return new LogicalOlapScan(cascadesContext.getStatementContext().getNextRelationId(),
                     (OlapTable) table, ImmutableList.of(dbName));
         } else if (table.getType() == TableType.VIEW) {
             Plan viewPlan = parseAndAnalyzeView(table.getDdlSql(), cascadesContext);
@@ -96,7 +96,7 @@ public class BindRelation extends OneAnalysisRuleFactory {
         }
         Table table = getTable(dbName, nameParts.get(1), connectContext.getEnv());
         if (table.getType() == TableType.OLAP) {
-            return new LogicalOlapScan(cascadesContext.getStatementContext().getNextId(),
+            return new LogicalOlapScan(cascadesContext.getStatementContext().getNextRelationId(),
                     (OlapTable) table, ImmutableList.of(dbName));
         } else if (table.getType() == TableType.VIEW) {
             Plan viewPlan = parseAndAnalyzeView(table.getDdlSql(), cascadesContext);

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/Alias.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/Alias.java
@@ -22,7 +22,6 @@ import org.apache.doris.nereids.trees.expressions.shape.UnaryExpression;
 import org.apache.doris.nereids.trees.expressions.visitor.ExpressionVisitor;
 import org.apache.doris.nereids.types.DataType;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 
@@ -48,7 +47,6 @@ public class Alias extends NamedExpression implements UnaryExpression {
         this(NamedExpressionUtil.newExprId(), child, name);
     }
 
-    @VisibleForTesting
     public Alias(ExprId exprId, Expression child, String name) {
         super(child);
         this.exprId = exprId;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/NamedExpressionUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/NamedExpressionUtil.java
@@ -27,7 +27,14 @@ import com.google.common.annotations.VisibleForTesting;
  */
 public class NamedExpressionUtil {
 
+    // for test only
+    private static StatementContext statementContext = new StatementContext();
+
     public static ExprId newExprId() {
+        // this branch is for test only
+        if (ConnectContext.get() == null || ConnectContext.get().getStatementContext() == null) {
+            return statementContext.getNextExprId();
+        }
         return ConnectContext.get().getStatementContext().getNextExprId();
     }
 
@@ -36,6 +43,9 @@ public class NamedExpressionUtil {
      */
     @VisibleForTesting
     public static void clear() throws Exception {
-        ConnectContext.get().setStatementContext(new StatementContext());
+        if (ConnectContext.get() != null) {
+            ConnectContext.get().setStatementContext(new StatementContext());
+        }
+        statementContext = new StatementContext();
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/NamedExpressionUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/NamedExpressionUtil.java
@@ -17,23 +17,18 @@
 
 package org.apache.doris.nereids.trees.expressions;
 
-import org.apache.doris.common.IdGenerator;
+import org.apache.doris.nereids.StatementContext;
+import org.apache.doris.qe.ConnectContext;
 
 import com.google.common.annotations.VisibleForTesting;
-
-import java.lang.reflect.Field;
 
 /**
  * The util of named expression.
  */
 public class NamedExpressionUtil {
-    /**
-     * Tool class for generate next ExprId.
-     */
-    private static final IdGenerator<ExprId> ID_GENERATOR = ExprId.createGenerator();
 
     public static ExprId newExprId() {
-        return ID_GENERATOR.getNextId();
+        return ConnectContext.get().getStatementContext().getNextExprId();
     }
 
     /**
@@ -41,8 +36,6 @@ public class NamedExpressionUtil {
      */
     @VisibleForTesting
     public static void clear() throws Exception {
-        Field nextId = ID_GENERATOR.getClass().getSuperclass().getDeclaredField("nextId");
-        nextId.setAccessible(true);
-        nextId.setInt(ID_GENERATOR, 0);
+        ConnectContext.get().setStatementContext(new StatementContext());
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectContext.java
@@ -31,6 +31,7 @@ import org.apache.doris.mysql.MysqlCapability;
 import org.apache.doris.mysql.MysqlChannel;
 import org.apache.doris.mysql.MysqlCommand;
 import org.apache.doris.mysql.MysqlSerializer;
+import org.apache.doris.nereids.StatementContext;
 import org.apache.doris.plugin.AuditEvent.AuditEventBuilder;
 import org.apache.doris.resource.Tag;
 import org.apache.doris.thrift.TResourceInfo;
@@ -145,6 +146,8 @@ public class ConnectContext {
     private InsertResult insertResult;
 
     private SessionContext sessionContext;
+
+    private StatementContext statementContext;
 
     public SessionContext getSessionContext() {
         return sessionContext;
@@ -510,6 +513,14 @@ public class ConnectContext {
 
     public void initTracer(String name) {
         this.tracer = Telemetry.getOpenTelemetry().getTracer(name);
+    }
+
+    public StatementContext getStatementContext() {
+        return statementContext;
+    }
+
+    public void setStatementContext(StatementContext statementContext) {
+        this.statementContext = statementContext;
     }
 
     // kill operation with no protect.

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectProcessor.java
@@ -264,10 +264,10 @@ public class ConnectProcessor {
                 try {
                     stmts = nereidsParser.parseSQL(originStmt);
                 } catch (Exception e) {
-                    nereidsParseException = e;
                     // TODO: We should catch all exception here until we support all query syntax.
+                    nereidsParseException = e;
                     LOG.info(" Fallback to stale planner."
-                            + " Nereids cannot process this statement: \"{}\".", originStmt.toString());
+                            + " Nereids cannot process this statement: \"{}\".", originStmt);
                 }
             }
             // stmts == null when Nereids cannot planner this query or Nereids is disabled.
@@ -283,7 +283,7 @@ public class ConnectProcessor {
                 parsedStmt = stmts.get(i);
                 if (parsedStmt instanceof SelectStmt) {
                     if (!ctx.getSessionVariable().enableFallbackToOriginalPlanner) {
-                        throw new Exception(String.format("SQL: {}", parsedStmt.toSql()), nereidsParseException);
+                        throw new Exception(String.format("SQL: %s", parsedStmt.toSql()), nereidsParseException);
                     }
                 }
                 parsedStmt.setOrigStmt(new OriginStatement(originStmt, i));

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/parser/NereidsParserTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/parser/NereidsParserTest.java
@@ -19,6 +19,8 @@ package org.apache.doris.nereids.parser;
 
 import org.apache.doris.analysis.ExplainOptions;
 import org.apache.doris.analysis.StatementBase;
+import org.apache.doris.common.Pair;
+import org.apache.doris.nereids.StatementContext;
 import org.apache.doris.nereids.exceptions.ParseException;
 import org.apache.doris.nereids.glue.LogicalPlanAdapter;
 import org.apache.doris.nereids.trees.expressions.literal.DecimalLiteral;
@@ -42,7 +44,7 @@ public class NereidsParserTest extends ParserTestBase {
     public void testParseMultiple() {
         NereidsParser nereidsParser = new NereidsParser();
         String sql = "SELECT b FROM test;SELECT a FROM test;";
-        List<LogicalPlan> logicalPlanList = nereidsParser.parseMultiple(sql);
+        List<Pair<LogicalPlan, StatementContext>> logicalPlanList = nereidsParser.parseMultiple(sql);
         Assertions.assertEquals(2, logicalPlanList.size());
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/logical/PushdownFilterThroughJoinTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/logical/PushdownFilterThroughJoinTest.java
@@ -34,7 +34,7 @@ import org.apache.doris.nereids.util.PlanChecker;
 import org.apache.doris.nereids.util.PlanConstructor;
 
 import com.google.common.collect.ImmutableList;
-import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
@@ -50,14 +50,26 @@ public class PushdownFilterThroughJoinTest implements PatternMatchSupported {
     /**
      * ut before.
      */
-    @BeforeAll
-    public final void beforeAll() {
+    @BeforeEach
+    public final void beforeEach() {
         rStudent = new LogicalOlapScan(PlanConstructor.getNextRelationId(), PlanConstructor.student,
                 ImmutableList.of(""));
         rScore = new LogicalOlapScan(PlanConstructor.getNextRelationId(), PlanConstructor.score, ImmutableList.of(""));
     }
 
-    public void testLeft(JoinType joinType) {
+    @Test
+    public void oneSide() {
+        testLeft(JoinType.CROSS_JOIN);
+        testLeft(JoinType.INNER_JOIN);
+        testLeft(JoinType.LEFT_OUTER_JOIN);
+        testLeft(JoinType.LEFT_SEMI_JOIN);
+        testLeft(JoinType.LEFT_ANTI_JOIN);
+        testRight(JoinType.RIGHT_OUTER_JOIN);
+        testRight(JoinType.RIGHT_SEMI_JOIN);
+        testRight(JoinType.RIGHT_ANTI_JOIN);
+    }
+
+    private void testLeft(JoinType joinType) {
         Expression whereCondition1 = new GreaterThan(rStudent.getOutput().get(1), Literal.of(18));
         Expression whereCondition2 = new GreaterThan(rStudent.getOutput().get(1), Literal.of(50));
         Expression whereCondition = ExpressionUtils.and(whereCondition1, whereCondition2);
@@ -78,7 +90,7 @@ public class PushdownFilterThroughJoinTest implements PatternMatchSupported {
                 );
     }
 
-    public void testRight(JoinType joinType) {
+    private void testRight(JoinType joinType) {
         Expression whereCondition1 = new GreaterThan(rStudent.getOutput().get(1), Literal.of(18));
         Expression whereCondition2 = new GreaterThan(rStudent.getOutput().get(1), Literal.of(50));
         Expression whereCondition = ExpressionUtils.and(whereCondition1, whereCondition2);
@@ -97,18 +109,6 @@ public class PushdownFilterThroughJoinTest implements PatternMatchSupported {
                                         .when(filter -> filter.getPredicates().equals(whereCondition))
                         )
                 );
-    }
-
-    @Test
-    public void oneSide() {
-        testLeft(JoinType.CROSS_JOIN);
-        testLeft(JoinType.INNER_JOIN);
-        testLeft(JoinType.LEFT_OUTER_JOIN);
-        testLeft(JoinType.LEFT_SEMI_JOIN);
-        testLeft(JoinType.LEFT_ANTI_JOIN);
-        testRight(JoinType.RIGHT_OUTER_JOIN);
-        testRight(JoinType.RIGHT_SEMI_JOIN);
-        testRight(JoinType.RIGHT_ANTI_JOIN);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/stats/StatsCalculatorTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/stats/StatsCalculatorTest.java
@@ -201,10 +201,10 @@ public class StatsCalculatorTest {
         List<String> qualifier = ImmutableList.of("test", "t");
         SlotReference slot1 = new SlotReference("c1", IntegerType.INSTANCE, true, qualifier);
         new Expectations() {{
-//                ConnectContext.get();
-//                result = context;
-//                context.getEnv();
-//                result = env;
+                ConnectContext.get();
+                result = context;
+                context.getEnv();
+                result = env;
                 env.getStatisticsManager();
                 result = statisticsManager;
                 statisticsManager.getStatistics();

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/stats/StatsCalculatorTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/stats/StatsCalculatorTest.java
@@ -43,8 +43,9 @@ import org.apache.doris.statistics.StatisticsManager;
 import org.apache.doris.statistics.StatsDeriveResult;
 import org.apache.doris.statistics.TableStats;
 
-import com.google.common.base.Supplier;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import mockit.Expectations;
 import mockit.Mocked;
 import org.junit.jupiter.api.Assertions;
@@ -58,13 +59,6 @@ import java.util.Map;
 import java.util.Optional;
 
 public class StatsCalculatorTest {
-
-    @Mocked
-    ConnectContext context;
-    @Mocked
-    Env env;
-    @Mocked
-    StatisticsManager statisticsManager;
 
     // TODO: temporary disable this test, until we could get column stats
     // @Test
@@ -107,7 +101,7 @@ public class StatsCalculatorTest {
 
     @Test
     public void testFilter() {
-        List<String> qualifier = new ArrayList<>();
+        List<String> qualifier = Lists.newArrayList();
         qualifier.add("test");
         qualifier.add("t");
         SlotReference slot1 = new SlotReference("c1", IntegerType.INSTANCE, true, qualifier);
@@ -118,8 +112,8 @@ public class StatsCalculatorTest {
         columnStat1.setNumNulls(5);
         ColumnStat columnStat2 = new ColumnStat();
         columnStat2.setNdv(20);
-        columnStat1.setNumNulls(10);
-        Map<Slot, ColumnStat> slotColumnStatsMap = new HashMap<>();
+        columnStat2.setNumNulls(10);
+        Map<Slot, ColumnStat> slotColumnStatsMap = Maps.newHashMap();
         slotColumnStatsMap.put(slot1, columnStat1);
         slotColumnStatsMap.put(slot2, columnStat2);
         StatsDeriveResult childStats = new StatsDeriveResult(10000, slotColumnStatsMap);
@@ -131,16 +125,11 @@ public class StatsCalculatorTest {
         Or or = new Or(eq1, eq2);
 
         Group childGroup = new Group();
-        childGroup.setLogicalProperties(new LogicalProperties(new Supplier<List<Slot>>() {
-            @Override
-            public List<Slot> get() {
-                return Collections.emptyList();
-            }
-        }));
+        childGroup.setLogicalProperties(new LogicalProperties(Collections::emptyList));
         GroupPlan groupPlan = new GroupPlan(childGroup);
         childGroup.setStatistics(childStats);
 
-        LogicalFilter logicalFilter = new LogicalFilter(and, groupPlan);
+        LogicalFilter<GroupPlan> logicalFilter = new LogicalFilter<>(and, groupPlan);
         GroupExpression groupExpression = new GroupExpression(logicalFilter);
         groupExpression.addChild(childGroup);
         Group ownerGroup = new Group();
@@ -148,7 +137,7 @@ public class StatsCalculatorTest {
         StatsCalculator.estimate(groupExpression);
         Assertions.assertEquals((long) (10000 * 0.1 * 0.05), ownerGroup.getStatistics().getRowCount(), 0.001);
 
-        LogicalFilter logicalFilterOr = new LogicalFilter(or, groupPlan);
+        LogicalFilter<GroupPlan> logicalFilterOr = new LogicalFilter<>(or, groupPlan);
         GroupExpression groupExpressionOr = new GroupExpression(logicalFilterOr);
         groupExpressionOr.addChild(childGroup);
         Group ownerGroupOr = new Group();
@@ -197,7 +186,10 @@ public class StatsCalculatorTest {
     // }
 
     @Test
-    public void testOlapScan() {
+    public void testOlapScan(
+            @Mocked ConnectContext context,
+            @Mocked Env env,
+            @Mocked StatisticsManager statisticsManager) {
         ColumnStat columnStat1 = new ColumnStat();
         columnStat1.setNdv(10);
         columnStat1.setNumNulls(5);
@@ -209,10 +201,10 @@ public class StatsCalculatorTest {
         List<String> qualifier = ImmutableList.of("test", "t");
         SlotReference slot1 = new SlotReference("c1", IntegerType.INSTANCE, true, qualifier);
         new Expectations() {{
-                ConnectContext.get();
-                result = context;
-                context.getEnv();
-                result = env;
+//                ConnectContext.get();
+//                result = context;
+//                context.getEnv();
+//                result = env;
                 env.getStatisticsManager();
                 result = statisticsManager;
                 statisticsManager.getStatistics();

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/util/MemoTestUtils.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/util/MemoTestUtils.java
@@ -50,7 +50,9 @@ public class MemoTestUtils {
     }
 
     public static StatementContext createStatementContext(ConnectContext connectContext, String sql) {
-        return new StatementContext(connectContext, new OriginStatement(sql, 0));
+        StatementContext statementContext = new StatementContext(connectContext, new OriginStatement(sql, 0));
+        connectContext.setStatementContext(statementContext);
+        return statementContext;
     }
 
     public static CascadesContext createCascadesContext(String sql) {

--- a/fe/fe-core/src/test/java/org/apache/doris/utframe/TestWithFeService.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/utframe/TestWithFeService.java
@@ -149,7 +149,9 @@ public abstract class TestWithFeService {
     }
 
     protected StatementContext createStatementCtx(String sql) {
-        return new StatementContext(connectContext, new OriginStatement(sql, 0));
+        StatementContext statementContext = new StatementContext(connectContext, new OriginStatement(sql, 0));
+        connectContext.setStatementContext(statementContext);
+        return statementContext;
     }
 
     protected CascadesContext createCascadesContext(String sql) {


### PR DESCRIPTION
# Proposed changes

Currently, ExprId in Nereids is generated by a global gnerator and shared by all statement. There are three problems:
1. ExprId could out of bound
2. hard to debug
3. could not use bitset to present ExprId set

This PR solve this problem by new Id generator for each statement. after this PR ExprId always start from 0 for each statement.

TODO:
1. refactor all place that new StatementContext in test code to ensure the logic is same with main code.

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
5. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
6. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
7. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
8. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

