### PR TITLE
[fix](DOE) fix ES query dsl is wrong after FE restarted.

### DIFF
--- a/docs/en/docs/ecosystem/external-table/multi-catalog.md
+++ b/docs/en/docs/ecosystem/external-table/multi-catalog.md
@@ -301,7 +301,7 @@ Parameter | Description
 **elasticsearch.hosts** | ES Connection Address, maybe one or more node, load-balance is also accepted
 **elasticsearch.username** | username for ES
 **elasticsearch.password** | password for the user
-**elasticsearch.doc_value_scan** | whether to enable ES/Lucene column storage to get the value of the query field, the default is false
+**elasticsearch.doc_value_scan** | whether to enable ES/Lucene column storage to get the value of the query field, the default is true
 **elasticsearch.keyword_sniff** | Whether to probe the string segmentation type text.fields in ES, query by keyword (the default is true, false matches the content after the segmentation)
 **elasticsearch.nodes_discovery** | Whether or not to enable ES node discovery, the default is true. In network isolation, set this parameter to false. Only the specified node is connected
 **elasticsearch.ssl** | Whether ES cluster enables https access mode, the current FE/BE implementation is to trust all

--- a/docs/en/docs/sql-manual/sql-reference/Data-Definition-Statements/Create/CREATE-CATALOG.md
+++ b/docs/en/docs/sql-manual/sql-reference/Data-Definition-Statements/Create/CREATE-CATALOG.md
@@ -65,6 +65,10 @@ CREATE CATALOG [IF NOT EXISTS] catalog_name
 2. Create catalog es
 
    ```sql
+   CREATE CATALOG es PROPERTIES (
+	   "type"="es",
+	   "elasticsearch.hosts"="http://127.0.0.1:9200"
+   );
    ```
 
 ### Keywords

--- a/docs/zh-CN/docs/ecosystem/external-table/multi-catalog.md
+++ b/docs/zh-CN/docs/ecosystem/external-table/multi-catalog.md
@@ -301,7 +301,7 @@ mysql> select * from test;
 **elasticsearch.hosts** | ES 地址，可以是一个或多个，也可以是 ES 的负载均衡地址
 **elasticsearch.username** | ES 用户名
 **elasticsearch.password** | 对应用户的密码信息
-**elasticsearch.doc_value_scan** | 是否开启通过 ES/Lucene 列式存储获取查询字段的值，默认为 false
+**elasticsearch.doc_value_scan** | 是否开启通过 ES/Lucene 列式存储获取查询字段的值，默认为 true
 **elasticsearch.keyword_sniff** | 是否对 ES 中字符串分词类型 text.fields 进行探测，通过 keyword 进行查询(默认为 true，设置为 false 会按照分词后的内容匹配)
 **elasticsearch.nodes_discovery** | 是否开启 ES 节点发现，默认为 true，在网络隔离环境下设置为 false，只连接指定节点
 **elasticsearch.ssl** | ES 是否开启 https 访问模式，目前在 fe/be 实现方式为信任所有

--- a/docs/zh-CN/docs/sql-manual/sql-reference/Data-Definition-Statements/Create/CREATE-CATALOG.md
+++ b/docs/zh-CN/docs/sql-manual/sql-reference/Data-Definition-Statements/Create/CREATE-CATALOG.md
@@ -69,6 +69,10 @@ CREATE CATALOG [IF NOT EXISTS] catalog_name
 2. 新建数据目录 es
 
    ```sql
+   CREATE CATALOG es PROPERTIES (
+	   "type"="es",
+	   "elasticsearch.hosts"="http://127.0.0.1:9200"
+   );
    ```
 
 ### Keywords

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/EsExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/EsExternalCatalog.java
@@ -90,6 +90,8 @@ public class EsExternalCatalog extends ExternalCatalog {
             nodes = properties.get(PROP_HOSTS).trim().split(",");
             if (properties.containsKey(PROP_SSL)) {
                 enableSsl = EsUtil.getBoolean(properties, PROP_SSL);
+            } else {
+                properties.put(PROP_SSL, String.valueOf(enableSsl));
             }
 
             if (StringUtils.isNotBlank(properties.get(PROP_USERNAME))) {
@@ -102,14 +104,20 @@ public class EsExternalCatalog extends ExternalCatalog {
 
             if (properties.containsKey(PROP_DOC_VALUE_SCAN)) {
                 enableDocValueScan = EsUtil.getBoolean(properties, PROP_DOC_VALUE_SCAN);
+            } else {
+                properties.put(PROP_DOC_VALUE_SCAN, String.valueOf(enableDocValueScan));
             }
 
             if (properties.containsKey(PROP_KEYWORD_SNIFF)) {
                 enableKeywordSniff = EsUtil.getBoolean(properties, PROP_KEYWORD_SNIFF);
+            } else {
+                properties.put(PROP_KEYWORD_SNIFF, String.valueOf(enableKeywordSniff));
             }
 
             if (properties.containsKey(PROP_NODES_DISCOVERY)) {
                 enableNodesDiscovery = EsUtil.getBoolean(properties, PROP_NODES_DISCOVERY);
+            } else {
+                properties.put(PROP_NODES_DISCOVERY, String.valueOf(enableNodesDiscovery));
             }
         } catch (DdlException e) {
             // should not happen. the properties are already checked in analysis phase.


### PR DESCRIPTION
# Proposed changes

Issue Number: close #14651
Some of default properties of ES catalog is not persisted in EditLog. So when FE is restarted, the default poperties is lost, such as `elasticsearch.doc_value_scan`, `elasticsearch.keyword_sniff` and so on.

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
3. Has document been added or modified:
    - [x] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

