### PR TITLE
[BugFix](function) fix reverse function dynamic buffer overflow due to illegal character

### DIFF
--- a/be/src/util/simd/vstring_function.h
+++ b/be/src/util/simd/vstring_function.h
@@ -144,7 +144,15 @@ public:
         } else {
             for (size_t i = 0, char_size = 0; i < str.len; i += char_size) {
                 char_size = get_utf8_byte_length((unsigned)(str.ptr)[i]);
-                std::copy(str.ptr + i, str.ptr + i + char_size, dst.ptr + str.len - i - char_size);
+                // there exists occasion where the last character is an illegal UTF-8 one which returns
+                // a char_size larger than the actual space, which would cause offset execeeding the buffer range
+                // for example, consider str.len=4, i = 3, then the last char returns char_size 2, then
+                // the str.ptr + offset would exceed the buffer range
+                size_t offset = i + char_size;
+                if (offset > str.len) {
+                    offset = str.len;
+                }
+                std::copy(str.ptr + i, str.ptr + offset, dst.ptr + str.len - offset);
             }
         }
     }


### PR DESCRIPTION
# Proposed changes
Like #13671, prevent unexpected coredump when encountering illegal character
Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

