### PR TITLE
[Fix](function) Fix retention function return wrong value type

### DIFF
--- a/be/src/vec/aggregate_functions/aggregate_function_retention.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_retention.h
@@ -72,7 +72,7 @@ struct RetentionState {
     }
 
     void insert_result_into(IColumn& to, size_t events_size, const uint8_t* events) const {
-        auto& data_to = assert_cast<ColumnUInt8&>(to).get_data();
+        auto& data_to = static_cast<ColumnUInt8&>(to).get_data();
 
         ColumnArray::Offset64 current_offset = data_to.size();
         data_to.resize(current_offset + events_size);

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/FunctionSet.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/FunctionSet.java
@@ -1476,6 +1476,7 @@ public class FunctionSet<T> {
         // retention vectorization
         addBuiltin(AggregateFunction.createBuiltin(FunctionSet.RETENTION,
                 Lists.newArrayList(Type.BOOLEAN),
+                // Type.BOOLEAN will return non-numeric results so we use Type.TINYINT
                 new ArrayType(Type.TINYINT),
                 Type.VARCHAR,
                 true,

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/FunctionSet.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/FunctionSet.java
@@ -1476,7 +1476,7 @@ public class FunctionSet<T> {
         // retention vectorization
         addBuiltin(AggregateFunction.createBuiltin(FunctionSet.RETENTION,
                 Lists.newArrayList(Type.BOOLEAN),
-                new ArrayType(Type.BOOLEAN),
+                new ArrayType(Type.TINYINT),
                 Type.VARCHAR,
                 true,
                 "",

--- a/regression-test/data/query_p0/sql_functions/aggregate_functions/test_aggregate_retention.out
+++ b/regression-test/data/query_p0/sql_functions/aggregate_functions/test_aggregate_retention.out
@@ -58,5 +58,5 @@
 2	[1, 0, 0]
 
 -- !test_aggregate_retention_13 --
-1
+3	2	1
 

--- a/regression-test/suites/query_p0/sql_functions/aggregate_functions/test_aggregate_retention.sql
+++ b/regression-test/suites/query_p0/sql_functions/aggregate_functions/test_aggregate_retention.sql
@@ -71,12 +71,18 @@ SELECT
             GROUP BY uid 
             ORDER BY uid ASC;
 
-SELECT SUM(cast(a.r[1] AS int))
-FROM 
-    (SELECT uid,
-         retention( date = '2022-10-14', date = '2022-10-12', date = '2022-11-04', date = '2022-11-07') AS r
-    FROM retention_test
-    WHERE (date >= '2022-10-11')
-            AND (date <= '2022-11-21')
-    GROUP BY  uid ) a;
-
+SELECT
+    sum(a.r[1])
+        AS s1, 
+    sum(a.r[2])
+        AS s2,
+    sum(a.r[3])
+        AS s3  
+            FROM(
+                SELECT
+                    uid,
+                    retention(date = '2022-10-12', date = '2022-10-13', date = '2022-10-14') 
+                        AS r 
+                            FROM retention_test
+                            GROUP BY uid 
+                ) a;


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

MySQL [db]> SELECT   SUM(a.r[1]) as active_user_num,   SUM(a.r[2]) as active_user_num_1day,   SUM(a.r[3]) as active_user_num_3day,   SUM(a.r[4]) as active_user_num_7day FROM ( SELECT   user_id,   retention(     day = '2022-11-01',     day = '2022-11-02',     day = '2022-11-04',     day = '2022-11-07') as r FROM login_event WHERE (day >= '2022-11-01') AND (day <= '2022-11-21') GROUP BY user_id ) a;
ERROR 1105 (HY000): errCode = 2, detailMessage = sum requires a numeric parameter: sum(%element_extract%(`a`.`r`, 1))

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

