### PR TITLE
[bugfix](VecDateTimeValue) eat the value of microsecond in function from_date_format_str

### DIFF
--- a/be/src/vec/runtime/vdatetime_value.cpp
+++ b/be/src/vec/runtime/vdatetime_value.cpp
@@ -1205,6 +1205,12 @@ bool VecDateTimeValue::from_date_format_str(const char* format, int format_len, 
                 break;
                 // Micro second
             case 'f':
+                // _microsecond is removed, but need to eat this val
+                tmp = val + min(6, val_end - val);
+                if (!str_to_int64(val, &tmp, &int_value)) {
+                    return false;
+                }
+                val = tmp;
                 break;
                 // AM/PM
             case 'p':


### PR DESCRIPTION
# Proposed changes

Issue Number: none

## Problem summary

**case**: select str_to_date("2022-05-24 10:00:00.123 PM", "%Y-%m-%d %h:%i:%s.%f %p");

1. disable_vectorized
Expected: 2022-05-24 22:00:00.123000
Actual: 2022-05-24 22:00:00.123000

2. enables_vectorized
Expected: 2022-05-24 22:00:00
Actual: null

In function **VecDateTimeValue::from_date_format_str**, it is necessary to eat the microsecond "**123**" before parsing "**PM**", even though _microsecond has been removed in class VecDateTimeValue.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No