### PR TITLE
[improvement](regression-test) sleep longer to void "table's state is not NORMAL" error

### DIFF
--- a/regression-test/suites/nereids_syntax_p0/rollup.groovy
+++ b/regression-test/suites/nereids_syntax_p0/rollup.groovy
@@ -59,7 +59,7 @@ suite("rollup") {
             }
         }
     }
-    Thread.sleep(200)
+    Thread.sleep(2000)
 
     sql "insert into rollup_t1 values(1, 2, 3, 4)"
     sql "insert into rollup_t1 values(1, 2, 3, 2)"

--- a/regression-test/suites/rollup/test_materialized_view_date.groovy
+++ b/regression-test/suites/rollup/test_materialized_view_date.groovy
@@ -51,7 +51,7 @@ suite("test_materialized_view_date", "rollup") {
             }
         }
     }
-    Thread.sleep(2)
+    Thread.sleep(2000)
     max_try_secs = 120
     sql "CREATE materialized VIEW amt_max2 AS SELECT store_id, max(sale_datetime1) FROM ${tbName1} GROUP BY store_id;"
     while (max_try_secs--) {
@@ -66,7 +66,7 @@ suite("test_materialized_view_date", "rollup") {
             }
         }
     }
-    Thread.sleep(2)
+    Thread.sleep(2000)
     max_try_secs = 120
     sql "CREATE materialized VIEW amt_max3 AS SELECT store_id, max(sale_datetime2) FROM ${tbName1} GROUP BY store_id;"
     while (max_try_secs--) {
@@ -81,7 +81,7 @@ suite("test_materialized_view_date", "rollup") {
             }
         }
     }
-    Thread.sleep(2)
+    Thread.sleep(2000)
     max_try_secs = 120
     sql "CREATE materialized VIEW amt_max4 AS SELECT store_id, max(sale_datetime3) FROM ${tbName1} GROUP BY store_id;"
     while (max_try_secs--) {
@@ -101,7 +101,7 @@ suite("test_materialized_view_date", "rollup") {
     sql "SHOW ALTER TABLE MATERIALIZED VIEW WHERE TableName='${tbName1}';"
     sql "insert into ${tbName1} values(1, 1, 1, '2020-05-30', '2020-05-30', '2020-05-30 11:11:11.111111', '2020-05-30 11:11:11.111111', '2020-05-30 11:11:11.111111',100);"
     sql "insert into ${tbName1} values(2, 1, 1, '2020-05-30', '2020-05-30', '2020-04-30 11:11:11.111111', '2020-04-30 11:11:11.111111', '2020-04-30 11:11:11.111111',100);"
-    Thread.sleep(1000)
+    Thread.sleep(2000)
     explain{
         sql("SELECT store_id, max(sale_date1) FROM ${tbName1} GROUP BY store_id")
         contains("(amt_max1)")

--- a/regression-test/suites/rollup_p0/test_rollup_agg.groovy
+++ b/regression-test/suites/rollup_p0/test_rollup_agg.groovy
@@ -51,7 +51,7 @@ suite("test_rollup_agg") {
             }
         }
     }
-    Thread.sleep(200)
+    Thread.sleep(2000)
     sql "ALTER TABLE ${tbName} ADD COLUMN vv BIGINT SUM NULL DEFAULT '0' TO rollup_city;"
     max_try_secs = 60
     while (max_try_secs--) {


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

There may be a little gap between alter job's finish and changing table's state to NORMAL.
The interval is at least 500ms. So sleep longer to avoid `table's state is not NORMAL` error when doing next alter job.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

