### PR TITLE
[branch-1.1-lts](restore) Add new property 'reserve_dynamic_partition…

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/RestoreStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/RestoreStmt.java
@@ -37,12 +37,14 @@ public class RestoreStmt extends AbstractBackupStmt {
     private final static String PROP_BACKUP_TIMESTAMP = "backup_timestamp";
     private final static String PROP_META_VERSION = "meta_version";
     private final static String PROP_RESERVE_REPLICA = "reserve_replica";
+    private final static String PROP_RESERVE_DYNAMIC_PARTITION_ENABLE = "reserve_dynamic_partition_enable";
 
     private boolean allowLoad = false;
     private ReplicaAllocation replicaAlloc = ReplicaAllocation.DEFAULT_ALLOCATION;
     private String backupTimestamp = null;
     private int metaVersion = -1;
     private boolean reserveReplica = false;
+    private boolean reserveDynamicPartitionEnable = false;
 
     public RestoreStmt(LabelName labelName, String repoName, AbstractBackupTableRefClause restoreTableRefClause,
                        Map<String, String> properties) {
@@ -67,6 +69,10 @@ public class RestoreStmt extends AbstractBackupStmt {
 
     public boolean reserveReplica() {
         return reserveReplica;
+    }
+
+    public boolean reserveDynamicPartitionEnable() {
+        return reserveDynamicPartitionEnable;
     }
 
     @Override
@@ -123,6 +129,19 @@ public class RestoreStmt extends AbstractBackupStmt {
                         "Invalid reserve_replica value: " + copiedProperties.get(PROP_RESERVE_REPLICA));
             }
             copiedProperties.remove(PROP_RESERVE_REPLICA);
+        }
+        // reserve dynamic partition enable
+        if (copiedProperties.containsKey(PROP_RESERVE_DYNAMIC_PARTITION_ENABLE)) {
+            if (copiedProperties.get(PROP_RESERVE_DYNAMIC_PARTITION_ENABLE).equalsIgnoreCase("true")) {
+                reserveDynamicPartitionEnable = true;
+            } else if (copiedProperties.get(PROP_RESERVE_DYNAMIC_PARTITION_ENABLE).equalsIgnoreCase("false")) {
+                reserveDynamicPartitionEnable = false;
+            } else {
+                ErrorReport.reportAnalysisException(ErrorCode.ERR_COMMON_ERROR,
+                        "Invalid reserve dynamic partition enable value: "
+                        + copiedProperties.get(PROP_RESERVE_DYNAMIC_PARTITION_ENABLE));
+            }
+            copiedProperties.remove(PROP_RESERVE_DYNAMIC_PARTITION_ENABLE);
         }
         // backup timestamp
         if (copiedProperties.containsKey(PROP_BACKUP_TIMESTAMP)) {

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowRestoreStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowRestoreStmt.java
@@ -40,9 +40,9 @@ public class ShowRestoreStmt extends ShowStmt {
     public static final ImmutableList<String> TITLE_NAMES = new ImmutableList.Builder<String>()
             .add("JobId").add("Label").add("Timestamp").add("DbName").add("State")
             .add("AllowLoad").add("ReplicationNum").add("ReplicaAllocation").add("ReserveReplica")
-            .add("RestoreObjs").add("CreateTime").add("MetaPreparedTime").add("SnapshotFinishedTime")
-            .add("DownloadFinishedTime").add("FinishedTime").add("UnfinishedTasks").add("Progress")
-            .add("TaskErrMsg").add("Status").add("Timeout")
+            .add("ReserveDynamicPartitionEnable").add("RestoreObjs").add("CreateTime").add("MetaPreparedTime")
+            .add("SnapshotFinishedTime").add("DownloadFinishedTime").add("FinishedTime").add("UnfinishedTasks")
+            .add("Progress").add("TaskErrMsg").add("Status").add("Timeout")
             .build();
 
     private String dbName;

--- a/fe/fe-core/src/main/java/org/apache/doris/backup/BackupHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/backup/BackupHandler.java
@@ -400,7 +400,8 @@ public class BackupHandler extends MasterDaemon implements Writable {
         // Create a restore job
         RestoreJob restoreJob = new RestoreJob(stmt.getLabel(), stmt.getBackupTimestamp(),
                 db.getId(), db.getFullName(), jobInfo, stmt.allowLoad(), stmt.getReplicaAlloc(),
-                stmt.getTimeoutMs(), stmt.getMetaVersion(), stmt.reserveReplica(), catalog, repository.getId());
+                stmt.getTimeoutMs(), stmt.getMetaVersion(), stmt.reserveReplica(), stmt.reserveDynamicPartitionEnable(),
+                catalog, repository.getId());
         catalog.getEditLog().logRestoreJob(restoreJob);
 
         // must put to dbIdToBackupOrRestoreJob after edit log, otherwise the state of job may be changed.

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
@@ -424,9 +424,9 @@ public class OlapTable extends Table {
     /**
      * Reset properties to correct values.
      */
-    public void resetPropertiesForRestore() {
+    public void resetPropertiesForRestore(boolean reserveDynamicPartitionEnable) {
         if (tableProperty != null) {
-            tableProperty.resetPropertiesForRestore();
+            tableProperty.resetPropertiesForRestore(reserveDynamicPartitionEnable);
         }
         // remove colocate property.
         setColocateGroup(null);

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/TableProperty.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/TableProperty.java
@@ -107,10 +107,12 @@ public class TableProperty implements Writable {
      * Reset properties to correct values.
      * @return this for chained
      */
-    public TableProperty resetPropertiesForRestore() {
+    public TableProperty resetPropertiesForRestore(boolean reserveDynamicPartitionEnable) {
         // disable dynamic partition
         if (properties.containsKey(DynamicPartitionProperty.ENABLE)) {
-            properties.put(DynamicPartitionProperty.ENABLE, "false");
+            if (!reserveDynamicPartitionEnable) {
+                properties.put(DynamicPartitionProperty.ENABLE, "false");
+            }
             executeBuildDynamicProperty();
         }
         return this;

--- a/fe/fe-core/src/test/java/org/apache/doris/backup/RestoreJobTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/backup/RestoreJobTest.java
@@ -234,7 +234,7 @@ public class RestoreJobTest {
         db.dropTable(expectedRestoreTbl.getName());
 
         job = new RestoreJob(label, "2018-01-01 01:01:01", db.getId(), db.getFullName(), jobInfo, false,
-                new ReplicaAllocation((short) 3), 100000, -1, false, catalog, repo.getId());
+                new ReplicaAllocation((short) 3), 100000, -1, false, false, catalog, repo.getId());
 
         List<Table> tbls = Lists.newArrayList();
         List<Resource> resources = Lists.newArrayList();

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/OlapTableTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/OlapTableTest.java
@@ -91,7 +91,7 @@ public class OlapTableTest {
         olapTable.setColocateGroup("test_group");
         Assert.assertTrue(olapTable.isColocateTable());
 
-        olapTable.resetPropertiesForRestore();
+        olapTable.resetPropertiesForRestore(false);
         Assert.assertEquals(tableProperty.getProperties(), olapTable.getTableProperty().getProperties());
         Assert.assertFalse(tableProperty.getDynamicPartitionProperty().isExist());
         Assert.assertFalse(olapTable.isColocateTable());
@@ -110,7 +110,7 @@ public class OlapTableTest {
 
         tableProperty = new TableProperty(properties);
         olapTable.setTableProperty(tableProperty);
-        olapTable.resetPropertiesForRestore();
+        olapTable.resetPropertiesForRestore(false);
 
         Map<String, String> expectedProperties = Maps.newHashMap(properties);
         expectedProperties.put(DynamicPartitionProperty.ENABLE, "false");


### PR DESCRIPTION
…_enable' to restore statement (#12498)

Add restore new property 'reserve_dynamic_partition_enable', which means you can get a table with dynamic_partition_enable property which has the same value as before the backup. before this commit, you always get a table with property 'dynamic_partition_enable=false' when restore.


relation pr: https://github.com/apache/doris/pull/12498/files

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

