### PR TITLE
[opt](nereids) optimize CostAndEnforceJob

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/cascades/CostAndEnforcerJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/cascades/CostAndEnforcerJob.java
@@ -144,6 +144,7 @@ public class CostAndEnforcerJob extends Job implements Cloneable {
                     if (prevChildIndex >= curChildIndex) {
                         // if run here, means that the child group will not generate the lowest cost plan map currently.
                         // and lowest cost children's size will not be equals to arity().
+                        groupExpression.setCost(Double.POSITIVE_INFINITY);
                         break;
                     }
 
@@ -166,7 +167,8 @@ public class CostAndEnforcerJob extends Job implements Cloneable {
 
                 curTotalCost += lowestCostExpr.getLowestCostTable().get(requestChildProperty).first;
                 if (curTotalCost > context.getCostUpperBound()) {
-                    curTotalCost = Double.POSITIVE_INFINITY;
+                    groupExpression.setCost(Double.POSITIVE_INFINITY);
+                    break;
                 }
                 // the request child properties will be covered by the output properties
                 // that corresponding to the request properties. so if we run a costAndEnforceJob of the same


### PR DESCRIPTION
# Proposed changes
1. set POSITIVE_INFINITE cost for groupExpression to avoid re-enter CostAndEnforceJob again. This is partly done by PR [14442](https://github.com/apache/doris/pull/14442)
2. stop job immediately to reduce stats derive process.

@morrySnow @jackwener PTAL
Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
3. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
5. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
6. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

