### PR TITLE
[fix](planner) cannot recogonize column's table when analyze rewrite expr

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/SlotRef.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/SlotRef.java
@@ -31,6 +31,7 @@ import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -185,6 +186,10 @@ public class SlotRef extends Expr {
         numDistinctValues = desc.getStats().getNumDistinctValues();
         if (type.equals(Type.BOOLEAN)) {
             selectivity = DEFAULT_SELECTIVITY;
+        }
+        if (tblName == null && StringUtils.isNotEmpty(desc.getParent().getLastAlias())
+                && !desc.getParent().getLastAlias().equals(desc.getParent().getTable().getName())) {
+            tblName = new TableName(null, desc.getParent().getLastAlias());
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/TupleDescriptor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/TupleDescriptor.java
@@ -161,8 +161,19 @@ public class TupleDescriptor {
         aliases_ = aliases;
         hasExplicitAlias_ = hasExplicitAlias;
     }
-    public boolean hasExplicitAlias() { return hasExplicitAlias_; }
-    public String getAlias() { return (aliases_ != null) ? aliases_[0] : null; }
+
+    public boolean hasExplicitAlias() {
+        return hasExplicitAlias_;
+    }
+
+    public String getAlias() {
+        return (aliases_ != null) ? aliases_[0] : null;
+    }
+
+    public String getLastAlias() {
+        return (aliases_ != null) ? aliases_[aliases_.length - 1] : null;
+    }
+
     public TableName getAliasAsName() {
         return (aliases_ != null) ? new TableName(null, aliases_[0]) : null;
     }

--- a/regression-test/suites/correctness/test_mv_alias_table_name.groovy
+++ b/regression-test/suites/correctness/test_mv_alias_table_name.groovy
@@ -1,0 +1,63 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+ // or more contributor license agreements.  See the NOTICE file
+ // distributed with this work for additional information
+ // regarding copyright ownership.  The ASF licenses this file
+ // to you under the Apache License, Version 2.0 (the
+ // "License"); you may not use this file except in compliance
+ // with the License.  You may obtain a copy of the License at
+ //
+ //   http://www.apache.org/licenses/LICENSE-2.0
+ //
+ // Unless required by applicable law or agreed to in writing,
+ // software distributed under the License is distributed on an
+ // "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ // KIND, either express or implied.  See the License for the
+ // specific language governing permissions and limitations
+ // under the License.
+
+
+/*
+exception throw before bug fix:  Unknown column 'mv_bitmap_union_mh' in 'default_cluster:test.original_table'
+*/
+suite("test_mv_alias_table_name") {
+    sql """
+        DROP TABLE IF EXISTS original_table;
+    """
+    sql """
+        CREATE TABLE original_table
+        (
+            day date,
+            aid bigint,
+            lid bigint,
+            yid bigint,
+            mh bigint,
+            my bigint
+        )
+        DUPLICATE KEY(`day`, `aid`, `lid`)
+        DISTRIBUTED BY HASH(aid)
+        PROPERTIES ("replication_num" = "1" );
+    """
+
+    sql """
+        create materialized view mv_table as
+        select day,aid,lid,
+            bitmap_union(to_bitmap(mh)) as wu,     
+            bitmap_union(to_bitmap(my)) as mu 
+        from original_table 
+        group by day, aid, lid;
+    """
+
+    sql """
+        insert into original_table values('2022-10-16', 1665710553, 1665710553, 1665710553, 1665700553, 1665700553);
+    """
+
+    sleep(2000)
+
+    sql """
+        select t0.aid, t0.lid, count(distinct mh), count(distinct my) 
+        from original_table t0 
+        where t0.day = '2022-10-16' and t0.lid > 0 group by t0.aid, t0.lid;
+    """
+
+ }
+


### PR DESCRIPTION
# Proposed changes

We save mv column with alias as table name, and search it with original table name.
cherry-pick from master #13597 


## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

