### PR TITLE
[improvement](profile) support ordinary user to get query profile via http api

### DIFF
--- a/docs/en/docs/admin-manual/http-actions/fe/manager/query-profile-action.md
+++ b/docs/en/docs/admin-manual/http-actions/fe/manager/query-profile-action.md
@@ -30,6 +30,8 @@ under the License.
 
 `GET /rest/v2/manager/query/query_info`
 
+`GET /rest/v2/manager/query/trace/{trace_id}`
+
 `GET /rest/v2/manager/query/sql/{query_id}`
 
 `GET /rest/v2/manager/query/profile/text/{query_id}`
@@ -96,6 +98,12 @@ Gets information about select queries for all fe nodes in the cluster.
 }
 ```
 
+<version since="1.2">
+
+Admin 和 Root 用户可以查看所有 Query。普通用户仅能查看自己发送的 Query。
+
+</version>
+
 ### Examples
 ```
 GET /rest/v2/manager/query/query_info
@@ -134,6 +142,54 @@ GET /rest/v2/manager/query/query_info
     "count": 0
 }
 ```
+
+## Get Query Id By Trace Id
+
+`GET /rest/v2/manager/query/trace_id/{trace_id}`
+
+### Description
+
+Get query id by trance id.
+
+Before executing a Query, set a unique trace id:
+
+`set set session_context="trace_id:your_trace_id";`
+
+After executing the Query within the same Session, the query id can be obtained through the trace id.
+    
+### Path parameters
+
+* `{trace_id}`
+
+    User specific trace id.
+
+### Query parameters
+
+### Response
+
+```
+{
+    "msg": "success", 
+    "code": 0, 
+    "data": "fb1d9737de914af1-a498d5c5dec638d3", 
+    "count": 0
+}
+```
+
+<version since="1.2">
+
+Admin and Root user can view all queries. Ordinary users can only view the Query sent by themselves. If the specified trace id does not exist or has no permission, it will return Bad Request:
+
+```
+{
+    "msg": "Bad Request", 
+    "code": 403, 
+    "data": "error messages",
+    "count": 0
+}
+```
+
+</version>
 
 ## Get the sql and text profile for the specified query
 
@@ -180,6 +236,21 @@ Get the sql and profile text for the specified query id.
     "count": 0
 }
 ```
+
+<version since="1.2">
+
+Admin and Root user can view all queries. Ordinary users can only view the Query sent by themselves. If the specified trace id does not exist or has no permission, it will return Bad Request:
+
+```
+{
+    "msg": "Bad Request", 
+    "code": 403, 
+    "data": "error messages",
+    "count": 0
+}
+```
+
+</version>
     
 ### Examples
 
@@ -237,6 +308,21 @@ Get the fragment name, instance id and execution time for the specified query id
     "count": 0
 }
 ```
+
+<version since="1.2">
+
+Admin and Root user can view all queries. Ordinary users can only view the Query sent by themselves. If the specified trace id does not exist or has no permission, it will return Bad Request:
+
+```
+{
+    "msg": "Bad Request", 
+    "code": 403, 
+    "data": "error messages",
+    "count": 0
+}
+```
+
+</version>
     
 ### Examples
 
@@ -312,6 +398,21 @@ Get the tree profile information of the specified query id, same as `show query 
     "count": 0
 }
 ```
+
+<version since="1.2">
+
+Admin and Root user can view all queries. Ordinary users can only view the Query sent by themselves. If the specified trace id does not exist or has no permission, it will return Bad Request:
+
+```
+{
+    "msg": "Bad Request", 
+    "code": 403, 
+    "data": "error messages",
+    "count": 0
+}
+```
+
+</version>
 
 ## Current running queries
 

--- a/docs/zh-CN/docs/admin-manual/http-actions/fe/manager/query-profile-action.md
+++ b/docs/zh-CN/docs/admin-manual/http-actions/fe/manager/query-profile-action.md
@@ -30,6 +30,8 @@ under the License.
 
 `GET /rest/v2/manager/query/query_info`
 
+`GET /rest/v2/manager/query/trace/{trace_id}`
+
 `GET /rest/v2/manager/query/sql/{query_id}`
 
 `GET /rest/v2/manager/query/profile/text/{query_id}`
@@ -96,6 +98,12 @@ under the License.
 }
 ```
 
+<version since="1.2">
+
+Admin 和 Root 用户可以查看所有 Query。普通用户仅能查看自己发送的 Query。
+
+</version>
+
 ### Examples
 ```
 GET /rest/v2/manager/query/query_info
@@ -134,6 +142,54 @@ GET /rest/v2/manager/query/query_info
     "count": 0
 }
 ```
+
+## 通过 Trace Id 获取 Query Id
+
+`GET /rest/v2/manager/query/trace_id/{trace_id}`
+
+### Description
+
+通过 Trace Id 获取 Query Id.
+
+在执行一个 Query 前，先设置一个唯一的 trace id:
+
+`set set session_context="trace_id:your_trace_id";`
+
+在同一个 Session 链接内执行 Query 后，可以通过 trace id 获取 query id。
+    
+### Path parameters
+
+* `{trace_id}`
+
+    用户设置的 trace id.
+
+### Query parameters
+
+### Response
+
+```
+{
+    "msg": "success", 
+    "code": 0, 
+    "data": "fb1d9737de914af1-a498d5c5dec638d3", 
+    "count": 0
+}
+```
+
+<version since="1.2">
+
+Admin 和 Root 用户可以查看所有 Query。普通用户仅能查看自己发送的 Query。若指定 trace id 不存在或无权限，则返回 Bad Request：
+
+```
+{
+    "msg": "Bad Request", 
+    "code": 403, 
+    "data": "error messages",
+    "count": 0
+}
+```
+
+</version>
 
 ## 获取指定查询的sql和文本profile
 
@@ -180,6 +236,21 @@ GET /rest/v2/manager/query/query_info
     "count": 0
 }
 ```
+
+<version since="1.2">
+
+Admin 和 Root 用户可以查看所有 Query。普通用户仅能查看自己发送的 Query。若指定 query id 不存在或无权限，则返回 Bad Request：
+
+```
+{
+    "msg": "Bad Request", 
+    "code": 403, 
+    "data": "error messages",
+    "count": 0
+}
+```
+
+</version>
     
 ### Examples
 
@@ -237,6 +308,21 @@ GET /rest/v2/manager/query/query_info
     "count": 0
 }
 ```
+
+<version since="1.2">
+
+Admin 和 Root 用户可以查看所有 Query。普通用户仅能查看自己发送的 Query。若指定 query id 不存在或无权限，则返回 Bad Request：
+
+```
+{
+    "msg": "Bad Request", 
+    "code": 403, 
+    "data": "error messages",
+    "count": 0
+}
+```
+
+</version>
     
 ### Examples
 
@@ -313,6 +399,21 @@ GET /rest/v2/manager/query/query_info
 }
 ```
 
+<version since="1.2">
+
+Admin 和 Root 用户可以查看所有 Query。普通用户仅能查看自己发送的 Query。若指定 query id 不存在或无权限，则返回 Bad Request：
+
+```
+{
+    "msg": "Bad Request", 
+    "code": 403, 
+    "data": "error messages",
+    "count": 0
+}
+```
+
+</version>
+
 ## 正在执行的query
 
 `GET /rest/v2/manager/query/current_queries`
@@ -372,3 +473,4 @@ GET /rest/v2/manager/query/query_info
     "count": 0
 }
 ```
+

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/ProfileManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/ProfileManager.java
@@ -217,7 +217,7 @@ public class ProfileManager {
      * @param queryId
      * @throws DdlException
      */
-    public void checkAuthForQueryId(String user, String queryId) throws DdlException {
+    public void checkAuthByUserAndQueryId(String user, String queryId) throws DdlException {
         readLock.lock();
         try {
             ProfileElement element = queryIdToProfileMap.get(queryId);

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/ProfileManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/ProfileManager.java
@@ -18,6 +18,7 @@
 package org.apache.doris.common.util;
 
 import org.apache.doris.common.AnalysisException;
+import org.apache.doris.common.AuthenticationException;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.DdlException;
 import org.apache.doris.common.profile.MultiProfileTreeBuilder;
@@ -217,15 +218,15 @@ public class ProfileManager {
      * @param queryId
      * @throws DdlException
      */
-    public void checkAuthByUserAndQueryId(String user, String queryId) throws DdlException {
+    public void checkAuthByUserAndQueryId(String user, String queryId) throws AuthenticationException {
         readLock.lock();
         try {
             ProfileElement element = queryIdToProfileMap.get(queryId);
             if (element == null) {
-                throw new DdlException("query with id " + queryId + " not found");
+                throw new AuthenticationException("query with id " + queryId + " not found");
             }
             if (!element.infoStrings.get(USER).equals(user)) {
-                throw new DdlException("Access deny to view query with id: " + queryId);
+                throw new AuthenticationException("Access deny to view query with id: " + queryId);
             }
         } finally {
             readLock.unlock();

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/manager/QueryProfileAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/manager/QueryProfileAction.java
@@ -302,7 +302,6 @@ public class QueryProfileAction extends RestBaseController {
             @PathVariable("trace_id") String traceId,
             @RequestParam(value = IS_ALL_NODE_PARA, required = false, defaultValue = "true") boolean isAllNode) {
         executeCheckPassword(request, response);
-        checkGlobalAuth(ConnectContext.get().getCurrentUserIdentity(), PrivPredicate.ADMIN);
 
         if (isAllNode) {
             String httpPath = "/rest/v2/manager/query/trace_id/" + traceId;
@@ -346,7 +345,6 @@ public class QueryProfileAction extends RestBaseController {
             @PathVariable("query_id") String queryId,
             @RequestParam(value = IS_ALL_NODE_PARA, required = false, defaultValue = "true") boolean isAllNode) {
         executeCheckPassword(request, response);
-        checkGlobalAuth(ConnectContext.get().getCurrentUserIdentity(), PrivPredicate.ADMIN);
 
         if (isAllNode) {
             String httpPath = "/rest/v2/manager/query/profile/fragments/" + queryId;

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/manager/QueryProfileAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/manager/QueryProfileAction.java
@@ -269,7 +269,7 @@ public class QueryProfileAction extends RestBaseController {
         try {
             checkAuthByUserAndQueryId(queryId);
         } catch (AuthenticationException e) {
-            return ResponseEntityBuilder.unauthorized(e.getMessage());
+            return ResponseEntityBuilder.badRequest(e.getMessage());
         }
 
         if (format.equals("text")) {
@@ -327,7 +327,7 @@ public class QueryProfileAction extends RestBaseController {
             try {
                 checkAuthByUserAndQueryId(queryId);
             } catch (AuthenticationException e) {
-                return ResponseEntityBuilder.unauthorized(e.getMessage());
+                return ResponseEntityBuilder.badRequest(e.getMessage());
             }
 
             return ResponseEntityBuilder.ok(queryId);
@@ -364,7 +364,7 @@ public class QueryProfileAction extends RestBaseController {
             try {
                 checkAuthByUserAndQueryId(queryId);
             } catch (AuthenticationException e) {
-                return ResponseEntityBuilder.unauthorized(e.getMessage());
+                return ResponseEntityBuilder.badRequest(e.getMessage());
             }
 
             try {


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

In previous implementation, the following http api can only be used by admin or root user:
```
GET /rest/v2/manager/query/query_info
GET /rest/v2/manager/query/trace/{trace_id}
GET /rest/v2/manager/query/sql/{query_id}
GET /rest/v2/manager/query/profile/text/{query_id}
GET /rest/v2/manager/query/profile/graph/{query_id}
GET /rest/v2/manager/query/profile/json/{query_id}
GET /rest/v2/manager/query/profile/fragments/{query_id}
```

This pr change the behavior, that ordinary users can get profile of their own queries.
And if no auth, `bad request` will be returned.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [x] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
3. Has document been added or modified:
    - [x] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

