### PR TITLE
[enhencement](netty) bind netty's default logger when launching fe

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/PaloFe.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/PaloFe.java
@@ -39,6 +39,8 @@ import org.apache.doris.service.FrontendOptions;
 
 import com.google.common.base.Charsets;
 import com.google.common.base.Strings;
+import io.grpc.netty.shaded.io.netty.util.internal.logging.InternalLoggerFactory;
+import io.grpc.netty.shaded.io.netty.util.internal.logging.Log4JLoggerFactory;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.DefaultParser;
@@ -56,6 +58,10 @@ import java.nio.channels.OverlappingFileLockException;
 
 public class PaloFe {
     private static final Logger LOG = LogManager.getLogger(PaloFe.class);
+
+    static {
+        InternalLoggerFactory.setDefaultFactory(Log4JLoggerFactory.INSTANCE);
+    }
 
     public static final String DORIS_HOME_DIR = System.getenv("DORIS_HOME");
     public static final String PID_DIR = System.getenv("PID_DIR");

--- a/fe/fe-core/src/main/java/org/apache/doris/PaloFe.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/PaloFe.java
@@ -39,13 +39,19 @@ import org.apache.doris.service.FrontendOptions;
 
 import com.google.common.base.Charsets;
 import com.google.common.base.Strings;
+import io.grpc.netty.shaded.io.netty.util.internal.logging.InternalLoggerFactory;
+import io.grpc.netty.shaded.io.netty.util.internal.logging.Log4JLoggerFactory;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
+import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.config.Configuration;
+import org.apache.logging.log4j.core.config.LoggerConfig;
 
 import java.io.File;
 import java.io.IOException;
@@ -56,6 +62,15 @@ import java.nio.channels.OverlappingFileLockException;
 
 public class PaloFe {
     private static final Logger LOG = LogManager.getLogger(PaloFe.class);
+
+    static {
+        InternalLoggerFactory.setDefaultFactory(Log4JLoggerFactory.INSTANCE);
+        LoggerContext ctx = (LoggerContext) LogManager.getContext(false);
+        Configuration config = ctx.getConfiguration();
+        LoggerConfig loggerConfig = config.getLoggerConfig("io.grpc.netty.shaded.io.netty");
+        loggerConfig.setLevel(Level.INFO);
+        ctx.updateLoggers();
+    }
 
     public static final String DORIS_HOME_DIR = System.getenv("DORIS_HOME");
     public static final String PID_DIR = System.getenv("PID_DIR");

--- a/fe/fe-core/src/main/java/org/apache/doris/PaloFe.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/PaloFe.java
@@ -39,19 +39,13 @@ import org.apache.doris.service.FrontendOptions;
 
 import com.google.common.base.Charsets;
 import com.google.common.base.Strings;
-import io.grpc.netty.shaded.io.netty.util.internal.logging.InternalLoggerFactory;
-import io.grpc.netty.shaded.io.netty.util.internal.logging.Log4JLoggerFactory;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
-import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.core.LoggerContext;
-import org.apache.logging.log4j.core.config.Configuration;
-import org.apache.logging.log4j.core.config.LoggerConfig;
 
 import java.io.File;
 import java.io.IOException;
@@ -62,15 +56,6 @@ import java.nio.channels.OverlappingFileLockException;
 
 public class PaloFe {
     private static final Logger LOG = LogManager.getLogger(PaloFe.class);
-
-    static {
-        InternalLoggerFactory.setDefaultFactory(Log4JLoggerFactory.INSTANCE);
-        LoggerContext ctx = (LoggerContext) LogManager.getContext(false);
-        Configuration config = ctx.getConfiguration();
-        LoggerConfig loggerConfig = config.getLoggerConfig("io.grpc.netty.shaded.io.netty");
-        loggerConfig.setLevel(Level.INFO);
-        ctx.updateLoggers();
-    }
 
     public static final String DORIS_HOME_DIR = System.getenv("DORIS_HOME");
     public static final String PID_DIR = System.getenv("PID_DIR");

--- a/tsan_suppressions
+++ b/tsan_suppressions
@@ -22,4 +22,3 @@ race:std::char_traits<char>::copy(char*, char const*, unsigned long)
 race:std::lock_guard<int volatile>::lock_guard(int volatile&)
 race:std::lock_guard<int volatile>::~lock_guard()
 race:void google::protobuf::internal::RepeatedPtrFieldBase::Clear<google::protobuf::RepeatedPtrField<doris::PTabletInfo>::TypeHandler>()
-race::doris::JniUtil::*

--- a/tsan_suppressions
+++ b/tsan_suppressions
@@ -22,3 +22,4 @@ race:std::char_traits<char>::copy(char*, char const*, unsigned long)
 race:std::lock_guard<int volatile>::lock_guard(int volatile&)
 race:std::lock_guard<int volatile>::~lock_guard()
 race:void google::protobuf::internal::RepeatedPtrFieldBase::Clear<google::protobuf::RepeatedPtrField<doris::PTabletInfo>::TypeHandler>()
+race::doris::JniUtil::*


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx
The logger Doris Fe uses is log4j, while netty might use slf4j to choose one logger. And it's [reported](https://github.com/grpc/grpc-java/issues/3033#issuecomment-309567676) some confusing occasions would happen under such circumstance. 
And this binding doesn't take effect if move the bind logic to other file or other place within PaloFe.java, so I have to leave it before the main function.
## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

