### PR TITLE
[feature-wip](multi-catalog) Support hive partition cache

### DIFF
--- a/be/src/exec/text_converter.hpp
+++ b/be/src/exec/text_converter.hpp
@@ -206,7 +206,6 @@ inline bool TextConverter::write_vec_column(const SlotDescriptor* slot_desc,
     }
 
     StringParser::ParseResult parse_result = StringParser::PARSE_SUCCESS;
-
     // Parse the raw-text data. Translate the text string to internal format.
     switch (slot_desc->type().type) {
     case TYPE_HLL: {
@@ -314,6 +313,7 @@ inline bool TextConverter::write_vec_column(const SlotDescriptor* slot_desc,
             size_t size = nullable_column->get_null_map_data().size();
             doris::vectorized::NullMap& null_map_data = nullable_column->get_null_map_data();
             null_map_data[size - 1] = 1;
+            nullable_column->get_nested_column().insert_default();
         }
         return false;
     }

--- a/docs/en/docs/admin-manual/config/fe-config.md
+++ b/docs/en/docs/admin-manual/config/fe-config.md
@@ -2258,3 +2258,55 @@ Default: 1
 Is it possible to configure dynamically: true
 
 Whether it is a configuration item unique to the Master FE node: true
+
+### `max_replica_count_when_schema_change`
+
+The maximum number of replicas allowed when OlapTable is doing schema changes. Too many replicas will lead to FE OOM.
+
+Default: 100000
+
+Is it possible to configure dynamically: true
+
+Whether it is a configuration item unique to the Master FE node: true
+
+### `max_hive_partition_cache_num`
+
+The maximum number of caches for the hive partition.
+
+Default: 100000
+
+Is it possible to dynamically configure: false
+
+Is it a configuration item unique to the Master FE node: false
+
+### `max_external_file_cache_num`
+
+Maximum number of file cache to use for external external tables.
+
+Default: 100000
+
+Is it possible to dynamically configure: false
+
+Is it a configuration item unique to the Master FE node: false
+
+### `max_external_schema_cache_num`
+
+Maximum number of schema cache to use for external external tables.
+
+Default: 10000
+
+Is it possible to dynamically configure: false
+
+Is it a configuration item unique to the Master FE node: false
+
+### `external_cache_expire_time_minutes_after_access`
+
+Set how long the data in the cache expires after the last access. The unit is minutes.
+Applies to External Schema Cache as well as Hive Partition Cache.
+
+Default: 1440
+
+Is it possible to dynamically configure: false
+
+Is it a configuration item unique to the Master FE node: false
+

--- a/docs/zh-CN/docs/admin-manual/config/fe-config.md
+++ b/docs/zh-CN/docs/admin-manual/config/fe-config.md
@@ -2315,7 +2315,7 @@ load 标签清理器将每隔 `label_clean_interval_second` 运行一次以清�
 是否为 Master FE 节点独有的配置项：true
 
 
-### max_replica_count_when_schema_change
+### `max_replica_count_when_schema_change`
 
 OlapTable在做schema change时，允许的最大副本数，副本数过大会导致FE OOM。
 
@@ -2324,3 +2324,44 @@ OlapTable在做schema change时，允许的最大副本数，副本数过大会�
 是否可以动态配置：true
 
 是否为 Master FE 节点独有的配置项：true
+
+### `max_hive_partition_cache_num`
+
+hive partition 的最大缓存数量。
+
+默认值：100000
+
+是否可以动态配置：false
+
+是否为 Master FE 节点独有的配置项：false
+
+### `max_external_file_cache_num`
+
+用于 external 外部表的最大文件缓存数量。
+
+默认值：100000
+
+是否可以动态配置：false
+
+是否为 Master FE 节点独有的配置项：false
+
+### `max_external_schema_cache_num`
+
+用于 external 外部表的最大 schema 缓存数量。
+
+默认值：10000
+
+是否可以动态配置：false
+
+是否为 Master FE 节点独有的配置项：false
+
+### `external_cache_expire_time_minutes_after_access`
+
+设置缓存中的数据，在最后一次访问后多久失效。单位为分钟。
+适用于 External Schema Cache 以及 Hive Partition Cache.
+
+默认值：1440
+
+是否可以动态配置：false
+
+是否为 Master FE 节点独有的配置项：false

--- a/docs/zh-CN/docs/admin-manual/maint-monitor/monitor-metrics/metrics.md
+++ b/docs/zh-CN/docs/admin-manual/maint-monitor/monitor-metrics/metrics.md
@@ -143,6 +143,11 @@ curl http://be_host:webserver_port/metrics?type=json
 |`doris_fe_txn_replica_num`|| Num| 指定DB正在执行的事务打开的副本数。如 {db="test"} 表示DB test 当前正在执行的事务打开的副本数 |该数值可以观测某个DB是否打开了过多的副本，可能会影响其他事务执行| P0 |
 |`doris_fe_thrift_rpc_total`|| Num| FE thrift接口各个方法接收的RPC请求次数。如 {method="report"} 表示 report 方法接收的RPC请求次数 |该数值可以观测某个thrift rpc方法的负载| |
 |`doris_fe_thrift_rpc_latency_ms`|| 毫秒| FE thrift接口各个方法接收的RPC请求耗时。如 {method="report"} 表示 report 方法接收的RPC请求耗时 |该数值可以观测某个thrift rpc方法的负载| |
+|`doris_fe_external_schema_cache` | {catalog="hive"} | Num | 指定 External Catalog 对应的 schema cache 的数量 |||
+|`doris_fe_hive_meta_cache` | {catalog="hive"} | Num | |||
+| | `{type="partition_value"}` | Num | 指定 External Hive Metastore Catalog 对应的 partition value cache 的数量 |||
+| | `{type="partition"}` | Num | 指定 External Hive Metastore Catalog 对应的 partition cache 的数量 |||
+| | `{type="file"}` | Num | 指定 External Hive Metastore Catalog 对应的 file cache 的数量 |||
 
 ### JVM 监控
 

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ColumnDef.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ColumnDef.java
@@ -199,14 +199,14 @@ public class ColumnDef {
         }
         FeNameFormat.checkColumnName(name);
 
-        // When string type length is not assigned, it need to be assigned to 1.
+        // When string type length is not assigned, it needs to be assigned to 1.
         if (typeDef.getType().isScalarType()) {
             final ScalarType targetType = (ScalarType) typeDef.getType();
             if (targetType.getPrimitiveType().isStringType() && !targetType.isLengthSet()) {
                 if (targetType.getPrimitiveType() != PrimitiveType.STRING) {
                     targetType.setLength(1);
                 } else {
-                    // alway set text length MAX_STRING_LENGTH
+                    // always set text length MAX_STRING_LENGTH
                     targetType.setLength(ScalarType.MAX_STRING_LENGTH);
                 }
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
@@ -124,6 +124,7 @@ import org.apache.doris.consistency.ConsistencyChecker;
 import org.apache.doris.datasource.CatalogIf;
 import org.apache.doris.datasource.CatalogMgr;
 import org.apache.doris.datasource.EsExternalCatalog;
+import org.apache.doris.datasource.ExternalMetaCacheMgr;
 import org.apache.doris.datasource.InternalCatalog;
 import org.apache.doris.deploy.DeployManager;
 import org.apache.doris.deploy.impl.AmbariDeployManager;
@@ -450,6 +451,8 @@ public class Env {
 
     private final StatisticsCache statisticsCache;
 
+    private ExternalMetaCacheMgr extMetaCacheMgr;
+
     public List<Frontend> getFrontends(FrontendNodeType nodeType) {
         if (nodeType == null) {
             // get all
@@ -513,6 +516,10 @@ public class Env {
 
     public MTMVJobManager getMTMVJobManager() {
         return mtmvJobManager;
+    }
+
+    public ExternalMetaCacheMgr getExtMetaCacheMgr() {
+        return extMetaCacheMgr;
     }
 
     public CatalogIf getCurrentCatalog() {
@@ -646,6 +653,7 @@ public class Env {
         this.mtmvJobManager = new MTMVJobManager();
         this.analysisJobScheduler = new AnalysisJobScheduler();
         this.statisticsCache = new StatisticsCache();
+        this.extMetaCacheMgr = new ExternalMetaCacheMgr();
     }
 
     public static void destroyCheckpoint() {

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/RefreshManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/RefreshManager.java
@@ -23,7 +23,6 @@ import org.apache.doris.analysis.RefreshDbStmt;
 import org.apache.doris.analysis.RefreshTableStmt;
 import org.apache.doris.analysis.TableName;
 import org.apache.doris.catalog.external.ExternalDatabase;
-import org.apache.doris.catalog.external.ExternalTable;
 import org.apache.doris.common.DdlException;
 import org.apache.doris.common.UserException;
 import org.apache.doris.datasource.CatalogIf;
@@ -160,7 +159,7 @@ public class RefreshManager {
         if (table == null) {
             throw new DdlException("Table " + tableName + " does not exist in db " + dbName);
         }
-        ((ExternalTable) table).setUnInitialized();
+        Env.getCurrentEnv().getExtMetaCacheMgr().removeSchemaCache(catalog.getId(), dbName, tableName);
         ExternalObjectLog log = new ExternalObjectLog();
         log.setCatalogId(catalog.getId());
         log.setDbId(db.getId());

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/RefreshManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/RefreshManager.java
@@ -159,7 +159,7 @@ public class RefreshManager {
         if (table == null) {
             throw new DdlException("Table " + tableName + " does not exist in db " + dbName);
         }
-        Env.getCurrentEnv().getExtMetaCacheMgr().removeSchemaCache(catalog.getId(), dbName, tableName);
+        Env.getCurrentEnv().getExtMetaCacheMgr().removeCache(catalog.getId(), dbName, tableName);
         ExternalObjectLog log = new ExternalObjectLog();
         log.setCatalogId(catalog.getId());
         log.setDbId(db.getId());

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/external/EsExternalDatabase.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/external/EsExternalDatabase.java
@@ -18,12 +18,10 @@
 package org.apache.doris.catalog.external;
 
 import org.apache.doris.catalog.Env;
-import org.apache.doris.common.util.Util;
 import org.apache.doris.datasource.EsExternalCatalog;
 import org.apache.doris.datasource.ExternalCatalog;
 import org.apache.doris.datasource.InitDatabaseLog;
 import org.apache.doris.persist.gson.GsonPostProcessable;
-import org.apache.doris.qe.MasterCatalogExecutor;
 
 import com.google.common.collect.Maps;
 import com.google.gson.annotations.SerializedName;
@@ -65,7 +63,6 @@ public class EsExternalDatabase extends ExternalDatabase<EsExternalTable> implem
         Map<Long, EsExternalTable> tmpIdToTbl = Maps.newConcurrentMap();
         for (int i = 0; i < log.getRefreshCount(); i++) {
             EsExternalTable table = getTableForReplay(log.getRefreshTableIds().get(i));
-            table.setUnInitialized();
             tmpTableNameToId.put(table.getName(), table.getId());
             tmpIdToTbl.put(table.getId(), table);
         }
@@ -86,24 +83,8 @@ public class EsExternalDatabase extends ExternalDatabase<EsExternalTable> implem
         }
     }
 
-    public synchronized void makeSureInitialized() {
-        if (!initialized) {
-            if (!Env.getCurrentEnv().isMaster()) {
-                // Forward to master and wait the journal to replay.
-                MasterCatalogExecutor remoteExecutor = new MasterCatalogExecutor();
-                try {
-                    remoteExecutor.forward(extCatalog.getId(), id, -1);
-                } catch (Exception e) {
-                    Util.logAndThrowRuntimeException(LOG,
-                            String.format("failed to forward init external db %s operation to master", name), e);
-                }
-                return;
-            }
-            init();
-        }
-    }
-
-    private void init() {
+    @Override
+    protected void init() {
         InitDatabaseLog initDatabaseLog = new InitDatabaseLog();
         initDatabaseLog.setType(InitDatabaseLog.Type.ES);
         initDatabaseLog.setCatalogId(extCatalog.getId());
@@ -118,7 +99,6 @@ public class EsExternalDatabase extends ExternalDatabase<EsExternalTable> implem
                     tblId = tableNameToId.get(tableName);
                     tmpTableNameToId.put(tableName, tblId);
                     EsExternalTable table = idToTbl.get(tblId);
-                    table.setUnInitialized();
                     tmpIdToTbl.put(tblId, table);
                     initDatabaseLog.addRefreshTable(tblId);
                 } else {

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/external/EsExternalTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/external/EsExternalTable.java
@@ -18,13 +18,8 @@
 package org.apache.doris.catalog.external;
 
 import org.apache.doris.catalog.Column;
-import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.EsTable;
-import org.apache.doris.common.util.Util;
 import org.apache.doris.datasource.EsExternalCatalog;
-import org.apache.doris.datasource.InitTableLog;
-import org.apache.doris.external.elasticsearch.EsUtil;
-import org.apache.doris.qe.MasterCatalogExecutor;
 import org.apache.doris.thrift.TEsTable;
 import org.apache.doris.thrift.TTableDescriptor;
 import org.apache.doris.thrift.TTableType;
@@ -54,82 +49,11 @@ public class EsExternalTable extends ExternalTable {
         super(id, name, catalog, dbName, TableType.ES_EXTERNAL_TABLE);
     }
 
-
     public synchronized void makeSureInitialized() {
-        if (!initialized) {
-            if (!Env.getCurrentEnv().isMaster()) {
-                fullSchema = null;
-                // Forward to master and wait the journal to replay.
-                MasterCatalogExecutor remoteExecutor = new MasterCatalogExecutor();
-                try {
-                    remoteExecutor.forward(catalog.getId(), catalog.getDbNullable(dbName).getId(), id);
-                } catch (Exception e) {
-                    Util.logAndThrowRuntimeException(LOG,
-                            String.format("failed to forward init external table %s operation to master", name), e);
-                }
-            } else {
-                init();
-            }
-        }
         if (!objectCreated) {
             esTable = toEsTable();
             objectCreated = true;
         }
-    }
-
-    private void init() {
-        boolean schemaChanged = false;
-        List<Column> tmpSchema = EsUtil.genColumnsFromEs(
-                ((EsExternalCatalog) catalog).getEsRestClient(), name, null);
-        if (fullSchema == null || fullSchema.size() != tmpSchema.size()) {
-            schemaChanged = true;
-        } else {
-            for (int i = 0; i < fullSchema.size(); i++) {
-                if (!fullSchema.get(i).equals(tmpSchema.get(i))) {
-                    schemaChanged = true;
-                    break;
-                }
-            }
-        }
-        if (schemaChanged) {
-            timestamp = System.currentTimeMillis();
-            fullSchema = tmpSchema;
-            esTable = toEsTable();
-        }
-        initialized = true;
-        InitTableLog initTableLog = new InitTableLog();
-        initTableLog.setCatalogId(catalog.getId());
-        initTableLog.setDbId(catalog.getDbNameToId().get(dbName));
-        initTableLog.setTableId(id);
-        initTableLog.setSchema(fullSchema);
-        Env.getCurrentEnv().getEditLog().logInitExternalTable(initTableLog);
-    }
-
-    @Override
-    public List<Column> getFullSchema() {
-        makeSureInitialized();
-        return fullSchema;
-    }
-
-    @Override
-    public List<Column> getBaseSchema() {
-        return getFullSchema();
-    }
-
-    @Override
-    public List<Column> getBaseSchema(boolean full) {
-        return getFullSchema();
-    }
-
-    @Override
-    public Column getColumn(String name) {
-        makeSureInitialized();
-        for (Column column : fullSchema) {
-            if (name.equals(column.getName())) {
-                return column;
-            }
-        }
-        return null;
     }
 
     public EsTable getEsTable() {
@@ -151,16 +75,18 @@ public class EsExternalTable extends ExternalTable {
 
     @Override
     public TTableDescriptor toThrift() {
+        List<Column> schema = getFullSchema();
         TEsTable tEsTable = new TEsTable();
-        TTableDescriptor tTableDescriptor = new TTableDescriptor(getId(), TTableType.ES_TABLE, fullSchema.size(), 0,
+        TTableDescriptor tTableDescriptor = new TTableDescriptor(getId(), TTableType.ES_TABLE, schema.size(), 0,
                 getName(), "");
         tTableDescriptor.setEsTable(tEsTable);
         return tTableDescriptor;
     }
 
     private EsTable toEsTable() {
+        List<Column> schema = getFullSchema();
         EsExternalCatalog esCatalog = (EsExternalCatalog) catalog;
-        EsTable esTable = new EsTable(this.id, this.name, this.fullSchema, TableType.ES_EXTERNAL_TABLE);
+        EsTable esTable = new EsTable(this.id, this.name, schema, TableType.ES_EXTERNAL_TABLE);
         esTable.setIndexName(name);
         esTable.setClient(esCatalog.getEsRestClient());
         esTable.setUserName(esCatalog.getUsername());

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/external/ExternalDatabase.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/external/ExternalDatabase.java
@@ -19,15 +19,18 @@ package org.apache.doris.catalog.external;
 
 import org.apache.doris.catalog.DatabaseIf;
 import org.apache.doris.catalog.DatabaseProperty;
+import org.apache.doris.catalog.Env;
 import org.apache.doris.common.DdlException;
 import org.apache.doris.common.MetaNotFoundException;
 import org.apache.doris.common.io.Text;
 import org.apache.doris.common.io.Writable;
+import org.apache.doris.common.util.Util;
 import org.apache.doris.datasource.ExternalCatalog;
 import org.apache.doris.datasource.InitDatabaseLog;
 import org.apache.doris.persist.gson.GsonPostProcessable;
 import org.apache.doris.persist.gson.GsonUtils;
 import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.qe.MasterCatalogExecutor;
 
 import com.google.gson.annotations.SerializedName;
 import org.apache.commons.lang.NotImplementedException;
@@ -87,7 +90,8 @@ public class ExternalDatabase<T extends ExternalTable> implements DatabaseIf<T>,
         this.extCatalog = extCatalog;
     }
 
-    public void setTableExtCatalog(ExternalCatalog extCatalog) {}
+    public void setTableExtCatalog(ExternalCatalog extCatalog) {
+    }
 
     public void setUnInitialized() {
         this.initialized = false;
@@ -97,7 +101,26 @@ public class ExternalDatabase<T extends ExternalTable> implements DatabaseIf<T>,
         return initialized;
     }
 
-    public void makeSureInitialized() {}
+    public final synchronized void makeSureInitialized() {
+        if (!initialized) {
+            if (!Env.getCurrentEnv().isMaster()) {
+                // Forward to master and wait the journal to replay.
+                MasterCatalogExecutor remoteExecutor = new MasterCatalogExecutor();
+                try {
+                    remoteExecutor.forward(extCatalog.getId(), id, -1);
+                } catch (Exception e) {
+                    Util.logAndThrowRuntimeException(LOG,
+                            String.format("failed to forward init external db %s operation to master", name), e);
+                }
+                return;
+            }
+            init();
+        }
+    }
+
+    protected void init() {
+        throw new NotImplementedException();
+    }
 
     public T getTableForReplay(long tableId) {
         throw new NotImplementedException();

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/external/ExternalTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/external/ExternalTable.java
@@ -19,12 +19,14 @@ package org.apache.doris.catalog.external;
 
 import org.apache.doris.alter.AlterCancelException;
 import org.apache.doris.catalog.Column;
+import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.TableIf;
 import org.apache.doris.common.DdlException;
 import org.apache.doris.common.MetaNotFoundException;
 import org.apache.doris.common.io.Text;
 import org.apache.doris.common.io.Writable;
 import org.apache.doris.datasource.ExternalCatalog;
+import org.apache.doris.datasource.ExternalSchemaCache;
 import org.apache.doris.persist.gson.GsonPostProcessable;
 import org.apache.doris.persist.gson.GsonUtils;
 import org.apache.doris.thrift.TTableDescriptor;
@@ -56,26 +58,20 @@ public class ExternalTable implements TableIf, Writable, GsonPostProcessable {
     protected String name;
     @SerializedName(value = "type")
     protected TableType type = null;
-    @SerializedName(value = "fullSchema")
-    protected volatile List<Column> fullSchema = null;
-    @SerializedName(value = "initialized")
-    protected boolean initialized = false;
     @SerializedName(value = "timestamp")
     protected long timestamp;
-
-    protected ExternalCatalog catalog;
     @SerializedName(value = "dbName")
     protected String dbName;
+
     protected boolean objectCreated = false;
+    protected ExternalCatalog catalog;
     protected ReentrantReadWriteLock rwLock = new ReentrantReadWriteLock(true);
 
     /**
      * No args constructor for persist.
      */
     public ExternalTable() {
-        this.initialized = false;
         this.objectCreated = false;
-        this.fullSchema = null;
     }
 
     /**
@@ -93,9 +89,7 @@ public class ExternalTable implements TableIf, Writable, GsonPostProcessable {
         this.catalog = catalog;
         this.dbName = dbName;
         this.type = type;
-        this.initialized = false;
         this.objectCreated = false;
-        this.fullSchema = null;
     }
 
     public void setCatalog(ExternalCatalog catalog) {
@@ -106,16 +100,9 @@ public class ExternalTable implements TableIf, Writable, GsonPostProcessable {
         return false;
     }
 
-    public void setUnInitialized() {
-        this.initialized = false;
+    public void makeSureInitialized() {
+        throw new NotImplementedException();
     }
-
-    public void replayInitTable(List<Column> schema) {
-        fullSchema = schema;
-        initialized = true;
-    }
-
-    public void makeSureInitialized() {}
 
     @Override
     public void readLock() {
@@ -226,27 +213,35 @@ public class ExternalTable implements TableIf, Writable, GsonPostProcessable {
 
     @Override
     public List<Column> getFullSchema() {
-        throw new NotImplementedException();
+        makeSureInitialized();
+        ExternalSchemaCache cache = Env.getCurrentEnv().getExtMetaCacheMgr().getSchemaCache(catalog);
+        return cache.getSchema(dbName, name);
     }
 
     @Override
     public List<Column> getBaseSchema() {
-        throw new NotImplementedException();
+        return getFullSchema();
     }
 
     @Override
     public List<Column> getBaseSchema(boolean full) {
-        throw new NotImplementedException();
+        return getFullSchema();
     }
+
 
     @Override
     public void setNewFullSchema(List<Column> newSchema) {
-        this.fullSchema = newSchema;
     }
 
     @Override
     public Column getColumn(String name) {
-        throw new NotImplementedException();
+        List<Column> schema = getFullSchema();
+        for (Column column : schema) {
+            if (name.equals(column.getName())) {
+                return column;
+            }
+        }
+        return null;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/external/HMSExternalTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/external/HMSExternalTable.java
@@ -18,15 +18,9 @@
 package org.apache.doris.catalog.external;
 
 import org.apache.doris.catalog.Column;
-import org.apache.doris.catalog.Env;
-import org.apache.doris.catalog.HiveMetaStoreClientHelper;
-import org.apache.doris.common.DdlException;
+import org.apache.doris.catalog.Type;
 import org.apache.doris.common.MetaNotFoundException;
-import org.apache.doris.common.util.Util;
 import org.apache.doris.datasource.HMSExternalCatalog;
-import org.apache.doris.datasource.InitTableLog;
-import org.apache.doris.datasource.PooledHiveMetaStoreClient;
-import org.apache.doris.qe.MasterCatalogExecutor;
 import org.apache.doris.thrift.THiveTable;
 import org.apache.doris.thrift.TTableDescriptor;
 import org.apache.doris.thrift.TTableType;
@@ -34,9 +28,6 @@ import org.apache.doris.thrift.TTableType;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
-import org.apache.hadoop.hive.metastore.api.Partition;
-import org.apache.hadoop.hive.ql.exec.SerializationUtilities;
-import org.apache.hadoop.hive.ql.plan.ExprNodeGenericFuncDesc;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -44,6 +35,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Hive metastore external table.
@@ -61,6 +53,8 @@ public class HMSExternalTable extends ExternalTable {
     }
 
     private volatile org.apache.hadoop.hive.metastore.api.Table remoteTable = null;
+    private List<Column> partitionColumns;
+
     private DLAType dlaType = DLAType.UNKNOWN;
 
     public enum DLAType {
@@ -106,21 +100,6 @@ public class HMSExternalTable extends ExternalTable {
             }
             objectCreated = true;
         }
-        if (!initialized) {
-            if (!Env.getCurrentEnv().isMaster()) {
-                fullSchema = null;
-                // Forward to master and wait the journal to replay.
-                MasterCatalogExecutor remoteExecutor = new MasterCatalogExecutor();
-                try {
-                    remoteExecutor.forward(catalog.getId(), catalog.getDbNullable(dbName).getId(), id);
-                } catch (Exception e) {
-                    Util.logAndThrowRuntimeException(LOG,
-                            String.format("failed to forward init external table %s operation to master", name), e);
-                }
-                return;
-            }
-            init();
-        }
     }
 
     /**
@@ -160,50 +139,10 @@ public class HMSExternalTable extends ExternalTable {
      * Now we only support three file input format hive tables: parquet/orc/text. And they must be managed_table.
      */
     private boolean supportedHiveTable() {
-        // boolean isManagedTable = remoteTable.getTableType().equalsIgnoreCase("MANAGED_TABLE");
-        // TODO: try to support EXTERNAL_TABLE
-        boolean isManagedTable = true;
         String inputFileFormat = remoteTable.getSd().getInputFormat();
         boolean supportedFileFormat = inputFileFormat != null && SUPPORTED_HIVE_FILE_FORMATS.contains(inputFileFormat);
         LOG.debug("hms table {} is {} with file format: {}", name, remoteTable.getTableType(), inputFileFormat);
-        return isManagedTable && supportedFileFormat;
-    }
-
-    private void init() {
-        boolean schemaChanged = false;
-        List<Column> tmpSchema = Lists.newArrayList();
-        if (dlaType.equals(DLAType.UNKNOWN)) {
-            schemaChanged = true;
-        } else {
-            List<FieldSchema> schema = ((HMSExternalCatalog) catalog).getClient().getSchema(dbName, name);
-            for (FieldSchema field : schema) {
-                int columnId = (int) Env.getCurrentEnv().getNextId();
-                tmpSchema.add(new Column(field.getName(),
-                        HiveMetaStoreClientHelper.hiveTypeToDorisType(field.getType()), true, null,
-                        true, null, field.getComment(), true, null, columnId));
-            }
-            if (fullSchema == null || fullSchema.size() != tmpSchema.size()) {
-                schemaChanged = true;
-            } else {
-                for (int i = 0; i < fullSchema.size(); i++) {
-                    if (!fullSchema.get(i).equals(tmpSchema.get(i))) {
-                        schemaChanged = true;
-                        break;
-                    }
-                }
-            }
-        }
-        if (schemaChanged) {
-            timestamp = System.currentTimeMillis();
-            fullSchema = tmpSchema;
-        }
-        initialized = true;
-        InitTableLog initTableLog = new InitTableLog();
-        initTableLog.setCatalogId(catalog.getId());
-        initTableLog.setDbId(catalog.getDbNameToId().get(dbName));
-        initTableLog.setTableId(id);
-        initTableLog.setSchema(fullSchema);
-        Env.getCurrentEnv().getEditLog().logInitExternalTable(initTableLog);
+        return supportedFileFormat;
     }
 
     /**
@@ -220,36 +159,21 @@ public class HMSExternalTable extends ExternalTable {
         return remoteTable;
     }
 
+    public List<Type> getPartitionColumnTypes() {
+        makeSureInitialized();
+        initPartitionColumns();
+        return partitionColumns.stream().map(c -> c.getType()).collect(Collectors.toList());
+    }
+
+    public List<Column> getPartitionColumns() {
+        makeSureInitialized();
+        initPartitionColumns();
+        return partitionColumns;
+    }
+
     @Override
     public boolean isView() {
         return remoteTable.isSetViewOriginalText() || remoteTable.isSetViewExpandedText();
-    }
-
-    @Override
-    public List<Column> getFullSchema() {
-        makeSureInitialized();
-        return fullSchema;
-    }
-
-    @Override
-    public List<Column> getBaseSchema() {
-        return getFullSchema();
-    }
-
-    @Override
-    public List<Column> getBaseSchema(boolean full) {
-        return getFullSchema();
-    }
-
-    @Override
-    public Column getColumn(String name) {
-        makeSureInitialized();
-        for (Column column : fullSchema) {
-            if (name.equals(column.getName())) {
-                return column;
-            }
-        }
-        return null;
     }
 
     @Override
@@ -321,8 +245,9 @@ public class HMSExternalTable extends ExternalTable {
 
     @Override
     public TTableDescriptor toThrift() {
+        List<Column> schema = getFullSchema();
         THiveTable tHiveTable = new THiveTable(dbName, name, new HashMap<>());
-        TTableDescriptor tTableDescriptor = new TTableDescriptor(getId(), TTableType.HIVE_TABLE, fullSchema.size(), 0,
+        TTableDescriptor tTableDescriptor = new TTableDescriptor(getId(), TTableType.HIVE_TABLE, schema.size(), 0,
                 getName(), dbName);
         tTableDescriptor.setHiveTable(tHiveTable);
         return tTableDescriptor;
@@ -340,12 +265,29 @@ public class HMSExternalTable extends ExternalTable {
         return catalog.getCatalogProperty().getS3Properties();
     }
 
-    public List<Partition> getHivePartitions(ExprNodeGenericFuncDesc hivePartitionPredicate) throws DdlException {
-        List<Partition> hivePartitions = Lists.newArrayList();
-        PooledHiveMetaStoreClient client = ((HMSExternalCatalog) catalog).getClient();
-        client.listPartitionsByExpr(remoteTable.getDbName(), remoteTable.getTableName(),
-                SerializationUtilities.serializeExpressionToKryo(hivePartitionPredicate), hivePartitions);
-        return hivePartitions;
+    private void initPartitionColumns() {
+        if (partitionColumns != null) {
+            return;
+        }
+        synchronized (this) {
+            if (partitionColumns != null) {
+                return;
+            }
+            Set<String> partitionKeys = remoteTable.getPartitionKeys().stream().map(FieldSchema::getName)
+                    .collect(Collectors.toSet());
+            partitionColumns = Lists.newArrayListWithCapacity(partitionKeys.size());
+            for (String partitionKey : partitionKeys) {
+                // Do not use "getColumn()", which will cause dead loop
+                List<Column> schema = getFullSchema();
+                for (Column column : schema) {
+                    if (partitionKey.equals(column.getName())) {
+                        partitionColumns.add(column);
+                        break;
+                    }
+                }
+            }
+            LOG.debug("get {} partition columns for table: {}", partitionColumns.size(), name);
+        }
     }
 }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/external/HMSExternalTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/external/HMSExternalTable.java
@@ -171,6 +171,10 @@ public class HMSExternalTable extends ExternalTable {
         return partitionColumns;
     }
 
+    public List<String> getPartitionColumnNames() {
+        return getPartitionColumns().stream().map(c -> c.getName()).collect(Collectors.toList());
+    }
+
     @Override
     public boolean isView() {
         return remoteTable.isSetViewOriginalText() || remoteTable.isSetViewExpandedText();

--- a/fe/fe-core/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/Config.java
@@ -1880,5 +1880,33 @@ public class Config extends ConfigBase {
      */
     @ConfField(mutable = true, masterOnly = true)
     public static long max_replica_count_when_schema_change = 100000;
+
+    /**
+     * Max cache num of hive partition.
+     * Decrease this value if FE's memory is small
+     */
+    @ConfField(mutable = false, masterOnly = false)
+    public static long max_hive_partition_cache_num = 100000;
+
+    /**
+     * Max cache num of external catalog's file
+     * Decrease this value if FE's memory is small
+     */
+    @ConfField(mutable = false, masterOnly = false)
+    public static long max_external_file_cache_num = 100000;
+
+    /**
+     * Max cache num of external table's schema
+     * Decrease this value if FE's memory is small
+     */
+    @ConfField(mutable = false, masterOnly = false)
+    public static long max_external_schema_cache_num = 10000;
+
+    /**
+     * The expiration time of a cache object after last access of it.
+     * For external schema cache and hive meta cache.
+     */
+    @ConfField(mutable = false, masterOnly = false)
+    public static long external_cache_expire_time_minutes_after_access = 24 * 60; // 1 day
 }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/CacheException.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/CacheException.java
@@ -1,0 +1,24 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.datasource;
+
+public class CacheException extends RuntimeException {
+    public CacheException(String format, Throwable cause, Object... msg) {
+        super(String.format(format, msg), cause);
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/CatalogMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/CatalogMgr.java
@@ -95,6 +95,7 @@ public class CatalogMgr implements Writable, GsonPostProcessable {
         CatalogIf catalog = idToCatalog.remove(catalogId);
         if (catalog != null) {
             nameToCatalog.remove(catalog.getName());
+            Env.getCurrentEnv().getExtMetaCacheMgr().removeCache(catalog.getName());
         }
         return catalog;
     }
@@ -423,16 +424,6 @@ public class CatalogMgr implements Writable, GsonPostProcessable {
         db.replayInitDb(log, catalog);
     }
 
-    public void replayInitExternalTable(InitTableLog log) {
-        ExternalCatalog catalog = (ExternalCatalog) idToCatalog.get(log.getCatalogId());
-        Preconditions.checkArgument(catalog != null);
-        ExternalDatabase db = catalog.getDbForReplay(log.getDbId());
-        Preconditions.checkArgument(db != null);
-        ExternalTable table = db.getTableForReplay(log.getTableId());
-        Preconditions.checkArgument(table != null);
-        table.replayInitTable(log.getSchema());
-    }
-
     public void replayRefreshExternalDb(ExternalObjectLog log) {
         writeLock();
         try {
@@ -445,15 +436,11 @@ public class CatalogMgr implements Writable, GsonPostProcessable {
     }
 
     public void replayRefreshExternalTable(ExternalObjectLog log) {
-        writeLock();
-        try {
-            ExternalCatalog catalog = (ExternalCatalog) idToCatalog.get(log.getCatalogId());
-            ExternalDatabase db = catalog.getDbForReplay(log.getDbId());
-            ExternalTable table = db.getTableForReplay(log.getTableId());
-            table.setUnInitialized();
-        } finally {
-            writeUnlock();
-        }
+        ExternalCatalog catalog = (ExternalCatalog) idToCatalog.get(log.getCatalogId());
+        ExternalDatabase db = catalog.getDbForReplay(log.getDbId());
+        ExternalTable table = db.getTableForReplay(log.getTableId());
+        Env.getCurrentEnv().getExtMetaCacheMgr().getSchemaCache(catalog)
+                .invalidateCache(db.getFullName(), table.getName());
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/EsExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/EsExternalCatalog.java
@@ -18,6 +18,7 @@
 package org.apache.doris.datasource;
 
 
+import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.external.EsExternalDatabase;
 import org.apache.doris.catalog.external.ExternalDatabase;
@@ -189,5 +190,11 @@ public class EsExternalCatalog extends ExternalCatalog {
     public void gsonPostProcess() throws IOException {
         super.gsonPostProcess();
         setProperties(this.catalogProperty.getProperties());
+    }
+
+    @Override
+    public List<Column> getSchema(String dbName, String tblName) {
+        makeSureInitialized();
+        return EsUtil.genColumnsFromEs(getEsRestClient(), tblName, null);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalCatalog.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.datasource;
 
+import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.external.EsExternalDatabase;
 import org.apache.doris.catalog.external.ExternalDatabase;
@@ -62,13 +63,13 @@ public abstract class ExternalCatalog implements CatalogIf<ExternalDatabase>, Wr
     protected CatalogProperty catalogProperty = new CatalogProperty();
     @SerializedName(value = "initialized")
     private boolean initialized = false;
-
-    // Cache of db name to db id
     @SerializedName(value = "idToDb")
     protected Map<Long, ExternalDatabase> idToDb = Maps.newConcurrentMap();
     // db name does not contains "default_cluster"
     protected Map<String, Long> dbNameToId = Maps.newConcurrentMap();
     private boolean objectCreated = false;
+
+    private ExternalSchemaCache schemaCache;
 
     /**
      * @return names of database in this catalog.
@@ -134,6 +135,8 @@ public abstract class ExternalCatalog implements CatalogIf<ExternalDatabase>, Wr
     public ExternalDatabase getDbForReplay(long dbId) {
         throw new NotImplementedException();
     }
+
+    public abstract List<Column> getSchema(String dbName, String tblName);
 
     @Override
     public long getId() {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalMetaCacheMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalMetaCacheMgr.java
@@ -80,9 +80,16 @@ public class ExternalMetaCacheMgr {
         }
     }
 
-    public void removeSchemaCache(long catalogId, String dbName, String tblName) {
-        ExternalSchemaCache cache = schemaCacheMap.get(catalogId);
-        cache.invalidateCache(dbName, tblName);
-        LOG.debug("invalid schema cache for {}.{} in catalog {}", dbName, tblName, catalogId);
+    public void removeCache(long catalogId, String dbName, String tblName) {
+        ExternalSchemaCache schemaCache = schemaCacheMap.get(catalogId);
+        if (schemaCache != null) {
+            schemaCache.invalidateCache(dbName, tblName);
+            LOG.debug("invalid schema cache for {}.{} in catalog {}", dbName, tblName, catalogId);
+        }
+        HiveMetaStoreCache metaCache = cacheMap.get(catalogId);
+        if (metaCache != null) {
+            metaCache.invalidateCache(dbName, tblName);
+            LOG.debug("invalid meta cache for {}.{} in catalog {}", dbName, tblName, catalogId);
+        }
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalMetaCacheMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalMetaCacheMgr.java
@@ -1,0 +1,88 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.datasource;
+
+import org.apache.doris.common.ThreadPoolManager;
+import org.apache.doris.datasource.hive.HiveMetaStoreCache;
+
+import com.google.common.collect.Maps;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.Map;
+import java.util.concurrent.Executor;
+
+/**
+ * Cache meta of external catalog
+ * 1. Meta for hive meta store, mainly for partition.
+ * 2. Table Schema cahce.
+ */
+public class ExternalMetaCacheMgr {
+    private static final Logger LOG = LogManager.getLogger(ExternalMetaCacheMgr.class);
+
+    // catalog id -> HiveMetaStoreCache
+    private Map<Long, HiveMetaStoreCache> cacheMap = Maps.newConcurrentMap();
+    // catalog id -> table schema cache
+    private Map<Long, ExternalSchemaCache> schemaCacheMap = Maps.newHashMap();
+    private Executor executor;
+
+    public ExternalMetaCacheMgr() {
+        executor = ThreadPoolManager.newDaemonCacheThreadPool(10, "ExternalMetaCacheMgr", false);
+    }
+
+    public HiveMetaStoreCache getMetaStoreCache(HMSExternalCatalog catalog) {
+        HiveMetaStoreCache cache = cacheMap.get(catalog.getId());
+        if (cache == null) {
+            synchronized (cacheMap) {
+                if (!cacheMap.containsKey(catalog.getId())) {
+                    cacheMap.put(catalog.getId(), new HiveMetaStoreCache(catalog, executor));
+                }
+                cache = cacheMap.get(catalog.getId());
+            }
+        }
+        return cache;
+    }
+
+    public ExternalSchemaCache getSchemaCache(ExternalCatalog catalog) {
+        ExternalSchemaCache cache = schemaCacheMap.get(catalog.getId());
+        if (cache == null) {
+            synchronized (schemaCacheMap) {
+                if (!schemaCacheMap.containsKey(catalog.getId())) {
+                    schemaCacheMap.put(catalog.getId(), new ExternalSchemaCache(catalog, executor));
+                }
+                cache = schemaCacheMap.get(catalog.getId());
+            }
+        }
+        return cache;
+    }
+
+    public void removeCache(String catalogId) {
+        if (cacheMap.remove(catalogId) != null) {
+            LOG.info("remove hive metastore cache for catalog {}" + catalogId);
+        }
+        if (schemaCacheMap.remove(catalogId) != null) {
+            LOG.info("remove schema cache for catalog {}" + catalogId);
+        }
+    }
+
+    public void removeSchemaCache(long catalogId, String dbName, String tblName) {
+        ExternalSchemaCache cache = schemaCacheMap.get(catalogId);
+        cache.invalidateCache(dbName, tblName);
+        LOG.debug("invalid schema cache for {}.{} in catalog {}", dbName, tblName, catalogId);
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalSchemaCache.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalSchemaCache.java
@@ -88,8 +88,7 @@ public class ExternalSchemaCache {
         try {
             return schemaCache.get(key);
         } catch (ExecutionException e) {
-            // TODO: how to handle exception?
-            throw new RuntimeException(e);
+            throw new CacheException("failed to get schema for %s in catalog %s", e, key, catalog.getName());
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalSchemaCache.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalSchemaCache.java
@@ -1,0 +1,132 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.datasource;
+
+import org.apache.doris.catalog.Column;
+import org.apache.doris.common.Config;
+import org.apache.doris.metric.GaugeMetric;
+import org.apache.doris.metric.Metric;
+import org.apache.doris.metric.MetricLabel;
+import org.apache.doris.metric.MetricRepo;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.common.collect.ImmutableList;
+import lombok.Data;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
+
+// The schema cache for external table
+public class ExternalSchemaCache {
+    private static final Logger LOG = LogManager.getLogger(ExternalSchemaCache.class);
+    private ExternalCatalog catalog;
+
+    private LoadingCache<SchemaCacheKey, ImmutableList<Column>> schemaCache;
+
+    public ExternalSchemaCache(ExternalCatalog catalog, Executor executor) {
+        this.catalog = catalog;
+        init(executor);
+        initMetrics();
+    }
+
+    private void init(Executor executor) {
+        schemaCache = CacheBuilder.newBuilder().maximumSize(Config.max_external_schema_cache_num)
+                .expireAfterAccess(Config.external_cache_expire_time_minutes_after_access, TimeUnit.MINUTES)
+                .build(CacheLoader.asyncReloading(new CacheLoader<SchemaCacheKey, ImmutableList<Column>>() {
+                    @Override
+                    public ImmutableList<Column> load(SchemaCacheKey key) throws Exception {
+                        return loadSchema(key);
+                    }
+                }, executor));
+    }
+
+    private void initMetrics() {
+        // schema cache
+        GaugeMetric<Long> schemaCacheGauge = new GaugeMetric<Long>("external_schema_cache",
+                Metric.MetricUnit.NOUNIT, "external schema cache number") {
+            @Override
+            public Long getValue() {
+                return schemaCache.size();
+            }
+        };
+        schemaCacheGauge.addLabel(new MetricLabel("catalog", catalog.getName()));
+        MetricRepo.DORIS_METRIC_REGISTER.addMetrics(schemaCacheGauge);
+    }
+
+    private ImmutableList<Column> loadSchema(SchemaCacheKey key) {
+        ImmutableList<Column> schema = ImmutableList.copyOf(catalog.getSchema(key.dbName, key.tblName));
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("load schema for {} in catalog {}", key, catalog.getName());
+        }
+        return schema;
+    }
+
+    public List<Column> getSchema(String dbName, String tblName) {
+        SchemaCacheKey key = new SchemaCacheKey(dbName, tblName);
+        try {
+            return schemaCache.get(key);
+        } catch (ExecutionException e) {
+            // TODO: how to handle exception?
+            throw new RuntimeException(e);
+        }
+    }
+
+    public void invalidateCache(String dbName, String tblName) {
+        SchemaCacheKey key = new SchemaCacheKey(dbName, tblName);
+        schemaCache.invalidate(key);
+    }
+
+    @Data
+    public static class SchemaCacheKey {
+        private String dbName;
+        private String tblName;
+
+        public SchemaCacheKey(String dbName, String tblName) {
+            this.dbName = dbName;
+            this.tblName = tblName;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (!(obj instanceof SchemaCacheKey)) {
+                return false;
+            }
+            return dbName.equals(((SchemaCacheKey) obj).dbName) && tblName.equals(((SchemaCacheKey) obj).tblName);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(dbName, tblName);
+        }
+
+        @Override
+        public String toString() {
+            return "SchemaCacheKey{" + "dbName='" + dbName + '\'' + ", tblName='" + tblName + '\'' + '}';
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/HMSClientException.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/HMSClientException.java
@@ -1,0 +1,24 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.datasource;
+
+public class HMSClientException extends RuntimeException {
+    public HMSClientException(String format, Throwable cause, Object... msg) {
+        super(String.format(format, msg), cause);
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/HMSExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/HMSExternalCatalog.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.datasource;
 
+import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.HiveMetaStoreClientHelper;
 import org.apache.doris.catalog.external.ExternalDatabase;
@@ -26,6 +27,7 @@ import org.apache.doris.cluster.ClusterNamespace;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.Nullable;
@@ -158,5 +160,18 @@ public class HMSExternalCatalog extends ExternalCatalog {
     public PooledHiveMetaStoreClient getClient() {
         makeSureInitialized();
         return client;
+    }
+
+    @Override
+    public List<Column> getSchema(String dbName, String tblName) {
+        makeSureInitialized();
+        List<FieldSchema> schema = getClient().getSchema(dbName, tblName);
+        List<Column> tmpSchema = Lists.newArrayListWithCapacity(schema.size());
+        for (FieldSchema field : schema) {
+            tmpSchema.add(new Column(field.getName(),
+                    HiveMetaStoreClientHelper.hiveTypeToDorisType(field.getType()), true, null,
+                    true, null, field.getComment(), true, null, -1));
+        }
+        return tmpSchema;
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/PooledHiveMetaStoreClient.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/PooledHiveMetaStoreClient.java
@@ -101,6 +101,15 @@ public class PooledHiveMetaStoreClient {
         }
     }
 
+    public List<Partition> getPartitionsByFilter(String dbName, String tblName, String filter) {
+        try (CachedClient client = getClient()) {
+            return client.client.listPartitionsByFilter(dbName, tblName, filter, MAX_LIST_PARTITION_NUM);
+        } catch (Exception e) {
+            throw new HMSClientException("failed to get partition by filter for table %s in db %s", e, tblName,
+                    dbName);
+        }
+    }
+
     public Table getTable(String dbName, String tblName) {
         try (CachedClient client = getClient()) {
             return client.client.getTable(dbName, tblName);

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/PooledHiveMetaStoreClient.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/PooledHiveMetaStoreClient.java
@@ -40,13 +40,15 @@ import java.util.List;
 import java.util.Queue;
 
 /**
- * A hive metastore client pool for a specific hive conf.
+ * A hive metastore client pool for a specific catalog with hive configuration.
  */
 public class PooledHiveMetaStoreClient {
     private static final Logger LOG = LogManager.getLogger(PooledHiveMetaStoreClient.class);
 
-    private Queue<CachedClient> clientPool = new LinkedList<>();
     private static final HiveMetaHookLoader DUMMY_HOOK_LOADER = t -> null;
+    private static final short MAX_LIST_PARTITION_NUM = 10000;
+
+    private Queue<CachedClient> clientPool = new LinkedList<>();
     private final int poolSize;
     private final HiveConf hiveConf;
 
@@ -62,7 +64,7 @@ public class PooledHiveMetaStoreClient {
         try (CachedClient client = getClient()) {
             return client.client.getAllDatabases();
         } catch (Exception e) {
-            throw new RuntimeException(e);
+            throw new HMSClientException("failed to get all database from hms client", e);
         }
     }
 
@@ -70,7 +72,7 @@ public class PooledHiveMetaStoreClient {
         try (CachedClient client = getClient()) {
             return client.client.getAllTables(dbName);
         } catch (Exception e) {
-            throw new RuntimeException(e);
+            throw new HMSClientException("failed to get all tables for db %s", e, dbName);
         }
     }
 
@@ -78,17 +80,24 @@ public class PooledHiveMetaStoreClient {
         try (CachedClient client = getClient()) {
             return client.client.tableExists(dbName, tblName);
         } catch (Exception e) {
-            throw new RuntimeException(e);
+            throw new HMSClientException("failed to check if table %s in db %s exists", e, tblName, dbName);
         }
     }
 
-    public boolean listPartitionsByExpr(String dbName, String tblName,
-            byte[] partitionPredicatesInBytes, List<Partition> hivePartitions) {
+    public List<String> listPartitionNames(String dbName, String tblName) {
         try (CachedClient client = getClient()) {
-            return client.client.listPartitionsByExpr(dbName, tblName, partitionPredicatesInBytes,
-                    null, (short) -1, hivePartitions);
+            return client.client.listPartitionNames(dbName, tblName, MAX_LIST_PARTITION_NUM);
         } catch (Exception e) {
-            throw new RuntimeException(e);
+            throw new HMSClientException("failed to list partition names for table %s in db %s", e, tblName, dbName);
+        }
+    }
+
+    public Partition getPartition(String dbName, String tblName, List<String> partitionValues) {
+        try (CachedClient client = getClient()) {
+            return client.client.getPartition(dbName, tblName, partitionValues);
+        } catch (Exception e) {
+            throw new HMSClientException("failed to get partition for table %s in db %s with value %s", e, tblName,
+                    dbName, partitionValues);
         }
     }
 
@@ -96,7 +105,7 @@ public class PooledHiveMetaStoreClient {
         try (CachedClient client = getClient()) {
             return client.client.getTable(dbName, tblName);
         } catch (Exception e) {
-            throw new RuntimeException(e);
+            throw new HMSClientException("failed to get table %s in db %s from hms client", e, tblName, dbName);
         }
     }
 
@@ -104,7 +113,7 @@ public class PooledHiveMetaStoreClient {
         try (CachedClient client = getClient()) {
             return client.client.getSchema(dbName, tblName);
         } catch (Exception e) {
-            throw new RuntimeException(e);
+            throw new HMSClientException("failed to get schema for table %s in db %s", e, tblName, dbName);
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HiveMetaStoreCache.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HiveMetaStoreCache.java
@@ -1,0 +1,383 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.datasource.hive;
+
+import org.apache.doris.analysis.PartitionValue;
+import org.apache.doris.catalog.ListPartitionItem;
+import org.apache.doris.catalog.PartitionKey;
+import org.apache.doris.catalog.Type;
+import org.apache.doris.common.AnalysisException;
+import org.apache.doris.common.Config;
+import org.apache.doris.common.FeConstants;
+import org.apache.doris.datasource.CacheException;
+import org.apache.doris.datasource.HMSExternalCatalog;
+import org.apache.doris.external.hive.util.HiveUtil;
+import org.apache.doris.metric.GaugeMetric;
+import org.apache.doris.metric.Metric;
+import org.apache.doris.metric.MetricLabel;
+import org.apache.doris.metric.MetricRepo;
+
+import com.google.common.base.Preconditions;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import lombok.Data;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hdfs.HdfsConfiguration;
+import org.apache.hadoop.hive.metastore.api.Partition;
+import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
+import org.apache.hadoop.mapred.FileInputFormat;
+import org.apache.hadoop.mapred.InputFormat;
+import org.apache.hadoop.mapred.InputSplit;
+import org.apache.hadoop.mapred.JobConf;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
+
+// The cache of a hms catalog. 3 kind of caches:
+// 1. partitionValuesCache: cache the partition values of a table, for partition prune.
+// 2. partitionCache: cache the partition info(location, input format, etc.) of a table.
+// 3. fileCache: cache the files of a location.
+public class HiveMetaStoreCache {
+    private static final Logger LOG = LogManager.getLogger(HiveMetaStoreCache.class);
+
+    private HMSExternalCatalog catalog;
+
+    // cache from <dbname-tblname> -> <values of partitions>
+    private LoadingCache<PartitionValueCacheKey, ImmutableList<ListPartitionItem>> partitionValuesCache;
+    // cache from <dbname-tblname-partition_values> -> <partition info>
+    private LoadingCache<PartitionCacheKey, HivePartition> partitionCache;
+    // cache from <location> -> <file list>
+    private LoadingCache<FileCacheKey, ImmutableList<InputSplit>> fileCache;
+
+    public HiveMetaStoreCache(HMSExternalCatalog catalog, Executor executor) {
+        this.catalog = catalog;
+        init(executor);
+        initMetrics();
+    }
+
+    private void init(Executor executor) {
+        partitionValuesCache = CacheBuilder.newBuilder().maximumSize(Config.max_hive_partition_cache_num)
+                .expireAfterAccess(Config.external_cache_expire_time_minutes_after_access, TimeUnit.MINUTES)
+                .build(CacheLoader.asyncReloading(
+                        new CacheLoader<PartitionValueCacheKey, ImmutableList<ListPartitionItem>>() {
+                            @Override
+                            public ImmutableList<ListPartitionItem> load(PartitionValueCacheKey key) throws Exception {
+                                return loadPartitionValues(key);
+                            }
+                        }, executor));
+
+        partitionCache = CacheBuilder.newBuilder().maximumSize(Config.max_hive_partition_cache_num)
+                .expireAfterAccess(Config.external_cache_expire_time_minutes_after_access, TimeUnit.MINUTES)
+                .build(CacheLoader.asyncReloading(new CacheLoader<PartitionCacheKey, HivePartition>() {
+                    @Override
+                    public HivePartition load(PartitionCacheKey key) throws Exception {
+                        return loadPartitions(key);
+                    }
+                }, executor));
+
+        fileCache = CacheBuilder.newBuilder().maximumSize(Config.max_external_file_cache_num)
+                .expireAfterAccess(Config.external_cache_expire_time_minutes_after_access, TimeUnit.MINUTES)
+                .build(CacheLoader.asyncReloading(new CacheLoader<FileCacheKey, ImmutableList<InputSplit>>() {
+                    @Override
+                    public ImmutableList<InputSplit> load(FileCacheKey key) throws Exception {
+                        return loadFiles(key);
+                    }
+                }, executor));
+    }
+
+    private void initMetrics() {
+        // partition value
+        GaugeMetric<Long> valueCacheGauge = new GaugeMetric<Long>("hive_meta_cache",
+                Metric.MetricUnit.NOUNIT, "hive partition value cache number") {
+            @Override
+            public Long getValue() {
+                return partitionValuesCache.size();
+            }
+        };
+        valueCacheGauge.addLabel(new MetricLabel("type", "partition_value"));
+        valueCacheGauge.addLabel(new MetricLabel("catalog", catalog.getName()));
+        MetricRepo.DORIS_METRIC_REGISTER.addMetrics(valueCacheGauge);
+        // partition
+        GaugeMetric<Long> partitionCacheGauge = new GaugeMetric<Long>("hive_meta_cache",
+                Metric.MetricUnit.NOUNIT, "hive partition cache number") {
+            @Override
+            public Long getValue() {
+                return partitionCache.size();
+            }
+        };
+        partitionCacheGauge.addLabel(new MetricLabel("type", "partition"));
+        partitionCacheGauge.addLabel(new MetricLabel("catalog", catalog.getName()));
+        MetricRepo.DORIS_METRIC_REGISTER.addMetrics(partitionCacheGauge);
+        // file
+        GaugeMetric<Long> fileCacheGauge = new GaugeMetric<Long>("hive_meta_cache",
+                Metric.MetricUnit.NOUNIT, "hive file cache number") {
+            @Override
+            public Long getValue() {
+                return fileCache.size();
+            }
+        };
+        fileCacheGauge.addLabel(new MetricLabel("type", "file"));
+        fileCacheGauge.addLabel(new MetricLabel("catalog", catalog.getName()));
+        MetricRepo.DORIS_METRIC_REGISTER.addMetrics(fileCacheGauge);
+    }
+
+    private ImmutableList<ListPartitionItem> loadPartitionValues(PartitionValueCacheKey key) {
+        // partition name format: nation=cn/city=beijing
+        List<String> partitionNames = catalog.getClient().listPartitionNames(key.dbName, key.tblName);
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("load #{} partitions for {} in catalog {}", partitionNames.size(), key, catalog.getName());
+        }
+        List<ListPartitionItem> partitionValues = Lists.newArrayListWithCapacity(partitionNames.size());
+        for (String partitionName : partitionNames) {
+            partitionValues.add(toListPartitionItem(partitionName, key.types));
+        }
+        return ImmutableList.copyOf(partitionValues);
+    }
+
+    private ListPartitionItem toListPartitionItem(String partitionName, List<Type> types) {
+        // Partition name will be in format: nation=cn/city=beijing
+        // parse it to get values "cn" and "beijing"
+        String[] parts = partitionName.split("/");
+        Preconditions.checkState(parts.length == types.size(), partitionName + " vs. " + types);
+        List<PartitionValue> values = Lists.newArrayListWithCapacity(types.size());
+        for (String part : parts) {
+            String[] kv = part.split("=");
+            Preconditions.checkState(kv.length == 2, partitionName);
+            values.add(new PartitionValue(kv[1]));
+        }
+        try {
+            PartitionKey key = PartitionKey.createListPartitionKeyWithTypes(values, types);
+            return new ListPartitionItem(Lists.newArrayList(key));
+        } catch (AnalysisException e) {
+            throw new CacheException("failed to convert hive partition %s to list partition in catalog %s",
+                    e, partitionName, catalog.getName());
+        }
+    }
+
+    private HivePartition loadPartitions(PartitionCacheKey key) {
+        Partition partition = catalog.getClient().getPartition(key.dbName, key.tblName, key.values);
+        StorageDescriptor sd = partition.getSd();
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("load partition format: {}, location: {} for {} in catalog {}",
+                    sd.getInputFormat(), sd.getLocation(), key, catalog.getName());
+        }
+        // TODO: more info?
+        return new HivePartition(sd.getInputFormat(), sd.getLocation(), key.values);
+    }
+
+    private ImmutableList<InputSplit> loadFiles(FileCacheKey key) {
+        String finalLocation = convertToS3IfNecessary(key.location);
+        Configuration conf = getConfiguration();
+        JobConf jobConf = new JobConf(conf);
+        // For Tez engine, it may generate subdirectories for "union" query.
+        // So there may be files and directories in the table directory at the same time. eg:
+        //      /user/hive/warehouse/region_tmp_union_all2/000000_0
+        //      /user/hive/warehouse/region_tmp_union_all2/1
+        //      /user/hive/warehouse/region_tmp_union_all2/2
+        // So we need to set this config to support visit dir recursively.
+        // Otherwise, getSplits() may throw exception: "Not a file xxx"
+        // https://blog.actorsfit.com/a?ID=00550-ce56ec63-1bff-4b0c-a6f7-447b93efaa31
+        jobConf.set("mapreduce.input.fileinputformat.input.dir.recursive", "true");
+        FileInputFormat.setInputPaths(jobConf, finalLocation);
+        try {
+            InputFormat<?, ?> inputFormat = HiveUtil.getInputFormat(conf, key.inputFormat, false);
+            InputSplit[] splits = inputFormat.getSplits(jobConf, 0);
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("load #{} files for {} in catalog {}", splits.length, key, catalog.getName());
+            }
+            return ImmutableList.copyOf(splits);
+        } catch (Exception e) {
+            throw new CacheException("failed to get input splits for %s in catalog %s", e, key, catalog.getName());
+        }
+    }
+
+    // convert oss:// to s3://
+    private String convertToS3IfNecessary(String location) {
+        LOG.debug("try convert location to s3 prefix: " + location);
+        if (location.startsWith(FeConstants.FS_PREFIX_COS)
+                || location.startsWith(FeConstants.FS_PREFIX_BOS)
+                || location.startsWith(FeConstants.FS_PREFIX_BOS)
+                || location.startsWith(FeConstants.FS_PREFIX_OSS)
+                || location.startsWith(FeConstants.FS_PREFIX_S3A)
+                || location.startsWith(FeConstants.FS_PREFIX_S3N)) {
+            int pos = location.indexOf("://");
+            if (pos == -1) {
+                throw new RuntimeException("No '://' found in location: " + location);
+            }
+            return "s3" + location.substring(pos);
+        }
+        return location;
+    }
+
+    private Configuration getConfiguration() {
+        Configuration configuration = new HdfsConfiguration();
+        for (Map.Entry<String, String> entry : catalog.getCatalogProperty().getProperties().entrySet()) {
+            configuration.set(entry.getKey(), entry.getValue());
+        }
+        Map<String, String> s3Properties = catalog.getCatalogProperty().getS3Properties();
+        for (Map.Entry<String, String> entry : s3Properties.entrySet()) {
+            configuration.set(entry.getKey(), entry.getValue());
+        }
+        return configuration;
+    }
+
+    public ImmutableList<ListPartitionItem> getPartitionValues(String dbName, String tblName, List<Type> types) {
+        PartitionValueCacheKey key = new PartitionValueCacheKey(dbName, tblName, types);
+        try {
+            return partitionValuesCache.get(key);
+        } catch (ExecutionException e) {
+            throw new CacheException("failed to get partition values for %s in catalog %s", e, key, catalog.getName());
+        }
+    }
+
+    public HivePartition getPartition(String dbName, String tblName, List<String> partitionValues) {
+        PartitionCacheKey key = new PartitionCacheKey(dbName, tblName, partitionValues);
+        try {
+            return partitionCache.get(key);
+        } catch (ExecutionException e) {
+            throw new CacheException("failed to get partition for %s in catalog %s", e, key, catalog.getName());
+        }
+    }
+
+    public ImmutableList<InputSplit> getFiles(String location, String inputFormat) {
+        FileCacheKey key = new FileCacheKey(location, inputFormat);
+        try {
+            return fileCache.get(key);
+        } catch (ExecutionException e) {
+            throw new CacheException("failed to get files for %s in catalog %s", e, key, catalog.getName());
+        }
+    }
+
+    /**
+     * The Key of hive partition value cache
+     */
+    @Data
+    public static class PartitionValueCacheKey {
+        private String dbName;
+        private String tblName;
+        // not in key
+        private List<Type> types;
+
+        public PartitionValueCacheKey(String dbName, String tblName, List<Type> types) {
+            this.dbName = dbName;
+            this.tblName = tblName;
+            this.types = types;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (!(obj instanceof PartitionValueCacheKey)) {
+                return false;
+            }
+            return dbName.equals(((PartitionValueCacheKey) obj).dbName)
+                    && tblName.equals(((PartitionValueCacheKey) obj).tblName);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(dbName, tblName);
+        }
+
+        @Override
+        public String toString() {
+            return "PartitionValueCacheKey{" + "dbName='" + dbName + '\'' + ", tblName='" + tblName + '\'' + '}';
+        }
+    }
+
+    @Data
+    public static class PartitionCacheKey {
+        private String dbName;
+        private String tblName;
+        private List<String> values;
+
+        public PartitionCacheKey(String dbName, String tblName, List<String> values) {
+            this.dbName = dbName;
+            this.tblName = tblName;
+            this.values = values;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (!(obj instanceof PartitionCacheKey)) {
+                return false;
+            }
+            return dbName.equals(((PartitionCacheKey) obj).dbName)
+                    && tblName.equals(((PartitionCacheKey) obj).tblName)
+                    && Objects.equals(values, ((PartitionCacheKey) obj).values);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(dbName, tblName, values);
+        }
+
+        @Override
+        public String toString() {
+            return "PartitionCacheKey{" + "dbName='" + dbName + '\'' + ", tblName='" + tblName + '\'' + ", values="
+                    + values + '}';
+        }
+    }
+
+    @Data
+    public static class FileCacheKey {
+        private String location;
+        // not in key
+        private String inputFormat;
+
+        public FileCacheKey(String location, String inputFormat) {
+            this.location = location;
+            this.inputFormat = inputFormat;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (!(obj instanceof FileCacheKey)) {
+                return false;
+            }
+            return location.equals(((FileCacheKey) obj).location);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(location);
+        }
+
+        @Override
+        public String toString() {
+            return "FileCacheKey{" + "location='" + location + '\'' + ", inputFormat='" + inputFormat + '\'' + '}';
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HiveMetaStoreCache.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HiveMetaStoreCache.java
@@ -278,7 +278,7 @@ public class HiveMetaStoreCache {
         List<InputSplit> retFiles = Lists.newArrayListWithExpectedSize(
                 fileLists.stream().mapToInt(l -> l.size()).sum());
         fileLists.stream().forEach(l -> retFiles.addAll(l));
-        LOG.debug("get #{} files by #{} partitions in catalog {} cost: {} ms",
+        LOG.debug("get #{} files from #{} partitions in catalog {} cost: {} ms",
                 retFiles.size(), partitions.size(), catalog.getName(), (System.currentTimeMillis() - start));
         return retFiles;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HiveMetaStoreCache.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HiveMetaStoreCache.java
@@ -272,6 +272,12 @@ public class HiveMetaStoreCache {
         }
     }
 
+    public void invalidateCache(String dbName, String tblName) {
+        PartitionValueCacheKey key = new PartitionValueCacheKey(dbName, tblName, null);
+        partitionValuesCache.invalidate(key);
+        // TODO: find a way to invalidate partitionCache and fileCache
+    }
+
     /**
      * The Key of hive partition value cache
      */

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HivePartition.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HivePartition.java
@@ -1,0 +1,46 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.datasource.hive;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class HivePartition {
+    private String inputFormat;
+    private String path;
+    private List<String> partitionValues;
+
+    public HivePartition(String inputFormat, String path, List<String> partitionValues) {
+        // eg: org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat
+        this.inputFormat = inputFormat;
+        // eg: hdfs://hk-dev01:8121/user/doris/parquet/partition_table/nation=cn/city=beijing
+        this.path = path;
+        // eg: cn, beijing
+        this.partitionValues = partitionValues;
+    }
+
+    @Override
+    public String toString() {
+        return "HivePartition{"
+                + "inputFormat='" + inputFormat + '\''
+                + ", path='" + path + '\''
+                + ", partitionValues=" + partitionValues + '}';
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/EditLog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/EditLog.java
@@ -45,7 +45,6 @@ import org.apache.doris.datasource.CatalogLog;
 import org.apache.doris.datasource.ExternalObjectLog;
 import org.apache.doris.datasource.InitCatalogLog;
 import org.apache.doris.datasource.InitDatabaseLog;
-import org.apache.doris.datasource.InitTableLog;
 import org.apache.doris.ha.MasterInfo;
 import org.apache.doris.journal.Journal;
 import org.apache.doris.journal.JournalCursor;
@@ -951,8 +950,7 @@ public class EditLog {
                     break;
                 }
                 case OperationType.OP_INIT_EXTERNAL_TABLE: {
-                    final InitTableLog log = (InitTableLog) journal.getData();
-                    env.getCatalogMgr().replayInitExternalTable(log);
+                    // Do nothing.
                     break;
                 }
                 default: {
@@ -1624,10 +1622,6 @@ public class EditLog {
 
     public void logRefreshExternalTable(ExternalObjectLog log) {
         logEdit(OperationType.OP_REFRESH_EXTERNAL_TABLE, log);
-    }
-
-    public void logInitExternalTable(InitTableLog log) {
-        logEdit(OperationType.OP_INIT_EXTERNAL_TABLE, log);
     }
 
     public Journal getJournal() {

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/OperationType.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/OperationType.java
@@ -243,6 +243,7 @@ public class OperationType {
     public static final short OP_REFRESH_EXTERNAL_DB = 326;
     public static final short OP_INIT_EXTERNAL_DB = 327;
     public static final short OP_REFRESH_EXTERNAL_TABLE = 328;
+    @Deprecated
     public static final short OP_INIT_EXTERNAL_TABLE = 329;
 
     // scheduler job and task 330-350

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/ScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/ScanNode.java
@@ -141,7 +141,6 @@ public abstract class ScanNode extends PlanNode {
                     columnNameToRange.put(column.getName(), columnRange);
                 }
             }
-
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/external/HiveScanProvider.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/external/HiveScanProvider.java
@@ -22,16 +22,23 @@ import org.apache.doris.analysis.Expr;
 import org.apache.doris.analysis.SlotDescriptor;
 import org.apache.doris.analysis.TupleDescriptor;
 import org.apache.doris.catalog.Column;
-import org.apache.doris.catalog.HiveBucketUtil;
+import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.HiveMetaStoreClientHelper;
+import org.apache.doris.catalog.ListPartitionItem;
+import org.apache.doris.catalog.PartitionItem;
 import org.apache.doris.catalog.TableIf;
+import org.apache.doris.catalog.Type;
 import org.apache.doris.catalog.external.HMSExternalTable;
 import org.apache.doris.common.DdlException;
 import org.apache.doris.common.FeConstants;
 import org.apache.doris.common.MetaNotFoundException;
 import org.apache.doris.common.UserException;
-import org.apache.doris.external.hive.util.HiveUtil;
+import org.apache.doris.datasource.HMSExternalCatalog;
+import org.apache.doris.datasource.hive.HiveMetaStoreCache;
+import org.apache.doris.datasource.hive.HivePartition;
 import org.apache.doris.load.BrokerFileGroup;
+import org.apache.doris.planner.ColumnRange;
+import org.apache.doris.planner.ListPartitionPrunerV2;
 import org.apache.doris.planner.external.ExternalFileScanNode.ParamCreateContext;
 import org.apache.doris.thrift.TFileAttributes;
 import org.apache.doris.thrift.TFileFormatType;
@@ -40,23 +47,20 @@ import org.apache.doris.thrift.TFileScanSlotInfo;
 import org.apache.doris.thrift.TFileTextScanRangeParams;
 import org.apache.doris.thrift.TFileType;
 
+import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdfs.HdfsConfiguration;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
-import org.apache.hadoop.hive.metastore.api.Partition;
 import org.apache.hadoop.hive.metastore.api.Table;
-import org.apache.hadoop.hive.ql.plan.ExprNodeGenericFuncDesc;
-import org.apache.hadoop.mapred.FileInputFormat;
-import org.apache.hadoop.mapred.InputFormat;
+import org.apache.hadoop.mapred.FileSplit;
 import org.apache.hadoop.mapred.InputSplit;
-import org.apache.hadoop.mapred.JobConf;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.io.IOException;
-import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -75,9 +79,13 @@ public class HiveScanProvider extends HMSTableScanProvider {
 
     protected final TupleDescriptor desc;
 
-    public HiveScanProvider(HMSExternalTable hmsTable, TupleDescriptor desc) {
+    protected Map<String, ColumnRange> columnNameToRange;
+
+    public HiveScanProvider(HMSExternalTable hmsTable, TupleDescriptor desc,
+            Map<String, ColumnRange> columnNameToRange) {
         this.hmsTable = hmsTable;
         this.desc = desc;
+        this.columnNameToRange = columnNameToRange;
     }
 
     @Override
@@ -127,80 +135,65 @@ public class HiveScanProvider extends HMSTableScanProvider {
     }
 
     @Override
-    public List<InputSplit> getSplits(List<Expr> exprs) throws IOException, UserException {
-        // eg:
-        // oss://buckts/data_dir
-        // hdfs://hosts/data_dir
-        String location = getRemoteHiveTable().getSd().getLocation();
-        List<String> partitionKeys = getRemoteHiveTable().getPartitionKeys().stream().map(FieldSchema::getName)
-                .collect(Collectors.toList());
-        List<Partition> hivePartitions = new ArrayList<>();
-
-        if (partitionKeys.size() > 0) {
-            ExprNodeGenericFuncDesc hivePartitionPredicate = HiveMetaStoreClientHelper.convertToHivePartitionExpr(exprs,
-                    partitionKeys, hmsTable.getName());
-            hivePartitions.addAll(hmsTable.getHivePartitions(hivePartitionPredicate));
-        }
-
-        String inputFormatName = getRemoteHiveTable().getSd().getInputFormat();
-
-        Configuration configuration = setConfiguration();
-        InputFormat<?, ?> inputFormat = HiveUtil.getInputFormat(configuration, inputFormatName, false);
-        List<InputSplit> splits;
-        if (!hivePartitions.isEmpty()) {
-            try {
-                splits = hivePartitions.stream().flatMap(x -> {
-                    try {
-                        return getSplitsByPath(inputFormat, configuration, x.getSd().getLocation()).stream();
-                    } catch (IOException e) {
-                        throw new RuntimeException(e);
-                    }
-                }).collect(Collectors.toList());
-            } catch (RuntimeException e) {
-                throw new IOException(e);
+    public List<InputSplit> getSplits(List<Expr> exprs) throws UserException {
+        try {
+            HiveMetaStoreCache cache = Env.getCurrentEnv().getExtMetaCacheMgr()
+                    .getMetaStoreCache((HMSExternalCatalog) hmsTable.getCatalog());
+            // 1. get ListPartitionItems from cache
+            ImmutableList<ListPartitionItem> partitionItems;
+            List<Type> partitionColumnTypes = hmsTable.getPartitionColumnTypes();
+            if (!partitionColumnTypes.isEmpty()) {
+                partitionItems = cache.getPartitionValues(hmsTable.getDbName(), hmsTable.getName(),
+                        partitionColumnTypes);
+            } else {
+                partitionItems = ImmutableList.of();
             }
-        } else {
-            splits = getSplitsByPath(inputFormat, configuration, location);
+
+            List<InputSplit> allFiles = Lists.newArrayList();
+            if (!partitionItems.isEmpty()) {
+                // 2. prune partitions by expr
+                Map<Long, PartitionItem> keyItemMap = Maps.newHashMap();
+                long pid = 0;
+                for (ListPartitionItem partitionItem : partitionItems) {
+                    keyItemMap.put(pid++, partitionItem);
+                }
+                ListPartitionPrunerV2 pruner = new ListPartitionPrunerV2(keyItemMap,
+                        hmsTable.getPartitionColumns(), columnNameToRange);
+                Collection<Long> filteredPartitionIds = pruner.prune();
+
+                // 3. get partitions from cache
+                List<HivePartition> partitions = Lists.newArrayListWithCapacity(filteredPartitionIds.size());
+                for (Long id : filteredPartitionIds) {
+                    ListPartitionItem listPartitionItem = (ListPartitionItem) keyItemMap.get(id);
+                    partitions.add(cache.getPartition(hmsTable.getDbName(), hmsTable.getName(),
+                            listPartitionItem.getItems().get(0).getPartitionValuesAsStringList()));
+                }
+                // 4. get all files of partitions
+                for (HivePartition partition : partitions) {
+                    getFileSplitByLocation(cache, partition.getPath(), partition.getInputFormat(), allFiles);
+                }
+            } else {
+                // unpartitioned table, get all files of partitions
+                getFileSplitByLocation(cache, hmsTable.getRemoteTable().getSd().getLocation(),
+                        hmsTable.getRemoteTable().getSd().getInputFormat(), allFiles);
+            }
+            LOG.debug("get {} files for table: {}", allFiles.size(), hmsTable.getName());
+            return allFiles;
+        } catch (Throwable t) {
+            LOG.warn("get file split failed for table: {}", hmsTable.getName(), t);
+            throw new UserException("get file split failed for table: " + hmsTable.getName(), t);
         }
-        return HiveBucketUtil.getPrunedSplitsByBuckets(splits, hmsTable.getName(), exprs,
-                getRemoteHiveTable().getSd().getBucketCols(), getRemoteHiveTable().getSd().getNumBuckets(),
-                getRemoteHiveTable().getParameters());
     }
 
-    private List<InputSplit> getSplitsByPath(InputFormat<?, ?> inputFormat, Configuration configuration,
-            String location) throws IOException {
-        String finalLocation = convertToS3IfNecessary(location);
-        JobConf jobConf = new JobConf(configuration);
-        // For Tez engine, it may generate subdirectoies for "union" query.
-        // So there may be files and directories in the table directory at the same time. eg:
-        //      /user/hive/warehouse/region_tmp_union_all2/000000_0
-        //      /user/hive/warehouse/region_tmp_union_all2/1
-        //      /user/hive/warehouse/region_tmp_union_all2/2
-        // So we need to set this config to support visit dir recursively.
-        // Otherwise, getSplits() may throw exception: "Not a file xxx"
-        // https://blog.actorsfit.com/a?ID=00550-ce56ec63-1bff-4b0c-a6f7-447b93efaa31
-        jobConf.set("mapreduce.input.fileinputformat.input.dir.recursive", "true");
-        FileInputFormat.setInputPaths(jobConf, finalLocation);
-        InputSplit[] splits = inputFormat.getSplits(jobConf, 0);
-        return Lists.newArrayList(splits);
-    }
-
-    // convert oss:// to s3://
-    private String convertToS3IfNecessary(String location) throws IOException {
-        LOG.debug("try convert location to s3 prefix: " + location);
-        if (location.startsWith(FeConstants.FS_PREFIX_COS)
-                || location.startsWith(FeConstants.FS_PREFIX_BOS)
-                || location.startsWith(FeConstants.FS_PREFIX_BOS)
-                || location.startsWith(FeConstants.FS_PREFIX_OSS)
-                || location.startsWith(FeConstants.FS_PREFIX_S3A)
-                || location.startsWith(FeConstants.FS_PREFIX_S3N)) {
-            int pos = location.indexOf("://");
-            if (pos == -1) {
-                throw new IOException("No '://' found in location: " + location);
-            }
-            return "s3" + location.substring(pos);
+    private void getFileSplitByLocation(HiveMetaStoreCache cache, String location, String inputFormat,
+            List<InputSplit> allFiles) {
+        LOG.debug("try get file split by location: {}", inputFormat);
+        allFiles.addAll(cache.getFiles(location, inputFormat));
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("get files from location: {}: {}", location,
+                    Joiner.on(",")
+                            .join(allFiles.stream().map(f -> ((FileSplit) f).getPath()).collect(Collectors.toList())));
         }
-        return location;
     }
 
     protected Configuration setConfiguration() {

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/external/HiveScanProvider.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/external/HiveScanProvider.java
@@ -74,7 +74,6 @@ public class HiveScanProvider extends HMSTableScanProvider {
     private static final String PROP_FIELD_DELIMITER = "field.delim";
     private static final String DEFAULT_FIELD_DELIMITER = "\1"; // "\x01"
     private static final String DEFAULT_LINE_DELIMITER = "\n";
-    private static final int MIN_BATCH_FETCH_PARTITION_NUM = 100;
 
     protected HMSExternalTable hmsTable;
 
@@ -137,6 +136,7 @@ public class HiveScanProvider extends HMSTableScanProvider {
 
     @Override
     public List<InputSplit> getSplits(List<Expr> exprs) throws UserException {
+        long start = System.currentTimeMillis();
         try {
             HiveMetaStoreCache cache = Env.getCurrentEnv().getExtMetaCacheMgr()
                     .getMetaStoreCache((HMSExternalCatalog) hmsTable.getCatalog());
@@ -179,7 +179,8 @@ public class HiveScanProvider extends HMSTableScanProvider {
                         hmsTable.getRemoteTable().getSd().getLocation(), null);
                 getFileSplitByPartitions(cache, Lists.newArrayList(dummyPartition), allFiles);
             }
-            LOG.debug("get {} files for table: {}", allFiles.size(), hmsTable.getName());
+            LOG.debug("get #{} files for table: {}.{}, cost: {} ms",
+                    allFiles.size(), hmsTable.getDbName(), hmsTable.getName(), (System.currentTimeMillis() - start));
             return allFiles;
         } catch (Throwable t) {
             LOG.warn("get file split failed for table: {}", hmsTable.getName(), t);

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/external/HiveScanProvider.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/external/HiveScanProvider.java
@@ -188,12 +188,13 @@ public class HiveScanProvider extends HMSTableScanProvider {
     private void getFileSplitByLocation(HiveMetaStoreCache cache, String location, String inputFormat,
             List<InputSplit> allFiles) {
         LOG.debug("try get file split by location: {}", inputFormat);
-        allFiles.addAll(cache.getFiles(location, inputFormat));
+        ImmutableList<InputSplit> files = cache.getFiles(location, inputFormat);
         if (LOG.isDebugEnabled()) {
-            LOG.debug("get files from location: {}: {}", location,
+            LOG.debug("get #{} files from location: {}: {}", files.size(), location,
                     Joiner.on(",")
-                            .join(allFiles.stream().map(f -> ((FileSplit) f).getPath()).collect(Collectors.toList())));
+                            .join(files.stream().map(f -> ((FileSplit) f).getPath()).collect(Collectors.toList())));
         }
+        allFiles.addAll(files);
     }
 
     protected Configuration setConfiguration() {

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/external/HudiScanProvider.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/external/HudiScanProvider.java
@@ -21,10 +21,12 @@ import org.apache.doris.analysis.TupleDescriptor;
 import org.apache.doris.catalog.external.HMSExternalTable;
 import org.apache.doris.common.DdlException;
 import org.apache.doris.common.MetaNotFoundException;
+import org.apache.doris.planner.ColumnRange;
 import org.apache.doris.thrift.TFileFormatType;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 /**
  * A file scan provider for hudi.
@@ -32,8 +34,9 @@ import java.util.List;
  */
 public class HudiScanProvider extends HiveScanProvider {
 
-    public HudiScanProvider(HMSExternalTable hmsTable, TupleDescriptor desc) {
-        super(hmsTable, desc);
+    public HudiScanProvider(HMSExternalTable hmsTable, TupleDescriptor desc,
+            Map<String, ColumnRange> columnNameToRange) {
+        super(hmsTable, desc, columnNameToRange);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/external/IcebergScanProvider.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/external/IcebergScanProvider.java
@@ -24,6 +24,7 @@ import org.apache.doris.common.DdlException;
 import org.apache.doris.common.MetaNotFoundException;
 import org.apache.doris.common.UserException;
 import org.apache.doris.external.iceberg.util.IcebergUtils;
+import org.apache.doris.planner.ColumnRange;
 import org.apache.doris.thrift.TFileFormatType;
 
 import org.apache.hadoop.conf.Configuration;
@@ -36,7 +37,6 @@ import org.apache.iceberg.TableScan;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.expressions.Expression;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -48,8 +48,9 @@ import java.util.Map;
  */
 public class IcebergScanProvider extends HiveScanProvider {
 
-    public IcebergScanProvider(HMSExternalTable hmsTable, TupleDescriptor desc) {
-        super(hmsTable, desc);
+    public IcebergScanProvider(HMSExternalTable hmsTable, TupleDescriptor desc,
+            Map<String, ColumnRange> columnNameToRange) {
+        super(hmsTable, desc, columnNameToRange);
     }
 
     @Override
@@ -69,7 +70,7 @@ public class IcebergScanProvider extends HiveScanProvider {
     }
 
     @Override
-    public List<InputSplit> getSplits(List<Expr> exprs) throws IOException, UserException {
+    public List<InputSplit> getSplits(List<Expr> exprs) throws UserException {
         List<Expression> expressions = new ArrayList<>();
         for (Expr conjunct : exprs) {
             Expression expression = IcebergUtils.convertToIcebergExpr(conjunct);

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/external/QueryScanProvider.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/external/QueryScanProvider.java
@@ -39,8 +39,8 @@ import org.apache.doris.thrift.TScanRangeLocations;
 import com.google.common.base.Joiner;
 import org.apache.hadoop.mapred.FileSplit;
 import org.apache.hadoop.mapred.InputSplit;
-import org.apache.log4j.LogManager;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.io.IOException;
 import java.util.List;
@@ -56,6 +56,7 @@ public abstract class QueryScanProvider implements FileScanProviderIf {
     @Override
     public void createScanRangeLocations(ParamCreateContext context, BackendPolicy backendPolicy,
             List<TScanRangeLocations> scanRangeLocations) throws UserException {
+        long start = System.currentTimeMillis();
         try {
             List<InputSplit> inputSplits = getSplits(context.conjuncts);
             this.inputSplitNum = inputSplits.size();
@@ -100,10 +101,9 @@ public abstract class QueryScanProvider implements FileScanProviderIf {
                 TFileRangeDesc rangeDesc = createFileRangeDesc(fileSplit, partitionValuesFromPath, pathPartitionKeys);
 
                 curLocations.getScanRange().getExtScanRange().getFileScanRange().addToRanges(rangeDesc);
-                LOG.info(
-                        "Assign to backend " + curLocations.getLocations().get(0).getBackendId() + " with table split: "
-                                + fileSplit.getPath() + " ( " + fileSplit.getStart() + "," + fileSplit.getLength() + ")"
-                                + " loaction: " + Joiner.on("|").join(split.getLocations()));
+                LOG.debug("assign to backend {} with table split: {} ({}, {}), location: {}",
+                        curLocations.getLocations().get(0).getBackendId(), fileSplit.getPath(), fileSplit.getStart(),
+                        fileSplit.getLength(), Joiner.on("|").join(split.getLocations()));
 
                 fileSplitStrategy.update(fileSplit);
                 // Add a new location when it's can be split
@@ -117,6 +117,8 @@ public abstract class QueryScanProvider implements FileScanProviderIf {
             if (curLocations.getScanRange().getExtScanRange().getFileScanRange().getRangesSize() > 0) {
                 scanRangeLocations.add(curLocations);
             }
+            LOG.debug("create #{} ScanRangeLocations cost: {} ms",
+                    scanRangeLocations.size(), (System.currentTimeMillis() - start));
         } catch (IOException e) {
             throw new UserException(e);
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -583,7 +583,7 @@ public class StmtExecutor implements ProfileWriter {
             throw e;
         } catch (UserException e) {
             // analysis exception only print message, not print the stack
-            LOG.warn("execute Exception. {}, {}", context.getQueryIdentifier(), e.getMessage(), e);
+            LOG.warn("execute Exception. {}, {}", context.getQueryIdentifier(), e.getMessage());
             context.getState().setError(e.getMysqlErrorCode(), e.getMessage());
             context.getState().setErrType(QueryState.ErrType.ANALYSIS_ERR);
         } catch (Exception e) {


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

1. Two Caches
	1. HiveMetaStoreCache: mainly used to cache table partition and file information
	2. ExternalSchemaCache: mainly used to cache the schema information of the table.

		ExternalSchemaCache works for all tables in ExternalCatalog, while HiveMetaStoreCache works only for tables in HMSExternalCatalog.
		
2. ExternalMetaCacheMgr

	Cache management class, responsible for managing the mapping relationship between Catalog and HiveMetaStoreCache and ExternalSchemaCache.
	
3. Cache strategy

	1. ExternalSchemaCache
		
		Both Database and Table in ExternalCatalog are persisted to Doris metadata. However, the schema information of the Table is not persisted, but is obtained directly from the ExternalSchemaCache. If it does not exist in the cache, it will access the HMS to get it and cache it.

		The cache uses Guava's LoadingCache class. The schema of up to 10,000 tables is cached by default, which can be modified through the FE configuration item max_external_schema_cache_num .
  
  		Each FE caches its own required schema independently.

	2. HiveMetaStoreCache

		Three types of information are cached:
		
		1. partitionValuesCache

			Cache table to all information with partition value. This information is mainly used for partition pruning.
			
    		When a table is accessed, Doris will obtain all the partition values ​​(Partition values) information of the table in full, and convert it into a ListPartitionItem object inside Doris and store it in the cache.
    		
    		The ListPartitionItem object can construct a RangeMap for partition clipping. After cropping, a set of partition IDs can be obtained.
    		
    		The default cache is 10W, which can be adjusted by max_hive_partition_cache_num

		2. partitionCache
    
    		Partition cache, the key is <table-partition_values>, and the value is the partition information, including the inputformat, location and other information of the partition. After the partition is cut, we can obtain a set of partitionCache keys through the partition ID, and then obtain the partition.
    		
    		The default cache is 10W, which can be adjusted by max_hive_partition_cache_num
    	
    	3. fileCache
    
    		File cache, the key is the location, and the value is the information of all files under the location. We can use the location of the partition as the key of the fileCache, and finally get all the file information.
    		
    		The default cache is 10W, which can be adjusted by max_external_file_cache_num

4. Cache optimization

	After partition pruning, a set of partitions is obtained. We need to traverse these partitions and get the partition information from the partitionCache in turn. When the cache misses, the HMS will be accessed to obtain partition information. If there are many partitions, a large number of RPCs will be generated. In the actual test, it is found that it takes more than 5 minutes to obtain 1W partition information with a single thread.
	
	Here we use java's parallelStream to acquire partition concurrently, and the time-consuming can be reduced to 1 minute.
	
	At the same time, we set the number of background threads of loadingCache to 10, and this thread pool is shared by all caches.
	
5. Why not get partitions in batch from HMS?

	Because partitionCache is partition-based, not table-based. Batch acquisition can only take the table as the granularity, and each cache entry caches all partition information of a table. In this way, the purpose of "on-demand caching" is achieved, and partition cutting cannot be performed.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [x] Yes
    - [ ] No
    - [ ] I don't know
6. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
7. Has document been added or modified:
    - [x] Yes
    - [ ] No
    - [ ] No Need
8. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
9. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

