### PR TITLE
[fix](statistics) Fix potential NPE in ShowStatisticsStmt

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowColumnStatsStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowColumnStatsStmt.java
@@ -111,6 +111,9 @@ public class ShowColumnStatsStmt extends ShowStmt {
     public ShowResultSet constructResultSet(List<Pair<String, ColumnStatistic>> columnStatistics) {
         List<List<String>> result = Lists.newArrayList();
         columnStatistics.forEach(p -> {
+            if (p.second == ColumnStatistic.DEFAULT) {
+                return;
+            }
             List<String> row = Lists.newArrayList();
             row.add(p.first);
             row.add(String.valueOf(p.second.count));
@@ -120,8 +123,8 @@ public class ShowColumnStatsStmt extends ShowStmt {
             row.add(String.valueOf(p.second.avgSizeByte));
             row.add(String.valueOf(p.second.minValue));
             row.add(String.valueOf(p.second.maxValue));
-            row.add(String.valueOf(p.second.minExpr.toSql()));
-            row.add(String.valueOf(p.second.maxExpr.toSql()));
+            row.add(String.valueOf(p.second.minExpr == null ? "N/A" : p.second.minExpr.toSql()));
+            row.add(String.valueOf(p.second.maxExpr == null ? "N/A" : p.second.maxExpr.toSql()));
             result.add(row);
         });
         return new ShowResultSet(getMetaData(), result);

--- a/regression-test/suites/statistics/alter_col_stats.groovy
+++ b/regression-test/suites/statistics/alter_col_stats.groovy
@@ -35,7 +35,7 @@ suite("alter_column_stats") {
 
     sql """ANALYZE statistics_test"""
 
-    sleep(3000)
+    sleep(9000)
 
     qt_sql """
         SHOW COLUMN STATS statistics_test


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

When required cache hasn't been loaded yet, cache would always return ColumnStatistics.DEFAULT which not define the max/min literal expr, add judge for that.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

