### PR TITLE
[Enhancement](bitmapfilter) Support bitmap filter to apply zone_map index to filter pages

### DIFF
--- a/be/src/exprs/runtime_filter.h
+++ b/be/src/exprs/runtime_filter.h
@@ -43,6 +43,7 @@ class PMinMaxFilter;
 class HashJoinNode;
 class RuntimeProfile;
 class BloomFilterFuncBase;
+class BitmapFilterFuncBase;
 
 namespace vectorized {
 class VExpr;
@@ -251,6 +252,8 @@ public:
     void set_push_down_profile();
 
     void ready_for_publish();
+
+    std::shared_ptr<BitmapFilterFuncBase> get_bitmap_filter() const;
 
     static bool enable_use_batch(int be_exec_version, PrimitiveType type) {
         return be_exec_version > 0 && (is_int_or_bool(type) || is_float_or_double(type));

--- a/be/src/olap/bitmap_filter_predicate.h
+++ b/be/src/olap/bitmap_filter_predicate.h
@@ -17,9 +17,14 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include "exprs/bitmapfilter_predicate.h"
+#include "exprs/cast_functions.h"
 #include "exprs/runtime_filter.h"
 #include "olap/column_predicate.h"
+#include "olap/wrapper_field.h"
+#include "util/bitmap_value.h"
 #include "vec/columns/column_dictionary.h"
 #include "vec/columns/column_nullable.h"
 #include "vec/columns/column_vector.h"
@@ -50,6 +55,26 @@ public:
                      bool* flags) const override {};
     void evaluate_and(ColumnBlock* block, uint16_t* sel, uint16_t size,
                       bool* flags) const override {};
+
+    bool evaluate_and(const std::pair<WrapperField*, WrapperField*>& statistic) const override {
+        if (_specific_filter->is_not_in()) {
+            return true;
+        }
+
+        CppType max_value;
+        if (statistic.second->is_null()) {
+            // no non-null values
+            return false;
+        } else {
+            max_value = *reinterpret_cast<const CppType*>(statistic.second->cell_ptr());
+        }
+
+        CppType min_value =
+                statistic.first->is_null() /* contains null values */
+                        ? 0
+                        : *reinterpret_cast<const CppType*>(statistic.first->cell_ptr());
+        return _specific_filter->contains_any(min_value, max_value);
+    }
 
     Status evaluate(BitmapIndexIterator*, uint32_t, roaring::Roaring*) const override {
         return Status::OK();
@@ -84,25 +109,7 @@ private:
 };
 
 template <PrimitiveType T>
-void BitmapFilterColumnPredicate<T>::evaluate(ColumnBlock* block, uint16_t* sel,
-                                              uint16_t* size) const {
-    uint16_t new_size = 0;
-    if (block->is_nullable()) {
-        for (uint16_t i = 0; i < *size; ++i) {
-            uint16_t idx = sel[i];
-            sel[new_size] = idx;
-            new_size += (!block->cell(idx).is_null() &&
-                         _specific_filter->find(*block->cell(idx).cell_ptr()));
-        }
-    } else {
-        for (uint16_t i = 0; i < *size; ++i) {
-            uint16_t idx = sel[i];
-            sel[new_size] = idx;
-            new_size += _specific_filter->find(*block->cell(idx).cell_ptr());
-        }
-    }
-    *size = new_size;
-}
+void BitmapFilterColumnPredicate<T>::evaluate(ColumnBlock*, uint16_t*, uint16_t*) const {}
 
 template <PrimitiveType T>
 uint16_t BitmapFilterColumnPredicate<T>::evaluate(const vectorized::IColumn& column, uint16_t* sel,

--- a/be/src/olap/olap_common.h
+++ b/be/src/olap/olap_common.h
@@ -286,6 +286,7 @@ struct OlapReaderStatistics {
     // block_load_ns
     //      block_init_ns
     //          block_init_seek_ns
+    //          block_conditions_filtered_ns
     //      first_read_ns
     //          block_first_read_seek_ns
     //      lazy_read_ns
@@ -322,6 +323,7 @@ struct OlapReaderStatistics {
     int64_t rows_del_by_bitmap = 0;
     // the number of rows filtered by various column indexes.
     int64_t rows_conditions_filtered = 0;
+    int64_t block_conditions_filtered_ns = 0;
 
     int64_t index_load_ns = 0;
 

--- a/be/src/olap/rowset/segment_v2/segment_iterator.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.cpp
@@ -282,6 +282,7 @@ Status SegmentIterator::_prepare_seek(const StorageReadOptions::KeyRange& key_ra
 }
 
 Status SegmentIterator::_get_row_ranges_by_column_conditions() {
+    SCOPED_RAW_TIMER(&_opts.stats->block_conditions_filtered_ns);
     if (_row_bitmap.isEmpty()) {
         return Status::OK();
     }

--- a/be/src/util/bitmap_value.h
+++ b/be/src/util/bitmap_value.h
@@ -1912,7 +1912,7 @@ public:
 
     BitmapValueIterator(const BitmapValueIterator& other)
             : _bitmap(other._bitmap), _sv(other._sv), _end(other._end) {
-        _iter = new detail::Roaring64MapSetBitForwardIterator(*other._iter);
+        _iter = other._iter ? new detail::Roaring64MapSetBitForwardIterator(*other._iter) : nullptr;
     }
 
     ~BitmapValueIterator() {

--- a/be/src/util/bitmap_value.h
+++ b/be/src/util/bitmap_value.h
@@ -21,6 +21,7 @@
 
 #include <algorithm>
 #include <cstdarg>
+#include <cstdint>
 #include <cstdio>
 #include <limits>
 #include <map>
@@ -32,6 +33,7 @@
 #include <utility>
 
 #include "common/logging.h"
+#include "gutil/integral_types.h"
 #include "udf/udf.h"
 #include "util/coding.h"
 #include "vec/common/pod_array.h"
@@ -1430,6 +1432,9 @@ public:
         return false;
     }
 
+    // true if contains a value that belongs to the range [left, right].
+    bool contains_any(uint64_t left, uint64_t right) const;
+
     uint64_t cardinality() const {
         switch (_type) {
         case EMPTY:
@@ -1677,6 +1682,16 @@ public:
         }
     }
 
+    uint64_t max(bool* empty) const {
+        return min_or_max(empty, [&]() { return _bitmap.maximum(); });
+    }
+
+    uint64_t min(bool* empty) const {
+        return min_or_max(empty, [&]() { return _bitmap.minimum(); });
+    }
+
+    bool empty() const { return _type == EMPTY; }
+
     /**
      * Return new set with specified range (not include the range_end)
      */
@@ -1823,6 +1838,7 @@ public:
 
     b_iterator begin() const;
     b_iterator end() const;
+    b_iterator lower_bound(uint64_t val) const;
 
 private:
     void _convert_to_smaller_type() {
@@ -1837,6 +1853,25 @@ private:
             }
             _bitmap.clear();
         }
+    }
+
+    uint64_t min_or_max(bool* empty, std::function<uint64_t()> func) const {
+        bool is_empty = false;
+        uint64_t result = 0;
+        switch (_type) {
+        case SINGLE:
+            result = _sv;
+            break;
+        case BITMAP:
+            result = func();
+            break;
+        default:
+            is_empty = true;
+        }
+        if (empty) {
+            *empty = is_empty;
+        }
+        return result;
     }
 
     enum BitmapDataType {
@@ -1876,7 +1911,9 @@ public:
     }
 
     BitmapValueIterator(const BitmapValueIterator& other)
-            : _bitmap(other._bitmap), _iter(other._iter), _sv(other._sv), _end(other._end) {}
+            : _bitmap(other._bitmap), _sv(other._sv), _end(other._end) {
+        _iter = new detail::Roaring64MapSetBitForwardIterator(*other._iter);
+    }
 
     ~BitmapValueIterator() {
         if (_iter != nullptr) {
@@ -1930,7 +1967,9 @@ public:
     }
 
     bool operator==(const BitmapValueIterator& other) const {
-        if (_end && other._end) return true;
+        if (_end && other._end) {
+            return true;
+        }
 
         switch (_bitmap._type) {
         case BitmapValue::BitmapDataType::EMPTY:
@@ -1947,6 +1986,27 @@ public:
 
     bool operator!=(const BitmapValueIterator& other) const { return !(*this == other); }
 
+    /**
+    * Move the iterator to the first value >= `val`.
+    */
+    BitmapValueIterator& move(uint64_t val) {
+        switch (_bitmap._type) {
+        case BitmapValue::BitmapDataType::SINGLE:
+            if (_sv < val) {
+                _end = true;
+            }
+            break;
+        case BitmapValue::BitmapDataType::BITMAP:
+            if (!_iter->move(val)) {
+                _end = true;
+            }
+            break;
+        default:
+            break;
+        }
+        return *this;
+    }
+
 private:
     const BitmapValue& _bitmap;
     detail::Roaring64MapSetBitForwardIterator* _iter = nullptr;
@@ -1960,6 +2020,18 @@ inline BitmapValueIterator BitmapValue::begin() const {
 
 inline BitmapValueIterator BitmapValue::end() const {
     return BitmapValueIterator(*this, true);
+}
+
+inline BitmapValueIterator BitmapValue::lower_bound(uint64_t val) const {
+    return BitmapValueIterator(*this).move(val);
+}
+
+inline bool BitmapValue::contains_any(uint64_t left, uint64_t right) const {
+    if (left > right) {
+        return false;
+    }
+    auto it = lower_bound(left);
+    return it != end() && *it <= right;
 }
 
 } // namespace doris

--- a/be/src/vec/exec/scan/new_olap_scan_node.cpp
+++ b/be/src/vec/exec/scan/new_olap_scan_node.cpp
@@ -66,6 +66,7 @@ Status NewOlapScanNode::_init_profile() {
     _block_init_timer = ADD_TIMER(_segment_profile, "BlockInitTime");
     _block_init_seek_timer = ADD_TIMER(_segment_profile, "BlockInitSeekTime");
     _block_init_seek_counter = ADD_COUNTER(_segment_profile, "BlockInitSeekCount", TUnit::UNIT);
+    _block_conditions_filtered_timer = ADD_TIMER(_segment_profile, "BlockConditionsFilteredTime");
 
     _rows_vec_cond_counter = ADD_COUNTER(_segment_profile, "RowsVectorPredFiltered", TUnit::UNIT);
     _vec_cond_timer = ADD_TIMER(_segment_profile, "VectorPredEvalTime");

--- a/be/src/vec/exec/scan/new_olap_scan_node.h
+++ b/be/src/vec/exec/scan/new_olap_scan_node.h
@@ -95,6 +95,7 @@ private:
     RuntimeProfile::Counter* _block_init_timer = nullptr;
     RuntimeProfile::Counter* _block_init_seek_timer = nullptr;
     RuntimeProfile::Counter* _block_init_seek_counter = nullptr;
+    RuntimeProfile::Counter* _block_conditions_filtered_timer = nullptr;
     RuntimeProfile::Counter* _first_read_timer = nullptr;
     RuntimeProfile::Counter* _first_read_seek_timer = nullptr;
     RuntimeProfile::Counter* _first_read_seek_counter = nullptr;

--- a/be/src/vec/exec/scan/new_olap_scanner.cpp
+++ b/be/src/vec/exec/scan/new_olap_scanner.cpp
@@ -386,6 +386,8 @@ void NewOlapScanner::_update_counters_before_close() {
     COUNTER_UPDATE(olap_parent->_block_init_timer, stats.block_init_ns);
     COUNTER_UPDATE(olap_parent->_block_init_seek_timer, stats.block_init_seek_ns);
     COUNTER_UPDATE(olap_parent->_block_init_seek_counter, stats.block_init_seek_num);
+    COUNTER_UPDATE(olap_parent->_block_conditions_filtered_timer,
+                   stats.block_conditions_filtered_ns);
     COUNTER_UPDATE(olap_parent->_first_read_timer, stats.first_read_ns);
     COUNTER_UPDATE(olap_parent->_first_read_seek_timer, stats.block_first_read_seek_ns);
     COUNTER_UPDATE(olap_parent->_first_read_seek_counter, stats.block_first_read_seek_num);

--- a/be/src/vec/runtime/shared_hash_table_controller.h
+++ b/be/src/vec/runtime/shared_hash_table_controller.h
@@ -42,7 +42,7 @@ struct SharedRuntimeFilterContext {
     std::shared_ptr<MinMaxFuncBase> minmax_func;
     std::shared_ptr<HybridSetBase> hybrid_set;
     std::shared_ptr<BloomFilterFuncBase> bloom_filter_func;
-    std::shared_ptr<BitmapFilterFuncBase> _bitmap_filter_func;
+    std::shared_ptr<BitmapFilterFuncBase> bitmap_filter_func;
 };
 
 struct SharedHashTableContext {


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

The zone_map index records the maximum value, minimum value, whether there are non-null value, whether there are null value in the page. If all the data in a range [min, max] does not exist in the bitmapfiler or there is no non-null data in the page, we can filter the page.

`RowsConditionsFiltered`: 0 -> 98.8M

![image](https://user-images.githubusercontent.com/37725793/204216162-34a42fcb-975c-43c8-a998-c67f89a68b8d.png)
![image](https://user-images.githubusercontent.com/37725793/204216173-25f2565e-9eaa-4a21-987a-c154e6047837.png)


## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

