### PR TITLE
[chore](macOS) Avoid using binutils from Homebrew to build third parties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ core.*
 .classpath
 nohup.out
 custom_env.sh
+custom_env_mac.sh
 derby.log
 dependency-reduced-pom.xml
 yarn.lock

--- a/be/src/vec/functions/function_string.h
+++ b/be/src/vec/functions/function_string.h
@@ -31,7 +31,6 @@
 #include <fmt/ranges.h>
 
 #include <cstdint>
-#include <memory_resource>
 #include <string>
 #include <string_view>
 

--- a/env.sh
+++ b/env.sh
@@ -64,7 +64,7 @@ CELLARS=(
 for cellar in "\${CELLARS[@]}"; do
     EXPORT_CELLARS="\${HOMEBREW_REPO_PREFIX}/opt/\${cellar}/bin:\${EXPORT_CELLARS}"
 done
-export PATH="\${EXPORT_CELLARS}:\${PATH}"
+export PATH="\${EXPORT_CELLARS}:/usr/bin:\${PATH}"
 
 export DORIS_BUILD_PYTHON_VERSION=python3
 EOF

--- a/env.sh
+++ b/env.sh
@@ -38,11 +38,11 @@ if [[ "$(uname -s)" == 'Darwin' ]]; then
         echo "Error: Homebrew is missing. Please install it first due to we use Homebrew to manage the tools which are needed to build the project."
         exit 1
     fi
-    if [[ ! -f "${DORIS_HOME}/custom_env.sh" ]] ||
-        ! grep HOMEBREW_REPO_PREFIX "${DORIS_HOME}/custom_env.sh" &>/dev/null; then
 
-        cat >>"${DORIS_HOME}/custom_env.sh" <<EOF
-HOMEBREW_REPO_PREFIX="$(brew --repo)"
+    cat >"${DORIS_HOME}/custom_env_mac.sh" <<EOF
+# This file is generated automatically. PLEASE DO NOT MODIFY IT.
+
+HOMEBREW_REPO_PREFIX="$(brew --prefix)"
 CELLARS=(
     automake
     autoconf
@@ -68,6 +68,16 @@ export PATH="\${EXPORT_CELLARS}:/usr/bin:\${PATH}"
 
 export DORIS_BUILD_PYTHON_VERSION=python3
 EOF
+
+    DORIS_HOME_ABSOLUATE_PATH="$(
+        set -e
+        cd "${DORIS_HOME}"
+        pwd
+    )"
+    SOURCE_MAC_ENV_CONTENT="source '${DORIS_HOME_ABSOLUATE_PATH}/custom_env_mac.sh'"
+    if [[ ! -f "${DORIS_HOME}/custom_env.sh" ]] ||
+        ! grep "${SOURCE_MAC_ENV_CONTENT}" "${DORIS_HOME}/custom_env.sh" &>/dev/null; then
+        echo "${SOURCE_MAC_ENV_CONTENT}" >>"${DORIS_HOME}/custom_env.sh"
     fi
 fi
 

--- a/thirdparty/build-thirdparty.sh
+++ b/thirdparty/build-thirdparty.sh
@@ -1493,7 +1493,7 @@ build_gettext() {
     mkdir -p "${BUILD_DIR}"
     cd "${BUILD_DIR}"
 
-    ../configure --prefix="${TP_INSTALL_DIR}"
+    ../configure --prefix="${TP_INSTALL_DIR}" --disable-java
     make -j "${PARALLEL}"
     make install
 


### PR DESCRIPTION
# Proposed changes

Overwrite the the environment variable `PATH` to avoid using binutils from Homebrew to build third parties which may cause compilation errors.

## Problem summary

building for macOS-x86_64 but attempting to link with file built for unknown-unsupported file format

![image](https://user-images.githubusercontent.com/1443003/196879154-89a0fdbf-ec7e-4290-a7fc-23c3b44a9882.png)


## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

