### PR TITLE
[test](arm) fix double result accuracy issue on arm

### DIFF
--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/util/OutputUtils.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/util/OutputUtils.groovy
@@ -67,8 +67,8 @@ class OutputUtils {
                 double expectDouble = Double.parseDouble(expectCell)
                 double realDouble = Double.parseDouble(realCell)
 
-                double realRelativeError = Math.abs(expectDouble - realDouble) / realDouble
-                double expectRelativeError = 1e-10
+                double realRelativeError = Math.abs(expectDouble - realDouble);
+                double expectRelativeError = 1e-3
 
                 if(expectRelativeError < realRelativeError) {
                     // Keep the scale of low precision data to solve TPCH cases like:


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

When running on arm, the result of percentile_approx in a little different:
```
Expect cell is: 5068.5966796875
But real is: 5068.59716796875
relative error is: 9.633459393571804E-8, bigger than 1.0E-10
```
Use decimal(27, 2) to skip this issue.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [x] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

