### PR TITLE
[feature](Nereids) Use simplifier to limit the number of subgraphs

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/joinreorder/hypergraph/CircleDetector.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/joinreorder/hypergraph/CircleDetector.java
@@ -39,8 +39,8 @@ public class CircleDetector {
     List<Integer> nodes = new ArrayList<>();
     // stored the dependency of each node
     List<BitSet> directedEdges = new ArrayList<>();
+    // the nodes are after than this node
     List<BitSet> subNodes = new ArrayList<>();
-    // whether the node has been visited in dfs
 
     CircleDetector(int size) {
         for (int i = 0; i < size; i++) {
@@ -67,9 +67,10 @@ public class CircleDetector {
         int order1 = orders.get(node1);
         int order2 = orders.get(node2);
         if (order1 >= order2) {
-            shift(order2, order1 + 1, subNodes.get(order2));
+            shift(order2, order1 + 1, subNodes.get(node2));
         }
         for (BitSet nodes : subNodes) {
+            // add all subNodes which contains node1 into subNodes of node2.
             if (Bitmap.get(nodes, node1)) {
                 Bitmap.or(nodes, subNodes.get(node2));
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/joinreorder/hypergraph/Node.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/joinreorder/hypergraph/Node.java
@@ -65,7 +65,11 @@ public class Node {
             throw new RuntimeException(String.format("There is no simple Edge <%d - %s>", index, nodes));
         } else if (Bitmap.isOverlap(complexNeighborhood, nodes)) {
             for (Edge edge : complexEdges) {
-                if (Bitmap.isSubset(edge.getLeft(), nodes) || Bitmap.isSubset(edge.getRight(), nodes)) {
+                // TODO: Right now we check all edges. But due to the simple cmp, we can only check that the edge with
+                // one side that equal to this node
+                if ((Bitmap.isSubset(edge.getLeft(), nodes) && Bitmap.isSubset(edge.getRight(),
+                        Bitmap.newBitmap(index))) || (Bitmap.isSubset(edge.getRight(), nodes) && Bitmap.isSubset(
+                        edge.getLeft(), Bitmap.newBitmap(index)))) {
                     return edge;
                 }
             }
@@ -137,6 +141,10 @@ public class Node {
      * by graph simplifier.
      */
     public void splitEdges() {
+        simpleEdges.clear();
+        Bitmap.clear(simpleNeighborhood);
+        complexEdges.clear();
+        Bitmap.clear(complexNeighborhood);
         for (Edge edge : edges) {
             if (edge.isSimple()) {
                 simpleEdges.add(edge);

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/joinreorder/hypergraph/receiver/AbstractReceiver.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/joinreorder/hypergraph/receiver/AbstractReceiver.java
@@ -32,5 +32,7 @@ public interface AbstractReceiver {
 
     public boolean contain(BitSet bitSet);
 
+    public void reset();
+
     public Plan getBestPlan(BitSet bitSet);
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/joinreorder/hypergraph/receiver/Counter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/joinreorder/hypergraph/receiver/Counter.java
@@ -30,7 +30,16 @@ import java.util.HashMap;
  */
 public class Counter implements AbstractReceiver {
     // limit define the max number of csg-cmp pair in this Receiver
+    private int limit;
     private HashMap<BitSet, Integer> counter = new HashMap<>();
+
+    public Counter() {
+        this.limit = Integer.MAX_VALUE;
+    }
+
+    public Counter(int limit) {
+        this.limit = limit;
+    }
 
     /**
      * Emit a new plan from bottom to top
@@ -51,7 +60,7 @@ public class Counter implements AbstractReceiver {
         } else {
             counter.put(bitSet, counter.get(bitSet) + counter.get(left) * counter.get(right));
         }
-        return true;
+        return counter.get(bitSet) < this.limit;
     }
 
     public void addPlan(BitSet bitSet, Plan plan) {
@@ -60,6 +69,10 @@ public class Counter implements AbstractReceiver {
 
     public boolean contain(BitSet bitSet) {
         return counter.containsKey(bitSet);
+    }
+
+    public void reset() {
+        this.counter.clear();
     }
 
     public Plan getBestPlan(BitSet bitSet) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/joinreorder/hypergraph/receiver/PlanTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/joinreorder/hypergraph/receiver/PlanTable.java
@@ -21,14 +21,12 @@ import org.apache.doris.nereids.rules.joinreorder.hypergraph.Edge;
 import org.apache.doris.nereids.trees.plans.Plan;
 
 import java.util.BitSet;
-import java.util.HashMap;
 
 /**
  * The Receiver is used for cached the plan that has been emitted and build the new plan
  */
 public class PlanTable implements AbstractReceiver {
     // limit define the max number of csg-cmp pair in this Receiver
-    HashMap<BitSet, Integer> counter;
 
     /**
      * Emit a new plan from bottom to top
@@ -48,6 +46,11 @@ public class PlanTable implements AbstractReceiver {
 
     public boolean contain(BitSet bitSet) {
         throw new RuntimeException("PlanTable does not support contain()");
+    }
+
+    @Override
+    public void reset() {
+        throw new RuntimeException("PlanTable does not support reset()");
     }
 
     public Plan getBestPlan(BitSet bitSet) {


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

In DPhyp, the number of subgraph is huge and the time of enumerating is long. Therefore, we need to use simplifier to limit the number of subgraphs

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [x] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

