### PR TITLE
[Bug](Vectorized) rapidjson should reset writer when output json

### DIFF
--- a/be/src/vec/functions/function_json.cpp
+++ b/be/src/vec/functions/function_json.cpp
@@ -557,6 +557,7 @@ public:
 
         for (int i = 0; i < input_rows_count; i++) {
             buf.Clear();
+            writer.Reset(buf);
             objects[i].Accept(writer);
             result_column.insert_data(buf.GetString(), buf.GetSize());
         }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx
according to the rapidjson document `https://rapidjson.org/md_doc_sax.html#CompletenessReset`, we should call `reset` when reuse writer to output json.

## Problem summary

pr #13775 on master branch, the p0 check would be failed before using `reset`, and add this `reset` code, it is successful. 

but test by myself on previous version(master and 1.1)  without this `reset` code would be successful

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

