### PR TITLE
[feat](Nereids) add graph simplifier

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/joinreorder/HyperGraphJoinReorder.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/joinreorder/HyperGraphJoinReorder.java
@@ -39,7 +39,6 @@ public class HyperGraphJoinReorder extends OneRewriteRuleFactory {
                     LogicalJoin<? extends Plan, ? extends Plan> rootJoin = ctx.root;
                     // TODO: check mark.
                     HyperGraph graph = HyperGraph.fromPlan(rootJoin);
-                    System.out.println(graph.toDottyHyperGraph());
                     if (graph.optimize()) {
                         return graph.toPlan();
                     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/joinreorder/HyperGraphJoinReorderGroupPlan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/joinreorder/HyperGraphJoinReorderGroupPlan.java
@@ -38,7 +38,6 @@ public class HyperGraphJoinReorderGroupPlan extends OneRewriteRuleFactory {
                 .thenApply(ctx -> {
                     LogicalJoin<? extends Plan, ? extends Plan> rootJoin = ctx.root;
                     HyperGraph graph = HyperGraph.fromPlan(rootJoin);
-                    System.out.println(graph.toDottyHyperGraph());
                     if (graph.optimize()) {
                         return graph.toPlan();
                     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/joinreorder/hypergraph/Edge.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/joinreorder/hypergraph/Edge.java
@@ -17,6 +17,8 @@
 
 package org.apache.doris.nereids.rules.joinreorder.hypergraph;
 
+import org.apache.doris.nereids.trees.plans.GroupPlan;
+import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalJoin;
 
 import java.util.BitSet;
@@ -24,28 +26,25 @@ import java.util.BitSet;
 class Edge {
     final int index;
     final LogicalJoin join;
+    final double selectivity;
 
     // The endpoints (hypernodes) of this hyperedge.
     // left and right may not overlap, and both must have at least one bit set.
-    BitSet left = new BitSet(32);
-    BitSet right = new BitSet(32);
-    BitSet constraints = new BitSet(32);
-    double selectivity = 1;
+    private BitSet left = new BitSet(32);
+    private BitSet right = new BitSet(32);
+    private BitSet constraints = new BitSet(32);
 
     /**
      * Create simple edge.
      */
-    public Edge(int index, LogicalJoin join) {
+    public Edge(LogicalJoin join, int index) {
         this.index = index;
         this.join = join;
+        this.selectivity = getRowCount(join) / (getRowCount(join.left()) * getRowCount(join.right()));
     }
 
     public LogicalJoin getJoin() {
         return join;
-    }
-
-    public double getSelectivity() {
-        return selectivity;
     }
 
     public boolean isSimple() {
@@ -56,8 +55,20 @@ class Edge {
         this.left.or(left);
     }
 
+    public void addLeftNodes(BitSet... bitSets) {
+        for (BitSet bitSet : bitSets) {
+            this.left.or(bitSet);
+        }
+    }
+
     public void addRightNode(BitSet right) {
         this.right.or(right);
+    }
+
+    public void addRightNodes(BitSet... bitSets) {
+        for (BitSet bitSet : bitSets) {
+            this.right.or(bitSet);
+        }
     }
 
     public void addConstraintNode(BitSet constraints) {
@@ -68,8 +79,24 @@ class Edge {
         return left;
     }
 
+    public void setLeft(BitSet left) {
+        this.left = left;
+    }
+
     public BitSet getRight() {
         return right;
+    }
+
+    public void setRight(BitSet right) {
+        this.right = right;
+    }
+
+    public boolean isBefore(Edge edge) {
+        // When this join reference nodes is a subset of other join, then this join must appear before that join
+        BitSet thisBitSet = getReferenceNodes();
+        BitSet otherBitSet = edge.getReferenceNodes();
+        thisBitSet.or(otherBitSet);
+        return thisBitSet.equals(otherBitSet);
     }
 
     public BitSet getReferenceNodes() {
@@ -80,12 +107,32 @@ class Edge {
         return bitSet;
     }
 
-    public Edge reverse() {
-        Edge newEdge = new Edge(index, join);
+    public Edge reverse(int index) {
+        Edge newEdge = new Edge(join, index);
         newEdge.addLeftNode(right);
         newEdge.addRightNode(left);
         newEdge.addConstraintNode(constraints);
         return newEdge;
+    }
+
+    public int getIndex() {
+        return index;
+    }
+
+    public double getSelectivity() {
+        return selectivity;
+    }
+
+    private double getRowCount(Plan plan) {
+        if (plan instanceof GroupPlan) {
+            return ((GroupPlan) plan).getGroup().getStatistics().getRowCount();
+        }
+        return plan.getGroupExpression().get().getOwnerGroup().getStatistics().getRowCount();
+    }
+
+    @Override
+    public String toString() {
+        return String.format("<%s - %s>", left, right);
     }
 }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/joinreorder/hypergraph/GraphSimplifier.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/joinreorder/hypergraph/GraphSimplifier.java
@@ -1,0 +1,383 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.rules.joinreorder.hypergraph;
+
+import org.apache.doris.common.Pair;
+import org.apache.doris.nereids.memo.Group;
+import org.apache.doris.nereids.memo.GroupExpression;
+import org.apache.doris.nereids.properties.PhysicalProperties;
+import org.apache.doris.nereids.stats.StatsCalculator;
+import org.apache.doris.nereids.trees.plans.GroupPlan;
+import org.apache.doris.nereids.trees.plans.Plan;
+import org.apache.doris.nereids.trees.plans.logical.LogicalJoin;
+
+import com.google.common.base.Preconditions;
+
+import java.util.ArrayList;
+import java.util.BitSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.PriorityQueue;
+
+/**
+ * GraphSimplifier is used to simplify HyperGraph {@link HyperGraph}
+ */
+public class GraphSimplifier {
+    // The graph we are simplifying
+    HyperGraph graph;
+    // It stores the children plan of one edge.
+    // we don't store it in hyper graph, because it's just used for simulating join.
+    // In fact, the graph simplifier just generate the partial order of join operator.
+    List<Pair<Plan, Plan>> joinPlans = new ArrayList<>();
+    // This is used for cache the intermediate results when calculate the benefit
+    // Note that we store it for the after. Because if we put B after A (t1 Join_A t2 Join_B t3),
+    // B is changed. Therefore, Any step that involves B need to be recalculated.
+    List<BestSimplification> simplifications = new ArrayList<>();
+    PriorityQueue<BestSimplification> priorityQueue = new PriorityQueue<>();
+    // Note that each index in the graph simplifier is the half of the actual index
+    int edgeSize;
+
+    GraphSimplifier(HyperGraph graph) {
+        this.graph = graph;
+        edgeSize = graph.getEdges().size();
+        for (Edge edge : graph.getEdges()) {
+            BestSimplification bestSimplification = new BestSimplification();
+            Plan leftPlan = graph.getPlan(edge.getLeft());
+            Plan rightPlan = graph.getPlan(edge.getRight());
+            joinPlans.add(Pair.of(leftPlan, rightPlan));
+            simplifications.add(bestSimplification);
+        }
+    }
+
+    /**
+     * This function init the first simplification step
+     */
+    public void initFirstStep() {
+        for (int i = 0; i < edgeSize; i += 1) {
+            processNeighbors(i, i + 1, edgeSize);
+        }
+    }
+
+    /**
+     * This function will repeatedly apply simplification steps util the number of csg-cmp pair
+     * is under the limit.
+     * In hyper graph, counting the csg-cmp pair is more expensive than the apply simplification step, therefore
+     * we use binary search to find the least step we should apply.
+     *
+     * @param limit the limit number of the csg-cmp pair
+     */
+    public boolean simplifyGraph(int limit) {
+        // Now we only support simplify graph until the hyperGraph only contains one plan
+        Preconditions.checkArgument(limit == 1);
+        while (applySimplificationStep()) {
+        }
+        return true;
+    }
+
+    /**
+     * This function apply a simplification step
+     *
+     * @return If there is no other steps, return false.
+     */
+    public boolean applySimplificationStep() {
+        if (priorityQueue.isEmpty()) {
+            return false;
+        }
+        BestSimplification bestSimplification = priorityQueue.poll();
+        bestSimplification.isInQueue = false;
+        SimplificationStep bestStep = bestSimplification.getStep();
+        // TODO: add circle detector to refuse the edge that can cause a circle
+        graph.modifyEdge(bestStep.afterIndex, bestStep.newLeft, bestStep.newRight);
+        joinPlans.set(bestStep.afterIndex, Pair.of(bestStep.leftPlan, bestStep.rightPlan));
+        processNeighbors(bestStep.afterIndex, 0, edgeSize);
+        return true;
+    }
+
+    /**
+     * Process all neighbors and try to make simplification step
+     * Note that when a given ordering is less advantageous and dropped out,
+     * we need to call this function recursively to update all relative steps.
+     *
+     * @param edgeIndex1 The index of join operator that we need to process its neighbors
+     * @param beginIndex The beginning index of the processing join operators
+     * @param endIndex The end index of the processing join operators
+     */
+    private void processNeighbors(int edgeIndex1, int beginIndex, int endIndex) {
+        // Go through the neighbors with lower index, where the best simplification is stored
+        // Because the best simplification is stored in the edge with lower index, we need to update it recursively
+        // when we can't reset that best simplification
+        for (int edgeIndex2 = beginIndex; edgeIndex2 < Integer.min(endIndex, edgeIndex1); edgeIndex2 += 1) {
+            BestSimplification bestSimplification = simplifications.get(edgeIndex2);
+            Optional<SimplificationStep> optionalStep = makeSimplificationStep(edgeIndex1, edgeIndex2);
+            if (optionalStep.isPresent() && trySetSimplificationStep(optionalStep.get(), bestSimplification, edgeIndex2,
+                    edgeIndex1)) {
+                continue;
+            }
+            processNeighbors(edgeIndex2, 0, edgeSize);
+        }
+
+        // Go through the neighbors with higher index, we only need to recalculate all related steps
+        for (int edgeIndex2 = Integer.max(beginIndex, edgeIndex1 + 1); edgeIndex2 < endIndex; edgeIndex2 += 1) {
+            BestSimplification bestSimplification = simplifications.get(edgeIndex1);
+            bestSimplification.bestNeighbor = -1;
+            Optional<SimplificationStep> optionalStep = makeSimplificationStep(edgeIndex1, edgeIndex2);
+            if (optionalStep.isPresent()) {
+                trySetSimplificationStep(optionalStep.get(), bestSimplification, edgeIndex1, edgeIndex2);
+            }
+        }
+    }
+
+    private boolean trySetSimplificationStep(SimplificationStep step, BestSimplification bestSimplification,
+            int index, int neighborIndex) {
+        if (bestSimplification.bestNeighbor == -1 || bestSimplification.getBenefit() <= step.getBenefit()) {
+            bestSimplification.bestNeighbor = neighborIndex;
+            bestSimplification.setStep(step);
+            updatePriorityQueue(index);
+            return true;
+        }
+        return false;
+    }
+
+    private void updatePriorityQueue(int index) {
+        BestSimplification bestSimplification = simplifications.get(index);
+        if (!bestSimplification.isInQueue) {
+            if (bestSimplification.bestNeighbor != -1) {
+                priorityQueue.add(bestSimplification);
+                bestSimplification.isInQueue = true;
+            }
+        } else {
+            priorityQueue.remove(bestSimplification);
+            if (bestSimplification.bestNeighbor == -1) {
+                bestSimplification.isInQueue = false;
+            } else {
+                priorityQueue.add(bestSimplification);
+            }
+        }
+    }
+
+    private Optional<SimplificationStep> makeSimplificationStep(int edgeIndex1, int edgeIndex2) {
+        Edge edge1 = graph.getEdge(edgeIndex1);
+        Edge edge2 = graph.getEdge(edgeIndex2);
+        if (edge1.isBefore(edge2) || edge2.isBefore(edge1)) {
+            return Optional.empty();
+        }
+
+        Plan leftPlan1 = joinPlans.get(edgeIndex1).first;
+        Plan rightPlan1 = joinPlans.get(edgeIndex1).second;
+        Plan leftPlan2 = joinPlans.get(edgeIndex2).first;
+        Plan rightPlan2 = joinPlans.get(edgeIndex2).second;
+        Edge edge1Before2;
+        Edge edge2Before1;
+        List<Plan> commonPlan = new ArrayList<>();
+        if (isSubPlan(leftPlan1, edge1.getLeft(), leftPlan2, edge2.getLeft(), commonPlan)) {
+            // (common Join1 right1) Join2 right2
+            edge1Before2 = threeLeftJoin(commonPlan.get(0), edge1, rightPlan1, edge2, rightPlan2);
+            // (common Join2 right2) Join1 right1
+            edge2Before1 = threeLeftJoin(commonPlan.get(0), edge2, rightPlan2, edge1, rightPlan1);
+        } else if (isSubPlan(leftPlan1, edge1.getLeft(), rightPlan2, edge2.getRight(), commonPlan)) {
+            // left2 Join2 (common Join1 right1)
+            edge1Before2 = threeRightJoin(leftPlan2, edge2, commonPlan.get(0), edge1, rightPlan1);
+            // (left2 Join2 common) join1 right1
+            edge2Before1 = threeLeftJoin(leftPlan2, edge2, commonPlan.get(0), edge1, rightPlan1);
+        } else if (isSubPlan(rightPlan1, edge1.getRight(), leftPlan2, edge2.getLeft(), commonPlan)) {
+            // (left1 Join1 common) Join2 right2
+            edge1Before2 = threeLeftJoin(leftPlan1, edge1, commonPlan.get(0), edge2, rightPlan2);
+            // left1 Join1 (common Join2 right2)
+            edge2Before1 = threeRightJoin(leftPlan1, edge1, commonPlan.get(0), edge2, rightPlan2);
+        } else if (isSubPlan(rightPlan1, edge1.getRight(), rightPlan2, edge2.getRight(), commonPlan)) {
+            // left2 Join2 (left1 Join1 common)
+            edge1Before2 = threeRightJoin(leftPlan2, edge2, leftPlan1, edge1, commonPlan.get(0));
+            // left1 Join1 (left2 Join2 common)
+            edge2Before1 = threeRightJoin(leftPlan1, edge1, leftPlan2, edge2, commonPlan.get(0));
+        } else {
+            return Optional.empty();
+        }
+        // edge1 is not the neighborhood of edge2
+        return Optional.of(orderJoin(edge1Before2, edge2Before1, edgeIndex1, edgeIndex2));
+    }
+
+    Edge threeLeftJoin(Plan plan1, Edge edge1, Plan plan2, Edge edge2, Plan plan3) {
+        // (plan1 edge1 plan2) edge2 plan3
+        LogicalJoin join = simulateJoin(simulateJoin(plan1, edge1.getJoin(), plan2), edge2.getJoin(), plan3);
+        Edge edge = new Edge(join, -1);
+        edge.addLeftNodes(edge1.getLeft(), edge1.getRight(), edge2.getLeft());
+        edge.addRightNode(edge2.getRight());
+        return edge;
+    }
+
+    Edge threeRightJoin(Plan plan1, Edge edge1, Plan plan2, Edge edge2, Plan plan3) {
+        // plan1 edge1 (plan2 edge2 plan3)
+        LogicalJoin join = simulateJoin(plan1, edge1.getJoin(), simulateJoin(plan2, edge2.getJoin(), plan3));
+        Edge edge = new Edge(join, -1);
+        edge.addLeftNode(edge1.getLeft());
+        edge.addRightNodes(edge2.getRight(), edge2.getLeft(), edge1.getRight());
+        return edge;
+    }
+
+    private Group getGroup(Plan plan) {
+        if (plan instanceof GroupPlan) {
+            return ((GroupPlan) plan).getGroup();
+        }
+        assert plan.getGroupExpression().isPresent() : "All plan in GraphSimplifier must have a group";
+        return plan.getGroupExpression().get().getOwnerGroup();
+    }
+
+    private SimplificationStep orderJoin(Edge edge1Before2, Edge edge2Before1, int edgeIndex1, int edgeIndex2) {
+        double cost1Before2 = getSimpleCost(edge1Before2.getJoin());
+        double cost2Before1 = getSimpleCost(edge2Before1.getJoin());
+        double benefit = Double.MAX_VALUE;
+        SimplificationStep step;
+        // Choose the plan with smaller cost and make the simplification step to replace the old edge by it.
+        if (cost1Before2 < cost2Before1) {
+            if (cost1Before2 != 0) {
+                benefit = cost2Before1 / cost1Before2;
+            }
+            step = new SimplificationStep(benefit, edgeIndex1, edgeIndex2, edge1Before2.getJoin().left(),
+                    edge1Before2.getJoin().right(), edge1Before2.getLeft(), edge1Before2.getRight());
+        } else {
+            if (cost2Before1 != 0) {
+                benefit = cost1Before2 / cost2Before1;
+            }
+            step = new SimplificationStep(benefit, edgeIndex2, edgeIndex1, edge2Before1.getJoin().left(),
+                    edge2Before1.getJoin().right(), edge2Before1.getLeft(), edge2Before1.getRight());
+        }
+        return step;
+    }
+
+    /**
+     * This function check whether the plan1 is a sub-plan of plan2 or the opposite
+     *
+     * @param plan1 the fist plan
+     * @param bitSet1 the reference nodes of the first plan
+     * @param plan2 the second plan
+     * @param bitSet2 the reference nodes of the second plan
+     * @param commonPlan the super plan is store here
+     * @return whether the plan1 is a sub-plan of plan2 or the opposite
+     */
+    private boolean isSubPlan(Plan plan1, BitSet bitSet1, Plan plan2, BitSet bitSet2, List<Plan> commonPlan) {
+        if (isSubset(bitSet1, bitSet2)) {
+            commonPlan.add(plan2);
+            return true;
+        } else if (isSubset(bitSet2, bitSet1)) {
+            commonPlan.add(plan1);
+            return true;
+        }
+        return false;
+    }
+
+    private double getSimpleCost(Plan plan) {
+        if (plan instanceof GroupPlan) {
+            return ((GroupPlan) plan).getGroup().getStatistics().getRowCount();
+        }
+        return plan.getGroupExpression().get().getCostByProperties(PhysicalProperties.ANY);
+    }
+
+    private LogicalJoin simulateJoin(Plan plan1, LogicalJoin join, Plan plan2) {
+        // In Graph Simplifier, we use the simple cost model, that is
+        //      Plan.cost = Plan.rowCount + Plan.children1.cost + ...
+        // The reason is that this cost model has ASI (adjacent sequence interchange) property.
+        // TODO: consider network, data distribution cost
+        double cost = 0;
+        LogicalJoin newJoin = new LogicalJoin(join.getJoinType(), plan1, plan2);
+        List<Group> children = new ArrayList<>();
+        cost += getGroup(plan1).getStatistics().getRowCount();
+        children.add(getGroup(plan1));
+        cost += getGroup(plan2).getStatistics().getRowCount();
+        children.add(getGroup(plan2));
+
+        GroupExpression groupExpression = new GroupExpression(newJoin, children);
+        Group group = new Group();
+        group.addGroupExpression(groupExpression);
+        StatsCalculator.estimate(groupExpression);
+        cost += group.getStatistics().getRowCount();
+
+        List<PhysicalProperties> inputs = new ArrayList<>();
+        inputs.add(PhysicalProperties.ANY);
+        inputs.add(PhysicalProperties.ANY);
+        groupExpression.updateLowestCostTable(PhysicalProperties.ANY, inputs, cost);
+
+        return (LogicalJoin) newJoin.withGroupExpression(Optional.of(groupExpression));
+    }
+
+    private boolean isSubset(BitSet bitSet1, BitSet bitSet2) {
+        BitSet bitSet = new BitSet();
+        bitSet.or(bitSet1);
+        bitSet.or(bitSet2);
+        return bitSet.equals(bitSet2);
+    }
+
+    class SimplificationStep {
+        double benefit;
+        int beforeIndex;
+        int afterIndex;
+        BitSet newLeft;
+        BitSet newRight;
+        Plan leftPlan;
+        Plan rightPlan;
+
+        SimplificationStep(double benefit, int beforeIndex, int afterIndex, Plan leftPlan, Plan rightPlan,
+                BitSet newLeft, BitSet newRight) {
+            this.afterIndex = afterIndex;
+            this.beforeIndex = beforeIndex;
+            this.benefit = benefit;
+            this.leftPlan = leftPlan;
+            this.rightPlan = rightPlan;
+            this.newLeft = newLeft;
+            this.newRight = newRight;
+        }
+
+        public double getBenefit() {
+            return benefit;
+        }
+
+        @Override
+        public String toString() {
+            return String.format("%d -> %d %.2f", beforeIndex, afterIndex, benefit);
+        }
+    }
+
+    class BestSimplification implements Comparable<BestSimplification> {
+        int bestNeighbor = -1;
+        Optional<SimplificationStep> step = Optional.empty();
+        // This data whether to be added to the queue
+        boolean isInQueue = false;
+
+        @Override
+        public int compareTo(GraphSimplifier.BestSimplification o) {
+            Preconditions.checkArgument(step.isPresent());
+            return Double.compare(getBenefit(), o.getBenefit());
+        }
+
+        public double getBenefit() {
+            return step.get().getBenefit();
+        }
+
+        public SimplificationStep getStep() {
+            return step.get();
+        }
+
+        public void setStep(SimplificationStep step) {
+            this.step = Optional.of(step);
+        }
+
+        @Override
+        public String toString() {
+            return step.toString();
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/joinreorder/hypergraph/HyperGraph.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/joinreorder/hypergraph/HyperGraph.java
@@ -26,6 +26,8 @@ import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalJoin;
 import org.apache.doris.nereids.trees.plans.logical.LogicalProject;
 
+import com.google.common.base.Preconditions;
+
 import java.util.ArrayList;
 import java.util.BitSet;
 import java.util.List;
@@ -47,6 +49,26 @@ public class HyperGraph {
         return graph;
     }
 
+    public List<Edge> getEdges() {
+        return edges;
+    }
+
+    public Edge getEdge(int index) {
+        return edges.get(index);
+    }
+
+    public Node getNode(int index) {
+        return nodes.get(index);
+    }
+
+    public Plan getPlan(BitSet bitSet) {
+        // In HyperGraph, we assume that each edge is a simple edge at first.
+        // Therefore, it only supports to get simple plan
+        Preconditions.checkArgument(bitSet.cardinality() == 1);
+        int index = bitSet.nextSetBit(0);
+        return nodes.get(index).getPlan();
+    }
+
     public Plan toPlan() {
         BitSet bitSet = new BitSet();
         bitSet.set(0, nodes.size());
@@ -54,7 +76,9 @@ public class HyperGraph {
     }
 
     public boolean simplify() {
-        return false;
+        GraphSimplifier graphSimplifier = new GraphSimplifier(this);
+        graphSimplifier.initFirstStep();
+        return graphSimplifier.simplifyGraph(1);
     }
 
     public boolean emitPlan() {
@@ -87,7 +111,9 @@ public class HyperGraph {
         // Now we only support inner join with Inside-Project
         // TODO: Other joins can be added according CD-C algorithm
         if (join.getJoinType() != JoinType.INNER_JOIN) {
-            nodes.add(new Node(nodes.size(), plan));
+            Node node = new Node(nodes.size(), plan);
+            receiver.addNode(node);
+            nodes.add(node);
             return;
         }
 
@@ -110,7 +136,7 @@ public class HyperGraph {
     }
 
     private void addEdge(LogicalJoin<? extends Plan, ? extends Plan> join) {
-        Edge edge = new Edge(edges.size(), join);
+        Edge edge = new Edge(join, edges.size());
         for (Expression expression : join.getHashJoinConjuncts()) {
             EqualTo equal = (EqualTo) expression;
             edge.addLeftNode(findNode(equal.left().getInputSlots()));
@@ -121,9 +147,41 @@ public class HyperGraph {
             edge.addConstraintNode(findNode(expression.getInputSlots()));
         }
 
+        // attach the edge to all reference nodes.
         edge.getReferenceNodes().stream().forEach(index -> nodes.get(index).attachEdge(edge));
         edges.add(edge);
-        edges.add(edge.reverse());
+        // In MySQL, each edge is reversed and store in edges again for reducing the branch miss
+        // We don't implement this trick now.
+    }
+
+    /**
+     * Graph simplifier need to update the edge for join ordering
+     *
+     * @param edgeIndex The index of updated edge
+     * @param newLeft The new left of updated edge
+     * @param newRight The new right of update edge
+     */
+    public void modifyEdge(int edgeIndex, BitSet newLeft, BitSet newRight) {
+        // When modify an edge in hyper graph, we need to update the left and right nodes
+        // For these nodes that are only in the old edge, we need remove the edge from them
+        // For these nodes that are only in the new edge, we need to add the edge to them
+        Edge edge = edges.get(edgeIndex);
+        updateEdges(edge, edge.getLeft(), newLeft);
+        updateEdges(edge, edge.getRight(), newRight);
+        edges.get(edgeIndex).setLeft(newLeft);
+        edges.get(edgeIndex).setRight(newRight);
+    }
+
+    private void updateEdges(Edge edge, BitSet oldNodes, BitSet newNodes) {
+        BitSet removeNodes = new BitSet();
+        removeNodes.or(oldNodes);
+        removeNodes.andNot(newNodes);
+        removeNodes.stream().forEach(index -> nodes.get(index).removeEdge(edge));
+
+        BitSet addedNodes = new BitSet();
+        addedNodes.or(newNodes);
+        addedNodes.andNot(oldNodes);
+        addedNodes.stream().forEach(index -> nodes.get(index).attachEdge(edge));
     }
 
     /**
@@ -137,21 +195,23 @@ public class HyperGraph {
      */
     public String toDottyHyperGraph() {
         StringBuilder builder = new StringBuilder();
-        builder.append(String.format("digraph G {  # %d edges\n", edges.size() / 2));
+        builder.append(String.format("digraph G {  # %d edges\n", edges.size()));
         List<String> graphvisNodes = new ArrayList<>();
         for (Node node : nodes) {
-            String nodeName = node.getPlan().getType().name() + node.getIndex();
+            String nodeName = node.getName();
             // nodeID is used to identify the node with the same name
             String nodeID = nodeName;
             while (graphvisNodes.contains(nodeID)) {
                 nodeID += "_";
             }
-            builder.append(String.format("  %s [label=\"%s\"];\n", nodeID, nodeName));
+            builder.append(String.format("  %s [label=\"%s \n rowCount=%.2f\"];\n",
+                    nodeID, nodeName, node.getRowCount()));
             graphvisNodes.add(nodeName);
         }
-        for (int i = 0; i < edges.size(); i += 2) {
+        for (int i = 0; i < edges.size(); i += 1) {
             Edge edge = edges.get(i);
-            String label = String.valueOf(edge.getSelectivity());
+            // TODO: add cardinality to label
+            String label = String.format("%.2f", edge.getSelectivity());
             if (edges.get(i).isSimple()) {
                 String arrowHead = "";
                 if (edge.getJoin().getJoinType() == JoinType.INNER_JOIN) {
@@ -164,7 +224,7 @@ public class HyperGraph {
                         graphvisNodes.get(rightIndex), label, arrowHead));
             } else {
                 // Hyper edge is considered as a tiny virtual node
-                builder.append(String.format("e%d [shape=circle, width=.001, label=\"\"\n", i));
+                builder.append(String.format("e%d [shape=circle, width=.001, label=\"\"]\n", i));
 
                 String leftLabel = "";
                 String rightLabel = "";
@@ -178,13 +238,13 @@ public class HyperGraph {
                 String finalLeftLabel = leftLabel;
                 edge.getLeft().stream().forEach(nodeIndex -> {
                     builder.append(String.format("%s -> e%d [arrowhead=none, label=\"%s\"]\n",
-                                graphvisNodes.get(nodeIndex), finalI, finalLeftLabel));
+                            graphvisNodes.get(nodeIndex), finalI, finalLeftLabel));
                 });
 
                 String finalRightLabel = rightLabel;
                 edge.getRight().stream().forEach(nodeIndex -> {
                     builder.append(String.format("%s -> e%d [arrowhead=none, label=\"%s\"]\n",
-                                graphvisNodes.get(nodeIndex), finalI, finalRightLabel));
+                            graphvisNodes.get(nodeIndex), finalI, finalRightLabel));
                 });
             }
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/joinreorder/hypergraph/Node.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/joinreorder/hypergraph/Node.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.nereids.rules.joinreorder.hypergraph;
 
+import org.apache.doris.nereids.trees.plans.GroupPlan;
 import org.apache.doris.nereids.trees.plans.Plan;
 
 import com.google.common.collect.Lists;
@@ -88,5 +89,24 @@ class Node {
         } else {
             complexEdges.add(edge);
         }
+    }
+
+    public void removeEdge(Edge edge) {
+        if (edge.isSimple()) {
+            simpleEdges.remove(edge);
+        } else {
+            complexEdges.remove(edge);
+        }
+        assert false : String.format("removed edge %d at %d that does not exists", edge.getIndex(), index);
+    }
+
+    public String getName() {
+        assert plan instanceof GroupPlan : "Each node is a group plan in child";
+        return ((GroupPlan) plan).getGroup().getLogicalExpression().getPlan().getType().name() + index;
+    }
+
+    public double getRowCount() {
+        assert plan instanceof GroupPlan : "Each node is a group plan in child";
+        return ((GroupPlan) plan).getGroup().getStatistics().getRowCount();
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/joinreorder/hypergraph/Receiver.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/joinreorder/hypergraph/Receiver.java
@@ -58,10 +58,14 @@ public class Receiver {
         return true;
     }
 
-    public void addPlan(Node node) {
+    public void addNode(Node node) {
         BitSet bitSet = new BitSet();
         bitSet.set(node.getIndex());
         planMap.put(bitSet, node.getPlan());
+    }
+
+    public void addPlan(BitSet referenceNodes, Plan plan) {
+        planMap.put(referenceNodes, plan);
     }
 
     public Plan getBestPlan(BitSet bitSet) {

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/joinreorder/HyperGraphJoinReorderGroupPlanTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/joinreorder/HyperGraphJoinReorderGroupPlanTest.java
@@ -45,6 +45,7 @@ class HyperGraphJoinReorderGroupPlanTest {
                 .build();
 
         PlanChecker.from(MemoTestUtils.createConnectContext(), plan)
+                .deriveStats()
                 .applyTopDown(new HyperGraphJoinReorderGroupPlan())
                 .printlnTree();
     }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/joinreorder/HyperGraphJoinReorderTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/joinreorder/HyperGraphJoinReorderTest.java
@@ -49,6 +49,7 @@ class HyperGraphJoinReorderTest {
                 .build();
 
         PlanChecker.from(MemoTestUtils.createConnectContext(), plan)
+                .deriveStats()
                 .applyTopDown(new HyperGraphJoinReorder())
                 .printlnTree();
     }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/joinreorder/hypergraph/GraphSimplifierTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/joinreorder/hypergraph/GraphSimplifierTest.java
@@ -22,9 +22,9 @@ import org.apache.doris.nereids.util.HyperGraphBuilder;
 
 import org.junit.jupiter.api.Test;
 
-public class HyperGraphTest {
+public class GraphSimplifierTest {
     @Test
-    void testHyperGraph() {
+    void testGraphSimplifier() {
         HyperGraph hyperGraph = new HyperGraphBuilder()
                 .init("t1", 10)
                 .join(JoinType.INNER_JOIN, "t2", 20)
@@ -32,7 +32,11 @@ public class HyperGraphTest {
                 .join(JoinType.INNER_JOIN, "t4", 40)
                 .join(JoinType.INNER_JOIN, "t5", 50)
                 .build();
-        String dottyGraph = hyperGraph.toDottyHyperGraph();
+        GraphSimplifier graphSimplifier = new GraphSimplifier(hyperGraph);
+        graphSimplifier.initFirstStep();
+        while (graphSimplifier.applySimplificationStep()) {
+        }
+
         String target = "digraph G {  # 4 edges\n"
                 + "  LOGICAL_OLAP_SCAN0 [label=\"LOGICAL_OLAP_SCAN0 \n"
                 + " rowCount=10.00\"];\n"
@@ -44,12 +48,24 @@ public class HyperGraphTest {
                 + " rowCount=40.00\"];\n"
                 + "  LOGICAL_OLAP_SCAN4 [label=\"LOGICAL_OLAP_SCAN4 \n"
                 + " rowCount=50.00\"];\n"
-                + "LOGICAL_OLAP_SCAN0 -> LOGICAL_OLAP_SCAN1 [label=\"0.10\",arrowhead=none]\n"
-                + "LOGICAL_OLAP_SCAN0 -> LOGICAL_OLAP_SCAN2 [label=\"0.05\",arrowhead=none]\n"
-                + "LOGICAL_OLAP_SCAN0 -> LOGICAL_OLAP_SCAN3 [label=\"0.03\",arrowhead=none]\n"
+                + "e0 [shape=circle, width=.001, label=\"\"]\n"
+                + "LOGICAL_OLAP_SCAN0 -> e0 [arrowhead=none, label=\"0.10\"]\n"
+                + "LOGICAL_OLAP_SCAN2 -> e0 [arrowhead=none, label=\"0.10\"]\n"
+                + "LOGICAL_OLAP_SCAN3 -> e0 [arrowhead=none, label=\"0.10\"]\n"
+                + "LOGICAL_OLAP_SCAN4 -> e0 [arrowhead=none, label=\"0.10\"]\n"
+                + "LOGICAL_OLAP_SCAN1 -> e0 [arrowhead=none, label=\"\"]\n"
+                + "e1 [shape=circle, width=.001, label=\"\"]\n"
+                + "LOGICAL_OLAP_SCAN0 -> e1 [arrowhead=none, label=\"0.05\"]\n"
+                + "LOGICAL_OLAP_SCAN3 -> e1 [arrowhead=none, label=\"0.05\"]\n"
+                + "LOGICAL_OLAP_SCAN4 -> e1 [arrowhead=none, label=\"0.05\"]\n"
+                + "LOGICAL_OLAP_SCAN2 -> e1 [arrowhead=none, label=\"\"]\n"
+                + "e2 [shape=circle, width=.001, label=\"\"]\n"
+                + "LOGICAL_OLAP_SCAN0 -> e2 [arrowhead=none, label=\"0.03\"]\n"
+                + "LOGICAL_OLAP_SCAN4 -> e2 [arrowhead=none, label=\"0.03\"]\n"
+                + "LOGICAL_OLAP_SCAN3 -> e2 [arrowhead=none, label=\"\"]\n"
                 + "LOGICAL_OLAP_SCAN0 -> LOGICAL_OLAP_SCAN4 [label=\"0.03\",arrowhead=none]\n"
                 + "}\n";
+        String dottyGraph = hyperGraph.toDottyHyperGraph();
         assert dottyGraph.equals(target) : dottyGraph;
-
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/util/HyperGraphBuilder.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/util/HyperGraphBuilder.java
@@ -1,0 +1,101 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.util;
+
+import org.apache.doris.nereids.CascadesContext;
+import org.apache.doris.nereids.pattern.GroupExpressionMatching;
+import org.apache.doris.nereids.rules.Rule;
+import org.apache.doris.nereids.rules.joinreorder.HyperGraphJoinReorderGroupPlan;
+import org.apache.doris.nereids.rules.joinreorder.hypergraph.HyperGraph;
+import org.apache.doris.nereids.stats.StatsCalculator;
+import org.apache.doris.nereids.trees.expressions.EqualTo;
+import org.apache.doris.nereids.trees.plans.GroupPlan;
+import org.apache.doris.nereids.trees.plans.JoinType;
+import org.apache.doris.nereids.trees.plans.Plan;
+import org.apache.doris.nereids.trees.plans.logical.LogicalJoin;
+import org.apache.doris.nereids.trees.plans.logical.LogicalOlapScan;
+import org.apache.doris.nereids.trees.plans.logical.LogicalPlan;
+import org.apache.doris.statistics.StatsDeriveResult;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+public class HyperGraphBuilder {
+    HashMap<String, Integer> tableRowCount = new HashMap<>();
+    LogicalPlan plan;
+
+    public HyperGraph build() {
+        Plan planWithStats = extractJoinCluster(this.plan);
+        System.out.println(planWithStats.treeString());
+        HyperGraph graph = HyperGraph.fromPlan(planWithStats);
+        return graph;
+    }
+
+    public HyperGraphBuilder init(String name, int rowCount) {
+        assert !tableRowCount.containsKey(name) : "The join table must be new";
+        tableRowCount.put(name, rowCount);
+        plan = PlanConstructor.newLogicalOlapScan(tableRowCount.size(), name, 0);
+        return this;
+    }
+
+    public HyperGraphBuilder join(JoinType joinType, String name, int rowCount) {
+        assert !tableRowCount.containsKey(name) : "The join table must be new";
+        tableRowCount.put(name, rowCount);
+        Plan scan = PlanConstructor.newLogicalOlapScan(tableRowCount.size(), name, 0);
+        ImmutableList<EqualTo> hashConjunts = ImmutableList.of(
+                new EqualTo(this.plan.getOutput().get(0), scan.getOutput().get(0)));
+        this.plan = new LogicalJoin<>(joinType, new ArrayList<>(hashConjunts),
+                this.plan, scan);
+        return this;
+    }
+
+    private Plan extractJoinCluster(Plan plan) {
+        Rule rule = new HyperGraphJoinReorderGroupPlan().build();
+        CascadesContext cascadesContext = MemoTestUtils.createCascadesContext(MemoTestUtils.createConnectContext(),
+                plan);
+        GroupExpressionMatching groupExpressionMatching
+                = new GroupExpressionMatching(rule.getPattern(),
+                cascadesContext.getMemo().getRoot().getLogicalExpression());
+        List<Plan> planList = new ArrayList<>();
+        for (Plan matchingPlan : groupExpressionMatching) {
+            planList.add(matchingPlan);
+        }
+        assert planList.size() == 1 : "Now we only support one join cluster";
+        injectRowcount(planList.get(0));
+        return planList.get(0);
+    }
+
+    private void injectRowcount(Plan plan) {
+        if (plan instanceof GroupPlan) {
+            GroupPlan olapGroupPlan = (GroupPlan) plan;
+            StatsCalculator.estimate(olapGroupPlan.getGroup().getLogicalExpression());
+            LogicalOlapScan scanPlan = (LogicalOlapScan) olapGroupPlan.getGroup().getLogicalExpression().getPlan();
+            StatsDeriveResult stats = olapGroupPlan.getGroup().getStatistics();
+            stats.setRowCount(tableRowCount.get(scanPlan.getTable().getName()));
+            return;
+        }
+        LogicalJoin join = (LogicalJoin) plan;
+        injectRowcount(join.left());
+        injectRowcount(join.right());
+        // Because the children stats has been changed, so we need to recalculate it
+        StatsCalculator.estimate(join.getGroupExpression().get());
+    }
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/util/PlanChecker.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/util/PlanChecker.java
@@ -23,6 +23,7 @@ import org.apache.doris.nereids.StatementContext;
 import org.apache.doris.nereids.glue.LogicalPlanAdapter;
 import org.apache.doris.nereids.jobs.JobContext;
 import org.apache.doris.nereids.jobs.batch.NereidsRewriteJobExecutor;
+import org.apache.doris.nereids.jobs.cascades.DeriveStatsJob;
 import org.apache.doris.nereids.memo.Group;
 import org.apache.doris.nereids.memo.GroupExpression;
 import org.apache.doris.nereids.memo.Memo;
@@ -243,6 +244,13 @@ public class PlanChecker {
         for (Group childGroup : groupExpression.children()) {
             applyExploration(childGroup, rule);
         }
+    }
+
+    public PlanChecker deriveStats() {
+        cascadesContext.pushJob(
+            new DeriveStatsJob(cascadesContext.getMemo().getRoot().getLogicalExpression(), cascadesContext.getCurrentJobContext()));
+        cascadesContext.getJobScheduler().executeJobPool(cascadesContext);
+        return this;
     }
 
     public PlanChecker matchesFromRoot(PatternDescriptor<? extends Plan> patternDesc) {


### PR DESCRIPTION
# Proposed changes

Issue Number: close #13903 

## Problem summary

Add a graph simplifier that can simplfy the hypergraph according cost.
Now we only support inner join, the very simple cost function.
And the circle detector has not been added

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [x] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

