### PR TITLE
[refactor](nereids) remove ColumnStatistics.UNKNOWN from StatsDerive

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/ExpressionEstimation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/ExpressionEstimation.java
@@ -161,7 +161,7 @@ public class ExpressionEstimation extends ExpressionVisitor<ColumnStatistic, Sta
                     .setNumNulls(numNulls).setDataSize(binaryArithmetic.getDataType().width()).setMinValue(min)
                     .setMaxValue(max).setSelectivity(1.0).setMaxExpr(null).setMinExpr(null).build();
         }
-        return ColumnStatistic.UNKNOWN;
+        return ColumnStatistic.DEFAULT;
     }
 
     private double noneZeroDivisor(double d) {
@@ -172,8 +172,8 @@ public class ExpressionEstimation extends ExpressionVisitor<ColumnStatistic, Sta
     public ColumnStatistic visitMin(Min min, StatsDeriveResult context) {
         Expression child = min.child();
         ColumnStatistic columnStat = child.accept(this, context);
-        if (columnStat == ColumnStatistic.UNKNOWN) {
-            return ColumnStatistic.UNKNOWN;
+        if (columnStat == ColumnStatistic.DEFAULT) {
+            return ColumnStatistic.DEFAULT;
         }
         /*
         we keep columnStat.min and columnStat.max, but set ndv=1.
@@ -190,8 +190,8 @@ public class ExpressionEstimation extends ExpressionVisitor<ColumnStatistic, Sta
     public ColumnStatistic visitMax(Max max, StatsDeriveResult context) {
         Expression child = max.child();
         ColumnStatistic columnStat = child.accept(this, context);
-        if (columnStat == ColumnStatistic.UNKNOWN) {
-            return ColumnStatistic.UNKNOWN;
+        if (columnStat == ColumnStatistic.DEFAULT) {
+            return ColumnStatistic.DEFAULT;
         }
         /*
         we keep columnStat.min and columnStat.max, but set ndv=1.
@@ -210,8 +210,8 @@ public class ExpressionEstimation extends ExpressionVisitor<ColumnStatistic, Sta
         }
         Expression child = count.child(0);
         ColumnStatistic columnStat = child.accept(this, context);
-        if (columnStat == ColumnStatistic.UNKNOWN) {
-            return ColumnStatistic.UNKNOWN;
+        if (columnStat == ColumnStatistic.DEFAULT) {
+            return ColumnStatistic.DEFAULT;
         }
         double expectedValue = context.getRowCount() - columnStat.numNulls;
         double width = (double) count.getDataType().width();

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/FilterEstimation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/FilterEstimation.java
@@ -399,7 +399,7 @@ public class FilterEstimation extends ExpressionVisitor<StatsDeriveResult, Estim
         boolean isNotIn = context != null && context.isNot;
         Expression compareExpr = inPredicate.getCompareExpr();
         ColumnStatistic compareExprStats = ExpressionEstimation.estimate(compareExpr, inputStats);
-        if (compareExprStats == ColumnStatistic.UNKNOWN) {
+        if (compareExprStats == ColumnStatistic.DEFAULT) {
             return inputStats;
         }
         List<Expression> options = inPredicate.getOptions();
@@ -427,7 +427,7 @@ public class FilterEstimation extends ExpressionVisitor<StatsDeriveResult, Estim
         if (isNotIn) {
             for (Expression option : options) {
                 ColumnStatistic optionStats = ExpressionEstimation.estimate(option, inputStats);
-                if (optionStats == ColumnStatistic.UNKNOWN) {
+                if (optionStats == ColumnStatistic.DEFAULT) {
                     continue;
                 }
                 double validOptionNdv = compareExprStats.ndvIntersection(optionStats);
@@ -441,7 +441,7 @@ public class FilterEstimation extends ExpressionVisitor<StatsDeriveResult, Estim
         } else {
             for (Expression option : options) {
                 ColumnStatistic optionStats = ExpressionEstimation.estimate(option, inputStats);
-                if (optionStats == ColumnStatistic.UNKNOWN) {
+                if (optionStats == ColumnStatistic.DEFAULT) {
                     validInOptCount++;
                     continue;
                 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/StatsCalculator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/StatsCalculator.java
@@ -295,7 +295,7 @@ public class StatsCalculator extends DefaultPlanVisitor<StatsDeriveResult, Void>
             }
             ColumnStatistic statistic =
                     Env.getCurrentEnv().getStatisticsCache().getColumnStatistics(table.getId(), colName);
-            if (statistic == ColumnStatistic.UNKNOWN) {
+            if (statistic == ColumnStatistic.DEFAULT) {
                 if (card == -1) {
                     card = roughlyEstimatedCard(scan);
                 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/StatsCalculatorV2.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/StatsCalculatorV2.java
@@ -289,9 +289,6 @@ public class StatsCalculatorV2 extends DefaultPlanVisitor<StatsDeriveResult, Voi
             }
             ColumnStatistic statistic =
                     Env.getCurrentEnv().getStatisticsCache().getColumnStatistics(table.getId(), colName);
-            if (statistic == ColumnStatistic.DEFAULT) {
-                statistic = ColumnStatistic.DEFAULT;
-            }
             rowCount = statistic.count;
             columnStatisticMap.put(slotReference.getExprId(), statistic);
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/StatsCalculatorV2.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/StatsCalculatorV2.java
@@ -289,7 +289,7 @@ public class StatsCalculatorV2 extends DefaultPlanVisitor<StatsDeriveResult, Voi
             }
             ColumnStatistic statistic =
                     Env.getCurrentEnv().getStatisticsCache().getColumnStatistics(table.getId(), colName);
-            if (statistic == ColumnStatistic.UNKNOWN) {
+            if (statistic == ColumnStatistic.DEFAULT) {
                 statistic = ColumnStatistic.DEFAULT;
             }
             rowCount = statistic.count;

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/ColumnStatistic.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/ColumnStatistic.java
@@ -38,12 +38,8 @@ public class ColumnStatistic {
 
     private static final Logger LOG = LogManager.getLogger(StmtExecutor.class);
 
-    public static ColumnStatistic UNKNOWN = new ColumnStatisticBuilder().setCount(Double.NaN).setNdv(Double.NaN)
-            .setAvgSizeByte(Double.NaN).setNumNulls(Double.NaN).setDataSize(Double.NaN)
-            .setMinValue(Double.NaN).setMaxValue(Double.NaN).setMinExpr(null).setMaxExpr(null).build();
-
     public static ColumnStatistic DEFAULT = new ColumnStatisticBuilder().setAvgSizeByte(1).setNdv(1)
-            .setNumNulls(1).setCount(1).setMaxValue(Double.MAX_VALUE).setMinValue(Double.MIN_VALUE)
+            .setNumNulls(1).setCount(1).setMaxValue(Double.MAX_VALUE).setMinValue(Double.MIN_VALUE).setSelectivity(1.0)
             .build();
 
     public static final Set<Type> MAX_MIN_UNSUPPORTED_TYPE = new HashSet<>();
@@ -106,7 +102,7 @@ public class ColumnStatistic {
             if (col == null) {
                 LOG.warn("Failed to deserialize column statistics, column:{}.{}.{}.{} not exists",
                         catalogId, dbID, tblId, colName);
-                return ColumnStatistic.UNKNOWN;
+                return ColumnStatistic.DEFAULT;
             }
             String min = resultRow.getColumnValue("min");
             String max = resultRow.getColumnValue("max");
@@ -119,7 +115,7 @@ public class ColumnStatistic {
         } catch (Exception e) {
             e.printStackTrace();
             LOG.warn("Failed to deserialize column statistics, column not exists", e);
-            return ColumnStatistic.UNKNOWN;
+            return ColumnStatistic.DEFAULT;
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/ColumnStatisticBuilder.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/ColumnStatisticBuilder.java
@@ -47,7 +47,7 @@ public class ColumnStatisticBuilder {
         this.selectivity = columnStatistic.selectivity;
         this.minExpr = columnStatistic.minExpr;
         this.maxExpr = columnStatistic.maxExpr;
-        this.buildOnUnknown = columnStatistic == ColumnStatistic.UNKNOWN;
+        this.buildOnUnknown = columnStatistic == ColumnStatistic.DEFAULT;
     }
 
     public ColumnStatisticBuilder setCount(double count) {

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticsCache.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticsCache.java
@@ -39,7 +39,7 @@ public class StatisticsCache {
 
     public ColumnStatistic getColumnStatistics(long tblId, String colName) {
         if (ConnectContext.get().getSessionVariable().internalSession) {
-            return ColumnStatistic.UNKNOWN;
+            return ColumnStatistic.DEFAULT;
         }
         StatisticsCacheKey k = new StatisticsCacheKey(tblId, colName);
         CompletableFuture<ColumnStatistic> f = cache.get(k);
@@ -48,10 +48,10 @@ public class StatisticsCache {
                 return f.get();
             } catch (Exception e) {
                 LOG.warn("Unexpected exception while returning ColumnStatistic", e);
-                return ColumnStatistic.UNKNOWN;
+                return ColumnStatistic.DEFAULT;
             }
         }
-        return ColumnStatistic.UNKNOWN;
+        return ColumnStatistic.DEFAULT;
     }
 
     // TODO: finish this method.

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticsRepository.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticsRepository.java
@@ -81,7 +81,7 @@ public class StatisticsRepository {
     public static ColumnStatistic queryColumnStatisticsByName(long tableId, String colName) {
         ResultRow resultRow = queryColumnStatisticById(tableId, colName);
         if (resultRow == null) {
-            return ColumnStatistic.UNKNOWN;
+            return ColumnStatistic.DEFAULT;
         }
         return ColumnStatistic.fromResultRow(resultRow);
     }

--- a/fe/fe-core/src/test/java/org/apache/doris/statistics/CacheTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/statistics/CacheTest.java
@@ -47,7 +47,7 @@ public class CacheTest extends TestWithFeService {
                     try {
                         Thread.sleep(50);
                     } catch (InterruptedException e) {
-                        return ColumnStatistic.UNKNOWN;
+                        return ColumnStatistic.DEFAULT;
                     }
                     return ColumnStatistic.DEFAULT;
                 });
@@ -55,7 +55,7 @@ public class CacheTest extends TestWithFeService {
         };
         StatisticsCache statisticsCache = new StatisticsCache();
         ColumnStatistic c = statisticsCache.getColumnStatistics(1, "col");
-        Assertions.assertEquals(c, ColumnStatistic.UNKNOWN);
+        Assertions.assertEquals(c, ColumnStatistic.DEFAULT);
         Thread.sleep(100);
         c = statisticsCache.getColumnStatistics(1, "col");
         Assertions.assertEquals(c, ColumnStatistic.DEFAULT);
@@ -118,7 +118,7 @@ public class CacheTest extends TestWithFeService {
         };
         StatisticsCache statisticsCache = new StatisticsCache();
         ColumnStatistic columnStatistic = statisticsCache.getColumnStatistics(0, "col");
-        Assertions.assertEquals(ColumnStatistic.UNKNOWN, columnStatistic);
+        Assertions.assertEquals(ColumnStatistic.DEFAULT, columnStatistic);
         Thread.sleep(100);
         columnStatistic = statisticsCache.getColumnStatistics(0, "col");
         Assertions.assertEquals(1, columnStatistic.count);


### PR DESCRIPTION
# Proposed changes

ColumnStatistics.UNKNOWN can be replaced by ColumnStatistics.DEFAULT

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

