### PR TITLE
[fix](compaction) segcompaction coredump if the rowset starts with a big segment (#14174)

### DIFF
--- a/be/src/olap/rowset/beta_rowset_writer.cpp
+++ b/be/src/olap/rowset/beta_rowset_writer.cpp
@@ -206,6 +206,7 @@ Status BetaRowsetWriter::_rename_compacted_segments(int64_t begin, int64_t end) 
 
 Status BetaRowsetWriter::_rename_compacted_segment_plain(uint64_t seg_id) {
     if (seg_id == _num_segcompacted) {
+        ++_num_segcompacted;
         return Status::OK();
     }
 

--- a/be/test/olap/segcompaction_test.cpp
+++ b/be/test/olap/segcompaction_test.cpp
@@ -91,6 +91,7 @@ public:
             delete l_engine;
             l_engine = nullptr;
         }
+        config::enable_segcompaction = false;
     }
 
 protected:
@@ -167,6 +168,7 @@ protected:
         tablet_schema->init_from_pb(tablet_schema_pb);
     }
 
+    // use different id to avoid conflict
     void create_rowset_writer_context(int64_t id, TabletSchemaSPtr tablet_schema,
                                       RowsetWriterContext* rowset_writer_context) {
         RowsetId rowset_id;
@@ -445,6 +447,129 @@ TEST_F(SegCompactionTest, SegCompactionInterleaveWithBig_ooooOOoOooooooooO) {
         ls.push_back("10048_4.dat"); // O
         ls.push_back("10048_5.dat"); // oooooooo
         ls.push_back("10048_6.dat"); // O
+        EXPECT_TRUE(check_dir(ls));
+    }
+}
+
+TEST_F(SegCompactionTest, SegCompactionInterleaveWithBig_OoOoO) {
+    config::enable_segcompaction = true;
+    config::enable_storage_vectorization = true;
+    Status s;
+    TabletSchemaSPtr tablet_schema = std::make_shared<TabletSchema>();
+    create_tablet_schema(tablet_schema);
+
+    RowsetSharedPtr rowset;
+    config::segcompaction_small_threshold = 6000; // set threshold above
+    config::segcompaction_threshold_segment_num = 5;
+    std::vector<uint32_t> segment_num_rows;
+    { // write `num_segments * rows_per_segment` rows to rowset
+        RowsetWriterContext writer_context;
+        create_rowset_writer_context(10049, tablet_schema, &writer_context);
+
+        std::unique_ptr<RowsetWriter> rowset_writer;
+        s = RowsetFactory::create_rowset_writer(writer_context, &rowset_writer);
+        EXPECT_EQ(Status::OK(), s);
+
+        RowCursor input_row;
+        input_row.init(tablet_schema);
+
+        // for segment "i", row "rid"
+        // k1 := rid*10 + i
+        // k2 := k1 * 10
+        // k3 := 4096 * i + rid
+        int num_segments = 1;
+        uint32_t rows_per_segment = 6400;
+        for (int i = 0; i < num_segments; ++i) {
+            MemPool mem_pool;
+            for (int rid = 0; rid < rows_per_segment; ++rid) {
+                uint32_t k1 = rid * 100 + i;
+                uint32_t k2 = i;
+                uint32_t k3 = rid;
+                input_row.set_field_content(0, reinterpret_cast<char*>(&k1), &mem_pool);
+                input_row.set_field_content(1, reinterpret_cast<char*>(&k2), &mem_pool);
+                input_row.set_field_content(2, reinterpret_cast<char*>(&k3), &mem_pool);
+                s = rowset_writer->add_row(input_row);
+                EXPECT_EQ(Status::OK(), s);
+            }
+            s = rowset_writer->flush();
+            EXPECT_EQ(Status::OK(), s);
+        }
+        num_segments = 1;
+        rows_per_segment = 4096;
+        for (int i = 0; i < num_segments; ++i) {
+            MemPool mem_pool;
+            for (int rid = 0; rid < rows_per_segment; ++rid) {
+                uint32_t k1 = rid * 100 + i;
+                uint32_t k2 = i;
+                uint32_t k3 = rid;
+                input_row.set_field_content(0, reinterpret_cast<char*>(&k1), &mem_pool);
+                input_row.set_field_content(1, reinterpret_cast<char*>(&k2), &mem_pool);
+                input_row.set_field_content(2, reinterpret_cast<char*>(&k3), &mem_pool);
+                s = rowset_writer->add_row(input_row);
+                EXPECT_EQ(Status::OK(), s);
+            }
+            s = rowset_writer->flush();
+            EXPECT_EQ(Status::OK(), s);
+        }
+        num_segments = 1;
+        rows_per_segment = 6400;
+        for (int i = 0; i < num_segments; ++i) {
+            MemPool mem_pool;
+            for (int rid = 0; rid < rows_per_segment; ++rid) {
+                uint32_t k1 = rid * 100 + i;
+                uint32_t k2 = i;
+                uint32_t k3 = rid;
+                input_row.set_field_content(0, reinterpret_cast<char*>(&k1), &mem_pool);
+                input_row.set_field_content(1, reinterpret_cast<char*>(&k2), &mem_pool);
+                input_row.set_field_content(2, reinterpret_cast<char*>(&k3), &mem_pool);
+                s = rowset_writer->add_row(input_row);
+                EXPECT_EQ(Status::OK(), s);
+            }
+            s = rowset_writer->flush();
+            EXPECT_EQ(Status::OK(), s);
+        }
+        num_segments = 1;
+        rows_per_segment = 4096;
+        for (int i = 0; i < num_segments; ++i) {
+            MemPool mem_pool;
+            for (int rid = 0; rid < rows_per_segment; ++rid) {
+                uint32_t k1 = rid * 100 + i;
+                uint32_t k2 = i;
+                uint32_t k3 = rid;
+                input_row.set_field_content(0, reinterpret_cast<char*>(&k1), &mem_pool);
+                input_row.set_field_content(1, reinterpret_cast<char*>(&k2), &mem_pool);
+                input_row.set_field_content(2, reinterpret_cast<char*>(&k3), &mem_pool);
+                s = rowset_writer->add_row(input_row);
+                EXPECT_EQ(Status::OK(), s);
+            }
+            s = rowset_writer->flush();
+            EXPECT_EQ(Status::OK(), s);
+        }
+        num_segments = 1;
+        rows_per_segment = 6400;
+        for (int i = 0; i < num_segments; ++i) {
+            MemPool mem_pool;
+            for (int rid = 0; rid < rows_per_segment; ++rid) {
+                uint32_t k1 = rid * 100 + i;
+                uint32_t k2 = i;
+                uint32_t k3 = rid;
+                input_row.set_field_content(0, reinterpret_cast<char*>(&k1), &mem_pool);
+                input_row.set_field_content(1, reinterpret_cast<char*>(&k2), &mem_pool);
+                input_row.set_field_content(2, reinterpret_cast<char*>(&k3), &mem_pool);
+                s = rowset_writer->add_row(input_row);
+                EXPECT_EQ(Status::OK(), s);
+            }
+            s = rowset_writer->flush();
+            EXPECT_EQ(Status::OK(), s);
+        }
+
+        rowset = rowset_writer->build();
+        std::vector<std::string> ls;
+        ls.push_back("10049_0.dat"); // O
+        ls.push_back("10049_1.dat"); // o
+        ls.push_back("10049_2.dat"); // O
+        ls.push_back("10049_3.dat"); // o
+        ls.push_back("10049_4.dat"); // O
         EXPECT_TRUE(check_dir(ls));
     }
 }


### PR DESCRIPTION
Signed-off-by: freemandealer <freeman.zhang1992@gmail.com>

# Proposed changes

Issue Number: close #14174

## Problem summary

Check will fail because _segid_statistics_map.find(_num_segcompacted) == _segid_statistics_map.end().
Here the check is ensuring _segid_statistics_map has no existing entry indexed by _num_segcompacted.

When will _segid_statistics_map add an entry? The answer is:
1) after a segment is flushed, or
2) after segcompacting, or
3) after renaming the big segments which need not segcompact.

We note a segment that has never been played by segcompaction as 'raw_seg'. When these raw segments are compacted, their records will be erased from _segid_statistics_map and 'new_seg' (compacted results) will be added to the map as a replacement.

For example:

For 7 raw segments 'oooOOoo' ('O' for the big segment while 'o' for the small), we break it into four parts: 1) ooo ,  2)O,  3)O,  4)oo.
Group 1 will be compacted to form 'new_seg_1-3', and raw_seg_1, raw_seg_2, raw_seg_3 are wiped out.
Group 2 will be renamed from 'raw_seg_4' to 'new_seg_2' and add it to the map.
Group 3 will be renamed from 'raw_seg_5' to 'new_seg_3' and add it to the map.
Group 4 will be compacted to form 'new_seg_6-7', and raw_seg_6, raw_seg_7 are wiped out.
Finally, we rename 'new_seg_1-3' to 'new_seg_1' and 'new_seg_6-7' to 'new_seg_4'. So we end up having new_seg_1, new_seg_2, new_seg_3, and new_seg_4.

But for those who start with one or more big segments, the problem happens.
Take 'OOoooo' as an example. We break them into 3 groups: 1) O, 2) O, 3) oooo.
Group 1 will be renamed from 'raw_seg_1' to 'new_seg_1' and add it to the map. Coz it is the first segment that is big, filenames get lined up -- src filename & dst filename are the same (ignore the raw/new sign that are only used to distinguish in this comment).

The case should be carefully handled. We do not need to actually rename it but we should count it as handled. If we miss counting (increase _num_segcompacted), the following group 2 will still want to be renamed as 'new_seg_1', but 'new_seg_1' is already in the map, causing the check to fail at last.

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [X] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [X] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [X] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [X] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [X] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

