### PR TITLE
[fix](java-udf) Disable the corresponding configuration if building BE without Java UDF support

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -307,7 +307,7 @@ if [[ "${BUILD_JAVA_UDF}" -eq 1 && "$(uname -s)" == 'Darwin' ]]; then
     fi
 
     if [[ -n "${CAUSE}" ]]; then
-        echo -e "\033[33;1mWARNNING: \033[37;1mSkip building with JAVA UDF due to ${CAUSE}.\033[0m"
+        echo -e "\033[33;1mWARNNING: \033[37;1mSkip building with Java UDF due to ${CAUSE}.\033[0m"
         BUILD_JAVA_UDF=0
     fi
 fi
@@ -513,6 +513,15 @@ if [[ "${BUILD_BE}" -eq 1 ]]; then
 
     cp -r -p "${DORIS_HOME}/be/output/bin"/* "${DORIS_OUTPUT}/be/bin"/
     cp -r -p "${DORIS_HOME}/be/output/conf"/* "${DORIS_OUTPUT}/be/conf"/
+
+    if [[ "${BUILD_JAVA_UDF}" -eq 0 ]]; then
+        echo -e "\033[33;1mWARNNING: \033[37;1mDisable Java UDF support in be.conf due to the BE was built without Java UDF.\033[0m"
+        cat >>"${DORIS_OUTPUT}/be/conf/be.conf" <<EOF
+
+# Java UDF support
+enable_java_support = false
+EOF
+    fi
 
     # Fix Killed: 9 error on MacOS (arm64).
     # See: https://stackoverflow.com/questions/67378106/mac-m1-cping-binary-over-another-results-in-crash


### PR DESCRIPTION
# Proposed changes

Issue Number: close #14301

## Problem summary

Currently, there are two scenarios in which BE can be built without Java UDF support.
1. Assign `ON` to the environment variable `DISABLE_JAVA_UDF` before build BE.
2. On macOS (M1), the architecture of `libjvm.dylib` under `JAVA_HOME` doesn't match the one of OS. (E.g. We can run JDK (x86_64) on macOS (arm64) through Rosetta 2.)

In #14062 , we enable support by default. That will cause a trouble that we can't start BE up which was built without Java UDF support.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
3. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
5. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
6. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

