### PR TITLE
[Fix](external table)fix iceberg table cannot access hdfs without hadoop user name

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/IcebergProperty.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/IcebergProperty.java
@@ -17,6 +17,8 @@
 
 package org.apache.doris.catalog;
 
+import org.apache.doris.common.util.BrokerUtil;
+
 import com.google.common.collect.Maps;
 
 import java.util.Iterator;
@@ -46,6 +48,8 @@ public class IcebergProperty {
             Map.Entry<String, String> entry = iterator.next();
             if (entry.getKey().startsWith(ICEBERG_HDFS_PREFIX)) {
                 dfsProperties.put(entry.getKey(), entry.getValue());
+            } else if (entry.getKey().equalsIgnoreCase(BrokerUtil.HADOOP_USER_NAME)) {
+                dfsProperties.put(BrokerUtil.HADOOP_USER_NAME, entry.getValue());
             }
         }
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/external/iceberg/IcebergCatalogMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/external/iceberg/IcebergCatalogMgr.java
@@ -26,6 +26,7 @@ import org.apache.doris.common.DdlException;
 import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.ErrorReport;
 import org.apache.doris.common.SystemIdGenerator;
+import org.apache.doris.common.util.BrokerUtil;
 import org.apache.doris.external.iceberg.util.IcebergUtils;
 
 import com.google.common.base.Enums;
@@ -132,6 +133,8 @@ public class IcebergCatalogMgr {
             while (iter.hasNext()) {
                 Map.Entry<String, String> entry = iter.next();
                 if (entry.getKey().startsWith(IcebergProperty.ICEBERG_HDFS_PREFIX)) {
+                    iter.remove();
+                } else if (entry.getKey().equalsIgnoreCase(BrokerUtil.HADOOP_USER_NAME)) {
                     iter.remove();
                 }
             }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

fix iceberg table cannot access hdfs without hadoop user name

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

