### PR TITLE
[Bugfix](manager) fix query profile key incompatible with old versions

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/manager/QueryProfileAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/manager/QueryProfileAction.java
@@ -429,8 +429,9 @@ public class QueryProfileAction extends RestBaseController {
         Map<String, String> result = Maps.newHashMap();
         if (!dataList.isEmpty()) {
             try {
-                String profile = JsonParser.parseString(dataList.get(0)).getAsJsonObject().get("profile").getAsString();
-                result.put("profile", profile);
+                String key = format.equals("graph") ? "graph" : "profile";
+                String profile = JsonParser.parseString(dataList.get(0)).getAsJsonObject().get(key).getAsString();
+                result.put(key, profile);
             } catch (Exception e) {
                 return ResponseEntityBuilder.badRequest(e.getMessage());
             }


### PR DESCRIPTION
# Proposed changes

fix query profile key incompatible with old versions

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

