### PR TITLE
[fix](memory) Fix `USE_JEMALLOC=true` UBSAN compilation error

### DIFF
--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -756,22 +756,22 @@ set(DORIS_LINK_LIBS ${DORIS_LINK_LIBS}
     -lresolv
 )
 
-if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-    set(ASAN_LIBS -static-libasan)
-    set(LSAN_LIBS -static-liblsan)
-    set(UBSAN_LIBS -static-libubsan tcmalloc)
-    set(TSAN_LIBS -static-libtsan)
-else ()
-    set(UBSAN_LIBS -rtlib=compiler-rt tcmalloc)
-endif ()
-
 if (USE_JEMALLOC)
     set(MALLOCLIB jemalloc)
 else ()
     set(MALLOCLIB tcmalloc)
 endif()
 
-# Add sanitize static link flags or tcmalloc
+if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+    set(ASAN_LIBS -static-libasan)
+    set(LSAN_LIBS -static-liblsan)
+    set(UBSAN_LIBS -static-libubsan ${MALLOCLIB})
+    set(TSAN_LIBS -static-libtsan)
+else ()
+    set(UBSAN_LIBS -rtlib=compiler-rt ${MALLOCLIB})
+endif ()
+
+# Add sanitize static link flags
 if ("${CMAKE_BUILD_TYPE}" STREQUAL "DEBUG" OR "${CMAKE_BUILD_TYPE}" STREQUAL "RELEASE")
     set(DORIS_LINK_LIBS ${DORIS_LINK_LIBS} ${MALLOCLIB})
 elseif ("${CMAKE_BUILD_TYPE}" STREQUAL "ASAN")


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

```
ld.lld: error: duplicate symbol: valloc
>>> defined at jemalloc_hook.cpp:91 (/mnt/disk1/liyifan/doris/core/be/src/runtime/memory/jemalloc_hook.cpp:91)
>>>            jemalloc_hook.cpp.o:(doris_valloc) in archive src/runtime/libRuntime.a
>>> defined at tcmalloc.cc:2185 (src/tcmalloc.cc:2185)
>>>            libtcmalloc_la-tcmalloc.o:(tc_valloc) in archive /mnt/disk1/liyifan/doris/core/thirdparty/installed//gperftools/lib/libtcmalloc.a
```

## Checklist(Required)

1. Does it affect the original behavior: 
    - [x] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

