### PR TITLE
[improvement](regression-test) avoid query empty result after loading finished

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/transaction/DatabaseTransactionMgr.java
@@ -945,6 +945,11 @@ public class DatabaseTransactionMgr {
         } finally {
             MetaLockUtils.writeUnlockTables(tableList);
         }
+        // The visible latch should only be counted down after all things are done
+        // (finish transaction, write edit log, etc).
+        // Otherwise, there is no way for stream load to query the result right after loading finished,
+        // even if we call "sync" before querying.
+        transactionState.countdownVisibleLatch();
         LOG.info("finish transaction {} successfully", transactionState);
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/transaction/TransactionState.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/transaction/TransactionState.java
@@ -189,9 +189,10 @@ public class TransactionState implements Writable {
     private String reason = "";
     // error replica ids
     private Set<Long> errorReplicas;
-    private CountDownLatch latch;
+    // this latch will be counted down when txn status change to VISIBLE
+    private CountDownLatch visibleLatch;
 
-    // this state need not to be serialized
+    // this state need not be serialized
     private Map<Long, PublishVersionTask> publishVersionTasks;
     private boolean hasSendTask;
     private long publishVersionTime = -1;
@@ -247,7 +248,7 @@ public class TransactionState implements Writable {
         this.errorReplicas = Sets.newHashSet();
         this.publishVersionTasks = Maps.newHashMap();
         this.hasSendTask = false;
-        this.latch = new CountDownLatch(1);
+        this.visibleLatch = new CountDownLatch(1);
         this.authCode = UUID.randomUUID().toString();
     }
 
@@ -270,7 +271,7 @@ public class TransactionState implements Writable {
         this.errorReplicas = Sets.newHashSet();
         this.publishVersionTasks = Maps.newHashMap();
         this.hasSendTask = false;
-        this.latch = new CountDownLatch(1);
+        this.visibleLatch = new CountDownLatch(1);
         this.callbackId = callbackId;
         this.timeoutMs = timeoutMs;
         this.authCode = UUID.randomUUID().toString();
@@ -380,7 +381,6 @@ public class TransactionState implements Writable {
 
         // after status changed
         if (transactionStatus == TransactionStatus.VISIBLE) {
-            this.latch.countDown();
             if (MetricRepo.isInit) {
                 MetricRepo.COUNTER_TXN_SUCCESS.increase(1L);
             }
@@ -458,8 +458,12 @@ public class TransactionState implements Writable {
         }
     }
 
+    public void countdownVisibleLatch() {
+        this.visibleLatch.countDown();
+    }
+
     public void waitTransactionVisible(long timeoutMillis) throws InterruptedException {
-        this.latch.await(timeoutMillis, TimeUnit.MILLISECONDS);
+        this.visibleLatch.await(timeoutMillis, TimeUnit.MILLISECONDS);
     }
 
     public void setPrepareTime(long prepareTime) {

--- a/regression-test/suites/ssb_unique_load_zstd_p0/load_one_step/load.groovy
+++ b/regression-test/suites/ssb_unique_load_zstd_p0/load_one_step/load.groovy
@@ -28,6 +28,8 @@ suite("load_one_step") {
         sql new File("""${context.file.parentFile.parent}/ddl/${tableName}_create.sql""").text
         streamLoad {
             table tableName
+            def label = "load_one_step_${tableName}_" + UUID.randomUUID().toString() 
+            set 'label', label
             set 'column_separator', '|'
             set 'compress_type', 'GZ'
             set 'columns', rows[0]


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

When running regression test, we always found that the query return empty result after loading finished,
even if we call "sync" before the query.
This is because for `stream load`, the load task result will be returned immediately after the txn's status changed to VISIBLE,
but before writing the edit log.
So if we do the query right after we got the load task result, it is possible that we can not see the latest loaded data.

Same issue with `insert` operation

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

