### PR TITLE
[fix](spark load)partition column is not duplicate key, spark load IndexOutOfBounds error

### DIFF
--- a/fe/spark-dpp/src/main/java/org/apache/doris/load/loadv2/dpp/SparkDpp.java
+++ b/fe/spark-dpp/src/main/java/org/apache/doris/load/loadv2/dpp/SparkDpp.java
@@ -461,7 +461,8 @@ public final class SparkDpp implements java.io.Serializable {
                     for (int i = 0; i < keyAndPartitionColumnNames.size(); i++) {
                         String columnName = keyAndPartitionColumnNames.get(i);
                         Object columnObject = row.get(row.fieldIndex(columnName));
-                        if (!validateData(columnObject, baseIndex.getColumn(columnName), parsers.get(columnName),row)) {
+                        if (!validateData(columnObject, baseIndex.getColumn(columnName),
+                            parsers.get(columnName), row)) {
                             abnormalRowAcc.add(1);
                             return result.iterator();
                         }

--- a/fe/spark-dpp/src/main/java/org/apache/doris/load/loadv2/dpp/SparkDpp.java
+++ b/fe/spark-dpp/src/main/java/org/apache/doris/load/loadv2/dpp/SparkDpp.java
@@ -20,8 +20,8 @@ package org.apache.doris.load.loadv2.dpp;
 import org.apache.doris.common.SparkDppException;
 import org.apache.doris.load.loadv2.etl.EtlJobConfig;
 
-import com.google.common.collect.Maps;
 import com.google.common.base.Strings;
+import com.google.common.collect.Maps;
 import com.google.gson.Gson;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -461,7 +461,7 @@ public final class SparkDpp implements java.io.Serializable {
                     for (int i = 0; i < keyAndPartitionColumnNames.size(); i++) {
                         String columnName = keyAndPartitionColumnNames.get(i);
                         Object columnObject = row.get(row.fieldIndex(columnName));
-                        if (!validateData(columnObject, baseIndex.getColumn(columnName), parsers.get(columnName), row)) {
+                        if (!validateData(columnObject, baseIndex.getColumn(columnName), parsers.get(columnName),row)) {
                             abnormalRowAcc.add(1);
                             return result.iterator();
                         }

--- a/fe/spark-dpp/src/main/java/org/apache/doris/load/loadv2/dpp/SparkDpp.java
+++ b/fe/spark-dpp/src/main/java/org/apache/doris/load/loadv2/dpp/SparkDpp.java
@@ -462,7 +462,7 @@ public final class SparkDpp implements java.io.Serializable {
                         String columnName = keyAndPartitionColumnNames.get(i);
                         Object columnObject = row.get(row.fieldIndex(columnName));
                         if (!validateData(columnObject, baseIndex.getColumn(columnName),
-                            parsers.get(columnName), row)) {
+                                parsers.get(columnName), row)) {
                             abnormalRowAcc.add(1);
                             return result.iterator();
                         }

--- a/fe/spark-dpp/src/main/java/org/apache/doris/load/loadv2/dpp/SparkDpp.java
+++ b/fe/spark-dpp/src/main/java/org/apache/doris/load/loadv2/dpp/SparkDpp.java
@@ -20,6 +20,7 @@ package org.apache.doris.load.loadv2.dpp;
 import org.apache.doris.common.SparkDppException;
 import org.apache.doris.load.loadv2.etl.EtlJobConfig;
 
+import com.google.common.collect.Maps;
 import com.google.common.base.Strings;
 import com.google.gson.Gson;
 import org.apache.commons.collections.CollectionUtils;
@@ -427,7 +428,7 @@ public final class SparkDpp implements java.io.Serializable {
     private JavaPairRDD<List<Object>, Object[]> fillTupleWithPartitionColumn(Dataset<Row> dataframe,
             EtlJobConfig.EtlPartitionInfo partitionInfo, List<Integer> partitionKeyIndex,
             List<DorisRangePartitioner.PartitionRangeKey> partitionRangeKeys,
-            List<String> keyColumnNames, List<String> valueColumnNames, StructType dstTableSchema,
+            List<String> keyAndPartitionColumnNames, List<String> valueColumnNames, StructType dstTableSchema,
             EtlJobConfig.EtlIndex baseIndex, List<Long> validPartitionIds) throws SparkDppException {
         List<String> distributeColumns = partitionInfo.distributionColumnRefs;
         Partitioner partitioner = new DorisRangePartitioner(partitionInfo, partitionKeyIndex, partitionRangeKeys);
@@ -444,9 +445,9 @@ public final class SparkDpp implements java.io.Serializable {
             }
         }
 
-        List<ColumnParser> parsers = new ArrayList<>();
+        Map<String, ColumnParser> parsers = Maps.newHashMap();
         for (EtlJobConfig.EtlColumn column : baseIndex.columns) {
-            parsers.add(ColumnParser.create(column));
+            parsers.put(column.columnName, ColumnParser.create(column));
         }
 
         // use PairFlatMapFunction instead of PairMapFunction because the there will be
@@ -454,30 +455,35 @@ public final class SparkDpp implements java.io.Serializable {
         JavaPairRDD<List<Object>, Object[]> resultPairRDD = dataframe.toJavaRDD().flatMapToPair(
                 (PairFlatMapFunction<Row, List<Object>, Object[]>) row -> {
                     List<Tuple2<List<Object>, Object[]>> result = new ArrayList<>();
+                    List<Object> keyAndPartitionColumns = new ArrayList<>();
                     List<Object> keyColumns = new ArrayList<>();
                     List<Object> valueColumns = new ArrayList<>(valueColumnNames.size());
-                    for (int i = 0; i < keyColumnNames.size(); i++) {
-                        String columnName = keyColumnNames.get(i);
+                    for (int i = 0; i < keyAndPartitionColumnNames.size(); i++) {
+                        String columnName = keyAndPartitionColumnNames.get(i);
                         Object columnObject = row.get(row.fieldIndex(columnName));
-                        if (!validateData(columnObject, baseIndex.getColumn(columnName), parsers.get(i), row)) {
+                        if (!validateData(columnObject, baseIndex.getColumn(columnName), parsers.get(columnName), row)) {
                             abnormalRowAcc.add(1);
                             return result.iterator();
                         }
-                        keyColumns.add(columnObject);
+                        keyAndPartitionColumns.add(columnObject);
+
+                        if (baseIndex.getColumn(columnName).isKey) {
+                            keyColumns.add(columnObject);
+                        }
                     }
 
                     for (int i = 0; i < valueColumnNames.size(); i++) {
                         String columnName = valueColumnNames.get(i);
                         Object columnObject = row.get(row.fieldIndex(columnName));
                         if (!validateData(columnObject, baseIndex.getColumn(columnName),
-                                parsers.get(i + keyColumnNames.size()), row)) {
+                                parsers.get(columnName), row)) {
                             abnormalRowAcc.add(1);
                             return result.iterator();
                         }
                         valueColumns.add(columnObject);
                     }
 
-                    DppColumns key = new DppColumns(keyColumns);
+                    DppColumns key = new DppColumns(keyAndPartitionColumns);
                     int pid = partitioner.getPartition(key);
                     if (!validPartitionIndex.contains(pid)) {
                         LOG.warn("invalid partition for row:" + row + ", pid:" + pid);
@@ -1032,13 +1038,16 @@ public final class SparkDpp implements java.io.Serializable {
                     }
                 }
 
-                // get key column names and value column names separately
-                List<String> keyColumnNames = new ArrayList<>();
+                // get key and partition column names and value column names separately
+                List<String> keyAndPartitionColumnNames = new ArrayList<>();
                 List<String> valueColumnNames = new ArrayList<>();
                 for (EtlJobConfig.EtlColumn etlColumn : baseIndex.columns) {
                     if (etlColumn.isKey) {
-                        keyColumnNames.add(etlColumn.columnName);
+                        keyAndPartitionColumnNames.add(etlColumn.columnName);
                     } else {
+                        if (etlTable.partitionInfo.partitionColumnRefs.contains(etlColumn.columnName)) {
+                            keyAndPartitionColumnNames.add(etlColumn.columnName);
+                        }
                         valueColumnNames.add(etlColumn.columnName);
                     }
                 }
@@ -1050,7 +1059,7 @@ public final class SparkDpp implements java.io.Serializable {
                     for (int i = 0; i < baseIndex.columns.size(); ++i) {
                         EtlJobConfig.EtlColumn column = baseIndex.columns.get(i);
                         if (column.columnName.equals(key)) {
-                            partitionKeyIndex.add(i);
+                            partitionKeyIndex.add(keyAndPartitionColumnNames.indexOf(key));
                             partitionKeySchema.add(DppUtils.getClassFromColumn(column));
                             break;
                         }
@@ -1087,7 +1096,7 @@ public final class SparkDpp implements java.io.Serializable {
                             fileGroupDataframe,
                             partitionInfo, partitionKeyIndex,
                             partitionRangeKeys,
-                            keyColumnNames, valueColumnNames,
+                            keyAndPartitionColumnNames, valueColumnNames,
                             dstTableSchema, baseIndex, fileGroup.partitions);
                     if (tablePairRDD == null) {
                         tablePairRDD = ret;


### PR DESCRIPTION
# Proposed changes

Issue Number: close #14600

## Problem summary

In spark load, the job failed when the partition column is not in the duplicate key column list.

We traced the sparkDpp.java and found that, the partition columns ware built with the key index in base metadata. But when partition column was not key, an IndexOutOfBoundsException occurs when obtaining it through DppColumns.

The exception is:
```
java.lang.IndexOutOfBoundsException: Index: 3, Size: 1 
at java.util.ArrayList.rangeCheck(ArrayList.java:657) 
at java.util.ArrayList.get(ArrayList.java:433) 
at org.apache.doris.load.loadv2.dpp.DppColumns.<init>(DppColumns.java:39) 
at org.apache.doris.load.loadv2.dpp.DorisRangePartitioner.getPartition(DorisRangePartitioner.java:56) 
at org.apache.doris.load.loadv2.dpp.SparkDpp$2.call(SparkDpp.java:487) 
at org.apache.doris.load.loadv2.dpp.SparkDpp$2.call(SparkDpp.java:460) 
at org.apache.spark.api.java.JavaRDDLike$$anonfun$fn$3$1.apply(JavaRDDLike.scala:143) 
at org.apache.spark.api.java.JavaRDDLike$$anonfun$fn$3$1.apply(JavaRDDLike.scala:143) 
at scala.collection.Iterator$$anon$12.nextCur(Iterator.scala:434) 
at scala.collection.Iterator$$anon$12.hasNext(Iterator.scala:440) 
at org.apache.spark.shuffle.sort.BypassMergeSortShuffleWriter.write(BypassMergeSortShuffleWriter.java:125) 
at org.apache.spark.scheduler.ShuffleMapTask.runTask(ShuffleMapTask.scala:96) 
at org.apache.spark.scheduler.ShuffleMapTask.runTask(ShuffleMapTask.scala:53) 
at org.apache.spark.scheduler.Task.run(Task.scala:109) 
at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:345) 
at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) 
at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) 
at java.lang.Thread.run(Thread.java:748) 
Driver stacktrace:
```

## Checklist(Required)

1. Does it affect the original behavior: 
    - [x] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

