### PR TITLE
[fix](function) StringRef should not be key of timezone cache

### DIFF
--- a/be/src/vec/functions/function_convert_tz.h
+++ b/be/src/vec/functions/function_convert_tz.h
@@ -27,7 +27,7 @@
 namespace doris::vectorized {
 
 struct ConvertTzCtx {
-    std::map<StringRef, cctz::time_zone> time_zone_cache;
+    std::map<std::string, cctz::time_zone> time_zone_cache;
 };
 
 template <typename DateValueType, typename ArgType>
@@ -53,7 +53,7 @@ struct ConvertTZImpl {
                         size_t input_rows_count) {
         auto convert_ctx = reinterpret_cast<ConvertTzCtx*>(
                 context->get_function_state(FunctionContext::FunctionStateScope::THREAD_LOCAL));
-        std::map<StringRef, cctz::time_zone> time_zone_cache_;
+        std::map<std::string, cctz::time_zone> time_zone_cache_;
         auto& time_zone_cache = convert_ctx ? convert_ctx->time_zone_cache : time_zone_cache_;
         for (size_t i = 0; i < input_rows_count; i++) {
             if (result_null_map[i]) {
@@ -61,16 +61,15 @@ struct ConvertTZImpl {
                 continue;
             }
 
-            StringRef from_tz = from_tz_column->get_data_at(i);
-            StringRef to_tz = to_tz_column->get_data_at(i);
+            auto from_tz = from_tz_column->get_data_at(i).to_string();
+            auto to_tz = to_tz_column->get_data_at(i).to_string();
 
             DateValueType ts_value =
                     binary_cast<NativeType, DateValueType>(date_column->get_element(i));
             int64_t timestamp;
 
             if (time_zone_cache.find(from_tz) == time_zone_cache.cend()) {
-                if (!TimezoneUtils::find_cctz_time_zone(from_tz.to_string(),
-                                                        time_zone_cache[from_tz])) {
+                if (!TimezoneUtils::find_cctz_time_zone(from_tz, time_zone_cache[from_tz])) {
                     result_null_map[i] = true;
                     result_column->insert_default();
                     continue;
@@ -78,8 +77,7 @@ struct ConvertTZImpl {
             }
 
             if (time_zone_cache.find(to_tz) == time_zone_cache.cend()) {
-                if (!TimezoneUtils::find_cctz_time_zone(to_tz.to_string(),
-                                                        time_zone_cache[to_tz])) {
+                if (!TimezoneUtils::find_cctz_time_zone(to_tz, time_zone_cache[to_tz])) {
                     result_null_map[i] = true;
                     result_column->insert_default();
                     continue;


### PR DESCRIPTION
# Proposed changes

In PR(#14616 ), the cache map's key was type of `StringRef`, but `StringRef` is a pointer indeed. So the key was not persistent.

## Problem Summary

```bash
ERROR: AddressSanitizer: heap-use-after-free on address 0x606004e1deb0 at pc 0x0000040a33d6 bp 0x7f4706326d40 sp 0x7f47063264e8
READ of size 13 at 0x606004e1deb0 thread T3048 (FragmentMgrThre)
    #0 0x40a33d5 in MemcmpInterceptorCommon(void*, int (*)(void const*, void const*, unsigned long), void const*, void const*, unsigned long) (/mnt/hdd01/branch-1.1-lts/VEC_ASAN/be/lib/doris_be+0x40a33d5)
    #1 0x40a38c9 in memcmp (/mnt/hdd01/branch-1.1-lts/VEC_ASAN/be/lib/doris_be+0x40a38c9)
    #2 0xb5b8c1d in operator<(StringRef, StringRef) /mnt/hdd01/repo_center/doris_branch-1.1-lts/doris/be/src/vec/common/string_ref.h:177:15
    #3 0xb5b865e in std::less<StringRef>::operator()(StringRef const&, StringRef const&) const /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_function.h:386:20
    #4 0xb5b81c5 in std::_Rb_tree<StringRef, std::pair<StringRef const, cctz::time_zone>, std::_Select1st<std::pair<StringRef const, cctz::time_zone> >, std::less<StringRef>, std::allocator<std::pair<StringRef const, cctz::time_zone> > >::_M_lower_bound(std::_Rb_tree_node<std::pair<StringRef const, cctz::time_zone> >*, std::_Rb_tree_node_base*, StringRef const&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_tree.h:1903:7
    #5 0xb5b7eee in std::_Rb_tree<StringRef, std::pair<StringRef const, cctz::time_zone>, std::_Select1st<std::pair<StringRef const, cctz::time_zone> >, std::less<StringRef>, std::allocator<std::pair<StringRef const, cctz::time_zone> > >::find(StringRef const&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_tree.h:2521:22
    #6 0xb5b7660 in std::map<StringRef, cctz::time_zone, std::less<StringRef>, std::allocator<std::pair<StringRef const, cctz::time_zone> > >::find(StringRef const&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_map.h:1170:21
    #7 0xb5b6930 in doris::vectorized::FunctionConvertTZ::execute_straight(doris_udf::FunctionContext*, doris::vectorized::ColumnVector<long> const*, doris::vectorized::ColumnString const*, doris::vectorized::ColumnString const*, doris::vectorized::ColumnVector<long>*, doris::vectorized::PODArray<unsigned char, 4096ul, Allocator<false, false>, 15ul, 16ul>&, unsigned long) /mnt/hdd01/repo_center/doris_branch-1.1-lts/doris/be/src/vec/functions/function_convert_tz.h:116:33
    #8 0xb5b5bf5 in doris::vectorized::FunctionConvertTZ::execute_impl(doris_udf::FunctionContext*, doris::vectorized::Block&, std::vector<unsigned long, std::allocator<unsigned long> > const&, unsigned long, unsigned long) /mnt/hdd01/repo_center/doris_branch-1.1-lts/doris/be/src/vec/functions/function_convert_tz.h:86:9
    #9 0x83f8479 in doris::vectorized::DefaultExecutable::execute_impl(doris_udf::FunctionContext*, doris::vectorized::Block&, std::vector<unsigned long, std::allocator<unsigned long> > const&, unsigned long, unsigned long) /mnt/hdd01/repo_center/doris_branch-1.1-lts/doris/be/src/vec/functions/function.h:438:26
    #10 0x9973f1d in doris::vectorized::PreparedFunctionImpl::execute_without_low_cardinality_columns(doris_udf::FunctionContext*, doris::vectorized::Block&, std::vector<unsigned long, std::allocator<unsigned long> > const&, unsigned long, unsigned long, bool) /mnt/hdd01/repo_center/doris_branch-1.1-lts/doris/be/src/vec/functions/function.cpp:251:16
    #11 0x99750a2 in doris::vectorized::PreparedFunctionImpl::execute(doris_udf::FunctionContext*, doris::vectorized::Block&, std::vector<unsigned long, std::allocator<unsigned long> > const&, unsigned long, unsigned long, bool) /mnt/hdd01/repo_center/doris_branch-1.1-lts/doris/be/src/vec/functions/function.cpp:272:12
    #12 0x83f5550 in doris::vectorized::IFunctionBase::execute(doris_udf::FunctionContext*, doris::vectorized::Block&, std::vector<unsigned long, std::allocator<unsigned long> > const&, unsigned long, unsigned long, bool) /mnt/hdd01/repo_center/doris_branch-1.1-lts/doris/be/src/vec/functions/function.h:137:19
    #13 0xb767c53 in doris::vectorized::VectorizedFnCall::execute(doris::vectorized::VExprContext*, doris::vectorized::Block*, int*) /mnt/hdd01/repo_center/doris_branch-1.1-lts/doris/be/src/vec/exprs/vectorized_fn_call.cpp:90:5
    #14 0xb767827 in doris::vectorized::VectorizedFnCall::execute(doris::vectorized::VExprContext*, doris::vectorized::Block*, int*) /mnt/hdd01/repo_center/doris_branch-1.1-lts/doris/be/src/vec/exprs/vectorized_fn_call.cpp:83:9
    #15 0x6c19483 in doris::vectorized::VExprContext::execute(doris::vectorized::Block*, int*) /mnt/hdd01/repo_center/doris_branch-1.1-lts/doris/be/src/vec/exprs/vexpr_context.cpp:41:24
    #16 0x768f771 in doris::vectorized::VUnionNode::materialize_block(doris::vectorized::Block*) /mnt/hdd01/repo_center/doris_branch-1.1-lts/doris/be/src/vec/exec/vunion_node.cpp:278:25
    #17 0x768ebd4 in doris::vectorized::VUnionNode::get_next_materialized(doris::RuntimeState*, doris::vectorized::Block*) /mnt/hdd01/repo_center/doris_branch-1.1-lts/doris/be/src/vec/exec/vunion_node.cpp:152:26
    #18 0x7692039 in doris::vectorized::VUnionNode::get_next(doris::RuntimeState*, doris::vectorized::Block*, bool*) /mnt/hdd01/repo_center/doris_branch-1.1-lts/doris/be/src/vec/exec/vunion_node.cpp:237:9
    #19 0x7671120 in doris::vectorized::VSortNode::sort_input(doris::RuntimeState*) /mnt/hdd01/repo_center/doris_branch-1.1-lts/doris/be/src/vec/exec/vsort_node.cpp:135:9
    #20 0x7670b0d in doris::vectorized::VSortNode::open(doris::RuntimeState*) /mnt/hdd01/repo_center/doris_branch-1.1-lts/doris/be/src/vec/exec/vsort_node.cpp:71:5
    #21 0x57454d1 in doris::PlanFragmentExecutor::open_vectorized_internal() /mnt/hdd01/repo_center/doris_branch-1.1-lts/doris/be/src/runtime/plan_fragment_executor.cpp:286:9
    #22 0x5742e2e in doris::PlanFragmentExecutor::open() /mnt/hdd01/repo_center/doris_branch-1.1-lts/doris/be/src/runtime/plan_fragment_executor.cpp:259:18
    #23 0x54f4cc7 in doris::FragmentExecState::execute() /mnt/hdd01/repo_center/doris_branch-1.1-lts/doris/be/src/runtime/fragment_mgr.cpp:249:9
    #24 0x54f8ee4 in doris::FragmentMgr::_exec_actual(std::shared_ptr<doris::FragmentExecState>, std::function<void (doris::PlanFragmentExecutor*)>) /mnt/hdd01/repo_center/doris_branch-1.1-lts/doris/be/src/runtime/fragment_mgr.cpp:485:17
    #25 0x5552dc7 in void std::__invoke_impl<void, void (doris::FragmentMgr::*&)(std::shared_ptr<doris::FragmentExecState>, std::function<void (doris::PlanFragmentExecutor*)>), doris::FragmentMgr*&, std::shared_ptr<doris::FragmentExecState>&, std::function<void (doris::PlanFragmentExecutor*)>&>(std::__invoke_memfun_deref, void (doris::FragmentMgr::*&)(std::shared_ptr<doris::FragmentExecState>, std::function<void (doris::PlanFragmentExecutor*)>), doris::FragmentMgr*&, std::shared_ptr<doris::FragmentExecState>&, std::function<void (doris::PlanFragmentExecutor*)>&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:74:14
    #26 0x5552abb in std::enable_if<is_invocable_r_v<void, void (doris::FragmentMgr::*&)(std::shared_ptr<doris::FragmentExecState>, std::function<void (doris::PlanFragmentExecutor*)>), doris::FragmentMgr*&, std::shared_ptr<doris::FragmentExecState>&, std::function<void (doris::PlanFragmentExecutor*)>&>, void>::type std::__invoke_r<void, void (doris::FragmentMgr::*&)(std::shared_ptr<doris::FragmentExecState>, std::function<void (doris::PlanFragmentExecutor*)>), doris::FragmentMgr*&, std::shared_ptr<doris::FragmentExecState>&, std::function<void (doris::PlanFragmentExecutor*)>&>(void (doris::FragmentMgr::*&)(std::shared_ptr<doris::FragmentExecState>, std::function<void (doris::PlanFragmentExecutor*)>), doris::FragmentMgr*&, std::shared_ptr<doris::FragmentExecState>&, std::function<void (doris::PlanFragmentExecutor*)>&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:111:2
    #27 0x55529e0 in void std::_Bind_result<void, void (doris::FragmentMgr::* (doris::FragmentMgr*, std::shared_ptr<doris::FragmentExecState>, std::function<void (doris::PlanFragmentExecutor*)>))(std::shared_ptr<doris::FragmentExecState>, std::function<void (doris::PlanFragmentExecutor*)>)>::__call<void, 0ul, 1ul, 2ul>(std::tuple<>&&, std::_Index_tuple<0ul, 1ul, 2ul>) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/functional:570:11
    #28 0x5552803 in void std::_Bind_result<void, void (doris::FragmentMgr::* (doris::FragmentMgr*, std::shared_ptr<doris::FragmentExecState>, std::function<void (doris::PlanFragmentExecutor*)>))(std::shared_ptr<doris::FragmentExecState>, std::function<void (doris::PlanFragmentExecutor*)>)>::operator()<>() /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/functional:629:17
    #29 0x55526fc in void std::__invoke_impl<void, std::_Bind_result<void, void (doris::FragmentMgr::* (doris::FragmentMgr*, std::shared_ptr<doris::FragmentExecState>, std::function<void (doris::PlanFragmentExecutor*)>))(std::shared_ptr<doris::FragmentExecState>, std::function<void (doris::PlanFragmentExecutor*)>)>&>(std::__invoke_other, std::_Bind_result<void, void (doris::FragmentMgr::* (doris::FragmentMgr*, std::shared_ptr<doris::FragmentExecState>, std::function<void (doris::PlanFragmentExecutor*)>))(std::shared_ptr<doris::FragmentExecState>, std::function<void (doris::PlanFragmentExecutor*)>)>&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61:14
    #30 0x555268c in std::enable_if<is_invocable_r_v<void, std::_Bind_result<void, void (doris::FragmentMgr::* (doris::FragmentMgr*, std::shared_ptr<doris::FragmentExecState>, std::function<void (doris::PlanFragmentExecutor*)>))(std::shared_ptr<doris::FragmentExecState>, std::function<void (doris::PlanFragmentExecutor*)>)>&>, void>::type std::__invoke_r<void, std::_Bind_result<void, void (doris::FragmentMgr::* (doris::FragmentMgr*, std::shared_ptr<doris::FragmentExecState>, std::function<void (doris::PlanFragmentExecutor*)>))(std::shared_ptr<doris::FragmentExecState>, std::function<void (doris::PlanFragmentExecutor*)>)>&>(std::_Bind_result<void, void (doris::FragmentMgr::* (doris::FragmentMgr*, std::shared_ptr<doris::FragmentExecState>, std::function<void (doris::PlanFragmentExecutor*)>))(std::shared_ptr<doris::FragmentExecState>, std::function<void (doris::PlanFragmentExecutor*)>)>&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:111:2
    #31 0x5551e5c in std::_Function_handler<void (), std::_Bind_result<void, void (doris::FragmentMgr::* (doris::FragmentMgr*, std::shared_ptr<doris::FragmentExecState>, std::function<void (doris::PlanFragmentExecutor*)>))(std::shared_ptr<doris::FragmentExecState>, std::function<void (doris::PlanFragmentExecutor*)>)> >::_M_invoke(std::_Any_data const&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291:9
    #32 0x5448d82 in std::function<void ()>::operator()() const /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:560:9
    #33 0x5b67788 in doris::FunctionRunnable::run() /mnt/hdd01/repo_center/doris_branch-1.1-lts/doris/be/src/util/threadpool.cpp:42:27
    #34 0x5b57969 in doris::ThreadPool::dispatch_thread() /mnt/hdd01/repo_center/doris_branch-1.1-lts/doris/be/src/util/threadpool.cpp:570:24
    #35 0x5b7a0ec in void std::__invoke_impl<void, void (doris::ThreadPool::*&)(), doris::ThreadPool*&>(std::__invoke_memfun_deref, void (doris::ThreadPool::*&)(), doris::ThreadPool*&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:74:14
    #36 0x5b79fb1 in std::__invoke_result<void (doris::ThreadPool::*&)(), doris::ThreadPool*&>::type std::__invoke<void (doris::ThreadPool::*&)(), doris::ThreadPool*&>(void (doris::ThreadPool::*&)(), doris::ThreadPool*&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:96:14
    #37 0x5b79f2a in void std::_Bind<void (doris::ThreadPool::* (doris::ThreadPool*))()>::__call<void, 0ul>(std::tuple<>&&, std::_Index_tuple<0ul>) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/functional:420:11
    #38 0x5b79dd3 in void std::_Bind<void (doris::ThreadPool::* (doris::ThreadPool*))()>::operator()<void>() /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/functional:503:17
    #39 0x5b79ccc in void std::__invoke_impl<void, std::_Bind<void (doris::ThreadPool::* (doris::ThreadPool*))()>&>(std::__invoke_other, std::_Bind<void (doris::ThreadPool::* (doris::ThreadPool*))()>&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61:14
    #40 0x5b79c5c in std::enable_if<is_invocable_r_v<void, std::_Bind<void (doris::ThreadPool::* (doris::ThreadPool*))()>&>, void>::type std::__invoke_r<void, std::_Bind<void (doris::ThreadPool::* (doris::ThreadPool*))()>&>(std::_Bind<void (doris::ThreadPool::* (doris::ThreadPool*))()>&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:111:2
    #41 0x5b798dc in std::_Function_handler<void (), std::_Bind<void (doris::ThreadPool::* (doris::ThreadPool*))()> >::_M_invoke(std::_Any_data const&) /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291:9
    #42 0x5448d82 in std::function<void ()>::operator()() const /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:560:9
    #43 0x5b38712 in doris::Thread::supervise_thread(void*) /mnt/hdd01/repo_center/doris_branch-1.1-lts/doris/be/src/util/thread.cpp:406:5
    #44 0x7f485383444f in start_thread (/lib/x86_64-linux-gnu/libpthread.so.0+0x944f)
    #45 0x7f4853ab9d52 in clone (/lib/x86_64-linux-gnu/libc.so.6+0x117d52)
```

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

