### PR TITLE
[chore](macOS) Support Java UDF

### DIFF
--- a/be/src/util/jni-util.cpp
+++ b/be/src/util/jni-util.cpp
@@ -22,6 +22,10 @@
 #include <jni_md.h>
 #include <stdlib.h>
 
+#include <cstdlib>
+#include <filesystem>
+#include <sstream>
+
 #include "common/config.h"
 #include "gutil/once.h"
 #include "gutil/strings/substitute.h"
@@ -34,20 +38,56 @@ namespace {
 JavaVM* g_vm;
 GoogleOnceType g_vm_once = GOOGLE_ONCE_INIT;
 
+const std::string GetDorisJNIClasspath() {
+    const auto* classpath = getenv("DORIS_JNI_CLASSPATH_PARAMETER");
+    if (classpath) {
+        return classpath;
+    } else {
+        const auto* doris_home = getenv("DORIS_HOME");
+        DCHECK(doris_home) << "Environment variable DORIS_HOME is not set.";
+
+        std::ostringstream out;
+        std::string path(doris_home);
+        path += "/lib";
+        for (const auto& entry : std::filesystem::directory_iterator(path)) {
+            if (entry.path().extension() != ".jar") {
+                continue;
+            }
+            if (out.str().empty()) {
+                out << "-Djava.class.path=" << entry.path().string();
+            } else {
+                out << ":" << entry.path().string();
+            }
+        }
+
+        DCHECK(!out.str().empty()) << "Empty classpath is invalid.";
+        return out.str();
+    }
+}
+
 void FindOrCreateJavaVM() {
     int num_vms;
     int rv = JNI_GetCreatedJavaVMs(&g_vm, 1, &num_vms);
     if (rv == 0) {
+        auto classpath = GetDorisJNIClasspath();
+        std::string heap_size = fmt::format("-Xmx{}", config::jvm_max_heap_size);
+
+        JavaVMOption options[] = {
+                {const_cast<char*>(classpath.c_str()), nullptr},
+                {const_cast<char*>(heap_size.c_str()), nullptr},
+#ifdef __APPLE__
+                // On macOS, we should disable MaxFDLimit, otherwise the RLIMIT_NOFILE
+                // will be assigned the minimum of OPEN_MAX (10240) and rlim_cur (See src/hotspot/os/bsd/os_bsd.cpp)
+                // and it can not pass the check performed by storage engine.
+                // The newer JDK has fixed this issue.
+                {const_cast<char*>("-XX:-MaxFDLimit"), nullptr},
+#endif
+        };
         JNIEnv* env;
         JavaVMInitArgs vm_args;
-        JavaVMOption options[2];
-        char* cp = getenv("DORIS_JNI_CLASSPATH_PARAMETER");
-        options[0].optionString = cp;
-        std::string heap_size = fmt::format("-Xmx{}", config::jvm_max_heap_size);
-        options[1].optionString = const_cast<char*>(heap_size.c_str());
         vm_args.version = JNI_VERSION_1_8;
         vm_args.options = options;
-        vm_args.nOptions = 2;
+        vm_args.nOptions = sizeof(options) / sizeof(JavaVMOption);
         // Set it to JNI_FALSE because JNI_TRUE will let JVM ignore the max size config.
         vm_args.ignoreUnrecognized = JNI_FALSE;
 

--- a/build.sh
+++ b/build.sh
@@ -294,7 +294,21 @@ if [[ -z "${RECORD_COMPILER_SWITCHES}" ]]; then
 fi
 
 if [[ "${BUILD_JAVA_UDF}" -eq 1 && "$(uname -s)" == 'Darwin' ]]; then
-    BUILD_JAVA_UDF=0
+    if [[ -z "${JAVA_HOME}" ]]; then
+        CAUSE='the environment variable JAVA_HOME is not set'
+    else
+        LIBJVM="$(find "${JAVA_HOME}/" -name 'libjvm.dylib')"
+        if [[ -z "${LIBJVM}" ]]; then
+            CAUSE="the library libjvm.dylib is missing"
+        elif [[ "$(file "${LIBJVM}" | awk '{print $NF}')" != "$(uname -m)" ]]; then
+            CAUSE='the architecture which the library libjvm.dylib is built for does not match'
+        fi
+    fi
+
+    if [[ -n "${CAUSE}" ]]; then
+        echo -e "\033[33;1mWARNNING: \033[37;1mSkip building with JAVA UDF due to ${CAUSE}.\033[0m"
+        BUILD_JAVA_UDF=0
+    fi
 fi
 
 if [[ "${DISABLE_JAVA_UDF}" == "ON" ]]; then


### PR DESCRIPTION
# Proposed changes

~~Issue Number: close #xxx~~

## Problem summary

Previously, there are some issues with BE (built with Java UDF support) on macOS and we disable it by default (#13563).

Now, all issues are resolved.
1. `ulimit -n` doesn't work.
    **Root cause**
    `RLIMIT_NOFILE` will be assigned the minimum of `OPEN_MAX (10240)` and `rlim_cur` when create a Java VM.
    
    **openjdk (tag: jdk-11+16)**
    _src/hotspot/os/bsd/os_bsd.cpp_
    ```cpp
    jint os::init_2(void) {
    
      os::Posix::init_2();
    
      // initialize suspend/resume support - must do this before signal_sets_init()
      if (SR_initialize() != 0) {
        perror("SR_initialize failed");
        return JNI_ERR;
      }
    
      Bsd::signal_sets_init();
      Bsd::install_signal_handlers();
      // Initialize data for jdk.internal.misc.Signal
      if (!ReduceSignalUsage) {
        jdk_misc_signal_init();
      }
    
      // Check and sets minimum stack sizes against command line options
      if (Posix::set_minimum_stack_sizes() == JNI_ERR) {
        return JNI_ERR;
      }
    
      if (MaxFDLimit) {
        // set the number of file descriptors to max. print out error
        // if getrlimit/setrlimit fails but continue regardless.
        struct rlimit nbr_files;
        int status = getrlimit(RLIMIT_NOFILE, &nbr_files);
        if (status != 0) {
          log_info(os)("os::init_2 getrlimit failed: %s", os::strerror(errno));
        } else {
          nbr_files.rlim_cur = nbr_files.rlim_max;
    
    #ifdef __APPLE__
          // Darwin returns RLIM_INFINITY for rlim_max, but fails with EINVAL if
          // you attempt to use RLIM_INFINITY. As per setrlimit(2), OPEN_MAX must
          // be used instead
          nbr_files.rlim_cur = MIN(OPEN_MAX, nbr_files.rlim_cur);
    #endif
    
          status = setrlimit(RLIMIT_NOFILE, &nbr_files);
          if (status != 0) {
            log_info(os)("os::init_2 setrlimit failed: %s", os::strerror(errno));
          }
        }
      }
    ...
    ```
    Here `MaxFDLimit` is true by default.

    **Solution**
    Disable `MaxFDLimit` on macOS.
2. Core dump when using lldb to debug.
    Environment variable `DORIS_JNI_CLASSPATH_PARAMETER` should be set before BE starts and BE use this variable to get the classpath needed by JVM.
    We can provide a workaround. If `DORIS_JNI_CLASSPATH_PARAMETER` is unset, we scan the `${DORIS_HOME}/lib` to get the jars and produce the classpath.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
4. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
5. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
6. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
7. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

