### PR TITLE
[fix](function) fix coredump cause by return type mismatch of vectorized repeat function

### DIFF
--- a/be/src/vec/exprs/vectorized_fn_call.cpp
+++ b/be/src/vec/exprs/vectorized_fn_call.cpp
@@ -37,6 +37,15 @@ VectorizedFnCall::VectorizedFnCall(const doris::TExprNode& node) : VExpr(node) {
 
 doris::Status VectorizedFnCall::prepare(doris::RuntimeState* state,
                                         const doris::RowDescriptor& desc, VExprContext* context) {
+    // In 1.2-lts, repeat function return type is changed to always nullable,
+    // which is not compatible with 1.1-lts
+    if ("repeat" == _fn.name.function_name and !_data_type->is_nullable()) {
+        const auto error_msg =
+                "In progress of upgrading from 1.1-lts to 1.2-lts, vectorized repeat "
+                "function cannot be executed, you can switch to non-vectorized engine by "
+                "'set global enable_vectorized_engine = false'";
+        return Status::InternalError(error_msg);
+    }
     RETURN_IF_ERROR_OR_PREPARED(VExpr::prepare(state, desc, context));
     ColumnsWithTypeAndName argument_template;
     argument_template.reserve(_children.size());


### PR DESCRIPTION

# Proposed changes

Issue Number: close #13863

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

