### PR TITLE
[enhancement](snapshot) add missed version log when make_snapshot in engine clone task

### DIFF
--- a/be/src/olap/olap_common.h
+++ b/be/src/olap/olap_common.h
@@ -233,6 +233,13 @@ inline std::ostream& operator<<(std::ostream& os, const Version& version) {
     return os << version.to_string();
 }
 
+inline std::ostream& operator<<(std::ostream& os, const Versions& versions) {
+    for (auto& version : versions) {
+        os << version;
+    }
+    return os;
+}
+
 // used for hash-struct of hash_map<Version, Rowset*>.
 struct HashOfVersion {
     size_t operator()(const Version& version) const {

--- a/be/src/olap/task/engine_clone_task.cpp
+++ b/be/src/olap/task/engine_clone_task.cpp
@@ -229,13 +229,15 @@ Status EngineCloneTask::_make_and_download_snapshots(DataDir& data_dir,
                     .tag("port", src.be_port)
                     .tag("tablet", _clone_req.tablet_id)
                     .tag("snapshot_path", *snapshot_path)
-                    .tag("signature", _signature);
+                    .tag("signature", _signature)
+                    .tag("missed_versions", missed_versions);
         } else {
             LOG_WARNING("failed to make snapshot in remote BE")
                     .tag("host", src.host)
                     .tag("port", src.be_port)
                     .tag("tablet", _clone_req.tablet_id)
                     .tag("signature", _signature)
+                    .tag("missed_versions", missed_versions)
                     .error(status);
             continue;
         }

--- a/be/src/olap/task/engine_clone_task.cpp
+++ b/be/src/olap/task/engine_clone_task.cpp
@@ -77,6 +77,8 @@ Status EngineCloneTask::_do_clone() {
     TabletSharedPtr tablet =
             StorageEngine::instance()->tablet_manager()->get_tablet(_clone_req.tablet_id);
     bool is_new_tablet = tablet == nullptr;
+    // try to incremental clone
+    std::vector<Version> missed_versions;
     // try to repair a tablet with missing version
     if (tablet != nullptr) {
         std::shared_lock migration_rlock(tablet->get_migration_lock(), std::try_to_lock);
@@ -88,8 +90,6 @@ Status EngineCloneTask::_do_clone() {
         auto local_data_path = fmt::format("{}/{}", tablet->tablet_path(), CLONE_PREFIX);
         bool allow_incremental_clone = false;
 
-        // try to incremental clone
-        std::vector<Version> missed_versions;
         tablet->calc_missed_versions(_clone_req.committed_version, &missed_versions);
 
         // if missed version size is 0, then it is useless to clone from remote be, it means local data is
@@ -110,7 +110,7 @@ Status EngineCloneTask::_do_clone() {
         // if tablet on src backend does not contains missing version, it will download all versions,
         // and set allow_incremental_clone to false
         RETURN_IF_ERROR(_make_and_download_snapshots(*(tablet->data_dir()), local_data_path,
-                                                     &src_host, &src_file_path, &missed_versions,
+                                                     &src_host, &src_file_path, missed_versions,
                                                      &allow_incremental_clone));
 
         RETURN_IF_ERROR(_finish_clone(tablet.get(), local_data_path, _clone_req.committed_version,
@@ -140,7 +140,7 @@ Status EngineCloneTask::_do_clone() {
 
         bool allow_incremental_clone = false;
         status = _make_and_download_snapshots(*store, tablet_dir, &src_host, &src_file_path,
-                                              nullptr, &allow_incremental_clone);
+                                              missed_versions, &allow_incremental_clone);
         if (!status.ok()) {
             return status;
         }
@@ -206,7 +206,7 @@ Status EngineCloneTask::_set_tablet_info(bool is_new_tablet) {
 Status EngineCloneTask::_make_and_download_snapshots(DataDir& data_dir,
                                                      const std::string& local_data_path,
                                                      TBackend* src_host, string* snapshot_path,
-                                                     const std::vector<Version>* missed_versions,
+                                                     const std::vector<Version>& missed_versions,
                                                      bool* allow_incremental_clone) {
     Status status = Status::OK();
 
@@ -285,19 +285,17 @@ Status EngineCloneTask::_make_and_download_snapshots(DataDir& data_dir,
 
 Status EngineCloneTask::_make_snapshot(const std::string& ip, int port, TTableId tablet_id,
                                        TSchemaHash schema_hash, int timeout_s,
-                                       const std::vector<Version>* missed_versions,
+                                       const std::vector<Version>& missed_versions,
                                        std::string* snapshot_path, bool* allow_incremental_clone) {
     TSnapshotRequest request;
     request.__set_tablet_id(tablet_id);
     request.__set_schema_hash(schema_hash);
     request.__set_preferred_snapshot_version(g_Types_constants.TPREFER_SNAPSHOT_REQ_VERSION);
-    if (missed_versions != nullptr) {
-        // TODO: missing version composed of singleton delta.
-        // if not, this place should be rewrote.
-        request.__isset.missing_version = true;
-        for (auto& version : *missed_versions) {
-            request.missing_version.push_back(version.first);
-        }
+    // TODO: missing version composed of singleton delta.
+    // if not, this place should be rewrote.
+    request.__isset.missing_version = (!missed_versions.empty());
+    for (auto& version : missed_versions) {
+        request.missing_version.push_back(version.first);
     }
     if (timeout_s > 0) {
         request.__set_timeout(timeout_s);

--- a/be/src/olap/task/engine_clone_task.h
+++ b/be/src/olap/task/engine_clone_task.h
@@ -52,7 +52,7 @@ private:
 
     Status _make_and_download_snapshots(DataDir& data_dir, const std::string& local_data_path,
                                         TBackend* src_host, string* src_file_path,
-                                        const vector<Version>* missing_versions,
+                                        const vector<Version>& missing_versions,
                                         bool* allow_incremental_clone);
 
     Status _set_tablet_info(bool is_new_tablet);
@@ -63,7 +63,7 @@ private:
 
     Status _make_snapshot(const std::string& ip, int port, TTableId tablet_id,
                           TSchemaHash schema_hash, int timeout_s,
-                          const std::vector<Version>* missed_versions, std::string* snapshot_path,
+                          const std::vector<Version>& missing_versions, std::string* snapshot_path,
                           bool* allow_incremental_clone);
 
     Status _release_snapshot(const std::string& ip, int port, const std::string& snapshot_path);

--- a/fe/fe-core/src/main/java/org/apache/doris/PaloFe.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/PaloFe.java
@@ -39,13 +39,19 @@ import org.apache.doris.service.FrontendOptions;
 
 import com.google.common.base.Charsets;
 import com.google.common.base.Strings;
+import io.grpc.netty.shaded.io.netty.util.internal.logging.InternalLoggerFactory;
+import io.grpc.netty.shaded.io.netty.util.internal.logging.Log4JLoggerFactory;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
+import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.config.Configuration;
+import org.apache.logging.log4j.core.config.LoggerConfig;
 
 import java.io.File;
 import java.io.IOException;
@@ -56,6 +62,15 @@ import java.nio.channels.OverlappingFileLockException;
 
 public class PaloFe {
     private static final Logger LOG = LogManager.getLogger(PaloFe.class);
+
+    static {
+        InternalLoggerFactory.setDefaultFactory(Log4JLoggerFactory.INSTANCE);
+        LoggerContext ctx = (LoggerContext) LogManager.getContext(false);
+        Configuration config = ctx.getConfiguration();
+        LoggerConfig loggerConfig = config.getLoggerConfig("io.grpc.netty.shaded.io.netty");
+        loggerConfig.setLevel(Level.INFO);
+        ctx.updateLoggers();
+    }
 
     public static final String DORIS_HOME_DIR = System.getenv("DORIS_HOME");
     public static final String PID_DIR = System.getenv("PID_DIR");

--- a/fe/fe-core/src/main/java/org/apache/doris/PaloFe.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/PaloFe.java
@@ -39,19 +39,13 @@ import org.apache.doris.service.FrontendOptions;
 
 import com.google.common.base.Charsets;
 import com.google.common.base.Strings;
-import io.grpc.netty.shaded.io.netty.util.internal.logging.InternalLoggerFactory;
-import io.grpc.netty.shaded.io.netty.util.internal.logging.Log4JLoggerFactory;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
-import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.core.LoggerContext;
-import org.apache.logging.log4j.core.config.Configuration;
-import org.apache.logging.log4j.core.config.LoggerConfig;
 
 import java.io.File;
 import java.io.IOException;
@@ -62,15 +56,6 @@ import java.nio.channels.OverlappingFileLockException;
 
 public class PaloFe {
     private static final Logger LOG = LogManager.getLogger(PaloFe.class);
-
-    static {
-        InternalLoggerFactory.setDefaultFactory(Log4JLoggerFactory.INSTANCE);
-        LoggerContext ctx = (LoggerContext) LogManager.getContext(false);
-        Configuration config = ctx.getConfiguration();
-        LoggerConfig loggerConfig = config.getLoggerConfig("io.grpc.netty.shaded.io.netty");
-        loggerConfig.setLevel(Level.INFO);
-        ctx.updateLoggers();
-    }
 
     public static final String DORIS_HOME_DIR = System.getenv("DORIS_HOME");
     public static final String PID_DIR = System.getenv("PID_DIR");


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx
Previously inside the `_make_and_download_snapshots` function we don't log the missed_version information, this pr aims to make it's easier to trace the versions during clone task.
## Problem summary

Describe your changes.
Enable log missed_version vector when executing.
## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

