### PR TITLE
[BugFix](file cache) don't clean clone dir when doing _gc_unused_file_caches

### DIFF
--- a/be/src/io/cache/file_cache_manager.cpp
+++ b/be/src/io/cache/file_cache_manager.cpp
@@ -107,7 +107,7 @@ void FileCacheManager::_gc_unused_file_caches(std::list<FileCachePtr>& result) {
             for (Path seg_file : seg_file_paths) {
                 std::string seg_filename = seg_file.native();
                 // check if it is a dir name
-                if (ends_with(seg_filename, ".dat")) {
+                if (ends_with(seg_filename, ".dat") || ends_with(seg_filename, "clone")) {
                     continue;
                 }
                 // skip file cache already in memory

--- a/be/src/olap/task/engine_clone_task.cpp
+++ b/be/src/olap/task/engine_clone_task.cpp
@@ -419,7 +419,8 @@ Status EngineCloneTask::_download_files(DataDir* data_dir, const std::string& re
             uint64_t local_file_size = std::filesystem::file_size(local_file_path, ec);
             if (ec) {
                 LOG(WARNING) << "download file error" << ec.message();
-                return Status::IOError("can't retrive file_size of {}, due to {}", local_file_path, ec.message());
+                return Status::IOError("can't retrive file_size of {}, due to {}", local_file_path,
+                                       ec.message());
             }
             if (local_file_size != file_size) {
                 LOG(WARNING) << "download file length error"

--- a/be/src/olap/task/engine_clone_task.cpp
+++ b/be/src/olap/task/engine_clone_task.cpp
@@ -18,6 +18,7 @@
 #include "olap/task/engine_clone_task.h"
 
 #include <set>
+#include <system_error>
 
 #include "env/env.h"
 #include "gen_cpp/BackendService.h"
@@ -413,8 +414,13 @@ Status EngineCloneTask::_download_files(DataDir* data_dir, const std::string& re
             client->set_timeout_ms(estimate_timeout * 1000);
             RETURN_IF_ERROR(client->download(local_file_path));
 
+            std::error_code ec;
             // Check file length
-            uint64_t local_file_size = std::filesystem::file_size(local_file_path);
+            uint64_t local_file_size = std::filesystem::file_size(local_file_path, ec);
+            if (ec) {
+                LOG(WARNING) << "download file error" << ec.message();
+                return Status::InternalError(ec.message());
+            }
             if (local_file_size != file_size) {
                 LOG(WARNING) << "download file length error"
                              << ", remote_path=" << remote_file_url << ", file_size=" << file_size

--- a/be/src/olap/task/engine_clone_task.cpp
+++ b/be/src/olap/task/engine_clone_task.cpp
@@ -419,7 +419,7 @@ Status EngineCloneTask::_download_files(DataDir* data_dir, const std::string& re
             uint64_t local_file_size = std::filesystem::file_size(local_file_path, ec);
             if (ec) {
                 LOG(WARNING) << "download file error" << ec.message();
-                return Status::InternalError(ec.message());
+                return Status::IOError("can't retrive file_size of {}, due to {}", local_file_path, ec.message());
             }
             if (local_file_size != file_size) {
                 LOG(WARNING) << "download file length error"


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

Previous implementation would clean `tablet_path/clone/xxx.dat` file even though we didn't set `file_cache_max_size_per_disk`. The log is as follows:
![image](https://user-images.githubusercontent.com/43750022/201297985-d154b93c-7d0d-49f2-835e-3b7cff0abf7a.png)

## Problem summary

Describe your changes.
Make the _gc_unused_file_caches skip clone dir.
BTW, i changed one function call which throws unhandled exception due to the clone dir is deleted to use to one noexcept overload.
## Checklist(Required)

1. Does it affect the original behavior: 
    - [x] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

