### PR TITLE
[chore](bin) check max_vm_count in start_be.sh

### DIFF
--- a/bin/start_be.sh
+++ b/bin/start_be.sh
@@ -53,6 +53,14 @@ export DORIS_HOME=$(
     pwd
 )
 
+if [[ "$(uname -s)" != 'Darwin' ]]; then
+    MAX_MAP_COUNT="$(sysctl -n vm.max_map_count)"
+    if [[ "${MAX_MAP_COUNT}" -lt 2000000 ]]; then
+        echo "Please set vm.max_map_count to be 2000000. sysctl -w vm.max_map_count=2000000"
+        exit 1
+    fi
+fi
+
 # export env variables from be.conf
 #
 # UDF_RUNTIME_DIR


### PR DESCRIPTION
If max_vm_count is not large enough, doris would crash sometimes.

# Proposed changes

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

