### PR TITLE
[enhancement](Nereids) reduce CostAndEnforcerJob call times

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/PlanContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/PlanContext.java
@@ -18,7 +18,6 @@
 package org.apache.doris.nereids;
 
 import org.apache.doris.common.Id;
-import org.apache.doris.nereids.memo.Group;
 import org.apache.doris.nereids.memo.GroupExpression;
 import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.trees.expressions.Slot;
@@ -26,7 +25,6 @@ import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.statistics.StatsDeriveResult;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.Lists;
 
 import java.util.List;
 
@@ -37,8 +35,6 @@ import java.util.List;
  * Inspired by GPORCA-CExpressionHandle.
  */
 public class PlanContext {
-    // array of children's derived stats
-    private final List<StatsDeriveResult> childrenStats;
     // attached group expression
     private final GroupExpression groupExpression;
 
@@ -47,19 +43,10 @@ public class PlanContext {
      */
     public PlanContext(GroupExpression groupExpression) {
         this.groupExpression = groupExpression;
-        childrenStats = Lists.newArrayListWithCapacity(groupExpression.children().size());
-
-        for (Group group : groupExpression.children()) {
-            childrenStats.add(group.getStatistics());
-        }
     }
 
     public GroupExpression getGroupExpression() {
         return groupExpression;
-    }
-
-    public List<StatsDeriveResult> getChildrenStats() {
-        return childrenStats;
     }
 
     public StatsDeriveResult getStatisticsWithCheck() {
@@ -84,7 +71,7 @@ public class PlanContext {
      * Get child statistics.
      */
     public StatsDeriveResult getChildStatistics(int index) {
-        StatsDeriveResult statistics = childrenStats.get(index);
+        StatsDeriveResult statistics = groupExpression.child(index).getStatistics();
         Preconditions.checkNotNull(statistics);
         return statistics;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/Job.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/Job.java
@@ -80,8 +80,7 @@ public abstract class Job {
      * @param candidateRules rules to be applied
      * @return all rules that can be applied on this group expression
      */
-    public List<Rule> getValidRules(GroupExpression groupExpression,
-            List<Rule> candidateRules) {
+    public List<Rule> getValidRules(GroupExpression groupExpression, List<Rule> candidateRules) {
         return candidateRules.stream()
                 .filter(rule -> Objects.nonNull(rule) && rule.getPattern().matchRoot(groupExpression.getPlan())
                         && groupExpression.notApplied(rule)).collect(Collectors.toList());

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/cascades/CostAndEnforcerJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/cascades/CostAndEnforcerJob.java
@@ -41,6 +41,7 @@ import java.util.Optional;
  * Inspired by NoisePage and ORCA-Paper.
  */
 public class CostAndEnforcerJob extends Job implements Cloneable {
+
     // GroupExpression to optimize
     private final GroupExpression groupExpression;
 
@@ -165,7 +166,7 @@ public class CostAndEnforcerJob extends Job implements Cloneable {
 
                 curTotalCost += lowestCostExpr.getLowestCostTable().get(requestChildProperty).first;
                 if (curTotalCost > context.getCostUpperBound()) {
-                    break;
+                    curTotalCost = Double.POSITIVE_INFINITY;
                 }
                 // the request child properties will be covered by the output properties
                 // that corresponding to the request properties. so if we run a costAndEnforceJob of the same

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Group.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Group.java
@@ -53,7 +53,7 @@ public class Group {
     // Map of cost lower bounds
     // Map required plan props to cost lower bound of corresponding plan
     private final Map<PhysicalProperties, Pair<Double, GroupExpression>> lowestCostPlans = Maps.newHashMap();
-    private double costLowerBound = -1;
+
     private boolean isExplored = false;
 
     private StatsDeriveResult statistics;
@@ -101,85 +101,9 @@ public class Group {
         return groupExpression;
     }
 
-    /**
-     * Remove groupExpression from this group.
-     *
-     * @param groupExpression to be removed
-     * @return removed {@link GroupExpression}
-     */
-    public GroupExpression removeGroupExpression(GroupExpression groupExpression) {
-        if (groupExpression.getPlan() instanceof LogicalPlan) {
-            logicalExpressions.remove(groupExpression);
-        } else {
-            physicalExpressions.remove(groupExpression);
-        }
-        groupExpression.setOwnerGroup(null);
-        return groupExpression;
-    }
-
     public void addLogicalExpression(GroupExpression groupExpression) {
         groupExpression.setOwnerGroup(this);
         logicalExpressions.add(groupExpression);
-    }
-
-    public List<GroupExpression> clearLogicalExpressions() {
-        List<GroupExpression> move = logicalExpressions.stream()
-                .peek(groupExpr -> groupExpr.setOwnerGroup(null))
-                .collect(Collectors.toList());
-        logicalExpressions.clear();
-        return move;
-    }
-
-    public List<GroupExpression> clearPhysicalExpressions() {
-        List<GroupExpression> move = physicalExpressions.stream()
-                .peek(groupExpr -> groupExpr.setOwnerGroup(null))
-                .collect(Collectors.toList());
-        physicalExpressions.clear();
-        return move;
-    }
-
-    public double getCostLowerBound() {
-        return costLowerBound;
-    }
-
-    /**
-     * Set or update lowestCostPlans: properties --> Pair.of(cost, expression)
-     */
-    public void setBestPlan(GroupExpression expression, double cost, PhysicalProperties properties) {
-        if (lowestCostPlans.containsKey(properties)) {
-            if (lowestCostPlans.get(properties).first >= cost) {
-                lowestCostPlans.put(properties, Pair.of(cost, expression));
-            }
-        } else {
-            lowestCostPlans.put(properties, Pair.of(cost, expression));
-        }
-    }
-
-    public GroupExpression getBestPlan(PhysicalProperties properties) {
-        if (lowestCostPlans.containsKey(properties)) {
-            return lowestCostPlans.get(properties).second;
-        }
-        return null;
-    }
-
-    /**
-     * replace best plan with new properties
-     */
-    public void replaceBestPlan(PhysicalProperties oldProperty, PhysicalProperties newProperty, double cost) {
-        Pair<Double, GroupExpression> pair = lowestCostPlans.get(oldProperty);
-        GroupExpression lowestGroupExpr = pair.second;
-        lowestGroupExpr.updateLowestCostTable(newProperty,
-                lowestGroupExpr.getInputPropertiesList(oldProperty), cost);
-        lowestCostPlans.remove(oldProperty);
-        lowestCostPlans.put(newProperty, pair);
-    }
-
-    public StatsDeriveResult getStatistics() {
-        return statistics;
-    }
-
-    public void setStatistics(StatsDeriveResult statistics) {
-        this.statistics = statistics;
     }
 
     public List<GroupExpression> getLogicalExpressions() {
@@ -208,20 +132,40 @@ public class Group {
         return physicalExpressions;
     }
 
-    public LogicalProperties getLogicalProperties() {
-        return logicalProperties;
+    /**
+     * Remove groupExpression from this group.
+     *
+     * @param groupExpression to be removed
+     * @return removed {@link GroupExpression}
+     */
+    public GroupExpression removeGroupExpression(GroupExpression groupExpression) {
+        if (groupExpression.getPlan() instanceof LogicalPlan) {
+            logicalExpressions.remove(groupExpression);
+        } else {
+            physicalExpressions.remove(groupExpression);
+        }
+        groupExpression.setOwnerGroup(null);
+        return groupExpression;
     }
 
-    public void setLogicalProperties(LogicalProperties logicalProperties) {
-        this.logicalProperties = logicalProperties;
+    public List<GroupExpression> clearLogicalExpressions() {
+        List<GroupExpression> move = logicalExpressions.stream()
+                .peek(groupExpr -> groupExpr.setOwnerGroup(null))
+                .collect(Collectors.toList());
+        logicalExpressions.clear();
+        return move;
     }
 
-    public boolean isExplored() {
-        return isExplored;
+    public List<GroupExpression> clearPhysicalExpressions() {
+        List<GroupExpression> move = physicalExpressions.stream()
+                .peek(groupExpr -> groupExpr.setOwnerGroup(null))
+                .collect(Collectors.toList());
+        physicalExpressions.clear();
+        return move;
     }
 
-    public void setExplored(boolean explored) {
-        isExplored = explored;
+    public double getCostLowerBound() {
+        return -1D;
     }
 
     /**
@@ -236,6 +180,62 @@ public class Group {
             return Optional.empty();
         }
         return Optional.ofNullable(lowestCostPlans.get(physicalProperties));
+    }
+
+    public GroupExpression getBestPlan(PhysicalProperties properties) {
+        if (lowestCostPlans.containsKey(properties)) {
+            return lowestCostPlans.get(properties).second;
+        }
+        return null;
+    }
+
+    /**
+     * Set or update lowestCostPlans: properties --> Pair.of(cost, expression)
+     */
+    public void setBestPlan(GroupExpression expression, double cost, PhysicalProperties properties) {
+        if (lowestCostPlans.containsKey(properties)) {
+            if (lowestCostPlans.get(properties).first >= cost) {
+                lowestCostPlans.put(properties, Pair.of(cost, expression));
+            }
+        } else {
+            lowestCostPlans.put(properties, Pair.of(cost, expression));
+        }
+    }
+
+    /**
+     * replace best plan with new properties
+     */
+    public void replaceBestPlan(PhysicalProperties oldProperty, PhysicalProperties newProperty, double cost) {
+        Pair<Double, GroupExpression> pair = lowestCostPlans.get(oldProperty);
+        GroupExpression lowestGroupExpr = pair.second;
+        lowestGroupExpr.updateLowestCostTable(newProperty,
+                lowestGroupExpr.getInputPropertiesList(oldProperty), cost);
+        lowestCostPlans.remove(oldProperty);
+        lowestCostPlans.put(newProperty, pair);
+    }
+
+    public StatsDeriveResult getStatistics() {
+        return statistics;
+    }
+
+    public void setStatistics(StatsDeriveResult statistics) {
+        this.statistics = statistics;
+    }
+
+    public LogicalProperties getLogicalProperties() {
+        return logicalProperties;
+    }
+
+    public void setLogicalProperties(LogicalProperties logicalProperties) {
+        this.logicalProperties = logicalProperties;
+    }
+
+    public boolean isExplored() {
+        return isExplored;
+    }
+
+    public void setExplored(boolean explored) {
+        isExplored = explored;
     }
 
     public List<GroupExpression> getParentGroupExpressions() {
@@ -255,6 +255,65 @@ public class Group {
     public int removeParentExpression(GroupExpression parent) {
         parentExpressions.remove(parent);
         return parentExpressions.size();
+    }
+
+    /**
+     * move the ownerGroup of all logical expressions to target group
+     * if this.equals(target), do nothing.
+     *
+     * @param target the new owner group of expressions
+     */
+    public void moveLogicalExpressionOwnership(Group target) {
+        if (equals(target)) {
+            return;
+        }
+        for (GroupExpression expression : logicalExpressions) {
+            target.addGroupExpression(expression);
+        }
+        logicalExpressions.clear();
+    }
+
+    /**
+     * move the ownerGroup of all physical expressions to target group
+     * if this.equals(target), do nothing.
+     *
+     * @param target the new owner group of expressions
+     */
+    public void movePhysicalExpressionOwnership(Group target) {
+        if (equals(target)) {
+            return;
+        }
+        for (GroupExpression expression : physicalExpressions) {
+            target.addGroupExpression(expression);
+        }
+        physicalExpressions.clear();
+    }
+
+    /**
+     * move the ownerGroup of all lowestCostPlans to target group
+     * if this.equals(target), do nothing.
+     *
+     * @param target the new owner group of expressions
+     */
+    public void moveLowestCostPlansOwnership(Group target) {
+        if (equals(target)) {
+            return;
+        }
+        lowestCostPlans.forEach((physicalProperties, costAndGroupExpr) -> {
+            GroupExpression bestGroupExpression = costAndGroupExpr.second;
+            // change into target group.
+            if (bestGroupExpression.getOwnerGroup() == this || bestGroupExpression.getOwnerGroup() == null) {
+                bestGroupExpression.setOwnerGroup(target);
+            }
+            if (!target.lowestCostPlans.containsKey(physicalProperties)) {
+                target.lowestCostPlans.put(physicalProperties, costAndGroupExpr);
+            } else {
+                if (costAndGroupExpr.first < target.lowestCostPlans.get(physicalProperties).first) {
+                    target.lowestCostPlans.put(physicalProperties, costAndGroupExpr);
+                }
+            }
+        });
+        lowestCostPlans.clear();
     }
 
     @Override
@@ -321,64 +380,5 @@ public class Group {
             }
         };
         return TreeStringUtils.treeString(this, toString, getChildren);
-    }
-
-    /**
-     * move the ownerGroup of all logical expressions to target group
-     * if this.equals(target), do nothing.
-     *
-     * @param target the new owner group of expressions
-     */
-    public void moveLogicalExpressionOwnership(Group target) {
-        if (equals(target)) {
-            return;
-        }
-        for (GroupExpression expression : logicalExpressions) {
-            target.addGroupExpression(expression);
-        }
-        logicalExpressions.clear();
-    }
-
-    /**
-     * move the ownerGroup of all physical expressions to target group
-     * if this.equals(target), do nothing.
-     *
-     * @param target the new owner group of expressions
-     */
-    public void movePhysicalExpressionOwnership(Group target) {
-        if (equals(target)) {
-            return;
-        }
-        for (GroupExpression expression : physicalExpressions) {
-            target.addGroupExpression(expression);
-        }
-        physicalExpressions.clear();
-    }
-
-    /**
-     * move the ownerGroup of all lowestCostPlans to target group
-     * if this.equals(target), do nothing.
-     *
-     * @param target the new owner group of expressions
-     */
-    public void moveLowestCostPlansOwnership(Group target) {
-        if (equals(target)) {
-            return;
-        }
-        lowestCostPlans.forEach((physicalProperties, costAndGroupExpr) -> {
-            GroupExpression bestGroupExpression = costAndGroupExpr.second;
-            // change into target group.
-            if (bestGroupExpression.getOwnerGroup() == this || bestGroupExpression.getOwnerGroup() == null) {
-                bestGroupExpression.setOwnerGroup(target);
-            }
-            if (!target.lowestCostPlans.containsKey(physicalProperties)) {
-                target.lowestCostPlans.put(physicalProperties, costAndGroupExpr);
-            } else {
-                if (costAndGroupExpr.first < target.lowestCostPlans.get(physicalProperties).first) {
-                    target.lowestCostPlans.put(physicalProperties, costAndGroupExpr);
-                }
-            }
-        });
-        lowestCostPlans.clear();
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/StatsDeriveResult.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/StatsDeriveResult.java
@@ -31,6 +31,7 @@ import java.util.Set;
  */
 public class StatsDeriveResult {
     private final double rowCount;
+    private double computeSize = -1D;
 
     private int width = 1;
     private double penalty = 0.0;
@@ -59,8 +60,12 @@ public class StatsDeriveResult {
     }
 
     public double computeSize() {
-        return Math.max(1, slotIdToColumnStats.values().stream().map(s -> s.dataSize).reduce(0D, Double::sum))
-                * rowCount;
+        if (computeSize < 0) {
+            computeSize = Math.max(1, slotIdToColumnStats.values().stream()
+                    .map(s -> s.dataSize).reduce(0D, Double::sum)
+            ) * rowCount;
+        }
+        return computeSize;
     }
 
     /**

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/properties/RequestPropertyDeriverTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/properties/RequestPropertyDeriverTest.java
@@ -132,11 +132,11 @@ public class RequestPropertyDeriverTest {
                 = requestPropertyDeriver.getRequestChildrenPropertyList(groupExpression);
 
         List<List<PhysicalProperties>> expected = Lists.newArrayList();
-        expected.add(Lists.newArrayList(PhysicalProperties.ANY, PhysicalProperties.REPLICATED));
         expected.add(Lists.newArrayList(
                 new PhysicalProperties(new DistributionSpecHash(Lists.newArrayList(new ExprId(0)), ShuffleType.JOIN)),
                 new PhysicalProperties(new DistributionSpecHash(Lists.newArrayList(new ExprId(1)), ShuffleType.JOIN))
         ));
+        expected.add(Lists.newArrayList(PhysicalProperties.ANY, PhysicalProperties.REPLICATED));
         Assertions.assertEquals(expected, actual);
     }
 


### PR DESCRIPTION
# Proposed changes

record pruned plan's cost to avoid optimize same GroupExpression more than once.

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

