### PR TITLE
[fix](Nereids) throw NPE when call getOutputExprIds in LogicalProperties

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/LogicalProperties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/LogicalProperties.java
@@ -71,7 +71,7 @@ public class LogicalProperties {
 
     public List<Id> getOutputExprIds() {
         if (outputExprIds == null) {
-            outputExprIds = outputExprIdSet.stream().map(Id.class::cast).collect(Collectors.toList());
+            outputExprIds = getOutputExprIdSet().stream().map(Id.class::cast).collect(Collectors.toList());
         }
         return outputExprIds;
     }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

