### PR TITLE
[fix](memtracker) Fix DCHECK `!std::count(_consumer_tracker_stack.begin(), _consumer_tracker_stack.end(), tracker) ThreadMemTrackerMgr`

### DIFF
--- a/be/src/runtime/thread_context.cpp
+++ b/be/src/runtime/thread_context.cpp
@@ -76,20 +76,21 @@ SwitchThreadMemTrackerLimiter::~SwitchThreadMemTrackerLimiter() {
 }
 
 AddThreadMemTrackerConsumer::AddThreadMemTrackerConsumer(MemTracker* mem_tracker) {
-    thread_context()->_thread_mem_tracker_mgr->push_consumer_tracker(mem_tracker);
+    _need_pop = thread_context()->_thread_mem_tracker_mgr->push_consumer_tracker(mem_tracker);
 }
 
 AddThreadMemTrackerConsumer::AddThreadMemTrackerConsumer(
         const std::shared_ptr<MemTracker>& mem_tracker)
         : _mem_tracker(mem_tracker) {
-    thread_context()->_thread_mem_tracker_mgr->push_consumer_tracker(_mem_tracker.get());
+    _need_pop =
+            thread_context()->_thread_mem_tracker_mgr->push_consumer_tracker(_mem_tracker.get());
 }
 
 AddThreadMemTrackerConsumer::~AddThreadMemTrackerConsumer() {
 #ifndef NDEBUG
     DorisMetrics::instance()->add_thread_mem_tracker_consumer_count->increment(1);
 #endif // NDEBUG
-    thread_context()->_thread_mem_tracker_mgr->pop_consumer_tracker();
+    if (_need_pop) thread_context()->_thread_mem_tracker_mgr->pop_consumer_tracker();
 }
 
 } // namespace doris

--- a/be/src/runtime/thread_context.h
+++ b/be/src/runtime/thread_context.h
@@ -311,6 +311,7 @@ public:
 
 private:
     std::shared_ptr<MemTracker> _mem_tracker = nullptr; // Avoid mem_tracker being released midway.
+    bool _need_pop = false;
 };
 
 class StopCheckThreadMemTrackerLimit {


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

```
F1106 06:33:30.999125 3353948 thread_mem_tracker_mgr.h:196] Check failed: !std::count(_consumer_tracker_stack.begin(), _consumer_tracker_stack.end(), tracker) ThreadMemTrackerMgr debug, _untracked_mem:0, _task_id:ab3ada5623524c30-a0008c9a632cdafe, _limiter_tracker:<MemTrackerLimiter Label=RuntimeState:instance:ab3ada5623524c30-a0008c9a632cdaff, Limit=-1.00 B(-1 B), Used=801.85 MB(840796700 B), Peak=802.48 MB(841465132 B), Exceeded=false
*** SIGABRT unkown detail explain (@0x332ca2) received by PID 3353762 (TID 0x7f2b2f0f3700) from PID 3353762; stack trace: ***
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /home/zcp/repo_center/doris_master/be/src/common/signal_handler.h:420
 1# 0x00007F2C26F2F0C0 in /lib/x86_64-linux-gnu/libc.so.6
 2# raise in /lib/x86_64-linux-gnu/libc.so.6
 3# abort in /lib/x86_64-linux-gnu/libc.so.6
 4# 0x00005646CD25E069 in /mnt/ssd01/doris-master/VEC_ASAN/be/lib/doris_be
 5# 0x00005646CD25367D in /mnt/ssd01/doris-master/VEC_ASAN/be/lib/doris_be
 6# google::LogMessage::SendToLog() in /mnt/ssd01/doris-master/VEC_ASAN/be/lib/doris_be
 7# google::LogMessage::Flush() in /mnt/ssd01/doris-master/VEC_ASAN/be/lib/doris_be
 8# google::LogMessageFatal::~LogMessageFatal() in /mnt/ssd01/doris-master/VEC_ASAN/be/lib/doris_be
 9# doris::ThreadMemTrackerMgr::push_consumer_tracker(doris::MemTracker*) at /home/zcp/repo_center/doris_master/be/src/runtime/memory/thread_mem_tracker_mgr.h:196
10# doris::AddThreadMemTrackerConsumer::AddThreadMemTrackerConsumer(doris::MemTracker*) at /home/zcp/repo_center/doris_master/be/src/runtime/thread_context.cpp:80
11# doris::stream_load::NodeChannel::cancel(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) at /home/zcp/repo_center/doris_master/be/src/exec/tablet_sink.cpp:465
12# doris::stream_load::VNodeChannel::try_send_block(doris::RuntimeState*) at /home/zcp/repo_center/doris_master/be/src/vec/sink/vtablet_sink.cpp:291
13# void std::__invoke_impl<void, void (doris::stream_load::VNodeChannel::*&)(doris::RuntimeState*), doris::stream_load::VNodeChannel*&, doris::RuntimeState*&>(std::__invoke_memfun_deref, void (doris::stream_load::VNodeChannel::*&)(doris::RuntimeState*), doris::stream_load::VNodeChannel*&, doris::RuntimeState*&) at /var/local/ldb_toolchain/include/c++/11/bits/invoke.h:74
14# std::__invoke_result<void (doris::stream_load::VNodeChannel::*&)(doris::RuntimeState*), doris::stream_load::VNodeChannel*&, doris::RuntimeState*&>::type std::__invoke<void (doris::stream_load::VNodeChannel::*&)(doris::RuntimeState*), doris::stream_load::VNodeChannel*&, doris::RuntimeState*&>(void (doris::stream_load::VNodeChannel::*&)(doris::RuntimeState*), doris::stream_load::VNodeChannel*&, doris::RuntimeState*&) at /var/local/ldb_toolchain/include/c++/11/bits/invoke.h:97
15# void std::_Bind<void (doris::stream_load::VNodeChannel::*(doris::stream_load::VNodeChannel*, doris::RuntimeState*))(doris::RuntimeState*)>::__call<void, , 0ul, 1ul>(std::tuple<>&&, std::_Index_tuple<0ul, 1ul>) at /var/local/ldb_toolchain/include/c++/11/functional:422
16# void std::_Bind<void (doris::stream_load::VNodeChannel::*(doris::stream_load::VNodeChannel*, doris::RuntimeState*))(doris::RuntimeState*)>::operator()<, void>() at /var/local/ldb_toolchain/include/c++/11/functional:505
17# void std::__invoke_impl<void, std::_Bind<void (doris::stream_load::VNodeChannel::*(doris::stream_load::VNodeChannel*, doris::RuntimeState*))(doris::RuntimeState*)>&>(std::__invoke_other, std::_Bind<void (doris::stream_load::VNodeChannel::*(doris::stream_load::VNodeChannel*, doris::RuntimeState*))(doris::RuntimeState*)>&) at /var/local/ldb_toolchain/include/c++/11/bits/invoke.h:61
18# std::enable_if<is_invocable_r_v<void, std::_Bind<void (doris::stream_load::VNodeChannel::*(doris::stream_load::VNodeChannel*, doris::RuntimeState*))(doris::RuntimeState*)>&>, void>::type std::__invoke_r<void, std::_Bind<void (doris::stream_load::VNodeChannel::*(doris::stream_load::VNodeChannel*, doris::RuntimeState*))(doris::RuntimeState*)>&>(std::_Bind<void (doris::stream_load::VNodeChannel::*(doris::stream_load::VNodeChannel*, doris::RuntimeState*))(doris::RuntimeState*)>&) at /var/local/ldb_toolchain/include/c++/11/bits/invoke.h:117
19# std::_Function_handler<void (), std::_Bind<void (doris::stream_load::VNodeChannel::*(doris::stream_load::VNodeChannel*, doris::RuntimeState*))(doris::RuntimeState*)> >::_M_invoke(std::_Any_data const&) at /var/local/ldb_toolchain/include/c++/11/bits/std_function.h:292
20# std::function<void ()>::operator()() const at /var/local/ldb_toolchain/include/c++/11/bits/std_function.h:560
21# doris::FunctionRunnable::run() at /home/zcp/repo_center/doris_master/be/src/util/threadpool.cpp:45
22# doris::ThreadPool::dispatch_thread() at /home/zcp/repo_center/doris_master/be/src/util/threadpool.cpp:549
23# void std::__invoke_impl<void, void (doris::ThreadPool::*&)(), doris::ThreadPool*&>(std::__invoke_memfun_deref, void (doris::ThreadPool::*&)(), doris::ThreadPool*&) at /var/local/ldb_toolchain/include/c++/11/bits/invoke.h:74
24# std::__invoke_result<void (doris::ThreadPool::*&)(), doris::ThreadPool*&>::type std::__invoke<void (doris::ThreadPool::*&)(), doris::ThreadPool*&>(void (doris::ThreadPool::*&)(), doris::ThreadPool*&) at /var/local/ldb_toolchain/include/c++/11/bits/invoke.h:97
25# void std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>::__call<void, , 0ul>(std::tuple<>&&, std::_Index_tuple<0ul>) at /var/local/ldb_toolchain/include/c++/11/functional:422
26# void std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>::operator()<, void>() at /var/local/ldb_toolchain/include/c++/11/functional:505
27# void std::__invoke_impl<void, std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>&>(std::__invoke_other, std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>&) at /var/local/ldb_toolchain/include/c++/11/bits/invoke.h:61
28# std::enable_if<is_invocable_r_v<void, std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>&>, void>::type std::__invoke_r<void, std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>&>(std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>&) at /var/local/ldb_toolchain/include/c++/11/bits/invoke.h:117
29# std::_Function_handler<void (), std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()> >::_M_invoke(std::_Any_data const&) at /var/local/ldb_toolchain/include/c++/11/bits/std_function.h:292
30# std::function<void ()>::operator()() const at /var/local/ldb_toolchain/include/c++/11/bits/std_function.h:560
31# doris::Thread::supervise_thread(void*) at /home/zcp/repo_center/doris_master/be/src/util/thread.cpp:455
32# start_thread at /build/glibc-sMfBJT/glibc-2.31/nptl/pthread_create.c:478
33# __clone in /lib/x86_64-linux-gnu/libc.so.6
```

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

