### PR TITLE
[chore](workflow) Disable memory tracker by default on BE UT (macOS)

### DIFF
--- a/.github/workflows/be-ut-clang.yml
+++ b/.github/workflows/be-ut-clang.yml
@@ -38,8 +38,9 @@ jobs:
       - name: Ccache ${{ github.ref }}
         uses: ./.github/actions/ccache-action
         with:
-          key: BE UT Clang
+          key: BE-UT-Clang
           max-size: "2G"
+          restore-keys: BE-UT-Clang-
 
       - name: Paths filter
         uses: ./.github/actions/paths-filter

--- a/.github/workflows/be-ut-mac.yml
+++ b/.github/workflows/be-ut-mac.yml
@@ -38,8 +38,9 @@ jobs:
       - name: Ccache ${{ github.ref }}
         uses: ./.github/actions/ccache-action
         with:
-          key: BE UT macOS
+          key: BE-UT-macOS
           max-size: "2G"
+          restore-keys: BE-UT-macOS-
 
       - name: Paths filter
         uses: ./.github/actions/paths-filter

--- a/run-be-ut.sh
+++ b/run-be-ut.sh
@@ -152,6 +152,14 @@ if [[ -z "${USE_LIBCPP}" ]]; then
     fi
 fi
 
+if [[ -z "${USE_MEM_TRACKER}" ]]; then
+    if [[ "$(uname -s)" != 'Darwin' ]]; then
+        USE_MEM_TRACKER='ON'
+    else
+        USE_MEM_TRACKER='OFF'
+    fi
+fi
+
 if [[ -z "${USE_DWARF}" ]]; then
     USE_DWARF='OFF'
 fi
@@ -172,7 +180,7 @@ cd "${CMAKE_BUILD_DIR}"
     -DBUILD_BENCHMARK_TOOL="${BUILD_BENCHMARK_TOOL}" \
     -DWITH_MYSQL=OFF \
     -DUSE_DWARF="${USE_DWARF}" \
-    -DUSE_MEM_TRACKER=ON \
+    -DUSE_MEM_TRACKER="${USE_MEM_TRACKER}" \
     -DUSE_JEMALLOC=OFF \
     -DSTRICT_MEMORY_USE=OFF \
     -DEXTRA_CXX_FLAGS="${EXTRA_CXX_FLAGS}" \


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

Currently, the feature memory tracker doesn't work well on macOS and we disable it by default on macOS. Therefore the workflow `BE UT (macOS)` should disable it as well.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

