### PR TITLE
[feature](table-valued-function)S3 table valued function supports `parquet/orc/json` file format

### DIFF
--- a/be/src/vec/exec/format/json/new_json_reader.cpp
+++ b/be/src/vec/exec/format/json/new_json_reader.cpp
@@ -49,12 +49,31 @@ NewJsonReader::NewJsonReader(RuntimeState* state, RuntimeProfile* profile, Scann
           _parse_allocator(_parse_buffer, sizeof(_parse_buffer)),
           _origin_json_doc(&_value_allocator, sizeof(_parse_buffer), &_parse_allocator),
           _scanner_eof(scanner_eof) {
-    _file_format_type = _params.format_type;
-
     _bytes_read_counter = ADD_COUNTER(_profile, "BytesRead", TUnit::BYTES);
     _read_timer = ADD_TIMER(_profile, "ReadTime");
     _file_read_timer = ADD_TIMER(_profile, "FileReadTime");
 }
+
+NewJsonReader::NewJsonReader(RuntimeProfile* profile, const TFileScanRangeParams& params,
+                             const TFileRangeDesc& range,
+                             const std::vector<SlotDescriptor*>& file_slot_descs)
+        : _vhandle_json_callback(nullptr),
+          _state(nullptr),
+          _profile(profile),
+          _params(params),
+          _range(range),
+          _file_slot_descs(file_slot_descs),
+          _file_reader(nullptr),
+          _file_reader_s(nullptr),
+          _real_file_reader(nullptr),
+          _line_reader(nullptr),
+          _reader_eof(false),
+          _skip_first_line(false),
+          _next_row(0),
+          _total_rows(0),
+          _value_allocator(_value_buffer, sizeof(_value_buffer)),
+          _parse_allocator(_parse_buffer, sizeof(_parse_buffer)),
+          _origin_json_doc(&_value_allocator, sizeof(_parse_buffer), &_parse_allocator) {}
 
 Status NewJsonReader::init_reader() {
     RETURN_IF_ERROR(_get_range_params());
@@ -116,6 +135,113 @@ Status NewJsonReader::get_columns(std::unordered_map<std::string, TypeDescriptor
                                   std::unordered_set<std::string>* missing_cols) {
     for (auto& slot : _file_slot_descs) {
         name_to_type->emplace(slot->col_name(), slot->type());
+    }
+    return Status::OK();
+}
+
+Status NewJsonReader::get_parsered_schema(std::vector<std::string>* col_names,
+                                          std::vector<TypeDescriptor>* col_types) {
+    RETURN_IF_ERROR(_get_range_params());
+
+    RETURN_IF_ERROR(_open_file_reader());
+    if (_read_json_by_line) {
+        RETURN_IF_ERROR(_open_line_reader());
+    }
+
+    // generate _parsed_jsonpaths and _parsed_json_root
+    RETURN_IF_ERROR(_parse_jsonpath_and_json_root());
+
+    bool eof = false;
+    const uint8_t* json_str = nullptr;
+    std::unique_ptr<uint8_t[]> json_str_ptr;
+    size_t size = 0;
+    if (_line_reader != nullptr) {
+        RETURN_IF_ERROR(_line_reader->read_line(&json_str, &size, &eof));
+    } else {
+        int64_t length = 0;
+        RETURN_IF_ERROR(_real_file_reader->read_one_message(&json_str_ptr, &length));
+        json_str = json_str_ptr.get();
+        size = length;
+        if (length == 0) {
+            eof = true;
+        }
+    }
+
+    if (size == 0 || eof) {
+        return Status::EndOfFile("Empty file.");
+    }
+
+    // clear memory here.
+    _value_allocator.Clear();
+    _parse_allocator.Clear();
+    bool has_parse_error = false;
+
+    // parse jsondata to JsonDoc
+    // As the issue: https://github.com/Tencent/rapidjson/issues/1458
+    // Now, rapidjson only support uint64_t, So lagreint load cause bug. We use kParseNumbersAsStringsFlag.
+    if (_num_as_string) {
+        has_parse_error =
+                _origin_json_doc.Parse<rapidjson::kParseNumbersAsStringsFlag>((char*)json_str, size)
+                        .HasParseError();
+    } else {
+        has_parse_error = _origin_json_doc.Parse((char*)json_str, size).HasParseError();
+    }
+
+    if (has_parse_error) {
+        return Status::DataQualityError(
+                "Parse json data for JsonDoc failed. code: {}, error info: {}",
+                _origin_json_doc.GetParseError(),
+                rapidjson::GetParseError_En(_origin_json_doc.GetParseError()));
+    }
+
+    // set json root
+    if (_parsed_json_root.size() != 0) {
+        _json_doc = JsonFunctions::get_json_object_from_parsed_json(
+                _parsed_json_root, &_origin_json_doc, _origin_json_doc.GetAllocator());
+        if (_json_doc == nullptr) {
+            return Status::DataQualityError("JSON Root not found.");
+        }
+    } else {
+        _json_doc = &_origin_json_doc;
+    }
+
+    if (_json_doc->IsArray() && !_strip_outer_array) {
+        return Status::DataQualityError(
+                "JSON data is array-object, `strip_outer_array` must be TRUE.");
+    } else if (!_json_doc->IsArray() && _strip_outer_array) {
+        return Status::DataQualityError(
+                "JSON data is not an array-object, `strip_outer_array` must be FALSE.");
+    }
+
+    rapidjson::Value* objectValue = nullptr;
+    if (_json_doc->IsArray()) {
+        if (_json_doc->Size() == 0) {
+            // may be passing an empty json, such as "[]"
+            return Status::InternalError("Empty first json line");
+        }
+        objectValue = &(*_json_doc)[0];
+    } else {
+        objectValue = _json_doc;
+    }
+
+    // use jsonpaths to col_names
+    if (_parsed_jsonpaths.size() > 0) {
+        for (size_t i = 0; i < _parsed_jsonpaths.size(); ++i) {
+            size_t len = _parsed_jsonpaths[i].size();
+            if (len == 0) {
+                return Status::InvalidArgument("It's invalid jsonpaths.");
+            }
+            std::string key = _parsed_jsonpaths[i][len - 1].key;
+            col_names->emplace_back(key);
+            col_types->emplace_back(TypeDescriptor::create_string_type());
+        }
+        return Status::OK();
+    }
+
+    for (int i = 0; i < objectValue->MemberCount(); ++i) {
+        auto it = objectValue->MemberBegin() + i;
+        col_names->emplace_back(it->name.GetString());
+        col_types->emplace_back(TypeDescriptor::create_string_type());
     }
     return Status::OK();
 }

--- a/be/src/vec/exec/format/json/new_json_reader.h
+++ b/be/src/vec/exec/format/json/new_json_reader.h
@@ -39,12 +39,17 @@ public:
     NewJsonReader(RuntimeState* state, RuntimeProfile* profile, ScannerCounter* counter,
                   const TFileScanRangeParams& params, const TFileRangeDesc& range,
                   const std::vector<SlotDescriptor*>& file_slot_descs, bool* scanner_eof);
+
+    NewJsonReader(RuntimeProfile* profile, const TFileScanRangeParams& params,
+                  const TFileRangeDesc& range, const std::vector<SlotDescriptor*>& file_slot_descs);
     ~NewJsonReader() override = default;
 
     Status init_reader();
     Status get_next_block(Block* block, size_t* read_rows, bool* eof) override;
     Status get_columns(std::unordered_map<std::string, TypeDescriptor>* name_to_type,
                        std::unordered_set<std::string>* missing_cols) override;
+    Status get_parsered_schema(std::vector<std::string>* col_names,
+                               std::vector<TypeDescriptor>* col_types) override;
 
 private:
     Status _get_range_params();
@@ -106,8 +111,6 @@ private:
     FileReader* _real_file_reader;
     std::unique_ptr<LineReader> _line_reader;
     bool _reader_eof;
-
-    TFileFormatType::type _file_format_type;
 
     // When we fetch range doesn't start from 0 will always skip the first line
     bool _skip_first_line;

--- a/be/src/vec/exec/format/orc/vorc_reader.cpp
+++ b/be/src/vec/exec/format/orc/vorc_reader.cpp
@@ -81,6 +81,14 @@ OrcReader::OrcReader(RuntimeProfile* profile, const TFileScanRangeParams& params
     _init_profile();
 }
 
+OrcReader::OrcReader(const TFileScanRangeParams& params, const TFileRangeDesc& range,
+                     const std::vector<std::string>& column_names, const std::string& ctz)
+        : _profile(nullptr),
+          _scan_params(params),
+          _scan_range(range),
+          _ctz(ctz),
+          _column_names(column_names) {}
+
 OrcReader::~OrcReader() {
     close();
 }
@@ -162,6 +170,40 @@ Status OrcReader::init_reader(
     for (int i = 0; i < selected_type.getSubtypeCount(); ++i) {
         _colname_to_idx[selected_type.getFieldName(i)] = i;
         _col_orc_type[i] = selected_type.getSubtype(i);
+    }
+    return Status::OK();
+}
+
+Status OrcReader::get_parsered_schema(std::vector<std::string>* col_names,
+                                      std::vector<TypeDescriptor>* col_types) {
+    if (_file_reader == nullptr) {
+        std::unique_ptr<FileReader> inner_reader;
+        RETURN_IF_ERROR(FileFactory::create_file_reader(_profile, _scan_params, _scan_range.path,
+                                                        _scan_range.start_offset,
+                                                        _scan_range.file_size, 0, inner_reader));
+        RETURN_IF_ERROR(inner_reader->open());
+        _file_reader = new ORCFileInputStream(_scan_range.path, inner_reader.release());
+    }
+    if (_file_reader->getLength() == 0) {
+        return Status::EndOfFile("Empty orc file");
+    }
+
+    // create orc reader
+    try {
+        orc::ReaderOptions options;
+        _reader = orc::createReader(std::unique_ptr<ORCFileInputStream>(_file_reader), options);
+    } catch (std::exception& e) {
+        return Status::InternalError("Init OrcReader failed. reason = {}", e.what());
+    }
+
+    if (_reader->getNumberOfRows() == 0) {
+        return Status::EndOfFile("Empty orc file");
+    }
+
+    auto& root_type = _reader->getType();
+    for (int i = 0; i < root_type.getSubtypeCount(); ++i) {
+        col_names->emplace_back(root_type.getFieldName(i));
+        col_types->emplace_back(_convert_to_doris_type(root_type.getSubtype(i)));
     }
     return Status::OK();
 }

--- a/be/src/vec/exec/format/orc/vorc_reader.h
+++ b/be/src/vec/exec/format/orc/vorc_reader.h
@@ -77,6 +77,9 @@ public:
               const TFileRangeDesc& range, const std::vector<std::string>& column_names,
               size_t batch_size, const std::string& ctz);
 
+    OrcReader(const TFileScanRangeParams& params, const TFileRangeDesc& range,
+              const std::vector<std::string>& column_names, const std::string& ctz);
+
     ~OrcReader() override;
     // for test
     void set_file_reader(const std::string& file_name, FileReader* file_reader) {
@@ -95,6 +98,9 @@ public:
     std::unordered_map<std::string, TypeDescriptor> get_name_to_type() override;
     Status get_columns(std::unordered_map<std::string, TypeDescriptor>* name_to_type,
                        std::unordered_set<std::string>* missing_cols) override;
+
+    Status get_parsered_schema(std::vector<std::string>* col_names,
+                               std::vector<TypeDescriptor>* col_types) override;
 
 private:
     struct OrcProfile {

--- a/be/src/vec/exec/format/parquet/vparquet_reader.h
+++ b/be/src/vec/exec/format/parquet/vparquet_reader.h
@@ -54,6 +54,9 @@ public:
                   const TFileRangeDesc& range, const std::vector<std::string>& column_names,
                   size_t batch_size, cctz::time_zone* ctz);
 
+    ParquetReader(const TFileScanRangeParams& params, const TFileRangeDesc& range,
+                  const std::vector<std::string>& column_names);
+
     ~ParquetReader() override;
     // for test
     void set_file_reader(FileReader* file_reader) { _file_reader.reset(file_reader); }
@@ -70,6 +73,9 @@ public:
     std::unordered_map<std::string, TypeDescriptor> get_name_to_type() override;
     Status get_columns(std::unordered_map<std::string, TypeDescriptor>* name_to_type,
                        std::unordered_set<std::string>* missing_cols) override;
+
+    Status get_parsered_schema(std::vector<std::string>* col_names,
+                               std::vector<TypeDescriptor>* col_types) override;
 
     Statistics& statistics() { return _statistics; }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/external/HiveScanProvider.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/external/HiveScanProvider.java
@@ -33,9 +33,11 @@ import org.apache.doris.common.UserException;
 import org.apache.doris.external.hive.util.HiveUtil;
 import org.apache.doris.load.BrokerFileGroup;
 import org.apache.doris.planner.external.ExternalFileScanNode.ParamCreateContext;
+import org.apache.doris.thrift.TFileAttributes;
 import org.apache.doris.thrift.TFileFormatType;
 import org.apache.doris.thrift.TFileScanRangeParams;
 import org.apache.doris.thrift.TFileScanSlotInfo;
+import org.apache.doris.thrift.TFileTextScanRangeParams;
 import org.apache.doris.thrift.TFileType;
 
 import com.google.common.collect.Lists;
@@ -270,21 +272,16 @@ public class HiveScanProvider extends HMSTableScanProvider {
     }
 
     @Override
-    public String getColumnSeparator() throws UserException {
-        return hmsTable.getRemoteTable().getSd().getSerdeInfo().getParameters()
-                .getOrDefault(PROP_FIELD_DELIMITER, DEFAULT_FIELD_DELIMITER);
+    public TFileAttributes getFileAttributes() throws UserException {
+        TFileTextScanRangeParams textParams = new TFileTextScanRangeParams();
+        textParams.setColumnSeparator(hmsTable.getRemoteTable().getSd().getSerdeInfo().getParameters()
+                .getOrDefault(PROP_FIELD_DELIMITER, DEFAULT_FIELD_DELIMITER));
+        textParams.setLineDelimiter(DEFAULT_LINE_DELIMITER);
+        TFileAttributes fileAttributes = new TFileAttributes();
+        fileAttributes.setTextParams(textParams);
+        fileAttributes.setHeaderType("");
+        return fileAttributes;
     }
-
-    @Override
-    public String getLineSeparator() {
-        return DEFAULT_LINE_DELIMITER;
-    }
-
-    @Override
-    public String getHeaderType() {
-        return "";
-    }
-
 }
 
 

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/external/QueryScanProvider.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/external/QueryScanProvider.java
@@ -29,7 +29,6 @@ import org.apache.doris.thrift.TFileFormatType;
 import org.apache.doris.thrift.TFileRangeDesc;
 import org.apache.doris.thrift.TFileScanRange;
 import org.apache.doris.thrift.TFileScanRangeParams;
-import org.apache.doris.thrift.TFileTextScanRangeParams;
 import org.apache.doris.thrift.TFileType;
 import org.apache.doris.thrift.THdfsParams;
 import org.apache.doris.thrift.TNetworkAddress;
@@ -52,11 +51,7 @@ public abstract class QueryScanProvider implements FileScanProviderIf {
     private int inputSplitNum = 0;
     private long inputFileSize = 0;
 
-    public abstract String getColumnSeparator() throws UserException;
-
-    public abstract String getLineSeparator();
-
-    public abstract String getHeaderType();
+    public abstract TFileAttributes getFileAttributes() throws UserException;
 
     @Override
     public void createScanRangeLocations(ParamCreateContext context, BackendPolicy backendPolicy,
@@ -78,14 +73,8 @@ public abstract class QueryScanProvider implements FileScanProviderIf {
             context.params.setFileType(locationType);
             TFileFormatType fileFormatType = getFileFormatType();
             context.params.setFormatType(getFileFormatType());
-            if (fileFormatType == TFileFormatType.FORMAT_CSV_PLAIN) {
-                TFileTextScanRangeParams textParams = new TFileTextScanRangeParams();
-                textParams.setColumnSeparator(getColumnSeparator());
-                textParams.setLineDelimiter(getLineSeparator());
-                TFileAttributes fileAttributes = new TFileAttributes();
-                fileAttributes.setTextParams(textParams);
-                fileAttributes.setHeaderType(getHeaderType());
-                context.params.setFileAttributes(fileAttributes);
+            if (fileFormatType == TFileFormatType.FORMAT_CSV_PLAIN || fileFormatType == TFileFormatType.FORMAT_JSON) {
+                context.params.setFileAttributes(getFileAttributes());
             }
 
             // set hdfs params for hdfs file type.

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/external/TVFScanProvider.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/external/TVFScanProvider.java
@@ -31,6 +31,7 @@ import org.apache.doris.load.BrokerFileGroup;
 import org.apache.doris.planner.external.ExternalFileScanNode.ParamCreateContext;
 import org.apache.doris.tablefunction.ExternalFileTableValuedFunction;
 import org.apache.doris.thrift.TBrokerFileStatus;
+import org.apache.doris.thrift.TFileAttributes;
 import org.apache.doris.thrift.TFileFormatType;
 import org.apache.doris.thrift.TFileScanRangeParams;
 import org.apache.doris.thrift.TFileScanSlotInfo;
@@ -59,18 +60,8 @@ public class TVFScanProvider extends QueryScanProvider {
 
     // =========== implement abstract methods of QueryScanProvider =================
     @Override
-    public String getColumnSeparator() throws UserException {
-        return tableValuedFunction.getColumnSeparator();
-    }
-
-    @Override
-    public String getLineSeparator() {
-        return tableValuedFunction.getLineSeparator();
-    }
-
-    @Override
-    public String getHeaderType() {
-        return tableValuedFunction.getHeaderType();
+    public TFileAttributes getFileAttributes() throws UserException {
+        return tableValuedFunction.getFileAttributes();
     }
 
 

--- a/fe/fe-core/src/main/java/org/apache/doris/tablefunction/S3TableValuedFunction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/tablefunction/S3TableValuedFunction.java
@@ -20,10 +20,8 @@ package org.apache.doris.tablefunction;
 import org.apache.doris.analysis.BrokerDesc;
 import org.apache.doris.analysis.StorageBackend.StorageType;
 import org.apache.doris.common.AnalysisException;
-import org.apache.doris.common.FeConstants;
 import org.apache.doris.common.UserException;
 import org.apache.doris.common.util.S3URI;
-import org.apache.doris.thrift.TFileFormatType;
 import org.apache.doris.thrift.TFileType;
 
 import com.google.common.collect.ImmutableSet;
@@ -40,14 +38,13 @@ import java.util.Map;
 public class S3TableValuedFunction extends ExternalFileTableValuedFunction {
     public static final Logger LOG = LogManager.getLogger(S3TableValuedFunction.class);
     public static final String NAME = "s3";
-    public static final String S3_URI = "URI";
+    public static final String S3_URI = "uri";
     public static final String S3_AK = "AWS_ACCESS_KEY";
     public static final String S3_SK = "AWS_SECRET_KEY";
     public static final String S3_ENDPOINT = "AWS_ENDPOINT";
     public static final String S3_REGION = "AWS_REGION";
-    public static final String FORMAT = "FORMAT";
-    private static final String AK = "ACCESS_KEY";
-    private static final String SK = "SECRET_KEY";
+    private static final String AK = "access_key";
+    private static final String SK = "secret_key";
 
     public static final String USE_PATH_STYLE = "use_path_style";
 
@@ -56,6 +53,10 @@ public class S3TableValuedFunction extends ExternalFileTableValuedFunction {
                         .add(AK)
                         .add(SK)
                         .add(FORMAT)
+                        .add(JSON_ROOT)
+                        .add(JSON_PATHS)
+                        .add(STRIP_OUTER_ARRAY)
+                        .add(READ_JSON_BY_LINE)
                         .build();
     private S3URI s3uri;
     private String s3AK;
@@ -64,31 +65,17 @@ public class S3TableValuedFunction extends ExternalFileTableValuedFunction {
     public S3TableValuedFunction(Map<String, String> params) throws UserException {
         Map<String, String> validParams = Maps.newHashMap();
         for (String key : params.keySet()) {
-            if (!PROPERTIES_SET.contains(key.toUpperCase())) {
+            if (!PROPERTIES_SET.contains(key.toLowerCase())) {
                 throw new AnalysisException(key + " is invalid property");
             }
-            validParams.put(key.toUpperCase(), params.get(key));
+            validParams.put(key.toLowerCase(), params.get(key));
         }
 
         s3uri = S3URI.create(validParams.get(S3_URI));
         s3AK = validParams.getOrDefault(AK, "");
         s3SK = validParams.getOrDefault(SK, "");
-        String formatString = validParams.getOrDefault(FORMAT, "");
-        switch (formatString.toLowerCase()) {
-            case "csv":
-                this.fileFormatType = TFileFormatType.FORMAT_CSV_PLAIN;
-                break;
-            case "csv_with_names":
-                this.headerType = FeConstants.csv_with_names;
-                this.fileFormatType = TFileFormatType.FORMAT_CSV_PLAIN;
-                break;
-            case "csv_with_names_and_types":
-                this.headerType = FeConstants.csv_with_names_and_types;
-                this.fileFormatType = TFileFormatType.FORMAT_CSV_PLAIN;
-                break;
-            default:
-                throw new AnalysisException("format:" + formatString + " is not supported.");
-        }
+
+        parseProperties(validParams);
 
         // set S3 location properties
         locationProperties = Maps.newHashMap();


### PR DESCRIPTION
# Proposed changes

Issue Number: close #13959

## Problem summary

S3 table valued function supports `parquet/orc/json` file format.
For example: `parquet format`
```
MySQL [(none)]> select * from s3("URI" = "http://127.0.0.1:9312/test2/test.snappy.parquet","ACCESS_KEY"= "minioadmin", "SECRET_KEY" = "minioadmin", "ForMAT" = "parquet") limit 10;
+-----------+------------------------------------------+----------------+----------+-------------------------+--------+-------------+---------------+----------------------+
| p_partkey | p_name                                   | p_mfgr         | p_brand  | p_type                  | p_size | p_container | p_retailprice | p_comment            |
+-----------+------------------------------------------+----------------+----------+-------------------------+--------+-------------+---------------+----------------------+
|         1 | goldenrod lavender spring chocolate lace | Manufacturer#1 | Brand#13 | PROMO BURNISHED COPPER  |      7 | JUMBO PKG   |           901 | ly. slyly ironi      |
|         2 | blush thistle blue yellow saddle         | Manufacturer#1 | Brand#13 | LARGE BRUSHED BRASS     |      1 | LG CASE     |           902 | lar accounts amo     |
|         3 | spring green yellow purple cornsilk      | Manufacturer#4 | Brand#42 | STANDARD POLISHED BRASS |     21 | WRAP CASE   |           903 | egular deposits hag  |
|         4 | cornflower chocolate smoke green pink    | Manufacturer#3 | Brand#34 | SMALL PLATED BRASS      |     14 | MED DRUM    |           904 | p furiously r        |
|         5 | forest brown coral puff cream            | Manufacturer#3 | Brand#32 | STANDARD POLISHED TIN   |     15 | SM PKG      |           905 |  wake carefully      |
|         6 | bisque cornflower lawn forest magenta    | Manufacturer#2 | Brand#24 | PROMO PLATED STEEL      |      4 | MED BAG     |           906 | sual a               |
|         7 | moccasin green thistle khaki floral      | Manufacturer#1 | Brand#11 | SMALL PLATED COPPER     |     45 | SM BAG      |           907 | lyly. ex             |
|         8 | misty lace thistle snow royal            | Manufacturer#4 | Brand#44 | PROMO BURNISHED TIN     |     41 | LG DRUM     |           908 | eposi                |
|         9 | thistle dim navajo dark gainsboro        | Manufacturer#4 | Brand#43 | SMALL BURNISHED STEEL   |     12 | WRAP CASE   |           909 | ironic foxe          |
|        10 | linen pink saddle puff powder            | Manufacturer#5 | Brand#54 | LARGE BURNISHED STEEL   |     44 | LG CAN      |           910 | ithely final deposit |
+-----------+------------------------------------------+----------------+----------+-------------------------+--------+-------------+---------------+----------------------+
```

orc format:
```
MySQL [(none)]> select * from s3("URI" = "http://127.0.0.1:9312/test2/test.snappy.orc","ACCESS_KEY"= "minioadmin", "SECRET_KEY" = "minioadmin", "ForMAT" = "orc") limit 10;
+-----------+------------------------------------------+----------------+----------+-------------------------+--------+-------------+---------------+----------------------+
| p_partkey | p_name                                   | p_mfgr         | p_brand  | p_type                  | p_size | p_container | p_retailprice | p_comment            |
+-----------+------------------------------------------+----------------+----------+-------------------------+--------+-------------+---------------+----------------------+
|         1 | goldenrod lavender spring chocolate lace | Manufacturer#1 | Brand#13 | PROMO BURNISHED COPPER  |      7 | JUMBO PKG   |           901 | ly. slyly ironi      |
|         2 | blush thistle blue yellow saddle         | Manufacturer#1 | Brand#13 | LARGE BRUSHED BRASS     |      1 | LG CASE     |           902 | lar accounts amo     |
|         3 | spring green yellow purple cornsilk      | Manufacturer#4 | Brand#42 | STANDARD POLISHED BRASS |     21 | WRAP CASE   |           903 | egular deposits hag  |
|         4 | cornflower chocolate smoke green pink    | Manufacturer#3 | Brand#34 | SMALL PLATED BRASS      |     14 | MED DRUM    |           904 | p furiously r        |
|         5 | forest brown coral puff cream            | Manufacturer#3 | Brand#32 | STANDARD POLISHED TIN   |     15 | SM PKG      |           905 |  wake carefully      |
|         6 | bisque cornflower lawn forest magenta    | Manufacturer#2 | Brand#24 | PROMO PLATED STEEL      |      4 | MED BAG     |           906 | sual a               |
|         7 | moccasin green thistle khaki floral      | Manufacturer#1 | Brand#11 | SMALL PLATED COPPER     |     45 | SM BAG      |           907 | lyly. ex             |
|         8 | misty lace thistle snow royal            | Manufacturer#4 | Brand#44 | PROMO BURNISHED TIN     |     41 | LG DRUM     |           908 | eposi                |
|         9 | thistle dim navajo dark gainsboro        | Manufacturer#4 | Brand#43 | SMALL BURNISHED STEEL   |     12 | WRAP CASE   |           909 | ironic foxe          |
|        10 | linen pink saddle puff powder            | Manufacturer#5 | Brand#54 | LARGE BURNISHED STEEL   |     44 | LG CAN      |           910 | ithely final deposit |
+-----------+------------------------------------------+----------------+----------+-------------------------+--------+-------------+---------------+----------------------+
```

json format:
```
MySQL [(none)]> select * from s3("URI" = "http://127.0.0.1:9312/test2/data1.json","ACCESS_KEY"= "minioadmin", "SECRET_KEY" = "minioadmin", "ForMAT" = "json", "strip_outer_array" = "true", "read_json_by_line" = "false");
+------+------+------+
| id   | name | age  |
+------+------+------+
| 1    | ftw  | 18   |
| 2    | xxx  | 17   |
| 3    | yyy  | 19   |
+------+------+------+

MySQL [(none)]> select * from s3("URI" = "http://127.0.0.1:9312/test2/data.json","ACCESS_KEY"= "minioadmin", "SECRET_KEY" = "minioadmin", "ForMAT" = "json", "strip_outer_array" = "true", "jsonpaths" = "[\"$.id\", \"$.age\"]");
+------+------+
| id   | age  |
+------+------+
| 1    | 18   |
| 2    | 17   |
| 3    | 19   |
+------+------+
```

## Checklist(Required)

1. Does it affect the original behavior: 
    - [x] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

