### PR TITLE
[fix](memory leak) Fix load fragment `QueryFragmentsCtx` is not destroyed

### DIFF
--- a/be/src/runtime/fragment_mgr.cpp
+++ b/be/src/runtime/fragment_mgr.cpp
@@ -510,10 +510,7 @@ void FragmentMgr::_exec_actual(std::shared_ptr<FragmentExecState> exec_state, Fi
         std::lock_guard<std::mutex> lock(_lock);
         _fragment_map.erase(exec_state->fragment_instance_id());
         if (all_done && fragments_ctx) {
-            auto search = _fragments_ctx_map.find(fragments_ctx->query_id);
-            if (search != _fragments_ctx_map.end()) {
-                _fragments_ctx_map.erase(fragments_ctx->query_id);
-            }
+            _fragments_ctx_map.erase(fragments_ctx->query_id);
         }
     }
 

--- a/be/src/runtime/fragment_mgr.cpp
+++ b/be/src/runtime/fragment_mgr.cpp
@@ -510,7 +510,10 @@ void FragmentMgr::_exec_actual(std::shared_ptr<FragmentExecState> exec_state, Fi
         std::lock_guard<std::mutex> lock(_lock);
         _fragment_map.erase(exec_state->fragment_instance_id());
         if (all_done && fragments_ctx) {
-            _fragments_ctx_map.erase(fragments_ctx->query_id);
+            auto search = _fragments_ctx_map.find(fragments_ctx->query_id);
+            if (search != _fragments_ctx_map.end()) {
+                _fragments_ctx_map.erase(fragments_ctx->query_id);
+            }
         }
     }
 

--- a/be/src/runtime/query_fragments_ctx.h
+++ b/be/src/runtime/query_fragments_ctx.h
@@ -61,7 +61,9 @@ public:
         }
     }
 
-    bool countdown() { return fragment_num.fetch_sub(1) == 1; }
+    // Notice. For load fragments, the fragment_num sent by FE has a small probability of 0.
+    // this may be a bug, but in theory it shouldn't cause any problems at this stage.
+    bool countdown() { return fragment_num.fetch_sub(1) <= 1; }
 
     bool is_timeout(const DateTimeValue& now) const {
         if (timeout_second <= 0) {

--- a/be/src/runtime/query_fragments_ctx.h
+++ b/be/src/runtime/query_fragments_ctx.h
@@ -62,7 +62,7 @@ public:
     }
 
     // Notice. For load fragments, the fragment_num sent by FE has a small probability of 0.
-    // this may be a bug, but in theory it shouldn't cause any problems at this stage.
+    // this may be a bug, bug <= 1 in theory it shouldn't cause any problems at this stage.
     bool countdown() { return fragment_num.fetch_sub(1) <= 1; }
 
     bool is_timeout(const DateTimeValue& now) const {

--- a/be/src/util/mem_info.cpp
+++ b/be/src/util/mem_info.cpp
@@ -68,7 +68,8 @@ void MemInfo::refresh_allocator_mem() {
 
     // https://jemalloc.net/jemalloc.3.html
     _s_allocator_cache_mem =
-            get_je_metrics(fmt::format("stats.arenas.{}.tcache_bytes", MALLCTL_ARENAS_ALL));
+            get_je_metrics(fmt::format("stats.arenas.{}.tcache_bytes", MALLCTL_ARENAS_ALL)) +
+            get_je_metrics(fmt::format("stats.metadata", MALLCTL_ARENAS_ALL));
     _s_allocator_cache_mem_str =
             PrettyPrinter::print(static_cast<uint64_t>(_s_allocator_cache_mem), TUnit::BYTES);
     _s_virtual_memory_used = get_je_metrics("stats.mapped");

--- a/be/src/util/mem_info.cpp
+++ b/be/src/util/mem_info.cpp
@@ -69,7 +69,7 @@ void MemInfo::refresh_allocator_mem() {
     // https://jemalloc.net/jemalloc.3.html
     _s_allocator_cache_mem =
             get_je_metrics(fmt::format("stats.arenas.{}.tcache_bytes", MALLCTL_ARENAS_ALL)) +
-            get_je_metrics(fmt::format("stats.metadata", MALLCTL_ARENAS_ALL));
+            get_je_metrics("stats.metadata");
     _s_allocator_cache_mem_str =
             PrettyPrinter::print(static_cast<uint64_t>(_s_allocator_cache_mem), TUnit::BYTES);
     _s_virtual_memory_used = get_je_metrics("stats.mapped");

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
@@ -633,6 +633,7 @@ public class Coordinator {
                                     profileFragmentId, tParam, this.addressToBackendID);
                     // Each tParam will set the total number of Fragments that need to be executed on the same BE,
                     // and the BE will determine whether all Fragments have been executed based on this information.
+                    // Notice. load fragment has a small probability that FragmentNumOnHost is 0, for unknown reasons.
                     tParam.setFragmentNumOnHost(hostCounter.count(execState.address));
                     tParam.setBackendId(execState.backend.getId());
                     tParam.setNeedWaitExecutionTrigger(twoPhaseExecution);


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

For load fragments, the fragment_num sent by FE has a small probability of 0.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

