### PR TITLE
[fix](rpc) The proxy removed when rpc exception occurs is not an abnormal proxy(#13836)

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/rpc/BackendServiceProxy.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/rpc/BackendServiceProxy.java
@@ -64,7 +64,7 @@ public class BackendServiceProxy {
         }
 
         static BackendServiceProxy get() {
-            return proxies[count.addAndGet(1) % PROXY_NUM];
+            return proxies[Math.abs(count.addAndGet(1) % PROXY_NUM)];
         }
     }
 


### PR DESCRIPTION
 
# Proposed changes

Issue Number: close #xxx
    `BackendServiceProxy.getInstance()` uses the round robin strategy to obtain the proxy,
    so when the current RPC request is abnormal, the proxy removed by
    `BackendServiceProxy.getInstance().removeProxy(...)` is not an abnormal proxy.

cherry pick:https://github.com/apache/doris/pull/13836

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

