### PR TITLE
[Enhancement](predicate) move create column predicate to create_predicate_function

### DIFF
--- a/be/src/exprs/create_predicate_function.h
+++ b/be/src/exprs/create_predicate_function.h
@@ -101,6 +101,9 @@ typename Traits::BasePtr create_predicate_function(PrimitiveType type) {
     using Creator = PredicateFunctionCreator<Traits>;
 
     switch (type) {
+    case TYPE_BOOLEAN: {
+        return Creator::template create<TYPE_BOOLEAN>();
+    }
 #define M(NAME)                                  \
     case NAME: {                                 \
         return Creator::template create<NAME>(); \

--- a/be/src/exprs/create_predicate_function.h
+++ b/be/src/exprs/create_predicate_function.h
@@ -104,6 +104,9 @@ typename Traits::BasePtr create_predicate_function(PrimitiveType type) {
     case TYPE_BOOLEAN: {
         return Creator::template create<TYPE_BOOLEAN>();
     }
+    case TYPE_DECIMALV2: {
+        return Creator::template create<TYPE_DECIMALV2>();
+    }
 #define M(NAME)                                  \
     case NAME: {                                 \
         return Creator::template create<NAME>(); \

--- a/be/src/exprs/create_predicate_function.h
+++ b/be/src/exprs/create_predicate_function.h
@@ -20,8 +20,11 @@
 #include "exprs/bloomfilter_predicate.h"
 #include "exprs/hybrid_set.h"
 #include "exprs/minmax_predicate.h"
+#include "olap/bitmap_filter_predicate.h"
+#include "olap/bloom_filter_predicate.h"
+#include "olap/column_predicate.h"
+#include "olap/in_list_predicate.h"
 #include "runtime/define_primitive_type.h"
-#include "vec/exprs/vbitmap_predicate.h"
 
 namespace doris {
 
@@ -74,54 +77,36 @@ public:
     }
 };
 
+#define APPLY_FOR_PRIMTYPE(M) \
+    M(TYPE_TINYINT)           \
+    M(TYPE_SMALLINT)          \
+    M(TYPE_INT)               \
+    M(TYPE_BIGINT)            \
+    M(TYPE_LARGEINT)          \
+    M(TYPE_FLOAT)             \
+    M(TYPE_DOUBLE)            \
+    M(TYPE_DATE)              \
+    M(TYPE_DATETIME)          \
+    M(TYPE_DATEV2)            \
+    M(TYPE_DATETIMEV2)        \
+    M(TYPE_CHAR)              \
+    M(TYPE_VARCHAR)           \
+    M(TYPE_STRING)            \
+    M(TYPE_DECIMAL32)         \
+    M(TYPE_DECIMAL64)         \
+    M(TYPE_DECIMAL128I)
+
 template <class Traits>
 typename Traits::BasePtr create_predicate_function(PrimitiveType type) {
     using Creator = PredicateFunctionCreator<Traits>;
 
     switch (type) {
-    case TYPE_BOOLEAN:
-        return Creator::template create<TYPE_BOOLEAN>();
-    case TYPE_TINYINT:
-        return Creator::template create<TYPE_TINYINT>();
-    case TYPE_SMALLINT:
-        return Creator::template create<TYPE_SMALLINT>();
-    case TYPE_INT:
-        return Creator::template create<TYPE_INT>();
-    case TYPE_BIGINT:
-        return Creator::template create<TYPE_BIGINT>();
-    case TYPE_LARGEINT:
-        return Creator::template create<TYPE_LARGEINT>();
-
-    case TYPE_FLOAT:
-        return Creator::template create<TYPE_FLOAT>();
-    case TYPE_DOUBLE:
-        return Creator::template create<TYPE_DOUBLE>();
-
-    case TYPE_DECIMALV2:
-        return Creator::template create<TYPE_DECIMALV2>();
-
-    case TYPE_DATE:
-        return Creator::template create<TYPE_DATE>();
-    case TYPE_DATETIME:
-        return Creator::template create<TYPE_DATETIME>();
-    case TYPE_DATEV2:
-        return Creator::template create<TYPE_DATEV2>();
-    case TYPE_DATETIMEV2:
-        return Creator::template create<TYPE_DATETIMEV2>();
-
-    case TYPE_CHAR:
-        return Creator::template create<TYPE_CHAR>();
-    case TYPE_VARCHAR:
-        return Creator::template create<TYPE_VARCHAR>();
-    case TYPE_STRING:
-        return Creator::template create<TYPE_STRING>();
-    case TYPE_DECIMAL32:
-        return Creator::template create<TYPE_DECIMAL32>();
-    case TYPE_DECIMAL64:
-        return Creator::template create<TYPE_DECIMAL64>();
-    case TYPE_DECIMAL128I:
-        return Creator::template create<TYPE_DECIMAL128I>();
-
+#define M(NAME)                                  \
+    case NAME: {                                 \
+        return Creator::template create<NAME>(); \
+    }
+        APPLY_FOR_PRIMTYPE(M)
+#undef M
     default:
         DCHECK(false) << "Invalid type.";
     }
@@ -167,6 +152,63 @@ inline auto create_bloom_filter(PrimitiveType type) {
 
 inline auto create_bitmap_filter(PrimitiveType type) {
     return create_bitmap_predicate_function<BitmapFilterTraits>(type);
+}
+
+template <PrimitiveType PT>
+inline ColumnPredicate* create_olap_column_predicate(
+        uint32_t column_id, const std::shared_ptr<BloomFilterFuncBase>& filter, int be_exec_version,
+        const TabletColumn*) {
+    std::shared_ptr<BloomFilterFuncBase> filter_olap;
+    filter_olap.reset(create_bloom_filter(PT));
+    filter_olap->light_copy(filter.get());
+    return new BloomFilterColumnPredicate<PT>(column_id, filter, be_exec_version);
+}
+
+template <PrimitiveType PT>
+inline ColumnPredicate* create_olap_column_predicate(
+        uint32_t column_id, const std::shared_ptr<BitmapFilterFuncBase>& filter,
+        int be_exec_version, const TabletColumn*) {
+    if constexpr (PT == TYPE_TINYINT || PT == TYPE_SMALLINT || PT == TYPE_INT ||
+                  PT == TYPE_BIGINT) {
+        std::shared_ptr<BitmapFilterFuncBase> filter_olap;
+        filter_olap.reset(create_bitmap_filter(PT));
+        filter_olap->light_copy(filter.get());
+        return new BitmapFilterColumnPredicate<PT>(column_id, filter, be_exec_version);
+    } else {
+        return nullptr;
+    }
+}
+
+template <PrimitiveType PT>
+inline ColumnPredicate* create_olap_column_predicate(uint32_t column_id,
+                                                     const std::shared_ptr<HybridSetBase>& filter,
+                                                     int, const TabletColumn* column = nullptr) {
+    return new InListPredicateBase<PT, PredicateType::IN_LIST>(column_id, filter, column->length());
+}
+
+template <typename T>
+inline ColumnPredicate* create_column_predicate(uint32_t column_id,
+                                                const std::shared_ptr<T>& filter, FieldType type,
+                                                int be_exec_version,
+                                                const TabletColumn* column = nullptr) {
+    switch (type) {
+#define M(NAME)                                                                                \
+    case OLAP_FIELD_##NAME: {                                                                  \
+        return create_olap_column_predicate<NAME>(column_id, filter, be_exec_version, column); \
+    }
+        APPLY_FOR_PRIMTYPE(M)
+#undef M
+    case OLAP_FIELD_TYPE_DECIMAL: {
+        return create_olap_column_predicate<TYPE_DECIMALV2>(column_id, filter, be_exec_version,
+                                                            column);
+    }
+    case OLAP_FIELD_TYPE_BOOL: {
+        return create_olap_column_predicate<TYPE_BOOLEAN>(column_id, filter, be_exec_version,
+                                                          column);
+    }
+    default:
+        return nullptr;
+    }
 }
 
 } // namespace doris

--- a/be/src/exprs/runtime_filter.cpp
+++ b/be/src/exprs/runtime_filter.cpp
@@ -39,6 +39,7 @@
 #include "util/string_parser.hpp"
 #include "vec/columns/column.h"
 #include "vec/columns/column_complex.h"
+#include "vec/exprs/vbitmap_predicate.h"
 #include "vec/exprs/vbloom_predicate.h"
 #include "vec/exprs/vdirect_in_predicate.h"
 #include "vec/exprs/vexpr.h"
@@ -1930,11 +1931,11 @@ Status RuntimePredicateWrapper::get_push_vexprs(std::vector<doris::vectorized::V
         node.__isset.vector_opcode = true;
         node.__set_vector_opcode(to_in_opcode(_column_return_type));
         node.__set_is_nullable(false);
-        auto bitmap_pred = _pool->add(new doris::vectorized::VBitmapPredicate(node));
+        auto bitmap_pred = _pool->add(new vectorized::VBitmapPredicate(node));
         bitmap_pred->set_filter(_context._bitmap_filter_func);
         auto cloned_vexpr = vprob_expr->root()->clone(_pool);
         bitmap_pred->add_child(cloned_vexpr);
-        auto wrapper = _pool->add(new doris::vectorized::VRuntimeFilterWrapper(node, bitmap_pred));
+        auto wrapper = _pool->add(new vectorized::VRuntimeFilterWrapper(node, bitmap_pred));
         container->push_back(wrapper);
         break;
     }

--- a/be/src/olap/reader.cpp
+++ b/be/src/olap/reader.cpp
@@ -20,8 +20,8 @@
 #include <parallel_hashmap/phmap.h>
 
 #include "common/status.h"
+#include "exprs/create_predicate_function.h"
 #include "exprs/hybrid_set.h"
-#include "olap/bitmap_filter_predicate.h"
 #include "olap/like_column_predicate.h"
 #include "olap/olap_common.h"
 #include "olap/predicate_creator.h"


### PR DESCRIPTION
# Proposed changes

1. move create column predicate to create_predicate_function
2. use same macro to `create_column_predicate` and `create_predicate_function`

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
3. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
5. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
6. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

