### PR TITLE
[bug](load) fix core dump when get_memtable_consumption_inflush

### DIFF
--- a/be/src/olap/delta_writer.cpp
+++ b/be/src/olap/delta_writer.cpp
@@ -389,7 +389,7 @@ void DeltaWriter::save_mem_consumption_snapshot() {
 }
 
 int64_t DeltaWriter::get_memtable_consumption_inflush() const {
-    if (_flush_token->get_stats().flush_running_count == 0) return 0;
+    if (!_is_init || _flush_token->get_stats().flush_running_count == 0) return 0;
     return _mem_consumption_snapshot - _memtable_consumption_snapshot;
 }
 


### PR DESCRIPTION
# Proposed changes

Issue Number: close #13610 

## Problem summary

If delta writer is not inited, `_flush_token` might be `nullptr`.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

