### PR TITLE
[fix](schemachange) fix the schema change that causes the be core dump.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
@@ -492,9 +492,8 @@ public class SchemaChangeHandler extends AlterHandler {
         if (KeysType.AGG_KEYS == olapTable.getKeysType()) {
             if (modColumn.isKey() && null != modColumn.getAggregationType()) {
                 throw new DdlException("Can not assign aggregation method on key column: " + modColumn.getName());
-            } else if (null == modColumn.getAggregationType()) {
-                // in aggregate key table, no aggregation method indicate key column
-                modColumn.setIsKey(true);
+            } else if (!modColumn.isKey() && null == modColumn.getAggregationType()) {
+                throw new DdlException("Aggregate method must be specified for value column: " + modColumn.getName());
             }
         } else if (KeysType.UNIQUE_KEYS == olapTable.getKeysType()) {
             if (null != modColumn.getAggregationType()) {

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/AddColumnClause.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/AddColumnClause.java
@@ -19,8 +19,12 @@ package org.apache.doris.analysis;
 
 import org.apache.doris.alter.AlterOpType;
 import org.apache.doris.catalog.Column;
+import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.KeysType;
+import org.apache.doris.catalog.OlapTable;
+import org.apache.doris.catalog.Table;
 import org.apache.doris.common.AnalysisException;
+import org.apache.doris.common.DdlException;
 import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.ErrorReport;
 
@@ -65,12 +69,17 @@ public class AddColumnClause extends AlterTableClause {
     }
 
     @Override
-    public void analyze(Analyzer analyzer) throws AnalysisException {
+    public void analyze(Analyzer analyzer) throws AnalysisException, DdlException {
         if (columnDef == null) {
             throw new AnalysisException("No column definition in add column clause.");
         }
-        if (table != null && table.getKeysType() == KeysType.AGG_KEYS && columnDef.getAggregateType() == null) {
-            columnDef.setIsKey(true);
+        if (tableName != null) {
+            Table table = Env.getCurrentInternalCatalog().getDbOrDdlException(tableName.getDb())
+                    .getTableOrDdlException(tableName.getTbl());
+            if (table instanceof OlapTable && ((OlapTable) table).getKeysType() == KeysType.AGG_KEYS
+                    && columnDef.getAggregateType() == null) {
+                columnDef.setIsKey(true);
+            }
         }
         columnDef.analyze(true);
         if (colPos != null) {

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/AddColumnClause.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/AddColumnClause.java
@@ -19,6 +19,7 @@ package org.apache.doris.analysis;
 
 import org.apache.doris.alter.AlterOpType;
 import org.apache.doris.catalog.Column;
+import org.apache.doris.catalog.KeysType;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.ErrorReport;
@@ -67,6 +68,9 @@ public class AddColumnClause extends AlterTableClause {
     public void analyze(Analyzer analyzer) throws AnalysisException {
         if (columnDef == null) {
             throw new AnalysisException("No column definition in add column clause.");
+        }
+        if (table != null && table.getKeysType() == KeysType.AGG_KEYS && columnDef.getAggregateType() == null) {
+            columnDef.setIsKey(true);
         }
         columnDef.analyze(true);
         if (colPos != null) {

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/AlterTableClause.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/AlterTableClause.java
@@ -18,7 +18,6 @@
 package org.apache.doris.analysis;
 
 import org.apache.doris.alter.AlterOpType;
-import org.apache.doris.catalog.OlapTable;
 
 // alter table clause
 public abstract class AlterTableClause extends AlterClause {
@@ -30,13 +29,13 @@ public abstract class AlterTableClause extends AlterClause {
     // if set to true, the corresponding table should be stable before processing this operation on it.
     protected boolean needTableStable = true;
 
-    protected OlapTable table;
+    protected TableName tableName;
 
     public boolean isNeedTableStable() {
         return needTableStable;
     }
 
-    public void setOlapTable(OlapTable table) {
-        this.table = table;
+    public void setTableName(TableName tableName) {
+        this.tableName = tableName;
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/AlterTableClause.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/AlterTableClause.java
@@ -36,7 +36,7 @@ public abstract class AlterTableClause extends AlterClause {
         return needTableStable;
     }
 
-    public void setTableName(OlapTable table) {
+    public void setOlapTable(OlapTable table) {
         this.table = table;
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/AlterTableClause.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/AlterTableClause.java
@@ -18,6 +18,7 @@
 package org.apache.doris.analysis;
 
 import org.apache.doris.alter.AlterOpType;
+import org.apache.doris.catalog.OlapTable;
 
 // alter table clause
 public abstract class AlterTableClause extends AlterClause {
@@ -29,7 +30,13 @@ public abstract class AlterTableClause extends AlterClause {
     // if set to true, the corresponding table should be stable before processing this operation on it.
     protected boolean needTableStable = true;
 
+    protected OlapTable table;
+
     public boolean isNeedTableStable() {
         return needTableStable;
+    }
+
+    public void setTableName(OlapTable table) {
+        this.table = table;
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/AlterTableStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/AlterTableStmt.java
@@ -26,7 +26,6 @@ import org.apache.doris.catalog.Type;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.ErrorReport;
-import org.apache.doris.common.FeConstants;
 import org.apache.doris.common.UserException;
 import org.apache.doris.common.util.PropertyAnalyzer;
 import org.apache.doris.common.util.Util;
@@ -78,14 +77,9 @@ public class AlterTableStmt extends DdlStmt {
         if (ops == null || ops.isEmpty()) {
             ErrorReport.reportAnalysisException(ErrorCode.ERR_NO_ALTER_OPERATION);
         }
-        Table table = null;
-        if (!FeConstants.runningUnitTest) {
-            table = Env.getCurrentInternalCatalog().getDbOrDdlException(tbl.getDb())
-                    .getTableOrDdlException(tbl.getTbl());
-        }
         for (AlterClause op : ops) {
-            if (op instanceof AlterTableClause && table instanceof OlapTable) {
-                ((AlterTableClause) op).setOlapTable((OlapTable) table);
+            if (op instanceof AlterTableClause) {
+                ((AlterTableClause) op).setTableName(tbl);
             }
             op.analyze(analyzer);
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/AlterTableStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/AlterTableStmt.java
@@ -26,6 +26,7 @@ import org.apache.doris.catalog.Type;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.ErrorReport;
+import org.apache.doris.common.FeConstants;
 import org.apache.doris.common.UserException;
 import org.apache.doris.common.util.PropertyAnalyzer;
 import org.apache.doris.common.util.Util;
@@ -77,8 +78,11 @@ public class AlterTableStmt extends DdlStmt {
         if (ops == null || ops.isEmpty()) {
             ErrorReport.reportAnalysisException(ErrorCode.ERR_NO_ALTER_OPERATION);
         }
-        Table table =
-                Env.getCurrentInternalCatalog().getDbOrDdlException(tbl.getDb()).getTableOrDdlException(tbl.getTbl());
+        Table table = null;
+        if (!FeConstants.runningUnitTest) {
+            table = Env.getCurrentInternalCatalog().getDbOrDdlException(tbl.getDb())
+                    .getTableOrDdlException(tbl.getTbl());
+        }
         for (AlterClause op : ops) {
             if (op instanceof AlterTableClause && table instanceof OlapTable) {
                 ((AlterTableClause) op).setOlapTable((OlapTable) table);

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/AlterTableStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/AlterTableStmt.java
@@ -81,7 +81,7 @@ public class AlterTableStmt extends DdlStmt {
                 Env.getCurrentInternalCatalog().getDbOrDdlException(tbl.getDb()).getTableOrDdlException(tbl.getTbl());
         for (AlterClause op : ops) {
             if (op instanceof AlterTableClause && table instanceof OlapTable) {
-                ((AlterTableClause) op).setTableName((OlapTable) table);
+                ((AlterTableClause) op).setOlapTable((OlapTable) table);
             }
             op.analyze(analyzer);
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/AlterTableStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/AlterTableStmt.java
@@ -77,7 +77,12 @@ public class AlterTableStmt extends DdlStmt {
         if (ops == null || ops.isEmpty()) {
             ErrorReport.reportAnalysisException(ErrorCode.ERR_NO_ALTER_OPERATION);
         }
+        Table table =
+                Env.getCurrentInternalCatalog().getDbOrDdlException(tbl.getDb()).getTableOrDdlException(tbl.getTbl());
         for (AlterClause op : ops) {
+            if (op instanceof AlterTableClause && table instanceof OlapTable) {
+                ((AlterTableClause) op).setTableName((OlapTable) table);
+            }
             op.analyze(analyzer);
         }
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ModifyColumnClause.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ModifyColumnClause.java
@@ -19,8 +19,12 @@ package org.apache.doris.analysis;
 
 import org.apache.doris.alter.AlterOpType;
 import org.apache.doris.catalog.Column;
+import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.KeysType;
+import org.apache.doris.catalog.OlapTable;
+import org.apache.doris.catalog.Table;
 import org.apache.doris.common.AnalysisException;
+import org.apache.doris.common.DdlException;
 
 import com.google.common.base.Strings;
 
@@ -60,12 +64,17 @@ public class ModifyColumnClause extends AlterTableClause {
     }
 
     @Override
-    public void analyze(Analyzer analyzer) throws AnalysisException {
+    public void analyze(Analyzer analyzer) throws AnalysisException, DdlException {
         if (columnDef == null) {
             throw new AnalysisException("No column definition in modify column clause.");
         }
-        if (table != null && table.getKeysType() == KeysType.AGG_KEYS && columnDef.getAggregateType() == null) {
-            columnDef.setIsKey(true);
+        if (tableName != null) {
+            Table table = Env.getCurrentInternalCatalog().getDbOrDdlException(tableName.getDb())
+                    .getTableOrDdlException(tableName.getTbl());
+            if (table instanceof OlapTable && ((OlapTable) table).getKeysType() == KeysType.AGG_KEYS
+                    && columnDef.getAggregateType() == null) {
+                columnDef.setIsKey(true);
+            }
         }
         columnDef.analyze(true);
         if (colPos != null) {

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ModifyColumnClause.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ModifyColumnClause.java
@@ -19,6 +19,7 @@ package org.apache.doris.analysis;
 
 import org.apache.doris.alter.AlterOpType;
 import org.apache.doris.catalog.Column;
+import org.apache.doris.catalog.KeysType;
 import org.apache.doris.common.AnalysisException;
 
 import com.google.common.base.Strings;
@@ -62,6 +63,9 @@ public class ModifyColumnClause extends AlterTableClause {
     public void analyze(Analyzer analyzer) throws AnalysisException {
         if (columnDef == null) {
             throw new AnalysisException("No column definition in modify column clause.");
+        }
+        if (table != null && table.getKeysType() == KeysType.AGG_KEYS && columnDef.getAggregateType() == null) {
+            columnDef.setIsKey(true);
         }
         columnDef.analyze(true);
         if (colPos != null) {

--- a/fe/fe-core/src/test/java/org/apache/doris/alter/SchemaChangeJobV2Test.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/alter/SchemaChangeJobV2Test.java
@@ -108,8 +108,9 @@ public class SchemaChangeJobV2Test {
     public ExpectedException expectedEx = ExpectedException.none();
 
     @Before
-    public void setUp() throws InstantiationException, IllegalAccessException, IllegalArgumentException,
-            InvocationTargetException, NoSuchMethodException, SecurityException, AnalysisException {
+    public void setUp()
+            throws InstantiationException, IllegalAccessException, IllegalArgumentException, InvocationTargetException,
+            NoSuchMethodException, SecurityException, AnalysisException, DdlException {
         FakeEnv.setMetaVersion(FeMetaVersion.VERSION_CURRENT);
         fakeEditLog = new FakeEditLog();
         fakeEnv = new FakeEnv();

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/AddColumnClauseTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/AddColumnClauseTest.java
@@ -22,6 +22,7 @@ import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.PrimitiveType;
 import org.apache.doris.catalog.ScalarType;
 import org.apache.doris.common.AnalysisException;
+import org.apache.doris.common.DdlException;
 
 import mockit.Expectations;
 import mockit.Mocked;
@@ -41,7 +42,7 @@ public class AddColumnClauseTest {
     }
 
     @Test
-    public void testNormal() throws AnalysisException {
+    public void testNormal() throws AnalysisException, DdlException {
         Column column = new Column("testCol", ScalarType.createType(PrimitiveType.INT));
         new Expectations() {
             {
@@ -91,14 +92,14 @@ public class AddColumnClauseTest {
     }
 
     @Test(expected = AnalysisException.class)
-    public void testNoColDef() throws AnalysisException {
+    public void testNoColDef() throws AnalysisException, DdlException {
         AddColumnClause clause = new AddColumnClause(null, null, null, null);
         clause.analyze(analyzer);
         Assert.fail("No exception throws.");
     }
 
     @Test(expected = AnalysisException.class)
-    public void testNoDefault() throws AnalysisException {
+    public void testNoDefault() throws AnalysisException, DdlException {
         new Expectations() {
             {
                 definition.analyze(true);
@@ -131,7 +132,7 @@ public class AddColumnClauseTest {
     }
 
     @Test(expected = AnalysisException.class)
-    public void testAggPos() throws AnalysisException {
+    public void testAggPos() throws AnalysisException, DdlException {
         new Expectations() {
             {
                 definition.analyze(true);
@@ -164,7 +165,7 @@ public class AddColumnClauseTest {
     }
 
     @Test(expected = AnalysisException.class)
-    public void testAddValueToFirst() throws AnalysisException {
+    public void testAddValueToFirst() throws AnalysisException, DdlException {
         new Expectations() {
             {
                 definition.analyze(true);

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/AlterTableStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/AlterTableStmtTest.java
@@ -18,6 +18,7 @@
 package org.apache.doris.analysis;
 
 import org.apache.doris.common.AnalysisException;
+import org.apache.doris.common.FeConstants;
 import org.apache.doris.common.UserException;
 import org.apache.doris.datasource.InternalCatalog;
 import org.apache.doris.mysql.privilege.PaloAuth;
@@ -30,6 +31,7 @@ import mockit.Expectations;
 import mockit.Mocked;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.util.List;
@@ -41,6 +43,11 @@ public class AlterTableStmtTest {
 
     @Mocked
     private PaloAuth auth;
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        FeConstants.runningUnitTest = true;
+    }
 
     @Before
     public void setUp() {

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/AlterTableStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/AlterTableStmtTest.java
@@ -18,7 +18,6 @@
 package org.apache.doris.analysis;
 
 import org.apache.doris.common.AnalysisException;
-import org.apache.doris.common.FeConstants;
 import org.apache.doris.common.UserException;
 import org.apache.doris.datasource.InternalCatalog;
 import org.apache.doris.mysql.privilege.PaloAuth;
@@ -31,7 +30,6 @@ import mockit.Expectations;
 import mockit.Mocked;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.util.List;
@@ -43,11 +41,6 @@ public class AlterTableStmtTest {
 
     @Mocked
     private PaloAuth auth;
-
-    @BeforeClass
-    public static void beforeClass() throws Exception {
-        FeConstants.runningUnitTest = true;
-    }
 
     @Before
     public void setUp() {

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/ModifyColumnClauseTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/ModifyColumnClauseTest.java
@@ -20,6 +20,7 @@ package org.apache.doris.analysis;
 import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.PrimitiveType;
 import org.apache.doris.common.AnalysisException;
+import org.apache.doris.common.DdlException;
 
 import mockit.Expectations;
 import mockit.Mocked;
@@ -36,7 +37,7 @@ public class ModifyColumnClauseTest {
     }
 
     @Test
-    public void testNormal(@Mocked ColumnDef definition) throws AnalysisException {
+    public void testNormal(@Mocked ColumnDef definition) throws AnalysisException, DdlException {
         Column column = new Column("tsetCol", PrimitiveType.INT);
         new Expectations() {
             {
@@ -76,7 +77,7 @@ public class ModifyColumnClauseTest {
     }
 
     @Test(expected = AnalysisException.class)
-    public void testNoColDef() throws AnalysisException {
+    public void testNoColDef() throws AnalysisException, DdlException {
         ModifyColumnClause clause = new ModifyColumnClause(null, null, null, null);
         clause.analyze(analyzer);
         Assert.fail("No exception throws.");

--- a/regression-test/suites/schema_change_p0/test_agg_keys_schema_change.groovy
+++ b/regression-test/suites/schema_change_p0/test_agg_keys_schema_change.groovy
@@ -122,6 +122,28 @@ suite ("test_agg_keys_schema_change") {
 
         qt_sc """ select count(*) from ${tableName} """
 
+        // test add double or float key column
+        test {
+            sql "ALTER table ${tableName} ADD COLUMN new_key_column_double DOUBLE"
+            exception "Float or double can not used as a key, use decimal instead."
+        }
+
+        test {
+            sql "ALTER table ${tableName} ADD COLUMN new_key_column_float FLOAT"
+            exception "Float or double can not used as a key, use decimal instead."
+        }
+
+        // test modify key column type to double or float
+        test {
+            sql "ALTER table ${tableName} MODIFY COLUMN age FLOAT"
+            exception "Float or double can not used as a key, use decimal instead."
+        }
+
+        test {
+            sql "ALTER table ${tableName} MODIFY COLUMN age DOUBLE"
+            exception "Float or double can not used as a key, use decimal instead."
+        }
+
         // drop key column, not light schema change
         sql """
             ALTER TABLE ${tableName} DROP COLUMN new_key_column


### PR DESCRIPTION
Forbid schema change to add or modify the key column of the agg model as double or float.

# Proposed changes

Issue Number: close #14803

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

