### PR TITLE
[chore](macOS) Fix the issues with protoc and protoc-gen-grpc-java on M1

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -451,10 +451,7 @@ if [[ "${FE_MODULES}" != '' ]]; then
     if [[ "${CLEAN}" -eq 1 ]]; then
         clean_fe
     fi
-    if [[ "$(uname -sm)" == 'Darwin arm64' ]]; then
-        os_arch='-Dos.arch=x86_64'
-    fi
-    "${MVN_CMD}" package -pl ${FE_MODULES:+${FE_MODULES}} -DskipTests ${os_arch:+${os_arch}}
+    "${MVN_CMD}" package -pl ${FE_MODULES:+${FE_MODULES}} -DskipTests
     cd "${DORIS_HOME}"
 fi
 

--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -33,6 +33,8 @@ under the License.
         <fe_ut_parallel>1</fe_ut_parallel>
         <doris.thirdparty>${basedir}/../../thirdparty</doris.thirdparty>
         <antlr4.version>4.9.3</antlr4.version>
+        <protoc.artifact>com.google.protobuf:protoc:${protobuf.version}</protoc.artifact>
+        <grpc.java.artifact>io.grpc:protoc-gen-grpc-java:${grpc.version}</grpc.java.artifact>
     </properties>
     <profiles>
         <profile>
@@ -55,6 +57,18 @@ under the License.
             </activation>
             <properties>
                 <fe_ut_parallel>${env.FE_UT_PARALLEL}</fe_ut_parallel>
+            </properties>
+        </profile>
+        <profile>
+            <activation>
+                <os>
+                    <name>Mac OS X</name>
+                    <arch>aarch64</arch>
+                </os>
+            </activation>
+            <properties>
+                <protoc.artifact>com.google.protobuf:protoc:${protobuf.version}:exe:osx-x86_64</protoc.artifact>
+                <grpc.java.artifact>io.grpc:protoc-gen-grpc-java:${grpc.version}:exe:osx-x86_64</grpc.java.artifact>
             </properties>
         </profile>
     </profiles>
@@ -791,7 +805,7 @@ under the License.
                         <configuration>
                             <!-- <protocCommand>${doris.thirdparty}/installed/bin/protoc</protocCommand> -->
                             <!--You can use following protocArtifact instead of protocCommand, so that you don't need to install protobuf tools-->
-                            <protocArtifact>com.google.protobuf:protoc:${protobuf.version}</protocArtifact>
+                            <protocArtifact>${protoc.artifact}</protocArtifact>
                             <protocVersion>${protobuf.version}</protocVersion>
                             <inputDirectories>
                                 <include>${doris.home}/gensrc/proto</include>
@@ -802,7 +816,7 @@ under the License.
                                 </outputTarget>
                                 <outputTarget>
                                     <type>grpc-java</type>
-                                    <pluginArtifact>io.grpc:protoc-gen-grpc-java:${grpc.version}</pluginArtifact>
+                                    <pluginArtifact>${grpc.java.artifact}</pluginArtifact>
                                 </outputTarget>
                             </outputTargets>
                         </configuration>


### PR DESCRIPTION
# Proposed changes

~~Issue Number: close #xxx~~

## Problem summary

There are some errors occur when building FE by JDK (arm64) on M1 because the dependencies `protoc` and `grpc-java` doesn't support M1. #13563 modified the `build.sh` to fix this issues by adding `-Dos.arch=x86_64` to build command. However, if some one executes `mvn clean package -DskipTests=true` under the folder `fe`, the errors will occur again.

This PR introduces a better way to fix them.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

