### PR TITLE
[fix](be-ut) AddressSanitizer detects container-overflow issues

### DIFF
--- a/be/src/exec/hash_table.cpp
+++ b/be/src/exec/hash_table.cpp
@@ -182,7 +182,7 @@ Status HashTable::resize_buckets(int64_t num_buckets) {
     }
     _mem_tracker->consume(delta_bytes);
 
-    _buckets.resize(num_buckets);
+    _buckets.resize(std::max(num_buckets, _num_buckets));
 
     // If we're doubling the number of buckets, all nodes in a particular bucket
     // either remain there, or move down to an analogous bucket in the other half.
@@ -222,6 +222,7 @@ Status HashTable::resize_buckets(int64_t num_buckets) {
         }
     }
 
+    _buckets.resize(num_buckets);
     _num_buckets = num_buckets;
     _num_buckets_till_resize = MAX_BUCKET_OCCUPANCY_FRACTION * _num_buckets;
     return Status::OK();

--- a/be/src/exprs/expr.cpp
+++ b/be/src/exprs/expr.cpp
@@ -472,8 +472,8 @@ int Expr::compute_results_layout(const std::vector<Expr*>& exprs, std::vector<in
     int current_alignment = data[0].byte_size;
     int byte_offset = 0;
 
-    offsets->resize(exprs.size());
     offsets->clear();
+    offsets->resize(exprs.size());
     *var_result_begin = -1;
 
     for (int i = 0; i < data.size(); ++i) {

--- a/be/src/olap/rowset/segment_v2/segment_iterator.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.cpp
@@ -165,8 +165,8 @@ Status SegmentIterator::init(const StorageReadOptions& opts) {
     if (!opts.column_predicates.empty()) {
         _col_predicates = opts.column_predicates;
     }
-    // Read options will not change, so that just reserve here
-    _block_rowids.reserve(_opts.block_row_max);
+    // Read options will not change, so that just resize here
+    _block_rowids.resize(_opts.block_row_max);
     return Status::OK();
 }
 
@@ -1144,7 +1144,7 @@ Status SegmentIterator::next_batch(vectorized::Block* block) {
         selected_size = _evaluate_short_circuit_predicate(sel_rowid_idx, selected_size);
 
         if (UNLIKELY(_opts.record_rowids)) {
-            _sel_rowid_idx.reserve(selected_size);
+            _sel_rowid_idx.resize(selected_size);
             _selected_size = selected_size;
             for (auto i = 0; i < _selected_size; i++) {
                 _sel_rowid_idx[i] = sel_rowid_idx[i];

--- a/be/src/runtime/thread_context.h
+++ b/be/src/runtime/thread_context.h
@@ -386,7 +386,6 @@ private:
 #define TRY_CONSUME_MEM_TRACKER(size) (void)0
 #define RELEASE_MEM_TRACKER(size) (void)0
 #define TRY_RELEASE_MEM_TRACKER(size) (void)0
-#define RETURN_IF_CATCH_BAD_ALLOC(stmt) \
-    { stmt; }
+#define RETURN_IF_CATCH_BAD_ALLOC(stmt) (stmt)
 #endif
 } // namespace doris

--- a/be/src/util/frame_of_reference_coding.cpp
+++ b/be/src/util/frame_of_reference_coding.cpp
@@ -259,7 +259,7 @@ bool ForDecoder<T>::init() {
         }
     }
 
-    _out_buffer.reserve(_max_frame_size);
+    _out_buffer.resize(_max_frame_size);
     _parsed = true;
 
     return true;


### PR DESCRIPTION
# Proposed changes

Issue Number: close #14251

## Problem summary

A typical example for the `container-overflow` issue.
```cpp
  std::vector<int> v(4);
  v.reserve(8);
  int *p = v.data();
  p[6] = 0; // BOOM
```

More details can be referenced to [AddressSanitizerContainerOverflow](https://github.com/google/sanitizers/wiki/AddressSanitizerContainerOverflow).

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

