### PR TITLE
[feature-wip](multi-catalog) reuse hdfsFS and decode values in batch without breaking up by null

### DIFF
--- a/be/src/io/hdfs_file_reader.cpp
+++ b/be/src/io/hdfs_file_reader.cpp
@@ -30,8 +30,7 @@ HdfsFileReader::HdfsFileReader(const THdfsParams& hdfs_params, const std::string
           _current_offset(start_offset),
           _file_size(-1),
           _hdfs_fs(nullptr),
-          _hdfs_file(nullptr),
-          _builder(createHDFSBuilder(_hdfs_params)) {
+          _hdfs_file(nullptr) {
     _namenode = _hdfs_params.fs_name;
 }
 
@@ -41,8 +40,7 @@ HdfsFileReader::HdfsFileReader(const std::map<std::string, std::string>& propert
           _current_offset(start_offset),
           _file_size(-1),
           _hdfs_fs(nullptr),
-          _hdfs_file(nullptr),
-          _builder(createHDFSBuilder(properties)) {
+          _hdfs_file(nullptr) {
     _parse_properties(properties);
 }
 
@@ -51,25 +49,17 @@ HdfsFileReader::~HdfsFileReader() {
 }
 
 void HdfsFileReader::_parse_properties(const std::map<std::string, std::string>& prop) {
+    _hdfs_params = parse_properties(prop);
     auto iter = prop.find(FS_KEY);
     if (iter != prop.end()) {
         _namenode = iter->second;
     }
 }
 
-Status HdfsFileReader::connect() {
-    if (_builder.is_need_kinit()) {
-        RETURN_IF_ERROR(_builder.run_kinit());
-    }
-    _hdfs_fs = hdfsBuilderConnect(_builder.get());
-    if (_hdfs_fs == nullptr) {
-        return Status::InternalError("connect to hdfs failed. namenode address:{}, error: {}",
-                                     _namenode, hdfsGetLastError());
-    }
-    return Status::OK();
-}
-
 Status HdfsFileReader::open() {
+    if (_opened) {
+        return Status::IOError("Can't reopen the same reader");
+    }
     if (_namenode.empty()) {
         LOG(WARNING) << "hdfs properties is incorrect.";
         return Status::InternalError("hdfs properties is incorrect");
@@ -80,39 +70,57 @@ Status HdfsFileReader::open() {
         _path = _path.substr(_namenode.size());
     }
 
-    if (!closed()) {
-        close();
-    }
-    RETURN_IF_ERROR(connect());
+    RETURN_IF_ERROR(HdfsFsCache::instance()->get_connection(_hdfs_params, &_fs_handle));
+    _hdfs_fs = _fs_handle->hdfs_fs;
     _hdfs_file = hdfsOpenFile(_hdfs_fs, _path.c_str(), O_RDONLY, 0, 0, 0);
     if (_hdfs_file == nullptr) {
-        return Status::InternalError("open file failed. (BE: {}) namenode:{}, path:{}, err: {}",
-                                     BackendOptions::get_localhost(), _namenode, _path,
-                                     hdfsGetLastError());
+        if (_fs_handle->from_cache) {
+            // hdfsFS may be disconnected if not used for a long time
+            _fs_handle->set_invalid();
+            _fs_handle->dec_ref();
+            // retry
+            RETURN_IF_ERROR(HdfsFsCache::instance()->get_connection(_hdfs_params, &_fs_handle));
+            _hdfs_fs = _fs_handle->hdfs_fs;
+            _hdfs_file = hdfsOpenFile(_hdfs_fs, _path.c_str(), O_RDONLY, 0, 0, 0);
+            if (_hdfs_fs == nullptr) {
+                return Status::InternalError(
+                        "open file failed. (BE: {}) namenode:{}, path:{}, err: {}",
+                        BackendOptions::get_localhost(), _namenode, _path, hdfsGetLastError());
+            }
+        } else {
+            return Status::InternalError("open file failed. (BE: {}) namenode:{}, path:{}, err: {}",
+                                         BackendOptions::get_localhost(), _namenode, _path,
+                                         hdfsGetLastError());
+        }
     }
     VLOG_NOTICE << "open file, namenode:" << _namenode << ", path:" << _path;
+    _opened = true;
     return seek(_current_offset);
 }
 
 void HdfsFileReader::close() {
-    if (!closed()) {
+    if (!_closed) {
         if (_hdfs_file != nullptr && _hdfs_fs != nullptr) {
             VLOG_NOTICE << "close hdfs file: " << _namenode << _path;
             //If the hdfs file was valid, the memory associated with it will
             // be freed at the end of this call, even if there was an I/O error
             hdfsCloseFile(_hdfs_fs, _hdfs_file);
         }
-        if (_hdfs_fs != nullptr) {
-            // Even if there is an error, the resources associated with the hdfsFS will be freed.
-            hdfsDisconnect(_hdfs_fs);
+
+        if (_fs_handle != nullptr) {
+            if (_fs_handle->from_cache) {
+                _fs_handle->dec_ref();
+            } else {
+                delete _fs_handle;
+            }
         }
     }
-    _hdfs_file = nullptr;
-    _hdfs_fs = nullptr;
+    _fs_handle = nullptr;
+    _closed = true;
 }
 
 bool HdfsFileReader::closed() {
-    return _hdfs_file == nullptr && _hdfs_fs == nullptr;
+    return _closed;
 }
 
 // Read all bytes
@@ -165,25 +173,10 @@ Status HdfsFileReader::readat(int64_t position, int64_t nbytes, int64_t* bytes_r
 
 int64_t HdfsFileReader::size() {
     if (_file_size == -1) {
-        bool need_init_fs = false;
-        if (_hdfs_fs == nullptr) {
-            need_init_fs = true;
-            if (!connect().ok()) {
-                return -1;
-            }
-        }
-        hdfsFileInfo* file_info = hdfsGetPathInfo(_hdfs_fs, _path.c_str());
-        if (file_info == nullptr) {
-            LOG(WARNING) << "get path info failed: " << _namenode << _path
-                         << ", err: " << hdfsGetLastError();
-            ;
-            close();
-            return -1;
-        }
-        _file_size = file_info->mSize;
-        hdfsFreeFileInfo(file_info, 1);
-        if (need_init_fs) {
-            close();
+        if (_hdfs_fs != nullptr) {
+            hdfsFileInfo* file_info = hdfsGetPathInfo(_hdfs_fs, _path.c_str());
+            _file_size = file_info->mSize;
+            hdfsFreeFileInfo(file_info, 1);
         }
     }
     return _file_size;
@@ -204,4 +197,105 @@ Status HdfsFileReader::tell(int64_t* position) {
     return Status::OK();
 }
 
+int HdfsFsCache::MAX_CACHE_HANDLE = 64;
+
+Status HdfsFsCache::_create_fs(THdfsParams& hdfs_params, hdfsFS* fs) {
+    HDFSCommonBuilder builder = createHDFSBuilder(hdfs_params);
+    if (builder.is_need_kinit()) {
+        RETURN_IF_ERROR(builder.run_kinit());
+    }
+    hdfsFS hdfs_fs = hdfsBuilderConnect(builder.get());
+    if (hdfs_fs == nullptr) {
+        return Status::InternalError("connect to hdfs failed. error: {}", hdfsGetLastError());
+    }
+    *fs = hdfs_fs;
+    return Status::OK();
+}
+
+void HdfsFsCache::_clean_invalid() {
+    std::vector<uint64> removed_handle;
+    for (auto& item : _cache) {
+        if (item.second->invalid() && item.second->ref_cnt() == 0) {
+            removed_handle.emplace_back(item.first);
+        }
+    }
+    for (auto& handle : removed_handle) {
+        _cache.erase(handle);
+    }
+}
+
+void HdfsFsCache::_clean_oldest() {
+    uint64_t oldest_time = ULONG_MAX;
+    uint64 oldest = 0;
+    for (auto& item : _cache) {
+        if (item.second->ref_cnt() == 0 && item.second->last_access_time() < oldest_time) {
+            oldest_time = item.second->last_access_time();
+            oldest = item.first;
+        }
+    }
+    _cache.erase(oldest);
+}
+
+Status HdfsFsCache::get_connection(THdfsParams& hdfs_params, HdfsFsHandle** fs_handle) {
+    uint64 hash_code = _hdfs_hash_code(hdfs_params);
+    {
+        std::lock_guard<std::mutex> l(_lock);
+        auto it = _cache.find(hash_code);
+        if (it != _cache.end()) {
+            HdfsFsHandle* handle = it->second.get();
+            if (handle->invalid()) {
+                hdfsFS hdfs_fs = nullptr;
+                RETURN_IF_ERROR(_create_fs(hdfs_params, &hdfs_fs));
+                *fs_handle = new HdfsFsHandle(hdfs_fs, false);
+            } else {
+                handle->inc_ref();
+                *fs_handle = handle;
+            }
+        } else {
+            hdfsFS hdfs_fs = nullptr;
+            RETURN_IF_ERROR(_create_fs(hdfs_params, &hdfs_fs));
+            if (_cache.size() >= MAX_CACHE_HANDLE) {
+                _clean_invalid();
+                _clean_oldest();
+            }
+            if (_cache.size() < MAX_CACHE_HANDLE) {
+                std::unique_ptr<HdfsFsHandle> handle =
+                        std::make_unique<HdfsFsHandle>(hdfs_fs, true);
+                handle->inc_ref();
+                *fs_handle = handle.get();
+                _cache[hash_code] = std::move(handle);
+            } else {
+                *fs_handle = new HdfsFsHandle(hdfs_fs, false);
+            }
+        }
+    }
+    return Status::OK();
+}
+
+uint64 HdfsFsCache::_hdfs_hash_code(THdfsParams& hdfs_params) {
+    uint64 hash_code = 0;
+    if (hdfs_params.__isset.fs_name) {
+        hash_code += Fingerprint(hdfs_params.fs_name);
+    }
+    if (hdfs_params.__isset.user) {
+        hash_code += Fingerprint(hdfs_params.user);
+    }
+    if (hdfs_params.__isset.hdfs_kerberos_principal) {
+        hash_code += Fingerprint(hdfs_params.hdfs_kerberos_principal);
+    }
+    if (hdfs_params.__isset.hdfs_kerberos_keytab) {
+        hash_code += Fingerprint(hdfs_params.hdfs_kerberos_keytab);
+    }
+    if (hdfs_params.__isset.hdfs_conf) {
+        std::map<std::string, std::string> conf_map;
+        for (auto& conf : hdfs_params.hdfs_conf) {
+            conf_map[conf.key] = conf.value;
+        }
+        for (auto& conf : conf_map) {
+            hash_code += Fingerprint(conf.first);
+            hash_code += Fingerprint(conf.second);
+        }
+    }
+    return hash_code;
+}
 } // namespace doris

--- a/be/src/io/hdfs_file_reader.h
+++ b/be/src/io/hdfs_file_reader.h
@@ -17,11 +17,93 @@
 
 #pragma once
 
+#include <chrono>
+
 #include "gen_cpp/PlanNodes_types.h"
+#include "gutil/hash/hash.h"
 #include "io/file_reader.h"
 #include "io/hdfs_builder.h"
 
 namespace doris {
+
+class HdfsFsHandle {
+private:
+    // the number of referenced client
+    std::atomic<int> _ref_cnt;
+    // HdfsFsCache try to remove the oldest handler when the cache is full
+    std::atomic<uint64_t> _last_access_time;
+    // Client will set invalid if error thrown, and HdfsFsCache will not reuse this handler
+    std::atomic<bool> _invalid;
+
+    uint64_t _now() {
+        return std::chrono::duration_cast<std::chrono::milliseconds>(
+                       std::chrono::system_clock::now().time_since_epoch())
+                .count();
+    }
+
+public:
+    hdfsFS hdfs_fs;
+    // When cache is full, and all handlers are in use, HdfsFsCache will return an uncached handler.
+    // Client should delete the handler in such case.
+    const bool from_cache;
+
+    HdfsFsHandle(hdfsFS fs, bool cached)
+            : _ref_cnt(0), _last_access_time(0), _invalid(false), hdfs_fs(fs), from_cache(cached) {}
+
+    ~HdfsFsHandle() {
+        DCHECK(_ref_cnt == 0);
+        if (hdfs_fs != nullptr) {
+            // Even if there is an error, the resources associated with the hdfsFS will be freed.
+            hdfsDisconnect(hdfs_fs);
+        }
+        hdfs_fs = nullptr;
+    }
+
+    int64_t last_access_time() { return _last_access_time; }
+
+    void inc_ref() {
+        _ref_cnt++;
+        _last_access_time = _now();
+    }
+
+    void dec_ref() {
+        _ref_cnt--;
+        _last_access_time = _now();
+    }
+
+    int ref_cnt() { return _ref_cnt; }
+
+    bool invalid() { return _invalid; }
+
+    void set_invalid() { _invalid = true; }
+};
+
+// Cache for HDFS file system
+class HdfsFsCache {
+public:
+    static int MAX_CACHE_HANDLE;
+
+    static HdfsFsCache* instance() {
+        static HdfsFsCache s_instance;
+        return &s_instance;
+    }
+
+    // This function is thread-safe
+    Status get_connection(THdfsParams& hdfs_params, HdfsFsHandle** fs_handle);
+
+private:
+    std::mutex _lock;
+    std::unordered_map<uint64, std::unique_ptr<HdfsFsHandle>> _cache;
+
+    HdfsFsCache() = default;
+    HdfsFsCache(const HdfsFsCache&) = delete;
+    const HdfsFsCache& operator=(const HdfsFsCache&) = delete;
+
+    uint64 _hdfs_hash_code(THdfsParams& hdfs_params);
+    Status _create_fs(THdfsParams& hdfs_params, hdfsFS* fs);
+    void _clean_invalid();
+    void _clean_oldest();
+};
 
 class HdfsFileReader : public FileReader {
 public:
@@ -47,7 +129,6 @@ public:
     virtual bool closed() override;
 
 private:
-    Status connect();
     void _parse_properties(const std::map<std::string, std::string>& prop);
 
 private:
@@ -58,7 +139,9 @@ private:
     int64_t _file_size;
     hdfsFS _hdfs_fs;
     hdfsFile _hdfs_file;
-    HDFSCommonBuilder _builder;
+    HdfsFsHandle* _fs_handle = nullptr;
+    bool _closed = false;
+    bool _opened = false;
 };
 
 } // namespace doris

--- a/be/src/vec/exec/format/parquet/parquet_common.h
+++ b/be/src/vec/exec/format/parquet/parquet_common.h
@@ -76,6 +76,9 @@ struct DecodeParams {
     DecimalScaleParams decimal_scale;
 };
 
+// the length of non-null values and null values are arranged in turn.
+using RunLengthNullMap = std::vector<u_short>;
+
 class Decoder {
 public:
     Decoder() = default;
@@ -99,10 +102,9 @@ public:
     void init_decimal_converter(DataTypePtr& data_type);
 
     // Write the decoded values batch to doris's column
-    Status decode_values(ColumnPtr& doris_column, DataTypePtr& data_type, size_t num_values);
-
     virtual Status decode_values(MutableColumnPtr& doris_column, DataTypePtr& data_type,
-                                 size_t num_values) = 0;
+                                 RunLengthNullMap& null_map, size_t num_values,
+                                 size_t num_nulls) = 0;
 
     virtual Status skip_values(size_t num_values) = 0;
 
@@ -148,7 +150,7 @@ public:
     ~FixLengthDecoder() override = default;
 
     Status decode_values(MutableColumnPtr& doris_column, DataTypePtr& data_type,
-                         size_t num_values) override;
+                         RunLengthNullMap& null_map, size_t num_values, size_t num_nulls) override;
 
     Status skip_values(size_t num_values) override;
 
@@ -157,30 +159,32 @@ public:
     void set_data(Slice* data) override;
 
 protected:
-    template <typename ShortIntType>
-    Status _decode_short_int(MutableColumnPtr& doris_column, size_t num_values);
-
     template <typename Numeric>
-    Status _decode_numeric(MutableColumnPtr& doris_column, size_t num_values);
+    Status _decode_numeric(MutableColumnPtr& doris_column, RunLengthNullMap& null_map,
+                           size_t num_values);
 
     template <typename CppType, typename ColumnType>
-    Status _decode_date(MutableColumnPtr& doris_column, TypeIndex& logical_type, size_t num_values);
+    Status _decode_date(MutableColumnPtr& doris_column, RunLengthNullMap& null_map,
+                        size_t num_values);
 
     template <typename CppType, typename ColumnType>
-    Status _decode_datetime64(MutableColumnPtr& doris_column, TypeIndex& logical_type,
+    Status _decode_datetime64(MutableColumnPtr& doris_column, RunLengthNullMap& null_map,
                               size_t num_values);
 
     template <typename CppType, typename ColumnType>
-    Status _decode_datetime96(MutableColumnPtr& doris_column, TypeIndex& logical_type,
+    Status _decode_datetime96(MutableColumnPtr& doris_column, RunLengthNullMap& null_map,
                               size_t num_values);
 
     template <typename DecimalPrimitiveType>
     Status _decode_binary_decimal(MutableColumnPtr& doris_column, DataTypePtr& data_type,
-                                  size_t num_values);
+                                  RunLengthNullMap& null_map, size_t num_values);
 
     template <typename DecimalPrimitiveType, typename DecimalPhysicalType>
     Status _decode_primitive_decimal(MutableColumnPtr& doris_column, DataTypePtr& data_type,
-                                     size_t num_values);
+                                     RunLengthNullMap& null_map, size_t num_values);
+
+    Status _decode_string(MutableColumnPtr& doris_column, RunLengthNullMap& null_map,
+                          size_t num_values);
 
 #define _FIXED_GET_DATA_OFFSET(index) \
     _has_dict ? _dict_items[_indexes[index]] : _data->data + _offset
@@ -197,154 +201,190 @@ protected:
     std::vector<uint32_t> _indexes;
 };
 
-template <typename ShortIntType>
-Status FixLengthDecoder::_decode_short_int(MutableColumnPtr& doris_column, size_t num_values) {
-    if (UNLIKELY(_physical_type != tparquet::Type::INT32)) {
-        return Status::InternalError("Short int can only be decoded from INT32");
-    }
-    auto& column_data = static_cast<ColumnVector<ShortIntType>&>(*doris_column).get_data();
-    auto origin_size = column_data.size();
-    column_data.resize(origin_size + num_values);
-    for (int i = 0; i < num_values; ++i) {
-        char* buf_start = _FIXED_GET_DATA_OFFSET(i);
-        column_data[origin_size + i] = *(ShortIntType*)buf_start;
-        _FIXED_SHIFT_DATA_OFFSET();
-    }
-    return Status::OK();
-}
-
 template <typename Numeric>
-Status FixLengthDecoder::_decode_numeric(MutableColumnPtr& doris_column, size_t num_values) {
+Status FixLengthDecoder::_decode_numeric(MutableColumnPtr& doris_column, RunLengthNullMap& null_map,
+                                         size_t num_values) {
     auto& column_data = static_cast<ColumnVector<Numeric>&>(*doris_column).get_data();
-    if (_has_dict) {
-        auto origin_size = column_data.size();
-        column_data.resize(origin_size + num_values);
-        for (int i = 0; i < num_values; ++i) {
-            char* buf_start = _FIXED_GET_DATA_OFFSET(i);
-            column_data[origin_size + i] = *(Numeric*)buf_start;
+    size_t data_index = column_data.size();
+    column_data.resize(data_index + num_values);
+    bool is_null = false;
+    size_t dict_index = 0;
+    for (auto& run_length : null_map) {
+        if (is_null) {
+            data_index += run_length;
+        } else {
+            for (int i = 0; i < run_length; ++i) {
+                char* buf_start = _FIXED_GET_DATA_OFFSET(dict_index++);
+                column_data[data_index++] = *(Numeric*)buf_start;
+                _FIXED_SHIFT_DATA_OFFSET();
+            }
         }
-    } else {
-        const auto* raw_data = reinterpret_cast<const Numeric*>(_data->data + _offset);
-        column_data.insert(raw_data, raw_data + num_values);
-        _offset += _type_length * num_values;
+        is_null = !is_null;
     }
     return Status::OK();
 }
 
 template <typename CppType, typename ColumnType>
-Status FixLengthDecoder::_decode_date(MutableColumnPtr& doris_column, TypeIndex& logical_type,
+Status FixLengthDecoder::_decode_date(MutableColumnPtr& doris_column, RunLengthNullMap& null_map,
                                       size_t num_values) {
     auto& column_data = static_cast<ColumnVector<ColumnType>&>(*doris_column).get_data();
-    auto origin_size = column_data.size();
-    column_data.resize(origin_size + num_values);
-    for (int i = 0; i < num_values; ++i) {
-        char* buf_start = _FIXED_GET_DATA_OFFSET(i);
-        int64_t date_value = static_cast<int64_t>(*reinterpret_cast<int32_t*>(buf_start));
-        auto& v = reinterpret_cast<CppType&>(column_data[origin_size + i]);
-        v.from_unixtime(date_value * 24 * 60 * 60, *_decode_params->ctz); // day to seconds
-        if constexpr (std::is_same_v<CppType, VecDateTimeValue>) {
-            // we should cast to date if using date v1.
-            v.cast_to_date();
+    size_t data_index = column_data.size();
+    column_data.resize(data_index + num_values);
+    bool is_null = false;
+    size_t dict_index = 0;
+    for (auto& run_length : null_map) {
+        if (is_null) {
+            data_index += run_length;
+        } else {
+            for (int i = 0; i < run_length; ++i) {
+                char* buf_start = _FIXED_GET_DATA_OFFSET(dict_index++);
+                int64_t date_value = static_cast<int64_t>(*reinterpret_cast<int32_t*>(buf_start));
+                auto& v = reinterpret_cast<CppType&>(column_data[data_index++]);
+                v.from_unixtime(date_value * 24 * 60 * 60, *_decode_params->ctz); // day to seconds
+                if constexpr (std::is_same_v<CppType, VecDateTimeValue>) {
+                    // we should cast to date if using date v1.
+                    v.cast_to_date();
+                }
+                _FIXED_SHIFT_DATA_OFFSET();
+            }
         }
-        _FIXED_SHIFT_DATA_OFFSET();
+        is_null = !is_null;
     }
     return Status::OK();
 }
 
 template <typename CppType, typename ColumnType>
-Status FixLengthDecoder::_decode_datetime64(MutableColumnPtr& doris_column, TypeIndex& logical_type,
-                                            size_t num_values) {
+Status FixLengthDecoder::_decode_datetime64(MutableColumnPtr& doris_column,
+                                            RunLengthNullMap& null_map, size_t num_values) {
     auto& column_data = static_cast<ColumnVector<ColumnType>&>(*doris_column).get_data();
-    auto origin_size = column_data.size();
-    column_data.resize(origin_size + num_values);
+    size_t data_index = column_data.size();
+    column_data.resize(data_index + num_values);
+    bool is_null = false;
+    size_t dict_index = 0;
     int64_t scale_to_micro = _decode_params->scale_to_nano_factor / 1000;
-    for (int i = 0; i < num_values; i++) {
-        char* buf_start = _FIXED_GET_DATA_OFFSET(i);
-        int64_t& date_value = *reinterpret_cast<int64_t*>(buf_start);
-        auto& v = reinterpret_cast<CppType&>(column_data[origin_size + i]);
-        v.from_unixtime(date_value / _decode_params->second_mask, *_decode_params->ctz);
-        if constexpr (std::is_same_v<CppType, DateV2Value<DateTimeV2ValueType>>) {
-            // nanoseconds will be ignored.
-            v.set_microsecond((date_value % _decode_params->second_mask) * scale_to_micro);
-            // TODO: the precision of datetime v1
+    for (auto& run_length : null_map) {
+        if (is_null) {
+            data_index += run_length;
+        } else {
+            for (int i = 0; i < run_length; ++i) {
+                char* buf_start = _FIXED_GET_DATA_OFFSET(dict_index++);
+                int64_t& date_value = *reinterpret_cast<int64_t*>(buf_start);
+                auto& v = reinterpret_cast<CppType&>(column_data[data_index++]);
+                v.from_unixtime(date_value / _decode_params->second_mask, *_decode_params->ctz);
+                if constexpr (std::is_same_v<CppType, DateV2Value<DateTimeV2ValueType>>) {
+                    // nanoseconds will be ignored.
+                    v.set_microsecond((date_value % _decode_params->second_mask) * scale_to_micro);
+                    // TODO: the precision of datetime v1
+                }
+                _FIXED_SHIFT_DATA_OFFSET();
+            }
         }
-        _FIXED_SHIFT_DATA_OFFSET();
+        is_null = !is_null;
     }
     return Status::OK();
 }
 
 template <typename CppType, typename ColumnType>
-Status FixLengthDecoder::_decode_datetime96(MutableColumnPtr& doris_column, TypeIndex& logical_type,
-                                            size_t num_values) {
+Status FixLengthDecoder::_decode_datetime96(MutableColumnPtr& doris_column,
+                                            RunLengthNullMap& null_map, size_t num_values) {
     auto& column_data = static_cast<ColumnVector<ColumnType>&>(*doris_column).get_data();
-    auto origin_size = column_data.size();
-    column_data.resize(origin_size + num_values);
-    for (int i = 0; i < num_values; ++i) {
-        char* buf_start = _FIXED_GET_DATA_OFFSET(i);
-        ParquetInt96& datetime96 = *reinterpret_cast<ParquetInt96*>(buf_start);
-        auto& v = reinterpret_cast<CppType&>(column_data[origin_size + i]);
-        int64_t micros = datetime96.to_timestamp_micros();
-        v.from_unixtime(micros / 1000000, *_decode_params->ctz);
-        if constexpr (std::is_same_v<CppType, DateV2Value<DateTimeV2ValueType>>) {
-            // spark.sql.parquet.outputTimestampType = INT96(NANOS) will lost precision.
-            // only keep microseconds.
-            v.set_microsecond(micros % 1000000);
+    size_t data_index = column_data.size();
+    column_data.resize(data_index + num_values);
+    bool is_null = false;
+    size_t dict_index = 0;
+    for (auto& run_length : null_map) {
+        if (is_null) {
+            data_index += run_length;
+        } else {
+            for (int i = 0; i < run_length; ++i) {
+                char* buf_start = _FIXED_GET_DATA_OFFSET(dict_index++);
+                ParquetInt96& datetime96 = *reinterpret_cast<ParquetInt96*>(buf_start);
+                auto& v = reinterpret_cast<CppType&>(column_data[data_index++]);
+                int64_t micros = datetime96.to_timestamp_micros();
+                v.from_unixtime(micros / 1000000, *_decode_params->ctz);
+                if constexpr (std::is_same_v<CppType, DateV2Value<DateTimeV2ValueType>>) {
+                    // spark.sql.parquet.outputTimestampType = INT96(NANOS) will lost precision.
+                    // only keep microseconds.
+                    v.set_microsecond(micros % 1000000);
+                }
+                _FIXED_SHIFT_DATA_OFFSET();
+            }
         }
-        _FIXED_SHIFT_DATA_OFFSET();
+        is_null = !is_null;
     }
     return Status::OK();
 }
 
 template <typename DecimalPrimitiveType>
 Status FixLengthDecoder::_decode_binary_decimal(MutableColumnPtr& doris_column,
-                                                DataTypePtr& data_type, size_t num_values) {
+                                                DataTypePtr& data_type, RunLengthNullMap& null_map,
+                                                size_t num_values) {
     init_decimal_converter<DecimalPrimitiveType>(data_type);
     auto& column_data =
             static_cast<ColumnDecimal<Decimal<DecimalPrimitiveType>>&>(*doris_column).get_data();
-    auto origin_size = column_data.size();
-    column_data.resize(origin_size + num_values);
+    size_t data_index = column_data.size();
+    column_data.resize(data_index + num_values);
+    bool is_null = false;
+    size_t dict_index = 0;
     DecimalScaleParams& scale_params = _decode_params->decimal_scale;
-    for (int i = 0; i < num_values; ++i) {
-        char* buf_start = _FIXED_GET_DATA_OFFSET(i);
-        // When Decimal in parquet is stored in byte arrays, binary and fixed,
-        // the unscaled number must be encoded as two's complement using big-endian byte order.
-        Int128 value = buf_start[0] & 0x80 ? -1 : 0;
-        memcpy(reinterpret_cast<char*>(&value) + sizeof(Int128) - _type_length, buf_start,
-               _type_length);
-        value = BigEndian::ToHost128(value);
-        if (scale_params.scale_type == DecimalScaleParams::SCALE_UP) {
-            value *= scale_params.scale_factor;
-        } else if (scale_params.scale_type == DecimalScaleParams::SCALE_DOWN) {
-            value /= scale_params.scale_factor;
+    for (auto& run_length : null_map) {
+        if (is_null) {
+            data_index += run_length;
+        } else {
+            for (int i = 0; i < run_length; ++i) {
+                char* buf_start = _FIXED_GET_DATA_OFFSET(dict_index++);
+                // When Decimal in parquet is stored in byte arrays, binary and fixed,
+                // the unscaled number must be encoded as two's complement using big-endian byte order.
+                Int128 value = buf_start[0] & 0x80 ? -1 : 0;
+                memcpy(reinterpret_cast<char*>(&value) + sizeof(Int128) - _type_length, buf_start,
+                       _type_length);
+                value = BigEndian::ToHost128(value);
+                if (scale_params.scale_type == DecimalScaleParams::SCALE_UP) {
+                    value *= scale_params.scale_factor;
+                } else if (scale_params.scale_type == DecimalScaleParams::SCALE_DOWN) {
+                    value /= scale_params.scale_factor;
+                }
+                auto& v = reinterpret_cast<DecimalPrimitiveType&>(column_data[data_index++]);
+                v = (DecimalPrimitiveType)value;
+                _FIXED_SHIFT_DATA_OFFSET();
+            }
         }
-        auto& v = reinterpret_cast<DecimalPrimitiveType&>(column_data[origin_size + i]);
-        v = (DecimalPrimitiveType)value;
-        _FIXED_SHIFT_DATA_OFFSET();
+        is_null = !is_null;
     }
     return Status::OK();
 }
 
 template <typename DecimalPrimitiveType, typename DecimalPhysicalType>
 Status FixLengthDecoder::_decode_primitive_decimal(MutableColumnPtr& doris_column,
-                                                   DataTypePtr& data_type, size_t num_values) {
+                                                   DataTypePtr& data_type,
+                                                   RunLengthNullMap& null_map, size_t num_values) {
     init_decimal_converter<DecimalPrimitiveType>(data_type);
     auto& column_data =
             static_cast<ColumnDecimal<Decimal<DecimalPrimitiveType>>&>(*doris_column).get_data();
-    auto origin_size = column_data.size();
-    column_data.resize(origin_size + num_values);
+    size_t data_index = column_data.size();
+    column_data.resize(data_index + num_values);
+    bool is_null = false;
+    size_t dict_index = 0;
     DecimalScaleParams& scale_params = _decode_params->decimal_scale;
-    for (int i = 0; i < num_values; ++i) {
-        char* buf_start = _FIXED_GET_DATA_OFFSET(i);
-        // we should use decimal128 to scale up/down
-        Int128 value = *reinterpret_cast<DecimalPhysicalType*>(buf_start);
-        if (scale_params.scale_type == DecimalScaleParams::SCALE_UP) {
-            value *= scale_params.scale_factor;
-        } else if (scale_params.scale_type == DecimalScaleParams::SCALE_DOWN) {
-            value /= scale_params.scale_factor;
+    for (auto& run_length : null_map) {
+        if (is_null) {
+            data_index += run_length;
+        } else {
+            for (int i = 0; i < run_length; ++i) {
+                char* buf_start = _FIXED_GET_DATA_OFFSET(dict_index++);
+                // we should use decimal128 to scale up/down
+                Int128 value = *reinterpret_cast<DecimalPhysicalType*>(buf_start);
+                if (scale_params.scale_type == DecimalScaleParams::SCALE_UP) {
+                    value *= scale_params.scale_factor;
+                } else if (scale_params.scale_type == DecimalScaleParams::SCALE_DOWN) {
+                    value /= scale_params.scale_factor;
+                }
+                auto& v = reinterpret_cast<DecimalPrimitiveType&>(column_data[data_index++]);
+                v = (DecimalPrimitiveType)value;
+                _FIXED_SHIFT_DATA_OFFSET();
+            }
         }
-        auto& v = reinterpret_cast<DecimalPrimitiveType&>(column_data[origin_size + i]);
-        v = (DecimalPrimitiveType)value;
-        _FIXED_SHIFT_DATA_OFFSET();
+        is_null = !is_null;
     }
     return Status::OK();
 }
@@ -355,7 +395,7 @@ public:
     ~ByteArrayDecoder() override = default;
 
     Status decode_values(MutableColumnPtr& doris_column, DataTypePtr& data_type,
-                         size_t num_values) override;
+                         RunLengthNullMap& null_map, size_t num_values, size_t num_nulls) override;
 
     Status skip_values(size_t num_values) override;
 
@@ -366,7 +406,7 @@ public:
 protected:
     template <typename DecimalPrimitiveType>
     Status _decode_binary_decimal(MutableColumnPtr& doris_column, DataTypePtr& data_type,
-                                  size_t num_values);
+                                  RunLengthNullMap& null_map, size_t num_values);
 
     // For dictionary encoding
     bool _has_dict = false;
@@ -378,41 +418,53 @@ protected:
 
 template <typename DecimalPrimitiveType>
 Status ByteArrayDecoder::_decode_binary_decimal(MutableColumnPtr& doris_column,
-                                                DataTypePtr& data_type, size_t num_values) {
+                                                DataTypePtr& data_type, RunLengthNullMap& null_map,
+                                                size_t num_values) {
     init_decimal_converter<DecimalPrimitiveType>(data_type);
     auto& column_data =
             static_cast<ColumnDecimal<Decimal<DecimalPrimitiveType>>&>(*doris_column).get_data();
-    auto origin_size = column_data.size();
-    column_data.resize(origin_size + num_values);
+    size_t data_index = column_data.size();
+    column_data.resize(data_index + num_values);
+    bool is_null = false;
+    size_t dict_index = 0;
     DecimalScaleParams& scale_params = _decode_params->decimal_scale;
-    for (int i = 0; i < num_values; ++i) {
-        char* buf_start;
-        uint32_t length;
-        if (_has_dict) {
-            StringRef& slice = _dict_items[_indexes[i]];
-            buf_start = const_cast<char*>(slice.data);
-            length = (uint32_t)slice.size;
+    for (auto& run_length : null_map) {
+        if (is_null) {
+            data_index += run_length;
         } else {
-            if (UNLIKELY(_offset + 4 > _data->size)) {
-                return Status::IOError("Can't read byte array length from plain decoder");
+            for (int i = 0; i < run_length; ++i) {
+                char* buf_start;
+                uint32_t length;
+                if (_has_dict) {
+                    StringRef& slice = _dict_items[_indexes[dict_index++]];
+                    buf_start = const_cast<char*>(slice.data);
+                    length = (uint32_t)slice.size;
+                } else {
+                    if (UNLIKELY(_offset + 4 > _data->size)) {
+                        return Status::IOError("Can't read byte array length from plain decoder");
+                    }
+                    length = decode_fixed32_le(reinterpret_cast<const uint8_t*>(_data->data) +
+                                               _offset);
+                    _offset += 4;
+                    buf_start = _data->data + _offset;
+                    _offset += length;
+                }
+                // When Decimal in parquet is stored in byte arrays, binary and fixed,
+                // the unscaled number must be encoded as two's complement using big-endian byte order.
+                Int128 value = buf_start[0] & 0x80 ? -1 : 0;
+                memcpy(reinterpret_cast<char*>(&value) + sizeof(Int128) - length, buf_start,
+                       length);
+                value = BigEndian::ToHost128(value);
+                if (scale_params.scale_type == DecimalScaleParams::SCALE_UP) {
+                    value *= scale_params.scale_factor;
+                } else if (scale_params.scale_type == DecimalScaleParams::SCALE_DOWN) {
+                    value /= scale_params.scale_factor;
+                }
+                auto& v = reinterpret_cast<DecimalPrimitiveType&>(column_data[data_index++]);
+                v = (DecimalPrimitiveType)value;
             }
-            length = decode_fixed32_le(reinterpret_cast<const uint8_t*>(_data->data) + _offset);
-            _offset += 4;
-            buf_start = _data->data + _offset;
-            _offset += length;
         }
-        // When Decimal in parquet is stored in byte arrays, binary and fixed,
-        // the unscaled number must be encoded as two's complement using big-endian byte order.
-        Int128 value = buf_start[0] & 0x80 ? -1 : 0;
-        memcpy(reinterpret_cast<char*>(&value) + sizeof(Int128) - length, buf_start, length);
-        value = BigEndian::ToHost128(value);
-        if (scale_params.scale_type == DecimalScaleParams::SCALE_UP) {
-            value *= scale_params.scale_factor;
-        } else if (scale_params.scale_type == DecimalScaleParams::SCALE_DOWN) {
-            value /= scale_params.scale_factor;
-        }
-        auto& v = reinterpret_cast<DecimalPrimitiveType&>(column_data[origin_size + i]);
-        v = (DecimalPrimitiveType)value;
+        is_null = !is_null;
     }
     return Status::OK();
 }
@@ -433,7 +485,7 @@ public:
     }
 
     Status decode_values(MutableColumnPtr& doris_column, DataTypePtr& data_type,
-                         size_t num_values) override;
+                         RunLengthNullMap& null_map, size_t num_values, size_t num_nulls) override;
 
     Status skip_values(size_t num_values) override;
 

--- a/be/src/vec/exec/format/parquet/vparquet_column_chunk_reader.cpp
+++ b/be/src/vec/exec/format/parquet/vparquet_column_chunk_reader.cpp
@@ -199,19 +199,6 @@ Status ColumnChunkReader::skip_values(size_t num_values, bool skip_data) {
     }
 }
 
-void ColumnChunkReader::insert_null_values(ColumnPtr& doris_column, size_t num_values) {
-    SCOPED_RAW_TIMER(&_statistics.decode_value_time);
-    DCHECK_GE(_remaining_num_values, num_values);
-    CHECK(doris_column->is_nullable());
-    auto* nullable_column = reinterpret_cast<vectorized::ColumnNullable*>(
-            (*std::move(doris_column)).mutate().get());
-    MutableColumnPtr data_column = nullable_column->get_nested_column_ptr();
-    for (int i = 0; i < num_values; ++i) {
-        data_column->insert_default();
-    }
-    _remaining_num_values -= num_values;
-}
-
 void ColumnChunkReader::insert_null_values(MutableColumnPtr& doris_column, size_t num_values) {
     SCOPED_RAW_TIMER(&_statistics.decode_value_time);
     doris_column->insert_many_defaults(num_values);
@@ -228,24 +215,24 @@ size_t ColumnChunkReader::get_def_levels(level_t* levels, size_t n) {
     return _def_level_decoder.get_levels(levels, n);
 }
 
-Status ColumnChunkReader::decode_values(ColumnPtr& doris_column, DataTypePtr& data_type,
-                                        size_t num_values) {
-    if (UNLIKELY(_remaining_num_values < num_values)) {
-        return Status::IOError("Decode too many values in current page");
-    }
-    SCOPED_RAW_TIMER(&_statistics.decode_value_time);
-    _remaining_num_values -= num_values;
-    return _page_decoder->decode_values(doris_column, data_type, num_values);
-}
-
 Status ColumnChunkReader::decode_values(MutableColumnPtr& doris_column, DataTypePtr& data_type,
-                                        size_t num_values) {
+                                        RunLengthNullMap& null_map) {
+    SCOPED_RAW_TIMER(&_statistics.decode_value_time);
+    size_t num_nulls = 0;
+    size_t num_values = 0;
+    bool is_null = false;
+    for (auto& run_length : null_map) {
+        if (is_null) {
+            num_nulls += run_length;
+        }
+        num_values += run_length;
+        is_null = !is_null;
+    }
     if (UNLIKELY(_remaining_num_values < num_values)) {
         return Status::IOError("Decode too many values in current page");
     }
-    SCOPED_RAW_TIMER(&_statistics.decode_value_time);
     _remaining_num_values -= num_values;
-    return _page_decoder->decode_values(doris_column, data_type, num_values);
+    return _page_decoder->decode_values(doris_column, data_type, null_map, num_values, num_nulls);
 }
 
 int32_t ColumnChunkReader::_get_type_length() {

--- a/be/src/vec/exec/format/parquet/vparquet_column_chunk_reader.h
+++ b/be/src/vec/exec/format/parquet/vparquet_column_chunk_reader.h
@@ -113,7 +113,6 @@ public:
     uint32_t remaining_num_values() const { return _remaining_num_values; };
     // null values are generated from definition levels
     // the caller should maintain the consistency after analyzing null values from definition levels.
-    void insert_null_values(ColumnPtr& doris_column, size_t num_values);
     void insert_null_values(MutableColumnPtr& doris_column, size_t num_values);
     // Get the raw data of current page.
     Slice& get_page_data() { return _page_data; }
@@ -124,8 +123,8 @@ public:
     size_t get_def_levels(level_t* levels, size_t n);
 
     // Decode values in current page into doris column.
-    Status decode_values(ColumnPtr& doris_column, DataTypePtr& data_type, size_t num_values);
-    Status decode_values(MutableColumnPtr& doris_column, DataTypePtr& data_type, size_t num_values);
+    Status decode_values(MutableColumnPtr& doris_column, DataTypePtr& data_type,
+                         RunLengthNullMap& null_map);
 
     // Get the repetition level decoder of current page.
     LevelDecoder& rep_level_decoder() { return _rep_level_decoder; }

--- a/be/src/vec/exec/format/parquet/vparquet_column_reader.cpp
+++ b/be/src/vec/exec/format/parquet/vparquet_column_reader.cpp
@@ -120,47 +120,59 @@ Status ScalarColumnReader::_skip_values(size_t num_values) {
 
 Status ScalarColumnReader::_read_values(size_t num_values, ColumnPtr& doris_column,
                                         DataTypePtr& type) {
-    CHECK(doris_column->is_nullable());
-    auto* nullable_column = reinterpret_cast<vectorized::ColumnNullable*>(
-            (*std::move(doris_column)).mutate().get());
-    MutableColumnPtr data_column = nullable_column->get_nested_column_ptr();
-    NullMap& map_data_column = nullable_column->get_null_map_data();
-    auto origin_size = map_data_column.size();
-    {
-        SCOPED_RAW_TIMER(&_decode_null_map_time);
-        map_data_column.resize(origin_size + num_values);
+    if (num_values == 0) {
+        return Status::OK();
     }
-
-    if (_chunk_reader->max_def_level() > 0) {
-        LevelDecoder& def_decoder = _chunk_reader->def_level_decoder();
-        size_t has_read = 0;
-        while (has_read < num_values) {
-            level_t def_level;
-            size_t loop_read = def_decoder.get_next_run(&def_level, num_values - has_read);
-            bool is_null = def_level == 0;
-            // fill NullMap
-            {
-                SCOPED_RAW_TIMER(&_decode_null_map_time);
+    MutableColumnPtr data_column;
+    RunLengthNullMap null_map;
+    if (doris_column->is_nullable()) {
+        SCOPED_RAW_TIMER(&_decode_null_map_time);
+        auto* nullable_column = reinterpret_cast<vectorized::ColumnNullable*>(
+                (*std::move(doris_column)).mutate().get());
+        data_column = nullable_column->get_nested_column_ptr();
+        NullMap& map_data_column = nullable_column->get_null_map_data();
+        auto origin_size = map_data_column.size();
+        map_data_column.resize(origin_size + num_values);
+        if (_chunk_reader->max_def_level() > 0) {
+            LevelDecoder& def_decoder = _chunk_reader->def_level_decoder();
+            size_t has_read = 0;
+            bool prev_is_null = true;
+            while (has_read < num_values) {
+                level_t def_level;
+                size_t max_read = std::min(num_values - has_read, (size_t)USHRT_MAX);
+                size_t loop_read = def_decoder.get_next_run(&def_level, max_read);
+                bool is_null = def_level == 0;
                 for (int i = 0; i < loop_read; ++i) {
                     map_data_column[origin_size + has_read + i] = (UInt8)is_null;
                 }
+                if (!(prev_is_null ^ is_null)) {
+                    null_map.emplace_back(0);
+                }
+                null_map.emplace_back((u_short)loop_read);
+                prev_is_null = is_null;
+                has_read += loop_read;
             }
-            // decode data
-            if (is_null) {
-                // null values
-                _chunk_reader->insert_null_values(data_column, loop_read);
-            } else {
-                RETURN_IF_ERROR(_chunk_reader->decode_values(data_column, type, loop_read));
+        } else {
+            for (int i = 0; i < num_values; ++i) {
+                map_data_column[origin_size + i] = (UInt8) false;
             }
-            has_read += loop_read;
         }
     } else {
-        for (int i = 0; i < num_values; ++i) {
-            map_data_column[origin_size + i] = (UInt8) false;
+        if (_chunk_reader->max_def_level() > 0) {
+            return Status::Corruption("Not nullable column has null values in parquet file");
         }
-        RETURN_IF_ERROR(_chunk_reader->decode_values(data_column, type, num_values));
+        data_column = doris_column->assume_mutable();
     }
-    return Status::OK();
+    if (null_map.size() == 0) {
+        size_t remaining = num_values;
+        while (remaining > USHRT_MAX) {
+            null_map.emplace_back(USHRT_MAX);
+            null_map.emplace_back(0);
+            remaining -= USHRT_MAX;
+        }
+        null_map.emplace_back((u_short)remaining);
+    }
+    return _chunk_reader->decode_values(data_column, type, null_map);
 }
 
 Status ScalarColumnReader::read_column_data(ColumnPtr& doris_column, DataTypePtr& type,
@@ -229,7 +241,8 @@ Status ArrayColumnReader::init(FileReader* file, FieldSchema* field, tparquet::C
     _chunk_reader.reset(new ColumnChunkReader(_stream_reader, chunk, &field->children[0], _ctz));
     RETURN_IF_ERROR(_chunk_reader->init());
     if (_chunk_reader->max_def_level() > 4) {
-        return Status::Corruption("Max definition level in array column can't exceed 4");
+        return Status::Corruption(
+                "Max definition level in array column can't exceed 4(not support nested array)");
     } else {
         FieldSchema& child = field->children[0];
         _CONCRETE_ELEMENT = child.definition_level;
@@ -242,7 +255,8 @@ Status ArrayColumnReader::init(FileReader* file, FieldSchema* field, tparquet::C
         }
     }
     if (_chunk_reader->max_rep_level() != 1) {
-        return Status::Corruption("Max repetition level in array column should be 1");
+        return Status::Corruption(
+                "Max repetition level in array column should be 1(not support nested array)");
     }
     return Status::OK();
 }
@@ -261,11 +275,16 @@ Status ArrayColumnReader::read_column_data(ColumnPtr& doris_column, DataTypePtr&
         _init_rep_levels_buf();
     }
 
-    CHECK(doris_column->is_nullable());
-    auto* nullable_column = reinterpret_cast<vectorized::ColumnNullable*>(
-            (*std::move(doris_column)).mutate().get());
-    NullMap& map_data_column = nullable_column->get_null_map_data();
-    MutableColumnPtr data_column = nullable_column->get_nested_column_ptr();
+    MutableColumnPtr data_column;
+    NullMap* map_data_ptr = nullptr;
+    if (doris_column->is_nullable()) {
+        auto* nullable_column = reinterpret_cast<vectorized::ColumnNullable*>(
+                (*std::move(doris_column)).mutate().get());
+        map_data_ptr = &nullable_column->get_null_map_data();
+        data_column = nullable_column->get_nested_column_ptr();
+    } else {
+        data_column = doris_column->assume_mutable();
+    }
 
     // generate array offset
     size_t real_batch_size = 0;
@@ -304,13 +323,21 @@ Status ArrayColumnReader::read_column_data(ColumnPtr& doris_column, DataTypePtr&
             size_t scan_values =
                     element_offsets[offset_index + scan_rows] - element_offsets[offset_index];
             // null array, should ignore the last offset in element_offsets
-            {
+            if (doris_column->is_nullable()) {
                 SCOPED_RAW_TIMER(&_decode_null_map_time);
+                NullMap& map_data_column = *map_data_ptr;
                 auto origin_size = map_data_column.size();
                 map_data_column.resize(origin_size + scan_rows);
                 for (int i = offset_index; i < offset_index + scan_rows; ++i) {
                     map_data_column[origin_size + i] =
                             (UInt8)(definitions[element_offsets[i]] == _NULL_ARRAY);
+                }
+            } else {
+                for (int i = offset_index; i < offset_index + scan_rows; ++i) {
+                    if (definitions[element_offsets[i]] == _NULL_ARRAY) {
+                        return Status::Corruption(
+                                "Not nullable column has null values in parquet file");
+                    }
                 }
             }
             // fill array offset, should skip a value when parsing null array
@@ -348,14 +375,13 @@ Status ArrayColumnReader::read_column_data(ColumnPtr& doris_column, DataTypePtr&
 
 Status ArrayColumnReader::_load_nested_column(ColumnPtr& doris_column, DataTypePtr& type,
                                               size_t read_values) {
-    // fill NullMap
-    CHECK(doris_column->is_nullable());
     level_t* definitions = _def_levels_buf.get();
-    auto* nullable_column = reinterpret_cast<vectorized::ColumnNullable*>(
-            (*std::move(doris_column)).mutate().get());
-    MutableColumnPtr data_column = nullable_column->get_nested_column_ptr();
-    {
+    MutableColumnPtr data_column;
+    if (doris_column->is_nullable()) {
         SCOPED_RAW_TIMER(&_decode_null_map_time);
+        auto* nullable_column = reinterpret_cast<vectorized::ColumnNullable*>(
+                (*std::move(doris_column)).mutate().get());
+        data_column = nullable_column->get_nested_column_ptr();
         NullMap& map_data_column = nullable_column->get_null_map_data();
         size_t null_map_size = 0;
         for (int i = _def_offset; i < _def_offset + read_values; ++i) {
@@ -374,7 +400,17 @@ Status ArrayColumnReader::_load_nested_column(ColumnPtr& doris_column, DataTypeP
                 map_data_column[null_map_idx++] = (UInt8) true;
             }
         }
+    } else {
+        doris_column->assume_mutable();
+        for (int i = _def_offset; i < _def_offset + read_values; ++i) {
+            if (definitions[i] == _NULL_ELEMENT) {
+                return Status::Corruption("Not nullable column has null values in parquet file");
+            }
+        }
     }
+
+    RunLengthNullMap null_map;
+    bool map_prev_is_null = true;
     // column with null values
     int start_idx = _def_offset;
     while (start_idx < read_values) {
@@ -401,26 +437,33 @@ Status ArrayColumnReader::_load_nested_column(ColumnPtr& doris_column, DataTypeP
         }
         bool curr_is_null = definitions[i] == _NULL_ELEMENT;
         if (prev_is_null ^ curr_is_null) {
-            if (prev_is_null) {
-                // null values
-                _chunk_reader->insert_null_values(data_column, num_values);
-            } else {
-                RETURN_IF_ERROR(_chunk_reader->decode_values(data_column, type, num_values));
+            if (!(map_prev_is_null ^ prev_is_null)) {
+                null_map.emplace_back(0);
             }
+            size_t remaining = num_values;
+            while (remaining > USHRT_MAX) {
+                null_map.emplace_back(USHRT_MAX);
+                null_map.emplace_back(0);
+            }
+            null_map.emplace_back((u_short)remaining);
+            map_prev_is_null = prev_is_null;
             prev_is_null = curr_is_null;
             num_values = 1;
         } else {
             num_values++;
         }
     }
-    if (prev_is_null) {
-        // null values
-        _chunk_reader->insert_null_values(data_column, num_values);
-    } else {
-        RETURN_IF_ERROR(_chunk_reader->decode_values(data_column, type, num_values));
+    if (!(map_prev_is_null ^ prev_is_null)) {
+        null_map.emplace_back(0);
     }
+    size_t remaining = num_values;
+    while (remaining > USHRT_MAX) {
+        null_map.emplace_back(USHRT_MAX);
+        null_map.emplace_back(0);
+    }
+    null_map.emplace_back((u_short)remaining);
     _def_offset += read_values;
-    return Status::OK();
+    return _chunk_reader->decode_values(data_column, type, null_map);
 }
 
 void ArrayColumnReader::close() {}

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/HiveMetaStoreClientHelper.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/HiveMetaStoreClientHelper.java
@@ -811,6 +811,7 @@ public class HiveMetaStoreClientHelper {
             case "double":
                 return Type.DOUBLE;
             case "string":
+            case "binary":
                 return Type.STRING;
             default:
                 break;
@@ -849,9 +850,7 @@ public class HiveMetaStoreClientHelper {
             }
             return ScalarType.createDecimalType(precision, scale);
         }
-        // TODO: Handle unsupported types.
-        LOG.warn("Hive type {} may not supported yet, will use STRING instead.", hiveType);
-        return Type.STRING;
+        return Type.INVALID;
     }
 
     public static String showCreateTable(org.apache.hadoop.hive.metastore.api.Table remoteTable) {


### PR DESCRIPTION
# Proposed changes

PR(https://github.com/apache/doris/pull/13404) introduced that ParquetReader will break up batch insertion when encountering null values, which leads to the bad performance compared to OrcReader. So this PR has pushed null map into decode function, reduce the time of virtual function call when encountering null values.

Further more, reuse hdfsFS among file readers to reduce the time of building connection to hdfs.

## Performance Test
Using one thread to query data in table with 10 million rows, and the table is generated from a [data generator tool](https://github.com/glebkorolkov/datagen) with all types supported by hive, and all values are random, and has a 10% probability of being null.
<meta charset="utf-8"><div data-page-id="N3sQdKUlGoZo3Vx3jdOcXp2UnYc" data-docx-has-block-data="true"><div>

| Type/Time(s) | Before Opt. | After Opt. |
| -- | -- | -- |
| tinyint | 0.34 | 0.14 |
| smallint | 0.34 | 0.14 |
| int | 0.32 | 0.13 |
| bigint | 0.34 | 0.15 |
| boolean | 0.31 | 0.13 |
| float | 0.32 | 0.12 |
| double | 0.32 | 0.14 |
| string | 2.41 | 2.31 |
| binary | 0.86 | 0.63 |
| timestamp | 1.12 | 0.88 |
| decimal | 0.40 | 0.20 |
| char | 0.44 | 0.21 |
| varchar | 0.44 | 0.21 |
| date | 1.12 | 0.91 |
| array<double> | 0.48 | 0.46 |
| array<string> | 2.33 | 1.86 |

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

