### PR TITLE
[fix](JdbcExecutor) fix that JdbcExecutor did not load the class jar

### DIFF
--- a/be/src/vec/exec/vjdbc_connector.cpp
+++ b/be/src/vec/exec/vjdbc_connector.cpp
@@ -122,6 +122,7 @@ Status JdbcConnector::open(RuntimeState* state, bool read) {
         ctor_params.__set_jdbc_user(_conn_param.user);
         ctor_params.__set_jdbc_password(_conn_param.passwd);
         ctor_params.__set_jdbc_driver_class(_conn_param.driver_class);
+        ctor_params.__set_jdbc_driver_url(_conn_param.driver_path);
         ctor_params.__set_batch_size(read ? state->batch_size() : 0);
         ctor_params.__set_op(read ? TJdbcOperation::READ : TJdbcOperation::WRITE);
 

--- a/be/src/vec/exec/vjdbc_connector.cpp
+++ b/be/src/vec/exec/vjdbc_connector.cpp
@@ -122,7 +122,7 @@ Status JdbcConnector::open(RuntimeState* state, bool read) {
         ctor_params.__set_jdbc_user(_conn_param.user);
         ctor_params.__set_jdbc_password(_conn_param.passwd);
         ctor_params.__set_jdbc_driver_class(_conn_param.driver_class);
-        ctor_params.__set_jdbc_driver_url(local_location);
+        ctor_params.__set_driver_path(local_location);
         ctor_params.__set_batch_size(read ? state->batch_size() : 0);
         ctor_params.__set_op(read ? TJdbcOperation::READ : TJdbcOperation::WRITE);
 

--- a/be/src/vec/exec/vjdbc_connector.cpp
+++ b/be/src/vec/exec/vjdbc_connector.cpp
@@ -122,7 +122,7 @@ Status JdbcConnector::open(RuntimeState* state, bool read) {
         ctor_params.__set_jdbc_user(_conn_param.user);
         ctor_params.__set_jdbc_password(_conn_param.passwd);
         ctor_params.__set_jdbc_driver_class(_conn_param.driver_class);
-        ctor_params.__set_jdbc_driver_url(_conn_param.driver_path);
+        ctor_params.__set_jdbc_driver_url(local_location);
         ctor_params.__set_batch_size(read ? state->batch_size() : 0);
         ctor_params.__set_op(read ? TJdbcOperation::READ : TJdbcOperation::WRITE);
 

--- a/fe/java-udf/src/main/java/org/apache/doris/udf/JdbcExecutor.java
+++ b/fe/java-udf/src/main/java/org/apache/doris/udf/JdbcExecutor.java
@@ -63,8 +63,8 @@ public class JdbcExecutor {
         } catch (TException e) {
             throw new InternalException(e.getMessage());
         }
-        init(request.jdbc_driver_url, request.statement, request.batch_size, request.jdbc_driver_class, request.jdbc_url, request.jdbc_user,
-                request.jdbc_password, request.op);
+        init(request.jdbc_driver_url, request.statement, request.batch_size, request.jdbc_driver_class,
+                request.jdbc_url, request.jdbc_user, request.jdbc_password, request.op);
     }
 
     public void close() throws Exception {

--- a/fe/java-udf/src/main/java/org/apache/doris/udf/JdbcExecutor.java
+++ b/fe/java-udf/src/main/java/org/apache/doris/udf/JdbcExecutor.java
@@ -62,7 +62,7 @@ public class JdbcExecutor {
         } catch (TException e) {
             throw new InternalException(e.getMessage());
         }
-        init(request.jdbc_driver_url, request.statement, request.batch_size, request.jdbc_driver_class,
+        init(request.driver_path, request.statement, request.batch_size, request.jdbc_driver_class,
                 request.jdbc_url, request.jdbc_user, request.jdbc_password, request.op);
     }
 

--- a/fe/java-udf/src/main/java/org/apache/doris/udf/JdbcExecutor.java
+++ b/fe/java-udf/src/main/java/org/apache/doris/udf/JdbcExecutor.java
@@ -32,7 +32,6 @@ import org.apache.thrift.protocol.TBinaryProtocol;
 import java.net.MalformedURLException;
 import java.sql.Connection;
 import java.sql.Date;
-import java.sql.DriverManager;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
@@ -216,7 +215,6 @@ public class JdbcExecutor {
 
             dataSource = new HikariDataSource(config);
             conn = dataSource.getConnection();
-            conn = DriverManager.getConnection(jdbcUrl, jdbcUser, jdbcPassword);
             if (op == TJdbcOperation.READ) {
                 Preconditions.checkArgument(sql != null);
                 stmt = conn.prepareStatement(sql, ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY);

--- a/fe/java-udf/src/main/java/org/apache/doris/udf/UdfUtils.java
+++ b/fe/java-udf/src/main/java/org/apache/doris/udf/UdfUtils.java
@@ -32,6 +32,8 @@ import com.google.common.collect.Sets;
 import org.apache.log4j.Logger;
 import sun.misc.Unsafe;
 
+import java.io.File;
+import java.io.FileNotFoundException;
 import java.lang.reflect.Field;
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -212,8 +214,13 @@ public class UdfUtils {
         }
     }
 
-    public static URLClassLoader getClassLoader(String jarPath, ClassLoader parent) throws MalformedURLException {
-        URL url = new URL(jarPath);
+    public static URLClassLoader getClassLoader(String jarPath, ClassLoader parent)
+                                    throws MalformedURLException, FileNotFoundException {
+        File file = new File(jarPath);
+        if (!file.exists()) {
+            throw new FileNotFoundException("Can not find local file: " + jarPath);
+        }
+        URL url = file.toURI().toURL();
         return URLClassLoader.newInstance(new URL[] {url}, parent);
     }
 

--- a/fe/java-udf/src/main/java/org/apache/doris/udf/UdfUtils.java
+++ b/fe/java-udf/src/main/java/org/apache/doris/udf/UdfUtils.java
@@ -32,7 +32,6 @@ import com.google.common.collect.Sets;
 import org.apache.log4j.Logger;
 import sun.misc.Unsafe;
 
-import java.io.File;
 import java.lang.reflect.Field;
 import java.math.BigDecimal;
 import java.math.BigInteger;

--- a/fe/java-udf/src/main/java/org/apache/doris/udf/UdfUtils.java
+++ b/fe/java-udf/src/main/java/org/apache/doris/udf/UdfUtils.java
@@ -214,7 +214,7 @@ public class UdfUtils {
     }
 
     public static URLClassLoader getClassLoader(String jarPath, ClassLoader parent) throws MalformedURLException {
-        URL url = new File(jarPath).toURI().toURL();
+        URL url = new URL(jarPath);
         return URLClassLoader.newInstance(new URL[] {url}, parent);
     }
 

--- a/gensrc/thrift/Types.thrift
+++ b/gensrc/thrift/Types.thrift
@@ -368,18 +368,21 @@ struct TJdbcExecutorCtorParams {
   // "jdbc:mysql://127.0.0.1:3307/test";
   2: optional string jdbc_url
 
-  //root
+  // root
   3: optional string jdbc_user
 
-  //password
+  // password
   4: optional string jdbc_password
 
-  //"com.mysql.jdbc.Driver"
+  // "com.mysql.jdbc.Driver"
   5: optional string jdbc_driver_class
 
   6: optional i32 batch_size
 
   7: optional TJdbcOperation op
+
+  // "file:///home/user/mysql-connector-java-5.1.47.jar"
+  8: optional string jdbc_driver_url
 }
 
 struct TJavaUdfExecutorCtorParams {

--- a/gensrc/thrift/Types.thrift
+++ b/gensrc/thrift/Types.thrift
@@ -381,8 +381,8 @@ struct TJdbcExecutorCtorParams {
 
   7: optional TJdbcOperation op
 
-  // "file:///home/user/mysql-connector-java-5.1.47.jar"
-  8: optional string jdbc_driver_url
+  // "/home/user/mysql-connector-java-5.1.47.jar"
+  8: optional string driver_path
 }
 
 struct TJavaUdfExecutorCtorParams {


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx


## Problem summary

JdbcExecutor did not load jdbc driver jar, so add classloader to load jdbc jar.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

