### PR TITLE
[improvement](hashjoin) support partitioned hash table in hash join

### DIFF
--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -357,6 +357,13 @@ public:
         return _query_options.__isset.skip_delete_predicate && _query_options.skip_delete_predicate;
     }
 
+    int partitioned_hash_join_rows_threshold() const {
+        if (!_query_options.__isset.partitioned_hash_join_rows_threshold) {
+            return 0;
+        }
+        return _query_options.partitioned_hash_join_rows_threshold;
+    }
+
     const std::vector<TTabletCommitInfo>& tablet_commit_infos() const {
         return _tablet_commit_infos;
     }

--- a/be/src/vec/common/hash_table/hash_table.h
+++ b/be/src/vec/common/hash_table/hash_table.h
@@ -431,7 +431,7 @@ protected:
     friend class Reader;
 
     template <typename, typename, typename, typename, typename, typename, size_t>
-    friend class TwoLevelHashTable;
+    friend class PartitionedHashTable;
 
     template <typename SubMaps>
     friend class StringHashTable;
@@ -1072,6 +1072,12 @@ public:
 
     size_t size() const { return m_size; }
 
+    std::vector<size_t> sizes() const {
+        std::vector<size_t> sizes;
+        sizes.push_back(m_size);
+        return sizes;
+    }
+
     bool empty() const { return 0 == m_size; }
 
     float get_factor() const { return MAX_BUCKET_OCCUPANCY_FRACTION; }
@@ -1111,6 +1117,12 @@ public:
     size_t get_buffer_size_in_bytes() const { return grower.buf_size() * sizeof(Cell); }
 
     size_t get_buffer_size_in_cells() const { return grower.buf_size(); }
+
+    std::vector<size_t> get_buffer_sizes_in_cells() const {
+        std::vector<size_t> sizes;
+        sizes.push_back(get_buffer_size_in_cells());
+        return sizes;
+    }
 
     bool add_elem_size_overflow(size_t add_size) const {
         return grower.overflow(add_size + m_size);

--- a/be/src/vec/common/hash_table/partitioned_hash_map.h
+++ b/be/src/vec/common/hash_table/partitioned_hash_map.h
@@ -1,0 +1,79 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+// This file is copied from
+// https://github.com/ClickHouse/ClickHouse/blob/master/src/Common/HashTable/TwoLevelHashMap.h
+// and modified by Doris
+#pragma once
+
+#include "vec/common/hash_table/hash_map.h"
+#include "vec/common/hash_table/partitioned_hash_table.h"
+
+template <typename Key, typename Cell, typename Hash = DefaultHash<Key>,
+          typename Grower = PartitionedHashTableGrower<>, typename Allocator = HashTableAllocator,
+          template <typename...> typename ImplTable = HashMapTable>
+class PartitionedHashMapTable
+        : public PartitionedHashTable<Key, Cell, Hash, Grower, Allocator,
+                                      ImplTable<Key, Cell, Hash, Grower, Allocator>> {
+public:
+    using Impl = ImplTable<Key, Cell, Hash, Grower, Allocator>;
+    using Base = PartitionedHashTable<Key, Cell, Hash, Grower, Allocator,
+                                      ImplTable<Key, Cell, Hash, Grower, Allocator>>;
+    using LookupResult = typename Impl::LookupResult;
+
+    using Base::Base;
+    using Base::prefetch;
+
+    using mapped_type = typename Cell::Mapped;
+
+    template <typename Func>
+    void ALWAYS_INLINE for_each_value(Func&& func) {
+        for (auto i = 0u; i < this->NUM_SUB_TABLES; ++i) this->sub_tables[i].for_each_value(func);
+    }
+
+    typename Cell::Mapped& ALWAYS_INLINE operator[](const Key& x) {
+        LookupResult it;
+        bool inserted;
+        this->emplace(x, it, inserted);
+
+        if (inserted) new (lookup_result_get_mapped(it)) mapped_type();
+
+        return *lookup_result_get_mapped(it);
+    }
+
+    size_t get_size() {
+        size_t count = 0;
+        for (auto i = 0u; i < this->NUM_SUB_TABLES; ++i) {
+            for (auto& v : this->sub_tables[i]) {
+                count += v.get_second().get_row_count();
+            }
+        }
+        return count;
+    }
+};
+
+template <typename Key, typename Mapped, typename Hash = DefaultHash<Key>,
+          typename Grower = PartitionedHashTableGrower<>, typename Allocator = HashTableAllocator,
+          template <typename...> typename ImplTable = HashMapTable>
+using PartitionedHashMap = PartitionedHashMapTable<Key, HashMapCell<Key, Mapped, Hash>, Hash,
+                                                   Grower, Allocator, ImplTable>;
+
+template <typename Key, typename Mapped, typename Hash = DefaultHash<Key>,
+          typename Grower = PartitionedHashTableGrower<>, typename Allocator = HashTableAllocator,
+          template <typename...> typename ImplTable = HashMapTable>
+using PartitionedHashMapWithSavedHash =
+        PartitionedHashMapTable<Key, HashMapCellWithSavedHash<Key, Mapped, Hash>, Hash, Grower,
+                                Allocator, ImplTable>;

--- a/be/src/vec/common/hash_table/partitioned_hash_table.h
+++ b/be/src/vec/common/hash_table/partitioned_hash_table.h
@@ -1,0 +1,379 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+// This file is copied from
+// https://github.com/ClickHouse/ClickHouse/blob/master/src/Common/HashTable/TwoLevelHashTable.h
+// and modified by Doris
+#pragma once
+
+#include "vec/common/hash_table/hash_table.h"
+
+/** Two-level hash table.
+  * Represents 16 (or 1ULL << BITS_FOR_SUB_TABLE) small hash tables (sub table count of the first level).
+  * To determine which one to use, one of the bytes of the hash function is taken.
+  *
+  * Usually works a little slower than a simple hash table.
+  * However, it has advantages in some cases:
+  * - if you need to merge two hash tables together, then you can easily parallelize it by sub tables;
+  * - delay during resizes is amortized, since the small hash tables will be resized separately;
+  * - in theory, resizes are cache-local in a larger range of sizes.
+  */
+
+template <size_t initial_size_degree = 8>
+struct PartitionedHashTableGrower : public HashTableGrowerWithPrecalculation<initial_size_degree> {
+    /// Increase the size of the hash table.
+    void increase_size() { this->increase_size_degree(this->size_degree() >= 15 ? 1 : 2); }
+};
+
+template <typename Key, typename Cell, typename Hash, typename Grower, typename Allocator,
+          typename ImplTable = HashTable<Key, Cell, Hash, Grower, Allocator>,
+          size_t BITS_FOR_SUB_TABLE = 4>
+class PartitionedHashTable : private boost::noncopyable,
+                             protected Hash /// empty base optimization
+{
+protected:
+    friend class const_iterator;
+    friend class iterator;
+
+    using HashValue = size_t;
+    using Self = PartitionedHashTable;
+
+public:
+    using Impl = ImplTable;
+
+    static constexpr size_t NUM_SUB_TABLES = 1ULL << BITS_FOR_SUB_TABLE;
+    static constexpr size_t MAX_SUB_TABLE = NUM_SUB_TABLES - 1;
+
+    //factor that will trigger growing the hash table on insert.
+    static constexpr float MAX_SUB_TABLE_OCCUPANCY_FRACTION = 0.5f;
+
+    size_t hash(const Key& x) const { return Hash::operator()(x); }
+
+    /// NOTE Bad for hash tables with more than 2^32 cells.
+    static size_t get_sub_table_from_hash(size_t hash_value) {
+        return (hash_value >> (32 - BITS_FOR_SUB_TABLE)) & MAX_SUB_TABLE;
+    }
+
+    float get_factor() const { return MAX_SUB_TABLE_OCCUPANCY_FRACTION; }
+
+    bool should_be_shrink(int64_t valid_row) { return false; }
+
+    void init_buf_size(size_t reserve_for_num_elements) {}
+
+    void delete_zero_key(Key key) {}
+
+    size_t get_buffer_size_in_bytes() const {
+        size_t buff_size = 0;
+        for (const auto& impl : sub_tables) buff_size += impl.get_buffer_size_in_bytes();
+        return buff_size;
+    }
+
+    size_t get_buffer_size_in_cells() const {
+        size_t buff_size = 0;
+        for (const auto& impl : sub_tables) buff_size += impl.get_buffer_size_in_cells();
+        return buff_size;
+    }
+
+    std::vector<size_t> get_buffer_sizes_in_cells() const {
+        std::vector<size_t> sizes;
+        for (size_t i = 0; i < NUM_SUB_TABLES; ++i) {
+            sizes.push_back(sub_tables[i].get_buffer_size_in_cells());
+        }
+        return sizes;
+    }
+
+    void reset_resize_timer() {
+        for (auto& impl : sub_tables) {
+            impl.reset_resize_timer();
+        }
+    }
+    int64_t get_resize_timer_value() const {
+        int64_t resize_timer_ns = 0;
+        for (const auto& impl : sub_tables) {
+            resize_timer_ns += impl.get_resize_timer_value();
+        }
+        return resize_timer_ns;
+    }
+
+protected:
+    typename Impl::iterator begin_of_next_non_empty_bucket(size_t& bucket) {
+        while (bucket != NUM_SUB_TABLES && sub_tables[bucket].empty()) ++bucket;
+
+        if (bucket != NUM_SUB_TABLES) return sub_tables[bucket].begin();
+
+        --bucket;
+        return sub_tables[MAX_SUB_TABLE].end();
+    }
+
+    typename Impl::const_iterator begin_of_next_non_empty_bucket(size_t& bucket) const {
+        while (bucket != NUM_SUB_TABLES && sub_tables[bucket].empty()) ++bucket;
+
+        if (bucket != NUM_SUB_TABLES) return sub_tables[bucket].begin();
+
+        --bucket;
+        return sub_tables[MAX_SUB_TABLE].end();
+    }
+
+public:
+    using key_type = typename Impl::key_type;
+    using mapped_type = typename Impl::mapped_type;
+    using value_type = typename Impl::value_type;
+    using cell_type = typename Impl::cell_type;
+
+    using LookupResult = typename Impl::LookupResult;
+    using ConstLookupResult = typename Impl::ConstLookupResult;
+
+    Impl sub_tables[NUM_SUB_TABLES];
+
+    PartitionedHashTable() = default;
+
+    explicit PartitionedHashTable(size_t size_hint) {
+        for (auto& impl : sub_tables) impl.reserve(size_hint / NUM_SUB_TABLES);
+    }
+
+    /// Copy the data from another (normal) hash table. It should have the same hash function.
+    template <typename Source>
+    explicit PartitionedHashTable(const Source& src) {
+        typename Source::const_iterator it = src.begin();
+
+        /// It is assumed that the zero key (stored separately) is first in iteration order.
+        if (it != src.end() && it.get_ptr()->is_zero(src)) {
+            insert(it->get_value());
+            ++it;
+        }
+
+        for (; it != src.end(); ++it) {
+            const Cell* cell = it.get_ptr();
+            size_t hash_value = cell->get_hash(src);
+            size_t buck = get_sub_table_from_hash(hash_value);
+            sub_tables[buck].insert_unique_non_zero(cell, hash_value);
+        }
+    }
+
+    PartitionedHashTable(PartitionedHashTable&& rhs) {
+        for (size_t i = 0; i < NUM_SUB_TABLES; ++i) {
+            sub_tables[i] = std::move(rhs.sub_tables[i]);
+        }
+    }
+
+    PartitionedHashTable& operator=(PartitionedHashTable&& rhs) {
+        for (size_t i = 0; i < NUM_SUB_TABLES; ++i) {
+            sub_tables[i] = std::move(rhs.sub_tables[i]);
+        }
+        return *this;
+    }
+
+    class iterator /// NOLINT
+    {
+        Self* container {};
+        size_t bucket {};
+        typename Impl::iterator current_it {};
+
+        friend class PartitionedHashTable;
+
+        iterator(Self* container_, size_t bucket_, typename Impl::iterator current_it_)
+                : container(container_), bucket(bucket_), current_it(current_it_) {}
+
+    public:
+        iterator() = default;
+
+        bool operator==(const iterator& rhs) const {
+            return bucket == rhs.bucket && current_it == rhs.current_it;
+        }
+        bool operator!=(const iterator& rhs) const { return !(*this == rhs); }
+
+        iterator& operator++() {
+            ++current_it;
+            if (current_it == container->sub_tables[bucket].end()) {
+                ++bucket;
+                current_it = container->begin_of_next_non_empty_bucket(bucket);
+            }
+
+            return *this;
+        }
+
+        Cell& operator*() const { return *current_it; }
+        Cell* operator->() const { return current_it.get_ptr(); }
+
+        Cell* get_ptr() const { return current_it.get_ptr(); }
+        size_t get_hash() const { return current_it.get_hash(); }
+    };
+
+    class const_iterator /// NOLINT
+    {
+        Self* container {};
+        size_t bucket {};
+        typename Impl::const_iterator current_it {};
+
+        friend class PartitionedHashTable;
+
+        const_iterator(Self* container_, size_t bucket_, typename Impl::const_iterator current_it_)
+                : container(container_), bucket(bucket_), current_it(current_it_) {}
+
+    public:
+        const_iterator() = default;
+        const_iterator(const iterator& rhs)
+                : container(rhs.container),
+                  bucket(rhs.bucket),
+                  current_it(rhs.current_it) {} /// NOLINT
+
+        bool operator==(const const_iterator& rhs) const {
+            return bucket == rhs.bucket && current_it == rhs.current_it;
+        }
+        bool operator!=(const const_iterator& rhs) const { return !(*this == rhs); }
+
+        const_iterator& operator++() {
+            ++current_it;
+            if (current_it == container->sub_tables[bucket].end()) {
+                ++bucket;
+                current_it = container->begin_of_next_non_empty_bucket(bucket);
+            }
+
+            return *this;
+        }
+
+        const Cell& operator*() const { return *current_it; }
+        const Cell* operator->() const { return current_it->get_ptr(); }
+
+        const Cell* get_ptr() const { return current_it.get_ptr(); }
+        size_t get_hash() const { return current_it.get_hash(); }
+    };
+
+    const_iterator begin() const {
+        size_t buck = 0;
+        typename Impl::const_iterator impl_it = begin_of_next_non_empty_bucket(buck);
+        return {this, buck, impl_it};
+    }
+
+    iterator begin() {
+        size_t buck = 0;
+        typename Impl::iterator impl_it = begin_of_next_non_empty_bucket(buck);
+        return {this, buck, impl_it};
+    }
+
+    const_iterator end() const { return {this, MAX_SUB_TABLE, sub_tables[MAX_SUB_TABLE].end()}; }
+    iterator end() { return {this, MAX_SUB_TABLE, sub_tables[MAX_SUB_TABLE].end()}; }
+
+    void expanse_for_add_elem(size_t num_elem) {
+        size_t num_elem_per_bucket = (num_elem + NUM_SUB_TABLES - 1) / NUM_SUB_TABLES;
+        for (size_t i = 0; i < NUM_SUB_TABLES; ++i)
+            sub_tables[i].expanse_for_add_elem(num_elem_per_bucket);
+    }
+
+    /// Insert a value. In the case of any more complex values, it is better to use the `emplace` function.
+    std::pair<LookupResult, bool> ALWAYS_INLINE insert(const value_type& x) {
+        size_t hash_value = hash(Cell::get_key(x));
+
+        std::pair<LookupResult, bool> res;
+        emplace(Cell::get_key(x), res.first, res.second, hash_value);
+
+        if (res.second) insert_set_mapped(lookup_result_get_mapped(res.first), x);
+
+        return res;
+    }
+
+    template <typename KeyHolder>
+    void ALWAYS_INLINE prefetch(KeyHolder& key_holder) {
+        const auto& key = key_holder_get_key(key_holder);
+        const auto key_hash = hash(key);
+        const auto bucket = get_sub_table_from_hash(key_hash);
+        sub_tables[bucket].prefetch(key_holder);
+    }
+
+    template <bool READ>
+    void ALWAYS_INLINE prefetch_by_hash(size_t hash_value) {
+        const auto bucket = get_sub_table_from_hash(hash_value);
+        sub_tables[bucket].template prefetch_by_hash<READ>(hash_value);
+    }
+
+    template <bool READ, typename KeyHolder>
+    void ALWAYS_INLINE prefetch(KeyHolder& key_holder) {
+        const auto& key = key_holder_get_key(key_holder);
+        const auto key_hash = hash(key);
+        const auto bucket = get_sub_table_from_hash(key_hash);
+        sub_tables[bucket].template prefetch<READ>(key_holder);
+    }
+
+    /** Insert the key,
+      * return an iterator to a position that can be used for `placement new` of value,
+      * as well as the flag - whether a new key was inserted.
+      *
+      * You have to make `placement new` values if you inserted a new key,
+      * since when destroying a hash table, the destructor will be invoked for it!
+      *
+      * Example usage:
+      *
+      * Map::iterator it;
+      * bool inserted;
+      * map.emplace(key, it, inserted);
+      * if (inserted)
+      *     new(&it->second) Mapped(value);
+      */
+    template <typename KeyHolder>
+    void ALWAYS_INLINE emplace(KeyHolder&& key_holder, LookupResult& it, bool& inserted) {
+        size_t hash_value = hash(key_holder_get_key(key_holder));
+        emplace(key_holder, it, inserted, hash_value);
+    }
+
+    /// Same, but with a precalculated values of hash function.
+    template <typename KeyHolder>
+    void ALWAYS_INLINE emplace(KeyHolder&& key_holder, LookupResult& it, bool& inserted,
+                               size_t hash_value) {
+        size_t buck = get_sub_table_from_hash(hash_value);
+        sub_tables[buck].emplace(key_holder, it, inserted, hash_value);
+    }
+
+    template <typename KeyHolder>
+    void ALWAYS_INLINE emplace(KeyHolder&& key_holder, LookupResult& it, size_t hash_value,
+                               bool& inserted) {
+        emplace(key_holder, it, inserted, hash_value);
+    }
+
+    LookupResult ALWAYS_INLINE find(Key x, size_t hash_value) {
+        size_t buck = get_sub_table_from_hash(hash_value);
+        return sub_tables[buck].find(x, hash_value);
+    }
+
+    ConstLookupResult ALWAYS_INLINE find(Key x, size_t hash_value) const {
+        return const_cast<std::decay_t<decltype(*this)>*>(this)->find(x, hash_value);
+    }
+
+    LookupResult ALWAYS_INLINE find(Key x) { return find(x, hash(x)); }
+
+    ConstLookupResult ALWAYS_INLINE find(Key x) const { return find(x, hash(x)); }
+
+    size_t size() const {
+        size_t res = 0;
+        for (size_t i = 0; i < NUM_SUB_TABLES; ++i) res += sub_tables[i].size();
+
+        return res;
+    }
+
+    std::vector<size_t> sizes() const {
+        std::vector<size_t> sizes;
+        for (size_t i = 0; i < NUM_SUB_TABLES; ++i) {
+            sizes.push_back(sub_tables[i].size());
+        }
+        return sizes;
+    }
+
+    bool empty() const {
+        for (size_t i = 0; i < NUM_SUB_TABLES; ++i)
+            if (!sub_tables[i].empty()) return false;
+
+        return true;
+    }
+};

--- a/be/src/vec/exec/join/process_hash_table_probe_impl.h
+++ b/be/src/vec/exec/join/process_hash_table_probe_impl.h
@@ -732,54 +732,97 @@ struct ExtractType<T(U)> {
             ExtractType<void(T)>::Type & hash_table_ctx, MutableBlock & mutable_block,        \
             Block * output_block, bool* eos)
 
-#define INSTANTIATION_FOR(JoinOpType)                                                      \
-    template struct ProcessHashTableProbe<JoinOpType>;                                     \
-                                                                                           \
-    template void ProcessHashTableProbe<JoinOpType>::build_side_output_column<false>(      \
-            MutableColumns & mcol, int column_offset, int column_length,                   \
-            const std::vector<bool>& output_slot_flags, int size);                         \
-    template void ProcessHashTableProbe<JoinOpType>::build_side_output_column<true>(       \
-            MutableColumns & mcol, int column_offset, int column_length,                   \
-            const std::vector<bool>& output_slot_flags, int size);                         \
-                                                                                           \
-    INSTANTIATION(JoinOpType, (SerializedHashTableContext<RowRefList>));                   \
-    INSTANTIATION(JoinOpType, (I8HashTableContext<RowRefList>));                           \
-    INSTANTIATION(JoinOpType, (I16HashTableContext<RowRefList>));                          \
-    INSTANTIATION(JoinOpType, (I32HashTableContext<RowRefList>));                          \
-    INSTANTIATION(JoinOpType, (I64HashTableContext<RowRefList>));                          \
-    INSTANTIATION(JoinOpType, (I128HashTableContext<RowRefList>));                         \
-    INSTANTIATION(JoinOpType, (I256HashTableContext<RowRefList>));                         \
-    INSTANTIATION(JoinOpType, (I64FixedKeyHashTableContext<true, RowRefList>));            \
-    INSTANTIATION(JoinOpType, (I64FixedKeyHashTableContext<false, RowRefList>));           \
-    INSTANTIATION(JoinOpType, (I128FixedKeyHashTableContext<true, RowRefList>));           \
-    INSTANTIATION(JoinOpType, (I128FixedKeyHashTableContext<false, RowRefList>));          \
-    INSTANTIATION(JoinOpType, (I256FixedKeyHashTableContext<true, RowRefList>));           \
-    INSTANTIATION(JoinOpType, (I256FixedKeyHashTableContext<false, RowRefList>));          \
-    INSTANTIATION(JoinOpType, (SerializedHashTableContext<RowRefListWithFlag>));           \
-    INSTANTIATION(JoinOpType, (I8HashTableContext<RowRefListWithFlag>));                   \
-    INSTANTIATION(JoinOpType, (I16HashTableContext<RowRefListWithFlag>));                  \
-    INSTANTIATION(JoinOpType, (I32HashTableContext<RowRefListWithFlag>));                  \
-    INSTANTIATION(JoinOpType, (I64HashTableContext<RowRefListWithFlag>));                  \
-    INSTANTIATION(JoinOpType, (I128HashTableContext<RowRefListWithFlag>));                 \
-    INSTANTIATION(JoinOpType, (I256HashTableContext<RowRefListWithFlag>));                 \
-    INSTANTIATION(JoinOpType, (I64FixedKeyHashTableContext<true, RowRefListWithFlag>));    \
-    INSTANTIATION(JoinOpType, (I64FixedKeyHashTableContext<false, RowRefListWithFlag>));   \
-    INSTANTIATION(JoinOpType, (I128FixedKeyHashTableContext<true, RowRefListWithFlag>));   \
-    INSTANTIATION(JoinOpType, (I128FixedKeyHashTableContext<false, RowRefListWithFlag>));  \
-    INSTANTIATION(JoinOpType, (I256FixedKeyHashTableContext<true, RowRefListWithFlag>));   \
-    INSTANTIATION(JoinOpType, (I256FixedKeyHashTableContext<false, RowRefListWithFlag>));  \
-    INSTANTIATION(JoinOpType, (SerializedHashTableContext<RowRefListWithFlags>));          \
-    INSTANTIATION(JoinOpType, (I8HashTableContext<RowRefListWithFlags>));                  \
-    INSTANTIATION(JoinOpType, (I16HashTableContext<RowRefListWithFlags>));                 \
-    INSTANTIATION(JoinOpType, (I32HashTableContext<RowRefListWithFlags>));                 \
-    INSTANTIATION(JoinOpType, (I64HashTableContext<RowRefListWithFlags>));                 \
-    INSTANTIATION(JoinOpType, (I128HashTableContext<RowRefListWithFlags>));                \
-    INSTANTIATION(JoinOpType, (I256HashTableContext<RowRefListWithFlags>));                \
-    INSTANTIATION(JoinOpType, (I64FixedKeyHashTableContext<true, RowRefListWithFlags>));   \
-    INSTANTIATION(JoinOpType, (I64FixedKeyHashTableContext<false, RowRefListWithFlags>));  \
-    INSTANTIATION(JoinOpType, (I128FixedKeyHashTableContext<true, RowRefListWithFlags>));  \
-    INSTANTIATION(JoinOpType, (I128FixedKeyHashTableContext<false, RowRefListWithFlags>)); \
-    INSTANTIATION(JoinOpType, (I256FixedKeyHashTableContext<true, RowRefListWithFlags>));  \
-    INSTANTIATION(JoinOpType, (I256FixedKeyHashTableContext<false, RowRefListWithFlags>))
+#define INSTANTIATION_FOR(JoinOpType)                                                              \
+    template struct ProcessHashTableProbe<JoinOpType>;                                             \
+                                                                                                   \
+    template void ProcessHashTableProbe<JoinOpType>::build_side_output_column<false>(              \
+            MutableColumns & mcol, int column_offset, int column_length,                           \
+            const std::vector<bool>& output_slot_flags, int size);                                 \
+    template void ProcessHashTableProbe<JoinOpType>::build_side_output_column<true>(               \
+            MutableColumns & mcol, int column_offset, int column_length,                           \
+            const std::vector<bool>& output_slot_flags, int size);                                 \
+                                                                                                   \
+    INSTANTIATION(JoinOpType, (SerializedHashTableContext<RowRefList>));                           \
+    INSTANTIATION(JoinOpType, (I8HashTableContext<RowRefList>));                                   \
+    INSTANTIATION(JoinOpType, (I16HashTableContext<RowRefList>));                                  \
+    INSTANTIATION(JoinOpType, (I32HashTableContext<RowRefList>));                                  \
+    INSTANTIATION(JoinOpType, (I64HashTableContext<RowRefList>));                                  \
+    INSTANTIATION(JoinOpType, (I128HashTableContext<RowRefList>));                                 \
+    INSTANTIATION(JoinOpType, (I256HashTableContext<RowRefList>));                                 \
+    INSTANTIATION(JoinOpType, (I64FixedKeyHashTableContext<true, RowRefList>));                    \
+    INSTANTIATION(JoinOpType, (I64FixedKeyHashTableContext<false, RowRefList>));                   \
+    INSTANTIATION(JoinOpType, (I128FixedKeyHashTableContext<true, RowRefList>));                   \
+    INSTANTIATION(JoinOpType, (I128FixedKeyHashTableContext<false, RowRefList>));                  \
+    INSTANTIATION(JoinOpType, (I256FixedKeyHashTableContext<true, RowRefList>));                   \
+    INSTANTIATION(JoinOpType, (I256FixedKeyHashTableContext<false, RowRefList>));                  \
+    INSTANTIATION(JoinOpType, (SerializedHashTableContext<RowRefListWithFlag>));                   \
+    INSTANTIATION(JoinOpType, (I8HashTableContext<RowRefListWithFlag>));                           \
+    INSTANTIATION(JoinOpType, (I16HashTableContext<RowRefListWithFlag>));                          \
+    INSTANTIATION(JoinOpType, (I32HashTableContext<RowRefListWithFlag>));                          \
+    INSTANTIATION(JoinOpType, (I64HashTableContext<RowRefListWithFlag>));                          \
+    INSTANTIATION(JoinOpType, (I128HashTableContext<RowRefListWithFlag>));                         \
+    INSTANTIATION(JoinOpType, (I256HashTableContext<RowRefListWithFlag>));                         \
+    INSTANTIATION(JoinOpType, (I64FixedKeyHashTableContext<true, RowRefListWithFlag>));            \
+    INSTANTIATION(JoinOpType, (I64FixedKeyHashTableContext<false, RowRefListWithFlag>));           \
+    INSTANTIATION(JoinOpType, (I128FixedKeyHashTableContext<true, RowRefListWithFlag>));           \
+    INSTANTIATION(JoinOpType, (I128FixedKeyHashTableContext<false, RowRefListWithFlag>));          \
+    INSTANTIATION(JoinOpType, (I256FixedKeyHashTableContext<true, RowRefListWithFlag>));           \
+    INSTANTIATION(JoinOpType, (I256FixedKeyHashTableContext<false, RowRefListWithFlag>));          \
+    INSTANTIATION(JoinOpType, (SerializedHashTableContext<RowRefListWithFlags>));                  \
+    INSTANTIATION(JoinOpType, (I8HashTableContext<RowRefListWithFlags>));                          \
+    INSTANTIATION(JoinOpType, (I16HashTableContext<RowRefListWithFlags>));                         \
+    INSTANTIATION(JoinOpType, (I32HashTableContext<RowRefListWithFlags>));                         \
+    INSTANTIATION(JoinOpType, (I64HashTableContext<RowRefListWithFlags>));                         \
+    INSTANTIATION(JoinOpType, (I128HashTableContext<RowRefListWithFlags>));                        \
+    INSTANTIATION(JoinOpType, (I256HashTableContext<RowRefListWithFlags>));                        \
+    INSTANTIATION(JoinOpType, (I64FixedKeyHashTableContext<true, RowRefListWithFlags>));           \
+    INSTANTIATION(JoinOpType, (I64FixedKeyHashTableContext<false, RowRefListWithFlags>));          \
+    INSTANTIATION(JoinOpType, (I128FixedKeyHashTableContext<true, RowRefListWithFlags>));          \
+    INSTANTIATION(JoinOpType, (I128FixedKeyHashTableContext<false, RowRefListWithFlags>));         \
+    INSTANTIATION(JoinOpType, (I256FixedKeyHashTableContext<true, RowRefListWithFlags>));          \
+    INSTANTIATION(JoinOpType, (I256FixedKeyHashTableContext<false, RowRefListWithFlags>));         \
+    INSTANTIATION(JoinOpType, (PartitionedSerializedHashTableContext<RowRefList>));                \
+    INSTANTIATION(JoinOpType, (I32PartitionedHashTableContext<RowRefList>));                       \
+    INSTANTIATION(JoinOpType, (I64PartitionedHashTableContext<RowRefList>));                       \
+    INSTANTIATION(JoinOpType, (I128PartitionedHashTableContext<RowRefList>));                      \
+    INSTANTIATION(JoinOpType, (I256PartitionedHashTableContext<RowRefList>));                      \
+    INSTANTIATION(JoinOpType, (I64PartitionedFixedKeyHashTableContext<true, RowRefList>));         \
+    INSTANTIATION(JoinOpType, (I64PartitionedFixedKeyHashTableContext<false, RowRefList>));        \
+    INSTANTIATION(JoinOpType, (I128PartitionedFixedKeyHashTableContext<true, RowRefList>));        \
+    INSTANTIATION(JoinOpType, (I128PartitionedFixedKeyHashTableContext<false, RowRefList>));       \
+    INSTANTIATION(JoinOpType, (I256PartitionedFixedKeyHashTableContext<true, RowRefList>));        \
+    INSTANTIATION(JoinOpType, (I256PartitionedFixedKeyHashTableContext<false, RowRefList>));       \
+    INSTANTIATION(JoinOpType, (PartitionedSerializedHashTableContext<RowRefListWithFlag>));        \
+    INSTANTIATION(JoinOpType, (I32PartitionedHashTableContext<RowRefListWithFlag>));               \
+    INSTANTIATION(JoinOpType, (I64PartitionedHashTableContext<RowRefListWithFlag>));               \
+    INSTANTIATION(JoinOpType, (I128PartitionedHashTableContext<RowRefListWithFlag>));              \
+    INSTANTIATION(JoinOpType, (I256PartitionedHashTableContext<RowRefListWithFlag>));              \
+    INSTANTIATION(JoinOpType, (I64PartitionedFixedKeyHashTableContext<true, RowRefListWithFlag>)); \
+    INSTANTIATION(JoinOpType,                                                                      \
+                  (I64PartitionedFixedKeyHashTableContext<false, RowRefListWithFlag>));            \
+    INSTANTIATION(JoinOpType,                                                                      \
+                  (I128PartitionedFixedKeyHashTableContext<true, RowRefListWithFlag>));            \
+    INSTANTIATION(JoinOpType,                                                                      \
+                  (I128PartitionedFixedKeyHashTableContext<false, RowRefListWithFlag>));           \
+    INSTANTIATION(JoinOpType,                                                                      \
+                  (I256PartitionedFixedKeyHashTableContext<true, RowRefListWithFlag>));            \
+    INSTANTIATION(JoinOpType,                                                                      \
+                  (I256PartitionedFixedKeyHashTableContext<false, RowRefListWithFlag>));           \
+    INSTANTIATION(JoinOpType, (PartitionedSerializedHashTableContext<RowRefListWithFlags>));       \
+    INSTANTIATION(JoinOpType, (I32PartitionedHashTableContext<RowRefListWithFlags>));              \
+    INSTANTIATION(JoinOpType, (I64PartitionedHashTableContext<RowRefListWithFlags>));              \
+    INSTANTIATION(JoinOpType, (I128PartitionedHashTableContext<RowRefListWithFlags>));             \
+    INSTANTIATION(JoinOpType, (I256PartitionedHashTableContext<RowRefListWithFlags>));             \
+    INSTANTIATION(JoinOpType,                                                                      \
+                  (I64PartitionedFixedKeyHashTableContext<true, RowRefListWithFlags>));            \
+    INSTANTIATION(JoinOpType,                                                                      \
+                  (I64PartitionedFixedKeyHashTableContext<false, RowRefListWithFlags>));           \
+    INSTANTIATION(JoinOpType,                                                                      \
+                  (I128PartitionedFixedKeyHashTableContext<true, RowRefListWithFlags>));           \
+    INSTANTIATION(JoinOpType,                                                                      \
+                  (I128PartitionedFixedKeyHashTableContext<false, RowRefListWithFlags>));          \
+    INSTANTIATION(JoinOpType,                                                                      \
+                  (I256PartitionedFixedKeyHashTableContext<true, RowRefListWithFlags>));           \
+    INSTANTIATION(JoinOpType, (I256PartitionedFixedKeyHashTableContext<false, RowRefListWithFlags>))
 
 } // namespace doris::vectorized

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -225,6 +225,8 @@ public class SessionVariable implements Serializable, Writable {
 
     public static final String INTERNAL_SESSION = "internal_session";
 
+    public static final String PARTITIONED_HASH_JOIN_ROWS_THRESHOLD = "partitioned_hash_join_rows_threshold";
+
     // session origin value
     public Map<Field, String> sessionOriginValue = new HashMap<Field, String>();
     // check stmt is or not [select /*+ SET_VAR(...)*/ ...]
@@ -589,6 +591,10 @@ public class SessionVariable implements Serializable, Writable {
     @VariableMgr.VarAttr(name = INTERNAL_SESSION)
     public boolean internalSession = false;
 
+    // Use partitioned hash join if build side row count >= the threshold . 0 - the threshold is not set.
+    @VariableMgr.VarAttr(name = PARTITIONED_HASH_JOIN_ROWS_THRESHOLD)
+    public int partitionedHashJoinRowsThreshold = 8388608;
+
     // If this fe is in fuzzy mode, then will use initFuzzyModeVariables to generate some variables,
     // not the default value set in the code.
     public void initFuzzyModeVariables() {
@@ -597,6 +603,7 @@ public class SessionVariable implements Serializable, Writable {
         this.enableLocalExchange = random.nextBoolean();
         this.disableJoinReorder = random.nextBoolean();
         this.disableStreamPreaggregations = random.nextBoolean();
+        this.partitionedHashJoinRowsThreshold = random.nextBoolean() ? 8 : 1048576;
     }
 
     public String getBlockEncryptionMode() {
@@ -1179,6 +1186,14 @@ public class SessionVariable implements Serializable, Writable {
         this.fragmentTransmissionCompressionCodec = codec;
     }
 
+    public int getPartitionedHashJoinRowsThreshold() {
+        return partitionedHashJoinRowsThreshold;
+    }
+
+    public void setPartitionedHashJoinRowsThreshold(int threshold) {
+        this.partitionedHashJoinRowsThreshold = threshold;
+    }
+
     /**
      * Serialize to thrift object.
      * Used for rest api.
@@ -1231,6 +1246,8 @@ public class SessionVariable implements Serializable, Writable {
         tResult.setSkipStorageEngineMerge(skipStorageEngineMerge);
 
         tResult.setSkipDeletePredicate(skipDeletePredicate);
+
+        tResult.setPartitionedHashJoinRowsThreshold(partitionedHashJoinRowsThreshold);
 
         return tResult;
     }

--- a/gensrc/thrift/PaloInternalService.thrift
+++ b/gensrc/thrift/PaloInternalService.thrift
@@ -179,6 +179,8 @@ struct TQueryOptions {
   51: optional bool enable_new_shuffle_hash_method
 
   52: optional i32 be_exec_version = 0
+  
+  53: optional i32 partitioned_hash_join_rows_threshold = 0
 }
     
 


### PR DESCRIPTION
# Proposed changes

Issue Number: close #13653
Add session variable `enable_partitioned_hash_join`(default to false) and be config option `partitioned_hash_join_rows_threshold`(default to 1048576) which is the build side row count threshold that to use partitioned hash join.

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

