### PR TITLE
[fix](tcmalloc) consider rss when free cached memory

### DIFF
--- a/be/src/common/daemon.cpp
+++ b/be/src/common/daemon.cpp
@@ -76,7 +76,7 @@ void Daemon::tcmalloc_gc_thread() {
     double release_rates[10] = {1.0, 1.0, 1.0, 5.0, 5.0, 20.0, 50.0, 100.0, 500.0, 2000.0};
     int64_t pressure_limit = 90;
     bool is_performance_mode = false;
-    size_t physical_limit_bytes = std::min(MemInfo::hard_mem_limit(), MemInfo::mem_limit());
+    int64_t physical_limit_bytes = std::min(MemInfo::hard_mem_limit(), MemInfo::mem_limit());
 
     if (config::memory_mode == std::string("performance")) {
         max_cache_percent = 100;
@@ -109,9 +109,10 @@ void Daemon::tcmalloc_gc_thread() {
                                                         &tc_alloc_bytes);
          MallocExtension::instance()->GetNumericProperty("generic.current_allocated_bytes",
                                                         &tc_used_bytes);
-        int64_t tc_cached_bytes = tc_alloc_bytes - tc_used_bytes;
+        int64_t tc_cached_bytes = (int64_t)tc_alloc_bytes - (int64_t)tc_used_bytes;
         int64_t to_free_bytes =
-                (int64_t)tc_cached_bytes - (tc_used_bytes * max_cache_percent / 100);
+                (int64_t)tc_cached_bytes - ((int64_t)tc_used_bytes * max_cache_percent / 100);
+        to_free_bytes = std::max(to_free_bytes, (int64_t)0);
 
         int64_t memory_pressure = 0;
         int64_t rss_pressure = 0;

--- a/be/src/common/daemon.cpp
+++ b/be/src/common/daemon.cpp
@@ -114,10 +114,10 @@ void Daemon::tcmalloc_gc_thread() {
                 (int64_t)tc_cached_bytes - (tc_used_bytes * max_cache_percent / 100);
 
         int64_t memory_pressure = 0;
-        int64_t memory_pressure_no_cache = 0;
+        int64_t rss_pressure = 0;
         int64_t alloc_bytes = std::max(rss, tc_alloc_bytes);
         memory_pressure = alloc_bytes * 100 / physical_limit_bytes;
-        memory_pressure_no_cache = (alloc_bytes - tc_cached_bytes) * 100 / physical_limit_bytes;
+        rss_pressure = rss / physical_limit_bytes;
 
         expected_aggressive_decommit = init_aggressive_decommit;
         if (memory_pressure > pressure_limit) {
@@ -126,12 +126,14 @@ void Daemon::tcmalloc_gc_thread() {
             // however, it is hard to set limit on cache of tcmalloc and doris
             // use mmap in vectorized mode.
             // Limit cache capactiy is enough.
-            int64_t min_free_bytes = alloc_bytes - physical_limit_bytes * 9 / 10;
-            to_free_bytes = std::max(to_free_bytes, min_free_bytes);
-            to_free_bytes = std::max(to_free_bytes, tc_cached_bytes * 30 / 100);
-            // We assure that we have at least 500M bytes in cache.
-            to_free_bytes = std::min(to_free_bytes, tc_cached_bytes - 500 * 1024 * 1024);
-            expected_aggressive_decommit = (memory_pressure_no_cache > pressure_limit);
+            if (rss_pressure > pressure_limit) {
+                int64_t min_free_bytes = alloc_bytes - physical_limit_bytes * 9 / 10;
+                to_free_bytes = std::max(to_free_bytes, min_free_bytes);
+                to_free_bytes = std::max(to_free_bytes, tc_cached_bytes * 30 / 100);
+                // We assure that we have at least 500M bytes in cache.
+                to_free_bytes = std::min(to_free_bytes, tc_cached_bytes - 500 * 1024 * 1024);
+                expected_aggressive_decommit = 1;
+            }
             last_ms = kMaxLastMs;
         } else if (memory_pressure > (pressure_limit - 10)) {
             // In most cases, adjusting release rate is enough, if memory are consumed quickly
@@ -143,7 +145,7 @@ void Daemon::tcmalloc_gc_thread() {
 
         int release_rate_index = memory_pressure / 10;
         double release_rate = 1.0;
-        if (release_rate_index >= sizeof(release_rates)) {
+        if (release_rate_index >= sizeof(release_rates) / sizeof(release_rates[0])) {
             release_rate = 2000.0;
         } else {
             release_rate = release_rates[release_rate_index];
@@ -158,7 +160,7 @@ void Daemon::tcmalloc_gc_thread() {
 
         last_memory_pressure = memory_pressure;
         // We release at least 2% bytes once, frequent releasing hurts performance.
-        if (to_free_bytes > physical_limit_bytes * 2 / 100) {
+        if (to_free_bytes > (physical_limit_bytes * 2 / 100)) {
             last_ms += kIntervalMs;
             if (last_ms >= kMaxLastMs) {
                 LOG(INFO) << "generic.current_allocated_bytes " << tc_used_bytes
@@ -170,7 +172,7 @@ void Daemon::tcmalloc_gc_thread() {
                           << current_aggressive_decommit;
                 MallocExtension::instance()->ReleaseToSystem(to_free_bytes);
                 last_ms = 0;
-             }
+            }
         } else {
             last_ms = 0;
         }

--- a/be/src/common/daemon.cpp
+++ b/be/src/common/daemon.cpp
@@ -117,7 +117,7 @@ void Daemon::tcmalloc_gc_thread() {
         int64_t rss_pressure = 0;
         int64_t alloc_bytes = std::max(rss, tc_alloc_bytes);
         memory_pressure = alloc_bytes * 100 / physical_limit_bytes;
-        rss_pressure = rss / physical_limit_bytes;
+        rss_pressure = rss * 100 / physical_limit_bytes;
 
         expected_aggressive_decommit = init_aggressive_decommit;
         if (memory_pressure > pressure_limit) {


### PR DESCRIPTION
If rss usage is low, we do not free cached memory aggressively.

# Proposed changes

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

