### PR TITLE
[improvement](config) allow to modify the master-only configuration of non-master nodes

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/ConfigBase.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/ConfigBase.java
@@ -17,8 +17,6 @@
 
 package org.apache.doris.common;
 
-import org.apache.doris.catalog.Env;
-
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -311,9 +309,6 @@ public class ConfigBase {
         ConfField anno = field.getAnnotation(ConfField.class);
         if (!anno.mutable()) {
             throw new DdlException("Config '" + key + "' is not mutable");
-        }
-        if (anno.masterOnly() && !Env.getCurrentEnv().isMaster()) {
-            throw new DdlException("Config '" + key + "' is master only");
         }
 
         try {


### PR DESCRIPTION

Non-master nodes may switch to master, so we should allow the master-only configuration of all fe nodes to be modified.

# Proposed changes

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

