### PR TITLE
[BugFix](Concat) output of string concat function exceeds UINT makes crash

### DIFF
--- a/regression-test/suites/tpcds_sf1_p1/functions_test/test_string_concat_extremely_long_string.groovy
+++ b/regression-test/suites/tpcds_sf1_p1/functions_test/test_string_concat_extremely_long_string.groovy
@@ -1,0 +1,44 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_concat_extreme_input") {
+    // there is need to check the result, the following query would return error due to
+    // concat output exceeds the UINT size. This case just tests whether the BE could cover
+    // such occasion without crash
+    test {
+        sql ''' select
+  concat(
+    cast(substr(
+      cast(ref_1.`cp_type` as varchar),
+      cast(
+        max(
+          cast(ref_1.`cp_catalog_page_number` as int)) over (partition by ref_1.`cp_end_date_sk` order by ref_1.`cp_catalog_page_number`) as int),
+      cast(ref_1.`cp_end_date_sk` as int)) as varchar),
+    cast(substring(
+      cast(ref_1.`cp_department` as varchar),
+      cast(ref_1.`cp_end_date_sk` as int),
+      cast(ref_1.`cp_end_date_sk` as int)) as varchar),
+    cast(rpad(
+      cast(ref_1.`cp_type` as varchar),
+      cast(ref_1.`cp_start_date_sk` as int),
+      cast(ref_1.`cp_description` as varchar)) as varchar)) as c1
+from
+  regression_test_tpcds_sf1_p1.catalog_page as ref_1 '''
+        exception "concat output is too large to allocate"
+    }
+}
+


### PR DESCRIPTION
# Proposed changes
The previously logic of concat function assumes all input string could be concat inside INT size buffer, user might accidentally input string parameters which could sum up to exceed the size.
Issue Number: close #xxx

## Problem summary
When input such query below be would coredump.
```
select
  concat(
    cast(substr(
      cast(ref_1.`cp_type` as varchar),
      cast(
        max(
          cast(ref_1.`cp_catalog_page_number` as int)) over (partition by ref_1.`cp_end_date_sk` order by ref_1.`cp_catalog_page_number`) as int),
      cast(ref_1.`cp_end_date_sk` as int)) as varchar),
    cast(substring(
      cast(ref_1.`cp_department` as varchar),
      cast(ref_1.`cp_end_date_sk` as int),
      cast(ref_1.`cp_end_date_sk` as int)) as varchar),
    cast(rpad(
      cast(ref_1.`cp_type` as varchar),
      cast(ref_1.`cp_start_date_sk` as int),
      cast(ref_1.`cp_description` as varchar)) as varchar)) as c1
from
  regression_test_tpcds_sf1_p1.catalog_page as ref_1
```
Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

