### PR TITLE
[test](pipline)Adjust mem limit to 30% for regression

### DIFF
--- a/regression-test/pipeline/p0/conf/be.conf
+++ b/regression-test/pipeline/p0/conf/be.conf
@@ -26,7 +26,7 @@ webserver_port = 8141
 heartbeat_service_port = 9151
 brpc_port = 8161
 
-mem_limit = 20%
+mem_limit = 30%
 disable_minidump = true
 path_gc_check_interval_second=1
 max_garbage_sweep_interval=180

--- a/regression-test/pipeline/p1/conf/be.conf
+++ b/regression-test/pipeline/p1/conf/be.conf
@@ -26,7 +26,7 @@ webserver_port = 8142
 heartbeat_service_port = 9152
 brpc_port = 8162
 
-mem_limit = 20%
+mem_limit = 30%
 disable_minidump = true
 path_gc_check_interval_second=1
 max_garbage_sweep_interval=180


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

load task of teamcity regression pipline occur cancel because of over memory limit  recently, so adjust mem limit of be.conf to 30%

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] No
2. Has unit tests been added:
    - [ ] No Need
3. Has document been added or modified:
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] No

