### PR TITLE
[fix](JSON) Fail to parse JSONPath (libc++)

### DIFF
--- a/be/src/exprs/json_functions.cpp
+++ b/be/src/exprs/json_functions.cpp
@@ -299,8 +299,8 @@ rapidjson::Value* JsonFunctions::match_value(const std::vector<JsonPath>& parsed
 }
 
 rapidjson::Value* JsonFunctions::get_json_object(FunctionContext* context,
-                                                 const std::string_view& json_string,
-                                                 const std::string_view& path_string,
+                                                 std::string_view json_string,
+                                                 std::string_view path_string,
                                                  const JsonFunctionType& fntype,
                                                  rapidjson::Document* document) {
     // split path by ".", and escape quota by "\"
@@ -319,13 +319,19 @@ rapidjson::Value* JsonFunctions::get_json_object(FunctionContext* context,
     }
 
     if (json_state->json_paths.size() == 0) {
+#ifdef USE_LIBCPP
+        std::string s(path_string);
+        auto tok = get_json_token(s);
+#else
         auto tok = get_json_token(path_string);
+#endif
         std::vector<std::string> paths(tok.begin(), tok.end());
         get_parsed_paths(paths, &json_state->json_paths);
     }
 #else
     json_state = &tmp_json_state;
-    auto tok = get_json_token(path_string);
+    std::string s(path_string);
+    auto tok = get_json_token(s);
     std::vector<std::string> paths(tok.begin(), tok.end());
     get_parsed_paths(paths, &json_state->json_paths);
 #endif

--- a/be/src/exprs/json_functions.h
+++ b/be/src/exprs/json_functions.h
@@ -108,9 +108,8 @@ public:
                                                 const doris_udf::StringVal& json_str,
                                                 const doris_udf::StringVal& path);
 
-    static rapidjson::Value* get_json_object(FunctionContext* context,
-                                             const std::string_view& json_string,
-                                             const std::string_view& path_string,
+    static rapidjson::Value* get_json_object(FunctionContext* context, std::string_view json_string,
+                                             std::string_view path_string,
                                              const JsonFunctionType& fntype,
                                              rapidjson::Document* document);
 

--- a/be/src/util/string_util.h
+++ b/be/src/util/string_util.h
@@ -130,14 +130,15 @@ template <class T>
 using StringCaseUnorderedMap =
         std::unordered_map<std::string, T, StringCaseHasher, StringCaseEqual>;
 
-inline auto get_json_token(const std::string_view& path_string) {
-#ifdef USE_LIBCPP
-    return boost::tokenizer<boost::escaped_list_separator<char>>(
-            std::string(path_string), boost::escaped_list_separator<char>("\\", ".", "\""));
-#else
+template <typename T>
+inline auto get_json_token(T& path_string) {
     return boost::tokenizer<boost::escaped_list_separator<char>>(
             path_string, boost::escaped_list_separator<char>("\\", ".", "\""));
-#endif
 }
+
+#ifdef USE_LIBCPP
+template <>
+inline auto get_json_token(std::string_view& path_string) = delete;
+#endif
 
 } // namespace doris

--- a/be/src/vec/functions/function_json.cpp
+++ b/be/src/vec/functions/function_json.cpp
@@ -187,13 +187,17 @@ rapidjson::Value* match_value(const std::vector<JsonPath>& parsed_paths, rapidjs
 }
 
 template <JsonFunctionType fntype>
-rapidjson::Value* get_json_object(const std::string_view& json_string,
-                                  const std::string_view& path_string,
+rapidjson::Value* get_json_object(std::string_view json_string, std::string_view path_string,
                                   rapidjson::Document* document) {
     std::vector<JsonPath>* parsed_paths;
     std::vector<JsonPath> tmp_parsed_paths;
 
+#ifdef USE_LIBCPP
+    std::string s(path_string);
+    auto tok = get_json_token(s);
+#else
     auto tok = get_json_token(path_string);
+#endif
     std::vector<std::string> paths(tok.begin(), tok.end());
     get_parsed_paths(paths, &tmp_parsed_paths);
     parsed_paths = &tmp_parsed_paths;


### PR DESCRIPTION
# Proposed changes

Issue Number: close #13939

## Problem summary

```cpp
inline auto get_json_token(const std::string_view& path_string) {
#ifdef USE_LIBCPP
    return boost::tokenizer<boost::escaped_list_separator<char>>(
            std::string(path_string), boost::escaped_list_separator<char>("\\", ".", "\""));
#else
    return boost::tokenizer<boost::escaped_list_separator<char>>(
            path_string, boost::escaped_list_separator<char>("\\", ".", "\""));
#endif
}
```

**BE built with libc++**

In function `inline auto get_json_token(const std::string_view& path_string)`, we use a temporary `std::string` object to create `boost::tokenizer`. As a consequence, the result of `std::vector<std::string> paths(tok.begin(), tok.end())` ([be/src/exprs/json_functions.cpp#329](https://github.com/apache/doris/blob/master/be/src/exprs/json_functions.cpp#L329)) is wrong.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

