### PR TITLE
[Fix](cherry-pick) fix sub_bitmap calculate wrong result to return null

### DIFF
--- a/be/src/util/bitmap_value.h
+++ b/be/src/util/bitmap_value.h
@@ -1622,19 +1622,35 @@ public:
      */
     int64_t sub_range(const int64_t& range_start, const int64_t& range_end,
                       BitmapValue* ret_bitmap) {
-        int64_t count = 0;
-        for (auto it = _bitmap.begin(); it != _bitmap.end(); ++it) {
-            if (*it < range_start) {
-                continue;
-            }
-            if (*it < range_end) {
-                ret_bitmap->add(*it);
-                ++count;
+        switch (_type) {
+        case EMPTY:
+            return 0;
+        case SINGLE: {
+            //only single value, so _sv must in [range_start,range_end)
+            if (range_start <= _sv && _sv < range_end) {
+                ret_bitmap->add(_sv);
+                return 1;
             } else {
-                break;
+                return 0;
             }
         }
-        return count;
+        case BITMAP: {
+            int64_t count = 0;
+            for (auto it = _bitmap.begin(); it != _bitmap.end(); ++it) {
+                if (*it < range_start) {
+                    continue;
+                }
+                if (*it < range_end) {
+                    ret_bitmap->add(*it);
+                    ++count;
+                } else {
+                    break;
+                }
+            }
+            return count;
+        }
+        }
+        return 0;
     }
 
     /**
@@ -1645,19 +1661,35 @@ public:
      */
     int64_t sub_limit(const int64_t& range_start, const int64_t& cardinality_limit,
                       BitmapValue* ret_bitmap) {
-        int64_t count = 0;
-        for (auto it = _bitmap.begin(); it != _bitmap.end(); ++it) {
-            if (*it < range_start) {
-                continue;
-            }
-            if (count < cardinality_limit) {
-                ret_bitmap->add(*it);
-                ++count;
+        switch (_type) {
+        case EMPTY:
+            return 0;
+        case SINGLE: {
+            //only single value, so range_start must less than _sv
+            if (range_start > _sv) {
+                return 0;
             } else {
-                break;
+                ret_bitmap->add(_sv);
+                return 1;
             }
         }
-        return count;
+        case BITMAP: {
+            int64_t count = 0;
+            for (auto it = _bitmap.begin(); it != _bitmap.end(); ++it) {
+                if (*it < range_start) {
+                    continue;
+                }
+                if (count < cardinality_limit) {
+                    ret_bitmap->add(*it);
+                    ++count;
+                } else {
+                    break;
+                }
+            }
+            return count;
+        }
+        }
+        return 0;
     }
 
     /**
@@ -1666,8 +1698,23 @@ public:
      * Analog of the substring string function, but for bitmap.
      */
     int64_t offset_limit(const int64_t& offset, const int64_t& limit, BitmapValue* ret_bitmap) {
-        if (std::abs(offset) >= _bitmap.cardinality()) {
+        switch (_type) {
+        case EMPTY:
             return 0;
+        case SINGLE: {
+            //only single value, so offset must start 0
+            if (offset == 0) {
+                ret_bitmap->add(_sv);
+                return 1;
+            } else {
+                return 0;
+            }
+        }
+        case BITMAP: {
+            if (std::abs(offset) >= _bitmap.cardinality()) {
+                return 0;
+            }
+        }
         }
         int64_t abs_offset = offset;
         if (offset < 0) {


### PR DESCRIPTION
# Proposed changes
cherry-pick from master #13978

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

