### PR TITLE
[fix](planner) Fix inconsistent nullability between outputTuple and groupByExpr when executing agg query

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/AggregateInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/AggregateInfo.java
@@ -441,6 +441,30 @@ public final class AggregateInfo extends AggregateInfoBase {
         if (secondPhaseDistinctAggInfo_ != null) {
             secondPhaseDistinctAggInfo_.substitute(smap, analyzer);
         }
+
+        // About why:
+        // The outputTuple of the first phase aggregate info is generated at analysis phase of SelectStmt,
+        // and the SlotDescriptor of output tuple of this agg info will refer to the origin column of the
+        // table in the same query block.
+        //
+        // However, if the child node is a HashJoinNode with outerJoin type, the nullability of the SlotDescriptor
+        // might be changed, those changed SlotDescriptor is referred by a SlotRef, and this SlotRef will be added
+        // to the outputSmap of the HashJoinNode.
+        //
+        // In BE execution, the SlotDescriptor which referred by output and groupBy should have the same nullability,
+        // So we need the update SlotDescriptor of output tuple.
+        //
+        // About how:
+        // Since the outputTuple of agg info is simply create a SlotRef and SlotDescriptor for each expr in aggregate
+        // expr and groupBy expr, so we could handle this as this way.
+        for (SlotDescriptor slotDesc : getOutputTupleDesc().getSlots()) {
+            List<Expr> exprList = slotDesc.getSourceExprs();
+            if (exprList.size() > 1) {
+                continue;
+            }
+            Expr srcExpr = exprList.get(0).substitute(smap);
+            slotDesc.setIsNullable(srcExpr.isNullable() || slotDesc.getIsNullable());
+        }
     }
 
     /**


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary
do similiar thing as https://github.com/apache/doris/pull/11361

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

