### PR TITLE
[opt](nereids) make fragment id in explain get inline with profile

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/profile/PlanTreeBuilder.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/profile/PlanTreeBuilder.java
@@ -62,7 +62,7 @@ public class PlanTreeBuilder {
                 } else {
                     sb.append("[").append(sink.getClass().getSimpleName()).append("]");
                 }
-                sb.append("\n[Fragment: ").append(fragment.getId().asInt()).append("]");
+                sb.append("\n[Fragment: ").append(fragment.getFragmentSequenceNum()).append("]");
                 sb.append("\n").append(sink.getExplainString("", TExplainLevel.BRIEF));
                 sinkNode = new PlanTreeNode(sink.getExchNodeId(), sb.toString());
                 if (i == 0) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/NereidsPlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/NereidsPlanner.java
@@ -91,7 +91,9 @@ public class NereidsPlanner extends Planner {
         scanNodeList = planTranslatorContext.getScanNodes();
         descTable = planTranslatorContext.getDescTable();
         fragments = new ArrayList<>(planTranslatorContext.getPlanFragments());
-
+        for (int seq = 0; seq < fragments.size(); seq++) {
+            fragments.get(seq).setFragmentSequenceNum(seq);
+        }
         // set output exprs
         logicalPlanAdapter.setResultExprs(root.getOutputExprs());
         ArrayList<String> columnLabelList = physicalPlan.getOutput().stream().map(NamedExpression::getName)

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/PlanFragment.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/PlanFragment.java
@@ -83,6 +83,7 @@ public class PlanFragment extends TreeNode<PlanFragment> {
 
     // id for this plan fragment
     private PlanFragmentId fragmentId;
+    private int fragmentSequenceNum;
     // private PlanId planId_;
     // private CohortId cohortId_;
 
@@ -413,5 +414,17 @@ public class PlanFragment extends TreeNode<PlanFragment> {
 
     public boolean isTransferQueryStatisticsWithEveryBatch() {
         return transferQueryStatisticsWithEveryBatch;
+    }
+
+    public int getFragmentSequenceNum() {
+        if (ConnectContext.get().getSessionVariable().isEnableNereidsPlanner()) {
+            return fragmentSequenceNum;
+        } else {
+            return fragmentId.asInt();
+        }
+    }
+
+    public void setFragmentSequenceNum(int seq) {
+        fragmentSequenceNum = seq;
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/PlanFragment.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/PlanFragment.java
@@ -83,6 +83,11 @@ public class PlanFragment extends TreeNode<PlanFragment> {
 
     // id for this plan fragment
     private PlanFragmentId fragmentId;
+    // nereids planner and original planner generate fragments in different order.
+    // This makes nereids fragment id different from that of original planner, and
+    // hence different from that in profile.
+    // in original planner, fragmentSequenceNum is fragmentId, and in nereids planner,
+    // fragmentSequenceNum is the id displayed in profile
     private int fragmentSequenceNum;
     // private PlanId planId_;
     // private CohortId cohortId_;

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/PlanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/PlanNode.java
@@ -235,6 +235,10 @@ public abstract class PlanNode extends TreeNode<PlanNode> implements PlanStats {
         return fragment.getFragmentId();
     }
 
+    public int getFragmentSeqenceNum() {
+        return fragment.getFragmentSequenceNum();
+    }
+
     public void setFragmentId(PlanFragmentId id) {
         fragmentId = id;
     }
@@ -887,7 +891,7 @@ public abstract class PlanNode extends TreeNode<PlanNode> implements PlanStats {
     public String getPlanTreeExplainStr() {
         StringBuilder sb = new StringBuilder();
         sb.append("[").append(getId().asInt()).append(": ").append(getPlanNodeName()).append("]");
-        sb.append("\n[Fragment: ").append(getFragmentId().asInt()).append("]");
+        sb.append("\n[Fragment: ").append(getFragmentSeqenceNum()).append("]");
         sb.append("\n").append(getNodeExplainString("", TExplainLevel.BRIEF));
         return sb.toString();
     }


### PR DESCRIPTION
# Proposed changes
Nereids assign fragment ID in its own way. The fragment Id in explain is different from the fragment id in profile.
This difference makes trouble to understand profile.

This pr aims to print fragment id in explain the same as that in profile.

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

