### PR TITLE
[Improvement](datatype) disable new types if vectorized engine is disabled

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/ScalarType.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/ScalarType.java
@@ -21,6 +21,7 @@ import org.apache.doris.common.Config;
 import org.apache.doris.common.io.Text;
 import org.apache.doris.common.util.VectorizedUtil;
 import org.apache.doris.persist.gson.GsonUtils;
+import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.thrift.TColumnType;
 import org.apache.doris.thrift.TScalarType;
 import org.apache.doris.thrift.TTypeDesc;
@@ -625,7 +626,8 @@ public class ScalarType extends Type {
     @Override
     public void toThrift(TTypeDesc container) {
         if (type.isDecimalV3Type() || type.isDateV2Type()) {
-            Preconditions.checkArgument(Config.enable_vectorized_load && VectorizedUtil.isVectorized(),
+            Preconditions.checkArgument((Config.enable_vectorized_load && ConnectContext.get() == null)
+                            || (VectorizedUtil.isVectorized() && ConnectContext.get() != null),
                     "Please make sure vectorized load and vectorized query engine are enabled to use data type: "
                             + type);
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/ScalarType.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/ScalarType.java
@@ -19,6 +19,7 @@ package org.apache.doris.catalog;
 
 import org.apache.doris.common.Config;
 import org.apache.doris.common.io.Text;
+import org.apache.doris.common.util.VectorizedUtil;
 import org.apache.doris.persist.gson.GsonUtils;
 import org.apache.doris.thrift.TColumnType;
 import org.apache.doris.thrift.TScalarType;
@@ -623,6 +624,11 @@ public class ScalarType extends Type {
 
     @Override
     public void toThrift(TTypeDesc container) {
+        if (type.isDecimalV3Type() || type.isDateV2Type()) {
+            Preconditions.checkArgument(Config.enable_vectorized_load && VectorizedUtil.isVectorized(),
+                    "Please make sure vectorized load and vectorized query engine are enabled to use data type: "
+                            + type);
+        }
         TTypeNode node = new TTypeNode();
         container.types.add(node);
         node.setType(TTypeNodeType.SCALAR);


### PR DESCRIPTION

# Proposed changes

disable datev2/datetimev2/decimalv3 if vectorized engine is disabled

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

