### PR TITLE
[enhancement](test) retry start be or fe when port has been bind.

### DIFF
--- a/fe/fe-core/src/test/java/org/apache/doris/utframe/UtFrameUtils.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/utframe/UtFrameUtils.java
@@ -149,6 +149,19 @@ public class UtFrameUtils {
 
     public static int startFEServer(String runningDir) throws EnvVarNotSetException, IOException,
             FeStartException, NotInitException, DdlException, InterruptedException {
+        IOException exception = null;
+        for (int i=0; i<=3; i++) {
+            try {
+                return startFEServerWithoutRetry(runningDir);
+            } catch (IOException ignore) {
+                exception = ignore;
+            }
+        }
+        throw exception;
+    }
+
+    private static int startFEServerWithoutRetry(String runningDir) throws EnvVarNotSetException, IOException,
+        FeStartException, NotInitException {
         // get DORIS_HOME
         String dorisHome = System.getenv("DORIS_HOME");
         if (Strings.isNullOrEmpty(dorisHome)) {
@@ -232,6 +245,18 @@ public class UtFrameUtils {
     }
 
     public static Backend createBackend(String beHost, int feRpcPort) throws IOException, InterruptedException {
+        IOException exception = null;
+        for (int i=0; i<=3; i++) {
+            try {
+                return createBackendWithoutRetry(beHost, feRpcPort);
+            } catch (IOException ignore) {
+                exception = ignore;
+            }
+        }
+        throw exception;
+    }
+
+    private static Backend createBackendWithoutRetry(String beHost, int feRpcPort) throws IOException {
         int beHeartbeatPort = findValidPort();
         int beThriftPort = findValidPort();
         int beBrpcPort = findValidPort();
@@ -239,8 +264,8 @@ public class UtFrameUtils {
 
         // start be
         MockedBackend backend = MockedBackendFactory.createBackend(beHost, beHeartbeatPort, beThriftPort, beBrpcPort,
-                beHttpPort, new DefaultHeartbeatServiceImpl(beThriftPort, beHttpPort, beBrpcPort),
-                new DefaultBeThriftServiceImpl(), new DefaultPBackendServiceImpl());
+            beHttpPort, new DefaultHeartbeatServiceImpl(beThriftPort, beHttpPort, beBrpcPort),
+            new DefaultBeThriftServiceImpl(), new DefaultPBackendServiceImpl());
         backend.setFeAddress(new TNetworkAddress("127.0.0.1", feRpcPort));
         backend.start();
 

--- a/fe/fe-core/src/test/java/org/apache/doris/utframe/UtFrameUtils.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/utframe/UtFrameUtils.java
@@ -148,7 +148,7 @@ public class UtFrameUtils {
     }
 
     public static int startFEServer(String runningDir) throws EnvVarNotSetException, IOException,
-        FeStartException, NotInitException, DdlException, InterruptedException {
+            FeStartException, NotInitException, DdlException, InterruptedException {
         IOException exception = null;
         for (int i = 0; i <= 3; i++) {
             try {
@@ -161,7 +161,7 @@ public class UtFrameUtils {
     }
 
     private static int startFEServerWithoutRetry(String runningDir) throws EnvVarNotSetException, IOException,
-        FeStartException, NotInitException {
+            FeStartException, NotInitException {
         // get DORIS_HOME
         String dorisHome = System.getenv("DORIS_HOME");
         if (Strings.isNullOrEmpty(dorisHome)) {
@@ -264,7 +264,7 @@ public class UtFrameUtils {
 
         // start be
         MockedBackend backend = MockedBackendFactory.createBackend(beHost, beHeartbeatPort, beThriftPort, beBrpcPort,
-            beHttpPort, new DefaultHeartbeatServiceImpl(beThriftPort, beHttpPort, beBrpcPort),
+                beHttpPort, new DefaultHeartbeatServiceImpl(beThriftPort, beHttpPort, beBrpcPort),
             new DefaultBeThriftServiceImpl(), new DefaultPBackendServiceImpl());
         backend.setFeAddress(new TNetworkAddress("127.0.0.1", feRpcPort));
         backend.start();

--- a/fe/fe-core/src/test/java/org/apache/doris/utframe/UtFrameUtils.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/utframe/UtFrameUtils.java
@@ -148,9 +148,9 @@ public class UtFrameUtils {
     }
 
     public static int startFEServer(String runningDir) throws EnvVarNotSetException, IOException,
-            FeStartException, NotInitException, DdlException, InterruptedException {
+        FeStartException, NotInitException, DdlException, InterruptedException {
         IOException exception = null;
-        for (int i=0; i<=3; i++) {
+        for (int i = 0; i <= 3; i++) {
             try {
                 return startFEServerWithoutRetry(runningDir);
             } catch (IOException ignore) {
@@ -246,7 +246,7 @@ public class UtFrameUtils {
 
     public static Backend createBackend(String beHost, int feRpcPort) throws IOException, InterruptedException {
         IOException exception = null;
-        for (int i=0; i<=3; i++) {
+        for (int i = 0; i <= 3; i++) {
             try {
                 return createBackendWithoutRetry(beHost, feRpcPort);
             } catch (IOException ignore) {


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

FE UT in TeamCity often run failed cause of some port has been bind, retry when port has been bind.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

