### PR TITLE
[fix](regression)when using regression-conf-custom.groovy, properties in regression-conf.groovy are missing

### DIFF
--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/Config.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/Config.groovy
@@ -123,16 +123,12 @@ class Config {
             def systemProperties = Maps.newLinkedHashMap(System.getProperties())
             configSlurper.setBinding(systemProperties)
             ConfigObject configObj = configSlurper.parse(new File(confFilePath).toURI().toURL())
-            config = Config.fromConfigObject(configObj)
-        }
-        String customConfFilePath = confFile.getParentFile().getPath() + "/regression-conf-custom.groovy"
-        File custFile = new File(customConfFilePath)
-        if (custFile.exists() && custFile.isFile()) {
-            log.info("Load custom config file ${customConfFilePath}".toString())
-            def configSlurper = new ConfigSlurper()
-            def systemProperties = Maps.newLinkedHashMap(System.getProperties())
-            configSlurper.setBinding(systemProperties)
-            ConfigObject configObj = configSlurper.parse(new File(customConfFilePath).toURI().toURL())
+            String customConfFilePath = confFile.getParentFile().getPath() + "/regression-conf-custom.groovy"
+            File custFile = new File(customConfFilePath)
+            if (custFile.exists() && custFile.isFile()) {
+                ConfigObject custConfigObj = configSlurper.parse(new File(customConfFilePath).toURI().toURL())
+                configObj.merge(custConfigObj)
+            }
             config = Config.fromConfigObject(configObj)
         }
         fillDefaultConfig(config)
@@ -274,7 +270,8 @@ class Config {
         }
 
         if (config.jdbcUrl == null) {
-            config.jdbcUrl = "jdbc:mysql://127.0.0.1:9030"
+            //jdbcUrl needs parameter here. Refer to function: buildUrl(String dbName)
+            config.jdbcUrl = "jdbc:mysql://127.0.0.1:9030/?useLocalSessionState=true"
             log.info("Set jdbcUrl to '${config.jdbcUrl}' because not specify.".toString())
         }
 


### PR DESCRIPTION
# Proposed changes
there is a bug when we load conf from regression-conf-custom.groovy. we re-new a conf, and hence lost information from regression-conf.groovy


Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

