### PR TITLE
[fix](ctas) fix wrong string column length after executing ctas from external table 

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/HiveMetaStoreClientHelper.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/HiveMetaStoreClientHelper.java
@@ -771,7 +771,7 @@ public class HiveMetaStoreClientHelper {
                 return Type.DOUBLE;
             case "string":
             case "binary":
-                return Type.STRING;
+                return ScalarType.createStringType();
             default:
                 break;
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
@@ -98,6 +98,7 @@ import org.apache.doris.catalog.Partition;
 import org.apache.doris.catalog.PartitionInfo;
 import org.apache.doris.catalog.PartitionItem;
 import org.apache.doris.catalog.PartitionType;
+import org.apache.doris.catalog.PrimitiveType;
 import org.apache.doris.catalog.RangePartitionItem;
 import org.apache.doris.catalog.Replica;
 import org.apache.doris.catalog.Replica.ReplicaState;
@@ -1206,7 +1207,6 @@ public class InternalCatalog implements CatalogIf<Database> {
                 Expr resultExpr = resultExprs.get(i);
                 Type resultType = resultExpr.getType();
                 if (resultType.isStringType() && resultType.getLength() < 0) {
-                    // alway set text length MAX_STRING_LENGTH
                     typeDef = new TypeDef(ScalarType.createStringType());
                 } else if (resultType.isDecimalV2() && resultType.equals(ScalarType.DECIMALV2)) {
                     typeDef = new TypeDef(ScalarType.createDecimalType(27, 9));
@@ -1220,9 +1220,9 @@ public class InternalCatalog implements CatalogIf<Database> {
                     // If this is the first column, because olap table does not support the first column to be
                     // string, float, double or array, we should check and modify its type
                     // For string type, change it to varchar.
-                    // For other unsupport types, just remain unchanged, the analysis phash of create table stmt
+                    // For other unsupported types, just remain unchanged, the analysis phash of create table stmt
                     // will handle it.
-                    if (typeDef.getType() == Type.STRING) {
+                    if (typeDef.getType().getPrimitiveType() == PrimitiveType.STRING) {
                         typeDef = TypeDef.createVarchar(ScalarType.MAX_VARCHAR_LENGTH);
                     }
                 }

--- a/fe/fe-core/src/main/java/org/apache/doris/external/elasticsearch/EsUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/external/elasticsearch/EsUtil.java
@@ -416,7 +416,7 @@ public class EsUtil {
             case "nested":
             case "object":
             default:
-                return Type.STRING;
+                return ScalarType.createStringType();
         }
     }
 

--- a/regression-test/suites/rollup_p0/test_rollup_agg_date.groovy
+++ b/regression-test/suites/rollup_p0/test_rollup_agg_date.groovy
@@ -54,7 +54,7 @@ suite("test_rollup_agg_date", "rollup") {
             }
         }
     }
-    Thread.sleep(200)
+    Thread.sleep(2000)
     sql "ALTER TABLE ${tbName} ADD COLUMN datetimev4 datetimev2(3) MAX NULL;"
     max_try_secs = 60
     while (max_try_secs--) {


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

1.
```
create table tbl1 as select * from hive.db.tbl;
```
Error: `length of input is too long than schema`

2.
add more metric to scanner's profile

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

