### PR TITLE
[fix](nereids) map literal to double in FilterSelectivityCalculator

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/logical/ColumnPruning.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/logical/ColumnPruning.java
@@ -35,7 +35,8 @@ public class ColumnPruning implements PlanRuleFactory {
                 new PruneFilterChildColumns().build(),
                 new PruneAggChildColumns().build(),
                 new PruneJoinChildrenColumns().build(),
-                new PruneSortChildColumns().build()
+                new PruneSortChildColumns().build(),
+                new MergeProjects().build()
         );
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/FilterSelectivityCalculator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/FilterSelectivityCalculator.java
@@ -100,8 +100,8 @@ public class FilterSelectivityCalculator extends ExpressionVisitor<Double, Void>
             throw new RuntimeException("FilterSelectivityCalculator - col stats not found: " + left);
         }
         ColumnStat newStats = new ColumnStat(1, columnStats.getAvgSizeByte(),
-            columnStats.getMaxSizeByte(), 0,
-            literal.getDouble(), literal.getDouble());
+                columnStats.getMaxSizeByte(), 0,
+                literal.getDouble(), literal.getDouble());
         newStats.setSelectivity(1.0 / columnStats.getNdv());
         slotRefToStats.put(left, newStats);
         double ndv = columnStats.getNdv();

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/FilterSelectivityCalculator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/FilterSelectivityCalculator.java
@@ -99,8 +99,9 @@ public class FilterSelectivityCalculator extends ExpressionVisitor<Double, Void>
         if (columnStats == null) {
             throw new RuntimeException("FilterSelectivityCalculator - col stats not found: " + left);
         }
-        ColumnStat newStats = new ColumnStat(1, columnStats.getAvgSizeByte(), columnStats.getMaxSizeByte(), 0,
-                Double.parseDouble(literal.getValue().toString()), Double.parseDouble(literal.getValue().toString()));
+        ColumnStat newStats = new ColumnStat(1, columnStats.getAvgSizeByte(),
+            columnStats.getMaxSizeByte(), 0,
+            literal.getDouble(), literal.getDouble());
         newStats.setSelectivity(1.0 / columnStats.getNdv());
         slotRefToStats.put(left, newStats);
         double ndv = columnStats.getNdv();

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/BooleanLiteral.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/BooleanLiteral.java
@@ -68,4 +68,13 @@ public class BooleanLiteral extends Literal {
     public LiteralExpr toLegacyLiteral() {
         return new BoolLiteral(value);
     }
+
+    @Override
+    public double getDouble() {
+        if (value) {
+            return 1.0;
+        } else {
+            return 0;
+        }
+    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/DecimalLiteral.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/DecimalLiteral.java
@@ -50,4 +50,9 @@ public class DecimalLiteral extends Literal {
     public LiteralExpr toLegacyLiteral() {
         return new org.apache.doris.analysis.DecimalLiteral(value);
     }
+
+    @Override
+    public double getDouble() {
+        return value.doubleValue();
+    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/LargeIntLiteral.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/LargeIntLiteral.java
@@ -56,4 +56,9 @@ public class LargeIntLiteral extends Literal {
                     "Can not convert to legacy literal: " + value, e);
         }
     }
+
+    @Override
+    public double getDouble() {
+        return value.doubleValue();
+    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/Literal.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/Literal.java
@@ -95,7 +95,11 @@ public abstract class Literal extends Expression implements LeafExpression {
      * @return double representation of literal.
      */
     public double getDouble() {
-        return Double.parseDouble(getValue().toString());
+        try {
+            return Double.parseDouble(getValue().toString());
+        } catch (Exception e) {
+            return 0.0;
+        }
     }
 
     public String getStringValue() {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/NullLiteral.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/NullLiteral.java
@@ -51,4 +51,9 @@ public class NullLiteral extends Literal {
     public LiteralExpr toLegacyLiteral() {
         return new org.apache.doris.analysis.NullLiteral();
     }
+
+    @Override
+    public double getDouble() {
+        return 0;
+    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -716,6 +716,7 @@ public class StmtExecutor implements ProfileWriter {
                 } catch (UserException e) {
                     throw e;
                 } catch (Exception e) {
+                    e.printStackTrace();
                     if (parsedStmt instanceof LogicalPlanAdapter) {
                         throw new NereidsException(new AnalysisException("Unexpected exception: " + e.getMessage()));
                     }


### PR DESCRIPTION
# Proposed changes
1. fix literal to double bug: all literal type implements getDouble() function

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
4. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
5. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
6. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
7. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

