### PR TITLE
[fix](thread) catch exception of std::thread

### DIFF
--- a/be/src/exec/hash_join_node.cpp
+++ b/be/src/exec/hash_join_node.cpp
@@ -239,7 +239,7 @@ Status HashJoinNode::open(RuntimeState* state) {
     try {
         std::thread(bind(&HashJoinNode::build_side_thread, this, state, &thread_status)).detach();
     } catch (const std::system_error& e) {
-        LOG(WARN) << "create thread fail, " << e.what();
+        LOG(WARNING) << "create thread fail, " << e.what();
         return Status::InternalError(e.what());
     }
 


### PR DESCRIPTION
Some users encounter core dump due to excpetion of std::thread in HashJoinNode::open().

# Proposed changes

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

