### PR TITLE
[enhancement](memory) Add Memory GC when the available memory of the BE process is lacking

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -68,9 +68,11 @@ CONF_Double(soft_mem_limit_frac, "0.9");
 // Turn down max. will use as much memory as possible.
 CONF_Int64(max_sys_mem_available_low_water_mark_bytes, "1717986918");
 
+// The size of the memory that full gc wants to release each time, as a percentage of the mem limit.
 CONF_mString(process_full_gc_size, "20%");
 
-CONF_mInt32(thread_wait_gc_max_milliseconds, "5000")
+// The maximum time a thread waits for a full GC. Currently only query will wait for full gc.
+CONF_mInt32(thread_wait_gc_max_milliseconds, "5000");
 
 // the port heartbeat service used
 CONF_Int32(heartbeat_service_port, "9050");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -68,6 +68,10 @@ CONF_Double(soft_mem_limit_frac, "0.9");
 // Turn down max. will use as much memory as possible.
 CONF_Int64(max_sys_mem_available_low_water_mark_bytes, "1717986918");
 
+CONF_mString(process_full_gc_size, "20%");
+
+CONF_mInt32(thread_wait_gc_max_milliseconds, "5000")
+
 // the port heartbeat service used
 CONF_Int32(heartbeat_service_port, "9050");
 // the count of heart beat service

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -68,11 +68,12 @@ CONF_Double(soft_mem_limit_frac, "0.9");
 // Turn down max. will use as much memory as possible.
 CONF_Int64(max_sys_mem_available_low_water_mark_bytes, "1717986918");
 
-// The size of the memory that full gc wants to release each time, as a percentage of the mem limit.
+// The size of the memory that gc wants to release each time, as a percentage of the mem limit.
+CONF_mString(process_minor_gc_size, "10%");
 CONF_mString(process_full_gc_size, "20%");
 
 // The maximum time a thread waits for a full GC. Currently only query will wait for full gc.
-CONF_mInt32(thread_wait_gc_max_milliseconds, "5000");
+CONF_mInt32(thread_wait_gc_max_milliseconds, "1000");
 
 // the port heartbeat service used
 CONF_Int32(heartbeat_service_port, "9050");

--- a/be/src/common/daemon.cpp
+++ b/be/src/common/daemon.cpp
@@ -228,11 +228,13 @@ void Daemon::memory_maintenance_thread() {
                     doris::MemInfo::sys_mem_available_low_water_mark() ||
             doris::MemInfo::proc_mem_no_allocator_cache() >= doris::MemInfo::mem_limit()) {
             interval_milliseconds = 100;
+            doris::MemInfo::process_full_gc();
         } else if (doris::MemInfo::sys_mem_available() <
                            doris::MemInfo::sys_mem_available_warning_water_mark() ||
                    doris::MemInfo::proc_mem_no_allocator_cache() >=
                            doris::MemInfo::soft_mem_limit()) {
             interval_milliseconds = 200;
+            doris::MemInfo::process_minor_gc();
         } else {
             interval_milliseconds = config::memory_maintenance_sleep_time_ms;
         }

--- a/be/src/olap/lru_cache.cpp
+++ b/be/src/olap/lru_cache.cpp
@@ -523,6 +523,10 @@ int64_t ShardedLRUCache::prune_if(CacheValuePredicate pred) {
     return num_prune;
 }
 
+int64_t ShardedLRUCache::mem_consumption() {
+    return _mem_tracker->consumption();
+}
+
 void ShardedLRUCache::update_cache_metrics() const {
     size_t total_capacity = 0;
     size_t total_usage = 0;

--- a/be/src/olap/lru_cache.h
+++ b/be/src/olap/lru_cache.h
@@ -372,8 +372,7 @@ public:
     virtual uint64_t new_id() override;
     virtual int64_t prune() override;
     virtual int64_t prune_if(CacheValuePredicate pred) override;
-
-    virtual int64_t mem_consumption() override { return _mem_tracker->consumption(); }
+    virtual int64_t mem_consumption() override;
 
 private:
     void update_cache_metrics() const;

--- a/be/src/olap/lru_cache.h
+++ b/be/src/olap/lru_cache.h
@@ -217,6 +217,8 @@ public:
     // may hold lock for a long time to execute predicate.
     virtual int64_t prune_if(CacheValuePredicate pred) { return 0; }
 
+    virtual int64_t mem_consumption() = 0;
+
 private:
     DISALLOW_COPY_AND_ASSIGN(Cache);
 };
@@ -370,6 +372,8 @@ public:
     virtual uint64_t new_id() override;
     virtual int64_t prune() override;
     virtual int64_t prune_if(CacheValuePredicate pred) override;
+
+    virtual int64_t mem_consumption() override { return _mem_tracker->consumption(); }
 
 private:
     void update_cache_metrics() const;

--- a/be/src/olap/lru_cache.h
+++ b/be/src/olap/lru_cache.h
@@ -372,7 +372,7 @@ public:
     virtual uint64_t new_id() override;
     virtual int64_t prune() override;
     virtual int64_t prune_if(CacheValuePredicate pred) override;
-    virtual int64_t mem_consumption() override;
+    int64_t mem_consumption() override;
 
 private:
     void update_cache_metrics() const;

--- a/be/src/olap/page_cache.cpp
+++ b/be/src/olap/page_cache.cpp
@@ -64,7 +64,7 @@ bool StoragePageCache::lookup(const CacheKey& key, PageCacheHandle* handle,
 
 void StoragePageCache::insert(const CacheKey& key, const Slice& data, PageCacheHandle* handle,
                               segment_v2::PageTypePB page_type, bool in_memory) {
-    auto deleter = [](const doris::CacheKey& key, void* value) { delete[](uint8_t*) value; };
+    auto deleter = [](const doris::CacheKey& key, void* value) { delete[] (uint8_t*)value; };
 
     CachePriority priority = CachePriority::NORMAL;
     if (in_memory) {

--- a/be/src/olap/page_cache.cpp
+++ b/be/src/olap/page_cache.cpp
@@ -64,7 +64,7 @@ bool StoragePageCache::lookup(const CacheKey& key, PageCacheHandle* handle,
 
 void StoragePageCache::insert(const CacheKey& key, const Slice& data, PageCacheHandle* handle,
                               segment_v2::PageTypePB page_type, bool in_memory) {
-    auto deleter = [](const doris::CacheKey& key, void* value) { delete[] (uint8_t*)value; };
+    auto deleter = [](const doris::CacheKey& key, void* value) { delete[](uint8_t*) value; };
 
     CachePriority priority = CachePriority::NORMAL;
     if (in_memory) {

--- a/be/src/olap/page_cache.cpp
+++ b/be/src/olap/page_cache.cpp
@@ -76,4 +76,9 @@ void StoragePageCache::insert(const CacheKey& key, const Slice& data, PageCacheH
     *handle = PageCacheHandle(cache, lru_handle);
 }
 
+void StoragePageCache::prune(segment_v2::PageTypePB page_type) {
+    auto cache = _get_page_cache(page_type);
+    cache->prune();
+}
+
 } // namespace doris

--- a/be/src/olap/page_cache.h
+++ b/be/src/olap/page_cache.h
@@ -91,6 +91,12 @@ public:
         return _get_page_cache(page_type) != nullptr;
     }
 
+    void prune(segment_v2::PageTypePB page_type);
+
+    int64_t get_page_cache_mem_consumption(segment_v2::PageTypePB page_type) {
+        return _get_page_cache(page_type)->mem_consumption();
+    }
+
 private:
     StoragePageCache();
     static StoragePageCache* _s_instance;

--- a/be/src/runtime/fragment_mgr.cpp
+++ b/be/src/runtime/fragment_mgr.cpp
@@ -818,6 +818,7 @@ Status FragmentMgr::exec_plan_fragment(const TExecPlanFragmentParams& params, Fi
             }
         }
     }
+    fragments_ctx->fragment_ids.push_back(fragment_instance_id);
 
     exec_state.reset(new FragmentExecState(fragments_ctx->query_id,
                                            params.params.fragment_instance_id, params.backend_num,
@@ -938,6 +939,21 @@ void FragmentMgr::cancel(const TUniqueId& fragment_id, const PPlanFragmentCancel
     }
     if (pipeline_fragment_ctx) {
         pipeline_fragment_ctx->cancel(reason, msg);
+    }
+}
+
+void FragmentMgr::cancel_query(const TUniqueId& query_id, const PPlanFragmentCancelReason& reason,
+                               const std::string& msg) {
+    std::vector<TUniqueId> cancel_fragment_ids;
+    {
+        std::lock_guard<std::mutex> lock(_lock);
+        auto ctx = _fragments_ctx_map.find(query_id);
+        if (ctx != _fragments_ctx_map.end()) {
+            cancel_fragment_ids = ctx->second->fragment_ids;
+        }
+    }
+    for (auto it : cancel_fragment_ids) {
+        cancel(it, reason, msg);
     }
 }
 

--- a/be/src/runtime/fragment_mgr.h
+++ b/be/src/runtime/fragment_mgr.h
@@ -87,6 +87,9 @@ public:
     void cancel(const TUniqueId& fragment_id, const PPlanFragmentCancelReason& reason,
                 const std::string& msg = "");
 
+    void cancel_query(const TUniqueId& query_id, const PPlanFragmentCancelReason& reason,
+                      const std::string& msg = "");
+
     void cancel_worker();
 
     virtual void debug(std::stringstream& ss);

--- a/be/src/runtime/memory/chunk_allocator.cpp
+++ b/be/src/runtime/memory/chunk_allocator.cpp
@@ -123,7 +123,9 @@ public:
     void clear() {
         std::lock_guard<SpinLock> l(_lock);
         for (int i = 0; i < 64; ++i) {
-            if (_chunk_lists[i].empty()) continue;
+            if (_chunk_lists[i].empty()) {
+                continue;
+            }
             for (auto ptr : _chunk_lists[i]) {
                 ::free(ptr);
             }

--- a/be/src/runtime/memory/chunk_allocator.cpp
+++ b/be/src/runtime/memory/chunk_allocator.cpp
@@ -120,6 +120,17 @@ public:
         _chunk_lists[idx].push_back(ptr);
     }
 
+    void clear() {
+        std::lock_guard<SpinLock> l(_lock);
+        for (int i = 0; i < 64; ++i) {
+            if (_chunk_lists[i].empty()) continue;
+            for (auto ptr : _chunk_lists[i]) {
+                ::free(ptr);
+            }
+            std::vector<uint8_t*>().swap(_chunk_lists[i]);
+        }
+    }
+
 private:
     SpinLock _lock;
     std::vector<std::vector<uint8_t*>> _chunk_lists;
@@ -254,6 +265,13 @@ void ChunkAllocator::free(uint8_t* data, size_t size) {
     chunk.size = size;
     chunk.core_id = CpuInfo::get_current_core();
     free(chunk);
+}
+
+void ChunkAllocator::clear() {
+    for (int i = 0; i < _arenas.size(); ++i) {
+        _arenas[i]->clear();
+    }
+    THREAD_MEM_TRACKER_TRANSFER_FROM(_mem_tracker->consumption(), _mem_tracker.get());
 }
 
 } // namespace doris

--- a/be/src/runtime/memory/chunk_allocator.h
+++ b/be/src/runtime/memory/chunk_allocator.h
@@ -72,6 +72,10 @@ public:
     // otherwise the capacity of chunk allocator will be wrong.
     void free(uint8_t* data, size_t size);
 
+    void clear();
+
+    int64_t mem_consumption() { return _reserved_bytes; }
+
 private:
     ChunkAllocator(size_t reserve_limit);
 

--- a/be/src/runtime/memory/mem_tracker_limiter.cpp
+++ b/be/src/runtime/memory/mem_tracker_limiter.cpp
@@ -242,10 +242,6 @@ Status MemTrackerLimiter::fragment_mem_limit_exceeded(RuntimeState* state, const
     return Status::MemoryLimitExceeded(failed_msg);
 }
 
-// Logs the usage of 'limit' number of queries based on maximum total memory consumption.
-// Helper function for LogTopNQueries that iterates through the MemTracker hierarchy
-// and populates 'min_pq' with 'limit' number of elements (that contain state related
-// to query MemTrackers) based on maximum total memory consumption.
 void MemTrackerLimiter::free_top_query(int64_t min_free_mem) {
     std::priority_queue<std::pair<int64_t, std::string>,
                         std::vector<std::pair<int64_t, std::string>>,

--- a/be/src/runtime/memory/mem_tracker_limiter.h
+++ b/be/src/runtime/memory/mem_tracker_limiter.h
@@ -146,7 +146,7 @@ public:
                                        int64_t failed_allocation_size = 0);
 
     // Start canceling from the query with the largest memory usage until the memory of min_free_mem size is released.
-    static void free_top_query(int64_t min_free_mem);
+    static int64_t free_top_query(int64_t min_free_mem);
 
     static std::string process_mem_log_str() {
         return fmt::format(

--- a/be/src/runtime/memory/mem_tracker_limiter.h
+++ b/be/src/runtime/memory/mem_tracker_limiter.h
@@ -145,9 +145,9 @@ public:
     Status fragment_mem_limit_exceeded(RuntimeState* state, const std::string& msg,
                                        int64_t failed_allocation_size = 0);
 
-    //
+    // Start canceling from the query with the largest memory usage until the memory of min_free_mem size is released.
     static void free_top_query(int64_t min_free_mem);
-    
+
     static std::string process_mem_log_str() {
         return fmt::format(
                 "physical memory {}, process memory used {} limit {}, sys mem available {} low "

--- a/be/src/runtime/memory/mem_tracker_limiter.h
+++ b/be/src/runtime/memory/mem_tracker_limiter.h
@@ -151,11 +151,12 @@ public:
     static std::string process_mem_log_str() {
         return fmt::format(
                 "physical memory {}, process memory used {} limit {}, sys mem available {} low "
-                "water mark {}",
+                "water mark {}, refresh interval memory growth {} B",
                 PrettyPrinter::print(MemInfo::physical_mem(), TUnit::BYTES),
                 PerfCounters::get_vm_rss_str(), MemInfo::mem_limit_str(),
                 MemInfo::sys_mem_available_str(),
-                PrettyPrinter::print(MemInfo::sys_mem_available_low_water_mark(), TUnit::BYTES));
+                PrettyPrinter::print(MemInfo::sys_mem_available_low_water_mark(), TUnit::BYTES),
+                MemInfo::refresh_interval_memory_growth);
     }
 
     std::string debug_string() {

--- a/be/src/runtime/memory/thread_mem_tracker_mgr.cpp
+++ b/be/src/runtime/memory/thread_mem_tracker_mgr.cpp
@@ -17,6 +17,9 @@
 
 #include "runtime/memory/thread_mem_tracker_mgr.h"
 
+#include <chrono>
+#include <thread>
+
 #include "runtime/exec_env.h"
 #include "runtime/fragment_mgr.h"
 #include "service/backend_options.h"
@@ -49,15 +52,22 @@ void ThreadMemTrackerMgr::cancel_fragment() {
     _check_limit = false; // Make sure it will only be canceled once
 }
 
-void ThreadMemTrackerMgr::exceeded() {
+void ThreadMemTrackerMgr::exceeded(int64_t size) {
     if (_cb_func != nullptr) {
         _cb_func();
     }
     _limiter_tracker_raw->print_log_usage(_exceed_mem_limit_msg);
 
     if (is_attach_query()) {
-        // TODO wait gc
-        cancel_fragment();
+        if (_is_process_exceed) {
+            std::this_thread::sleep_for(
+                    std::chrono::milliseconds(config::thread_wait_gc_max_milliseconds));
+            if (MemTrackerLimiter::sys_mem_exceed_limit_check(size)) {
+                cancel_fragment();
+            }
+        } else {
+            cancel_fragment();
+        }
     }
 }
 

--- a/be/src/runtime/memory/thread_mem_tracker_mgr.cpp
+++ b/be/src/runtime/memory/thread_mem_tracker_mgr.cpp
@@ -59,7 +59,7 @@ void ThreadMemTrackerMgr::exceeded(int64_t size) {
     _limiter_tracker_raw->print_log_usage(_exceed_mem_limit_msg);
 
     if (is_attach_query()) {
-        if (_is_process_exceed) {
+        if (_is_process_exceed && _wait_gc) {
             int64_t wait_milliseconds = config::thread_wait_gc_max_milliseconds;
             while (wait_milliseconds > 0) {
                 std::this_thread::sleep_for(std::chrono::milliseconds(100)); // Check every 100 ms.

--- a/be/src/runtime/memory/thread_mem_tracker_mgr.h
+++ b/be/src/runtime/memory/thread_mem_tracker_mgr.h
@@ -104,6 +104,7 @@ public:
     void set_check_limit(bool check_limit) { _check_limit = check_limit; }
     std::string exceed_mem_limit_msg() { return _exceed_mem_limit_msg; }
     void clear_exceed_mem_limit_msg() { _exceed_mem_limit_msg = ""; }
+    void disable_wait_gc() { _wait_gc = false; }
 
     std::string print_debug_string() {
         fmt::memory_buffer consumer_tracker_buf;
@@ -137,8 +138,9 @@ private:
     int64_t _scope_mem = 0;
 
     std::string _failed_consume_msg = std::string();
-    bool _is_process_exceed = false;
     std::string _exceed_mem_limit_msg = std::string();
+    bool _is_process_exceed = false;
+    bool _wait_gc = true;
 
     std::shared_ptr<MemTrackerLimiter> _limiter_tracker;
     MemTrackerLimiter* _limiter_tracker_raw = nullptr;

--- a/be/src/runtime/plan_fragment_executor.cpp
+++ b/be/src/runtime/plan_fragment_executor.cpp
@@ -99,6 +99,8 @@ Status PlanFragmentExecutor::prepare(const TExecPlanFragmentParams& request,
     _runtime_state->set_tracer(std::move(tracer));
 
     SCOPED_ATTACH_TASK(_runtime_state.get());
+    // The brpc server should respond as quickly as possible, turn off check memory limit.
+    STOP_CHECK_THREAD_MEM_TRACKER_LIMIT();
     _runtime_state->init_scanner_mem_trackers();
     _runtime_state->runtime_filter_mgr()->init();
     _runtime_state->set_be_number(request.backend_num);
@@ -276,6 +278,7 @@ Status PlanFragmentExecutor::open_vectorized_internal() {
         SCOPED_CPU_TIMER(_fragment_cpu_timer);
         SCOPED_TIMER(profile()->total_time_counter());
         RETURN_IF_ERROR(_plan->open(_runtime_state.get()));
+        RETURN_IF_CANCELLED(_runtime_state);
     }
     if (_sink == nullptr) {
         return Status::OK();
@@ -289,6 +292,7 @@ Status PlanFragmentExecutor::open_vectorized_internal() {
         auto sink_send_span_guard = Defer {[this]() { this->_sink->end_send_span(); }};
         while (true) {
             doris::vectorized::Block* block;
+            RETURN_IF_CANCELLED(_runtime_state);
 
             {
                 SCOPED_CPU_TIMER(_fragment_cpu_timer);

--- a/be/src/runtime/plan_fragment_executor.cpp
+++ b/be/src/runtime/plan_fragment_executor.cpp
@@ -99,8 +99,6 @@ Status PlanFragmentExecutor::prepare(const TExecPlanFragmentParams& request,
     _runtime_state->set_tracer(std::move(tracer));
 
     SCOPED_ATTACH_TASK(_runtime_state.get());
-    // The brpc server should respond as quickly as possible, turn off check memory limit.
-    STOP_CHECK_THREAD_MEM_TRACKER_LIMIT();
     _runtime_state->init_scanner_mem_trackers();
     _runtime_state->runtime_filter_mgr()->init();
     _runtime_state->set_be_number(request.backend_num);

--- a/be/src/runtime/query_fragments_ctx.h
+++ b/be/src/runtime/query_fragments_ctx.h
@@ -138,6 +138,8 @@ public:
     // MemTracker that is shared by all fragment instances running on this host.
     std::shared_ptr<MemTrackerLimiter> query_mem_tracker;
 
+    std::vector<TUniqueId> fragment_ids;
+
 private:
     ExecEnv* _exec_env;
     DateTimeValue _start_time;

--- a/be/src/runtime/thread_context.h
+++ b/be/src/runtime/thread_context.h
@@ -205,7 +205,8 @@ static void pthread_attach_bthread() {
         // 2. A pthread switch occurs. Because the pthread switch cannot be accurately identified at the moment.
         // So tracker call reset 0 like reuses btls.
         bthread_context = new ThreadContext;
-        bthread_context->thread_mem_tracker_mgr->set_check_limit(false);
+        // The brpc server should respond as quickly as possible.
+        bthread_context->thread_mem_tracker_mgr->disable_wait_gc();
         // set the data so that next time bthread_getspecific in the thread returns the data.
         CHECK_EQ(0, bthread_setspecific(btls_key, bthread_context));
     }

--- a/be/src/runtime/thread_context.h
+++ b/be/src/runtime/thread_context.h
@@ -205,6 +205,7 @@ static void pthread_attach_bthread() {
         // 2. A pthread switch occurs. Because the pthread switch cannot be accurately identified at the moment.
         // So tracker call reset 0 like reuses btls.
         bthread_context = new ThreadContext;
+        bthread_context->thread_mem_tracker_mgr->set_check_limit(false);
         // set the data so that next time bthread_getspecific in the thread returns the data.
         CHECK_EQ(0, bthread_setspecific(btls_key, bthread_context));
     }

--- a/be/src/util/mem_info.cpp
+++ b/be/src/util/mem_info.cpp
@@ -34,6 +34,7 @@
 
 #include "common/config.h"
 #include "gutil/strings/split.h"
+#include "olap/page_cache.h"
 #include "util/cgroup_util.h"
 #include "util/parse_util.h"
 #include "util/pretty_printer.h"
@@ -57,6 +58,7 @@ int64_t MemInfo::_s_sys_mem_available = 0;
 std::string MemInfo::_s_sys_mem_available_str = "";
 int64_t MemInfo::_s_sys_mem_available_low_water_mark = 0;
 int64_t MemInfo::_s_sys_mem_available_warning_water_mark = 0;
+int64_t MemInfo::_s_process_full_gc_size = -1;
 
 void MemInfo::refresh_allocator_mem() {
 #if defined(ADDRESS_SANITIZER) || defined(LEAK_SANITIZER) || defined(THREAD_SANITIZER)
@@ -82,6 +84,24 @@ void MemInfo::refresh_allocator_mem() {
     _s_virtual_memory_used = get_tc_metrics("generic.total_physical_bytes") +
                              get_tc_metrics("tcmalloc.pageheap_unmapped_bytes");
 #endif
+}
+
+void MemInfo::process_minor_gc() {
+    StoragePageCache::instance()->prune(segment_v2::DATA_PAGE);
+    ChunkAllocator::instance()->clear();
+    // TODO, free more cache etc.
+}
+
+void MemInfo::process_full_gc() {
+    int64_t prepare_free_mem = _s_process_full_gc_size;
+    prepare_free_mem -=
+            StoragePageCache::instance()->get_page_cache_mem_consumption(segment_v2::DATA_PAGE);
+    StoragePageCache::instance()->prune(segment_v2::DATA_PAGE);
+    if (prepare_free_mem <= 0) return;
+    prepare_free_mem -= ChunkAllocator::instance()->mem_consumption();
+    ChunkAllocator::instance()->clear();
+    if (prepare_free_mem <= 0) return;
+    MemTrackerLimiter::free_top_query(prepare_free_mem);
 }
 
 #ifndef __APPLE__
@@ -141,6 +161,9 @@ void MemInfo::init() {
     }
     _s_mem_limit_str = PrettyPrinter::print(_s_mem_limit, TUnit::BYTES);
     _s_soft_mem_limit = _s_mem_limit * config::soft_mem_limit_frac;
+
+    _s_process_full_gc_size =
+            ParseUtil::parse_mem_spec(config::process_full_gc_size, -1, _s_mem_limit, &is_percent);
 
     std::string line;
     int64_t _s_vm_min_free_kbytes = 0;

--- a/be/src/util/mem_info.cpp
+++ b/be/src/util/mem_info.cpp
@@ -52,6 +52,7 @@ int64_t MemInfo::_s_allocator_cache_mem = 0;
 std::string MemInfo::_s_allocator_cache_mem_str = "";
 int64_t MemInfo::_s_virtual_memory_used = 0;
 int64_t MemInfo::_s_proc_mem_no_allocator_cache = -1;
+std::atomic<int64_t> MemInfo::refresh_interval_memory_growth = 0;
 
 static std::unordered_map<std::string, int64_t> _mem_info_bytes;
 int64_t MemInfo::_s_sys_mem_available = 0;

--- a/be/src/util/mem_info.cpp
+++ b/be/src/util/mem_info.cpp
@@ -92,7 +92,7 @@ void MemInfo::process_minor_gc() {
     // TODO, free more cache, and should free a certain percentage of capacity, not all.
     int64_t freed_mem = 0;
     Defer defer {[&]() {
-        LOG(INFO) << fmt::format("Process minor gc free memory {} Bytes", freed_mem);
+        LOG(INFO) << fmt::format("Process Minor GC Free Memory {} Bytes", freed_mem);
     }};
 
     freed_mem += ChunkAllocator::instance()->mem_consumption();
@@ -108,7 +108,7 @@ void MemInfo::process_minor_gc() {
 void MemInfo::process_full_gc() {
     int64_t freed_mem = 0;
     Defer defer {
-            [&]() { LOG(INFO) << fmt::format("Process full gc free memory {} Bytes", freed_mem); }};
+            [&]() { LOG(INFO) << fmt::format("Process Full GC Free Memory {} Bytes", freed_mem); }};
 
     freed_mem +=
             StoragePageCache::instance()->get_page_cache_mem_consumption(segment_v2::DATA_PAGE);
@@ -121,7 +121,7 @@ void MemInfo::process_full_gc() {
     if (freed_mem > _s_process_full_gc_size) {
         return;
     }
-    MemTrackerLimiter::free_top_query(_s_process_full_gc_size - freed_mem);
+    freed_mem += MemTrackerLimiter::free_top_query(_s_process_full_gc_size - freed_mem);
 }
 
 #ifndef __APPLE__

--- a/be/src/util/mem_info.h
+++ b/be/src/util/mem_info.h
@@ -109,6 +109,9 @@ public:
 
     static std::string debug_string();
 
+    static void process_minor_gc();
+    static void process_full_gc();
+
 private:
     static bool _s_initialized;
     static int64_t _s_physical_mem;
@@ -125,6 +128,7 @@ private:
     static std::string _s_sys_mem_available_str;
     static int64_t _s_sys_mem_available_low_water_mark;
     static int64_t _s_sys_mem_available_warning_water_mark;
+    static int64_t _s_process_full_gc_size;
 };
 
 } // namespace doris

--- a/be/src/util/mem_info.h
+++ b/be/src/util/mem_info.h
@@ -53,7 +53,9 @@ public:
 
     static void refresh_proc_meminfo();
 
-    static inline int64_t sys_mem_available() { return _s_sys_mem_available; }
+    static inline int64_t sys_mem_available() {
+        return _s_sys_mem_available - refresh_interval_memory_growth;
+    }
     static inline std::string sys_mem_available_str() { return _s_sys_mem_available_str; }
     static inline int64_t sys_mem_available_low_water_mark() {
         return _s_sys_mem_available_low_water_mark;
@@ -83,7 +85,9 @@ public:
     static inline size_t allocator_virtual_mem() { return _s_virtual_memory_used; }
     static inline size_t allocator_cache_mem() { return _s_allocator_cache_mem; }
     static inline std::string allocator_cache_mem_str() { return _s_allocator_cache_mem_str; }
-    static inline int64_t proc_mem_no_allocator_cache() { return _s_proc_mem_no_allocator_cache; }
+    static inline int64_t proc_mem_no_allocator_cache() {
+        return _s_proc_mem_no_allocator_cache + refresh_interval_memory_growth;
+    }
 
     // Tcmalloc property `generic.total_physical_bytes` records the total length of the virtual memory
     // obtained by the process malloc, not the physical memory actually used by the process in the OS.
@@ -92,6 +96,7 @@ public:
     static inline void refresh_proc_mem_no_allocator_cache() {
         _s_proc_mem_no_allocator_cache =
                 PerfCounters::get_vm_rss() - static_cast<int64_t>(_s_allocator_cache_mem);
+        refresh_interval_memory_growth = 0;
     }
 
     static inline int64_t mem_limit() {
@@ -111,6 +116,10 @@ public:
 
     static void process_minor_gc();
     static void process_full_gc();
+
+    // It is only used after the memory limit is exceeded. When multiple threads are waiting for the available memory of the process,
+    // avoid multiple threads starting at the same time and causing OOM.
+    static std::atomic<int64_t> refresh_interval_memory_growth;
 
 private:
     static bool _s_initialized;

--- a/be/src/util/mem_info.h
+++ b/be/src/util/mem_info.h
@@ -137,6 +137,7 @@ private:
     static std::string _s_sys_mem_available_str;
     static int64_t _s_sys_mem_available_low_water_mark;
     static int64_t _s_sys_mem_available_warning_water_mark;
+    static int64_t _s_process_minor_gc_size;
     static int64_t _s_process_full_gc_size;
 };
 


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

1. When the system MemAvailable is less than the warning water mark, or the memory used by the BE process exceeds the mem soft limit, run minor gc and try to release cache.

2. When the MemAvailable of the system is less than the low water mark, or the memory used by the BE process exceeds the mem limit, run fucc gc, try to release the cache, and start canceling from the query with the largest memory usage until the memory of mem_limit * 20% is released.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [x] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

