### PR TITLE
[improvement](hashjoin) support partitioned hash table in hash join

### DIFF
--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -357,6 +357,13 @@ public:
         return _query_options.__isset.skip_delete_predicate && _query_options.skip_delete_predicate;
     }
 
+    int partitioned_hash_join_rows_threshold() const {
+        if (!_query_options.__isset.partitioned_hash_join_rows_threshold) {
+            return 0;
+        }
+        return _query_options.partitioned_hash_join_rows_threshold;
+    }
+
     const std::vector<TTabletCommitInfo>& tablet_commit_infos() const {
         return _tablet_commit_infos;
     }

--- a/be/src/vec/common/hash_table/hash_map.h
+++ b/be/src/vec/common/hash_table/hash_map.h
@@ -21,8 +21,8 @@
 #pragma once
 
 #include "vec/common/hash_table/hash.h"
+#include "vec/common/hash_table/hash_table.h"
 #include "vec/common/hash_table/hash_table_allocator.h"
-#include "vec/common/hash_table/partitioned_hash_table.h"
 /** NOTE HashMap could only be used for memmoveable (position independent) types.
   * Example: std::string is not position independent in libstdc++ with C++11 ABI or in libc++.
   * Also, key in hash table must be of type, that zero bytes is compared equals to zero key.

--- a/be/src/vec/common/hash_table/hash_map.h
+++ b/be/src/vec/common/hash_table/hash_map.h
@@ -21,8 +21,8 @@
 #pragma once
 
 #include "vec/common/hash_table/hash.h"
-#include "vec/common/hash_table/hash_table.h"
 #include "vec/common/hash_table/hash_table_allocator.h"
+#include "vec/common/hash_table/partitioned_hash_table.h"
 /** NOTE HashMap could only be used for memmoveable (position independent) types.
   * Example: std::string is not position independent in libstdc++ with C++11 ABI or in libc++.
   * Also, key in hash table must be of type, that zero bytes is compared equals to zero key.

--- a/be/src/vec/common/hash_table/hash_table.h
+++ b/be/src/vec/common/hash_table/hash_table.h
@@ -444,10 +444,11 @@ protected:
     Cell* buf;         /// A piece of memory for all elements except the element with zero key.
     Grower grower;
     int64_t _resize_timer_ns;
+
     // the bucket count threshold above which it's converted to partioned hash table
     // 0: don't convert
     int _partitioned_threshold = 0;
-    // bucket count >= threshold, need to be converted
+    // if bucket count >= _partitioned_threshold, this flag is set to true
     bool _need_partition = false;
 
     //factor that will trigger growing the hash table on insert.
@@ -458,6 +459,10 @@ protected:
 #endif
 
     void set_partitioned_threshold(int threshold) { _partitioned_threshold = threshold; }
+
+    bool check_if_need_partition(size_t bucket_count) {
+        return _partitioned_threshold > 0 && bucket_count >= _partitioned_threshold;
+    }
 
     bool need_partition() { return _need_partition; }
 
@@ -508,67 +513,6 @@ protected:
             Allocator::free(buf, get_buffer_size_in_bytes());
             buf = nullptr;
         }
-    }
-
-    /// Increase the size of the buffer.
-    void resize(size_t for_num_elems = 0, size_t for_buf_size = 0) {
-        SCOPED_RAW_TIMER(&_resize_timer_ns);
-#ifdef DBMS_HASH_MAP_DEBUG_RESIZES
-        Stopwatch watch;
-#endif
-
-        size_t old_size = grower.buf_size();
-        if (_partitioned_threshold > 0 && old_size >= _partitioned_threshold) {
-            _need_partition = true;
-            return;
-        }
-
-        /** In case of exception for the object to remain in the correct state,
-          *  changing the variable `grower` (which determines the buffer size of the hash table)
-          *  is postponed for a moment after a real buffer change.
-          * The temporary variable `new_grower` is used to determine the new size.
-          */
-        Grower new_grower = grower;
-        if (for_num_elems) {
-            new_grower.set(for_num_elems);
-            if (new_grower.buf_size() <= old_size) return;
-        } else if (for_buf_size) {
-            new_grower.set_buf_size(for_buf_size);
-            if (new_grower.buf_size() <= old_size) return;
-        } else
-            new_grower.increase_size();
-
-        /// Expand the space.
-        buf = reinterpret_cast<Cell*>(Allocator::realloc(buf, get_buffer_size_in_bytes(),
-                                                         new_grower.buf_size() * sizeof(Cell)));
-        grower = new_grower;
-
-        /** Now some items may need to be moved to a new location.
-          * The element can stay in place, or move to a new location "on the right",
-          *  or move to the left of the collision resolution chain, because the elements to the left of it have been moved to the new "right" location.
-          */
-        size_t i = 0;
-        for (; i < old_size; ++i)
-            if (!buf[i].is_zero(*this) && !buf[i].is_deleted())
-                reinsert(buf[i], buf[i].get_hash(*this));
-
-        /** There is also a special case:
-          *    if the element was to be at the end of the old buffer,                  [        x]
-          *    but is at the beginning because of the collision resolution chain,      [o       x]
-          *    then after resizing, it will first be out of place again,               [        xo        ]
-          *    and in order to transfer it where necessary,
-          *    after transferring all the elements from the old halves you need to     [         o   x    ]
-          *    process tail from the collision resolution chain immediately after it   [        o    x    ]
-          */
-        for (; !buf[i].is_zero(*this) && !buf[i].is_deleted(); ++i)
-            reinsert(buf[i], buf[i].get_hash(*this));
-
-#ifdef DBMS_HASH_MAP_DEBUG_RESIZES
-        watch.stop();
-        std::cerr << std::fixed << std::setprecision(3) << "Resize from " << old_size << " to "
-                  << grower.buf_size() << " took " << watch.elapsedSeconds() << " sec."
-                  << std::endl;
-#endif
     }
 
     /** Paste into the new buffer the value that was in the old buffer.
@@ -697,6 +641,8 @@ public:
         std::swap(buf, rhs.buf);
         std::swap(m_size, rhs.m_size);
         std::swap(grower, rhs.grower);
+        std::swap(_need_partition, rhs._need_partition);
+        std::swap(_partitioned_threshold, rhs._partitioned_threshold);
 
         Hash::operator=(std::move(rhs));
         Allocator::operator=(std::move(rhs));
@@ -1137,4 +1083,69 @@ public:
 #ifdef DBMS_HASH_MAP_COUNT_COLLISIONS
     size_t getCollisions() const { return collisions; }
 #endif
+
+private:
+    /// Increase the size of the buffer.
+    void resize(size_t for_num_elems = 0, size_t for_buf_size = 0) {
+        SCOPED_RAW_TIMER(&_resize_timer_ns);
+#ifdef DBMS_HASH_MAP_DEBUG_RESIZES
+        Stopwatch watch;
+#endif
+
+        size_t old_size = grower.buf_size();
+
+        /** In case of exception for the object to remain in the correct state,
+          *  changing the variable `grower` (which determines the buffer size of the hash table)
+          *  is postponed for a moment after a real buffer change.
+          * The temporary variable `new_grower` is used to determine the new size.
+          */
+        Grower new_grower = grower;
+        if (for_num_elems) {
+            new_grower.set(for_num_elems);
+            if (new_grower.buf_size() <= old_size) return;
+        } else if (for_buf_size) {
+            new_grower.set_buf_size(for_buf_size);
+            if (new_grower.buf_size() <= old_size) return;
+        } else
+            new_grower.increase_size();
+
+        // new bucket count exceed partitioned hash table bucket count threshold,
+        // don't resize and set need partition flag
+        if (check_if_need_partition(new_grower.buf_size())) {
+            _need_partition = true;
+            return;
+        }
+
+        /// Expand the space.
+        buf = reinterpret_cast<Cell*>(Allocator::realloc(buf, get_buffer_size_in_bytes(),
+                                                         new_grower.buf_size() * sizeof(Cell)));
+        grower = new_grower;
+
+        /** Now some items may need to be moved to a new location.
+          * The element can stay in place, or move to a new location "on the right",
+          *  or move to the left of the collision resolution chain, because the elements to the left of it have been moved to the new "right" location.
+          */
+        size_t i = 0;
+        for (; i < old_size; ++i)
+            if (!buf[i].is_zero(*this) && !buf[i].is_deleted())
+                reinsert(buf[i], buf[i].get_hash(*this));
+
+        /** There is also a special case:
+          *    if the element was to be at the end of the old buffer,                  [        x]
+          *    but is at the beginning because of the collision resolution chain,      [o       x]
+          *    then after resizing, it will first be out of place again,               [        xo        ]
+          *    and in order to transfer it where necessary,
+          *    after transferring all the elements from the old halves you need to     [         o   x    ]
+          *    process tail from the collision resolution chain immediately after it   [        o    x    ]
+          */
+        for (; !buf[i].is_zero(*this) && !buf[i].is_deleted(); ++i)
+            reinsert(buf[i], buf[i].get_hash(*this));
+
+#ifdef DBMS_HASH_MAP_DEBUG_RESIZES
+        watch.stop();
+        std::cerr << std::fixed << std::setprecision(3) << "Resize from " << old_size << " to "
+                  << grower.buf_size() << " took " << watch.elapsedSeconds() << " sec."
+                  << std::endl;
+#endif
+    }
 };

--- a/be/src/vec/common/hash_table/hash_table.h
+++ b/be/src/vec/common/hash_table/hash_table.h
@@ -430,7 +430,7 @@ class HashTable : private boost::noncopyable,
 protected:
     friend class Reader;
 
-    template <typename, typename, typename, typename, typename, typename, bool, size_t>
+    template <typename, typename, typename, typename, typename, typename, size_t>
     friend class PartitionedHashTable;
 
     template <typename SubMaps>
@@ -446,7 +446,8 @@ protected:
     int64_t _resize_timer_ns;
 
     // the bucket count threshold above which it's converted to partioned hash table
-    // 0: don't convert
+    // > 0: enable convert dynamically
+    // 0: convert is disabled
     int _partitioned_threshold = 0;
     // if bucket count >= _partitioned_threshold, this flag is set to true
     bool _need_partition = false;

--- a/be/src/vec/common/hash_table/hash_table.h
+++ b/be/src/vec/common/hash_table/hash_table.h
@@ -829,7 +829,7 @@ protected:
                 throw;
             }
 
-            if (UNLIKELY(!_need_partition)) {
+            if (LIKELY(!_need_partition)) {
                 // The hash table was rehashed, so we have to re-find the key.
                 size_t new_place = find_cell(key, hash_value, grower.place(hash_value));
                 assert(!buf[new_place].is_zero(*this));
@@ -868,7 +868,7 @@ protected:
                 throw;
             }
 
-            if (UNLIKELY(!_need_partition)) {
+            if (LIKELY(!_need_partition)) {
                 // The hash table was rehashed, so we have to re-find the key.
                 size_t new_place = find_cell(key, hash_value, grower.place(hash_value));
                 assert(!buf[new_place].is_zero(*this));

--- a/be/src/vec/common/hash_table/hash_table.h
+++ b/be/src/vec/common/hash_table/hash_table.h
@@ -449,7 +449,9 @@ protected:
     // > 0: enable convert dynamically
     // 0: convert is disabled
     int _partitioned_threshold = 0;
-    // if bucket count >= _partitioned_threshold, this flag is set to true
+    // if need resize and bucket count after resize will be >= _partitioned_threshold,
+    // this flag is set to true, and resize does not actually happen,
+    // PartitionedHashTable will convert this hash table to partitioned hash table
     bool _need_partition = false;
 
     //factor that will trigger growing the hash table on insert.

--- a/be/src/vec/common/hash_table/partitioned_hash_map.h
+++ b/be/src/vec/common/hash_table/partitioned_hash_map.h
@@ -22,19 +22,16 @@
 #include "vec/common/hash_table/hash_map.h"
 #include "vec/common/hash_table/partitioned_hash_table.h"
 
-template <typename Key, typename Cell, bool ENABLE_PARTITIONED = false,
-          typename Hash = DefaultHash<Key>, typename Grower = PartitionedHashTableGrower<>,
-          typename Allocator = HashTableAllocator,
+template <typename Key, typename Cell, typename Hash = DefaultHash<Key>,
+          typename Grower = PartitionedHashTableGrower<>, typename Allocator = HashTableAllocator,
           template <typename...> typename ImplTable = HashMapTable>
 class PartitionedHashMapTable
         : public PartitionedHashTable<Key, Cell, Hash, Grower, Allocator,
-                                      ImplTable<Key, Cell, Hash, Grower, Allocator>,
-                                      ENABLE_PARTITIONED> {
+                                      ImplTable<Key, Cell, Hash, Grower, Allocator>> {
 public:
     using Impl = ImplTable<Key, Cell, Hash, Grower, Allocator>;
-    using Base =
-            PartitionedHashTable<Key, Cell, Hash, Grower, Allocator,
-                                 ImplTable<Key, Cell, Hash, Grower, Allocator>, ENABLE_PARTITIONED>;
+    using Base = PartitionedHashTable<Key, Cell, Hash, Grower, Allocator,
+                                      ImplTable<Key, Cell, Hash, Grower, Allocator>>;
     using LookupResult = typename Impl::LookupResult;
 
     using Base::Base;
@@ -53,18 +50,15 @@ public:
     }
 };
 
-template <typename Key, typename Mapped, bool ENABLE_PARTITIONED = false,
-          typename Hash = DefaultHash<Key>, typename Grower = PartitionedHashTableGrower<>,
-          typename Allocator = HashTableAllocator,
+template <typename Key, typename Mapped, typename Hash = DefaultHash<Key>,
+          typename Grower = PartitionedHashTableGrower<>, typename Allocator = HashTableAllocator,
           template <typename...> typename ImplTable = HashMapTable>
-using PartitionedHashMap =
-        PartitionedHashMapTable<Key, HashMapCell<Key, Mapped, Hash>, ENABLE_PARTITIONED, Hash,
-                                Grower, Allocator, ImplTable>;
+using PartitionedHashMap = PartitionedHashMapTable<Key, HashMapCell<Key, Mapped, Hash>, Hash,
+                                                   Grower, Allocator, ImplTable>;
 
-template <typename Key, typename Mapped, bool ENABLE_PARTITIONED = false,
-          typename Hash = DefaultHash<Key>, typename Grower = PartitionedHashTableGrower<>,
-          typename Allocator = HashTableAllocator,
+template <typename Key, typename Mapped, typename Hash = DefaultHash<Key>,
+          typename Grower = PartitionedHashTableGrower<>, typename Allocator = HashTableAllocator,
           template <typename...> typename ImplTable = HashMapTable>
 using PartitionedHashMapWithSavedHash =
-        PartitionedHashMapTable<Key, HashMapCellWithSavedHash<Key, Mapped, Hash>,
-                                ENABLE_PARTITIONED, Hash, Grower, Allocator, ImplTable>;
+        PartitionedHashMapTable<Key, HashMapCellWithSavedHash<Key, Mapped, Hash>, Hash, Grower,
+                                Allocator, ImplTable>;

--- a/be/src/vec/common/hash_table/partitioned_hash_map.h
+++ b/be/src/vec/common/hash_table/partitioned_hash_map.h
@@ -42,12 +42,6 @@ public:
 
     using mapped_type = typename Cell::Mapped;
 
-    template <typename Func>
-    void ALWAYS_INLINE for_each_value(Func&& func) {
-        for (auto i = 0u; i < this->NUM_LEVEL1_SUB_TABLES; ++i)
-            this->level1_sub_tables[i].for_each_value(func);
-    }
-
     typename Cell::Mapped& ALWAYS_INLINE operator[](const Key& x) {
         LookupResult it;
         bool inserted;
@@ -56,16 +50,6 @@ public:
         if (inserted) new (lookup_result_get_mapped(it)) mapped_type();
 
         return *lookup_result_get_mapped(it);
-    }
-
-    size_t get_size() {
-        size_t count = 0;
-        for (auto i = 0u; i < this->NUM_LEVEL1_SUB_TABLES; ++i) {
-            for (auto& v : this->level1_sub_tables[i]) {
-                count += v.get_second().get_row_count();
-            }
-        }
-        return count;
     }
 };
 

--- a/be/src/vec/common/hash_table/partitioned_hash_map.h
+++ b/be/src/vec/common/hash_table/partitioned_hash_map.h
@@ -1,0 +1,86 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+// This file is copied from
+// https://github.com/ClickHouse/ClickHouse/blob/master/src/Common/HashTable/TwoLevelHashMap.h
+// and modified by Doris
+#pragma once
+
+#include "vec/common/hash_table/hash_map.h"
+#include "vec/common/hash_table/partitioned_hash_table.h"
+
+template <typename Key, typename Cell, bool ENABLE_PARTITIONED = false,
+          typename Hash = DefaultHash<Key>, typename Grower = PartitionedHashTableGrower<>,
+          typename Allocator = HashTableAllocator,
+          template <typename...> typename ImplTable = HashMapTable>
+class PartitionedHashMapTable
+        : public PartitionedHashTable<Key, Cell, Hash, Grower, Allocator,
+                                      ImplTable<Key, Cell, Hash, Grower, Allocator>,
+                                      ENABLE_PARTITIONED> {
+public:
+    using Impl = ImplTable<Key, Cell, Hash, Grower, Allocator>;
+    using Base =
+            PartitionedHashTable<Key, Cell, Hash, Grower, Allocator,
+                                 ImplTable<Key, Cell, Hash, Grower, Allocator>, ENABLE_PARTITIONED>;
+    using LookupResult = typename Impl::LookupResult;
+
+    using Base::Base;
+    using Base::prefetch;
+
+    using mapped_type = typename Cell::Mapped;
+
+    template <typename Func>
+    void ALWAYS_INLINE for_each_value(Func&& func) {
+        for (auto i = 0u; i < this->NUM_LEVEL1_SUB_TABLES; ++i)
+            this->level1_sub_tables[i].for_each_value(func);
+    }
+
+    typename Cell::Mapped& ALWAYS_INLINE operator[](const Key& x) {
+        LookupResult it;
+        bool inserted;
+        this->emplace(x, it, inserted);
+
+        if (inserted) new (lookup_result_get_mapped(it)) mapped_type();
+
+        return *lookup_result_get_mapped(it);
+    }
+
+    size_t get_size() {
+        size_t count = 0;
+        for (auto i = 0u; i < this->NUM_LEVEL1_SUB_TABLES; ++i) {
+            for (auto& v : this->level1_sub_tables[i]) {
+                count += v.get_second().get_row_count();
+            }
+        }
+        return count;
+    }
+};
+
+template <typename Key, typename Mapped, bool ENABLE_PARTITIONED = false,
+          typename Hash = DefaultHash<Key>, typename Grower = PartitionedHashTableGrower<>,
+          typename Allocator = HashTableAllocator,
+          template <typename...> typename ImplTable = HashMapTable>
+using PartitionedHashMap =
+        PartitionedHashMapTable<Key, HashMapCell<Key, Mapped, Hash>, ENABLE_PARTITIONED, Hash,
+                                Grower, Allocator, ImplTable>;
+
+template <typename Key, typename Mapped, bool ENABLE_PARTITIONED = false,
+          typename Hash = DefaultHash<Key>, typename Grower = PartitionedHashTableGrower<>,
+          typename Allocator = HashTableAllocator,
+          template <typename...> typename ImplTable = HashMapTable>
+using PartitionedHashMapWithSavedHash =
+        PartitionedHashMapTable<Key, HashMapCellWithSavedHash<Key, Mapped, Hash>,
+                                ENABLE_PARTITIONED, Hash, Grower, Allocator, ImplTable>;

--- a/be/src/vec/common/hash_table/partitioned_hash_table.h
+++ b/be/src/vec/common/hash_table/partitioned_hash_table.h
@@ -1,0 +1,629 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+// This file is copied from
+// https://github.com/ClickHouse/ClickHouse/blob/master/src/Common/HashTable/TwoLevelHashTable.h
+// and modified by Doris
+#pragma once
+
+#include "vec/common/hash_table/hash_table.h"
+
+/** Two-level hash table.
+  * Represents 16 (or 1ULL << BITS_FOR_SUB_TABLE) small hash tables (sub table count of the first level).
+  * To determine which one to use, one of the bytes of the hash function is taken.
+  *
+  * Usually works a little slower than a simple hash table.
+  * However, it has advantages in some cases:
+  * - if you need to merge two hash tables together, then you can easily parallelize it by sub tables;
+  * - delay during resizes is amortized, since the small hash tables will be resized separately;
+  * - in theory, resizes are cache-local in a larger range of sizes.
+  */
+
+template <size_t initial_size_degree = 8>
+struct PartitionedHashTableGrower : public HashTableGrowerWithPrecalculation<initial_size_degree> {
+    /// Increase the size of the hash table.
+    void increase_size() { this->increase_size_degree(this->size_degree() >= 15 ? 1 : 2); }
+};
+
+template <typename Key, typename Cell, typename Hash, typename Grower, typename Allocator,
+          typename ImplTable = HashTable<Key, Cell, Hash, Grower, Allocator>,
+          bool ENABLE_PARTITIONED = false, size_t BITS_FOR_SUB_TABLE = 4>
+class PartitionedHashTable : private boost::noncopyable,
+                             protected Hash /// empty base optimization
+{
+protected:
+    friend class const_iterator;
+    friend class iterator;
+
+    using HashValue = size_t;
+    using Self = PartitionedHashTable;
+
+    static const int PARTITIONED_BUCKET_THRESHOLD = 8388608;
+
+public:
+    using Impl = ImplTable;
+
+    static constexpr size_t NUM_LEVEL1_SUB_TABLES = 1ULL << BITS_FOR_SUB_TABLE;
+    static constexpr size_t MAX_SUB_TABLE = NUM_LEVEL1_SUB_TABLES - 1;
+
+    //factor that will trigger growing the hash table on insert.
+    static constexpr float MAX_SUB_TABLE_OCCUPANCY_FRACTION = 0.5f;
+
+    size_t hash(const Key& x) const { return Hash::operator()(x); }
+
+    float get_factor() const { return MAX_SUB_TABLE_OCCUPANCY_FRACTION; }
+
+    bool should_be_shrink(int64_t valid_row) const {
+        if constexpr (ENABLE_PARTITIONED) {
+            if (_is_partitioned) {
+                return false;
+            } else {
+                return level0_sub_table.should_be_shrink(valid_row);
+            }
+        } else {
+            return level0_sub_table.should_be_shrink(valid_row);
+        }
+    }
+
+    void init_buf_size(size_t reserve_for_num_elements) {
+        if constexpr (ENABLE_PARTITIONED) {
+            if (_is_partitioned) {
+                for (auto& impl : level1_sub_tables) {
+                    impl.init_buf_size(reserve_for_num_elements / NUM_LEVEL1_SUB_TABLES);
+                }
+            } else {
+                level0_sub_table.init_buf_size(reserve_for_num_elements);
+            }
+        } else {
+            level0_sub_table.init_buf_size(reserve_for_num_elements);
+        }
+    }
+
+    void delete_zero_key(Key key) {
+        if constexpr (ENABLE_PARTITIONED) {
+            if (_is_partitioned) {
+            } else {
+            }
+        } else {
+        }
+    }
+
+    size_t get_buffer_size_in_bytes() const {
+        if constexpr (ENABLE_PARTITIONED) {
+            if (_is_partitioned) {
+                size_t buff_size = 0;
+                for (const auto& impl : level1_sub_tables)
+                    buff_size += impl.get_buffer_size_in_bytes();
+                return buff_size;
+            } else {
+                return level0_sub_table.get_buffer_size_in_bytes();
+            }
+        } else {
+            return level0_sub_table.get_buffer_size_in_bytes();
+        }
+    }
+
+    size_t get_buffer_size_in_cells() const {
+        if constexpr (ENABLE_PARTITIONED) {
+            if (_is_partitioned) {
+                size_t buff_size = 0;
+                for (const auto& impl : level1_sub_tables)
+                    buff_size += impl.get_buffer_size_in_cells();
+                return buff_size;
+            } else {
+                return level0_sub_table.get_buffer_size_in_cells();
+            }
+        } else {
+            return level0_sub_table.get_buffer_size_in_cells();
+        }
+    }
+
+    std::vector<size_t> get_buffer_sizes_in_cells() const {
+        if constexpr (ENABLE_PARTITIONED) {
+            if (_is_partitioned) {
+                std::vector<size_t> sizes;
+                for (size_t i = 0; i < NUM_LEVEL1_SUB_TABLES; ++i) {
+                    sizes.push_back(level1_sub_tables[i].get_buffer_size_in_cells());
+                }
+                return sizes;
+            } else {
+                return level0_sub_table.get_buffer_size_in_cells();
+            }
+        } else {
+            return level0_sub_table.get_buffer_size_in_cells();
+        }
+    }
+
+    void reset_resize_timer() {
+        if constexpr (ENABLE_PARTITIONED) {
+            if (_is_partitioned) {
+                for (auto& impl : level1_sub_tables) {
+                    impl.reset_resize_timer();
+                }
+            } else {
+                level0_sub_table.reset_resize_timer();
+            }
+        } else {
+            level0_sub_table.reset_resize_timer();
+        }
+    }
+    int64_t get_resize_timer_value() const {
+        if constexpr (ENABLE_PARTITIONED) {
+            if (_is_partitioned) {
+                int64_t resize_timer_ns = 0;
+                for (const auto& impl : level1_sub_tables) {
+                    resize_timer_ns += impl.get_resize_timer_value();
+                }
+                return resize_timer_ns;
+            } else {
+                return level0_sub_table.get_resize_timer_value();
+            }
+        } else {
+            return level0_sub_table.get_resize_timer_value();
+        }
+    }
+
+protected:
+    typename Impl::iterator begin_of_next_non_empty_bucket(size_t& bucket) {
+        while (bucket != NUM_LEVEL1_SUB_TABLES && level1_sub_tables[bucket].empty()) ++bucket;
+
+        if (bucket != NUM_LEVEL1_SUB_TABLES) return level1_sub_tables[bucket].begin();
+
+        --bucket;
+        return level1_sub_tables[MAX_SUB_TABLE].end();
+    }
+
+    typename Impl::const_iterator begin_of_next_non_empty_bucket(size_t& bucket) const {
+        while (bucket != NUM_LEVEL1_SUB_TABLES && level1_sub_tables[bucket].empty()) ++bucket;
+
+        if (bucket != NUM_LEVEL1_SUB_TABLES) return level1_sub_tables[bucket].begin();
+
+        --bucket;
+        return level1_sub_tables[MAX_SUB_TABLE].end();
+    }
+
+public:
+    using key_type = typename Impl::key_type;
+    using mapped_type = typename Impl::mapped_type;
+    using value_type = typename Impl::value_type;
+    using cell_type = typename Impl::cell_type;
+
+    using LookupResult = typename Impl::LookupResult;
+    using ConstLookupResult = typename Impl::ConstLookupResult;
+
+    Impl level0_sub_table;
+    Impl level1_sub_tables[NUM_LEVEL1_SUB_TABLES];
+
+    PartitionedHashTable() {
+        if constexpr (ENABLE_PARTITIONED) {
+            level0_sub_table.set_partitioned_threshold(PARTITIONED_BUCKET_THRESHOLD);
+        }
+    }
+
+    explicit PartitionedHashTable(size_t size_hint) {
+        level0_sub_table.reserve(size_hint);
+        if constexpr (ENABLE_PARTITIONED) {
+            level0_sub_table.set_partitioned_threshold(PARTITIONED_BUCKET_THRESHOLD);
+        }
+        // for (auto& impl : level1_sub_tables) impl.reserve(size_hint / NUM_LEVEL1_SUB_TABLES);
+    }
+
+    /// Copy the data from another (normal) hash table. It should have the same hash function.
+    /*
+    template <typename Source>
+    explicit PartitionedHashTable(const Source& src) {
+        if constexpr (ENABLE_PARTITIONED) {
+            level0_sub_table.set_partitioned_threshold(PARTITIONED_BUCKET_THRESHOLD);
+        }
+        typename Source::const_iterator it = src.begin();
+
+        /// It is assumed that the zero key (stored separately) is first in iteration order.
+        if (it != src.end() && it.get_ptr()->is_zero(src)) {
+            insert(it->get_value());
+            ++it;
+        }
+
+        for (; it != src.end(); ++it) {
+            const Cell* cell = it.get_ptr();
+            size_t hash_value = cell->get_hash(src);
+            size_t buck = get_sub_table_from_hash(hash_value);
+            level1_sub_tables[buck].insert_unique_non_zero(cell, hash_value);
+        }
+    }
+    */
+
+    PartitionedHashTable(PartitionedHashTable&& rhs) {
+        if constexpr (ENABLE_PARTITIONED) {
+            level0_sub_table.set_partitioned_threshold(PARTITIONED_BUCKET_THRESHOLD);
+        }
+        for (size_t i = 0; i < NUM_LEVEL1_SUB_TABLES; ++i) {
+            level1_sub_tables[i] = std::move(rhs.level1_sub_tables[i]);
+        }
+    }
+
+    PartitionedHashTable& operator=(PartitionedHashTable&& rhs) {
+        for (size_t i = 0; i < NUM_LEVEL1_SUB_TABLES; ++i) {
+            level1_sub_tables[i] = std::move(rhs.level1_sub_tables[i]);
+        }
+        return *this;
+    }
+
+    void set_partitioned_threshold(int threshold) {
+        if constexpr (ENABLE_PARTITIONED) {
+            level0_sub_table.set_partitioned_threshold(PARTITIONED_BUCKET_THRESHOLD);
+        }
+    }
+
+    bool is_partitioned() const {
+        if constexpr (ENABLE_PARTITIONED) {
+            return _is_partitioned;
+        } else {
+            return false;
+        }
+    }
+
+    class iterator /// NOLINT
+    {
+        Self* container {};
+        size_t bucket {};
+        typename Impl::iterator current_it {};
+
+        friend class PartitionedHashTable;
+
+        iterator(Self* container_, size_t bucket_, typename Impl::iterator current_it_)
+                : container(container_), bucket(bucket_), current_it(current_it_) {}
+
+    public:
+        iterator() = default;
+
+        bool operator==(const iterator& rhs) const {
+            return bucket == rhs.bucket && current_it == rhs.current_it;
+        }
+        bool operator!=(const iterator& rhs) const { return !(*this == rhs); }
+
+        iterator& operator++() {
+            ++current_it;
+            if constexpr (ENABLE_PARTITIONED) {
+                if (current_it == container->level1_sub_tables[bucket].end()) {
+                    ++bucket;
+                    current_it = container->begin_of_next_non_empty_bucket(bucket);
+                }
+            }
+
+            return *this;
+        }
+
+        Cell& operator*() const { return *current_it; }
+        Cell* operator->() const { return current_it.get_ptr(); }
+
+        Cell* get_ptr() const { return current_it.get_ptr(); }
+        size_t get_hash() const { return current_it.get_hash(); }
+    };
+
+    class const_iterator /// NOLINT
+    {
+        Self* container {};
+        size_t bucket {};
+        typename Impl::const_iterator current_it {};
+
+        friend class PartitionedHashTable;
+
+        const_iterator(Self* container_, size_t bucket_, typename Impl::const_iterator current_it_)
+                : container(container_), bucket(bucket_), current_it(current_it_) {}
+
+    public:
+        const_iterator() = default;
+        const_iterator(const iterator& rhs)
+                : container(rhs.container),
+                  bucket(rhs.bucket),
+                  current_it(rhs.current_it) {} /// NOLINT
+
+        bool operator==(const const_iterator& rhs) const {
+            return bucket == rhs.bucket && current_it == rhs.current_it;
+        }
+        bool operator!=(const const_iterator& rhs) const { return !(*this == rhs); }
+
+        const_iterator& operator++() {
+            ++current_it;
+            if constexpr (ENABLE_PARTITIONED) {
+                if (current_it == container->level1_sub_tables[bucket].end()) {
+                    ++bucket;
+                    current_it = container->begin_of_next_non_empty_bucket(bucket);
+                }
+            }
+
+            return *this;
+        }
+
+        const Cell& operator*() const { return *current_it; }
+        const Cell* operator->() const { return current_it->get_ptr(); }
+
+        const Cell* get_ptr() const { return current_it.get_ptr(); }
+        size_t get_hash() const { return current_it.get_hash(); }
+    };
+
+    const_iterator begin() const {
+        if constexpr (ENABLE_PARTITIONED) {
+            if (_is_partitioned) {
+                size_t buck = 0;
+                typename Impl::const_iterator impl_it = begin_of_next_non_empty_bucket(buck);
+                return {this, buck, impl_it};
+            } else {
+                return {this, NUM_LEVEL1_SUB_TABLES, level0_sub_table.begin()};
+            }
+        } else {
+            return {this, NUM_LEVEL1_SUB_TABLES, level0_sub_table.begin()};
+        }
+    }
+
+    iterator begin() {
+        if constexpr (ENABLE_PARTITIONED) {
+            if (_is_partitioned) {
+                size_t buck = 0;
+                typename Impl::iterator impl_it = begin_of_next_non_empty_bucket(buck);
+                return {this, buck, impl_it};
+            } else {
+                return {this, NUM_LEVEL1_SUB_TABLES, level0_sub_table.begin()};
+            }
+        } else {
+            return {this, NUM_LEVEL1_SUB_TABLES, level0_sub_table.begin()};
+        }
+    }
+
+    const_iterator end() const {
+        if constexpr (ENABLE_PARTITIONED) {
+            if (_is_partitioned) {
+                return {this, MAX_SUB_TABLE, level1_sub_tables[MAX_SUB_TABLE].end()};
+            } else {
+                return {this, NUM_LEVEL1_SUB_TABLES, level0_sub_table.end()};
+            }
+        } else {
+            return {this, NUM_LEVEL1_SUB_TABLES, level0_sub_table.end()};
+        }
+    }
+    iterator end() {
+        if constexpr (ENABLE_PARTITIONED) {
+            if (_is_partitioned) {
+                return {this, MAX_SUB_TABLE, level1_sub_tables[MAX_SUB_TABLE].end()};
+            } else {
+                return {this, NUM_LEVEL1_SUB_TABLES, level0_sub_table.end()};
+            }
+        } else {
+            return {this, NUM_LEVEL1_SUB_TABLES, level0_sub_table.end()};
+        }
+    }
+
+    /// Insert a value. In the case of any more complex values, it is better to use the `emplace` function.
+    std::pair<LookupResult, bool> ALWAYS_INLINE insert(const value_type& x) {
+        size_t hash_value = hash(Cell::get_key(x));
+
+        std::pair<LookupResult, bool> res;
+        emplace(Cell::get_key(x), res.first, res.second, hash_value);
+
+        if (res.second) insert_set_mapped(lookup_result_get_mapped(res.first), x);
+
+        return res;
+    }
+
+    void expanse_for_add_elem(size_t num_elem) {
+        if constexpr (ENABLE_PARTITIONED) {
+            if (_is_partitioned) {
+                size_t num_elem_per_bucket =
+                        (num_elem + NUM_LEVEL1_SUB_TABLES - 1) / NUM_LEVEL1_SUB_TABLES;
+                for (size_t i = 0; i < NUM_LEVEL1_SUB_TABLES; ++i) {
+                    level1_sub_tables[i].expanse_for_add_elem(num_elem_per_bucket);
+                }
+            } else {
+                level0_sub_table.expanse_for_add_elem(num_elem);
+            }
+        } else {
+            level0_sub_table.expanse_for_add_elem(num_elem);
+        }
+    }
+
+    template <typename KeyHolder>
+    void ALWAYS_INLINE prefetch(KeyHolder& key_holder) {
+        if constexpr (ENABLE_PARTITIONED) {
+            if (_is_partitioned) {
+                const auto& key = key_holder_get_key(key_holder);
+                const auto key_hash = hash(key);
+                const auto bucket = get_sub_table_from_hash(key_hash);
+                level1_sub_tables[bucket].prefetch(key_holder);
+            } else {
+                level0_sub_table.prefetch(key_holder);
+            }
+        } else {
+            level0_sub_table.prefetch(key_holder);
+        }
+    }
+
+    template <bool READ>
+    void ALWAYS_INLINE prefetch_by_hash(size_t hash_value) {
+        if constexpr (ENABLE_PARTITIONED) {
+            if (_is_partitioned) {
+                const auto bucket = get_sub_table_from_hash(hash_value);
+                level1_sub_tables[bucket].template prefetch_by_hash<READ>(hash_value);
+            } else {
+                level0_sub_table.template prefetch_by_hash<READ>(hash_value);
+            }
+        } else {
+            level0_sub_table.template prefetch_by_hash<READ>(hash_value);
+        }
+    }
+
+    template <bool READ, typename KeyHolder>
+    void ALWAYS_INLINE prefetch(KeyHolder& key_holder) {
+        if constexpr (ENABLE_PARTITIONED) {
+            if (_is_partitioned) {
+                const auto& key = key_holder_get_key(key_holder);
+                const auto key_hash = hash(key);
+                const auto bucket = get_sub_table_from_hash(key_hash);
+                level1_sub_tables[bucket].template prefetch<READ>(key_holder);
+            } else {
+                level0_sub_table.template prefetch<READ>(key_holder);
+            }
+        } else {
+            level0_sub_table.template prefetch<READ>(key_holder);
+        }
+    }
+
+    /** Insert the key,
+      * return an iterator to a position that can be used for `placement new` of value,
+      * as well as the flag - whether a new key was inserted.
+      *
+      * You have to make `placement new` values if you inserted a new key,
+      * since when destroying a hash table, the destructor will be invoked for it!
+      *
+      * Example usage:
+      *
+      * Map::iterator it;
+      * bool inserted;
+      * map.emplace(key, it, inserted);
+      * if (inserted)
+      *     new(&it->second) Mapped(value);
+      */
+    template <typename KeyHolder>
+    void ALWAYS_INLINE emplace(KeyHolder&& key_holder, LookupResult& it, bool& inserted) {
+        size_t hash_value = hash(key_holder_get_key(key_holder));
+        emplace(key_holder, it, inserted, hash_value);
+    }
+
+    /// Same, but with a precalculated values of hash function.
+    template <typename KeyHolder>
+    void ALWAYS_INLINE emplace(KeyHolder&& key_holder, LookupResult& it, bool& inserted,
+                               size_t hash_value) {
+        if constexpr (ENABLE_PARTITIONED) {
+            if (_is_partitioned) {
+                size_t buck = get_sub_table_from_hash(hash_value);
+                level1_sub_tables[buck].emplace(key_holder, it, inserted, hash_value);
+            } else {
+                level0_sub_table.emplace(key_holder, it, inserted, hash_value);
+                if (UNLIKELY(level0_sub_table.need_partition())) {
+                    convert_to_partitioned();
+
+                    // The hash table was converted to partitioned, so we have to re-find the key.
+                    size_t buck = get_sub_table_from_hash(hash_value);
+                    it = level1_sub_tables[buck].find(key_holder_get_key(key_holder), hash_value);
+                }
+            }
+        } else {
+            level0_sub_table.emplace(key_holder, it, inserted, hash_value);
+        }
+    }
+
+    template <typename KeyHolder>
+    void ALWAYS_INLINE emplace(KeyHolder&& key_holder, LookupResult& it, size_t hash_value,
+                               bool& inserted) {
+        emplace(key_holder, it, inserted, hash_value);
+    }
+
+    LookupResult ALWAYS_INLINE find(Key x, size_t hash_value) {
+        if constexpr (ENABLE_PARTITIONED) {
+            if (_is_partitioned) {
+                size_t buck = get_sub_table_from_hash(hash_value);
+                return level1_sub_tables[buck].find(x, hash_value);
+            } else {
+                return level0_sub_table.find(x, hash_value);
+            }
+        } else {
+            return level0_sub_table.find(x, hash_value);
+        }
+    }
+
+    ConstLookupResult ALWAYS_INLINE find(Key x, size_t hash_value) const {
+        return const_cast<std::decay_t<decltype(*this)>*>(this)->find(x, hash_value);
+    }
+
+    LookupResult ALWAYS_INLINE find(Key x) { return find(x, hash(x)); }
+
+    ConstLookupResult ALWAYS_INLINE find(Key x) const { return find(x, hash(x)); }
+
+    size_t size() const {
+        if constexpr (ENABLE_PARTITIONED) {
+            if (_is_partitioned) {
+                size_t res = 0;
+                for (size_t i = 0; i < NUM_LEVEL1_SUB_TABLES; ++i)
+                    res += level1_sub_tables[i].size();
+                return res;
+            } else {
+                return level0_sub_table.size();
+            }
+        } else {
+            return level0_sub_table.size();
+        }
+    }
+
+    std::vector<size_t> sizes() const {
+        if constexpr (ENABLE_PARTITIONED) {
+            if (_is_partitioned) {
+                std::vector<size_t> sizes;
+                for (size_t i = 0; i < NUM_LEVEL1_SUB_TABLES; ++i) {
+                    sizes.push_back(level1_sub_tables[i].size());
+                }
+                return sizes;
+            } else {
+                return level0_sub_table.size();
+            }
+        } else {
+            return level0_sub_table.size();
+        }
+    }
+
+    bool empty() const {
+        if constexpr (ENABLE_PARTITIONED) {
+            if (_is_partitioned) {
+                for (size_t i = 0; i < NUM_LEVEL1_SUB_TABLES; ++i)
+                    if (!level1_sub_tables[i].empty()) return false;
+                return true;
+            } else {
+                return level0_sub_table.empty();
+            }
+        } else {
+            return level0_sub_table.empty();
+        }
+    }
+
+private:
+    void convert_to_partitioned() {
+        auto it = level0_sub_table.begin();
+
+        /// It is assumed that the zero key (stored separately) is first in iteration order.
+        if (it != level0_sub_table.end() && it.get_ptr()->is_zero(level0_sub_table)) {
+            insert(it->get_value());
+            ++it;
+        }
+
+        for (; it != level0_sub_table.end(); ++it) {
+            const Cell* cell = it.get_ptr();
+            size_t hash_value = cell->get_hash(level0_sub_table);
+            size_t buck = get_sub_table_from_hash(hash_value);
+            level1_sub_tables[buck].insert_unique_non_zero(cell, hash_value);
+        }
+
+        _is_partitioned = true;
+    }
+
+    /// NOTE Bad for hash tables with more than 2^32 cells.
+    static size_t get_sub_table_from_hash(size_t hash_value) {
+        return (hash_value >> (32 - BITS_FOR_SUB_TABLE)) & MAX_SUB_TABLE;
+    }
+
+private:
+    bool _is_partitioned = false;
+    // if ENABLE_PARTITIONED, the threshold of bucket count of level0 hash table above
+    // which the hash table is converted to partioned hash table
+    int _partitioned_threshold = 0;
+};

--- a/be/src/vec/exec/join/vhash_join_node.cpp
+++ b/be/src/vec/exec/join/vhash_join_node.cpp
@@ -357,7 +357,8 @@ Status HashJoinNode::prepare(RuntimeState* state) {
     _build_table_insert_timer = ADD_TIMER(build_phase_profile, "BuildTableInsertTime");
     _build_expr_call_timer = ADD_TIMER(build_phase_profile, "BuildExprCallTime");
     _build_table_expanse_timer = ADD_TIMER(build_phase_profile, "BuildTableExpanseTime");
-    _build_table_convert_timer = ADD_TIMER(build_phase_profile, "BuildTableConvertToPartitioedTime");
+    _build_table_convert_timer =
+            ADD_TIMER(build_phase_profile, "BuildTableConvertToPartitioedTime");
     _build_rows_counter = ADD_COUNTER(build_phase_profile, "BuildRows", TUnit::UNIT);
     _build_side_compute_hash_timer = ADD_TIMER(build_phase_profile, "BuildSideHashComputingTime");
 

--- a/be/src/vec/exec/join/vhash_join_node.cpp
+++ b/be/src/vec/exec/join/vhash_join_node.cpp
@@ -358,7 +358,7 @@ Status HashJoinNode::prepare(RuntimeState* state) {
     _build_expr_call_timer = ADD_TIMER(build_phase_profile, "BuildExprCallTime");
     _build_table_expanse_timer = ADD_TIMER(build_phase_profile, "BuildTableExpanseTime");
     _build_table_convert_timer =
-            ADD_TIMER(build_phase_profile, "BuildTableConvertToPartitioedTime");
+            ADD_TIMER(build_phase_profile, "BuildTableConvertToPartitionedTime");
     _build_rows_counter = ADD_COUNTER(build_phase_profile, "BuildRows", TUnit::UNIT);
     _build_side_compute_hash_timer = ADD_TIMER(build_phase_profile, "BuildSideHashComputingTime");
 

--- a/be/src/vec/exec/join/vhash_join_node.cpp
+++ b/be/src/vec/exec/join/vhash_join_node.cpp
@@ -189,6 +189,9 @@ struct ProcessHashTableBuild {
 
         COUNTER_UPDATE(_join_node->_build_table_expanse_timer,
                        hash_table_ctx.hash_table.get_resize_timer_value());
+        COUNTER_UPDATE(_join_node->_build_table_convert_timer,
+                       hash_table_ctx.hash_table.get_convert_timer_value());
+
         return Status::OK();
     }
 
@@ -354,6 +357,7 @@ Status HashJoinNode::prepare(RuntimeState* state) {
     _build_table_insert_timer = ADD_TIMER(build_phase_profile, "BuildTableInsertTime");
     _build_expr_call_timer = ADD_TIMER(build_phase_profile, "BuildExprCallTime");
     _build_table_expanse_timer = ADD_TIMER(build_phase_profile, "BuildTableExpanseTime");
+    _build_table_convert_timer = ADD_TIMER(build_phase_profile, "BuildTableConvertToPartitioedTime");
     _build_rows_counter = ADD_COUNTER(build_phase_profile, "BuildRows", TUnit::UNIT);
     _build_side_compute_hash_timer = ADD_TIMER(build_phase_profile, "BuildSideHashComputingTime");
 

--- a/be/src/vec/exec/join/vhash_join_node.h
+++ b/be/src/vec/exec/join/vhash_join_node.h
@@ -39,7 +39,6 @@ class SharedHashTableController;
 template <typename RowRefListType>
 struct SerializedHashTableContext {
     using Mapped = RowRefListType;
-    // using HashTable = HashMap<StringRef, Mapped>;
     using HashTable = PartitionedHashMap<StringRef, Mapped, true>;
     using State = ColumnsHashing::HashMethodSerialized<typename HashTable::value_type, Mapped>;
     using Iter = typename HashTable::iterator;
@@ -71,7 +70,6 @@ struct IsSerializedHashTableContextTraits<ColumnsHashing::HashMethodSerialized<V
 template <class T, typename RowRefListType>
 struct PrimaryTypeHashTableContext {
     using Mapped = RowRefListType;
-    // using HashTable = HashMap<T, Mapped, HashCRC32<T>>;
     using HashTable = PartitionedHashMap<T, Mapped, true, HashCRC32<T>>;
     using State =
             ColumnsHashing::HashMethodOneNumber<typename HashTable::value_type, Mapped, T, false>;
@@ -107,7 +105,6 @@ using I256HashTableContext = PrimaryTypeHashTableContext<UInt256, RowRefListType
 template <class T, bool has_null, typename RowRefListType>
 struct FixedKeyHashTableContext {
     using Mapped = RowRefListType;
-    // using HashTable = HashMap<T, Mapped, HashCRC32<T>>;
     using HashTable = PartitionedHashMap<T, Mapped, true, HashCRC32<T>>;
     using State = ColumnsHashing::HashMethodKeysFixed<typename HashTable::value_type, T, Mapped,
                                                       has_null, false>;
@@ -195,6 +192,8 @@ public:
     Status get_next(RuntimeState* state, RowBatch* row_batch, bool* eos) override;
     Status get_next(RuntimeState* state, Block* block, bool* eos) override;
     Status close(RuntimeState* state) override;
+    void add_hash_buckets_info(const std::string& info);
+    void add_hash_buckets_filled_info(const std::string& info);
 
 private:
     using VExprContexts = std::vector<VExprContext*>;
@@ -224,6 +223,7 @@ private:
     RuntimeProfile::Counter* _probe_expr_call_timer;
     RuntimeProfile::Counter* _probe_next_timer;
     RuntimeProfile::Counter* _build_buckets_counter;
+    RuntimeProfile::Counter* _build_buckets_fill_counter;
     RuntimeProfile::Counter* _push_down_timer;
     RuntimeProfile::Counter* _push_compute_timer;
     RuntimeProfile::Counter* _search_hashtable_timer;

--- a/be/src/vec/exec/join/vhash_join_node.h
+++ b/be/src/vec/exec/join/vhash_join_node.h
@@ -39,7 +39,7 @@ class SharedHashTableController;
 template <typename RowRefListType>
 struct SerializedHashTableContext {
     using Mapped = RowRefListType;
-    using HashTable = PartitionedHashMap<StringRef, Mapped, true>;
+    using HashTable = PartitionedHashMap<StringRef, Mapped>;
     using State = ColumnsHashing::HashMethodSerialized<typename HashTable::value_type, Mapped>;
     using Iter = typename HashTable::iterator;
 
@@ -70,7 +70,7 @@ struct IsSerializedHashTableContextTraits<ColumnsHashing::HashMethodSerialized<V
 template <class T, typename RowRefListType>
 struct PrimaryTypeHashTableContext {
     using Mapped = RowRefListType;
-    using HashTable = PartitionedHashMap<T, Mapped, true, HashCRC32<T>>;
+    using HashTable = PartitionedHashMap<T, Mapped, HashCRC32<T>>;
     using State =
             ColumnsHashing::HashMethodOneNumber<typename HashTable::value_type, Mapped, T, false>;
     using Iter = typename HashTable::iterator;
@@ -105,7 +105,7 @@ using I256HashTableContext = PrimaryTypeHashTableContext<UInt256, RowRefListType
 template <class T, bool has_null, typename RowRefListType>
 struct FixedKeyHashTableContext {
     using Mapped = RowRefListType;
-    using HashTable = PartitionedHashMap<T, Mapped, true, HashCRC32<T>>;
+    using HashTable = PartitionedHashMap<T, Mapped, HashCRC32<T>>;
     using State = ColumnsHashing::HashMethodKeysFixed<typename HashTable::value_type, T, Mapped,
                                                       has_null, false>;
     using Iter = typename HashTable::iterator;
@@ -220,6 +220,7 @@ private:
     RuntimeProfile::Counter* _build_expr_call_timer;
     RuntimeProfile::Counter* _build_table_insert_timer;
     RuntimeProfile::Counter* _build_table_expanse_timer;
+    RuntimeProfile::Counter* _build_table_convert_timer;
     RuntimeProfile::Counter* _probe_expr_call_timer;
     RuntimeProfile::Counter* _probe_next_timer;
     RuntimeProfile::Counter* _build_buckets_counter;

--- a/be/src/vec/runtime/shared_hash_table_controller.cpp
+++ b/be/src/vec/runtime/shared_hash_table_controller.cpp
@@ -121,10 +121,10 @@ Status SharedHashTableController::release_ref_count_if_need(TUniqueId fragment_i
 
 Status SharedHashTableController::wait_for_closable(RuntimeState* state, int my_node_id) {
     std::unique_lock<std::mutex> lock(_mutex);
-    RETURN_IF_CANCELLED(state);
     if (!_ref_fragments[my_node_id].empty()) {
         _cv.wait(lock, [&]() { return _ref_fragments[my_node_id].empty(); });
     }
+    RETURN_IF_CANCELLED(state);
     return Status::OK();
 }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -605,7 +605,7 @@ public class SessionVariable implements Serializable, Writable {
 
     // Use partitioned hash join if build side row count >= the threshold . 0 - the threshold is not set.
     @VariableMgr.VarAttr(name = PARTITIONED_HASH_JOIN_ROWS_THRESHOLD)
-    public int partitionedHashJoinRowsThreshold = 8388608;
+    public int partitionedHashJoinRowsThreshold = 1;
 
     // If this fe is in fuzzy mode, then will use initFuzzyModeVariables to generate some variables,
     // not the default value set in the code.

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -229,6 +229,8 @@ public class SessionVariable implements Serializable, Writable {
 
     public static final String INTERNAL_SESSION = "internal_session";
 
+    public static final String PARTITIONED_HASH_JOIN_ROWS_THRESHOLD = "partitioned_hash_join_rows_threshold";
+
     // session origin value
     public Map<Field, String> sessionOriginValue = new HashMap<Field, String>();
     // check stmt is or not [select /*+ SET_VAR(...)*/ ...]
@@ -601,6 +603,10 @@ public class SessionVariable implements Serializable, Writable {
     @VariableMgr.VarAttr(name = INTERNAL_SESSION)
     public boolean internalSession = false;
 
+    // Use partitioned hash join if build side row count >= the threshold . 0 - the threshold is not set.
+    @VariableMgr.VarAttr(name = PARTITIONED_HASH_JOIN_ROWS_THRESHOLD)
+    public int partitionedHashJoinRowsThreshold = 8388608;
+
     // If this fe is in fuzzy mode, then will use initFuzzyModeVariables to generate some variables,
     // not the default value set in the code.
     public void initFuzzyModeVariables() {
@@ -609,6 +615,7 @@ public class SessionVariable implements Serializable, Writable {
         this.enableLocalExchange = random.nextBoolean();
         this.disableJoinReorder = random.nextBoolean();
         this.disableStreamPreaggregations = random.nextBoolean();
+        this.partitionedHashJoinRowsThreshold = random.nextBoolean() ? 8 : 1048576;
     }
 
     public String getBlockEncryptionMode() {
@@ -840,6 +847,14 @@ public class SessionVariable implements Serializable, Writable {
 
     public void setEnablePartitionCache(boolean enablePartitionCache) {
         this.enablePartitionCache = enablePartitionCache;
+    }
+
+    public int getPartitionedHashJoinRowsThreshold() {
+        return partitionedHashJoinRowsThreshold;
+    }
+
+    public void setPartitionedHashJoinRowsThreshold(int threshold) {
+        this.partitionedHashJoinRowsThreshold = threshold;
     }
 
     // Serialize to thrift object
@@ -1243,6 +1258,8 @@ public class SessionVariable implements Serializable, Writable {
         tResult.setSkipStorageEngineMerge(skipStorageEngineMerge);
 
         tResult.setSkipDeletePredicate(skipDeletePredicate);
+
+        tResult.setPartitionedHashJoinRowsThreshold(partitionedHashJoinRowsThreshold);
 
         return tResult;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -605,7 +605,7 @@ public class SessionVariable implements Serializable, Writable {
 
     // Use partitioned hash join if build side row count >= the threshold . 0 - the threshold is not set.
     @VariableMgr.VarAttr(name = PARTITIONED_HASH_JOIN_ROWS_THRESHOLD)
-    public int partitionedHashJoinRowsThreshold = 1;
+    public int partitionedHashJoinRowsThreshold = 0;
 
     // If this fe is in fuzzy mode, then will use initFuzzyModeVariables to generate some variables,
     // not the default value set in the code.
@@ -615,7 +615,7 @@ public class SessionVariable implements Serializable, Writable {
         this.enableLocalExchange = random.nextBoolean();
         this.disableJoinReorder = random.nextBoolean();
         this.disableStreamPreaggregations = random.nextBoolean();
-        this.partitionedHashJoinRowsThreshold = random.nextBoolean() ? 8 : 1048576;
+        // this.partitionedHashJoinRowsThreshold = random.nextBoolean() ? 8 : 1048576;
     }
 
     public String getBlockEncryptionMode() {

--- a/gensrc/thrift/PaloInternalService.thrift
+++ b/gensrc/thrift/PaloInternalService.thrift
@@ -179,6 +179,8 @@ struct TQueryOptions {
   51: optional bool enable_new_shuffle_hash_method
 
   52: optional i32 be_exec_version = 0
+  
+  53: optional i32 partitioned_hash_join_rows_threshold = 0
 }
     
 


### PR DESCRIPTION
# Proposed changes

Issue Number: close #13654
A nother implementation of partitioned hash table that's simplifies usage.
Add session variable `partitioned_hash_join_rows_threshold`(default to 8388608) which is the build side row count threshold that hash table is converted to partitioned hash table.

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

