### PR TITLE
[fix](array-type) fix the be core dump when import array<largeint>

### DIFF
--- a/be/src/util/array_parser.h
+++ b/be/src/util/array_parser.h
@@ -184,7 +184,7 @@ private:
                 stream << view;
                 stream >> value;
             }
-            *val = reinterpret_cast<AnyVal*>(context->allocate(sizeof(LargeIntVal)));
+            *val = reinterpret_cast<AnyVal*>(context->aligned_allocate(16, sizeof(LargeIntVal)));
             new (*val) LargeIntVal(value);
             break;
         }


### PR DESCRIPTION
# Proposed changes
1. this pr is used to fix the be core dump when import array<largeint>.
2. before the change, we import array<largeint> by rapidjson string will core dump under the non-vectorized scenario.
3. after the change, we can import array<largeint> by rapidjson string successfully.

Issue Number: #7570

## Problem summary
the be core dump stack:
start time: Mon Oct 31 16:22:58 CST 2022
*** Query id: 0-0 ***
*** Aborted at 1667204606 (unix time) try "date -d @1667204606" if you are using GNU date ***
*** Current BE git commitID: 53e5f3939 ***
*** SIGSEGV unkown detail explain (@0x0) received by PID 21684 (TID 0x7ff2746b0700) from PID 0; stack trace: ***
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /home/disk1/hugo_work/doris_dev/baidu/bdg/doris/core/be/src/common/signal_handler.h:420
 1# 0x00007FF47B7A9920 in /lib64/libc.so.6
 2# doris::Status doris::ArrayParser::_parse<rapidjson::UTF8<char> >(doris_udf::AnyVal**, doris_udf::FunctionContext*, doris::ConstArray::ValueIterator, doris::TypeDescriptor const&) at /home/disk1/hugo_work/doris_dev/baidu/bdg/doris/core/be/src/util/array_parser.h:192
 3# doris::Status doris::ArrayParser::_parse<rapidjson::UTF8<char> >(doris_udf::CollectionVal&, doris_udf::FunctionContext*, rapidjson::GenericValue<rapidjson::UTF8<char>, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator> >::ConstArray const&, doris::TypeDescriptor const&) at /home/disk1/hugo_work/doris_dev/baidu/bdg/doris/core/be/src/util/array_parser.h:97
 4# doris::ArrayParser::parse(doris_udf::CollectionVal&, doris_udf::FunctionContext*, doris_udf::StringVal const&) at /home/disk1/hugo_work/doris_dev/baidu/bdg/doris/core/be/src/util/array_parser.h:56
 5# doris::CastFunctions::cast_to_array_val(doris_udf::FunctionContext*, doris_udf::StringVal const&) at /home/disk1/hugo_work/doris_dev/baidu/bdg/doris/core/be/src/exprs/cast_functions.cpp:819
 6# doris_udf::CollectionVal doris::ScalarFnCall::interpret_eval<doris_udf::CollectionVal>(doris::ExprContext*, doris::TupleRow*) at /home/disk1/hugo_work/doris_dev/baidu/bdg/doris/core/be/src/exprs/scalar_fn_call.cpp:236
 7# doris::ScalarFnCall::get_array_val(doris::ExprContext*, doris::TupleRow*) at /home/disk1/hugo_work/doris_dev/baidu/bdg/doris/core/be/src/exprs/scalar_fn_call.cpp:542
 8# doris::ExprContext::get_value(doris::Expr*, doris::TupleRow*, int, int) at /home/disk1/hugo_work/doris_dev/baidu/bdg/doris/core/be/src/exprs/expr_context.cpp:312
 9# doris::BaseScanner::_fill_dest_tuple(doris::Tuple*, doris::MemPool*) at /home/disk1/hugo_work/doris_dev/baidu/bdg/doris/core/be/src/exec/base_scanner.cpp:221
10# doris::BaseScanner::fill_dest_tuple(doris::Tuple*, doris::MemPool*, bool*) at /home/disk1/hugo_work/doris_dev/baidu/bdg/doris/core/be/src/exec/base_scanner.cpp:194
11# doris::BrokerScanner::_convert_one_row(doris::Slice const&, doris::Tuple*, doris::MemPool*, bool*) at /home/disk1/hugo_work/doris_dev/baidu/bdg/doris/core/be/src/exec/broker_scanner.cpp:407
12# doris::BrokerScanner::get_next(doris::Tuple*, doris::MemPool*, bool*, bool*) at /home/disk1/hugo_work/doris_dev/baidu/bdg/doris/core/be/src/exec/broker_scanner.cpp:101
13# doris::BrokerScanNode::scanner_scan(doris::TBrokerScanRange const&, std::vector<doris::ExprContext*, std::allocator<doris::ExprContext*> > const&, doris::ScannerCounter*) at /home/disk1/hugo_work/doris_dev/baidu/bdg/doris/core/be/src/exec/broker_scan_node.cpp:319
14# doris::BrokerScanNode::scanner_worker(int, int) at /home/disk1/hugo_work/doris_dev/baidu/bdg/doris/core/be/src/exec/broker_scan_node.cpp:391
15# execute_native_thread_routine in /home/disk1/hugo_work/doris_env/output/be/lib/doris_be
16# start_thread in /lib64/libpthread.so.0
17# clone in /lib64/libc.so.6

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
4. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
5. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
6. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
7. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

