### PR TITLE
[fix](thirdparty) g++-11: error: unrecognized command-line option '-m…

### DIFF
--- a/thirdparty/build-thirdparty.sh
+++ b/thirdparty/build-thirdparty.sh
@@ -1345,8 +1345,13 @@ build_hdfs3() {
     cd "${BUILD_DIR}"
     rm -rf ./*
 
+    if [[ "$(uname -m)" == "aarch64" ]]; then
+        SSE_OPTION='-DENABLE_SSE=OFF'
+    else
+        SSE_OPTION='-DENABLE_SSE=ON'
+    fi
     cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX="${TP_INSTALL_DIR}" \
-        -DBUILD_STATIC_LIBS=ON -DBUILD_SHARED_LIBS=OFF -DBUILD_TEST=OFF \
+        -DBUILD_STATIC_LIBS=ON -DBUILD_SHARED_LIBS=OFF -DBUILD_TEST=OFF "${SSE_OPTION}" \
         -DProtobuf_PROTOC_EXECUTABLE="${TP_INSTALL_DIR}/bin/protoc" \
         -DProtobuf_INCLUDE_DIR="${TP_INSTALL_DIR}/include" \
         -DProtobuf_LIBRARIES="${TP_INSTALL_DIR}/lib/libprotoc.a" \

--- a/thirdparty/build-thirdparty.sh
+++ b/thirdparty/build-thirdparty.sh
@@ -1345,10 +1345,10 @@ build_hdfs3() {
     cd "${BUILD_DIR}"
     rm -rf ./*
 
-    if [[ "$(uname -m)" == "aarch64" ]]; then
-        SSE_OPTION='-DENABLE_SSE=OFF'
-    else
+    if [[ "$(uname -m)" == "x86_64" ]]; then
         SSE_OPTION='-DENABLE_SSE=ON'
+    else
+        SSE_OPTION='-DENABLE_SSE=OFF'
     fi
     cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX="${TP_INSTALL_DIR}" \
         -DBUILD_STATIC_LIBS=ON -DBUILD_SHARED_LIBS=OFF -DBUILD_TEST=OFF "${SSE_OPTION}" \


### PR DESCRIPTION
…sse4.2'

# Proposed changes

Issue Number: close #xxx

## Problem summary

When compiling third-party hdfs on aarch64 machine, 
got error: g++-11: error: unrecognized command-line option '-msse4.2'


## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

