### PR TITLE
[enhance](nereids) remove cast from numeric literal to decimal

### DIFF
--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/rewrite/TypeCoercionTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/rewrite/TypeCoercionTest.java
@@ -114,29 +114,24 @@ public class TypeCoercionTest extends ExpressionRewriteTestHelper {
 
     @Test
     public void testBinaryPredicate() {
-        Expression left = new DecimalLiteral(new BigDecimal(2.4));
+        Expression left = new DecimalLiteral(new BigDecimal("2.4"));
         Expression right = new TinyIntLiteral((byte) 2);
+        Expression promotedRight = new DecimalLiteral(new BigDecimal("2.0"));
         Expression lessThanEq = new LessThanEqual(left, right);
-        Expression rewrittenPred =
-                new LessThanEqual(
-                        left,
-                        new Cast(right, left.getDataType()));
+        Expression rewrittenPred = new LessThanEqual(left, promotedRight);
         assertRewrite(lessThanEq, rewrittenPred);
 
-        rewrittenPred =
-                new LessThanEqual(
-                        new Cast(right, left.getDataType()),
-                        left
-                        );
+        rewrittenPred = new LessThanEqual(promotedRight, left);
         lessThanEq = new LessThanEqual(right, left);
         assertRewrite(lessThanEq, rewrittenPred);
 
         left = new DecimalLiteral(new BigDecimal(1));
         lessThanEq = new LessThanEqual(left, right);
+        promotedRight = new DecimalLiteral(new BigDecimal("2"));
         rewrittenPred =
-                new LessThanEqual(
-                        new Cast(left, DecimalType.forType(TinyIntType.INSTANCE)),
-                        new Cast(right, DecimalType.forType(TinyIntType.INSTANCE))
+                new LessThanEqual(left, promotedRight
+                        //new Cast(left, DecimalType.forType(TinyIntType.INSTANCE)),
+                        //new Cast(right, DecimalType.forType(TinyIntType.INSTANCE))
                 );
         assertRewrite(lessThanEq, rewrittenPred);
     }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/rewrite/TypeCoercionTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/rewrite/TypeCoercionTest.java
@@ -40,11 +40,9 @@ import org.apache.doris.nereids.trees.expressions.literal.SmallIntLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.StringLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.TinyIntLiteral;
 import org.apache.doris.nereids.types.DateV2Type;
-import org.apache.doris.nereids.types.DecimalType;
 import org.apache.doris.nereids.types.DoubleType;
 import org.apache.doris.nereids.types.IntegerType;
 import org.apache.doris.nereids.types.StringType;
-import org.apache.doris.nereids.types.TinyIntType;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
@@ -128,11 +126,7 @@ public class TypeCoercionTest extends ExpressionRewriteTestHelper {
         left = new DecimalLiteral(new BigDecimal(1));
         lessThanEq = new LessThanEqual(left, right);
         promotedRight = new DecimalLiteral(new BigDecimal("2"));
-        rewrittenPred =
-                new LessThanEqual(left, promotedRight
-                        //new Cast(left, DecimalType.forType(TinyIntType.INSTANCE)),
-                        //new Cast(right, DecimalType.forType(TinyIntType.INSTANCE))
-                );
+        rewrittenPred = new LessThanEqual(left, promotedRight);
         assertRewrite(lessThanEq, rewrittenPred);
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/util/TypeCoercionUtilsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/util/TypeCoercionUtilsTest.java
@@ -145,7 +145,8 @@ public class TypeCoercionUtilsTest {
         testFindTightestCommonType(BigIntType.INSTANCE, IntegerType.INSTANCE, BigIntType.INSTANCE);
         testFindTightestCommonType(StringType.INSTANCE, StringType.INSTANCE, IntegerType.INSTANCE);
         testFindTightestCommonType(StringType.INSTANCE, IntegerType.INSTANCE, StringType.INSTANCE);
-        testFindTightestCommonType(null, DecimalType.SYSTEM_DEFAULT, DecimalType.createDecimalType(2, 1));
+        testFindTightestCommonType(DecimalType.SYSTEM_DEFAULT, DecimalType.SYSTEM_DEFAULT, DecimalType.createDecimalType(2, 1));
+        testFindTightestCommonType(DecimalType.createDecimalType(11, 6), DecimalType.createDecimalType(10, 6), DecimalType.createDecimalType(10, 5));
         testFindTightestCommonType(VarcharType.createVarcharType(10), CharType.createCharType(8), CharType.createCharType(10));
         testFindTightestCommonType(VarcharType.createVarcharType(10), VarcharType.createVarcharType(8), VarcharType.createVarcharType(10));
         testFindTightestCommonType(VarcharType.createVarcharType(10), VarcharType.createVarcharType(8), CharType.createCharType(10));


### PR DESCRIPTION
# Proposed changes
1. remove cast from numeric literal to decimal literal
2. fix decimal scale bug: we will miss scale if first operand scale is smaller than the second operand scale. For example, 1.0 + l_quantity,  decimal(2,1) + decimal(15,2), we expect (15,2), not (15,1)
     
Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
4. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
5. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
6. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
7. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

