### PR TITLE
[fix](DOE) Support ES index which contains dynamic_templates

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/external/elasticsearch/EsUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/external/elasticsearch/EsUtil.java
@@ -164,9 +164,7 @@ public class EsUtil {
         // 3. Equal 6.8.x and before user not passed
         if (mappingType == null) {
             // remove dynamic templates, for ES 7.x and 8.x
-            if (mappings.containsKey("dynamic_templates")) {
-                mappings.remove("dynamic_templates");
-            }
+            mappings.remove("dynamic_templates");
             if (mappings.isEmpty()) {
                 throw new DorisEsException("Do not support index without explicit mapping.");
             }
@@ -175,7 +173,8 @@ public class EsUtil {
                 // If type is not passed in takes the first type.
                 JSONObject firstData = (JSONObject) mappings.get(firstType);
                 // check for ES 6.x and before
-                if (firstData.size() == 1 && firstData.containsKey("dynamic_templates")) {
+                firstData.remove("dynamic_templates");
+                if (firstData.isEmpty()) {
                     throw new DorisEsException("Do not support index without explicit mapping.");
                 }
                 return firstData;
@@ -186,7 +185,8 @@ public class EsUtil {
             if (mappings.containsKey(mappingType)) {
                 JSONObject jsonData = (JSONObject) mappings.get(mappingType);
                 // check for ES 6.x and before
-                if (jsonData.size() == 1 && jsonData.containsKey("dynamic_templates")) {
+                jsonData.remove("dynamic_templates");
+                if (jsonData.isEmpty()) {
                     throw new DorisEsException("Do not support index without explicit mapping.");
                 }
                 return jsonData;

--- a/fe/fe-core/src/main/java/org/apache/doris/external/elasticsearch/EsUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/external/elasticsearch/EsUtil.java
@@ -164,19 +164,13 @@ public class EsUtil {
         // 3. Equal 6.8.x and before user not passed
         if (mappingType == null) {
             // remove dynamic templates, for ES 7.x and 8.x
-            mappings.remove("dynamic_templates");
-            if (mappings.isEmpty()) {
-                throw new DorisEsException("Do not support index without explicit mapping.");
-            }
+            checkDynamicTemplates(mappings);
             String firstType = (String) mappings.keySet().iterator().next();
             if (!"properties".equals(firstType)) {
                 // If type is not passed in takes the first type.
                 JSONObject firstData = (JSONObject) mappings.get(firstType);
                 // check for ES 6.x and before
-                firstData.remove("dynamic_templates");
-                if (firstData.isEmpty()) {
-                    throw new DorisEsException("Do not support index without explicit mapping.");
-                }
+                checkDynamicTemplates(firstData);
                 return firstData;
             }
             // Equal 7.x and after
@@ -185,14 +179,22 @@ public class EsUtil {
             if (mappings.containsKey(mappingType)) {
                 JSONObject jsonData = (JSONObject) mappings.get(mappingType);
                 // check for ES 6.x and before
-                jsonData.remove("dynamic_templates");
-                if (jsonData.isEmpty()) {
-                    throw new DorisEsException("Do not support index without explicit mapping.");
-                }
+                checkDynamicTemplates(jsonData);
                 return jsonData;
             }
             // Compatible type error
             return getRootSchema(mappings, null);
+        }
+    }
+
+    /**
+     * Remove `dynamic_templates` and check explicit mapping
+     * @param mappings
+     */
+    private static void checkDynamicTemplates(JSONObject mappings) {
+        mappings.remove("dynamic_templates");
+        if (mappings.isEmpty()) {
+            throw new DorisEsException("Do not support index without explicit mapping.");
         }
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/external/elasticsearch/EsUtilTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/external/elasticsearch/EsUtilTest.java
@@ -41,8 +41,10 @@ import mockit.Injectable;
 import org.json.simple.JSONObject;
 import org.json.simple.JSONValue;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.jupiter.api.Assertions;
+import org.junit.rules.ExpectedException;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -67,6 +69,9 @@ public class EsUtilTest extends EsTestCase {
             + "                  \"uuid\": \"plNNtKiiQ9-n6NpNskFzhQ\",\n" + "                  \"version\": {\n"
             + "                     \"created\": \"5050099\"\n" + "                  }\n" + "               }\n"
             + "            }}";
+
+    @Rule
+    public ExpectedException expectedEx = ExpectedException.none();
 
     /**
      * Init columns.
@@ -298,17 +303,36 @@ public class EsUtilTest extends EsTestCase {
         Assertions.assertEquals("{\"test4\":{\"type\":\"date\"},\"test2\":{\"type\":\"text\","
                 + "\"fields\":{\"keyword\":{\"ignore_above\":256,\"type\":\"keyword\"}}},"
                 + "\"test3\":{\"type\":\"double\"},\"test1\":{\"type\":\"keyword\"}}", testAliases.toJSONString());
+
         JSONObject testAliasesNoType = EsUtil.getMappingProps("test",
                 loadJsonFromFile("data/es/es6_aliases_mapping.json"), null);
         Assertions.assertEquals("{\"test4\":{\"type\":\"date\"},\"test2\":{\"type\":\"text\","
                         + "\"fields\":{\"keyword\":{\"ignore_above\":256,\"type\":\"keyword\"}}},"
                         + "\"test3\":{\"type\":\"double\"},\"test1\":{\"type\":\"keyword\"}}",
                 testAliasesNoType.toJSONString());
+
         JSONObject testIndex = EsUtil.getMappingProps("test", loadJsonFromFile("data/es/es6_index_mapping.json"),
                 "doc");
         Assertions.assertEquals("{\"test4\":{\"type\":\"date\"},\"test2\":{\"type\":\"text\","
                 + "\"fields\":{\"keyword\":{\"ignore_above\":256,\"type\":\"keyword\"}}},"
                 + "\"test3\":{\"type\":\"double\"},\"test1\":{\"type\":\"keyword\"}}", testIndex.toJSONString());
+
+        JSONObject testDynamicTemplates = EsUtil.getMappingProps("test", loadJsonFromFile("data/es/es6_dynamic_templates_mapping.json"),
+                "doc");
+        Assertions.assertEquals("{\"test4\":{\"type\":\"date\"},\"test2\":{\"type\":\"text\","
+                + "\"fields\":{\"keyword\":{\"ignore_above\":256,\"type\":\"keyword\"}}},"
+                + "\"test3\":{\"type\":\"double\"},\"test1\":{\"type\":\"keyword\"}}",
+                testDynamicTemplates.toJSONString());
+
+        expectedEx.expect(DorisEsException.class);
+        expectedEx.expectMessage("Do not support index without explicit mapping.");
+        EsUtil.getMappingProps("test", loadJsonFromFile("data/es/es6_only_dynamic_templates_mapping.json"),
+                "doc");
+
+        expectedEx.expect(DorisEsException.class);
+        expectedEx.expectMessage("Do not support index without explicit mapping.");
+        EsUtil.getMappingProps("test", loadJsonFromFile("data/es/es6_only_dynamic_templates_mapping.json"),
+                null);
     }
 
     @Test
@@ -318,17 +342,31 @@ public class EsUtilTest extends EsTestCase {
         Assertions.assertEquals("{\"test4\":{\"type\":\"date\"},\"test2\":{\"type\":\"text\","
                 + "\"fields\":{\"keyword\":{\"ignore_above\":256,\"type\":\"keyword\"}}},"
                 + "\"test3\":{\"type\":\"double\"},\"test1\":{\"type\":\"keyword\"}}", testAliases.toJSONString());
+
         JSONObject testAliasesErrorType = EsUtil.getMappingProps("test",
                 loadJsonFromFile("data/es/es7_aliases_mapping.json"), "doc");
         Assertions.assertEquals("{\"test4\":{\"type\":\"date\"},\"test2\":{\"type\":\"text\","
                         + "\"fields\":{\"keyword\":{\"ignore_above\":256,\"type\":\"keyword\"}}},"
                         + "\"test3\":{\"type\":\"double\"},\"test1\":{\"type\":\"keyword\"}}",
                 testAliasesErrorType.toJSONString());
+
         JSONObject testIndex = EsUtil.getMappingProps("test", loadJsonFromFile("data/es/es7_index_mapping.json"),
                 "doc");
         Assertions.assertEquals("{\"test4\":{\"type\":\"date\"},\"test2\":{\"type\":\"text\","
                 + "\"fields\":{\"keyword\":{\"ignore_above\":256,\"type\":\"keyword\"}}},"
                 + "\"test3\":{\"type\":\"double\"},\"test1\":{\"type\":\"keyword\"}}", testIndex.toJSONString());
+
+        JSONObject testDynamicTemplates = EsUtil.getMappingProps("test", loadJsonFromFile("data/es/es7_dynamic_templates_mapping.json"),
+                null);
+        Assertions.assertEquals("{\"test4\":{\"type\":\"date\"},\"test2\":{\"type\":\"text\","
+                + "\"fields\":{\"keyword\":{\"ignore_above\":256,\"type\":\"keyword\"}}},"
+                + "\"test3\":{\"type\":\"double\"},\"test1\":{\"type\":\"keyword\"}}",
+                testDynamicTemplates.toJSONString());
+
+        expectedEx.expect(DorisEsException.class);
+        expectedEx.expectMessage("Do not support index without explicit mapping.");
+        EsUtil.getMappingProps("test", loadJsonFromFile("data/es/es7_only_dynamic_templates_mapping.json"),
+                null);
     }
 
     @Test
@@ -338,17 +376,31 @@ public class EsUtilTest extends EsTestCase {
         Assertions.assertEquals("{\"test4\":{\"type\":\"date\"},\"test2\":{\"type\":\"text\","
                 + "\"fields\":{\"keyword\":{\"ignore_above\":256,\"type\":\"keyword\"}}},"
                 + "\"test3\":{\"type\":\"double\"},\"test1\":{\"type\":\"keyword\"}}", testAliases.toJSONString());
+
         JSONObject testAliasesErrorType = EsUtil.getMappingProps("test",
                 loadJsonFromFile("data/es/es8_aliases_mapping.json"), "doc");
         Assertions.assertEquals("{\"test4\":{\"type\":\"date\"},\"test2\":{\"type\":\"text\","
                         + "\"fields\":{\"keyword\":{\"ignore_above\":256,\"type\":\"keyword\"}}},"
                         + "\"test3\":{\"type\":\"double\"},\"test1\":{\"type\":\"keyword\"}}",
                 testAliasesErrorType.toJSONString());
+
         JSONObject testIndex = EsUtil.getMappingProps("test", loadJsonFromFile("data/es/es8_index_mapping.json"),
                 "doc");
         Assertions.assertEquals("{\"test4\":{\"type\":\"date\"},\"test2\":{\"type\":\"text\","
                 + "\"fields\":{\"keyword\":{\"ignore_above\":256,\"type\":\"keyword\"}}},"
                 + "\"test3\":{\"type\":\"double\"},\"test1\":{\"type\":\"keyword\"}}", testIndex.toJSONString());
+
+        JSONObject testDynamicTemplates = EsUtil.getMappingProps("test", loadJsonFromFile("data/es/es8_dynamic_templates_mapping.json"),
+                "doc");
+        Assertions.assertEquals("{\"test4\":{\"type\":\"date\"},\"test2\":{\"type\":\"text\","
+                + "\"fields\":{\"keyword\":{\"ignore_above\":256,\"type\":\"keyword\"}}},"
+                + "\"test3\":{\"type\":\"double\"},\"test1\":{\"type\":\"keyword\"}}",
+                testDynamicTemplates.toJSONString());
+
+        expectedEx.expect(DorisEsException.class);
+        expectedEx.expectMessage("Do not support index without explicit mapping.");
+        EsUtil.getMappingProps("test", loadJsonFromFile("data/es/es8_only_dynamic_templates_mapping.json"),
+                "doc");
     }
 
 }

--- a/fe/fe-core/src/test/resources/data/es/es6_dynamic_templates_mapping.json
+++ b/fe/fe-core/src/test/resources/data/es/es6_dynamic_templates_mapping.json
@@ -1,0 +1,60 @@
+{
+  "test_202207": {
+    "mappings": {
+      "doc": {
+        "dynamic_templates" : [
+          {
+            "message_full" : {
+              "match" : "message_full",
+              "mapping" : {
+                "fields" : {
+                  "keyword" : {
+                    "ignore_above" : 2048,
+                    "type" : "keyword"
+                  }
+                },
+                "type" : "text"
+              }
+            }
+          },
+          {
+            "message" : {
+              "match" : "message",
+              "mapping" : {
+                "type" : "text"
+              }
+            }
+          },
+          {
+            "strings" : {
+              "match_mapping_type" : "string",
+              "mapping" : {
+                "type" : "keyword"
+              }
+            }
+          }
+        ],
+        "properties": {
+          "test1": {
+            "type": "keyword"
+          },
+          "test2": {
+            "type": "text",
+            "fields": {
+              "keyword": {
+                "type": "keyword",
+                "ignore_above": 256
+              }
+            }
+          },
+          "test3": {
+            "type": "double"
+          },
+          "test4": {
+            "type": "date"
+          }
+        }
+      }
+    }
+  }
+}

--- a/fe/fe-core/src/test/resources/data/es/es6_only_dynamic_templates_mapping.json
+++ b/fe/fe-core/src/test/resources/data/es/es6_only_dynamic_templates_mapping.json
@@ -1,0 +1,40 @@
+{
+  "test_202207": {
+    "mappings": {
+      "doc": {
+        "dynamic_templates" : [
+          {
+            "message_full" : {
+              "match" : "message_full",
+              "mapping" : {
+                "fields" : {
+                  "keyword" : {
+                    "ignore_above" : 2048,
+                    "type" : "keyword"
+                  }
+                },
+                "type" : "text"
+              }
+            }
+          },
+          {
+            "message" : {
+              "match" : "message",
+              "mapping" : {
+                "type" : "text"
+              }
+            }
+          },
+          {
+            "strings" : {
+              "match_mapping_type" : "string",
+              "mapping" : {
+                "type" : "keyword"
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/fe/fe-core/src/test/resources/data/es/es7_dynamic_templates_mapping.json
+++ b/fe/fe-core/src/test/resources/data/es/es7_dynamic_templates_mapping.json
@@ -1,0 +1,58 @@
+{
+  "test_202207": {
+    "mappings": {
+      "dynamic_templates" : [
+        {
+          "message_full" : {
+            "match" : "message_full",
+            "mapping" : {
+              "fields" : {
+                "keyword" : {
+                  "ignore_above" : 2048,
+                  "type" : "keyword"
+                }
+              },
+              "type" : "text"
+            }
+          }
+        },
+        {
+          "message" : {
+            "match" : "message",
+            "mapping" : {
+              "type" : "text"
+            }
+          }
+        },
+        {
+          "strings" : {
+            "match_mapping_type" : "string",
+            "mapping" : {
+              "type" : "keyword"
+            }
+          }
+        }
+      ],
+      "properties": {
+        "test1": {
+          "type": "keyword"
+        },
+        "test2": {
+          "type": "text",
+          "fields": {
+            "keyword": {
+              "type": "keyword",
+              "ignore_above": 256
+            }
+          }
+        },
+        "test3": {
+          "type": "double"
+        },
+        "test4": {
+          "type": "date"
+        }
+      }
+    }
+  }
+}

--- a/fe/fe-core/src/test/resources/data/es/es7_only_dynamic_templates_mapping.json
+++ b/fe/fe-core/src/test/resources/data/es/es7_only_dynamic_templates_mapping.json
@@ -1,0 +1,38 @@
+{
+  "test_202207": {
+    "mappings": {
+      "dynamic_templates" : [
+        {
+          "message_full" : {
+            "match" : "message_full",
+            "mapping" : {
+              "fields" : {
+                "keyword" : {
+                  "ignore_above" : 2048,
+                  "type" : "keyword"
+                }
+              },
+              "type" : "text"
+            }
+          }
+        },
+        {
+          "message" : {
+            "match" : "message",
+            "mapping" : {
+              "type" : "text"
+            }
+          }
+        },
+        {
+          "strings" : {
+            "match_mapping_type" : "string",
+            "mapping" : {
+              "type" : "keyword"
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/fe/fe-core/src/test/resources/data/es/es8_dynamic_templates_mapping.json
+++ b/fe/fe-core/src/test/resources/data/es/es8_dynamic_templates_mapping.json
@@ -1,0 +1,58 @@
+{
+  "test_202207": {
+    "mappings": {
+      "dynamic_templates" : [
+        {
+          "message_full" : {
+            "match" : "message_full",
+            "mapping" : {
+              "fields" : {
+                "keyword" : {
+                  "ignore_above" : 2048,
+                  "type" : "keyword"
+                }
+              },
+              "type" : "text"
+            }
+          }
+        },
+        {
+          "message" : {
+            "match" : "message",
+            "mapping" : {
+              "type" : "text"
+            }
+          }
+        },
+        {
+          "strings" : {
+            "match_mapping_type" : "string",
+            "mapping" : {
+              "type" : "keyword"
+            }
+          }
+        }
+      ],
+      "properties": {
+        "test1": {
+          "type": "keyword"
+        },
+        "test2": {
+          "type": "text",
+          "fields": {
+            "keyword": {
+              "type": "keyword",
+              "ignore_above": 256
+            }
+          }
+        },
+        "test3": {
+          "type": "double"
+        },
+        "test4": {
+          "type": "date"
+        }
+      }
+    }
+  }
+}

--- a/fe/fe-core/src/test/resources/data/es/es8_only_dynamic_templates_mapping.json
+++ b/fe/fe-core/src/test/resources/data/es/es8_only_dynamic_templates_mapping.json
@@ -1,0 +1,38 @@
+{
+  "test_202207": {
+    "mappings": {
+      "dynamic_templates" : [
+        {
+          "message_full" : {
+            "match" : "message_full",
+            "mapping" : {
+              "fields" : {
+                "keyword" : {
+                  "ignore_above" : 2048,
+                  "type" : "keyword"
+                }
+              },
+              "type" : "text"
+            }
+          }
+        },
+        {
+          "message" : {
+            "match" : "message",
+            "mapping" : {
+              "type" : "text"
+            }
+          }
+        },
+        {
+          "strings" : {
+            "match_mapping_type" : "string",
+            "mapping" : {
+              "type" : "keyword"
+            }
+          }
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
# Proposed changes

Issue Number: close #14761

## Problem summary

Support ES index with `dynamic_templates`. And do not support index mapping without explicit mapping.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [x] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

