### PR TITLE
[feature](Nereids) support datev2 and datetimev2 type

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rewrite/ExpressionOptimization.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rewrite/ExpressionOptimization.java
@@ -19,6 +19,7 @@ package org.apache.doris.nereids.rules.expression.rewrite;
 
 import org.apache.doris.nereids.rules.expression.rewrite.rules.DistinctPredicatesRule;
 import org.apache.doris.nereids.rules.expression.rewrite.rules.ExtractCommonFactorRule;
+import org.apache.doris.nereids.rules.expression.rewrite.rules.SimplifyComparisonPredicate;
 
 import com.google.common.collect.ImmutableList;
 
@@ -30,7 +31,8 @@ import java.util.List;
 public class ExpressionOptimization extends ExpressionRewrite {
     public static final List<ExpressionRewriteRule> OPTIMIZE_REWRITE_RULES = ImmutableList.of(
             ExtractCommonFactorRule.INSTANCE,
-            DistinctPredicatesRule.INSTANCE);
+            DistinctPredicatesRule.INSTANCE,
+            SimplifyComparisonPredicate.INSTANCE);
     private static final ExpressionRuleExecutor EXECUTOR = new ExpressionRuleExecutor(OPTIMIZE_REWRITE_RULES);
 
     public ExpressionOptimization() {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rewrite/rules/SimplifyComparisonPredicate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rewrite/rules/SimplifyComparisonPredicate.java
@@ -1,0 +1,140 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.rules.expression.rewrite.rules;
+
+import org.apache.doris.nereids.rules.expression.rewrite.AbstractExpressionRewriteRule;
+import org.apache.doris.nereids.rules.expression.rewrite.ExpressionRewriteContext;
+import org.apache.doris.nereids.trees.expressions.Cast;
+import org.apache.doris.nereids.trees.expressions.ComparisonPredicate;
+import org.apache.doris.nereids.trees.expressions.EqualTo;
+import org.apache.doris.nereids.trees.expressions.Expression;
+import org.apache.doris.nereids.trees.expressions.GreaterThan;
+import org.apache.doris.nereids.trees.expressions.GreaterThanEqual;
+import org.apache.doris.nereids.trees.expressions.LessThan;
+import org.apache.doris.nereids.trees.expressions.LessThanEqual;
+import org.apache.doris.nereids.trees.expressions.literal.DateLiteral;
+import org.apache.doris.nereids.trees.expressions.literal.DateTimeLiteral;
+import org.apache.doris.nereids.trees.expressions.literal.DateTimeV2Literal;
+import org.apache.doris.nereids.trees.expressions.literal.DateV2Literal;
+import org.apache.doris.nereids.types.DateTimeType;
+import org.apache.doris.nereids.types.DateType;
+import org.apache.doris.nereids.types.DateV2Type;
+import org.apache.doris.nereids.types.coercion.DateLikeType;
+
+/**
+ * simplify comparison
+ * such as: cast(c1 as DateV2) >= DateV2Literal --> c1 >= DateLiteral
+ */
+public class SimplifyComparisonPredicate extends AbstractExpressionRewriteRule {
+
+    public static SimplifyComparisonPredicate INSTANCE = new SimplifyComparisonPredicate();
+
+    enum AdjustType {
+        LOWER,
+        UPPER,
+        NONE
+    }
+
+    @Override
+    public Expression visitComparisonPredicate(ComparisonPredicate cp, ExpressionRewriteContext context) {
+        Expression left = rewrite(cp.left(), context);
+        Expression right = rewrite(cp.right(), context);
+
+        // date like type
+        if (left.getDataType() instanceof DateLikeType && right.getDataType() instanceof DateLikeType) {
+            return processDateLikeTypeCoercion(cp, left, right);
+        }
+
+        if (left != cp.left() || right != cp.right()) {
+            return cp.withChildren(left, right);
+        } else {
+            return cp;
+        }
+    }
+
+    private Expression processDateLikeTypeCoercion(ComparisonPredicate cp, Expression left, Expression right) {
+        if (left instanceof DateLiteral) {
+            cp = cp.commute();
+            Expression temp = left;
+            left = right;
+            right = temp;
+        }
+
+        if (left instanceof Cast && right instanceof DateLiteral) {
+            Cast cast = (Cast) left;
+            if (cast.child().getDataType() instanceof DateTimeType) {
+                if (right instanceof DateTimeV2Literal) {
+                    left = cast.child();
+                    right = migrateToDateTime((DateTimeV2Literal) right);
+                }
+            }
+            // datetime to datev2
+            if (cast.child().getDataType() instanceof DateType || cast.child().getDataType() instanceof DateV2Type) {
+                if (right instanceof DateTimeLiteral) {
+                    if (cannotAdjust((DateTimeLiteral) right, cp)) {
+                        return cp;
+                    }
+                    AdjustType type = AdjustType.NONE;
+                    if (cp instanceof GreaterThanEqual || cp instanceof LessThan) {
+                        type = AdjustType.UPPER;
+                    } else if (cp instanceof GreaterThan || cp instanceof LessThanEqual) {
+                        type = AdjustType.LOWER;
+                    }
+                    right = migrateToDateV2((DateTimeLiteral) right, type);
+                    if (cast.child().getDataType() instanceof DateV2Type) {
+                        left = cast.child();
+                    }
+                }
+            }
+
+            // datev2 to date
+            if (cast.child().getDataType() instanceof DateType) {
+                if (right instanceof DateV2Literal) {
+                    left = cast.child();
+                    right = migrateToDate((DateV2Literal) right);
+                }
+            }
+        }
+
+        if (left != cp.left() || right != cp.right()) {
+            return cp.withChildren(left, right);
+        } else {
+            return cp;
+        }
+    }
+
+    private Expression migrateToDateTime(DateTimeV2Literal l) {
+        return new DateTimeLiteral(l.getYear(), l.getMonth(), l.getDay(), l.getHour(), l.getMinute(), l.getSecond());
+    }
+
+    private boolean cannotAdjust(DateTimeLiteral l, ComparisonPredicate cp) {
+        return cp instanceof EqualTo && (l.getHour() != 0 || l.getMinute() != 0 || l.getSecond() != 0);
+    }
+
+    private Expression migrateToDateV2(DateTimeLiteral l, AdjustType type) {
+        DateV2Literal d = new DateV2Literal(l.getYear(), l.getMonth(), l.getDay());
+        if (type == AdjustType.UPPER) {
+            d = d.plusDays(1);
+        }
+        return d;
+    }
+
+    private Expression migrateToDate(DateV2Literal l) {
+        return new DateLiteral(l.getYear(), l.getMonth(), l.getDay());
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/DateLiteral.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/DateLiteral.java
@@ -18,11 +18,12 @@
 package org.apache.doris.nereids.trees.expressions.literal;
 
 import org.apache.doris.analysis.LiteralExpr;
-import org.apache.doris.catalog.ScalarType;
+import org.apache.doris.catalog.Type;
 import org.apache.doris.nereids.exceptions.AnalysisException;
 import org.apache.doris.nereids.trees.expressions.visitor.ExpressionVisitor;
 import org.apache.doris.nereids.types.DataType;
 import org.apache.doris.nereids.types.DateType;
+import org.apache.doris.nereids.types.coercion.DateLikeType;
 import org.apache.doris.nereids.util.DateUtils;
 
 import org.apache.logging.log4j.LogManager;
@@ -35,13 +36,12 @@ import org.joda.time.format.DateTimeFormatter;
  */
 public class DateLiteral extends Literal {
 
+    protected static DateTimeFormatter DATE_FORMATTER = null;
+    protected static DateTimeFormatter DATE_FORMATTER_TWO_DIGIT = null;
+    protected static DateTimeFormatter DATEKEY_FORMATTER = null;
+
     private static final Logger LOG = LogManager.getLogger(DateLiteral.class);
-
     private static final int DATEKEY_LENGTH = 8;
-
-    private static DateTimeFormatter DATE_FORMATTER = null;
-    private static DateTimeFormatter DATE_FORMATTER_TWO_DIGIT = null;
-    private static DateTimeFormatter DATEKEY_FORMATTER = null;
 
     protected long year;
     protected long month;
@@ -59,7 +59,11 @@ public class DateLiteral extends Literal {
     }
 
     public DateLiteral(String s) throws AnalysisException {
-        super(DataType.fromCatalogType(ScalarType.createDateType()));
+        this(DateType.INSTANCE, s);
+    }
+
+    protected DateLiteral(DateLikeType dataType, String s) throws AnalysisException {
+        super(dataType);
         init(s);
     }
 
@@ -71,7 +75,14 @@ public class DateLiteral extends Literal {
      * C'tor for date type.
      */
     public DateLiteral(long year, long month, long day) {
-        super(DateType.INSTANCE);
+        this(DateType.INSTANCE, year, month, day);
+    }
+
+    /**
+     * C'tor for date type.
+     */
+    public DateLiteral(DateLikeType dataType, long year, long month, long day) {
+        super(dataType);
         this.year = year;
         this.month = month;
         this.day = day;
@@ -87,7 +98,7 @@ public class DateLiteral extends Literal {
         this.day = other.day;
     }
 
-    private void init(String s) throws AnalysisException {
+    protected void init(String s) throws AnalysisException {
         try {
             LocalDateTime dateTime;
             if (s.split("-")[0].length() == 2) {
@@ -106,23 +117,8 @@ public class DateLiteral extends Literal {
     }
 
     @Override
-    public <R, C> R accept(ExpressionVisitor<R, C> visitor, C context) {
-        return visitor.visitDateLiteral(this, context);
-    }
-
-    @Override
     public Long getValue() {
         return (year * 10000 + month * 100 + day) * 1000000L;
-    }
-
-    @Override
-    public String toSql() {
-        return toString();
-    }
-
-    @Override
-    public String toString() {
-        return String.format("%04d-%02d-%02d", year, month, day);
     }
 
     @Override
@@ -131,8 +127,23 @@ public class DateLiteral extends Literal {
     }
 
     @Override
+    public String toSql() {
+        return toString();
+    }
+
+    @Override
+    public <R, C> R accept(ExpressionVisitor<R, C> visitor, C context) {
+        return visitor.visitDateLiteral(this, context);
+    }
+
+    @Override
+    public String toString() {
+        return String.format("%04d-%02d-%02d", year, month, day);
+    }
+
+    @Override
     public LiteralExpr toLegacyLiteral() {
-        return new org.apache.doris.analysis.DateLiteral(year, month, day);
+        return new org.apache.doris.analysis.DateLiteral(year, month, day, Type.DATE);
     }
 
     public long getYear() {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/DateTimeV2Literal.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/DateTimeV2Literal.java
@@ -1,0 +1,89 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.trees.expressions.literal;
+
+import org.apache.doris.nereids.exceptions.UnboundException;
+import org.apache.doris.nereids.types.DateTimeV2Type;
+
+import org.joda.time.LocalDateTime;
+
+/**
+ * date time v2 literal for nereids
+ */
+public class DateTimeV2Literal extends DateTimeLiteral {
+
+    public DateTimeV2Literal(String s) {
+        super(DateTimeV2Type.INSTANCE, s);
+    }
+
+    public DateTimeV2Literal(long year, long month, long day, long hour, long minute, long second) {
+        super(DateTimeV2Type.INSTANCE, year, month, day, hour, minute, second);
+    }
+
+    public DateTimeV2Literal(DateTimeV2Type dataType,
+            long year, long month, long day, long hour, long minute, long second) {
+        super(dataType, year, month, day, hour, minute, second);
+    }
+
+    @Override
+    public DateTimeV2Type getDataType() throws UnboundException {
+        return (DateTimeV2Type) super.getDataType();
+    }
+
+    @Override
+    public DateTimeV2Literal plusYears(int years) {
+        LocalDateTime d = LocalDateTime.parse(getStringValue(), DATE_TIME_FORMATTER).plusYears(years);
+        return new DateTimeV2Literal(this.getDataType(), d.getYear(), d.getMonthOfYear(), d.getDayOfMonth(),
+                d.getHourOfDay(), d.getMinuteOfHour(), d.getSecondOfMinute());
+    }
+
+    @Override
+    public DateTimeV2Literal plusMonths(int months) {
+        LocalDateTime d = LocalDateTime.parse(getStringValue(), DATE_TIME_FORMATTER).plusMonths(months);
+        return new DateTimeV2Literal(this.getDataType(), d.getYear(), d.getMonthOfYear(), d.getDayOfMonth(),
+                d.getHourOfDay(), d.getMinuteOfHour(), d.getSecondOfMinute());
+    }
+
+    @Override
+    public DateTimeLiteral plusDays(int days) {
+        LocalDateTime d = LocalDateTime.parse(getStringValue(), DATE_TIME_FORMATTER).plusDays(days);
+        return new DateTimeV2Literal(this.getDataType(), d.getYear(), d.getMonthOfYear(), d.getDayOfMonth(),
+                d.getHourOfDay(), d.getMinuteOfHour(), d.getSecondOfMinute());
+    }
+
+    @Override
+    public DateTimeV2Literal plusHours(int hours) {
+        LocalDateTime d = LocalDateTime.parse(getStringValue(), DATE_TIME_FORMATTER).plusHours(hours);
+        return new DateTimeV2Literal(this.getDataType(), d.getYear(), d.getMonthOfYear(), d.getDayOfMonth(),
+                d.getHourOfDay(), d.getMinuteOfHour(), d.getSecondOfMinute());
+    }
+
+    @Override
+    public DateTimeV2Literal plusMinutes(int minutes) {
+        LocalDateTime d = LocalDateTime.parse(getStringValue(), DATE_TIME_FORMATTER).plusMinutes(minutes);
+        return new DateTimeV2Literal(this.getDataType(), d.getYear(), d.getMonthOfYear(), d.getDayOfMonth(),
+                d.getHourOfDay(), d.getMinuteOfHour(), d.getSecondOfMinute());
+    }
+
+    @Override
+    public DateTimeV2Literal plusSeconds(int seconds) {
+        LocalDateTime d = LocalDateTime.parse(getStringValue(), DATE_TIME_FORMATTER).plusSeconds(seconds);
+        return new DateTimeV2Literal(this.getDataType(), d.getYear(), d.getMonthOfYear(), d.getDayOfMonth(),
+                d.getHourOfDay(), d.getMinuteOfHour(), d.getSecondOfMinute());
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/DateV2Literal.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/DateV2Literal.java
@@ -1,0 +1,49 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.trees.expressions.literal;
+
+import org.apache.doris.analysis.LiteralExpr;
+import org.apache.doris.catalog.Type;
+import org.apache.doris.nereids.exceptions.AnalysisException;
+import org.apache.doris.nereids.types.DateV2Type;
+
+import org.joda.time.LocalDateTime;
+
+/**
+ * date v2 literal for nereids
+ */
+public class DateV2Literal extends DateLiteral {
+
+    public DateV2Literal(String s) throws AnalysisException {
+        super(DateV2Type.INSTANCE, s);
+    }
+
+    public DateV2Literal(long year, long month, long day) {
+        super(DateV2Type.INSTANCE, year, month, day);
+    }
+
+    @Override
+    public LiteralExpr toLegacyLiteral() {
+        return new org.apache.doris.analysis.DateLiteral(year, month, day, Type.DATEV2);
+    }
+
+    public DateV2Literal plusDays(int days) {
+        LocalDateTime dateTime = LocalDateTime.parse(getStringValue(), DATE_FORMATTER).plusDays(days);
+        return new DateV2Literal(dateTime.getYear(), dateTime.getMonthOfYear(), dateTime.getDayOfMonth());
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/types/DateTimeType.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/types/DateTimeType.java
@@ -18,12 +18,12 @@
 package org.apache.doris.nereids.types;
 
 import org.apache.doris.catalog.Type;
-import org.apache.doris.nereids.types.coercion.PrimitiveType;
+import org.apache.doris.nereids.types.coercion.DateLikeType;
 
 /**
  * Datetime type in Nereids.
  */
-public class DateTimeType extends PrimitiveType {
+public class DateTimeType extends DateLikeType {
 
     public static final DateTimeType INSTANCE = new DateTimeType();
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/types/DateTimeV2Type.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/types/DateTimeV2Type.java
@@ -19,7 +19,7 @@ package org.apache.doris.nereids.types;
 
 import org.apache.doris.catalog.ScalarType;
 import org.apache.doris.catalog.Type;
-import org.apache.doris.nereids.types.coercion.PrimitiveType;
+import org.apache.doris.nereids.types.coercion.DateLikeType;
 
 import com.google.common.base.Preconditions;
 
@@ -28,7 +28,7 @@ import java.util.Objects;
 /**
  * Datetime type in Nereids.
  */
-public class DateTimeV2Type extends PrimitiveType {
+public class DateTimeV2Type extends DateLikeType {
     public static final int MAX_SCALE = 6;
     public static final DateTimeV2Type INSTANCE = new DateTimeV2Type(0);
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/types/DateType.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/types/DateType.java
@@ -18,12 +18,12 @@
 package org.apache.doris.nereids.types;
 
 import org.apache.doris.catalog.Type;
-import org.apache.doris.nereids.types.coercion.PrimitiveType;
+import org.apache.doris.nereids.types.coercion.DateLikeType;
 
 /**
  * Date type in Nereids.
  */
-public class DateType extends PrimitiveType {
+public class DateType extends DateLikeType {
 
     public static final DateType INSTANCE = new DateType();
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/types/coercion/DateLikeType.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/types/coercion/DateLikeType.java
@@ -15,31 +15,10 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package org.apache.doris.nereids.types;
-
-import org.apache.doris.catalog.Type;
-import org.apache.doris.nereids.types.coercion.DateLikeType;
+package org.apache.doris.nereids.types.coercion;
 
 /**
- * Date type in Nereids.
+ * date like type.
  */
-public class DateV2Type extends DateLikeType {
-
-    public static final DateV2Type INSTANCE = new DateV2Type();
-
-    private static final int WIDTH = 4;
-
-    private DateV2Type() {
-    }
-
-    @Override
-    public Type toCatalogDataType() {
-        return Type.DATEV2;
-    }
-
-    @Override
-    public int width() {
-        return WIDTH;
-    }
+public abstract class DateLikeType extends PrimitiveType {
 }
-

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/util/TypeCoercionUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/util/TypeCoercionUtils.java
@@ -26,6 +26,8 @@ import org.apache.doris.nereids.types.BigIntType;
 import org.apache.doris.nereids.types.BooleanType;
 import org.apache.doris.nereids.types.DataType;
 import org.apache.doris.nereids.types.DateTimeType;
+import org.apache.doris.nereids.types.DateTimeV2Type;
+import org.apache.doris.nereids.types.DateV2Type;
 import org.apache.doris.nereids.types.DecimalV2Type;
 import org.apache.doris.nereids.types.DoubleType;
 import org.apache.doris.nereids.types.FloatType;
@@ -37,6 +39,7 @@ import org.apache.doris.nereids.types.StringType;
 import org.apache.doris.nereids.types.TinyIntType;
 import org.apache.doris.nereids.types.coercion.AbstractDataType;
 import org.apache.doris.nereids.types.coercion.CharacterType;
+import org.apache.doris.nereids.types.coercion.DateLikeType;
 import org.apache.doris.nereids.types.coercion.FractionalType;
 import org.apache.doris.nereids.types.coercion.IntegralType;
 import org.apache.doris.nereids.types.coercion.NumericType;
@@ -207,6 +210,22 @@ public class TypeCoercionUtils {
             tightestCommonType = DecimalV2Type.widerDecimalV2Type((DecimalV2Type) left, DecimalV2Type.forType(right));
         } else if (left instanceof IntegralType && right instanceof DecimalV2Type) {
             tightestCommonType = DecimalV2Type.widerDecimalV2Type((DecimalV2Type) right, DecimalV2Type.forType(left));
+        } else if (left instanceof DateLikeType && right instanceof DateLikeType) {
+            if (left instanceof DateTimeV2Type && right instanceof DateTimeV2Type) {
+                if (((DateTimeV2Type) left).getScale() > ((DateTimeV2Type) right).getScale()) {
+                    tightestCommonType = left;
+                } else {
+                    tightestCommonType = right;
+                }
+            } else if (left instanceof DateTimeV2Type) {
+                tightestCommonType = left;
+            } else if (right instanceof DateTimeV2Type) {
+                tightestCommonType = right;
+            } else if (left instanceof DateTimeType || right instanceof DateTimeType) {
+                tightestCommonType = DateTimeType.INSTANCE;
+            } else if (left instanceof DateV2Type || right instanceof DateV2Type) {
+                tightestCommonType = DateV2Type.INSTANCE;
+            }
         }
         return Optional.ofNullable(tightestCommonType);
     }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/rewrite/ExpressionRewriteTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/rewrite/ExpressionRewriteTest.java
@@ -23,16 +23,26 @@ import org.apache.doris.nereids.rules.expression.rewrite.rules.ExtractCommonFact
 import org.apache.doris.nereids.rules.expression.rewrite.rules.InPredicateToEqualToRule;
 import org.apache.doris.nereids.rules.expression.rewrite.rules.NormalizeBinaryPredicatesRule;
 import org.apache.doris.nereids.rules.expression.rewrite.rules.SimplifyCastRule;
+import org.apache.doris.nereids.rules.expression.rewrite.rules.SimplifyComparisonPredicate;
 import org.apache.doris.nereids.rules.expression.rewrite.rules.SimplifyNotExprRule;
 import org.apache.doris.nereids.trees.expressions.Cast;
+import org.apache.doris.nereids.trees.expressions.EqualTo;
+import org.apache.doris.nereids.trees.expressions.Expression;
+import org.apache.doris.nereids.trees.expressions.GreaterThan;
+import org.apache.doris.nereids.trees.expressions.LessThan;
 import org.apache.doris.nereids.trees.expressions.literal.BigIntLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.CharLiteral;
+import org.apache.doris.nereids.trees.expressions.literal.DateLiteral;
+import org.apache.doris.nereids.trees.expressions.literal.DateTimeLiteral;
+import org.apache.doris.nereids.trees.expressions.literal.DateTimeV2Literal;
+import org.apache.doris.nereids.trees.expressions.literal.DateV2Literal;
 import org.apache.doris.nereids.trees.expressions.literal.DecimalLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.IntegerLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.SmallIntLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.StringLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.TinyIntLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.VarcharLiteral;
+import org.apache.doris.nereids.types.DateTimeV2Type;
 import org.apache.doris.nereids.types.DecimalV2Type;
 import org.apache.doris.nereids.types.StringType;
 import org.apache.doris.nereids.types.VarcharType;
@@ -211,5 +221,71 @@ public class ExpressionRewriteTest extends ExpressionRewriteTestHelper {
                 new DecimalLiteral(new BigDecimal(1)));
         assertRewrite(new Cast(new BigIntLiteral(1L), DecimalV2Type.createDecimalV2Type(15, 9)),
                 new DecimalLiteral(new BigDecimal(1)));
+    }
+
+    @Test
+    public void testSimplifyComparisonPredicateRule() {
+        executor = new ExpressionRuleExecutor(ImmutableList.of(SimplifyComparisonPredicate.INSTANCE));
+
+        Expression dtv2 = new DateTimeV2Literal(1, 1, 1, 1, 1, 1);
+        Expression dt = new DateTimeLiteral(1, 1, 1, 1, 1, 1);
+        Expression dv2 = new DateV2Literal(1, 1, 1);
+        Expression dv2PlusOne = new DateV2Literal(1, 1, 2);
+        Expression d = new DateLiteral(1, 1, 1);
+        Expression dPlusOne = new DateLiteral(1, 1, 2);
+
+        // DateTimeV2 -> DateTime
+        assertRewrite(
+                new GreaterThan(new Cast(dt, DateTimeV2Type.INSTANCE), dtv2),
+                new GreaterThan(dt, dt));
+
+        // DateTimeV2 -> DateV2
+        assertRewrite(
+                new GreaterThan(new Cast(dv2, DateTimeV2Type.INSTANCE), dtv2),
+                new GreaterThan(dv2, dv2));
+        assertRewrite(
+                new LessThan(new Cast(dv2, DateTimeV2Type.INSTANCE), dtv2),
+                new LessThan(dv2, dv2PlusOne));
+        assertRewrite(
+                new EqualTo(new Cast(dv2, DateTimeV2Type.INSTANCE), dtv2),
+                new EqualTo(new Cast(dv2, DateTimeV2Type.INSTANCE), dtv2));
+
+        // DateTime -> DateV2
+        assertRewrite(
+                new GreaterThan(new Cast(dv2, DateTimeV2Type.INSTANCE), dt),
+                new GreaterThan(dv2, dv2));
+        assertRewrite(
+                new LessThan(new Cast(dv2, DateTimeV2Type.INSTANCE), dt),
+                new LessThan(dv2, dv2PlusOne));
+        assertRewrite(
+                new EqualTo(new Cast(dv2, DateTimeV2Type.INSTANCE), dt),
+                new EqualTo(new Cast(dv2, DateTimeV2Type.INSTANCE), dt));
+
+        // DateTimeV2 -> Date
+        assertRewrite(
+                new GreaterThan(new Cast(d, DateTimeV2Type.INSTANCE), dtv2),
+                new GreaterThan(d, d));
+        assertRewrite(
+                new LessThan(new Cast(d, DateTimeV2Type.INSTANCE), dtv2),
+                new LessThan(d, dPlusOne));
+        assertRewrite(
+                new EqualTo(new Cast(d, DateTimeV2Type.INSTANCE), dtv2),
+                new EqualTo(new Cast(d, DateTimeV2Type.INSTANCE), dtv2));
+
+        // DateTime -> Date
+        assertRewrite(
+                new GreaterThan(new Cast(d, DateTimeV2Type.INSTANCE), dt),
+                new GreaterThan(d, d));
+        assertRewrite(
+                new LessThan(new Cast(d, DateTimeV2Type.INSTANCE), dt),
+                new LessThan(d, dPlusOne));
+        assertRewrite(
+                new EqualTo(new Cast(d, DateTimeV2Type.INSTANCE), dt),
+                new EqualTo(new Cast(d, DateTimeV2Type.INSTANCE), dt));
+
+        // DateV2 -> Date
+        assertRewrite(
+                new GreaterThan(new Cast(d, DateTimeV2Type.INSTANCE), dv2),
+                new GreaterThan(d, d));
     }
 }


### PR DESCRIPTION
# Proposed changes

1. split DateLiteral and DateTimeLiteral into V1 and V2
2. add a type coercion about DateLikeType: DateTimeV2Type > DateTimeType > DateV2Type > DateType
3. add a rule to remove unnecessary CAST on DateLikeType in ComparisonPredicate

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
4. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
5. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
6. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
7. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

