### PR TITLE
[fix](nereids) after injection, min/max value in columnStats for date/dateV2 type is wrong

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticsRepository.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticsRepository.java
@@ -192,11 +192,11 @@ public class StatisticsRepository {
         }
         if (min != null) {
             builder.setMinExpr(StatisticsUtil.readableValue(column.getType(), min));
-            builder.setMinValue(StatisticsUtil.convertStringToDouble(min));
+            builder.setMinValue(StatisticsUtil.convertToDouble(column.getType(), min));
         }
         if (max != null) {
             builder.setMaxExpr(StatisticsUtil.readableValue(column.getType(), max));
-            builder.setMaxValue(StatisticsUtil.convertStringToDouble(max));
+            builder.setMaxValue(StatisticsUtil.convertToDouble(column.getType(), max));
         }
         if (dataSize != null) {
             builder.setDataSize(Double.parseDouble(dataSize));

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/util/StatisticsUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/util/StatisticsUtil.java
@@ -41,6 +41,7 @@ import org.apache.doris.common.FeConstants;
 import org.apache.doris.common.UserException;
 import org.apache.doris.datasource.CatalogIf;
 import org.apache.doris.nereids.trees.expressions.literal.DateTimeLiteral;
+import org.apache.doris.nereids.trees.expressions.literal.VarcharLiteral;
 import org.apache.doris.qe.AutoCloseConnectContext;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.SessionVariable;
@@ -218,7 +219,8 @@ public class StatisticsUtil {
                     return dateTimeLiteral.getDouble();
                 case CHAR:
                 case VARCHAR:
-                    return convertStringToDouble(columnValue);
+                    VarcharLiteral varchar = new VarcharLiteral(columnValue);
+                    return varchar.getDouble();
                 case HLL:
                 case BITMAP:
                 case ARRAY:
@@ -233,16 +235,6 @@ public class StatisticsUtil {
 
     }
 
-    public static double convertStringToDouble(String s) {
-        long v = 0;
-        int pos = 0;
-        int len = Math.min(s.length(), 8);
-        while (pos < len) {
-            v += ((long) s.charAt(pos)) << ((7 - pos) * 8);
-            pos++;
-        }
-        return (double) v;
-    }
 
     public static DBObjects convertTableNameToObjects(TableName tableName) {
         CatalogIf<DatabaseIf> catalogIf = Env.getCurrentEnv().getCatalogMgr().getCatalog(tableName.getCtl());

--- a/fe/fe-core/src/test/java/org/apache/doris/statistics/util/StatisticsUtilTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/statistics/util/StatisticsUtilTest.java
@@ -1,0 +1,70 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.statistics.util;
+
+import org.apache.doris.catalog.Type;
+import org.apache.doris.common.AnalysisException;
+
+import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+
+public class StatisticsUtilTest {
+    @Test
+    public void testConvertToDouble() {
+        try {
+            //test DATE
+            double date1 = StatisticsUtil.convertToDouble(Type.DATE, "1990-01-01");
+            double date2 = StatisticsUtil.convertToDouble(Type.DATE, "1990-01-02");
+            double date3 = StatisticsUtil.convertToDouble(Type.DATE, "1990-01-03");
+            Assertions.assertTrue(date2 > date1);
+            Assertions.assertTrue(date3 > date2);
+            //test DATEV2
+            date1 = StatisticsUtil.convertToDouble(Type.DATEV2, "1990-01-01");
+            date2 = StatisticsUtil.convertToDouble(Type.DATEV2, "1990-01-02");
+            date3 = StatisticsUtil.convertToDouble(Type.DATEV2, "1990-01-03");
+            Assertions.assertTrue(date2 > date1);
+            Assertions.assertTrue(date3 > date2);
+
+            //test CHAR
+            double str1 = StatisticsUtil.convertToDouble(Type.CHAR, "aaa");
+            double str2 = StatisticsUtil.convertToDouble(Type.CHAR, "aab");
+            double str3 = StatisticsUtil.convertToDouble(Type.CHAR, "abb");
+            Assertions.assertTrue(str1 < str2);
+            Assertions.assertTrue(str2 < str3);
+            double str4 = StatisticsUtil.convertToDouble(Type.CHAR, "abbccdde");
+            double str5 = StatisticsUtil.convertToDouble(Type.CHAR, "abbccddee");
+            Assertions.assertTrue(str4 > str3);
+            //we only count first 8 char, tailing chars are ignored
+            Assertions.assertEquals(str4, str5);
+            //test VARCHAR
+            str1 = StatisticsUtil.convertToDouble(Type.VARCHAR, "aaa");
+            str2 = StatisticsUtil.convertToDouble(Type.VARCHAR, "aab");
+            str3 = StatisticsUtil.convertToDouble(Type.VARCHAR, "abb");
+            Assertions.assertTrue(str1 < str2);
+            Assertions.assertTrue(str2 < str3);
+            str4 = StatisticsUtil.convertToDouble(Type.VARCHAR, "abbccdde");
+            str5 = StatisticsUtil.convertToDouble(Type.VARCHAR, "abbccddee");
+            Assertions.assertTrue(str4 > str3);
+            //we only count first 8 char, tailing chars are ignored
+            Assertions.assertEquals(str4, str5);
+
+        } catch (AnalysisException e) {
+            Assertions.fail();
+        }
+    }
+}


### PR DESCRIPTION
# Proposed changes
after injection, min/max value in columnStats for date/dateV2 type is wrong.

@Kikyou1997 @morrySnow PTAL

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

