### PR TITLE
[fix](Dictionary-codec) heap overflow with in-predicate on nullable columns (#14319)

### DIFF
--- a/be/src/olap/in_list_predicate.h
+++ b/be/src/olap/in_list_predicate.h
@@ -458,11 +458,18 @@ private:
                 auto* nested_col_ptr = vectorized::check_and_get_column<
                         vectorized::ColumnDictionary<vectorized::Int32>>(column);
                 auto& data_array = nested_col_ptr->get_data();
-                auto& value_in_dict_flags =
-                        _segment_id_to_value_in_dict_flags[column->get_rowset_segment_id()];
+                auto segid = column->get_rowset_segment_id();
+                DCHECK((segid.first.hi | segid.first.mi | segid.first.lo) != 0);
+                auto& value_in_dict_flags = _segment_id_to_value_in_dict_flags[segid];
                 if (value_in_dict_flags.empty()) {
                     nested_col_ptr->find_codes(*_values, value_in_dict_flags);
                 }
+
+                CHECK(value_in_dict_flags.size() == nested_col_ptr->dict_size())
+                        << "value_in_dict_flags.size()!=nested_col_ptr->dict_size(), "
+                        << value_in_dict_flags.size() << " vs " << nested_col_ptr->dict_size()
+                        << " rowsetid=" << segid.first << " segmentid=" << segid.second
+                        << "dict_info" << nested_col_ptr->dict_debug_string();
 
                 for (uint16_t i = 0; i < size; i++) {
                     uint16_t idx = sel[i];

--- a/be/src/olap/rowset/segment_v2/segment.h
+++ b/be/src/olap/rowset/segment_v2/segment.h
@@ -71,7 +71,7 @@ public:
     Status new_iterator(const Schema& schema, const StorageReadOptions& read_options,
                         std::unique_ptr<RowwiseIterator>* iter);
 
-    uint64_t id() const { return _segment_id; }
+    uint32_t id() const { return _segment_id; }
 
     RowsetId rowset_id() const { return _rowset_id; }
 

--- a/be/src/olap/rowset/segment_v2/segment_iterator.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.cpp
@@ -1113,6 +1113,8 @@ Status SegmentIterator::next_batch(vectorized::Block* block) {
             if (_is_pred_column[cid]) {
                 _current_return_columns[cid] =
                         Schema::get_predicate_column_nullable_ptr(*column_desc);
+                _current_return_columns[cid]->set_rowset_segment_id(
+                        {_segment->rowset_id(), _segment->id()});
                 _current_return_columns[cid]->reserve(_opts.block_row_max);
             } else if (i >= block->columns()) {
                 // if i >= block->columns means the column and not the pred_column means `column i` is
@@ -1259,7 +1261,6 @@ void SegmentIterator::_convert_dict_code_for_predicate_if_necessary_impl(
         ColumnPredicate* predicate) {
     auto& column = _current_return_columns[predicate->column_id()];
     auto* col_ptr = column.get();
-    column->set_rowset_segment_id({_segment->rowset_id(), _segment->id()});
 
     if (PredicateTypeTraits::is_range(predicate->type())) {
         col_ptr->convert_dict_codes_if_necessary();

--- a/be/src/vec/columns/column_dictionary.h
+++ b/be/src/vec/columns/column_dictionary.h
@@ -300,6 +300,10 @@ public:
         return result;
     }
 
+    size_t dict_size() const { return _dict.size(); }
+
+    std::string dict_debug_string() const { return _dict.debug_string(); }
+
     class Dictionary {
     public:
         Dictionary() : _dict_data(new DictContainer()), _total_str_len(0) {};
@@ -435,6 +439,27 @@ public:
         bool empty() { return _dict_data->empty(); }
 
         size_t avg_str_len() { return empty() ? 0 : _total_str_len / _dict_data->size(); }
+
+        size_t size() const {
+            if (!_dict_data) {
+                return 0;
+            }
+            return _dict_data->size();
+        }
+
+        std::string debug_string() const {
+            std::string str = "[";
+            if (_dict_data) {
+                for (size_t i = 0; i < _dict_data->size(); i++) {
+                    if (i) {
+                        str += ',';
+                    }
+                    str += (*_dict_data)[i].to_string();
+                }
+            }
+            str += ']';
+            return str;
+        }
 
     private:
         StringValue _null_value = StringValue();

--- a/be/src/vec/columns/column_nullable.h
+++ b/be/src/vec/columns/column_nullable.h
@@ -311,6 +311,14 @@ public:
     void sort_column(const ColumnSorter* sorter, EqualFlags& flags, IColumn::Permutation& perms,
                      EqualRange& range, bool last_column) const override;
 
+    void set_rowset_segment_id(std::pair<RowsetId, uint32_t> rowset_segment_id) override {
+        nested_column->set_rowset_segment_id(rowset_segment_id);
+    }
+
+    std::pair<RowsetId, uint32_t> get_rowset_segment_id() const override {
+        return nested_column->get_rowset_segment_id();
+    }
+
 private:
     WrappedPtr nested_column;
     WrappedPtr null_map;


### PR DESCRIPTION
Losing segmentid info will mess up the _segment_id_to_value_in_dict_flags map in InListPredicate,
causing two distinct segments to collide and crash the BE at last.

Root causes of the problem:
1) NullableColumn use nested column but the rowsetid&segmentid info cannot pass on to the nested one.
    So overrided set function should be provided instead of use the dummy virtual one in the base class.
2) Set function only called in short_cir_eval and pre_eval while delete_range and delete_bloom_filter are left.

Signed-off-by: freemandealer <freeman.zhang1992@gmail.com>

Co-authored-by: Pxl <pxl290@qq.com>

# Proposed changes

Issue Number: close #14319



## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

