### PR TITLE
[improvement](join) Share hash table in fragments for broadcast join

### DIFF
--- a/be/src/exprs/runtime_filter.h
+++ b/be/src/exprs/runtime_filter.h
@@ -141,6 +141,8 @@ public:
                          const TQueryOptions* query_options, const RuntimeFilterRole role,
                          int node_id, IRuntimeFilter** res);
 
+    Status apply_from_other(IRuntimeFilter* other);
+
     // insert data to build filter
     // only used for producer
     void insert(const void* data);
@@ -245,6 +247,8 @@ public:
     static bool enable_use_batch(int be_exec_version, PrimitiveType type) {
         return be_exec_version > 0 && (is_int_or_bool(type) || is_float_or_double(type));
     }
+
+    int filter_id() const { return _filter_id; }
 
 protected:
     // serialize _wrapper to protobuf

--- a/be/src/exprs/runtime_filter_slots.h
+++ b/be/src/exprs/runtime_filter_slots.h
@@ -229,6 +229,24 @@ public:
         }
     }
 
+    Status apply_from_other(RuntimeFilterSlotsBase<ExprCtxType>* other) {
+        for (auto& it : _runtime_filters) {
+            auto& other_filters = other->_runtime_filters[it.first];
+            for (auto& filter : it.second) {
+                auto filter_id = filter->filter_id();
+                auto ret = std::find_if(other_filters.begin(), other_filters.end(),
+                                        [&](IRuntimeFilter* other_filter) {
+                                            return other_filter->filter_id() == filter_id;
+                                        });
+                if (ret == other_filters.end()) {
+                    return Status::Aborted("invalid runtime filter id: {}", filter_id);
+                }
+                filter->apply_from_other(*ret);
+            }
+        }
+        return Status::OK();
+    }
+
     bool empty() { return !_runtime_filters.size(); }
 
 private:

--- a/be/src/runtime/fragment_mgr.cpp
+++ b/be/src/runtime/fragment_mgr.cpp
@@ -240,7 +240,13 @@ Status FragmentExecState::execute() {
     }
 #ifndef BE_TEST
     if (_executor.runtime_state()->is_cancelled()) {
-        return Status::Cancelled("cancelled before execution");
+        Status status = Status::Cancelled("cancelled before execution");
+        _executor.runtime_state()
+                ->get_query_fragments_ctx()
+                ->get_shared_hash_table_controller()
+                ->release_ref_count_if_need(_executor.runtime_state()->fragment_instance_id(),
+                                            status);
+        return status;
     }
 #endif
     int64_t duration_ns = 0;
@@ -248,10 +254,18 @@ Status FragmentExecState::execute() {
         SCOPED_RAW_TIMER(&duration_ns);
         CgroupsMgr::apply_system_cgroup();
         opentelemetry::trace::Tracer::GetCurrentSpan()->AddEvent("start executing Fragment");
-        WARN_IF_ERROR(_executor.open(), strings::Substitute("Got error while opening fragment $0",
-                                                            print_id(_fragment_instance_id)));
+        Status status = _executor.open();
+        WARN_IF_ERROR(status, strings::Substitute("Got error while opening fragment $0",
+                                                  print_id(_fragment_instance_id)));
 
         _executor.close();
+        if (!status.ok()) {
+            _executor.runtime_state()
+                    ->get_query_fragments_ctx()
+                    ->get_shared_hash_table_controller()
+                    ->release_ref_count_if_need(_executor.runtime_state()->fragment_instance_id(),
+                                                status);
+        }
     }
     DorisMetrics::instance()->fragment_requests_total->increment(1);
     DorisMetrics::instance()->fragment_request_duration_us->increment(duration_ns / 1000);
@@ -697,6 +711,9 @@ Status FragmentMgr::exec_plan_fragment(const TExecPlanFragmentParams& params, Fi
     }
     g_fragmentmgr_prepare_latency << (duration_ns / 1000);
 
+    _setup_shared_hashtable_for_broadcast_join(params, exec_state->executor()->runtime_state(),
+                                               fragments_ctx.get());
+
     std::shared_ptr<RuntimeFilterMergeControllerEntity> handler;
     _runtimefilter_controller.add_entity(params, &handler, exec_state->executor()->runtime_state());
     exec_state->set_merge_controller_handler(handler);
@@ -764,6 +781,26 @@ void FragmentMgr::_set_scan_concurrency(const TExecPlanFragmentParams& params,
     }
     fragments_ctx->set_thread_token(concurrency, is_serial);
 #endif
+}
+
+void FragmentMgr::_setup_shared_hashtable_for_broadcast_join(const TExecPlanFragmentParams& params,
+                                                             RuntimeState* state,
+                                                             QueryFragmentsCtx* fragments_ctx) {
+    if (!params.__isset.fragment || !params.fragment.__isset.plan ||
+        params.fragment.plan.nodes.empty()) {
+        return;
+    }
+
+    for (auto& node : params.fragment.plan.nodes) {
+        if (node.node_type != TPlanNodeType::HASH_JOIN_NODE ||
+            !node.hash_join_node.__isset.is_broadcast_join ||
+            !node.hash_join_node.is_broadcast_join) {
+            continue;
+        }
+
+        std::lock_guard<std::mutex> lock(_lock_for_shared_hash_table);
+        fragments_ctx->get_shared_hash_table_controller()->acquire_ref_count(state, node.node_id);
+    }
 }
 
 bool FragmentMgr::_is_scan_node(const TPlanNodeType::type& type) {

--- a/be/src/runtime/fragment_mgr.h
+++ b/be/src/runtime/fragment_mgr.h
@@ -107,12 +107,19 @@ private:
 
     bool _is_scan_node(const TPlanNodeType::type& type);
 
+    void _setup_shared_hashtable_for_broadcast_join(const TExecPlanFragmentParams& params,
+                                                    RuntimeState* state,
+                                                    QueryFragmentsCtx* fragments_ctx);
+
     // This is input params
     ExecEnv* _exec_env;
 
     std::mutex _lock;
 
     std::condition_variable _cv;
+
+    std::mutex _lock_for_shared_hash_table;
+    std::condition_variable _cv_for_sharing_hashtable;
 
     // Make sure that remove this before no data reference FragmentExecState
     std::unordered_map<TUniqueId, std::shared_ptr<FragmentExecState>> _fragment_map;

--- a/be/src/runtime/query_fragments_ctx.h
+++ b/be/src/runtime/query_fragments_ctx.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <atomic>
+#include <memory>
 #include <string>
 
 #include "common/config.h"
@@ -29,6 +30,7 @@
 #include "runtime/memory/mem_tracker_limiter.h"
 #include "util/pretty_printer.h"
 #include "util/threadpool.h"
+#include "vec/runtime/shared_hash_table_controller.h"
 
 namespace doris {
 
@@ -41,6 +43,7 @@ public:
     QueryFragmentsCtx(int total_fragment_num, ExecEnv* exec_env)
             : fragment_num(total_fragment_num), timeout_second(-1), _exec_env(exec_env) {
         _start_time = DateTimeValue::local_time();
+        _shared_hash_table_controller.reset(new vectorized::SharedHashTableController());
     }
 
     ~QueryFragmentsCtx() {
@@ -97,6 +100,10 @@ public:
         return _ready_to_execute.load() && !_is_cancelled.load();
     }
 
+    vectorized::SharedHashTableController* get_shared_hash_table_controller() {
+        return _shared_hash_table_controller.get();
+    }
+
 public:
     TUniqueId query_id;
     DescriptorTbl* desc_tbl;
@@ -136,6 +143,8 @@ private:
     // And all fragments of this query will start execution when this is set to true.
     std::atomic<bool> _ready_to_execute {false};
     std::atomic<bool> _is_cancelled {false};
+
+    std::unique_ptr<vectorized::SharedHashTableController> _shared_hash_table_controller;
 };
 
 } // namespace doris

--- a/be/src/vec/CMakeLists.txt
+++ b/be/src/vec/CMakeLists.txt
@@ -228,8 +228,9 @@ set(VEC_FILES
   runtime/vpartition_info.cpp
   runtime/vparquet_writer.cpp
   runtime/vorc_writer.cpp
-  utils/arrow_column_to_doris_column.cpp
   runtime/vsorted_run_merger.cpp
+  runtime/shared_hash_table_controller.cpp
+  utils/arrow_column_to_doris_column.cpp
   exec/format/parquet/vparquet_column_chunk_reader.cpp
   exec/format/parquet/vparquet_group_reader.cpp
   exec/format/parquet/vparquet_page_index.cpp

--- a/be/src/vec/exec/join/vhash_join_node.h
+++ b/be/src/vec/exec/join/vhash_join_node.h
@@ -28,6 +28,7 @@
 #include "vec/exec/join/join_op.h"
 #include "vec/exec/join/vacquire_list.hpp"
 #include "vec/functions/function.h"
+#include "vec/runtime/shared_hash_table_controller.h"
 
 namespace doris {
 namespace vectorized {
@@ -40,6 +41,7 @@ struct SerializedHashTableContext {
     using Iter = typename HashTable::iterator;
 
     HashTable hash_table;
+    HashTable* hash_table_ptr = &hash_table;
     Iter iter;
     bool inited = false;
 
@@ -71,6 +73,7 @@ struct PrimaryTypeHashTableContext {
     using Iter = typename HashTable::iterator;
 
     HashTable hash_table;
+    HashTable* hash_table_ptr = &hash_table;
     Iter iter;
     bool inited = false;
 
@@ -105,6 +108,7 @@ struct FixedKeyHashTableContext {
     using Iter = typename HashTable::iterator;
 
     HashTable hash_table;
+    HashTable* hash_table_ptr = &hash_table;
     Iter iter;
     bool inited = false;
 
@@ -353,6 +357,9 @@ private:
     // 3. In probe phase, if _short_circuit_for_null_in_probe_side is true, join node returns empty block directly. Otherwise, probing will continue as the same as generic left anti join.
     bool _short_circuit_for_null_in_build_side = false;
     bool _short_circuit_for_null_in_probe_side = false;
+    bool _is_broadcast_join = false;
+    SharedHashTableController* _shared_hashtable_controller = nullptr;
+    VRuntimeFilterSlots* _runtime_filter_slots;
 
     Block _join_block;
 

--- a/be/src/vec/runtime/shared_hash_table_controller.cpp
+++ b/be/src/vec/runtime/shared_hash_table_controller.cpp
@@ -1,0 +1,132 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "shared_hash_table_controller.h"
+
+#include <runtime/runtime_state.h>
+
+namespace doris {
+namespace vectorized {
+
+bool SharedHashTableController::should_build_hash_table(RuntimeState* state, int my_node_id) {
+    std::lock_guard<std::mutex> lock(_mutex);
+    auto it = _builder_fragment_ids.find(my_node_id);
+    if (it == _builder_fragment_ids.cend()) {
+        _builder_fragment_ids[my_node_id] = state->fragment_instance_id();
+        return true;
+    }
+    return false;
+}
+
+bool SharedHashTableController::supposed_to_build_hash_table(RuntimeState* state, int my_node_id) {
+    std::lock_guard<std::mutex> lock(_mutex);
+    auto it = _builder_fragment_ids.find(my_node_id);
+    if (it != _builder_fragment_ids.cend()) {
+        return _builder_fragment_ids[my_node_id] == state->fragment_instance_id();
+    }
+    return false;
+}
+
+void SharedHashTableController::put_hash_table(SharedHashTableEntry&& entry, int my_node_id) {
+    std::lock_guard<std::mutex> lock(_mutex);
+    DCHECK(_hash_table_entries.find(my_node_id) == _hash_table_entries.cend());
+    _hash_table_entries.insert({my_node_id, std::move(entry)});
+    _cv.notify_all();
+}
+
+SharedHashTableEntry& SharedHashTableController::wait_for_hash_table(int my_node_id) {
+    std::unique_lock<std::mutex> lock(_mutex);
+    auto it = _hash_table_entries.find(my_node_id);
+    if (it == _hash_table_entries.cend()) {
+        _cv.wait(lock, [this, &it, my_node_id]() {
+            it = _hash_table_entries.find(my_node_id);
+            return it != _hash_table_entries.cend();
+        });
+    }
+    return it->second;
+}
+
+void SharedHashTableController::acquire_ref_count(RuntimeState* state, int my_node_id) {
+    std::unique_lock<std::mutex> lock(_mutex);
+    _ref_fragments[my_node_id].emplace_back(state->fragment_instance_id());
+}
+
+Status SharedHashTableController::release_ref_count(RuntimeState* state, int my_node_id) {
+    std::unique_lock<std::mutex> lock(_mutex);
+    auto id = state->fragment_instance_id();
+    auto it = std::find(_ref_fragments[my_node_id].begin(), _ref_fragments[my_node_id].end(), id);
+    CHECK(it != _ref_fragments[my_node_id].end());
+    _ref_fragments[my_node_id].erase(it);
+    _put_an_empty_entry_if_need(Status::Cancelled("hash table not build"), id, my_node_id);
+    _cv.notify_all();
+    return Status::OK();
+}
+
+void SharedHashTableController::_put_an_empty_entry_if_need(Status status, TUniqueId fragment_id,
+                                                            int node_id) {
+    auto builder_it = _builder_fragment_ids.find(node_id);
+    if (builder_it != _builder_fragment_ids.end()) {
+        if (builder_it->second == fragment_id) {
+            if (_hash_table_entries.find(builder_it->first) == _hash_table_entries.cend()) {
+                // "here put an empty SharedHashTableEntry to avoid deadlocking"
+                _hash_table_entries.insert(
+                        {builder_it->first, SharedHashTableEntry::empty_entry_with_status(status)});
+            }
+        }
+    }
+}
+
+Status SharedHashTableController::release_ref_count_if_need(TUniqueId fragment_id, Status status) {
+    std::unique_lock<std::mutex> lock(_mutex);
+    bool need_to_notify = false;
+    for (auto& ref : _ref_fragments) {
+        auto it = std::find(ref.second.begin(), ref.second.end(), fragment_id);
+        if (it == ref.second.end()) {
+            continue;
+        }
+        ref.second.erase(it);
+        need_to_notify = true;
+        LOG(INFO) << "release_ref_count in node: " << ref.first
+                  << " for fragment id: " << fragment_id;
+    }
+
+    for (auto& builder : _builder_fragment_ids) {
+        if (builder.second == fragment_id) {
+            if (_hash_table_entries.find(builder.first) == _hash_table_entries.cend()) {
+                _hash_table_entries.insert(
+                        {builder.first, SharedHashTableEntry::empty_entry_with_status(status)});
+            }
+        }
+    }
+
+    if (need_to_notify) {
+        _cv.notify_all();
+    }
+    return Status::OK();
+}
+
+Status SharedHashTableController::wait_for_closable(RuntimeState* state, int my_node_id) {
+    std::unique_lock<std::mutex> lock(_mutex);
+    RETURN_IF_CANCELLED(state);
+    if (!_ref_fragments[my_node_id].empty()) {
+        _cv.wait(lock, [&]() { return _ref_fragments[my_node_id].empty(); });
+    }
+    return Status::OK();
+}
+
+} // namespace vectorized
+} // namespace doris

--- a/be/src/vec/runtime/shared_hash_table_controller.h
+++ b/be/src/vec/runtime/shared_hash_table_controller.h
@@ -1,0 +1,89 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <condition_variable>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <vector>
+
+#include "vec/core/block.h"
+
+namespace doris {
+
+class RuntimeState;
+class TUniqueId;
+
+template <typename ExprCtxType>
+class RuntimeFilterSlotsBase;
+
+namespace vectorized {
+
+class VExprContext;
+
+struct SharedHashTableEntry {
+    SharedHashTableEntry(Status status_, void* hash_table_ptr_, std::vector<Block>* blocks_,
+                         RuntimeFilterSlotsBase<VExprContext>* runtime_filter_slots_)
+            : status(status_),
+              hash_table_ptr(hash_table_ptr_),
+              blocks(blocks_),
+              runtime_filter_slots(runtime_filter_slots_) {}
+    SharedHashTableEntry(SharedHashTableEntry&& entry)
+            : status(entry.status),
+              hash_table_ptr(entry.hash_table_ptr),
+              blocks(entry.blocks),
+              runtime_filter_slots(entry.runtime_filter_slots) {}
+
+    static SharedHashTableEntry empty_entry_with_status(const Status& status) {
+        return SharedHashTableEntry(status, nullptr, nullptr, nullptr);
+    }
+
+    Status status;
+    void* hash_table_ptr;
+    std::vector<Block>* blocks;
+    RuntimeFilterSlotsBase<VExprContext>* runtime_filter_slots;
+};
+
+class SharedHashTableController {
+public:
+    bool should_build_hash_table(RuntimeState* state, int my_node_id);
+    bool supposed_to_build_hash_table(RuntimeState* state, int my_node_id);
+    void acquire_ref_count(RuntimeState* state, int my_node_id);
+    SharedHashTableEntry& wait_for_hash_table(int my_node_id);
+    Status release_ref_count(RuntimeState* state, int my_node_id);
+    Status release_ref_count_if_need(TUniqueId fragment_id, Status status);
+    void put_hash_table(SharedHashTableEntry&& entry, int my_node_id);
+    Status wait_for_closable(RuntimeState* state, int my_node_id);
+
+private:
+    // If the fragment instance was supposed to build hash table, but it didn't build.
+    // To avoid deadlocking other fragment instances,
+    // here need to put an empty SharedHashTableEntry with canceled status.
+    void _put_an_empty_entry_if_need(Status status, TUniqueId fragment_id, int node_id);
+
+private:
+    std::mutex _mutex;
+    std::condition_variable _cv;
+    std::map<int /*node id*/, TUniqueId /*fragment id*/> _builder_fragment_ids;
+    std::map<int /*node id*/, SharedHashTableEntry> _hash_table_entries;
+    std::map<int /*node id*/, std::vector<TUniqueId>> _ref_fragments;
+};
+
+} // namespace vectorized
+} // namespace doris

--- a/be/src/vec/runtime/shared_hashtable_controller.cpp
+++ b/be/src/vec/runtime/shared_hashtable_controller.cpp
@@ -1,0 +1,95 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "shared_hashtable_controller.h"
+
+#include <runtime/runtime_state.h>
+
+namespace doris {
+namespace vectorized {
+
+bool SharedHashTableController::should_build_hash_table(RuntimeState* state, int my_node_id) {
+    std::lock_guard<std::mutex> lock(_mutex);
+    auto it = _builder_fragment_ids.find(my_node_id);
+    if (it == _builder_fragment_ids.cend()) {
+        _builder_fragment_ids[my_node_id] = state->fragment_instance_id();
+        return true;
+    }
+    return false;
+}
+
+void SharedHashTableController::put_hash_table(SharedHashTableEntry&& entry, int my_node_id) {
+    std::lock_guard<std::mutex> lock(_mutex);
+    DCHECK(_hash_table_entries.find(my_node_id) == _hash_table_entries.cend());
+    _hash_table_entries.insert({my_node_id, std::move(entry)});
+    _cv.notify_all();
+}
+
+SharedHashTableEntry& SharedHashTableController::wait_for_hash_table(int my_node_id) {
+    std::unique_lock<std::mutex> lock(_mutex);
+    auto it = _hash_table_entries.find(my_node_id);
+    if (it == _hash_table_entries.cend()) {
+        _cv.wait(lock, [this, &it, my_node_id]() {
+            it = _hash_table_entries.find(my_node_id);
+            return it != _hash_table_entries.cend();
+        });
+    }
+    return it->second;
+}
+
+void SharedHashTableController::acquire_ref_count(RuntimeState* state, int my_node_id) {
+    std::unique_lock<std::mutex> lock(_mutex);
+    _ref_fragments[my_node_id].emplace_back(state->fragment_instance_id());
+}
+
+Status SharedHashTableController::release_ref_count(RuntimeState* state, int my_node_id) {
+    std::unique_lock<std::mutex> lock(_mutex);
+    RETURN_IF_CANCELLED(state);
+    auto id = state->fragment_instance_id();
+    auto it = std::find(_ref_fragments[my_node_id].begin(), _ref_fragments[my_node_id].end(), id);
+    CHECK(it != _ref_fragments[my_node_id].end());
+    _ref_fragments[my_node_id].erase(it);
+    _cv.notify_all();
+    return Status::OK();
+}
+
+Status SharedHashTableController::release_ref_count_if_need(TUniqueId fragment_id) {
+    std::unique_lock<std::mutex> lock(_mutex);
+    bool need_to_notify = false;
+    for (auto& ref : _ref_fragments) {
+        auto it = std::find(ref.second.begin(), ref.second.end(), fragment_id);
+        if (it == ref.second.end()) continue;
+        ref.second.erase(it);
+        need_to_notify = true;
+        LOG(INFO) << "release_ref_count in node: " << ref.first
+                  << " for fragment id: " << fragment_id;
+    }
+    if (need_to_notify) _cv.notify_all();
+    return Status::OK();
+}
+
+Status SharedHashTableController::wait_for_closable(RuntimeState* state, int my_node_id) {
+    std::unique_lock<std::mutex> lock(_mutex);
+    RETURN_IF_CANCELLED(state);
+    if (!_ref_fragments[my_node_id].empty()) {
+        _cv.wait(lock, [&]() { return _ref_fragments[my_node_id].empty(); });
+    }
+    return Status::OK();
+}
+
+} // namespace vectorized
+} // namespace doris

--- a/be/src/vec/runtime/shared_hashtable_controller.h
+++ b/be/src/vec/runtime/shared_hashtable_controller.h
@@ -1,0 +1,75 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <condition_variable>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <vector>
+
+#include "vec/core/block.h"
+
+namespace doris {
+
+class RuntimeState;
+class TUniqueId;
+
+namespace vectorized {
+
+class VExprContext;
+
+struct SharedHashTableEntry {
+    SharedHashTableEntry(void* hash_table_ptr_, std::vector<Block>& blocks_,
+                         std::unordered_map<const Block*, std::vector<int>>& inserted_rows_,
+                         const std::vector<VExprContext*>& exprs)
+            : hash_table_ptr(hash_table_ptr_),
+              blocks(blocks_),
+              inserted_rows(inserted_rows_),
+              build_exprs(exprs) {}
+    SharedHashTableEntry(SharedHashTableEntry&& entry)
+            : hash_table_ptr(entry.hash_table_ptr),
+              blocks(entry.blocks),
+              inserted_rows(entry.inserted_rows),
+              build_exprs(entry.build_exprs) {}
+    void* hash_table_ptr;
+    std::vector<Block>& blocks;
+    std::unordered_map<const Block*, std::vector<int>>& inserted_rows;
+    std::vector<VExprContext*> build_exprs;
+};
+
+class SharedHashTableController {
+public:
+    bool should_build_hash_table(RuntimeState* state, int my_node_id);
+    void acquire_ref_count(RuntimeState* state, int my_node_id);
+    SharedHashTableEntry& wait_for_hash_table(int my_node_id);
+    Status release_ref_count(RuntimeState* state, int my_node_id);
+    Status release_ref_count_if_need(TUniqueId fragment_id);
+    void put_hash_table(SharedHashTableEntry&& entry, int my_node_id);
+    Status wait_for_closable(RuntimeState* state, int my_node_id);
+
+private:
+    std::mutex _mutex;
+    std::condition_variable _cv;
+    std::map<int /*node id*/, TUniqueId /*fragment id*/> _builder_fragment_ids;
+    std::map<int /*node id*/, SharedHashTableEntry> _hash_table_entries;
+    std::map<int /*node id*/, std::vector<TUniqueId>> _ref_fragments;
+};
+
+} // namespace vectorized
+} // namespace doris

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/HashJoinNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/HashJoinNode.java
@@ -1068,6 +1068,7 @@ public class HashJoinNode extends PlanNode {
         msg.node_type = TPlanNodeType.HASH_JOIN_NODE;
         msg.hash_join_node = new THashJoinNode();
         msg.hash_join_node.join_op = joinOp.toThrift();
+        msg.hash_join_node.setIsBroadcastJoin(distrMode == DistributionMode.BROADCAST);
         for (BinaryPredicate eqJoinPredicate : eqJoinConjuncts) {
             TEqJoinCondition eqJoinCondition = new TEqJoinCondition(eqJoinPredicate.getChild(0).treeToThrift(),
                     eqJoinPredicate.getChild(1).treeToThrift());

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -579,6 +579,8 @@ struct THashJoinNode {
   8: optional Types.TTupleId voutput_tuple_id
 
   9: optional list<Types.TTupleId> vintermediate_tuple_id_list
+
+  10: optional bool is_broadcast_join;
 }
 
 struct TMergeJoinNode {


### PR DESCRIPTION
# Proposed changes

The hash table could be shared in join nodes of the same BE for broadcast join.
Hash join nodes with a shared hash table could significantly reduce memory and CPU usage.

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

