### PR TITLE
[chore](cmake) Fix wrong include_directories statements

### DIFF
--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -600,13 +600,13 @@ include_directories(
     ${GENSRC_DIR}/
     ${THIRDPARTY_DIR}/include
     ${GPERFTOOLS_HOME}/include
-    include_directories($ENV{JAVA_HOME}/include)
-    if (NOT OS_MACOSX)
-        include_directories($ENV{JAVA_HOME}/include/linux)
-    else()
-        include_directories($ENV{JAVA_HOME}/include/darwin)
-    endif()
 )
+include_directories($ENV{JAVA_HOME}/include)
+if (NOT OS_MACOSX)
+    include_directories($ENV{JAVA_HOME}/include/linux)
+else()
+    include_directories($ENV{JAVA_HOME}/include/darwin)
+endif()
 
 if (NOT OS_MACOSX)
     set(WL_START_GROUP "-Wl,--start-group")


### PR DESCRIPTION
# Proposed changes

~~Issue Number: close #xxx~~

## Problem summary

#14062 introduced wrong `include_directories` statements.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

