### PR TITLE
[fix](memtracker) Fix scanner thread ending after fragment thread causing mem tracker null pointer 

### DIFF
--- a/be/src/exec/tablet_sink.cpp
+++ b/be/src/exec/tablet_sink.cpp
@@ -46,7 +46,7 @@ namespace stream_load {
 
 NodeChannel::NodeChannel(OlapTableSink* parent, IndexChannel* index_channel, int64_t node_id)
         : _parent(parent), _index_channel(index_channel), _node_id(node_id) {
-    _node_channel_tracker = std::make_unique<MemTracker>(fmt::format(
+    _node_channel_tracker = std::make_shared<MemTracker>(fmt::format(
             "NodeChannel:indexID={}:threadId={}", std::to_string(_index_channel->_index_id),
             thread_context()->get_thread_id()));
 }
@@ -518,7 +518,7 @@ int NodeChannel::try_send_and_fetch_status(RuntimeState* state,
 void NodeChannel::try_send_batch(RuntimeState* state) {
     SCOPED_ATOMIC_TIMER(&_actual_consume_ns);
     SCOPED_ATTACH_TASK(state);
-    SCOPED_CONSUME_MEM_TRACKER(_node_channel_tracker.get());
+    SCOPED_CONSUME_MEM_TRACKER(_node_channel_tracker);
     AddBatchReq send_batch;
     {
         debug::ScopedTSANIgnoreReadsAndWrites ignore_tsan;
@@ -833,7 +833,7 @@ Status OlapTableSink::prepare(RuntimeState* state) {
     // profile must add to state's object pool
     _profile = state->obj_pool()->add(new RuntimeProfile("OlapTableSink"));
     _mem_tracker =
-            std::make_unique<MemTracker>("OlapTableSink:" + std::to_string(state->load_job_id()));
+            std::make_shared<MemTracker>("OlapTableSink:" + std::to_string(state->load_job_id()));
     SCOPED_TIMER(_profile->total_time_counter());
     SCOPED_CONSUME_MEM_TRACKER(_mem_tracker.get());
 
@@ -1405,7 +1405,7 @@ Status OlapTableSink::_validate_data(RuntimeState* state, RowBatch* batch, Bitma
 void OlapTableSink::_send_batch_process(RuntimeState* state) {
     SCOPED_TIMER(_non_blocking_send_timer);
     SCOPED_ATTACH_TASK(state);
-    SCOPED_CONSUME_MEM_TRACKER(_mem_tracker.get());
+    SCOPED_CONSUME_MEM_TRACKER(_mem_tracker);
     do {
         int running_channels_num = 0;
         for (auto index_channel : _channels) {

--- a/be/src/exec/tablet_sink.h
+++ b/be/src/exec/tablet_sink.h
@@ -260,7 +260,7 @@ protected:
     std::string _load_info;
     std::string _name;
 
-    std::unique_ptr<MemTracker> _node_channel_tracker;
+    std::shared_ptr<MemTracker> _node_channel_tracker;
 
     TupleDescriptor* _tuple_desc = nullptr;
     NodeInfo _node_info;
@@ -466,7 +466,7 @@ protected:
 
     bool _is_vectorized = false;
 
-    std::unique_ptr<MemTracker> _mem_tracker;
+    std::shared_ptr<MemTracker> _mem_tracker;
 
     ObjectPool* _pool;
     const RowDescriptor& _input_row_desc;

--- a/be/src/olap/memtable.cpp
+++ b/be/src/olap/memtable.cpp
@@ -434,7 +434,7 @@ Status MemTable::_generate_delete_bitmap() {
 }
 
 Status MemTable::flush() {
-    SCOPED_CONSUME_MEM_TRACKER(_flush_mem_tracker.get());
+    SCOPED_CONSUME_MEM_TRACKER(_flush_mem_tracker);
     VLOG_CRITICAL << "begin to flush memtable for tablet: " << tablet_id()
                   << ", memsize: " << memory_usage() << ", rows: " << _rows;
     int64_t duration_ns = 0;

--- a/be/src/olap/olap_server.cpp
+++ b/be/src/olap/olap_server.cpp
@@ -125,7 +125,7 @@ Status StorageEngine::start_bg_threads() {
             RETURN_IF_ERROR(Thread::create(
                     "StorageEngine", "path_scan_thread",
                     [this, data_dir]() {
-                        SCOPED_CONSUME_MEM_TRACKER(_mem_tracker.get());
+                        SCOPED_CONSUME_MEM_TRACKER(_mem_tracker);
                         this->_path_scan_thread_callback(data_dir);
                     },
                     &path_scan_thread));
@@ -135,7 +135,7 @@ Status StorageEngine::start_bg_threads() {
             RETURN_IF_ERROR(Thread::create(
                     "StorageEngine", "path_gc_thread",
                     [this, data_dir]() {
-                        SCOPED_CONSUME_MEM_TRACKER(_mem_tracker.get());
+                        SCOPED_CONSUME_MEM_TRACKER(_mem_tracker);
                         this->_path_gc_thread_callback(data_dir);
                     },
                     &path_gc_thread));

--- a/be/src/olap/storage_engine.cpp
+++ b/be/src/olap/storage_engine.cpp
@@ -106,7 +106,7 @@ StorageEngine::StorageEngine(const EngineOptions& options)
           _available_storage_medium_type_count(0),
           _effective_cluster_id(-1),
           _is_all_cluster_id_exist(true),
-          _mem_tracker(std::make_unique<MemTracker>("StorageEngine")),
+          _mem_tracker(std::make_shared<MemTracker>("StorageEngine")),
           _segcompaction_mem_tracker(std::make_unique<MemTracker>("SegCompaction")),
           _segment_meta_mem_tracker(std::make_unique<MemTracker>("SegmentMeta")),
           _stop_background_threads_latch(1),

--- a/be/src/olap/storage_engine.h
+++ b/be/src/olap/storage_engine.h
@@ -324,7 +324,7 @@ private:
     std::unordered_map<std::string, RowsetSharedPtr> _unused_rowsets;
 
     // StorageEngine oneself
-    std::unique_ptr<MemTracker> _mem_tracker;
+    std::shared_ptr<MemTracker> _mem_tracker;
     // Count the memory consumption of segment compaction tasks.
     std::unique_ptr<MemTracker> _segcompaction_mem_tracker;
     // This mem tracker is only for tracking memory use by segment meta data such as footer or index page.

--- a/be/src/vec/exec/scan/scanner_scheduler.cpp
+++ b/be/src/vec/exec/scan/scanner_scheduler.cpp
@@ -186,7 +186,7 @@ void ScannerScheduler::_scanner_scan(ScannerScheduler* scheduler, ScannerContext
     INIT_AND_SCOPE_REENTRANT_SPAN_IF(ctx->state()->enable_profile(), ctx->state()->get_tracer(),
                                      ctx->scan_span(), "VScanner::scan");
     SCOPED_ATTACH_TASK(scanner->runtime_state());
-    SCOPED_CONSUME_MEM_TRACKER(scanner->runtime_state()->scanner_mem_tracker().get());
+    SCOPED_CONSUME_MEM_TRACKER(scanner->runtime_state()->scanner_mem_tracker());
     Thread::set_self_name("_scanner_scan");
     scanner->update_wait_worker_timer();
     // Do not use ScopedTimer. There is no guarantee that, the counter

--- a/be/src/vec/sink/vtablet_sink.cpp
+++ b/be/src/vec/sink/vtablet_sink.cpp
@@ -247,7 +247,7 @@ int VNodeChannel::try_send_and_fetch_status(RuntimeState* state,
 
 void VNodeChannel::try_send_block(RuntimeState* state) {
     SCOPED_ATTACH_TASK(state);
-    SCOPED_CONSUME_MEM_TRACKER(_node_channel_tracker.get());
+    SCOPED_CONSUME_MEM_TRACKER(_node_channel_tracker);
     SCOPED_ATOMIC_TIMER(&_actual_consume_ns);
     AddBlockReq send_block;
     {


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

```
#0 0x5618cbbb167e in std::_shared_ptr<doris::RuntimeProfile::HighWaterMarkCounter, (_gnu_cxx::_Lock_policy)2>::get() const ..//projects/ldb_toolchain/include/c++/11/bits/shared_ptr_base.h:1291
#1 0x5618cbbac27f in std::_shared_ptr_access<doris::RuntimeProfile::HighWaterMarkCounter, (_gnu_cxx::_Lock_policy)2, false, false>::_M_get() const ..//projects/ldb_toolchain/include/c++/11/bits/shared_ptr_base.h:990
#2 0x5618cbba5d0b in std::_shared_ptr_access<doris::RuntimeProfile::HighWaterMarkCounter, (_gnu_cxx::_Lock_policy)2, false, false>::operator->() const ..//projects/ldb_toolchain/include/c++/11/bits/shared_ptr_base.h:984
#3 0x5618cbb9e86c in doris::MemTracker::consume(long) ..//projects/doris/be/src/runtime/memory/mem_tracker.h:68
#4 0x5618ce023263 in doris::ThreadMemTrackerMgr::pop_consumer_tracker() ..//projects/doris/be/src/runtime/memory/thread_mem_tracker_mgr.h:163
#5 0x5618ce01e91a in doris::AddThreadMemTrackerConsumer::~AddThreadMemTrackerConsumer() ..//projects/doris/be/src/runtime/thread_context.cpp:84
#6 0x5618d73df587 in doris::vectorized::ScannerScheduler::_scanner_scan(doris::vectorized::ScannerScheduler*, doris::vectorized::ScannerContext*, doris::vectorized::VScanner*) ..//projects/doris/be/src/vec/exec/scan/scanner_scheduler.cpp:285
#7 0x5618d73dc852 in operator() ..//projects/doris/be/src/vec/exec/scan/scanner_scheduler.cpp:146
#8 0x5618d73e0d71 in __invoke_impl<void, doris::vectorized::ScannerScheduler::_schedule_scanners(doris::vectorized::ScannerContext*)::<lambda()>&> ..//projects/ldb_toolchain/include/c++/11/bits/invoke.h:61
#9 0x5618d73e09e9 in __invoke_r<void, doris::vectorized::ScannerScheduler::_schedule_scanners(doris::vectorized::ScannerContext*)::<lambda()>&> ..//projects/ldb_toolchain/include/c++/11/bits/invoke.h:111
#10 0x5618d73e0456 in _M_invoke ..//projects/ldb_toolchain/include/c++/11/bits/std_function.h:291
#11 0x5618cdf0a6c3 in std::function<void ()>::operator()() const ..//projects/ldb_toolchain/include/c++/11/bits/std_function.h:560
#12 0x5618cea63b1d in doris::FunctionRunnable::run() ..//projects/doris/be/src/util/threadpool.cpp:45
#13 0x5618cea5e969 in doris::ThreadPool::dispatch_thread() ..//projects/doris/be/src/util/threadpool.cpp:534
#14 0x5618cea802eb in void std::_invoke_impl<void, void (doris::ThreadPool::&)(), doris::ThreadPool&>(std::_invoke_memfun_deref, void (doris::ThreadPool::&)(), doris::ThreadPool&) ..//projects/ldb_toolchain/include/c++/11/bits/invoke.h:74
#15 0x5618cea7fb8a in std::_invoke_result<void (doris::ThreadPool::&)(), doris::ThreadPool&>::type std::_invoke<void (doris::ThreadPool::&)(), doris::ThreadPool&>(void (doris::ThreadPool::&)(), doris::ThreadPool&) ..//projects/ldb_toolchain/include/c++/11/bits/invoke.h:96
#16 0x5618cea7ef29 in void std::Bind<void (doris::ThreadPool::(doris::ThreadPool))()>::_call<void, , 0ul>(std::tuple<>&&, std::_Index_tuple<0ul>) ..//projects/ldb_toolchain/include/c++/11/functional:420
#17 0x5618cea7da3a in void std::_Bind<void (doris::ThreadPool::(doris::ThreadPool))()>::operator()<, void>() ..//projects/ldb_toolchain/include/c++/11/functional:503
#18 0x5618cea7a62b in void std::_invoke_impl<void, std::_Bind<void (doris::ThreadPool::(doris::ThreadPool))()>&>(std::_invoke_other, std::_Bind<void (doris::ThreadPool::(doris::ThreadPool))()>&) ..//projects/ldb_toolchain/include/c++/11/bits/invoke.h:61
#19 0x5618cea77ae3 in std::enable_if<is_invocable_r_v<void, std::Bind<void (doris::ThreadPool::(doris::ThreadPool))()>&>, void>::type std::_invoke_r<void, std::_Bind<void (doris::ThreadPool::(doris::ThreadPool))()>&>(std::_Bind<void (doris::ThreadPool::(doris::ThreadPool))()>&) ..//projects/ldb_toolchain/include/c++/11/bits/invoke.h:111
#20 0x5618cea72de2 in std::_Function_handler<void (), std::_Bind<void (doris::ThreadPool::(doris::ThreadPool))()> >::_M_invoke(std::_Any_data const&) ..//projects/ldb_toolchain/include/c++/11/bits/std_function.h:291
#21 0x5618cdf0a6c3 in std::function<void ()>::operator()() const ..//projects/ldb_toolchain/include/c++/11/bits/std_function.h:560
#22 0x5618cea3e60d in doris::Thread::supervise_thread(void*) ..//projects/doris/be/src/util/thread.cpp:454
#23 0x7ff820bbb608 in start_thread /build/glibc-SzIz7B/glibc-2.31/nptl/pthread_create.c:477
#24 0x7ff820cf5132 in __clone (/lib/x86_64-linux-gnu/libc.so.6+0x11f132)
```

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

