### PR TITLE
[ehancement](fe) Remove unnecessary kill in AutoCloseConnectContext

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/AutoCloseConnectContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/AutoCloseConnectContext.java
@@ -28,7 +28,6 @@ public class AutoCloseConnectContext implements AutoCloseable {
 
     @Override
     public void close() {
-        connectContext.kill(false);
         ConnectContext.remove();
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/AnalysisJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/AnalysisJob.java
@@ -26,7 +26,6 @@ import org.apache.doris.catalog.TableIf;
 import org.apache.doris.common.FeConstants;
 import org.apache.doris.datasource.CatalogIf;
 import org.apache.doris.qe.AutoCloseConnectContext;
-import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.StmtExecutor;
 import org.apache.doris.statistics.AnalysisJobInfo.JobState;
 import org.apache.doris.statistics.util.StatisticsUtil;
@@ -182,10 +181,7 @@ public class AnalysisJob {
             this.stmtExecutor = new StmtExecutor(r.connectContext, sql);
             this.stmtExecutor.execute();
             Env.getCurrentEnv().getStatisticsCache().refreshSync(tbl.getId(), col.getName());
-        } finally {
-            ConnectContext.remove();
         }
-
     }
 
     public int getLastExecTime() {


### PR DESCRIPTION
# Proposed changes

Issue Number: noissue

## Problem summary

The invocation in ConnectContext.kill in AutoCloseConnectContext is redundant and caused too many useless logs

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

