### PR TITLE
[minor](log) remove some unused logs

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/alter/MaterializedViewHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/MaterializedViewHandler.java
@@ -1034,7 +1034,7 @@ public class MaterializedViewHandler extends AlterHandler {
             LOG.info("set table's state to NORMAL, table id: {}, job id: {}", alterJob.getTableId(),
                     alterJob.getJobId());
         } else {
-            LOG.info("not set table's state, table id: {}, is job done: {}, job id: {}", alterJob.getTableId(),
+            LOG.debug("not set table's state, table id: {}, is job done: {}, job id: {}", alterJob.getTableId(),
                     alterJob.isDone(), alterJob.getJobId());
         }
     }

--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/RegressionTest.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/RegressionTest.groovy
@@ -136,7 +136,6 @@ class RegressionTest {
             canRun(config, suiteName, groupName)
         }
         def file = source.getFile()
-        log.info("run ${file}")
         def eventListeners = getEventListeners(config, recorder)
         new ScriptContext(file, suiteExecutors, actionExecutors,
                 config, eventListeners, suiteFilter).start { scriptContext ->

--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/suite/SuiteScript.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/suite/SuiteScript.groovy
@@ -45,6 +45,7 @@ abstract class SuiteScript extends Script {
             return
         }
 
+        log.info("run ${context.file.absolutePath}")
         try {
             context.createAndRunSuite(suiteName, group, suiteBody)
         } catch (Throwable t) {
@@ -76,7 +77,6 @@ abstract class SuiteScript extends Script {
              // There is no specified group, mark it as p0
              groups.add("p0")
         }
-        log.info("path: ${path}, groupPath: ${groupPath}".toString())
         return groups.join(",")
     }
 }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

1. When running regression test with specific suites or group, do not print other suite name or file name
2. Remove a unused alter table job log.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

