### PR TITLE
[improvement](planner) eliminating useless sort node

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -223,6 +223,8 @@ public class SessionVariable implements Serializable, Writable {
 
     public static final String ENABLE_NEREIDS_STATS_DERIVE_V2 = "enable_nereids_stats_derive_v2";
 
+    public static final String ENABLE_ELIMINATE_SORT_NODE = "enable_eliminate_sort_node";
+
     public static final String INTERNAL_SESSION = "internal_session";
 
     // session origin value
@@ -585,6 +587,9 @@ public class SessionVariable implements Serializable, Writable {
 
     @VariableMgr.VarAttr(name = ENABLE_NEREIDS_STATS_DERIVE_V2)
     public boolean enableNereidsStatsDeriveV2 = false;
+
+    @VariableMgr.VarAttr(name = ENABLE_ELIMINATE_SORT_NODE)
+    public boolean enableEliminateSortNode = true;
 
     @VariableMgr.VarAttr(name = INTERNAL_SESSION)
     public boolean internalSession = false;


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

### for example
case1:
initial sql: select * from t1 where k1 = 1 order by k1
optimized sql: select * from t1 where k1 = 1

case2:
initial sql: select * from t1 where k1 in (1) order by k1
optimized sql: select * from t1 where k1 in (1)

case3:
initial sql: select * from t1 where k1 in (concat("1","2")) order by k1
optimized sql: select * from t1 where k1 in (concat("1","2")) 

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

