### PR TITLE
[enhancement](thriftclient) remove client_map to optimize thrift client lock

### DIFF
--- a/be/src/runtime/client_cache.cpp
+++ b/be/src/runtime/client_cache.cpp
@@ -145,7 +145,7 @@ void ClientCacheHelper::release_client(ClientImplPair*& client_pair) {
         DCHECK(cache_list != _client_cache.end());
         // restore the client unless cache of this host if full
         if (_max_cache_size_per_host >= 0 &&
-              cache_list->second.size() >= _max_cache_size_per_host) {
+            cache_list->second.size() >= _max_cache_size_per_host) {
             // cache of this host is full, close this client connection and remove if from _client_map
             delete client_pair;
         } else {

--- a/be/src/runtime/client_cache.cpp
+++ b/be/src/runtime/client_cache.cpp
@@ -20,6 +20,7 @@
 #include <thrift/protocol/TBinaryProtocol.h>
 
 #include <memory>
+#include <mutex>
 #include <sstream>
 
 #include "common/logging.h"
@@ -42,7 +43,8 @@ ClientCacheHelper::~ClientCacheHelper() {
 
 void ClientCacheHelper::_get_client_from_cache(const TNetworkAddress& hostport, void** client_key) {
     *client_key = nullptr;
-    std::lock_guard<std::mutex> lock(_lock);
+    // std::lock_guard<std::mutex> lock(_lock);
+    std::lock_guard<std::mutex> lock{_shard_locks[_get_addr_lock_idx(hostport)]};
     //VLOG_RPC << "get_client(" << hostport << ")";
     auto cache_entry = _client_cache.find(hostport);
 
@@ -180,7 +182,8 @@ void ClientCacheHelper::release_client(void** client_key) {
 void ClientCacheHelper::close_connections(const TNetworkAddress& hostport) {
     std::vector<ThriftClientImpl*> to_close;
     {
-        std::lock_guard<std::mutex> lock(_lock);
+        // std::lock_guard<std::mutex> lock(_lock);
+        std::lock_guard<std::mutex> lock(_shard_locks[_get_addr_lock_idx(hostport)]);
         auto cache_entry = _client_cache.find(hostport);
 
         if (cache_entry == _client_cache.end()) {

--- a/be/src/runtime/client_cache.cpp
+++ b/be/src/runtime/client_cache.cpp
@@ -125,6 +125,7 @@ Status ClientCacheHelper::_create_client(const TNetworkAddress& hostport,
     if (_metrics_enabled) {
         thrift_opened_clients->increment(1);
     }
+    client_impl.release();
 
     return Status::OK();
 }

--- a/be/src/runtime/client_cache.cpp
+++ b/be/src/runtime/client_cache.cpp
@@ -38,37 +38,39 @@ ClientCacheHelper::~ClientCacheHelper() {
     // for (auto& it : _client_map) {
     //     delete it.second;
     // }
-    for (auto& pairs: _client_cache) {
-        for (auto& pair: pairs.second) {
+    for (auto& pairs : _client_cache) {
+        for (auto& pair : pairs.second) {
             delete pair->second;
         }
     }
 }
 
-void ClientCacheHelper::_get_client_from_cache(const TNetworkAddress& hostport, ClientImplPair& client_key) {
-    client_key.first = nullptr;
+void ClientCacheHelper::_get_client_from_cache(const TNetworkAddress& hostport,
+                                               ClientImplPair*& client_pair) {
+    client_pair->first = nullptr;
     std::lock_guard<std::mutex> lock(_lock);
     //VLOG_RPC << "get_client(" << hostport << ")";
     auto cache_entry = _client_cache.find(hostport);
 
     if (cache_entry == _client_cache.end()) {
-        cache_entry = _client_cache.insert(std::make_pair(hostport, std::list<ClientImplPair*>())).first;
+        cache_entry =
+                _client_cache.insert(std::make_pair(hostport, std::list<ClientImplPair*>())).first;
         DCHECK(cache_entry != _client_cache.end());
     }
 
     std::list<ClientImplPair*>& info_list = cache_entry->second;
     if (!info_list.empty()) {
-        client_key = *info_list.front();
+        client_pair = info_list.front();
         VLOG_RPC << "get_client(): cached client for " << hostport;
         info_list.pop_front();
     }
 }
 
 Status ClientCacheHelper::get_client(const TNetworkAddress& hostport, ClientFactory& factory_method,
-                                     ClientImplPair& client_key, int timeout_ms) {
-    _get_client_from_cache(hostport, client_key);
-    if (client_key.first == nullptr) {
-        RETURN_IF_ERROR(_create_client(hostport, factory_method, client_key, timeout_ms));
+                                     ClientImplPair*& client_pair, int timeout_ms) {
+    _get_client_from_cache(hostport, client_pair);
+    if (client_pair->first == nullptr) {
+        RETURN_IF_ERROR(_create_client(hostport, factory_method, client_pair, timeout_ms));
     }
 
     if (_metrics_enabled) {
@@ -78,11 +80,11 @@ Status ClientCacheHelper::get_client(const TNetworkAddress& hostport, ClientFact
     return Status::OK();
 }
 
-Status ClientCacheHelper::reopen_client(ClientFactory& factory_method, ClientImplPair& client_key,
+Status ClientCacheHelper::reopen_client(ClientFactory& factory_method, ClientImplPair*& client_pair,
                                         int timeout_ms) {
-    DCHECK(client_key.first != nullptr) << "Trying to reopen nullptr client";
-    ThriftClientImpl* client_to_close = client_key.second;
-    
+    DCHECK(client_pair->first != nullptr) << "Trying to reopen nullptr client";
+    ThriftClientImpl* client_to_close = client_pair->second;
+
     const std::string ipaddress = client_to_close->ipaddress();
     int port = client_to_close->port();
 
@@ -92,22 +94,22 @@ Status ClientCacheHelper::reopen_client(ClientFactory& factory_method, ClientImp
     // not clean up internal buffers it reopens. To work around this issue, create a new
     // client instead.
     delete client_to_close;
-    client_key.first = nullptr;
+    client_pair->first = nullptr;
 
     if (_metrics_enabled) {
         thrift_opened_clients->increment(-1);
     }
 
     RETURN_IF_ERROR(_create_client(make_network_address(ipaddress, port), factory_method,
-                                   client_key, timeout_ms));
+                                   client_pair, timeout_ms));
 
     return Status::OK();
 }
 
 Status ClientCacheHelper::_create_client(const TNetworkAddress& hostport,
-                                         ClientFactory& factory_method, ClientImplPair& client_key,
-                                         int timeout_ms) {
-    std::unique_ptr<ThriftClientImpl> client_impl(factory_method(hostport, client_key));
+                                         ClientFactory& factory_method,
+                                         ClientImplPair*& client_pair, int timeout_ms) {
+    std::unique_ptr<ThriftClientImpl> client_impl(factory_method(hostport, client_pair));
     //VLOG_CONNECTION << "create_client(): adding new client for "
     //                << client_impl->ipaddress() << ":" << client_impl->port();
 
@@ -116,7 +118,7 @@ Status ClientCacheHelper::_create_client(const TNetworkAddress& hostport,
     Status status = client_impl->open();
 
     if (!status.ok()) {
-        client_key.first = nullptr;
+        client_pair->first = nullptr;
         return status;
     }
     client_impl->set_send_timeout(timeout_ms);
@@ -129,24 +131,20 @@ Status ClientCacheHelper::_create_client(const TNetworkAddress& hostport,
     return Status::OK();
 }
 
-void ClientCacheHelper::release_client(ClientImplPair& client_key) {
-    DCHECK(client_key.first != nullptr) << "Trying to release nullptr client";
+void ClientCacheHelper::release_client(ClientImplPair*& client_pair) {
+    DCHECK(client_pair->first != nullptr) << "Trying to release nullptr client";
     ThriftClientImpl* client_to_close = nullptr;
     {
         std::lock_guard<std::mutex> lock(_lock);
-        // auto client_map_entry = _client_map.find(*client_key);
-        // DCHECK(client_map_entry != _client_map.end());
-        client_to_close = client_key.second;
+        client_to_close = client_pair->second;
 
         auto cache_list = _client_cache.find(
                 make_network_address(client_to_close->ipaddress(), client_to_close->port()));
         DCHECK(cache_list != _client_cache.end());
-        if (_max_cache_size_per_host >= 0 &&
-            cache_list->second.size() >= _max_cache_size_per_host) {
-            // cache of this host is full, close this client connection and remove if from _client_map
-            // _client_map.erase(*client_key);
-        } else {
-            cache_list->second.push_back(&client_key);
+        // restore the client unless cache of this host if full
+        if (!(_max_cache_size_per_host >= 0 &&
+              cache_list->second.size() >= _max_cache_size_per_host)) {
+            cache_list->second.push_back(client_pair);
             // There is no need to close client if we put it to cache list.
             client_to_close = nullptr;
         }
@@ -164,6 +162,10 @@ void ClientCacheHelper::release_client(ClientImplPair& client_key) {
         thrift_used_clients->increment(-1);
     }
 
+    // make sure the resouce wouldn't be deleted by
+    // deleting the pair
+    client_pair->first = nullptr;
+    client_pair->second = nullptr;
 }
 
 void ClientCacheHelper::close_connections(const TNetworkAddress& hostport) {

--- a/be/src/runtime/client_cache.cpp
+++ b/be/src/runtime/client_cache.cpp
@@ -35,9 +35,6 @@ DEFINE_GAUGE_METRIC_PROTOTYPE_3ARG(thrift_opened_clients, MetricUnit::NOUNIT,
                                    "Total clients in the cache, including those in use");
 
 ClientCacheHelper::~ClientCacheHelper() {
-    // for (auto& it : _client_map) {
-    //     delete it.second;
-    // }
     for (auto& pairs : _client_cache) {
         for (auto& pair : pairs.second) {
             delete pair->second;

--- a/be/src/runtime/client_cache.cpp
+++ b/be/src/runtime/client_cache.cpp
@@ -79,7 +79,8 @@ Status ClientCacheHelper::get_client(const TNetworkAddress& hostport, ClientFact
 
 Status ClientCacheHelper::reopen_client(ClientFactory& factory_method, ClientImplPair*& client_pair,
                                         int timeout_ms) {
-    DCHECK(client_pair != nullptr && client_pair->first != nullptr) << "Trying to reopen nullptr client";
+    DCHECK(client_pair != nullptr && client_pair->first != nullptr)
+            << "Trying to reopen nullptr client";
     ThriftClientImpl* client_to_close = client_pair->second;
 
     const std::string ipaddress = client_to_close->ipaddress();
@@ -129,7 +130,8 @@ Status ClientCacheHelper::_create_client(const TNetworkAddress& hostport,
 }
 
 void ClientCacheHelper::release_client(ClientImplPair*& client_pair) {
-    DCHECK(client_pair != nullptr && client_pair->first != nullptr) << "Trying to release nullptr client";
+    DCHECK(client_pair != nullptr && client_pair->first != nullptr)
+            << "Trying to release nullptr client";
     ThriftClientImpl* client_to_close = nullptr;
     {
         std::lock_guard<std::mutex> lock(_lock);

--- a/be/src/runtime/client_cache.cpp
+++ b/be/src/runtime/client_cache.cpp
@@ -92,7 +92,8 @@ Status ClientCacheHelper::reopen_client(ClientFactory& factory_method, ClientImp
     // not clean up internal buffers it reopens. To work around this issue, create a new
     // client instead.
     delete client_to_close;
-    client_pair->first = nullptr;
+    delete client_pair;
+    client_pair = nullptr;
 
     if (_metrics_enabled) {
         thrift_opened_clients->increment(-1);
@@ -116,7 +117,8 @@ Status ClientCacheHelper::_create_client(const TNetworkAddress& hostport,
     Status status = client_impl->open();
 
     if (!status.ok()) {
-        client_pair->first = nullptr;
+        delete client_pair;
+        client_pair = nullptr;
         return status;
     }
     client_impl->set_send_timeout(timeout_ms);

--- a/be/src/runtime/client_cache.cpp
+++ b/be/src/runtime/client_cache.cpp
@@ -44,7 +44,7 @@ ClientCacheHelper::~ClientCacheHelper() {
 
 void ClientCacheHelper::_get_client_from_cache(const TNetworkAddress& hostport,
                                                ClientImplPair*& client_pair) {
-    client_pair->first = nullptr;
+    client_pair = nullptr;
     std::lock_guard<std::mutex> lock(_lock);
     //VLOG_RPC << "get_client(" << hostport << ")";
     auto cache_entry = _client_cache.find(hostport);
@@ -66,7 +66,7 @@ void ClientCacheHelper::_get_client_from_cache(const TNetworkAddress& hostport,
 Status ClientCacheHelper::get_client(const TNetworkAddress& hostport, ClientFactory& factory_method,
                                      ClientImplPair*& client_pair, int timeout_ms) {
     _get_client_from_cache(hostport, client_pair);
-    if (client_pair->first == nullptr) {
+    if (client_pair == nullptr) {
         RETURN_IF_ERROR(_create_client(hostport, factory_method, client_pair, timeout_ms));
     }
 
@@ -79,7 +79,7 @@ Status ClientCacheHelper::get_client(const TNetworkAddress& hostport, ClientFact
 
 Status ClientCacheHelper::reopen_client(ClientFactory& factory_method, ClientImplPair*& client_pair,
                                         int timeout_ms) {
-    DCHECK(client_pair->first != nullptr) << "Trying to reopen nullptr client";
+    DCHECK(client_pair != nullptr && client_pair->first != nullptr) << "Trying to reopen nullptr client";
     ThriftClientImpl* client_to_close = client_pair->second;
 
     const std::string ipaddress = client_to_close->ipaddress();
@@ -129,7 +129,7 @@ Status ClientCacheHelper::_create_client(const TNetworkAddress& hostport,
 }
 
 void ClientCacheHelper::release_client(ClientImplPair*& client_pair) {
-    DCHECK(client_pair->first != nullptr) << "Trying to release nullptr client";
+    DCHECK(client_pair != nullptr && client_pair->first != nullptr) << "Trying to release nullptr client";
     ThriftClientImpl* client_to_close = nullptr;
     {
         std::lock_guard<std::mutex> lock(_lock);

--- a/be/src/runtime/client_cache.h
+++ b/be/src/runtime/client_cache.h
@@ -151,7 +151,7 @@ public:
         *status = _client_cache->get_client(address, _client_pair, 0);
 
         if (status->ok()) {
-            DCHECK(_client_pair->first != nullptr);
+            DCHECK(_client_pair != nullptr);
         }
     }
 
@@ -161,18 +161,18 @@ public:
         *status = _client_cache->get_client(address, _client_pair, timeout_ms);
 
         if (status->ok()) {
-            DCHECK(_client_pair->first != nullptr);
+            DCHECK(_client_pair != nullptr);
         }
     }
 
     ~ClientConnection() {
-        if (_client_pair->first != nullptr) {
+        if (_client_pair != nullptr) {
             _client_cache->release_client(_client_pair);
+            // the client is owned by others, we should just only point to nullptr
+            // and delete the memory for the pair
+            _client_pair->first = nullptr;
+            _client_pair->second = nullptr;
         }
-        // the client is owned by others, we should just only point to nullptr
-        // and delete the memory for the pair
-        _client_pair->first = nullptr;
-        _client_pair->second = nullptr;
         delete _client_pair;
         _client_pair = nullptr;
     }

--- a/be/src/runtime/client_cache.h
+++ b/be/src/runtime/client_cache.h
@@ -118,6 +118,7 @@ private:
     // if cache not found, set client_key as nullptr
     void _get_client_from_cache(const TNetworkAddress& hostport, void** client_key);
 
+    // TODO(为什么)这里非要设计一层void* 到 Impl的强转 上面的list也是存的void* 为什么不干脆放在一个结构体IClient里然后上面也只存IClient*
     // Map from client key back to its associated ThriftClientImpl transport
     using ClientMap = std::unordered_map<void*, ThriftClientImpl*>;
     ClientMap _client_map;

--- a/be/src/runtime/client_cache.h
+++ b/be/src/runtime/client_cache.h
@@ -86,6 +86,13 @@ public:
     void init_metrics(const std::string& name);
 
 private:
+
+    size_t _get_addr_lock_idx(const TNetworkAddress& address) {
+        size_t h = std::hash<TNetworkAddress>()(address);
+        return h % _shard_nums;
+    }
+
+
     template <class T>
     friend class ClientCache;
     // Private constructor so that only ClientCache can instantiate this class.
@@ -97,7 +104,12 @@ private:
     // Protects all member variables
     // TODO: have more fine-grained locks or use lock-free data structures,
     // this isn't going to scale for a high request rate
+    // now it only protects client map
     std::mutex _lock;
+
+    constexpr static size_t _shard_nums = 8;
+
+    std::mutex _shard_locks[_shard_nums];
 
     // map from (host, port) to list of client keys for that address
     using ClientCacheMap = std::unordered_map<TNetworkAddress, std::list<void*>>;

--- a/be/src/runtime/client_cache.h
+++ b/be/src/runtime/client_cache.h
@@ -168,13 +168,7 @@ public:
     ~ClientConnection() {
         if (_client_pair != nullptr) {
             _client_cache->release_client(_client_pair);
-            // the client is owned by others, we should just only point to nullptr
-            // and delete the memory for the pair
-            _client_pair->first = nullptr;
-            _client_pair->second = nullptr;
         }
-        delete _client_pair;
-        _client_pair = nullptr;
     }
 
     Status reopen(int timeout_ms) { return _client_cache->reopen_client(_client_pair, timeout_ms); }

--- a/be/src/runtime/client_cache.h
+++ b/be/src/runtime/client_cache.h
@@ -86,13 +86,6 @@ public:
     void init_metrics(const std::string& name);
 
 private:
-
-    size_t _get_addr_lock_idx(const TNetworkAddress& address) {
-        size_t h = std::hash<TNetworkAddress>()(address);
-        return h % _shard_nums;
-    }
-
-
     template <class T>
     friend class ClientCache;
     // Private constructor so that only ClientCache can instantiate this class.
@@ -104,12 +97,7 @@ private:
     // Protects all member variables
     // TODO: have more fine-grained locks or use lock-free data structures,
     // this isn't going to scale for a high request rate
-    // now it only protects client map
     std::mutex _lock;
-
-    constexpr static size_t _shard_nums = 8;
-
-    std::mutex _shard_locks[_shard_nums];
 
     // map from (host, port) to list of client keys for that address
     using ClientCacheMap = std::unordered_map<TNetworkAddress, std::list<void*>>;

--- a/be/src/runtime/client_cache.h
+++ b/be/src/runtime/client_cache.h
@@ -59,22 +59,23 @@ public:
     ~ClientCacheHelper();
     // Callback method which produces a client object when one cannot be
     // found in the cache. Supplied by the ClientCache wrapper.
-    using ClientFactory =
-            std::function<ThriftClientImpl*(const TNetworkAddress& hostport, ClientImplPair& client_key)>;
+    using ClientFactory = std::function<ThriftClientImpl*(const TNetworkAddress& hostport,
+                                                          ClientImplPair*& client_pair)>;
 
     // Return client for specific host/port in 'client'. If a client
     // is not available, the client parameter is set to nullptr.
     Status get_client(const TNetworkAddress& hostport, ClientFactory& factory_method,
-                      ClientImplPair& client_key, int timeout_ms);
+                      ClientImplPair*& client_pair, int timeout_ms);
 
     // Close and delete the underlying transport and remove the client from _client_map.
     // Return a new client connecting to the same host/port.
     // Return an error status and set client_key to nullptr if a new client cannot
     // created.
-    Status reopen_client(ClientFactory& factory_method, ClientImplPair& client_key, int timeout_ms);
+    Status reopen_client(ClientFactory& factory_method, ClientImplPair*& client_pair,
+                         int timeout_ms);
 
     // Return a client to the cache, without closing it, and set *client_key to nullptr.
-    void release_client(ClientImplPair& client_key);
+    void release_client(ClientImplPair*& client_pair);
 
     // Close all connections to a host (e.g., in case of failure) so that on their
     // next use they will have to be Reopen'ed.
@@ -105,12 +106,7 @@ private:
     ClientCacheMap _client_cache;
 
     // if cache not found, set client_key as nullptr
-    void _get_client_from_cache(const TNetworkAddress& hostport, ClientImplPair& client_key);
-
-    // TODO(为什么)这里非要设计一层void* 到 Impl的强转 上面的list也是存的void* 为什么不干脆放在一个结构体IClient里然后上面也只存IClient*
-    // Map from client key back to its associated ThriftClientImpl transport
-    using ClientMap = std::unordered_map<void*, ThriftClientImpl*>;
-    // ClientMap _client_map;
+    void _get_client_from_cache(const TNetworkAddress& hostport, ClientImplPair*& client_pair);
 
     bool _metrics_enabled;
 
@@ -127,7 +123,7 @@ private:
 
     // Create a new client for specific host/port in 'client' and put it in _client_map
     Status _create_client(const TNetworkAddress& hostport, ClientFactory& factory_method,
-                          ClientImplPair& client_key, int timeout_ms);
+                          ClientImplPair*& client_pair, int timeout_ms);
 };
 
 template <class T>
@@ -151,7 +147,7 @@ template <class T>
 class ClientConnection {
 public:
     ClientConnection(ClientCache<T>* client_cache, const TNetworkAddress& address, Status* status)
-            : _client_cache(client_cache), _client_pair(new ClientImplPair(nullptr, nullptr)) {
+            : _client_cache(client_cache), _client_pair(nullptr) {
         *status = _client_cache->get_client(address, _client_pair, 0);
 
         if (status->ok()) {
@@ -161,7 +157,7 @@ public:
 
     ClientConnection(ClientCache<T>* client_cache, const TNetworkAddress& address, int timeout_ms,
                      Status* status)
-            : _client_cache(client_cache), _client_pair(new ClientImplPair(nullptr, nullptr)) {
+            : _client_cache(client_cache), _client_pair(nullptr) {
         *status = _client_cache->get_client(address, _client_pair, timeout_ms);
 
         if (status->ok()) {
@@ -171,22 +167,25 @@ public:
 
     ~ClientConnection() {
         if (_client_pair->first != nullptr) {
-            _client_cache->release_client(*_client_pair);
+            _client_cache->release_client(_client_pair);
         }
-        // actually the pointer is restored by cache
+        // the client is owned by others, we should just only point to nullptr
+        // and delete the memory for the pair
+        _client_pair->first = nullptr;
+        _client_pair->second = nullptr;
+        delete _client_pair;
         _client_pair = nullptr;
     }
 
-    Status reopen(int timeout_ms) { return _client_cache->reopen_client(*_client_pair, timeout_ms); }
+    Status reopen(int timeout_ms) { return _client_cache->reopen_client(_client_pair, timeout_ms); }
 
-    Status reopen() { return _client_cache->reopen_client(*_client_pair, 0); }
+    Status reopen() { return _client_cache->reopen_client(_client_pair, 0); }
 
-    T* operator->() const { return  reinterpret_cast<T*>(_client_pair->first); }
+    T* operator->() const { return reinterpret_cast<T*>(_client_pair->first); }
 
 private:
     ClientCache<T>* _client_cache;
-    // T* _client;
-    // We should not own the lifetime of pair, cause we
+    // We should not own the lifetime of the pair, cause we
     // need to return it once we don't need this connection
     ClientImplPair* _client_pair;
 };
@@ -244,31 +243,29 @@ private:
     // Obtains a pointer to a Thrift interface object (of type T),
     // backed by a live transport which is already open. Returns
     // Status::OK() unless there was an error opening the transport.
-    Status get_client(const TNetworkAddress& hostport, ClientImplPair& iface_pair, int timeout_ms) {
-        return _client_cache_helper.get_client(hostport, _client_factory,
-                                               iface_pair, timeout_ms);
+    Status get_client(const TNetworkAddress& hostport, ClientImplPair*& client_pair,
+                      int timeout_ms) {
+        return _client_cache_helper.get_client(hostport, _client_factory, client_pair, timeout_ms);
     }
 
     // Close and delete the underlying transport. Return a new client connecting to the
     // same host/port.
     // Return an error status if a new connection cannot be established and *client will be
     // nullptr in that case.
-    Status reopen_client(ClientImplPair& client, int timeout_ms) {
-        return _client_cache_helper.reopen_client(_client_factory, client,
-                                                  timeout_ms);
+    Status reopen_client(ClientImplPair*& client, int timeout_ms) {
+        return _client_cache_helper.reopen_client(_client_factory, client, timeout_ms);
     }
 
     // Return the client to the cache and set *client to nullptr.
-    void release_client(ClientImplPair& client) {
-        return _client_cache_helper.release_client(client);
+    void release_client(ClientImplPair*& client_pair) {
+        return _client_cache_helper.release_client(client_pair);
     }
 
     // Factory method to produce a new ThriftClient<T> for the wrapped cache
-    ThriftClientImpl* make_client(const TNetworkAddress& hostport, ClientImplPair*& client_key) {
+    ThriftClientImpl* make_client(const TNetworkAddress& hostport, ClientImplPair*& client_pair) {
         static ThriftServer::ServerType server_type = get_thrift_server_type();
         Client* client = new Client(hostport.hostname, hostport.port, server_type);
-        client_key->first = reinterpret_cast<void*>(client->iface());
-        client_key->second = client;
+        client_pair = new ClientImplPair(reinterpret_cast<void*>(client->iface()), client);
         return client;
     }
 

--- a/be/src/util/thrift_client.h
+++ b/be/src/util/thrift_client.h
@@ -26,6 +26,7 @@
 #include <thrift/transport/TBufferTransports.h>
 #include <thrift/transport/TSocket.h>
 
+#include <memory>
 #include <ostream>
 #include <sstream>
 #include <string>
@@ -93,6 +94,7 @@ public:
 
 private:
     std::shared_ptr<InterfaceType> _iface;
+    std::unique_ptr<ThriftClientImpl> _impl;
 };
 
 template <class InterfaceType>

--- a/be/src/util/thrift_client.h
+++ b/be/src/util/thrift_client.h
@@ -26,7 +26,6 @@
 #include <thrift/transport/TBufferTransports.h>
 #include <thrift/transport/TSocket.h>
 
-#include <memory>
 #include <ostream>
 #include <sstream>
 #include <string>
@@ -94,7 +93,6 @@ public:
 
 private:
     std::shared_ptr<InterfaceType> _iface;
-    std::unique_ptr<ThriftClientImpl> _impl;
 };
 
 template <class InterfaceType>


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx
The former logic of client_cache would use two unordered_map, one for <HostAddress, List<ClientPointer>> while the other for <ClientPointer, ImplPointer>. Lock should be acquired no matter accessing whichever map. Actually we can use one pair to maintain the <ClientPointer, ImplPointer> relation to reduce the lock pressure.
## Problem summary

Describe your changes.
Remove client_cache map and use pair to maintain the <ClientPointer, ImplPointer> relation.
## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

