### PR TITLE
[Enhancement](Nereids) Explain display extra information

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Group.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Group.java
@@ -394,6 +394,14 @@ public class Group {
             }
         };
 
-        return TreeStringUtils.treeString(this, toString, getChildren, getExtraPlans);
+        Function<Object, Boolean> displayExtraPlan = obj -> {
+            if (obj instanceof Plan) {
+                return ((Plan) obj).displayExtraPlanFirst();
+            } else {
+                return false;
+            }
+        };
+
+        return TreeStringUtils.treeString(this, toString, getChildren, getExtraPlans, displayExtraPlan);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Group.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Group.java
@@ -20,6 +20,7 @@ package org.apache.doris.nereids.memo;
 import org.apache.doris.common.Pair;
 import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.properties.PhysicalProperties;
+import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalJoin;
 import org.apache.doris.nereids.trees.plans.logical.LogicalPlan;
 import org.apache.doris.nereids.util.TreeStringUtils;
@@ -384,6 +385,15 @@ public class Group {
                 return ImmutableList.of();
             }
         };
-        return TreeStringUtils.treeString(this, toString, getChildren);
+
+        Function<Object, List<Object>> getExtraPlans = obj -> {
+            if (obj instanceof Plan) {
+                return (List) ((Plan) obj).extraPlans();
+            } else {
+                return ImmutableList.of();
+            }
+        };
+
+        return TreeStringUtils.treeString(this, toString, getChildren, getExtraPlans);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/AbstractPlan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/AbstractPlan.java
@@ -98,7 +98,8 @@ public abstract class AbstractPlan extends AbstractTreeNode<Plan> implements Pla
         return TreeStringUtils.treeString(this,
                 plan -> plan.toString(),
                 plan -> (List) ((Plan) plan).children(),
-                plan -> (List) ((Plan) plan).extraPlans());
+                plan -> (List) ((Plan) plan).extraPlans(),
+                plan -> ((Plan) plan).displayExtraPlanFirst());
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/AbstractPlan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/AbstractPlan.java
@@ -97,7 +97,8 @@ public abstract class AbstractPlan extends AbstractTreeNode<Plan> implements Pla
     public String treeString() {
         return TreeStringUtils.treeString(this,
                 plan -> plan.toString(),
-                plan -> (List) ((Plan) plan).children());
+                plan -> (List) ((Plan) plan).children(),
+                plan -> (List) ((Plan) plan).extraPlans());
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/Plan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/Plan.java
@@ -27,6 +27,7 @@ import org.apache.doris.nereids.trees.expressions.NamedExpression;
 import org.apache.doris.nereids.trees.expressions.Slot;
 import org.apache.doris.nereids.trees.plans.visitor.PlanVisitor;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 
 import java.util.List;
@@ -68,6 +69,13 @@ public interface Plan extends TreeNode<Plan> {
 
     default LogicalProperties computeLogicalProperties() {
         throw new IllegalStateException("Not support compute logical properties for " + getClass().getName());
+    }
+
+    /**
+     * Get extra plans.
+     */
+    default List<Plan> extraPlans() {
+        return ImmutableList.of();
     }
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/Plan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/Plan.java
@@ -78,6 +78,10 @@ public interface Plan extends TreeNode<Plan> {
         return ImmutableList.of();
     }
 
+    default boolean displayExtraPlanFirst() {
+        return false;
+    }
+
     /**
      * Get output slot list of the plan.
      */

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalCTE.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalCTE.java
@@ -77,6 +77,11 @@ public class LogicalCTE<CHILD_TYPE extends Plan> extends LogicalUnary<CHILD_TYPE
     }
 
     @Override
+    public boolean displayExtraPlanFirst() {
+        return true;
+    }
+
+    @Override
     public boolean equals(Object o) {
         if (this == o) {
             return true;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalCTE.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalCTE.java
@@ -54,6 +54,11 @@ public class LogicalCTE<CHILD_TYPE extends Plan> extends LogicalUnary<CHILD_TYPE
         return aliasQueries;
     }
 
+    @Override
+    public List<Plan> extraPlans() {
+        return (List) aliasQueries;
+    }
+
     /**
      * In fact, the action of LogicalCTE is to store and register with clauses, and this logical node will be
      * eliminated immediately after finishing the process of with-clause registry; This process is executed before

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/util/TreeStringUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/util/TreeStringUtils.java
@@ -29,34 +29,42 @@ import java.util.function.Function;
 public class TreeStringUtils {
 
     public static String treeString(Object object, Function<Object, String> objectToString,
-            Function<Object, List<Object>> childSupplier) {
+            Function<Object, List<Object>> childSupplier,
+            Function<Object, List<Object>> extraPlansSupplier) {
         List<String> lines = new ArrayList<>();
-        treeString(lines, 0, new ArrayList<>(), object, objectToString, childSupplier);
+        treeString(lines, new ArrayList<>(), object, objectToString, childSupplier, extraPlansSupplier, false);
         return StringUtils.join(lines, "\n");
     }
 
-    private static void treeString(List<String> lines, int depth, List<Boolean> lastChildren, Object object,
-            Function<Object, String> objectToString, Function<Object, List<Object>> childrenSupplier) {
+    private static void treeString(List<String> lines, List<Boolean> lastChildren, Object object,
+            Function<Object, String> objectToString, Function<Object, List<Object>> childrenSupplier,
+            Function<Object, List<Object>> extraPlansSupplier,
+            boolean extra) {
         StringBuilder sb = new StringBuilder();
-        if (depth > 0) {
-            if (lastChildren.size() > 1) {
-                for (int i = 0; i < lastChildren.size() - 1; i++) {
-                    sb.append(lastChildren.get(i) ? "   " : "|  ");
-                }
-            }
-            if (lastChildren.size() > 0) {
-                Boolean last = lastChildren.get(lastChildren.size() - 1);
-                sb.append(last ? "+--" : "|--");
-            }
+
+        for (int i = 0; i < lastChildren.size() - 1; i++) {
+            sb.append(lastChildren.get(i) ? "   " : "|  ");
         }
+
+        if (lastChildren.size() > 0) {
+            Boolean last = lastChildren.get(lastChildren.size() - 1);
+            sb.append(last ? "+-" : "|-");
+            sb.append(extra ? "*" : "-");
+        }
+
         sb.append(objectToString.apply(object));
         lines.add(sb.toString());
 
+        List<Object> allObjects = new ArrayList<>();
         List<Object> children = childrenSupplier.apply(object);
-        for (int i = 0; i < children.size(); i++) {
+        List<Object> extraPlans = extraPlansSupplier.apply(object);
+        allObjects.addAll(extraPlans);
+        allObjects.addAll(children);
+        for (int i = 0; i < allObjects.size(); i++) {
             List<Boolean> newLasts = new ArrayList<>(lastChildren);
-            newLasts.add(i + 1 == children.size());
-            treeString(lines, depth + 1, newLasts, children.get(i), objectToString, childrenSupplier);
+            newLasts.add(i + 1 == allObjects.size());
+            treeString(lines, newLasts, allObjects.get(i),
+                    objectToString, childrenSupplier, extraPlansSupplier, i < extraPlans.size());
         }
     }
 }

--- a/regression-test/suites/nereids_syntax_p0/explain.groovy
+++ b/regression-test/suites/nereids_syntax_p0/explain.groovy
@@ -47,4 +47,14 @@ suite("nereids_explain") {
         sql("parsed plan select 100")
         contains "UnboundOneRowRelation"
     }
+
+    explain {
+        sql("plan select * from lineorder where lo_orderkey > (select avg(lo_orderkey) from lineorder)")
+        contains "*LogicalSubQueryAlias"
+    }
+
+    explain {
+        sql("plan with s as (select * from supplier) select * from s as s1, s as s2")
+        contains "*LogicalSubQueryAlias"
+    }
 }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #14554

## Problem summary

1. provide a function **Plan.extraPlans** that returns extra plans, eg: LogicalSubQueryAlias in LogicalCTE.
2. combine the extra plans and the children in the AbstractPlan.treeString(), distinguished by the * at the beginning.
```
========== PARSED PLAN ==========
LogicalCTE ( aliasQueries=[LogicalSubQueryAlias ( alias=s )] )
|-*LogicalSubQueryAlias ( alias=s )
|  +--LogicalProject ( projects=['s_suppkey] )
|     +--LogicalFilter ( predicates=('s_suppkey = '') )
|        +--LogicalCheckPolicy ( child=UnboundRelation ( nameParts=supplier ) )
|           +--UnboundRelation ( nameParts=supplier )
+--LogicalProject ( projects=[*] )
   +--LogicalJoin ( type=CROSS_JOIN, hashJoinConjuncts=[], otherJoinConjuncts=[] )
      |--LogicalSubQueryAlias ( alias=t1 )
      |  +--LogicalCheckPolicy ( child=UnboundRelation ( nameParts=s ) )
      |     +--UnboundRelation ( nameParts=s )
      +--LogicalSubQueryAlias ( alias=t2 )
         +--LogicalCheckPolicy ( child=UnboundRelation ( nameParts=s ) )
            +--UnboundRelation ( nameParts=s )
```

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
4. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
5. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
6. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
7. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

