### PR TITLE
[refactor](array-type) Remove encoding info for array type

### DIFF
--- a/be/src/olap/rowset/segment_v2/encoding_info.cpp
+++ b/be/src/olap/rowset/segment_v2/encoding_info.cpp
@@ -82,18 +82,18 @@ struct TypeEncodingTraits<type, BIT_SHUFFLE, CppType,
     }
 };
 
-template <>
-struct TypeEncodingTraits<OLAP_FIELD_TYPE_ARRAY, BIT_SHUFFLE, CollectionValue> {
-    static Status create_page_builder(const PageBuilderOptions& opts, PageBuilder** builder) {
-        *builder = new BitshufflePageBuilder<OLAP_FIELD_TYPE_UNSIGNED_BIGINT>(opts);
-        return Status::OK();
-    }
-    static Status create_page_decoder(const Slice& data, const PageDecoderOptions& opts,
-                                      PageDecoder** decoder) {
-        *decoder = new BitShufflePageDecoder<OLAP_FIELD_TYPE_UNSIGNED_BIGINT>(data, opts);
-        return Status::OK();
-    }
-};
+//template <>
+//struct TypeEncodingTraits<OLAP_FIELD_TYPE_ARRAY, BIT_SHUFFLE, CollectionValue> {
+//    static Status create_page_builder(const PageBuilderOptions& opts, PageBuilder** builder) {
+//        *builder = new BitshufflePageBuilder<OLAP_FIELD_TYPE_UNSIGNED_BIGINT>(opts);
+//        return Status::OK();
+//    }
+//    static Status create_page_decoder(const Slice& data, const PageDecoderOptions& opts,
+//                                      PageDecoder** decoder) {
+//        *decoder = new BitShufflePageDecoder<OLAP_FIELD_TYPE_UNSIGNED_BIGINT>(data, opts);
+//        return Status::OK();
+//    }
+//};
 
 template <>
 struct TypeEncodingTraits<OLAP_FIELD_TYPE_BOOL, RLE, bool> {
@@ -263,7 +263,7 @@ EncodingInfoResolver::EncodingInfoResolver() {
 
     _add_map<OLAP_FIELD_TYPE_UNSIGNED_BIGINT, BIT_SHUFFLE>();
     _add_map<OLAP_FIELD_TYPE_UNSIGNED_INT, BIT_SHUFFLE>();
-    _add_map<OLAP_FIELD_TYPE_ARRAY, BIT_SHUFFLE>();
+    //_add_map<OLAP_FIELD_TYPE_ARRAY, BIT_SHUFFLE>();
 
     _add_map<OLAP_FIELD_TYPE_LARGEINT, BIT_SHUFFLE>();
     _add_map<OLAP_FIELD_TYPE_LARGEINT, PLAIN_ENCODING>();

--- a/be/src/olap/rowset/segment_v2/encoding_info.cpp
+++ b/be/src/olap/rowset/segment_v2/encoding_info.cpp
@@ -82,19 +82,6 @@ struct TypeEncodingTraits<type, BIT_SHUFFLE, CppType,
     }
 };
 
-//template <>
-//struct TypeEncodingTraits<OLAP_FIELD_TYPE_ARRAY, BIT_SHUFFLE, CollectionValue> {
-//    static Status create_page_builder(const PageBuilderOptions& opts, PageBuilder** builder) {
-//        *builder = new BitshufflePageBuilder<OLAP_FIELD_TYPE_UNSIGNED_BIGINT>(opts);
-//        return Status::OK();
-//    }
-//    static Status create_page_decoder(const Slice& data, const PageDecoderOptions& opts,
-//                                      PageDecoder** decoder) {
-//        *decoder = new BitShufflePageDecoder<OLAP_FIELD_TYPE_UNSIGNED_BIGINT>(data, opts);
-//        return Status::OK();
-//    }
-//};
-
 template <>
 struct TypeEncodingTraits<OLAP_FIELD_TYPE_BOOL, RLE, bool> {
     static Status create_page_builder(const PageBuilderOptions& opts, PageBuilder** builder) {
@@ -263,7 +250,6 @@ EncodingInfoResolver::EncodingInfoResolver() {
 
     _add_map<OLAP_FIELD_TYPE_UNSIGNED_BIGINT, BIT_SHUFFLE>();
     _add_map<OLAP_FIELD_TYPE_UNSIGNED_INT, BIT_SHUFFLE>();
-    //_add_map<OLAP_FIELD_TYPE_ARRAY, BIT_SHUFFLE>();
 
     _add_map<OLAP_FIELD_TYPE_LARGEINT, BIT_SHUFFLE>();
     _add_map<OLAP_FIELD_TYPE_LARGEINT, PLAIN_ENCODING>();


### PR DESCRIPTION
# Proposed changes

Issue Number: close #7570

## Problem summary

Array column should not have encoding info because it use its sub columns' encoding info
And this encoding info is never used and easy to make people confused.
We should remove it.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

