### PR TITLE
[Bug](outfile) Fix wrong decimal format for ORC

### DIFF
--- a/be/src/vec/runtime/vorc_writer.cpp
+++ b/be/src/vec/runtime/vorc_writer.cpp
@@ -445,13 +445,16 @@ Status VOrcWriterWrapper::write(const Block& block) {
                             cur_batch->notNull[row_id] = 1;
                             auto& v = assert_cast<const ColumnDecimal128&>(*col).get_data()[row_id];
                             orc::Int128 value(v >> 64, (uint64_t)v);
-                            cur_batch->values[row_id] += value;
+                            cur_batch->values[row_id] = value;
                         }
                     }
                 } else if (const auto& not_null_column =
                                    check_and_get_column<const ColumnDecimal128>(col)) {
-                    memcpy(reinterpret_cast<void*>(cur_batch->values.data()),
-                           not_null_column->get_data().data(), sz * sizeof(Int128));
+                    for (size_t row_id = 0; row_id < sz; row_id++) {
+                        auto v = not_null_column->get_data()[row_id];
+                        orc::Int128 value(v >> 64, (uint64_t)v);
+                        cur_batch->values[row_id] = value;
+                    }
                 } else {
                     RETURN_WRONG_TYPE
                 }

--- a/be/src/vec/runtime/vorc_writer.cpp
+++ b/be/src/vec/runtime/vorc_writer.cpp
@@ -450,8 +450,9 @@ Status VOrcWriterWrapper::write(const Block& block) {
                     }
                 } else if (const auto& not_null_column =
                                    check_and_get_column<const ColumnDecimal128>(col)) {
+                    auto ptr = not_null_column->get_data().data();
                     for (size_t row_id = 0; row_id < sz; row_id++) {
-                        auto v = not_null_column->get_data()[row_id];
+                        auto v = ptr[row_id];
                         orc::Int128 value(v >> 64, (uint64_t)v);
                         cur_batch->values[row_id] = value;
                     }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/OutFileClause.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/OutFileClause.java
@@ -288,8 +288,7 @@ public class OutFileClause {
                     break;
                 case DECIMALV2:
                     if (!expr.getType().isWildcardDecimal()) {
-                        type = String.format("decimal(%d, %d)", ScalarType.MAX_DECIMAL128_PRECISION,
-                                ((ScalarType) expr.getType()).decimalScale());
+                        type = String.format("decimal(%d, 9)", ScalarType.MAX_DECIMAL128_PRECISION);
                     } else {
                         throw new AnalysisException("currently ORC writer do not support WildcardDecimal!");
                     }


### PR DESCRIPTION
# Proposed changes

1. memory format for Decimal in ORC is different from Doris so we can't use `memcpy`
2. Scale should be 9 for DecimalV2 type instead of the real scale of type

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

