### PR TITLE
[fix](service) dup metric hook when enable single replica load (#14456)

### DIFF
--- a/be/src/service/brpc_service.cpp
+++ b/be/src/service/brpc_service.cpp
@@ -40,9 +40,10 @@ BRpcService::BRpcService(ExecEnv* exec_env) : _exec_env(exec_env), _server(new b
 
 BRpcService::~BRpcService() {}
 
-Status BRpcService::start(int port, int num_threads) {
+Status BRpcService::start(int port, int num_threads, bool need_metric) {
     // Add service
-    _server->AddService(new PInternalServiceImpl(_exec_env), brpc::SERVER_OWNS_SERVICE);
+    _server->AddService(new PInternalServiceImpl(_exec_env, need_metric),
+                        brpc::SERVER_OWNS_SERVICE);
     // start service
     brpc::ServerOptions options;
     if (num_threads != -1) {

--- a/be/src/service/brpc_service.h
+++ b/be/src/service/brpc_service.h
@@ -35,7 +35,7 @@ public:
     BRpcService(ExecEnv* exec_env);
     ~BRpcService();
 
-    Status start(int port, int num_threads);
+    Status start(int port, int num_threads, bool need_metric);
     void join();
 
 private:

--- a/be/src/service/doris_main.cpp
+++ b/be/src/service/doris_main.cpp
@@ -431,7 +431,7 @@ int main(int argc, char** argv) {
 
     // 2. bprc service
     doris::BRpcService brpc_service(exec_env);
-    status = brpc_service.start(doris::config::brpc_port, doris::config::brpc_num_threads);
+    status = brpc_service.start(doris::config::brpc_port, doris::config::brpc_num_threads, true);
     if (!status.ok()) {
         LOG(ERROR) << "BRPC service did not start correctly, exiting";
         doris::shutdown_logging();
@@ -442,7 +442,7 @@ int main(int argc, char** argv) {
     if (doris::config::enable_single_replica_load) {
         status = single_replica_load_brpc_service.start(
                 doris::config::single_replica_load_brpc_port,
-                doris::config::single_replica_load_brpc_num_threads);
+                doris::config::single_replica_load_brpc_num_threads, false);
         if (!status.ok()) {
             LOG(ERROR) << "single replica load BRPC service did not start correctly, exiting";
             doris::shutdown_logging();

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -92,18 +92,23 @@ private:
     google::protobuf::Closure* _done = nullptr;
 };
 
-PInternalServiceImpl::PInternalServiceImpl(ExecEnv* exec_env)
+PInternalServiceImpl::PInternalServiceImpl(ExecEnv* exec_env, bool need_metric)
         : _exec_env(exec_env),
           _tablet_worker_pool(config::number_tablet_writer_threads, 10240, "tablet_writer"),
           _slave_replica_worker_pool(config::number_slave_replica_download_threads, 10240,
-                                     "replica_download") {
-    REGISTER_HOOK_METRIC(add_batch_task_queue_size,
-                         [this]() { return _tablet_worker_pool.get_queue_size(); });
+                                     "replica_download"),
+          _need_metric(need_metric) {
+    if (_need_metric) {
+        REGISTER_HOOK_METRIC(add_batch_task_queue_size,
+                             [this]() { return _tablet_worker_pool.get_queue_size(); });
+    }
     CHECK_EQ(0, bthread_key_create(&btls_key, thread_context_deleter));
 }
 
 PInternalServiceImpl::~PInternalServiceImpl() {
-    DEREGISTER_HOOK_METRIC(add_batch_task_queue_size);
+    if (_need_metric) {
+        DEREGISTER_HOOK_METRIC(add_batch_task_queue_size);
+    }
     CHECK_EQ(0, bthread_key_delete(btls_key));
 }
 

--- a/be/src/service/internal_service.h
+++ b/be/src/service/internal_service.h
@@ -32,7 +32,7 @@ class ExecEnv;
 
 class PInternalServiceImpl : public PBackendService {
 public:
-    PInternalServiceImpl(ExecEnv* exec_env);
+    PInternalServiceImpl(ExecEnv* exec_env, bool need_metric);
     virtual ~PInternalServiceImpl();
 
     void transmit_data(::google::protobuf::RpcController* controller,
@@ -196,6 +196,7 @@ private:
     ExecEnv* _exec_env;
     PriorityThreadPool _tablet_worker_pool;
     PriorityThreadPool _slave_replica_worker_pool;
+    bool _need_metric;
 };
 
 } // namespace doris


### PR DESCRIPTION
SingleReplica service registers metric 'add_batch_task_queue_size' which is unnecessary and will cause duplicated registration of the metric.

Signed-off-by: freemandealer <freeman.zhang1992@gmail.com>

# Proposed changes

Issue Number: close #14456

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

