### PR TITLE
[enhancement](BE)add metric for too many version

### DIFF
--- a/be/src/olap/delta_writer.cpp
+++ b/be/src/olap/delta_writer.cpp
@@ -111,7 +111,7 @@ Status DeltaWriter::init() {
     }
 
     // check tablet version number
-    if (_tablet->version_count() > config::max_tablet_version_num - 100) {
+    if (_tablet->exceed_version_limit(config::max_tablet_version_num - 100)) {
         //trigger compaction
         StorageEngine::instance()->submit_compaction_task(_tablet,
                                                           CompactionType::CUMULATIVE_COMPACTION);

--- a/be/src/olap/push_handler.cpp
+++ b/be/src/olap/push_handler.cpp
@@ -127,7 +127,7 @@ Status PushHandler::_do_streaming_ingestion(TabletSharedPtr tablet, const TPushR
     }
 
     // check if version number exceed limit
-    if (tablet->version_count() > config::max_tablet_version_num) {
+    if (tablet->exceed_version_limit()) {
         LOG(WARNING) << "failed to push data. version count: " << tablet->version_count()
                      << ", exceed limit: " << config::max_tablet_version_num
                      << ". tablet: " << tablet->full_name();

--- a/be/src/olap/push_handler.cpp
+++ b/be/src/olap/push_handler.cpp
@@ -127,7 +127,7 @@ Status PushHandler::_do_streaming_ingestion(TabletSharedPtr tablet, const TPushR
     }
 
     // check if version number exceed limit
-    if (tablet->exceed_version_limit()) {
+    if (tablet->exceed_version_limit(config::max_tablet_version_num)) {
         LOG(WARNING) << "failed to push data. version count: " << tablet->version_count()
                      << ", exceed limit: " << config::max_tablet_version_num
                      << ". tablet: " << tablet->full_name();

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -17,6 +17,8 @@
 
 #include "olap/tablet.h"
 
+#include <bvar/reducer.h>
+#include <bvar/window.h>
 #include <ctype.h>
 #include <fmt/core.h>
 #include <glog/logging.h>
@@ -74,6 +76,10 @@ using std::vector;
 
 DEFINE_COUNTER_METRIC_PROTOTYPE_2ARG(flush_bytes, MetricUnit::BYTES);
 DEFINE_COUNTER_METRIC_PROTOTYPE_2ARG(flush_finish_count, MetricUnit::OPERATIONS);
+
+bvar::Adder<uint64_t> exceed_version_limit_counter;
+bvar::Window<bvar::Adder<uint64_t>> xceed_version_limit_counter_minute(
+        &exceed_version_limit_counter, 60);
 
 TabletSharedPtr Tablet::create_tablet_from_meta(TabletMetaSharedPtr tablet_meta,
                                                 DataDir* data_dir) {
@@ -673,6 +679,14 @@ Status Tablet::capture_consistent_versions(const Version& spec_version,
 Status Tablet::check_version_integrity(const Version& version, bool quiet) {
     std::shared_lock rdlock(_meta_lock);
     return capture_consistent_versions(version, nullptr, quiet);
+}
+
+bool Tablet::exceed_version_limit() const {
+    if (_tablet_meta->version_count() > config::max_tablet_version_num) {
+        exceed_version_limit_counter << 1;
+        return true;
+    }
+    return false;
 }
 
 // If any rowset contains the specific version, it means the version already exist

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -681,8 +681,8 @@ Status Tablet::check_version_integrity(const Version& version, bool quiet) {
     return capture_consistent_versions(version, nullptr, quiet);
 }
 
-bool Tablet::exceed_version_limit() const {
-    if (_tablet_meta->version_count() > config::max_tablet_version_num) {
+bool Tablet::exceed_version_limit(int32_t limit) const {
+    if (_tablet_meta->version_count() > limit) {
         exceed_version_limit_counter << 1;
         return true;
     }

--- a/be/src/olap/tablet.h
+++ b/be/src/olap/tablet.h
@@ -94,7 +94,7 @@ public:
 
     size_t num_rows();
     int version_count() const;
-    bool exceed_version_limit() const;
+    bool exceed_version_limit(int32_t limit) const;
     Version max_version() const;
     Version max_version_unlocked() const;
     CumulativeCompactionPolicy* cumulative_compaction_policy();

--- a/be/src/olap/tablet.h
+++ b/be/src/olap/tablet.h
@@ -27,6 +27,7 @@
 #include <unordered_set>
 #include <vector>
 
+#include "common/config.h"
 #include "gen_cpp/AgentService_types.h"
 #include "gen_cpp/MasterService_types.h"
 #include "gen_cpp/olap_file.pb.h"
@@ -93,6 +94,7 @@ public:
 
     size_t num_rows();
     int version_count() const;
+    bool exceed_version_limit() const;
     Version max_version() const;
     Version max_version_unlocked() const;
     CumulativeCompactionPolicy* cumulative_compaction_policy();

--- a/be/src/olap/tablet.h
+++ b/be/src/olap/tablet.h
@@ -27,7 +27,6 @@
 #include <unordered_set>
 #include <vector>
 
-#include "common/config.h"
 #include "gen_cpp/AgentService_types.h"
 #include "gen_cpp/MasterService_types.h"
 #include "gen_cpp/olap_file.pb.h"


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx
Add metric to detect ERR_TOO_MANY_VERSION. Once detecting the value is too high, it might help if using one higher `max_tablet_version` or more compaction threads.
## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

