### PR TITLE
[Fix]Fix the extension mysql_to_doris  bug

### DIFF
--- a/extension/mysql_to_doris/bin/e_mysql_to_doris.sh
+++ b/extension/mysql_to_doris/bin/e_mysql_to_doris.sh
@@ -31,8 +31,8 @@ rm -f $path
 #get create table sql for mysql
 for table in $(cat ../conf/mysql_tables |grep -v '#' | awk -F '\n' '{print $1}')
         do
-        d_d=`echo $table` |awk -F '.' '{print $1}'
-        d_t=`echo $table` |awk -F '.' '{print $2}'
+        d_d=`echo $table |awk -F '.' '{print $1}'`
+        d_t=`echo $table |awk -F '.' '{print $2}'`
         echo "show create table \`$d_d\`.\`$d_t\`;" |mysql -h$mysql_host -uroot -p$mysql_password  >> $path
 done
 

--- a/extension/mysql_to_doris/bin/e_mysql_to_doris.sh
+++ b/extension/mysql_to_doris/bin/e_mysql_to_doris.sh
@@ -31,8 +31,8 @@ rm -f $path
 #get create table sql for mysql
 for table in $(cat ../conf/mysql_tables |grep -v '#' | awk -F '\n' '{print $1}')
         do
-        d_d=`echo $table |awk -F '.' '{print $1}'`
-        d_t=`echo $table |awk -F '.' '{print $2}'`
+        d_d=$(echo $table |awk -F '.' '{print $1}')
+        d_t=$(echo $table |awk -F '.' '{print $2}')
         echo "show create table \`$d_d\`.\`$d_t\`;" |mysql -h$mysql_host -uroot -p$mysql_password  >> $path
 done
 


### PR DESCRIPTION
e_mysql_to_doris.sh: command error,This error causes script execution errors.  :ERROR 1103 (42000) at line 1: Incorrect table name ''.
 ` ` symbol position error.

Issue Number: close #13722

## Problem summary
Using extension mysql_to_doris ,there was an error executing the e_mysql_to_doris.sh script.
ERROR 1103 (42000) at line 1: Incorrect table name ''.

Describe your changes.
fix ` ` symbol position error.


1. Does it affect the original behavior: 
    - [x] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [x] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No


