### PR TITLE
[fix](Dictionary-codec) heap overflow with in-predicate on nullable columns (#14319)

### DIFF
--- a/be/src/vec/columns/column.h
+++ b/be/src/vec/columns/column.h
@@ -131,9 +131,11 @@ public:
     }
 
     // Only used on ColumnDictionary
-    virtual void set_rowset_segment_id(std::pair<RowsetId, uint32_t> rowset_segment_id) {}
+    void set_rowset_segment_id(std::pair<RowsetId, uint32_t> rowset_segment_id) {
+        _rowset_segment_id = rowset_segment_id;
+    }
 
-    virtual std::pair<RowsetId, uint32_t> get_rowset_segment_id() const { return {}; }
+    std::pair<RowsetId, uint32_t> get_rowset_segment_id() const { return _rowset_segment_id; }
 
     /// Returns number of values in column.
     virtual size_t size() const = 0;
@@ -646,6 +648,7 @@ protected:
 
     template <typename Derived>
     void append_data_by_selector_impl(MutablePtr& res, const Selector& selector) const;
+    std::pair<RowsetId, uint32_t> _rowset_segment_id;
 };
 
 using ColumnPtr = IColumn::Ptr;

--- a/be/src/vec/columns/column_dictionary.h
+++ b/be/src/vec/columns/column_dictionary.h
@@ -262,14 +262,6 @@ public:
         return _dict.find_codes(values, selected);
     }
 
-    void set_rowset_segment_id(std::pair<RowsetId, uint32_t> rowset_segment_id) override {
-        _rowset_segment_id = rowset_segment_id;
-    }
-
-    std::pair<RowsetId, uint32_t> get_rowset_segment_id() const override {
-        return _rowset_segment_id;
-    }
-
     bool is_dict_sorted() const { return _dict_sorted; }
 
     bool is_dict_code_converted() const { return _dict_code_converted; }
@@ -299,6 +291,10 @@ public:
         }
         return result;
     }
+
+    size_t dict_size() const { return _dict.size(); }
+
+    std::string dict_debug_string() const { return _dict.debug_string(); }
 
     class Dictionary {
     public:
@@ -436,6 +432,27 @@ public:
 
         size_t avg_str_len() { return empty() ? 0 : _total_str_len / _dict_data->size(); }
 
+        size_t size() const {
+            if (!_dict_data) {
+                return 0;
+            }
+            return _dict_data->size();
+        }
+
+        std::string debug_string() const {
+            std::string str = "[";
+            if (_dict_data) {
+                for (size_t i = 0; i < _dict_data->size(); i++) {
+                    if (i) {
+                        str += ',';
+                    }
+                    str += (*_dict_data)[i].to_string();
+                }
+            }
+            str += ']';
+            return str;
+        }
+
     private:
         StringValue _null_value = StringValue();
         StringValue::Comparator _comparator;
@@ -459,7 +476,6 @@ private:
     Dictionary _dict;
     Container _codes;
     FieldType _type;
-    std::pair<RowsetId, uint32_t> _rowset_segment_id;
 };
 
 template class ColumnDictionary<int32_t>;


### PR DESCRIPTION
Losing segmentid info will mess up the _segment_id_to_value_in_dict_flags map
in InListPredicate, causing two distinct segments to collide and crash the BE at last.

There are two facts that can lead to lose segmentid info:
1) mistakenly invoke IColumn dummy virtual function instead of the one in derived class
2) ColumnNullable::get_nested_column() does not pass on the segmentid info.

Signed-off-by: freemandealer <freeman.zhang1992@gmail.com>

# Proposed changes

Issue Number: close #14319

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [] Yes
    - [X] No
    - [] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [X] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [X] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [X] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [X] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

