### PR TITLE
[Bugfix](MV) Fixed load negative values into bitmap type materialized views successfully under non-vectorization

### DIFF
--- a/be/src/exprs/bitmap_function.cpp
+++ b/be/src/exprs/bitmap_function.cpp
@@ -190,7 +190,7 @@ StringVal BitmapFunctions::to_bitmap_with_check(doris_udf::FunctionContext* ctx,
                   "18446744073709551615 currently, cannot load negative values to column with"
                   " to_bitmap MV on it.";
             ctx->set_error(ss.str().c_str());
-            return serialize(ctx, nullptr);
+            return StringVal::null();
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateMaterializedViewStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateMaterializedViewStmt.java
@@ -137,6 +137,7 @@ public class CreateMaterializedViewStmt extends DdlStmt {
     public void analyze(Analyzer analyzer) throws UserException {
         super.analyze(analyzer);
         FeNameFormat.checkTableName(mvName);
+        rewriteToBitmapWithCheck();
         // TODO(ml): The mv name in from clause should pass the analyze without error.
         selectStmt.forbiddenMVRewrite();
         selectStmt.analyze(analyzer);
@@ -210,25 +211,6 @@ public class CreateMaterializedViewStmt extends DdlStmt {
                     if (!mvColumnPattern.match(functionCallExpr)) {
                         throw new AnalysisException(
                                 "The function " + functionName + " must match pattern:" + mvColumnPattern.toString());
-                    }
-
-                    // for bitmap_union(to_bitmap(column)) function, we should check value is not negative
-                    // in vectorized schema_change mode, so we should rewrite the function to
-                    // bitmap_union(to_bitmap_with_check(column))
-                    if (functionName.equalsIgnoreCase("bitmap_union")) {
-                        if (functionCallExpr.getChildren().size() == 1
-                                && functionCallExpr.getChild(0) instanceof FunctionCallExpr) {
-                            Expr child = functionCallExpr.getChild(0);
-                            FunctionCallExpr childFunctionCallExpr = (FunctionCallExpr) child;
-                            if (childFunctionCallExpr.getFnName().getFunction().equalsIgnoreCase("to_bitmap")) {
-                                childFunctionCallExpr.setFnName(
-                                        new FunctionName(childFunctionCallExpr.getFnName().getDb(),
-                                                "to_bitmap_with_check"));
-                                childFunctionCallExpr.getFn().setName(
-                                        new FunctionName(childFunctionCallExpr.getFn().getFunctionName().getDb(),
-                                                "to_bitmap_with_check"));
-                            }
-                        }
                     }
                 }
                 // check duplicate column
@@ -502,6 +484,26 @@ public class CreateMaterializedViewStmt extends DdlStmt {
             }
         }
         return result;
+    }
+
+    // for bitmap_union(to_bitmap(column)) function, we should check value is not negative
+    // in vectorized schema_change mode, so we should rewrite the function to
+    // bitmap_union(to_bitmap_with_check(column))
+    private void rewriteToBitmapWithCheck() {
+        for (SelectListItem item : selectStmt.selectList.getItems()) {
+            if (item.getExpr() instanceof FunctionCallExpr){
+                String functionName = ((FunctionCallExpr) item.getExpr()).getFnName().getFunction();
+                if (functionName.equalsIgnoreCase("bitmap_union")) {
+                    if (item.getExpr().getChildren().size() == 1
+                            && item.getExpr().getChild(0) instanceof FunctionCallExpr) {
+                        FunctionCallExpr childFunctionCallExpr = (FunctionCallExpr) item.getExpr().getChild(0);
+                        if (childFunctionCallExpr.getFnName().getFunction().equalsIgnoreCase("to_bitmap")) {
+                            childFunctionCallExpr.setFnName(FunctionName.createBuiltinName("to_bitmap_with_check"));
+                        }
+                    }
+                }
+            }
+        }
     }
 
     public static String mvColumnBuilder(String functionName, String sourceColumnName) {

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateMaterializedViewStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateMaterializedViewStmt.java
@@ -490,7 +490,7 @@ public class CreateMaterializedViewStmt extends DdlStmt {
     // in vectorized schema_change mode, so we should rewrite the function to
     // bitmap_union(to_bitmap_with_check(column))
     private void rewriteToBitmapWithCheck() {
-        for (SelectListItem item : selectStmt.selectList.getItems()) {
+        for (SelectListItem item : selectStmt.getSelectList().getItems()) {
             if (item.getExpr() instanceof FunctionCallExpr) {
                 String functionName = ((FunctionCallExpr) item.getExpr()).getFnName().getFunction();
                 if (functionName.equalsIgnoreCase("bitmap_union")) {

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateMaterializedViewStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateMaterializedViewStmt.java
@@ -491,7 +491,7 @@ public class CreateMaterializedViewStmt extends DdlStmt {
     // bitmap_union(to_bitmap_with_check(column))
     private void rewriteToBitmapWithCheck() {
         for (SelectListItem item : selectStmt.selectList.getItems()) {
-            if (item.getExpr() instanceof FunctionCallExpr){
+            if (item.getExpr() instanceof FunctionCallExpr) {
                 String functionName = ((FunctionCallExpr) item.getExpr()).getFnName().getFunction();
                 if (functionName.equalsIgnoreCase("bitmap_union")) {
                     if (item.getExpr().getChildren().size() == 1


### PR DESCRIPTION
# Proposed changes

Issue Number: close #13502

## Problem summary

Fixed load negative values into bitmap type materialized views successfully under non-vectorization, this is because of on-vec function must return null for error checking

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

