### PR TITLE
[fix](version) fix recover bug for lower version

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/CatalogRecycleBin.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/CatalogRecycleBin.java
@@ -847,7 +847,6 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
                     tableIds.add(entry.getKey());
                 }
                 dbInfo.setTableIds(tableIds);
-                idToDatabase.put(dbEntry.getKey(), dbInfo);
             }
         }
     }


### PR DESCRIPTION
Signed-off-by: nextdreamblue <zxw520blue1@163.com>

# Proposed changes

relation with: #13067

## Problem summary

在 https://github.com/apache/doris/pull/13067 中对catalog recyble bin的优化中，在RecycleDatabaseInfo中增加了保存tableid的变量，用于支持根据id区分不同的同名table。但是这个信息在之前版本的元数据中是没有的，导致旧版本的fe升级到新的版本（VERSION_114）后，原有回收站中的database不能正确恢复，属于 https://github.com/apache/doris/pull/13067 pr代码的新旧版本的兼容性bug。

建议将该代码合并到包含 https://github.com/apache/doris/pull/13067 相关的分支中

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

