### PR TITLE
[Chore](env) add error information when DORIS_GCC_HOME not set well

### DIFF
--- a/env.sh
+++ b/env.sh
@@ -166,7 +166,7 @@ if [[ -z "${DORIS_GCC_HOME}" ]]; then
     export DORIS_GCC_HOME
 fi
 
-if [[ ! -f "${DORIS_GCC_HOME}/bin/gcc" ]];then
+if [[ ! -f "${DORIS_GCC_HOME}/bin/gcc" ]]; then
     echo "Error: wrong directory DORIS_GCC_HOME=${DORIS_GCC_HOME}"
     exit 1
 fi

--- a/env.sh
+++ b/env.sh
@@ -161,8 +161,17 @@ if [[ -z "${DORIS_BIN_UTILS}" ]]; then
     export DORIS_BIN_UTILS='/usr/bin/'
 fi
 
+if [[ -z "${DORIS_GCC_HOME}" ]]; then
+    export DORIS_GCC_HOME="$(dirname "$(which gcc)")/.."
+fi
+
+if [ ! -f "${DORIS_GCC_HOME}/bin/gcc" ];then
+    echo "Error: wrong directory DORIS_GCC_HOME=${DORIS_GCC_HOME}"
+    exit 1
+fi
+
 # export CLANG COMPATIBLE FLAGS
-CLANG_COMPATIBLE_FLAGS="$(echo | "${DORIS_GCC_HOME:-"$(dirname "$(which gcc)")/.."}/bin/gcc" -Wp,-v -xc++ - -fsyntax-only 2>&1 |
+CLANG_COMPATIBLE_FLAGS="$(echo | "${DORIS_GCC_HOME}/bin/gcc" -Wp,-v -xc++ - -fsyntax-only 2>&1 |
     grep -E '^\s+/' | awk '{print "-I" $1}' | tr '\n' ' ')"
 export CLANG_COMPATIBLE_FLAGS
 

--- a/env.sh
+++ b/env.sh
@@ -162,10 +162,11 @@ if [[ -z "${DORIS_BIN_UTILS}" ]]; then
 fi
 
 if [[ -z "${DORIS_GCC_HOME}" ]]; then
-    export DORIS_GCC_HOME="$(dirname "$(which gcc)")/.."
+    DORIS_GCC_HOME="$(dirname "$(which gcc)")/.."
+    export DORIS_GCC_HOME
 fi
 
-if [ ! -f "${DORIS_GCC_HOME}/bin/gcc" ];then
+if [[ ! -f "${DORIS_GCC_HOME}/bin/gcc" ]];then
     echo "Error: wrong directory DORIS_GCC_HOME=${DORIS_GCC_HOME}"
     exit 1
 fi


### PR DESCRIPTION
# Proposed changes

add error information when DORIS_GCC_HOME not set well

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

