### PR TITLE
[memory](chunkallocator) disable chunkallocator when reserved bytes == 0

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -414,7 +414,7 @@ CONF_Bool(disable_mem_pools, "false");
 // must larger than 0. and if larger than physical memory size, it will be set to physical memory size.
 // increase this variable can improve performance,
 // but will acquire more free memory which can not be used by other modules.
-CONF_mString(chunk_reserved_bytes_limit, "10%");
+CONF_mString(chunk_reserved_bytes_limit, "0");
 // 1024, The minimum chunk allocator size (in bytes)
 CONF_Int32(min_chunk_reserved_bytes, "1024");
 // Disable Chunk Allocator in Vectorized Allocator, this will reduce memory cache.

--- a/be/src/runtime/exec_env_init.cpp
+++ b/be/src/runtime/exec_env_init.cpp
@@ -274,12 +274,6 @@ Status ExecEnv::_init_mem_env() {
     int64_t chunk_reserved_bytes_limit =
             ParseUtil::parse_mem_spec(config::chunk_reserved_bytes_limit, MemInfo::mem_limit(),
                                       MemInfo::physical_mem(), &is_percent);
-    if (chunk_reserved_bytes_limit <= 0) {
-        ss << "Invalid config chunk_reserved_bytes_limit value, must be a percentage or "
-              "positive bytes value or percentage: "
-           << config::chunk_reserved_bytes_limit;
-        return Status::InternalError(ss.str());
-    }
     chunk_reserved_bytes_limit =
             BitUtil::RoundDown(chunk_reserved_bytes_limit, config::min_chunk_reserved_bytes);
     ChunkAllocator::init_instance(chunk_reserved_bytes_limit);

--- a/be/src/runtime/mem_pool.cpp
+++ b/be/src/runtime/mem_pool.cpp
@@ -143,7 +143,7 @@ Status MemPool::find_chunk(size_t min_size, bool check_limits, bool free_old_chu
         free_all();
     }
     Chunk chunk;
-    RETURN_IF_ERROR(ChunkAllocator::instance()->allocate(chunk_size, &chunk));
+    RETURN_IF_ERROR(ChunkAllocator::instance()->allocate_align(chunk_size, &chunk));
     if (_mem_tracker) _mem_tracker->consume(chunk_size);
     ASAN_POISON_MEMORY_REGION(chunk.data, chunk_size);
     // Put it before the first free chunk. If no free chunks, it goes at the end.

--- a/be/src/runtime/memory/chunk_allocator.cpp
+++ b/be/src/runtime/memory/chunk_allocator.cpp
@@ -153,7 +153,7 @@ ChunkAllocator::ChunkAllocator(size_t reserve_limit)
 }
 
 Status ChunkAllocator::allocate_align(size_t size, Chunk* chunk) {
-    CHECK((size > 0);
+    CHECK(size > 0);
     size = BitUtil::RoundUpToPowerOfTwo(size);
     // fast path: allocate from current core arena
     int core_id = CpuInfo::get_current_core();

--- a/be/src/runtime/memory/chunk_allocator.cpp
+++ b/be/src/runtime/memory/chunk_allocator.cpp
@@ -152,13 +152,19 @@ ChunkAllocator::ChunkAllocator(size_t reserve_limit)
     INT_GAUGE_METRIC_REGISTER(_chunk_allocator_metric_entity, chunk_pool_reserved_bytes);
 }
 
-Status ChunkAllocator::allocate(size_t size, Chunk* chunk) {
-    CHECK((size > 0 && (size & (size - 1)) == 0));
-
+Status ChunkAllocator::allocate_align(size_t size, Chunk* chunk) {
+    CHECK((size > 0);
+    size = BitUtil::RoundUpToPowerOfTwo(size);
     // fast path: allocate from current core arena
     int core_id = CpuInfo::get_current_core();
     chunk->size = size;
     chunk->core_id = core_id;
+
+    if (_reserve_bytes_limit < 1) {
+        // allocate from system allocator
+        chunk->data = SystemAllocator::allocate(size);
+        return Status::OK();
+    }
 
     if (_arenas[core_id]->pop_free_chunk(size, &chunk->data)) {
         DCHECK_GE(_reserved_bytes, 0);
@@ -205,7 +211,7 @@ Status ChunkAllocator::allocate(size_t size, Chunk* chunk) {
 void ChunkAllocator::free(const Chunk& chunk) {
     DCHECK(chunk.core_id != -1);
     CHECK((chunk.size & (chunk.size - 1)) == 0);
-    if (config::disable_mem_pools) {
+    if (config::disable_mem_pools || _reserve_bytes_limit < 1) {
         SystemAllocator::free(chunk.data, chunk.size);
         return;
     }
@@ -240,10 +246,6 @@ void ChunkAllocator::free(const Chunk& chunk) {
     // The chunk's memory ownership is transferred from tls tracker to ChunkAllocator.
     THREAD_MEM_TRACKER_TRANSFER_TO(chunk.size, _mem_tracker.get());
     _arenas[chunk.core_id]->push_free_chunk(chunk.data, chunk.size);
-}
-
-Status ChunkAllocator::allocate_align(size_t size, Chunk* chunk) {
-    return allocate(BitUtil::RoundUpToPowerOfTwo(size), chunk);
 }
 
 void ChunkAllocator::free(uint8_t* data, size_t size) {

--- a/be/src/runtime/memory/chunk_allocator.h
+++ b/be/src/runtime/memory/chunk_allocator.h
@@ -73,14 +73,7 @@ public:
     void free(uint8_t* data, size_t size);
 
 private:
-    friend class MemPool;
-
     ChunkAllocator(size_t reserve_limit);
-
-    // Allocate a Chunk with a power-of-two length "size".
-    // Return true if success and allocated chunk is saved in "chunk".
-    // Otherwise return false.
-    Status allocate(size_t size, Chunk* Chunk);
 
 private:
     static ChunkAllocator* _s_instance;

--- a/be/test/runtime/memory/chunk_allocator_test.cpp
+++ b/be/test/runtime/memory/chunk_allocator_test.cpp
@@ -30,7 +30,7 @@ namespace doris {
 TEST(ChunkAllocatorTest, Normal) {
     for (size_t size = 4096; size <= 1024 * 1024; size <<= 1) {
         Chunk chunk;
-        EXPECT_TRUE(ChunkAllocator::instance()->allocate(size, &chunk).ok());
+        EXPECT_TRUE(ChunkAllocator::instance()->allocate_align(size, &chunk).ok());
         EXPECT_NE(nullptr, chunk.data);
         EXPECT_EQ(size, chunk.size);
         ChunkAllocator::instance()->free(chunk);


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

1. disable chunkallocator when reserved bytes == 0
2. disable chunkallocator by default

## Checklist(Required)

1. Does it affect the original behavior: 
    - [x] Yes
    - [ ] No
    - [ ] I don't know
3. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
5. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
6. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

