### PR TITLE
[typo](docs) fix four string functions' document issue

### DIFF
--- a/docs/en/docs/sql-manual/sql-functions/string-functions/left.md
+++ b/docs/en/docs/sql-manual/sql-functions/string-functions/left.md
@@ -28,7 +28,7 @@ under the License.
 ### Description
 #### Syntax
 
-`VARCHAR left (VARCHAR str)`
+`VARCHAR left (VARCHAR str, INT len)`
 
 
 It returns the left part of a string of specified length, length is char length not the byte size.

--- a/docs/en/docs/sql-manual/sql-functions/string-functions/right.md
+++ b/docs/en/docs/sql-manual/sql-functions/string-functions/right.md
@@ -28,7 +28,7 @@ under the License.
 ### Description
 #### Syntax
 
-`VARCHAR RIGHT (VARCHAR STR)`
+`VARCHAR RIGHT (VARCHAR str, INT len)`
 
 
 It returns the right part of a string of specified length, length is char length not the byte size.

--- a/docs/en/docs/sql-manual/sql-functions/string-functions/strleft.md
+++ b/docs/en/docs/sql-manual/sql-functions/string-functions/strleft.md
@@ -28,7 +28,7 @@ under the License.
 ### Description
 #### Syntax
 
-`VARCHAR STRAIGHT (VARCHAR STR)`
+`VARCHAR STRAIGHT (VARCHAR str, INT len)`
 
 
 It returns the left part of a string of specified length, length is char length not the byte size.

--- a/docs/en/docs/sql-manual/sql-functions/string-functions/strright.md
+++ b/docs/en/docs/sql-manual/sql-functions/string-functions/strright.md
@@ -29,7 +29,7 @@ under the License.
 ### Description
 #### Syntax
 
-`VARCHAR strright (VARCHAR str)`
+`VARCHAR strright (VARCHAR str, INT len)`
 
 
 It returns the right part of a string of specified length, length is char length not the byte size.

--- a/docs/zh-CN/docs/sql-manual/sql-functions/string-functions/left.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/string-functions/left.md
@@ -28,7 +28,7 @@ under the License.
 ### description
 #### Syntax
 
-`VARCHAR left(VARCHAR str)`
+`VARCHAR left(VARCHAR str, INT len)`
 
 
 它返回具有指定长度的字符串的左边部分, 长度的单位为utf8字符

--- a/docs/zh-CN/docs/sql-manual/sql-functions/string-functions/right.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/string-functions/right.md
@@ -28,7 +28,7 @@ under the License.
 ### description
 #### Syntax
 
-`VARCHAR right(VARCHAR str)`
+`VARCHAR right(VARCHAR str, INT len)`
 
 
 它返回具有指定长度的字符串的右边部分, 长度的单位为utf8字符

--- a/docs/zh-CN/docs/sql-manual/sql-functions/string-functions/strleft.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/string-functions/strleft.md
@@ -28,7 +28,7 @@ under the License.
 ### description
 #### Syntax
 
-`VARCHAR strleft(VARCHAR str)`
+`VARCHAR strleft(VARCHAR str, INT len)`
 
 
 它返回具有指定长度的字符串的左边部分,长度的单位为utf8字符

--- a/docs/zh-CN/docs/sql-manual/sql-functions/string-functions/strright.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/string-functions/strright.md
@@ -28,7 +28,7 @@ under the License.
 ### description
 #### Syntax
 
-`VARCHAR strright(VARCHAR str)`
+`VARCHAR strright(VARCHAR str, INT len)`
 
 
 它返回具有指定长度的字符串的右边部分, 长度的单位为utf8字符


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [x] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

documents for four string functions are not correct, fix it. they are: left, right, strleft, strright