### PR TITLE
[feature](multi-catalog) persist external catalog/db/tbl

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
@@ -1937,7 +1937,7 @@ public class Env {
      **/
     public long loadCatalog(DataInputStream in, long checksum) throws IOException {
         CatalogMgr mgr = CatalogMgr.read(in);
-        // When enable the multi catalog in the first time, the mgr will be a null value.
+        // When enable the multi catalog in the first time, the "mgr" will be a null value.
         // So ignore it to use default catalog manager.
         if (mgr != null) {
             this.catalogMgr = mgr;

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/external/EsExternalTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/external/EsExternalTable.java
@@ -36,9 +36,6 @@ import java.util.List;
 public class EsExternalTable extends ExternalTable {
 
     private static final Logger LOG = LogManager.getLogger(EsExternalTable.class);
-
-    private final EsExternalCatalog catalog;
-    private final String dbName;
     private EsTable esTable;
 
     /**
@@ -65,7 +62,7 @@ public class EsExternalTable extends ExternalTable {
     }
 
     private void init() {
-        fullSchema = EsUtil.genColumnsFromEs(catalog.getEsRestClient(), name, null);
+        fullSchema = EsUtil.genColumnsFromEs(((EsExternalCatalog) catalog).getEsRestClient(), name, null);
         esTable = toEsTable();
     }
 
@@ -123,17 +120,18 @@ public class EsExternalTable extends ExternalTable {
     }
 
     private EsTable toEsTable() {
+        EsExternalCatalog esCatalog = (EsExternalCatalog) catalog;
         EsTable esTable = new EsTable(this.id, this.name, this.fullSchema, TableType.ES_EXTERNAL_TABLE);
         esTable.setIndexName(name);
-        esTable.setClient(catalog.getEsRestClient());
-        esTable.setUserName(catalog.getUsername());
-        esTable.setPasswd(catalog.getPassword());
-        esTable.setEnableDocValueScan(catalog.isEnableDocValueScan());
-        esTable.setEnableKeywordSniff(catalog.isEnableKeywordSniff());
-        esTable.setNodesDiscovery(catalog.isEnableNodesDiscovery());
-        esTable.setHttpSslEnabled(catalog.isEnableSsl());
-        esTable.setSeeds(catalog.getNodes());
-        esTable.setHosts(String.join(",", catalog.getNodes()));
+        esTable.setClient(esCatalog.getEsRestClient());
+        esTable.setUserName(esCatalog.getUsername());
+        esTable.setPasswd(esCatalog.getPassword());
+        esTable.setEnableDocValueScan(esCatalog.isEnableDocValueScan());
+        esTable.setEnableKeywordSniff(esCatalog.isEnableKeywordSniff());
+        esTable.setNodesDiscovery(esCatalog.isEnableNodesDiscovery());
+        esTable.setHttpSslEnabled(esCatalog.isEnableSsl());
+        esTable.setSeeds(esCatalog.getNodes());
+        esTable.setHosts(String.join(",", esCatalog.getNodes()));
         esTable.syncTableMetaData();
         return esTable;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/external/ExternalDatabase.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/external/ExternalDatabase.java
@@ -24,6 +24,7 @@ import org.apache.doris.common.MetaNotFoundException;
 import org.apache.doris.datasource.ExternalCatalog;
 import org.apache.doris.qe.ConnectContext;
 
+import com.google.gson.annotations.SerializedName;
 import org.apache.commons.lang.NotImplementedException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -44,11 +45,16 @@ public class ExternalDatabase<T extends ExternalTable> implements DatabaseIf<T> 
 
     private ReentrantReadWriteLock rwLock = new ReentrantReadWriteLock(true);
 
+    @SerializedName(value = "id")
     protected long id;
+    @SerializedName(value = "name")
     protected String name;
-    protected ExternalCatalog extCatalog;
-    protected DatabaseProperty dbProperties;
+    @SerializedName(value = "dbProperties")
+    protected DatabaseProperty dbProperties = new DatabaseProperty();
+    @SerializedName(value = "initialized")
     protected boolean initialized = false;
+
+    protected ExternalCatalog extCatalog;
 
     /**
      * Create external database.
@@ -61,6 +67,10 @@ public class ExternalDatabase<T extends ExternalTable> implements DatabaseIf<T> 
         this.extCatalog = extCatalog;
         this.id = id;
         this.name = name;
+    }
+
+    public void setExtCatalog(ExternalCatalog extCatalog) {
+        this.extCatalog = extCatalog;
     }
 
     public synchronized void setUnInitialized() {

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/external/ExternalTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/external/ExternalTable.java
@@ -22,8 +22,10 @@ import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.TableIf;
 import org.apache.doris.common.DdlException;
 import org.apache.doris.common.MetaNotFoundException;
+import org.apache.doris.datasource.ExternalCatalog;
 import org.apache.doris.thrift.TTableDescriptor;
 
+import com.google.gson.annotations.SerializedName;
 import org.apache.commons.lang.NotImplementedException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -37,15 +39,23 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
  * Such as tables from hive, iceberg, es, etc.
  */
 public class ExternalTable implements TableIf {
-
     private static final Logger LOG = LogManager.getLogger(ExternalTable.class);
 
+    @SerializedName(value = "id")
     protected long id;
+    @SerializedName(value = "name")
     protected String name;
-    protected ReentrantReadWriteLock rwLock = new ReentrantReadWriteLock(true);
+    @SerializedName(value = "type")
     protected TableType type = null;
+    @SerializedName(value = "fullSchema")
     protected volatile List<Column> fullSchema = null;
+    @SerializedName(value = "initialized")
     protected boolean initialized = false;
+
+    protected ExternalCatalog catalog;
+    protected String dbName;
+
+    protected ReentrantReadWriteLock rwLock = new ReentrantReadWriteLock(true);
 
     /**
      * Create external table.
@@ -69,6 +79,10 @@ public class ExternalTable implements TableIf {
         this.id = id;
         this.name = name;
         this.type = type;
+    }
+
+    public void setCatalog(ExternalCatalog catalog) {
+        this.catalog = catalog;
     }
 
     public boolean isView() {
@@ -260,7 +274,6 @@ public class ExternalTable implements TableIf {
     @Override
     public String getComment(boolean escapeQuota) {
         return "";
-
     }
 
     public TTableDescriptor toThrift() {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/EsExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/EsExternalCatalog.java
@@ -54,10 +54,6 @@ public class EsExternalCatalog extends ExternalCatalog {
     private static final String PROP_NODES_DISCOVERY = "elasticsearch.nodes_discovery";
     private static final String PROP_SSL = "elasticsearch.ssl";
 
-    // Cache of db name to db id.
-    private Map<String, Long> dbNameToId;
-    private Map<Long, EsExternalDatabase> idToDb;
-
     private EsRestClient esRestClient;
 
     private String[] nodes;

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/HMSExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/HMSExternalCatalog.java
@@ -41,9 +41,6 @@ import java.util.Map;
 public class HMSExternalCatalog extends ExternalCatalog {
     private static final Logger LOG = LogManager.getLogger(HMSExternalCatalog.class);
 
-    // Cache of db name to db id.
-    private Map<String, Long> dbNameToId = Maps.newConcurrentMap();
-    private Map<Long, HMSExternalDatabase> idToDb = Maps.newConcurrentMap();
     protected HiveMetaStoreClient client;
 
     /**
@@ -63,7 +60,7 @@ public class HMSExternalCatalog extends ExternalCatalog {
 
     private void init() {
         Map<String, Long> tmpDbNameToId = Maps.newConcurrentMap();
-        Map<Long, HMSExternalDatabase> tmpIdToDb = Maps.newConcurrentMap();
+        Map<Long, ExternalDatabase> tmpIdToDb = Maps.newConcurrentMap();
         HiveConf hiveConf = new HiveConf();
         hiveConf.setVar(HiveConf.ConfVars.METASTOREURIS, getHiveMetastoreUris());
         try {
@@ -88,7 +85,7 @@ public class HMSExternalCatalog extends ExternalCatalog {
             if (dbNameToId != null && dbNameToId.containsKey(dbName)) {
                 dbId = dbNameToId.get(dbName);
                 tmpDbNameToId.put(dbName, dbId);
-                HMSExternalDatabase db = idToDb.get(dbId);
+                ExternalDatabase db = idToDb.get(dbId);
                 db.setUnInitialized();
                 tmpIdToDb.put(dbId, db);
             } else {

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/gson/GsonUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/gson/GsonUtils.java
@@ -21,6 +21,7 @@ import org.apache.doris.alter.AlterJobV2;
 import org.apache.doris.alter.RollupJobV2;
 import org.apache.doris.alter.SchemaChangeJobV2;
 import org.apache.doris.catalog.ArrayType;
+import org.apache.doris.catalog.DatabaseIf;
 import org.apache.doris.catalog.DistributionInfo;
 import org.apache.doris.catalog.HashDistributionInfo;
 import org.apache.doris.catalog.JdbcResource;
@@ -32,6 +33,13 @@ import org.apache.doris.catalog.S3Resource;
 import org.apache.doris.catalog.ScalarType;
 import org.apache.doris.catalog.SparkResource;
 import org.apache.doris.catalog.StructType;
+import org.apache.doris.catalog.TableIf;
+import org.apache.doris.catalog.external.EsExternalDatabase;
+import org.apache.doris.catalog.external.EsExternalTable;
+import org.apache.doris.catalog.external.ExternalDatabase;
+import org.apache.doris.catalog.external.ExternalTable;
+import org.apache.doris.catalog.external.HMSExternalDatabase;
+import org.apache.doris.catalog.external.HMSExternalTable;
 import org.apache.doris.datasource.CatalogIf;
 import org.apache.doris.datasource.EsExternalCatalog;
 import org.apache.doris.datasource.HMSExternalCatalog;
@@ -140,7 +148,6 @@ public class GsonUtils {
             = RuntimeTypeAdapterFactory.of(LoadJobStateUpdateInfo.class, "clazz")
             .registerSubtype(SparkLoadJobStateUpdateInfo.class, SparkLoadJobStateUpdateInfo.class.getSimpleName());
 
-
     // runtime adapter for class "Policy"
     private static RuntimeTypeAdapterFactory<Policy> policyTypeAdapterFactory = RuntimeTypeAdapterFactory.of(
                     Policy.class, "clazz").registerSubtype(RowPolicy.class, RowPolicy.class.getSimpleName())
@@ -151,6 +158,18 @@ public class GsonUtils {
             .registerSubtype(InternalCatalog.class, InternalCatalog.class.getSimpleName())
             .registerSubtype(HMSExternalCatalog.class, HMSExternalCatalog.class.getSimpleName())
             .registerSubtype(EsExternalCatalog.class, EsExternalCatalog.class.getSimpleName());
+
+    private static RuntimeTypeAdapterFactory<DatabaseIf> dbTypeAdapterFactory = RuntimeTypeAdapterFactory.of(
+                    DatabaseIf.class, "clazz")
+            .registerSubtype(ExternalDatabase.class, ExternalDatabase.class.getSimpleName())
+            .registerSubtype(EsExternalDatabase.class, EsExternalDatabase.class.getSimpleName())
+            .registerSubtype(HMSExternalDatabase.class, HMSExternalDatabase.class.getSimpleName());
+
+    private static RuntimeTypeAdapterFactory<TableIf> tblTypeAdapterFactory = RuntimeTypeAdapterFactory.of(
+                    TableIf.class, "clazz")
+            .registerSubtype(ExternalTable.class, ExternalTable.class.getSimpleName())
+            .registerSubtype(EsExternalTable.class, EsExternalTable.class.getSimpleName())
+            .registerSubtype(HMSExternalTable.class, HMSExternalTable.class.getSimpleName());
 
     // the builder of GSON instance.
     // Add any other adapters if necessary.
@@ -165,7 +184,10 @@ public class GsonUtils {
             .registerTypeAdapterFactory(alterJobV2TypeAdapterFactory)
             .registerTypeAdapterFactory(syncJobTypeAdapterFactory)
             .registerTypeAdapterFactory(loadJobStateUpdateInfoTypeAdapterFactory)
-            .registerTypeAdapterFactory(policyTypeAdapterFactory).registerTypeAdapterFactory(dsTypeAdapterFactory)
+            .registerTypeAdapterFactory(policyTypeAdapterFactory)
+            .registerTypeAdapterFactory(dsTypeAdapterFactory)
+            .registerTypeAdapterFactory(dbTypeAdapterFactory)
+            .registerTypeAdapterFactory(tblTypeAdapterFactory)
             .registerTypeAdapter(ImmutableMap.class, new ImmutableMapDeserializer())
             .registerTypeAdapter(AtomicBoolean.class, new AtomicBooleanAdapter());
 

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/CatalogMgrTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/CatalogMgrTest.java
@@ -27,7 +27,13 @@ import org.apache.doris.analysis.GrantStmt;
 import org.apache.doris.analysis.ShowCatalogStmt;
 import org.apache.doris.analysis.SwitchStmt;
 import org.apache.doris.analysis.UserIdentity;
+import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.Env;
+import org.apache.doris.catalog.PrimitiveType;
+import org.apache.doris.catalog.external.EsExternalDatabase;
+import org.apache.doris.catalog.external.EsExternalTable;
+import org.apache.doris.catalog.external.HMSExternalDatabase;
+import org.apache.doris.catalog.external.HMSExternalTable;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.FeConstants;
@@ -37,6 +43,7 @@ import org.apache.doris.qe.ShowResultSet;
 import org.apache.doris.system.SystemInfoService;
 import org.apache.doris.utframe.TestWithFeService;
 
+import com.clearspring.analytics.util.Lists;
 import org.junit.Assert;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -95,6 +102,15 @@ public class CatalogMgrTest extends TestWithFeService {
                 rootCtx);
         env.getCatalogMgr().createCatalog(iceBergCatalog);
 
+        // create es catalog
+        CreateCatalogStmt esCatalog = (CreateCatalogStmt) parseAndAnalyzeStmt(
+                "create catalog es properties('type' = 'es', 'elasticsearch.hosts' = 'http://192.168.0.1');",
+                rootCtx);
+        env.getCatalogMgr().createCatalog(esCatalog);
+
+        createDbAndTableForCatalog(env.getCatalogMgr().getCatalog("hive"));
+        createDbAndTableForCatalog(env.getCatalogMgr().getCatalog("es"));
+
         // switch to hive.
         SwitchStmt switchHive = (SwitchStmt) parseAndAnalyzeStmt("switch hive;", rootCtx);
         env.changeCatalog(rootCtx, switchHive.getCatalogName());
@@ -109,6 +125,26 @@ public class CatalogMgrTest extends TestWithFeService {
         user2.analyze(SystemInfoService.DEFAULT_CLUSTER);
     }
 
+    private void createDbAndTableForCatalog(CatalogIf catalog) {
+        List<Column> schema = Lists.newArrayList();
+        schema.add(new Column("k1", PrimitiveType.INT));
+        if (catalog instanceof HMSExternalCatalog) {
+            HMSExternalCatalog hmsCatalog = (HMSExternalCatalog) catalog;
+            HMSExternalDatabase db = new HMSExternalDatabase(hmsCatalog, 10000, "hive_db1");
+            HMSExternalTable tbl = new HMSExternalTable(10001, "hive_tbl1", "hive_db1", hmsCatalog);
+            tbl.setNewFullSchema(schema);
+            db.addTableForTest(tbl);
+            hmsCatalog.addDatabaseForTest(db);
+        } else if (catalog instanceof ExternalCatalog) {
+            EsExternalCatalog esCatalog = (EsExternalCatalog) catalog;
+            EsExternalDatabase db = new EsExternalDatabase(esCatalog, 10002, "es_db1");
+            EsExternalTable tbl = new EsExternalTable(10003, "es_tbl1", "es_tbl1", esCatalog);
+            tbl.setNewFullSchema(schema);
+            db.addTableForTest(tbl);
+            esCatalog.addDatabaseForTest(db);
+        }
+    }
+
     @Test
     public void testNormalCase() throws Exception {
         String createCatalogSql = "CREATE CATALOG hms_catalog "
@@ -119,7 +155,7 @@ public class CatalogMgrTest extends TestWithFeService {
         String showCatalogSql = "SHOW CATALOGS";
         ShowCatalogStmt showStmt = (ShowCatalogStmt) parseAndAnalyzeStmt(showCatalogSql);
         ShowResultSet showResultSet = mgr.showCatalogs(showStmt);
-        Assertions.assertEquals(4, showResultSet.getResultRows().size());
+        Assertions.assertEquals(5, showResultSet.getResultRows().size());
 
         String alterCatalogNameSql = "ALTER CATALOG hms_catalog RENAME " + MY_CATALOG + ";";
         AlterCatalogNameStmt alterNameStmt = (AlterCatalogNameStmt) parseAndAnalyzeStmt(alterCatalogNameSql);
@@ -151,7 +187,7 @@ public class CatalogMgrTest extends TestWithFeService {
         DropCatalogStmt dropCatalogStmt = (DropCatalogStmt) parseAndAnalyzeStmt(dropCatalogSql);
         mgr.dropCatalog(dropCatalogStmt);
         showResultSet = mgr.showCatalogs(showStmt);
-        Assertions.assertEquals(3, showResultSet.getResultRows().size());
+        Assertions.assertEquals(4, showResultSet.getResultRows().size());
     }
 
     private void testCatalogMgrPersist() throws Exception {
@@ -173,7 +209,7 @@ public class CatalogMgrTest extends TestWithFeService {
         DataInputStream dis = new DataInputStream(new FileInputStream(file));
         CatalogMgr mgr2 = CatalogMgr.read(dis);
 
-        Assert.assertEquals(4, mgr2.listCatalogs().size());
+        Assert.assertEquals(5, mgr2.listCatalogs().size());
         Assert.assertEquals(myCatalog.getId(), mgr2.getCatalog(MY_CATALOG).getId());
         Assert.assertEquals(0, mgr2.getInternalCatalog().getId());
         Assert.assertEquals(0, mgr2.getCatalog(InternalCatalog.INTERNAL_DS_ID).getId());


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

1. Persist external catalog/db/tbl with GSON

    1. Move idToDb/dbNameToId from EsExternalCatalog/HMSExternalCatalog to their parent class ExternalCatalog
    2. Can't move idToTbl/tableNameToId from EsExternalDatabase/HMSEXTERNALDatabase to their parent class ExternalDatabase,
       because of there interface problem, so I left them there.
    3. Add RuntimeTypeAdapterFactory for db/tbl to GSON_BUILDER, to support inherit serde.

2. NOTICE

    the field "initialized" in ExternalDatabase/Table has also been serialized to Gson.
    But some of fields, such as "remoteTable" in HMSExternalTable is null, and it depends on "initialized" to init it.
    We need to modify there logic. And I think the "remoteTable" can be initialized lazily.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
3. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
5. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
6. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

