### PR TITLE
[fix](iterator) Fix leak in VCollectorIterator

### DIFF
--- a/be/src/vec/olap/vcollect_iterator.cpp
+++ b/be/src/vec/olap/vcollect_iterator.cpp
@@ -31,6 +31,12 @@ namespace vectorized {
         }                                                                               \
     } while (false)
 
+VCollectIterator::~VCollectIterator() {
+    for (auto child : _children) {
+        delete child;
+    }
+}
+
 void VCollectIterator::init(TabletReader* reader, bool force_merge, bool is_reverse) {
     _reader = reader;
     // when aggregate is enabled or key_type is DUP_KEYS, we don't merge

--- a/be/src/vec/olap/vcollect_iterator.h
+++ b/be/src/vec/olap/vcollect_iterator.h
@@ -37,7 +37,7 @@ namespace vectorized {
 class VCollectIterator {
 public:
     // Hold reader point to get reader params
-    ~VCollectIterator() = default;
+    ~VCollectIterator();
 
     void init(TabletReader* reader, bool force_merge, bool is_reverse);
 


### PR DESCRIPTION
`VCollectIterator::build_heap()` leaks memory when there is a `VCollectIterator::LevelIterator::init()` fails.

# Proposed changes

Issue Number:  #14546

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

