### PR TITLE
[improvement](load) add a log when close OlapTableSink with error

### DIFF
--- a/be/src/exec/tablet_sink.cpp
+++ b/be/src/exec/tablet_sink.cpp
@@ -1185,6 +1185,9 @@ Status OlapTableSink::close(RuntimeState* state, Status close_status) {
                 ch->cancel(status.get_error_msg());
             });
         }
+        LOG(INFO) << "finished to close olap table sink. load_id=" << print_id(_load_id)
+                  << ", txn_id=" << _txn_id
+                  << ", canceled all node channels due to error: " << status.get_error_msg();
     }
 
     // Sender join() must put after node channels mark_close/cancel.


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

We have log when close OlapTableSink success, but don't log when status not ok

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

