### PR TITLE
[improvement](planner)sort show catalogs result by name

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/CatalogMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/CatalogMgr.java
@@ -302,7 +302,7 @@ public class CatalogMgr implements Writable, GsonPostProcessable {
                     if (Env.getCurrentEnv().getAuth()
                             .checkCtlPriv(ConnectContext.get(), catalog.getName(), PrivPredicate.SHOW)) {
                         String name = catalog.getName();
-                        // Filter dbname
+                        // Filter catalog name
                         if (matcher != null && !matcher.match(name)) {
                             continue;
                         }
@@ -312,6 +312,11 @@ public class CatalogMgr implements Writable, GsonPostProcessable {
                         row.add(catalog.getType());
                         rows.add(row);
                     }
+
+                    // sort by catalog name
+                    rows.sort((x, y) -> {
+                        return x.get(1).compareTo(y.get(1));
+                    });
                 }
             } else {
                 if (!nameToCatalog.containsKey(showStmt.getCatalogName())) {

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/CatalogMgrTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/CatalogMgrTest.java
@@ -158,6 +158,10 @@ public class CatalogMgrTest extends TestWithFeService {
         ShowResultSet showResultSet = mgr.showCatalogs(showStmt);
         Assertions.assertEquals(5, showResultSet.getResultRows().size());
 
+        //test result order
+        Assertions.assertEquals("es", showResultSet.getResultRows().get(0).get(1));
+        Assertions.assertEquals("internal", showResultSet.getResultRows().get(4).get(1));
+
         showCatalogSql = "SHOW CATALOGS LIKE 'hms%'";
         showStmt = (ShowCatalogStmt) parseAndAnalyzeStmt(showCatalogSql);
         showResultSet = mgr.showCatalogs(showStmt);


### PR DESCRIPTION
**Result of `show databases`, `show tables`, `show data` are all sorted by name, so make `show catalogs` behavior same.**

# Proposed changes

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [x] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [x] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...


