### PR TITLE
[fix](nereids) cannot collect decimal column stats

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ColumnDef.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ColumnDef.java
@@ -343,6 +343,9 @@ public class ColumnDef {
                 new FloatLiteral(defaultValue);
                 break;
             case DECIMALV2:
+                //no need to check precision and scale, since V2 is fixed point
+                new DecimalLiteral(defaultValue);
+                break;
             case DECIMAL32:
             case DECIMAL64:
             case DECIMAL128:

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/DecimalLiteral.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/DecimalLiteral.java
@@ -110,10 +110,10 @@ public class DecimalLiteral extends LiteralExpr {
 
     public void checkPrecisionAndScale(int precision, int scale) throws AnalysisException {
         Preconditions.checkNotNull(this.value);
+        int realPrecision = this.value.precision();
+        int realScale = this.value.scale();
         boolean valid = true;
         if (precision != -1 && scale != -1) {
-            int realPrecision = this.value.precision();
-            int realScale = this.value.scale();
             if (precision < realPrecision || scale < realScale) {
                 valid = false;
             }
@@ -122,7 +122,9 @@ public class DecimalLiteral extends LiteralExpr {
         }
 
         if (!valid) {
-            throw new AnalysisException("Invalid precision and scale: " + precision + ", " + scale);
+            throw new AnalysisException(
+                    String.format("Invalid precision and scale - expect (%d, %d), but (%d, %d)",
+                            precision, scale, realPrecision, realScale));
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/ColumnStat.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/ColumnStat.java
@@ -407,6 +407,8 @@ public class ColumnStat {
             case DOUBLE:
                 return new FloatLiteral(columnValue);
             case DECIMALV2:
+                //no need to check precision and scale, since V2 is fixed point
+                return new DecimalLiteral(columnValue);
             case DECIMAL32:
             case DECIMAL64:
             case DECIMAL128:

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticsTaskScheduler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticsTaskScheduler.java
@@ -166,7 +166,7 @@ public class StatisticsTaskScheduler extends MasterDaemon {
                         } catch (TimeoutException | ExecutionException | InterruptedException
                                 | CancellationException e) {
                             errorMsg = e.getMessage();
-                            LOG.info("Failed to get statistics. jobId: {}, taskId: {}, e: {}", jobId, taskId, e);
+                            LOG.error("Failed to get statistics. jobId: {}, taskId: {}, e: {}", jobId, taskId, e);
                         }
 
                         try {


### PR DESCRIPTION
# Proposed changes
When execute `analyze table`, doris fails on decimal columns.
The root cause is the scale in decimalV2 is 9, but 2 in schema.
There is no need to check scale for decimalV2, since it is not a float point type.

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

