### PR TITLE
[fix](array-type) fix the be core dump when select the invalid array …

### DIFF
--- a/be/src/vec/exprs/vexpr.cpp
+++ b/be/src/vec/exprs/vexpr.cpp
@@ -322,7 +322,9 @@ ColumnPtrWrapper* VExpr::get_const_col(VExprContext* context) {
     // If block is empty, some functions will produce no result. So we insert a column with
     // single value here.
     block.insert({ColumnUInt8::create(1), std::make_shared<DataTypeUInt8>(), ""});
-    execute(context, &block, &result);
+    if (!execute(context, &block, &result).ok()) {
+        return nullptr;
+    }
     DCHECK(result != -1);
     const auto& column = block.get_by_position(result).column;
     _constant_col = std::make_shared<ColumnPtrWrapper>(column);

--- a/regression-test/suites/query_p0/sql_functions/array_functions/test_array_functions_by_literal.groovy
+++ b/regression-test/suites/query_p0/sql_functions/array_functions/test_array_functions_by_literal.groovy
@@ -162,4 +162,10 @@ suite("test_array_functions_by_literal") {
     qt_sql "select array_join([null, null, 1, 2, '', '', null], '_', 'any')"
     qt_sql "select array_join([''], '_')"
     qt_sql "select array_join(['', ''], '_')"
+
+    // abnormal test
+    test {
+        sql "select array_intersect([1, 2, 3, 1, 2, 3], '1[3, 2, 5]')"
+        exception "errCode = 2, detailMessage = No matching function with signature: array_intersect(array<tinyint(4)>, varchar(-1))"
+    }
 }


### PR DESCRIPTION
# Proposed changes
1. this pr is used to fix the be core dump when select the invalid array.
2. before the change, we run "select array_intersect([1, 2, 3, 1, 2, 3], '1[3, 2, 5]');" will cause be core dump.
MySQL [example_db]> select array_intersect([1, 2, 3, 1, 2, 3], '1[3, 2, 5]');
ERROR 1105 (HY000): RpcException, msg: io.grpc.StatusRuntimeException: UNAVAILABLE: Network closed for unknown reason
3. after the change, we run "select array_intersect([1, 2, 3, 1, 2, 3], '1[3, 2, 5]');" will get error message.
MySQL [example_db]> select array_intersect([1, 2, 3, 1, 2, 3], '1[3, 2, 5]');
errCode = 2, detailMessage = No matching function with signature: array_intersect(array<tinyint(4)>, varchar(-1))"

Issue Number: #7570

the be core dump stack:
start time: Thu Oct 20 15:23:44 CST 2022
*** Query id: ff34085b3e1541a1-863d31b87029665f ***
*** Aborted at 1666250639 (unix time) try "date -d @1666250639" if you are using GNU date ***
*** Current BE git commitID: b5cd16771 ***
*** SIGSEGV invalid permissions for mapped object (@0x55d7ec505760) received by PID 36426 (TID 0x7fb5371ff700) from PID 18446744073379272544; stack trace: ***
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /home/disk1/hugo_work/doris_dev/baidu/bdg/doris/core/be/src/common/signal_handler.h:420
 1# 0x00007FB61750F920 in /lib64/libc.so.6
 2# doris::vectorized::VExpr::get_const_col(doris::vectorized::VExprContext*) at /home/disk1/hugo_work/doris_dev/baidu/bdg/doris/core/be/src/vec/exprs/vexpr.cpp:330
 3# doris::vectorized::VExpr::init_function_context(doris::vectorized::VExprContext*, doris_udf::FunctionContext::FunctionStateScope, std::shared_ptr<doris::vectorized::IFunctionBase> const&) const at /home/disk1/h
ugo_work/doris_dev/baidu/bdg/doris/core/be/src/vec/exprs/vexpr.cpp:351
 4# doris::vectorized::VectorizedFnCall::open(doris::RuntimeState*, doris::vectorized::VExprContext*, doris_udf::FunctionContext::FunctionStateScope) at /home/disk1/hugo_work/doris_dev/baidu/bdg/doris/core/be/src/v
ec/exprs/vectorized_fn_call.cpp:73
 5# doris::vectorized::VExprContext::open(doris::RuntimeState*) at /home/disk1/hugo_work/doris_dev/baidu/bdg/doris/core/be/src/vec/exprs/vexpr_context.cpp:66
 6# doris::vectorized::VExpr::open(std::vector<doris::vectorized::VExprContext*, std::allocator<doris::vectorized::VExprContext*> > const&, doris::RuntimeState*) at /home/disk1/hugo_work/doris_dev/baidu/bdg/doris/core/be/src/vec/exprs/vexpr.cpp:245
 7# doris::vectorized::VUnionNode::open(doris::RuntimeState*) at /home/disk1/hugo_work/doris_dev/baidu/bdg/doris/core/be/src/vec/exec/vunion_node.cpp:85
 8# doris::PlanFragmentExecutor::open_vectorized_internal() at /home/disk1/hugo_work/doris_dev/baidu/bdg/doris/core/be/src/runtime/plan_fragment_executor.cpp:280
 9# doris::PlanFragmentExecutor::open() at /home/disk1/hugo_work/doris_dev/baidu/bdg/doris/core/be/src/runtime/plan_fragment_executor.cpp:252
10# doris::FragmentExecState::execute() at /home/disk1/hugo_work/doris_dev/baidu/bdg/doris/core/be/src/runtime/fragment_mgr.cpp:253
11# doris::FragmentMgr::_exec_actual(std::shared_ptr<doris::FragmentExecState>, std::function<void (doris::PlanFragmentExecutor*)>) at /home/disk1/hugo_work/doris_dev/baidu/bdg/doris/core/be/src/runtime/fragment_mgr.cpp:499
12# std::_Function_handler<void (), doris::FragmentMgr::exec_plan_fragment(doris::TExecPlanFragmentParams const&, std::function<void (doris::PlanFragmentExecutor*)>)::{lambda()#1}>::_M_invoke(std::_Any_data const&) at /home/disk1/hugo_work/doris_dev/baidu/bdg/doris/palo-toolchain/ldb_toolchain/include/c++/11/bits/std_function.h:291
13# doris::ThreadPool::dispatch_thread() at /home/disk1/hugo_work/doris_dev/baidu/bdg/doris/core/be/src/util/threadpool.cpp:548
14# doris::Thread::supervise_thread(void*) at /home/disk1/hugo_work/doris_dev/baidu/bdg/doris/core/be/src/util/thread.cpp:455
15# start_thread in /lib64/libpthread.so.0
16# clone in /lib64/libc.so.6

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
5. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
6. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
7. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
8. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

