### PR TITLE
[chore](macOS) Fix the build for thirdparty

### DIFF
--- a/thirdparty/build-thirdparty.sh
+++ b/thirdparty/build-thirdparty.sh
@@ -820,6 +820,7 @@ build_cyrus_sasl() {
     CFLAGS="-fPIC" \
         CPPFLAGS="-I${TP_INCLUDE_DIR}" \
         LDFLAGS="-L${TP_LIB_DIR}" \
+        LIBS="-lcrypto" \
         ./configure --prefix="${TP_INSTALL_DIR}" --enable-static --enable-shared=no --with-openssl="${TP_INSTALL_DIR}" --with-pic --enable-gssapi="${TP_INSTALL_DIR}" --with-gss_impl=mit --with-dblib=none
 
     if [[ "${KERNEL}" != 'Darwin' ]]; then


### PR DESCRIPTION
# Proposed changes

~~Issue Number: close #xxx~~

## Problem summary

When building third-parties from source, some errors occur (See [https://github.com/apache/doris-thirdparty/actions/runs/3514518494](https://github.com/apache/doris-thirdparty/actions/runs/3514518494)).

```shell
2022-11-21T14:11:12.8840970Z Undefined symbols for architecture x86_64:
2022-11-21T14:11:12.8841990Z   "_DES_cbc_encrypt", referenced from:
2022-11-21T14:11:12.8842770Z       _enc_des in libsasl2.a(digestmd5.o)
2022-11-21T14:11:12.8843390Z       _dec_des in libsasl2.a(digestmd5.o)
2022-11-21T14:11:12.8844010Z   "_DES_ede3_cbc_encrypt", referenced from:
2022-11-21T14:11:12.8844600Z       _enc_3des in libsasl2.a(digestmd5.o)
2022-11-21T14:11:12.8845200Z       _dec_3des in libsasl2.a(digestmd5.o)
2022-11-21T14:11:12.8845860Z   "_DES_key_sched", referenced from:
2022-11-21T14:11:12.8846460Z       _init_des in libsasl2.a(digestmd5.o)
2022-11-21T14:11:12.8847040Z       _init_3des in libsasl2.a(digestmd5.o)
2022-11-21T14:11:12.8847630Z   "_EVP_Digest", referenced from:
2022-11-21T14:11:12.8848320Z       _scram_server_mech_step2 in libsasl2.a(scram.o)
2022-11-21T14:11:12.8848990Z       _GenerateScramSecrets in libsasl2.a(scram.o)
2022-11-21T14:11:12.8849640Z       _scram_client_mech_step2 in libsasl2.a(scram.o)
2022-11-21T14:11:12.8850320Z   "_EVP_DigestFinal", referenced from:
2022-11-21T14:11:12.8850940Z       _word2bin in libsasl2.a(otp.o)
2022-11-21T14:11:12.8851510Z       _otp_hash in libsasl2.a(otp.o)
2022-11-21T14:11:12.8852110Z   "_EVP_DigestInit", referenced from:
2022-11-21T14:11:12.8852690Z       _word2bin in libsasl2.a(otp.o)
2022-11-21T14:11:12.8853270Z       _otp_hash in libsasl2.a(otp.o)
2022-11-21T14:11:12.8853850Z   "_EVP_DigestUpdate", referenced from:
2022-11-21T14:11:12.8854430Z       _word2bin in libsasl2.a(otp.o)
2022-11-21T14:11:12.8855010Z       _otp_hash in libsasl2.a(otp.o)
2022-11-21T14:11:12.8855660Z   "_EVP_MD_CTX_free", referenced from:
2022-11-21T14:11:12.8856290Z       __plug_EVP_MD_CTX_free in libsasl2.a(otp.o)
2022-11-21T14:11:12.8856890Z   "_EVP_MD_CTX_new", referenced from:
2022-11-21T14:11:12.8857490Z       __plug_EVP_MD_CTX_new in libsasl2.a(otp.o)
2022-11-21T14:11:12.8858080Z   "_EVP_MD_size", referenced from:
2022-11-21T14:11:12.8858690Z       _scram_server_mech_step in libsasl2.a(scram.o)
2022-11-21T14:11:12.8859300Z       _scram_setpass in libsasl2.a(scram.o)
2022-11-21T14:11:12.8860720Z       _scram_server_mech_step1 in libsasl2.a(scram.o)
2022-11-21T14:11:12.8861360Z       _scram_server_mech_step2 in libsasl2.a(scram.o)
2022-11-21T14:11:12.8861980Z       _scram_server_user_salt in libsasl2.a(scram.o)
2022-11-21T14:11:12.8862610Z       _GenerateScramSecrets in libsasl2.a(scram.o)
2022-11-21T14:11:12.8863180Z       _Hi in libsasl2.a(scram.o)
2022-11-21T14:11:12.8863730Z       ...
2022-11-21T14:11:12.8864300Z   "_EVP_get_digestbyname", referenced from:
2022-11-21T14:11:12.8864910Z       _verify_response in libsasl2.a(otp.o)
2022-11-21T14:11:12.8865490Z       _generate_otp in libsasl2.a(otp.o)
2022-11-21T14:11:12.8866190Z       _scram_server_mech_new in libsasl2.a(scram.o)
2022-11-21T14:11:12.8866830Z       _scram_setpass in libsasl2.a(scram.o)
2022-11-21T14:11:12.8867420Z       _scram_client_mech_new in libsasl2.a(scram.o)
2022-11-21T14:11:12.8868010Z   "_HMAC", referenced from:
2022-11-21T14:11:12.8868610Z       _scram_server_mech_step2 in libsasl2.a(scram.o)
2022-11-21T14:11:12.8869260Z       _GenerateScramSecrets in libsasl2.a(scram.o)
2022-11-21T14:11:12.8869840Z       _Hi in libsasl2.a(scram.o)
2022-11-21T14:11:12.8870440Z       _scram_client_mech_step2 in libsasl2.a(scram.o)
2022-11-21T14:11:12.8871060Z       _scram_client_mech_step3 in libsasl2.a(scram.o)
2022-11-21T14:11:12.8871680Z   "_OPENSSL_init_crypto", referenced from:
2022-11-21T14:11:12.8872280Z       _otp_server_plug_init in libsasl2.a(otp.o)
2022-11-21T14:11:12.8872890Z       _otp_client_plug_init in libsasl2.a(otp.o)
```

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

