### PR TITLE
[Opt](exec) prevent the scan key split whole range

### DIFF
--- a/be/src/exec/olap_common.h
+++ b/be/src/exec/olap_common.h
@@ -537,6 +537,17 @@ bool ColumnValueRange<primitive_type>::convert_to_avg_range_value(
         end_scan_keys.back().add_value(
                 cast_to_string<primitive_type, CppType>(get_range_max_value(), scale()));
         return true;
+    } else if (is_low_value_mininum() && is_high_value_maximum()) {
+        // Do not split the range of whole range. TODO: figure out why the code
+        // execute here
+        begin_scan_keys.emplace_back();
+        begin_scan_keys.back().add_value(
+                cast_to_string<primitive_type, CppType>(get_range_min_value(), scale()),
+                contain_null());
+        end_scan_keys.emplace_back();
+        end_scan_keys.back().add_value(
+                cast_to_string<primitive_type, CppType>(get_range_max_value(), scale()));
+        return true;
     } else {
         CppType current = get_range_min_value();
         CppType max_value = get_range_max_value();

--- a/be/test/exec/olap_common_test.cpp
+++ b/be/test/exec/olap_common_test.cpp
@@ -624,9 +624,9 @@ TEST_F(OlapScanKeysTest, EachtypeTest) {
         EXPECT_EQ(exact_range, true);
         scan_keys.get_key_range(&key_range);
         // contain null, [-128, 127]
-        EXPECT_EQ(key_range.size(), 256);
-        EXPECT_EQ(OlapScanKeys::to_print_key(key_range[0]->begin_scan_range), "-128");
-        EXPECT_EQ(OlapScanKeys::to_print_key(key_range[254]->end_scan_range), "127");
+        EXPECT_EQ(key_range.size(), 1);
+        EXPECT_EQ(OlapScanKeys::to_print_key(key_range[0]->begin_scan_range), "null(-128)");
+        EXPECT_EQ(OlapScanKeys::to_print_key(key_range[0]->end_scan_range), "127");
 
         EXPECT_TRUE(range.add_range(FILTER_LESS, 50).ok());
         scan_keys.clear();
@@ -648,9 +648,9 @@ TEST_F(OlapScanKeysTest, EachtypeTest) {
         EXPECT_TRUE(scan_keys.extend_scan_key(range, max_scan_key, &exact_range).ok());
         EXPECT_EQ(exact_range, true);
         scan_keys.get_key_range(&key_range);
-        EXPECT_EQ(key_range.size(), 49);
-        EXPECT_EQ(OlapScanKeys::to_print_key(key_range[0]->begin_scan_range), "-32768");
-        EXPECT_EQ(OlapScanKeys::to_print_key(key_range[max_scan_key - 1]->end_scan_range), "32767");
+        EXPECT_EQ(key_range.size(), 1);
+        EXPECT_EQ(OlapScanKeys::to_print_key(key_range[0]->begin_scan_range), "null(-32768)");
+        EXPECT_EQ(OlapScanKeys::to_print_key(key_range[0]->end_scan_range), "32767");
 
         EXPECT_TRUE(range.add_range(FILTER_LARGER, 0).ok());
         scan_keys.clear();

--- a/run-be-ut.sh
+++ b/run-be-ut.sh
@@ -72,7 +72,7 @@ fi
 
 eval set -- "${OPTS}"
 
-PARALLEL="$(($(nproc) / 5 + 1))"
+PARALLEL="$(($(nproc) / 2 + 1))"
 
 CLEAN=0
 RUN=0


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

