### PR TITLE
[opt](planner) let cardinality in explain result more readable

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslator.java
@@ -375,7 +375,9 @@ public class PhysicalPlanTranslator extends DefaultPlanVisitor<PlanFragment, Pla
         TupleDescriptor tupleDescriptor = generateTupleDesc(slotList, olapTable, context);
         tupleDescriptor.setTable(olapTable);
         OlapScanNode olapScanNode = new OlapScanNode(context.nextPlanNodeId(), tupleDescriptor, "OlapScanNode");
-        olapScanNode.setCardinality((long) olapScan.getStats().getRowCount());
+        if (olapScan.getStats() != null) {
+            olapScanNode.setCardinality((long) olapScan.getStats().getRowCount());
+        }
         // TODO: Do we really need tableName here?
         TableName tableName = new TableName(null, "", "");
         TableRef ref = new TableRef(tableName, null, null);

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslator.java
@@ -375,6 +375,7 @@ public class PhysicalPlanTranslator extends DefaultPlanVisitor<PlanFragment, Pla
         TupleDescriptor tupleDescriptor = generateTupleDesc(slotList, olapTable, context);
         tupleDescriptor.setTable(olapTable);
         OlapScanNode olapScanNode = new OlapScanNode(context.nextPlanNodeId(), tupleDescriptor, "OlapScanNode");
+        olapScanNode.setCardinality((long) olapScan.getStats().getRowCount());
         // TODO: Do we really need tableName here?
         TableName tableName = new TableName(null, "", "");
         TableRef ref = new TableRef(tableName, null, null);

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/AggregationNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/AggregationNode.java
@@ -299,7 +299,7 @@ public class AggregationNode extends PlanNode {
 
         if (detailLevel == TExplainLevel.BRIEF) {
             output.append(detailPrefix).append(String.format(
-                    "cardinality=%s", cardinality)).append("\n");
+                    "cardinality=%,d",  cardinality)).append("\n");
             return output.toString();
         }
 
@@ -315,7 +315,7 @@ public class AggregationNode extends PlanNode {
             output.append(detailPrefix).append("having: ").append(getExplainString(conjuncts)).append("\n");
         }
         output.append(detailPrefix).append(String.format(
-                "cardinality=%s", cardinality)).append("\n");
+                "cardinality=%,d", cardinality)).append("\n");
         return output.toString();
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/HashJoinNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/HashJoinNode.java
@@ -783,7 +783,8 @@ public class HashJoinNode extends JoinNodeBase {
                         .append(distrModeStr).append(")").append("[").append(colocateReason).append("]\n");
 
         if (detailLevel == TExplainLevel.BRIEF) {
-            output.append(detailPrefix).append(String.format("cardinality=%s", cardinality)).append("\n");
+            output.append(detailPrefix).append(
+                    String.format("cardinality=%,d", cardinality)).append("\n");
             if (!runtimeFilters.isEmpty()) {
                 output.append(detailPrefix).append("Build RFs: ");
                 output.append(getRuntimeFilterExplainString(true, true));
@@ -805,7 +806,7 @@ public class HashJoinNode extends JoinNodeBase {
             output.append(detailPrefix).append("runtime filters: ");
             output.append(getRuntimeFilterExplainString(true));
         }
-        output.append(detailPrefix).append(String.format("cardinality=%s", cardinality)).append("\n");
+        output.append(detailPrefix).append(String.format("cardinality=%,d", cardinality)).append("\n");
         // todo unify in plan node
         if (vOutputTupleDesc != null) {
             output.append(detailPrefix).append("vec output tuple id: ").append(vOutputTupleDesc.getId()).append("\n");

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/NestedLoopJoinNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/NestedLoopJoinNode.java
@@ -221,7 +221,8 @@ public class NestedLoopJoinNode extends JoinNodeBase {
                         .append(distrModeStr).append(")\n");
 
         if (detailLevel == TExplainLevel.BRIEF) {
-            output.append(detailPrefix).append(String.format("cardinality=%s", cardinality)).append("\n");
+            output.append(detailPrefix).append(
+                    String.format("cardinality=%,d", cardinality)).append("\n");
             return output.toString();
         }
 
@@ -233,7 +234,7 @@ public class NestedLoopJoinNode extends JoinNodeBase {
             output.append(getRuntimeFilterExplainString(true));
             output.append("isOutputLeftSideOnly: ").append(isOutputLeftSideOnly).append("\n");
         }
-        output.append(detailPrefix).append(String.format("cardinality=%s", cardinality)).append("\n");
+        output.append(detailPrefix).append(String.format("cardinality=%,d", cardinality)).append("\n");
         // todo unify in plan node
         if (vOutputTupleDesc != null) {
             output.append(detailPrefix).append("vec output tuple id: ").append(vOutputTupleDesc.getId()).append("\n");

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/OlapScanNode.java
@@ -944,7 +944,7 @@ public class OlapScanNode extends ScanNode {
         output.append(prefix).append("TABLE: ").append(olapTable.getQualifiedName())
                 .append("(").append(indexName).append(")");
         if (detailLevel == TExplainLevel.BRIEF) {
-            output.append("\n").append(prefix).append(String.format("cardinality=%s", cardinality));
+            output.append("\n").append(prefix).append(String.format("cardinality=%,d", cardinality));
             if (!runtimeFilters.isEmpty()) {
                 output.append("\n").append(prefix).append("Apply RFs: ");
                 output.append(getRuntimeFilterExplainString(false, true));

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/TableFunctionNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/TableFunctionNode.java
@@ -168,7 +168,7 @@ public class TableFunctionNode extends PlanNode {
         output.append("\n");
 
         if (detailLevel == TExplainLevel.BRIEF) {
-            output.append(prefix).append(String.format("cardinality=%s", cardinality)).append("\n");
+            output.append(prefix).append(String.format("cardinality=%,d", cardinality)).append("\n");
             return output.toString();
         }
 
@@ -182,7 +182,7 @@ public class TableFunctionNode extends PlanNode {
             output.append(prefix).append("PREDICATES: ").append(
                     getExplainString(conjuncts)).append("\n");
         }
-        output.append(prefix).append(String.format("cardinality=%s", cardinality)).append("\n");
+        output.append(prefix).append(String.format("cardinality=%,d", cardinality)).append("\n");
         return output.toString();
     }
 


### PR DESCRIPTION
# Proposed changes
1. add common for big int in explain. for example "1500000" will be printed as "1,500,000"
2. Scan node cardinal is missing 

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
3. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
5. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
6. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

