### PR TITLE
[chore](github) Optimize BE UT workflows

### DIFF
--- a/.github/workflows/be-ut-clang.yml
+++ b/.github/workflows/be-ut-clang.yml
@@ -37,14 +37,8 @@ jobs:
           persist-credentials: false
           submodules: recursive
 
-      - name: Ccache ${{ github.ref }}
-        uses: ./.github/actions/ccache-action
-        with:
-          key: BE-UT-Clang
-          max-size: "2G"
-          restore-keys: BE-UT-Clang-
-
-      - name: Paths filter
+      - name: Paths Filter
+        if: ${{ github.event_name != 'schedule' }}
         uses: ./.github/actions/paths-filter
         id: filter
         with:
@@ -54,8 +48,16 @@ jobs:
               - 'gensrc/proto/**'
               - 'gensrc/thrift/**'
 
+      - name: Ccache ${{ github.ref }}
+        if: ${{ github.event_name == 'schedule' || steps.filter.outputs.be_changes == 'true' }}
+        uses: ./.github/actions/ccache-action
+        with:
+          key: BE-UT-Clang
+          max-size: "2G"
+          restore-keys: BE-UT-Clang-
+
       - name: Run UT ${{ github.ref }}
-        if: ${{ steps.filter.outputs.be_changes == 'true' }}
+        if: ${{ github.event_name == 'schedule' || steps.filter.outputs.be_changes == 'true' }}
         run: |
           export DEFAULT_DIR='/opt/doris'
 
@@ -81,6 +83,3 @@ jobs:
           export PATH="${DEFAULT_DIR}/ldb-toolchain/bin/:$(pwd)/thirdparty/installed/bin/:${PATH}"
           DORIS_TOOLCHAIN=clang ./run-be-ut.sh -j "$(nproc)" --run --clean
 
-      - name: Skip UT ${{ github.ref }}
-        if: ${{ steps.filter.outputs.be_changes == 'false' }}
-        run: echo 'No need to run.'

--- a/.github/workflows/be-ut-mac.yml
+++ b/.github/workflows/be-ut-mac.yml
@@ -37,14 +37,8 @@ jobs:
           persist-credentials: false
           submodules: recursive
 
-      - name: Ccache ${{ github.ref }}
-        uses: ./.github/actions/ccache-action
-        with:
-          key: BE-UT-macOS
-          max-size: "2G"
-          restore-keys: BE-UT-macOS-
-
-      - name: Paths filter
+      - name: Paths Filter
+        if: ${{ github.event_name != 'schedule' }}
         uses: ./.github/actions/paths-filter
         id: filter
         with:
@@ -54,8 +48,16 @@ jobs:
               - 'gensrc/proto/**'
               - 'gensrc/thrift/**'
 
+      - name: Ccache ${{ github.ref }}
+        if: ${{ github.event_name == 'schedule' || steps.filter.outputs.be_changes == 'true' }}
+        uses: ./.github/actions/ccache-action
+        with:
+          key: BE-UT-macOS
+          max-size: "2G"
+          restore-keys: BE-UT-macOS-
+
       - name: Run UT ${{ github.ref }}
-        if: ${{ steps.filter.outputs.be_changes == 'true' }}
+        if: ${{ github.event_name == 'schedule' || steps.filter.outputs.be_changes == 'true' }}
         run: |
           cellars=(
             'automake'
@@ -88,6 +90,3 @@ jobs:
 
           ./run-be-ut.sh --run -j "$(nproc)" --clean
 
-      - name: Skip UT ${{ github.ref }}
-        if: ${{ steps.filter.outputs.be_changes == 'false' }}
-        run: echo 'No need to run.'


### PR DESCRIPTION
# Proposed changes

~~Issue Number: close #xxx~~

## Problem summary

In #14533 , we run `BE UT` workflows periodically to share the cache with brand new pull requests. However, we don't need to save the cache when the unit tests doesn't run, otherwise it may occupy huge cache space and some useful caches will be evicted by GitHub.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

