### PR TITLE
[chore](build) add instructions to build version string

### DIFF
--- a/be/src/util/debug_util.cpp
+++ b/be/src/util/debug_util.cpp
@@ -55,6 +55,15 @@ std::string print_plan_node_type(const TPlanNodeType::type& type) {
 std::string get_build_version(bool compact) {
     std::stringstream ss;
     ss << DORIS_BUILD_VERSION
+#if defined(__x86_64__) || defined(_M_X64)
+#ifdef __AVX2__
+       << "(AVX2)"
+#else
+       << "(SSE4.2)"
+#endif
+#elif defined(__aarch64__)
+       << "(AArch64)"
+#endif
 #ifdef NDEBUG
        << " RELEASE"
 #else


### PR DESCRIPTION
# Proposed changes

add instructions to build version string, new version string like 
```
doris-0.0.0-trunk(AVX2) DEBUG (build git://host@45dfe38357c435f236f8b16ddb24c58e781e8598)
Built on Tue, 08 Nov 2022 14:37:16 CST by host
```

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

