### PR TITLE
[Improvement](nereids) nereids uses decimal(27,9) as default decimal

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/types/DecimalType.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/types/DecimalType.java
@@ -98,7 +98,7 @@ public class DecimalType extends FractionalType {
 
     @Override
     public Type toCatalogDataType() {
-        return Type.DECIMALV2;
+        return Type.MAX_DECIMALV2_TYPE;
     }
 
     public int getPrecision() {


### PR DESCRIPTION
# Proposed changes
Nereids use decimal(27,9) as default size. 
This change is following the change in "[Improvement](decimal) print decimal according to the real precision and scale (#13437)" 
commit: 9a3c1f08

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

