### PR TITLE
[feature](Nereids) bind alias in group by list

### DIFF
--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/datasets/clickbench/AnalyzeClickBenchTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/datasets/clickbench/AnalyzeClickBenchTest.java
@@ -110,10 +110,10 @@ public class AnalyzeClickBenchTest extends ClickBenchTestBase {
         checkAnalyze(ClickBenchUtils.Q17);
     }
 
-    // @Test
-    // public void q18() {
-    //     checkAnalyze(ClickBenchUtils.Q18);
-    // }
+    @Test
+    public void q18() {
+        checkAnalyze(ClickBenchUtils.Q18);
+    }
 
     @Test
     public void q19() {
@@ -160,10 +160,10 @@ public class AnalyzeClickBenchTest extends ClickBenchTestBase {
         checkAnalyze(ClickBenchUtils.Q27);
     }
 
-    // @Test
-    // public void q28() {
-    //     checkAnalyze(ClickBenchUtils.Q28);
-    // }
+    @Test
+    public void q28() {
+        checkAnalyze(ClickBenchUtils.Q28);
+    }
 
     @Test
     public void q29() {
@@ -215,10 +215,10 @@ public class AnalyzeClickBenchTest extends ClickBenchTestBase {
         checkAnalyze(ClickBenchUtils.Q38);
     }
 
-    // @Test
-    // public void q39() {
-    //     checkAnalyze(ClickBenchUtils.Q39);
-    // }
+    @Test
+    public void q39() {
+        checkAnalyze(ClickBenchUtils.Q39);
+    }
 
     @Test
     public void q40() {


### PR DESCRIPTION
# Proposed changes

support query having alias in group by list, such as:
```sql
SELECT c1 AS a, SUM(c2) FROM t GROUP BY a;
```

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [x] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [x] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

