### PR TITLE
[chore](macOS) Support macOS Ventura (13.0)

### DIFF
--- a/env.sh
+++ b/env.sh
@@ -48,6 +48,7 @@ CELLARS=(
     autoconf
     libtool
     pkg-config
+    texinfo
     coreutils
     gnu-getopt
     python


### PR DESCRIPTION
# Proposed changes

~~Issue Number: close #xxx~~

## Problem summary

We need the tool `makeinfo` to build third parties on macOS Ventura (13.0).

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

