### PR TITLE
[feature](multi-catalog) Support data on s3-compatible oss and support aliyun DLF

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -58,6 +58,7 @@ github:
           - Build Broker
           - Build Documents
           - BE UT (Clang)
+          - ShellCheck
 
       required_pull_request_reviews:
         dismiss_stale_reviews: true

--- a/build.sh
+++ b/build.sh
@@ -50,9 +50,10 @@ Usage: $0 <options>
      -j                 build Backend parallel
 
   Environment variables:
-    USE_AVX2            If the CPU does not support AVX2 instruction set, please set USE_AVX2=0. Default is ON.
-    STRIP_DEBUG_INFO    If set STRIP_DEBUG_INFO=ON, the debug information in the compiled binaries will be stored separately in the 'be/lib/debug_info' directory. Default is OFF.
-    DISABLE_JAVA_UDF    If set DISABLE_JAVA_UDF=ON, we will do not build binary with java-udf. Default is OFF.
+    USE_AVX2                    If the CPU does not support AVX2 instruction set, please set USE_AVX2=0. Default is ON.
+    STRIP_DEBUG_INFO            If set STRIP_DEBUG_INFO=ON, the debug information in the compiled binaries will be stored separately in the 'be/lib/debug_info' directory. Default is OFF.
+    DISABLE_JAVA_UDF            If set DISABLE_JAVA_UDF=ON, we will do not build binary with java-udf. Default is OFF.
+    DISABLE_JAVA_CHECK_STYLE    If set DISABLE_JAVA_CHECK_STYLE=ON, it will skip style check of java code in FE.
   Eg.
     $0                                      build all
     $0 --be                                 build Backend
@@ -463,7 +464,11 @@ if [[ "${FE_MODULES}" != '' ]]; then
     if [[ "${CLEAN}" -eq 1 ]]; then
         clean_fe
     fi
-    "${MVN_CMD}" package -pl ${FE_MODULES:+${FE_MODULES}} -DskipTests
+    skip_check_stype=""
+    if [[ "${DISABLE_JAVA_CHECK_STYLE}" = "ON" ]]; then
+        skip_check_stype="-Dcheckstyle.skip=true"
+    fi
+    "${MVN_CMD}" package -pl ${FE_MODULES:+${FE_MODULES}} -DskipTests ${skip_check_stype}
     cd "${DORIS_HOME}"
 fi
 

--- a/build.sh
+++ b/build.sh
@@ -290,6 +290,10 @@ if [[ -z "${DISABLE_JAVA_UDF}" ]]; then
     DISABLE_JAVA_UDF='OFF'
 fi
 
+if [[ -z "${DISABLE_JAVA_CHECK_STYLE}" ]]; then
+    DISABLE_JAVA_CHECK_STYLE='OFF'
+fi
+
 if [[ -z "${RECORD_COMPILER_SWITCHES}" ]]; then
     RECORD_COMPILER_SWITCHES='OFF'
 fi
@@ -468,7 +472,7 @@ if [[ "${FE_MODULES}" != '' ]]; then
     if [[ "${DISABLE_JAVA_CHECK_STYLE}" = "ON" ]]; then
         skip_check_stype="-Dcheckstyle.skip=true"
     fi
-    "${MVN_CMD}" package -pl ${FE_MODULES:+${FE_MODULES}} -DskipTests ${skip_check_stype}
+    "${MVN_CMD}" package -pl ${FE_MODULES:+${FE_MODULES}} -DskipTests "${skip_check_stype}"
     cd "${DORIS_HOME}"
 fi
 

--- a/build.sh
+++ b/build.sh
@@ -468,11 +468,11 @@ if [[ "${FE_MODULES}" != '' ]]; then
     if [[ "${CLEAN}" -eq 1 ]]; then
         clean_fe
     fi
-    skip_check_stype=""
     if [[ "${DISABLE_JAVA_CHECK_STYLE}" = "ON" ]]; then
-        skip_check_stype="-Dcheckstyle.skip=true"
+        "${MVN_CMD}" package -pl ${FE_MODULES:+${FE_MODULES}} -DskipTests -Dcheckstyle.skip=true
+    else
+        "${MVN_CMD}" package -pl ${FE_MODULES:+${FE_MODULES}} -DskipTests
     fi
-    "${MVN_CMD}" package -pl ${FE_MODULES:+${FE_MODULES}} -DskipTests "${skip_check_stype}"
     cd "${DORIS_HOME}"
 fi
 

--- a/docs/en/docs/ecosystem/external-table/multi-catalog.md
+++ b/docs/en/docs/ecosystem/external-table/multi-catalog.md
@@ -24,6 +24,8 @@ specific language governing permissions and limitations
 under the License.
 -->
 
+<version since="1.2.0">
+
 # Multi-Catalog
 
 Multi-Catalog is a feature introduced in Doris 1.2.0, which aims to make it easier to interface with external data sources to enhance Doris' data lake analysis and federated data query capabilities.
@@ -292,7 +294,7 @@ mysql> select * from test;
 +------------+-------------+--------+-------+
 ```
 
-## Parameters that：
+#### Parameters:
 
 Parameter | Description
 ---|---
@@ -304,6 +306,68 @@ Parameter | Description
 **elasticsearch.nodes_discovery** | Whether or not to enable ES node discovery, the default is true. In network isolation, set this parameter to false. Only the specified node is connected.
 **elasticsearch.ssl** | Whether ES cluster enables https access mode, the current FE/BE implementation is to trust all
 
+### Connect Aliyun Data Lake Formation
+
+> [What is Data Lake Formation](https://www.alibabacloud.com/product/datalake-formation)
+
+1. Create hive-site.xml
+
+	Create hive-site.xml and put it in `fe/conf` and `be/conf`.
+	
+	```
+	<?xml version="1.0"?>
+	<configuration>
+	    <!--Set to use dlf client-->
+	    <property>
+	        <name>hive.metastore.type</name>
+	        <value>dlf</value>
+	    </property>
+	    <property>
+	        <name>dlf.catalog.endpoint</name>
+	        <value>dlf-vpc.cn-beijing.aliyuncs.com</value>
+	    </property>
+	    <property>
+	        <name>dlf.catalog.region</name>
+	        <value>cn-beijing</value>
+	    </property>
+	    <property>
+	        <name>dlf.catalog.proxyMode</name>
+	        <value>DLF_ONLY</value>
+	    </property>
+	    <property>
+	        <name>dlf.catalog.uid</name>
+	        <value>20000000000000000</value>
+	    </property>
+	    <property>
+	        <name>dlf.catalog.accessKeyId</name>
+	        <value>XXXXXXXXXXXXXXX</value>
+	    </property>
+	    <property>
+	        <name>dlf.catalog.accessKeySecret</name>
+	        <value>XXXXXXXXXXXXXXXXX</value>
+	    </property>
+	</configuration>
+	```
+
+	* `dlf.catalog.endpoint`: DLF Endpoint. See: [Regions and endpoints of DLF](https://www.alibabacloud.com/help/en/data-lake-formation/latest/regions-and-endpoints)
+	* `dlf.catalog.region`: DLF Regio. See: [Regions and endpoints of DLF](https://www.alibabacloud.com/help/en/data-lake-formation/latest/regions-and-endpoints)
+	* `dlf.catalog.uid`: Ali Cloud Account ID. That is, the "cloud account ID" of the personal information in the upper right corner of the Alibaba Cloud console.	* `dlf.catalog.accessKeyId`: AccessKey. See: [Ali Could Console](https://ram.console.aliyun.com/manage/ak).
+	* `dlf.catalog.accessKeySecret`: SecretKey. See: [Ali Could Console](https://ram.console.aliyun.com/manage/ak).
+
+	Other configuration items are fixed values and do not need to be changed.
+
+2. Restart FE and create a catalog with the `CREATE CATALOG` statement.
+
+	```
+	CREATE CATALOG dlf PROPERTIES (
+	    "type"="hms",
+	    "hive.metastore.uris" = "thrift://127.0.0.1:9083"
+	);
+	```
+	
+	where `type` is fixed to `hms`. The value of `hive.metastore.uris` can be filled in at will, but it will not be used in practice. But it needs to be filled in the standard hive metastore thrift uri format.
+
+After that, the metadata under DLF can be accessed like a normal Hive MetaStore.
 
 ## Column Type Mapping
 
@@ -366,3 +430,5 @@ Metadata changes of external data sources, such as creating, dropping tables, ad
 Currently, users need to manually refresh metadata via the [REFRESH CATALOG](../../sql-manual/sql-reference/Utility-Statements/REFRESH-CATALOG.md) command.
 
 Automatic synchronization of metadata will be supported soon.
+
+</version>

--- a/docs/en/docs/sql-manual/sql-reference/Data-Definition-Statements/Create/CREATE-TABLE-AS-SELECT.md
+++ b/docs/en/docs/sql-manual/sql-reference/Data-Definition-Statements/Create/CREATE-TABLE-AS-SELECT.md
@@ -55,7 +55,7 @@ illustrate:
 - After a table is created, data is imported. If the import fails, the table is deleted
 - You can specify the key type. The default key type is `Duplicate Key`
 
-<verison since='1.2'>
+<version since='1.2'>
 
 - If the created source is an external table and the first column is of type String, the first column is automatically set to VARCHAR(65533). Because of Doris internal table, String column is not allowed as first column.
 

--- a/docs/en/docs/sql-manual/sql-reference/Data-Definition-Statements/Create/CREATE-TABLE-AS-SELECT.md
+++ b/docs/en/docs/sql-manual/sql-reference/Data-Definition-Statements/Create/CREATE-TABLE-AS-SELECT.md
@@ -55,6 +55,12 @@ illustrate:
 - After a table is created, data is imported. If the import fails, the table is deleted
 - You can specify the key type. The default key type is `Duplicate Key`
 
+<verison since='1.2'>
+
+- If the created source is an external table and the first column is of type String, the first column is automatically set to VARCHAR(65533). Because of Doris internal table, String column is not allowed as first column.
+
+<version>
+
 ### Example
 
 1. Using the field names in the SELECT statement

--- a/docs/en/docs/sql-manual/sql-reference/Data-Definition-Statements/Create/CREATE-TABLE-AS-SELECT.md
+++ b/docs/en/docs/sql-manual/sql-reference/Data-Definition-Statements/Create/CREATE-TABLE-AS-SELECT.md
@@ -59,7 +59,7 @@ illustrate:
 
 - If the created source is an external table and the first column is of type String, the first column is automatically set to VARCHAR(65533). Because of Doris internal table, String column is not allowed as first column.
 
-<version>
+</version>
 
 ### Example
 

--- a/docs/zh-CN/docs/ecosystem/external-table/multi-catalog.md
+++ b/docs/zh-CN/docs/ecosystem/external-table/multi-catalog.md
@@ -24,6 +24,8 @@ specific language governing permissions and limitations
 under the License.
 -->
 
+<version since="1.2.0">
+
 # 多源数据目录
 
 多源数据目录（Multi-Catalog）是 Doris 1.2.0 版本中推出的功能，旨在能够更方便对接外部数据目录，以增强Doris的数据湖分析和联邦数据查询能力。
@@ -292,7 +294,7 @@ mysql> select * from test;
 +------------+-------------+--------+-------+
 ```
 
-## 参数说明：
+#### 参数说明：
 
 参数 | 说明
 ---|---
@@ -303,6 +305,71 @@ mysql> select * from test;
 **elasticsearch.keyword_sniff** | 是否对 ES 中字符串类型分词类型 text.fields 进行探测，获取额外的未分词 keyword 字段名 multi-fields 机制
 **elasticsearch.nodes_discovery** | 是否开启 ES 节点发现，默认为 true，在网络隔离环境下设置为 false，只连接指定节点
 **elasticsearch.ssl** | ES 是否开启 https 访问模式，目前在 fe/be 实现方式为信任所有
+
+### 连接阿里云 Data Lake Formation
+
+> [什么是 Data Lake Formation](https://www.aliyun.com/product/bigdata/dlf)
+
+1. 创建 hive-site.xml
+
+	创建 hive-site.xml 文件，并将其放置在 `fe/conf` 和 `be/conf` 目录下。
+	
+	```
+	<?xml version="1.0"?>
+	<configuration>
+	    <!--Set to use dlf client-->
+	    <property>
+	        <name>hive.metastore.type</name>
+	        <value>dlf</value>
+	    </property>
+	    <property>
+	        <name>dlf.catalog.endpoint</name>
+	        <value>dlf-vpc.cn-beijing.aliyuncs.com</value>
+	    </property>
+	    <property>
+	        <name>dlf.catalog.region</name>
+	        <value>cn-beijing</value>
+	    </property>
+	    <property>
+	        <name>dlf.catalog.proxyMode</name>
+	        <value>DLF_ONLY</value>
+	    </property>
+	    <property>
+	        <name>dlf.catalog.uid</name>
+	        <value>20000000000000000</value>
+	    </property>
+	    <property>
+	        <name>dlf.catalog.accessKeyId</name>
+	        <value>XXXXXXXXXXXXXXX</value>
+	    </property>
+	    <property>
+	        <name>dlf.catalog.accessKeySecret</name>
+	        <value>XXXXXXXXXXXXXXXXX</value>
+	    </property>
+	</configuration>
+	```
+
+	* `dlf.catalog.endpoint`：DLF Endpoint，参阅：[DLF Region和Endpoint对照表](https://www.alibabacloud.com/help/zh/data-lake-formation/latest/regions-and-endpoints)
+	* `dlf.catalog.region`：DLF Region，参阅：[DLF Region和Endpoint对照表](https://www.alibabacloud.com/help/zh/data-lake-formation/latest/regions-and-endpoints)
+	* `dlf.catalog.uid`：阿里云账号。即阿里云控制台右上角个人信息的“云账号ID”。
+	* `dlf.catalog.accessKeyId`：AccessKey。可以在 [阿里云控制台](https://ram.console.aliyun.com/manage/ak) 中创建和管理。
+	* `dlf.catalog.accessKeySecret`：SecretKey。可以在 [阿里云控制台](https://ram.console.aliyun.com/manage/ak) 中创建和管理。
+
+	其他配置项为固定值，无需改动。
+
+2. 重启 FE，并通过 `CREATE CATALOG` 语句创建 catalog。
+
+	```
+	CREATE CATALOG dlf PROPERTIES (
+	    "type"="hms",
+	    "hive.metastore.uris" = "thrift://127.0.0.1:9083"
+	);
+	```
+	
+	其中 `type` 固定为 `hms`。 `hive.metastore.uris` 的值随意填写即可，实际不会使用。但需要按照标准 hive metastore thrift uri 格式填写。
+	
+之后，可以像正常的 Hive MetaStore 一样，访问 DLF 下的元数据。 
+
 
 ## 列类型映射
 
@@ -365,3 +432,5 @@ Doris 的权限管理功能提供了对 Cataloig 层级的扩展，具体可参�
 目前需要用户通过 [REFRESH CATALOG](../../sql-manual/sql-reference/Utility-Statements/REFRESH-CATALOG.md) 命令手动刷新元数据。
 
 后续会支持元数据的自动同步。
+
+</version>

--- a/docs/zh-CN/docs/sql-manual/sql-reference/Data-Definition-Statements/Create/CREATE-TABLE-AS-SELECT.md
+++ b/docs/zh-CN/docs/sql-manual/sql-reference/Data-Definition-Statements/Create/CREATE-TABLE-AS-SELECT.md
@@ -59,7 +59,7 @@ CREATE TABLE table_name [( column_name_list )]
 
 - 如果创建的来源为外部表，并且第一列为 String 类型，则会自动将第一列设置为 VARCHAR(65533)。因为 Doris 内部表，不允许 String 列作为第一列。
 
-<version>
+</version>
 
 ### Example
 

--- a/docs/zh-CN/docs/sql-manual/sql-reference/Data-Definition-Statements/Create/CREATE-TABLE-AS-SELECT.md
+++ b/docs/zh-CN/docs/sql-manual/sql-reference/Data-Definition-Statements/Create/CREATE-TABLE-AS-SELECT.md
@@ -55,6 +55,12 @@ CREATE TABLE table_name [( column_name_list )]
 - 创建表成功后，会进行数据导入，如果导入失败，将会删除表
 - 可以自行指定 key type，默认为`Duplicate Key`
 
+<verison since='1.2'>
+
+- 如果创建的来源为外部表，并且第一列为 String 类型，则会自动将第一列设置为 VARCHAR(65533)。因为 Doris 内部表，不允许 String 列作为第一列。
+
+<version>
+
 ### Example
 
 1. 使用 select 语句中的字段名

--- a/docs/zh-CN/docs/sql-manual/sql-reference/Data-Definition-Statements/Create/CREATE-TABLE-AS-SELECT.md
+++ b/docs/zh-CN/docs/sql-manual/sql-reference/Data-Definition-Statements/Create/CREATE-TABLE-AS-SELECT.md
@@ -55,7 +55,7 @@ CREATE TABLE table_name [( column_name_list )]
 - 创建表成功后，会进行数据导入，如果导入失败，将会删除表
 - 可以自行指定 key type，默认为`Duplicate Key`
 
-<verison since='1.2'>
+<version since='1.2'>
 
 - 如果创建的来源为外部表，并且第一列为 String 类型，则会自动将第一列设置为 VARCHAR(65533)。因为 Doris 内部表，不允许 String 列作为第一列。
 

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateTableStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateTableStmt.java
@@ -332,7 +332,7 @@ public class CreateTableStmt extends DdlStmt {
                         }
                         keysColumnNames.add(columnDef.getName());
                     }
-                    // The OLAP table must has at least one short key and the float and double should not be short key.
+                    // The OLAP table must have at least one short key and the float and double should not be short key.
                     // So the float and double could not be the first column in OLAP table.
                     if (keysColumnNames.isEmpty()) {
                         throw new AnalysisException("The olap table first column could not be float, double, string"

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/HiveMetaStoreClientHelper.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/HiveMetaStoreClientHelper.java
@@ -151,7 +151,7 @@ public class HiveMetaStoreClientHelper {
         IMetaStoreClient metaStoreClient = null;
         String type = hiveConf.get(HIVE_METASTORE_TYPE);
         try {
-            if (type.equalsIgnoreCase("dlf")) {
+            if ("dlf".equalsIgnoreCase(type)) {
                 // For aliyun DLF
                 metaStoreClient = new ProxyMetaStoreClient(hiveConf);
             } else {

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/HiveMetaStoreClientHelper.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/HiveMetaStoreClientHelper.java
@@ -930,6 +930,9 @@ public class HiveMetaStoreClientHelper {
     }
 
     public static Map<String, String> getPropertiesForDLF(String catalogName, HiveConf hiveConf) {
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("get properties from hive-site.xml for catalog {}: {}", catalogName, hiveConf.getAllProperties());
+        }
         Map<String, String> res = Maps.newHashMap();
         String metastoreType = hiveConf.get(HIVE_METASTORE_TYPE);
         if (!"dlf".equalsIgnoreCase(metastoreType)) {

--- a/fe/fe-core/src/main/java/org/apache/doris/common/FeConstants.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/FeConstants.java
@@ -64,4 +64,14 @@ public class FeConstants {
     public static String csv_with_names_and_types = "csv_with_names_and_types";
 
     public static String text = "text";
+
+    public static String FS_PREFIX_S3 = "s3";
+    public static String FS_PREFIX_S3A = "s3a";
+    public static String FS_PREFIX_S3N = "s3n";
+    public static String FS_PREFIX_OSS = "oss";
+    public static String FS_PREFIX_BOS = "bos";
+    public static String FS_PREFIX_COS = "cos";
+    public static String FS_PREFIX_OBS = "obs";
+    public static String FS_PREFIX_HDFS = "hdfs";
+    public static String FS_PREFIX_FILE = "file";
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/CatalogMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/CatalogMgr.java
@@ -104,7 +104,7 @@ public class CatalogMgr implements Writable, GsonPostProcessable {
         if (catalog != null) {
             String catalogName = catalog.getName();
             if (!catalogName.equals(InternalCatalog.INTERNAL_CATALOG_NAME)) {
-                ((ExternalCatalog) catalog).setInitialized(false);
+                ((ExternalCatalog) catalog).setUninitialized();
             }
         }
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/EsExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/EsExternalCatalog.java
@@ -23,10 +23,8 @@ import org.apache.doris.catalog.external.EsExternalDatabase;
 import org.apache.doris.catalog.external.ExternalDatabase;
 import org.apache.doris.cluster.ClusterNamespace;
 import org.apache.doris.common.DdlException;
-import org.apache.doris.common.util.Util;
 import org.apache.doris.external.elasticsearch.EsRestClient;
 import org.apache.doris.external.elasticsearch.EsUtil;
-import org.apache.doris.qe.MasterCatalogExecutor;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -118,33 +116,13 @@ public class EsExternalCatalog extends ExternalCatalog {
         }
     }
 
-    /**
-     * Datasource can't be init when creating because the external datasource may depend on third system.
-     * So you have to make sure the client of third system is initialized before any method was called.
-     */
     @Override
-    public synchronized void makeSureInitialized() {
-        if (!objectCreated) {
-            esRestClient = new EsRestClient(this.nodes, this.username, this.password, this.enableSsl);
-            objectCreated = true;
-        }
-        if (!initialized) {
-            if (!Env.getCurrentEnv().isMaster()) {
-                // Forward to master and wait the journal to replay.
-                MasterCatalogExecutor remoteExecutor = new MasterCatalogExecutor();
-                try {
-                    remoteExecutor.forward(id, -1, -1);
-                } catch (Exception e) {
-                    Util.logAndThrowRuntimeException(LOG,
-                            String.format("failed to forward init catalog %s operation to master.", name), e);
-                }
-                return;
-            }
-            init();
-        }
+    protected void initLocalObjectsImpl() {
+        esRestClient = new EsRestClient(this.nodes, this.username, this.password, this.enableSsl);
     }
 
-    private void init() {
+    @Override
+    protected void init() {
         InitCatalogLog initCatalogLog = new InitCatalogLog();
         this.esRestClient = new EsRestClient(this.nodes, this.username, this.password, this.enableSsl);
         initCatalogLog.setCatalogId(id);
@@ -161,7 +139,6 @@ public class EsExternalCatalog extends ExternalCatalog {
             idToDb.put(defaultDbId, db);
             initCatalogLog.addCreateDb(defaultDbId, DEFAULT_DB);
         }
-        initialized = true;
         Env.getCurrentEnv().getEditLog().logInitCatalog(initCatalogLog);
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalCatalog.java
@@ -17,14 +17,17 @@
 
 package org.apache.doris.datasource;
 
+import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.external.EsExternalDatabase;
 import org.apache.doris.catalog.external.ExternalDatabase;
 import org.apache.doris.catalog.external.HMSExternalDatabase;
 import org.apache.doris.cluster.ClusterNamespace;
 import org.apache.doris.common.io.Text;
 import org.apache.doris.common.io.Writable;
+import org.apache.doris.common.util.Util;
 import org.apache.doris.persist.gson.GsonPostProcessable;
 import org.apache.doris.persist.gson.GsonUtils;
+import org.apache.doris.qe.MasterCatalogExecutor;
 
 import com.google.common.collect.Maps;
 import com.google.gson.annotations.SerializedName;
@@ -58,14 +61,14 @@ public abstract class ExternalCatalog implements CatalogIf<ExternalDatabase>, Wr
     @SerializedName(value = "catalogProperty")
     protected CatalogProperty catalogProperty = new CatalogProperty();
     @SerializedName(value = "initialized")
-    protected boolean initialized = false;
+    private boolean initialized = false;
 
     // Cache of db name to db id
     @SerializedName(value = "idToDb")
     protected Map<Long, ExternalDatabase> idToDb = Maps.newConcurrentMap();
     // db name does not contains "default_cluster"
     protected Map<String, Long> dbNameToId = Maps.newConcurrentMap();
-    protected boolean objectCreated = false;
+    private boolean objectCreated = false;
 
     /**
      * @return names of database in this catalog.
@@ -87,10 +90,45 @@ public abstract class ExternalCatalog implements CatalogIf<ExternalDatabase>, Wr
      */
     public abstract boolean tableExist(SessionContext ctx, String dbName, String tblName);
 
-    public abstract void makeSureInitialized();
+    /**
+     * Catalog can't be init when creating because the external catalog may depend on third system.
+     * So you have to make sure the client of third system is initialized before any method was called.
+     */
+    public final synchronized void makeSureInitialized() {
+        initLocalObjects();
+        if (!initialized) {
+            if (!Env.getCurrentEnv().isMaster()) {
+                // Forward to master and wait the journal to replay.
+                MasterCatalogExecutor remoteExecutor = new MasterCatalogExecutor();
+                try {
+                    remoteExecutor.forward(id, -1, -1);
+                } catch (Exception e) {
+                    Util.logAndThrowRuntimeException(LOG,
+                            String.format("failed to forward init catalog %s operation to master.", name), e);
+                }
+                return;
+            }
+            init();
+            initialized = true;
+        }
+    }
 
-    public void setInitialized(boolean initialized) {
-        this.initialized = initialized;
+    protected final void initLocalObjects() {
+        if (!objectCreated) {
+            initLocalObjectsImpl();
+            objectCreated = true;
+        }
+    }
+
+    // init some local objects such as:
+    // hms client, read properties from hive-site.xml, es client
+    protected abstract void initLocalObjectsImpl();
+
+    // init schema related objects
+    protected abstract void init();
+
+    public void setUninitialized() {
+        this.initialized = false;
     }
 
     public ExternalDatabase getDbForReplay(long dbId) {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
@@ -1215,6 +1215,16 @@ public class InternalCatalog implements CatalogIf<Database> {
                 } else {
                     typeDef = new TypeDef(resultExpr.getType());
                 }
+                if (i == 0) {
+                    // If this is the first column, because olap table does not support the first column to be
+                    // string, float, double or array, we should check and modify its type
+                    // For string type, change it to varchar.
+                    // For other unsupport types, just remain unchanged, the analysis phash of create table stmt
+                    // will handle it.
+                    if (typeDef.getType() == Type.STRING) {
+                        typeDef = TypeDef.createVarchar(ScalarType.MAX_VARCHAR_LENGTH);
+                    }
+                }
                 ColumnDef columnDef;
                 if (resultExpr.getSrcSlotRef() == null) {
                     columnDef = new ColumnDef(name, typeDef, false, null, true, new DefaultValue(false, null), "");

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
@@ -181,7 +181,7 @@ import com.google.common.collect.Sets;
 import lombok.Getter;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.hadoop.hive.metastore.IMetaStoreClient;
+import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.Nullable;
@@ -2278,10 +2278,11 @@ public class InternalCatalog implements CatalogIf<Database> {
         HiveTable hiveTable = new HiveTable(tableId, tableName, columns, stmt.getProperties());
         hiveTable.setComment(stmt.getComment());
         // check hive table whether exists in hive database
-        IMetaStoreClient hiveMetaStoreClient = HiveMetaStoreClientHelper.getClient(
-                hiveTable.getHiveProperties().get(HiveTable.HIVE_METASTORE_URIS));
-        if (!HiveMetaStoreClientHelper.tableExists(hiveMetaStoreClient, hiveTable.getHiveDb(),
-                hiveTable.getHiveTable())) {
+        HiveConf hiveConf = new HiveConf();
+        hiveConf.set(HiveMetaStoreClientHelper.HIVE_METASTORE_URIS,
+                hiveTable.getHiveProperties().get(HiveMetaStoreClientHelper.HIVE_METASTORE_URIS));
+        PooledHiveMetaStoreClient client = new PooledHiveMetaStoreClient(hiveConf, 1);
+        if (!client.tableExists(hiveTable.getHiveDb(), hiveTable.getHiveTable())) {
             throw new DdlException(String.format("Table [%s] dose not exist in Hive.", hiveTable.getHiveDbTable()));
         }
         // check hive table if exists in doris database
@@ -2300,15 +2301,17 @@ public class InternalCatalog implements CatalogIf<Database> {
         // check hudi properties in create stmt.
         HudiUtils.validateCreateTable(hudiTable);
         // check hudi table whether exists in hive database
-        String metastoreUris = hudiTable.getTableProperties().get(HudiProperty.HUDI_HIVE_METASTORE_URIS);
-        IMetaStoreClient hiveMetaStoreClient = HiveMetaStoreClientHelper.getClient(metastoreUris);
-        if (!HiveMetaStoreClientHelper.tableExists(hiveMetaStoreClient, hudiTable.getHmsDatabaseName(),
-                hudiTable.getHmsTableName())) {
+        HiveConf hiveConf = new HiveConf();
+        hiveConf.set(HiveMetaStoreClientHelper.HIVE_METASTORE_URIS,
+                hudiTable.getTableProperties().get(HudiProperty.HUDI_HIVE_METASTORE_URIS));
+        PooledHiveMetaStoreClient client = new PooledHiveMetaStoreClient(hiveConf, 1);
+        if (!client.tableExists(hudiTable.getHmsDatabaseName(), hudiTable.getHmsTableName())) {
             throw new DdlException(
                     String.format("Table [%s] dose not exist in Hive Metastore.", hudiTable.getHmsTableIdentifer()));
         }
-        org.apache.hadoop.hive.metastore.api.Table hiveTable = HiveMetaStoreClientHelper.getTable(
-                hudiTable.getHmsDatabaseName(), hudiTable.getHmsTableName(), metastoreUris);
+
+        org.apache.hadoop.hive.metastore.api.Table hiveTable = client.getTable(
+                hudiTable.getHmsDatabaseName(), hudiTable.getHmsTableName());
         if (!HudiUtils.isHudiTable(hiveTable)) {
             throw new DdlException(String.format("Table [%s] is not a hudi table.", hudiTable.getHmsTableIdentifer()));
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/PooledHiveMetaStoreClient.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/PooledHiveMetaStoreClient.java
@@ -1,0 +1,146 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.datasource;
+
+import org.apache.doris.catalog.HiveMetaStoreClientHelper;
+import org.apache.doris.common.Config;
+
+import com.aliyun.datalake.metastore.hive2.ProxyMetaStoreClient;
+import com.google.common.base.Preconditions;
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.conf.HiveConf.ConfVars;
+import org.apache.hadoop.hive.metastore.HiveMetaHookLoader;
+import org.apache.hadoop.hive.metastore.HiveMetaStoreClient;
+import org.apache.hadoop.hive.metastore.IMetaStoreClient;
+import org.apache.hadoop.hive.metastore.RetryingMetaStoreClient;
+import org.apache.hadoop.hive.metastore.api.FieldSchema;
+import org.apache.hadoop.hive.metastore.api.MetaException;
+import org.apache.hadoop.hive.metastore.api.Partition;
+import org.apache.hadoop.hive.metastore.api.Table;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Queue;
+
+/**
+ * A hive metastore client pool for a specific hive conf.
+ */
+public class PooledHiveMetaStoreClient {
+    private static final Logger LOG = LogManager.getLogger(PooledHiveMetaStoreClient.class);
+
+    private Queue<CachedClient> clientPool = new LinkedList<>();
+    private static final HiveMetaHookLoader DUMMY_HOOK_LOADER = t -> null;
+    private final int poolSize;
+    private final HiveConf hiveConf;
+
+    public PooledHiveMetaStoreClient(HiveConf hiveConf, int pooSize) {
+        Preconditions.checkArgument(pooSize > 0, pooSize);
+        hiveConf.set(ConfVars.METASTORE_CLIENT_SOCKET_TIMEOUT.name(),
+                String.valueOf(Config.hive_metastore_client_timeout_second));
+        this.hiveConf = hiveConf;
+        this.poolSize = pooSize;
+    }
+
+    public List<String> getAllDatabases() {
+        try (CachedClient client = getClient()) {
+            return client.client.getAllDatabases();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public List<String> getAllTables(String dbName) {
+        try (CachedClient client = getClient()) {
+            return client.client.getAllTables(dbName);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public boolean tableExists(String dbName, String tblName) {
+        try (CachedClient client = getClient()) {
+            return client.client.tableExists(dbName, tblName);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public boolean listPartitionsByExpr(String dbName, String tblName,
+            byte[] partitionPredicatesInBytes, List<Partition> hivePartitions) {
+        try (CachedClient client = getClient()) {
+            return client.client.listPartitionsByExpr(dbName, tblName, partitionPredicatesInBytes,
+                    null, (short) -1, hivePartitions);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public Table getTable(String dbName, String tblName) {
+        try (CachedClient client = getClient()) {
+            return client.client.getTable(dbName, tblName);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public List<FieldSchema> getSchema(String dbName, String tblName) {
+        try (CachedClient client = getClient()) {
+            return client.client.getSchema(dbName, tblName);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private class CachedClient implements AutoCloseable {
+        private final IMetaStoreClient client;
+
+        private CachedClient(HiveConf hiveConf) throws MetaException {
+            String type = hiveConf.get(HiveMetaStoreClientHelper.HIVE_METASTORE_TYPE);
+            if (HiveMetaStoreClientHelper.DLF_TYPE.equalsIgnoreCase(type)) {
+                client = RetryingMetaStoreClient.getProxy(hiveConf, DUMMY_HOOK_LOADER,
+                        ProxyMetaStoreClient.class.getName());
+            } else {
+                client = RetryingMetaStoreClient.getProxy(hiveConf, DUMMY_HOOK_LOADER,
+                        HiveMetaStoreClient.class.getName());
+            }
+        }
+
+        @Override
+        public void close() throws Exception {
+            synchronized (clientPool) {
+                if (clientPool.size() > poolSize) {
+                    client.close();
+                } else {
+                    clientPool.offer(this);
+                }
+            }
+        }
+    }
+
+    private CachedClient getClient() throws MetaException {
+        synchronized (clientPool) {
+            CachedClient client = clientPool.poll();
+            if (client == null) {
+                return new CachedClient(hiveConf);
+            }
+            return client;
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/external/QueryScanProvider.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/external/QueryScanProvider.java
@@ -70,6 +70,9 @@ public abstract class QueryScanProvider implements FileScanProviderIf {
 
             String fullPath = ((FileSplit) inputSplits.get(0)).getPath().toUri().toString();
             String filePath = ((FileSplit) inputSplits.get(0)).getPath().toUri().getPath();
+            // eg:
+            // hdfs://namenode
+            // s3://buckets
             String fsName = fullPath.replace(filePath, "");
             TFileType locationType = getLocationType();
             context.params.setFileType(locationType);


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

1. Support [Aliyun DLF](https://www.aliyun.com/product/bigdata/dlf)
2. Support data on s3-compatible object storage, such as aliyun oss.
3. Refactor some interface of catalog, to make it more tidy.
4. Fix bug that the default text format field delimiter of hive should be `\x01`
5. Add a new class `PooledHiveMetaStoreClient` to wrap the IMetaStoreClient.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
6. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
7. Has document been added or modified:
    - [x] Yes
    - [ ] No
    - [ ] No Need
8. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
9. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

