### PR TITLE
[enhancement](be)limit mem cost to 16m when pre serialize keys in agg node

### DIFF
--- a/be/src/runtime/mem_pool.cpp
+++ b/be/src/runtime/mem_pool.cpp
@@ -94,7 +94,7 @@ void MemPool::free_all() {
     DorisMetrics::instance()->memory_pool_bytes_total->increment(-total_bytes_released);
 }
 
-Status MemPool::find_chunk(size_t min_size, bool check_limits) {
+Status MemPool::find_chunk(size_t min_size, bool check_limits, bool free_old_chunks) {
     // Try to allocate from a free chunk. We may have free chunks after the current chunk
     // if Clear() was called. The current chunk may be free if ReturnPartialAllocation()
     // was called. The first free chunk (if there is one) can therefore be either the
@@ -139,6 +139,9 @@ Status MemPool::find_chunk(size_t min_size, bool check_limits) {
     }
 
     // Allocate a new chunk. Return early if allocate fails.
+    if (free_old_chunks) {
+        free_all();
+    }
     Chunk chunk;
     RETURN_IF_ERROR(ChunkAllocator::instance()->allocate(chunk_size, &chunk));
     if (_mem_tracker) _mem_tracker->consume(chunk_size);

--- a/be/src/vec/common/columns_hashing.h
+++ b/be/src/vec/common/columns_hashing.h
@@ -112,14 +112,12 @@ protected:
   * That is, for example, for strings, it contains first the serialized length of the string, and then the bytes.
   * Therefore, when aggregating by several strings, there is no ambiguity.
   */
-template <typename Value, typename Mapped, bool keys_pre_serialized = false>
+template <typename Value, typename Mapped>
 struct HashMethodSerialized
         : public columns_hashing_impl::HashMethodBase<
-                  HashMethodSerialized<Value, Mapped, keys_pre_serialized>, Value, Mapped, false> {
-    using Self = HashMethodSerialized<Value, Mapped, keys_pre_serialized>;
+                  HashMethodSerialized<Value, Mapped>, Value, Mapped, false> {
+    using Self = HashMethodSerialized<Value, Mapped>;
     using Base = columns_hashing_impl::HashMethodBase<Self, Value, Mapped, false>;
-    using KeyHolderType =
-            std::conditional_t<keys_pre_serialized, ArenaKeyHolder, SerializedKeyHolder>;
 
     ColumnRawPtrs key_columns;
     size_t keys_size;
@@ -131,13 +129,9 @@ struct HashMethodSerialized
 
     void set_serialized_keys(const StringRef* keys_) { keys = keys_; }
 
-    ALWAYS_INLINE KeyHolderType get_key_holder(size_t row, Arena& pool) const {
-        if constexpr (keys_pre_serialized) {
-            return KeyHolderType {keys[row], pool};
-        } else {
-            return KeyHolderType {
-                    serialize_keys_to_pool_contiguous(row, keys_size, key_columns, pool), pool};
-        }
+    ALWAYS_INLINE SerializedKeyHolder get_key_holder(size_t row, Arena& pool) const {
+        return SerializedKeyHolder {
+                serialize_keys_to_pool_contiguous(row, keys_size, key_columns, pool), pool};
     }
 
 protected:
@@ -150,7 +144,7 @@ struct IsPreSerializedKeysHashMethodTraits {
 };
 
 template <typename Value, typename Mapped>
-struct IsPreSerializedKeysHashMethodTraits<HashMethodSerialized<Value, Mapped, true>> {
+struct IsPreSerializedKeysHashMethodTraits<HashMethodSerialized<Value, Mapped>> {
     constexpr static bool value = true;
 };
 

--- a/be/src/vec/common/columns_hashing.h
+++ b/be/src/vec/common/columns_hashing.h
@@ -114,8 +114,8 @@ protected:
   */
 template <typename Value, typename Mapped>
 struct HashMethodSerialized
-        : public columns_hashing_impl::HashMethodBase<
-                  HashMethodSerialized<Value, Mapped>, Value, Mapped, false> {
+        : public columns_hashing_impl::HashMethodBase<HashMethodSerialized<Value, Mapped>, Value,
+                                                      Mapped, false> {
     using Self = HashMethodSerialized<Value, Mapped>;
     using Base = columns_hashing_impl::HashMethodBase<Self, Value, Mapped, false>;
 

--- a/be/src/vec/exec/join/vnested_loop_join_node.cpp
+++ b/be/src/vec/exec/join/vnested_loop_join_node.cpp
@@ -77,6 +77,7 @@ Status VNestedLoopJoinNode::close(RuntimeState* state) {
         return Status::OK();
     }
     START_AND_SCOPE_SPAN(state->get_tracer(), span, "VNestedLoopJoinNode::close");
+    _release_mem();
     return VJoinNodeBase::close(state);
 }
 
@@ -483,6 +484,16 @@ void VNestedLoopJoinNode::debug_string(int indentation_level, std::stringstream*
          << " left_block_pos=" << _left_block_pos;
     VJoinNodeBase::debug_string(indentation_level, out);
     *out << ")";
+}
+
+void VNestedLoopJoinNode::_release_mem() {
+    _left_block.clear();
+
+    Blocks tmp_build_blocks;
+    _build_blocks.swap(tmp_build_blocks);
+
+    MutableColumns tmp_build_side_visited_flags;
+    _build_side_visited_flags.swap(tmp_build_side_visited_flags);
 }
 
 } // namespace doris::vectorized

--- a/be/src/vec/exec/join/vnested_loop_join_node.h
+++ b/be/src/vec/exec/join/vnested_loop_join_node.h
@@ -75,6 +75,8 @@ private:
 
     void _reset_with_next_probe_row(MutableColumns& dst_columns);
 
+    void _release_mem();
+
     // List of build blocks, constructed in prepare()
     Blocks _build_blocks;
     // Visited flags for each row in build side.

--- a/be/src/vec/exec/vaggregation_node.cpp
+++ b/be/src/vec/exec/vaggregation_node.cpp
@@ -804,7 +804,8 @@ void AggregationNode::_emplace_into_hash_table(AggregateDataPtr* places, ColumnR
                 using AggState = typename HashMethodType::State;
                 AggState state(key_columns, _probe_key_sz, nullptr);
 
-                bool is_pre_serialized = _pre_serialize_key_if_need(state, agg_method, key_columns, num_rows);
+                bool is_pre_serialized =
+                        _pre_serialize_key_if_need(state, agg_method, key_columns, num_rows);
 
                 if constexpr (HashTableTraits<HashTableType>::is_phmap) {
                     if (_hash_values.size() < num_rows) _hash_values.resize(num_rows);
@@ -901,7 +902,8 @@ void AggregationNode::_find_in_hash_table(AggregateDataPtr* places, ColumnRawPtr
                 using AggState = typename HashMethodType::State;
                 AggState state(key_columns, _probe_key_sz, nullptr);
 
-                bool is_pre_serialized = _pre_serialize_key_if_need(state, agg_method, key_columns, num_rows);
+                bool is_pre_serialized =
+                        _pre_serialize_key_if_need(state, agg_method, key_columns, num_rows);
 
                 if constexpr (HashTableTraits<HashTableType>::is_phmap) {
                     if (_hash_values.size() < num_rows) _hash_values.resize(num_rows);

--- a/be/src/vec/exec/vaggregation_node.cpp
+++ b/be/src/vec/exec/vaggregation_node.cpp
@@ -804,14 +804,21 @@ void AggregationNode::_emplace_into_hash_table(AggregateDataPtr* places, ColumnR
                 using AggState = typename HashMethodType::State;
                 AggState state(key_columns, _probe_key_sz, nullptr);
 
-                _pre_serialize_key_if_need(state, agg_method, key_columns, num_rows);
+                bool is_pre_serialized = _pre_serialize_key_if_need(state, agg_method, key_columns, num_rows);
 
                 if constexpr (HashTableTraits<HashTableType>::is_phmap) {
                     if (_hash_values.size() < num_rows) _hash_values.resize(num_rows);
                     if constexpr (ColumnsHashing::IsPreSerializedKeysHashMethodTraits<
                                           AggState>::value) {
-                        for (size_t i = 0; i < num_rows; ++i) {
-                            _hash_values[i] = agg_method.data.hash(agg_method.keys[i]);
+                        if (is_pre_serialized) {
+                            for (size_t i = 0; i < num_rows; ++i) {
+                                _hash_values[i] = agg_method.data.hash(agg_method.keys[i]);
+                            }
+                        } else {
+                            for (size_t i = 0; i < num_rows; ++i) {
+                                _hash_values[i] = agg_method.data.hash(
+                                        state.get_key_holder(i, *_agg_arena_pool).key);
+                            }
                         }
                     } else {
                         for (size_t i = 0; i < num_rows; ++i) {
@@ -886,7 +893,7 @@ void AggregationNode::_emplace_into_hash_table(AggregateDataPtr* places, ColumnR
 }
 
 void AggregationNode::_find_in_hash_table(AggregateDataPtr* places, ColumnRawPtrs& key_columns,
-                                          size_t rows) {
+                                          size_t num_rows) {
     std::visit(
             [&](auto&& agg_method) -> void {
                 using HashMethodType = std::decay_t<decltype(agg_method)>;
@@ -894,17 +901,24 @@ void AggregationNode::_find_in_hash_table(AggregateDataPtr* places, ColumnRawPtr
                 using AggState = typename HashMethodType::State;
                 AggState state(key_columns, _probe_key_sz, nullptr);
 
-                _pre_serialize_key_if_need(state, agg_method, key_columns, rows);
+                bool is_pre_serialized = _pre_serialize_key_if_need(state, agg_method, key_columns, num_rows);
 
                 if constexpr (HashTableTraits<HashTableType>::is_phmap) {
-                    if (_hash_values.size() < rows) _hash_values.resize(rows);
+                    if (_hash_values.size() < num_rows) _hash_values.resize(num_rows);
                     if constexpr (ColumnsHashing::IsPreSerializedKeysHashMethodTraits<
                                           AggState>::value) {
-                        for (size_t i = 0; i < rows; ++i) {
-                            _hash_values[i] = agg_method.data.hash(agg_method.keys[i]);
+                        if (is_pre_serialized) {
+                            for (size_t i = 0; i < num_rows; ++i) {
+                                _hash_values[i] = agg_method.data.hash(agg_method.keys[i]);
+                            }
+                        } else {
+                            for (size_t i = 0; i < num_rows; ++i) {
+                                _hash_values[i] = agg_method.data.hash(
+                                        state.get_key_holder(i, *_agg_arena_pool).key);
+                            }
                         }
                     } else {
-                        for (size_t i = 0; i < rows; ++i) {
+                        for (size_t i = 0; i < num_rows; ++i) {
                             _hash_values[i] =
                                     agg_method.data.hash(state.get_key_holder(i, *_agg_arena_pool));
                         }
@@ -912,10 +926,10 @@ void AggregationNode::_find_in_hash_table(AggregateDataPtr* places, ColumnRawPtr
                 }
 
                 /// For all rows.
-                for (size_t i = 0; i < rows; ++i) {
+                for (size_t i = 0; i < num_rows; ++i) {
                     auto find_result = [&]() {
                         if constexpr (HashTableTraits<HashTableType>::is_phmap) {
-                            if (LIKELY(i + HASH_MAP_PREFETCH_DIST < rows)) {
+                            if (LIKELY(i + HASH_MAP_PREFETCH_DIST < num_rows)) {
                                 if constexpr (HashTableTraits<HashTableType>::is_parallel_phmap) {
                                     agg_method.data.prefetch_by_key(state.get_key_holder(
                                             i + HASH_MAP_PREFETCH_DIST, *_agg_arena_pool));
@@ -1349,6 +1363,7 @@ void AggregationNode::_release_mem() {
     _agg_data = nullptr;
     _aggregate_data_container = nullptr;
     _mem_pool = nullptr;
+    _agg_arena_pool = nullptr;
     _preagg_block.clear();
 
     PODArray<AggregateDataPtr> tmp_places;

--- a/be/src/vec/exec/vaggregation_node.h
+++ b/be/src/vec/exec/vaggregation_node.h
@@ -76,7 +76,7 @@ struct AggregationMethodSerialized {
         if (total_bytes > _serialized_key_buffer_size) {
             _serialized_key_buffer_size = total_bytes;
             _mem_pool->clear();
-            _serialized_key_buffer = _mem_pool->allocate(_serialized_key_buffer_size);
+            _serialized_key_buffer = _mem_pool->allocate(_serialized_key_buffer_size, true);
         }
 
         if (keys.size() < num_rows) keys.resize(num_rows);


### PR DESCRIPTION

# Proposed changes

Issue Number: close #xxx

## Problem summary
1. limit the memory cost for pre serialize keys in agg node to prevent oom
2. release memory in nest loop join node's close method

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
3. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
4. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
5. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
6. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

