### PR TITLE
[branch-1.1-lts](memtracker) Fix mem hook cancel query

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -632,7 +632,10 @@ CONF_Int16(mem_tracker_level, "0");
 // Whether Hook TCmalloc new/delete, currently consume/release tls mem tracker in Hook.
 CONF_Bool(enable_tcmalloc_hook, "true");
 
-CONF_Bool(enable_cancel_query, "false");
+// Cancel query if the process physical memory recorded in `/proc/mem_info` exceeds the limit.
+CONF_Bool(enable_proc_meminfo_cancel_query, "false");
+// Cancel query if query mem tracker exceeds the limit.
+CONF_Bool(enable_mem_tracker_cancel_query, "false");
 
 // If true, switch TLS MemTracker to count more detailed memory,
 // including caches such as ExecNode operators and TabletManager.

--- a/be/src/runtime/mem_tracker.h
+++ b/be/src/runtime/mem_tracker.h
@@ -173,7 +173,7 @@ public:
         // This is independent of the consumption value of the mem tracker, which counts the virtual memory
         // of the process malloc.
         // for fast, expect MemInfo::initialized() to be true.
-        if (PerfCounters::get_vm_rss() + bytes >= MemInfo::mem_limit() && config::enable_cancel_query) {
+        if (PerfCounters::get_vm_rss() + bytes >= MemInfo::mem_limit()) {
             return Status::MemoryLimitExceeded(fmt::format(
                     "{}: TryConsume failed, bytes={} process whole consumption={}  mem limit={}",
                     label_, bytes, MemInfo::current_mem(), MemInfo::mem_limit()));

--- a/be/src/runtime/memory/thread_mem_tracker_mgr.cpp
+++ b/be/src/runtime/memory/thread_mem_tracker_mgr.cpp
@@ -45,7 +45,7 @@ void ThreadMemTrackerMgr::detach_limiter_tracker() {
 }
 
 void ThreadMemTrackerMgr::exceeded_cancel_task(const std::string& cancel_details) {
-    if (_fragment_instance_id_stack.back() != TUniqueId() && config::enable_cancel_query) {
+    if (_fragment_instance_id_stack.back() != TUniqueId()) {
         ExecEnv::GetInstance()->fragment_mgr()->cancel(
                 _fragment_instance_id_stack.back(), PPlanFragmentCancelReason::MEMORY_LIMIT_EXCEED,
                 cancel_details);

--- a/be/src/runtime/runtime_state.cpp
+++ b/be/src/runtime/runtime_state.cpp
@@ -322,7 +322,7 @@ Status RuntimeState::set_mem_limit_exceeded(const std::string& msg) {
 Status RuntimeState::check_query_state(const std::string& msg) {
     // TODO: it would be nice if this also checked for cancellation, but doing so breaks
     // cases where we use Status::Cancelled("Cancelled") to indicate that the limit was reached.
-    if (config::enable_cancel_query) RETURN_IF_LIMIT_EXCEEDED(this, msg);
+    if (config::enable_mem_tracker_cancel_query) RETURN_IF_LIMIT_EXCEEDED(this, msg);
     return query_status();
 }
 

--- a/be/test/runtime/mem_limit_test.cpp
+++ b/be/test/runtime/mem_limit_test.cpp
@@ -24,7 +24,7 @@
 namespace doris {
 
 TEST(MemTrackerTest, SingleTrackerNoLimit) {
-    config::enable_cancel_query = true;
+    config::enable_mem_tracker_cancel_query = true;
     auto t = MemTracker::CreateTracker();
     EXPECT_FALSE(t->has_limit());
     t->Consume(10);
@@ -38,7 +38,7 @@ TEST(MemTrackerTest, SingleTrackerNoLimit) {
 }
 
 TEST(MemTestTest, SingleTrackerWithLimit) {
-    config::enable_cancel_query = true;
+    config::enable_mem_tracker_cancel_query = true;
     auto t = MemTracker::CreateTracker(11, "limit tracker");
     EXPECT_TRUE(t->has_limit());
     t->Consume(10);
@@ -54,7 +54,7 @@ TEST(MemTestTest, SingleTrackerWithLimit) {
 }
 
 TEST(MemTestTest, TrackerHierarchy) {
-    config::enable_cancel_query = true;
+    config::enable_mem_tracker_cancel_query = true;
     auto p = MemTracker::CreateTracker(100);
     auto c1 = MemTracker::CreateTracker(80, "c1", p);
     auto c2 = MemTracker::CreateTracker(50, "c2", p);
@@ -98,7 +98,7 @@ TEST(MemTestTest, TrackerHierarchy) {
 }
 
 TEST(MemTestTest, TrackerHierarchyTryConsume) {
-    config::enable_cancel_query = true;
+    config::enable_mem_tracker_cancel_query = true;
     auto p = MemTracker::CreateTracker(100);
     auto c1 = MemTracker::CreateTracker(80, "c1", p);
     auto c2 = MemTracker::CreateTracker(50, "c2", p);


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

Allow independent enable based on `proc/mem_info` check mem limit and cancel query

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

