### PR TITLE
[enhancement](branch1.1) add missed_version log information

### DIFF
--- a/be/src/olap/olap_common.h
+++ b/be/src/olap/olap_common.h
@@ -168,10 +168,10 @@ enum FieldAggregationMethod {
 enum OLAPCompressionType {
     // Compression algorithm used for network transmission, low compression rate, low cpu overhead
     OLAP_COMP_TRANSPORT = 1,
-    // Compression algorithm used for hard disk data, with high compression rate and high CPU overhead 
-    OLAP_COMP_STORAGE = 2,  
-    // The compression algorithm used for storage, the compression rate is low, and the cpu overhead is low 
-    OLAP_COMP_LZ4 = 3,       
+    // Compression algorithm used for hard disk data, with high compression rate and high CPU overhead
+    OLAP_COMP_STORAGE = 2,
+    // The compression algorithm used for storage, the compression rate is low, and the cpu overhead is low
+    OLAP_COMP_LZ4 = 3,
 };
 
 enum PushType {
@@ -214,6 +214,13 @@ typedef std::vector<Version> Versions;
 
 inline std::ostream& operator<<(std::ostream& os, const Version& version) {
     return os << "[" << version.first << "-" << version.second << "]";
+}
+
+inline std::ostream& operator<<(std::ostream& os, const Versions& versions) {
+    for (auto& version : versions) {
+        os << version;
+    }
+    return os;
 }
 
 // used for hash-struct of hash_map<Version, Rowset*>.
@@ -290,12 +297,12 @@ struct OlapReaderStatistics {
     // general_debug_ns is designed for the purpose of DEBUG, to record any infomations of debugging or profiling.
     // different from specific meaningful timer such as index_load_ns, general_debug_ns can be used flexibly.
     // general_debug_ns has associated with OlapScanNode's _general_debug_timer already.
-    // so general_debug_ns' values will update to _general_debug_timer automaticly, 
+    // so general_debug_ns' values will update to _general_debug_timer automaticly,
     // the timer result can be checked through QueryProfile web page easily.
-    // when search general_debug_ns, you can find that general_debug_ns has not been used, 
+    // when search general_debug_ns, you can find that general_debug_ns has not been used,
     // this is because such codes added for debug purpose should not commit, it's just for debuging.
     // so, please do not delete general_debug_ns defined here
-    // usage example: 
+    // usage example:
     //               SCOPED_RAW_TIMER(&_stats->general_debug_ns[1]);
     int64_t general_debug_ns[GENERAL_DEBUG_COUNT] = {};
 };

--- a/be/src/olap/task/engine_clone_task.h
+++ b/be/src/olap/task/engine_clone_task.h
@@ -53,7 +53,7 @@ private:
 
     Status _make_and_download_snapshots(DataDir& data_dir, const string& local_data_path, TBackend* src_host,
                             string* src_file_path, vector<string>* error_msgs,
-                            const vector<Version>* missing_versions, bool* allow_incremental_clone);
+                            const vector<Version>& missing_versions, bool* allow_incremental_clone);
 
     void _set_tablet_info(Status status, bool is_new_tablet);
 
@@ -63,7 +63,7 @@ private:
 
     Status _make_snapshot(const std::string& ip, int port, TTableId tablet_id,
                           TSchemaHash schema_hash, int timeout_s,
-                          const std::vector<Version>* missed_versions, std::string* snapshot_path,
+                          const std::vector<Version>& missed_versions, std::string* snapshot_path,
                           bool* allow_incremental_clone, int32_t* snapshot_version);
 
     Status _release_snapshot(const std::string& ip, int port, const std::string& snapshot_path);


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx
Previously inside the _make_and_download_snapshots function we don't log the missed_version information, this pr aims to make it's easier to trace the versions during clone task.
## Problem summary

Describe your changes.
Enable log missed_version vector when executing.
## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

