### PR TITLE
[fix](ColumnVector) ColumnVector::insert_date_column crashed

### DIFF
--- a/be/src/vec/columns/column_vector.h
+++ b/be/src/vec/columns/column_vector.h
@@ -166,6 +166,7 @@ public:
     }
 
     void insert_date_column(const char* data_ptr, size_t num) {
+        data.reserve(data.size() + num);
         size_t input_value_size = sizeof(uint24_t);
 
         for (int i = 0; i < num; i++) {
@@ -180,6 +181,7 @@ public:
     }
 
     void insert_datetime_column(const char* data_ptr, size_t num) {
+        data.reserve(data.size() + num);
         size_t value_size = sizeof(uint64_t);
         for (int i = 0; i < num; i++) {
             const char* cur_ptr = data_ptr + value_size * i;

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -342,6 +342,7 @@ set(VEC_TEST_FILES
     vec/core/column_array_test.cpp
     vec/core/column_complex_test.cpp
     vec/core/column_nullable_test.cpp
+    vec/core/column_vector_test.cpp
     vec/exec/vgeneric_iterators_test.cpp
     vec/exec/vbroker_scan_node_test.cpp
     vec/exec/vbroker_scanner_test.cpp

--- a/be/test/vec/core/column_vector_test.cpp
+++ b/be/test/vec/core/column_vector_test.cpp
@@ -1,0 +1,41 @@
+
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "vec/columns/column_vector.h"
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <string>
+
+#include "vec/data_types/data_type_date.h"
+
+namespace doris::vectorized {
+
+TEST(VColumnVectorTest, insert_date_column) {
+    auto column = ColumnVector<Int64>::create();
+
+    size_t rows = 4096;
+    int64_t val = 0;
+    for (size_t i = 0; i < rows; ++i) {
+        column->insert_date_column(reinterpret_cast<char*>(&val), 1);
+    }
+    ASSERT_EQ(column->size(), rows);
+}
+
+} // namespace doris::vectorized


### PR DESCRIPTION
# Proposed changes

Issue Number: close https://github.com/apache/doris/issues/14838

## Problem summary

ColumnVector::insert_date_column make BE crashed with large data(>512 rows).

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [x] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

