### PR TITLE
[Improvement](profile) Improve readability for runtime filters in profile string

### DIFF
--- a/be/src/exprs/runtime_filter.cpp
+++ b/be/src/exprs/runtime_filter.cpp
@@ -1175,14 +1175,10 @@ Status IRuntimeFilter::get_push_expr_ctxs(std::vector<vectorized::VExpr*>* push_
     DCHECK(is_consumer());
     if (!_is_ignored) {
         _set_push_down();
-        if (_profile != nullptr) {
-            _profile->add_info_string("Info", _format_status());
-        }
+        _profile->add_info_string("Info", _format_status());
         return _wrapper->get_push_vexprs(push_vexprs, _state, _vprobe_ctx);
     } else {
-        if (_profile != nullptr) {
-            _profile->add_info_string("Info", _format_status());
-        }
+        _profile->add_info_string("Info", _format_status());
         return Status::OK();
     }
 }
@@ -1214,9 +1210,7 @@ Status IRuntimeFilter::get_prepared_context(std::vector<ExprContext*>* push_expr
 
 Status IRuntimeFilter::get_prepared_vexprs(std::vector<doris::vectorized::VExpr*>* vexprs,
                                            const RowDescriptor& desc) {
-    if (_profile != nullptr) {
-        _profile->add_info_string("Info", _format_status());
-    }
+    _profile->add_info_string("Info", _format_status());
     if (_is_ignored) {
         return Status::OK();
     }

--- a/be/src/exprs/runtime_filter.cpp
+++ b/be/src/exprs/runtime_filter.cpp
@@ -1174,9 +1174,17 @@ Status IRuntimeFilter::get_push_expr_ctxs(std::list<ExprContext*>* push_expr_ctx
 Status IRuntimeFilter::get_push_expr_ctxs(std::vector<vectorized::VExpr*>* push_vexprs) {
     DCHECK(is_consumer());
     if (!_is_ignored) {
+        _set_push_down();
+        if (_profile != nullptr) {
+            _profile->add_info_string("Info", _format_status());
+        }
         return _wrapper->get_push_vexprs(push_vexprs, _state, _vprobe_ctx);
+    } else {
+        if (_profile != nullptr) {
+            _profile->add_info_string("Info", _format_status());
+        }
+        return Status::OK();
     }
-    return Status::OK();
 }
 
 Status IRuntimeFilter::get_push_expr_ctxs(std::list<ExprContext*>* push_expr_ctxs,
@@ -1206,6 +1214,9 @@ Status IRuntimeFilter::get_prepared_context(std::vector<ExprContext*>* push_expr
 
 Status IRuntimeFilter::get_prepared_vexprs(std::vector<doris::vectorized::VExpr*>* vexprs,
                                            const RowDescriptor& desc) {
+    if (_profile != nullptr) {
+        _profile->add_info_string("Info", _format_status());
+    }
     if (_is_ignored) {
         return Status::OK();
     }
@@ -1242,7 +1253,6 @@ void IRuntimeFilter::signal() {
     DCHECK(is_consumer());
     _is_ready = true;
     _inner_cv.notify_all();
-    _effect_timer.reset();
 
     if (_wrapper->get_real_type() == RuntimeFilterType::IN_FILTER) {
         _profile->add_info_string("InFilterSize", std::to_string(_wrapper->get_in_filter_size()));
@@ -1365,15 +1375,11 @@ Status IRuntimeFilter::_create_wrapper(RuntimeState* state, const T* param, Obje
 
 void IRuntimeFilter::init_profile(RuntimeProfile* parent_profile) {
     DCHECK(parent_profile != nullptr);
-    _profile.reset(new RuntimeProfile("RuntimeFilter:" + ::doris::to_string(_runtime_filter_type)));
+    _profile.reset(new RuntimeProfile(fmt::format("RuntimeFilter: (id = {}, type = {})", _filter_id,
+                                                  ::doris::to_string(_runtime_filter_type))));
     parent_profile->add_child(_profile.get(), true, nullptr);
-    _profile->add_info_string("Ignored", _is_ignored ? "true" : "false");
-
-    _effect_time_cost = ADD_TIMER(_profile, "EffectTimeCost");
     _await_time_cost = ADD_TIMER(_profile, "AWaitTimeCost");
-    _effect_timer.reset(new ScopedTimer<MonotonicStopWatch>(_effect_time_cost));
-    _effect_timer->start();
-
+    _profile->add_info_string("Info", _format_status());
     if (_runtime_filter_type == RuntimeFilterType::IN_OR_BLOOM_FILTER) {
         update_runtime_filter_type_to_profile();
     }

--- a/be/src/exprs/runtime_filter.h
+++ b/be/src/exprs/runtime_filter.h
@@ -262,6 +262,15 @@ protected:
     static Status _create_wrapper(RuntimeState* state, const T* param, ObjectPool* pool,
                                   std::unique_ptr<RuntimePredicateWrapper>* wrapper);
 
+    void _set_push_down() { _is_push_down = true; }
+
+    std::string _format_status() {
+        return fmt::format(
+                "[IsPushDown = {}, IsEffective = {}, IsIgnored = {}, HasRemoteTarget = {}, "
+                "HasLocalTarget = {}]",
+                _is_push_down, _is_ready, _is_ignored, _has_remote_target, _has_local_target);
+    }
+
     RuntimeState* _state;
     ObjectPool* _pool;
     // _wrapper is a runtime filter function wrapper
@@ -286,6 +295,8 @@ protected:
     // used for await or signal
     std::mutex _inner_mutex;
     std::condition_variable _inner_cv;
+
+    bool _is_push_down = false;
 
     // if set always_true = true
     // this filter won't filter any data
@@ -318,8 +329,6 @@ protected:
     std::unique_ptr<RuntimeProfile> _profile;
     // unix millis
     RuntimeProfile::Counter* _await_time_cost = nullptr;
-    RuntimeProfile::Counter* _effect_time_cost = nullptr;
-    std::unique_ptr<ScopedTimer<MonotonicStopWatch>> _effect_timer;
 
     /// Time in ms (from MonotonicMillis()), that the filter was registered.
     const int64_t registration_time_;


### PR DESCRIPTION
# Proposed changes

For example,  run sql below on TPCH 1g
`SELECT
  s_acctbal,
  s_name,
  p_partkey,
  p_mfgr,
  s_address,
  s_phone,
  s_comment
FROM
  part,
  supplier,
  partsupp
WHERE
  p_partkey = ps_partkey
  AND s_suppkey = ps_suppkey
  AND p_size = 15
  AND p_type LIKE '%BRASS'
ORDER BY
  s_acctbal DESC,
  s_name,
  p_partkey
LIMIT 100`

Now runtime filter's profile is displayed as below
![2be11ffd-4668-4ba5-b6d1-9cce911ccbcf](https://user-images.githubusercontent.com/37700562/201044217-374bddea-5232-4025-8661-2781983331ee.jpeg)

After this patch, runtime filter's profile has been changed to:
(effective in await time)
![e5bef191-20d3-4746-92da-8a9238a9d24e](https://user-images.githubusercontent.com/37700562/201044327-cc976aa4-4f53-4cee-af83-f4298200d366.jpeg)
(not effective in await time)
![ta47xOQ4Sp](https://user-images.githubusercontent.com/37700562/201044482-2f69a1af-4b4d-44bf-9c6a-131186e9f569.jpg)


## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

