### PR TITLE
[Vectorized](udaf) fix java-udaf couldn't get jar core dump

### DIFF
--- a/be/src/runtime/user_function_cache.h
+++ b/be/src/runtime/user_function_cache.h
@@ -70,6 +70,7 @@ public:
     Status get_jarpath(int64_t fid, const std::string& url, const std::string& checksum,
                        std::string* libpath);
     Status check_jar(int64_t fid, const std::string& url, const std::string& checksum);
+
 private:
     Status _load_cached_lib();
     Status _load_entry_from_lib(const std::string& dir, const std::string& file);

--- a/be/src/runtime/user_function_cache.h
+++ b/be/src/runtime/user_function_cache.h
@@ -69,7 +69,7 @@ public:
 
     Status get_jarpath(int64_t fid, const std::string& url, const std::string& checksum,
                        std::string* libpath);
-
+    Status check_jar(int64_t fid, const std::string& url, const std::string& checksum);
 private:
     Status _load_cached_lib();
     Status _load_entry_from_lib(const std::string& dir, const std::string& file);

--- a/be/src/vec/aggregate_functions/aggregate_function.h
+++ b/be/src/vec/aggregate_functions/aggregate_function.h
@@ -22,6 +22,7 @@
 
 #include <parallel_hashmap/phmap.h>
 
+#include "common/status.h"
 #include "vec/columns/column_complex.h"
 #include "vec/common/exception.h"
 #include "vec/core/block.h"
@@ -197,6 +198,9 @@ public:
     virtual MutableColumnPtr create_serialize_column() const { return ColumnString::create(); }
 
     virtual DataTypePtr get_serialized_type() const { return std::make_shared<DataTypeString>(); }
+
+    //only used to check java udaf jar is valided, so it's could retrn error for user before open phase
+    virtual Status check_udaf(const TFunction& fn) { return Status::OK(); }
 
 protected:
     DataTypes argument_types;

--- a/be/src/vec/aggregate_functions/aggregate_function.h
+++ b/be/src/vec/aggregate_functions/aggregate_function.h
@@ -22,7 +22,6 @@
 
 #include <parallel_hashmap/phmap.h>
 
-#include "common/status.h"
 #include "vec/columns/column_complex.h"
 #include "vec/common/exception.h"
 #include "vec/core/block.h"

--- a/be/src/vec/aggregate_functions/aggregate_function.h
+++ b/be/src/vec/aggregate_functions/aggregate_function.h
@@ -199,9 +199,6 @@ public:
 
     virtual DataTypePtr get_serialized_type() const { return std::make_shared<DataTypeString>(); }
 
-    //only used to check java udaf jar is valided, so it's could retrn error for user before open phase
-    virtual Status check_udaf(const TFunction& fn) { return Status::OK(); }
-
 protected:
     DataTypes argument_types;
     Array parameters;

--- a/be/src/vec/aggregate_functions/aggregate_function_java_udaf.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_java_udaf.h
@@ -311,7 +311,7 @@ public:
     }
     //Note: The condition is added because maybe the BE can't find java-udaf impl jar
     //So need to check as soon as possible, before call Data function
-    Status check_udaf(const TFunction& fn) override {
+    Status check_udaf(const TFunction& fn) {
         auto function_cache = UserFunctionCache::instance();
         return function_cache->get_jarpath(fn.id, fn.hdfs_location, fn.checksum, &_local_location);
     }

--- a/be/src/vec/aggregate_functions/aggregate_function_java_udaf.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_java_udaf.h
@@ -78,14 +78,15 @@ public:
         RETURN_IF_ERROR(JniUtil::GetGlobalClassRef(env, UDAF_EXECUTOR_CLASS, &executor_cl));
         RETURN_NOT_OK_STATUS_WITH_WARN(register_func_id(env),
                                        "Java-Udaf register_func_id function");
+
         // Add a scoped cleanup jni reference object. This cleans up local refs made below.
         JniLocalFrame jni_frame;
         {
-            TJavaUdfExecutorCtorParams ctor_params;
             std::string local_location;
             auto function_cache = UserFunctionCache::instance();
             RETURN_IF_ERROR(function_cache->get_jarpath(fn.id, fn.hdfs_location, fn.checksum,
                                                         &local_location));
+            TJavaUdfExecutorCtorParams ctor_params;
             ctor_params.__set_fn(fn);
             ctor_params.__set_location(local_location);
             ctor_params.__set_input_offsets_ptrs((int64_t)input_offsets_ptrs.get());

--- a/be/src/vec/exprs/vectorized_agg_fn.cpp
+++ b/be/src/vec/exprs/vectorized_agg_fn.cpp
@@ -116,11 +116,11 @@ Status AggFnEvaluator::prepare(RuntimeState* state, const RowDescriptor& desc, M
     if (_fn.binary_type == TFunctionBinaryType::JAVA_UDF) {
         if (config::enable_java_support) {
             _function = AggregateJavaUdaf::create(_fn, argument_types, {}, _data_type);
-            RETURN_IF_ERROR(_function->check_udaf(_fn));
+            RETURN_IF_ERROR(static_cast<AggregateJavaUdaf*>(_function.get())->check_udaf(_fn));
         } else {
             return Status::InternalError(
-                    "Java UDF is not enabled, you can change be config enable_java_support to true "
-                    "and restart be.");
+                    "Java UDAF is not enabled, you can change be config enable_java_support to "
+                    "true and restart be.");
         }
     } else if (_fn.binary_type == TFunctionBinaryType::RPC) {
         _function = AggregateRpcUdaf::create(_fn, argument_types, {}, _data_type);

--- a/be/src/vec/exprs/vectorized_agg_fn.cpp
+++ b/be/src/vec/exprs/vectorized_agg_fn.cpp
@@ -116,6 +116,7 @@ Status AggFnEvaluator::prepare(RuntimeState* state, const RowDescriptor& desc, M
     if (_fn.binary_type == TFunctionBinaryType::JAVA_UDF) {
         if (config::enable_java_support) {
             _function = AggregateJavaUdaf::create(_fn, argument_types, {}, _data_type);
+            RETURN_IF_ERROR(_function->check_udaf(_fn));
         } else {
             return Status::InternalError(
                     "Java UDF is not enabled, you can change be config enable_java_support to true "

--- a/docs/en/docs/ecosystem/udf/java-user-defined-function.md
+++ b/docs/en/docs/ecosystem/udf/java-user-defined-function.md
@@ -164,8 +164,7 @@ CREATE AGGREGATE FUNCTION simple_sum(INT) RETURNS INT PROPERTIES (
 );
 ```
 * The implemented jar package can be stored at local or in a remote server and downloaded via http, And each BE node must be able to obtain the jar package;
-Otherwise, the BE node that does not obtain the jar package will not be able to participate in the calculation, which may cause errors in the execution results;
-When a BE node fails to obtain the jar package, query the related log "java udaf couldn't find implementation jar" in be.WARNING
+Otherwise, the error status message "Couldn't open file..." will be returned
 
 Currently, UDTF are not supported.
 

--- a/docs/en/docs/ecosystem/udf/java-user-defined-function.md
+++ b/docs/en/docs/ecosystem/udf/java-user-defined-function.md
@@ -163,6 +163,9 @@ CREATE AGGREGATE FUNCTION simple_sum(INT) RETURNS INT PROPERTIES (
     "type"="JAVA_UDF"
 );
 ```
+* The implemented jar package can be stored at local or in a remote server and downloaded via http, And each BE node must be able to obtain the jar package;
+Otherwise, the BE node that does not obtain the jar package will not be able to participate in the calculation, which may cause errors in the execution results;
+When a BE node fails to obtain the jar package, query the related log "java udaf couldn't find implementation jar" in be.WARNING
 
 Currently, UDTF are not supported.
 

--- a/docs/zh-CN/docs/ecosystem/udf/java-user-defined-function.md
+++ b/docs/zh-CN/docs/ecosystem/udf/java-user-defined-function.md
@@ -163,8 +163,7 @@ CREATE AGGREGATE FUNCTION simple_sum(int) RETURNS int PROPERTIES (
 );
 ```
 * 实现的jar包可以放在本地也可以存放在远程服务端通过http下载，但必须让每个BE节点都能获取到jar包;
-否则没有获取jar包的BE节点将无法参与计算，可能造成执行结果错误;
-当某个BE节点获取jar包失败时，可在be.WARNING中查询相关日志“java udaf couldn't find implement jar”.
+否则将会返回错误状态信息"Couldn't open file ......".
 
 目前还暂不支持UDTF
 

--- a/docs/zh-CN/docs/ecosystem/udf/java-user-defined-function.md
+++ b/docs/zh-CN/docs/ecosystem/udf/java-user-defined-function.md
@@ -162,6 +162,9 @@ CREATE AGGREGATE FUNCTION simple_sum(int) RETURNS int PROPERTIES (
     "type"="JAVA_UDF"
 );
 ```
+* 实现的jar包可以放在本地也可以存放在远程服务端通过http下载，但必须让每个BE节点都能获取到jar包;
+否则没有获取jar包的BE节点将无法参与计算，可能造成执行结果错误;
+当某个BE节点获取jar包失败时，可在be.WARNING中查询相关日志“java udaf couldn't find implement jar”.
 
 目前还暂不支持UDTF
 

--- a/regression-test/suites/query_p0/sql_functions/array_functions/test_array_functions.groovy
+++ b/regression-test/suites/query_p0/sql_functions/array_functions/test_array_functions.groovy
@@ -136,8 +136,8 @@ suite("test_array_functions") {
                   "storage_format" = "V2"
                   );
         """
-    sql """ insert into ${tableName3} values (10005,'四年级三班',[10005,null,null]) """
-    sql """ insert into ${tableName3} values (10006,'六年级一班',[60002,60002,60003,null,60005]) """
+    sql """ insert into ${tableName3} values (10005,'aaaaa',[10005,null,null]) """
+    sql """ insert into ${tableName3} values (10006,'bbbbb',[60002,60002,60003,null,60005]) """
     
     qt_select_union "select class_id, student_ids, array_union(student_ids,[1,2,3]) from ${tableName3} order by class_id;"
     qt_select_except "select class_id, student_ids, array_except(student_ids,[1,2,3]) from ${tableName3} order by class_id;"


### PR DESCRIPTION
# Proposed changes

**If be couldn't get jar, when  call agg create function will be failed, so exec_place is nullptr cause core dump** 

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

