### PR TITLE
[improvement](vec) optimize the logic for _has_null in ColumnNullable

### DIFF
--- a/be/src/vec/columns/column_nullable.cpp
+++ b/be/src/vec/columns/column_nullable.cpp
@@ -49,6 +49,7 @@ ColumnNullable::ColumnNullable(MutableColumnPtr&& nested_column_, MutableColumnP
     if (is_column_const(*null_map)) {
         LOG(FATAL) << "ColumnNullable cannot have constant null map";
     }
+    _need_update_has_null = true;
 }
 
 MutableColumnPtr ColumnNullable::get_shrinked_column() {
@@ -152,24 +153,23 @@ StringRef ColumnNullable::get_data_at(size_t n) const {
 void ColumnNullable::insert_data(const char* pos, size_t length) {
     if (pos == nullptr) {
         get_nested_column().insert_default();
-        get_null_map_data().push_back(1);
+        _get_null_map_data().push_back(1);
         _has_null = true;
     } else {
         get_nested_column().insert_data(pos, length);
-        get_null_map_data().push_back(0);
+        _get_null_map_data().push_back(0);
     }
 }
 
 void ColumnNullable::insert_many_strings(const StringRef* strings, size_t num) {
-    auto& nested_column = get_nested_column();
-    auto& null_map_data = get_null_map_data();
+    auto& null_map_data = _get_null_map_data();
     for (size_t i = 0; i != num; ++i) {
         if (strings[i].data == nullptr) {
-            nested_column.insert_default();
+            nested_column->insert_default();
             null_map_data.push_back(1);
             _has_null = true;
         } else {
-            nested_column.insert_data(strings[i].data, strings[i].size);
+            nested_column->insert_data(strings[i].data, strings[i].size);
             null_map_data.push_back(0);
         }
     }
@@ -195,7 +195,7 @@ const char* ColumnNullable::deserialize_and_insert_from_arena(const char* pos) {
     UInt8 val = *reinterpret_cast<const UInt8*>(pos);
     pos += sizeof(val);
 
-    get_null_map_data().push_back(val);
+    _get_null_map_data().push_back(val);
 
     if (val == 0) {
         pos = get_nested_column().deserialize_and_insert_from_arena(pos);
@@ -226,10 +226,11 @@ void ColumnNullable::serialize_vec(std::vector<StringRef>& keys, size_t num_rows
 }
 
 void ColumnNullable::deserialize_vec(std::vector<StringRef>& keys, const size_t num_rows) {
-    auto& arr = get_null_map_data();
+    auto& arr = _get_null_map_data();
     const size_t old_size = arr.size();
     arr.resize(old_size + num_rows);
 
+    _has_null = has_null();
     auto* null_map_data = &arr[old_size];
     for (size_t i = 0; i != num_rows; ++i) {
         UInt8 val = *reinterpret_cast<const UInt8*>(keys[i].data);
@@ -243,9 +244,10 @@ void ColumnNullable::deserialize_vec(std::vector<StringRef>& keys, const size_t 
 
 void ColumnNullable::insert_range_from(const IColumn& src, size_t start, size_t length) {
     const ColumnNullable& nullable_col = assert_cast<const ColumnNullable&>(src);
-    get_null_map_column().insert_range_from(*nullable_col.null_map, start, length);
+    _get_null_map_column().insert_range_from(*nullable_col.null_map, start, length);
     get_nested_column().insert_range_from(*nullable_col.nested_column, start, length);
     auto& src_null_map_data = nullable_col.get_null_map_data();
+    _has_null = has_null();
     _has_null |= simd::contain_byte(src_null_map_data.data() + start, length, 1);
 }
 
@@ -254,14 +256,15 @@ void ColumnNullable::insert_indices_from(const IColumn& src, const int* indices_
     const ColumnNullable& src_concrete = assert_cast<const ColumnNullable&>(src);
     get_nested_column().insert_indices_from(src_concrete.get_nested_column(), indices_begin,
                                             indices_end);
-    get_null_map_column().insert_indices_from(src_concrete.get_null_map_column(), indices_begin,
-                                              indices_end);
+    _get_null_map_column().insert_indices_from(src_concrete.get_null_map_column(), indices_begin,
+                                               indices_end);
+    _need_update_has_null = true;
 }
 
 void ColumnNullable::insert(const Field& x) {
     if (x.is_null()) {
         get_nested_column().insert_default();
-        get_null_map_data().push_back(1);
+        _get_null_map_data().push_back(1);
         _has_null = true;
     } else {
         get_nested_column().insert(x);
@@ -274,18 +277,19 @@ void ColumnNullable::insert_from(const IColumn& src, size_t n) {
     get_nested_column().insert_from(src_concrete.get_nested_column(), n);
     auto is_null = src_concrete.get_null_map_data()[n];
     _has_null |= is_null;
-    get_null_map_data().push_back(is_null);
+    _get_null_map_data().push_back(is_null);
 }
 
 void ColumnNullable::insert_from_not_nullable(const IColumn& src, size_t n) {
     get_nested_column().insert_from(src, n);
-    get_null_map_data().push_back(0);
+    _get_null_map_data().push_back(0);
 }
 
 void ColumnNullable::insert_range_from_not_nullable(const IColumn& src, size_t start,
                                                     size_t length) {
     get_nested_column().insert_range_from(src, start, length);
-    get_null_map_data().resize_fill(get_null_map_data().size() + length, 0);
+    _get_null_map_data().resize_fill(get_null_map_data().size() + length, 0);
+    _need_update_has_null = true;
 }
 
 void ColumnNullable::insert_many_from_not_nullable(const IColumn& src, size_t position,
@@ -575,12 +579,15 @@ void ColumnNullable::sort_column(const ColumnSorter* sorter, EqualFlags& flags,
 }
 
 void ColumnNullable::_update_has_null() {
-    const UInt8* null_pos = get_null_map_data().data();
-    _has_null = simd::contain_byte(null_pos, get_null_map_data().size(), 1);
+    const UInt8* null_pos = _get_null_map_data().data();
+    _has_null = simd::contain_byte(null_pos, _get_null_map_data().size(), 1);
     _need_update_has_null = false;
 }
 
 bool ColumnNullable::has_null(size_t size) const {
+    if (!_has_null && !_need_update_has_null) {
+        return false;
+    }
     const UInt8* null_pos = get_null_map_data().data();
     return simd::contain_byte(null_pos, size, 1);
 }

--- a/be/src/vec/columns/column_nullable.h
+++ b/be/src/vec/columns/column_nullable.h
@@ -141,17 +141,20 @@ public:
 
     void insert_default() override {
         get_nested_column().insert_default();
-        get_null_map_data().push_back(1);
+        _get_null_map_data().push_back(1);
+        _has_null = true;
     }
 
     void insert_many_defaults(size_t length) override {
         get_nested_column().insert_many_defaults(length);
-        get_null_map_data().resize_fill(get_null_map_data().size() + length, 1);
+        _get_null_map_data().resize_fill(get_null_map_data().size() + length, 1);
+        _has_null = true;
     }
 
     void insert_null_elements(int num) {
         get_nested_column().insert_many_defaults(num);
-        get_null_map_column().fill(1, num);
+        _get_null_map_column().fill(1, num);
+        _has_null = true;
     }
 
     void pop_back(size_t n) override;
@@ -312,6 +315,10 @@ public:
                      EqualRange& range, bool last_column) const override;
 
 private:
+    // the two functions will not update `_need_update_has_null`
+    ColumnUInt8& _get_null_map_column() { return assert_cast<ColumnUInt8&>(*null_map); }
+    NullMap& _get_null_map_data() { return get_null_map_column().get_data(); }
+
     WrappedPtr nested_column;
     WrappedPtr null_map;
 


### PR DESCRIPTION
# Proposed changes

Some insert_*(eg. `insert_null_elements()`) functions will make `_has_null` be true, so there is no need to calculate whether it is nullable.

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

