### PR TITLE
[fix](array-type) support CTAS for ARRAY column from collect_list and collect_set

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/FunctionCallExpr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/FunctionCallExpr.java
@@ -1082,6 +1082,11 @@ public class FunctionCallExpr extends Expr {
             throw new AnalysisException(getFunctionNotFoundError(collectChildReturnTypes()));
         }
 
+        if (fnName.getFunction().equalsIgnoreCase("collect_list")
+                || fnName.getFunction().equalsIgnoreCase("collect_set")) {
+            fn.setReturnType(new ArrayType(getChild(0).type));
+        }
+
         applyAutoTypeConversionForDatetimeV2();
 
         if (fnName.getFunction().equalsIgnoreCase("from_unixtime")

--- a/regression-test/data/query_p0/sql_functions/aggregate_functions/test_aggregate_collect.out
+++ b/regression-test/data/query_p0/sql_functions/aggregate_functions/test_aggregate_collect.out
@@ -13,3 +13,6 @@
 -- !select --
 ['hello']	['hello']
 
+-- !select --
+1	[1, 2, 1, 2]	['hello']	[2022-07-04, 2022-07-04]	[1.23]	['hello', 'hello', 'hello', 'hello']
+

--- a/regression-test/suites/query_p0/sql_functions/aggregate_functions/test_aggregate_collect.groovy
+++ b/regression-test/suites/query_p0/sql_functions/aggregate_functions/test_aggregate_collect.groovy
@@ -19,7 +19,9 @@ suite("test_aggregate_collect") {
     sql "set enable_vectorized_engine = true"
 
     def tableName = "collect_test"
+    def tableCTAS = "collect_test_ctas"
     sql "DROP TABLE IF EXISTS ${tableName}"
+    sql "DROP TABLE IF EXISTS ${tableCTAS}"
     sql """
 	    CREATE TABLE IF NOT EXISTS ${tableName} (
 	        c_int INT,
@@ -42,4 +44,7 @@ suite("test_aggregate_collect") {
     // test without GROUP BY
     qt_select "select collect_list(c_string),collect_list(c_string_not_null) from ${tableName}"
     qt_select "select collect_set(c_string),collect_set(c_string_not_null) from ${tableName}"
+
+    sql """ CREATE TABLE ${tableCTAS} PROPERTIES("replication_num" = "1") AS SELECT 1,collect_list(c_int),collect_set(c_string),collect_list(c_date),collect_set(c_decimal),collect_list(c_string_not_null) FROM ${tableName} """
+    qt_select "SELECT * from ${tableCTAS}"
 }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

Describe your changes.

CTAS got wrong result for CHAR or VARCHAR type. 

```
mysql> create table l1 as select 1, 2, 3, collect_list(k6), collect_list(k7), collect_list(k5) from test_query_qa.test;

ERROR 5025 (HY000): Insert has filtered data in strict mode, tracking_url=http://xxxx.20:8641/api/_load_error_log?file=__shard_0/error_log_insert_stmt_9450186f9af3454c-a7f27c70d8331338_9450186f9af3454c_a7f27c70d8331338
```

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [x] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

