### PR TITLE
[fix](nereids) column stats min/max missing

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/ColumnStat.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/ColumnStat.java
@@ -227,8 +227,8 @@ public class ColumnStat {
         result.add(Double.toString(avgSizeByte));
         result.add(Double.toString(maxSizeByte));
         result.add(Double.toString(numNulls));
-        result.add(minExpr == null ? "N/A" : minExpr.toSql());
-        result.add(maxExpr == null ? "N/A" : maxExpr.toSql());
+        result.add(Double.toString(minValue));
+        result.add(Double.toString(maxValue));
         return result;
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/statistics/ColumnStatsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/statistics/ColumnStatsTest.java
@@ -85,7 +85,7 @@ public class ColumnStatsTest {
         statsTypeToValue.put(StatsType.MAX_VALUE, "1000");
 
         columnStatsUnderTest.updateStats(columnType, statsTypeToValue);
-        String[] expectedInfo = {"1.0", "8.0", "8.0", "2.0", "0", "1000"};
+        String[] expectedInfo = {"1.0", "8.0", "8.0", "2.0", "0.0", "1000.0"};
 
         // Run the test
         List<String> showInfo = columnStatsUnderTest.getShowInfo();


### PR DESCRIPTION
# Proposed changes
'show column stats TBL'
min/max value is not displayed.

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

