### PR TITLE
[feature-wip](multi-catalog) implement predicate pushdown in native OrcReader

### DIFF
--- a/be/src/exec/olap_common.h
+++ b/be/src/exec/olap_common.h
@@ -254,6 +254,8 @@ public:
         _contain_null = contain_null;
     };
 
+    int precision() const { return _precision; }
+
     int scale() const { return _scale; }
 
     static void add_fixed_value_range(ColumnValueRange<primitive_type>& range, CppType* value) {

--- a/be/src/vec/exec/format/parquet/parquet_common.h
+++ b/be/src/vec/exec/format/parquet/parquet_common.h
@@ -266,6 +266,7 @@ Status FixLengthDecoder::_decode_datetime64(MutableColumnPtr& doris_column, Type
         if constexpr (std::is_same_v<CppType, DateV2Value<DateTimeV2ValueType>>) {
             // nanoseconds will be ignored.
             v.set_microsecond((date_value % _decode_params->second_mask) * scale_to_micro);
+            // TODO: the precision of datetime v1
         }
         _FIXED_SHIFT_DATA_OFFSET();
     }


### PR DESCRIPTION
# Proposed changes
Implement predicate pushdown in `OrcReader` by converting doris `ColumnValueRange` to orc `SearchArgument`.

## Remaining problems
1. Orc support `not in`, which may have effect on bloom filter. However, doris `ScanNode` has not push down `not in` to file scanner.
2. Orc support `is null`, and row range has `hasNull` identifier. However,  `_contain_null` in `ColumnValueRange` is ambiguous. `_contain_null = true` only means that the value can be nullable, not equal to null.
3. `DateTimeV2` has lost microsecond precision in `ColumnValueRange`, which may cause filtering error when a min-max value equals to the predicate value.
4. `DateTimeV1`  is not accurate enough, and only saved to seconds.
5. Orc support the predicate pushdown of `float&double` type, but doris has not push down `float&double` type for precision reason.

## Performance test
Using one thread to query data in table with 10 million rows, and the table is generated from a [data generator tool](https://github.com/glebkorolkov/datagen) with all types supported by hive, and all values are random, and has a 10% probability of being null.
| Type | Predicate | Before opt.<br>Time / (scan rows) | After opt.<br>Time / (scan rows) |
| -- | -- | -- | -- |
| int | int_col > 999874452 | 0.82s<br>10000000 | 0.49s<br>2754994 |
| date<br>(datev2) | date_col < date '2012-09-08' | 4.05s<br>10000000 | 1.05s<br>2579997 |
| timestamp<br>(datetimev2) | timestamp_col > timestamp '2022-09-05 21:34:44.000' | 3.41s<br>10000000 | 0.63s<br>950000 |
| decimal<br>(decimalv2) | decimal_col < 100032.0057 | 1.06s<br>10000000 | 0.59s<br>1685001 |
| bigint | bigint_col < 26495468801273 | 1.01s<br>10000000 | 0.55s<br>1874999 |
| string | select count(string_col) from types_sf1_r1000w where string_col <= 'A d' | 7.73s<br>10000000 | 4.17s<br>3404995 |
| mix | int_col <= 14019 and decimal_col < 338745.937 and date_col = date '2014-10-08'; | 9.41s<br>10000000 | 2.40s<br>1854998 |

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
7. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
8. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
9. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
10. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

