### PR TITLE
[improvement](memory) simplify memory config related to tcmalloc

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -43,7 +43,8 @@ CONF_Int32(brpc_num_threads, "-1");
 CONF_String(priority_networks, "");
 
 // memory mode
-CONF_String(memory_mode, "performance")
+// performance or compact
+CONF_String(memory_mode, "performance");
 
 // process memory limit specified as number of bytes
 // ('<int>[bB]?'), megabytes ('<float>[mM]'), gigabytes ('<float>[gG]'),

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -42,25 +42,8 @@ CONF_Int32(brpc_num_threads, "-1");
 // If no ip match this rule, will choose one randomly.
 CONF_String(priority_networks, "");
 
-////
-//// tcmalloc gc parameter
-////
-// min memory for TCmalloc, when used memory is smaller than this, do not returned to OS
-CONF_mInt64(tc_use_memory_min, "10737418240");
-// free memory rate.[0-100]
-CONF_mInt64(tc_free_memory_rate, "20");
-// tcmallc aggressive_memory_decommit
-CONF_mBool(tc_enable_aggressive_memory_decommit, "true");
-
-// Bound on the total amount of bytes allocated to thread caches.
-// This bound is not strict, so it is possible for the cache to go over this bound
-// in certain circumstances. This value defaults to 1GB
-// If you suspect your application is not scaling to many threads due to lock contention in TCMalloc,
-// you can try increasing this value. This may improve performance, at a cost of extra memory
-// use by TCMalloc.
-// reference: https://gperftools.github.io/gperftools/tcmalloc.html: TCMALLOC_MAX_TOTAL_THREAD_CACHE_BYTES
-//            https://github.com/gperftools/gperftools/issues/1111
-CONF_Int64(tc_max_total_thread_cache_bytes, "1073741824");
+// memory mode
+CONF_String(memory_mode, "performance")
 
 // process memory limit specified as number of bytes
 // ('<int>[bB]?'), megabytes ('<float>[mM]'), gigabytes ('<float>[gG]'),

--- a/be/src/common/daemon.cpp
+++ b/be/src/common/daemon.cpp
@@ -72,7 +72,8 @@ void Daemon::tcmalloc_gc_thread() {
 
     size_t tc_use_memory_min = MemInfo::mem_limit();
     if (config::memory_mode == std::string("performance")) {
-        tc_use_memory_min = std::max(tc_use_memory_min / 10 * 9, tc_use_memory_min - size_t(10) * 1024 * 1024 * 1024);
+        tc_use_memory_min = std::max(tc_use_memory_min / 10 * 9,
+                                     tc_use_memory_min - size_t(10) * 1024 * 1024 * 1024);
     } else {
         tc_use_memory_min = tc_use_memory_min >> 1;
     }

--- a/be/src/common/daemon.cpp
+++ b/be/src/common/daemon.cpp
@@ -70,11 +70,11 @@ bool k_doris_exit = false;
 void Daemon::tcmalloc_gc_thread() {
     // TODO All cache GC wish to be supported
 
-    size_t tc_use_memory_min = 0;
+    size_t tc_use_memory_min = MemInfo::mem_limit();
     if (config::memory_mode == std::string("performance")) {
-        tc_use_memory_min = MemInfo::mem_limit() * 0.9;
+        tc_use_memory_min = std::max(tc_use_memory_min / 10 * 9, tc_use_memory_min - size_t(10) * 1024 * 1024 * 1024);
     } else {
-        tc_use_memory_min = MemInfo::mem_limit() >> 1;
+        tc_use_memory_min = tc_use_memory_min >> 1;
     }
 
     while (!_stop_background_threads_latch.wait_for(MonoDelta::FromSeconds(10))) {

--- a/be/src/service/doris_main.cpp
+++ b/be/src/service/doris_main.cpp
@@ -323,7 +323,7 @@ int main(int argc, char** argv) {
         !defined(THREAD_SANITIZER) && !defined(USE_JEMALLOC)
     // Change the total TCMalloc thread cache size if necessary.
     size_t total_thread_cache_bytes;
-    if (!MallocExtenstion::instance()->GetNumericProperty(
+    if (!MallocExtension::instance()->GetNumericProperty(
                 "tcmalloc.max_total_thread_cache_bytes", &total_thread_cache_bytes)) {
         fprintf(stderr, "Failed to get TCMalloc total thread cache size.\n");
     }

--- a/be/src/service/doris_main.cpp
+++ b/be/src/service/doris_main.cpp
@@ -319,6 +319,25 @@ int main(int argc, char** argv) {
         exit(-1);
     }
 
+#if !defined(__SANITIZE_ADDRESS__) && !defined(ADDRESS_SANITIZER) && !defined(LEAK_SANITIZER) && \
+        !defined(THREAD_SANITIZER) && !defined(USE_JEMALLOC)
+    // Change the total TCMalloc thread cache size if necessary.
+    size_t total_thread_cache_bytes;
+    if (!MallocExtenstion::instance()->GetNumericProperty(
+                "tcmalloc.max_total_thread_cache_bytes", &total_thread_cache_bytes)) {
+        fprintf(stderr, "Failed to get TCMalloc total thread cache size.\n");
+    }
+    const size_t kDefaultTotalThreadCacheBytes = 1024 * 1024 * 1024;
+    if (total_thread_cache_bytes < kDefaultTotalThreadCacheBytes) {
+        if (!MallocExtension::instance()->SetNumericProperty(
+                "tcmalloc.max_total_thread_cache_bytes",
+                kDefaultTotalThreadCacheBytes)) {
+            fprintf(stderr, "Failed to change TCMalloc total thread cache size.\n");
+            return -1;
+        }
+    }
+#endif
+ 
     std::vector<doris::StorePath> paths;
     auto olap_res = doris::parse_conf_store_paths(doris::config::storage_root_path, &paths);
     if (olap_res != doris::OLAP_SUCCESS) {

--- a/be/src/service/doris_main.cpp
+++ b/be/src/service/doris_main.cpp
@@ -323,15 +323,14 @@ int main(int argc, char** argv) {
         !defined(THREAD_SANITIZER) && !defined(USE_JEMALLOC)
     // Change the total TCMalloc thread cache size if necessary.
     size_t total_thread_cache_bytes;
-    if (!MallocExtension::instance()->GetNumericProperty(
-                "tcmalloc.max_total_thread_cache_bytes", &total_thread_cache_bytes)) {
+    if (!MallocExtension::instance()->GetNumericProperty("tcmalloc.max_total_thread_cache_bytes",
+                                                         &total_thread_cache_bytes)) {
         fprintf(stderr, "Failed to get TCMalloc total thread cache size.\n");
     }
     const size_t kDefaultTotalThreadCacheBytes = 1024 * 1024 * 1024;
     if (total_thread_cache_bytes < kDefaultTotalThreadCacheBytes) {
         if (!MallocExtension::instance()->SetNumericProperty(
-                "tcmalloc.max_total_thread_cache_bytes",
-                kDefaultTotalThreadCacheBytes)) {
+                    "tcmalloc.max_total_thread_cache_bytes", kDefaultTotalThreadCacheBytes)) {
             fprintf(stderr, "Failed to change TCMalloc total thread cache size.\n");
             return -1;
         }

--- a/be/src/service/doris_main.cpp
+++ b/be/src/service/doris_main.cpp
@@ -314,21 +314,6 @@ int main(int argc, char** argv) {
         return -1;
     }
 
-#if !defined(ADDRESS_SANITIZER) && !defined(LEAK_SANITIZER) && !defined(THREAD_SANITIZER)
-    // Aggressive decommit is required so that unused pages in the TCMalloc page heap are
-    // not backed by physical pages and do not contribute towards memory consumption.
-    if (doris::config::tc_enable_aggressive_memory_decommit) {
-        MallocExtension::instance()->SetNumericProperty("tcmalloc.aggressive_memory_decommit", 1);
-    }
-    // Change the total TCMalloc thread cache size if necessary.
-    if (!MallocExtension::instance()->SetNumericProperty(
-                "tcmalloc.max_total_thread_cache_bytes",
-                doris::config::tc_max_total_thread_cache_bytes)) {
-        fprintf(stderr, "Failed to change TCMalloc total thread cache size.\n");
-        return -1;
-    }
-#endif
-
     if (!doris::Env::init()) {
         LOG(FATAL) << "init env failed.";
         exit(-1);


### PR DESCRIPTION
There are several configs related to tcmalloc, users do know how to config them. Actually users just want two modes, performance or compact, in performance mode, users want doris run query and load quickly while in compact mode, users want doris run with less memory usage.

If we want to config tcmalloc individually, we can use env variables which are supported by tcmalloc.

# Proposed changes

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

