### PR TITLE
[fix](unique-key-merge-on-write) Types don't match when calling IndexedColumnIterator::seek_at_or_after

### DIFF
--- a/be/src/olap/rowset/segment_v2/indexed_column_reader.h
+++ b/be/src/olap/rowset/segment_v2/indexed_column_reader.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <memory>
+#include <string>
 
 #include "common/status.h"
 #include "env/env.h"
@@ -114,6 +115,10 @@ public:
     // Return NotFound if the given key is greater than all keys in this column.
     // Return NotSupported for column without value index.
     Status seek_at_or_after(const void* key, bool* exact_match);
+    Status seek_at_or_after(const std::string* key, bool* exact_match) {
+        Slice slice(key->data(), key->size());
+        return seek_at_or_after(static_cast<const void*>(&slice), exact_match);
+    }
 
     // Get the ordinal index that the iterator is currently pointed to.
     ordinal_t get_current_ordinal() const {


### PR DESCRIPTION
# Proposed changes

Issue Number: close #13884

## Problem summary

We pass `&index_key` (`std::string*`) to `IndexedColumnIterator::seek_at_or_after` and  reach the function `BinaryPrefixPageDecoder::seek_at_or_after_value` finally.

In function `BinaryPrefixPageDecoder::seek_at_or_after_value`, we cast the argument `value` (`&index_key`) to `Slice`. These types don't match.

The wrong type casting works well with **libstdc++**, but exposes some problems when we use **libc++**.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

