### PR TITLE
[fix](export)(outfile) fix bug that export may fail when writing SUCCESS file

### DIFF
--- a/be/src/vec/runtime/vfile_result_writer.cpp
+++ b/be/src/vec/runtime/vfile_result_writer.cpp
@@ -80,7 +80,8 @@ Status VFileResultWriter::_create_success_file() {
     std::string file_name;
     RETURN_IF_ERROR(_get_success_file_name(&file_name));
     RETURN_IF_ERROR(_create_file_writer(file_name));
-    return _close_file_writer(true);
+    // set only close to true to avoid dead loop
+    return _close_file_writer(true, true);
 }
 
 Status VFileResultWriter::_get_success_file_name(std::string* file_name) {
@@ -422,13 +423,17 @@ Status VFileResultWriter::_create_new_file_if_exceed_size() {
     return Status::OK();
 }
 
-Status VFileResultWriter::_close_file_writer(bool done) {
+Status VFileResultWriter::_close_file_writer(bool done, bool only_close) {
     if (_vfile_writer) {
         _vfile_writer->close();
         COUNTER_UPDATE(_written_data_bytes, _current_written_bytes);
         _vfile_writer.reset(nullptr);
     } else if (_file_writer_impl) {
         _file_writer_impl->close();
+    }
+
+    if (only_close) {
+        return Status::OK();
     }
 
     if (!done) {

--- a/be/src/vec/runtime/vfile_result_writer.h
+++ b/be/src/vec/runtime/vfile_result_writer.h
@@ -70,7 +70,7 @@ private:
     std::string _file_format_to_name();
     // close file writer, and if !done, it will create new writer for next file.
     // if only_close is true, this method will just close the file writer and return.
-    Status _close_file_writer(bool done);
+    Status _close_file_writer(bool done, bool only_close = false);
     // create a new file if current file size exceed limit
     Status _create_new_file_if_exceed_size();
     // send the final statistic result

--- a/regression-test/suites/export_p0/test_outfile.groovy
+++ b/regression-test/suites/export_p0/test_outfile.groovy
@@ -168,7 +168,8 @@ suite("test_outfile") {
 
         File[] files = path.listFiles()
         assert files.length == 2 // one is outfile, the other is SUCCESS file
-        List<String> outLines = Files.readAllLines(Paths.get(files[0].getAbsolutePath()), StandardCharsets.UTF_8);
+        File dataFile = files[0].getName().contains("SUCCESS") ? files[1] : files[0];
+        List<String> outLines = Files.readAllLines(Paths.get(dataFile.getAbsolutePath()), StandardCharsets.UTF_8);
         assertEquals(2, outLines.size())
         String[] outLine1 = outLines.get(0).split("\t")
         assertEquals(3, outLine1.size())

--- a/regression-test/suites/export_p0/test_outfile.groovy
+++ b/regression-test/suites/export_p0/test_outfile.groovy
@@ -163,11 +163,11 @@ suite("test_outfile") {
 
         sql "set return_object_data_as_binary = false"
         sql """
-            SELECT * FROM ${tableName} t ORDER BY k1, v2 INTO OUTFILE "file://${outFilePath}/";
+            SELECT * FROM ${tableName} t ORDER BY k1, v2 INTO OUTFILE "file://${outFilePath}/" properties("success_file_name" = "SUCCESS")
         """
 
         File[] files = path.listFiles()
-        assert files.length == 1
+        assert files.length == 2 // one is outfile, the other is SUCCESS file
         List<String> outLines = Files.readAllLines(Paths.get(files[0].getAbsolutePath()), StandardCharsets.UTF_8);
         assertEquals(2, outLines.size())
         String[] outLine1 = outLines.get(0).split("\t")


### PR DESCRIPTION
# Proposed changes

Issue Number: close #13525 

## Problem summary

The doing export or outfile operation with property: `"success_file_name" = "SUCCESS"`
The error may return like:
```
ERROR 1105 (HY000): errCode = 2, detailMessage = File already exists: /tmp/label_SUCCESS. Host: xxx
```
or run in dead loop.

Only affect export or outfile with vec-engine

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [x] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

