### PR TITLE
[fix](recycle) refactor the logic of erase meta with same name

### DIFF
--- a/docs/en/docs/admin-manual/config/fe-config.md
+++ b/docs/en/docs/admin-manual/config/fe-config.md
@@ -2338,7 +2338,7 @@ Is it a configuration item unique to the Master FE node: false
 
 ### `max_same_name_catalog_trash_num`
 
-It is used to set the maximum number of meta information with the same name in the catalog recycle bin. When the maximum value is exceeded, the earliest deleted meta trash will be completely deleted and cannot be recovered.
+It is used to set the maximum number of meta information with the same name in the catalog recycle bin. When the maximum value is exceeded, the earliest deleted meta trash will be completely deleted and cannot be recovered. 0 means not to keep objects of the same name. < 0 means no limit.
 
 Note: The judgment of metadata with the same name will be limited to a certain range. For example, the judgment of the database with the same name will be limited to the same cluster, the judgment of the table with the same name will be limited to the same database (with the same database id), the judgment of the partition with the same name will be limited to the same database (with the same database id) and the same table (with the same table) same table id).
 

--- a/docs/zh-CN/docs/admin-manual/config/fe-config.md
+++ b/docs/zh-CN/docs/admin-manual/config/fe-config.md
@@ -2394,7 +2394,7 @@ hive partition 的最大缓存数量。
 
 ### `max_same_name_catalog_trash_num`
 
-用于设置回收站中同名元数据的最大个数，超过最大值时，最早删除的元数据将被彻底删除，不能再恢复。
+用于设置回收站中同名元数据的最大个数，超过最大值时，最早删除的元数据将被彻底删除，不能再恢复。0 表示不保留同名对象。< 0 表示不做限制。
 
 注意：同名元数据的判断会局限在一定的范围内。比如同名database的判断会限定在相同cluster下，同名table的判断会限定在相同database（指相同database id）下，同名partition的判断会限定在相同database（指相同database id）并且相同table（指相同table id）下。
 

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/CatalogRecycleBin.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/CatalogRecycleBin.java
@@ -396,6 +396,7 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
 
             idToTable.remove(tableId);
             idToRecycleTime.remove(tableId);
+            Env.getCurrentEnv().getEditLog().logEraseTable(tableId);
             LOG.info("erase table[{}] name: {} from db[{}]", tableId, tableName, dbId);
         }
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/CatalogRecycleBin.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/CatalogRecycleBin.java
@@ -289,10 +289,11 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
             if (table.getType() == TableType.OLAP) {
                 Env.getCurrentEnv().onEraseOlapTable((OlapTable) table, false);
             }
-            LOG.info("erase db[{}] with table[{}]: {}", dbId, table.getId(), table.getName());
             iterator.remove();
             idToRecycleTime.remove(table.getId());
             tableNames.remove(table.getName());
+            Env.getCurrentEnv().getEditLog().logEraseTable(table.getId());
+            LOG.info("erase db[{}] with table[{}]: {}", dbId, table.getId(), table.getName());
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/CatalogRecycleBin.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/CatalogRecycleBin.java
@@ -262,7 +262,7 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
             eraseAllTables(dbInfo);
             idToDatabase.remove(dbId);
             idToRecycleTime.remove(dbId);
-            Env.getCurrentEnv().eraseDatabase(dbId, false);
+            Env.getCurrentEnv().eraseDatabase(dbId, true);
             LOG.info("erase database[{}] name: {}", dbId, dbName);
         }
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/CatalogRecycleBin.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/CatalogRecycleBin.java
@@ -213,6 +213,9 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
             }
         }
         // 2. erase exceed number
+        if (keepNum < 0) {
+            return;
+        }
         Set<String> dbNames = idToDatabase.values().stream().map(d -> d.getDb().getFullName())
                 .collect(Collectors.toSet());
         for (String dbName : dbNames) {
@@ -236,14 +239,14 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
             }
         }
         List<Long> dbIdToErase = Lists.newArrayList();
-        if (dbRecycleTimeLists.size() < maxSameNameTrashNum) {
+        if (dbRecycleTimeLists.size() <= maxSameNameTrashNum) {
             return dbIdToErase;
         }
         // order by recycle time desc
         dbRecycleTimeLists.sort((x, y) ->
                 (x.get(1).longValue() < y.get(1).longValue()) ? 1 : ((x.get(1).equals(y.get(1))) ? 0 : -1));
 
-        for (int i = maxSameNameTrashNum - 1; i < dbRecycleTimeLists.size(); i++) {
+        for (int i = maxSameNameTrashNum; i < dbRecycleTimeLists.size(); i++) {
             dbIdToErase.add(dbRecycleTimeLists.get(i).get(0));
         }
         return dbIdToErase;
@@ -318,6 +321,9 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
         } // end for tables
 
         // 2. erase exceed num
+        if (keepNum < 0) {
+            return;
+        }
         Map<Long, Set<String>> dbId2TableNames = Maps.newHashMap();
         for (RecycleTableInfo tableInfo : idToTable.values()) {
             Set<String> tblNames = dbId2TableNames.get(tableInfo.dbId);
@@ -355,15 +361,14 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
             }
         }
         List<Long> tableIdToErase = Lists.newArrayList();
-        if (tableRecycleTimeLists.size() < maxSameNameTrashNum) {
+        if (tableRecycleTimeLists.size() <= maxSameNameTrashNum) {
             return tableIdToErase;
         }
         // order by recycle time desc
-        tableRecycleTimeLists.sort((x, y) -> {
-            return (x.get(1).longValue() < y.get(1).longValue()) ? 1 : ((x.get(1).equals(y.get(1))) ? 0 : -1);
-        });
+        tableRecycleTimeLists.sort((x, y) ->
+                (x.get(1).longValue() < y.get(1).longValue()) ? 1 : ((x.get(1).equals(y.get(1))) ? 0 : -1));
 
-        for (int i = maxSameNameTrashNum - 1; i < tableRecycleTimeLists.size(); i++) {
+        for (int i = maxSameNameTrashNum; i < tableRecycleTimeLists.size(); i++) {
             tableIdToErase.add(tableRecycleTimeLists.get(i).get(0));
         }
         return tableIdToErase;
@@ -416,6 +421,9 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
         } // end for partitions
 
         // 2. erase exceed number
+        if (keepNum < 0) {
+            return;
+        }
         com.google.common.collect.Table<Long, Long, Set<String>> dbTblId2PartitionNames = HashBasedTable.create();
         for (RecyclePartitionInfo partitionInfo : idToPartition.values()) {
             Set<String> partitionNames = dbTblId2PartitionNames.get(partitionInfo.dbId, partitionInfo.tableId);
@@ -453,15 +461,14 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
             }
         }
         List<Long> partitionIdToErase = Lists.newArrayList();
-        if (partitionRecycleTimeLists.size() < maxSameNameTrashNum) {
+        if (partitionRecycleTimeLists.size() <= maxSameNameTrashNum) {
             return partitionIdToErase;
         }
         // order by recycle time desc
-        partitionRecycleTimeLists.sort((x, y) -> {
-            return (x.get(1).longValue() < y.get(1).longValue()) ? 1 : ((x.get(1).equals(y.get(1))) ? 0 : -1);
-        });
+        partitionRecycleTimeLists.sort((x, y) ->
+                (x.get(1).longValue() < y.get(1).longValue()) ? 1 : ((x.get(1).equals(y.get(1))) ? 0 : -1));
 
-        for (int i = maxSameNameTrashNum - 1; i < partitionRecycleTimeLists.size(); i++) {
+        for (int i = maxSameNameTrashNum; i < partitionRecycleTimeLists.size(); i++) {
             partitionIdToErase.add(partitionRecycleTimeLists.get(i).get(0));
         }
         return partitionIdToErase;

--- a/fe/fe-core/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/Config.java
@@ -1920,6 +1920,8 @@ public class Config extends ConfigBase {
     /**
      * Max num of same name meta informatntion in catalog recycle bin.
      * Default is 3.
+     * 0 means do not keep any meta obj with same name.
+     * < 0 means no limit
      */
     @ConfField(mutable = true, masterOnly = true)
     public static int max_same_name_catalog_trash_num = 3;


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

in #14482, we implement the feature to keep specific number of meta with same name in catalog recycle bin.
But it will cause meta replay bug.
Because every time we drop db/table/partition, it will try to erase a certain number of meta with same name.
And when replay "drop" edit log, it will do same thing. But the number of meta to erase it based on current config value,
not persist in edit log, so it will cause inconsistency with "drop" and "replay drop".

In this PR, I move the "erase meta with same name" logic to the daemon thread of catalog recycle bin.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

