### PR TITLE
[chore](macOS) Fix issues found on macOS x86_64

### DIFF
--- a/be/src/exec/arrow/parquet_reader.cpp
+++ b/be/src/exec/arrow/parquet_reader.cpp
@@ -275,7 +275,7 @@ Status ParquetReaderWrap::read(Tuple* tuple, MemPool* mem_pool, bool* eof) {
                     RETURN_IF_ERROR(set_field_null(tuple, slot_desc));
                 } else {
                     int32_t value = int32_array->Value(_current_line_of_batch);
-                    wbytes = sprintf((char*)tmp_buf, "%d", value);
+                    wbytes = snprintf((char*)tmp_buf, sizeof(tmp_buf), "%d", value);
                     fill_slot(tuple, slot_desc, mem_pool, tmp_buf, wbytes);
                 }
                 break;
@@ -287,7 +287,7 @@ Status ParquetReaderWrap::read(Tuple* tuple, MemPool* mem_pool, bool* eof) {
                     RETURN_IF_ERROR(set_field_null(tuple, slot_desc));
                 } else {
                     int64_t value = int64_array->Value(_current_line_of_batch);
-                    wbytes = sprintf((char*)tmp_buf, "%" PRId64, value);
+                    wbytes = snprintf((char*)tmp_buf, sizeof(tmp_buf), "%" PRId64, value);
                     fill_slot(tuple, slot_desc, mem_pool, tmp_buf, wbytes);
                 }
                 break;
@@ -299,7 +299,7 @@ Status ParquetReaderWrap::read(Tuple* tuple, MemPool* mem_pool, bool* eof) {
                     RETURN_IF_ERROR(set_field_null(tuple, slot_desc));
                 } else {
                     uint32_t value = uint32_array->Value(_current_line_of_batch);
-                    wbytes = sprintf((char*)tmp_buf, "%u", value);
+                    wbytes = snprintf((char*)tmp_buf, sizeof(tmp_buf), "%u", value);
                     fill_slot(tuple, slot_desc, mem_pool, tmp_buf, wbytes);
                 }
                 break;
@@ -311,7 +311,7 @@ Status ParquetReaderWrap::read(Tuple* tuple, MemPool* mem_pool, bool* eof) {
                     RETURN_IF_ERROR(set_field_null(tuple, slot_desc));
                 } else {
                     uint64_t value = uint64_array->Value(_current_line_of_batch);
-                    wbytes = sprintf((char*)tmp_buf, "%" PRIu64, value);
+                    wbytes = snprintf((char*)tmp_buf, sizeof(tmp_buf), "%" PRIu64, value);
                     fill_slot(tuple, slot_desc, mem_pool, tmp_buf, wbytes);
                 }
                 break;
@@ -360,7 +360,7 @@ Status ParquetReaderWrap::read(Tuple* tuple, MemPool* mem_pool, bool* eof) {
                     RETURN_IF_ERROR(set_field_null(tuple, slot_desc));
                 } else {
                     uint8_t value = uint8_array->Value(_current_line_of_batch);
-                    wbytes = sprintf((char*)tmp_buf, "%d", value);
+                    wbytes = snprintf((char*)tmp_buf, sizeof(tmp_buf), "%d", value);
                     fill_slot(tuple, slot_desc, mem_pool, tmp_buf, wbytes);
                 }
                 break;
@@ -372,7 +372,7 @@ Status ParquetReaderWrap::read(Tuple* tuple, MemPool* mem_pool, bool* eof) {
                     RETURN_IF_ERROR(set_field_null(tuple, slot_desc));
                 } else {
                     int8_t value = int8_array->Value(_current_line_of_batch);
-                    wbytes = sprintf((char*)tmp_buf, "%d", value);
+                    wbytes = snprintf((char*)tmp_buf, sizeof(tmp_buf), "%d", value);
                     fill_slot(tuple, slot_desc, mem_pool, tmp_buf, wbytes);
                 }
                 break;
@@ -384,7 +384,7 @@ Status ParquetReaderWrap::read(Tuple* tuple, MemPool* mem_pool, bool* eof) {
                     RETURN_IF_ERROR(set_field_null(tuple, slot_desc));
                 } else {
                     uint16_t value = uint16_array->Value(_current_line_of_batch);
-                    wbytes = sprintf((char*)tmp_buf, "%d", value);
+                    wbytes = snprintf((char*)tmp_buf, sizeof(tmp_buf), "%d", value);
                     fill_slot(tuple, slot_desc, mem_pool, tmp_buf, wbytes);
                 }
                 break;
@@ -396,7 +396,7 @@ Status ParquetReaderWrap::read(Tuple* tuple, MemPool* mem_pool, bool* eof) {
                     RETURN_IF_ERROR(set_field_null(tuple, slot_desc));
                 } else {
                     int16_t value = int16_array->Value(_current_line_of_batch);
-                    wbytes = sprintf((char*)tmp_buf, "%d", value);
+                    wbytes = snprintf((char*)tmp_buf, sizeof(tmp_buf), "%d", value);
                     fill_slot(tuple, slot_desc, mem_pool, tmp_buf, wbytes);
                 }
                 break;
@@ -408,7 +408,7 @@ Status ParquetReaderWrap::read(Tuple* tuple, MemPool* mem_pool, bool* eof) {
                     RETURN_IF_ERROR(set_field_null(tuple, slot_desc));
                 } else {
                     float value = half_float_array->Value(_current_line_of_batch);
-                    wbytes = sprintf((char*)tmp_buf, "%f", value);
+                    wbytes = snprintf((char*)tmp_buf, sizeof(tmp_buf), "%f", value);
                     fill_slot(tuple, slot_desc, mem_pool, tmp_buf, wbytes);
                 }
                 break;
@@ -423,7 +423,7 @@ Status ParquetReaderWrap::read(Tuple* tuple, MemPool* mem_pool, bool* eof) {
                     // Because the decimal type currently only supports (27, 9).
                     // Therefore, we use %.9f to give priority to the progress of the decimal type.
                     // Cannot use %f directly, this will cause 4000.9 to be converted to 4000.8999
-                    wbytes = sprintf((char*)tmp_buf, "%.9f", value);
+                    wbytes = snprintf((char*)tmp_buf, sizeof(tmp_buf), "%.9f", value);
                     fill_slot(tuple, slot_desc, mem_pool, tmp_buf, wbytes);
                 }
                 break;
@@ -435,7 +435,7 @@ Status ParquetReaderWrap::read(Tuple* tuple, MemPool* mem_pool, bool* eof) {
                     RETURN_IF_ERROR(set_field_null(tuple, slot_desc));
                 } else {
                     double value = double_array->Value(_current_line_of_batch);
-                    wbytes = sprintf((char*)tmp_buf, "%.9f", value);
+                    wbytes = snprintf((char*)tmp_buf, sizeof(tmp_buf), "%.9f", value);
                     fill_slot(tuple, slot_desc, mem_pool, tmp_buf, wbytes);
                 }
                 break;

--- a/be/src/exec/json_scanner.cpp
+++ b/be/src/exec/json_scanner.cpp
@@ -485,19 +485,19 @@ Status JsonReader::_write_data_to_tuple(rapidjson::Value::ConstValueIterator val
         break;
     case rapidjson::Type::kNumberType:
         if (value->IsUint()) {
-            wbytes = sprintf((char*)tmp_buf, "%u", value->GetUint());
+            wbytes = snprintf((char*)tmp_buf, sizeof(tmp_buf), "%u", value->GetUint());
             _fill_slot(tuple, desc, tuple_pool, tmp_buf, wbytes);
         } else if (value->IsInt()) {
-            wbytes = sprintf((char*)tmp_buf, "%d", value->GetInt());
+            wbytes = snprintf((char*)tmp_buf, sizeof(tmp_buf), "%d", value->GetInt());
             _fill_slot(tuple, desc, tuple_pool, tmp_buf, wbytes);
         } else if (value->IsUint64()) {
-            wbytes = sprintf((char*)tmp_buf, "%" PRIu64, value->GetUint64());
+            wbytes = snprintf((char*)tmp_buf, sizeof(tmp_buf), "%" PRIu64, value->GetUint64());
             _fill_slot(tuple, desc, tuple_pool, tmp_buf, wbytes);
         } else if (value->IsInt64()) {
-            wbytes = sprintf((char*)tmp_buf, "%" PRId64, value->GetInt64());
+            wbytes = snprintf((char*)tmp_buf, sizeof(tmp_buf), "%" PRId64, value->GetInt64());
             _fill_slot(tuple, desc, tuple_pool, tmp_buf, wbytes);
         } else {
-            wbytes = sprintf((char*)tmp_buf, "%f", value->GetDouble());
+            wbytes = snprintf((char*)tmp_buf, sizeof(tmp_buf), "%f", value->GetDouble());
             _fill_slot(tuple, desc, tuple_pool, tmp_buf, wbytes);
         }
         break;

--- a/be/src/exec/orc_scanner.cpp
+++ b/be/src/exec/orc_scanner.cpp
@@ -212,7 +212,7 @@ Status ORCScanner::get_next(Tuple* tuple, MemPool* tuple_pool, bool* eof, bool* 
                     case orc::SHORT:
                     case orc::LONG: {
                         int64_t value = ((orc::LongVectorBatch*)cvb)->data[_current_line_of_group];
-                        wbytes = sprintf((char*)tmp_buf, "%" PRId64, value);
+                        wbytes = snprintf((char*)tmp_buf, sizeof(tmp_buf), "%" PRId64, value);
                         str_slot->ptr = reinterpret_cast<char*>(tuple_pool->allocate(wbytes));
                         memcpy(str_slot->ptr, tmp_buf, wbytes);
                         str_slot->len = wbytes;
@@ -221,7 +221,7 @@ Status ORCScanner::get_next(Tuple* tuple, MemPool* tuple_pool, bool* eof, bool* 
                     case orc::FLOAT:
                     case orc::DOUBLE: {
                         double value = ((orc::DoubleVectorBatch*)cvb)->data[_current_line_of_group];
-                        wbytes = sprintf((char*)tmp_buf, "%.9f", value);
+                        wbytes = snprintf((char*)tmp_buf, sizeof(tmp_buf), "%.9f", value);
                         str_slot->ptr = reinterpret_cast<char*>(tuple_pool->allocate(wbytes));
                         memcpy(str_slot->ptr, tmp_buf, wbytes);
                         str_slot->len = wbytes;

--- a/be/src/exprs/table_function/explode_json_array.cpp
+++ b/be/src/exprs/table_function/explode_json_array.cpp
@@ -73,15 +73,15 @@ int ParsedData::set_output(ExplodeJsonArrayType type, rapidjson::Document& docum
                 break;
             case rapidjson::Type::kNumberType:
                 if (v.IsUint()) {
-                    wbytes = sprintf(tmp_buf, "%u", v.GetUint());
+                    wbytes = snprintf(tmp_buf, sizeof(tmp_buf), "%u", v.GetUint());
                 } else if (v.IsInt()) {
-                    wbytes = sprintf(tmp_buf, "%d", v.GetInt());
+                    wbytes = snprintf(tmp_buf, sizeof(tmp_buf), "%d", v.GetInt());
                 } else if (v.IsUint64()) {
-                    wbytes = sprintf(tmp_buf, "%" PRIu64, v.GetUint64());
+                    wbytes = snprintf(tmp_buf, sizeof(tmp_buf), "%" PRIu64, v.GetUint64());
                 } else if (v.IsInt64()) {
-                    wbytes = sprintf(tmp_buf, "%" PRId64, v.GetInt64());
+                    wbytes = snprintf(tmp_buf, sizeof(tmp_buf), "%" PRId64, v.GetInt64());
                 } else {
-                    wbytes = sprintf(tmp_buf, "%f", v.GetDouble());
+                    wbytes = snprintf(tmp_buf, sizeof(tmp_buf), "%f", v.GetDouble());
                 }
                 _backup_string.emplace_back(tmp_buf, wbytes);
                 _string_nulls.push_back(false);

--- a/be/src/runtime/mem_pool.cpp
+++ b/be/src/runtime/mem_pool.cpp
@@ -241,7 +241,7 @@ std::string MemPool::debug_string() {
     char str[16];
     out << "MemPool(#chunks=" << chunks_.size() << " [";
     for (int i = 0; i < chunks_.size(); ++i) {
-        sprintf(str, "0x%lx=", reinterpret_cast<size_t>(chunks_[i].chunk.data));
+        snprintf(str, sizeof(str), "0x%lx=", reinterpret_cast<size_t>(chunks_[i].chunk.data));
         out << (i > 0 ? " " : "") << str << chunks_[i].chunk.size << "/"
             << chunks_[i].allocated_bytes;
     }

--- a/be/src/vec/exec/vjson_scanner.cpp
+++ b/be/src/vec/exec/vjson_scanner.cpp
@@ -327,15 +327,15 @@ Status VJsonReader::_write_data_to_column(rapidjson::Value::ConstValueIterator v
         break;
     case rapidjson::Type::kNumberType:
         if (value->IsUint()) {
-            wbytes = sprintf(tmp_buf, "%u", value->GetUint());
+            wbytes = snprintf(tmp_buf, sizeof(tmp_buf), "%u", value->GetUint());
         } else if (value->IsInt()) {
-            wbytes = sprintf(tmp_buf, "%d", value->GetInt());
+            wbytes = snprintf(tmp_buf, sizeof(tmp_buf), "%d", value->GetInt());
         } else if (value->IsUint64()) {
-            wbytes = sprintf(tmp_buf, "%" PRIu64, value->GetUint64());
+            wbytes = snprintf(tmp_buf, sizeof(tmp_buf), "%" PRIu64, value->GetUint64());
         } else if (value->IsInt64()) {
-            wbytes = sprintf(tmp_buf, "%" PRId64, value->GetInt64());
+            wbytes = snprintf(tmp_buf, sizeof(tmp_buf), "%" PRId64, value->GetInt64());
         } else {
-            wbytes = sprintf(tmp_buf, "%f", value->GetDouble());
+            wbytes = snprintf(tmp_buf, sizeof(tmp_buf), "%f", value->GetDouble());
         }
         str_value = tmp_buf;
         break;

--- a/bin/start_be.sh
+++ b/bin/start_be.sh
@@ -21,7 +21,7 @@ set -eo pipefail
 curdir="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
 if [[ "$(uname -s)" == 'Darwin' ]] && command -v brew &>/dev/null; then
-    PATH="$(brew --repo)/opt/gnu-getopt/bin:${PATH}"
+    PATH="$(brew --prefix)/opt/gnu-getopt/bin:${PATH}"
     export PATH
 fi
 

--- a/bin/start_fe.sh
+++ b/bin/start_fe.sh
@@ -21,7 +21,7 @@ set -eo pipefail
 curdir="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
 if [[ "$(uname -s)" == 'Darwin' ]] && command -v brew &>/dev/null; then
-    PATH="$(brew --repo)/opt/gnu-getopt/bin:${PATH}"
+    PATH="$(brew --prefix)/opt/gnu-getopt/bin:${PATH}"
     export PATH
 fi
 

--- a/fs_brokers/apache_hdfs_broker/bin/start_broker.sh
+++ b/fs_brokers/apache_hdfs_broker/bin/start_broker.sh
@@ -20,6 +20,11 @@ set -eo pipefail
 
 curdir="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
+if [[ "$(uname -s)" == 'Darwin' ]] && command -v brew &>/dev/null; then
+    PATH="$(brew --prefix)/opt/gnu-getopt/bin:${PATH}"
+    export PATH
+fi
+
 OPTS="$(getopt \
     -n "$0" \
     -o '' \


### PR DESCRIPTION
# Proposed changes

~~Issue Number: close #xxx~~

## Problem summary

Fix issues found on macOS x86_64.
1. Should use `brew --prefix` instead of `brew --repo` in start scripts.
2. `sprintf` is marked as a deprecated function in MacOSX sdk (13.0).

```shell
$ ls -l /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk
/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk -> MacOSX13.0.sdk

$ clang --version
Apple clang version 14.0.0 (clang-1400.0.29.201)
Target: x86_64-apple-darwin21.6.0
Thread model: posix
InstalledDir: /Library/Developer/CommandLineTools/usr/bin
```

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
3. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
5. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
6. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

