### PR TITLE
[Bug](function) change log fatal to log warning to avoid code dump on nullable double column cast to decimal column

### DIFF
--- a/be/src/vec/data_types/data_type_decimal.cpp
+++ b/be/src/vec/data_types/data_type_decimal.cpp
@@ -37,8 +37,9 @@ std::string DataTypeDecimal<T>::do_get_name() const {
 
 template <typename T>
 bool DataTypeDecimal<T>::equals(const IDataType& rhs) const {
-    if (auto* ptype = typeid_cast<const DataTypeDecimal<T>*>(&rhs))
+    if (auto* ptype = typeid_cast<const DataTypeDecimal<T>*>(&rhs)) {
         return scale == ptype->get_scale();
+    }
     return false;
 }
 
@@ -154,7 +155,7 @@ T DataTypeDecimal<T>::parse_from_string(const std::string& str) const {
     T value = StringParser::string_to_decimal<__int128>(str.c_str(), str.size(), precision, scale,
                                                         &result);
     if (result != StringParser::PARSE_SUCCESS) {
-        LOG(FATAL) << "Failed to parse string of decimal";
+        LOG(WARNING) << "Failed to parse string of decimal";
     }
     return value;
 }
@@ -169,10 +170,11 @@ DataTypePtr create_decimal(UInt64 precision_value, UInt64 scale_value) {
         LOG(FATAL) << "Negative scales and scales larger than precision are not supported";
     }
 
-    if (precision_value <= max_decimal_precision<Decimal32>())
+    if (precision_value <= max_decimal_precision<Decimal32>()) {
         return std::make_shared<DataTypeDecimal<Decimal32>>(precision_value, scale_value);
-    else if (precision_value <= max_decimal_precision<Decimal64>())
+    } else if (precision_value <= max_decimal_precision<Decimal64>()) {
         return std::make_shared<DataTypeDecimal<Decimal64>>(precision_value, scale_value);
+    }
     return std::make_shared<DataTypeDecimal<Decimal128>>(precision_value, scale_value);
 }
 
@@ -210,7 +212,7 @@ void convert_to_decimal(T* from_value, T* to_value, int32_t from_scale, int32_t 
                                  static_cast<T>(DataTypeDecimal<Decimal<T>>::get_scale_multiplier(
                                          to_scale - from_scale)),
                                  *to_value)) {
-            LOG(FATAL) << "Decimal convert overflow";
+            LOG(WARNING) << "Decimal convert overflow";
         }
     }
 }

--- a/be/src/vec/data_types/data_type_decimal.h
+++ b/be/src/vec/data_types/data_type_decimal.h
@@ -376,13 +376,13 @@ convert_to_decimal(const typename FromDataType::FieldType& value, UInt32 scale) 
 
     if constexpr (std::is_floating_point_v<FromFieldType>) {
         if (!std::isfinite(value)) {
-            LOG(FATAL) << "Decimal convert overflow. Cannot convert infinity or NaN to decimal";
+            return 0;
         }
 
         auto out = value * ToDataType::get_scale_multiplier(scale);
         if (out <= static_cast<FromFieldType>(std::numeric_limits<ToNativeType>::min()) ||
             out >= static_cast<FromFieldType>(std::numeric_limits<ToNativeType>::max())) {
-            LOG(FATAL) << "Decimal convert overflow. Float is out of Decimal range";
+            return 0;
         }
         return out;
     } else {


### PR DESCRIPTION
# Proposed changes

change log fatal to warning to avoid code dump on nullable double column cast to decimal column

```sql
start time: Mon Oct 31 15:49:03 CST 2022
F1031 15:52:21.753562 140995 data_type_decimal.h:379] Decimal convert overflow. Cannot convert infinity or NaN to decimal
*** Check failure stack trace: ***
    @     0x559d1bcc91cd  google::LogMessage::Fail()
    @     0x559d1bccb709  google::LogMessage::SendToLog()
    @     0x559d1bcc8d36  google::LogMessage::Flush()
    @     0x559d1bccbd79  google::LogMessageFatal::~LogMessageFatal()
    @     0x559d1aa8b6c8  _ZN5doris10vectorized18convert_to_decimalINS0_14DataTypeNumberIdEENS0_15DataTypeDecimalINS0_7DecimalInEEEEEENSt9enable_ifIXaa16IsDataTypeNumberIT_E17IsDataTypeDecimalIT0_EENSA_9FieldTypeEE4typeERKNS9_9FieldTypeEj
    @     0x559d1aa8b4a0  doris::vectorized::ConvertImpl<>::execute<>()
    @     0x559d1aa8941f  _ZN5doris10vectorized27call_on_index_and_data_typeINS0_15DataTypeDecimalINS0_7DecimalInEEEEZZNKS0_12FunctionCast22create_decimal_wrapperIS4_EESt8functionIFNS_6StatusEPN9doris_udf15FunctionContextERNS0_5BlockERKSt6vectorImSaImEEmmEERKSt10shared_ptrIKNS0_9IDataTypeEEPKNS2_IT_EEENKUlSC_SE_SJ_mmE_clESC_SE_SJ_mmEUlRKSS_E_EEbNS0_9TypeIndexEOT0_
    @     0x559d1aa88f53  _ZZNK5doris10vectorized12FunctionCast22create_decimal_wrapperINS0_7DecimalInEEEESt8functionIFNS_6StatusEPN9doris_udf15FunctionContextERNS0_5BlockERKSt6vectorImSaImEEmmEERKSt10shared_ptrIKNS0_9IDataTypeEEPKNS0_15DataTypeDecimalIT_EEENKUlS9_SB_SG_mmE_clES9_SB_SG_mm
    @     0x559d1aa88ebf  _ZNSt17_Function_handlerIFN5doris6StatusEPN9doris_udf15FunctionContextERNS0_10vectorized5BlockERKSt6vectorImSaImEEmmEZNKS5_12FunctionCast22create_decimal_wrapperINS5_7DecimalInEEEESt8functionISD_ERKSt10shared_ptrIKNS5_9IDataTypeEEPKNS5_15DataTypeDecimalIT_EEEUlS4_S7_SC_mmE_E9_M_invokeERKSt9_Any_dataOS4_S7_SC_OmS11_
    @     0x559d1aab3cd4  _ZZNK5doris10vectorized12FunctionCast23prepare_remove_nullableERKSt10shared_ptrIKNS0_9IDataTypeEES7_bENKUlPN9doris_udf15FunctionContextERNS0_5BlockERKSt6vectorImSaImEEmmE_clESA_SC_SH_mm
    @     0x559d1aab36d2  _ZNSt17_Function_handlerIFN5doris6StatusEPN9doris_udf15FunctionContextERNS0_10vectorized5BlockERKSt6vectorImSaImEEmmEZNKS5_12FunctionCast23prepare_remove_nullableERKSt10shared_ptrIKNS5_9IDataTypeEESK_bEUlS4_S7_SC_mmE_E9_M_invokeERKSt9_Any_dataOS4_S7_SC_OmSR_
    @     0x559d1aa3a7ab  doris::vectorized::PreparedFunctionCast::execute_impl()
    @     0x559d1a96d507  doris::vectorized::PreparedFunctionImpl::execute_without_low_cardinality_columns()
    @     0x559d1a96d8d6  doris::vectorized::PreparedFunctionImpl::execute()
    @     0x559d1a31791f  doris::vectorized::IFunctionBase::execute()
    @     0x559d1a30ccb6  doris::vectorized::VCastExpr::execute()
    @     0x559d1a30101c  doris::vectorized::VExprContext::get_output_block_after_execute_exprs()
    @     0x559d1b755871  doris::stream_load::VOlapTableSink::send()
    @     0x559d18b37868  doris::PlanFragmentExecutor::open_vectorized_internal()
    @     0x559d18b368c4  doris::PlanFragmentExecutor::open()
    @     0x559d18b20027  doris::FragmentExecState::execute()
    @     0x559d18b224cb  doris::FragmentMgr::_exec_actual()
    @     0x559d18b2ab41  std::_Function_handler<>::_M_invoke()
    @     0x559d18d309bf  doris::ThreadPool::dispatch_thread()
    @     0x559d18d29bdc  doris::Thread::supervise_thread()
    @     0x7fd63d236ea5  start_thread
    @     0x7fd63da4fb0d  __clone
    @              (nil)  (unknown)
*** Query id: cdf34abc878049f0-a7d82a54dd7a8d32 ***
*** Aborted at 1667202950 (unix time) try "date -d @1667202950" if you are using GNU date ***
*** Current BE git commitID: 4f2ea0776 ***
*** SIGABRT unkown detail explain (@0x41000022570) received by PID 140656 (TID 0x7fd5c7716700) from PID 140656; stack trace: ***
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /mnt/disk1/pxl/doris/be/src/common/signal_handler.h:420
 1# 0x00007FD63D987400 in /lib64/libc.so.6
 2# gsignal in /lib64/libc.so.6
 3# abort in /lib64/libc.so.6
 4# 0x0000559D1BCD3BB9 in /mnt/disk1/pxl/doris/output/be/lib/doris_be
 5# 0x0000559D1BCC91CD in /mnt/disk1/pxl/doris/output/be/lib/doris_be
 6# google::LogMessage::SendToLog() in /mnt/disk1/pxl/doris/output/be/lib/doris_be
 7# google::LogMessage::Flush() in /mnt/disk1/pxl/doris/output/be/lib/doris_be
 8# google::LogMessageFatal::~LogMessageFatal() in /mnt/disk1/pxl/doris/output/be/lib/doris_be
 9# std::enable_if<(IsDataTypeNumber<doris::vectorized::DataTypeNumber<double> >)&&(IsDataTypeDecimal<doris::vectorized::DataTypeDecimal<doris::vectorized::Decimal<__int128> > >), doris::vectorized::DataTypeDecimal<doris::vectorized::Decimal<__int128> >::FieldType>::type doris::vectorized::convert_to_decimal<doris::vectorized::DataTypeNumber<double>, doris::vectorized::DataTypeDecimal<doris::vectorized::Decimal<__int128> > >(doris::vectorized::DataTypeNumber<double>::FieldType const&, unsigned int) in /mnt/disk1/pxl/doris/output/be/lib/doris_be
10# doris::Status doris::vectorized::ConvertImpl<doris::vectorized::DataTypeNumber<double>, doris::vectorized::DataTypeDecimal<doris::vectorized::Decimal<__int128> >, doris::vectorized::NameCast>::execute<unsigned int>(doris::vectorized::Block&, std::vector<unsigned long, std::allocator<unsigned long> > const&, unsigned long, unsigned long, unsigned int) at /mnt/disk1/pxl/doris/be/src/vec/functions/function_cast.h:119
11# bool doris::vectorized::call_on_index_and_data_type<doris::vectorized::DataTypeDecimal<doris::vectorized::Decimal<__int128> >, doris::vectorized::FunctionCast::create_decimal_wrapper<doris::vectorized::Decimal<__int128> >(std::shared_ptr<doris::vectorized::IDataType const> const&, doris::vectorized::DataTypeDecimal<doris::vectorized::Decimal<__int128> > const*) const::{lambda(doris_udf::FunctionContext*, doris::vectorized::Block&, std::vector<unsigned long, std::allocator<unsigned long> > const&, unsigned long, unsigned long)#1}::operator()(doris_udf::FunctionContext*, doris::vectorized::Block&, std::vector<unsigned long, std::allocator<unsigned long> > const&, unsigned long, unsigned long) const::{lambda(auto:1 const&)#1}>(doris::vectorized::TypeIndex, doris::vectorized::FunctionCast::create_decimal_wrapper<doris::vectorized::Decimal<__int128> >(std::shared_ptr<doris::vectorized::IDataType const> const&, doris::vectorized::DataTypeDecimal<doris::vectorized::Decimal<__int128> > const*) const::{lambda(doris_udf::FunctionContext*, doris::vectorized::Block&, std::vector<unsigned long, std::allocator<unsigned long> > const&, unsigned long, unsigned long)#1}::operator()(doris_udf::FunctionContext*, doris::vectorized::Block&, std::vector<unsigned long, std::allocator<unsigned long> > const&, unsigned long, unsigned long) const::{lambda(auto:1 const&)#1}&&) at /mnt/disk1/pxl/doris/be/src/vec/core/call_on_type_index.h:199
12# doris::vectorized::FunctionCast::create_decimal_wrapper<doris::vectorized::Decimal<__int128> >(std::shared_ptr<doris::vectorized::IDataType const> const&, doris::vectorized::DataTypeDecimal<doris::vectorized::Decimal<__int128> > const*) const::{lambda(doris_udf::FunctionContext*, doris::vectorized::Block&, std::vector<unsigned long, std::allocator<unsigned long> > const&, unsigned long, unsigned long)#1}::operator()(doris_udf::FunctionContext*, doris::vectorized::Block&, std::vector<unsigned long, std::allocator<unsigned long> > const&, unsigned long, unsigned long) const at /mnt/disk1/pxl/doris/be/src/vec/functions/function_cast.h:1342
13# std::_Function_handler<doris::Status (doris_udf::FunctionContext*, doris::vectorized::Block&, std::vector<unsigned long, std::allocator<unsigned long> > const&, unsigned long, unsigned long), doris::vectorized::FunctionCast::create_decimal_wrapper<doris::vectorized::Decimal<__int128> >(std::shared_ptr<doris::vectorized::IDataType const> const&, doris::vectorized::DataTypeDecimal<doris::vectorized::Decimal<__int128> > const*) const::{lambda(doris_udf::FunctionContext*, doris::vectorized::Block&, std::vector<unsigned long, std::allocator<unsigned long> > const&, unsigned long, unsigned long)#1}>::_M_invoke(std::_Any_data const&, doris_udf::FunctionContext*&&, doris::vectorized::Block&, std::vector<unsigned long, std::allocator<unsigned long> > const&, unsigned long&&, unsigned long&&) at /mnt/disk1/pxl/ldb/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291
14# doris::vectorized::FunctionCast::prepare_remove_nullable(std::shared_ptr<doris::vectorized::IDataType const> const&, std::shared_ptr<doris::vectorized::IDataType const> const&, bool) const::{lambda(doris_udf::FunctionContext*, doris::vectorized::Block&, std::vector<unsigned long, std::allocator<unsigned long> > const&, unsigned long, unsigned long)#1}::operator()(doris_udf::FunctionContext*, doris::vectorized::Block&, std::vector<unsigned long, std::allocator<unsigned long> > const&, unsigned long, unsigned long) const at /mnt/disk1/pxl/doris/be/src/vec/functions/function_cast.h:1556
15# std::_Function_handler<doris::Status (doris_udf::FunctionContext*, doris::vectorized::Block&, std::vector<unsigned long, std::allocator<unsigned long> > const&, unsigned long, unsigned long), doris::vectorized::FunctionCast::prepare_remove_nullable(std::shared_ptr<doris::vectorized::IDataType const> const&, std::shared_ptr<doris::vectorized::IDataType const> const&, bool) const::{lambda(doris_udf::FunctionContext*, doris::vectorized::Block&, std::vector<unsigned long, std::allocator<unsigned long> > const&, unsigned long, unsigned long)#1}>::_M_invoke(std::_Any_data const&, doris_udf::FunctionContext*&&, doris::vectorized::Block&, std::vector<unsigned long, std::allocator<unsigned long> > const&, unsigned long&&, unsigned long&&) at /mnt/disk1/pxl/ldb/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291
16# doris::vectorized::PreparedFunctionCast::execute_impl(doris_udf::FunctionContext*, doris::vectorized::Block&, std::vector<unsigned long, std::allocator<unsigned long> > const&, unsigned long, unsigned long) at /mnt/disk1/pxl/doris/be/src/vec/functions/function_cast.h:1021
17# doris::vectorized::PreparedFunctionImpl::execute_without_low_cardinality_columns(doris_udf::FunctionContext*, doris::vectorized::Block&, std::vector<unsigned long, std::allocator<unsigned long> > const&, unsigned long, unsigned long, bool) in /mnt/disk1/pxl/doris/output/be/lib/doris_be
18# doris::vectorized::PreparedFunctionImpl::execute(doris_udf::FunctionContext*, doris::vectorized::Block&, std::vector<unsigned long, std::allocator<unsigned long> > const&, unsigned long, unsigned long, bool) at /mnt/disk1/pxl/doris/be/src/vec/functions/function.cpp:272
19# doris::vectorized::IFunctionBase::execute(doris_udf::FunctionContext*, doris::vectorized::Block&, std::vector<unsigned long, std::allocator<unsigned long> > const&, unsigned long, unsigned long, bool) at /mnt/disk1/pxl/doris/be/src/vec/functions/function.h:136
20# doris::vectorized::VCastExpr::execute(doris::vectorized::VExprContext*, doris::vectorized::Block*, int*) at /mnt/disk1/pxl/doris/be/src/vec/exprs/vcast_expr.cpp:87
21# doris::vectorized::VExprContext::get_output_block_after_execute_exprs(std::vector<doris::vectorized::VExprContext*, std::allocator<doris::vectorized::VExprContext*> > const&, doris::vectorized::Block const&, doris::Status&) at /mnt/disk1/pxl/doris/be/src/vec/exprs/vexpr_context.cpp:143
22# doris::stream_load::VOlapTableSink::send(doris::RuntimeState*, doris::vectorized::Block*) at /mnt/disk1/pxl/doris/be/src/vec/sink/vtablet_sink.cpp:472
23# doris::PlanFragmentExecutor::open_vectorized_internal() in /mnt/disk1/pxl/doris/output/be/lib/doris_be
24# doris::PlanFragmentExecutor::open() in /mnt/disk1/pxl/doris/output/be/lib/doris_be
25# doris::FragmentExecState::execute() at /mnt/disk1/pxl/doris/be/src/runtime/fragment_mgr.cpp:249
26# doris::FragmentMgr::_exec_actual(std::shared_ptr<doris::FragmentExecState>, std::function<void (doris::PlanFragmentExecutor*)>) at /mnt/disk1/pxl/doris/be/src/runtime/fragment_mgr.cpp:493
27# std::_Function_handler<void (), doris::FragmentMgr::exec_plan_fragment(doris::TExecPlanFragmentParams const&, std::function<void (doris::PlanFragmentExecutor*)>)::$_3>::_M_invoke(std::_Any_data const&) at /mnt/disk1/pxl/ldb/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291
28# doris::ThreadPool::dispatch_thread() in /mnt/disk1/pxl/doris/output/be/lib/doris_be
29# doris::Thread::supervise_thread(void*) at /mnt/disk1/pxl/doris/be/src/util/thread.cpp:455
30# start_thread in /lib64/libpthread.so.0
31# clone in /lib64/libc.so.6

```

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

