### PR TITLE
[improvement](bitmap) try to improve bitmap value deserialize performance

### DIFF
--- a/be/test/util/bitmap_value_test.cpp
+++ b/be/test/util/bitmap_value_test.cpp
@@ -312,7 +312,8 @@ TEST(BitmapValueTest, Roaring64Map) {
     uint32_t expectedsize = r1.getSizeInBytes();
     char* serializedbytes = new char[expectedsize];
     r1.write(serializedbytes);
-    Roaring64Map t = Roaring64Map::read(serializedbytes);
+    Roaring64Map t;
+    Roaring64Map::read(serializedbytes, t);
     EXPECT_TRUE(r1 == t);
     delete[] serializedbytes;
 


### PR DESCRIPTION

# Proposed changes

Issue Number: close #xxx

## Problem summary

Roaring64Map's move constructor is same as copy constructor.  So that there will be a copy at _bitmap = detail::Roaring64Map::read(src); and then there will also a deconstruct process.

#8  0x0000557874223841 in ra_clear_containers ()
#9  0x0000557874223869 in ra_reset ()
#10 0x0000557871b5078f in roaring::Roaring::~Roaring (this=<optimized out>, __in_chrg=<optimized out>) at /var/local/thirdparty/installed/include/roaring/roaring.hh:189
#11 0x00005578724ed8c9 in read (buf=<optimized out>) at /root/doris/be/src/util/bitmap_value.h:713
#12 doris::BitmapValue::deserialize (this=0x7f14633d26e0, src=<optimized out>) at /root/doris/be/src/util/bitmap_value.h:1604
#13 0x00005578724ef7c4 in doris::vectorized::ColumnComplexType<doris::BitmapValue>::insert_many_binary_data (this=0x55789513cde0, data_array=0x5578f115a000 "\002:0", len_array=0x7f14633d2780, start_offset_array=0x7f14633d2760, num=4) at /var/local/ldb-toolchain/include/c++/11/ext/new_allocator.h:89
#14 0x0000557871dcc022 in doris::segment_v2::BinaryPlainPageDecoder::read_by_rowids (this=<optimized out>, rowids=<optimized out>, page_first_ordinal=11154, n=0x7f14633d2898, dst=...) at /root/doris/be/src/vec/common/cow.h:210
#15 0x00005578727675cd in doris::segment_v2::FileColumnIterator::read_by_rowids (this=0x557b765b4dc0, rowids=0x5578c4b68a00, count=360, dst=...) at /root/doris/be/src/olap/rowset/segment_v2/column_reader.cpp:730
#16 0x0000557872730625 in doris::segment_v2::SegmentIterator::_read_columns_by_rowids(std::vector<unsigned int, std::allocator<unsigned int> >&, std::vector<unsigned int, std::allocator<unsigned int> >&, unsigned short*, unsigned long, std::vector<COW<doris::vectorized::IColumn>::mutable_ptr<doris::vectorized::IColumn>, std::allocator<COW<doris::vectorized::IColumn>::mutable_ptr<doris::vectorized::IColumn> > >*) () at /var/local/ldb-toolchain/include/c++/11/bits/stl_vector.h:1043
#17 0x00005578727373f1 in doris::segment_v2::SegmentIterator::next_batch(doris::vectorized::Block*) () at /root/doris/be/src/olap/rowset/segment_v2/segment_iterator.cpp:994
#18 0x000055787250c41a in doris::vectorized::VUnionIterator::next_batch (this=0x5578e4aefb00, block=0x557b6f3972c0) at /root/doris/be/src/vec/olap/vgeneric_iterators.cpp:442
#19 0x0000557871e137d9 in doris::BetaRowsetReader::next_block(doris::vectorized::Block*) () at /root/doris/be/src/util/stopwatch.hpp:65
#20 0x00005578735ac0a8 in doris::vectorized::VCollectIterator::Level0Iterator::next (this=0x5582b08b4b90, block=0x557b6f3972c0) at /var/local/ldb-toolchain/include/c++/11/bits/shared_ptr_base.h:1290
#21 0x00005578735ac19c in _normal_next (block=<optimized out>, this=<optimized out>) at /root/doris/be/src/vec/olap/vcollect_iterator.cpp:389
#22 doris::vectorized::VCollectIterator::Level1Iterator::next(doris::vectorized::Block*) () at /root/doris/be/src/vec/olap/vcollect_iterator.cpp:287
#23 0x000055787353b7a8 in doris::vectorized::BlockReader::_direct_next_block (this=<optimized out>, block=<optimized out>, mem_pool=<optimized out>, agg_pool=<optimized out>, eof=0x7f14633d863e) at /root/doris/be/src/vec/olap/block_reader.cpp:176
#24 0x000055787284013e in doris::vectorized::VOlapScanner::get_block(doris::RuntimeState*, doris::vectorized::Block*, bool*) () at /var/local/ldb-toolchain/include/c++/11/bits/unique_ptr.h:421
#25 0x0000557872835ade in doris::vectorized::VOlapScanNode::scanner_thread(doris::vectorized::VOlapScanner*) () at /root/doris/be/src/vec/exec/volap_scan_node.cpp:227

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

