### PR TITLE
[fix](memtracker) Fix `DCHECK(!std::count(_consumer_tracker_stack.begin(), _consumer_tracker_stack.end(), tracker))`

### DIFF
--- a/be/src/vec/exec/join/vhash_join_node.cpp
+++ b/be/src/vec/exec/join/vhash_join_node.cpp
@@ -997,10 +997,6 @@ Status HashJoinNode::prepare(RuntimeState* state) {
             std::bind<int64_t>(&RuntimeProfile::units_per_second, _rows_returned_counter,
                                runtime_profile()->total_time_counter()),
             "");
-    _mem_tracker = std::make_unique<MemTracker>("ExecNode:" + _runtime_profile->name(),
-                                                _runtime_profile.get());
-    SCOPED_CONSUME_MEM_TRACKER(mem_tracker());
-
     if (_vconjunct_ctx_ptr) {
         RETURN_IF_ERROR((*_vconjunct_ctx_ptr)->prepare(state, _intermediate_row_desc));
     }
@@ -1008,6 +1004,7 @@ Status HashJoinNode::prepare(RuntimeState* state) {
     for (int i = 0; i < _children.size(); ++i) {
         RETURN_IF_ERROR(_children[i]->prepare(state));
     }
+    SCOPED_CONSUME_MEM_TRACKER(mem_tracker());
 
     // Build phase
     auto build_phase_profile = runtime_profile()->create_child("BuildPhase", true, true);


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

```
start time: Thu 03 Nov 2022 11:31:45 AM CST
==1874800==WARNING: ASan is ignoring requested __asan_handle_no_return: stack type: default top: 0x7fdad29c01c0; bottom 0x7fda9c117000; size: 0x0000368a91c0 (915050944)
False positive error reports may follow
For details see https://github.com/google/sanitizers/issues/189
F1103 11:39:49.077111 1875516 thread_mem_tracker_mgr.h:196] Check failed: !std::count(_consumer_tracker_stack.begin(), _consumer_tracker_stack.end(), tracker) ThreadMemTrackerMgr debug, _untracked_mem:57344, _task_id:e82de32573724bec-8c1ef002d7641cdd, _limiter_tracker:<MemTrackerLimiter Label=RuntimeState:instance:e82de32573724bec-8c1ef002d7641cde, Limit=-1.00 B(-1 B), Used=0(0 B), Peak=0(0 B), Exceeded=false
    MemTracker Label=[Observer] RuntimeFilterMgr, Parent Label=RuntimeState:instance:e82de32573724bec-8c1ef002d7641cde, Used=0(0 B), Peak=0(0 B)
    MemTracker Label=[Observer] BufferedBlockMgr2, Parent Label=RuntimeState:instance:e82de32573724bec-8c1ef002d7641cde, Used=0(0 B), Peak=0(0 B)
    MemTracker Label=[Observer] ExecNode:VAGGREGATION_NODE (id=6), Parent Label=RuntimeState:instance:e82de32573724bec-8c1ef002d7641cde, Used=-56.00 KB(-57344 B), Peak=0(0 B)
    MemTracker Label=[Observer] ExecNode:VHASH_JOIN_NODE (id=5), Parent Label=RuntimeState:instance:e82de32573724bec-8c1ef002d7641cde, Used=-56.00 KB(-57344 B), Peak=0(0 B)
    MemTracker Label=[Observer] ExecNode:VCROSS_JOIN_NODE (id=3), Parent Label=RuntimeState:instance:e82de32573724bec-8c1ef002d7641cde, Used=-56.00 KB(-57344 B), Peak=0(0 B)
    MemTracker Label=[Observer] ExecNode:VNewOlapScanNode(customer) (id=0), Parent Label=RuntimeState:instance:e82de32573724bec-8c1ef002d7641cde, Used=0(0 B), Peak=0(0 B)
    MemTracker Label=[Observer] ExecNode:VEXCHANGE_NODE (id=10), Parent Label=RuntimeState:instance:e82de32573724bec-8c1ef002d7641cde, Used=0(0 B), Peak=0(0 B)
    MemTracker Label=[Observer] VDataStreamRecvr:e82de32573724bec-8c1ef002d7641cde, Parent Label=RuntimeState:instance:e82de32573724bec-8c1ef002d7641cde, Used=0(0 B), Peak=0(0 B)>, _consumer_tracker_stack:<MemTracker Label=[Observer] ExecNode:VAGGREGATION_NODE (id=6), Parent Label=RuntimeState:instance:e82de32573724bec-8c1ef002d7641cde, Used=-56.00 KB(-57344 B), Peak=0(0 B), MemTracker Label=[Observer] ExecNode:VHASH_JOIN_NODE (id=5), Parent Label=RuntimeState:instance:e82de32573724bec-8c1ef002d7641cde, Used=-56.00 KB(-57344 B), Peak=0(0 B), MemTracker Label=[Observer] ExecNode:VCROSS_JOIN_NODE (id=3), Parent Label=RuntimeState:instance:e82de32573724bec-8c1ef002d7641cde, Used=-56.00 KB(-57344 B), Peak=0(0 B), >
*** Check failure stack trace: ***
    @     0x555ded1bed7d  google::LogMessage::Fail()
    @     0x555ded1c12b9  google::LogMessage::SendToLog()
    @     0x555ded1be8e6  google::LogMessage::Flush()
    @     0x555ded1c1929  google::LogMessageFatal::~LogMessageFatal()
    @     0x555de17fea30  doris::ThreadMemTrackerMgr::push_consumer_tracker()
    @     0x555de17f8a4b  doris::AddThreadMemTrackerConsumer::AddThreadMemTrackerConsumer()
    @     0x555de50b7afb  doris::vectorized::VNestedLoopJoinNode::prepare()
    @     0x555de542c75c  doris::vectorized::HashJoinNode::prepare()
    @     0x555de0d85bf3  doris::ExecNode::prepare()
    @     0x555de4cb3333  doris::vectorized::AggregationNode::prepare()
    @     0x555de18a8866  doris::PlanFragmentExecutor::prepare()
    @     0x555de18274ac  doris::FragmentExecState::prepare()
    @     0x555de184902b  doris::FragmentMgr::exec_plan_fragment()
    @     0x555de1852e2d  doris::FragmentMgr::exec_plan_fragment()
    @     0x555de1dfa306  doris::PInternalServiceImpl::_exec_plan_fragment()
    @     0x555de1dffe44  doris::PInternalServiceImpl::exec_plan_fragment()
    @     0x555de1de730f  doris::PInternalServiceImpl::exec_plan_fragment_prepare()
    @     0x555de2cc0485  doris::PBackendService::CallMethod()
    @     0x555deda4cb35  brpc::policy::ProcessHttpRequest()
    @     0x555ded9fc2d7  brpc::ProcessInputMessage()
    @     0x555ded9fd1f1  brpc::InputMessenger::OnNewMessages()
    @     0x555dedb21b1e  brpc::Socket::ProcessEvent()
    @     0x555ded98f26f  bthread::TaskGroup::task_runner()
    @     0x555ded98c6e1  bthread_make_fcontext
```

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

