### PR TITLE
[chore](github) Remove required workflow Clang Formatter temporarily

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -49,7 +49,6 @@ github:
         strict: false
         contexts:
           - License Check
-          - Clang Formatter
           - CheckStyle
           - P0 Regression (Doris Regression)
           - P1 Regression (Doris Regression)


### PR DESCRIPTION
# Proposed changes

~~Issue Number: close #xxx~~

## Problem summary

The job clang-tidy needs `pull_request_target` like #12633 . Remove required workflow `Clang Formatter` temporarily to let #14758 work.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

