### PR TITLE
[improvement](load) add more log on rpc error

### DIFF
--- a/be/src/exec/tablet_sink.cpp
+++ b/be/src/exec/tablet_sink.cpp
@@ -153,7 +153,7 @@ void NodeChannel::open() {
 }
 
 void NodeChannel::_cancel_with_msg(const std::string& msg) {
-    LOG(WARNING) << channel_info() << ", " << msg;
+    LOG(WARNING) << "cancel node channel " << channel_info() << ", error message: " << msg;
     {
         std::lock_guard<SpinLock> l(_cancel_msg_lock);
         if (_cancel_msg == "") {
@@ -205,7 +205,10 @@ Status NodeChannel::open_wait() {
             }
             // If rpc failed, mark all tablets on this node channel as failed
             _index_channel->mark_as_failed(this->node_id(), this->host(),
-                                           _add_batch_closure->cntl.ErrorText(), -1);
+                                           fmt::format("rpc failed, error coed:{}, error text:{}",
+                                                       _add_batch_closure->cntl.ErrorCode(),
+                                                       _add_batch_closure->cntl.ErrorText()),
+                                           -1);
             Status st = _index_channel->check_intolerable_failure();
             if (!st.ok()) {
                 _cancel_with_msg(fmt::format("{}, err: {}", channel_info(), st.get_error_msg()));

--- a/be/src/exec/tablet_sink.cpp
+++ b/be/src/exec/tablet_sink.cpp
@@ -232,7 +232,8 @@ Status NodeChannel::open_wait() {
             if (status.ok()) {
                 // if has error tablet, handle them first
                 for (auto& error : result.tablet_errors()) {
-                    _index_channel->mark_as_failed(this->node_id(), this->host(), error.msg(),
+                    _index_channel->mark_as_failed(this->node_id(), this->host(),
+                                                   "tablet error: " + error.msg(),
                                                    error.tablet_id());
                 }
 

--- a/be/src/vec/sink/vtablet_sink.cpp
+++ b/be/src/vec/sink/vtablet_sink.cpp
@@ -95,7 +95,10 @@ Status VNodeChannel::open_wait() {
         }
         // If rpc failed, mark all tablets on this node channel as failed
         _index_channel->mark_as_failed(this->node_id(), this->host(),
-                                       _add_block_closure->cntl.ErrorText(), -1);
+                                       fmt::format("rpc failed, error coed:{}, error text:{}",
+                                                   _add_block_closure->cntl.ErrorCode(),
+                                                   _add_block_closure->cntl.ErrorText()),
+                                       -1);
         Status st = _index_channel->check_intolerable_failure();
         if (!st.ok()) {
             _cancel_with_msg(fmt::format("{}, err: {}", channel_info(), st.get_error_msg()));
@@ -119,8 +122,8 @@ Status VNodeChannel::open_wait() {
         if (status.ok()) {
             // if has error tablet, handle them first
             for (auto& error : result.tablet_errors()) {
-                _index_channel->mark_as_failed(this->node_id(), this->host(), error.msg(),
-                                               error.tablet_id());
+                _index_channel->mark_as_failed(this->node_id(), this->host(),
+                                               "tablet error: " + error.msg(), error.tablet_id());
             }
 
             Status st = _index_channel->check_intolerable_failure();


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

A stream load failed, and we found the following log, which missed critical error message. 
I guess it might be a rpc error and ErrorText is empty, add more logs.
```
W1124 16:39:14.329555 874006 tablet_sink.cpp:158] VNodeChannel[2869579-10003], load_id=5c4bf7fcacae1dd8-9a8c82bdc624695, txn_id=2120726589419520, node=172.29.123.127:8060, **, host: 172.29.123.127**
W1124 16:39:15.866672 874004 tablet_sink.cpp:158] VNodeChannel[2869579-10004], load_id=5c4bf7fcacae1dd8-9a8c82bdc624695, txn_id=2120726589419520, node=172.29.123.126:8060, **, host: 172.29.123.127**
```

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

