### PR TITLE
[fix](load) fix that load channel failed to be released in time

### DIFF
--- a/be/src/exec/tablet_sink.cpp
+++ b/be/src/exec/tablet_sink.cpp
@@ -1114,6 +1114,8 @@ Status OlapTableSink::close(RuntimeState* state, Status close_status) {
                             if (!s.ok()) {
                                 index_channel->mark_as_failed(ch->node_id(), ch->host(),
                                                               s.get_error_msg(), -1);
+                                // cancel the node channel in best effort
+                                ch->cancel(s.get_error_msg());
                                 LOG(WARNING)
                                         << ch->channel_info()
                                         << ", close channel failed, err: " << s.get_error_msg();


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary
### Problem
After Import failed, the load channel was released after a long time.

W1107 22:39:40.250975  6352 tablet_sink.cpp:158] VNodeChannel[11200-10003], load_id=bfc1f85bd4d743db-8804da3331d2cc84, txn_id=2038581140244480, node=172.16.11.186:8060, tablet writer failed to reduce mem consumption by flushing memtable, tablet_id=11291, txn_id=2038581117976576, err=6, errcode=-238, msg: 0# doris::Status::ConstructErrorStatus(short) at /disk0/be/src/common/status.cpp:78
I1108 02:40:38.573726  6308 load_channel_mgr.cpp:188] erase timeout load channel: bfc1f85bd4d743db-8804da3331d2cc84

### Why
When the data transmission of a node channel fails, then the node channel is marked as cancel. The subsequent add batch skips the node. 
The normal node channel sends the last data with an EOS flag. The destination will process the EOS flag and actively erase the corresponding load channel.
However, the cancelled node channel will not send EOS, nor actively send a cancel request to the destination, so the destination load channel will not be released.

### How
When closing, the failed node channel initiates a cancel operation.


## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

