### PR TITLE
[fix](restore) fix wrong replica allocation after restore

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/backup/RestoreJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/backup/RestoreJob.java
@@ -672,7 +672,7 @@ public class RestoreJob extends AbstractJob {
                     }
 
                     // Reset properties to correct values.
-                    remoteOlapTbl.resetPropertiesForRestore(reserveDynamicPartitionEnable);
+                    remoteOlapTbl.resetPropertiesForRestore(reserveDynamicPartitionEnable, replicaAlloc);
 
                     // DO NOT set remote table's new name here, cause we will still need the origin name later
                     // remoteOlapTbl.setName(jobInfo.getAliasByOriginNameIfSet(tblInfo.name));

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
@@ -425,9 +425,9 @@ public class OlapTable extends Table {
     /**
      * Reset properties to correct values.
      */
-    public void resetPropertiesForRestore(boolean reserveDynamicPartitionEnable) {
+    public void resetPropertiesForRestore(boolean reserveDynamicPartitionEnable, ReplicaAllocation replicaAlloc) {
         if (tableProperty != null) {
-            tableProperty.resetPropertiesForRestore(reserveDynamicPartitionEnable);
+            tableProperty.resetPropertiesForRestore(reserveDynamicPartitionEnable, replicaAlloc);
         }
         // remove colocate property.
         setColocateGroup(null);

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/TableProperty.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/TableProperty.java
@@ -118,7 +118,8 @@ public class TableProperty implements Writable {
      *
      * @return this for chained
      */
-    public TableProperty resetPropertiesForRestore(boolean reserveDynamicPartitionEnable) {
+    public TableProperty resetPropertiesForRestore(boolean reserveDynamicPartitionEnable,
+            ReplicaAllocation replicaAlloc) {
         // disable dynamic partition
         if (properties.containsKey(DynamicPartitionProperty.ENABLE)) {
             if (!reserveDynamicPartitionEnable) {
@@ -126,6 +127,7 @@ public class TableProperty implements Writable {
             }
             executeBuildDynamicProperty();
         }
+        setReplicaAlloc(replicaAlloc);
         return this;
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/OlapTableTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/OlapTableTest.java
@@ -89,11 +89,14 @@ public class OlapTableTest {
         olapTable.setTableProperty(tableProperty);
         olapTable.setColocateGroup("test_group");
         Assert.assertTrue(olapTable.isColocateTable());
+        Assert.assertTrue(olapTable.getDefaultReplicaAllocation() == ReplicaAllocation.DEFAULT_ALLOCATION);
 
-        olapTable.resetPropertiesForRestore(false);
+        ReplicaAllocation replicaAlloc = new ReplicaAllocation((short) 4);
+        olapTable.resetPropertiesForRestore(false, replicaAlloc);
         Assert.assertEquals(tableProperty.getProperties(), olapTable.getTableProperty().getProperties());
         Assert.assertFalse(tableProperty.getDynamicPartitionProperty().isExist());
         Assert.assertFalse(olapTable.isColocateTable());
+        Assert.assertEquals((short) 4, olapTable.getDefaultReplicaAllocation().getTotalReplicaNum());
 
         // restore with dynamic partition keys
         properties = Maps.newHashMap();
@@ -109,12 +112,13 @@ public class OlapTableTest {
 
         tableProperty = new TableProperty(properties);
         olapTable.setTableProperty(tableProperty);
-        olapTable.resetPropertiesForRestore(false);
+        olapTable.resetPropertiesForRestore(false, ReplicaAllocation.DEFAULT_ALLOCATION);
 
         Map<String, String> expectedProperties = Maps.newHashMap(properties);
         expectedProperties.put(DynamicPartitionProperty.ENABLE, "false");
         Assert.assertEquals(expectedProperties, olapTable.getTableProperty().getProperties());
         Assert.assertTrue(olapTable.getTableProperty().getDynamicPartitionProperty().isExist());
         Assert.assertFalse(olapTable.getTableProperty().getDynamicPartitionProperty().getEnable());
+        Assert.assertEquals((short) 3, olapTable.getDefaultReplicaAllocation().getTotalReplicaNum());
     }
 }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

How to reproduce:
1. create a table with replica allocation, eg:
    ```
    "replication_allocation"="tag.location.group_01:1, tag.location.group_02:1, tag.location.group_03:1"
    ```
2. Backup this table
3. Restore this table with specific replication allocation, eg: `"replication_allocation" = "tag.location.default: 3"`
4. After restore, executing `show create table xxx`, you will be the `replication_allocation` is still:
    ```
    "replication_allocation"="tag.location.group_01:1, tag.location.group_02:1, tag.location.group_03:1"
    ```
    Not what we expected
5. But if you execute `show partitions from xxx`, the replication allocation of each partition is what we expected:
    ```
    "replication_allocation" = "tag.location.default: 3"
    ```

This is because when doing restore job, we forget to set the "default" replica allocation property of the table.
And the result of `show create table` is got from "default" replica allocation property, not from the real replica property of each partition

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
7. Has unit tests been added:
    - [x] Yes
    - [ ] No
    - [ ] No Need
8. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
9. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
10. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

