### PR TITLE
[Enhancement](runtime-filter) optimize for runtimefilter 64bit type hash function

### DIFF
--- a/be/src/util/hash_util.hpp
+++ b/be/src/util/hash_util.hpp
@@ -45,11 +45,19 @@ namespace doris {
 // Utility class to compute hash values.
 class HashUtil {
 public:
+    // like hash_combine but without hash
+    static inline uint32_t direct_combine(uint32_t x, uint32_t y) {
+        return x + 0x9e3779b9 + (y << 6) + (y >> 2);
+    }
+
     template <typename T>
     static uint32_t fixed_len_to_uint32(T value) {
         if constexpr (sizeof(T) <= sizeof(uint32_t)) {
             return value;
+        } else if constexpr (sizeof(T) == sizeof(uint64_t)) {
+            return direct_combine(((uint64_t)value << 32) >> 32, (uint64_t)value >> 32);
         }
+
         return std::hash<T>()(value);
     }
 

--- a/be/src/vec/functions/like.h
+++ b/be/src/vec/functions/like.h
@@ -76,7 +76,7 @@ struct LikeSearchState {
             hs_scratch;
 
     // hyperscan match callback
-    static int hs_match_handler(unsigned int /* from */,       // NOLINT
+    static int hs_match_handler(unsigned int /* id */,         // NOLINT
                                 unsigned long long /* from */, // NOLINT
                                 unsigned long long /* to */,   // NOLINT
                                 unsigned int /* flags */, void* ctx) {

--- a/tools/tpch-tools/queries/q13.sql
+++ b/tools/tpch-tools/queries/q13.sql
@@ -17,7 +17,7 @@
 
 -- Modified
 
-select /*+SET_VAR(exec_mem_limit=8589934592, parallel_fragment_exec_instance_num=16, enable_vectorized_engine=true, batch_size=4096, disable_join_reorder=true, enable_cost_based_join_reorder=true, enable_projection=true) */
+select /*+SET_VAR(exec_mem_limit=18589934592, parallel_fragment_exec_instance_num=16, enable_vectorized_engine=true, batch_size=4096, disable_join_reorder=true, enable_cost_based_join_reorder=true, enable_projection=true) */
     c_count,
     count(*) as custdist
 from

--- a/tools/tpch-tools/queries/q18.sql
+++ b/tools/tpch-tools/queries/q18.sql
@@ -17,7 +17,7 @@
 
 -- Modified
 
-select /*+SET_VAR(exec_mem_limit=8589934592, parallel_fragment_exec_instance_num=16, enable_vectorized_engine=true, batch_size=4096, disable_join_reorder=true, enable_cost_based_join_reorder=true, enable_projection=true) */
+select /*+SET_VAR(exec_mem_limit=18589934592, parallel_fragment_exec_instance_num=16, enable_vectorized_engine=true, batch_size=4096, disable_join_reorder=true, enable_cost_based_join_reorder=true, enable_projection=true) */
     c_name,
     c_custkey,
     t3.o_orderkey,

--- a/tools/tpch-tools/queries/q20.sql
+++ b/tools/tpch-tools/queries/q20.sql
@@ -17,7 +17,7 @@
 
 -- Modified
 
-select /*+SET_VAR(exec_mem_limit=8589934592, parallel_fragment_exec_instance_num=16, enable_vectorized_engine=true, batch_size=4096, disable_join_reorder=true, enable_cost_based_join_reorder=true, enable_projection=true) */
+select /*+SET_VAR(exec_mem_limit=8589934592, parallel_fragment_exec_instance_num=32, enable_vectorized_engine=true, batch_size=4096, disable_join_reorder=true, enable_cost_based_join_reorder=true, enable_projection=true) */
 s_name, s_address from
 supplier left semi join
 (


### PR DESCRIPTION
# Proposed changes

1. change 64bit hash function from std::hash to direct_combine
2. modify some tpch query.
3. fix like function signature typo
<img width="1380" alt="图片" src="https://user-images.githubusercontent.com/7939630/197101949-6097adeb-9214-4c8a-824a-185972d562d7.png">

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
4. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
5. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
6. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
7. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

