### PR TITLE
[feature](nereids) runtime filter prune

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/RuntimeFilterGenerator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/RuntimeFilterGenerator.java
@@ -21,7 +21,9 @@ import org.apache.doris.common.IdGenerator;
 import org.apache.doris.nereids.CascadesContext;
 import org.apache.doris.nereids.trees.expressions.Alias;
 import org.apache.doris.nereids.trees.expressions.EqualTo;
+import org.apache.doris.nereids.trees.expressions.Slot;
 import org.apache.doris.nereids.trees.expressions.SlotReference;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
 import org.apache.doris.nereids.trees.plans.JoinType;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalHashJoin;
@@ -30,6 +32,9 @@ import org.apache.doris.nereids.trees.plans.physical.PhysicalPlan;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalProject;
 import org.apache.doris.nereids.trees.plans.physical.RuntimeFilter;
 import org.apache.doris.planner.RuntimeFilterId;
+import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.statistics.ColumnStat;
+import org.apache.doris.statistics.StatsDeriveResult;
 import org.apache.doris.thrift.TRuntimeFilterType;
 
 import com.google.common.collect.ImmutableSet;
@@ -37,6 +42,7 @@ import com.google.common.collect.ImmutableSet;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
@@ -119,6 +125,7 @@ public class RuntimeFilterGenerator extends PlanPostProcessor {
                         ctx.setTargetExprIdToFilters(slots.get(tag ^ 1).getExprId(),
                                 copiedRuntimeFilter.toArray(new RuntimeFilter[0]));
                     })*/
+                    .filter(expr -> isEffectiveRuntimeFilter(expr, join))
                     .forEach(expr -> legalTypes.stream()
                             .map(type -> RuntimeFilter.createRuntimeFilter(generator.getNextId(), expr,
                                     type, cnt.getAndIncrement(), join))
@@ -129,6 +136,45 @@ public class RuntimeFilterGenerator extends PlanPostProcessor {
         join.left().accept(this, context);
         join.right().accept(this, context);
         return join;
+    }
+
+    /**
+     * consider L join R on L.a=R.b
+     * runtime-filter: L.a<-R.b is effective,
+     * if R.b.selectivity<1 or b is partly covered by a
+     *
+     * TODO: min-max
+     * @param equalTo join condition
+     * @param join join node
+     * @return true if runtime-filter is effective
+     */
+    private boolean isEffectiveRuntimeFilter(EqualTo equalTo, PhysicalHashJoin join) {
+        if (!ConnectContext.get().getSessionVariable().enableRuntimeFilterPrune) {
+            return true;
+        }
+        StatsDeriveResult leftStats = ((AbstractPlan) join.child(0)).getStats();
+        StatsDeriveResult rightStats = ((AbstractPlan) join.child(1)).getStats();
+        Set<Slot> leftSlots = equalTo.child(0).getInputSlots();
+        if (leftSlots.size() > 1) {
+            return false;
+        }
+        Set<Slot> rightSlots = equalTo.child(1).getInputSlots();
+        if (rightSlots.size() > 1) {
+            return false;
+        }
+        Slot leftSlot = leftSlots.iterator().next();
+        Slot rightSlot = rightSlots.iterator().next();
+        ColumnStat probeColumnStat = leftStats.getColumnStatsBySlot(leftSlot);
+        ColumnStat buildColumnStat = rightStats.getColumnStatsBySlot(rightSlot);
+        //TODO remove these code when we ensure left child if from probe side
+        if (probeColumnStat == null || buildColumnStat == null) {
+            probeColumnStat = leftStats.getColumnStatsBySlot(rightSlot);
+            buildColumnStat = rightStats.getColumnStatsBySlot(leftSlot);
+            if (probeColumnStat == null || buildColumnStat == null) {
+                return false;
+            }
+        }
+        return buildColumnStat.getSelectivity() < 1 || probeColumnStat.coverage(buildColumnStat) < 1;
     }
 
     // TODO: support src key is agg slot.

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/ExpressionEstimation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/ExpressionEstimation.java
@@ -170,8 +170,12 @@ public class ExpressionEstimation extends ExpressionVisitor<ColumnStat, StatsDer
         if (columnStat == ColumnStat.UNKNOWN) {
             return ColumnStat.UNKNOWN;
         }
+        /*
+        we keep columnStat.min and columnStat.max, but set ndv=1.
+        if there is group-by keys, we will update ndv when visiting group clause
+        */
         return new ColumnStat(1, min.child().getDataType().width(),
-                min.child().getDataType().width(), 1, columnStat.getMinValue(), columnStat.getMinValue());
+                min.child().getDataType().width(), 1, columnStat.getMinValue(), columnStat.getMaxValue());
     }
 
     @Override
@@ -181,15 +185,19 @@ public class ExpressionEstimation extends ExpressionVisitor<ColumnStat, StatsDer
         if (columnStat == ColumnStat.UNKNOWN) {
             return ColumnStat.UNKNOWN;
         }
+        /*
+        we keep columnStat.min and columnStat.max, but set ndv=1.
+        if there is group-by keys, we will update ndv when visiting group clause
+        */
         return new ColumnStat(1, max.child().getDataType().width(),
-                max.child().getDataType().width(), 0, columnStat.getMaxValue(), columnStat.getMaxValue());
+                max.child().getDataType().width(), 0, columnStat.getMinValue(), columnStat.getMaxValue());
     }
 
     @Override
     public ColumnStat visitCount(Count count, StatsDeriveResult context) {
         //count() returns long type
         return new ColumnStat(1.0, 8.0, 8.0, 0.0,
-                Double.MIN_VALUE, Double.MAX_VALUE);
+                0, Double.MAX_VALUE);
     }
 
     // TODO: return a proper estimated stat after supports histogram

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/HashJoinNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/HashJoinNode.java
@@ -1122,6 +1122,10 @@ public class HashJoinNode extends PlanNode {
 
         if (detailLevel == TExplainLevel.BRIEF) {
             output.append(detailPrefix).append(String.format("cardinality=%s", cardinality)).append("\n");
+            if (!runtimeFilters.isEmpty()) {
+                output.append(detailPrefix).append("Build RFs: ");
+                output.append(getRuntimeFilterExplainString(true, true));
+            }
             return output.toString();
         }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/OlapScanNode.java
@@ -945,6 +945,13 @@ public class OlapScanNode extends ScanNode {
                 .append("(").append(indexName).append(")");
         if (detailLevel == TExplainLevel.BRIEF) {
             output.append("\n").append(prefix).append(String.format("cardinality=%s", cardinality));
+            if (!runtimeFilters.isEmpty()) {
+                output.append("\n").append(prefix).append("Apply RFs: ");
+                output.append(getRuntimeFilterExplainString(false, true));
+            }
+            if (!conjuncts.isEmpty()) {
+                output.append("\n").append(prefix).append("PREDICATES: ").append(conjuncts.size()).append("\n");
+            }
             return output.toString();
         }
         if (isPreAggregation) {

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/PlanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/PlanNode.java
@@ -918,7 +918,7 @@ public abstract class PlanNode extends TreeNode<PlanNode> implements PlanStats {
         runtimeFilters.clear();
     }
 
-    protected String getRuntimeFilterExplainString(boolean isBuildNode) {
+    protected String getRuntimeFilterExplainString(boolean isBuildNode, boolean isBrief) {
         if (runtimeFilters.isEmpty()) {
             return "";
         }
@@ -926,19 +926,25 @@ public abstract class PlanNode extends TreeNode<PlanNode> implements PlanStats {
         for (RuntimeFilter filter : runtimeFilters) {
             StringBuilder filterStr = new StringBuilder();
             filterStr.append(filter.getFilterId());
-            filterStr.append("[");
-            filterStr.append(filter.getType().toString().toLowerCase());
-            filterStr.append("]");
-            if (isBuildNode) {
-                filterStr.append(" <- ");
-                filterStr.append(filter.getSrcExpr().toSql());
-            } else {
-                filterStr.append(" -> ");
-                filterStr.append(filter.getTargetExpr(getId()).toSql());
+            if (!isBrief) {
+                filterStr.append("[");
+                filterStr.append(filter.getType().toString().toLowerCase());
+                filterStr.append("]");
+                if (isBuildNode) {
+                    filterStr.append(" <- ");
+                    filterStr.append(filter.getSrcExpr().toSql());
+                } else {
+                    filterStr.append(" -> ");
+                    filterStr.append(filter.getTargetExpr(getId()).toSql());
+                }
             }
             filtersStr.add(filterStr.toString());
         }
         return Joiner.on(", ").join(filtersStr) + "\n";
+    }
+
+    protected String getRuntimeFilterExplainString(boolean isBuildNode) {
+        return getRuntimeFilterExplainString(isBuildNode, false);
     }
 
     public void convertToVectoriezd() {

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/RuntimeFilter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/RuntimeFilter.java
@@ -279,7 +279,7 @@ public final class RuntimeFilter {
         if (LOG.isTraceEnabled()) {
             LOG.trace("Generating runtime filter from predicate " + joinPredicate);
         }
-        if (ConnectContext.get().getSessionVariable().enableRemoveNoConjunctsRuntimeFilterPolicy) {
+        if (ConnectContext.get().getSessionVariable().enableRuntimeFilterPrune) {
             if (srcExpr instanceof SlotRef) {
                 if (!tupleHasConjuncts.contains(((SlotRef) srcExpr).getDesc().getParent().getId())) {
                     // src tuple has no conjunct, don't create runtime filter

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/RuntimeFilterGenerator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/RuntimeFilterGenerator.java
@@ -162,7 +162,7 @@ public final class RuntimeFilterGenerator {
         Preconditions.checkState(runtimeFilterType >= 0, "runtimeFilterType not expected");
         Preconditions.checkState(runtimeFilterType <= Arrays.stream(TRuntimeFilterType.values())
                 .mapToInt(TRuntimeFilterType::getValue).sum(), "runtimeFilterType not expected");
-        if (ConnectContext.get().getSessionVariable().enableRemoveNoConjunctsRuntimeFilterPolicy) {
+        if (ConnectContext.get().getSessionVariable().enableRuntimeFilterPrune) {
             filterGenerator.findAllTuplesHavingConjuncts(plan);
         }
         filterGenerator.generateFilters(plan);

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -195,8 +195,8 @@ public class SessionVariable implements Serializable, Writable {
     public static final String ENABLE_NEREIDS_REORDER_TO_ELIMINATE_CROSS_JOIN =
             "enable_nereids_reorder_to_eliminate_cross_join";
 
-    public static final String ENABLE_REMOVE_NO_CONJUNCTS_RUNTIME_FILTER =
-            "enable_remove_no_conjuncts_runtime_filter_policy";
+    public static final String ENABLE_RUNTIME_FILTER_PRUNE =
+            "enable_runtime_filter_prune";
 
     static final String SESSION_CONTEXT = "session_context";
 
@@ -525,8 +525,8 @@ public class SessionVariable implements Serializable, Writable {
     @VariableMgr.VarAttr(name = ENABLE_NEREIDS_REORDER_TO_ELIMINATE_CROSS_JOIN)
     private boolean enableNereidsReorderToEliminateCrossJoin = true;
 
-    @VariableMgr.VarAttr(name = ENABLE_REMOVE_NO_CONJUNCTS_RUNTIME_FILTER)
-    public boolean enableRemoveNoConjunctsRuntimeFilterPolicy = false;
+    @VariableMgr.VarAttr(name = ENABLE_RUNTIME_FILTER_PRUNE)
+    public boolean enableRuntimeFilterPrune = false;
 
     /**
      * The client can pass some special information by setting this session variable in the format: "k1:v1;k2:v2".
@@ -1139,24 +1139,22 @@ public class SessionVariable implements Serializable, Writable {
         this.enableNereidsStatsDeriveV2 = enableNereidsStatsDeriveV2;
     }
 
-    /**
-     * Serialize to thrift object.
-     * Used for rest api.
-     **/
-    public boolean isEnableRemoveNoConjunctsRuntimeFilterPolicy() {
-        return enableRemoveNoConjunctsRuntimeFilterPolicy;
+    public boolean isEnableRuntimeFilterPrune() {
+        return enableRuntimeFilterPrune;
     }
 
-    public void setEnableRemoveNoConjunctsRuntimeFilterPolicy(boolean enableRemoveNoConjunctsRuntimeFilterPolicy) {
-        this.enableRemoveNoConjunctsRuntimeFilterPolicy = enableRemoveNoConjunctsRuntimeFilterPolicy;
+    public void setEnableRuntimeFilterPrune(boolean enableRuntimeFilterPrune) {
+        this.enableRuntimeFilterPrune = enableRuntimeFilterPrune;
     }
 
     public void setFragmentTransmissionCompressionCodec(String codec) {
         this.fragmentTransmissionCompressionCodec = codec;
     }
 
-    // Serialize to thrift object
-    // used for rest api
+    /**
+     * Serialize to thrift object.
+     * Used for rest api.
+     **/
     public TQueryOptions toThrift() {
         TQueryOptions tResult = new TQueryOptions();
         tResult.setMemLimit(maxExecMemByte);

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/ColumnStat.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/ColumnStat.java
@@ -465,4 +465,24 @@ public class ColumnStat {
             return 1;
         }
     }
+
+    /**
+     * the percentage of intersection range to this range
+     * @param other
+     * @return
+     */
+    public double coverage(ColumnStat other) {
+        if (minValue == maxValue) {
+            if (other.minValue <= minValue && minValue <= other.maxValue) {
+                return 1.0;
+            } else {
+                return 0.0;
+            }
+        } else {
+            double myRange = maxValue - minValue;
+            double interSection = Math.min(maxValue, other.maxValue) - Math.max(minValue, other.minValue);
+            return interSection / myRange;
+        }
+    }
+
 }

--- a/tools/tpch-tools/queries/q9.sql
+++ b/tools/tpch-tools/queries/q9.sql
@@ -17,7 +17,7 @@
 
 -- Modified
 
-select/*+SET_VAR(exec_mem_limit=37179869184, parallel_fragment_exec_instance_num=8, enable_vectorized_engine=true, batch_size=4096, disable_join_reorder=false, enable_cost_based_join_reorder=false, enable_projection=true, enable_remove_no_conjuncts_runtime_filter_policy=true, runtime_filter_wait_time_ms=10000) */
+select/*+SET_VAR(exec_mem_limit=37179869184, parallel_fragment_exec_instance_num=8, enable_vectorized_engine=true, batch_size=4096, disable_join_reorder=false, enable_cost_based_join_reorder=false, enable_projection=true, enable_runtime_filter_prune=true, runtime_filter_wait_time_ms=10000) */
     nation,
     o_year,
     sum(amount) as sum_profit


### PR DESCRIPTION
# Proposed changes
consider L join R on L.a=R.b
runtime-filter: L.a<-R.b is effective,
     if a is not completely covered by b,
     or R.b.selectivity<1
     
Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

