### PR TITLE
[BugFix](function) fix reverse function dynamic buffer overflow due to illegal character

### DIFF
--- a/be/src/util/simd/vstring_function.h
+++ b/be/src/util/simd/vstring_function.h
@@ -20,6 +20,7 @@
 #include <unistd.h>
 
 #include <array>
+#include <cstddef>
 #include <cstdint>
 
 #ifdef __aarch64__
@@ -144,7 +145,12 @@ public:
         } else {
             for (size_t i = 0, char_size = 0; i < str.len; i += char_size) {
                 char_size = UTF8_BYTE_LENGTH[(unsigned char)(str.ptr)[i]];
-                std::copy(str.ptr + i, str.ptr + i + char_size, dst.ptr + str.len - i - char_size);
+                // str.len = 4, i = 3, char_size = 2 might cause dynamic stack buffer overflow
+                size_t offset = i + char_size;
+                if (offset > str.len) {
+                    offset = str.len;
+                }
+                std::copy(str.ptr + i, str.ptr + offset, dst.ptr + str.len - offset);
             }
         }
     }

--- a/be/src/util/simd/vstring_function.h
+++ b/be/src/util/simd/vstring_function.h
@@ -145,7 +145,10 @@ public:
         } else {
             for (size_t i = 0, char_size = 0; i < str.len; i += char_size) {
                 char_size = UTF8_BYTE_LENGTH[(unsigned char)(str.ptr)[i]];
-                // str.len = 4, i = 3, char_size = 2 might cause dynamic stack buffer overflow
+                // there exists occasion where the last character is an illegal UTF-8 one which returns
+                // a char_size larger than the actual space, which would cause offset execeeding the buffer range
+                // for example, consider str.len=4, i = 3, then the last char returns char_size 2, then
+                // the str.ptr + offset would exceed the buffer range
                 size_t offset = i + char_size;
                 if (offset > str.len) {
                     offset = str.len;

--- a/regression-test/data/query_p0/sql_functions/string_functions/test_reverse.out
+++ b/regression-test/data/query_p0/sql_functions/string_functions/test_reverse.out
@@ -5,5 +5,5 @@ fsnnygnaw
 kn@8jlnuy
 
 -- !select --
-�֬&
+4
 

--- a/regression-test/data/query_p0/sql_functions/string_functions/test_reverse.out
+++ b/regression-test/data/query_p0/sql_functions/string_functions/test_reverse.out
@@ -4,3 +4,6 @@
 fsnnygnaw
 kn@8jlnuy
 
+-- !select --
+�֬&
+

--- a/regression-test/suites/query_p0/sql_functions/string_functions/test_reverse.groovy
+++ b/regression-test/suites/query_p0/sql_functions/string_functions/test_reverse.groovy
@@ -17,6 +17,6 @@
 
 suite("test_reverse") {
     qt_select "select reverse(k7) from test_query_db.test order by k1"
-    qt_select "select    reverse(cast(unhex(         cast(hex(651603156) as varchar)) as varchar));"
+    qt_select "select length( cast(reverse( cast(unhex( cast(hex( cast(651603156 as bigint)) as varchar)) as varchar)) as varchar)) as c3"
 }
 

--- a/regression-test/suites/query_p0/sql_functions/string_functions/test_reverse.groovy
+++ b/regression-test/suites/query_p0/sql_functions/string_functions/test_reverse.groovy
@@ -17,5 +17,6 @@
 
 suite("test_reverse") {
     qt_select "select reverse(k7) from test_query_db.test order by k1"
+    qt_select "select    reverse(cast(unhex(         cast(hex(651603156) as varchar)) as varchar));"
 }
 


### PR DESCRIPTION
# Proposed changes

Previous logic of reverse function might not be strong enough to handle illegal character. For example, one one byte size character would be mistaken as one utf-8 character which occupies more than one byte space. And unfortunately exceeding the buffer space during future process.
Issue Number: close #xxx

## Problem summary

Truncate the copy process when detecting overflow memory accessing.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

