### PR TITLE
[chore](build) Pass the compile flag -Wno-unused-but-set-variable on demand

### DIFF
--- a/be/src/geo/CMakeLists.txt
+++ b/be/src/geo/CMakeLists.txt
@@ -29,8 +29,12 @@ add_library(Geo STATIC
     ${GENSRC_DIR}/geo/wkt_lex.l.cpp
     ${GENSRC_DIR}/geo/wkt_yacc.y.cpp
 )
-if (COMPILER_GCC OR CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "14.0.0")
-    target_compile_options(Geo PRIVATE -Wno-unused-but-set-variable)
+
+include(CheckCXXCompilerFlag)
+set(WARNING_OPTION "-Wno-unused-but-set-variable")
+check_cxx_compiler_flag(${WARNING_OPTION} HAS_WARNING_OPTION)
+if (HAS_WARNING_OPTION)
+    target_compile_options(Geo PRIVATE ${WARNING_OPTION})
 endif()
 
 add_custom_command(

--- a/be/src/util/simd/vstring_function.h
+++ b/be/src/util/simd/vstring_function.h
@@ -19,6 +19,7 @@
 
 #include <unistd.h>
 
+#include <array>
 #include <cstdint>
 
 #ifdef __aarch64__

--- a/thirdparty/build-thirdparty.sh
+++ b/thirdparty/build-thirdparty.sh
@@ -146,8 +146,8 @@ elif [[ "${CC}" == *clang ]]; then
     warning_option_ignored='-Wno-option-ignored'
     boost_toolset='clang'
     libhdfs_cxx17='-std=c++1z'
-    clang_version="$("${CC}" -dumpversion)"
-    if [[ "${clang_version}" < '14.0.0' ]]; then
+
+    if "${CC}" -xc++ "${warning_unused_but_set_variable}" /dev/null 2>&1 | grep 'unknown warning option'; then
         warning_unused_but_set_variable=''
     fi
 fi


### PR DESCRIPTION
# Proposed changes

~~Issue Number: close #xxx~~

## Problem summary

There are some issues with the compile flag `-Wno-unused-but-set-variable` for clang.
1. `-Wno-unused-but-set-variable` should be set when building source by clang-15 on Linux. (#13000 #13016)
2. On macOS Monterey, Apple Clang 13 may treat it as a unknown warning option and the compilation process may interrupt.

This PR introduces a better way to make this compile flag more portable.
1. Test whether the compiler recognizes this flag.
2. Add this flag if the compiler recognizes it.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
4. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
5. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
6. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
7. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

