### PR TITLE
[chore](macOS) Fix compilation errors caused by the deprecated function

### DIFF
--- a/be/src/vec/exec/format/json/new_json_reader.cpp
+++ b/be/src/vec/exec/format/json/new_json_reader.cpp
@@ -601,15 +601,15 @@ Status NewJsonReader::_write_data_to_column(rapidjson::Value::ConstValueIterator
         break;
     case rapidjson::Type::kNumberType:
         if (value->IsUint()) {
-            wbytes = sprintf(tmp_buf, "%u", value->GetUint());
+            wbytes = snprintf(tmp_buf, sizeof(tmp_buf), "%u", value->GetUint());
         } else if (value->IsInt()) {
-            wbytes = sprintf(tmp_buf, "%d", value->GetInt());
+            wbytes = snprintf(tmp_buf, sizeof(tmp_buf), "%d", value->GetInt());
         } else if (value->IsUint64()) {
-            wbytes = sprintf(tmp_buf, "%" PRIu64, value->GetUint64());
+            wbytes = snprintf(tmp_buf, sizeof(tmp_buf), "%" PRIu64, value->GetUint64());
         } else if (value->IsInt64()) {
-            wbytes = sprintf(tmp_buf, "%" PRId64, value->GetInt64());
+            wbytes = snprintf(tmp_buf, sizeof(tmp_buf), "%" PRId64, value->GetInt64());
         } else {
-            wbytes = sprintf(tmp_buf, "%f", value->GetDouble());
+            wbytes = snprintf(tmp_buf, sizeof(tmp_buf), "%f", value->GetDouble());
         }
         str_value = tmp_buf;
         break;


### PR DESCRIPTION
# Proposed changes

~~Issue Number: close #xxx~~

## Problem summary

Should use `snprintf` instead of `sprintf`. See #13583 .

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

