### PR TITLE
[fix](metric) fix metric jvm_xxx_size_bytes{type=max, ...}

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/monitor/jvm/JvmStats.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/monitor/jvm/JvmStats.java
@@ -71,7 +71,7 @@ public class JvmStats {
                 }
                 pools.add(new MemoryPool(name,
                         usage.getUsed() < 0 ? 0 : usage.getUsed(),
-                        usage.getMax() < 0 ? 0 : usage.getMax(),
+                        usage.getMax() < 0 ? heapMax : usage.getMax(),
                         peakUsage.getUsed() < 0 ? 0 : peakUsage.getUsed(),
                         peakUsage.getMax() < 0 ? 0 : peakUsage.getMax()
                 ));


### PR DESCRIPTION
# Proposed changes

## Problem summary

If there is no limit for max young or old gen size, `jvm_xxx_size_bytes{type=max, ...}` should be max heap size, otherwise the graph would be a little wired.

![image](https://user-images.githubusercontent.com/5926365/203791081-3f9e801a-6d9b-4879-8984-103169861fd2.png)

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

