### PR TITLE
[fix](nereids) stats derive bug: width/penalty not transferred

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/JoinEstimation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/JoinEstimation.java
@@ -199,14 +199,14 @@ public class JoinEstimation {
             throw new RuntimeException("joinType is not supported");
         }
 
-        StatsDeriveResult statsDeriveResult = new StatsDeriveResult(rowCount, Maps.newHashMap());
+        StatsDeriveResult statsDeriveResult = new StatsDeriveResult(rowCount,
+                rightStats.getWidth() + leftStats.getWidth(), 0, Maps.newHashMap());
         if (joinType.isRemainLeftJoin()) {
             statsDeriveResult.merge(leftStats);
         }
         if (joinType.isRemainRightJoin()) {
             statsDeriveResult.merge(rightStats);
         }
-        statsDeriveResult.setWidth(rightStats.getWidth() + leftStats.getWidth());
         statsDeriveResult.setPenalty(0.0);
         return statsDeriveResult;
     }
@@ -283,16 +283,17 @@ public class JoinEstimation {
             throw new RuntimeException("joinType is not supported");
         }
 
-        StatsDeriveResult statsDeriveResult = new StatsDeriveResult(rowCount, Maps.newHashMap());
+        StatsDeriveResult statsDeriveResult = new StatsDeriveResult(rowCount,
+                rightStats.getWidth() + leftStats.getWidth(),
+                0, Maps.newHashMap());
         if (joinType.isRemainLeftJoin()) {
             statsDeriveResult.merge(leftStats);
         }
         if (joinType.isRemainRightJoin()) {
             statsDeriveResult.merge(rightStats);
         }
-        statsDeriveResult = new StatsDeriveResult(rowCount);
+
         statsDeriveResult.isReduced = !forbiddenReducePropagation && (isReducedByHashJoin || leftStats.isReduced);
-        statsDeriveResult.setWidth(rightStats.getWidth() + leftStats.getWidth());
         return statsDeriveResult;
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/StatsCalculator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/StatsCalculator.java
@@ -353,7 +353,8 @@ public class StatsCalculator extends DefaultPlanVisitor<StatsDeriveResult, Void>
         for (NamedExpression outputExpression : outputExpressions) {
             slotToColumnStats.put(outputExpression.toSlot().getExprId(), ColumnStatistic.DEFAULT);
         }
-        StatsDeriveResult statsDeriveResult = new StatsDeriveResult(resultSetCount, slotToColumnStats);
+        StatsDeriveResult statsDeriveResult = new StatsDeriveResult(resultSetCount, childStats.getWidth(),
+                childStats.getPenalty(), slotToColumnStats);
         statsDeriveResult.isReduced = true;
         // TODO: Update ColumnStats properly, add new mapping from output slot to ColumnStats
         return statsDeriveResult;
@@ -362,8 +363,8 @@ public class StatsCalculator extends DefaultPlanVisitor<StatsDeriveResult, Void>
     // TODO: do real project on column stats
     private StatsDeriveResult computeProject(Project project) {
         List<NamedExpression> projections = project.getProjects();
-        StatsDeriveResult statsDeriveResult = groupExpression.childStatistics(0);
-        Map<Id, ColumnStatistic> childColumnStats = statsDeriveResult.getSlotIdToColumnStats();
+        StatsDeriveResult childStats = groupExpression.childStatistics(0);
+        Map<Id, ColumnStatistic> childColumnStats = childStats.getSlotIdToColumnStats();
         Map<Id, ColumnStatistic> columnsStats = projections.stream().map(projection -> {
             ColumnStatistic value = null;
             Set<Slot> slots = projection.getInputSlots();
@@ -383,7 +384,8 @@ public class StatsCalculator extends DefaultPlanVisitor<StatsDeriveResult, Void>
             }
             return new SimpleEntry<>(projection.toSlot().getExprId(), value);
         }).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (item1, item2) -> item1));
-        return new StatsDeriveResult(statsDeriveResult.getRowCount(), columnsStats);
+        return new StatsDeriveResult(childStats.getRowCount(), childStats.getWidth(),
+                childStats.getPenalty(), columnsStats);
     }
 
     private StatsDeriveResult computeOneRowRelation(OneRowRelation oneRowRelation) {

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/StatsDeriveResult.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/StatsDeriveResult.java
@@ -40,13 +40,33 @@ public class StatsDeriveResult {
     //TODO: isReduced to be removed after remove StatsCalculatorV1
     public boolean isReduced = false;
 
-    public StatsDeriveResult(double rowCount, Map<Id, ColumnStatistic> slotIdToColumnStats) {
+    public StatsDeriveResult(double rowCount, int width, double penalty,
+            Map<Id, ColumnStatistic> slotIdToColumnStats) {
         this.rowCount = rowCount;
+        this.width = width;
+        this.penalty = penalty;
         this.slotIdToColumnStats = slotIdToColumnStats;
+    }
+
+    public StatsDeriveResult(double rowCount,
+            Map<Id, ColumnStatistic> slotIdToColumnStats) {
+        this.rowCount = rowCount;
+        this.width = 1;
+        this.penalty = 0;
+        this.slotIdToColumnStats = slotIdToColumnStats;
+    }
+
+    public StatsDeriveResult(double rowCount, int width, double penalty) {
+        this.rowCount = rowCount;
+        this.width = width;
+        this.penalty = penalty;
+        slotIdToColumnStats = new HashMap<>();
     }
 
     public StatsDeriveResult(double rowCount) {
         this.rowCount = rowCount;
+        this.width = 1;
+        this.penalty = 0;
         slotIdToColumnStats = new HashMap<>();
     }
 
@@ -94,7 +114,7 @@ public class StatsDeriveResult {
     }
 
     public StatsDeriveResult updateBySelectivity(double selectivity, Set<Id> exclude) {
-        StatsDeriveResult statsDeriveResult = new StatsDeriveResult(rowCount * selectivity);
+        StatsDeriveResult statsDeriveResult = new StatsDeriveResult(rowCount * selectivity, width, penalty);
         for (Entry<Id, ColumnStatistic> entry : slotIdToColumnStats.entrySet()) {
             statsDeriveResult.addColumnStats(entry.getKey(),
                         entry.getValue().updateBySelectivity(selectivity, rowCount));
@@ -107,7 +127,7 @@ public class StatsDeriveResult {
     }
 
     public StatsDeriveResult updateRowCountByLimit(long limit) {
-        StatsDeriveResult statsDeriveResult = new StatsDeriveResult(limit);
+        StatsDeriveResult statsDeriveResult = new StatsDeriveResult(limit, width, penalty);
         if (limit > 0 && rowCount > 0 && rowCount > limit) {
             double selectivity = ((double) limit) / rowCount;
             for (Entry<Id, ColumnStatistic> entry : slotIdToColumnStats.entrySet()) {
@@ -147,7 +167,7 @@ public class StatsDeriveResult {
     }
 
     public StatsDeriveResult updateRowCountOnCopy(double selectivity) {
-        StatsDeriveResult copy = new StatsDeriveResult(rowCount * selectivity);
+        StatsDeriveResult copy = new StatsDeriveResult(rowCount * selectivity, width, penalty);
         for (Entry<Id, ColumnStatistic> entry : slotIdToColumnStats.entrySet()) {
             copy.addColumnStats(entry.getKey(), entry.getValue().multiply(selectivity));
         }
@@ -155,7 +175,7 @@ public class StatsDeriveResult {
     }
 
     public StatsDeriveResult updateRowCount(double rowCount) {
-        return new StatsDeriveResult(rowCount, slotIdToColumnStats);
+        return new StatsDeriveResult(rowCount, width, penalty, slotIdToColumnStats);
     }
 
     public StatsDeriveResult addColumnStats(Id id, ColumnStatistic stats) {

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/stats/ExpressionEstimationTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/stats/ExpressionEstimationTest.java
@@ -77,7 +77,7 @@ class ExpressionEstimationTest {
                 .setMinValue(0)
                 .setMaxValue(1000);
         slotToColumnStat.put(a.getExprId(), builder.build());
-        StatsDeriveResult stat = new StatsDeriveResult(1000, slotToColumnStat);
+        StatsDeriveResult stat = new StatsDeriveResult(1000, 1, 0, slotToColumnStat);
         Min max = new Min(a);
         //min/max not changed. select max(A) as X from T group by B. X.min is A.min, not A.max
         ColumnStatistic estimated = ExpressionEstimation.estimate(max, stat);
@@ -107,7 +107,7 @@ class ExpressionEstimationTest {
                 .setMinValue(300)
                 .setMaxValue(1000);
         slotToColumnStat.put(a.getExprId(), builder.build());
-        StatsDeriveResult stat = new StatsDeriveResult(1000, slotToColumnStat);
+        StatsDeriveResult stat = new StatsDeriveResult(1000, 1, 0, slotToColumnStat);
         SlotReference b = new SlotReference("b", IntegerType.INSTANCE);
         slotToColumnStat.put(b.getExprId(), builder1.build());
         Add add = new Add(a, b);
@@ -130,7 +130,7 @@ class ExpressionEstimationTest {
                 .setMinValue(0)
                 .setMaxValue(500);
         slotToColumnStat.put(a.getExprId(), builder.build());
-        StatsDeriveResult stat = new StatsDeriveResult(1000, slotToColumnStat);
+        StatsDeriveResult stat = new StatsDeriveResult(1000, 1, 0, slotToColumnStat);
         SlotReference b = new SlotReference("b", IntegerType.INSTANCE);
         builder.setMinValue(300);
         builder.setMaxValue(1000);
@@ -155,7 +155,7 @@ class ExpressionEstimationTest {
                 .setMinValue(-200)
                 .setMaxValue(-100);
         slotToColumnStat.put(a.getExprId(), builder.build());
-        StatsDeriveResult stat = new StatsDeriveResult(1000, slotToColumnStat);
+        StatsDeriveResult stat = new StatsDeriveResult(1000, 1, 0, slotToColumnStat);
         SlotReference b = new SlotReference("b", IntegerType.INSTANCE);
         builder.setMinValue(-300);
         builder.setMaxValue(1000);
@@ -180,7 +180,7 @@ class ExpressionEstimationTest {
                 .setMinValue(-200)
                 .setMaxValue(-100);
         slotToColumnStat.put(a.getExprId(), builder.build());
-        StatsDeriveResult stat = new StatsDeriveResult(1000, slotToColumnStat);
+        StatsDeriveResult stat = new StatsDeriveResult(1000, 1, 0, slotToColumnStat);
         SlotReference b = new SlotReference("b", IntegerType.INSTANCE);
         builder.setMinValue(-1000);
         builder.setMaxValue(-300);
@@ -212,7 +212,7 @@ class ExpressionEstimationTest {
                 .setMinValue(-300)
                 .setMaxValue(1000);
         slotToColumnStat.put(a.getExprId(), builder.build());
-        StatsDeriveResult stat = new StatsDeriveResult(1000, slotToColumnStat);
+        StatsDeriveResult stat = new StatsDeriveResult(1000, 1, 0, slotToColumnStat);
         SlotReference b = new SlotReference("b", IntegerType.INSTANCE);
         slotToColumnStat.put(b.getExprId(), builder1.build());
         Divide divide = new Divide(a, b);
@@ -242,7 +242,7 @@ class ExpressionEstimationTest {
                 .setMinValue(-1000)
                 .setMaxValue(-100);
         slotToColumnStat.put(a.getExprId(), builder.build());
-        StatsDeriveResult stat = new StatsDeriveResult(1000, slotToColumnStat);
+        StatsDeriveResult stat = new StatsDeriveResult(1000, 1, 0, slotToColumnStat);
         SlotReference b = new SlotReference("b", IntegerType.INSTANCE);
         slotToColumnStat.put(b.getExprId(), builder1.build());
         Divide divide = new Divide(a, b);

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/stats/FilterEstimationTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/stats/FilterEstimationTest.java
@@ -103,7 +103,7 @@ class FilterEstimationTest {
         slotToColumnStat.put(a.getExprId(), aBuilder.build());
         slotToColumnStat.put(b.getExprId(), aBuilder.build());
         slotToColumnStat.put(c.getExprId(), aBuilder.build());
-        StatsDeriveResult stat = new StatsDeriveResult(1000, slotToColumnStat);
+        StatsDeriveResult stat = new StatsDeriveResult(1000, 1, 0, slotToColumnStat);
         FilterEstimation filterEstimation = new FilterEstimation(stat);
         StatsDeriveResult expected = filterEstimation.estimate(or);
         Assertions.assertTrue(
@@ -128,7 +128,7 @@ class FilterEstimationTest {
                 .setMinValue(0)
                 .setMaxValue(500);
         slotToColumnStat.put(a.getExprId(), builder.build());
-        StatsDeriveResult stat = new StatsDeriveResult(1000, slotToColumnStat);
+        StatsDeriveResult stat = new StatsDeriveResult(1000, 1, 0, slotToColumnStat);
         FilterEstimation filterEstimation = new FilterEstimation(stat);
         StatsDeriveResult expected = filterEstimation.estimate(ge);
         Assertions.assertEquals(1000 * 1.0 / 500, expected.getRowCount());
@@ -149,7 +149,7 @@ class FilterEstimationTest {
                 .setMinValue(500)
                 .setMaxValue(1000);
         slotToColumnStat.put(a.getExprId(), builder1.build());
-        StatsDeriveResult stat = new StatsDeriveResult(1000, slotToColumnStat);
+        StatsDeriveResult stat = new StatsDeriveResult(1000, 1, 0, slotToColumnStat);
         FilterEstimation filterEstimation = new FilterEstimation(stat);
         StatsDeriveResult expected = filterEstimation.estimate(le);
         Assertions.assertEquals(1000 * 1.0 / 500, expected.getRowCount());
@@ -170,7 +170,7 @@ class FilterEstimationTest {
                 .setMinValue(500)
                 .setMaxValue(1000);
         slotToColumnStat.put(a.getExprId(), builder.build());
-        StatsDeriveResult stat = new StatsDeriveResult(1000, slotToColumnStat);
+        StatsDeriveResult stat = new StatsDeriveResult(1000, 1, 0, slotToColumnStat);
         FilterEstimation filterEstimation = new FilterEstimation(stat);
         StatsDeriveResult expected = filterEstimation.estimate(less);
         Assertions.assertEquals(0, expected.getRowCount());
@@ -191,7 +191,7 @@ class FilterEstimationTest {
                 .setMinValue(500)
                 .setMaxValue(1000);
         slotToColumnStat.put(a.getExprId(), builder.build());
-        StatsDeriveResult stat = new StatsDeriveResult(1000, slotToColumnStat);
+        StatsDeriveResult stat = new StatsDeriveResult(1000, 1, 0, slotToColumnStat);
         FilterEstimation filterEstimation = new FilterEstimation(stat);
         StatsDeriveResult expected = filterEstimation.estimate(ge);
         Assertions.assertEquals(0, expected.getRowCount());
@@ -220,7 +220,7 @@ class FilterEstimationTest {
                 .setMaxValue(1000);
         slotToColumnStat.put(a.getExprId(), builder1.build());
         slotToColumnStat.put(b.getExprId(), builder2.build());
-        StatsDeriveResult stat = new StatsDeriveResult(1000, slotToColumnStat);
+        StatsDeriveResult stat = new StatsDeriveResult(1000, 1, 0, slotToColumnStat);
         FilterEstimation filterEstimation = new FilterEstimation(stat);
         StatsDeriveResult expected = filterEstimation.estimate(ge);
         Assertions.assertEquals(0, expected.getRowCount());
@@ -249,7 +249,7 @@ class FilterEstimationTest {
                 .setMaxValue(1000);
         slotToColumnStat.put(a.getExprId(), builder1.build());
         slotToColumnStat.put(b.getExprId(), builder2.build());
-        StatsDeriveResult stat = new StatsDeriveResult(1000, slotToColumnStat);
+        StatsDeriveResult stat = new StatsDeriveResult(1000, 1, 0, slotToColumnStat);
         FilterEstimation filterEstimation = new FilterEstimation(stat);
         StatsDeriveResult esimated = filterEstimation.estimate(less);
         Assertions.assertEquals(1000, esimated.getRowCount());
@@ -278,7 +278,7 @@ class FilterEstimationTest {
                 .setMaxValue(500);
         slotToColumnStat.put(a.getExprId(), builder1.build());
         slotToColumnStat.put(b.getExprId(), builder2.build());
-        StatsDeriveResult stat = new StatsDeriveResult(1000, slotToColumnStat);
+        StatsDeriveResult stat = new StatsDeriveResult(1000, 1, 0, slotToColumnStat);
         FilterEstimation filterEstimation = new FilterEstimation(stat);
         StatsDeriveResult estimated = filterEstimation.estimate(ge);
         Assertions.assertEquals(1000, estimated.getRowCount());
@@ -301,7 +301,7 @@ class FilterEstimationTest {
                 .setMinValue(1)
                 .setMaxValue(10);
         slotToColumnStat.put(a.getExprId(), builder.build());
-        StatsDeriveResult stat = new StatsDeriveResult(1000, slotToColumnStat);
+        StatsDeriveResult stat = new StatsDeriveResult(1000, 1, 0, slotToColumnStat);
         FilterEstimation filterEstimation = new FilterEstimation(stat);
         StatsDeriveResult estimated = filterEstimation.estimate(inPredicate);
         Assertions.assertEquals(1000 * 3.0 / 10.0, estimated.getRowCount());
@@ -325,7 +325,7 @@ class FilterEstimationTest {
                 .setMinValue(1)
                 .setMaxValue(10);
         slotToColumnStat.put(a.getExprId(), builder.build());
-        StatsDeriveResult stat = new StatsDeriveResult(1000, slotToColumnStat);
+        StatsDeriveResult stat = new StatsDeriveResult(1000, 1, 0, slotToColumnStat);
         FilterEstimation filterEstimation = new FilterEstimation(stat);
         StatsDeriveResult estimated = filterEstimation.estimate(not);
         Assertions.assertEquals(1000 * 7.0 / 10.0, estimated.getRowCount());


### PR DESCRIPTION
# Proposed changes
a previous pr [(#13883)](https://github.com/apache/doris/pull/13883) refactor stats derive code, but missed width and penalty.

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

