### PR TITLE
[branch-1.1](log) add tracing log for publish task

### DIFF
--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -729,14 +729,12 @@ void TaskWorkerPool::_publish_version_worker_thread_callback() {
             st = Status::RuntimeError(strings::Substitute("publish version failed. error=$0", res));
             finish_task_request.__set_error_tablet_ids(error_tablet_ids);
         } else {
-            int submit_tablets = 0;
             if (config::enable_quick_compaction && config::quick_compaction_batch_size > 0) {
                 for (auto& entry : succ_tablet_ids) {
                     TabletSharedPtr tablet =
                             StorageEngine::instance()->tablet_manager()->get_tablet(
                                     entry.first, entry.second);
                     if (tablet != nullptr) {
-                        submit_tablets++;
                         tablet->publised_count++;
                         if (tablet->publised_count % config::quick_compaction_batch_size == 0) {
                             StorageEngine::instance()->submit_quick_compaction_task(tablet);

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -308,6 +308,7 @@ CONF_mInt64(row_step_for_compaction_merge_log, "0");
 // Threshold to logging compaction trace, in seconds.
 CONF_mInt32(base_compaction_trace_threshold, "60");
 CONF_mInt32(cumulative_compaction_trace_threshold, "10");
+CONF_mInt32(publish_task_trace_threshold, "2");
 CONF_mBool(disable_compaction_trace_log, "true");
 
 // Threshold to logging agent task trace, in seconds.
@@ -553,7 +554,7 @@ CONF_mInt64(max_runnings_transactions_per_txn_map, "100");
 
 // tablet_map_lock shard size, the value is 2^n, n=0,1,2,3,4
 // this is a an enhancement for better performance to manage tablet
-CONF_Int32(tablet_map_shard_size, "1");
+CONF_Int32(tablet_map_shard_size, "4");
 
 // txn_map_lock shard size, the value is 2^n, n=0,1,2,3,4
 // this is a an enhancement for better performance to manage txn

--- a/be/src/olap/data_dir.h
+++ b/be/src/olap/data_dir.h
@@ -40,6 +40,11 @@ class TabletManager;
 class TabletMeta;
 class TxnManager;
 
+struct PublishStatistic {
+    size_t get_lock_time = 0;
+    size_t save_meta_time = 0;
+};
+
 // A DataDir used to manage data in same path.
 // Now, After DataDir was created, it will never be deleted for easy implementation.
 class DataDir {

--- a/be/src/olap/txn_manager.h
+++ b/be/src/olap/txn_manager.h
@@ -79,7 +79,7 @@ public:
                           const RowsetSharedPtr& rowset_ptr, bool is_recovery);
 
     OLAPStatus publish_txn(TPartitionId partition_id, const TabletSharedPtr& tablet,
-                           TTransactionId transaction_id, const Version& version);
+                           TTransactionId transaction_id, const Version& version, PublishStatistic* stat = nullptr);
 
     // delete the txn from manager if it is not committed(not have a valid rowset)
     OLAPStatus rollback_txn(TPartitionId partition_id, const TabletSharedPtr& tablet,
@@ -103,7 +103,7 @@ public:
     // not persist rowset meta because
     OLAPStatus publish_txn(OlapMeta* meta, TPartitionId partition_id, TTransactionId transaction_id,
                            TTabletId tablet_id, SchemaHash schema_hash, TabletUid tablet_uid,
-                           const Version& version);
+                           const Version& version, PublishStatistic* stat = nullptr);
 
     // delete the txn from manager if it is not committed(not have a valid rowset)
     OLAPStatus rollback_txn(TPartitionId partition_id, TTransactionId transaction_id,

--- a/be/test/olap/delta_writer_test.cpp
+++ b/be/test/olap/delta_writer_test.cpp
@@ -488,11 +488,12 @@ TEST_F(TestDeltaWriter, write) {
     std::map<TabletInfo, RowsetSharedPtr> tablet_related_rs;
     StorageEngine::instance()->txn_manager()->get_txn_related_tablets(
             write_req.txn_id, write_req.partition_id, &tablet_related_rs);
+    PublishStatistic stat;
     for (auto& tablet_rs : tablet_related_rs) {
         RowsetSharedPtr rowset = tablet_rs.second;
         res = k_engine->txn_manager()->publish_txn(meta, write_req.partition_id, write_req.txn_id,
                                                    write_req.tablet_id, write_req.schema_hash,
-                                                   tablet_rs.first.tablet_uid, version);
+                                                   tablet_rs.first.tablet_uid, version, &stat);
         EXPECT_EQ(OLAP_SUCCESS, res);
         res = tablet->add_inc_rowset(rowset);
         EXPECT_EQ(OLAP_SUCCESS, res);
@@ -559,11 +560,12 @@ TEST_F(TestDeltaWriter, sequence_col) {
     std::map<TabletInfo, RowsetSharedPtr> tablet_related_rs;
     StorageEngine::instance()->txn_manager()->get_txn_related_tablets(
             write_req.txn_id, write_req.partition_id, &tablet_related_rs);
+    PublishStatistic stat;
     for (auto& tablet_rs : tablet_related_rs) {
         RowsetSharedPtr rowset = tablet_rs.second;
         res = k_engine->txn_manager()->publish_txn(meta, write_req.partition_id, write_req.txn_id,
                                                    write_req.tablet_id, write_req.schema_hash,
-                                                   tablet_rs.first.tablet_uid, version);
+                                                   tablet_rs.first.tablet_uid, version, &stat);
         EXPECT_EQ(OLAP_SUCCESS, res);
         res = tablet->add_inc_rowset(rowset);
         EXPECT_EQ(OLAP_SUCCESS, res);

--- a/be/test/olap/txn_manager_test.cpp
+++ b/be/test/olap/txn_manager_test.cpp
@@ -283,8 +283,9 @@ TEST_F(TxnManagerTest, PublishVersionSuccessful) {
                                  _tablet_uid, load_id, _alpha_rowset, false);
     EXPECT_TRUE(status == OLAP_SUCCESS);
     Version new_version(10, 11);
+    PublishStatistic stat;
     status = _txn_mgr->publish_txn(_meta, partition_id, transaction_id, tablet_id, schema_hash,
-                                   _tablet_uid, new_version);
+                                   _tablet_uid, new_version, &stat);
     EXPECT_TRUE(status == OLAP_SUCCESS);
 
     RowsetMetaSharedPtr rowset_meta(new AlphaRowsetMeta());
@@ -299,8 +300,9 @@ TEST_F(TxnManagerTest, PublishVersionSuccessful) {
 // 1. publish version failed if not found related txn and rowset
 TEST_F(TxnManagerTest, PublishNotExistedTxn) {
     Version new_version(10, 11);
+    PublishStatistic stat;
     OLAPStatus status = _txn_mgr->publish_txn(_meta, partition_id, transaction_id, tablet_id,
-                                              schema_hash, _tablet_uid, new_version);
+                                              schema_hash, _tablet_uid, new_version, &stat);
     EXPECT_TRUE(status != OLAP_SUCCESS);
 }
 


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

Add some tracing log for publish task.
If a publish task cost more than 2 seconds(configured by be config: `publish_task_trace_threshold`), 
it will print a log like:
```
Trace 5 publish stat(ns): get lock time: 382, save meta time: 68638
```
5： txn id
get lock time: time to get txn and txn map lock
save meta time: time to save rowset meta when publish

And also add partition and tablet num for publish finish log:
```
finish to publish version on transaction.transaction_id=5, cost(us): 105, error_tablet_size=0, partition num: 1, tablet num: 3
```

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

