### PR TITLE
[fix](memtracker) Fix thrift BackendService thread local is not initialized, memtracker init fail

### DIFF
--- a/be/src/runtime/fragment_mgr.cpp
+++ b/be/src/runtime/fragment_mgr.cpp
@@ -673,6 +673,10 @@ Status FragmentMgr::exec_plan_fragment(const TExecPlanFragmentParams& params, Fi
             fragments_ctx->query_mem_tracker = std::make_shared<MemTrackerLimiter>(
                     MemTrackerLimiter::Type::LOAD,
                     fmt::format("Load#Id={}", print_id(fragments_ctx->query_id)), bytes_limit);
+        } else { // EXTERNAL
+            fragments_ctx->query_mem_tracker = std::make_shared<MemTrackerLimiter>(
+                    MemTrackerLimiter::Type::LOAD,
+                    fmt::format("External#Id={}", print_id(fragments_ctx->query_id)), bytes_limit);
         }
         if (params.query_options.__isset.is_report_success &&
             params.query_options.is_report_success) {

--- a/be/src/runtime/memory/mem_tracker.cpp
+++ b/be/src/runtime/memory/mem_tracker.cpp
@@ -61,8 +61,7 @@ MemTracker::MemTracker(const std::string& label, RuntimeProfile* profile, MemTra
     if (parent) {
         _parent_label = parent->label();
         _parent_group_num = parent->group_num();
-    } else {
-        DCHECK(thread_context()->thread_mem_tracker_mgr->limiter_mem_tracker() != nullptr);
+    } else if (thread_context_ptr.init) {
         _parent_label = thread_context()->thread_mem_tracker()->label();
         _parent_group_num = thread_context()->thread_mem_tracker()->group_num();
     }

--- a/be/src/runtime/memory/mem_tracker.h
+++ b/be/src/runtime/memory/mem_tracker.h
@@ -94,8 +94,8 @@ protected:
     std::shared_ptr<RuntimeProfile::HighWaterMarkCounter> _consumption; // in bytes
 
     // Tracker is located in group num in mem_tracker_pool
-    int64_t _parent_group_num;
-    std::string _parent_label;
+    int64_t _parent_group_num = 0;
+    std::string _parent_label = "-";
 
     // Iterator into mem_tracker_pool for this object. Stored to have O(1) remove.
     std::list<MemTracker*>::iterator _tracker_group_it;


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

```
#0  0x000056186e4c1f88 in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_assign(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) ()
#1  0x000056186878c3bc in assign (__str=..., this=0x7fa1fd46af78) at /var/local/ldb-toolchain/include/c++/11/bits/basic_string.h:1342
#2  operator= (__str=..., this=0x7fa1fd46af78) at /var/local/ldb-toolchain/include/c++/11/bits/basic_string.h:667
#3  doris::MemTracker::MemTracker (this=0x7fa1fd46af40, label=..., profile=<optimized out>, parent=<optimized out>) at /root/doris/doris/be/src/runtime/memory/mem_tracker.cpp:66
#4  0x0000561868642171 in construct<doris::MemTracker, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > (__p=0x7fa1fd46af40, this=<optimized out>) at /var/local/ldb-toolchain/include/c++/11/ext/new_allocator.h:154
#5  construct<doris::MemTracker, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > (__p=0x7fa1fd46af40, __a=...) at /var/local/ldb-toolchain/include/c++/11/bits/alloc_traits.h:512
#6  _Sp_counted_ptr_inplace<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > (__a=..., this=0x7fa1fd46af30) at /var/local/ldb-toolchain/include/c++/11/bits/shared_ptr_base.h:519
#7  __shared_count<doris::MemTracker, std::allocator<doris::MemTracker>, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > (__a=..., __p=<optimized out>, this=<optimized out>)
    at /var/local/ldb-toolchain/include/c++/11/bits/shared_ptr_base.h:650
#8  __shared_ptr<std::allocator<doris::MemTracker>, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > (__tag=..., this=<optimized out>) at /var/local/ldb-toolchain/include/c++/11/bits/shared_ptr_base.h:1337
#9  shared_ptr<std::allocator<doris::MemTracker>, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > (__tag=..., this=<optimized out>) at /var/local/ldb-toolchain/include/c++/11/bits/shared_ptr.h:409
#10 allocate_shared<doris::MemTracker, std::allocator<doris::MemTracker>, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > (__a=...) at /var/local/ldb-toolchain/include/c++/11/bits/shared_ptr.h:861
#11 make_shared<doris::MemTracker, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > () at /var/local/ldb-toolchain/include/c++/11/bits/shared_ptr.h:877
#12 init_scanner_mem_trackers (this=0x7fa1fd53f000) at /root/doris/doris/be/src/runtime/runtime_state.h:81
#13 doris::PlanFragmentExecutor::prepare (this=this@entry=0x7fa1fd52d070, request=..., fragments_ctx=0x7fa1fd589000) at /root/doris/doris/be/src/runtime/plan_fragment_executor.cpp:102
#14 0x000056186861b37d in doris::FragmentExecState::prepare (this=this@entry=0x7fa1fd52d000, params=...) at /root/doris/doris/be/src/runtime/fragment_mgr.cpp:229
#15 0x00005618686227f2 in doris::FragmentMgr::exec_plan_fragment(doris::TExecPlanFragmentParams const&, std::function<void (doris::PlanFragmentExecutor*)>) (this=this@entry=0x7fa2134d9000, params=..., cb=...) at /root/doris/doris/be/src/runtime/fragment_mgr.cpp:711
#16 0x0000561868625391 in doris::FragmentMgr::exec_plan_fragment (this=this@entry=0x7fa2134d9000, params=...) at /var/local/ldb-toolchain/include/c++/11/tuple:746
#17 0x0000561868628f32 in doris::FragmentMgr::exec_external_plan_fragment (this=0x7fa2134d9000, params=..., fragment_instance_id=..., selected_columns=selected_columns@entry=0x7fa0980da190) at /root/doris/doris/be/src/runtime/fragment_mgr.cpp:993
#18 0x000056186879d055 in doris::BackendService::open_scanner (this=0x7fa1facf84a0, result_=..., params=...) at /root/doris/doris/be/src/runtime/exec_env.h:147
#19 0x0000561868984fd1 in doris::BackendServiceProcessor::process_open_scanner (this=0x7fa1fc7934c0, seqid=1, iprot=<optimized out>, oprot=0x7fa1fce761c0, callContext=<optimized out>) at /var/local/ldb-toolchain/include/c++/11/bits/shared_ptr_base.h:1290
#20 0x0000561868987bc2 in doris::BackendServiceProcessor::dispatchCall (this=0x7fa1fc7934c0, iprot=0x7fa1fce76180, oprot=0x7fa1fce761c0, fname=..., seqid=1, callContext=0x7fa1fd47bbc0) at /root/doris/doris/gensrc/build/gen_cpp/BackendService.cpp:5002
```

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

