### PR TITLE
[fix](parquet-orc) fix that be core dump when some columns specified are not in the parquet or orc file

### DIFF
--- a/be/src/vec/exec/varrow_scanner.cpp
+++ b/be/src/vec/exec/varrow_scanner.cpp
@@ -153,6 +153,12 @@ Status VArrowScanner::_init_arrow_batch_if_necessary() {
 Status VArrowScanner::_init_src_block() {
     size_t batch_pos = 0;
     _src_block.clear();
+    if (_batch->num_columns() < _num_of_columns_from_file) {
+        LOG(WARNING) << "some cloumns not found in the file, num_columns_obtained: "
+                     << _batch->num_columns()
+                     << " num_columns_required: " << _num_of_columns_from_file;
+        return Status::InvalidArgument("some cloumns not found in the file");
+    }
     for (auto i = 0; i < _num_of_columns_from_file; ++i) {
         SlotDescriptor* slot_desc = _src_slot_descs[i];
         if (slot_desc == nullptr) {


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

When some columns specified are not in the parquet or orc file in broker load, `_batch->num_columns()` will less than `_num_of_columns_from_file`. It will lead to be core dump.
To prevent be core dump, just return an error in this case.


## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

