### PR TITLE
[feature](nereids) Support authentication

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/batch/AnalyzeRulesJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/batch/AnalyzeRulesJob.java
@@ -24,6 +24,7 @@ import org.apache.doris.nereids.rules.analysis.BindSlotReference;
 import org.apache.doris.nereids.rules.analysis.ProjectToGlobalAggregate;
 import org.apache.doris.nereids.rules.analysis.ResolveHaving;
 import org.apache.doris.nereids.rules.analysis.Scope;
+import org.apache.doris.nereids.rules.analysis.UserAuthentication;
 
 import com.google.common.collect.ImmutableList;
 
@@ -44,6 +45,7 @@ public class AnalyzeRulesJob extends BatchRulesJob {
         rulesJob.addAll(ImmutableList.of(
                 bottomUpBatch(ImmutableList.of(
                         new BindRelation(),
+                        new UserAuthentication(),
                         new BindSlotReference(scope),
                         new BindFunction(),
                         new ResolveHaving(),

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/RuleType.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/RuleType.java
@@ -51,6 +51,8 @@ public enum RuleType {
     RESOLVE_AGGREGATE_ALIAS(RuleTypeClass.REWRITE),
     PROJECT_TO_GLOBAL_AGGREGATE(RuleTypeClass.REWRITE),
 
+    RELATION_AUTHENTICATION(RuleTypeClass.VALIDATION),
+
     // check analysis rule
     CHECK_ANALYSIS(RuleTypeClass.CHECK),
 
@@ -184,8 +186,10 @@ public enum RuleType {
     enum RuleTypeClass {
         REWRITE,
         EXPLORATION,
+        // This type is used for unit test only.
         CHECK,
         IMPLEMENTATION,
+        VALIDATION,
         SENTINEL,
         ;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/UserAuthentication.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/UserAuthentication.java
@@ -1,0 +1,52 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.rules.analysis;
+
+import org.apache.doris.common.ErrorCode;
+import org.apache.doris.mysql.privilege.PrivPredicate;
+import org.apache.doris.nereids.exceptions.AnalysisException;
+import org.apache.doris.nereids.rules.Rule;
+import org.apache.doris.nereids.rules.RuleType;
+import org.apache.doris.nereids.trees.plans.Plan;
+import org.apache.doris.nereids.trees.plans.logical.LogicalRelation;
+import org.apache.doris.qe.ConnectContext;
+
+/**
+ * Check whether a user is permitted to scan specific tables.
+ */
+public class UserAuthentication extends OneAnalysisRuleFactory {
+
+    @Override
+    public Rule build() {
+        return logicalRelation().thenApply(ctx -> checkPermission(ctx.root, ctx.connectContext))
+                .toRule(RuleType.RELATION_AUTHENTICATION);
+    }
+
+    private Plan checkPermission(LogicalRelation relation, ConnectContext connectContext) {
+        String dbName = !relation.getQualifier().isEmpty() ? relation.getQualifier().get(0) : null;
+        String tableName = relation.getTable().getName();
+        if (!connectContext.getEnv().getAuth().checkTblPriv(connectContext, dbName, tableName, PrivPredicate.SELECT)) {
+            String message = ErrorCode.ERR_TABLEACCESS_DENIED_ERROR.formatErrorMsg("SELECT",
+                    ConnectContext.get().getQualifiedUser(), ConnectContext.get().getRemoteIP(),
+                    dbName + ": " + tableName);
+            throw new AnalysisException(message);
+
+        }
+        return relation;
+    }
+}

--- a/regression-test/suites/account_p0/test_nereids_authentication.groovy
+++ b/regression-test/suites/account_p0/test_nereids_authentication.groovy
@@ -1,0 +1,83 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_nereids_authentication", "query") {
+    def create_table = { tableName ->
+        sql "DROP TABLE IF EXISTS ${tableName}"
+        sql """
+            CREATE TABLE ${tableName} (
+                `key` INT,
+                value INT
+            ) DUPLICATE KEY (`key`) DISTRIBUTED BY HASH (`key`) BUCKETS 1
+            PROPERTIES ('replication_num' = '1')
+        """
+    }
+
+    sql "set enable_nereids_planner = true"
+
+    def dbName = "nereids_authentication"
+    sql "DROP DATABASE IF EXISTS ${dbName}"
+    sql "CREATE DATABASE ${dbName}"
+    sql "USE ${dbName}"
+
+    def tableName1 = "accessible_table";
+    def tableName2 = "inaccessible_table";
+    create_table.call(tableName1);
+    create_table.call(tableName2);
+
+    def user='nereids_user'
+    try_sql "DROP USER ${user}"
+    sql "CREATE USER ${user} IDENTIFIED BY '123456'"
+    sql "GRANT SELECT_PRIV ON internal.${dbName}.${tableName1} TO ${user}"
+
+    def tokens = context.config.jdbcUrl.split('/')
+    def url=tokens[0] + "//" + tokens[2] + "/" + dbName + "?"
+    def result = connect(user=user, password='123456', url=url) {
+        sql "SELECT * FROM ${tableName1}"
+    }
+    assertEquals(result.size(), 0)
+
+    connect(user=user, password='123456', url=url) {
+        try {
+            sql "SELECT * FROM ${tableName2}"
+            fail()
+        } catch (Exception e) {
+            log.info(e.getMessage())
+            assertTrue(e.getMessage().contains('SELECT command denied to user'))
+        }
+    }
+
+    connect(user=user, password='123456', url=url) {
+        try {
+            sql "SELECT * FROM ${tableName1}, ${tableName2} WHERE ${tableName1}.`key` = ${tableName2}.`key`"
+            fail()
+        } catch (Exception e) {
+            log.info(e.getMessage())
+            assertTrue(e.getMessage().contains('SELECT command denied to user'))
+        }
+    }
+
+    sql "GRANT SELECT_PRIV ON internal.${dbName}.${tableName2} TO ${user}"
+    connect(user=user, password='123456', url=url) {
+        sql "SELECT * FROM ${tableName2}"
+    }
+    assertEquals(result.size(), 0)
+    connect(user=user, password='123456', url=url) {
+        sql "SELECT * FROM ${tableName1}, ${tableName2} WHERE ${tableName1}.`key` = ${tableName2}.`key`"
+    }
+    assertEquals(result.size(), 0)
+}


### PR DESCRIPTION
# Proposed changes

Add a rule to check the permission of a user who are executing a query. Forbid users who don't have `SELECT_PRIV` on some tables from executing queries on these tables.

## Problem summary

Currently, nereids planner doesn't authenticate the ones who execute queries.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [x] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

