### PR TITLE
[Enhancement](threadpool) print thread pool name on error

### DIFF
--- a/be/src/util/threadpool.cpp
+++ b/be/src/util/threadpool.cpp
@@ -258,7 +258,7 @@ ThreadPool::~ThreadPool() {
 
 Status ThreadPool::init() {
     if (!_pool_status.is_uninitialized()) {
-        return Status::NotSupported("The thread pool is already initialized");
+        return Status::NotSupported("The thread pool {} is already initialized", _name);
     }
     _pool_status = Status::OK();
     _num_threads_pending_start = _min_threads;
@@ -281,7 +281,7 @@ void ThreadPool::shutdown() {
     // capacity, so clients can't tell them apart. This isn't really a practical
     // concern though because shutting down a pool typically requires clients to
     // be quiesced first, so there's no danger of a client getting confused.
-    _pool_status = Status::ServiceUnavailable("The pool has been shut down.");
+    _pool_status = Status::ServiceUnavailable("The thread pool {} has been shut down.", _name);
 
     // Clear the various queues under the lock, but defer the releasing
     // of the tasks outside the lock, in case there are concurrent threads
@@ -364,7 +364,7 @@ Status ThreadPool::do_submit(std::shared_ptr<Runnable> r, ThreadPoolToken* token
     }
 
     if (PREDICT_FALSE(!token->may_submit_new_tasks())) {
-        return Status::ServiceUnavailable("Thread pool token was shut down");
+        return Status::ServiceUnavailable("Thread pool({}) token was shut down", _name);
     }
 
     // Size limit check.
@@ -372,7 +372,7 @@ Status ThreadPool::do_submit(std::shared_ptr<Runnable> r, ThreadPoolToken* token
                                  static_cast<int64_t>(_max_queue_size) - _total_queued_tasks;
     if (capacity_remaining < 1) {
         return Status::ServiceUnavailable(
-                "Thread pool is at capacity ({}/{} tasks running, {}/{} tasks queued)",
+                "Thread pool {} is at capacity ({}/{} tasks running, {}/{} tasks queued)", _name,
                 _num_threads + _num_threads_pending_start, _max_threads, _total_queued_tasks,
                 _max_queue_size);
     }
@@ -454,7 +454,8 @@ Status ThreadPool::do_submit(std::shared_ptr<Runnable> r, ThreadPoolToken* token
             }
             // If we failed to create a thread, but there are still some other
             // worker threads, log a warning message and continue.
-            LOG(WARNING) << "Thread pool failed to create thread: " << status.to_string();
+            LOG(WARNING) << "Thread pool " << _name
+                         << " failed to create thread: " << status.to_string();
         }
     }
 
@@ -623,7 +624,7 @@ Status ThreadPool::set_min_threads(int min_threads) {
     std::lock_guard<std::mutex> l(_lock);
     if (min_threads > _max_threads) {
         // min threads can not be set greater than max threads
-        return Status::InternalError("set thread pool min_threads failed");
+        return Status::InternalError("set thread pool {} min_threads failed", _name);
     }
     _min_threads = min_threads;
     if (min_threads > _num_threads + _num_threads_pending_start) {
@@ -633,7 +634,8 @@ Status ThreadPool::set_min_threads(int min_threads) {
             Status status = create_thread();
             if (!status.ok()) {
                 _num_threads_pending_start--;
-                LOG(WARNING) << "Thread pool failed to create thread: " << status.to_string();
+                LOG(WARNING) << "Thread pool " << _name
+                             << " failed to create thread: " << status.to_string();
                 return status;
             }
         }
@@ -645,7 +647,7 @@ Status ThreadPool::set_max_threads(int max_threads) {
     std::lock_guard<std::mutex> l(_lock);
     if (_min_threads > max_threads) {
         // max threads can not be set less than min threads
-        return Status::InternalError("set thread pool max_threads failed");
+        return Status::InternalError("set thread pool {} max_threads failed", _name);
     }
 
     _max_threads = max_threads;
@@ -657,7 +659,8 @@ Status ThreadPool::set_max_threads(int max_threads) {
             Status status = create_thread();
             if (!status.ok()) {
                 _num_threads_pending_start--;
-                LOG(WARNING) << "Thread pool failed to create thread: " << status.to_string();
+                LOG(WARNING) << "Thread pool " << _name
+                             << " failed to create thread: " << status.to_string();
                 return status;
             }
         }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

Add thread pool name in error message to help better trouble shooting.
e.g. in the following waring message, we can't know which thread pool token is shut down.
```
W1026 14:09:19.774461 2412915 fragment_mgr.cpp:252] Got error while opening fragment 681bfe3bf8b242f9-a33eea3bfc309555: Service unavailable: Thread pool token was shut down
```

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

