### PR TITLE
[enhancemennt](be)optimize mem usage in join and set node

### DIFF
--- a/be/src/vec/common/columns_hashing_impl.h
+++ b/be/src/vec/common/columns_hashing_impl.h
@@ -191,6 +191,15 @@ public:
         data.template prefetch_by_hash<READ>(hash_value);
     }
 
+    ALWAYS_INLINE auto get_key_holder(size_t row, Arena& pool) {
+        return static_cast<Derived&>(*this).get_key_holder(row, pool);
+    }
+
+    template <typename Data, typename KeyHolder>
+    ALWAYS_INLINE EmplaceResult emplace_key(Data& data, size_t hash_value, KeyHolder key_holder) {
+        return emplaceImpl(key_holder, hash_value, data);
+    }
+
 protected:
     Cache cache;
 

--- a/be/src/vec/exec/join/process_hash_table_probe.h
+++ b/be/src/vec/exec/join/process_hash_table_probe.h
@@ -74,7 +74,8 @@ struct ProcessHashTableProbe {
     vectorized::HashJoinNode* _join_node;
     const int _batch_size;
     const std::vector<Block>& _build_blocks;
-    Arena _arena;
+    std::unique_ptr<Arena> _arena;
+    std::vector<StringRef> _probe_keys;
 
     std::vector<uint32_t> _items_counts;
     std::vector<int8_t> _build_block_offsets;

--- a/be/src/vec/exec/join/vhash_join_node.cpp
+++ b/be/src/vec/exec/join/vhash_join_node.cpp
@@ -115,6 +115,11 @@ struct ProcessHashTableBuild {
         auto& arena = *(_join_node->_arena);
         {
             SCOPED_TIMER(_build_side_compute_hash_timer);
+            if constexpr (IsSerializedHashTableContextTraits<KeyGetter>::value) {
+                hash_table_ctx.serialize_keys(_build_raw_ptrs, _rows);
+                key_getter.set_serialized_keys(hash_table_ctx.keys.data());
+            }
+
             for (size_t k = 0; k < _rows; ++k) {
                 if constexpr (ignore_null) {
                     if ((*null_map)[k]) {

--- a/be/src/vec/exec/vset_operation_node.cpp
+++ b/be/src/vec/exec/vset_operation_node.cpp
@@ -45,6 +45,11 @@ struct HashTableBuild {
 
         KeyGetter key_getter(_build_raw_ptrs, _operation_node->_build_key_sz, nullptr);
 
+        if constexpr (IsSerializedHashTableContextTraits<KeyGetter>::value) {
+            hash_table_ctx.serialize_keys(_build_raw_ptrs, _rows);
+            key_getter.set_serialized_keys(hash_table_ctx.keys.data());
+        }
+
         for (size_t k = 0; k < _rows; ++k) {
             auto emplace_result = key_getter.emplace_key(hash_table_ctx.hash_table, k,
                                                          *(_operation_node->_arena));

--- a/be/src/vec/exec/vset_operation_node.h
+++ b/be/src/vec/exec/vset_operation_node.h
@@ -172,7 +172,6 @@ struct HashTableProbe {
               _probe_index(operation_node->_probe_index),
               _num_rows_returned(operation_node->_num_rows_returned),
               _probe_raw_ptrs(operation_node->_probe_columns),
-              _arena(*(operation_node->_arena)),
               _rows_returned_counter(operation_node->_rows_returned_counter),
               _build_col_idx(operation_node->_build_col_idx),
               _mutable_cols(operation_node->_mutable_cols) {}
@@ -183,10 +182,28 @@ struct HashTableProbe {
 
         KeyGetter key_getter(_probe_raw_ptrs, _operation_node->_probe_key_sz, nullptr);
 
+        if (_probe_index == 0) {
+            _arena.reset(new Arena());
+            if constexpr (IsSerializedHashTableContextTraits<KeyGetter>::value) {
+                if (_probe_keys.size() < _probe_rows) {
+                    _probe_keys.resize(_probe_rows);
+                }
+                size_t keys_size = _probe_raw_ptrs.size();
+                for (size_t i = 0; i < _probe_rows; ++i) {
+                    _probe_keys[i] = serialize_keys_to_pool_contiguous(i, keys_size,
+                                                                       _probe_raw_ptrs, *_arena);
+                }
+            }
+        }
+
+        if constexpr (IsSerializedHashTableContextTraits<KeyGetter>::value) {
+            key_getter.set_serialized_keys(_probe_keys.data());
+        }
+
         if constexpr (std::is_same_v<typename HashTableContext::Mapped, RowRefListWithFlags>) {
             for (; _probe_index < _probe_rows;) {
                 auto find_result =
-                        key_getter.find_key(hash_table_ctx.hash_table, _probe_index, _arena);
+                        key_getter.find_key(hash_table_ctx.hash_table, _probe_index, *_arena);
                 if (find_result.is_found()) { //if found, marked visited
                     auto it = find_result.get_mapped().begin();
                     if (!(it->visited)) {
@@ -263,7 +280,8 @@ private:
     int& _probe_index;
     int64_t& _num_rows_returned;
     ColumnRawPtrs& _probe_raw_ptrs;
-    Arena& _arena;
+    std::unique_ptr<Arena> _arena;
+    std::vector<StringRef> _probe_keys;
     RuntimeProfile::Counter* _rows_returned_counter;
     std::unordered_map<int, int>& _build_col_idx;
     std::vector<MutableColumnPtr>& _mutable_cols;


### PR DESCRIPTION
# Proposed changes

In hash join node and set node, the keys maby be serialized multiple times in build and probe phase, which wastes lots of memory, this pr fix it and release memory ASAP.

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

