### PR TITLE
[Enhancement](load) consider memtable in flush while reducing load me…

### DIFF
--- a/be/src/olap/delta_writer.cpp
+++ b/be/src/olap/delta_writer.cpp
@@ -383,9 +383,14 @@ Status DeltaWriter::cancel() {
     return Status::OK();
 }
 
-int64_t DeltaWriter::save_memtable_consumption_snapshot() {
+void DeltaWriter::save_mem_consumption_snapshot() {
+    _mem_consumption_snapshot = mem_consumption();
     _memtable_consumption_snapshot = memtable_consumption();
-    return _memtable_consumption_snapshot;
+}
+
+int64_t DeltaWriter::get_memtable_consumption_inflush() const {
+    if (_flush_token->get_stats().flush_running_count == 0) return 0;
+    return _mem_consumption_snapshot - _memtable_consumption_snapshot;
 }
 
 int64_t DeltaWriter::get_memtable_consumption_snapshot() const {

--- a/be/src/olap/delta_writer.h
+++ b/be/src/olap/delta_writer.h
@@ -104,7 +104,9 @@ public:
 
     int64_t memtable_consumption() const;
 
-    int64_t save_memtable_consumption_snapshot();
+    void save_mem_consumption_snapshot();
+
+    int64_t get_memtable_consumption_inflush() const;
 
     int64_t get_memtable_consumption_snapshot() const;
 
@@ -161,6 +163,9 @@ private:
     // use in vectorized load
     bool _is_vec;
 
+    // memory consumption snapshot for current delta_writer, only
+    // used for std::sort
+    int64_t _mem_consumption_snapshot = 0;
     // memory consumption snapshot for current memtable, only
     // used for std::sort
     int64_t _memtable_consumption_snapshot = 0;

--- a/be/src/runtime/load_channel.h
+++ b/be/src/runtime/load_channel.h
@@ -177,9 +177,6 @@ Status LoadChannel::handle_mem_exceed_limit(TabletWriterAddResult* response) {
     {
         // lock so that only one thread can check mem limit
         std::lock_guard<std::mutex> l(_lock);
-
-        LOG(INFO) << "reducing memory of " << *this
-                  << " ,mem consumption: " << _mem_tracker->consumption();
         found = _find_largest_consumption_channel(&channel);
     }
     // Release lock so that other threads can still call add_batch concurrently.

--- a/be/src/runtime/tablets_channel.cpp
+++ b/be/src/runtime/tablets_channel.cpp
@@ -199,7 +199,8 @@ Status TabletsChannel::reduce_mem_usage(TabletWriterAddResult* response) {
     if (_try_to_wait_flushing()) {
         // `_try_to_wait_flushing()` returns true means other thread already
         // reduced the mem usage, and current thread do not need to reduce again.
-        LOG(INFO) << "Duplicate reduce mem usage on ";
+        LOG(INFO) << "Duplicate reduce mem usage on TabletsChannel, txn_id: " << _txn_id
+                  << ", index_id: " << _index_id;
         return Status::OK();
     }
 


### PR DESCRIPTION
# Proposed changes

We should consider memory which are being flushed from memtable to disk when trying to reduce memory by flushing memtable. Otherwise, we might not release memory space as expected. (e.g. lots of large memtable is in flush, the `reduce_mem_usage` method picks some small memtables to flush, it can't release enough memory and also can generate lots of small segments, which can cause -238 error)

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

