### PR TITLE
[enhancement](memtracker)  Use proc/meminfo MemAvailable to control memory and optimize MemTracker log printing

### DIFF
--- a/be/src/runtime/buffer_control_block.h
+++ b/be/src/runtime/buffer_control_block.h
@@ -91,6 +91,8 @@ public:
         }
     }
 
+    // TODO: The value of query peak mem usage in fe.audit.log comes from a random BE,
+    // not the BE with the largest peak mem usage
     void update_max_peak_memory_bytes() {
         if (_query_statistics.get() != nullptr) {
             int64_t max_peak_memory_bytes = _query_statistics->calculate_max_peak_memory_bytes();

--- a/be/src/runtime/memory/mem_tracker_limiter.cpp
+++ b/be/src/runtime/memory/mem_tracker_limiter.cpp
@@ -168,7 +168,7 @@ std::string MemTrackerLimiter::log_usage(MemTracker::Snapshot snapshot) {
 }
 
 std::string MemTrackerLimiter::type_log_usage(MemTracker::Snapshot snapshot) {
-    return fmt::format("Memory Type={}, Used={}({} B), Peak={}({} B)", snapshot.type,
+    return fmt::format("Type={}, Used={}({} B), Peak={}({} B)", snapshot.type,
                        print_bytes(snapshot.cur_consumption), snapshot.cur_consumption,
                        print_bytes(snapshot.peak_consumption), snapshot.peak_consumption);
 }

--- a/be/src/runtime/memory/mem_tracker_limiter.cpp
+++ b/be/src/runtime/memory/mem_tracker_limiter.cpp
@@ -167,6 +167,12 @@ std::string MemTrackerLimiter::log_usage(MemTracker::Snapshot snapshot) {
             print_bytes(snapshot.peak_consumption), snapshot.peak_consumption);
 }
 
+std::string MemTrackerLimiter::type_log_usage(MemTracker::Snapshot snapshot) {
+    return fmt::format("Memory Type={}, Used={}({} B), Peak={}({} B)", snapshot.type,
+                       print_bytes(snapshot.cur_consumption), snapshot.cur_consumption,
+                       print_bytes(snapshot.peak_consumption), snapshot.peak_consumption);
+}
+
 void MemTrackerLimiter::print_log_usage(const std::string& msg) {
     if (_enable_print_log_usage) {
         _enable_print_log_usage = false;
@@ -190,13 +196,16 @@ void MemTrackerLimiter::print_log_process_usage(const std::string& msg, bool wit
     if (MemTrackerLimiter::_enable_print_log_process_usage) {
         MemTrackerLimiter::_enable_print_log_process_usage = false;
         std::string detail = msg;
-        detail += "\n    " + MemTrackerLimiter::process_mem_log_str();
-        if (with_stacktrace) detail += "\n" + get_stack_trace();
+        detail += "\nProcess Memory Summary:\n    " + MemTrackerLimiter::process_mem_log_str();
+        if (with_stacktrace) detail += "\nAlloc Stacktrace:\n" + get_stack_trace();
         std::vector<MemTracker::Snapshot> snapshots;
         MemTrackerLimiter::make_process_snapshots(&snapshots);
         MemTrackerLimiter::make_type_snapshots(&snapshots, MemTrackerLimiter::Type::GLOBAL);
+        detail += "\nMemory Tracker Summary:";
         for (const auto& snapshot : snapshots) {
-            if (snapshot.parent_label == "") {
+            if (snapshot.label == "" && snapshot.parent_label == "") {
+                detail += "\n    " + MemTrackerLimiter::type_log_usage(snapshot);
+            } else if (snapshot.parent_label == "") {
                 detail += "\n    " + MemTrackerLimiter::log_usage(snapshot);
             } else {
                 detail += "\n    " + MemTracker::log_usage(snapshot);

--- a/be/src/runtime/memory/mem_tracker_limiter.h
+++ b/be/src/runtime/memory/mem_tracker_limiter.h
@@ -181,8 +181,7 @@ private:
 
     static std::string process_mem_log_str() {
         return fmt::format(
-                "process memory used {}, limit {}, sys mem available {}, system mem available min "
-                "reserve {}, tc/jemalloc "
+                "process memory used {} limit {}, sys mem available {} min reserve {}, tc/jemalloc "
                 "allocator cache {}",
                 PerfCounters::get_vm_rss_str(), MemInfo::mem_limit_str(),
                 MemInfo::sys_mem_available_str(),

--- a/be/src/runtime/memory/mem_tracker_limiter.h
+++ b/be/src/runtime/memory/mem_tracker_limiter.h
@@ -88,7 +88,7 @@ public:
         // because `new/malloc` will trigger mem hook when using tcmalloc/jemalloc allocator cache,
         // but it may not actually alloc physical memory, which is not expected in mem hook fail.
         if (MemInfo::proc_mem_no_allocator_cache() + bytes >= MemInfo::mem_limit() ||
-            MemInfo::sys_mem_available() < MemInfo::sys_mem_available_min_reserve()) {
+            MemInfo::sys_mem_available() < MemInfo::sys_mem_available_low_water_mark()) {
             print_log_process_usage(
                     fmt::format("System Mem Exceed Limit Check Faild, Try Alloc: {}", bytes));
             return true;
@@ -178,7 +178,7 @@ private:
                 "alloc size {}, tc/jemalloc allocator cache {}",
                 PerfCounters::get_vm_rss_str(), MemInfo::mem_limit_str(),
                 MemInfo::sys_mem_available_str(),
-                PrettyPrinter::print(MemInfo::sys_mem_available_min_reserve(), TUnit::BYTES),
+                PrettyPrinter::print(MemInfo::sys_mem_available_low_water_mark(), TUnit::BYTES),
                 print_bytes(bytes), MemInfo::allocator_cache_mem_str());
     }
 
@@ -188,7 +188,7 @@ private:
                 "allocator cache {}",
                 PerfCounters::get_vm_rss_str(), MemInfo::mem_limit_str(),
                 MemInfo::sys_mem_available_str(),
-                PrettyPrinter::print(MemInfo::sys_mem_available_min_reserve(), TUnit::BYTES),
+                PrettyPrinter::print(MemInfo::sys_mem_available_low_water_mark(), TUnit::BYTES),
                 MemInfo::allocator_cache_mem_str());
     }
 

--- a/be/src/runtime/memory/mem_tracker_limiter.h
+++ b/be/src/runtime/memory/mem_tracker_limiter.h
@@ -173,10 +173,13 @@ private:
 
     static std::string process_limit_exceeded_errmsg_str(int64_t bytes) {
         return fmt::format(
-                "process memory used {}, tc/jemalloc allocator cache {}, exceed limit {}, failed "
-                "alloc size {}",
-                PerfCounters::get_vm_rss_str(), MemInfo::allocator_cache_mem_str(),
-                MemInfo::mem_limit_str(), print_bytes(bytes));
+                "process memory used {} exceed limit {} or sys mem available {} less than min "
+                "reserve {}, failed "
+                "alloc size {}, tc/jemalloc allocator cache {}",
+                PerfCounters::get_vm_rss_str(), MemInfo::mem_limit_str(),
+                MemInfo::sys_mem_available_str(),
+                PrettyPrinter::print(MemInfo::sys_mem_available_min_reserve(), TUnit::BYTES),
+                print_bytes(bytes), MemInfo::allocator_cache_mem_str());
     }
 
     static std::string process_mem_log_str() {

--- a/be/src/service/doris_main.cpp
+++ b/be/src/service/doris_main.cpp
@@ -499,12 +499,13 @@ int main(int argc, char** argv) {
         __lsan_do_leak_check();
 #endif
         doris::PerfCounters::refresh_proc_status();
+        doris::MemInfo::refresh_proc_meminfo();
         doris::MemTrackerLimiter::refresh_global_counter();
         doris::ExecEnv::GetInstance()->load_channel_mgr()->refresh_mem_tracker();
-#if !defined(ADDRESS_SANITIZER) && !defined(LEAK_SANITIZER) && !defined(THREAD_SANITIZER) && \
-        !defined(USE_JEMALLOC)
+#if !defined(ADDRESS_SANITIZER) && !defined(LEAK_SANITIZER) && !defined(THREAD_SANITIZER)
         doris::MemInfo::refresh_allocator_mem();
 #endif
+        doris::MemInfo::refresh_proc_mem_no_allocator_cache();
         if (doris::config::memory_debug) {
             doris::MemTrackerLimiter::print_log_process_usage("memory_debug", false);
         }

--- a/be/src/util/mem_info.cpp
+++ b/be/src/util/mem_info.cpp
@@ -118,9 +118,9 @@ void MemInfo::init() {
     }
     _s_mem_limit_str = PrettyPrinter::print(_s_mem_limit, TUnit::BYTES);
 
+    // max 6.4G, avoid wasting too much memory on machines with large memory larger than 64G.
     _s_sys_mem_available_min_reserve = std::min<int64_t>(
-            std::min<int64_t>(_s_physical_mem - _s_mem_limit, _s_physical_mem * 0.1),
-            2147483648L); // max 2G
+            std::min<int64_t>(_s_physical_mem - _s_mem_limit, _s_physical_mem * 0.1), 6871947673L);
 
     LOG(INFO) << "Physical Memory: " << PrettyPrinter::print(_s_physical_mem, TUnit::BYTES)
               << ", Mem Limit: " << _s_mem_limit_str
@@ -142,8 +142,6 @@ void MemInfo::init() {
     bool is_percent = true;
     _s_mem_limit = ParseUtil::parse_mem_spec(config::mem_limit, -1, _s_physical_mem, &is_percent);
     _s_mem_limit_str = PrettyPrinter::print(_s_mem_limit, TUnit::BYTES);
-    _s_hard_mem_limit =
-            _s_physical_mem - std::max<int64_t>(209715200L, _s_physical_mem / 10); // 200M
 
     LOG(INFO) << "Physical Memory: " << PrettyPrinter::print(_s_physical_mem, TUnit::BYTES);
     _s_initialized = true;

--- a/be/src/util/mem_info.cpp
+++ b/be/src/util/mem_info.cpp
@@ -158,7 +158,7 @@ void MemInfo::init() {
     _s_initialized = true;
 }
 #else
-MemInfo::refresh_proc_meminfo() {};
+void MemInfo::refresh_proc_meminfo() {}
 
 void MemInfo::init() {
     size_t size = sizeof(_s_physical_mem);

--- a/be/src/util/mem_info.h
+++ b/be/src/util/mem_info.h
@@ -50,8 +50,8 @@ public:
 
     static inline int64_t sys_mem_available() { return _s_sys_mem_available; }
     static inline std::string sys_mem_available_str() { return _s_sys_mem_available_str; }
-    static inline int64_t sys_mem_available_min_reserve() {
-        return _s_sys_mem_available_min_reserve;
+    static inline int64_t sys_mem_available_low_water_mark() {
+        return _s_sys_mem_available_low_water_mark;
     }
 
     static inline size_t current_mem() { return _s_allocator_physical_mem; }
@@ -118,7 +118,7 @@ private:
 
     static int64_t _s_sys_mem_available;
     static std::string _s_sys_mem_available_str;
-    static int64_t _s_sys_mem_available_min_reserve;
+    static int64_t _s_sys_mem_available_low_water_mark;
 };
 
 } // namespace doris

--- a/be/src/util/mem_info.h
+++ b/be/src/util/mem_info.h
@@ -46,6 +46,14 @@ public:
         return _s_physical_mem;
     }
 
+    static void refresh_proc_meminfo();
+
+    static inline int64_t sys_mem_available() { return _s_sys_mem_available; }
+    static inline std::string sys_mem_available_str() { return _s_sys_mem_available_str; }
+    static inline int64_t sys_mem_available_min_reserve() {
+        return _s_sys_mem_available_min_reserve;
+    }
+
     static inline size_t current_mem() { return _s_allocator_physical_mem; }
     static inline size_t allocator_virtual_mem() { return _s_virtual_memory_used; }
     static inline size_t allocator_cache_mem() { return _s_allocator_cache_mem; }
@@ -55,6 +63,7 @@ public:
     // Tcmalloc property `generic.total_physical_bytes` records the total length of the virtual memory
     // obtained by the process malloc, not the physical memory actually used by the process in the OS.
     static inline void refresh_allocator_mem() {
+#if !defined(USE_JEMALLOC)
         MallocExtension::instance()->GetNumericProperty("generic.total_physical_bytes",
                                                         &_s_allocator_physical_mem);
         MallocExtension::instance()->GetNumericProperty("tcmalloc.pageheap_unmapped_bytes",
@@ -72,6 +81,10 @@ public:
         _s_allocator_cache_mem_str =
                 PrettyPrinter::print(static_cast<uint64_t>(_s_allocator_cache_mem), TUnit::BYTES);
         _s_virtual_memory_used = _s_allocator_physical_mem + _s_pageheap_unmapped_bytes;
+#endif
+    }
+
+    static inline void refresh_proc_mem_no_allocator_cache() {
         _s_proc_mem_no_allocator_cache =
                 PerfCounters::get_vm_rss() - static_cast<int64_t>(_s_allocator_cache_mem);
     }
@@ -84,7 +97,6 @@ public:
         DCHECK(_s_initialized);
         return _s_mem_limit_str;
     }
-    static inline int64_t hard_mem_limit() { return _s_hard_mem_limit; }
 
     static std::string debug_string();
 
@@ -93,7 +105,6 @@ private:
     static int64_t _s_physical_mem;
     static int64_t _s_mem_limit;
     static std::string _s_mem_limit_str;
-    static int64_t _s_hard_mem_limit;
     static size_t _s_allocator_physical_mem;
     static size_t _s_pageheap_unmapped_bytes;
     static size_t _s_tcmalloc_pageheap_free_bytes;
@@ -104,6 +115,10 @@ private:
     static std::string _s_allocator_cache_mem_str;
     static size_t _s_virtual_memory_used;
     static int64_t _s_proc_mem_no_allocator_cache;
+
+    static int64_t _s_sys_mem_available;
+    static std::string _s_sys_mem_available_str;
+    static int64_t _s_sys_mem_available_min_reserve;
 };
 
 } // namespace doris

--- a/be/src/vec/sink/vresult_sink.cpp
+++ b/be/src/vec/sink/vresult_sink.cpp
@@ -115,6 +115,7 @@ Status VResultSink::close(RuntimeState* state, Status exec_status) {
     // close sender, this is normal path end
     if (_sender) {
         if (_writer) _sender->update_num_written_rows(_writer->get_written_rows());
+        _sender->update_max_peak_memory_bytes();
         _sender->close(final_status);
     }
     state->exec_env()->result_mgr()->cancel_at_time(


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

1. When Doris BE is deployed with Hadoop, there is an OOM risk in only using BE process memory control limit at present, and additionally use `/proc/meminfo MemAvailable` to control memory;
2. Optimize the log printing of MemTracker, and fix the bug that Jemalloc does not print the log when the process memory exceeds the limit.
3. Print query peak mem usage in `fe.audit.log`.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

