### PR TITLE
[fix](vec) VMergeIterator add key same label for agg table

### DIFF
--- a/be/src/olap/olap_define.h
+++ b/be/src/olap/olap_define.h
@@ -38,7 +38,7 @@ static const uint32_t OLAP_DEFAULT_MAX_UNPACKED_ROW_BLOCK_SIZE = 1024 * 1024 * 1
 // 列存储文件的块大小,由于可能会被全部载入内存,所以需要严格控制大小, 这里定义为256MB
 static const uint32_t OLAP_MAX_COLUMN_SEGMENT_FILE_SIZE = 268435456;
 // 列存储文件大小的伸缩性
-static const double OLAP_COLUMN_FILE_SEGMENT_SIZE_SCALE = 0.02;
+static const double OLAP_COLUMN_FILE_SEGMENT_SIZE_SCALE = 0.9;
 // 在列存储文件中, 数据分块压缩, 每个块的默认压缩前的大小
 static const uint32_t OLAP_DEFAULT_COLUMN_STREAM_BUFFER_SIZE = 10 * 1024;
 // 在列存储文件中, 对字符串使用字典编码的字典大小门限

--- a/be/src/olap/olap_define.h
+++ b/be/src/olap/olap_define.h
@@ -38,7 +38,7 @@ static const uint32_t OLAP_DEFAULT_MAX_UNPACKED_ROW_BLOCK_SIZE = 1024 * 1024 * 1
 // 列存储文件的块大小,由于可能会被全部载入内存,所以需要严格控制大小, 这里定义为256MB
 static const uint32_t OLAP_MAX_COLUMN_SEGMENT_FILE_SIZE = 268435456;
 // 列存储文件大小的伸缩性
-static const double OLAP_COLUMN_FILE_SEGMENT_SIZE_SCALE = 0.9;
+static const double OLAP_COLUMN_FILE_SEGMENT_SIZE_SCALE = 0.02;
 // 在列存储文件中, 数据分块压缩, 每个块的默认压缩前的大小
 static const uint32_t OLAP_DEFAULT_COLUMN_STREAM_BUFFER_SIZE = 10 * 1024;
 // 在列存储文件中, 对字符串使用字典编码的字典大小门限

--- a/be/src/vec/core/block.cpp
+++ b/be/src/vec/core/block.cpp
@@ -341,7 +341,7 @@ void Block::set_num_rows(size_t length) {
             }
         }
         if (length < row_same_bit.size()) {
-            std::vector<uint64_t> tmp_row_same_bit(row_same_bit.begin(),
+            std::vector<bool> tmp_row_same_bit(row_same_bit.begin(),
                                                    row_same_bit.begin() + length);
             row_same_bit = tmp_row_same_bit;
         }
@@ -360,7 +360,7 @@ void Block::skip_num_rows(int64_t& length) {
             }
         }
         if (length < row_same_bit.size()) {
-            std::vector<uint64_t> tmp_row_same_bit(row_same_bit.begin() + length,
+            std::vector<bool> tmp_row_same_bit(row_same_bit.begin() + length,
                                                    row_same_bit.end());
             row_same_bit = tmp_row_same_bit;
         }

--- a/be/src/vec/core/block.cpp
+++ b/be/src/vec/core/block.cpp
@@ -198,6 +198,8 @@ void Block::erase_impl(size_t position) {
             ++it;
         }
     }
+    if (position < row_same_bit.size())
+        row_same_bit.erase(row_same_bit.begin() + position);
 }
 
 void Block::erase(const String& name) {
@@ -339,6 +341,10 @@ void Block::set_num_rows(size_t length) {
                 elem.column = elem.column->cut(0, length);
             }
         }
+        if (length < row_same_bit.size()) {
+            std::vector <uint64_t> tmp_row_same_bit(row_same_bit.begin(), row_same_bit.begin() + length);
+            row_same_bit = tmp_row_same_bit;
+        }
     }
 }
 
@@ -352,6 +358,10 @@ void Block::skip_num_rows(int64_t& length) {
             if (elem.column) {
                 elem.column = elem.column->cut(length, origin_rows - length);
             }
+        }
+        if (length < row_same_bit.size()) {
+            std::vector <uint64_t> tmp_row_same_bit(row_same_bit.begin() + length, row_same_bit.end());
+            row_same_bit = tmp_row_same_bit;
         }
     }
 }
@@ -593,6 +603,7 @@ DataTypes Block::get_data_types() const {
 void Block::clear() {
     data.clear();
     index_by_name.clear();
+    row_same_bit.clear();
 }
 
 void Block::clear_column_data(int column_size) noexcept {
@@ -607,17 +618,20 @@ void Block::clear_column_data(int column_size) noexcept {
         DCHECK_EQ(d.column->use_count(), 1);
         (*std::move(d.column)).assume_mutable()->clear();
     }
+    row_same_bit.clear();
 }
 
 void Block::swap(Block& other) noexcept {
     data.swap(other.data);
     index_by_name.swap(other.index_by_name);
+    row_same_bit.swap(other.row_same_bit);
 }
 
 void Block::swap(Block&& other) noexcept {
     clear();
     data = std::move(other.data);
     initialize_index_by_name();
+    row_same_bit = std::move(other.row_same_bit);
 }
 
 void Block::update_hash(SipHash& hash) const {

--- a/be/src/vec/core/block.cpp
+++ b/be/src/vec/core/block.cpp
@@ -341,7 +341,7 @@ void Block::set_num_rows(size_t length) {
             }
         }
         if (length < row_same_bit.size()) {
-            std::vector <uint64_t> tmp_row_same_bit(row_same_bit.begin(),
+            std::vector<uint64_t> tmp_row_same_bit(row_same_bit.begin(),
                                                     row_same_bit.begin() + length);
             row_same_bit = tmp_row_same_bit;
         }
@@ -360,7 +360,7 @@ void Block::skip_num_rows(int64_t& length) {
             }
         }
         if (length < row_same_bit.size()) {
-            std::vector <uint64_t> tmp_row_same_bit(row_same_bit.begin() + length,
+            std::vector<uint64_t> tmp_row_same_bit(row_same_bit.begin() + length,
                                                     row_same_bit.end());
             row_same_bit = tmp_row_same_bit;
         }

--- a/be/src/vec/core/block.cpp
+++ b/be/src/vec/core/block.cpp
@@ -341,8 +341,7 @@ void Block::set_num_rows(size_t length) {
             }
         }
         if (length < row_same_bit.size()) {
-            std::vector<bool> tmp_row_same_bit(row_same_bit.begin(),
-                                                   row_same_bit.begin() + length);
+            std::vector<bool> tmp_row_same_bit(row_same_bit.begin(), row_same_bit.begin() + length);
             row_same_bit = tmp_row_same_bit;
         }
     }
@@ -360,8 +359,7 @@ void Block::skip_num_rows(int64_t& length) {
             }
         }
         if (length < row_same_bit.size()) {
-            std::vector<bool> tmp_row_same_bit(row_same_bit.begin() + length,
-                                                   row_same_bit.end());
+            std::vector<bool> tmp_row_same_bit(row_same_bit.begin() + length, row_same_bit.end());
             row_same_bit = tmp_row_same_bit;
         }
     }

--- a/be/src/vec/core/block.cpp
+++ b/be/src/vec/core/block.cpp
@@ -342,7 +342,7 @@ void Block::set_num_rows(size_t length) {
         }
         if (length < row_same_bit.size()) {
             std::vector<uint64_t> tmp_row_same_bit(row_same_bit.begin(),
-                                                    row_same_bit.begin() + length);
+                                                   row_same_bit.begin() + length);
             row_same_bit = tmp_row_same_bit;
         }
     }
@@ -361,7 +361,7 @@ void Block::skip_num_rows(int64_t& length) {
         }
         if (length < row_same_bit.size()) {
             std::vector<uint64_t> tmp_row_same_bit(row_same_bit.begin() + length,
-                                                    row_same_bit.end());
+                                                   row_same_bit.end());
             row_same_bit = tmp_row_same_bit;
         }
     }

--- a/be/src/vec/core/block.cpp
+++ b/be/src/vec/core/block.cpp
@@ -343,8 +343,7 @@ void Block::set_num_rows(size_t length) {
             }
         }
         if (length < row_same_bit.size()) {
-            std::vector<bool> tmp_row_same_bit(row_same_bit.begin(), row_same_bit.begin() + length);
-            row_same_bit = tmp_row_same_bit;
+            row_same_bit.resize(length);
         }
     }
 }
@@ -361,8 +360,7 @@ void Block::skip_num_rows(int64_t& length) {
             }
         }
         if (length < row_same_bit.size()) {
-            std::vector<bool> tmp_row_same_bit(row_same_bit.begin() + length, row_same_bit.end());
-            row_same_bit = tmp_row_same_bit;
+            row_same_bit.assign(row_same_bit.begin() + length, row_same_bit.end());
         }
     }
 }

--- a/be/src/vec/core/block.cpp
+++ b/be/src/vec/core/block.cpp
@@ -198,8 +198,7 @@ void Block::erase_impl(size_t position) {
             ++it;
         }
     }
-    if (position < row_same_bit.size())
-        row_same_bit.erase(row_same_bit.begin() + position);
+    if (position < row_same_bit.size()) row_same_bit.erase(row_same_bit.begin() + position);
 }
 
 void Block::erase(const String& name) {
@@ -342,7 +341,8 @@ void Block::set_num_rows(size_t length) {
             }
         }
         if (length < row_same_bit.size()) {
-            std::vector <uint64_t> tmp_row_same_bit(row_same_bit.begin(), row_same_bit.begin() + length);
+            std::vector <uint64_t> tmp_row_same_bit(row_same_bit.begin(),
+                                                    row_same_bit.begin() + length);
             row_same_bit = tmp_row_same_bit;
         }
     }
@@ -360,7 +360,8 @@ void Block::skip_num_rows(int64_t& length) {
             }
         }
         if (length < row_same_bit.size()) {
-            std::vector <uint64_t> tmp_row_same_bit(row_same_bit.begin() + length, row_same_bit.end());
+            std::vector <uint64_t> tmp_row_same_bit(row_same_bit.begin() + length,
+                                                    row_same_bit.end());
             row_same_bit = tmp_row_same_bit;
         }
     }

--- a/be/src/vec/core/block.cpp
+++ b/be/src/vec/core/block.cpp
@@ -198,7 +198,9 @@ void Block::erase_impl(size_t position) {
             ++it;
         }
     }
-    if (position < row_same_bit.size()) row_same_bit.erase(row_same_bit.begin() + position);
+    if (position < row_same_bit.size()) {
+        row_same_bit.erase(row_same_bit.begin() + position);
+    }
 }
 
 void Block::erase(const String& name) {

--- a/be/src/vec/core/block.h
+++ b/be/src/vec/core/block.h
@@ -350,8 +350,8 @@ public:
     int64_t get_decompressed_bytes() const { return _decompressed_bytes; }
     int64_t get_compress_time() const { return _compress_time_ns; }
 
-    void set_same_bit(bool is_same) {
-        is_same ? row_same_bit.push_back(1) : row_same_bit.push_back(0);
+    void set_same_bit(std::vector<uint64_t>::iterator begin, std::vector<uint64_t>::iterator end) {
+        row_same_bit.insert(row_same_bit.end(), begin, end);
 
         DCHECK_EQ(row_same_bit.size(), rows());
     }

--- a/be/src/vec/core/block.h
+++ b/be/src/vec/core/block.h
@@ -62,6 +62,7 @@ private:
 
     Container data;
     IndexByName index_by_name;
+    std::vector<uint64_t> row_same_bit;
 
     int64_t _decompress_time_ns = 0;
     int64_t _decompressed_bytes = 0;
@@ -348,6 +349,19 @@ public:
     int64_t get_decompress_time() const { return _decompress_time_ns; }
     int64_t get_decompressed_bytes() const { return _decompressed_bytes; }
     int64_t get_compress_time() const { return _compress_time_ns; }
+
+    void set_same_bit(bool is_same) {
+        is_same ? row_same_bit.push_back(1) : row_same_bit.push_back(0);
+
+        DCHECK_EQ(row_same_bit.size(), rows());
+    }
+
+    bool get_same_bit(size_t position) {
+        if (position >= row_same_bit.size()) {
+            return false;
+        }
+        return row_same_bit[position] > 0 ? true : false;
+    }
 
 private:
     void erase_impl(size_t position);

--- a/be/src/vec/core/block.h
+++ b/be/src/vec/core/block.h
@@ -62,7 +62,7 @@ private:
 
     Container data;
     IndexByName index_by_name;
-    std::vector<uint64_t> row_same_bit;
+    std::vector<bool> row_same_bit;
 
     int64_t _decompress_time_ns = 0;
     int64_t _decompressed_bytes = 0;
@@ -350,7 +350,7 @@ public:
     int64_t get_decompressed_bytes() const { return _decompressed_bytes; }
     int64_t get_compress_time() const { return _compress_time_ns; }
 
-    void set_same_bit(std::vector<uint64_t>::iterator begin, std::vector<uint64_t>::iterator end) {
+    void set_same_bit(std::vector<bool>::iterator begin, std::vector<bool>::iterator end) {
         row_same_bit.insert(row_same_bit.end(), begin, end);
 
         DCHECK_EQ(row_same_bit.size(), rows());
@@ -360,7 +360,7 @@ public:
         if (position >= row_same_bit.size()) {
             return false;
         }
-        return row_same_bit[position] > 0 ? true : false;
+        return row_same_bit[position];
     }
 
 private:

--- a/be/src/vec/core/block.h
+++ b/be/src/vec/core/block.h
@@ -350,7 +350,7 @@ public:
     int64_t get_decompressed_bytes() const { return _decompressed_bytes; }
     int64_t get_compress_time() const { return _compress_time_ns; }
 
-    void set_same_bit(std::vector<bool>::iterator begin, std::vector<bool>::iterator end) {
+    void set_same_bit(std::vector<bool>::const_iterator begin, std::vector<bool>::const_iterator end) {
         row_same_bit.insert(row_same_bit.end(), begin, end);
 
         DCHECK_EQ(row_same_bit.size(), rows());

--- a/be/src/vec/core/block.h
+++ b/be/src/vec/core/block.h
@@ -350,7 +350,8 @@ public:
     int64_t get_decompressed_bytes() const { return _decompressed_bytes; }
     int64_t get_compress_time() const { return _compress_time_ns; }
 
-    void set_same_bit(std::vector<bool>::const_iterator begin, std::vector<bool>::const_iterator end) {
+    void set_same_bit(std::vector<bool>::const_iterator begin,
+                      std::vector<bool>::const_iterator end) {
         row_same_bit.insert(row_same_bit.end(), begin, end);
 
         DCHECK_EQ(row_same_bit.size(), rows());

--- a/be/src/vec/olap/block_reader.cpp
+++ b/be/src/vec/olap/block_reader.cpp
@@ -416,8 +416,7 @@ void BlockReader::_update_agg_value(MutableColumns& columns, int begin, int end,
 bool BlockReader::_get_next_row_same() {
     if (_next_row.is_same) {
         return true;
-    }
-    else {
+    } else {
         auto block = _next_row.block.get();
         return block->get_same_bit(_next_row.row_pos);
     }

--- a/be/src/vec/olap/block_reader.cpp
+++ b/be/src/vec/olap/block_reader.cpp
@@ -414,8 +414,9 @@ void BlockReader::_update_agg_value(MutableColumns& columns, int begin, int end,
 }
 
 bool BlockReader::_get_next_row_same() {
-    if (_next_row.is_same)
+    if (_next_row.is_same) {
         return true;
+    }
     else {
         auto block = _next_row.block.get();
         return block->get_same_bit(_next_row.row_pos);

--- a/be/src/vec/olap/block_reader.cpp
+++ b/be/src/vec/olap/block_reader.cpp
@@ -418,10 +418,7 @@ bool BlockReader::_get_next_row_same() {
         return true;
     else {
         auto block = _next_row.block.get();
-        if (block->get_same_bit(_next_row.row_pos))
-            return true;
-        else
-            return false;
+        return block->get_same_bit(_next_row.row_pos);
     }
 }
 

--- a/be/src/vec/olap/block_reader.cpp
+++ b/be/src/vec/olap/block_reader.cpp
@@ -213,7 +213,7 @@ Status BlockReader::_agg_key_next_block(Block* block, MemPool* mem_pool, ObjectP
             return res;
         }
 
-        if (!_next_row.is_same) {
+        if (!_get_next_row_same()) {
             if (target_block_row == _batch_size) {
                 break;
             }
@@ -410,6 +410,18 @@ void BlockReader::_update_agg_value(MutableColumns& columns, int begin, int end,
             function->destroy(place);
             function->create(place);
         }
+    }
+}
+
+bool BlockReader::_get_next_row_same() {
+    if (_next_row.is_same)
+        return true;
+    else {
+        auto block = _next_row.block.get();
+        if (block->get_same_bit(_next_row.row_pos))
+            return true;
+        else
+            return false;
     }
 }
 

--- a/be/src/vec/olap/block_reader.h
+++ b/be/src/vec/olap/block_reader.h
@@ -79,6 +79,8 @@ private:
 
     void _update_agg_value(MutableColumns& columns, int begin, int end, bool is_close = true);
 
+    bool _get_next_row_same();
+
     VCollectIterator _vcollect_iter;
     IteratorRowRef _next_row {{}, -1, false};
 

--- a/be/src/vec/olap/vgeneric_iterators.cpp
+++ b/be/src/vec/olap/vgeneric_iterators.cpp
@@ -161,8 +161,9 @@ void VMergeIteratorContext::copy_rows(BlockView* view, bool advanced) {
     size_t start = _index_in_block - _cur_batch_num + 1 - advanced;
     DCHECK(start >= 0);
 
+    auto tmp_pre_ctx_same_bit = get_pre_ctx_same();
     for (size_t i = 0; i < _cur_batch_num; ++i) {
-        view->push_back({_block, static_cast<int>(start + i), false});
+        view->push_back({_block, static_cast<int>(start + i), (tmp_pre_ctx_same_bit[i] > 0 ? true : false)});
     }
 
     _cur_batch_num = 0;

--- a/be/src/vec/olap/vgeneric_iterators.cpp
+++ b/be/src/vec/olap/vgeneric_iterators.cpp
@@ -149,7 +149,8 @@ void VMergeIteratorContext::copy_rows(Block* block, bool advanced) {
 
         d_cp->assume_mutable()->insert_range_from(*s_cp, start, _cur_batch_num);
     }
-    dst.set_same_bit(get_pre_ctx_same());
+    auto tmp_pre_ctx_same_bit = get_pre_ctx_same();
+    dst.set_same_bit(tmp_pre_ctx_same_bit.begin(), tmp_pre_ctx_same_bit.begin() + _cur_batch_num);
     _cur_batch_num = 0;
 }
 
@@ -257,6 +258,8 @@ Status VMergeIteratorContext::init(const StorageReadOptions& opts) {
     if (valid()) {
         RETURN_IF_ERROR(advance());
     }
+    _pre_ctx_same_bit.reserve(_block_row_max);
+    _pre_ctx_same_bit.assign(_block_row_max, 0);
     return Status::OK();
 }
 

--- a/be/src/vec/olap/vgeneric_iterators.cpp
+++ b/be/src/vec/olap/vgeneric_iterators.cpp
@@ -163,7 +163,8 @@ void VMergeIteratorContext::copy_rows(BlockView* view, bool advanced) {
 
     auto tmp_pre_ctx_same_bit = get_pre_ctx_same();
     for (size_t i = 0; i < _cur_batch_num; ++i) {
-        view->push_back({_block, static_cast<int>(start + i), (tmp_pre_ctx_same_bit[i] > 0 ? true : false)});
+        view->push_back({_block, static_cast<int>(start + i),
+                         (tmp_pre_ctx_same_bit[i] > 0 ? true : false)});
     }
 
     _cur_batch_num = 0;

--- a/be/src/vec/olap/vgeneric_iterators.cpp
+++ b/be/src/vec/olap/vgeneric_iterators.cpp
@@ -124,6 +124,7 @@ bool VMergeIteratorContext::compare(const VMergeIteratorContext& rhs) const {
     if (_is_unique) {
         result ? set_skip(true) : rhs.set_skip(true);
     }
+    result ? set_same(true) : rhs.set_same(true);
     return result;
 }
 
@@ -148,6 +149,7 @@ void VMergeIteratorContext::copy_rows(Block* block, bool advanced) {
 
         d_cp->assume_mutable()->insert_range_from(*s_cp, start, _cur_batch_num);
     }
+    dst.set_same_bit(get_pre_ctx_same());
     _cur_batch_num = 0;
 }
 
@@ -260,6 +262,7 @@ Status VMergeIteratorContext::init(const StorageReadOptions& opts) {
 
 Status VMergeIteratorContext::advance() {
     _skip = false;
+    _same = false;
     // NOTE: we increase _index_in_block directly to valid one check
     do {
         _index_in_block++;

--- a/be/src/vec/olap/vgeneric_iterators.cpp
+++ b/be/src/vec/olap/vgeneric_iterators.cpp
@@ -164,7 +164,7 @@ void VMergeIteratorContext::copy_rows(BlockView* view, bool advanced) {
     auto tmp_pre_ctx_same_bit = get_pre_ctx_same();
     for (size_t i = 0; i < _cur_batch_num; ++i) {
         view->push_back({_block, static_cast<int>(start + i),
-                         (tmp_pre_ctx_same_bit[i] > 0 ? true : false)});
+                         tmp_pre_ctx_same_bit[i]});
     }
 
     _cur_batch_num = 0;
@@ -261,7 +261,7 @@ Status VMergeIteratorContext::init(const StorageReadOptions& opts) {
         RETURN_IF_ERROR(advance());
     }
     _pre_ctx_same_bit.reserve(_block_row_max);
-    _pre_ctx_same_bit.assign(_block_row_max, 0);
+    _pre_ctx_same_bit.assign(_block_row_max, false);
     return Status::OK();
 }
 

--- a/be/src/vec/olap/vgeneric_iterators.cpp
+++ b/be/src/vec/olap/vgeneric_iterators.cpp
@@ -149,7 +149,7 @@ void VMergeIteratorContext::copy_rows(Block* block, bool advanced) {
 
         d_cp->assume_mutable()->insert_range_from(*s_cp, start, _cur_batch_num);
     }
-    auto tmp_pre_ctx_same_bit = get_pre_ctx_same();
+    const auto& tmp_pre_ctx_same_bit = get_pre_ctx_same();
     dst.set_same_bit(tmp_pre_ctx_same_bit.begin(), tmp_pre_ctx_same_bit.begin() + _cur_batch_num);
     _cur_batch_num = 0;
 }
@@ -161,7 +161,7 @@ void VMergeIteratorContext::copy_rows(BlockView* view, bool advanced) {
     size_t start = _index_in_block - _cur_batch_num + 1 - advanced;
     DCHECK(start >= 0);
 
-    auto tmp_pre_ctx_same_bit = get_pre_ctx_same();
+    const auto& tmp_pre_ctx_same_bit = get_pre_ctx_same();
     for (size_t i = 0; i < _cur_batch_num; ++i) {
         view->push_back({_block, static_cast<int>(start + i), tmp_pre_ctx_same_bit[i]});
     }

--- a/be/src/vec/olap/vgeneric_iterators.cpp
+++ b/be/src/vec/olap/vgeneric_iterators.cpp
@@ -163,8 +163,7 @@ void VMergeIteratorContext::copy_rows(BlockView* view, bool advanced) {
 
     auto tmp_pre_ctx_same_bit = get_pre_ctx_same();
     for (size_t i = 0; i < _cur_batch_num; ++i) {
-        view->push_back({_block, static_cast<int>(start + i),
-                         tmp_pre_ctx_same_bit[i]});
+        view->push_back({_block, static_cast<int>(start + i), tmp_pre_ctx_same_bit[i]});
     }
 
     _cur_batch_num = 0;

--- a/be/src/vec/olap/vgeneric_iterators.h
+++ b/be/src/vec/olap/vgeneric_iterators.h
@@ -124,7 +124,7 @@ public:
 
     void set_same(bool same) const { _same = same; }
 
-    std::vector<bool> get_pre_ctx_same() const { return _pre_ctx_same_bit; }
+    const std::vector<bool>& get_pre_ctx_same() const { return _pre_ctx_same_bit; }
 
     void set_pre_ctx_same(VMergeIteratorContext* ctx) const {
         int64_t index = ctx->get_cur_batch() - 1;

--- a/be/src/vec/olap/vgeneric_iterators.h
+++ b/be/src/vec/olap/vgeneric_iterators.h
@@ -124,17 +124,13 @@ public:
 
     void set_same(bool same) const { _same = same; }
 
-    std::vector<uint64_t> get_pre_ctx_same() const { return _pre_ctx_same_bit; }
+    std::vector<bool> get_pre_ctx_same() const { return _pre_ctx_same_bit; }
 
     void set_pre_ctx_same(VMergeIteratorContext* ctx) const {
         int64_t index = ctx->get_cur_batch() - 1;
         DCHECK(index >= 0);
         DCHECK_LT(index, _pre_ctx_same_bit.size());
-        if (ctx->is_same()) {
-            _pre_ctx_same_bit[index] = 1;
-        } else {
-            _pre_ctx_same_bit[index] = 0;
-        }
+        _pre_ctx_same_bit[index] = ctx->is_same();
     }
 
     size_t get_cur_batch() { return _cur_batch_num; }
@@ -171,7 +167,7 @@ private:
     std::shared_ptr<Block> _block;
     // used to store data still on block view
     std::list<std::shared_ptr<Block>> _block_list;
-    mutable std::vector<uint64_t> _pre_ctx_same_bit;
+    mutable std::vector<bool> _pre_ctx_same_bit;
 };
 
 class VMergeIterator : public RowwiseIterator {

--- a/be/src/vec/olap/vgeneric_iterators.h
+++ b/be/src/vec/olap/vgeneric_iterators.h
@@ -133,7 +133,7 @@ public:
         _pre_ctx_same_bit[index] = ctx->is_same();
     }
 
-    size_t get_cur_batch() { return _cur_batch_num; }
+    size_t get_cur_batch() const { return _cur_batch_num; }
 
     void add_cur_batch() { _cur_batch_num++; }
 

--- a/be/src/vec/olap/vgeneric_iterators.h
+++ b/be/src/vec/olap/vgeneric_iterators.h
@@ -120,6 +120,14 @@ public:
 
     void set_skip(bool skip) const { _skip = skip; }
 
+    bool is_same() const { return _same; }
+
+    void set_same(bool same) const { _same = same; }
+
+    bool get_pre_ctx_same() const { return _pre_ctx_same; }
+
+    void set_pre_ctx_same(bool pre_ctx_same) const { _pre_ctx_same = pre_ctx_same; }
+
     void add_cur_batch() { _cur_batch_num++; }
 
     void reset_cur_batch() { _cur_batch_num = 0; }
@@ -137,6 +145,8 @@ private:
     bool _is_reverse = false;
     bool _valid = false;
     mutable bool _skip = false;
+    mutable bool _same = false;
+    mutable bool _pre_ctx_same = false;
     size_t _index_in_block = -1;
     // 4096 minus 16 + 16 bytes padding that in padding pod array
     int _block_row_max = 4064;
@@ -220,6 +230,7 @@ private:
                         pre_ctx->copy_rows(block);
                     }
                     pre_ctx = ctx;
+                    pre_ctx->set_pre_ctx_same(ctx->is_same());
                 }
                 if (UNLIKELY(_record_rowids)) {
                     _block_row_locations[row_idx] = ctx->current_row_location();

--- a/be/test/olap/segcompaction_test.cpp
+++ b/be/test/olap/segcompaction_test.cpp
@@ -294,6 +294,7 @@ TEST_F(SegCompactionTest, SegCompactionInterleaveWithBig_ooooOOoOooooooooO) {
             s = rowset_writer->flush();
             EXPECT_EQ(Status::OK(), s);
         }
+        sleep(1);
         num_segments = 8;
         rows_per_segment = 4096;
         for (int i = 0; i < num_segments; ++i) {

--- a/be/test/olap/segcompaction_test.cpp
+++ b/be/test/olap/segcompaction_test.cpp
@@ -310,6 +310,7 @@ TEST_F(SegCompactionTest, SegCompactionInterleaveWithBig_ooooOOoOooooooooO) {
             }
             s = rowset_writer->flush();
             EXPECT_EQ(Status::OK(), s);
+            sleep(1);
         }
         num_segments = 1;
         rows_per_segment = 6400;

--- a/be/test/olap/segcompaction_test.cpp
+++ b/be/test/olap/segcompaction_test.cpp
@@ -310,7 +310,6 @@ TEST_F(SegCompactionTest, SegCompactionInterleaveWithBig_ooooOOoOooooooooO) {
             }
             s = rowset_writer->flush();
             EXPECT_EQ(Status::OK(), s);
-            sleep(1);
         }
         num_segments = 1;
         rows_per_segment = 6400;

--- a/be/test/olap/segcompaction_test.cpp
+++ b/be/test/olap/segcompaction_test.cpp
@@ -294,7 +294,6 @@ TEST_F(SegCompactionTest, SegCompactionInterleaveWithBig_ooooOOoOooooooooO) {
             s = rowset_writer->flush();
             EXPECT_EQ(Status::OK(), s);
         }
-        sleep(1);
         num_segments = 8;
         rows_per_segment = 4096;
         for (int i = 0; i < num_segments; ++i) {
@@ -311,6 +310,7 @@ TEST_F(SegCompactionTest, SegCompactionInterleaveWithBig_ooooOOoOooooooooO) {
             }
             s = rowset_writer->flush();
             EXPECT_EQ(Status::OK(), s);
+            sleep(1);
         }
         num_segments = 1;
         rows_per_segment = 6400;


### PR DESCRIPTION
right now, when query from aggregate table, VCollectIterator build a heap to sort all rows from rowsets, and set same if key column value is equal between rows. when there are many segments in one rowset,  VMergeIterator build a heap to sort all rows from segment, but not set same if key column equal between rows. if you get many rows with same key from several segments of one rowset, VCollectIterator can not set same for all rows, _agg_key_next_block will get several rows with same key and not merge for agg.

Signed-off-by: nextdreamblue <zxw520blue1@163.com>

# Proposed changes

Issue Number: close #14726

## Problem summary

right now, when query from aggregate table, VCollectIterator build a heap to sort all rows from rowsets, and set same if key column value is equal between rows. when there are many segments in one rowset,  VMergeIterator build a heap to sort all rows from segment, but not set same if key column equal between rows. if you get many rows with same key from several segments of one rowset, VCollectIterator can not set same for all rows, _agg_key_next_block will get several rows with same key and not merge for agg.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

