### PR TITLE
[feature](Nereids): Add subgraph enumerator

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/joinreorder/hypergraph/Edge.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/joinreorder/hypergraph/Edge.java
@@ -17,13 +17,17 @@
 
 package org.apache.doris.nereids.rules.joinreorder.hypergraph;
 
+import org.apache.doris.nereids.rules.joinreorder.hypergraph.bitmap.Bitmap;
 import org.apache.doris.nereids.trees.plans.GroupPlan;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalJoin;
 
 import java.util.BitSet;
 
-class Edge {
+/**
+ * Edge in HyperGraph
+ */
+public class Edge {
     final int index;
     final LogicalJoin join;
     final double selectivity;
@@ -90,7 +94,7 @@ class Edge {
         // When this join reference nodes is a subset of other join, then this join must appear before that join
         BitSet bitSet = getReferenceNodes();
         BitSet otherBitset = edge.getReferenceNodes();
-        return isSubset(bitSet, otherBitset);
+        return Bitmap.isSubset(bitSet, otherBitset);
     }
 
     public BitSet getReferenceNodes() {
@@ -126,13 +130,6 @@ class Edge {
     @Override
     public String toString() {
         return String.format("<%s - %s>", left, right);
-    }
-
-    private boolean isSubset(BitSet bitSet1, BitSet bitSet2) {
-        BitSet bitSet = new BitSet();
-        bitSet.or(bitSet1);
-        bitSet.or(bitSet2);
-        return bitSet.equals(bitSet2);
     }
 }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/joinreorder/hypergraph/GraphSimplifier.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/joinreorder/hypergraph/GraphSimplifier.java
@@ -20,6 +20,7 @@ package org.apache.doris.nereids.rules.joinreorder.hypergraph;
 import org.apache.doris.nereids.memo.Group;
 import org.apache.doris.nereids.memo.GroupExpression;
 import org.apache.doris.nereids.properties.PhysicalProperties;
+import org.apache.doris.nereids.rules.joinreorder.hypergraph.bitmap.Bitmap;
 import org.apache.doris.nereids.stats.StatsCalculator;
 import org.apache.doris.nereids.trees.plans.GroupPlan;
 import org.apache.doris.nereids.trees.plans.Plan;
@@ -293,10 +294,10 @@ public class GraphSimplifier {
     }
 
     private boolean tryGetSuperset(BitSet bitSet1, BitSet bitSet2, List<BitSet> superset) {
-        if (isSubset(bitSet1, bitSet2)) {
+        if (Bitmap.isSubset(bitSet1, bitSet2)) {
             superset.add(bitSet2);
             return true;
-        } else if (isSubset(bitSet2, bitSet1)) {
+        } else if (Bitmap.isSubset(bitSet2, bitSet1)) {
             superset.add(bitSet1);
             return true;
         }
@@ -348,13 +349,6 @@ public class GraphSimplifier {
                 }
             }
         }
-    }
-
-    private boolean isSubset(BitSet bitSet1, BitSet bitSet2) {
-        BitSet bitSet = new BitSet();
-        bitSet.or(bitSet1);
-        bitSet.or(bitSet2);
-        return bitSet.equals(bitSet2);
     }
 
     class SimplificationStep {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/joinreorder/hypergraph/HyperGraph.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/joinreorder/hypergraph/HyperGraph.java
@@ -38,10 +38,9 @@ import java.util.Set;
  * It's used for join ordering
  */
 public class HyperGraph {
-    List<Edge> edges = new ArrayList<>();
-    List<Node> nodes = new ArrayList<>();
-    // TODO: add system arg: limit
-    Receiver receiver = new Receiver(100);
+    private List<Edge> edges = new ArrayList<>();
+    private List<Node> nodes = new ArrayList<>();
+    private Plan bestPlan;
 
     public static HyperGraph fromPlan(Plan plan) {
         HyperGraph graph = new HyperGraph();
@@ -73,10 +72,13 @@ public class HyperGraph {
         return nodes.get(index).getPlan();
     }
 
+    /**
+     * Extract the best plan of HyperGraph
+     *
+     * @return return the best plan
+     */
     public Plan toPlan() {
-        BitSet bitSet = new BitSet();
-        bitSet.set(0, nodes.size());
-        return receiver.getBestPlan(bitSet);
+        return bestPlan;
     }
 
     public boolean simplify() {
@@ -85,6 +87,11 @@ public class HyperGraph {
         return graphSimplifier.simplifyGraph(1);
     }
 
+    /**
+     * Try to enumerate all csg-cmp pairs and get the best plan
+     *
+     * @return whether enumerate successfully
+     */
     public boolean emitPlan() {
         return false;
     }
@@ -116,7 +123,6 @@ public class HyperGraph {
         // TODO: Other joins can be added according CD-C algorithm
         if (join.getJoinType() != JoinType.INNER_JOIN) {
             Node node = new Node(nodes.size(), plan);
-            receiver.addNode(node);
             nodes.add(node);
             return;
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/joinreorder/hypergraph/Node.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/joinreorder/hypergraph/Node.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.nereids.rules.joinreorder.hypergraph;
 
+import org.apache.doris.nereids.rules.joinreorder.hypergraph.bitmap.Bitmap;
 import org.apache.doris.nereids.trees.plans.GroupPlan;
 import org.apache.doris.nereids.trees.plans.Plan;
 
@@ -25,24 +26,50 @@ import com.google.common.collect.Lists;
 
 import java.util.BitSet;
 import java.util.List;
+import javax.annotation.Nullable;
 
 /**
  * HyperGraph Node.
  */
-class Node {
+public class Node {
     private final int index;
     private Plan plan;
     // We split these into simple edges (only one node on each side) and complex edges (others)
     // because we can often quickly discard all simple edges by testing the set of interesting nodes
     // against the “simple_neighborhood” bitmap.
     private List<Edge> complexEdges = Lists.newArrayList();
-    private List<Edge> simpleEdges = Lists.newArrayList();
-
     private BitSet simpleNeighborhood = new BitSet();
+    private List<Edge> simpleEdges = Lists.newArrayList();
+    private BitSet complexNeighborhood = new BitSet();
 
     public Node(int index, Plan plan) {
         this.plan = plan;
         this.index = index;
+    }
+
+    /**
+     * Try to find the edge between this node and nodes
+     *
+     * @param nodes the other side of the edge
+     * @return The edge between this node and parameters
+     */
+    @Nullable
+    public Edge tryGetEdgeWith(BitSet nodes) {
+        if (simpleNeighborhood.intersects(nodes)) {
+            for (Edge edge : simpleEdges) {
+                if (Bitmap.isSubset(edge.getLeft(), nodes) || Bitmap.isSubset(edge.getRight(), nodes)) {
+                    return edge;
+                }
+            }
+            throw new RuntimeException(String.format("There is no simple Edge <%d - %s>", index, nodes));
+        } else if (complexNeighborhood.intersects(nodes)) {
+            for (Edge edge : simpleEdges) {
+                if (edge.getLeft().equals(nodes) || edge.getRight().equals(nodes)) {
+                    return edge;
+                }
+            }
+        }
+        return null;
     }
 
     public int getIndex() {
@@ -87,6 +114,11 @@ class Node {
         this.simpleNeighborhood = simpleNeighborhood;
     }
 
+    /**
+     * Attach all edge in this node if the edge references this node
+     *
+     * @param edge the edge that references this node
+     */
     public void attachEdge(Edge edge) {
         if (edge.isSimple()) {
             simpleEdges.add(edge);
@@ -94,6 +126,9 @@ class Node {
             edge.getRight().stream().forEach(index -> simpleNeighborhood.set(index));
             simpleNeighborhood.clear(index);
         } else {
+            edge.getLeft().stream().forEach(index -> complexNeighborhood.set(index));
+            edge.getRight().stream().forEach(index -> complexNeighborhood.set(index));
+            simpleNeighborhood.clear(index);
             complexEdges.add(edge);
         }
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/joinreorder/hypergraph/SubgraphEnumerator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/joinreorder/hypergraph/SubgraphEnumerator.java
@@ -1,0 +1,194 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.rules.joinreorder.hypergraph;
+
+import org.apache.doris.nereids.rules.joinreorder.hypergraph.bitmap.Bitmap;
+import org.apache.doris.nereids.rules.joinreorder.hypergraph.bitmap.SubsetIterator;
+import org.apache.doris.nereids.rules.joinreorder.hypergraph.receiver.AbstractReceiver;
+
+import java.util.BitSet;
+import java.util.List;
+
+/**
+ * This class enumerate all subgraph of HyperGraph. CSG means connected subgraph
+ * and CMP means complement subgraph. More details are in Dynamic Programming
+ * Strikes Back and Build Query Optimizer.
+ */
+public class SubgraphEnumerator {
+    //The receiver receives the csg and cmp and record them, named DPTable in paper
+    AbstractReceiver receiver;
+    //The enumerated hyperGraph
+    HyperGraph hyperGraph;
+
+    SubgraphEnumerator(AbstractReceiver receiver, HyperGraph hyperGraph) {
+        this.receiver = receiver;
+        this.hyperGraph = hyperGraph;
+    }
+
+    /**
+     * Entry function of enumerating hyperGraph
+     *
+     * @return whether the hyperGraph is enumerated successfully
+     */
+    public boolean enumerate() {
+        List<Node> nodes = hyperGraph.getNodes();
+        // Init all nodes in Receiver
+        for (Node node : nodes) {
+            receiver.addPlan(node.getBitSet(), node.getPlan());
+        }
+        int size = nodes.size();
+
+        // We skip the last element due to it can't generate valid csg-cmp pair
+        BitSet forbiddenNodes = new BitSet();
+        forbiddenNodes.set(0, size - 1);
+        for (int i = size - 2; i >= 0; i--) {
+            BitSet csg = new BitSet();
+            csg.set(i);
+            forbiddenNodes.set(i, false);
+            emitCsg(csg);
+            enumerateCsgRec(csg, cloneBitSet(forbiddenNodes));
+        }
+        return true;
+    }
+
+    // The general purpose of EnumerateCsgRec is to extend a given set csg, which
+    // induces a connected subgraph of G to a larger set with the same property.
+    private void enumerateCsgRec(BitSet csg, BitSet forbiddenNodes) {
+        BitSet neighborhood = calcNeighborhood(csg, forbiddenNodes);
+        SubsetIterator subsetIterator = new SubsetIterator(neighborhood);
+        for (BitSet subset : subsetIterator) {
+            BitSet newCsg = new BitSet();
+            newCsg.or(csg);
+            newCsg.or(subset);
+            if (receiver.contain(newCsg)) {
+                emitCsg(newCsg);
+            }
+        }
+        forbiddenNodes.or(neighborhood);
+        for (BitSet subset : subsetIterator) {
+            BitSet newCsg = new BitSet();
+            newCsg.or(csg);
+            newCsg.or(subset);
+            enumerateCsgRec(newCsg, cloneBitSet(forbiddenNodes));
+        }
+    }
+
+    private void enumerateCmpRec(BitSet csg, BitSet cmp, BitSet forbiddenNodes) {
+        BitSet neighborhood = calcNeighborhood(cmp, forbiddenNodes);
+        SubsetIterator subsetIterator = new SubsetIterator(neighborhood);
+        for (BitSet subset : subsetIterator) {
+            BitSet newCmp = new BitSet();
+            newCmp.or(cmp);
+            newCmp.or(subset);
+            // We need to check whether Cmp is connected and then try to find hyper edge
+            if (receiver.contain(newCmp)) {
+                // We check all edges for finding an edge. That is inefficient.
+                // MySQL use full neighborhood for it. Or a hashMap may be useful
+                for (Edge edge : hyperGraph.getEdges()) {
+                    if (Bitmap.isSubset(csg, edge.getLeft()) && Bitmap.isSubset(cmp, edge.getRight()) || (
+                            Bitmap.isSubset(cmp, edge.getLeft()) && Bitmap.isSubset(csg, edge.getRight()))) {
+                        receiver.emitCsgCmp(csg, cmp, edge);
+                        break;
+                    }
+                }
+            }
+        }
+        forbiddenNodes.or(neighborhood);
+        for (BitSet subset : subsetIterator) {
+            BitSet newCmp = new BitSet();
+            newCmp.or(cmp);
+            newCmp.or(subset);
+            enumerateCmpRec(csg, newCmp, cloneBitSet(forbiddenNodes));
+        }
+    }
+
+    // EmitCsg takes as an argument a non-empty, proper subset csg of HyperGraph , which
+    // induces a connected subgraph. It is then responsible to generate the seeds for
+    // all cmp such that (csg, cmp) becomes a csg-cmp-pair.
+    private void emitCsg(BitSet csg) {
+        BitSet forbiddenNodes = new BitSet();
+        forbiddenNodes.set(0, csg.nextSetBit(0));
+        forbiddenNodes.or(csg);
+        BitSet neighborhoods = calcNeighborhood(csg, cloneBitSet(forbiddenNodes));
+        int cardinality = neighborhoods.cardinality();
+        int nodeIndex = neighborhoods.size();
+
+        for (int i = cardinality - 1; i >= 0; i--) {
+            nodeIndex = neighborhoods.previousSetBit(nodeIndex - 1);
+            BitSet cmp = new BitSet();
+            cmp.set(nodeIndex);
+            // whether there is an edge between csg and cmp
+            Node cmpNode = hyperGraph.getNode(nodeIndex);
+            Edge edge = cmpNode.tryGetEdgeWith(csg);
+            if (edge != null) {
+                receiver.emitCsgCmp(csg, cmp, edge);
+            }
+
+            // In order to avoid enumerate repeated cmp, e.g.,
+            //       t1 (csg)
+            //      /  \
+            //     t2 - t3
+            // for csg {t1}, we can get neighborhoods {t2, t3}
+            // 1. The cmp is {t3} and expanded from {t3} to {t2, t3}
+            // 2. The cmp is {t2} and expanded from {t2} to {t2, t3}
+            // We don't want get {t2, t3} twice. So In first enumeration, we
+            // can exclude {t2}
+            BitSet newForbiddenNodes = new BitSet();
+            newForbiddenNodes.set(0, nodeIndex);
+            newForbiddenNodes.or(forbiddenNodes);
+            enumerateCmpRec(csg, cmp, newForbiddenNodes);
+        }
+    }
+
+    // This function is used to calculate neighborhoods of given subgraph.
+    // Though a direct way is to add all nodes u that satisfies:
+    //              <u, v> \in E && v \in subgraph && v \intersect X = empty
+    // We don't used it because they can cause some repeated subgraph when
+    // expand csg and cmp. In fact, we just need a seed node that can be expanded
+    // to all subgraph. That is any one node of hyper nodes. In fact, the neighborhoods
+    // is the minimum set that we choose one node from above v.
+
+    // Note there are many tricks implemented in MySQL, such as neighbor cache, complex edges
+    // We hope implement them after a benchmark.
+    private BitSet calcNeighborhood(BitSet subGraph, BitSet forbiddenNodes) {
+        BitSet neighborhoods = new BitSet();
+        subGraph.stream()
+                .forEach(nodeIndex -> neighborhoods.or(hyperGraph.getNode(nodeIndex).getSimpleNeighborhood()));
+        neighborhoods.andNot(forbiddenNodes);
+        forbiddenNodes.or(subGraph);
+        forbiddenNodes.or(neighborhoods);
+
+        for (Edge edge : hyperGraph.getEdges()) {
+            BitSet left = edge.getLeft();
+            BitSet right = edge.getRight();
+            if (Bitmap.isSubset(left, subGraph) && !left.intersects(forbiddenNodes)) {
+                neighborhoods.set(right.nextSetBit(0));
+            } else if (Bitmap.isSubset(right, subGraph) && !right.intersects(forbiddenNodes)) {
+                neighborhoods.set(left.nextSetBit(0));
+            }
+            forbiddenNodes.or(neighborhoods);
+        }
+        return neighborhoods;
+    }
+
+    private BitSet cloneBitSet(BitSet bitSet) {
+        BitSet cloned = new BitSet();
+        cloned.or(bitSet);
+        return cloned;
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/joinreorder/hypergraph/bitmap/Bitmap.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/joinreorder/hypergraph/bitmap/Bitmap.java
@@ -1,0 +1,49 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.rules.joinreorder.hypergraph.bitmap;
+
+import java.util.BitSet;
+
+/**
+ * This is helper class for some bitmap operation
+ */
+public class Bitmap {
+    public static boolean isSubset(BitSet bitSet1, BitSet bitSet2) {
+        BitSet bitSet = new BitSet();
+        bitSet.or(bitSet1);
+        bitSet.or(bitSet2);
+        return bitSet.equals(bitSet2);
+    }
+
+    public static BitSet newBitmap(int... values) {
+        BitSet bitSet = new BitSet();
+        for (int v : values) {
+            bitSet.set(v);
+        }
+        return bitSet;
+    }
+
+    public static BitSet unionBitmap(BitSet... bitSets) {
+        BitSet u = new BitSet();
+        for (BitSet bitSet : bitSets) {
+            u.or(bitSet);
+        }
+        return u;
+    }
+}
+

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/joinreorder/hypergraph/bitmap/SubsetIterator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/joinreorder/hypergraph/bitmap/SubsetIterator.java
@@ -1,0 +1,84 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.rules.joinreorder.hypergraph.bitmap;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.BitSet;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * This is a class for iterating all true subset of a bitset, referenced in
+ * https://groups.google.com/forum/#!msg/rec.games.chess/KnJvBnhgDKU/yCi5yBx18PQJ
+ */
+public class SubsetIterator implements Iterable<BitSet> {
+    List<BitSet> subsets = new ArrayList<>();
+    int cursor = 0;
+
+    /**
+     * Generate all subset for this bitSet
+     *
+     * @param bitSet The bitset that need to be generated
+     */
+    public SubsetIterator(BitSet bitSet) {
+        long[] setVal = bitSet.toLongArray();
+        int len = setVal.length;
+        long[] baseVal = new long[len];
+        subsets.add(new BitSet());
+        for (int i = 0; i < len; i++) {
+            long subVal = (-setVal[i]) & setVal[i];
+            int size = subsets.size();
+            while (subVal != 0) {
+                baseVal[i] = subVal;
+                for (int j = 0; j < size; j++) {
+                    BitSet newSubset = BitSet.valueOf(baseVal);
+                    newSubset.or(subsets.get(j));
+                    subsets.add(newSubset);
+                }
+                subVal = (subVal - setVal[i]) & setVal[i];
+            }
+            baseVal[i] = 0;
+        }
+        // remove empty subset
+        subsets.remove(0);
+    }
+
+    @NotNull
+    @Override
+    public Iterator<BitSet> iterator() {
+        class Iter implements Iterator<BitSet> {
+            @Override
+            public boolean hasNext() {
+                return (cursor < subsets.size());
+            }
+
+            @Override
+            public BitSet next() {
+                return subsets.get(cursor++);
+            }
+
+            @Override
+            public void remove() {
+            }
+        }
+
+        return new Iter();
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/joinreorder/hypergraph/receiver/AbstractReceiver.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/joinreorder/hypergraph/receiver/AbstractReceiver.java
@@ -1,0 +1,36 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.rules.joinreorder.hypergraph.receiver;
+
+import org.apache.doris.nereids.rules.joinreorder.hypergraph.Edge;
+import org.apache.doris.nereids.trees.plans.Plan;
+
+import java.util.BitSet;
+
+/**
+ * A interface of receiver
+ */
+public interface AbstractReceiver {
+    public boolean emitCsgCmp(BitSet csg, BitSet cmp, Edge edge);
+
+    public void addPlan(BitSet bitSet, Plan plan);
+
+    public boolean contain(BitSet bitSet);
+
+    public Plan getBestPlan(BitSet bitSet);
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/joinreorder/hypergraph/receiver/Counter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/joinreorder/hypergraph/receiver/Counter.java
@@ -1,0 +1,76 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.rules.joinreorder.hypergraph.receiver;
+
+import org.apache.doris.nereids.rules.joinreorder.hypergraph.Edge;
+import org.apache.doris.nereids.trees.plans.Plan;
+
+import com.google.common.base.Preconditions;
+
+import java.util.BitSet;
+import java.util.HashMap;
+
+/**
+ * The Receiver is used for cached the plan that has been emitted and build the new plan
+ */
+public class Counter implements AbstractReceiver {
+    // limit define the max number of csg-cmp pair in this Receiver
+    private HashMap<BitSet, Integer> counter = new HashMap<>();
+
+    /**
+     * Emit a new plan from bottom to top
+     *
+     * @param left the bitmap of left child tree
+     * @param right the bitmap of the right child tree
+     * @param edge the join operator
+     * @return the left and the right can be connected by the edge
+     */
+    public boolean emitCsgCmp(BitSet left, BitSet right, Edge edge) {
+        Preconditions.checkArgument(counter.containsKey(left));
+        Preconditions.checkArgument(counter.containsKey(right));
+        BitSet bitSet = new BitSet();
+        bitSet.or(left);
+        bitSet.or(right);
+        if (!counter.containsKey(bitSet)) {
+            counter.put(bitSet, 1);
+        } else {
+            counter.put(bitSet, counter.get(bitSet) + 1);
+        }
+        return true;
+    }
+
+    public void addPlan(BitSet bitSet, Plan plan) {
+        counter.put(bitSet, 1);
+    }
+
+    public boolean contain(BitSet bitSet) {
+        return counter.containsKey(bitSet);
+    }
+
+    public Plan getBestPlan(BitSet bitSet) {
+        throw new RuntimeException("Counter does not support getBestPlan()");
+    }
+
+    public int getCount(BitSet bitSet) {
+        return counter.get(bitSet);
+    }
+
+    public HashMap<BitSet, Integer> getAllCount() {
+        return counter;
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/joinreorder/hypergraph/receiver/PlanTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/joinreorder/hypergraph/receiver/PlanTable.java
@@ -15,12 +15,10 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package org.apache.doris.nereids.rules.joinreorder.hypergraph;
+package org.apache.doris.nereids.rules.joinreorder.hypergraph.receiver;
 
+import org.apache.doris.nereids.rules.joinreorder.hypergraph.Edge;
 import org.apache.doris.nereids.trees.plans.Plan;
-import org.apache.doris.nereids.trees.plans.logical.LogicalJoin;
-
-import com.google.common.base.Preconditions;
 
 import java.util.BitSet;
 import java.util.HashMap;
@@ -28,14 +26,9 @@ import java.util.HashMap;
 /**
  * The Receiver is used for cached the plan that has been emitted and build the new plan
  */
-public class Receiver {
+public class PlanTable implements AbstractReceiver {
     // limit define the max number of csg-cmp pair in this Receiver
-    int limit;
-    HashMap<BitSet, Plan> planMap;
-
-    Receiver(int limit) {
-        this.limit = limit;
-    }
+    HashMap<BitSet, Integer> counter;
 
     /**
      * Emit a new plan from bottom to top
@@ -46,29 +39,19 @@ public class Receiver {
      * @return the left and the right can be connected by the edge
      */
     public boolean emitCsgCmp(BitSet left, BitSet right, Edge edge) {
-        limit -= 1;
-        if (limit < 0) {
-            return false;
-        }
-        Preconditions.checkArgument(planMap.containsKey(left));
-        Preconditions.checkArgument(planMap.containsKey(right));
-        Plan plan = new LogicalJoin<>(edge.join.getJoinType(), planMap.get(left), planMap.get(right));
-        left.or(right);
-        planMap.put(left, plan);
-        return true;
+        throw new RuntimeException("PlanTable does not support emitCsgCmp()");
     }
 
-    public void addNode(Node node) {
-        BitSet bitSet = new BitSet();
-        bitSet.set(node.getIndex());
-        planMap.put(bitSet, node.getPlan());
+    public void addPlan(BitSet bitSet, Plan plan) {
+        throw new RuntimeException("PlanTable does not support addPlan()");
     }
 
-    public void addPlan(BitSet referenceNodes, Plan plan) {
-        planMap.put(referenceNodes, plan);
+    public boolean contain(BitSet bitSet) {
+        throw new RuntimeException("PlanTable does not support contain()");
     }
 
     public Plan getBestPlan(BitSet bitSet) {
-        return planMap.get(bitSet);
+        throw new RuntimeException("PlanTable does not support getBestPlan()");
     }
 }
+

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/joinreorder/hypergraph/BitSetTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/joinreorder/hypergraph/BitSetTest.java
@@ -1,0 +1,43 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.rules.joinreorder.hypergraph;
+
+import org.apache.doris.nereids.rules.joinreorder.hypergraph.bitmap.Bitmap;
+import org.apache.doris.nereids.rules.joinreorder.hypergraph.bitmap.SubsetIterator;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.BitSet;
+import java.util.HashSet;
+
+public class BitSetTest {
+    @Test
+    void subsetIteratorTest() {
+        BitSet bitSet = new BitSet();
+        bitSet.set(0, 3);
+        bitSet.set(64, 67);
+        SubsetIterator subsetIterator = new SubsetIterator(bitSet);
+        HashSet<BitSet> subsets = new HashSet<>();
+        for (BitSet subset : subsetIterator) {
+            Assertions.assertTrue(Bitmap.isSubset(subset, bitSet));
+            subsets.add(subset);
+        }
+        Assertions.assertEquals(subsets.size(), Math.pow(2, 6) - 1);
+    }
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/joinreorder/hypergraph/SubgraphEnumeratorTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/joinreorder/hypergraph/SubgraphEnumeratorTest.java
@@ -1,0 +1,104 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.rules.joinreorder.hypergraph;
+
+import org.apache.doris.nereids.rules.joinreorder.hypergraph.bitmap.Bitmap;
+import org.apache.doris.nereids.rules.joinreorder.hypergraph.receiver.Counter;
+import org.apache.doris.nereids.trees.plans.JoinType;
+import org.apache.doris.nereids.util.HyperGraphBuilder;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class SubgraphEnumeratorTest {
+    @Test
+    void testStarQuery() {
+        //      t2
+        //      |
+        //t3-- t1 -- t4
+        //      |
+        //     t5
+        HyperGraph hyperGraph = new HyperGraphBuilder()
+                .init(10, 20, 30, 40, 50)
+                .addEdge(JoinType.INNER_JOIN, 0, 1)
+                .addEdge(JoinType.INNER_JOIN, 0, 2)
+                .addEdge(JoinType.INNER_JOIN, 0, 3)
+                .addEdge(JoinType.INNER_JOIN, 0, 4)
+                .build();
+        Counter counter = new Counter();
+        SubgraphEnumerator subgraphEnumerator = new SubgraphEnumerator(counter, hyperGraph);
+        subgraphEnumerator.enumerate();
+        Assertions.assertEquals(counter.getCount(Bitmap.newBitmap(0)), 1);
+        Assertions.assertEquals(counter.getCount(Bitmap.newBitmap(1)), 1);
+        Assertions.assertEquals(counter.getCount(Bitmap.newBitmap(2)), 1);
+        Assertions.assertEquals(counter.getCount(Bitmap.newBitmap(3)), 1);
+        Assertions.assertEquals(counter.getCount(Bitmap.newBitmap(4)), 1);
+        Assertions.assertEquals(counter.getCount(Bitmap.newBitmap(0, 1)), 1);
+        Assertions.assertEquals(counter.getCount(Bitmap.newBitmap(0, 2)), 1);
+        Assertions.assertEquals(counter.getCount(Bitmap.newBitmap(0, 3)), 1);
+        Assertions.assertEquals(counter.getCount(Bitmap.newBitmap(0, 4)), 1);
+        Assertions.assertEquals(counter.getCount(Bitmap.newBitmap(0, 1, 2)), 2);
+        Assertions.assertEquals(counter.getCount(Bitmap.newBitmap(0, 1, 3)), 2);
+        Assertions.assertEquals(counter.getCount(Bitmap.newBitmap(0, 1, 4)), 2);
+        Assertions.assertEquals(counter.getCount(Bitmap.newBitmap(0, 2, 3)), 2);
+        Assertions.assertEquals(counter.getCount(Bitmap.newBitmap(0, 2, 4)), 2);
+        Assertions.assertEquals(counter.getCount(Bitmap.newBitmap(0, 3, 4)), 2);
+        Assertions.assertEquals(counter.getCount(Bitmap.newBitmap(0, 1, 2, 3)), 3);
+        Assertions.assertEquals(counter.getCount(Bitmap.newBitmap(0, 1, 2, 4)), 3);
+        Assertions.assertEquals(counter.getCount(Bitmap.newBitmap(0, 1, 3, 4)), 3);
+        Assertions.assertEquals(counter.getCount(Bitmap.newBitmap(0, 2, 3, 4)), 3);
+        Assertions.assertEquals(counter.getCount(Bitmap.newBitmap(0, 1, 2, 3, 4)), 4);
+    }
+
+    @Test
+    void testTime() {
+        HyperGraphBuilder hyperGraphBuilder = new HyperGraphBuilder();
+        // generate 14 tables and 90 edges
+        int tableNum = 5;
+        int edgeNum = 10;
+        int[] rowCounts = new int[tableNum];
+        for (int i = 0; i < tableNum; i++) {
+            rowCounts[i] = i + 1;
+        }
+        hyperGraphBuilder.init(rowCounts);
+
+        int left = 0;
+        int right = 1;
+        for (int i = 0; i < edgeNum; i++) {
+            hyperGraphBuilder.addEdge(JoinType.INNER_JOIN, left, right);
+            left += (right + 1) / tableNum;
+            right = (right + 1) % tableNum;
+            if (left == right) {
+                left += (right + 1) / tableNum;
+                right = (right + 1) % tableNum;
+            }
+        }
+
+        HyperGraph hyperGraph = hyperGraphBuilder.build();
+        Assertions.assertEquals(hyperGraph.getEdges().size(), edgeNum);
+        Assertions.assertEquals(hyperGraph.getNodes().size(), tableNum);
+
+        Counter counter = new Counter();
+        SubgraphEnumerator subgraphEnumerator = new SubgraphEnumerator(counter, hyperGraph);
+        double startTime = System.currentTimeMillis();
+        subgraphEnumerator.enumerate();
+        double endTime = System.currentTimeMillis();
+        System.out.println(
+                String.format("enumerate %d tables %d edges cost %f ms", tableNum, edgeNum, endTime - startTime));
+    }
+}


### PR DESCRIPTION
Signed-off-by: xiejiann <jianxie0@gmail.com>

# Proposed changes

Issue Number: close #xxx

Add subgraph enumerator to find the best plan

## Problem summary

For DPHyp, we need an enumerator for all csg-cmp pairs to find the best plan

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [x] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

