### PR TITLE
[fix](planner) inlineView alias error

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/Analyzer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/Analyzer.java
@@ -152,18 +152,10 @@ public class Analyzer {
 
     // Flag indicating if this analyzer instance belongs to a subquery.
     private boolean isSubquery = false;
-
-    public boolean isInlineView() {
-        return isInlineView;
-    }
-
-    public void setInlineView(boolean inlineView) {
-        isInlineView = inlineView;
-    }
-
     // Flag indicating if this analyzer instance belongs to an inlineview.
     private boolean isInlineView = false;
 
+    private String explicitViewAlias;
     // Flag indicating whether this analyzer belongs to a WITH clause view.
     private boolean isWithClause = false;
 
@@ -519,6 +511,18 @@ public class Analyzer {
         return callDepth;
     }
 
+    public void setInlineView(boolean inlineView) {
+        isInlineView = inlineView;
+    }
+
+    public void setExplicitViewAlias(String alias) {
+        explicitViewAlias = alias;
+    }
+
+    public String getExplicitViewAlias() {
+        return explicitViewAlias;
+    }
+
     /**
      * Registers a local view definition with this analyzer. Throws an exception if a view
      * definition with the same alias has already been registered or if the number of
@@ -806,7 +810,7 @@ public class Analyzer {
             // ===================================================
             // Someone may concern that if t2 is not alias of t, this fix will cause incorrect resolve. In fact,
             // this does not happen, since we push t2.a in (1.2) down to this inline view, t2 must be alias of t.
-            if (d == null && isInlineView) {
+            if (d == null && isInlineView && newTblName.getTbl().equals(explicitViewAlias)) {
                 d = resolveColumnRef(colName);
             }
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/InlineViewRef.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/InlineViewRef.java
@@ -187,6 +187,9 @@ public class InlineViewRef extends TableRef {
         // Analyze the inline view query statement with its own analyzer
         inlineViewAnalyzer = new Analyzer(analyzer);
         inlineViewAnalyzer.setInlineView(true);
+        if (hasExplicitAlias) {
+            inlineViewAnalyzer.setExplicitViewAlias(aliases[0]);
+        }
         queryStmt.analyze(inlineViewAnalyzer);
         correlatedTupleIds.addAll(queryStmt.getCorrelatedTupleIds(inlineViewAnalyzer));
 

--- a/regression-test/suites/correctness/test_pushdown_pred_to_view.groovy
+++ b/regression-test/suites/correctness/test_pushdown_pred_to_view.groovy
@@ -54,7 +54,7 @@ The same resolve error occurs when re-analyze v2.
      """
 
      qt_sql """
-         select * from ${viewName} as v1 join ${viewName} as v2 on v1.id=v2.id and v1.id>0;
+         select * from ${viewName} as v1 join ${viewName} as v2 where v1.id=v2.id and v1.id>0;
      """
      sql "DROP VIEW ${viewName}"
      sql "DROP TABLE ${tableName}"

--- a/regression-test/suites/correctness/test_table_alias.groovy
+++ b/regression-test/suites/correctness/test_table_alias.groovy
@@ -1,0 +1,47 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+ // or more contributor license agreements.  See the NOTICE file
+ // distributed with this work for additional information
+ // regarding copyright ownership.  The ASF licenses this file
+ // to you under the Apache License, Version 2.0 (the
+ // "License"); you may not use this file except in compliance
+ // with the License.  You may obtain a copy of the License at
+ //
+ //   http://www.apache.org/licenses/LICENSE-2.0
+ //
+ // Unless required by applicable law or agreed to in writing,
+ // software distributed under the License is distributed on an
+ // "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ // KIND, either express or implied.  See the License for the
+ // specific language governing permissions and limitations
+ // under the License.
+
+suite("test_table_alias") {
+     sql """ DROP TABLE IF EXISTS tbl_alias """
+     sql """
+         CREATE TABLE tbl_alias (
+             `id` int
+         ) ENGINE=OLAP
+         AGGREGATE KEY(`id`)
+         COMMENT "OLAP"
+         DISTRIBUTED BY HASH(`id`) BUCKETS 1
+         PROPERTIES (
+             "replication_allocation" = "tag.location.default: 1",
+             "in_memory" = "false",
+             "storage_format" = "V2"
+         );
+     """
+
+    try {
+        test {
+            sql """
+            select * 
+            from (select t3.id 
+                  from (select * from tbl_alias) t1
+                 ) t2
+            """
+            exception "errCode = 2, detailMessage = Unknown column 'id' in 't3'"            
+        }
+    } finally {
+        sql "drop table if exists tbl_alias"
+    }
+}


### PR DESCRIPTION
# Proposed changes
set alias for `inlineViewAnalyzaer`, and check alias name when `resolveColumnRef()`


Issue Number: 13431
https://github.com/apache/doris/issues/13431

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

