### PR TITLE
[Enhancement](predicate) Support in_or_bitmap filter.

### DIFF
--- a/be/src/exprs/runtime_filter.h
+++ b/be/src/exprs/runtime_filter.h
@@ -56,7 +56,8 @@ enum class RuntimeFilterType {
     MINMAX_FILTER = 1,
     BLOOM_FILTER = 2,
     IN_OR_BLOOM_FILTER = 3,
-    BITMAP_FILTER = 4
+    BITMAP_FILTER = 4,
+    IN_OR_BITMAP_FILTER = 5
 };
 
 inline std::string to_string(RuntimeFilterType type) {
@@ -75,6 +76,9 @@ inline std::string to_string(RuntimeFilterType type) {
     }
     case RuntimeFilterType::BITMAP_FILTER: {
         return std::string("bitmapfilter");
+    }
+    case RuntimeFilterType::IN_OR_BITMAP_FILTER: {
+        return std::string("in_or_bitmapfilter");
     }
     default:
         return std::string("UNKNOWN");
@@ -225,6 +229,7 @@ public:
                                  ObjectPool* pool,
                                  std::unique_ptr<RuntimePredicateWrapper>* wrapper);
     void change_to_bloom_filter();
+    bool try_change_bitmap_to_in_filter();
     Status update_filter(const UpdateRuntimeFilterParams* param);
 
     void set_ignored() { _is_ignored = true; }
@@ -236,6 +241,8 @@ public:
 
     // for ut
     bool is_bloomfilter();
+
+    bool is_in_or_bitmap_filter();
 
     // consumer should call before released
     Status consumer_close();

--- a/be/src/exprs/runtime_filter_slots_cross.h
+++ b/be/src/exprs/runtime_filter_slots_cross.h
@@ -90,6 +90,7 @@ public:
 
     void publish() {
         for (auto& filter : _runtime_filters) {
+            filter->try_change_bitmap_to_in_filter();
             filter->publish();
         }
         for (auto& filter : _runtime_filters) {

--- a/be/src/vec/exec/scan/vscan_node.cpp
+++ b/be/src/vec/exec/scan/vscan_node.cpp
@@ -300,7 +300,9 @@ Status VScanNode::close(RuntimeState* state) {
 
     for (auto& ctx : _runtime_filter_ctxs) {
         IRuntimeFilter* runtime_filter = ctx.runtime_filter;
-        runtime_filter->consumer_close();
+        if (runtime_filter) {
+            runtime_filter->consumer_close();
+        }
     }
 
     for (auto& ctx : _stale_vexpr_ctxs) {

--- a/be/src/vec/runtime/shared_hash_table_controller.h
+++ b/be/src/vec/runtime/shared_hash_table_controller.h
@@ -42,7 +42,7 @@ struct SharedRuntimeFilterContext {
     std::shared_ptr<MinMaxFuncBase> minmax_func;
     std::shared_ptr<HybridSetBase> hybrid_set;
     std::shared_ptr<BloomFilterFuncBase> bloom_filter_func;
-    std::shared_ptr<BitmapFilterFuncBase> _bitmap_filter_func;
+    std::shared_ptr<BitmapFilterFuncBase> bitmap_filter_func;
 };
 
 struct SharedHashTableContext {

--- a/docs/en/docs/advanced/join-optimization/runtime-filter.md
+++ b/docs/en/docs/advanced/join-optimization/runtime-filter.md
@@ -89,7 +89,7 @@ For query options related to Runtime Filter, please refer to the following secti
 
 - The first query option is to adjust the type of Runtime Filter used. In most cases, you only need to adjust this option, and keep the other options as default.
 
-  - `runtime_filter_type`: Including Bloom Filter, MinMax Filter, IN predicate, IN_OR_BLOOM Filter and Bitmap_Filter. By default, only IN_OR_BLOOM Filter will be used. In some cases, the performance will be higher when both Bloom Filter, MinMax Filter and IN predicate are used at the same time.
+  - `runtime_filter_type`: Including Bloom Filter, MinMax Filter, IN predicate, IN_OR_BLOOM Filter and IN_OR_Bitmap_Filter. By default, IN_OR_BLOOM Filter and IN_OR_BITAP Filter will be used. In some cases, the performance will be higher when both Bloom Filter, MinMax Filter and IN predicate are used at the same time.
 
 - Other query options usually only need to be further adjusted in certain specific scenarios to achieve the best results. Usually only after performance testing, optimize for resource-intensive, long enough running time and high enough frequency queries.
 
@@ -112,7 +112,7 @@ The query options are further explained below.
 #### 1.runtime_filter_type
 Type of Runtime Filter used.
 
-**Type**: Number (1, 2, 4, 8, 16) or the corresponding mnemonic string (IN, BLOOM_FILTER, MIN_MAX, IN_OR_BLOOM_FILTER, BITMAP_FILTER), the default is 8 (IN_OR_BLOOM FILTER), use multiple commas to separate, pay attention to the need to add quotation marks , Or add any number of types, for example:
+**Type**: Number (1, 2, 4, 8, 16) or the corresponding mnemonic string (IN, BLOOM_FILTER, MIN_MAX, IN_OR_BLOOM_FILTER, IN_OR_BITMAP_FILTER), the default is 24 (IN_OR_BLOOM FILTER, IN_OR_BITMAP FILTER), use multiple commas to separate, pay attention to the need to add quotation marks , Or add any number of types, for example:
 ```
 set runtime_filter_type="BLOOM_FILTER,IN,MIN_MAX";
 ```
@@ -138,7 +138,8 @@ set runtime_filter_type=7;
     - Currently IN predicate already implement a merge method.
     - When IN predicate and other filters are specified at the same time, and the filtering value of IN predicate does not reach runtime_filter_max_in_num will try to remove other filters. The reason is that IN predicate is an accurate filtering condition. Even if there is no other filter, it can filter efficiently. If it is used at the same time, other filters will do useless work. Currently, only when the producer and consumer of the runtime filter are in the same fragment can there be logic to remove the Non-IN predicate.
 
-- **Bitmap Filter**:
+- **Bitmap Filter**: According to the actual number of rows in the right table during execution, the system automatically determines whether to use IN predicate or Bitmap Filter.
+    - Bitmap Filter can only be converted from in or bitmap filter and cannot be specified manually.
     - Currently, the bitmap filter is used only when the subquery in the [in subquery](../../sql-manual/sql-reference/Operators/in.md) operation returns a bitmap column.
     - Currently, bitmap filter is only supported in vectorization engine.
 

--- a/docs/zh-CN/docs/advanced/join-optimization/runtime-filter.md
+++ b/docs/zh-CN/docs/advanced/join-optimization/runtime-filter.md
@@ -94,7 +94,7 @@ Runtime Filter主要用于大表join小表的优化，如果左表的数据量�
 与Runtime Filter相关的查询选项信息，请参阅以下部分:
 
 - 第一个查询选项是调整使用的Runtime Filter类型，大多数情况下，您只需要调整这一个选项，其他选项保持默认即可。
-  - `runtime_filter_type`: 包括Bloom Filter、MinMax Filter、IN predicate、IN Or Bloom Filter、Bitmap Filter，默认会使用IN Or Bloom Filter，部分情况下同时使用Bloom Filter、MinMax Filter、IN predicate时性能更高。
+  - `runtime_filter_type`: 包括Bloom Filter、MinMax Filter、IN predicate、IN Or Bloom Filter、IN Or Bitmap Filter，默认会使用IN Or Bloom Filter和IN Or Bitmap Filter，部分情况下同时使用Bloom Filter、MinMax Filter、IN predicate时性能更高。
 - 其他查询选项通常仅在某些特定场景下，才需进一步调整以达到最优效果。通常只在性能测试后，针对资源密集型、运行耗时足够长且频率足够高的查询进行优化。
   - `runtime_filter_mode`: 用于调整Runtime Filter的下推策略，包括OFF、LOCAL、GLOBAL三种策略，默认设置为GLOBAL策略
   - `runtime_filter_wait_time_ms`: 左表的ScanNode等待每个Runtime Filter的时间，默认1000ms
@@ -110,7 +110,7 @@ Runtime Filter主要用于大表join小表的优化，如果左表的数据量�
 
 使用的Runtime Filter类型。
 
-**类型**: 数字(1, 2, 4, 8, 16)或者相对应的助记符字符串(IN, BLOOM_FILTER, MIN_MAX, `IN_OR_BLOOM_FILTER`, BITMAP_FILTER)，默认8(`IN_OR_BLOOM_FILTER`)，使用多个时用逗号分隔，注意需要加引号，或者将任意多个类型的数字相加，例如:
+**类型**: 数字(1, 2, 4, 8, 16)或者相对应的助记符字符串(IN, BLOOM_FILTER, MIN_MAX, `IN_OR_BLOOM_FILTER`, `IN_OR_BITMAP_FILTER`)，默认24(`IN_OR_BLOOM_FILTER`,`IN_OR_BITMAP_FILTER`)，使用多个时用逗号分隔，注意需要加引号，或者将任意多个类型的数字相加，例如:
 
 ```sql
 set runtime_filter_type="BLOOM_FILTER,IN,MIN_MAX";
@@ -136,9 +136,10 @@ set runtime_filter_type=7;
 - **IN predicate**: 根据join on clause中Key列在右表上的所有值构建IN predicate，使用构建的IN predicate在左表上过滤，相比Bloom Filter构建和应用的开销更低，在右表数据量较少时往往性能更高。
   - 目前IN predicate已实现合并方法。
   - 当同时指定In predicate和其他filter，并且in的过滤数值没达到runtime_filter_max_in_num时，会尝试把其他filter去除掉。原因是In predicate是精确的过滤条件，即使没有其他filter也可以高效过滤，如果同时使用则其他filter会做无用功。目前仅在Runtime filter的生产者和消费者处于同一个fragment时才会有去除非in filter的逻辑。
-- **Bitmap Filter**:
-  - 当前仅当[in subquery](../../sql-manual/sql-reference/Operators/in.md)操作中的子查询返回bitmap列时会使用bitmap filter.
-  - 当前只在仅在向量化引擎中支持bitmap filter.
+- **IN or Bitmap Filter**: 根据右表bitmap在执行过程中的真实大小，自动判断使用 IN predicate 还是 Bitmap Filter
+  - Bitmap Filter 只能由in or bitmap filter转换而来，无法手动指定。
+  - 当前仅当[in subquery](../../sql-manual/sql-reference/Operators/in.md)操作中的子查询返回bitmap列时会使用in or bitmap filter。
+  - 当前只在仅在向量化引擎中支持in or bitmap filter.
 
 #### 2.runtime_filter_mode
 

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/BitmapFilterPredicate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/BitmapFilterPredicate.java
@@ -72,7 +72,7 @@ public class BitmapFilterPredicate extends Predicate {
         }
 
         if (ConnectContext.get() == null || (ConnectContext.get().getSessionVariable().getRuntimeFilterType()
-                & TRuntimeFilterType.BITMAP.getValue()) == 0) {
+                & TRuntimeFilterType.IN_OR_BITMAP.getValue()) == 0) {
             throw new AnalysisException("In bitmap syntax requires runtime filter of bitmap_filter to be enabled. "
                     + "Please `set runtime_filter_type = 'xxx, bitmap_filter'` first.");
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/RuntimeFilter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/RuntimeFilter.java
@@ -194,7 +194,7 @@ public final class RuntimeFilter {
         }
         tFilter.setType(runtimeFilterType);
         tFilter.setBloomFilterSizeBytes(filterSizeBytes);
-        if (runtimeFilterType.equals(TRuntimeFilterType.BITMAP)) {
+        if (runtimeFilterType.equals(TRuntimeFilterType.IN_OR_BITMAP)) {
             tFilter.setBitmapTargetExpr(targets.get(0).expr.treeToThrift());
             tFilter.setBitmapFilterNotIn(bitmapFilterNotIn);
         }
@@ -315,7 +315,7 @@ public final class RuntimeFilter {
         Preconditions.checkNotNull(joinPredicate);
         Preconditions.checkNotNull(filterSrcNode);
 
-        if (type.equals(TRuntimeFilterType.BITMAP)) {
+        if (type.equals(TRuntimeFilterType.IN_OR_BITMAP)) {
             if (!(joinPredicate instanceof BitmapFilterPredicate)) {
                 return null;
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/RuntimeFilterGenerator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/RuntimeFilterGenerator.java
@@ -79,7 +79,7 @@ public final class RuntimeFilterGenerator {
                     TRuntimeFilterType.IN_OR_BLOOM);
 
     private static final List<TRuntimeFilterType> NESTED_LOOP_JOIN_RUNTIME_FILTER_TYPES =
-            Lists.newArrayList(TRuntimeFilterType.BITMAP);
+            Lists.newArrayList(TRuntimeFilterType.IN_OR_BITMAP);
 
     // Map of base table tuple ids to a list of runtime filters that
     // can be applied at the corresponding scan nodes.
@@ -280,7 +280,7 @@ public final class RuntimeFilterGenerator {
                 if ((sessionVariable.getRuntimeFilterType() & type.getValue()) == 0) {
                     continue;
                 }
-                if (type == TRuntimeFilterType.BITMAP) {
+                if (type == TRuntimeFilterType.IN_OR_BITMAP) {
                     for (int i = 0; i < runtimeFilterConjuncts.size(); ++i) {
                         Expr conjunct = runtimeFilterConjuncts.get(i);
                         RuntimeFilter filter =
@@ -458,7 +458,7 @@ public final class RuntimeFilterGenerator {
                 return null;
             }
         }
-        if (filter.getType().equals(TRuntimeFilterType.BITMAP)) {
+        if (filter.getType().equals(TRuntimeFilterType.IN_OR_BITMAP)) {
             return targetExpr;
         }
         Type srcType = filter.getSrcExpr().getType();

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/RuntimeFilterTypeHelper.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/RuntimeFilterTypeHelper.java
@@ -43,7 +43,7 @@ public class RuntimeFilterTypeHelper {
             | TRuntimeFilterType.BLOOM.getValue()
             | TRuntimeFilterType.MIN_MAX.getValue()
             | TRuntimeFilterType.IN_OR_BLOOM.getValue()
-            | TRuntimeFilterType.BITMAP.getValue());
+            | TRuntimeFilterType.IN_OR_BITMAP.getValue());
 
     private static final Map<String, Long> varValueSet = Maps.newTreeMap(String.CASE_INSENSITIVE_ORDER);
 
@@ -52,7 +52,7 @@ public class RuntimeFilterTypeHelper {
         varValueSet.put("BLOOM_FILTER", (long) TRuntimeFilterType.BLOOM.getValue());
         varValueSet.put("MIN_MAX", (long) TRuntimeFilterType.MIN_MAX.getValue());
         varValueSet.put("IN_OR_BLOOM_FILTER", (long) TRuntimeFilterType.IN_OR_BLOOM.getValue());
-        varValueSet.put("BITMAP_FILTER", (long) TRuntimeFilterType.BITMAP.getValue());
+        varValueSet.put("IN_OR_BITMAP_FILTER", (long) TRuntimeFilterType.IN_OR_BITMAP.getValue());
     }
 
     // convert long type variable value to string type that user can read

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -504,7 +504,7 @@ public class SessionVariable implements Serializable, Writable {
 
     // Set runtimeFilterType to IN_OR_BLOOM filter
     @VariableMgr.VarAttr(name = RUNTIME_FILTER_TYPE)
-    private int runtimeFilterType = 8;
+    private int runtimeFilterType = 24;
 
     @VariableMgr.VarAttr(name = RUNTIME_FILTER_MAX_IN_NUM)
     private int runtimeFilterMaxInNum = 102400;

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -911,7 +911,7 @@ enum TRuntimeFilterType {
   BLOOM = 2
   MIN_MAX = 4
   IN_OR_BLOOM = 8
-  BITMAP = 16
+  IN_OR_BITMAP = 16
 }
 
 // Specification of a runtime filter.


### PR DESCRIPTION
1. When the bitmap cardinality is less than runtime_filter_max_in_num, in_or_bitmap filter will be converted to in filter, otherwise it will be converted to bitmap filter.
2.  Enable in_or_bitmap filter by default.

# Proposed changes

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
3. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
4. Has document been added or modified:
    - [x] Yes
    - [ ] No
    - [ ] No Need
5. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
6. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

