### PR TITLE
[pipeline](conf) set fragment_pool_thread_num_max=5000 in be.conf

### DIFF
--- a/regression-test/pipeline/p0/conf/be.conf
+++ b/regression-test/pipeline/p0/conf/be.conf
@@ -67,3 +67,4 @@ storage_root_path=/mnt/ssd01/cluster_storage/doris.SSD/P0/cluster1
 disable_auto_compaction=true
 tablet_map_shard_size=4
 priority_networks=172.19.0.0/24
+fragment_pool_thread_num_max=5000

--- a/regression-test/pipeline/p1/conf/be.conf
+++ b/regression-test/pipeline/p1/conf/be.conf
@@ -65,3 +65,4 @@ priority_networks=172.19.0.0/24
 
 disable_auto_compaction=true
 tablet_map_shard_size=4
+fragment_pool_thread_num_max=5000


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

set fragment_pool_thread_num_max=5000 in be.coonf
some tpc-ds queries may open lots of fragments, which often failed in fuzzy mode, turn up fragment_pool_thread_num_max to fix it.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

