### PR TITLE
[fix](outfile) duplicate SUCCESS file request

### DIFF
--- a/be/src/runtime/file_result_writer.cpp
+++ b/be/src/runtime/file_result_writer.cpp
@@ -61,7 +61,7 @@ FileResultWriter::FileResultWriter(const ResultFileOptions* file_opts,
 }
 
 FileResultWriter::~FileResultWriter() {
-    _close_file_writer(true);
+    _close_file_writer(true, true);
 }
 
 Status FileResultWriter::init(RuntimeState* state) {


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

Problem desc:
While we call `SELECT xxx INTO OUTFILE`,  if we output data file success, we also write an empty `SUCCESS` file.
But now the problem is:
1. if we write data file failed, we also write out an empty `SUCCESS` file;
2. if we write data file success, we write out the empty `SUCCESS` file twice;

Why the problem:
After https://github.com/apache/doris/pull/5489, we refractor _close_file_writer, but not change the caller.
So we will create `SUCCESS` file once inside `close` function, and the other call while we deconstruct `FileResultWriter`.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
4. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
5. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
6. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
7. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

