### PR TITLE
[JavaUDF](loader) Fix compatible problem for JAVA 11

### DIFF
--- a/be/src/runtime/user_function_cache.cpp
+++ b/be/src/runtime/user_function_cache.cpp
@@ -307,9 +307,7 @@ Status UserFunctionCache::_load_cache_entry(const std::string& url, UserFunction
 
     if (entry->type == LibType::SO) {
         RETURN_IF_ERROR(_load_cache_entry_internal(entry));
-    } else if (entry->type == LibType::JAR) {
-        RETURN_IF_ERROR(_add_to_classpath(entry));
-    } else {
+    } else if (entry->type != LibType::JAR) {
         return Status::InvalidArgument(
                 "Unsupported lib type! Make sure your lib type is one of 'so' and 'jar'!");
     }
@@ -374,33 +372,6 @@ Status UserFunctionCache::_load_cache_entry_internal(UserFunctionCacheEntry* ent
     RETURN_IF_ERROR(dynamic_open(entry->lib_file.c_str(), &entry->lib_handle));
     entry->is_loaded.store(true);
     return Status::OK();
-}
-
-Status UserFunctionCache::_add_to_classpath(UserFunctionCacheEntry* entry) {
-    if (config::enable_java_support) {
-        const std::string path = "file://" + entry->lib_file;
-        LOG(INFO) << "Add jar " << path << " to classpath";
-        JNIEnv* env;
-        RETURN_IF_ERROR(JniUtil::GetJNIEnv(&env));
-        jclass class_class_loader = env->FindClass("java/lang/ClassLoader");
-        jmethodID method_get_system_class_loader = env->GetStaticMethodID(
-                class_class_loader, "getSystemClassLoader", "()Ljava/lang/ClassLoader;");
-        jobject class_loader =
-                env->CallStaticObjectMethod(class_class_loader, method_get_system_class_loader);
-        jclass class_url_class_loader = env->FindClass("java/net/URLClassLoader");
-        jmethodID method_add_url =
-                env->GetMethodID(class_url_class_loader, "addURL", "(Ljava/net/URL;)V");
-        jclass class_url = env->FindClass("java/net/URL");
-        jmethodID url_ctor = env->GetMethodID(class_url, "<init>", "(Ljava/lang/String;)V");
-        jobject urlInstance = env->NewObject(class_url, url_ctor, env->NewStringUTF(path.c_str()));
-        env->CallVoidMethod(class_loader, method_add_url, urlInstance);
-        entry->is_loaded.store(true);
-        return Status::OK();
-    } else {
-        return Status::InternalError(
-                "Java UDF is not enabled, you can change be config enable_java_support to true and "
-                "restart be.");
-    }
 }
 
 std::string UserFunctionCache::_make_lib_file(int64_t function_id, const std::string& checksum,

--- a/be/src/runtime/user_function_cache.h
+++ b/be/src/runtime/user_function_cache.h
@@ -80,8 +80,6 @@ private:
     Status _download_lib(const std::string& url, UserFunctionCacheEntry* entry);
     Status _load_cache_entry_internal(UserFunctionCacheEntry* entry);
 
-    Status _add_to_classpath(UserFunctionCacheEntry* entry);
-
     std::string _make_lib_file(int64_t function_id, const std::string& checksum, LibType type);
     void _destroy_cache_entry(UserFunctionCacheEntry* entry);
 

--- a/fe/java-udf/src/main/java/org/apache/doris/udf/UdafExecutor.java
+++ b/fe/java-udf/src/main/java/org/apache/doris/udf/UdafExecutor.java
@@ -23,7 +23,6 @@ import org.apache.doris.thrift.TJavaUdfExecutorCtorParams;
 import org.apache.doris.udf.UdfUtils.JavaUdfDataType;
 
 import com.google.common.base.Joiner;
-import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import org.apache.log4j.Logger;
 import org.apache.thrift.TDeserializer;
@@ -467,10 +466,16 @@ public class UdafExecutor {
             throws UdfRuntimeException {
         ArrayList<String> signatures = Lists.newArrayList();
         try {
-            Preconditions.checkArgument(jarPath != null);
-            ClassLoader parent = getClass().getClassLoader();
-            classLoader = UdfUtils.getClassLoader(jarPath, parent);
-            Class<?> c = Class.forName(udfPath, true, classLoader);
+            ClassLoader loader;
+            if (jarPath != null) {
+                ClassLoader parent = getClass().getClassLoader();
+                classLoader = UdfUtils.getClassLoader(jarPath, parent);
+                loader = classLoader;
+            } else {
+                // for test
+                loader = ClassLoader.getSystemClassLoader();
+            }
+            Class<?> c = Class.forName(udfPath, true, loader);
             Constructor<?> ctor = c.getConstructor();
             udaf = ctor.newInstance();
             Method[] methods = c.getDeclaredMethods();

--- a/fe/java-udf/src/main/java/org/apache/doris/udf/UdafExecutor.java
+++ b/fe/java-udf/src/main/java/org/apache/doris/udf/UdafExecutor.java
@@ -23,6 +23,7 @@ import org.apache.doris.thrift.TJavaUdfExecutorCtorParams;
 import org.apache.doris.udf.UdfUtils.JavaUdfDataType;
 
 import com.google.common.base.Joiner;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import org.apache.log4j.Logger;
 import org.apache.thrift.TDeserializer;
@@ -466,15 +467,10 @@ public class UdafExecutor {
             throws UdfRuntimeException {
         ArrayList<String> signatures = Lists.newArrayList();
         try {
-            ClassLoader loader;
-            if (jarPath != null) {
-                ClassLoader parent = getClass().getClassLoader();
-                classLoader = UdfUtils.getClassLoader(jarPath, parent);
-                loader = classLoader;
-            } else {
-                loader = ClassLoader.getSystemClassLoader();
-            }
-            Class<?> c = Class.forName(udfPath, true, loader);
+            Preconditions.checkArgument(jarPath != null);
+            ClassLoader parent = getClass().getClassLoader();
+            classLoader = UdfUtils.getClassLoader(jarPath, parent);
+            Class<?> c = Class.forName(udfPath, true, classLoader);
             Constructor<?> ctor = c.getConstructor();
             udaf = ctor.newInstance();
             Method[] methods = c.getDeclaredMethods();

--- a/fe/java-udf/src/main/java/org/apache/doris/udf/UdfExecutor.java
+++ b/fe/java-udf/src/main/java/org/apache/doris/udf/UdfExecutor.java
@@ -23,6 +23,7 @@ import org.apache.doris.thrift.TJavaUdfExecutorCtorParams;
 import org.apache.doris.udf.UdfUtils.JavaUdfDataType;
 
 import com.google.common.base.Joiner;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import org.apache.log4j.Logger;
 import org.apache.thrift.TDeserializer;
@@ -448,16 +449,10 @@ public class UdfExecutor {
         ArrayList<String> signatures = Lists.newArrayList();
         try {
             LOG.debug("Loading UDF '" + udfPath + "' from " + jarPath);
-            ClassLoader loader;
-            if (jarPath != null) {
-                // Save for cleanup.
-                ClassLoader parent = getClass().getClassLoader();
-                classLoader = UdfUtils.getClassLoader(jarPath, parent);
-                loader = classLoader;
-            } else {
-                loader = ClassLoader.getSystemClassLoader();
-            }
-            Class<?> c = Class.forName(udfPath, true, loader);
+            Preconditions.checkArgument(jarPath != null);
+            ClassLoader parent = getClass().getClassLoader();
+            classLoader = UdfUtils.getClassLoader(jarPath, parent);
+            Class<?> c = Class.forName(udfPath, true, classLoader);
             Constructor<?> ctor = c.getConstructor();
             udf = ctor.newInstance();
             Method[] methods = c.getMethods();


### PR DESCRIPTION
# Proposed changes

close #14521

The class loader hierarchy has changed in Java 11 [1]. So current behavior is incorrect using Java 11.

[1] https://learn.microsoft.com/en-us/java/openjdk/transition-from-java-8-to-java-11#classloader-cautions

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

