### PR TITLE
[fix](runtime profile) Fix HighWaterMarkCounter update max Bug

### DIFF
--- a/be/src/util/runtime_profile.h
+++ b/be/src/util/runtime_profile.h
@@ -115,9 +115,9 @@ public:
         HighWaterMarkCounter(TUnit::type unit) : Counter(unit), current_value_(0) {}
 
         virtual void add(int64_t delta) {
-            int64_t new_val = current_value_.fetch_add(delta, std::memory_order_relaxed);
+            current_value_.fetch_add(delta, std::memory_order_relaxed);
             if (delta > 0) {
-                UpdateMax(new_val);
+                UpdateMax(current_value_);
             }
         }
 


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

The Max of HighWaterMarkCounter does not contain the value of the last add

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

