### PR TITLE
[fix](plan)result exprs should be substituted in the same way as agg exprs

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/SelectStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/SelectStmt.java
@@ -1410,7 +1410,6 @@ public class SelectStmt extends QueryStmt {
                 rewriter.rewriteList(oriGroupingExprs, analyzer);
                 // after rewrite, need reset the analyze status for later re-analyze
                 for (Expr expr : oriGroupingExprs) {
-                    expr.reset();
                     if (!(expr instanceof SlotRef)) {
                         expr.reset();
                     }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/SelectStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/SelectStmt.java
@@ -1062,6 +1062,9 @@ public class SelectStmt extends QueryStmt {
         countAllMap = ExprSubstitutionMap.compose(multiCountOrSumDistinctMap, countAllMap, analyzer);
         List<Expr> substitutedAggs =
                 Expr.substituteList(aggExprs, countAllMap, analyzer, false);
+        // the resultExprs must substitute in the same way as aggExprs
+        // then resultExprs can be substitute correctly using combinedSmap
+        resultExprs = Expr.substituteList(resultExprs, countAllMap, analyzer, false);
         aggExprs.clear();
         TreeNode.collect(substitutedAggs, Expr.isAggregatePredicate(), aggExprs);
 
@@ -1395,7 +1398,11 @@ public class SelectStmt extends QueryStmt {
                 // we must make sure the expr is analyzed before rewrite
                 try {
                     for (Expr expr : oriGroupingExprs) {
-                        expr.analyze(analyzer);
+                        if (!(expr instanceof SlotRef)) {
+                            // if group expr is not a slotRef, it should be analyzed in the same way as result expr
+                            // otherwise, the group expr is either a simple column or an alias, no need to analyze
+                            expr.analyze(analyzer);
+                        }
                     }
                 } catch (AnalysisException ex) {
                     //ignore any exception
@@ -1404,6 +1411,9 @@ public class SelectStmt extends QueryStmt {
                 // after rewrite, need reset the analyze status for later re-analyze
                 for (Expr expr : oriGroupingExprs) {
                     expr.reset();
+                    if (!(expr instanceof SlotRef)) {
+                        expr.reset();
+                    }
                 }
             }
         }
@@ -1411,13 +1421,20 @@ public class SelectStmt extends QueryStmt {
             for (OrderByElement orderByElem : orderByElements) {
                 // we must make sure the expr is analyzed before rewrite
                 try {
-                    orderByElem.getExpr().analyze(analyzer);
+                    if (!(orderByElem.getExpr() instanceof SlotRef)) {
+                        // if sort expr is not a slotRef, it should be analyzed in the same way as result expr
+                        // otherwise, the sort expr is either a simple column or an alias, no need to analyze
+                        orderByElem.getExpr().analyze(analyzer);
+                    }
                 } catch (AnalysisException ex) {
                     //ignore any exception
                 }
                 orderByElem.setExpr(rewriter.rewrite(orderByElem.getExpr(), analyzer));
                 // after rewrite, need reset the analyze status for later re-analyze
                 orderByElem.getExpr().reset();
+                if (!(orderByElem.getExpr() instanceof SlotRef)) {
+                    orderByElem.getExpr().reset();
+                }
             }
         }
     }


### PR DESCRIPTION

# Proposed changes

Issue Number: pick from master https://github.com/apache/doris/pull/13744

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

