### PR TITLE
[Chore](build) add a environment variable DISABLE_JAVA_UDF

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -129,7 +129,7 @@ BUILD_BROKER=0
 BUILD_AUDIT=0
 BUILD_META_TOOL='OFF'
 BUILD_SPARK_DPP=0
-BUILD_JAVA_UDF=0
+BUILD_JAVA_UDF=1
 BUILD_HIVE_UDF=0
 CLEAN=0
 HELP=0
@@ -143,7 +143,6 @@ if [[ "$#" == 1 ]]; then
     BUILD_AUDIT=1
     BUILD_META_TOOL='OFF'
     BUILD_SPARK_DPP=1
-    BUILD_JAVA_UDF=1
     BUILD_HIVE_UDF=1
     CLEAN=0
 else
@@ -152,13 +151,11 @@ else
         --fe)
             BUILD_FE=1
             BUILD_SPARK_DPP=1
-            BUILD_JAVA_UDF=1
             BUILD_HIVE_UDF=1
             shift
             ;;
         --be)
             BUILD_BE=1
-            BUILD_JAVA_UDF=1
             shift
             ;;
         --broker)
@@ -216,7 +213,6 @@ else
         BUILD_AUDIT=1
         BUILD_META_TOOL='ON'
         BUILD_SPARK_DPP=1
-        BUILD_JAVA_UDF=1
         BUILD_HIVE_UDF=1
         CLEAN=0
     fi

--- a/build.sh
+++ b/build.sh
@@ -289,8 +289,8 @@ if [[ -z "${USE_DWARF}" ]]; then
     USE_DWARF='OFF'
 fi
 
-if [[ "${DISABLE_JAVA_UDF}" == "ON" ]]; then
-    BUILD_JAVA_UDF=0
+if [[ -z "${DISABLE_JAVA_UDF}" ]]; then
+    DISABLE_JAVA_UDF='OFF'
 fi
 
 if [[ -z "${RECORD_COMPILER_SWITCHES}" ]]; then
@@ -298,6 +298,10 @@ if [[ -z "${RECORD_COMPILER_SWITCHES}" ]]; then
 fi
 
 if [[ "${BUILD_JAVA_UDF}" -eq 1 && "$(uname -s)" == 'Darwin' ]]; then
+    BUILD_JAVA_UDF=0
+fi
+
+if [[ "${DISABLE_JAVA_UDF}" == "ON" ]]; then
     BUILD_JAVA_UDF=0
 fi
 

--- a/build.sh
+++ b/build.sh
@@ -46,14 +46,13 @@ Usage: $0 <options>
      --audit            build audit loader. Default ON.
      --spark-dpp        build Spark DPP application. Default ON.
      --hive-udf         build Hive UDF library for Spark Load. Default ON.
-     --java-udf         build Java UDF library. Default ON.
      --clean            clean and build target
      -j                 build Backend parallel
 
   Environment variables:
     USE_AVX2            If the CPU does not support AVX2 instruction set, please set USE_AVX2=0. Default is ON.
     STRIP_DEBUG_INFO    If set STRIP_DEBUG_INFO=ON, the debug information in the compiled binaries will be stored separately in the 'be/lib/debug_info' directory. Default is OFF.
-
+    DISABLE_JAVA_UDF    If set DISABLE_JAVA_UDF=ON, we will do not build binary with java-udf. Default is OFF.
   Eg.
     $0                                      build all
     $0 --be                                 build Backend
@@ -62,7 +61,7 @@ Usage: $0 <options>
     $0 --fe --be --clean                    clean and build Frontend, Spark Dpp application and Backend
     $0 --spark-dpp                          build Spark DPP application alone
     $0 --broker                             build Broker
-    $0 --be --fe --java-udf                 build Backend, Frontend, Spark Dpp application and Java UDF library
+    $0 --be --fe                            build Backend, Frontend, Spark Dpp application and Java UDF library
 
     USE_AVX2=0 $0 --be                      build Backend and not using AVX2 instruction.
     USE_AVX2=0 STRIP_DEBUG_INFO=ON $0       build all and not using AVX2 instruction, and strip the debug info for Backend
@@ -113,7 +112,6 @@ if ! OPTS="$(getopt \
     -l 'audit' \
     -l 'meta-tool' \
     -l 'spark-dpp' \
-    -l 'java-udf' \
     -l 'hive-udf' \
     -l 'clean' \
     -l 'help' \
@@ -179,12 +177,6 @@ else
             BUILD_SPARK_DPP=1
             shift
             ;;
-        --java-udf)
-            BUILD_JAVA_UDF=1
-            BUILD_FE=1
-            BUILD_SPARK_DPP=1
-            shift
-            ;;
         --hive-udf)
             BUILD_HIVE_UDF=1
             shift
@@ -224,6 +216,7 @@ else
         BUILD_AUDIT=1
         BUILD_META_TOOL='ON'
         BUILD_SPARK_DPP=1
+        BUILD_JAVA_UDF=1
         BUILD_HIVE_UDF=1
         CLEAN=0
     fi
@@ -294,6 +287,10 @@ fi
 
 if [[ -z "${USE_DWARF}" ]]; then
     USE_DWARF='OFF'
+fi
+
+if [[ "${DISABLE_JAVA_UDF}" == "ON" ]]; then
+    BUILD_JAVA_UDF=0
 fi
 
 if [[ -z "${RECORD_COMPILER_SWITCHES}" ]]; then


### PR DESCRIPTION
# Proposed changes

Currently we have no way to compile the backend without java-udf, which will cause us to spend 50s more per compilation, so I added an environment variable that disables java-udf.

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

