### PR TITLE
[Bug](jvm memory) Support multiple java version to get max heap size

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/monitor/jvm/JvmInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/monitor/jvm/JvmInfo.java
@@ -26,7 +26,6 @@ import java.lang.management.MemoryMXBean;
 import java.lang.management.MemoryPoolMXBean;
 import java.lang.management.PlatformManagedObject;
 import java.lang.management.RuntimeMXBean;
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Collections;
 import java.util.List;


### PR DESCRIPTION
# Proposed changes

`sun.misc.VM.maxDirectMemory` is used in JDK1.8 only. This PR add the interface for JDK11

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

