### PR TITLE
[enhancement](outfile) add retry for broker pwrite

### DIFF
--- a/be/src/io/broker_writer.cpp
+++ b/be/src/io/broker_writer.cpp
@@ -144,16 +144,12 @@ Status BrokerWriter::write(const uint8_t* buf, size_t buf_len, size_t* written_l
             return status;
         }
 
-        // we do not re-try simply, because broker server may already write data
         try {
             client->pwrite(response, request);
         } catch (apache::thrift::transport::TTransportException& e) {
             RETURN_IF_ERROR(client.reopen());
-
-            std::stringstream ss;
-            ss << "Fail to write to broker, broker:" << broker_addr << " failed:" << e.what();
-            LOG(WARNING) << ss.str();
-            return Status::RpcError(ss.str());
+            // broker server will check write offset, so it is safe to re-try
+            client->pwrite(response, request);
         }
     } catch (apache::thrift::TException& e) {
         std::stringstream ss;
@@ -206,8 +202,8 @@ Status BrokerWriter::close() {
         try {
             client->closeWriter(response, request);
         } catch (apache::thrift::transport::TTransportException& e) {
-            LOG(WARNING) << "Close broker writer failed. broker=" << broker_addr
-                         << ", status=" << status.get_error_msg();
+            LOG(WARNING) << "Close broker writer failed. broker:" << broker_addr
+                         << " msg:" << e.what();
             status = client.reopen();
             if (!status.ok()) {
                 LOG(WARNING) << "Reopen broker writer failed. broker=" << broker_addr


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

Problem:
We got following error frequently while `SELECT xxx INTO OUTFILE`:
`ERROR 1064 (HY000): RpcException, msg: Fail to write to broker, broker:TNetworkAddress(hostname=a.b.c.d, port=8111) failed:write() send(): Broken pipe`

Reason:
1. we cache broker thrift client in BE;
2. thrift client check connect `isOpen` only return cached flag, not care the real socket is opened or closed;
3. after we get client from cache, the socket may already closed, then `pwrite` will failed.

How to fix:
Other interfaces such as open and close, will reopen and retry again, but `pwrite` do not retry.
As there are write offset inside `pwrite`, and the broker(server) side also will check the write offset, it is safe to retry `pwrite`.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
4. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
5. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
6. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
7. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

