### PR TITLE
[fix](aggregate) agg table and unique table get different result when…

### DIFF
--- a/be/src/olap/generic_iterators.cpp
+++ b/be/src/olap/generic_iterators.cpp
@@ -266,9 +266,17 @@ private:
             // here we sort segment id in reverse order, because of the row order in AGG_KEYS
             // dose no matter, but in UNIQUE_KEYS table we only read the latest is one, so we
             // return the row in reverse order of segment id
-            bool result = res == 0 ? lhs->data_id() < rhs->data_id() : res < 0;
-            if (_is_unique) {
-                result ? lhs->set_skip(true) : rhs->set_skip(true);
+            bool result = false;
+            if (res == 0) {
+                result = lhs->data_id() > rhs->data_id();
+                if (_is_unique) {
+                    !result ? lhs->set_skip(true) : rhs->set_skip(true);
+                }
+            } else {
+                result = res < 0;
+                if (_is_unique) {
+                    result ? lhs->set_skip(true) : rhs->set_skip(true);
+                }
             }
 
             return result;

--- a/be/src/olap/generic_iterators.cpp
+++ b/be/src/olap/generic_iterators.cpp
@@ -268,12 +268,12 @@ private:
             // when in AGG_KEYS table, we return the row in order of segment id, because
             // we need replace the value with lower segment id by the one with higher segment id when
             // non-vectorized.
-
             if (_is_unique) {
                 bool result = res == 0 ? lhs->data_id() < rhs->data_id() : res < 0;
                 result ? lhs->set_skip(true) : rhs->set_skip(true);
                 return result;
-            }     
+            }
+
             return lhs->data_id() > rhs->data_id();
         }
 

--- a/be/src/olap/generic_iterators.cpp
+++ b/be/src/olap/generic_iterators.cpp
@@ -263,23 +263,18 @@ private:
             }
 
             // if row cursors equal, compare segment id.
-            // here we sort segment id in reverse order, because of the row order in AGG_KEYS
-            // dose no matter, but in UNIQUE_KEYS table we only read the latest is one, so we
-            // return the row in reverse order of segment id
-            bool result = false;
-            if (res == 0) {
-                result = lhs->data_id() > rhs->data_id();
-                if (_is_unique) {
-                    !result ? lhs->set_skip(true) : rhs->set_skip(true);
-                }
-            } else {
-                result = res < 0;
-                if (_is_unique) {
-                    result ? lhs->set_skip(true) : rhs->set_skip(true);
-                }
-            }
+            // when in UNIQUE_KEYS table, we need only read the latest one, so we
+            // return the row in reverse order of segment id.
+            // when in AGG_KEYS table, we return the row in order of segment id, because
+            // we need replace the value with lower segment id by the one with higher segment id when
+            // non-vectorized.
 
-            return result;
+            if (_is_unique) {
+                bool result = res == 0 ? lhs->data_id() < rhs->data_id() : res < 0;
+                result ? lhs->set_skip(true) : rhs->set_skip(true);
+                return result;
+            }     
+            return lhs->data_id() > rhs->data_id();
         }
 
         int _sequence_id_idx;


### PR DESCRIPTION
… non-vectorized

when enable_vectorized_engine=false, agg table and unique table get different result, agg table will get replace column value with lower segment id from a rowset, but unique table get the one which has higher segment id.

Signed-off-by: nextdreamblue <zxw520blue1@163.com>

# Proposed changes

Issue Number: close #14811

## Problem summary

when enable_vectorized_engine=false, agg table and unique table get different result, agg table will get replace column value with lower segment id from a rowset, but unique table get the one which has higher segment id.

it is wrong, and this pr fix it.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [x] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

