### PR TITLE
[fix](chore) read max_map_count from proc and make notice much more u…

### DIFF
--- a/bin/start_be.sh
+++ b/bin/start_be.sh
@@ -65,8 +65,7 @@ export DORIS_HOME
 if [[ "$(uname -s)" != 'Darwin' ]]; then
     MAX_MAP_COUNT="$(cat /proc/sys/vm/max_map_count)"
     if [[ "${MAX_MAP_COUNT}" -lt 2000000 ]]; then
-        echo "Please set vm.max_map_count to be 2000000 under root using 'sysctl -w vm.max_map_count=2000000' OR"\
-             "'echo 2000000 > /proc/sys/vm/max_map_count'."
+        echo "Please set vm.max_map_count to be 2000000 under root using 'sysctl -w vm.max_map_count=2000000'."
         exit 1
     fi
 fi

--- a/bin/start_be.sh
+++ b/bin/start_be.sh
@@ -63,9 +63,10 @@ DORIS_HOME="$(
 export DORIS_HOME
 
 if [[ "$(uname -s)" != 'Darwin' ]]; then
-    MAX_MAP_COUNT="$(sysctl -n vm.max_map_count)"
+    MAX_MAP_COUNT="$(cat /proc/sys/vm/max_map_count)"
     if [[ "${MAX_MAP_COUNT}" -lt 2000000 ]]; then
-        echo "Please set vm.max_map_count to be 2000000. sysctl -w vm.max_map_count=2000000"
+        echo "Please set vm.max_map_count to be 2000000 under root using 'sysctl -w vm.max_map_count=2000000' OR"\
+             "'echo 2000000 > /proc/sys/vm/max_map_count'."
         exit 1
     fi
 fi


### PR DESCRIPTION
…nstandable

Some users can not use sysctl under non-root in linux, so we read max_map_count from proc. Notice users that they can change max_map_count under root.

# Proposed changes

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

