### PR TITLE
[branch-1.1-lts](restore) new add the property of reserve_replica to …

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/RestoreStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/RestoreStmt.java
@@ -36,11 +36,13 @@ public class RestoreStmt extends AbstractBackupStmt {
     private final static String PROP_REPLICATION_NUM = "replication_num";
     private final static String PROP_BACKUP_TIMESTAMP = "backup_timestamp";
     private final static String PROP_META_VERSION = "meta_version";
+    private final static String PROP_RESERVE_REPLICA = "reserve_replica";
 
     private boolean allowLoad = false;
     private ReplicaAllocation replicaAlloc = ReplicaAllocation.DEFAULT_ALLOCATION;
     private String backupTimestamp = null;
     private int metaVersion = -1;
+    private boolean reserveReplica = false;
 
     public RestoreStmt(LabelName labelName, String repoName, AbstractBackupTableRefClause restoreTableRefClause,
                        Map<String, String> properties) {
@@ -61,6 +63,10 @@ public class RestoreStmt extends AbstractBackupStmt {
 
     public int getMetaVersion() {
         return metaVersion;
+    }
+
+    public boolean reserveReplica() {
+        return reserveReplica;
     }
 
     @Override
@@ -105,6 +111,18 @@ public class RestoreStmt extends AbstractBackupStmt {
         this.replicaAlloc = PropertyAnalyzer.analyzeReplicaAllocation(copiedProperties, "");
         if (this.replicaAlloc.isNotSet()) {
             this.replicaAlloc = ReplicaAllocation.DEFAULT_ALLOCATION;
+        }
+        // reserve replica
+        if (copiedProperties.containsKey(PROP_RESERVE_REPLICA)) {
+            if (copiedProperties.get(PROP_RESERVE_REPLICA).equalsIgnoreCase("true")) {
+                reserveReplica = true;
+            } else if (copiedProperties.get(PROP_RESERVE_REPLICA).equalsIgnoreCase("false")) {
+                reserveReplica = false;
+            } else {
+                ErrorReport.reportAnalysisException(ErrorCode.ERR_COMMON_ERROR,
+                        "Invalid reserve_replica value: " + copiedProperties.get(PROP_RESERVE_REPLICA));
+            }
+            copiedProperties.remove(PROP_RESERVE_REPLICA);
         }
         // backup timestamp
         if (copiedProperties.containsKey(PROP_BACKUP_TIMESTAMP)) {

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowRestoreStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowRestoreStmt.java
@@ -39,7 +39,7 @@ import java.util.function.Predicate;
 public class ShowRestoreStmt extends ShowStmt {
     public static final ImmutableList<String> TITLE_NAMES = new ImmutableList.Builder<String>()
             .add("JobId").add("Label").add("Timestamp").add("DbName").add("State")
-            .add("AllowLoad").add("ReplicationNum").add("ReplicaAllocation")
+            .add("AllowLoad").add("ReplicationNum").add("ReplicaAllocation").add("ReserveReplica")
             .add("RestoreObjs").add("CreateTime").add("MetaPreparedTime").add("SnapshotFinishedTime")
             .add("DownloadFinishedTime").add("FinishedTime").add("UnfinishedTasks").add("Progress")
             .add("TaskErrMsg").add("Status").add("Timeout")

--- a/fe/fe-core/src/main/java/org/apache/doris/backup/BackupHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/backup/BackupHandler.java
@@ -400,7 +400,7 @@ public class BackupHandler extends MasterDaemon implements Writable {
         // Create a restore job
         RestoreJob restoreJob = new RestoreJob(stmt.getLabel(), stmt.getBackupTimestamp(),
                 db.getId(), db.getFullName(), jobInfo, stmt.allowLoad(), stmt.getReplicaAlloc(),
-                stmt.getTimeoutMs(), stmt.getMetaVersion(), catalog, repository.getId());
+                stmt.getTimeoutMs(), stmt.getMetaVersion(), stmt.reserveReplica(), catalog, repository.getId());
         catalog.getEditLog().logRestoreJob(restoreJob);
 
         // must put to dbIdToBackupOrRestoreJob after edit log, otherwise the state of job may be changed.

--- a/fe/fe-core/src/test/java/org/apache/doris/backup/RestoreJobTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/backup/RestoreJobTest.java
@@ -233,9 +233,9 @@ public class RestoreJobTest {
         // drop this table, cause we want to try restoring this table
         db.dropTable(expectedRestoreTbl.getName());
 
-        job = new RestoreJob(label, "2018-01-01 01:01:01", db.getId(), db.getFullName(),
-                jobInfo, false, new ReplicaAllocation((short) 3), 100000, -1, catalog, repo.getId());
-        
+        job = new RestoreJob(label, "2018-01-01 01:01:01", db.getId(), db.getFullName(), jobInfo, false,
+                new ReplicaAllocation((short) 3), 100000, -1, false, catalog, repo.getId());
+
         List<Table> tbls = Lists.newArrayList();
         List<Resource> resources = Lists.newArrayList();
         tbls.add(expectedRestoreTbl);


### PR DESCRIPTION
…restore statement

Add a new property called 'reserve_replica', which means you can get a table with same partitions with the same replication num as before the backup.

relation pr: https://github.com/apache/doris/pull/11942

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

