### PR TITLE
[fix](multi-catalog) use last used database for catalog when switch back

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
@@ -4443,8 +4443,16 @@ public class Env {
             throw new DdlException(ErrorCode.ERR_UNKNOWN_CATALOG.formatErrorMsg(catalogName),
                     ErrorCode.ERR_UNKNOWN_CATALOG);
         }
+
+        String currentDB = ctx.getDatabase();
+        if (StringUtils.isNotEmpty(currentDB)) {
+            catalogMgr.addLastDBOfCatalog(ctx.getCurrentCatalog().getName(), currentDB);
+        }
         ctx.changeDefaultCatalog(catalogName);
-        if (catalogIf instanceof EsExternalCatalog) {
+        String lastDb = catalogMgr.getLastDB(catalogName);
+        if (StringUtils.isNotEmpty(lastDb)) {
+            ctx.setDatabase(lastDb);
+        } else if (catalogIf instanceof EsExternalCatalog) {
             ctx.setDatabase(SystemInfoService.DEFAULT_CLUSTER + ClusterNamespace.CLUSTER_DELIMITER
                     + EsExternalCatalog.DEFAULT_DB);
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
@@ -4452,7 +4452,8 @@ public class Env {
         String lastDb = catalogMgr.getLastDB(catalogName);
         if (StringUtils.isNotEmpty(lastDb)) {
             ctx.setDatabase(lastDb);
-        } else if (catalogIf instanceof EsExternalCatalog) {
+        }
+        if (catalogIf instanceof EsExternalCatalog) {
             ctx.setDatabase(SystemInfoService.DEFAULT_CLUSTER + ClusterNamespace.CLUSTER_DELIMITER
                     + EsExternalCatalog.DEFAULT_DB);
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/CatalogMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/CatalogMgr.java
@@ -76,6 +76,8 @@ public class CatalogMgr implements Writable, GsonPostProcessable {
     private final Map<Long, CatalogIf> idToCatalog = Maps.newConcurrentMap();
     // this map will be regenerated from idToCatalog, so not need to persist.
     private final Map<String, CatalogIf> nameToCatalog = Maps.newConcurrentMap();
+    // record last used database of every catalog
+    private final Map<String, String> lastDBOfCatalog = Maps.newConcurrentMap();
 
     // Use a separate instance to facilitate access.
     // internalDataSource still exists in idToDataSource and nameToDataSource
@@ -144,6 +146,14 @@ public class CatalogMgr implements Writable, GsonPostProcessable {
         return getCatalogOrException(name,
                 catalog -> new AnalysisException(ErrorCode.ERR_UNKNOWN_CATALOG.formatErrorMsg(catalog),
                         ErrorCode.ERR_UNKNOWN_CATALOG));
+    }
+
+    public void addLastDBOfCatalog(String catalog, String db) {
+        lastDBOfCatalog.put(catalog, db);
+    }
+
+    public String getLastDB(String catalog) {
+        return lastDBOfCatalog.get(catalog);
     }
 
     public List<Long> getCatalogIds() {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/CatalogMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/CatalogMgr.java
@@ -251,6 +251,8 @@ public class CatalogMgr implements Writable, GsonPostProcessable {
             CatalogLog log = CatalogFactory.constructorCatalogLog(catalog.getId(), stmt);
             replayDropCatalog(log);
             Env.getCurrentEnv().getEditLog().logCatalogLog(OperationType.OP_DROP_CATALOG, log);
+
+            lastDBOfCatalog.remove(stmt.getCatalogName());
         } finally {
             writeUnlock();
         }
@@ -269,6 +271,12 @@ public class CatalogMgr implements Writable, GsonPostProcessable {
             CatalogLog log = CatalogFactory.constructorCatalogLog(catalog.getId(), stmt);
             replayAlterCatalogName(log);
             Env.getCurrentEnv().getEditLog().logCatalogLog(OperationType.OP_ALTER_CATALOG_NAME, log);
+
+            String db = lastDBOfCatalog.get(stmt.getCatalogName());
+            if (db != null) {
+                lastDBOfCatalog.remove(stmt.getCatalogName());
+                lastDBOfCatalog.put(log.getNewCatalogName(), db);
+            }
         } finally {
             writeUnlock();
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/CatalogMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/CatalogMgr.java
@@ -107,6 +107,7 @@ public class CatalogMgr implements Writable, GsonPostProcessable {
         if (catalog != null) {
             catalog.onClose();
             nameToCatalog.remove(catalog.getName());
+            lastDBOfCatalog.remove(catalog.getName());
             Env.getCurrentEnv().getExtMetaCacheMgr().removeCache(catalog.getName());
         }
         return catalog;

--- a/regression-test/suites/external_table_emr_p2/hive/test_external_catalog_hive.groovy
+++ b/regression-test/suites/external_table_emr_p2/hive/test_external_catalog_hive.groovy
@@ -89,6 +89,25 @@ suite("test_external_catalog_hive", "p2") {
             sql """ use tpch_1000_orc; """
             q03()
 
+
+            // test remember last used database after switch / rename catalog
+            sql """switch ${catalog_name};"""
+
+            sql """use test;"""
+
+            def res2 = sql """select count(*) from hive_test limit 10;"""
+            logger.info("recoding select: " + res2.toString())
+
+            sql """switch internal;"""
+
+            sql """alter catalog ${catalog_name} rename hms;"""
+
+            sql """switch hms;"""
+
+            def res3 = sql """select count(*) from hive_test limit 10;"""
+            logger.info("recoding select: " + res3.toString())
+
+            sql """alter catalog hms rename ${catalog_name};"""
         } finally {
             // sql """admin set frontend config ("enable_multi_catalog" = "false")"""
         }

--- a/regression-test/suites/external_table_emr_p2/hive/test_external_hive.groovy
+++ b/regression-test/suites/external_table_emr_p2/hive/test_external_hive.groovy
@@ -56,4 +56,3 @@ suite("test_external_hive", "p2") {
 
 
 
-


### PR DESCRIPTION
remember last used database of every catalog and use it when switch back

# Proposed changes

Issue Number: close #14792

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [x] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

