### PR TITLE
[Enhancement](broker load) enhance broker load for parquet and orc file when missing columns in …

### DIFF
--- a/be/src/exec/arrow/arrow_reader.h
+++ b/be/src/exec/arrow/arrow_reader.h
@@ -122,7 +122,8 @@ protected:
     std::map<std::string, int> _map_column; // column-name <---> column-index
     std::vector<int> _include_column_ids;   // columns that need to get from file
     std::vector<std::string> _include_cols; // columns that need to get from file
-    std::vector<int> _slots_order_in_file; // slots order by index in file; if slot not in file, given nullptr
+    std::vector<int>
+            _slots_order_in_file; // slots order by index in file; if slot not in file, given nullptr
     std::shared_ptr<Statistics> _statistics;
 
     std::atomic<bool> _closed = false;

--- a/be/src/exec/arrow/arrow_reader.h
+++ b/be/src/exec/arrow/arrow_reader.h
@@ -122,6 +122,7 @@ protected:
     std::map<std::string, int> _map_column; // column-name <---> column-index
     std::vector<int> _include_column_ids;   // columns that need to get from file
     std::vector<std::string> _include_cols; // columns that need to get from file
+    std::vector<int> _slots_order_in_file; // slots order by index in file; if slot not in file, given nullptr
     std::shared_ptr<Statistics> _statistics;
 
     std::atomic<bool> _closed = false;

--- a/be/src/exec/arrow/parquet_reader.cpp
+++ b/be/src/exec/arrow/parquet_reader.cpp
@@ -126,7 +126,12 @@ Status ParquetReaderWrap::get_columns(std::unordered_map<std::string, TypeDescri
                                       std::unordered_set<std::string>* missing_cols) {
     auto schema_desc = _file_metadata->schema();
     std::shared_ptr<::arrow::Schema> arrow_schema = nullptr;
-    parquet::arrow::FromParquetSchema(schema_desc, &arrow_schema);
+
+    auto st = parquet::arrow::FromParquetSchema(schema_desc, &arrow_schema);
+    if (!st.ok()) {
+        LOG(WARNING) << "failed to create arrow schema, errmsg=" << st.ToString();
+        return Status::InternalError("failed to create arrow schema");
+    }
 
     for (size_t i = 0; i < arrow_schema->num_fields(); ++i) {
         std::string schema_name = _case_sensitive ? arrow_schema->field(i)->name()

--- a/be/src/exec/arrow/parquet_reader.cpp
+++ b/be/src/exec/arrow/parquet_reader.cpp
@@ -19,12 +19,12 @@
 #include <arrow/array.h>
 #include <arrow/status.h>
 #include <arrow/type_fwd.h>
+#include <parquet/arrow/schema.h>
 #include <time.h>
 
 #include <algorithm>
 #include <cinttypes>
 #include <mutex>
-#include <parquet/arrow/schema.h>
 #include <thread>
 
 #include "common/logging.h"
@@ -123,14 +123,14 @@ Status ParquetReaderWrap::init_reader(const TupleDescriptor* tuple_desc,
 }
 
 Status ParquetReaderWrap::get_columns(std::unordered_map<std::string, TypeDescriptor>* name_to_type,
-                                  std::unordered_set<std::string>* missing_cols) {
+                                      std::unordered_set<std::string>* missing_cols) {
     auto schema_desc = _file_metadata->schema();
-    std::shared_ptr<::arrow::Schema> arrow_schema= nullptr;
+    std::shared_ptr<::arrow::Schema> arrow_schema = nullptr;
     parquet::arrow::FromParquetSchema(schema_desc, &arrow_schema);
 
     for (size_t i = 0; i < arrow_schema->num_fields(); ++i) {
-        std::string schema_name =
-                _case_sensitive ? arrow_schema->field(i)->name() : to_lower(arrow_schema->field(i)->name());
+        std::string schema_name = _case_sensitive ? arrow_schema->field(i)->name()
+                                                  : to_lower(arrow_schema->field(i)->name());
         TypeDescriptor type;
         RETURN_IF_ERROR(
                 vectorized::arrow_type_to_doris_type(arrow_schema->field(i)->type()->id(), &type));

--- a/be/src/exec/arrow/parquet_reader.h
+++ b/be/src/exec/arrow/parquet_reader.h
@@ -75,6 +75,9 @@ public:
                        const std::string& timezone) override;
     Status init_parquet_type();
 
+    Status get_columns(std::unordered_map<std::string, TypeDescriptor>* name_to_type,
+                       std::unordered_set<std::string>* missing_cols) override;
+
 private:
     void fill_slot(Tuple* tuple, SlotDescriptor* slot_desc, MemPool* mem_pool, const uint8_t* value,
                    int32_t len);

--- a/be/src/exec/base_scanner.cpp
+++ b/be/src/exec/base_scanner.cpp
@@ -235,7 +235,7 @@ Status BaseScanner::fill_missing_columns(Tuple* tuple, MemPool* mem_pool) {
 
     const TupleDescriptor* src_tuple_desc =
             _state->desc_tbl().get_tuple_descriptor(_params.src_tuple_id);
-        if (src_tuple_desc == nullptr) {
+    if (src_tuple_desc == nullptr) {
         return Status::InternalError("Unknown source tuple descriptor, tuple_id={}",
                                      _params.src_tuple_id);
     }

--- a/be/src/exec/base_scanner.h
+++ b/be/src/exec/base_scanner.h
@@ -84,7 +84,6 @@ public:
     Status fill_dest_tuple(Tuple* dest_tuple, MemPool* mem_pool, bool* fill_tuple);
     Status fill_missing_columns(Tuple* tuple, MemPool* mem_pool);
 
-
     void fill_slots_of_columns_from_path(int start,
                                          const std::vector<std::string>& columns_from_path);
 

--- a/be/src/exec/base_scanner.h
+++ b/be/src/exec/base_scanner.h
@@ -82,6 +82,8 @@ public:
     // Close this scanner
     virtual void close() = 0;
     Status fill_dest_tuple(Tuple* dest_tuple, MemPool* mem_pool, bool* fill_tuple);
+    Status fill_missing_columns(Tuple* tuple, MemPool* mem_pool);
+
 
     void fill_slots_of_columns_from_path(int start,
                                          const std::vector<std::string>& columns_from_path);
@@ -125,6 +127,17 @@ protected:
 
     // dest slot desc index to src slot desc index
     std::unordered_map<int, int> _dest_slot_to_src_slot_index;
+
+    // col name to default value expr for vectorized
+    std::unordered_map<std::string, vectorized::VExprContext*> _col_default_value_vexpr_ctx;
+    // col name to default value expr
+    std::unordered_map<std::string, ExprContext*> _col_default_value_expr_ctx;
+
+    // Get from GenericReader, save the existing columns in file to their type.
+    std::unordered_map<std::string, TypeDescriptor> _name_to_col_type;
+    // Get from GenericReader, save columns that requried by scan but not exist in file.
+    // These columns will be filled by default value or null.
+    std::unordered_set<std::string> _missing_cols;
 
     // to filter src tuple directly
     // the `_pre_filter_texprs` is the origin thrift exprs passed from scan node,

--- a/be/src/exec/orc_scanner.cpp
+++ b/be/src/exec/orc_scanner.cpp
@@ -439,7 +439,7 @@ Status ORCScanner::open_next_reader() {
 void ORCScanner::build_name_id_map() {
     _map_column_to_id.clear();
     std::vector<std::string> columns;
-     const orc::Type& type = _reader->getType();
+    const orc::Type& type = _reader->getType();
     build_name_id_map_impl(columns, &type);
 }
 
@@ -469,7 +469,7 @@ std::string ORCScanner::dot_column_path(const std::vector<std::string>& columns)
               std::ostream_iterator<std::string>(columnStream, "."));
     std::string columnPath = columnStream.str();
     return columnPath.substr(0, columnPath.length() - 1);
-}   
+}
 
 void ORCScanner::close() {
     BaseScanner::close();

--- a/be/src/exec/orc_scanner.h
+++ b/be/src/exec/orc_scanner.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <orc/OrcFile.hh>
+#include <orc/Type.hh>
 
 #include "exec/base_scanner.h"
 
@@ -45,6 +46,11 @@ public:
 private:
     // Read next buffer from reader
     Status open_next_reader();
+    // Generate column path
+    std::string dot_column_path(const std::vector<std::string>& columns);
+    // Build map from column name to type id
+    void build_name_id_map();
+    void build_name_id_map_impl(std::vector<std::string>& columns, const orc::Type* type);
 
 private:
     // Reader
@@ -60,6 +66,7 @@ private:
     // so we need to record the index in the original order to correspond the column names to the order
     std::vector<int> _position_in_orc_original;
     int _num_of_columns_from_file;
+    std::map<std::string, int> _map_column_to_id;
 
     int _total_groups; // groups in a orc file
     int _current_group;

--- a/be/src/exec/parquet_scanner.cpp
+++ b/be/src/exec/parquet_scanner.cpp
@@ -65,6 +65,7 @@ Status ParquetScanner::get_next(Tuple* tuple, MemPool* tuple_pool, bool* eof, bo
 
         COUNTER_UPDATE(_rows_read_counter, 1);
         SCOPED_TIMER(_materialize_timer);
+        RETURN_IF_ERROR(BaseScanner::fill_missing_columns(_src_tuple, tuple_pool));
         RETURN_IF_ERROR(fill_dest_tuple(tuple, tuple_pool, fill_tuple));
         break; // break always
     }
@@ -118,6 +119,7 @@ Status ParquetScanner::open_next_reader() {
                                              status.get_error_msg());
             } else {
                 RETURN_IF_ERROR(_cur_file_reader->init_parquet_type());
+                RETURN_IF_ERROR(_cur_file_reader->get_columns(&_name_to_col_type, &_missing_cols));
                 return status;
             }
         }

--- a/be/src/vec/exec/varrow_scanner.cpp
+++ b/be/src/vec/exec/varrow_scanner.cpp
@@ -176,9 +176,7 @@ Status VArrowScanner::_fill_missing_columns(Block* block) {
         if (it->second == nullptr) {
             //fill with null
             auto nullable_column = reinterpret_cast<vectorized::ColumnNullable*>(
-                    (*std::move(block->get_by_name(slot_desc->col_name()).column))
-                            .mutate()
-                            .get());
+                    (*std::move(block->get_by_name(slot_desc->col_name()).column)).mutate().get());
             nullable_column->insert_many_defaults(rows);
         } else {
             // fill with default value
@@ -215,14 +213,13 @@ Status VArrowScanner::_init_src_block() {
         DataTypePtr data_type;
         auto it = _name_to_col_type.find(slot_desc->col_name());
         if (it == _name_to_col_type.end()) {
-            data_type =
-                    DataTypeFactory::instance().create_data_type(slot_desc->type(), slot_desc->is_nullable());
+            data_type = DataTypeFactory::instance().create_data_type(slot_desc->type(),
+                                                                     slot_desc->is_nullable());
         } else {
             auto* array = _batch->GetColumnByName(slot_desc->col_name()).get();
-            data_type =
-                    DataTypeFactory::instance().create_data_type(array->type().get(), true);
+            data_type = DataTypeFactory::instance().create_data_type(array->type().get(), true);
         }
-        
+
         if (data_type == nullptr) {
             return Status::NotSupported(
                     fmt::format("Not support arrow type:{}", slot_desc->col_name()));

--- a/be/src/vec/exec/varrow_scanner.h
+++ b/be/src/vec/exec/varrow_scanner.h
@@ -76,6 +76,7 @@ private:
     Status _init_src_block() override;
     Status _append_batch_to_src_block(Block* block);
     Status _cast_src_block(Block* block);
+    Status _fill_missing_columns(Block* block);
 
 private:
     // Reader
@@ -84,6 +85,11 @@ private:
     std::shared_ptr<arrow::RecordBatch> _batch;
     size_t _arrow_batch_cur_idx;
 
+    // Get from GenericReader, save the existing columns in file to their type.
+    std::unordered_map<std::string, TypeDescriptor> _name_to_col_type;
+    // Get from GenericReader, save columns that requried by scan but not exist in file.
+    // These columns will be filled by default value or null.
+    std::unordered_set<std::string> _missing_cols;
     RuntimeProfile::Counter* _filtered_row_groups_counter;
     RuntimeProfile::Counter* _filtered_rows_counter;
     RuntimeProfile::Counter* _filtered_bytes_counter;

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/BrokerScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/BrokerScanNode.java
@@ -600,7 +600,7 @@ public class BrokerScanNode extends LoadScanNode {
     }
 
     protected void setDefaultValueExprs(Table tableRef, ParamCreateContext context) throws UserException {
-        Preconditions.checkNotNull(tableRef);+
+        Preconditions.checkNotNull(tableRef);
         TExpr tExpr = new TExpr();
         tExpr.setNodes(Lists.newArrayList());
         for (Column column : tableRef.getBaseSchema()) {

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -193,24 +193,25 @@ struct TBrokerScanRangeParams {
     // This is expr that convert the content read from file
     // the format that need by the compute layer.
     6: optional map<Types.TSlotId, Exprs.TExpr> expr_of_dest_slot
+    7: optional map<Types.TSlotId, Exprs.TExpr> default_value_of_src_slot
 
     // properties need to access broker.
-    7: optional map<string, string> properties;
+    8: optional map<string, string> properties;
 
     // If partition_ids is set, data that doesn't in this partition will be filtered.
-    8: optional list<i64> partition_ids
+    9: optional list<i64> partition_ids
     
     // This is the mapping of dest slot id and src slot id in load expr
     // It excludes the slot id which has the transform expr
-    9: optional map<Types.TSlotId, Types.TSlotId> dest_sid_to_src_sid_without_trans
+    10: optional map<Types.TSlotId, Types.TSlotId> dest_sid_to_src_sid_without_trans
     // strictMode is a boolean
     // if strict mode is true, the incorrect data (the result of cast is null) will not be loaded
-    10: optional bool strict_mode
+    11: optional bool strict_mode
     // for multibytes separators
-    11: optional i32 column_separator_length = 1;
-    12: optional i32 line_delimiter_length = 1;
-    13: optional string column_separator_str;
-    14: optional string line_delimiter_str;
+    12: optional i32 column_separator_length = 1;
+    13: optional i32 line_delimiter_length = 1;
+    14: optional string column_separator_str;
+    15: optional string line_delimiter_str;
 
 }
 


### PR DESCRIPTION

# Proposed changes
enhance broker load for parquet and orc file when missing columns in src files
## Problem summary
source my_file.orc/parquet like below:
+------+------+-------------+-------+------+
| name | id   | impressions | click | cost |
+------+------+-------------+-------+------+
|    1 |    1 |           2 |  NULL |    2 |
|    4 |    4 |           8 |     8 |    8 |
|    5 |    5 |          10 |    10 |   10 |
|    3 |    3 |           6 |     6 |    6 |
|    2 |    2 |           4 |     4 |    4 |
|   11 |   11 |          22 |    22 |   22 |
+------+------+-------------+-------+------+
case 1:   
create table t1 like below
 CREATE TABLE `t1` (
  `name` bigint(20) NOT NULL,
  `id` bigint(20) NOT NULL,
  `impressions` bigint(20) SUM NULL DEFAULT "0" COMMENT '用户总展现',
  `click` bigint(20) SUM NULL DEFAULT "0" COMMENT '用户总点击',
  `cost` bigint(20) SUM NULL DEFAULT "0" COMMENT '用户总消费'
) ENGINE=OLAP
AGGREGATE KEY(`name`, `id`)
COMMENT 'OLAP'
PARTITION BY RANGE(`name`)
(PARTITION p201901 VALUES [("1"), ("100")))
DISTRIBUTED BY HASH(`id`) BUCKETS 16
PROPERTIES (
"replication_allocation" = "tag.location.default: 3",
"in_memory" = "false",
"storage_format" = "V2",
"disable_auto_compaction" = "false"
);

when we load from source file, we wil get 
+------+------+-------------+-------+------+
| name | id   | impressions | click | cost |
+------+------+-------------+-------+------+
|    1 |    1 |           2 |  NULL |    2 |
|    4 |    4 |           8 |     8 |    8 |
|    5 |    5 |          10 |    10 |   10 |
|    3 |    3 |           6 |     6 |    6 |
|    2 |    2 |           4 |     4 |    4 |
|   11 |   11 |          22 |    22 |   22 |
+------+------+-------------+-------+------+


case 2:
when create table t1 like below(column id2 is missing from src file):
CREATE TABLE `t1` (
  `name` bigint(20) NOT NULL,
  `id` bigint(20) NOT NULL,
  `id2` bigint(20) NULL DEFAULT "0",
  `impressions` bigint(20) SUM NULL DEFAULT "0" COMMENT '用户总展现',
  `click` bigint(20) SUM NULL DEFAULT "0" COMMENT '用户总点击',
  `cost` bigint(20) SUM NULL DEFAULT "0" COMMENT '用户总消费'
) ENGINE=OLAP
AGGREGATE KEY(`name`, `id`, `id2`)
COMMENT 'OLAP'
PARTITION BY RANGE(`name`)
(PARTITION p201901 VALUES [("1"), ("100")))
DISTRIBUTED BY HASH(`id`) BUCKETS 16
PROPERTIES (
"replication_allocation" = "tag.location.default: 3",
"in_memory" = "false",
"storage_format" = "V2",
"disable_auto_compaction" = "false"
);

after broker load from my_file.orc/parquet. we will get:
+------+------+------+-------------+-------+------+
| name | id   | id2  | impressions | click | cost |
+------+------+------+-------------+-------+------+
|    5 |    5 |    0 |           5 |     5 |    5 |
|    4 |    4 |    0 |           4 |     4 |    4 |
|   11 |   11 |    0 |          11 |    11 |   11 |
|    1 |    1 |    0 |           1 |  NULL |    1 |
|    2 |    2 |    0 |           2 |     2 |    2 |
|    3 |    3 |    0 |           3 |     3 |    3 |
+------+------+------+-------------+-------+------+

....

Note:
the case that enable_new_load_scan_node=true is not included in this pr.

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

