### PR TITLE
[fix](array-type) fix the be core dump when import array by orc format

### DIFF
--- a/be/src/vec/exec/varrow_scanner.cpp
+++ b/be/src/vec/exec/varrow_scanner.cpp
@@ -153,7 +153,8 @@ Status VArrowScanner::_init_arrow_batch_if_necessary() {
 Status VArrowScanner::_init_src_block() {
     size_t batch_pos = 0;
     _src_block.clear();
-    for (auto i = 0; i < _num_of_columns_from_file; ++i) {
+    auto _num_of_columns = std::min(_num_of_columns_from_file, _batch->num_columns());
+    for (auto i = 0; i < _num_of_columns; ++i) {
         SlotDescriptor* slot_desc = _src_slot_descs[i];
         if (slot_desc == nullptr) {
             continue;


### PR DESCRIPTION
# Proposed changes
1. this pr is used to fix the be core dump when import array by orc format.
2. before the change, the be will core dump when import array by orc format.
    A typical scenario is that the number of columns from the file is not equal to the number of columns in the batch, and there will cause the out-of-bounds problem.
4. after the change, the be won't core dump when import array by orc format.

Issue Number: #7570

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
5. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
6. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
7. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
8. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

