### PR TITLE
[enhancement](regression) don't terminate when encountering one stmt exception

### DIFF
--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/suite/ScriptSource.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/suite/ScriptSource.groovy
@@ -78,12 +78,21 @@ class SqlFileSource implements ScriptSource {
             Object run() {
                 suite(suiteName, groupName) {
                     String tag = suiteName
+                    String exceptionStr = ""
                     boolean order = suiteName.endsWith("_order")
                     List<String> sqls = getSqls(file.text)
+                    log.info("Try to execute group: ${groupName} suite: ${suiteName} with ${sqls.size()} stmts")
                     for (int i = 0; i < sqls.size(); ++i) {
                         String singleSql = sqls.get(i)
                         String tagName = (i == 0) ? tag : "${tag}_${i + 1}"
-                        quickTest(tagName, singleSql, order)
+                        try {
+                            quickTest(tagName, singleSql, order)
+                        } catch (Throwable e) {
+                            exceptionStr += "\n${e.getMessage()}\n"
+                        }
+                    }
+                    if (exceptionStr.size() != 0) {
+                        throw new IllegalStateException("exceptions : ${exceptionStr}")
                     }
                 }
             }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx
Previously one sql file consisting of multi stmts might terminate immediately once encountering one exception regardless the remaining untested stmts. This pr aims to make the framework return only when all the stmts of the sql file are tested.
## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [x] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

