### PR TITLE
[Fix](function) fix function `retention` lost `ARRAY`'s element type …

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/FunctionSet.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/FunctionSet.java
@@ -1476,7 +1476,7 @@ public class FunctionSet<T> {
         // retention vectorization
         addBuiltin(AggregateFunction.createBuiltin(FunctionSet.RETENTION,
                 Lists.newArrayList(Type.BOOLEAN),
-                Type.ARRAY,
+                new ArrayType(Type.BOOLEAN),
                 Type.VARCHAR,
                 true,
                 "",

--- a/regression-test/data/query_p0/sql_functions/aggregate_functions/test_aggregate_retention.out
+++ b/regression-test/data/query_p0/sql_functions/aggregate_functions/test_aggregate_retention.out
@@ -57,3 +57,6 @@
 1	[1, 1, 0]
 2	[1, 0, 0]
 
+-- !test_aggregate_retention_13 --
+1
+

--- a/regression-test/suites/query_p0/sql_functions/aggregate_functions/test_aggregate_retention.sql
+++ b/regression-test/suites/query_p0/sql_functions/aggregate_functions/test_aggregate_retention.sql
@@ -70,3 +70,13 @@ SELECT
             FROM retention_test 
             GROUP BY uid 
             ORDER BY uid ASC;
+
+SELECT SUM(cast(a.r[1] AS int))
+FROM 
+    (SELECT uid,
+         retention( date = '2022-10-14', date = '2022-10-12', date = '2022-11-04', date = '2022-11-07') AS r
+    FROM retention_test
+    WHERE (date >= '2022-10-11')
+            AND (date <= '2022-11-21')
+    GROUP BY  uid ) a;
+


### PR DESCRIPTION
…in `Builtin function` retType

# Proposed changes

Issue Number: close #14537

## Problem summary

```
SELECT SUM(cast(a.r[1] as int)) as active_user_num_7day FROM ( SELECT user_id, retention( day = '2022-11-01', day = '2022-11-02', day = '2022-11-04', day = '2022-11-07') as r FROM login_event WHERE (day >= '2022-11-01') AND (day <= '2022-11-21') GROUP BY user_id ) a;

**ERROR 1105 (HY000): errCode = 2, detailMessage = Unsupported type 'ARRAY<NULL_TYPE>' in '`a`.`r`'.**
```

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

