### PR TITLE
fix(sec): upgrade org.apache.thrift:libthrift to 0.14.0

### DIFF
--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -188,7 +188,7 @@ under the License.
         <commons-io.version>2.6</commons-io.version>
         <json-simple.version>1.1.1</json-simple.version>
         <junit.version>5.8.2</junit.version>
-        <thrift.version>0.13.0</thrift.version>
+        <thrift.version>0.14.0</thrift.version>
         <log4j2.version>2.18.0</log4j2.version>
         <metrics-core.version>4.0.2</metrics-core.version>
         <netty-all.version>4.1.42.Final</netty-all.version>

--- a/fs_brokers/apache_hdfs_broker/pom.xml
+++ b/fs_brokers/apache_hdfs_broker/pom.xml
@@ -229,7 +229,7 @@ under the License.
         <dependency>
             <groupId>org.apache.thrift</groupId>
             <artifactId>libthrift</artifactId>
-            <version>0.13.0</version>
+            <version>0.14.0</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-api -->
         <dependency>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.apache.thrift:libthrift 0.13.0
- [CVE-2020-13949](https://www.oscs1024.com/hd/CVE-2020-13949)


### What did I do？
Upgrade org.apache.thrift:libthrift from 0.13.0 to 0.14.0 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS