### PR TITLE
[ehancement](nereids) Read lock table when analyze and generate query plan

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/CascadesContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/CascadesContext.java
@@ -17,7 +17,11 @@
 
 package org.apache.doris.nereids;
 
+import org.apache.doris.catalog.Database;
+import org.apache.doris.catalog.Env;
+import org.apache.doris.catalog.Table;
 import org.apache.doris.nereids.analyzer.NereidsAnalyzer;
+import org.apache.doris.nereids.analyzer.UnboundRelation;
 import org.apache.doris.nereids.jobs.Job;
 import org.apache.doris.nereids.jobs.JobContext;
 import org.apache.doris.nereids.jobs.rewrite.RewriteBottomUpJob;
@@ -36,14 +40,23 @@ import org.apache.doris.nereids.rules.analysis.CTEContext;
 import org.apache.doris.nereids.rules.analysis.Scope;
 import org.apache.doris.nereids.trees.expressions.SubqueryExpr;
 import org.apache.doris.nereids.trees.plans.Plan;
+import org.apache.doris.nereids.trees.plans.logical.LogicalCTE;
+import org.apache.doris.nereids.trees.plans.logical.LogicalFilter;
+import org.apache.doris.nereids.trees.plans.logical.LogicalPlan;
+import org.apache.doris.nereids.trees.plans.logical.LogicalSubQueryAlias;
 import org.apache.doris.qe.ConnectContext;
 
 import com.google.common.collect.ImmutableList;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import java.util.Stack;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Context used in memo.
@@ -60,6 +73,8 @@ public class CascadesContext {
     // subqueryExprIsAnalyzed: whether the subquery has been analyzed.
     private final Map<SubqueryExpr, Boolean> subqueryExprIsAnalyzed;
     private final RuntimeFilterContext runtimeFilterContext;
+
+    private List<Table> tables = null;
 
     public CascadesContext(Memo memo, StatementContext statementContext) {
         this(memo, statementContext, new CTEContext());
@@ -196,5 +211,135 @@ public class CascadesContext {
         pushJob(job);
         jobScheduler.executeJobPool(this);
         return this;
+    }
+
+    public void addToTable(Table table) {
+        tables.add(table);
+    }
+
+    public void lockTableOnRead() {
+        for (Table t : tables) {
+            t.readLock();
+        }
+    }
+
+    public void releaseTableReadLock() {
+        for (Table t : tables) {
+            t.readUnlock();
+        }
+    }
+
+    /**
+     * Extract tables.
+     */
+    public void extractTables(LogicalPlan logicalPlan) {
+        Set<UnboundRelation> relations = getTables(logicalPlan);
+        tables = new ArrayList<>();
+        for (UnboundRelation r : relations) {
+            try {
+                tables.add(getTable(r));
+            } catch (Throwable e) {
+                // IGNORE
+            }
+        }
+    }
+
+    private Set<UnboundRelation> getTables(LogicalPlan logicalPlan) {
+        Set<UnboundRelation> unboundRelations = new HashSet<>();
+        logicalPlan.foreach(p -> {
+            if (p instanceof LogicalFilter) {
+                unboundRelations.addAll(extractUnboundRelationFromFilter((LogicalFilter) p));
+            } else if (p instanceof LogicalCTE) {
+                unboundRelations.addAll(extractUnboundRelationFromCTE((LogicalCTE) p));
+            } else {
+                unboundRelations.addAll(p.collect(UnboundRelation.class::isInstance));
+            }
+        });
+        return unboundRelations;
+    }
+
+    private Set<UnboundRelation> extractUnboundRelationFromFilter(LogicalFilter filter) {
+        Set<SubqueryExpr> subqueryExprs = filter.getPredicates()
+                .collect(SubqueryExpr.class::isInstance);
+        Set<UnboundRelation> relations = new HashSet<>();
+        for (SubqueryExpr expr : subqueryExprs) {
+            LogicalPlan plan = expr.getQueryPlan();
+            relations.addAll(getTables(plan));
+        }
+        return relations;
+    }
+
+    private Set<UnboundRelation> extractUnboundRelationFromCTE(LogicalCTE cte) {
+        List<LogicalSubQueryAlias<Plan>> subQueryAliases = cte.getAliasQueries();
+        Set<UnboundRelation> relations = new HashSet<>();
+        for (LogicalSubQueryAlias<Plan> subQueryAlias : subQueryAliases) {
+            relations.addAll(getTables(subQueryAlias));
+        }
+        return relations;
+    }
+
+    private Table getTable(UnboundRelation unboundRelation) {
+        List<String> nameParts = unboundRelation.getNameParts();
+        switch (nameParts.size()) {
+            case 1: { // table
+                String dbName = getConnectContext().getDatabase();
+                return getTable(dbName, nameParts.get(0), getConnectContext().getEnv());
+            }
+            case 2: { // db.table
+                String dbName = nameParts.get(0);
+                if (!dbName.equals(getConnectContext().getDatabase())) {
+                    dbName = getConnectContext().getClusterName() + ":" + dbName;
+                }
+                return getTable(dbName, nameParts.get(1), getConnectContext().getEnv());
+            }
+            default:
+                throw new IllegalStateException("Table name [" + unboundRelation.getTableName() + "] is invalid.");
+        }
+    }
+
+    /**
+     * Find table from catalog.
+     */
+    public Table getTable(String dbName, String tableName, Env env) {
+        Database db = env.getInternalCatalog().getDb(dbName)
+                .orElseThrow(() -> new RuntimeException("Database [" + dbName + "] does not exist."));
+        db.readLock();
+        try {
+            return db.getTable(tableName).orElseThrow(() -> new RuntimeException(
+                    "Table [" + tableName + "] does not exist in database [" + dbName + "]."));
+        } finally {
+            db.readUnlock();
+        }
+    }
+
+    /**
+     * Used to lock table
+     */
+    public static class Lock implements AutoCloseable {
+
+        CascadesContext cascadesContext;
+
+        private Stack<Table> locked = new Stack<>();
+
+        /**
+         * Try to acquire read locks on tables, throw runtime exception once the acquiring for read lock failed.
+         */
+        public Lock(LogicalPlan plan, CascadesContext cascadesContext) {
+            this.cascadesContext = cascadesContext;
+            cascadesContext.extractTables(plan);
+            for (Table table : cascadesContext.tables) {
+                if (!table.tryReadLock(1, TimeUnit.SECONDS)) {
+                    throw new RuntimeException(String.format("Failed to get read lock on table: %s", table.getName()));
+                }
+                locked.push(table);
+            }
+        }
+
+        @Override
+        public void close() {
+            while (!locked.empty()) {
+                locked.pop().readUnlock();
+            }
+        }
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/analyzer/NereidsAnalyzer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/analyzer/NereidsAnalyzer.java
@@ -54,4 +54,5 @@ public class NereidsAnalyzer {
         // check whether analyze result is meaningful
         new CheckAnalysisJob(cascadesContext).execute();
     }
+
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/util/ReadLockTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/util/ReadLockTest.java
@@ -1,0 +1,106 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.util;
+
+import org.apache.doris.catalog.Table;
+import org.apache.doris.common.jmockit.Deencapsulation;
+import org.apache.doris.nereids.CascadesContext;
+import org.apache.doris.nereids.NereidsPlanner;
+import org.apache.doris.nereids.StatementContext;
+import org.apache.doris.nereids.datasets.ssb.SSBTestBase;
+import org.apache.doris.nereids.parser.NereidsParser;
+import org.apache.doris.nereids.properties.PhysicalProperties;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+public class ReadLockTest extends SSBTestBase {
+
+    private final NereidsParser parser = new NereidsParser();
+
+    @Test
+    public void testSimple() {
+        String sql = "SELECT s_suppkey FROM supplier";
+        StatementContext statementContext = MemoTestUtils.createStatementContext(connectContext, sql);
+        NereidsPlanner planner = new NereidsPlanner(statementContext);
+        planner.plan(
+                parser.parseSingle(sql),
+                PhysicalProperties.ANY
+        );
+        CascadesContext cascadesContext = planner.getCascadesContext();
+        List<Table> f = (List<Table>) Deencapsulation.getField(cascadesContext, "tables");
+        Assertions.assertEquals(1, f.size());
+        Assertions.assertEquals("supplier", f.stream().map(Table::getName).findFirst().get());
+
+    }
+
+    @Test
+    public void testCTE() {
+        String sql = "        WITH cte1 AS (\n"
+                + "            SELECT s_suppkey\n"
+                + "            FROM supplier\n"
+                + "            WHERE s_suppkey < 30\n"
+                + "        )\n"
+                + "        SELECT *\n"
+                + "        FROM cte1 as t1, cte1 as t2";
+        StatementContext statementContext = MemoTestUtils.createStatementContext(connectContext, sql);
+        NereidsPlanner planner = new NereidsPlanner(statementContext);
+        planner.plan(
+                parser.parseSingle(sql),
+                PhysicalProperties.ANY
+        );
+        CascadesContext cascadesContext = planner.getCascadesContext();
+        List<Table> f = (List<Table>) Deencapsulation.getField(cascadesContext, "tables");
+        Assertions.assertEquals(1, f.size());
+        Assertions.assertEquals("supplier", f.stream().map(Table::getName).findFirst().get());
+    }
+
+    @Test
+    public void testSubQuery() {
+        String sql = "SELECT s_suppkey FROM (SELECT * FROM supplier) t";
+        StatementContext statementContext = MemoTestUtils.createStatementContext(connectContext, sql);
+        NereidsPlanner planner = new NereidsPlanner(statementContext);
+        planner.plan(
+                parser.parseSingle(sql),
+                PhysicalProperties.ANY
+        );
+        CascadesContext cascadesContext = planner.getCascadesContext();
+        List<Table> f = (List<Table>) Deencapsulation.getField(cascadesContext, "tables");
+
+        Assertions.assertEquals(1, f.size());
+        Assertions.assertEquals("supplier", f.stream().map(Table::getName).findFirst().get());
+    }
+
+    @Test
+    public void testScalarSubQuery() {
+        String sql = "SELECT s_suppkey FROM supplier WHERE s_suppkey > (SELECT MAX(lo_orderkey) FROM lineorder)";
+        StatementContext statementContext = MemoTestUtils.createStatementContext(connectContext, sql);
+        NereidsPlanner planner = new NereidsPlanner(statementContext);
+        planner.plan(
+                parser.parseSingle(sql),
+                PhysicalProperties.ANY
+        );
+        CascadesContext cascadesContext = planner.getCascadesContext();
+        List<Table> f = (List<Table>) Deencapsulation.getField(cascadesContext, "tables");
+        Assertions.assertEquals(2, f.size());
+        Assertions.assertEquals("supplier", f.stream().map(Table::getName).findFirst().get());
+
+    }
+}


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

So that we could avoid some concurrentmodifications to the basic structures in FE

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

