### PR TITLE
[fix](planner) cannot recogonize column's table when analyze rewrite expr

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/SlotRef.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/SlotRef.java
@@ -34,6 +34,7 @@ import org.apache.doris.thrift.TSlotRef;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -188,6 +189,11 @@ public class SlotRef extends Expr {
         numDistinctValues = desc.getStats().getNumDistinctValues();
         if (type.equals(Type.BOOLEAN)) {
             selectivity = DEFAULT_SELECTIVITY;
+        }
+        if (tblName == null) {
+            if (StringUtils.isNotEmpty(desc.getParent().getAlias())) {
+                tblName = new TableName(null, null, desc.getParent().getAlias());
+            }
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/SlotRef.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/SlotRef.java
@@ -190,10 +190,9 @@ public class SlotRef extends Expr {
         if (type.equals(Type.BOOLEAN)) {
             selectivity = DEFAULT_SELECTIVITY;
         }
-        if (tblName == null) {
-            if (StringUtils.isNotEmpty(desc.getParent().getAlias())) {
-                tblName = new TableName(null, null, desc.getParent().getAlias());
-            }
+        if (tblName == null && StringUtils.isNotEmpty(desc.getParent().getLastAlias())
+                && !desc.getParent().getLastAlias().equals(desc.getParent().getTable().getName())) {
+            tblName = new TableName(null, null, desc.getParent().getLastAlias());
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/TupleDescriptor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/TupleDescriptor.java
@@ -192,6 +192,10 @@ public class TupleDescriptor {
         return (aliases != null) ? aliases[0] : null;
     }
 
+    public String getLastAlias() {
+        return (aliases != null) ? aliases[aliases.length - 1] : null;
+    }
+
     public TableName getAliasAsName() {
         return (aliases != null) ? new TableName(null, null, aliases[0]) : null;
     }

--- a/fe/fe-core/src/test/java/org/apache/doris/policy/PolicyTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/policy/PolicyTest.java
@@ -189,7 +189,7 @@ public class PolicyTest extends TestWithFeService {
         String subQuerySql = "select * from table2 where k1 in (select k1 from table1)";
         Assertions.assertTrue(getSQLPlanOrErrorMsg(subQuerySql).contains("PREDICATES: `k1` = 1, `k2` = 1"));
         String aliasSql = "select * from table1 t1 join table2 t2 on t1.k1=t2.k1";
-        Assertions.assertTrue(getSQLPlanOrErrorMsg(aliasSql).contains("PREDICATES: `k1` = 1, `k2` = 1"));
+        Assertions.assertTrue(getSQLPlanOrErrorMsg(aliasSql).contains("PREDICATES: `t1`.`k1` = 1, `t1`.`k2` = 1"));
         dropPolicy("DROP ROW POLICY test_row_policy1 ON test.table1");
         dropPolicy("DROP ROW POLICY test_row_policy2 ON test.table1");
     }

--- a/regression-test/conf/regression-conf.groovy
+++ b/regression-test/conf/regression-conf.groovy
@@ -20,11 +20,11 @@
 // **Note**: default db will be create if not exist
 defaultDb = "regression_test"
 
-jdbcUrl = "jdbc:mysql://127.0.0.1:9030/?"
+jdbcUrl = "jdbc:mysql://127.0.0.1:9636/?"
 jdbcUser = "root"
 jdbcPassword = ""
 
-feHttpAddress = "127.0.0.1:8030"
+feHttpAddress = "127.0.0.1:8636"
 feHttpUser = "root"
 feHttpPassword = ""
 

--- a/regression-test/conf/regression-conf.groovy
+++ b/regression-test/conf/regression-conf.groovy
@@ -20,11 +20,11 @@
 // **Note**: default db will be create if not exist
 defaultDb = "regression_test"
 
-jdbcUrl = "jdbc:mysql://127.0.0.1:9636/?"
+jdbcUrl = "jdbc:mysql://127.0.0.1:9030/?"
 jdbcUser = "root"
 jdbcPassword = ""
 
-feHttpAddress = "127.0.0.1:8636"
+feHttpAddress = "127.0.0.1:8030"
 feHttpUser = "root"
 feHttpPassword = ""
 

--- a/regression-test/suites/correctness/test_mv_alias_table_name.groovy
+++ b/regression-test/suites/correctness/test_mv_alias_table_name.groovy
@@ -21,10 +21,10 @@ exception throw before bug fix:  Unknown column 'mv_bitmap_union_mh' in 'default
 */
 suite("test_mv_alias_table_name") {
     sql """
-        DROP TABLE IF EXISTS test.original_table;
+        DROP TABLE IF EXISTS original_table;
     """
     sql """
-        CREATE TABLE test.original_table
+        CREATE TABLE original_table
         (
             day date,
             aid bigint,
@@ -43,19 +43,19 @@ suite("test_mv_alias_table_name") {
         select day,aid,lid,
             bitmap_union(to_bitmap(mh)) as wu,     
             bitmap_union(to_bitmap(my)) as mu 
-        from test.original_table 
+        from original_table 
         group by day, aid, lid;
     """
 
     sql """
-        insert into test.original_table values('2022-10-16', 1665710553, 1665710553, 1665710553, 1665700553, 1665700553);
+        insert into original_table values('2022-10-16', 1665710553, 1665710553, 1665710553, 1665700553, 1665700553);
     """
 
     sleep(2000)
 
     sql """
         select t0.aid, t0.lid, count(distinct mh), count(distinct my) 
-        from test.original_table t0 
+        from original_table t0 
         where t0.day = '2022-10-16' and t0.lid > 0 group by t0.aid, t0.lid;
     """
 

--- a/regression-test/suites/correctness/test_mv_alias_table_name.groovy
+++ b/regression-test/suites/correctness/test_mv_alias_table_name.groovy
@@ -1,0 +1,63 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+ // or more contributor license agreements.  See the NOTICE file
+ // distributed with this work for additional information
+ // regarding copyright ownership.  The ASF licenses this file
+ // to you under the Apache License, Version 2.0 (the
+ // "License"); you may not use this file except in compliance
+ // with the License.  You may obtain a copy of the License at
+ //
+ //   http://www.apache.org/licenses/LICENSE-2.0
+ //
+ // Unless required by applicable law or agreed to in writing,
+ // software distributed under the License is distributed on an
+ // "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ // KIND, either express or implied.  See the License for the
+ // specific language governing permissions and limitations
+ // under the License.
+
+
+/*
+exception throw before bug fix:  Unknown column 'mv_bitmap_union_mh' in 'default_cluster:test.original_table'
+*/
+suite("test_mv_alias_table_name") {
+    sql """
+        DROP TABLE IF EXISTS test.original_table;
+    """
+    sql """
+        CREATE TABLE test.original_table
+        (
+            day date,
+            aid bigint,
+            lid bigint,
+            yid bigint,
+            mh bigint,
+            my bigint
+        )
+        DUPLICATE KEY(`day`, `aid`, `lid`)
+        DISTRIBUTED BY HASH(aid)
+        PROPERTIES ("replication_num" = "1" );
+    """
+
+    sql """
+        create materialized view mv_table as
+        select day,aid,lid,
+            bitmap_union(to_bitmap(mh)) as wu,     
+            bitmap_union(to_bitmap(my)) as mu 
+        from test.original_table 
+        group by day, aid, lid;
+    """
+
+    sql """
+        insert into test.original_table values('2022-10-16', 1665710553, 1665710553, 1665710553, 1665700553, 1665700553);
+    """
+
+    sleep(2000)
+
+    sql """
+        select t0.aid, t0.lid, count(distinct mh), count(distinct my) 
+        from test.original_table t0 
+        where t0.day = '2022-10-16' and t0.lid > 0 group by t0.aid, t0.lid;
+    """
+
+ }
+


### PR DESCRIPTION
# Proposed changes

Issue Number: close #13605

## Problem summary

We save mv column with alias as table name, and search it with original table name.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

