### PR TITLE
[fix](mem) failure of allocating memory(ASAN)

### DIFF
--- a/be/src/runtime/mem_pool.h
+++ b/be/src/runtime/mem_pool.h
@@ -231,16 +231,17 @@ private:
         // I refers to https://github.com/mcgov/asan_alignment_example.
 
         ChunkInfo& info = chunks_[current_chunk_idx_];
-        int64_t aligned_allocated_bytes = BitUtil::RoundUpToMultiplyOfFactor(
-                info.allocated_bytes + DEFAULT_PADDING_SIZE, alignment);
-        if (aligned_allocated_bytes + size + DEFAULT_PADDING_SIZE <= info.chunk.size) {
+        int64_t aligned_allocated_bytes =
+                BitUtil::RoundUpToMultiplyOfFactor(info.allocated_bytes, alignment);
+        auto size_with_padding = size + DEFAULT_PADDING_SIZE;
+        if (aligned_allocated_bytes + size_with_padding <= info.chunk.size) {
             // Ensure the requested alignment is respected.
             int64_t padding = aligned_allocated_bytes - info.allocated_bytes;
             uint8_t* result = info.chunk.data + aligned_allocated_bytes;
-            ASAN_UNPOISON_MEMORY_REGION(result, size);
-            DCHECK_LE(info.allocated_bytes + size, info.chunk.size);
-            info.allocated_bytes += padding + size;
-            total_allocated_bytes_ += padding + size;
+            ASAN_UNPOISON_MEMORY_REGION(result, size_with_padding);
+            DCHECK_LE(info.allocated_bytes + size_with_padding, info.chunk.size);
+            info.allocated_bytes += padding + size_with_padding;
+            total_allocated_bytes_ += padding + size_with_padding;
             DCHECK_LE(current_chunk_idx_, chunks_.size() - 1);
             return result;
         }


### PR DESCRIPTION
# Proposed changes

When the target size to allocate is 8164, MemPool will return nullptr.

```bash
0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /home/zcp/repo_center/doris_master/be/src/common/signal_handler.h:420
 1# 0x00007F44CF126090 in /lib/x86_64-linux-gnu/libc.so.6
 2# doris::vectorized::ColumnNullable::serialize_vec(std::vector<StringRef, std::allocator<StringRef> >&, unsigned long, unsigned long) const at /home/zcp/repo_center/doris_maste
r/be/src/vec/columns/column_nullable.cpp:216
 3# doris::vectorized::AggregationMethodSerialized<PHHashMap<StringRef, char*, DefaultHash<StringRef, void>, false> >::serialize_keys(std::vector<doris::vectorized::IColumn const
*, std::allocator<doris::vectorized::IColumn const*> > const&, unsigned long) at /home/zcp/repo_center/doris_master/be/src/vec/exec/vaggregation_node.h:86
 4# void doris::vectorized::AggregationNode::_pre_serialize_key_if_need<doris::vectorized::ColumnsHashing::HashMethodSerialized<std::pair<StringRef const, char*>, char*, true>, d
oris::vectorized::AggregationMethodSerialized<PHHashMap<StringRef, char*, DefaultHash<StringRef, void>, false> > >(doris::vectorized::ColumnsHashing::HashMethodSerialized<std::pa
ir<StringRef const, char*>, char*, true>&, doris::vectorized::AggregationMethodSerialized<PHHashMap<StringRef, char*, DefaultHash<StringRef, void>, false> >&, std::vector<doris::
vectorized::IColumn const*, std::allocator<doris::vectorized::IColumn const*> > const&, unsigned long) at /home/zcp/repo_center/doris_master/be/src/vec/exec/vaggregation_node.h:8
51
 5# void doris::vectorized::AggregationNode::_emplace_into_hash_table(char**, std::vector<doris::vectorized::IColumn const*, std::allocator<doris::vectorized::IColumn const*> >&,
 unsigned long)::{lambda(auto:1&&)#1}::operator()<doris::vectorized::AggregationMethodSerialized<PHHashMap<StringRef, char*, DefaultHash<StringRef, void>, false> >&>(doris::vecto
rized::AggregationMethodSerialized<PHHashMap<StringRef, char*, DefaultHash<StringRef, void>, false> >&) const at /home/zcp/repo_center/doris_master/be/src/vec/exec/vaggregation_n
ode.cpp:792
 6# void std::__invoke_impl<void, doris::vectorized::AggregationNode::_emplace_into_hash_table(char**, std::vector<doris::vectorized::IColumn const*, std::allocator<doris::vector
ized::IColumn const*> >&, unsigned long)::{lambda(auto:1&&)#1}, doris::vectorized::AggregationMethodSerialized<PHHashMap<StringRef, char*, DefaultHash<StringRef, void>, false> >&
>(std::__invoke_other, doris::vectorized::AggregationNode::_emplace_into_hash_table(char**, std::vector<doris::vectorized::IColumn const*, std::allocator<doris::vectorized::IColu
mn const*> >&, unsigned long)::{lambda(auto:1&&)#1}&&, doris::vectorized::AggregationMethodSerialized<PHHashMap<StringRef, char*, DefaultHash<StringRef, void>, false> >&) at /var
/local/ldb_toolchain/include/c++/11/bits/invoke.h:61
 7# std::__invoke_result<doris::vectorized::AggregationNode::_emplace_into_hash_table(char**, std::vector<doris::vectorized::IColumn const*, std::allocator<doris::vectorized::ICo
lumn const*> >&, unsigned long)::{lambda(auto:1&&)#1}, doris::vectorized::AggregationMethodSerialized<PHHashMap<StringRef, char*, DefaultHash<StringRef, void>, false> >&>::type s
td::__invoke<doris::vectorized::AggregationNode::_emplace_into_hash_table(char**, std::vector<doris::vectorized::IColumn const*, std::allocator<doris::vectorized::IColumn const*>
 >&, unsigned long)::{lambda(auto:1&&)#1}, doris::vectorized::AggregationMethodSerialized<PHHashMap<StringRef, char*, DefaultHash<StringRef, void>, false> >&>(doris::vectorized::
AggregationNode::_emplace_into_hash_table(char**, std::vector<doris::vectorized::IColumn const*, std::allocator<doris::vectorized::IColumn const*> >&, unsigned long)::{lambda(aut
o:1&&)#1}&&, doris::vectorized::AggregationMethodSerialized<PHHashMap<StringRef, char*, DefaultHash<StringRef, void>, false> >&) at /var/local/ldb_toolchain/include/c++/11/bits/i
nvoke.h:97
 8# _ZNSt8__detail9__variant17__gen_vtable_implINS0_12_Multi_arrayIPFNS0_21__deduce_visit_resultIvEEOZN5doris10vectorized15AggregationNode24_emplace_into_hash_tableEPPcRSt6vector
IPKNS6_7IColumnESaISD_EEmEUlOT_E_RSt7variantIJNS6_27AggregationMethodSerializedI9PHHashMapI9StringRefS8_11DefaultHashISO_vELb0EEEENS6_26AggregationMethodOneNumberIh12FixedHashMap
IhS8_28FixedHashMapImplicitZeroCellIhS8_16HashTableNoStateE28FixedHashTableCalculatedSizeISX_E9AllocatorILb1ELb1EEELb0EEENST_ItSU_ItS8_SV_ItS8_SW_E24FixedHashTableStoredSizeIS14_
ES11_ELb0EEENST_IjSN_IjS8_9HashCRC32IjELb0EELb0EEENST_ImSN_ImS8_S19_ImELb0EELb0EEENS6_30AggregationMethodStringNoCacheI13StringHashMapIS8_S11_EEENST_INS6_7UInt128ESN_IS1K_S8_S19_
IS1K_ELb0EELb0EEENST_IjSN_IjS8_14HashMixWrapperIjS1A_ELb0EELb0EEENST_ImSN_ImS8_S1O_ImS1D_ELb0EELb0EEENST_IS1K_SN_IS1K_S8_S1O_IS1K_S1L_ELb0EELb0EEENS6_37AggregationMethodSingleNul
lableColumnINST_IhNS6_26AggregationDataWithNullKeyIS12_EELb0EEEEENS1Y_INST_ItNS1Z_IS17_EELb0EEEEENS1Y_INST_IjNS1Z_IS1B_EELb0EEEEENS1Y_INST_ImNS1Z_IS1E_EELb0EEEEENS1Y_INST_IjNS1Z_
IS1Q_EELb0EEEEENS1Y_INST_ImNS1Z_IS1T_EELb0EEEEENS1Y_INST_IS1K_NS1Z_IS1M_EELb0EEEEENS1Y_INST_IS1K_NS1Z_IS1W_EELb0EEEEENS1Y_INS1G_INS1Z_IS1I_EEEEEENS6_26AggregationMethodKeysFixedI
S1E_Lb0EEENS2R_IS1E_Lb1EEENS2R_IS1M_Lb0EEENS2R_IS1M_Lb1EEENS2R_ISN_INS6_7UInt256ES8_S19_IS2W_ELb0EELb0EEENS2R_IS2Y_Lb1EEENS2R_IS1T_Lb0EEENS2R_IS1T_Lb1EEENS2R_IS1W_Lb0EEENS2R_IS1W
_Lb1EEENS2R_ISN_IS2W_S8_S1O_IS2W_S2X_ELb0EELb0EEENS2R_IS36_Lb1EEEEEEJEEESt16integer_sequenceImJLm0EEEE14__visit_invokeESK_S3A_ at /var/local/ldb_toolchain/include/c++/11/variant:
1015
 9# _ZSt10__do_visitINSt8__detail9__variant21__deduce_visit_resultIvEEZN5doris10vectorized15AggregationNode24_emplace_into_hash_tableEPPcRSt6vectorIPKNS5_7IColumnESaISC_EEmEUlOT_
E_JRSt7variantIJNS5_27AggregationMethodSerializedI9PHHashMapI9StringRefS7_11DefaultHashISM_vELb0EEEENS5_26AggregationMethodOneNumberIh12FixedHashMapIhS7_28FixedHashMapImplicitZer
oCellIhS7_16HashTableNoStateE28FixedHashTableCalculatedSizeISV_E9AllocatorILb1ELb1EEELb0EEENSR_ItSS_ItS7_ST_ItS7_SU_E24FixedHashTableStoredSizeIS12_ESZ_ELb0EEENSR_IjSL_IjS7_9Hash
CRC32IjELb0EELb0EEENSR_ImSL_ImS7_S17_ImELb0EELb0EEENS5_30AggregationMethodStringNoCacheI13StringHashMapIS7_SZ_EEENSR_INS5_7UInt128ESL_IS1I_S7_S17_IS1I_ELb0EELb0EEENSR_IjSL_IjS7_1
4HashMixWrapperIjS18_ELb0EELb0EEENSR_ImSL_ImS7_S1M_ImS1B_ELb0EELb0EEENSR_IS1I_SL_IS1I_S7_S1M_IS1I_S1J_ELb0EELb0EEENS5_37AggregationMethodSingleNullableColumnINSR_IhNS5_26Aggregat
ionDataWithNullKeyIS10_EELb0EEEEENS1W_INSR_ItNS1X_IS15_EELb0EEEEENS1W_INSR_IjNS1X_IS19_EELb0EEEEENS1W_INSR_ImNS1X_IS1C_EELb0EEEEENS1W_INSR_IjNS1X_IS1O_EELb0EEEEENS1W_INSR_ImNS1X_
IS1R_EELb0EEEEENS1W_INSR_IS1I_NS1X_IS1K_EELb0EEEEENS1W_INSR_IS1I_NS1X_IS1U_EELb0EEEEENS1W_INS1E_INS1X_IS1G_EEEEEENS5_26AggregationMethodKeysFixedIS1C_Lb0EEENS2P_IS1C_Lb1EEENS2P_I
S1K_Lb0EEENS2P_IS1K_Lb1EEENS2P_ISL_INS5_7UInt256ES7_S17_IS2U_ELb0EELb0EEENS2P_IS2W_Lb1EEENS2P_IS1R_Lb0EEENS2P_IS1R_Lb1EEENS2P_IS1U_Lb0EEENS2P_IS1U_Lb1EEENS2P_ISL_IS2U_S7_S1M_IS2U
_S2V_ELb0EELb0EEENS2P_IS34_Lb1EEEEEEEDcOT0_DpOT1_ at /var/local/ldb_toolchain/include/c++/11/variant:1715
10# _ZSt5visitIZN5doris10vectorized15AggregationNode24_emplace_into_hash_tableEPPcRSt6vectorIPKNS1_7IColumnESaIS8_EEmEUlOT_E_JRSt7variantIJNS1_27AggregationMethodSerializedI9PHHa
shMapI9StringRefS3_11DefaultHashISI_vELb0EEEENS1_26AggregationMethodOneNumberIh12FixedHashMapIhS3_28FixedHashMapImplicitZeroCellIhS3_16HashTableNoStateE28FixedHashTableCalculated
SizeISR_E9AllocatorILb1ELb1EEELb0EEENSN_ItSO_ItS3_SP_ItS3_SQ_E24FixedHashTableStoredSizeISY_ESV_ELb0EEENSN_IjSH_IjS3_9HashCRC32IjELb0EELb0EEENSN_ImSH_ImS3_S13_ImELb0EELb0EEENS1_3
0AggregationMethodStringNoCacheI13StringHashMapIS3_SV_EEENSN_INS1_7UInt128ESH_IS1E_S3_S13_IS1E_ELb0EELb0EEENSN_IjSH_IjS3_14HashMixWrapperIjS14_ELb0EELb0EEENSN_ImSH_ImS3_S1I_ImS17
_ELb0EELb0EEENSN_IS1E_SH_IS1E_S3_S1I_IS1E_S1F_ELb0EELb0EEENS1_37AggregationMethodSingleNullableColumnINSN_IhNS1_26AggregationDataWithNullKeyISW_EELb0EEEEENS1S_INSN_ItNS1T_IS11_EE
Lb0EEEEENS1S_INSN_IjNS1T_IS15_EELb0EEEEENS1S_INSN_ImNS1T_IS18_EELb0EEEEENS1S_INSN_IjNS1T_IS1K_EELb0EEEEENS1S_INSN_ImNS1T_IS1N_EELb0EEEEENS1S_INSN_IS1E_NS1T_IS1G_EELb0EEEEENS1S_IN
SN_IS1E_NS1T_IS1Q_EELb0EEEEENS1S_INS1A_INS1T_IS1C_EEEEEENS1_26AggregationMethodKeysFixedIS18_Lb0EEENS2L_IS18_Lb1EEENS2L_IS1G_Lb0EEENS2L_IS1G_Lb1EEENS2L_ISH_INS1_7UInt256ES3_S13_I
S2Q_ELb0EELb0EEENS2L_IS2S_Lb1EEENS2L_IS1N_Lb0EEENS2L_IS1N_Lb1EEENS2L_IS1Q_Lb0EEENS2L_IS1Q_Lb1EEENS2L_ISH_IS2Q_S3_S1I_IS2Q_S2R_ELb0EELb0EEENS2L_IS30_Lb1EEEEEEEDcSD_DpOT0_ at /var/
local/ldb_toolchain/include/c++/11/variant:1766
11# doris::vectorized::AggregationNode::_emplace_into_hash_table(char**, std::vector<doris::vectorized::IColumn const*, std::allocator<doris::vectorized::IColumn const*> >&, unsi
gned long) at /home/zcp/repo_center/doris_master/be/src/vec/exec/vaggregation_node.cpp:877
12# doris::vectorized::AggregationNode::_pre_agg_with_serialized_key(doris::vectorized::Block*, doris::vectorized::Block*) at /home/zcp/repo_center/doris_master/be/src/vec/exec/v
aggregation_node.cpp:1055
13# doris::Status std::__invoke_impl<doris::Status, doris::Status (doris::vectorized::AggregationNode::*&)(doris::vectorized::Block*, doris::vectorized::Block*), doris::vectorize
d::AggregationNode*&, doris::vectorized::Block*, doris::vectorized::Block*>(std::__invoke_memfun_deref, doris::Status (doris::vectorized::AggregationNode::*&)(doris::vectorized::
Block*, doris::vectorized::Block*), doris::vectorized::AggregationNode*&, doris::vectorized::Block*&&, doris::vectorized::Block*&&) at /var/local/ldb_toolchain/include/c++/11/bit
s/invoke.h:75
14# std::enable_if<is_invocable_r_v<doris::Status, doris::Status (doris::vectorized::AggregationNode::*&)(doris::vectorized::Block*, doris::vectorized::Block*), doris::vectorized
::AggregationNode*&, doris::vectorized::Block*, doris::vectorized::Block*>, doris::Status>::type std::__invoke_r<doris::Status, doris::Status (doris::vectorized::AggregationNode:
:*&)(doris::vectorized::Block*, doris::vectorized::Block*), doris::vectorized::AggregationNode*&, doris::vectorized::Block*, doris::vectorized::Block*>(doris::Status (doris::vect
orized::AggregationNode::*&)(doris::vectorized::Block*, doris::vectorized::Block*), doris::vectorized::AggregationNode*&, doris::vectorized::Block*&&, doris::vectorized::Block*&&
) at /var/local/ldb_toolchain/include/c++/11/bits/invoke.h:117
15# doris::Status std::_Bind_result<doris::Status, doris::Status (doris::vectorized::AggregationNode::*(doris::vectorized::AggregationNode*, std::_Placeholder<1>, std::_Placehold
er<2>))(doris::vectorized::Block*, doris::vectorized::Block*)>::__call<doris::Status, doris::vectorized::Block*&&, doris::vectorized::Block*&&, 0ul, 1ul, 2ul>(std::tuple<doris::v
ectorized::Block*&&, doris::vectorized::Block*&&>&&, std::_Index_tuple<0ul, 1ul, 2ul>) at /var/local/ldb_toolchain/include/c++/11/functional:568
16# doris::Status std::_Bind_result<doris::Status, doris::Status (doris::vectorized::AggregationNode::*(doris::vectorized::AggregationNode*, std::_Placeholder<1>, std::_Placehold
er<2>))(doris::vectorized::Block*, doris::vectorized::Block*)>::operator()<doris::vectorized::Block*, doris::vectorized::Block*>(doris::vectorized::Block*&&, doris::vectorized::B
lock*&&) at /var/local/ldb_toolchain/include/c++/11/functional:627
17# doris::Status std::__invoke_impl<doris::Status, std::_Bind_result<doris::Status, doris::Status (doris::vectorized::AggregationNode::*(doris::vectorized::AggregationNode*, std
::_Placeholder<1>, std::_Placeholder<2>))(doris::vectorized::Block*, doris::vectorized::Block*)>&, doris::vectorized::Block*, doris::vectorized::Block*>(std::__invoke_other, std:
:_Bind_result<doris::Status, doris::Status (doris::vectorized::AggregationNode::*(doris::vectorized::AggregationNode*, std::_Placeholder<1>, std::_Placeholder<2>))(doris::vectori
zed::Block*, doris::vectorized::Block*)>&, doris::vectorized::Block*&&, doris::vectorized::Block*&&) at /var/local/ldb_toolchain/include/c++/11/bits/invoke.h:61
18# std::enable_if<is_invocable_r_v<doris::Status, std::_Bind_result<doris::Status, doris::Status (doris::vectorized::AggregationNode::*(doris::vectorized::AggregationNode*, std:
:_Placeholder<1>, std::_Placeholder<2>))(doris::vectorized::Block*, doris::vectorized::Block*)>&, doris::vectorized::Block*, doris::vectorized::Block*>, doris::Status>::type std:
:__invoke_r<doris::Status, std::_Bind_result<doris::Status, doris::Status (doris::vectorized::AggregationNode::*(doris::vectorized::AggregationNode*, std::_Placeholder<1>, std::_
Placeholder<2>))(doris::vectorized::Block*, doris::vectorized::Block*)>&, doris::vectorized::Block*, doris::vectorized::Block*>(std::_Bind_result<doris::Status, doris::Status (do
17# doris::Status std::__invoke_impl<doris::Status, std::_Bind_result<doris::Status, doris::Status (doris::vectorized::AggregationNode::*(doris::vectorized::AggregationNode*, std
::_Placeholder<1>, std::_Placeholder<2>))(doris::vectorized::Block*, doris::vectorized::Block*)>&, doris::vectorized::Block*, doris::vectorized::Block*>(std::__invoke_other, std:
:_Bind_result<doris::Status, doris::Status (doris::vectorized::AggregationNode::*(doris::vectorized::AggregationNode*, std::_Placeholder<1>, std::_Placeholder<2>))(doris::vectori
zed::Block*, doris::vectorized::Block*)>&, doris::vectorized::Block*&&, doris::vectorized::Block*&&) at /var/local/ldb_toolchain/include/c++/11/bits/invoke.h:61
18# std::enable_if<is_invocable_r_v<doris::Status, std::_Bind_result<doris::Status, doris::Status (doris::vectorized::AggregationNode::*(doris::vectorized::AggregationNode*, std:
:_Placeholder<1>, std::_Placeholder<2>))(doris::vectorized::Block*, doris::vectorized::Block*)>&, doris::vectorized::Block*, doris::vectorized::Block*>, doris::Status>::type std:
:__invoke_r<doris::Status, std::_Bind_result<doris::Status, doris::Status (doris::vectorized::AggregationNode::*(doris::vectorized::AggregationNode*, std::_Placeholder<1>, std::_
Placeholder<2>))(doris::vectorized::Block*, doris::vectorized::Block*)>&, doris::vectorized::Block*, doris::vectorized::Block*>(std::_Bind_result<doris::Status, doris::Status (do
ris::vectorized::AggregationNode::*(doris::vectorized::AggregationNode*, std::_Placeholder<1>, std::_Placeholder<2>))(doris::vectorized::Block*, doris::vectorized::Block*)>&, dor
is::vectorized::Block*&&, doris::vectorized::Block*&&) at /var/local/ldb_toolchain/include/c++/11/bits/invoke.h:117
19# std::_Function_handler<doris::Status (doris::vectorized::Block*, doris::vectorized::Block*), std::_Bind_result<doris::Status, doris::Status (doris::vectorized::AggregationNod
e::*(doris::vectorized::AggregationNode*, std::_Placeholder<1>, std::_Placeholder<2>))(doris::vectorized::Block*, doris::vectorized::Block*)> >::_M_invoke(std::_Any_data const&,
doris::vectorized::Block*&&, doris::vectorized::Block*&&) at /var/local/ldb_toolchain/include/c++/11/bits/std_function.h:293
20# std::function<doris::Status (doris::vectorized::Block*, doris::vectorized::Block*)>::operator()(doris::vectorized::Block*, doris::vectorized::Block*) const at /var/local/ldb_
toolchain/include/c++/11/bits/std_function.h:556
21# doris::vectorized::AggregationNode::get_next(doris::RuntimeState*, doris::vectorized::Block*, bool*) at /home/zcp/repo_center/doris_master/be/src/vec/exec/vaggregation_node.c
pp:502
22# doris::ExecNode::get_next_after_projects(doris::RuntimeState*, doris::vectorized::Block*, bool*) at /home/zcp/repo_center/doris_master/be/src/exec/exec_node.cpp:863
23# doris::PlanFragmentExecutor::get_vectorized_internal(doris::vectorized::Block**) at /home/zcp/repo_center/doris_master/be/src/runtime/plan_fragment_executor.cpp:349
24# doris::PlanFragmentExecutor::open_vectorized_internal() at /home/zcp/repo_center/doris_master/be/src/runtime/plan_fragment_executor.cpp:297
25# doris::PlanFragmentExecutor::open() at /home/zcp/repo_center/doris_master/be/src/runtime/plan_fragment_executor.cpp:252
26# doris::FragmentExecState::execute() at /home/zcp/repo_center/doris_master/be/src/runtime/fragment_mgr.cpp:253
27# doris::FragmentMgr::_exec_actual(std::shared_ptr<doris::FragmentExecState>, std::function<void (doris::PlanFragmentExecutor*)>) at /home/zcp/repo_center/doris_master/be/src/r
untime/fragment_mgr.cpp:499
28# doris::FragmentMgr::exec_plan_fragment(doris::TExecPlanFragmentParams const&, std::function<void (doris::PlanFragmentExecutor*)>)::{lambda()#1}::operator()() const at /home/z
cp/repo_center/doris_master/be/src/runtime/fragment_mgr.cpp:706
29# void std::__invoke_impl<void, doris::FragmentMgr::exec_plan_fragment(doris::TExecPlanFragmentParams const&, std::function<void (doris::PlanFragmentExecutor*)>)::{lambda()#1}&
>(std::__invoke_other, doris::FragmentMgr::exec_plan_fragment(doris::TExecPlanFragmentParams const&, std::function<void (doris::PlanFragmentExecutor*)>)::{lambda()#1}&) at /var/l
ocal/ldb_toolchain/include/c++/11/bits/invoke.h:61
30# std::enable_if<is_invocable_r_v<void, doris::FragmentMgr::exec_plan_fragment(doris::TExecPlanFragmentParams const&, std::function<void (doris::PlanFragmentExecutor*)>)::{lamb
da()#1}&>, void>::type std::__invoke_r<void, doris::FragmentMgr::exec_plan_fragment(doris::TExecPlanFragmentParams const&, std::function<void (doris::PlanFragmentExecutor*)>)::{l
ambda()#1}&>(doris::FragmentMgr::exec_plan_fragment(doris::TExecPlanFragmentParams const&, std::function<void (doris::PlanFragmentExecutor*)>)::{lambda()#1}&) at /var/local/ldb_t
oolchain/include/c++/11/bits/invoke.h:117
31# std::_Function_handler<void (), doris::FragmentMgr::exec_plan_fragment(doris::TExecPlanFragmentParams const&, std::function<void (doris::PlanFragmentExecutor*)>)::{lambda()#1
}>::_M_invoke(std::_Any_data const&) at /var/local/ldb_toolchain/include/c++/11/bits/std_function.h:292
32# std::function<void ()>::operator()() const at /var/local/ldb_toolchain/include/c++/11/bits/std_function.h:560
33# doris::FunctionRunnable::run() at /home/zcp/repo_center/doris_master/be/src/util/threadpool.cpp:45
34# doris::ThreadPool::dispatch_thread() at /home/zcp/repo_center/doris_master/be/src/util/threadpool.cpp:548
35# void std::__invoke_impl<void, void (doris::ThreadPool::*&)(), doris::ThreadPool*&>(std::__invoke_memfun_deref, void (doris::ThreadPool::*&)(), doris::ThreadPool*&) at /var/lo
cal/ldb_toolchain/include/c++/11/bits/invoke.h:74
36# std::__invoke_result<void (doris::ThreadPool::*&)(), doris::ThreadPool*&>::type std::__invoke<void (doris::ThreadPool::*&)(), doris::ThreadPool*&>(void (doris::ThreadPool::*&
)(), doris::ThreadPool*&) at /var/local/ldb_toolchain/include/c++/11/bits/invoke.h:97
37# void std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>::__call<void, , 0ul>(std::tuple<>&&, std::_Index_tuple<0ul>) at /var/local/ldb_toolchain/include/c++/11/fun
ctional:422
38# void std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>::operator()<, void>() at /var/local/ldb_toolchain/include/c++/11/functional:505
39# void std::__invoke_impl<void, std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>&>(std::__invoke_other, std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))(
)>&) at /var/local/ldb_toolchain/include/c++/11/bits/invoke.h:61
40# std::enable_if<is_invocable_r_v<void, std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>&>, void>::type std::__invoke_r<void, std::_Bind<void (doris::ThreadPool::*
(doris::ThreadPool*))()>&>(std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>&) at /var/local/ldb_toolchain/include/c++/11/bits/invoke.h:117
41# std::_Function_handler<void (), std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()> >::_M_invoke(std::_Any_data const&) at /var/local/ldb_toolchain/include/c++/11/b
its/std_function.h:292
42# std::function<void ()>::operator()() const at /var/local/ldb_toolchain/include/c++/11/bits/std_function.h:560
43# doris::Thread::supervise_thread(void*) at /home/zcp/repo_center/doris_master/be/src/util/thread.cpp:426
44# start_thread at /build/glibc-SzIz7B/glibc-2.31/nptl/pthread_create.c:478
45# __clone at ../sysdeps/unix/sysv/linux/x86_64/clone.S:97 
```

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

