### PR TITLE
[fix](thrift) fix that thrift struct sequence number is not consistent in 1.1-lts and master

### DIFF
--- a/gensrc/thrift/PaloInternalService.thrift
+++ b/gensrc/thrift/PaloInternalService.thrift
@@ -168,17 +168,17 @@ struct TQueryOptions {
 
   46: optional string fragment_transmission_compression_codec;
 
-  47: optional bool enable_local_exchange;
+  48: optional bool enable_local_exchange;
 
   // For debug purpose, dont' merge unique key and agg key when reading data.
-  48: optional bool skip_storage_engine_merge = false
+  49: optional bool skip_storage_engine_merge = false
 
   // For debug purpose, skip delete predicates when reading data
-  49: optional bool skip_delete_predicate = false
+  50: optional bool skip_delete_predicate = false
 
-  50: optional bool enable_new_shuffle_hash_method
+  51: optional bool enable_new_shuffle_hash_method
 
-  51: optional i32 be_exec_version = 0
+  52: optional i32 be_exec_version = 0
 }
     
 


### PR DESCRIPTION
Definition of TQueryOptions in gensrc/thrift/PaloInternalService.thrift
is not consistent:

1.1-lts:   47: optional i32 num_free_block_in_scan
master:   47: optional bool enable_local_exchange

# Proposed changes

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

