### PR TITLE
[enhancement](metric)Add metric for exec_state prepare function

### DIFF
--- a/be/src/runtime/fragment_mgr.cpp
+++ b/be/src/runtime/fragment_mgr.cpp
@@ -17,6 +17,7 @@
 
 #include "runtime/fragment_mgr.h"
 
+#include <bvar/latency_recorder.h>
 #include <gperftools/profiler.h>
 #include <thrift/protocol/TDebugProtocol.h>
 
@@ -44,6 +45,7 @@
 #include "runtime/stream_load/stream_load_pipe.h"
 #include "runtime/thread_context.h"
 #include "service/backend_options.h"
+#include "service/brpc_conflict.h"
 #include "util/debug_util.h"
 #include "util/doris_metrics.h"
 #include "util/stopwatch.hpp"
@@ -58,6 +60,7 @@ namespace doris {
 DEFINE_GAUGE_METRIC_PROTOTYPE_2ARG(plan_fragment_count, MetricUnit::NOUNIT);
 DEFINE_GAUGE_METRIC_PROTOTYPE_2ARG(timeout_canceled_fragment_count, MetricUnit::NOUNIT);
 DEFINE_GAUGE_METRIC_PROTOTYPE_2ARG(fragment_thread_pool_queue_size, MetricUnit::NOUNIT);
+bvar::LatencyRecorder g_fragmentmgr_prepare_latency("doris_FragmentMgr", "prepare");
 
 std::string to_load_error_http_path(const std::string& file_name) {
     if (file_name.empty()) {
@@ -665,11 +668,17 @@ Status FragmentMgr::exec_plan_fragment(const TExecPlanFragmentParams& params, Fi
     _runtimefilter_controller.add_entity(params, &handler, exec_state->executor()->runtime_state());
     exec_state->set_merge_controller_handler(handler);
 
+    int64_t duration_ns = 0;
     {
-        std::lock_guard<std::mutex> lock(_lock);
-        _fragment_map.insert(std::make_pair(params.params.fragment_instance_id, exec_state));
-        _cv.notify_all();
+        SCOPED_RAW_TIMER(&duration_ns);
+        RETURN_IF_ERROR(exec_state->prepare(params));
+        {
+            std::lock_guard<std::mutex> lock(_lock);
+            _fragment_map.insert(std::make_pair(params.params.fragment_instance_id, exec_state));
+            _cv.notify_all();
+        }
     }
+    g_fragmentmgr_prepare_latency << (duration_ns / 1000);
 
     auto st = _thread_pool->submit_func(
             [this, exec_state, cb, parent_span = opentelemetry::trace::Tracer::GetCurrentSpan()] {


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

Previously, we found out that sometimes the rpc service might timeout due to the extremely time consuming operation during exec_state prepare, thus this pr adds one metric to monitor the prepare time cost of each single fragment.
After compiling with this commit, BE would be able to generate data compatible with grafana, and you can watch the data using dashboard like below.
![image](https://user-images.githubusercontent.com/43750022/198478670-a234b2a7-b1af-41d7-9e12-b9a185ccbd1e.png)
As for the total time consumption of all the fragments prepare, you can refer to the brpc port to watch the rpc metric for more detailed message.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [x] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [x] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

