### PR TITLE
[improvement](cache) close compaction&schema_change&checksum index meta cache

### DIFF
--- a/be/src/olap/reader.h
+++ b/be/src/olap/reader.h
@@ -62,11 +62,8 @@ public:
         bool direct_mode = false;
         bool aggregation = false;
         bool need_agg_finalize = true;
-        // 1. when read column data page:
-        //     for compaction, schema_change, check_sum: we don't use page cache
-        //     for query and config::disable_storage_page_cache is false, we use page cache
-        // 2. when read column index page
-        //     if config::disable_storage_page_cache is false, we use page cache
+        // for compaction, schema_change, check_sum: we don't use page cache
+        // for query and config::disable_storage_page_cache is false, we use page cache
         bool use_page_cache = false;
         Version version = Version(-1, 0);
 

--- a/be/src/olap/rowset/segment_v2/column_reader.cpp
+++ b/be/src/olap/rowset/segment_v2/column_reader.cpp
@@ -616,6 +616,9 @@ FileColumnIterator::FileColumnIterator(ColumnReader* reader) : _reader(reader) {
 
 Status FileColumnIterator::init(const ColumnIteratorOptions& opts) {
     _opts = opts;
+    if (!_opts.use_page_cache) {
+        _reader->disable_index_meta_cache();
+    }
     RETURN_IF_ERROR(get_block_compression_codec(_reader->get_compression(), &_compress_codec));
     if (config::enable_low_cardinality_optimize &&
         _reader->encoding_info()->encoding() == DICT_ENCODING) {

--- a/be/src/olap/rowset/segment_v2/column_reader.h
+++ b/be/src/olap/rowset/segment_v2/column_reader.h
@@ -154,6 +154,8 @@ public:
 
     DictEncodingType get_dict_encoding_type() { return _dict_encoding_type; }
 
+    void disable_index_meta_cache() { _index_meta_use_page_cache = false; }
+
 private:
     ColumnReader(const ColumnReaderOptions& opts, const ColumnMetaPB& meta, uint64_t num_rows,
                  io::FileReaderSPtr file_reader);
@@ -163,7 +165,7 @@ private:
     // May be called multiple times, subsequent calls will no op.
     Status _ensure_index_loaded() {
         return _load_index_once.call([this] {
-            bool use_page_cache = !config::disable_storage_page_cache;
+            bool use_page_cache = !config::disable_storage_page_cache && _index_meta_use_page_cache;
             RETURN_IF_ERROR(_load_zone_map_index(use_page_cache, _opts.kept_in_memory));
             RETURN_IF_ERROR(_load_ordinal_index(use_page_cache, _opts.kept_in_memory));
             RETURN_IF_ERROR(_load_bitmap_index(use_page_cache, _opts.kept_in_memory));
@@ -205,6 +207,7 @@ private:
             nullptr; // initialized in init(), used for create PageDecoder
 
     // meta for various column indexes (null if the index is absent)
+    bool _index_meta_use_page_cache = true;
     const ZoneMapIndexPB* _zone_map_index_meta = nullptr;
     const OrdinalIndexPB* _ordinal_index_meta = nullptr;
     const BitmapIndexPB* _bitmap_index_meta = nullptr;


### PR DESCRIPTION
In compaction、schema_change and checksum, rowsets index meta will be loaded into page cache, this will cost a lot memory and seems to be useless, rowsets read in compaction and schema_change are going to be eliminated later. 

# Proposed changes

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

