### PR TITLE
[fix](fe) fix leaks of connect context

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/AutoCloseConnectContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/AutoCloseConnectContext.java
@@ -1,0 +1,34 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.qe;
+
+public class AutoCloseConnectContext implements AutoCloseable {
+
+    public final ConnectContext connectContext;
+
+    public AutoCloseConnectContext(ConnectContext connectContext) {
+        this.connectContext = connectContext;
+        connectContext.setThreadLocalInfo();
+    }
+
+    @Override
+    public void close() {
+        connectContext.kill(false);
+        ConnectContext.remove();
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/IcebergAnalysisJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/IcebergAnalysisJob.java
@@ -18,7 +18,7 @@
 package org.apache.doris.statistics;
 
 import org.apache.doris.common.FeConstants;
-import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.qe.AutoCloseConnectContext;
 import org.apache.doris.qe.StmtExecutor;
 import org.apache.doris.statistics.util.StatisticsUtil;
 
@@ -116,8 +116,9 @@ public class IcebergAnalysisJob extends HMSAnalysisJob {
         // Update table level stats info of this column.
         StringSubstitutor stringSubstitutor = new StringSubstitutor(params);
         String sql = stringSubstitutor.replace(INSERT_TABLE_SQL_TEMPLATE);
-        ConnectContext connectContext = StatisticsUtil.buildConnectContext();
-        this.stmtExecutor = new StmtExecutor(connectContext, sql);
-        this.stmtExecutor.execute();
+        try (AutoCloseConnectContext r = StatisticsUtil.buildConnectContext()) {
+            this.stmtExecutor = new StmtExecutor(r.connectContext, sql);
+            this.stmtExecutor.execute();
+        }
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/statistics/AnalysisJobTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/statistics/AnalysisJobTest.java
@@ -19,6 +19,7 @@ package org.apache.doris.statistics;
 
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.InternalSchemaInitializer;
+import org.apache.doris.qe.AutoCloseConnectContext;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.StmtExecutor;
 import org.apache.doris.statistics.AnalysisJobInfo.JobType;
@@ -30,6 +31,7 @@ import mockit.Expectations;
 import mockit.Mock;
 import mockit.MockUp;
 import mockit.Mocked;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class AnalysisJobTest extends TestWithFeService {
@@ -63,17 +65,24 @@ public class AnalysisJobTest extends TestWithFeService {
         new MockUp<StatisticsUtil>() {
 
             @Mock
-            public ConnectContext buildConnectContext() {
-                return connectContext;
+            public AutoCloseConnectContext buildConnectContext() {
+                return new AutoCloseConnectContext(connectContext);
             }
 
             @Mock
             public void execUpdate(String sql) throws Exception {
             }
         };
+
+        new MockUp<ConnectContext>() {
+
+            @Mock
+            public ConnectContext get() {
+                return connectContext;
+            }
+        };
         String sql = "ANALYZE t1";
-        StmtExecutor executor = getSqlStmtExecutor(sql);
-        executor.execute();
+        Assertions.assertNotNull(getSqlStmtExecutor(sql));
     }
 
     @Test


### PR DESCRIPTION
# Proposed changes

## Problem summary

Remove `ConnectContext` which built for internal statistics  from threadlocal to avoid memory leaks

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

