### PR TITLE
[fix](tablet sink) fallback to non-vectorized interface in tablet_sink if is in progress of upgrding from 1.1-lts to 1.2-lts

### DIFF
--- a/be/src/exec/tablet_sink.cpp
+++ b/be/src/exec/tablet_sink.cpp
@@ -338,6 +338,49 @@ Status NodeChannel::add_row(Tuple* input_tuple, int64_t tablet_id) {
     return Status::OK();
 }
 
+// Used for vectorized engine.
+// TODO(cmy): deprecated, need refactor
+Status NodeChannel::add_row(const BlockRow& block_row, int64_t tablet_id) {
+    SCOPED_CONSUME_MEM_TRACKER(_node_channel_tracker.get());
+    // If add_row() when _eos_is_produced==true, there must be sth wrong, we can only mark this channel as failed.
+    auto st = none_of({_cancelled, _eos_is_produced});
+    if (!st.ok()) {
+        if (_cancelled) {
+            std::lock_guard<SpinLock> l(_cancel_msg_lock);
+            return Status::InternalError("add row failed. " + _cancel_msg);
+        } else {
+            return std::move(st.prepend("already stopped, can't add row. cancelled/eos: "));
+        }
+    }
+
+    constexpr size_t BATCH_SIZE_FOR_SEND = 2 * 1024 * 1024; //2M
+    auto row_no = _cur_batch->add_row();
+    if (row_no == RowBatch::INVALID_ROW_INDEX ||
+        _cur_batch->tuple_data_pool()->total_allocated_bytes() > BATCH_SIZE_FOR_SEND) {
+        {
+            SCOPED_ATOMIC_TIMER(&_queue_push_lock_ns);
+            std::lock_guard<std::mutex> l(_pending_batches_lock);
+            _pending_batches_bytes += _cur_batch->tuple_data_pool()->total_reserved_bytes();
+            //To simplify the add_row logic, postpone adding batch into req until the time of sending req
+            _pending_batches.emplace(std::move(_cur_batch), _cur_add_batch_request);
+            _pending_batches_num++;
+        }
+
+        _cur_batch.reset(new RowBatch(*_row_desc, _batch_size));
+        _cur_add_batch_request.clear_tablet_ids();
+
+        row_no = _cur_batch->add_row();
+    }
+    DCHECK_NE(row_no, RowBatch::INVALID_ROW_INDEX);
+
+    _cur_batch->get_row(row_no)->set_tuple(
+            0, block_row.first->deep_copy_tuple(*_tuple_desc, _cur_batch->tuple_data_pool(),
+                                                block_row.second, 0, true));
+    _cur_batch->commit_last_row();
+    _cur_add_batch_request.add_tablet_ids(tablet_id);
+    return Status::OK();
+}
+
 void NodeChannel::mark_close() {
     SCOPED_CONSUME_MEM_TRACKER(_node_channel_tracker.get());
     auto st = none_of({_cancelled, _eos_is_produced});
@@ -883,6 +926,7 @@ Status OlapTableSink::prepare(RuntimeState* state) {
     _load_mem_limit = state->get_load_mem_limit();
 
     // open all channels
+    bool use_vec = _is_vectorized && state->be_exec_version() > 0;
     const auto& partitions = _partition->get_partitions();
     for (int i = 0; i < _schema->indexes().size(); ++i) {
         // collect all tablets belong to this rollup
@@ -896,7 +940,7 @@ Status OlapTableSink::prepare(RuntimeState* state) {
                 tablets.emplace_back(std::move(tablet_with_partition));
             }
         }
-        _channels.emplace_back(new IndexChannel(this, index->index_id, _is_vectorized));
+        _channels.emplace_back(new IndexChannel(this, index->index_id, use_vec));
         RETURN_IF_ERROR(_channels.back()->init(state, tablets));
     }
 

--- a/be/src/exec/tablet_sink.h
+++ b/be/src/exec/tablet_sink.h
@@ -187,6 +187,8 @@ public:
 
     Status add_row(Tuple* tuple, int64_t tablet_id);
 
+    Status add_row(const BlockRow& block_row, int64_t tablet_id);
+
     virtual Status add_block(vectorized::Block* block,
                              const std::pair<std::unique_ptr<vectorized::IColumn::Selector>,
                                              std::vector<int64_t>>& payload) {
@@ -236,7 +238,7 @@ public:
 
     void clear_all_batches();
 
-    virtual void clear_all_blocks() { LOG(FATAL) << "NodeChannel::clear_all_blocks not supported"; }
+    virtual void clear_all_blocks() {}
 
     std::string channel_info() const {
         return fmt::format("{}, {}, node={}:{}", _name, _load_info, _node_info.host,

--- a/be/src/vec/sink/vtablet_sink.h
+++ b/be/src/vec/sink/vtablet_sink.h
@@ -110,6 +110,10 @@ private:
     // so here need to do the convert operation
     void _convert_to_dest_desc_block(vectorized::Block* block);
 
+    Status find_tablet(RuntimeState* state, vectorized::Block* block, int row_index,
+                       const VOlapTablePartition** partition, uint32_t& tablet_index,
+                       bool& stop_processing, bool& is_continue);
+
     VOlapTablePartitionParam* _vpartition = nullptr;
     std::vector<vectorized::VExprContext*> _output_vexpr_ctxs;
 };

--- a/be/test/vec/exec/vtablet_sink_test.cpp
+++ b/be/test/vec/exec/vtablet_sink_test.cpp
@@ -33,13 +33,13 @@
 #include "runtime/runtime_state.h"
 #include "runtime/stream_load/load_stream_mgr.h"
 #include "runtime/thread_resource_mgr.h"
+#include "runtime/tuple_row.h"
 #include "runtime/types.h"
 #include "service/brpc.h"
 #include "util/brpc_client_cache.h"
 #include "util/cpu_info.h"
 #include "util/debug/leakcheck_disabler.h"
 #include "util/proto_util.h"
-#include "runtime/tuple_row.h"
 
 namespace doris {
 

--- a/be/test/vec/exec/vtablet_sink_test.cpp
+++ b/be/test/vec/exec/vtablet_sink_test.cpp
@@ -39,53 +39,13 @@
 #include "util/cpu_info.h"
 #include "util/debug/leakcheck_disabler.h"
 #include "util/proto_util.h"
+#include "runtime/tuple_row.h"
 
 namespace doris {
 
 namespace stream_load {
 
 extern Status k_add_batch_status;
-
-class VOlapTableSinkTest : public testing::Test {
-public:
-    VOlapTableSinkTest() {}
-    virtual ~VOlapTableSinkTest() {}
-    void SetUp() override {
-        k_add_batch_status = Status::OK();
-        _env = ExecEnv::GetInstance();
-        _env->_thread_mgr = new ThreadResourceMgr();
-        _env->_master_info = new TMasterInfo();
-        _env->_load_stream_mgr = new LoadStreamMgr();
-        _env->_internal_client_cache = new BrpcClientCache<PBackendService_Stub>();
-        _env->_function_client_cache = new BrpcClientCache<PFunctionService_Stub>();
-        _env->_task_pool_mem_tracker_registry = new MemTrackerTaskPool();
-        ThreadPoolBuilder("SendBatchThreadPool")
-                .set_min_threads(1)
-                .set_max_threads(5)
-                .set_max_queue_size(100)
-                .build(&_env->_send_batch_thread_pool);
-        config::tablet_writer_open_rpc_timeout_sec = 60;
-        config::max_send_batch_parallelism_per_job = 1;
-    }
-
-    void TearDown() override {
-        SAFE_DELETE(_env->_internal_client_cache);
-        SAFE_DELETE(_env->_function_client_cache);
-        SAFE_DELETE(_env->_load_stream_mgr);
-        SAFE_DELETE(_env->_master_info);
-        SAFE_DELETE(_env->_thread_mgr);
-        SAFE_DELETE(_env->_task_pool_mem_tracker_registry);
-        if (_server) {
-            _server->Stop(100);
-            _server->Join();
-            SAFE_DELETE(_server);
-        }
-    }
-
-private:
-    ExecEnv* _env = nullptr;
-    brpc::Server* _server = nullptr;
-};
 
 TDataSink get_data_sink(TDescriptorTable* desc_tbl);
 TDataSink get_decimal_sink(TDescriptorTable* desc_tbl);
@@ -109,6 +69,31 @@ public:
         brpc::ClosureGuard done_guard(done);
         Status status;
         status.to_protobuf(response->mutable_status());
+    }
+
+    void tablet_writer_add_batch(google::protobuf::RpcController* controller,
+                                 const PTabletWriterAddBatchRequest* request,
+                                 PTabletWriterAddBatchResult* response,
+                                 google::protobuf::Closure* done) override {
+        brpc::ClosureGuard done_guard(done);
+        {
+            std::lock_guard<std::mutex> l(_lock);
+            _row_counters += request->tablet_ids_size();
+            if (request->eos()) {
+                _eof_counters++;
+            }
+            k_add_batch_status.to_protobuf(response->mutable_status());
+
+            if (request->has_row_batch() && _row_desc != nullptr) {
+                brpc::Controller* cntl = static_cast<brpc::Controller*>(controller);
+                attachment_transfer_request_row_batch<PTabletWriterAddBatchRequest>(request, cntl);
+                RowBatch batch(*_row_desc, request->row_batch());
+                for (int i = 0; i < batch.num_rows(); ++i) {
+                    LOG(INFO) << batch.get_row(i)->to_string(*_row_desc);
+                    _output_set->emplace(batch.get_row(i)->to_string(*_row_desc));
+                }
+            }
+        }
     }
 
     void tablet_writer_add_block(google::protobuf::RpcController* controller,
@@ -160,107 +145,157 @@ public:
     std::set<std::string>* _output_set = nullptr;
 };
 
+class VOlapTableSinkTest : public testing::Test {
+public:
+    VOlapTableSinkTest() {}
+    virtual ~VOlapTableSinkTest() {}
+    void SetUp() override {
+        k_add_batch_status = Status::OK();
+        _env = ExecEnv::GetInstance();
+        _env->_thread_mgr = new ThreadResourceMgr();
+        _env->_master_info = new TMasterInfo();
+        _env->_load_stream_mgr = new LoadStreamMgr();
+        _env->_internal_client_cache = new BrpcClientCache<PBackendService_Stub>();
+        _env->_function_client_cache = new BrpcClientCache<PFunctionService_Stub>();
+        _env->_task_pool_mem_tracker_registry = new MemTrackerTaskPool();
+        ThreadPoolBuilder("SendBatchThreadPool")
+                .set_min_threads(1)
+                .set_max_threads(5)
+                .set_max_queue_size(100)
+                .build(&_env->_send_batch_thread_pool);
+        config::tablet_writer_open_rpc_timeout_sec = 60;
+        config::max_send_batch_parallelism_per_job = 1;
+    }
+
+    void TearDown() override {
+        SAFE_DELETE(_env->_internal_client_cache);
+        SAFE_DELETE(_env->_function_client_cache);
+        SAFE_DELETE(_env->_load_stream_mgr);
+        SAFE_DELETE(_env->_master_info);
+        SAFE_DELETE(_env->_thread_mgr);
+        SAFE_DELETE(_env->_task_pool_mem_tracker_registry);
+        if (_server) {
+            _server->Stop(100);
+            _server->Join();
+            SAFE_DELETE(_server);
+        }
+    }
+
+    void test_normal(int be_exec_version) {
+        // start brpc service first
+        _server = new brpc::Server();
+        auto service = new VTestInternalService();
+        ASSERT_EQ(_server->AddService(service, brpc::SERVER_OWNS_SERVICE), 0);
+        brpc::ServerOptions options;
+        {
+            debug::ScopedLeakCheckDisabler disable_lsan;
+            _server->Start(4356, &options);
+        }
+
+        TUniqueId fragment_id;
+        TQueryOptions query_options;
+        query_options.batch_size = 1;
+        query_options.be_exec_version = be_exec_version;
+        RuntimeState state(fragment_id, query_options, TQueryGlobals(), _env);
+        state.init_mem_trackers(TUniqueId());
+
+        ObjectPool obj_pool;
+        TDescriptorTable tdesc_tbl;
+        auto t_data_sink = get_data_sink(&tdesc_tbl);
+
+        // crate desc_tabl
+        DescriptorTbl* desc_tbl = nullptr;
+        auto st = DescriptorTbl::create(&obj_pool, tdesc_tbl, &desc_tbl);
+        ASSERT_TRUE(st.ok());
+        state._desc_tbl = desc_tbl;
+
+        TupleDescriptor* tuple_desc = desc_tbl->get_tuple_descriptor(0);
+        LOG(INFO) << "tuple_desc=" << tuple_desc->debug_string();
+
+        RowDescriptor row_desc(*desc_tbl, {0}, {false});
+        service->_row_desc = &row_desc;
+        std::set<std::string> output_set;
+        service->_output_set = &output_set;
+
+        VOlapTableSink sink(&obj_pool, row_desc, {}, &st);
+        ASSERT_TRUE(st.ok());
+
+        // init
+        st = sink.init(t_data_sink);
+        ASSERT_TRUE(st.ok());
+        // prepare
+        st = sink.prepare(&state);
+        ASSERT_TRUE(st.ok());
+        // open
+        st = sink.open(&state);
+        ASSERT_TRUE(st.ok());
+
+        int slot_count = tuple_desc->slots().size();
+        std::vector<vectorized::MutableColumnPtr> columns(slot_count);
+        for (int i = 0; i < slot_count; i++) {
+            columns[i] = tuple_desc->slots()[i]->get_empty_mutable_column();
+        }
+
+        int col_idx = 0;
+        auto* column_ptr = columns[col_idx++].get();
+        auto column_vector_int = column_ptr;
+        int int_val = 12;
+        column_vector_int->insert_data((const char*)&int_val, 0);
+        int_val = 13;
+        column_vector_int->insert_data((const char*)&int_val, 0);
+        int_val = 14;
+        column_vector_int->insert_data((const char*)&int_val, 0);
+
+        column_ptr = columns[col_idx++].get();
+        auto column_vector_bigint = column_ptr;
+        int64_t int64_val = 9;
+        column_vector_bigint->insert_data((const char*)&int64_val, 0);
+        int64_val = 25;
+        column_vector_bigint->insert_data((const char*)&int64_val, 0);
+        int64_val = 50;
+        column_vector_bigint->insert_data((const char*)&int64_val, 0);
+
+        column_ptr = columns[col_idx++].get();
+        auto column_vector_str = column_ptr;
+        column_vector_str->insert_data("abc", 3);
+        column_vector_str->insert_data("abcd", 4);
+        column_vector_str->insert_data("abcde1234567890", 15);
+
+        vectorized::Block block;
+        col_idx = 0;
+        for (const auto slot_desc : tuple_desc->slots()) {
+            block.insert(vectorized::ColumnWithTypeAndName(std::move(columns[col_idx++]),
+                                                           slot_desc->get_data_type_ptr(),
+                                                           slot_desc->col_name()));
+        }
+
+        // send
+        st = sink.send(&state, &block);
+        ASSERT_TRUE(st.ok());
+        // close
+        st = sink.close(&state, Status::OK());
+        ASSERT_TRUE(st.ok() || st.to_string() == "Internal error: wait close failed. ")
+                << st.to_string();
+
+        // each node has a eof
+        ASSERT_EQ(2, service->_eof_counters);
+        ASSERT_EQ(2 * 2, service->_row_counters);
+
+        // 2node * 2
+        ASSERT_EQ(1, state.num_rows_load_filtered());
+    }
+
+private:
+    ExecEnv* _env = nullptr;
+    brpc::Server* _server = nullptr;
+};
+
 TEST_F(VOlapTableSinkTest, normal) {
-    // start brpc service first
-    _server = new brpc::Server();
-    auto service = new VTestInternalService();
-    ASSERT_EQ(_server->AddService(service, brpc::SERVER_OWNS_SERVICE), 0);
-    brpc::ServerOptions options;
-    {
-        debug::ScopedLeakCheckDisabler disable_lsan;
-        _server->Start(4356, &options);
-    }
+    test_normal(1);
+}
 
-    TUniqueId fragment_id;
-    TQueryOptions query_options;
-    query_options.batch_size = 1;
-    RuntimeState state(fragment_id, query_options, TQueryGlobals(), _env);
-    state.init_mem_trackers(TUniqueId());
-
-    ObjectPool obj_pool;
-    TDescriptorTable tdesc_tbl;
-    auto t_data_sink = get_data_sink(&tdesc_tbl);
-
-    // crate desc_tabl
-    DescriptorTbl* desc_tbl = nullptr;
-    auto st = DescriptorTbl::create(&obj_pool, tdesc_tbl, &desc_tbl);
-    ASSERT_TRUE(st.ok());
-    state._desc_tbl = desc_tbl;
-
-    TupleDescriptor* tuple_desc = desc_tbl->get_tuple_descriptor(0);
-    LOG(INFO) << "tuple_desc=" << tuple_desc->debug_string();
-
-    RowDescriptor row_desc(*desc_tbl, {0}, {false});
-    service->_row_desc = &row_desc;
-    std::set<std::string> output_set;
-    service->_output_set = &output_set;
-
-    VOlapTableSink sink(&obj_pool, row_desc, {}, &st);
-    ASSERT_TRUE(st.ok());
-
-    // init
-    st = sink.init(t_data_sink);
-    ASSERT_TRUE(st.ok());
-    // prepare
-    st = sink.prepare(&state);
-    ASSERT_TRUE(st.ok());
-    // open
-    st = sink.open(&state);
-    ASSERT_TRUE(st.ok());
-
-    int slot_count = tuple_desc->slots().size();
-    std::vector<vectorized::MutableColumnPtr> columns(slot_count);
-    for (int i = 0; i < slot_count; i++) {
-        columns[i] = tuple_desc->slots()[i]->get_empty_mutable_column();
-    }
-
-    int col_idx = 0;
-    auto* column_ptr = columns[col_idx++].get();
-    auto column_vector_int = column_ptr;
-    int int_val = 12;
-    column_vector_int->insert_data((const char*)&int_val, 0);
-    int_val = 13;
-    column_vector_int->insert_data((const char*)&int_val, 0);
-    int_val = 14;
-    column_vector_int->insert_data((const char*)&int_val, 0);
-
-    column_ptr = columns[col_idx++].get();
-    auto column_vector_bigint = column_ptr;
-    int64_t int64_val = 9;
-    column_vector_bigint->insert_data((const char*)&int64_val, 0);
-    int64_val = 25;
-    column_vector_bigint->insert_data((const char*)&int64_val, 0);
-    int64_val = 50;
-    column_vector_bigint->insert_data((const char*)&int64_val, 0);
-
-    column_ptr = columns[col_idx++].get();
-    auto column_vector_str = column_ptr;
-    column_vector_str->insert_data("abc", 3);
-    column_vector_str->insert_data("abcd", 4);
-    column_vector_str->insert_data("abcde1234567890", 15);
-
-    vectorized::Block block;
-    col_idx = 0;
-    for (const auto slot_desc : tuple_desc->slots()) {
-        block.insert(vectorized::ColumnWithTypeAndName(std::move(columns[col_idx++]),
-                                                       slot_desc->get_data_type_ptr(),
-                                                       slot_desc->col_name()));
-    }
-
-    // send
-    st = sink.send(&state, &block);
-    ASSERT_TRUE(st.ok());
-    // close
-    st = sink.close(&state, Status::OK());
-    ASSERT_TRUE(st.ok() || st.to_string() == "Internal error: wait close failed. ")
-            << st.to_string();
-
-    // each node has a eof
-    ASSERT_EQ(2, service->_eof_counters);
-    ASSERT_EQ(2 * 2, service->_row_counters);
-
-    // 2node * 2
-    ASSERT_EQ(1, state.num_rows_load_filtered());
+TEST_F(VOlapTableSinkTest, fallback) {
+    test_normal(0);
 }
 
 TEST_F(VOlapTableSinkTest, convert) {
@@ -277,6 +312,7 @@ TEST_F(VOlapTableSinkTest, convert) {
     TUniqueId fragment_id;
     TQueryOptions query_options;
     query_options.batch_size = 1024;
+    query_options.be_exec_version = 1;
     RuntimeState state(fragment_id, query_options, TQueryGlobals(), _env);
     state.init_mem_trackers(TUniqueId());
 
@@ -406,6 +442,7 @@ TEST_F(VOlapTableSinkTest, add_block_failed) {
     TUniqueId fragment_id;
     TQueryOptions query_options;
     query_options.batch_size = 1;
+    query_options.be_exec_version = 1;
     RuntimeState state(fragment_id, query_options, TQueryGlobals(), _env);
     state.init_mem_trackers(TUniqueId());
 
@@ -519,6 +556,7 @@ TEST_F(VOlapTableSinkTest, decimal) {
     TUniqueId fragment_id;
     TQueryOptions query_options;
     query_options.batch_size = 1;
+    query_options.be_exec_version = 1;
     RuntimeState state(fragment_id, query_options, TQueryGlobals(), _env);
     state.init_mem_trackers(TUniqueId());
 


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

In a test env of 1FE and 3BE, the original version is 1.3-rc02-c61d8bbb2. After upgrading be1 and be2 to master-6f3db8b4b, regression test case regression-test/suites/ddl_p0/test_ctas.groovy cause BE coredump, `_vec_row_comparator` in memtable is null:
```
(gdb) t 33
[Switching to thread 33 (Thread 0x7fc8c07fe700 (LWP 3209504))]
#0  0x0000556e2f213ca7 in doris::MemTable::RowInBlockComparator::set_block (this=0x0, pblock=0x617000485fe8) at /mnt/hdd01/tjp/doris/be/src/olap/memtable.h:109
109	/mnt/hdd01/tjp/doris/be/src/olap/memtable.h: No such file or directory.
(gdb) bt
#0  0x0000556e2f213ca7 in doris::MemTable::RowInBlockComparator::set_block (this=0x0, pblock=0x617000485fe8) at /mnt/hdd01/tjp/doris/be/src/olap/memtable.h:109
#1  0x0000556e2f202d89 in doris::MemTable::insert (this=0x617000485e00, input_block=0x7fc8c07f62f0, row_idxs=std::vector of length 1, capacity 1 = {...})
    at /mnt/hdd01/tjp/doris/be/src/olap/memtable.cpp:185
#2  0x0000556e2f5e6846 in doris::DeltaWriter::write (this=0x617000b30580, block=0x7fc8c07f62f0, row_idxs=std::vector of length 1, capacity 1 = {...})
    at /mnt/hdd01/tjp/doris/be/src/olap/delta_writer.cpp:219
#3  0x0000556e30a04049 in doris::TabletsChannel::add_batch<doris::PTabletWriterAddBlockRequest, doris::PTabletWriterAddBlockResult> (this=0x615000c0bf00, request=...,
    response=0x6110002efd00) at /mnt/hdd01/tjp/doris/be/src/runtime/tablets_channel.cpp:463
#4  0x0000556e30ced01c in doris::LoadChannel::add_batch<doris::PTabletWriterAddBlockRequest, doris::PTabletWriterAddBlockResult> (this=0x611000c85400, request=...,
    response=0x6110002efd00) at /mnt/hdd01/tjp/doris/be/src/runtime/load_channel.h:151
#5  0x0000556e30ce458d in doris::LoadChannelMgr::add_batch<doris::PTabletWriterAddBlockRequest, doris::PTabletWriterAddBlockResult> (this=0x612000164140, request=...,
    response=0x6110002efd00) at /mnt/hdd01/tjp/doris/be/src/runtime/load_channel_mgr.h:143
#6  0x0000556e30cbe123 in operator() (__closure=0x6040008fad50) at /mnt/hdd01/tjp/doris/be/src/service/internal_service.cpp:262
#7  0x0000556e30cd092c in std::__invoke_impl<void, doris::PInternalServiceImpl::_tablet_writer_add_block(google::protobuf::RpcController*, const doris::PTabletWriterAddBlockRequest*, doris::PTabletWriterAddBlockResult*, google::protobuf::Closure*)::<lambda()>&>(std::__invoke_other, struct {...} &) (__f=...) at /usr/local/ldb_toolchain/include/c++/11/bits/invoke.h:61
#8  0x0000556e30ccfc80 in std::__invoke_r<void, doris::PInternalServiceImpl::_tablet_writer_add_block(google::protobuf::RpcController*, const doris::PTabletWriterAddBlockRequest*, doris::PTabletWriterAddBlockResult*, google::protobuf::Closure*)::<lambda()>&>(struct {...} &) (__fn=...) at /usr/local/ldb_toolchain/include/c++/11/bits/invoke.h:111
#9  0x0000556e30ccf3fc in std::_Function_handler<void(), doris::PInternalServiceImpl::_tablet_writer_add_block(google::protobuf::RpcController*, const doris::PTabletWriterAddBlockRequest*, doris::PTabletWriterAddBlockResult*, google::protobuf::Closure*)::<lambda()> >::_M_invoke(const std::_Any_data &) (__functor=...)
    at /usr/local/ldb_toolchain/include/c++/11/bits/std_function.h:291
#10 0x0000556e30521ef4 in std::function<void ()>::operator()() const (this=0x7fc8c07f6cf8) at /usr/local/ldb_toolchain/include/c++/11/bits/std_function.h:560
#11 0x0000556e3051da37 in doris::PriorityThreadPool::work_thread (this=0x618000026490, thread_id=15) at /mnt/hdd01/tjp/doris/be/src/util/priority_thread_pool.hpp:138
#12 0x0000556e3053b642 in std::__invoke_impl<void, void (doris::PriorityThreadPool::* const&)(int), doris::PriorityThreadPool*&, int&> (__f=
    @0x6040006639d8: (void (doris::PriorityThreadPool::*)(doris::PriorityThreadPool * const, int)) 0x556e3051d882 <doris::PriorityThreadPool::work_thread(int)>,
    __t=@0x6040006639f0: 0x618000026490) at /usr/local/ldb_toolchain/include/c++/11/bits/invoke.h:74
#13 0x0000556e3053b2c2 in std::__invoke<void (doris::PriorityThreadPool::* const&)(int), doris::PriorityThreadPool*&, int&> (__fn=
    @0x6040006639d8: (void (doris::PriorityThreadPool::*)(doris::PriorityThreadPool * const, int)) 0x556e3051d882 <doris::PriorityThreadPool::work_thread(int)>)
    at /usr/local/ldb_toolchain/include/c++/11/bits/invoke.h:96
#14 0x0000556e3053b1f7 in std::_Mem_fn_base<void (doris::PriorityThreadPool::*)(int), true>::operator()<doris::PriorityThreadPool*&, int&> (this=0x6040006639d8)
    at /usr/local/ldb_toolchain/include/c++/11/functional:131
#15 0x0000556e3053b105 in std::__invoke_impl<void, std::_Mem_fn<void (doris::PriorityThreadPool::*)(int)>&, doris::PriorityThreadPool*&, int&> (__f=...)
    at /usr/local/ldb_toolchain/include/c++/11/bits/invoke.h:61
#16 0x0000556e3053afcd in std::__invoke_r<void, std::_Mem_fn<void (doris::PriorityThreadPool::*)(int)>&, doris::PriorityThreadPool*&, int&> (__fn=...)
    at /usr/local/ldb_toolchain/include/c++/11/bits/invoke.h:111
#17 0x0000556e3053adc7 in std::_Bind_result<void, std::_Mem_fn<void (doris::PriorityThreadPool::*)(int)> (doris::PriorityThreadPool*, int)>::__call<void, , 0ul, 1ul>(std::tuple<>&&, std::_Index_tuple<0ul, 1ul>) (this=0x6040006639d8, __args=...) at /usr/local/ldb_toolchain/include/c++/11/functional:570
#18 0x0000556e3053aa95 in std::_Bind_result<void, std::_Mem_fn<void (doris::PriorityThreadPool::*)(int)> (doris::PriorityThreadPool*, int)>::operator()<>() (this=0x6040006639d8)
    at /usr/local/ldb_toolchain/include/c++/11/functional:629
#19 0x0000556e3053a8be in std::__invoke_impl<void, std::_Bind_result<void, std::_Mem_fn<void (doris::PriorityThreadPool::*)(int)> (doris::PriorityThreadPool*, int)>>(std::__invoke_other, std::_Bind_result<void, std::_Mem_fn<void (doris::PriorityThreadPool::*)(int)> (doris::PriorityThreadPool*, int)>&&) (__f=...)
    at /usr/local/ldb_toolchain/include/c++/11/bits/invoke.h:61
#20 0x0000556e3053a80c in std::__invoke<std::_Bind_result<void, std::_Mem_fn<void (doris::PriorityThreadPool::*)(int)> (doris::PriorityThreadPool*, int)>>(std::_Bind_result<void, std::_Mem_fn<void (doris::PriorityThreadPool::*)(int)> (doris::PriorityThreadPool*, int)>&&) (__fn=...) at /usr/local/ldb_toolchain/include/c++/11/bits/invoke.h:96
#21 0x0000556e3053a766 in std::thread::_Invoker<std::tuple<std::_Bind_result<void, std::_Mem_fn<void (doris::PriorityThreadPool::*)(int)> (doris::PriorityThreadPool*, int)> > >::_M_invoke<0ul>(std::_Index_tuple<0ul>) (this=0x6040006639d8) at /usr/local/ldb_toolchain/include/c++/11/bits/std_thread.h:253
#22 0x0000556e3053a6b2 in std::thread::_Invoker<std::tuple<std::_Bind_result<void, std::_Mem_fn<void (doris::PriorityThreadPool::*)(int)> (doris::PriorityThreadPool*, int)> > >::operator()() (this=0x6040006639d8) at /usr/local/ldb_toolchain/include/c++/11/bits/std_thread.h:260
#23 0x0000556e3053a5fa in std::thread::_State_impl<std::thread::_Invoker<std::tuple<std::_Bind_result<void, std::_Mem_fn<void (doris::PriorityThreadPool::*)(int)> (doris::PriorityThreadPool*, int)> > > >::_M_run() (this=0x6040006639d0) at /usr/local/ldb_toolchain/include/c++/11/bits/std_thread.h:211
#24 0x0000556e3d046270 in execute_native_thread_routine ()
#25 0x00007fca847ac609 in start_thread (arg=<optimized out>) at pthread_create.c:477
#26 0x00007fca848e6133 in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:95
(gdb) f 1
#1  0x0000556e2f202d89 in doris::MemTable::insert (this=0x617000485e00, input_block=0x7fc8c07f62f0, row_idxs=std::vector of length 1, capacity 1 = {...})
    at /mnt/hdd01/tjp/doris/be/src/olap/memtable.cpp:185
185	/mnt/hdd01/tjp/doris/be/src/olap/memtable.cpp: No such file or directory.
(gdb) p _vec_row_comparator
$1 = std::shared_ptr<doris::MemTable::RowInBlockComparator> (empty) = {get() = 0x0}
(gdb)
```

The root cause is, for this sql statement:
```
CREATE TABLE IF NOT EXISTS `test_ctas1`
    PROPERTIES (
      "replication_allocation" = "tag.location.default: 3",
      "in_memory" = "false",
      "storage_format" = "V2"
    ) as select * from test_ctas;
```
for be1, if the `PTabletWriterOpenRequest ` from be3 reaches be1 first，since be3 will not set the `is_vectorized` flag in the `PTabletWriterOpenRequest`, a non-vectorized memtable will be created in be1. But be1 and be2 are both executing vectorized plan, be2 will call the vectorized interface tablet_writer_add_block to send Block data to be1, with will resulting in be1 coredump.

The fix is to check the `be_exec_version` query option, which is zero for FE of version 1.1-lts and is non-zero for FE of 1.2-lts, if it's zero, then BE fallback to 1.1-lts behaviour.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

