### PR TITLE
[bug](ColumnDecimal)call set_decimalv2_type when cloning ColumnDecimal

### DIFF
--- a/be/src/vec/columns/column_decimal.cpp
+++ b/be/src/vec/columns/column_decimal.cpp
@@ -214,6 +214,9 @@ ColumnPtr ColumnDecimal<T>::permute(const IColumn::Permutation& perm, size_t lim
 template <typename T>
 MutableColumnPtr ColumnDecimal<T>::clone_resized(size_t size) const {
     auto res = this->create(0, scale);
+    if (this->is_decimalv2_type()) {
+        res->set_decimalv2_type();
+    }
 
     if (size > 0) {
         auto& new_col = assert_cast<Self&>(*res);

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -331,6 +331,7 @@ set(VEC_TEST_FILES
     vec/aggregate_functions/vec_window_funnel_test.cpp
     vec/aggregate_functions/vec_retention_test.cpp
     vec/aggregate_functions/agg_min_max_by_test.cpp
+    vec/columns/column_decimal_test.cpp
     vec/core/block_test.cpp
     vec/core/column_array_test.cpp
     vec/core/column_complex_test.cpp

--- a/be/test/vec/columns/column_decimal_test.cpp
+++ b/be/test/vec/columns/column_decimal_test.cpp
@@ -1,0 +1,52 @@
+
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "vec/columns/column_decimal.h"
+#include "vec/columns/columns_number.h"
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <string>
+
+namespace doris::vectorized {
+
+TEST(ColumnDecimalTest, CloneDecimalv2TypeTest) {
+    auto column1 = ColumnDecimal128::create(0, 1);
+    EXPECT_EQ(false, column1->is_decimalv2_type());
+    EXPECT_EQ(false, column1->clone_resized(0)->is_decimalv2_type());
+    column1->set_decimalv2_type();
+    EXPECT_EQ(true, column1->is_decimalv2_type());
+    EXPECT_EQ(true, column1->clone_resized(0)->is_decimalv2_type());
+
+    auto column2 = ColumnDecimal64::create(0, 1);
+    EXPECT_EQ(false, column2->is_decimalv2_type());
+    EXPECT_EQ(false, column2->clone_resized(0)->is_decimalv2_type());
+    column2->set_decimalv2_type();
+    EXPECT_EQ(true, column2->is_decimalv2_type());
+    EXPECT_EQ(true, column2->clone_resized(0)->is_decimalv2_type());
+
+    auto column3 = ColumnDecimal32::create(0, 1);
+    EXPECT_EQ(false, column3->is_decimalv2_type());
+    EXPECT_EQ(false, column3->clone_resized(0)->is_decimalv2_type());
+    column3->set_decimalv2_type();
+    EXPECT_EQ(true, column3->is_decimalv2_type());
+    EXPECT_EQ(true, column3->clone_resized(0)->is_decimalv2_type());
+}
+
+} // namespace doris::vectorized

--- a/be/test/vec/columns/column_decimal_test.cpp
+++ b/be/test/vec/columns/column_decimal_test.cpp
@@ -17,12 +17,13 @@
 // under the License.
 
 #include "vec/columns/column_decimal.h"
-#include "vec/columns/columns_number.h"
 
 #include <gtest/gtest.h>
 
 #include <memory>
 #include <string>
+
+#include "vec/columns/columns_number.h"
 
 namespace doris::vectorized {
 


### PR DESCRIPTION
# Proposed changes

Issue Number: close #14060

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [x] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

