### PR TITLE
[feature](Nereids): Add cache to avoid repeatly calculation in DPhyp

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/joinorder/hypergraph/Edge.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/joinorder/hypergraph/Edge.java
@@ -36,6 +36,7 @@ public class Edge {
     // left and right may not overlap, and both must have at least one bit set.
     private BitSet left = Bitmap.newBitmap();
     private BitSet right = Bitmap.newBitmap();
+    private BitSet referenceNodes = Bitmap.newBitmap();
 
     /**
      * Create simple edge.
@@ -56,21 +57,25 @@ public class Edge {
 
     public void addLeftNode(BitSet left) {
         Bitmap.or(this.left, left);
+        Bitmap.or(referenceNodes, left);
     }
 
     public void addLeftNodes(BitSet... bitSets) {
         for (BitSet bitSet : bitSets) {
             Bitmap.or(this.left, bitSet);
+            Bitmap.or(referenceNodes, bitSet);
         }
     }
 
     public void addRightNode(BitSet right) {
         Bitmap.or(this.right, right);
+        Bitmap.or(referenceNodes, right);
     }
 
     public void addRightNodes(BitSet... bitSets) {
         for (BitSet bitSet : bitSets) {
             Bitmap.or(this.right, bitSet);
+            Bitmap.or(referenceNodes, bitSet);
         }
     }
 
@@ -79,6 +84,7 @@ public class Edge {
     }
 
     public void setLeft(BitSet left) {
+        referenceNodes.clear();
         this.left = left;
     }
 
@@ -87,18 +93,21 @@ public class Edge {
     }
 
     public void setRight(BitSet right) {
+        referenceNodes.clear();
         this.right = right;
     }
 
     public boolean isSub(Edge edge) {
         // When this join reference nodes is a subset of other join, then this join must appear before that join
-        BitSet bitSet = getReferenceNodes();
         BitSet otherBitset = edge.getReferenceNodes();
-        return Bitmap.isSubset(bitSet, otherBitset);
+        return Bitmap.isSubset(getReferenceNodes(), otherBitset);
     }
 
     public BitSet getReferenceNodes() {
-        return Bitmap.newBitmapUnion(this.left, this.right);
+        if (referenceNodes.cardinality() == 0) {
+            referenceNodes = Bitmap.newBitmapUnion(left, right);
+        }
+        return referenceNodes;
     }
 
     public Edge reverse(int index) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/joinorder/hypergraph/GraphSimplifier.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/joinorder/hypergraph/GraphSimplifier.java
@@ -74,7 +74,7 @@ public class GraphSimplifier {
             simplifications.add(bestSimplification);
         }
         for (Node node : graph.getNodes()) {
-            cachePlan.put(node.getBitSet(), node.getPlan());
+            cachePlan.put(node.getNodeMap(), node.getPlan());
         }
         circleDetector = new CircleDetector(edgeSize);
     }
@@ -208,12 +208,12 @@ public class GraphSimplifier {
         SimplificationStep bestStep = bestSimplification.getStep();
         while (bestSimplification.bestNeighbor == -1 || !circleDetector.tryAddDirectedEdge(bestStep.beforeIndex,
                 bestStep.afterIndex)) {
+            processNeighbors(bestStep.afterIndex, 0, edgeSize);
             if (priorityQueue.isEmpty()) {
                 return null;
             }
             bestSimplification = priorityQueue.poll();
             bestSimplification.isInQueue = false;
-            processNeighbors(bestStep.afterIndex, 0, edgeSize);
             bestStep = bestSimplification.getStep();
         }
         return bestStep;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/joinorder/hypergraph/HyperGraph.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/joinorder/hypergraph/HyperGraph.java
@@ -61,12 +61,6 @@ public class HyperGraph {
         return nodes.get(index);
     }
 
-    public void splitEdgesForNodes() {
-        for (Node node : nodes) {
-            node.splitEdges();
-        }
-    }
-
     public void addNode(Group group) {
         Preconditions.checkArgument(!group.isJoinGroup());
         // TODO: replace plan with group expression or others

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/joinorder/hypergraph/Node.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/joinorder/hypergraph/Node.java
@@ -79,40 +79,12 @@ public class Node {
         return index;
     }
 
-    public BitSet getBitSet() {
+    public BitSet getNodeMap() {
         return Bitmap.newBitmap(index);
     }
 
     public Plan getPlan() {
         return group.getLogicalExpression().getPlan();
-    }
-
-    //    public void setPlan(Plan plan) {
-    //        this.plan = plan;
-    //    }
-
-    public List<Edge> getComplexEdges() {
-        return complexEdges;
-    }
-
-    public void setComplexEdges(List<Edge> complexEdges) {
-        this.complexEdges = complexEdges;
-    }
-
-    public List<Edge> getSimpleEdges() {
-        return simpleEdges;
-    }
-
-    public void setSimpleEdges(List<Edge> simpleEdges) {
-        this.simpleEdges = simpleEdges;
-    }
-
-    public BitSet getSimpleNeighborhood() {
-        return simpleNeighborhood;
-    }
-
-    public void setSimpleNeighborhood(BitSet simpleNeighborhood) {
-        this.simpleNeighborhood = simpleNeighborhood;
     }
 
     /**
@@ -131,31 +103,6 @@ public class Node {
      */
     public void removeEdge(Edge edge) {
         edges.remove(edge);
-    }
-
-    /**
-     * This function split edge into complex edges and simple edges
-     * We do it after constructing HyperGraph because the edge may be modified
-     * by graph simplifier.
-     */
-    public void splitEdges() {
-        simpleEdges.clear();
-        Bitmap.clear(simpleNeighborhood);
-        complexEdges.clear();
-        Bitmap.clear(complexNeighborhood);
-        for (Edge edge : edges) {
-            if (edge.isSimple()) {
-                simpleEdges.add(edge);
-                Bitmap.or(simpleNeighborhood, edge.getLeft());
-                Bitmap.or(simpleNeighborhood, edge.getRight());
-            } else {
-                complexEdges.add(edge);
-                Bitmap.or(complexNeighborhood, edge.getLeft());
-                Bitmap.or(complexNeighborhood, edge.getRight());
-            }
-        }
-        Bitmap.unset(simpleNeighborhood, index);
-        Bitmap.unset(complexNeighborhood, index);
     }
 
     public String getName() {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/joinorder/hypergraph/bitmap/Bitmap.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/joinorder/hypergraph/bitmap/Bitmap.java
@@ -26,8 +26,8 @@ public class Bitmap {
     public static boolean isSubset(BitSet bitSet1, BitSet bitSet2) {
         BitSet bitSet = new BitSet();
         bitSet.or(bitSet1);
-        bitSet.or(bitSet2);
-        return bitSet.equals(bitSet2);
+        bitSet.andNot(bitSet2);
+        return bitSet.cardinality() == 0;
     }
 
     public static BitSet newBitmap(int... values) {
@@ -62,6 +62,14 @@ public class Bitmap {
         u.or(bitSet1);
         u.andNot(bitSet2);
         return u;
+    }
+
+    //return bitset1 ∩ bitset2
+    public static BitSet newBitmapIntersect(BitSet bitSet1, BitSet bitSet2) {
+        BitSet intersect = newBitmap();
+        intersect.or(bitSet1);
+        intersect.and(bitSet2);
+        return intersect;
     }
 
     public static BitSet newBitmapBetween(int start, int end) {
@@ -121,5 +129,6 @@ public class Bitmap {
     public static SubsetIterator getSubsetIterator(BitSet bitSet) {
         return new SubsetIterator(bitSet);
     }
+
 }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/joinorder/hypergraph/receiver/AbstractReceiver.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/joinorder/hypergraph/receiver/AbstractReceiver.java
@@ -21,12 +21,13 @@ import org.apache.doris.nereids.jobs.joinorder.hypergraph.Edge;
 import org.apache.doris.nereids.memo.Group;
 
 import java.util.BitSet;
+import java.util.List;
 
 /**
  * A interface of receiver
  */
 public interface AbstractReceiver {
-    public boolean emitCsgCmp(BitSet csg, BitSet cmp, Edge edge);
+    public boolean emitCsgCmp(BitSet csg, BitSet cmp, List<Edge> edges);
 
     public void addGroup(BitSet bitSet, Group group);
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/joinorder/hypergraph/receiver/Counter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/joinorder/hypergraph/receiver/Counter.java
@@ -24,6 +24,7 @@ import com.google.common.base.Preconditions;
 
 import java.util.BitSet;
 import java.util.HashMap;
+import java.util.List;
 
 /**
  * The Receiver is used for cached the plan that has been emitted and build the new plan
@@ -47,10 +48,10 @@ public class Counter implements AbstractReceiver {
      *
      * @param left the bitmap of left child tree
      * @param right the bitmap of the right child tree
-     * @param edge the join operator
+     * @param edges the join operator
      * @return the left and the right can be connected by the edge
      */
-    public boolean emitCsgCmp(BitSet left, BitSet right, Edge edge) {
+    public boolean emitCsgCmp(BitSet left, BitSet right, List<Edge> edges) {
         Preconditions.checkArgument(counter.containsKey(left));
         Preconditions.checkArgument(counter.containsKey(right));
         emitCount += 1;

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/jobs/joinorder/hypergraph/GraphSimplifierTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/jobs/joinorder/hypergraph/GraphSimplifierTest.java
@@ -165,9 +165,35 @@ public class GraphSimplifierTest {
 
     @Disabled
     @Test
+    void testComplexQuery() {
+        HyperGraph hyperGraph = new HyperGraphBuilder()
+                .init(6, 2, 1, 3, 5, 4)
+                .addEdge(JoinType.INNER_JOIN, 3, 4)
+                .addEdge(JoinType.INNER_JOIN, 3, 5)
+                .addEdge(JoinType.INNER_JOIN, 2, 3)
+                .addEdge(JoinType.INNER_JOIN, 2, 5)
+                .addEdge(JoinType.INNER_JOIN, 2, 4)
+                .addEdge(JoinType.INNER_JOIN, 1, 5)
+                .addEdge(JoinType.INNER_JOIN, 1, 4)
+                .addEdge(JoinType.INNER_JOIN, 0, 2)
+                .build();
+        GraphSimplifier graphSimplifier = new GraphSimplifier(hyperGraph);
+        graphSimplifier.initFirstStep();
+        while (graphSimplifier.applySimplificationStep()) {
+        }
+        Counter counter = new Counter();
+        SubgraphEnumerator subgraphEnumerator = new SubgraphEnumerator(counter, hyperGraph);
+        subgraphEnumerator.enumerate();
+        for (int count : counter.getAllCount().values()) {
+            Assertions.assertTrue(count < 1000);
+        }
+        Assertions.assertTrue(graphSimplifier.isTotalOrder());
+    }
+
+    @Test
     void testRandomQuery() {
-        for (int i = 0; i < 100; i++) {
-            HyperGraph hyperGraph = new HyperGraphBuilder().randomBuildWith(20, 40);
+        for (int i = 0; i < 10; i++) {
+            HyperGraph hyperGraph = new HyperGraphBuilder().randomBuildWith(6, 6);
             GraphSimplifier graphSimplifier = new GraphSimplifier(hyperGraph);
             graphSimplifier.initFirstStep();
             while (graphSimplifier.applySimplificationStep()) {
@@ -175,9 +201,6 @@ public class GraphSimplifierTest {
             Counter counter = new Counter();
             SubgraphEnumerator subgraphEnumerator = new SubgraphEnumerator(counter, hyperGraph);
             subgraphEnumerator.enumerate();
-            for (int count : counter.getAllCount().values()) {
-                Assertions.assertTrue(count < 1000);
-            }
             Assertions.assertTrue(graphSimplifier.isTotalOrder());
         }
     }
@@ -195,6 +218,5 @@ public class GraphSimplifierTest {
             subgraphEnumerator.enumerate();
             Assertions.assertTrue(counter.getLimit() >= 0);
         }
-
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/jobs/joinorder/hypergraph/SubgraphEnumeratorTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/jobs/joinorder/hypergraph/SubgraphEnumeratorTest.java
@@ -35,9 +35,9 @@ public class SubgraphEnumeratorTest {
     void testStarQuery() {
         //      t2
         //      |
-        //t3-- t1 -- t4
+        //t3-- t0 -- t4
         //      |
-        //     t5
+        //     t1
         HyperGraph hyperGraph = new HyperGraphBuilder()
                 .init(10, 20, 30, 40, 50)
                 .addEdge(JoinType.INNER_JOIN, 0, 1)
@@ -96,8 +96,8 @@ public class SubgraphEnumeratorTest {
 
     @Test
     void testTime() {
-        int tableNum = 10;
-        int edgeNum = 40;
+        int tableNum = 20;
+        int edgeNum = 21;
         HyperGraph hyperGraph = new HyperGraphBuilder().randomBuildWith(tableNum, edgeNum);
 
         Counter counter = new Counter();


### PR DESCRIPTION
Signed-off-by: xiejiann <jianxie0@gmail.com>

# Proposed changes

To calculated edges efficiently, we can only process these newly added node .
Issue Number: close #xxx

## Problem summary

In DPhyp, we need to calculation neighborhood and edges that connected csg and cmp. 

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [x] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

