### PR TITLE
[Fix](multi-catalog)Fix NPE caused by GsonUtils created objects.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/external/EsExternalDatabase.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/external/EsExternalDatabase.java
@@ -67,7 +67,7 @@ public class EsExternalDatabase extends ExternalDatabase<EsExternalTable> {
             Map<Long, EsExternalTable> tmpIdToTbl = Maps.newHashMap();
             for (String tableName : tableNames) {
                 long tblId;
-                if (tableNameToId.containsKey(tableName)) {
+                if (tableNameToId != null && tableNameToId.containsKey(tableName)) {
                     tblId = tableNameToId.get(tableName);
                     tmpTableNameToId.put(tableName, tblId);
                     EsExternalTable table = idToTbl.get(tblId);

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/external/HMSExternalDatabase.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/external/HMSExternalDatabase.java
@@ -69,7 +69,7 @@ public class HMSExternalDatabase extends ExternalDatabase<HMSExternalTable> {
             Map<Long, HMSExternalTable> tmpIdToTbl = Maps.newHashMap();
             for (String tableName : tableNames) {
                 long tblId;
-                if (tableNameToId.containsKey(tableName)) {
+                if (tableNameToId != null && tableNameToId.containsKey(tableName)) {
                     tblId = tableNameToId.get(tableName);
                     tmpTableNameToId.put(tableName, tblId);
                     HMSExternalTable table = idToTbl.get(tblId);

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/HMSExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/HMSExternalCatalog.java
@@ -84,7 +84,7 @@ public class HMSExternalCatalog extends ExternalCatalog {
         }
         for (String dbName : allDatabases) {
             long dbId;
-            if (dbNameToId.containsKey(dbName)) {
+            if (dbNameToId != null && dbNameToId.containsKey(dbName)) {
                 dbId = dbNameToId.get(dbName);
                 tmpDbNameToId.put(dbName, dbId);
                 HMSExternalDatabase db = idToDb.get(dbId);


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

The `HMSExternalCatalog` fields `dbNameToId` and `idToDb` could be NULL when the HMSExternalCatalog object is created by Gson. Add NPE check before using these two maps. 

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

