### PR TITLE
[improvement](function) add timezone cache for convert_tz

### DIFF
--- a/be/src/exprs/timestamp_functions.h
+++ b/be/src/exprs/timestamp_functions.h
@@ -43,8 +43,11 @@ struct FormatCtx {
 struct ConvertTzCtx {
     // false means the format is invalid, and the function always return null
     bool is_valid = false;
+    bool constant_from = false;
+    bool constant_to = false;
     cctz::time_zone from_tz;
     cctz::time_zone to_tz;
+    std::map<std::string, cctz::time_zone> time_zone_cache;
 };
 
 class TimestampFunctions {

--- a/regression-test/data/query_p0/sql_functions/datetime_functions/test_date_function.out
+++ b/regression-test/data/query_p0/sql_functions/datetime_functions/test_date_function.out
@@ -23,6 +23,64 @@
 -- !sql --
 \N
 
+-- !sql1 --
+1	2019-08-01T13:21:03	Asia/Shanghai	Asia/Shanghai	2019-08-01T13:21:03
+2	2019-08-01T13:21:03	Asia/Singapore	Asia/Shanghai	2019-08-01T13:21:03
+3	2019-08-01T13:21:03	Asia/Taipei	Asia/Shanghai	2019-08-01T13:21:03
+4	2019-08-02T13:21:03	Australia/Queensland	Asia/Shanghai	2019-08-02T11:21:03
+5	2019-08-02T13:21:03	Australia/Lindeman	Asia/Shanghai	2019-08-02T11:21:03
+6	2019-08-03T13:21:03	America/Aruba	Asia/Shanghai	2019-08-04T01:21:03
+7	2019-08-03T13:21:03	America/Blanc-Sablon	Asia/Shanghai	2019-08-04T01:21:03
+8	2019-08-04T13:21:03	America/Dawson	Africa/Lusaka	2019-08-04T22:21:03
+9	2019-08-04T13:21:03	America/Creston	Africa/Lusaka	2019-08-04T22:21:03
+10	2019-08-05T13:21:03	Asia/Shanghai	Asia/Shanghai	2019-08-05T13:21:03
+11	2019-08-05T13:21:03	Asia/Shanghai	Asia/Singapore	2019-08-05T13:21:03
+12	2019-08-05T13:21:03	Asia/Shanghai	Asia/Taipei	2019-08-05T13:21:03
+13	2019-08-06T13:21:03	Asia/Shanghai	Australia/Queensland	2019-08-06T15:21:03
+14	2019-08-06T13:21:03	Asia/Shanghai	Australia/Lindeman	2019-08-06T15:21:03
+15	2019-08-07T13:21:03	Asia/Shanghai	America/Aruba	2019-08-07T01:21:03
+16	2019-08-07T13:21:03	Asia/Shanghai	America/Blanc-Sablon	2019-08-07T01:21:03
+17	2019-08-08T13:21:03	Africa/Lusaka	America/Dawson	2019-08-08T04:21:03
+18	2019-08-08T13:21:03	Africa/Lusaka	America/Creston	2019-08-08T04:21:03
+
+-- !sql2 --
+2019-08-01T13:21:03	2019-08-01T13:21:03	2019-08-01T13:21:03
+
+-- !sql3 --
+2019-08-02T11:21:03	2019-08-02T11:21:03	2019-08-02T11:21:03
+
+-- !sql4 --
+2019-08-04T22:21:03	2019-08-04T22:21:03	2019-08-04T22:21:03
+
+-- !sql_vec1 --
+1	2019-08-01T13:21:03	Asia/Shanghai	Asia/Shanghai	2019-08-01T13:21:03
+2	2019-08-01T13:21:03	Asia/Singapore	Asia/Shanghai	2019-08-01T13:21:03
+3	2019-08-01T13:21:03	Asia/Taipei	Asia/Shanghai	2019-08-01T13:21:03
+4	2019-08-02T13:21:03	Australia/Queensland	Asia/Shanghai	2019-08-02T11:21:03
+5	2019-08-02T13:21:03	Australia/Lindeman	Asia/Shanghai	2019-08-02T11:21:03
+6	2019-08-03T13:21:03	America/Aruba	Asia/Shanghai	2019-08-04T01:21:03
+7	2019-08-03T13:21:03	America/Blanc-Sablon	Asia/Shanghai	2019-08-04T01:21:03
+8	2019-08-04T13:21:03	America/Dawson	Africa/Lusaka	2019-08-04T22:21:03
+9	2019-08-04T13:21:03	America/Creston	Africa/Lusaka	2019-08-04T22:21:03
+10	2019-08-05T13:21:03	Asia/Shanghai	Asia/Shanghai	2019-08-05T13:21:03
+11	2019-08-05T13:21:03	Asia/Shanghai	Asia/Singapore	2019-08-05T13:21:03
+12	2019-08-05T13:21:03	Asia/Shanghai	Asia/Taipei	2019-08-05T13:21:03
+13	2019-08-06T13:21:03	Asia/Shanghai	Australia/Queensland	2019-08-06T15:21:03
+14	2019-08-06T13:21:03	Asia/Shanghai	Australia/Lindeman	2019-08-06T15:21:03
+15	2019-08-07T13:21:03	Asia/Shanghai	America/Aruba	2019-08-07T01:21:03
+16	2019-08-07T13:21:03	Asia/Shanghai	America/Blanc-Sablon	2019-08-07T01:21:03
+17	2019-08-08T13:21:03	Africa/Lusaka	America/Dawson	2019-08-08T04:21:03
+18	2019-08-08T13:21:03	Africa/Lusaka	America/Creston	2019-08-08T04:21:03
+
+-- !sql_vec2 --
+2019-08-01T13:21:03	2019-08-01T13:21:03	2019-08-01T13:21:03
+
+-- !sql_vec3 --
+2019-08-02T11:21:03	2019-08-02T11:21:03	2019-08-02T11:21:03
+
+-- !sql_vec4 --
+2019-08-04T22:21:03	2019-08-04T22:21:03	2019-08-04T22:21:03
+
 -- !sql --
 2012-11-30T23:59:59
 

--- a/regression-test/suites/query_p0/sql_functions/datetime_functions/test_date_function.groovy
+++ b/regression-test/suites/query_p0/sql_functions/datetime_functions/test_date_function.groovy
@@ -94,6 +94,8 @@ suite("test_date_function") {
             (18, "2019-08-08 13:21:03", "Africa/Lusaka", "America/Creston")
     """
 
+    sql "set parallel_fragment_exec_instance_num = 8"
+
     qt_sql1 """
         SELECT
             `id`, `test_datetime`, `origin_tz`, `target_tz`, convert_tz(`test_datetime`, `origin_tz`, `target_tz`)

--- a/regression-test/suites/query_p0/sql_functions/datetime_functions/test_date_function.groovy
+++ b/regression-test/suites/query_p0/sql_functions/datetime_functions/test_date_function.groovy
@@ -52,6 +52,125 @@ suite("test_date_function") {
 
     sql """ truncate table ${tableName} """
 
+    def timezoneCachedTableName = "test_convert_tz_with_timezone_cache"
+    sql """ SET enable_vectorized_engine = false """
+    sql """ DROP TABLE IF EXISTS ${timezoneCachedTableName} """
+    sql """
+        CREATE TABLE ${timezoneCachedTableName} (
+            id int,
+            test_datetime datetime NULL COMMENT "",
+            origin_tz VARCHAR(255),
+            target_tz VARCHAR(255)
+        ) ENGINE=OLAP
+        DUPLICATE KEY(id)
+        COMMENT "OLAP"
+        DISTRIBUTED BY HASH(id) BUCKETS 1
+        PROPERTIES (
+            "replication_allocation" = "tag.location.default: 1",
+            "in_memory" = "false",
+            "storage_format" = "V2"
+        )
+    """
+
+    sql """
+        INSERT INTO ${timezoneCachedTableName} VALUES
+            (1, "2019-08-01 13:21:03", "Asia/Shanghai", "Asia/Shanghai"),
+            (2, "2019-08-01 13:21:03", "Asia/Singapore", "Asia/Shanghai"),
+            (3, "2019-08-01 13:21:03", "Asia/Taipei", "Asia/Shanghai"),
+            (4, "2019-08-02 13:21:03", "Australia/Queensland", "Asia/Shanghai"),
+            (5, "2019-08-02 13:21:03", "Australia/Lindeman", "Asia/Shanghai"),
+            (6, "2019-08-03 13:21:03", "America/Aruba", "Asia/Shanghai"),
+            (7, "2019-08-03 13:21:03", "America/Blanc-Sablon", "Asia/Shanghai"),
+            (8, "2019-08-04 13:21:03", "America/Dawson", "Africa/Lusaka"),
+            (9, "2019-08-04 13:21:03", "America/Creston", "Africa/Lusaka"),
+            (10, "2019-08-05 13:21:03", "Asia/Shanghai", "Asia/Shanghai"),
+            (11, "2019-08-05 13:21:03", "Asia/Shanghai", "Asia/Singapore"),
+            (12, "2019-08-05 13:21:03", "Asia/Shanghai", "Asia/Taipei"),
+            (13, "2019-08-06 13:21:03", "Asia/Shanghai", "Australia/Queensland"),
+            (14, "2019-08-06 13:21:03", "Asia/Shanghai", "Australia/Lindeman"),
+            (15, "2019-08-07 13:21:03", "Asia/Shanghai", "America/Aruba"),
+            (16, "2019-08-07 13:21:03", "Asia/Shanghai", "America/Blanc-Sablon"),
+            (17, "2019-08-08 13:21:03", "Africa/Lusaka", "America/Dawson"),
+            (18, "2019-08-08 13:21:03", "Africa/Lusaka", "America/Creston")
+    """
+
+    qt_sql1 """
+        SELECT
+            `id`, `test_datetime`, `origin_tz`, `target_tz`, convert_tz(`test_datetime`, `origin_tz`, `target_tz`)
+        FROM
+            ${timezoneCachedTableName}
+        ORDER BY `id`
+    """
+    qt_sql2 """
+        SELECT
+            convert_tz(`test_datetime`, `origin_tz`, `target_tz`),
+            convert_tz(`test_datetime`, "Asia/Singapore", `target_tz`),
+            convert_tz(`test_datetime`, `origin_tz`, "Asia/Shanghai")
+        FROM
+            ${timezoneCachedTableName}
+        WHERE
+            id = 2;
+    """
+    qt_sql3 """
+        SELECT
+            convert_tz(`test_datetime`, `origin_tz`, `target_tz`),
+            convert_tz(`test_datetime`, "Australia/Queensland", `target_tz`),
+            convert_tz(`test_datetime`, `origin_tz`, "Asia/Shanghai")
+        FROM
+            ${timezoneCachedTableName}
+        WHERE
+            id = 4;
+    """
+    qt_sql4 """
+        SELECT
+            convert_tz(`test_datetime`, `origin_tz`, `target_tz`),
+            convert_tz(`test_datetime`, "America/Dawson", `target_tz`),
+            convert_tz(`test_datetime`, `origin_tz`, "Africa/Lusaka")
+        FROM
+            ${timezoneCachedTableName}
+        WHERE
+            id = 8;
+    """
+
+    sql """ SET enable_vectorized_engine = true """
+    qt_sql_vec1 """
+        SELECT
+            `id`, `test_datetime`, `origin_tz`, `target_tz`, convert_tz(`test_datetime`, `origin_tz`, `target_tz`)
+        FROM
+            ${timezoneCachedTableName}
+        ORDER BY `id`
+    """
+    qt_sql_vec2 """
+        SELECT
+            convert_tz(`test_datetime`, `origin_tz`, `target_tz`),
+            convert_tz(`test_datetime`, "Asia/Singapore", `target_tz`),
+            convert_tz(`test_datetime`, `origin_tz`, "Asia/Shanghai")
+        FROM
+            ${timezoneCachedTableName}
+        WHERE
+            id = 2;
+    """
+    qt_sql_vec3 """
+        SELECT
+            convert_tz(`test_datetime`, `origin_tz`, `target_tz`),
+            convert_tz(`test_datetime`, "Australia/Queensland", `target_tz`),
+            convert_tz(`test_datetime`, `origin_tz`, "Asia/Shanghai")
+        FROM
+            ${timezoneCachedTableName}
+        WHERE
+            id = 4;
+    """
+    qt_sql_vec4 """
+        SELECT
+            convert_tz(`test_datetime`, `origin_tz`, `target_tz`),
+            convert_tz(`test_datetime`, "America/Dawson", `target_tz`),
+            convert_tz(`test_datetime`, `origin_tz`, "Africa/Lusaka")
+        FROM
+            ${timezoneCachedTableName}
+        WHERE
+            id = 8;
+    """
+
     // curdate,current_date
     String curdate_str = new SimpleDateFormat("yyyy-MM-dd").format(new Date())
     def curdate_result = sql """ SELECT CURDATE() """


### PR DESCRIPTION
# Proposed changes

`cctz::fixed_time_zone` will lock&unlock the mutex in each call, this is a non-negligible performance cost.
This PR adds a map to cache the timezone to avoid finding the same timezone repeatedly.

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

