### PR TITLE
[enhancement](Nereids)remove constraint that root node must maintain output order

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/logical/EliminateUnnecessaryProject.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/logical/EliminateUnnecessaryProject.java
@@ -20,8 +20,7 @@ package org.apache.doris.nereids.rules.rewrite.logical;
 import org.apache.doris.nereids.rules.Rule;
 import org.apache.doris.nereids.rules.RuleType;
 import org.apache.doris.nereids.rules.rewrite.OneRewriteRuleFactory;
-import org.apache.doris.nereids.trees.plans.Plan;
-import org.apache.doris.nereids.trees.plans.logical.LogicalProject;
+import org.apache.doris.nereids.trees.UnaryNode;
 
 /**
  * remove the project that output same with its child to avoid we get two consecutive projects in best plan.
@@ -33,19 +32,7 @@ public class EliminateUnnecessaryProject extends OneRewriteRuleFactory {
     public Rule build() {
         return logicalProject(any())
                 .when(project -> project.getOutputSet().equals(project.child().getOutputSet()))
-                .thenApply(ctx -> {
-                    int rootGroupId = ctx.cascadesContext.getMemo().getRoot().getGroupId().asInt();
-                    LogicalProject<Plan> project = ctx.root;
-                    // if project is root, we need to ensure the output order is same.
-                    if (project.getGroupExpression().get().getOwnerGroup().getGroupId().asInt() == rootGroupId) {
-                        if (project.getOutput().equals(project.child().getOutput())) {
-                            return project.child();
-                        } else {
-                            return null;
-                        }
-                    } else {
-                        return project.child();
-                    }
-                }).toRule(RuleType.ELIMINATE_UNNECESSARY_PROJECT);
+                .then(UnaryNode::child)
+                .toRule(RuleType.ELIMINATE_UNNECESSARY_PROJECT);
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/postprocess/RuntimeFilterTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/postprocess/RuntimeFilterTest.java
@@ -219,7 +219,8 @@ public class RuntimeFilterTest extends SSBTestBase {
         PhysicalPlan plan = checker.getPhysicalPlan();
         new PlanPostProcessors(checker.getCascadesContext()).process(plan);
         System.out.println(plan.treeString());
-        new PhysicalPlanTranslator().translatePlan(plan, new PlanTranslatorContext(checker.getCascadesContext()));
+        new PhysicalPlanTranslator().translatePlan(plan, new PlanTranslatorContext(checker.getCascadesContext()),
+                plan.getOutput());
         RuntimeFilterContext context = checker.getCascadesContext().getRuntimeFilterContext();
         List<RuntimeFilter> filters = context.getNereidsRuntimeFilter();
         Assertions.assertEquals(filters.size(), context.getLegacyFilters().size() + context.getTargetNullCount());

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/analysis/AnalyzeSubQueryTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/analysis/AnalyzeSubQueryTest.java
@@ -97,7 +97,7 @@ public class AnalyzeSubQueryTest extends TestWithFeService implements PatternMat
                     PhysicalProperties.ANY
             );
             // Just to check whether translate will throw exception
-            new PhysicalPlanTranslator().translatePlan(plan, new PlanTranslatorContext(planner.getCascadesContext()));
+            new PhysicalPlanTranslator().translatePlan(plan, new PlanTranslatorContext(planner.getCascadesContext()), plan.getOutput());
         }
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/analysis/AnalyzeWhereSubqueryTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/analysis/AnalyzeWhereSubqueryTest.java
@@ -137,7 +137,7 @@ public class AnalyzeWhereSubqueryTest extends TestWithFeService implements Patte
                     PhysicalProperties.ANY
             );
             // Just to check whether translate will throw exception
-            new PhysicalPlanTranslator().translatePlan(plan, new PlanTranslatorContext());
+            new PhysicalPlanTranslator().translatePlan(plan, new PlanTranslatorContext(), plan.getOutput());
         }
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/analysis/RegisterCTETest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/analysis/RegisterCTETest.java
@@ -134,7 +134,7 @@ public class RegisterCTETest extends TestWithFeService implements PatternMatchSu
                     PhysicalProperties.ANY
             );
             // Just to check whether translate will throw exception
-            new PhysicalPlanTranslator().translatePlan(plan, new PlanTranslatorContext());
+            new PhysicalPlanTranslator().translatePlan(plan, new PlanTranslatorContext(), plan.getOutput());
         }
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/ViewTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/ViewTest.java
@@ -105,7 +105,7 @@ public class ViewTest extends TestWithFeService implements PatternMatchSupported
                     PhysicalProperties.ANY
             );
             // Just to check whether translate will throw exception
-            new PhysicalPlanTranslator().translatePlan(plan, new PlanTranslatorContext(planner.getCascadesContext()));
+            new PhysicalPlanTranslator().translatePlan(plan, new PlanTranslatorContext(planner.getCascadesContext()), plan.getOutput());
         }
     }
 


### PR DESCRIPTION
# Proposed changes

Before this PR, we must let ROOT plan of Nereids maintain its output order to ensure the result output's order is same with query.
In this PR, we record the output order after analyze and inject it into fragment after translate. So we could remove the constraint of ROOT plan.

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

