### PR TITLE
[improvement](load) release load channel actively when error occurs

### DIFF
--- a/be/src/olap/delta_writer.h
+++ b/be/src/olap/delta_writer.h
@@ -82,6 +82,7 @@ public:
     // abandon current memtable and wait for all pending-flushing memtables to be destructed.
     // mem_consumption() should be 0 after this function returns.
     Status cancel();
+    Status cancel_with_status(const Status& st);
 
     // submit current memtable to flush queue, and wait all memtables in flush queue
     // to be flushed.
@@ -128,6 +129,7 @@ private:
 
     bool _is_init = false;
     bool _is_cancelled = false;
+    Status _cancel_status;
     WriteRequest _req;
     TabletSharedPtr _tablet;
     RowsetSharedPtr _cur_rowset;

--- a/be/src/runtime/load_channel_mgr.cpp
+++ b/be/src/runtime/load_channel_mgr.cpp
@@ -217,4 +217,136 @@ Status LoadChannelMgr::_start_load_channels_clean() {
     return Status::OK();
 }
 
+void LoadChannelMgr::_handle_mem_exceed_limit() {
+    // Check the soft limit.
+    DCHECK(_load_soft_mem_limit > 0);
+    int64_t process_mem_limit = MemInfo::mem_limit() * config::soft_mem_limit_frac;
+    if (_mem_tracker->consumption() < _load_soft_mem_limit &&
+        MemInfo::proc_mem_no_allocator_cache() < process_mem_limit) {
+        return;
+    }
+    // Indicate whether current thread is reducing mem on hard limit.
+    bool reducing_mem_on_hard_limit = false;
+    std::vector<std::shared_ptr<LoadChannel>> channels_to_reduce_mem;
+    {
+        std::unique_lock<std::mutex> l(_lock);
+        while (_should_wait_flush) {
+            LOG(INFO) << "Reached the load hard limit " << _load_hard_mem_limit
+                      << ", waiting for flush";
+            _wait_flush_cond.wait(l);
+        }
+        bool hard_limit_reached = _mem_tracker->consumption() >= _load_hard_mem_limit ||
+                                  MemInfo::proc_mem_no_allocator_cache() >= process_mem_limit;
+        // Some other thread is flushing data, and not reached hard limit now,
+        // we don't need to handle mem limit in current thread.
+        if (_soft_reduce_mem_in_progress && !hard_limit_reached) {
+            return;
+        }
+
+        // Pick LoadChannels to reduce memory usage, if some other thread is reducing memory
+        // due to soft limit, and we reached hard limit now, current thread may pick some
+        // duplicate channels and trigger duplicate reducing memory process.
+        // But the load channel's reduce memory process is thread safe, only 1 thread can
+        // reduce memory at the same time, other threads will wait on a condition variable,
+        // after the reduce-memory work finished, all threads will return.
+        using ChannelMemPair = std::pair<std::shared_ptr<LoadChannel>, int64_t>;
+        std::vector<ChannelMemPair> candidate_channels;
+        int64_t total_consume = 0;
+        for (auto& kv : _load_channels) {
+            if (kv.second->is_high_priority()) {
+                // do not select high priority channel to reduce memory
+                // to avoid blocking them.
+                continue;
+            }
+            int64_t mem = kv.second->mem_consumption();
+            // save the mem consumption, since the calculation might be expensive.
+            candidate_channels.push_back(std::make_pair(kv.second, mem));
+            total_consume += mem;
+        }
+
+        if (candidate_channels.empty()) {
+            // should not happen, add log to observe
+            LOG(WARNING) << "All load channels are high priority, failed to find suitable"
+                         << "channels to reduce memory when total load mem limit exceed";
+            return;
+        }
+
+        // sort all load channels, try to find the largest one.
+        std::sort(candidate_channels.begin(), candidate_channels.end(),
+                  [](const ChannelMemPair& lhs, const ChannelMemPair& rhs) {
+                      return lhs.second > rhs.second;
+                  });
+
+        int64_t mem_consumption_in_picked_channel = 0;
+        auto largest_channel = *candidate_channels.begin();
+        // If some load-channel is big enough, we can reduce it only, try our best to avoid
+        // reducing small load channels.
+        if (_load_channel_min_mem_to_reduce > 0 &&
+            largest_channel.second > _load_channel_min_mem_to_reduce) {
+            // Pick 1 load channel to reduce memory.
+            channels_to_reduce_mem.push_back(largest_channel.first);
+            mem_consumption_in_picked_channel = largest_channel.second;
+        } else {
+            // Pick multiple channels to reduce memory.
+            int64_t mem_to_flushed = total_consume / 3;
+            for (auto ch : candidate_channels) {
+                channels_to_reduce_mem.push_back(ch.first);
+                mem_consumption_in_picked_channel += ch.second;
+                if (mem_consumption_in_picked_channel >= mem_to_flushed) {
+                    break;
+                }
+            }
+        }
+
+        std::ostringstream oss;
+        if (MemInfo::proc_mem_no_allocator_cache() < process_mem_limit) {
+            oss << "reducing memory of " << channels_to_reduce_mem.size()
+                << " load channels (total mem consumption: " << mem_consumption_in_picked_channel
+                << " bytes), because total load mem consumption "
+                << PrettyPrinter::print(_mem_tracker->consumption(), TUnit::BYTES)
+                << " has exceeded";
+            if (_mem_tracker->consumption() > _load_hard_mem_limit) {
+                _should_wait_flush = true;
+                reducing_mem_on_hard_limit = true;
+                oss << " hard limit: " << PrettyPrinter::print(_load_hard_mem_limit, TUnit::BYTES);
+            } else {
+                _soft_reduce_mem_in_progress = true;
+                oss << " soft limit: " << PrettyPrinter::print(_load_soft_mem_limit, TUnit::BYTES);
+            }
+        } else {
+            _should_wait_flush = true;
+            reducing_mem_on_hard_limit = true;
+            oss << "reducing memory of " << channels_to_reduce_mem.size()
+                << " load channels (total mem consumption: " << mem_consumption_in_picked_channel
+                << " bytes), because " << PerfCounters::get_vm_rss_str() << " has exceeded limit "
+                << PrettyPrinter::print(process_mem_limit, TUnit::BYTES)
+                << " , tc/jemalloc allocator cache " << MemInfo::allocator_cache_mem_str();
+        }
+        LOG(INFO) << oss.str();
+    }
+
+    for (auto ch : channels_to_reduce_mem) {
+        uint64_t begin = GetCurrentTimeMicros();
+        int64_t mem_usage = ch->mem_consumption();
+        ch->handle_mem_exceed_limit();
+        LOG(INFO) << "reduced memory of " << *ch << ", cost "
+                  << (GetCurrentTimeMicros() - begin) / 1000
+                  << " ms, released memory: " << mem_usage - ch->mem_consumption() << " bytes";
+    }
+
+    {
+        std::lock_guard<std::mutex> l(_lock);
+        // If a thread have finished the memtable flush for soft limit, and now
+        // the hard limit is already reached, it should not update these variables.
+        if (reducing_mem_on_hard_limit && _should_wait_flush) {
+            _should_wait_flush = false;
+            _wait_flush_cond.notify_all();
+        }
+        if (_soft_reduce_mem_in_progress) {
+            _soft_reduce_mem_in_progress = false;
+        }
+    }
+    return;
+}
+
 } // namespace doris

--- a/be/src/runtime/load_channel_mgr.h
+++ b/be/src/runtime/load_channel_mgr.h
@@ -77,8 +77,7 @@ private:
     void _finish_load_channel(UniqueId load_id);
     // check if the total load mem consumption exceeds limit.
     // If yes, it will pick a load channel to try to reduce memory consumption.
-    template <typename TabletWriterAddResult>
-    Status _handle_mem_exceed_limit(TabletWriterAddResult* response);
+    void _handle_mem_exceed_limit();
 
     Status _start_bg_worker();
 
@@ -154,153 +153,23 @@ Status LoadChannelMgr::add_batch(const TabletWriterAddRequest& request,
         // 2. check if mem consumption exceed limit
         // If this is a high priority load task, do not handle this.
         // because this may block for a while, which may lead to rpc timeout.
-        RETURN_IF_ERROR(_handle_mem_exceed_limit(response));
+        _handle_mem_exceed_limit();
     }
 
     // 3. add batch to load channel
     // batch may not exist in request(eg: eos request without batch),
     // this case will be handled in load channel's add batch method.
-    RETURN_IF_ERROR(channel->add_batch(request, response));
+    Status st = channel->add_batch(request, response);
+    if (UNLIKELY(!st.ok())) {
+        channel->cancel();
+        return st;
+    }
 
     // 4. handle finish
     if (channel->is_finished()) {
         _finish_load_channel(load_id);
     }
     return Status::OK();
-}
-
-template <typename TabletWriterAddResult>
-Status LoadChannelMgr::_handle_mem_exceed_limit(TabletWriterAddResult* response) {
-    // Check the soft limit.
-    DCHECK(_load_soft_mem_limit > 0);
-    int64_t process_mem_limit = MemInfo::mem_limit() * config::soft_mem_limit_frac;
-    if (_mem_tracker->consumption() < _load_soft_mem_limit &&
-        MemInfo::proc_mem_no_allocator_cache() < process_mem_limit) {
-        return Status::OK();
-    }
-    // Indicate whether current thread is reducing mem on hard limit.
-    bool reducing_mem_on_hard_limit = false;
-    std::vector<std::shared_ptr<LoadChannel>> channels_to_reduce_mem;
-    {
-        std::unique_lock<std::mutex> l(_lock);
-        while (_should_wait_flush) {
-            LOG(INFO) << "Reached the load hard limit " << _load_hard_mem_limit
-                      << ", waiting for flush";
-            _wait_flush_cond.wait(l);
-        }
-        bool hard_limit_reached = _mem_tracker->consumption() >= _load_hard_mem_limit ||
-                                  MemInfo::proc_mem_no_allocator_cache() >= process_mem_limit;
-        // Some other thread is flushing data, and not reached hard limit now,
-        // we don't need to handle mem limit in current thread.
-        if (_soft_reduce_mem_in_progress && !hard_limit_reached) {
-            return Status::OK();
-        }
-
-        // Pick LoadChannels to reduce memory usage, if some other thread is reducing memory
-        // due to soft limit, and we reached hard limit now, current thread may pick some
-        // duplicate channels and trigger duplicate reducing memory process.
-        // But the load channel's reduce memory process is thread safe, only 1 thread can
-        // reduce memory at the same time, other threads will wait on a condition variable,
-        // after the reduce-memory work finished, all threads will return.
-        using ChannelMemPair = std::pair<std::shared_ptr<LoadChannel>, int64_t>;
-        std::vector<ChannelMemPair> candidate_channels;
-        int64_t total_consume = 0;
-        for (auto& kv : _load_channels) {
-            if (kv.second->is_high_priority()) {
-                // do not select high priority channel to reduce memory
-                // to avoid blocking them.
-                continue;
-            }
-            int64_t mem = kv.second->mem_consumption();
-            // save the mem consumption, since the calculation might be expensive.
-            candidate_channels.push_back(std::make_pair(kv.second, mem));
-            total_consume += mem;
-        }
-
-        if (candidate_channels.empty()) {
-            // should not happen, add log to observe
-            LOG(WARNING) << "All load channels are high priority, failed to find suitable"
-                         << "channels to reduce memory when total load mem limit exceed";
-            return Status::OK();
-        }
-
-        // sort all load channels, try to find the largest one.
-        std::sort(candidate_channels.begin(), candidate_channels.end(),
-                  [](const ChannelMemPair& lhs, const ChannelMemPair& rhs) {
-                      return lhs.second > rhs.second;
-                  });
-
-        int64_t mem_consumption_in_picked_channel = 0;
-        auto largest_channel = *candidate_channels.begin();
-        // If some load-channel is big enough, we can reduce it only, try our best to avoid
-        // reducing small load channels.
-        if (_load_channel_min_mem_to_reduce > 0 &&
-            largest_channel.second > _load_channel_min_mem_to_reduce) {
-            // Pick 1 load channel to reduce memory.
-            channels_to_reduce_mem.push_back(largest_channel.first);
-            mem_consumption_in_picked_channel = largest_channel.second;
-        } else {
-            // Pick multiple channels to reduce memory.
-            int64_t mem_to_flushed = total_consume / 3;
-            for (auto ch : candidate_channels) {
-                channels_to_reduce_mem.push_back(ch.first);
-                mem_consumption_in_picked_channel += ch.second;
-                if (mem_consumption_in_picked_channel >= mem_to_flushed) {
-                    break;
-                }
-            }
-        }
-
-        std::ostringstream oss;
-        if (MemInfo::proc_mem_no_allocator_cache() < process_mem_limit) {
-            oss << "reducing memory of " << channels_to_reduce_mem.size()
-                << " load channels (total mem consumption: " << mem_consumption_in_picked_channel
-                << " bytes), because total load mem consumption "
-                << PrettyPrinter::print(_mem_tracker->consumption(), TUnit::BYTES)
-                << " has exceeded";
-            if (_mem_tracker->consumption() > _load_hard_mem_limit) {
-                _should_wait_flush = true;
-                reducing_mem_on_hard_limit = true;
-                oss << " hard limit: " << PrettyPrinter::print(_load_hard_mem_limit, TUnit::BYTES);
-            } else {
-                _soft_reduce_mem_in_progress = true;
-                oss << " soft limit: " << PrettyPrinter::print(_load_soft_mem_limit, TUnit::BYTES);
-            }
-        } else {
-            _should_wait_flush = true;
-            reducing_mem_on_hard_limit = true;
-            oss << "reducing memory of " << channels_to_reduce_mem.size()
-                << " load channels (total mem consumption: " << mem_consumption_in_picked_channel
-                << " bytes), because " << PerfCounters::get_vm_rss_str() << " has exceeded limit "
-                << PrettyPrinter::print(process_mem_limit, TUnit::BYTES)
-                << " , tc/jemalloc allocator cache " << MemInfo::allocator_cache_mem_str();
-        }
-        LOG(INFO) << oss.str();
-    }
-
-    Status st = Status::OK();
-    for (auto ch : channels_to_reduce_mem) {
-        uint64_t begin = GetCurrentTimeMicros();
-        int64_t mem_usage = ch->mem_consumption();
-        st = ch->handle_mem_exceed_limit(response);
-        LOG(INFO) << "reduced memory of " << *ch << ", cost "
-                  << (GetCurrentTimeMicros() - begin) / 1000
-                  << " ms, released memory: " << mem_usage - ch->mem_consumption() << " bytes";
-    }
-
-    {
-        std::lock_guard<std::mutex> l(_lock);
-        // If a thread have finished the memtable flush for soft limit, and now
-        // the hard limit is already reached, it should not update these variables.
-        if (reducing_mem_on_hard_limit && _should_wait_flush) {
-            _should_wait_flush = false;
-            _wait_flush_cond.notify_all();
-        }
-        if (_soft_reduce_mem_in_progress) {
-            _soft_reduce_mem_in_progress = false;
-        }
-    }
-    return st;
 }
 
 } // namespace doris

--- a/be/src/runtime/tablets_channel.h
+++ b/be/src/runtime/tablets_channel.h
@@ -92,8 +92,7 @@ public:
     // eg. flush the largest memtable immediately.
     // return Status::OK if mem is reduced.
     // no-op when this channel has been closed or cancelled
-    template <typename TabletWriterAddResult>
-    Status reduce_mem_usage(TabletWriterAddResult* response);
+    void reduce_mem_usage();
 
     int64_t mem_consumption();
 


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

`_handle_ mem_ exceed_ limit` will return the error information of the previous load to the next load. So I change this function to a void function. 
When some error occur, the load channel will not be release in time in some case. So I cancel the delta writer or load channel actively.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

