### PR TITLE
[fix](build) CMake fails to find the Boost package 

### DIFF
--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -120,7 +120,7 @@ endif()
 # Set Boost
 set(Boost_DEBUG FALSE)
 set(Boost_USE_MULTITHREADED ON)
-set(BOOST_ROOT ${THIRDPARTY_DIR})
+set(Boost_ROOT ${THIRDPARTY_DIR})
 set(Boost_NO_BOOST_CMAKE OFF)
 set(BOOST_VERSION "1.73.0")
 


### PR DESCRIPTION
the find_package command can use the variable of Boost_ROOT,BOOST_ROOT  will not work.

# Proposed changes

Issue Number: none issue

## Problem summary

When execute shell command  `bash build.sh --be ` to build the backend, the cmake tool will show can't find the boost library, because the variable of BOOST_ROOT has some spelling mistake.

OS: Ubuntu 22.04 x86_64
CMake: 3.22.1
compiler: gcc (Ubuntu 11.2.0-7ubuntu2) 11.2.0

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

