### PR TITLE
[fix](multi catalog)Use -1 as external es table column id instead of uniq id.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/external/elasticsearch/EsUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/external/elasticsearch/EsUtil.java
@@ -37,7 +37,6 @@ import org.apache.doris.analysis.RangePartitionDesc;
 import org.apache.doris.analysis.SlotRef;
 import org.apache.doris.catalog.ArrayType;
 import org.apache.doris.catalog.Column;
-import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.ScalarType;
 import org.apache.doris.catalog.Type;
 import org.apache.doris.common.AnalysisException;
@@ -378,7 +377,7 @@ public class EsUtil {
             column.setName(key);
             column.setIsKey(true);
             column.setIsAllowNull(true);
-            column.setUniqueId((int) Env.getCurrentEnv().getNextId());
+            column.setUniqueId(-1);
             if (arrayFields.contains(key)) {
                 column.setType(ArrayType.create(type, true));
             } else {


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

Using cache to store external table columns, doesn't persist uniq id for external columns anymore. So use -1 as column id for ES external table. Avoid non-master FE trying to get uniq id problem. The problem will cause non-master FE fail to write bdbje.
## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

