### PR TITLE
[fix](log) fix and clarify error msg for tablet writer write failure (#14078)

### DIFF
--- a/be/src/olap/memtable_flush_executor.cpp
+++ b/be/src/olap/memtable_flush_executor.cpp
@@ -92,7 +92,7 @@ void FlushToken::_flush_memtable(MemTable* memtable, int64_t submit_task_time) {
         LOG(WARNING) << "Flush memtable failed with res = " << s;
     }
     // If s is not ok, ignore the code, just use other code is ok
-    _flush_status.store(s.ok() ? OLAP_SUCCESS : OLAP_ERR_OTHER_ERROR);
+    _flush_status.store(s.ok() ? OLAP_SUCCESS : (ErrorCode)s.precise_code());
     if (_flush_status.load() != OLAP_SUCCESS) {
         return;
     }

--- a/be/src/runtime/tablets_channel.cpp
+++ b/be/src/runtime/tablets_channel.cpp
@@ -476,10 +476,9 @@ Status TabletsChannel::add_batch(const TabletWriterAddRequest& request,
         if (!st.ok()) {
             auto err_msg = strings::Substitute(
                     "tablet writer write failed, tablet_id=$0, txn_id=$1, err=$2"
-                    ", errcode=$3, msg:$4",
-                    tablet_to_rowidxs_it.first, _txn_id, st.code(), st.precise_code(),
-                    st.get_error_msg());
-            LOG(WARNING) << err_msg;
+                    ", precise_code=$3",
+                    tablet_to_rowidxs_it.first, _txn_id, st.code(), st.precise_code());
+            LOG(WARNING) << err_msg << " bt:" << st.get_error_msg();
             PTabletError* error = tablet_errors->Add();
             error->set_tablet_id(tablet_to_rowidxs_it.first);
             error->set_msg(err_msg);


### PR DESCRIPTION
Fix vague error code in err log and stop printing backtrace stack in load result if tablet writer write failed. Providing error code & precise code is enough to identify the cause of the problem and leave the backtrace only in be log.

Signed-off-by: freemandealer <freeman.zhang1992@gmail.com>

# Proposed changes

Issue Number: close #14078

## Problem summary

Stop printing backtrace stack in load result if tablet writer write failed. Providing error code & precise code is enough to identify the cause of the problem and leave the backtrace only in be log.

Original load results:

![image](https://user-images.githubusercontent.com/6492193/200560530-97c41ae7-e2f6-4bad-8dc4-24920c06096c.png)


Load results after applying the patch:
```
{
    "TxnId": 4019,
    "Label": "08753366-87c5-444a-80bf-d733562b8a2b",
    "TwoPhaseCommit": "false",
    "Status": "Fail",
    "Message": "cancelled: tablet writer write failed, tablet_id=18155, txn_id=4019, err=6, precise_code=-238, host: 127.0.0.1",
    "NumberTotalRows": 0,
    "NumberLoadedRows": 0,
    "NumberFilteredRows": 0,
    "NumberUnselectedRows": 0,
    "LoadBytes": 632619008,
    "LoadTimeMs": 51621,
    "BeginTxnTimeMs": 0,
    "StreamLoadPutTimeMs": 40,
    "ReadDataTimeMs": 35999,
    "WriteDataTimeMs": 50574,
    "CommitAndPublishTimeMs": 0
}
```

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [X] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [X] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [X] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [X] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [X] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

