### PR TITLE
[enhancement](load) multipass segcompaction to reduce segments before publish (#14590)

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -854,6 +854,9 @@ CONF_Int32(segcompaction_threshold_segment_num, "10");
 // The segment whose row number above the threshold will be compacted during segcompaction
 CONF_Int32(segcompaction_small_threshold, "1048576");
 
+// Enable multi pass segcompaction, only effective when enable_segcompaction=true
+CONF_Bool(enable_segcompaction_before_publish, "false");
+
 CONF_String(jvm_max_heap_size, "1024M");
 
 // enable java udf and jdbc scannode

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -846,7 +846,7 @@ CONF_String(be_node_role, "mix");
 // Hide the be config page for webserver.
 CONF_Bool(hide_webserver_config_page, "false");
 
-CONF_Bool(enable_segcompaction, "false"); // currently only support vectorized storage
+CONF_Bool(enable_segcompaction_during_load, "false"); // currently only support vectorized storage
 
 // Trigger segcompaction if the num of segments in a rowset exceeds this threshold.
 CONF_Int32(segcompaction_threshold_segment_num, "10");
@@ -854,8 +854,8 @@ CONF_Int32(segcompaction_threshold_segment_num, "10");
 // The segment whose row number above the threshold will be compacted during segcompaction
 CONF_Int32(segcompaction_small_threshold, "1048576");
 
-// Enable multi pass segcompaction, only effective when enable_segcompaction=true
-CONF_Bool(enable_segcompaction_before_publish, "false");
+// Enable final-pass segcompaction before commit txn
+CONF_Bool(enable_segcompaction_after_load, "false");
 
 CONF_String(jvm_max_heap_size, "1024M");
 

--- a/be/src/olap/merger.cpp
+++ b/be/src/olap/merger.cpp
@@ -114,7 +114,7 @@ Status Merger::vmerge_rowsets(TabletSharedPtr tablet, ReaderType reader_type,
     }
 
     RETURN_NOT_OK_LOG(
-            dst_rowset_writer->flush(),
+            dst_rowset_writer->flush_by_merger(),
             "failed to flush rowset when merging rowsets of tablet " + tablet->full_name());
 
     return Status::OK();

--- a/be/src/olap/olap_server.cpp
+++ b/be/src/olap/olap_server.cpp
@@ -81,7 +81,7 @@ Status StorageEngine::start_bg_threads() {
             .set_min_threads(config::max_cumu_compaction_threads)
             .set_max_threads(config::max_cumu_compaction_threads)
             .build(&_cumu_compaction_thread_pool);
-    if (config::enable_segcompaction && config::enable_storage_vectorization) {
+    if (config::enable_segcompaction_during_load && config::enable_storage_vectorization) {
         ThreadPoolBuilder("SegCompactionTaskThreadPool")
                 .set_min_threads(config::seg_compaction_max_threads)
                 .set_max_threads(config::seg_compaction_max_threads)

--- a/be/src/olap/rowset/beta_rowset_writer.h
+++ b/be/src/olap/rowset/beta_rowset_writer.h
@@ -32,6 +32,12 @@ class FileWriter;
 using SegCompactionCandidates = std::vector<segment_v2::SegmentSharedPtr>;
 using SegCompactionCandidatesSharedPtr = std::shared_ptr<SegCompactionCandidates>;
 
+enum SegCompactionType {
+    NORMAL_SEGCOMPACTION_TYPE,
+    REMAIN_SEGCOMPACTION_TYPE,
+    FINAL_SEGCOMPACTION_TYPE,
+};
+
 class BetaRowsetWriter : public RowsetWriter {
 public:
     BetaRowsetWriter();
@@ -103,6 +109,7 @@ private:
     void _build_rowset_meta(std::shared_ptr<RowsetMeta> rowset_meta);
     Status _segcompaction_if_necessary();
     Status _segcompaction_ramaining_if_necessary();
+    Status _segcompaction_finalpass();
     vectorized::VMergeIterator* _get_segcompaction_reader(SegCompactionCandidatesSharedPtr segments,
                                                           std::shared_ptr<Schema> schema,
                                                           OlapReaderStatistics* stat,
@@ -115,7 +122,8 @@ private:
     Status _load_noncompacted_segments(std::vector<segment_v2::SegmentSharedPtr>* segments,
                                        size_t num);
     Status _find_longest_consecutive_small_segment(SegCompactionCandidatesSharedPtr segments);
-    Status _get_segcompaction_candidates(SegCompactionCandidatesSharedPtr& segments, bool is_last);
+    Status _get_segcompaction_candidates(SegCompactionCandidatesSharedPtr& segments,
+                                         doris::SegCompactionType type);
     Status _wait_flying_segcompaction();
     bool _is_segcompacted() { return (_num_segcompacted > 0) ? true : false; }
     void _clear_statistics_for_deleting_segments_unsafe(uint64_t begin, uint64_t end);

--- a/be/src/olap/rowset/rowset_writer.h
+++ b/be/src/olap/rowset/rowset_writer.h
@@ -62,6 +62,9 @@ public:
     virtual Status flush_columns() { return Status::Error<ErrorCode::NOT_IMPLEMENTED_ERROR>(); }
     virtual Status final_flush() { return Status::Error<ErrorCode::NOT_IMPLEMENTED_ERROR>(); }
 
+    // for compaction
+    virtual Status flush_by_merger() { return Status::Error<ErrorCode::NOT_IMPLEMENTED_ERROR>(); };
+
     virtual Status flush_single_memtable(MemTable* memtable, int64_t* flush_size) {
         return Status::Error<ErrorCode::NOT_IMPLEMENTED_ERROR>();
     }

--- a/docs/en/docs/admin-manual/config/be-config.md
+++ b/docs/en/docs/admin-manual/config/be-config.md
@@ -588,7 +588,7 @@ Metrics: {"filtered_rows":0,"input_row_num":3346807,"input_rowsets_count":42,"in
 * Description: The maximum of thread number in cumulative compaction thread pool.
 * Default value: 10
 
-#### `enable_segcompaction`
+#### `enable_segcompaction_during_load`
 
 * Type: bool
 * Description: Enable to use segment compaction during loading
@@ -605,6 +605,12 @@ Metrics: {"filtered_rows":0,"input_row_num":3346807,"input_rowsets_count":42,"in
 * Type: int32
 * Description: The segment whose row number above the threshold will be compacted during segcompaction
 * Default value: 1048576
+
+### `enable_segcompaction_after_load`
+
+* Type: bool
+* Description: Do final-pass segcompaction before committing txn to reduce segment number. Will increase load time but eliminate OLAP_ERR_TOO_MANY_SEGMENTS failure. Independent with enable_segcompaction_during_load
+* Default value: false
 
 #### `disable_compaction_trace_log`
 

--- a/docs/zh-CN/docs/admin-manual/config/be-config.md
+++ b/docs/zh-CN/docs/admin-manual/config/be-config.md
@@ -602,7 +602,7 @@ Metrics: {"filtered_rows":0,"input_row_num":3346807,"input_rowsets_count":42,"in
 * 描述：Cumulative Compaction线程池中线程数量的最大值。
 * 默认值：10
 
-#### `enable_segcompaction`
+#### `enable_segcompaction_during_load`
 
 * 类型：bool
 * 描述：在导入时进行 segment compaction 来减少 segment 数量
@@ -619,6 +619,12 @@ Metrics: {"filtered_rows":0,"input_row_num":3346807,"input_rowsets_count":42,"in
 * 类型：int32
 * 描述：当 segment 文件超过此大小时则会在 segment compaction 时被 compact，否则跳过
 * 默认值：1048576
+
+### `enable_segcompaction_after_load`
+
+* 类型：bool
+* 描述：导入过程中在数据对用户可见前进行最后一遍 segment 级别的 compaction 以减少 segment 文件数量。可用于避免 OLAP_ERR_TOO_MANY_SEGMENTS 失败，但会增加导入完成时间。可独立于 enable_segcompaction_during_load 进行开关。
+* 默认值：false
 
 #### `disable_compaction_trace_log`
 


### PR DESCRIPTION
# Proposed changes

Issue Number: close #14590

## Problem summary

Do final-pass segcompaction before committing txn to reduce segment number. Will increase load time but eliminate OLAP_ERR_TOO_MANY_SEGMENTS failure. 

Test results
```
test config:
  4* 8c32g  4be&3fe
  5*7.5G tpch data
  Parallel = 2
  set   write_buffer_size=20971520 (20M) to simulate memory-shortage-memtble-flushing to get more segments.
```
|Segment Num      |      |
| ------------------------- | ---- |
| Original                  | 3869 |
| After 1st SegCompaction   | 396  |
| After final SegCompaction | 7    |

| Memory Consumption              |      |
| ------------------------------- | ---- |
| SegCompaction Memory usage Peak | 4GB  |

| Time Cost                          |        |
| ---------------------------------- | ------ |
| Total load time                    | 1h15m  |
| Publish wait final compaction time | 5.7min |



## Checklist(Required)

1. Does it affect the original behavior: 
    - [X] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [X] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [X] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [X] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [X] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

