### PR TITLE
[doc](community) update release-verify doc when gpg import

### DIFF
--- a/docs/en/community/release-and-verify/release-verify.md
+++ b/docs/en/community/release-and-verify/release-verify.md
@@ -70,6 +70,7 @@ gpg --import KEYS
 gpg --verify apache-doris-a.b.c-incubating-src.tar.gz.asc apache-doris-a.b.c-incubating-src.tar.gz
 sha512sum --check apache-doris-a.b.c-incubating-src.tar.gz.sha512
 ```
+> Note: If gpg --import reports **no valid user IDs**, it may be that the gpg version does not match. You can upgrade the version to 2.2.x or above
 
 ## 3. Verify the source protocol header
 

--- a/docs/zh-CN/community/release-and-verify/release-verify.md
+++ b/docs/zh-CN/community/release-and-verify/release-verify.md
@@ -72,6 +72,8 @@ gpg --import KEYS
 gpg --verify apache-doris-a.b.c-incubating-src.tar.gz.asc apache-doris-a.b.c-incubating-src.tar.gz
 sha512sum --check apache-doris-a.b.c-incubating-src.tar.gz.sha512
 ```
+> 注意： gpg --import 如果报错 **no valid user IDs**, 此时可能是gpg版本不匹配，可升级版本至2.2.x或以上
+
 
 ## 3. 验证源码协议头
 


### PR DESCRIPTION
## Problem summary

when gpg --import reports **no valid user IDs**
can upgrade the version to 2.2.x or above

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

