### PR TITLE
[bugfix](short_key) fix short key coder for nullable key

### DIFF
--- a/be/src/olap/rowset/segment_v2/segment_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_writer.cpp
@@ -233,6 +233,7 @@ std::string SegmentWriter::_encode_keys(
             } else {
                 encoded_keys.push_back(KEY_NULL_LAST_MARKER);
             }
+            ++cid;
             continue;
         }
         encoded_keys.push_back(KEY_NORMAL_MARKER);


### PR DESCRIPTION
If key type is nullable and it's value is null, filed = column->get_data_at(pos) will return null and than go to next column, 
but key_coders still use old cid to encode keys, makes key_coder and cid mismatch

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

