### PR TITLE
[optimization](array-type) update the exception message when create t…

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateTableStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateTableStmt.java
@@ -341,7 +341,7 @@ public class CreateTableStmt extends DdlStmt {
                     // So the float and double could not be the first column in OLAP table.
                     if (keysColumnNames.isEmpty()) {
                         throw new AnalysisException("The olap table first column could not be float, double, string"
-                                + " use decimal or varchar instead.");
+                                + " or array, please use decimal or varchar instead.");
                     }
                     keysDesc = new KeysDesc(KeysType.DUP_KEYS, keysColumnNames);
                 }

--- a/regression-test/suites/datatype_p0/string/test_string_basic.groovy
+++ b/regression-test/suites/datatype_p0/string/test_string_basic.groovy
@@ -20,7 +20,7 @@ suite("test_string_basic") {
     // first column could not be string
     test {
         sql """CREATE TABLE IF NOT EXISTS fail_tb1 (k1 STRING NOT NULL, v1 STRING NOT NULL) DISTRIBUTED BY HASH(k1) BUCKETS 5 properties("replication_num" = "1")"""
-        exception "The olap table first column could not be float, double, string use decimal or varchar instead."
+        exception "The olap table first column could not be float, double, string or array, please use decimal or varchar instead."
     }
     // string type should could not be key
     test {


### PR DESCRIPTION
# Proposed changes
1. this pr is used to update the exception message when create table with array column.

2. before the change, we run "CREATE TABLE" will get the Inaccurate error message.
MySQL [example_db]> CREATE TABLE array_test_problem108 ( k2 ARRAY<INT> NOT NULL, k1 INT NOT NULL )  DISTRIBUTED BY HASH(k1) BUCKETS 1;
ERROR 1105 (HY000): errCode = 2, detailMessage = The olap table first column could not be float, double, string, use decimal or varchar instead.

3. after the change, we run "CREATE TABLE" will get the accurate error message.
MySQL [example_db]> CREATE TABLE array_test_problem108 ( k2 ARRAY<INT> NOT NULL, k1 INT NOT NULL )  DISTRIBUTED BY HASH(k1) BUCKETS 1;
ERROR 1105 (HY000): errCode = 2, detailMessage = The olap table first column could not be float, double, string or array, please use decimal or varchar instead.

Issue Number: #7570

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
5. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
6. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
7. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
8. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

