### PR TITLE
[fix](storage) evaluate_and of ComparisonPredicateBase has logical error

### DIFF
--- a/be/src/olap/comparison_predicate.h
+++ b/be/src/olap/comparison_predicate.h
@@ -138,7 +138,7 @@ public:
             }
         } else {
             for (uint16_t i = 0; i < size; ++i) {
-                if (flags[i]) {
+                if (!flags[i]) {
                     continue;
                 }
                 uint16_t idx = sel[i];


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

`evaluate_and` of `ComparisonPredicateBase` has logical error. When flag is true, we should evaluate new predicator, and continue the loop if flag is false.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

