### PR TITLE
[feature](catalog) add max num of same name meta information in catalog recycle bin

### DIFF
--- a/docs/en/docs/admin-manual/config/fe-config.md
+++ b/docs/en/docs/admin-manual/config/fe-config.md
@@ -2334,4 +2334,4 @@ Default: 3
 
 Is it possible to dynamically configure: true
 
-Is it a configuration item unique to the Master FE node: false
+Is it a configuration item unique to the Master FE node: true

--- a/docs/en/docs/admin-manual/config/fe-config.md
+++ b/docs/en/docs/admin-manual/config/fe-config.md
@@ -2324,3 +2324,14 @@ Is it possible to dynamically configure: false
 
 Is it a configuration item unique to the Master FE node: false
 
+### `max_same_name_catalog_trash_num`
+
+It is used to set the maximum number of meta information with the same name in the catalog recycle bin. When the maximum value is exceeded, the earliest deleted meta trash will be completely deleted and cannot be recovered.
+
+Note: The judgment of metadata with the same name will be limited to a certain range. For example, the judgment of the database with the same name will be limited to the same cluster, the judgment of the table with the same name will be limited to the same database (with the same database id), the judgment of the partition with the same name will be limited to the same database (with the same database id) and the same table (with the same table) same table id).
+
+Default: 3
+
+Is it possible to dynamically configure: true
+
+Is it a configuration item unique to the Master FE node: false

--- a/docs/zh-CN/docs/admin-manual/config/fe-config.md
+++ b/docs/zh-CN/docs/admin-manual/config/fe-config.md
@@ -2379,3 +2379,15 @@ hive partition 的最大缓存数量。
 是否可以动态配置：false
 
 是否为 Master FE 节点独有的配置项：false
+
+### `max_same_name_catalog_trash_num`
+
+用于设置回收站中同名元数据的最大个数，超过最大值时，最早删除的元数据将被彻底删除，不能再恢复。
+
+注意：同名元数据的判断会局限在一定的范围内。比如同名database的判断会限定在相同cluster下，同名table的判断会限定在相同database（指相同database id）下，同名partition的判断会限定在相同database（指相同database id）并且相同table（指相同table id）下。
+
+默认值：3
+
+是否可以动态配置：true
+
+是否为 Master FE 节点独有的配置项：false

--- a/docs/zh-CN/docs/admin-manual/config/fe-config.md
+++ b/docs/zh-CN/docs/admin-manual/config/fe-config.md
@@ -2390,4 +2390,4 @@ hive partition 的最大缓存数量。
 
 是否可以动态配置：true
 
-是否为 Master FE 节点独有的配置项：false
+是否为 Master FE 节点独有的配置项：true

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/CatalogRecycleBin.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/CatalogRecycleBin.java
@@ -131,6 +131,11 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
         // db should be empty. all tables are recycled before
         Preconditions.checkState(db.getTables().isEmpty());
 
+        // erase db with same name
+        if (Config.max_same_name_catalog_trash_num > 0) {
+            eraseDatabaseWithSameName(db.getFullName(), isReplay, Config.max_same_name_catalog_trash_num);
+        }
+
         // recycle db
         RecycleDatabaseInfo databaseInfo = new RecycleDatabaseInfo(db, tableNames, tableIds);
         idToDatabase.put(db.getId(), databaseInfo);
@@ -149,6 +154,11 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
         if (idToTable.containsKey(table.getId())) {
             LOG.error("table[{}] already in recycle bin.", table.getId());
             return false;
+        }
+
+        // erase table with same name
+        if (Config.max_same_name_catalog_trash_num > 0) {
+            eraseTableWithSameName(dbId, table.getName(), isReplay, Config.max_same_name_catalog_trash_num);
         }
 
         // recycle table
@@ -171,6 +181,11 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
         if (idToPartition.containsKey(partition.getId())) {
             LOG.error("partition[{}] already in recycle bin.", partition.getId());
             return false;
+        }
+
+        // erase partition with same name
+        if (Config.max_same_name_catalog_trash_num > 0) {
+            erasePartitionWithSameName(dbId, tableId, partition.getName(), Config.max_same_name_catalog_trash_num);
         }
 
         // recycle partition
@@ -211,6 +226,74 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
         }
     }
 
+    private synchronized List<Long> getSameNameDbIdListToErase(String dbName, int maxSameNameTrashNum) {
+        Iterator<Map.Entry<Long, RecycleDatabaseInfo>> iterator = idToDatabase.entrySet().iterator();
+        List<List<Long>> dbRecycleTimeLists = Lists.newArrayList();
+        while (iterator.hasNext()) {
+            Map.Entry<Long, RecycleDatabaseInfo> entry = iterator.next();
+            RecycleDatabaseInfo dbInfo = entry.getValue();
+            Database db = dbInfo.getDb();
+            if (db.getFullName().equals(dbName)) {
+                List<Long> dbRecycleTimeInfo = Lists.newArrayList();
+                dbRecycleTimeInfo.add(entry.getKey());
+                dbRecycleTimeInfo.add(idToRecycleTime.get(entry.getKey()));
+
+                dbRecycleTimeLists.add(dbRecycleTimeInfo);
+            }
+        }
+        List<Long> dbIdToErase = Lists.newArrayList();
+        if (dbRecycleTimeLists.size() < maxSameNameTrashNum) {
+            return dbIdToErase;
+        }
+        // order by recycle time desc
+        dbRecycleTimeLists.sort((x, y) -> {
+            return (x.get(1).longValue() < y.get(1).longValue()) ? 1 : ((x.get(1).equals(y.get(1))) ? 0 : -1);
+        });
+
+        for (int i = maxSameNameTrashNum - 1; i < dbRecycleTimeLists.size(); i++) {
+            dbIdToErase.add(dbRecycleTimeLists.get(i).get(0));
+        }
+        return dbIdToErase;
+    }
+
+    private synchronized void eraseDatabaseWithSameName(String dbName, boolean isReplay, int maxSameNameTrashNum) {
+        List<Long> dbIdToErase = getSameNameDbIdListToErase(dbName, maxSameNameTrashNum);
+        for (Long dbId : dbIdToErase) {
+            RecycleDatabaseInfo dbInfo = idToDatabase.get(dbId);
+            eraseAllTables(dbInfo, isReplay);
+            idToDatabase.remove(dbId);
+            idToRecycleTime.remove(dbId);
+            Env.getCurrentEnv().eraseDatabase(dbId, false);
+
+            LOG.info("erase database[{}] name: {}", dbId, dbName);
+        }
+    }
+
+    private void eraseAllTables(RecycleDatabaseInfo dbInfo, boolean isReplay) {
+        Database db = dbInfo.getDb();
+        Set<String> tableNames = Sets.newHashSet(dbInfo.getTableNames());
+        Set<Long> tableIds = Sets.newHashSet(dbInfo.getTableIds());
+        long dbId = db.getId();
+        Iterator<Map.Entry<Long, RecycleTableInfo>> iterator = idToTable.entrySet().iterator();
+        while (iterator.hasNext()) {
+            Map.Entry<Long, RecycleTableInfo> entry = iterator.next();
+            RecycleTableInfo tableInfo = entry.getValue();
+            if (tableInfo.getDbId() != dbId || !tableNames.contains(tableInfo.getTable().getName())
+                    || !tableIds.contains(tableInfo.getTable().getId())) {
+                continue;
+            }
+
+            Table table = tableInfo.getTable();
+            if (table.getType() == TableType.OLAP) {
+                Env.getCurrentEnv().onEraseOlapTable((OlapTable) table, isReplay);
+            }
+            LOG.info("erase db[{}] with table[{}]: {}", dbId, table.getId(), table.getName());
+            iterator.remove();
+            idToRecycleTime.remove(table.getId());
+            tableNames.remove(table.getName());
+        }
+    }
+
     public synchronized void replayEraseDatabase(long dbId) {
         idToDatabase.remove(dbId);
         idToRecycleTime.remove(dbId);
@@ -240,6 +323,57 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
                 LOG.info("erase table[{}]", tableId);
             }
         } // end for tables
+    }
+
+    private synchronized List<Long> getSameNameTableIdListToErase(long dbId, String tableName,
+                                                                  int maxSameNameTrashNum) {
+        Iterator<Map.Entry<Long, RecycleTableInfo>> iterator = idToTable.entrySet().iterator();
+        List<List<Long>> tableRecycleTimeLists = Lists.newArrayList();
+        while (iterator.hasNext()) {
+            Map.Entry<Long, RecycleTableInfo> entry = iterator.next();
+            RecycleTableInfo tableInfo = entry.getValue();
+            if (tableInfo.getDbId() != dbId) {
+                continue;
+            }
+
+            Table table = tableInfo.getTable();
+            if (table.getName().equals(tableName)) {
+                List<Long> tableRecycleTimeInfo = Lists.newArrayList();
+                tableRecycleTimeInfo.add(entry.getKey());
+                tableRecycleTimeInfo.add(idToRecycleTime.get(entry.getKey()));
+
+                tableRecycleTimeLists.add(tableRecycleTimeInfo);
+            }
+        }
+        List<Long> tableIdToErase = Lists.newArrayList();
+        if (tableRecycleTimeLists.size() < maxSameNameTrashNum) {
+            return tableIdToErase;
+        }
+        // order by recycle time desc
+        tableRecycleTimeLists.sort((x, y) -> {
+            return (x.get(1).longValue() < y.get(1).longValue()) ? 1 : ((x.get(1).equals(y.get(1))) ? 0 : -1);
+        });
+
+        for (int i = maxSameNameTrashNum - 1; i < tableRecycleTimeLists.size(); i++) {
+            tableIdToErase.add(tableRecycleTimeLists.get(i).get(0));
+        }
+        return tableIdToErase;
+    }
+
+    private synchronized void eraseTableWithSameName(long dbId, String tableName, boolean isReplay,
+                                                     int maxSameNameTrashNum) {
+        List<Long> tableIdToErase = getSameNameTableIdListToErase(dbId, tableName, maxSameNameTrashNum);
+        for (Long tableId : tableIdToErase) {
+            RecycleTableInfo tableInfo = idToTable.get(tableId);
+            Table table = tableInfo.getTable();
+            if (table.getType() == TableType.OLAP) {
+                Env.getCurrentEnv().onEraseOlapTable((OlapTable) table, isReplay);
+            }
+
+            idToTable.remove(tableId);
+            idToRecycleTime.remove(tableId);
+            LOG.info("erase table[{}] name: {} from db[{}]", tableId, tableName, dbId);
+        }
     }
 
     public synchronized void replayEraseTable(long tableId) {
@@ -272,6 +406,58 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
                 LOG.info("erase partition[{}]", partitionId);
             }
         } // end for partitions
+    }
+
+    private synchronized List<Long> getSameNamePartitionIdListToErase(long dbId, long tableId, String partitionName,
+                                                                      int maxSameNameTrashNum) {
+        Iterator<Map.Entry<Long, RecyclePartitionInfo>> iterator = idToPartition.entrySet().iterator();
+        List<List<Long>> partitionRecycleTimeLists = Lists.newArrayList();
+        while (iterator.hasNext()) {
+            Map.Entry<Long, RecyclePartitionInfo> entry = iterator.next();
+            RecyclePartitionInfo partitionInfo = entry.getValue();
+            if (partitionInfo.getDbId() != dbId || partitionInfo.getTableId() != tableId) {
+                continue;
+            }
+
+            Partition partition = partitionInfo.getPartition();
+            if (partition.getName().equals(partitionName)) {
+                List<Long> partitionRecycleTimeInfo = Lists.newArrayList();
+                partitionRecycleTimeInfo.add(entry.getKey());
+                partitionRecycleTimeInfo.add(idToRecycleTime.get(entry.getKey()));
+
+                partitionRecycleTimeLists.add(partitionRecycleTimeInfo);
+            }
+        }
+        List<Long> partitionIdToErase = Lists.newArrayList();
+        if (partitionRecycleTimeLists.size() < maxSameNameTrashNum) {
+            return partitionIdToErase;
+        }
+        // order by recycle time desc
+        partitionRecycleTimeLists.sort((x, y) -> {
+            return (x.get(1).longValue() < y.get(1).longValue()) ? 1 : ((x.get(1).equals(y.get(1))) ? 0 : -1);
+        });
+
+        for (int i = maxSameNameTrashNum - 1; i < partitionRecycleTimeLists.size(); i++) {
+            partitionIdToErase.add(partitionRecycleTimeLists.get(i).get(0));
+        }
+        return partitionIdToErase;
+    }
+
+    private synchronized void erasePartitionWithSameName(long dbId, long tableId, String partitionName,
+                                                         int maxSameNameTrashNum) {
+        List<Long> partitionIdToErase = getSameNamePartitionIdListToErase(dbId, tableId, partitionName,
+                                        maxSameNameTrashNum);
+        for (Long partitionId : partitionIdToErase) {
+            RecyclePartitionInfo partitionInfo = idToPartition.get(partitionId);
+            Partition partition = partitionInfo.getPartition();
+
+            Env.getCurrentEnv().onErasePartition(partition);
+            idToPartition.remove(partitionId);
+            idToRecycleTime.remove(partitionId);
+
+            LOG.info("erase partition[{}] name: {} from table[{}] from db[{}]", partitionId, partitionName, tableId,
+                    dbId);
+        }
     }
 
     public synchronized void replayErasePartition(long partitionId) {

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/CatalogRecycleBin.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/CatalogRecycleBin.java
@@ -275,7 +275,7 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
         Set<Long> tableIds = Sets.newHashSet(dbInfo.getTableIds());
         long dbId = db.getId();
         Iterator<Map.Entry<Long, RecycleTableInfo>> iterator = idToTable.entrySet().iterator();
-        while (iterator.hasNext()) {
+        while (iterator.hasNext() && !tableNames.isEmpty()) {
             Map.Entry<Long, RecycleTableInfo> entry = iterator.next();
             RecycleTableInfo tableInfo = entry.getValue();
             if (tableInfo.getDbId() != dbId || !tableNames.contains(tableInfo.getTable().getName())
@@ -528,7 +528,7 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
         Set<Long> tableIds = Sets.newHashSet(dbInfo.getTableIds());
         long dbId = db.getId();
         Iterator<Map.Entry<Long, RecycleTableInfo>> iterator = idToTable.entrySet().iterator();
-        while (iterator.hasNext()) {
+        while (iterator.hasNext() && !tableNames.isEmpty()) {
             Map.Entry<Long, RecycleTableInfo> entry = iterator.next();
             RecycleTableInfo tableInfo = entry.getValue();
             if (tableInfo.getDbId() != dbId || !tableNames.contains(tableInfo.getTable().getName())

--- a/fe/fe-core/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/Config.java
@@ -1916,5 +1916,12 @@ public class Config extends ConfigBase {
      */
     @ConfField(mutable = true)
     public static boolean collect_external_table_stats_by_sql = false;
+
+    /**
+     * Max num of same name meta informatntion in catalog recycle bin.
+     * Default is 3.
+     */
+    @ConfField(mutable = true, masterOnly = false)
+    public static int max_same_name_catalog_trash_num = 3;
 }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/Config.java
@@ -1921,7 +1921,7 @@ public class Config extends ConfigBase {
      * Max num of same name meta informatntion in catalog recycle bin.
      * Default is 3.
      */
-    @ConfField(mutable = true, masterOnly = false)
+    @ConfField(mutable = true, masterOnly = true)
     public static int max_same_name_catalog_trash_num = 3;
 }
 

--- a/regression-test/data/ddl_p0/test_recover.out
+++ b/regression-test/data/ddl_p0/test_recover.out
@@ -21,13 +21,22 @@ test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` d
 test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p2000 VALUES [("1000"), ("2000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
 
 -- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p2000 VALUES [("2000"), ("3000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p2000 VALUES [("3000"), ("4000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p2000 VALUES [("4000"), ("5000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
 test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
 
 -- !select --
-test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p2000 VALUES [("1000"), ("2000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p2000 VALUES [("4000"), ("5000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
 
 -- !select --
-test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p1000 VALUES [("333"), ("1000")),\nPARTITION p2000 VALUES [("1000"), ("2000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p1000 VALUES [("3000"), ("4000")),\nPARTITION p2000 VALUES [("4000"), ("5000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
 
 -- !select --
 
@@ -35,6 +44,15 @@ test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` d
 test_recover_tb
 
 -- !select --
+
+-- !select --
+test_recover_tb
+
+-- !select --
+test_recover_tb
+
+-- !select --
+test_recover_tb
 
 -- !select --
 test_recover_tb
@@ -58,6 +76,15 @@ test_recover_db	CREATE DATABASE `test_recover_db`
 test_recover_db	CREATE DATABASE `test_recover_db`
 
 -- !select --
+test_recover_db	CREATE DATABASE `test_recover_db`
+
+-- !select --
+test_recover_db	CREATE DATABASE `test_recover_db`
+
+-- !select --
+test_recover_db	CREATE DATABASE `test_recover_db`
+
+-- !select --
 test_recover_db_new	CREATE DATABASE `test_recover_db_new`
 
 -- !select --
@@ -67,16 +94,11 @@ test_recover_db	CREATE DATABASE `test_recover_db`
 test_recover_db_new	CREATE DATABASE `test_recover_db_new`
 
 -- !select --
-test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p1000 VALUES [("333"), ("1000")),\nPARTITION p2000 VALUES [("1000"), ("2000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
-
--- !select --
-test_recover_tb_new	CREATE TABLE `test_recover_tb_new` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p1000 VALUES [("333"), ("1000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p1000 VALUES [("333"), ("1000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
 
 -- !select --
 test_recover_tb
-test_recover_tb_1
 test_recover_tb_2
-test_recover_tb_new
 
 -- !select --
 test_recover_tb_2
@@ -103,13 +125,22 @@ test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` d
 test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p2000 VALUES [("1000"), ("2000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
 
 -- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p2000 VALUES [("2000"), ("3000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p2000 VALUES [("3000"), ("4000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p2000 VALUES [("4000"), ("5000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
 test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
 
 -- !select --
-test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p2000 VALUES [("1000"), ("2000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p2000 VALUES [("4000"), ("5000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
 
 -- !select --
-test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p1000 VALUES [("333"), ("1000")),\nPARTITION p2000 VALUES [("1000"), ("2000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p1000 VALUES [("3000"), ("4000")),\nPARTITION p2000 VALUES [("4000"), ("5000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
 
 -- !select --
 
@@ -117,6 +148,15 @@ test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` d
 test_recover_tb
 
 -- !select --
+
+-- !select --
+test_recover_tb
+
+-- !select --
+test_recover_tb
+
+-- !select --
+test_recover_tb
 
 -- !select --
 test_recover_tb
@@ -140,6 +180,15 @@ test_recover_db	CREATE DATABASE `test_recover_db`
 test_recover_db	CREATE DATABASE `test_recover_db`
 
 -- !select --
+test_recover_db	CREATE DATABASE `test_recover_db`
+
+-- !select --
+test_recover_db	CREATE DATABASE `test_recover_db`
+
+-- !select --
+test_recover_db	CREATE DATABASE `test_recover_db`
+
+-- !select --
 test_recover_db_new	CREATE DATABASE `test_recover_db_new`
 
 -- !select --
@@ -149,16 +198,11 @@ test_recover_db	CREATE DATABASE `test_recover_db`
 test_recover_db_new	CREATE DATABASE `test_recover_db_new`
 
 -- !select --
-test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p1000 VALUES [("333"), ("1000")),\nPARTITION p2000 VALUES [("1000"), ("2000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
-
--- !select --
-test_recover_tb_new	CREATE TABLE `test_recover_tb_new` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p1000 VALUES [("333"), ("1000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p1000 VALUES [("333"), ("1000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
 
 -- !select --
 test_recover_tb
-test_recover_tb_1
 test_recover_tb_2
-test_recover_tb_new
 
 -- !select --
 test_recover_tb_2
@@ -185,13 +229,22 @@ test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` d
 test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p2000 VALUES [("1000"), ("2000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
 
 -- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p2000 VALUES [("2000"), ("3000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p2000 VALUES [("3000"), ("4000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p2000 VALUES [("4000"), ("5000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
 test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
 
 -- !select --
-test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p2000 VALUES [("1000"), ("2000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p2000 VALUES [("4000"), ("5000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
 
 -- !select --
-test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p1000 VALUES [("333"), ("1000")),\nPARTITION p2000 VALUES [("1000"), ("2000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p1000 VALUES [("3000"), ("4000")),\nPARTITION p2000 VALUES [("4000"), ("5000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
 
 -- !select --
 
@@ -199,6 +252,15 @@ test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` d
 test_recover_tb
 
 -- !select --
+
+-- !select --
+test_recover_tb
+
+-- !select --
+test_recover_tb
+
+-- !select --
+test_recover_tb
 
 -- !select --
 test_recover_tb
@@ -222,6 +284,15 @@ test_recover_db	CREATE DATABASE `test_recover_db`
 test_recover_db	CREATE DATABASE `test_recover_db`
 
 -- !select --
+test_recover_db	CREATE DATABASE `test_recover_db`
+
+-- !select --
+test_recover_db	CREATE DATABASE `test_recover_db`
+
+-- !select --
+test_recover_db	CREATE DATABASE `test_recover_db`
+
+-- !select --
 test_recover_db_new	CREATE DATABASE `test_recover_db_new`
 
 -- !select --
@@ -231,16 +302,11 @@ test_recover_db	CREATE DATABASE `test_recover_db`
 test_recover_db_new	CREATE DATABASE `test_recover_db_new`
 
 -- !select --
-test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p1000 VALUES [("333"), ("1000")),\nPARTITION p2000 VALUES [("1000"), ("2000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
-
--- !select --
-test_recover_tb_new	CREATE TABLE `test_recover_tb_new` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p1000 VALUES [("333"), ("1000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p1000 VALUES [("333"), ("1000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
 
 -- !select --
 test_recover_tb
-test_recover_tb_1
 test_recover_tb_2
-test_recover_tb_new
 
 -- !select --
 test_recover_tb_2
@@ -267,13 +333,22 @@ test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` d
 test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p2000 VALUES [("1000"), ("2000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
 
 -- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p2000 VALUES [("2000"), ("3000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p2000 VALUES [("3000"), ("4000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p2000 VALUES [("4000"), ("5000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
 test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
 
 -- !select --
-test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p2000 VALUES [("1000"), ("2000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p2000 VALUES [("4000"), ("5000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
 
 -- !select --
-test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p1000 VALUES [("333"), ("1000")),\nPARTITION p2000 VALUES [("1000"), ("2000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p1000 VALUES [("3000"), ("4000")),\nPARTITION p2000 VALUES [("4000"), ("5000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
 
 -- !select --
 
@@ -281,6 +356,15 @@ test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` d
 test_recover_tb
 
 -- !select --
+
+-- !select --
+test_recover_tb
+
+-- !select --
+test_recover_tb
+
+-- !select --
+test_recover_tb
 
 -- !select --
 test_recover_tb
@@ -304,6 +388,15 @@ test_recover_db	CREATE DATABASE `test_recover_db`
 test_recover_db	CREATE DATABASE `test_recover_db`
 
 -- !select --
+test_recover_db	CREATE DATABASE `test_recover_db`
+
+-- !select --
+test_recover_db	CREATE DATABASE `test_recover_db`
+
+-- !select --
+test_recover_db	CREATE DATABASE `test_recover_db`
+
+-- !select --
 test_recover_db_new	CREATE DATABASE `test_recover_db_new`
 
 -- !select --
@@ -313,16 +406,11 @@ test_recover_db	CREATE DATABASE `test_recover_db`
 test_recover_db_new	CREATE DATABASE `test_recover_db_new`
 
 -- !select --
-test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p1000 VALUES [("333"), ("1000")),\nPARTITION p2000 VALUES [("1000"), ("2000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
-
--- !select --
-test_recover_tb_new	CREATE TABLE `test_recover_tb_new` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p1000 VALUES [("333"), ("1000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p1000 VALUES [("333"), ("1000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
 
 -- !select --
 test_recover_tb
-test_recover_tb_1
 test_recover_tb_2
-test_recover_tb_new
 
 -- !select --
 test_recover_tb_2
@@ -349,13 +437,22 @@ test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` d
 test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p2000 VALUES [("1000"), ("2000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
 
 -- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p2000 VALUES [("2000"), ("3000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p2000 VALUES [("3000"), ("4000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p2000 VALUES [("4000"), ("5000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
 test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
 
 -- !select --
-test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p2000 VALUES [("1000"), ("2000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p2000 VALUES [("4000"), ("5000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
 
 -- !select --
-test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p1000 VALUES [("333"), ("1000")),\nPARTITION p2000 VALUES [("1000"), ("2000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p1000 VALUES [("3000"), ("4000")),\nPARTITION p2000 VALUES [("4000"), ("5000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
 
 -- !select --
 
@@ -363,6 +460,15 @@ test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` d
 test_recover_tb
 
 -- !select --
+
+-- !select --
+test_recover_tb
+
+-- !select --
+test_recover_tb
+
+-- !select --
+test_recover_tb
 
 -- !select --
 test_recover_tb
@@ -386,6 +492,15 @@ test_recover_db	CREATE DATABASE `test_recover_db`
 test_recover_db	CREATE DATABASE `test_recover_db`
 
 -- !select --
+test_recover_db	CREATE DATABASE `test_recover_db`
+
+-- !select --
+test_recover_db	CREATE DATABASE `test_recover_db`
+
+-- !select --
+test_recover_db	CREATE DATABASE `test_recover_db`
+
+-- !select --
 test_recover_db_new	CREATE DATABASE `test_recover_db_new`
 
 -- !select --
@@ -395,16 +510,11 @@ test_recover_db	CREATE DATABASE `test_recover_db`
 test_recover_db_new	CREATE DATABASE `test_recover_db_new`
 
 -- !select --
-test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p1000 VALUES [("333"), ("1000")),\nPARTITION p2000 VALUES [("1000"), ("2000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
-
--- !select --
-test_recover_tb_new	CREATE TABLE `test_recover_tb_new` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p1000 VALUES [("333"), ("1000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p1000 VALUES [("333"), ("1000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
 
 -- !select --
 test_recover_tb
-test_recover_tb_1
 test_recover_tb_2
-test_recover_tb_new
 
 -- !select --
 test_recover_tb_2
@@ -431,13 +541,22 @@ test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` d
 test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p2000 VALUES [("1000"), ("2000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
 
 -- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p2000 VALUES [("2000"), ("3000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p2000 VALUES [("3000"), ("4000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p2000 VALUES [("4000"), ("5000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
 test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
 
 -- !select --
-test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p2000 VALUES [("1000"), ("2000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p2000 VALUES [("4000"), ("5000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
 
 -- !select --
-test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p1000 VALUES [("333"), ("1000")),\nPARTITION p2000 VALUES [("1000"), ("2000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p1000 VALUES [("3000"), ("4000")),\nPARTITION p2000 VALUES [("4000"), ("5000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
 
 -- !select --
 
@@ -445,6 +564,15 @@ test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` d
 test_recover_tb
 
 -- !select --
+
+-- !select --
+test_recover_tb
+
+-- !select --
+test_recover_tb
+
+-- !select --
+test_recover_tb
 
 -- !select --
 test_recover_tb
@@ -468,6 +596,15 @@ test_recover_db	CREATE DATABASE `test_recover_db`
 test_recover_db	CREATE DATABASE `test_recover_db`
 
 -- !select --
+test_recover_db	CREATE DATABASE `test_recover_db`
+
+-- !select --
+test_recover_db	CREATE DATABASE `test_recover_db`
+
+-- !select --
+test_recover_db	CREATE DATABASE `test_recover_db`
+
+-- !select --
 test_recover_db_new	CREATE DATABASE `test_recover_db_new`
 
 -- !select --
@@ -477,16 +614,11 @@ test_recover_db	CREATE DATABASE `test_recover_db`
 test_recover_db_new	CREATE DATABASE `test_recover_db_new`
 
 -- !select --
-test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p1000 VALUES [("333"), ("1000")),\nPARTITION p2000 VALUES [("1000"), ("2000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
-
--- !select --
-test_recover_tb_new	CREATE TABLE `test_recover_tb_new` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p1000 VALUES [("333"), ("1000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p1000 VALUES [("333"), ("1000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
 
 -- !select --
 test_recover_tb
-test_recover_tb_1
 test_recover_tb_2
-test_recover_tb_new
 
 -- !select --
 test_recover_tb_2
@@ -513,13 +645,22 @@ test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` d
 test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p2000 VALUES [("1000"), ("2000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
 
 -- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p2000 VALUES [("2000"), ("3000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p2000 VALUES [("3000"), ("4000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p2000 VALUES [("4000"), ("5000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
 test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
 
 -- !select --
-test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p2000 VALUES [("1000"), ("2000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p2000 VALUES [("4000"), ("5000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
 
 -- !select --
-test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p1000 VALUES [("333"), ("1000")),\nPARTITION p2000 VALUES [("1000"), ("2000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p1000 VALUES [("3000"), ("4000")),\nPARTITION p2000 VALUES [("4000"), ("5000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
 
 -- !select --
 
@@ -527,6 +668,15 @@ test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` d
 test_recover_tb
 
 -- !select --
+
+-- !select --
+test_recover_tb
+
+-- !select --
+test_recover_tb
+
+-- !select --
+test_recover_tb
 
 -- !select --
 test_recover_tb
@@ -550,6 +700,15 @@ test_recover_db	CREATE DATABASE `test_recover_db`
 test_recover_db	CREATE DATABASE `test_recover_db`
 
 -- !select --
+test_recover_db	CREATE DATABASE `test_recover_db`
+
+-- !select --
+test_recover_db	CREATE DATABASE `test_recover_db`
+
+-- !select --
+test_recover_db	CREATE DATABASE `test_recover_db`
+
+-- !select --
 test_recover_db_new	CREATE DATABASE `test_recover_db_new`
 
 -- !select --
@@ -559,16 +718,11 @@ test_recover_db	CREATE DATABASE `test_recover_db`
 test_recover_db_new	CREATE DATABASE `test_recover_db_new`
 
 -- !select --
-test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p1000 VALUES [("333"), ("1000")),\nPARTITION p2000 VALUES [("1000"), ("2000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
-
--- !select --
-test_recover_tb_new	CREATE TABLE `test_recover_tb_new` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p1000 VALUES [("333"), ("1000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p1000 VALUES [("333"), ("1000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
 
 -- !select --
 test_recover_tb
-test_recover_tb_1
 test_recover_tb_2
-test_recover_tb_new
 
 -- !select --
 test_recover_tb_2
@@ -595,13 +749,22 @@ test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` d
 test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p2000 VALUES [("1000"), ("2000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
 
 -- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p2000 VALUES [("2000"), ("3000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p2000 VALUES [("3000"), ("4000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p2000 VALUES [("4000"), ("5000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
 test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
 
 -- !select --
-test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p2000 VALUES [("1000"), ("2000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p2000 VALUES [("4000"), ("5000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
 
 -- !select --
-test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p1000 VALUES [("333"), ("1000")),\nPARTITION p2000 VALUES [("1000"), ("2000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p1000 VALUES [("3000"), ("4000")),\nPARTITION p2000 VALUES [("4000"), ("5000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
 
 -- !select --
 
@@ -609,6 +772,15 @@ test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` d
 test_recover_tb
 
 -- !select --
+
+-- !select --
+test_recover_tb
+
+-- !select --
+test_recover_tb
+
+-- !select --
+test_recover_tb
 
 -- !select --
 test_recover_tb
@@ -621,6 +793,15 @@ test_recover_tb_new
 -- !select --
 test_recover_tb
 test_recover_tb_new
+
+-- !select --
+test_recover_db	CREATE DATABASE `test_recover_db`
+
+-- !select --
+test_recover_db	CREATE DATABASE `test_recover_db`
+
+-- !select --
+test_recover_db	CREATE DATABASE `test_recover_db`
 
 -- !select --
 test_recover_db	CREATE DATABASE `test_recover_db`
@@ -639,182 +820,13 @@ test_recover_db	CREATE DATABASE `test_recover_db`
 
 -- !select --
 test_recover_db_new	CREATE DATABASE `test_recover_db_new`
-
--- !select --
-test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p1000 VALUES [("333"), ("1000")),\nPARTITION p2000 VALUES [("1000"), ("2000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
-
--- !select --
-test_recover_tb_new	CREATE TABLE `test_recover_tb_new` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p1000 VALUES [("333"), ("1000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
-
--- !select --
-test_recover_tb
-test_recover_tb_1
-test_recover_tb_2
-test_recover_tb_new
-
--- !select --
-test_recover_tb_2
 
 -- !select --
 test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p1000 VALUES [("333"), ("1000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
 
 -- !select --
-test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
-
--- !select --
-test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p1000 VALUES [("333"), ("1000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
-
--- !select --
-test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
-
--- !select --
-test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p2000 VALUES [("333"), ("1000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
-
--- !select --
-test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
-
--- !select --
-test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p2000 VALUES [("1000"), ("2000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
-
--- !select --
-test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
-
--- !select --
-test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p2000 VALUES [("1000"), ("2000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
-
--- !select --
-test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p1000 VALUES [("333"), ("1000")),\nPARTITION p2000 VALUES [("1000"), ("2000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
-
--- !select --
-
--- !select --
 test_recover_tb
-
--- !select --
-
--- !select --
-test_recover_tb
-
--- !select --
-
--- !select --
-test_recover_tb_new
-
--- !select --
-test_recover_tb
-test_recover_tb_new
-
--- !select --
-test_recover_db	CREATE DATABASE `test_recover_db`
-
--- !select --
-test_recover_db	CREATE DATABASE `test_recover_db`
-
--- !select --
-test_recover_db	CREATE DATABASE `test_recover_db`
-
--- !select --
-test_recover_db_new	CREATE DATABASE `test_recover_db_new`
-
--- !select --
-test_recover_db	CREATE DATABASE `test_recover_db`
-
--- !select --
-test_recover_db_new	CREATE DATABASE `test_recover_db_new`
-
--- !select --
-test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p1000 VALUES [("333"), ("1000")),\nPARTITION p2000 VALUES [("1000"), ("2000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
-
--- !select --
-test_recover_tb_new	CREATE TABLE `test_recover_tb_new` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p1000 VALUES [("333"), ("1000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
-
--- !select --
-test_recover_tb
-test_recover_tb_1
 test_recover_tb_2
-test_recover_tb_new
-
--- !select --
-test_recover_tb_2
-
--- !select --
-test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p1000 VALUES [("333"), ("1000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
-
--- !select --
-test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
-
--- !select --
-test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p1000 VALUES [("333"), ("1000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
-
--- !select --
-test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
-
--- !select --
-test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p2000 VALUES [("333"), ("1000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
-
--- !select --
-test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
-
--- !select --
-test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p2000 VALUES [("1000"), ("2000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
-
--- !select --
-test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
-
--- !select --
-test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p2000 VALUES [("1000"), ("2000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
-
--- !select --
-test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p1000 VALUES [("333"), ("1000")),\nPARTITION p2000 VALUES [("1000"), ("2000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
-
--- !select --
-
--- !select --
-test_recover_tb
-
--- !select --
-
--- !select --
-test_recover_tb
-
--- !select --
-
--- !select --
-test_recover_tb_new
-
--- !select --
-test_recover_tb
-test_recover_tb_new
-
--- !select --
-test_recover_db	CREATE DATABASE `test_recover_db`
-
--- !select --
-test_recover_db	CREATE DATABASE `test_recover_db`
-
--- !select --
-test_recover_db	CREATE DATABASE `test_recover_db`
-
--- !select --
-test_recover_db_new	CREATE DATABASE `test_recover_db_new`
-
--- !select --
-test_recover_db	CREATE DATABASE `test_recover_db`
-
--- !select --
-test_recover_db_new	CREATE DATABASE `test_recover_db_new`
-
--- !select --
-test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p1000 VALUES [("333"), ("1000")),\nPARTITION p2000 VALUES [("1000"), ("2000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
-
--- !select --
-test_recover_tb_new	CREATE TABLE `test_recover_tb_new` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p1000 VALUES [("333"), ("1000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
-
--- !select --
-test_recover_tb
-test_recover_tb_1
-test_recover_tb_2
-test_recover_tb_new
 
 -- !select --
 test_recover_tb_2

--- a/regression-test/data/ddl_p0/test_recover.out
+++ b/regression-test/data/ddl_p0/test_recover.out
@@ -81,3 +81,741 @@ test_recover_tb_new
 -- !select --
 test_recover_tb_2
 
+-- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p1000 VALUES [("333"), ("1000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p1000 VALUES [("333"), ("1000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p2000 VALUES [("333"), ("1000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p2000 VALUES [("1000"), ("2000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p2000 VALUES [("1000"), ("2000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p1000 VALUES [("333"), ("1000")),\nPARTITION p2000 VALUES [("1000"), ("2000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+
+-- !select --
+test_recover_tb
+
+-- !select --
+
+-- !select --
+test_recover_tb
+
+-- !select --
+
+-- !select --
+test_recover_tb_new
+
+-- !select --
+test_recover_tb
+test_recover_tb_new
+
+-- !select --
+test_recover_db	CREATE DATABASE `test_recover_db`
+
+-- !select --
+test_recover_db	CREATE DATABASE `test_recover_db`
+
+-- !select --
+test_recover_db	CREATE DATABASE `test_recover_db`
+
+-- !select --
+test_recover_db_new	CREATE DATABASE `test_recover_db_new`
+
+-- !select --
+test_recover_db	CREATE DATABASE `test_recover_db`
+
+-- !select --
+test_recover_db_new	CREATE DATABASE `test_recover_db_new`
+
+-- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p1000 VALUES [("333"), ("1000")),\nPARTITION p2000 VALUES [("1000"), ("2000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+test_recover_tb_new	CREATE TABLE `test_recover_tb_new` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p1000 VALUES [("333"), ("1000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+test_recover_tb
+test_recover_tb_1
+test_recover_tb_2
+test_recover_tb_new
+
+-- !select --
+test_recover_tb_2
+
+-- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p1000 VALUES [("333"), ("1000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p1000 VALUES [("333"), ("1000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p2000 VALUES [("333"), ("1000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p2000 VALUES [("1000"), ("2000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p2000 VALUES [("1000"), ("2000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p1000 VALUES [("333"), ("1000")),\nPARTITION p2000 VALUES [("1000"), ("2000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+
+-- !select --
+test_recover_tb
+
+-- !select --
+
+-- !select --
+test_recover_tb
+
+-- !select --
+
+-- !select --
+test_recover_tb_new
+
+-- !select --
+test_recover_tb
+test_recover_tb_new
+
+-- !select --
+test_recover_db	CREATE DATABASE `test_recover_db`
+
+-- !select --
+test_recover_db	CREATE DATABASE `test_recover_db`
+
+-- !select --
+test_recover_db	CREATE DATABASE `test_recover_db`
+
+-- !select --
+test_recover_db_new	CREATE DATABASE `test_recover_db_new`
+
+-- !select --
+test_recover_db	CREATE DATABASE `test_recover_db`
+
+-- !select --
+test_recover_db_new	CREATE DATABASE `test_recover_db_new`
+
+-- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p1000 VALUES [("333"), ("1000")),\nPARTITION p2000 VALUES [("1000"), ("2000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+test_recover_tb_new	CREATE TABLE `test_recover_tb_new` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p1000 VALUES [("333"), ("1000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+test_recover_tb
+test_recover_tb_1
+test_recover_tb_2
+test_recover_tb_new
+
+-- !select --
+test_recover_tb_2
+
+-- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p1000 VALUES [("333"), ("1000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p1000 VALUES [("333"), ("1000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p2000 VALUES [("333"), ("1000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p2000 VALUES [("1000"), ("2000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p2000 VALUES [("1000"), ("2000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p1000 VALUES [("333"), ("1000")),\nPARTITION p2000 VALUES [("1000"), ("2000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+
+-- !select --
+test_recover_tb
+
+-- !select --
+
+-- !select --
+test_recover_tb
+
+-- !select --
+
+-- !select --
+test_recover_tb_new
+
+-- !select --
+test_recover_tb
+test_recover_tb_new
+
+-- !select --
+test_recover_db	CREATE DATABASE `test_recover_db`
+
+-- !select --
+test_recover_db	CREATE DATABASE `test_recover_db`
+
+-- !select --
+test_recover_db	CREATE DATABASE `test_recover_db`
+
+-- !select --
+test_recover_db_new	CREATE DATABASE `test_recover_db_new`
+
+-- !select --
+test_recover_db	CREATE DATABASE `test_recover_db`
+
+-- !select --
+test_recover_db_new	CREATE DATABASE `test_recover_db_new`
+
+-- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p1000 VALUES [("333"), ("1000")),\nPARTITION p2000 VALUES [("1000"), ("2000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+test_recover_tb_new	CREATE TABLE `test_recover_tb_new` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p1000 VALUES [("333"), ("1000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+test_recover_tb
+test_recover_tb_1
+test_recover_tb_2
+test_recover_tb_new
+
+-- !select --
+test_recover_tb_2
+
+-- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p1000 VALUES [("333"), ("1000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p1000 VALUES [("333"), ("1000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p2000 VALUES [("333"), ("1000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p2000 VALUES [("1000"), ("2000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p2000 VALUES [("1000"), ("2000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p1000 VALUES [("333"), ("1000")),\nPARTITION p2000 VALUES [("1000"), ("2000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+
+-- !select --
+test_recover_tb
+
+-- !select --
+
+-- !select --
+test_recover_tb
+
+-- !select --
+
+-- !select --
+test_recover_tb_new
+
+-- !select --
+test_recover_tb
+test_recover_tb_new
+
+-- !select --
+test_recover_db	CREATE DATABASE `test_recover_db`
+
+-- !select --
+test_recover_db	CREATE DATABASE `test_recover_db`
+
+-- !select --
+test_recover_db	CREATE DATABASE `test_recover_db`
+
+-- !select --
+test_recover_db_new	CREATE DATABASE `test_recover_db_new`
+
+-- !select --
+test_recover_db	CREATE DATABASE `test_recover_db`
+
+-- !select --
+test_recover_db_new	CREATE DATABASE `test_recover_db_new`
+
+-- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p1000 VALUES [("333"), ("1000")),\nPARTITION p2000 VALUES [("1000"), ("2000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+test_recover_tb_new	CREATE TABLE `test_recover_tb_new` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p1000 VALUES [("333"), ("1000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+test_recover_tb
+test_recover_tb_1
+test_recover_tb_2
+test_recover_tb_new
+
+-- !select --
+test_recover_tb_2
+
+-- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p1000 VALUES [("333"), ("1000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p1000 VALUES [("333"), ("1000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p2000 VALUES [("333"), ("1000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p2000 VALUES [("1000"), ("2000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p2000 VALUES [("1000"), ("2000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p1000 VALUES [("333"), ("1000")),\nPARTITION p2000 VALUES [("1000"), ("2000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+
+-- !select --
+test_recover_tb
+
+-- !select --
+
+-- !select --
+test_recover_tb
+
+-- !select --
+
+-- !select --
+test_recover_tb_new
+
+-- !select --
+test_recover_tb
+test_recover_tb_new
+
+-- !select --
+test_recover_db	CREATE DATABASE `test_recover_db`
+
+-- !select --
+test_recover_db	CREATE DATABASE `test_recover_db`
+
+-- !select --
+test_recover_db	CREATE DATABASE `test_recover_db`
+
+-- !select --
+test_recover_db_new	CREATE DATABASE `test_recover_db_new`
+
+-- !select --
+test_recover_db	CREATE DATABASE `test_recover_db`
+
+-- !select --
+test_recover_db_new	CREATE DATABASE `test_recover_db_new`
+
+-- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p1000 VALUES [("333"), ("1000")),\nPARTITION p2000 VALUES [("1000"), ("2000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+test_recover_tb_new	CREATE TABLE `test_recover_tb_new` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p1000 VALUES [("333"), ("1000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+test_recover_tb
+test_recover_tb_1
+test_recover_tb_2
+test_recover_tb_new
+
+-- !select --
+test_recover_tb_2
+
+-- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p1000 VALUES [("333"), ("1000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p1000 VALUES [("333"), ("1000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p2000 VALUES [("333"), ("1000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p2000 VALUES [("1000"), ("2000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p2000 VALUES [("1000"), ("2000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p1000 VALUES [("333"), ("1000")),\nPARTITION p2000 VALUES [("1000"), ("2000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+
+-- !select --
+test_recover_tb
+
+-- !select --
+
+-- !select --
+test_recover_tb
+
+-- !select --
+
+-- !select --
+test_recover_tb_new
+
+-- !select --
+test_recover_tb
+test_recover_tb_new
+
+-- !select --
+test_recover_db	CREATE DATABASE `test_recover_db`
+
+-- !select --
+test_recover_db	CREATE DATABASE `test_recover_db`
+
+-- !select --
+test_recover_db	CREATE DATABASE `test_recover_db`
+
+-- !select --
+test_recover_db_new	CREATE DATABASE `test_recover_db_new`
+
+-- !select --
+test_recover_db	CREATE DATABASE `test_recover_db`
+
+-- !select --
+test_recover_db_new	CREATE DATABASE `test_recover_db_new`
+
+-- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p1000 VALUES [("333"), ("1000")),\nPARTITION p2000 VALUES [("1000"), ("2000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+test_recover_tb_new	CREATE TABLE `test_recover_tb_new` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p1000 VALUES [("333"), ("1000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+test_recover_tb
+test_recover_tb_1
+test_recover_tb_2
+test_recover_tb_new
+
+-- !select --
+test_recover_tb_2
+
+-- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p1000 VALUES [("333"), ("1000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p1000 VALUES [("333"), ("1000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p2000 VALUES [("333"), ("1000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p2000 VALUES [("1000"), ("2000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p2000 VALUES [("1000"), ("2000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p1000 VALUES [("333"), ("1000")),\nPARTITION p2000 VALUES [("1000"), ("2000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+
+-- !select --
+test_recover_tb
+
+-- !select --
+
+-- !select --
+test_recover_tb
+
+-- !select --
+
+-- !select --
+test_recover_tb_new
+
+-- !select --
+test_recover_tb
+test_recover_tb_new
+
+-- !select --
+test_recover_db	CREATE DATABASE `test_recover_db`
+
+-- !select --
+test_recover_db	CREATE DATABASE `test_recover_db`
+
+-- !select --
+test_recover_db	CREATE DATABASE `test_recover_db`
+
+-- !select --
+test_recover_db_new	CREATE DATABASE `test_recover_db_new`
+
+-- !select --
+test_recover_db	CREATE DATABASE `test_recover_db`
+
+-- !select --
+test_recover_db_new	CREATE DATABASE `test_recover_db_new`
+
+-- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p1000 VALUES [("333"), ("1000")),\nPARTITION p2000 VALUES [("1000"), ("2000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+test_recover_tb_new	CREATE TABLE `test_recover_tb_new` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p1000 VALUES [("333"), ("1000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+test_recover_tb
+test_recover_tb_1
+test_recover_tb_2
+test_recover_tb_new
+
+-- !select --
+test_recover_tb_2
+
+-- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p1000 VALUES [("333"), ("1000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p1000 VALUES [("333"), ("1000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p2000 VALUES [("333"), ("1000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p2000 VALUES [("1000"), ("2000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p2000 VALUES [("1000"), ("2000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p1000 VALUES [("333"), ("1000")),\nPARTITION p2000 VALUES [("1000"), ("2000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+
+-- !select --
+test_recover_tb
+
+-- !select --
+
+-- !select --
+test_recover_tb
+
+-- !select --
+
+-- !select --
+test_recover_tb_new
+
+-- !select --
+test_recover_tb
+test_recover_tb_new
+
+-- !select --
+test_recover_db	CREATE DATABASE `test_recover_db`
+
+-- !select --
+test_recover_db	CREATE DATABASE `test_recover_db`
+
+-- !select --
+test_recover_db	CREATE DATABASE `test_recover_db`
+
+-- !select --
+test_recover_db_new	CREATE DATABASE `test_recover_db_new`
+
+-- !select --
+test_recover_db	CREATE DATABASE `test_recover_db`
+
+-- !select --
+test_recover_db_new	CREATE DATABASE `test_recover_db_new`
+
+-- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p1000 VALUES [("333"), ("1000")),\nPARTITION p2000 VALUES [("1000"), ("2000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+test_recover_tb_new	CREATE TABLE `test_recover_tb_new` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p1000 VALUES [("333"), ("1000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+test_recover_tb
+test_recover_tb_1
+test_recover_tb_2
+test_recover_tb_new
+
+-- !select --
+test_recover_tb_2
+
+-- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p1000 VALUES [("333"), ("1000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p1000 VALUES [("333"), ("1000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p2000 VALUES [("333"), ("1000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p2000 VALUES [("1000"), ("2000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p2000 VALUES [("1000"), ("2000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p1000 VALUES [("333"), ("1000")),\nPARTITION p2000 VALUES [("1000"), ("2000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+
+-- !select --
+test_recover_tb
+
+-- !select --
+
+-- !select --
+test_recover_tb
+
+-- !select --
+
+-- !select --
+test_recover_tb_new
+
+-- !select --
+test_recover_tb
+test_recover_tb_new
+
+-- !select --
+test_recover_db	CREATE DATABASE `test_recover_db`
+
+-- !select --
+test_recover_db	CREATE DATABASE `test_recover_db`
+
+-- !select --
+test_recover_db	CREATE DATABASE `test_recover_db`
+
+-- !select --
+test_recover_db_new	CREATE DATABASE `test_recover_db_new`
+
+-- !select --
+test_recover_db	CREATE DATABASE `test_recover_db`
+
+-- !select --
+test_recover_db_new	CREATE DATABASE `test_recover_db_new`
+
+-- !select --
+test_recover_tb	CREATE TABLE `test_recover_tb` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p1000 VALUES [("333"), ("1000")),\nPARTITION p2000 VALUES [("1000"), ("2000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+test_recover_tb_new	CREATE TABLE `test_recover_tb_new` (\n  `k1` int(11) NULL,\n  `k2` datetime NULL\n) ENGINE=OLAP\nUNIQUE KEY(`k1`)\nCOMMENT 'OLAP'\nPARTITION BY RANGE(`k1`)\n(PARTITION p111 VALUES [("-1000"), ("111")),\nPARTITION p222 VALUES [("111"), ("222")),\nPARTITION p333 VALUES [("222"), ("333")),\nPARTITION p1000 VALUES [("333"), ("1000")))\nDISTRIBUTED BY HASH(`k1`) BUCKETS 3\nPROPERTIES (\n"replication_allocation" = "tag.location.default: 1",\n"in_memory" = "false",\n"storage_format" = "V2",\n"disable_auto_compaction" = "false"\n);
+
+-- !select --
+test_recover_tb
+test_recover_tb_1
+test_recover_tb_2
+test_recover_tb_new
+
+-- !select --
+test_recover_tb_2
+

--- a/regression-test/suites/ddl_p0/test_recover.groovy
+++ b/regression-test/suites/ddl_p0/test_recover.groovy
@@ -17,252 +17,258 @@
 
 suite("test_recover") {
     try {
-        sql """
-    CREATE DATABASE IF NOT EXISTS `test_recover_db`
-    """
+        for (int i = 1; i <= 10; i++) {
+                sql """
+            CREATE DATABASE IF NOT EXISTS `test_recover_db`
+            """
 
-        sql """
-    CREATE TABLE IF NOT EXISTS `test_recover_db`.`test_recover_tb` (
-      `k1` int(11) NULL,
-      `k2` datetime NULL
-    ) ENGINE=OLAP
-    UNIQUE KEY(`k1`)
-    PARTITION BY RANGE(`k1`)
-    (PARTITION p111 VALUES [('-1000'), ('111')),
-    PARTITION p222 VALUES [('111'), ('222')),
-    PARTITION p333 VALUES [('222'), ('333')),
-    PARTITION p1000 VALUES [('333'), ('1000')))
-    DISTRIBUTED BY HASH(`k1`) BUCKETS 3
-      PROPERTIES (
-      "replication_allocation" = "tag.location.default: 1",
-      "in_memory" = "false",
-      "storage_format" = "V2"
-    )
-    """
+                sql """
+            CREATE TABLE IF NOT EXISTS `test_recover_db`.`test_recover_tb` (
+            `k1` int(11) NULL,
+            `k2` datetime NULL
+            ) ENGINE=OLAP
+            UNIQUE KEY(`k1`)
+            PARTITION BY RANGE(`k1`)
+            (PARTITION p111 VALUES [('-1000'), ('111')),
+            PARTITION p222 VALUES [('111'), ('222')),
+            PARTITION p333 VALUES [('222'), ('333')),
+            PARTITION p1000 VALUES [('333'), ('1000')))
+            DISTRIBUTED BY HASH(`k1`) BUCKETS 3
+            PROPERTIES (
+            "replication_allocation" = "tag.location.default: 1",
+            "in_memory" = "false",
+            "storage_format" = "V2"
+            )
+            """
 
-    // test drop/recover partition
+            // test drop/recover partition
 
-        qt_select """ SHOW CREATE TABLE `test_recover_db`.`test_recover_tb` """
+                qt_select """ SHOW CREATE TABLE `test_recover_db`.`test_recover_tb` """
 
-        sql """
-    ALTER TABLE `test_recover_db`.`test_recover_tb` DROP PARTITION p1000;
-    """
+                sql """
+            ALTER TABLE `test_recover_db`.`test_recover_tb` DROP PARTITION p1000;
+            """
 
-        qt_select """ SHOW CREATE TABLE `test_recover_db`.`test_recover_tb` """
+                qt_select """ SHOW CREATE TABLE `test_recover_db`.`test_recover_tb` """
 
-        sql """
-    RECOVER PARTITION p1000 FROM `test_recover_db`.`test_recover_tb`
-    """
+                sql """
+            RECOVER PARTITION p1000 FROM `test_recover_db`.`test_recover_tb`
+            """
 
-        qt_select """ SHOW CREATE TABLE `test_recover_db`.`test_recover_tb` """
+                qt_select """ SHOW CREATE TABLE `test_recover_db`.`test_recover_tb` """
 
-        sql """
-    ALTER TABLE `test_recover_db`.`test_recover_tb` DROP PARTITION p1000
-    """
+                sql """
+            ALTER TABLE `test_recover_db`.`test_recover_tb` DROP PARTITION p1000
+            """
 
-        qt_select """ SHOW CREATE TABLE `test_recover_db`.`test_recover_tb` """
+                qt_select """ SHOW CREATE TABLE `test_recover_db`.`test_recover_tb` """
 
-        sql """
-    RECOVER PARTITION p1000 AS p2000 FROM `test_recover_db`.`test_recover_tb`
-    """
+                sql """
+            RECOVER PARTITION p1000 AS p2000 FROM `test_recover_db`.`test_recover_tb`
+            """
 
-        qt_select """ SHOW CREATE TABLE `test_recover_db`.`test_recover_tb` """
+                qt_select """ SHOW CREATE TABLE `test_recover_db`.`test_recover_tb` """
 
-        sql """
-    ALTER TABLE `test_recover_db`.`test_recover_tb` DROP PARTITION p2000
-    """
+                sql """
+            ALTER TABLE `test_recover_db`.`test_recover_tb` DROP PARTITION p2000
+            """
 
-        qt_select """ SHOW CREATE TABLE `test_recover_db`.`test_recover_tb` """
+                qt_select """ SHOW CREATE TABLE `test_recover_db`.`test_recover_tb` """
 
-        sql """
-    ALTER TABLE `test_recover_db`.`test_recover_tb` ADD PARTITION p2000 VALUES [('1000'), ('2000'))
-    """
+                sql """
+            ALTER TABLE `test_recover_db`.`test_recover_tb` ADD PARTITION p2000 VALUES [('1000'), ('2000'))
+            """
 
-        qt_select """ SHOW CREATE TABLE `test_recover_db`.`test_recover_tb` """
+                qt_select """ SHOW CREATE TABLE `test_recover_db`.`test_recover_tb` """
 
-        sql """
-    ALTER TABLE `test_recover_db`.`test_recover_tb` DROP PARTITION p2000
-    """
+                sql """
+            ALTER TABLE `test_recover_db`.`test_recover_tb` DROP PARTITION p2000
+            """
 
-        qt_select """ SHOW CREATE TABLE `test_recover_db`.`test_recover_tb` """
+                qt_select """ SHOW CREATE TABLE `test_recover_db`.`test_recover_tb` """
 
-        sql """
-    RECOVER PARTITION p2000 FROM `test_recover_db`.`test_recover_tb`
-    """
+                sql """
+            RECOVER PARTITION p2000 FROM `test_recover_db`.`test_recover_tb`
+            """
 
-        qt_select """ SHOW CREATE TABLE `test_recover_db`.`test_recover_tb` """
+                qt_select """ SHOW CREATE TABLE `test_recover_db`.`test_recover_tb` """
 
-        sql """
-    RECOVER PARTITION p2000 AS p1000 FROM `test_recover_db`.`test_recover_tb`
-    """
+                sql """
+            RECOVER PARTITION p2000 AS p1000 FROM `test_recover_db`.`test_recover_tb`
+            """
 
-        qt_select """ SHOW CREATE TABLE `test_recover_db`.`test_recover_tb` """
+                qt_select """ SHOW CREATE TABLE `test_recover_db`.`test_recover_tb` """
 
-    // test drop/recover table
+            // test drop/recover table
 
-        sql """
-    DROP TABLE `test_recover_db`.`test_recover_tb`
-    """
+                sql """
+            DROP TABLE `test_recover_db`.`test_recover_tb`
+            """
 
-        qt_select """SHOW TABLES FROM `test_recover_db`"""
+                qt_select """SHOW TABLES FROM `test_recover_db`"""
 
-        sql """
-    RECOVER TABLE `test_recover_db`.`test_recover_tb`
-    """
+                sql """
+            RECOVER TABLE `test_recover_db`.`test_recover_tb`
+            """
 
-        qt_select """SHOW TABLES FROM `test_recover_db`"""
+                qt_select """SHOW TABLES FROM `test_recover_db`"""
 
-        sql """
-    DROP TABLE `test_recover_db`.`test_recover_tb`
-    """
+                sql """
+            DROP TABLE `test_recover_db`.`test_recover_tb`
+            """
 
-        qt_select """SHOW TABLES FROM `test_recover_db`"""
+                qt_select """SHOW TABLES FROM `test_recover_db`"""
 
-        sql """
-    CREATE TABLE `test_recover_db`.`test_recover_tb` (
-      `k1` int(11) NULL,
-      `k2` datetime NULL
-    ) ENGINE=OLAP
-    UNIQUE KEY(`k1`)
-    PARTITION BY RANGE(`k1`)
-    (PARTITION p111 VALUES [('-1000'), ('111')),
-    PARTITION p222 VALUES [('111'), ('222')),
-    PARTITION p333 VALUES [('222'), ('333')),
-    PARTITION p1000 VALUES [('333'), ('1000')))
-    DISTRIBUTED BY HASH(`k1`) BUCKETS 3
-      PROPERTIES (
-      "replication_allocation" = "tag.location.default: 1",
-      "in_memory" = "false",
-      "storage_format" = "V2"
-    )
-    """
+                sql """
+            CREATE TABLE `test_recover_db`.`test_recover_tb` (
+            `k1` int(11) NULL,
+            `k2` datetime NULL
+            ) ENGINE=OLAP
+            UNIQUE KEY(`k1`)
+            PARTITION BY RANGE(`k1`)
+            (PARTITION p111 VALUES [('-1000'), ('111')),
+            PARTITION p222 VALUES [('111'), ('222')),
+            PARTITION p333 VALUES [('222'), ('333')),
+            PARTITION p1000 VALUES [('333'), ('1000')))
+            DISTRIBUTED BY HASH(`k1`) BUCKETS 3
+            PROPERTIES (
+            "replication_allocation" = "tag.location.default: 1",
+            "in_memory" = "false",
+            "storage_format" = "V2"
+            )
+            """
 
-        qt_select """SHOW TABLES FROM `test_recover_db`"""
+                qt_select """SHOW TABLES FROM `test_recover_db`"""
 
-        sql """
-    DROP TABLE `test_recover_db`.`test_recover_tb`
-    """
+                sql """
+            DROP TABLE `test_recover_db`.`test_recover_tb`
+            """
 
-        qt_select """SHOW TABLES FROM `test_recover_db`"""
+                qt_select """SHOW TABLES FROM `test_recover_db`"""
 
-        sql """
-    RECOVER TABLE `test_recover_db`.`test_recover_tb` AS `test_recover_tb_new`
-    """
+                sql """
+            RECOVER TABLE `test_recover_db`.`test_recover_tb` AS `test_recover_tb_new`
+            """
 
-        qt_select """SHOW TABLES FROM `test_recover_db`"""
+                qt_select """SHOW TABLES FROM `test_recover_db`"""
 
-        sql """
-    RECOVER TABLE `test_recover_db`.`test_recover_tb`
-    """
+                sql """
+            RECOVER TABLE `test_recover_db`.`test_recover_tb`
+            """
 
-        qt_select """SHOW TABLES FROM `test_recover_db`"""
+                qt_select """SHOW TABLES FROM `test_recover_db`"""
 
-        
-    // test drop/recover db
+                
+            // test drop/recover db
 
-        qt_select """ SHOW CREATE DATABASE `test_recover_db` """
+                qt_select """ SHOW CREATE DATABASE `test_recover_db` """
 
-        sql """
-    DROP DATABASE `test_recover_db`
-    """
+                sql """
+            DROP DATABASE `test_recover_db`
+            """
 
-        sql """
-    RECOVER DATABASE `test_recover_db`
-    """
+                sql """
+            RECOVER DATABASE `test_recover_db`
+            """
 
-        qt_select """ SHOW CREATE DATABASE `test_recover_db` """
+                qt_select """ SHOW CREATE DATABASE `test_recover_db` """
 
-        sql """
-    CREATE TABLE `test_recover_db`.`test_recover_tb_1` (
-      `k1` int(11) NULL,
-      `k2` datetime NULL
-    ) ENGINE=OLAP
-    UNIQUE KEY(`k1`)
-    PARTITION BY RANGE(`k1`)
-    (PARTITION p111 VALUES [('-1000'), ('111')),
-    PARTITION p222 VALUES [('111'), ('222')),
-    PARTITION p333 VALUES [('222'), ('333')),
-    PARTITION p1000 VALUES [('333'), ('1000')))
-    DISTRIBUTED BY HASH(`k1`) BUCKETS 3
-      PROPERTIES (
-      "replication_allocation" = "tag.location.default: 1",
-      "in_memory" = "false",
-      "storage_format" = "V2"
-    )
-    """
+                sql """
+            CREATE TABLE `test_recover_db`.`test_recover_tb_1` (
+            `k1` int(11) NULL,
+            `k2` datetime NULL
+            ) ENGINE=OLAP
+            UNIQUE KEY(`k1`)
+            PARTITION BY RANGE(`k1`)
+            (PARTITION p111 VALUES [('-1000'), ('111')),
+            PARTITION p222 VALUES [('111'), ('222')),
+            PARTITION p333 VALUES [('222'), ('333')),
+            PARTITION p1000 VALUES [('333'), ('1000')))
+            DISTRIBUTED BY HASH(`k1`) BUCKETS 3
+            PROPERTIES (
+            "replication_allocation" = "tag.location.default: 1",
+            "in_memory" = "false",
+            "storage_format" = "V2"
+            )
+            """
 
-        sql """
-    DROP DATABASE `test_recover_db`
-    """
+                sql """
+            DROP DATABASE `test_recover_db`
+            """
 
-        sql """
-    CREATE DATABASE `test_recover_db`
-    """
+                sql """
+            CREATE DATABASE `test_recover_db`
+            """
 
-        qt_select """ SHOW CREATE DATABASE `test_recover_db` """
+                qt_select """ SHOW CREATE DATABASE `test_recover_db` """
 
-        sql """
-    DROP DATABASE `test_recover_db`
-    """
+                sql """
+            DROP DATABASE `test_recover_db`
+            """
 
-        sql """
-    RECOVER DATABASE `test_recover_db` AS `test_recover_db_new`
-    """
+                sql """
+            RECOVER DATABASE `test_recover_db` AS `test_recover_db_new`
+            """
 
-        qt_select """ SHOW CREATE DATABASE `test_recover_db_new` """
+                qt_select """ SHOW CREATE DATABASE `test_recover_db_new` """
 
-        sql """
-    CREATE TABLE `test_recover_db_new`.`test_recover_tb_2` (
-      `k1` int(11) NULL,
-      `k2` datetime NULL
-    ) ENGINE=OLAP
-    UNIQUE KEY(`k1`)
-    PARTITION BY RANGE(`k1`)
-    (PARTITION p111 VALUES [('-1000'), ('111')),
-    PARTITION p222 VALUES [('111'), ('222')),
-    PARTITION p333 VALUES [('222'), ('333')),
-    PARTITION p1000 VALUES [('333'), ('1000')))
-    DISTRIBUTED BY HASH(`k1`) BUCKETS 3
-      PROPERTIES (
-      "replication_allocation" = "tag.location.default: 1",
-      "in_memory" = "false",
-      "storage_format" = "V2"
-    )
-    """
+                sql """
+            CREATE TABLE `test_recover_db_new`.`test_recover_tb_2` (
+            `k1` int(11) NULL,
+            `k2` datetime NULL
+            ) ENGINE=OLAP
+            UNIQUE KEY(`k1`)
+            PARTITION BY RANGE(`k1`)
+            (PARTITION p111 VALUES [('-1000'), ('111')),
+            PARTITION p222 VALUES [('111'), ('222')),
+            PARTITION p333 VALUES [('222'), ('333')),
+            PARTITION p1000 VALUES [('333'), ('1000')))
+            DISTRIBUTED BY HASH(`k1`) BUCKETS 3
+            PROPERTIES (
+            "replication_allocation" = "tag.location.default: 1",
+            "in_memory" = "false",
+            "storage_format" = "V2"
+            )
+            """
 
-        sql """
-    RECOVER DATABASE `test_recover_db`
-    """    
+                sql """
+            RECOVER DATABASE `test_recover_db`
+            """    
 
-        sql """
-    CREATE TABLE `test_recover_db`.`test_recover_tb_2` (
-      `k1` int(11) NULL,
-      `k2` datetime NULL
-    ) ENGINE=OLAP
-    UNIQUE KEY(`k1`)
-    PARTITION BY RANGE(`k1`)
-    (PARTITION p111 VALUES [('-1000'), ('111')),
-    PARTITION p222 VALUES [('111'), ('222')),
-    PARTITION p333 VALUES [('222'), ('333')),
-    PARTITION p1000 VALUES [('333'), ('1000')))
-    DISTRIBUTED BY HASH(`k1`) BUCKETS 3
-      PROPERTIES (
-      "replication_allocation" = "tag.location.default: 1",
-      "in_memory" = "false",
-      "storage_format" = "V2"
-    )
-    """
+                sql """
+            CREATE TABLE `test_recover_db`.`test_recover_tb_2` (
+            `k1` int(11) NULL,
+            `k2` datetime NULL
+            ) ENGINE=OLAP
+            UNIQUE KEY(`k1`)
+            PARTITION BY RANGE(`k1`)
+            (PARTITION p111 VALUES [('-1000'), ('111')),
+            PARTITION p222 VALUES [('111'), ('222')),
+            PARTITION p333 VALUES [('222'), ('333')),
+            PARTITION p1000 VALUES [('333'), ('1000')))
+            DISTRIBUTED BY HASH(`k1`) BUCKETS 3
+            PROPERTIES (
+            "replication_allocation" = "tag.location.default: 1",
+            "in_memory" = "false",
+            "storage_format" = "V2"
+            )
+            """
 
-        qt_select """ SHOW CREATE DATABASE `test_recover_db` """
-        qt_select """ SHOW CREATE DATABASE `test_recover_db_new` """
-        qt_select """SHOW CREATE TABLE `test_recover_db`.`test_recover_tb`"""
-        qt_select """SHOW CREATE TABLE `test_recover_db`.`test_recover_tb_new`"""
-        qt_select """SHOW TABLES FROM `test_recover_db`"""
-        qt_select """SHOW TABLES FROM `test_recover_db_new`"""
-    
+                qt_select """ SHOW CREATE DATABASE `test_recover_db` """
+                qt_select """ SHOW CREATE DATABASE `test_recover_db_new` """
+                qt_select """SHOW CREATE TABLE `test_recover_db`.`test_recover_tb`"""
+                qt_select """SHOW CREATE TABLE `test_recover_db`.`test_recover_tb_new`"""
+                qt_select """SHOW TABLES FROM `test_recover_db`"""
+                qt_select """SHOW TABLES FROM `test_recover_db_new`"""
+
+            // test drop many times
+                sql """ DROP DATABASE `test_recover_db` """
+                sql """ DROP DATABASE `test_recover_db_new` """
+            sleep(30000);
+        }
     } finally {
-        sql """ DROP DATABASE IF EXISTS `test_recover_db` FORCE """
-        sql """ DROP DATABASE IF EXISTS `test_recover_db_new` FORCE """
+    //    sql """ DROP DATABASE IF EXISTS `test_recover_db` FORCE """
+    //    sql """ DROP DATABASE IF EXISTS `test_recover_db_new` FORCE """
     }
 
 }

--- a/regression-test/suites/ddl_p0/test_recover.groovy
+++ b/regression-test/suites/ddl_p0/test_recover.groovy
@@ -17,7 +17,7 @@
 
 suite("test_recover") {
     try {
-        for (int i = 1; i <= 10; i++) {
+        for (int i = 0; i <= 7; i++) {
                 sql """
             CREATE DATABASE IF NOT EXISTS `test_recover_db`
             """
@@ -84,6 +84,33 @@ suite("test_recover") {
                 sql """
             ALTER TABLE `test_recover_db`.`test_recover_tb` DROP PARTITION p2000
             """
+                sql """
+            ALTER TABLE `test_recover_db`.`test_recover_tb` ADD PARTITION p2000 VALUES [('2000'), ('3000'))
+            """
+
+                qt_select """ SHOW CREATE TABLE `test_recover_db`.`test_recover_tb` """
+
+                sql """
+            ALTER TABLE `test_recover_db`.`test_recover_tb` DROP PARTITION p2000
+            """
+                sql """
+            ALTER TABLE `test_recover_db`.`test_recover_tb` ADD PARTITION p2000 VALUES [('3000'), ('4000'))
+            """
+
+                qt_select """ SHOW CREATE TABLE `test_recover_db`.`test_recover_tb` """
+
+                sql """
+            ALTER TABLE `test_recover_db`.`test_recover_tb` DROP PARTITION p2000
+            """
+                sql """
+            ALTER TABLE `test_recover_db`.`test_recover_tb` ADD PARTITION p2000 VALUES [('4000'), ('5000'))
+            """
+
+                qt_select """ SHOW CREATE TABLE `test_recover_db`.`test_recover_tb` """
+
+                sql """
+            ALTER TABLE `test_recover_db`.`test_recover_tb` DROP PARTITION p2000
+            """
 
                 qt_select """ SHOW CREATE TABLE `test_recover_db`.`test_recover_tb` """
 
@@ -119,6 +146,78 @@ suite("test_recover") {
 
                 qt_select """SHOW TABLES FROM `test_recover_db`"""
 
+                sql """
+            CREATE TABLE `test_recover_db`.`test_recover_tb` (
+            `k1` int(11) NULL,
+            `k2` datetime NULL
+            ) ENGINE=OLAP
+            UNIQUE KEY(`k1`)
+            PARTITION BY RANGE(`k1`)
+            (PARTITION p111 VALUES [('-1000'), ('111')),
+            PARTITION p222 VALUES [('111'), ('222')),
+            PARTITION p333 VALUES [('222'), ('333')),
+            PARTITION p1000 VALUES [('333'), ('1000')))
+            DISTRIBUTED BY HASH(`k1`) BUCKETS 3
+            PROPERTIES (
+            "replication_allocation" = "tag.location.default: 1",
+            "in_memory" = "false",
+            "storage_format" = "V2"
+            )
+            """
+
+                qt_select """SHOW TABLES FROM `test_recover_db`"""
+
+                sql """
+            DROP TABLE `test_recover_db`.`test_recover_tb`
+            """
+                sql """
+            CREATE TABLE `test_recover_db`.`test_recover_tb` (
+            `k1` int(11) NULL,
+            `k2` datetime NULL
+            ) ENGINE=OLAP
+            UNIQUE KEY(`k1`)
+            PARTITION BY RANGE(`k1`)
+            (PARTITION p111 VALUES [('-1000'), ('111')),
+            PARTITION p222 VALUES [('111'), ('222')),
+            PARTITION p333 VALUES [('222'), ('333')),
+            PARTITION p1000 VALUES [('333'), ('1000')))
+            DISTRIBUTED BY HASH(`k1`) BUCKETS 3
+            PROPERTIES (
+            "replication_allocation" = "tag.location.default: 1",
+            "in_memory" = "false",
+            "storage_format" = "V2"
+            )
+            """
+
+                qt_select """SHOW TABLES FROM `test_recover_db`"""
+
+                sql """
+            DROP TABLE `test_recover_db`.`test_recover_tb`
+            """
+                sql """
+            CREATE TABLE `test_recover_db`.`test_recover_tb` (
+            `k1` int(11) NULL,
+            `k2` datetime NULL
+            ) ENGINE=OLAP
+            UNIQUE KEY(`k1`)
+            PARTITION BY RANGE(`k1`)
+            (PARTITION p111 VALUES [('-1000'), ('111')),
+            PARTITION p222 VALUES [('111'), ('222')),
+            PARTITION p333 VALUES [('222'), ('333')),
+            PARTITION p1000 VALUES [('333'), ('1000')))
+            DISTRIBUTED BY HASH(`k1`) BUCKETS 3
+            PROPERTIES (
+            "replication_allocation" = "tag.location.default: 1",
+            "in_memory" = "false",
+            "storage_format" = "V2"
+            )
+            """
+
+                qt_select """SHOW TABLES FROM `test_recover_db`"""
+
+                sql """
+            DROP TABLE `test_recover_db`.`test_recover_tb`
+            """
                 sql """
             CREATE TABLE `test_recover_db`.`test_recover_tb` (
             `k1` int(11) NULL,
@@ -205,6 +304,53 @@ suite("test_recover") {
                 sql """
             DROP DATABASE `test_recover_db`
             """
+                sql """
+            CREATE DATABASE `test_recover_db`
+            """
+
+                qt_select """ SHOW CREATE DATABASE `test_recover_db` """
+
+                sql """
+            DROP DATABASE `test_recover_db`
+            """
+
+                sql """
+            CREATE DATABASE `test_recover_db`
+            """
+
+                qt_select """ SHOW CREATE DATABASE `test_recover_db` """
+                
+                sql """
+            CREATE TABLE `test_recover_db`.`test_recover_tb` (
+            `k1` int(11) NULL,
+            `k2` datetime NULL
+            ) ENGINE=OLAP
+            UNIQUE KEY(`k1`)
+            PARTITION BY RANGE(`k1`)
+            (PARTITION p111 VALUES [('-1000'), ('111')),
+            PARTITION p222 VALUES [('111'), ('222')),
+            PARTITION p333 VALUES [('222'), ('333')),
+            PARTITION p1000 VALUES [('333'), ('1000')))
+            DISTRIBUTED BY HASH(`k1`) BUCKETS 3
+            PROPERTIES (
+            "replication_allocation" = "tag.location.default: 1",
+            "in_memory" = "false",
+            "storage_format" = "V2"
+            )
+            """
+
+                sql """
+            DROP DATABASE `test_recover_db`
+            """
+                sql """
+            CREATE DATABASE `test_recover_db`
+            """
+
+                qt_select """ SHOW CREATE DATABASE `test_recover_db` """
+
+                sql """
+            DROP DATABASE `test_recover_db`
+            """
 
                 sql """
             RECOVER DATABASE `test_recover_db` AS `test_recover_db_new`
@@ -257,18 +403,16 @@ suite("test_recover") {
                 qt_select """ SHOW CREATE DATABASE `test_recover_db` """
                 qt_select """ SHOW CREATE DATABASE `test_recover_db_new` """
                 qt_select """SHOW CREATE TABLE `test_recover_db`.`test_recover_tb`"""
-                qt_select """SHOW CREATE TABLE `test_recover_db`.`test_recover_tb_new`"""
                 qt_select """SHOW TABLES FROM `test_recover_db`"""
                 qt_select """SHOW TABLES FROM `test_recover_db_new`"""
 
             // test drop many times
                 sql """ DROP DATABASE `test_recover_db` """
                 sql """ DROP DATABASE `test_recover_db_new` """
-            sleep(30000);
         }
     } finally {
-    //    sql """ DROP DATABASE IF EXISTS `test_recover_db` FORCE """
-    //    sql """ DROP DATABASE IF EXISTS `test_recover_db_new` FORCE """
+        sql """ DROP DATABASE IF EXISTS `test_recover_db` FORCE """
+        sql """ DROP DATABASE IF EXISTS `test_recover_db_new` FORCE """
     }
 
 }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #14292

## Problem summary

new fe conf : max_same_name_catalog_trash_num, it can tell fe just save max mun of catalog trash with same name, if some meta information with same name beyond this num, fe can delete immediately these meta information that be dropped earliest. default value: 3

## Checklist(Required)

1. Does it affect the original behavior: 
    - [x] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [x] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [x] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

