### PR TITLE
[opt](nereids) right deep tree penalty adjust: use right rowCount, not (left - right)

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/cost/CostCalculator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/cost/CostCalculator.java
@@ -218,7 +218,7 @@ public class CostCalculator {
                     * Math.min(probeStats.getPenalty(), buildStats.getPenalty());
             if (buildStats.getWidth() >= 2) {
                 //penalty for right deep tree
-                penalty += Math.abs(leftRowCount - rightRowCount);
+                penalty += rightRowCount;
             }
 
             if (physicalHashJoin.getJoinType().isCrossJoin()) {


### PR DESCRIPTION
# Proposed changes
in origin algorithm, the penalty is abs(leftRowCount - RightRowCount). 
this will make some right deep tree escape from penalty， because the substraction is almost  zero.
Penalty by RightRowCount can avoid this escape.

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

