### PR TITLE
[opt](nereids) set Ndv=rowCount if ndv is almost equal to rowCount on ColumnStatisitics load

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/StatsCalculatorV2.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/StatsCalculatorV2.java
@@ -331,6 +331,7 @@ public class StatsCalculatorV2 extends DefaultPlanVisitor<StatsDeriveResult, Voi
         StatsDeriveResult childStats = groupExpression.childStatistics(0);
         Map<Id, ColumnStatistic> childSlotToColumnStats = childStats.getSlotIdToColumnStats();
         double resultSetCount = groupByExpressions.stream().flatMap(expr -> expr.getInputSlots().stream())
+                .map(Slot::getExprId)
                 .filter(childSlotToColumnStats::containsKey).map(childSlotToColumnStats::get).map(s -> s.ndv)
                 .reduce(1d, (a, b) -> a * b);
         if (resultSetCount <= 0) {

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/ColumnStatistic.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/ColumnStatistic.java
@@ -87,8 +87,13 @@ public class ColumnStatistic {
     public static ColumnStatistic fromResultRow(ResultRow resultRow) {
         try {
             ColumnStatisticBuilder columnStatisticBuilder = new ColumnStatisticBuilder();
-            columnStatisticBuilder.setCount(Double.parseDouble(resultRow.getColumnValue("count")));
-            columnStatisticBuilder.setNdv(Double.parseDouble(resultRow.getColumnValue("ndv")));
+            double count = Double.parseDouble(resultRow.getColumnValue("count"));
+            columnStatisticBuilder.setCount(count);
+            double ndv = Double.parseDouble(resultRow.getColumnValue("ndv"));
+            if (0.99 * count < ndv && ndv < 1.01 * count) {
+                ndv = count;
+            }
+            columnStatisticBuilder.setNdv(ndv);
             columnStatisticBuilder.setNumNulls(Double.parseDouble(resultRow.getColumnValue("null_count")));
             columnStatisticBuilder.setDataSize(Double
                     .parseDouble(resultRow.getColumnValue("data_size_in_bytes")));
@@ -110,6 +115,7 @@ public class ColumnStatistic {
             columnStatisticBuilder.setMinExpr(StatisticsUtil.readableValue(col.getType(), min));
             return columnStatisticBuilder.build();
         } catch (Exception e) {
+            e.printStackTrace();
             LOG.warn("Failed to deserialize column statistics, column not exists", e);
             return ColumnStatistic.UNKNOWN;
         }


### PR DESCRIPTION
# Proposed changes
if they are almost equal, this is caused by `ndv` algorithm. 
Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

