### PR TITLE
[fix](csv-reader) fix bug that csv reader can not read text format hms table

### DIFF
--- a/be/src/exec/text_converter.hpp
+++ b/be/src/exec/text_converter.hpp
@@ -194,7 +194,7 @@ inline bool TextConverter::write_vec_column(const SlotDescriptor* slot_desc,
                                             size_t len, bool copy_string, bool need_escape) {
     vectorized::IColumn* col_ptr = nullable_col_ptr;
     // \N means it's NULL
-    if (true == slot_desc->is_nullable()) {
+    if (slot_desc->is_nullable()) {
         auto* nullable_column = reinterpret_cast<vectorized::ColumnNullable*>(nullable_col_ptr);
         if ((len == 2 && data[0] == '\\' && data[1] == 'N') || len == SQL_NULL_DATA) {
             nullable_column->insert_data(nullptr, 0);

--- a/be/src/vec/exec/format/csv/csv_reader.h
+++ b/be/src/vec/exec/format/csv/csv_reader.h
@@ -43,8 +43,7 @@ public:
 
 private:
     Status _create_decompressor();
-    // Status _fill_dest_columns(const Slice& line, std::vector<MutableColumnPtr>& columns);
-    Status _fill_dest_columns(const Slice& line, Block* block);
+    Status _fill_dest_columns(const Slice& line, Block* block, size_t* rows);
     Status _line_split_to_values(const Slice& line, bool* success);
     void _split_line(const Slice& line);
     Status _check_array_format(std::vector<Slice>& split_values, bool* is_success);
@@ -60,14 +59,11 @@ private:
     const std::vector<SlotDescriptor*>& _file_slot_descs;
     // Only for query task, save the columns' index which need to be read.
     // eg, there are 3 cols in "_file_slot_descs" named: k1, k2, k3
-    // and the corressponding pposition in file is 0, 3, 5.
+    // and the corressponding position in file is 0, 3, 5.
     // So the _col_idx will be: <0, 3, 5>
     std::vector<int> _col_idxs;
     // True if this is a load task
     bool _is_load = false;
-    // Save column position in block, order by _file_slot_descs
-    bool _init_column_pos = false;
-    std::vector<size_t> _col_posistions;
 
     // _file_reader_s is for stream load pipe reader,
     // and _file_reader is for other file reader.

--- a/be/src/vec/exec/format/csv/csv_reader.h
+++ b/be/src/vec/exec/format/csv/csv_reader.h
@@ -36,14 +36,15 @@ public:
               const std::vector<SlotDescriptor*>& file_slot_descs);
     ~CsvReader() override;
 
-    Status init_reader();
+    Status init_reader(bool is_query);
     Status get_next_block(Block* block, size_t* read_rows, bool* eof) override;
     Status get_columns(std::unordered_map<std::string, TypeDescriptor>* name_to_type,
                        std::unordered_set<std::string>* missing_cols) override;
 
 private:
     Status _create_decompressor();
-    Status _fill_dest_columns(const Slice& line, std::vector<MutableColumnPtr>& columns);
+    // Status _fill_dest_columns(const Slice& line, std::vector<MutableColumnPtr>& columns);
+    Status _fill_dest_columns(const Slice& line, Block* block);
     Status _line_split_to_values(const Slice& line, bool* success);
     void _split_line(const Slice& line);
     Status _check_array_format(std::vector<Slice>& split_values, bool* is_success);
@@ -57,6 +58,16 @@ private:
     const TFileScanRangeParams& _params;
     const TFileRangeDesc& _range;
     const std::vector<SlotDescriptor*>& _file_slot_descs;
+    // Only for query task, save the columns' index which need to be read.
+    // eg, there are 3 cols in "_file_slot_descs" named: k1, k2, k3
+    // and the corressponding pposition in file is 0, 3, 5.
+    // So the _col_idx will be: <0, 3, 5>
+    std::vector<int> _col_idxs;
+    // True if this is a load task
+    bool _is_load = false;
+    // Save column position in block, order by _file_slot_descs
+    bool _init_column_pos = false;
+    std::vector<size_t> _col_posistions;
 
     // _file_reader_s is for stream load pipe reader,
     // and _file_reader is for other file reader.

--- a/be/src/vec/exec/scan/vfile_scanner.cpp
+++ b/be/src/vec/exec/scan/vfile_scanner.cpp
@@ -492,7 +492,7 @@ Status VFileScanner::_get_next_reader() {
         case TFileFormatType::FORMAT_CSV_DEFLATE: {
             _cur_reader.reset(
                     new CsvReader(_state, _profile, &_counter, _params, range, _file_slot_descs));
-            init_status = ((CsvReader*)(_cur_reader.get()))->init_reader();
+            init_status = ((CsvReader*)(_cur_reader.get()))->init_reader(_is_load);
             break;
         }
         default:

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/HiveMetaStoreClientHelper.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/HiveMetaStoreClientHelper.java
@@ -810,6 +810,8 @@ public class HiveMetaStoreClientHelper {
                 return Type.FLOAT;
             case "double":
                 return Type.DOUBLE;
+            case "string":
+                return Type.STRING;
             default:
                 break;
         }
@@ -923,3 +925,4 @@ public class HiveMetaStoreClientHelper {
         return output.toString();
     }
 }
+

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/TableIf.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/TableIf.java
@@ -73,6 +73,17 @@ public interface TableIf {
 
     Column getColumn(String name);
 
+    default int getBaseColumnIdxByName(String colName) {
+        int i = 0;
+        for (Column col : getBaseSchema()) {
+            if (col.getName().equalsIgnoreCase(colName)) {
+                return i;
+            }
+            ++i;
+        }
+        return -1;
+    }
+
     String getMysqlType();
 
     String getEngine();
@@ -163,3 +174,4 @@ public interface TableIf {
         }
     }
 }
+

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/external/HMSExternalTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/external/HMSExternalTable.java
@@ -311,3 +311,4 @@ public class HMSExternalTable extends ExternalTable {
         return catalog.getCatalogProperty().getS3Properties();
     }
 }
+

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/HMSExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/HMSExternalCatalog.java
@@ -70,6 +70,7 @@ public class HMSExternalCatalog extends ExternalCatalog {
             client = new HiveMetaStoreClient(hiveConf);
         } catch (MetaException e) {
             LOG.warn("Failed to create HiveMetaStoreClient: {}", e.getMessage());
+            return;
         }
         List<String> allDatabases;
         try {

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -289,6 +289,8 @@ struct TFileScanRangeParams {
     14: optional list<Types.TNetworkAddress> broker_addresses
     15: optional TFileAttributes file_attributes
     16: optional Exprs.TExpr pre_filter_exprs
+    // For csv query task, same the column index in file, order by dest_tuple
+    17: optional list<i32> column_idxs
 }
 
 struct TFileRangeDesc {


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

1. Missing field and line delimiter
2. When query external table with text(csv) format, we should pass the column position map to BE,
    otherwise the column order is wrong.

TODO:
1. For now, if we query csv file with non-exist column, it will return null.
    But it should return null or default value of that column.
2. Add regression test after hive docker is ready.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
4. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
5. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
6. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
7. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

