### PR TITLE
[Bug](DorisWrite )modify dorisWrite obtain LoadHost(streamLoad) bug

### DIFF
--- a/extension/DataX/doriswriter/src/main/java/com/alibaba/datax/plugin/writer/doriswriter/DorisStreamLoadObserver.java
+++ b/extension/DataX/doriswriter/src/main/java/com/alibaba/datax/plugin/writer/doriswriter/DorisStreamLoadObserver.java
@@ -38,6 +38,7 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -49,7 +50,7 @@ public class DorisStreamLoadObserver {
 
     private Keys options;
 
-    private long pos;
+    private int pos;
     private static final String RESULT_FAILED = "Fail";
     private static final String RESULT_LABEL_EXISTED = "Label Already Exists";
     private static final String LAEBL_STATE_VISIBLE = "VISIBLE";
@@ -224,9 +225,10 @@ public class DorisStreamLoadObserver {
 
     private String getLoadHost() {
         List<String> hostList = options.getLoadUrlList();
+        Collections.shuffle(hostList);
         long tmp = pos + hostList.size();
         for (; pos < tmp; pos++) {
-            String host = new StringBuilder("http://").append(hostList.get((int) (pos % hostList.size()))).toString();
+            String host = new StringBuilder("http://").append(hostList.get(pos)).toString();
             if (checkConnection(host)) {
                 return host;
             }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary
When useing dorisWrite loading data , DorisWriter create a DorisWriterManager object when Initialize . Meanwhile , in the construction method of DorisWriterManager ,it will create a DorisStreamLoadObserver object . In DorisStreamLoadObserver object , it is mainly to obtain the load host through getLoadHost() method and "pos" property . When create a new DorisStreamLoadObserver object , the "pos" value always equals 0 ,if you connect BE running streamload task and "hostList" connection no change , you always get the same host . This will cause all the streamload tasks to running on the same node, resulting in too many streamload requests for a BE node , cause OOM error.

Describe your changes.

When you obtain the load host, it will be shuffered the "hostList" connection firstly, and then obtain the host with pos=0 from the "hostlist". If the connection is successful, return the host. If the host connection failed, it will be  incremented obtain the host in the "hostlist" until the connection is successful.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [√ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [√] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [√] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [√ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [√ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

