### PR TITLE
[enhancement](load) Increase batch size of node channel to improve import performance

### DIFF
--- a/be/src/vec/sink/vtablet_sink.cpp
+++ b/be/src/vec/sink/vtablet_sink.cpp
@@ -68,6 +68,12 @@ Status VNodeChannel::init(RuntimeState* state) {
     _cur_add_block_request.set_eos(false);
 
     _name = fmt::format("VNodeChannel[{}-{}]", _index_channel->_index_id, _node_id);
+    // The node channel will send _batch_size rows of data each rpc. When the
+    // number of tablets is large, the number of data rows received by each
+    // tablet is small, TabletsChannel need to traverse each tablet for import.
+    // so the import performance is poor. Therefore, we set _batch_size to
+    // a relatively large value to improve the import performance.
+    _batch_size = std::max(_batch_size, 8192);
 
     return Status::OK();
 }


### PR DESCRIPTION

# Proposed changes

Issue Number: close #xxx

## Problem summary

change the _batch_size of node channel from 2048 to 8192.  The stream load  performance is improved by about two times when import  ssb lineorder table.
Test with tools/ssb-tools for single node. 600MB data load time: 14s -> 7s.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

