### PR TITLE
[feature](Nereids): Make complex edge for complex project and prune column in Plan of DPHyp

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/NereidsPlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/NereidsPlanner.java
@@ -36,9 +36,11 @@ import org.apache.doris.nereids.processor.post.PlanPostProcessors;
 import org.apache.doris.nereids.processor.pre.PlanPreprocessors;
 import org.apache.doris.nereids.properties.PhysicalProperties;
 import org.apache.doris.nereids.trees.expressions.NamedExpression;
+import org.apache.doris.nereids.trees.expressions.Slot;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.commands.ExplainCommand.ExplainLevel;
 import org.apache.doris.nereids.trees.plans.logical.LogicalPlan;
+import org.apache.doris.nereids.trees.plans.logical.LogicalProject;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalPlan;
 import org.apache.doris.planner.PlanFragment;
 import org.apache.doris.planner.Planner;
@@ -207,8 +209,24 @@ public class NereidsPlanner extends Planner {
     }
 
     private void joinReorder() {
-        cascadesContext.pushJob(new JoinOrderJob(getRoot(), cascadesContext.getCurrentJobContext()));
+        Group root = getRoot();
+        boolean changeRoot = false;
+        if (root.isJoinGroup()) {
+            // If the root group is join group, DPHyp can change the root group.
+            // To keep the root group is not changed, we add a project operator above join
+            List<Slot> outputs = root.getLogicalExpression().getPlan().getOutput();
+            GroupExpression newExpr = new GroupExpression(
+                    new LogicalProject(outputs, root.getLogicalExpression().getPlan()),
+                    Lists.newArrayList(root));
+            root = new Group();
+            root.addGroupExpression(newExpr);
+            changeRoot = true;
+        }
+        cascadesContext.pushJob(new JoinOrderJob(root, cascadesContext.getCurrentJobContext()));
         cascadesContext.getJobScheduler().executeJobPool(cascadesContext);
+        if (changeRoot) {
+            cascadesContext.getMemo().setRoot(root.getLogicalExpression().child(0));
+        }
     }
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/NereidsPlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/NereidsPlanner.java
@@ -28,6 +28,7 @@ import org.apache.doris.nereids.glue.translator.PlanTranslatorContext;
 import org.apache.doris.nereids.jobs.batch.NereidsRewriteJobExecutor;
 import org.apache.doris.nereids.jobs.batch.OptimizeRulesJob;
 import org.apache.doris.nereids.jobs.cascades.DeriveStatsJob;
+import org.apache.doris.nereids.jobs.joinorder.JoinOrderJob;
 import org.apache.doris.nereids.memo.Group;
 import org.apache.doris.nereids.memo.GroupExpression;
 import org.apache.doris.nereids.metrics.event.CounterEvent;
@@ -206,6 +207,8 @@ public class NereidsPlanner extends Planner {
     }
 
     private void joinReorder() {
+        cascadesContext.pushJob(new JoinOrderJob(getRoot(), cascadesContext.getCurrentJobContext()));
+        cascadesContext.getJobScheduler().executeJobPool(cascadesContext);
     }
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/joinorder/JoinOrderJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/joinorder/JoinOrderJob.java
@@ -28,22 +28,26 @@ import org.apache.doris.nereids.jobs.joinorder.hypergraph.receiver.PlanReceiver;
 import org.apache.doris.nereids.memo.Group;
 import org.apache.doris.nereids.memo.GroupExpression;
 import org.apache.doris.nereids.trees.expressions.Alias;
-import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.NamedExpression;
+import org.apache.doris.nereids.trees.expressions.Slot;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalProject;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Join Order job with DPHyp
  */
 public class JoinOrderJob extends Job {
     private final Group group;
-    private List<Expression> otherProject = new ArrayList<>();
+    private final Set<NamedExpression> otherProject = new HashSet<>();
 
     public JoinOrderJob(Group group, JobContext context) {
         super(JobType.JOIN_ORDER, context);
@@ -52,29 +56,30 @@ public class JoinOrderJob extends Job {
 
     @Override
     public void execute() throws AnalysisException {
-        Preconditions.checkArgument(!group.isJoinGroup());
         GroupExpression rootExpr = group.getLogicalExpression();
         int arity = rootExpr.arity();
         for (int i = 0; i < arity; i++) {
-            rootExpr.setChild(i, optimizePlan(rootExpr.child(i)));
+            rootExpr.setChild(i, optimizePlan(rootExpr.child(i), rootExpr.getPlan().getInputSlots()));
         }
     }
 
-    private Group optimizePlan(Group group) {
+    private Group optimizePlan(Group group, Set<Slot> requires) {
         if (group.isJoinGroup()) {
-            return optimizeJoin(group);
+            return optimizeJoin(group, requires);
         }
         GroupExpression rootExpr = group.getLogicalExpression();
         int arity = rootExpr.arity();
+        Set<Slot> newRequires = new HashSet<>(rootExpr.getPlan().getInputSlots());
+        newRequires.addAll(requires);
         for (int i = 0; i < arity; i++) {
-            rootExpr.setChild(i, optimizePlan(rootExpr.child(i)));
+            rootExpr.setChild(i, optimizePlan(rootExpr.child(i), newRequires));
         }
         return group;
     }
 
-    private Group optimizeJoin(Group group) {
+    private Group optimizeJoin(Group group, Set<Slot> requires) {
         HyperGraph hyperGraph = new HyperGraph();
-        buildGraph(group, hyperGraph);
+        buildGraph(group, hyperGraph, requires);
         // TODO: Right now, we just hardcode the limit with 10000, maybe we need a better way to set it
         int limit = 10000;
         PlanReceiver planReceiver = new PlanReceiver(limit);
@@ -87,12 +92,30 @@ public class JoinOrderJob extends Job {
             }
         }
         Group optimized = planReceiver.getBestPlan(hyperGraph.getNodesMap());
+        // Apply column pruning after optimizing
+        Group memoRoot = copyToMemo(optimized);
+        Set<Slot> newRequires = new HashSet<>(memoRoot.getLogicalExpression().getPlan().getInputSlots());
+        newRequires.addAll(requires);
+        int arity = memoRoot.getLogicalExpression().arity();
+        for (int i = 0; i < arity; i++) {
+            Group childGroup = memoRoot.getLogicalExpression().child(i);
+            Preconditions.checkArgument(childGroup.getGroupId() != null);
+            memoRoot.getLogicalExpression().setChild(i, pruneColumn(childGroup, newRequires));
+        }
 
-        return copyToMemo(optimized);
+        // For other projects, such as project constant or project nullable, we construct a new project above root
+        if (otherProject.size() != 0) {
+            otherProject.addAll(memoRoot.getLogicalExpression().getPlan().getOutput());
+            LogicalProject logicalProject = new LogicalProject(new ArrayList<>(otherProject),
+                    memoRoot.getLogicalExpression().getPlan());
+            GroupExpression groupExpression = new GroupExpression(logicalProject, Lists.newArrayList(group));
+            memoRoot = context.getCascadesContext().getMemo().copyInGroupExpression(groupExpression);
+        }
+        return memoRoot;
     }
 
     private Group copyToMemo(Group root) {
-        if (!root.isJoinGroup()) {
+        if (root.getGroupId() != null) {
             return root;
         }
         GroupExpression groupExpression = root.getLogicalExpression();
@@ -107,24 +130,57 @@ public class JoinOrderJob extends Job {
         return newRoot;
     }
 
+    private Group pruneColumn(Group root, Set<Slot> requires) {
+        Preconditions.checkArgument(!requires.isEmpty());
+        Plan plan = root.getLogicalExpression().getPlan();
+
+        Set<Slot> newRequires = new HashSet<>(requires);
+        newRequires.addAll(plan.getInputSlots());
+
+        int arity = plan.arity();
+        for (int i = 0; i < arity; i++) {
+            Group childGroup = root.getLogicalExpression().child(i);
+            root.getLogicalExpression().setChild(i, pruneColumn(childGroup, newRequires));
+        }
+
+        List<Slot> inputs = plan.getOutput().stream().filter(slot -> requires.contains(slot)).collect(
+                Collectors.toList());
+
+        if (!inputs.equals(plan.getOutput())) {
+            Group childGroup = root;
+            if (root.isProjectGroup()) {
+                // if root is a project, we need to merge them
+                LogicalProject project = (LogicalProject) plan;
+                inputs.addAll(project.getProjects());
+                childGroup = root.getLogicalExpression().child(0);
+            }
+            LogicalProject logicalProject = new LogicalProject(inputs, plan);
+            GroupExpression groupExpression = new GroupExpression(logicalProject, Lists.newArrayList(childGroup));
+            root = context.getCascadesContext().getMemo().copyInGroupExpression(groupExpression);
+        }
+        return root;
+    }
+
     /**
      * build a hyperGraph for the root group
      *
      * @param group root group, should be join type
      * @param hyperGraph build hyperGraph
      */
-    public void buildGraph(Group group, HyperGraph hyperGraph) {
+    public void buildGraph(Group group, HyperGraph hyperGraph, Set<Slot> requires) {
+        Set<Slot> newRequires = new HashSet<>(requires);
+        newRequires.addAll(group.getLogicalExpression().getPlan().getInputSlots());
         if (group.isProjectGroup()) {
-            buildGraph(group.getLogicalExpression().child(0), hyperGraph);
+            buildGraph(group.getLogicalExpression().child(0), hyperGraph, newRequires);
             processProjectPlan(hyperGraph, group);
             return;
         }
         if (!group.isJoinGroup()) {
-            hyperGraph.addNode(optimizePlan(group));
+            hyperGraph.addNode(optimizePlan(group, newRequires));
             return;
         }
-        buildGraph(group.getLogicalExpression().child(0), hyperGraph);
-        buildGraph(group.getLogicalExpression().child(1), hyperGraph);
+        buildGraph(group.getLogicalExpression().child(0), hyperGraph, requires);
+        buildGraph(group.getLogicalExpression().child(1), hyperGraph, requires);
         hyperGraph.addEdge(group);
     }
 
@@ -132,7 +188,7 @@ public class JoinOrderJob extends Job {
      * Process project expression in HyperGraph
      * 1. If it's a simple expression for column pruning, we just ignore it
      * 2. If it's an alias that may be used in the join operator, we need to add it to graph
-     * 3. If it's other expressions, we can ignore them and add it after optimizing
+     * 3. If it's other expression, we can ignore them and add it after optimizing
      * 4. If it's a project only associate with one table, it's seen as an endNode just like a table
      */
     private void processProjectPlan(HyperGraph hyperGraph, Group group) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/joinorder/hypergraph/Node.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/joinorder/hypergraph/Node.java
@@ -37,6 +37,10 @@ public class Node {
         this.index = index;
     }
 
+    public void replaceGroupWith(Group group) {
+        this.group = group;
+    }
+
     public int getIndex() {
         return index;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/joinorder/hypergraph/SubgraphEnumerator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/joinorder/hypergraph/SubgraphEnumerator.java
@@ -120,7 +120,7 @@ public class SubgraphEnumerator {
                 if (edges.isEmpty()) {
                     continue;
                 }
-                if (!receiver.emitCsgCmp(csg, newCmp, edges)) {
+                if (!receiver.emitCsgCmp(csg, newCmp, edges, hyperGraph.getComplexProject())) {
                     return false;
                 }
             }
@@ -144,16 +144,15 @@ public class SubgraphEnumerator {
         forbiddenNodes = LongBitmap.or(forbiddenNodes, csg);
         long neighborhoods = neighborhoodCalculator.calcNeighborhood(csg, LongBitmap.clone(forbiddenNodes),
                 edgeCalculator);
-
         for (int nodeIndex : LongBitmap.getReverseIterator(neighborhoods)) {
             long cmp = LongBitmap.newBitmap(nodeIndex);
             // whether there is an edge between csg and cmp
             List<Edge> edges = edgeCalculator.connectCsgCmp(csg, cmp);
-            if (edges.isEmpty()) {
-                continue;
-            }
-            if (!receiver.emitCsgCmp(csg, cmp, edges)) {
-                return false;
+
+            if (!edges.isEmpty()) {
+                if (!receiver.emitCsgCmp(csg, cmp, edges, hyperGraph.getComplexProject())) {
+                    return false;
+                }
             }
 
             // In order to avoid enumerate repeated cmp, e.g.,
@@ -191,7 +190,6 @@ public class SubgraphEnumerator {
             forbiddenNodes = LongBitmap.or(forbiddenNodes, subgraph);
             neighborhoods = LongBitmap.andNot(neighborhoods, forbiddenNodes);
             forbiddenNodes = LongBitmap.or(forbiddenNodes, neighborhoods);
-
             for (Edge edge : edgeCalculator.foundComplexEdgesContain(subgraph)) {
                 long left = edge.getLeft();
                 long right = edge.getRight();
@@ -268,11 +266,11 @@ public class SubgraphEnumerator {
             simpleContains.or(containSimpleEdges.get(bitmap1));
             simpleContains.or(containSimpleEdges.get(bitmap2));
             BitSet complexContains = new BitSet();
-            simpleContains.or(containComplexEdges.get(bitmap1));
-            simpleContains.or(containComplexEdges.get(bitmap2));
+            complexContains.or(containComplexEdges.get(bitmap1));
+            complexContains.or(containComplexEdges.get(bitmap2));
             BitSet overlaps = new BitSet();
-            simpleContains.or(overlapEdges.get(bitmap1));
-            simpleContains.or(overlapEdges.get(bitmap2));
+            overlaps.or(overlapEdges.get(bitmap1));
+            overlaps.or(overlapEdges.get(bitmap2));
             for (int index : overlaps.stream().toArray()) {
                 Edge edge = edges.get(index);
                 if (isContainEdge(subgraph, edge)) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/joinorder/hypergraph/receiver/AbstractReceiver.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/joinorder/hypergraph/receiver/AbstractReceiver.java
@@ -19,20 +19,23 @@ package org.apache.doris.nereids.jobs.joinorder.hypergraph.receiver;
 
 import org.apache.doris.nereids.jobs.joinorder.hypergraph.Edge;
 import org.apache.doris.nereids.memo.Group;
+import org.apache.doris.nereids.trees.expressions.NamedExpression;
 
+import java.util.HashMap;
 import java.util.List;
 
 /**
  * A interface of receiver
  */
 public interface AbstractReceiver {
-    public boolean emitCsgCmp(long csg, long cmp, List<Edge> edges);
+    boolean emitCsgCmp(long csg, long cmp, List<Edge> edges,
+            HashMap<Long, NamedExpression> projectExpression);
 
-    public void addGroup(long bitSet, Group group);
+    void addGroup(long bitSet, Group group);
 
-    public boolean contain(long bitSet);
+    boolean contain(long bitSet);
 
-    public void reset();
+    void reset();
 
-    public Group getBestPlan(long bitSet);
+    Group getBestPlan(long bitSet);
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/joinorder/hypergraph/receiver/Counter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/joinorder/hypergraph/receiver/Counter.java
@@ -20,6 +20,7 @@ package org.apache.doris.nereids.jobs.joinorder.hypergraph.receiver;
 import org.apache.doris.nereids.jobs.joinorder.hypergraph.Edge;
 import org.apache.doris.nereids.jobs.joinorder.hypergraph.bitmap.LongBitmap;
 import org.apache.doris.nereids.memo.Group;
+import org.apache.doris.nereids.trees.expressions.NamedExpression;
 
 import com.google.common.base.Preconditions;
 
@@ -31,9 +32,9 @@ import java.util.List;
  */
 public class Counter implements AbstractReceiver {
     // limit define the max number of csg-cmp pair in this Receiver
-    private int limit;
+    private final int limit;
     private int emitCount = 0;
-    private HashMap<Long, Integer> counter = new HashMap<>();
+    private final HashMap<Long, Integer> counter = new HashMap<>();
 
     public Counter() {
         this.limit = Integer.MAX_VALUE;
@@ -51,7 +52,8 @@ public class Counter implements AbstractReceiver {
      * @param edges the join operator
      * @return the left and the right can be connected by the edge
      */
-    public boolean emitCsgCmp(long left, long right, List<Edge> edges) {
+    public boolean emitCsgCmp(long left, long right, List<Edge> edges,
+            HashMap<Long, NamedExpression> projectExpression) {
         Preconditions.checkArgument(counter.containsKey(left));
         Preconditions.checkArgument(counter.containsKey(right));
         emitCount += 1;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Group.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Group.java
@@ -23,6 +23,7 @@ import org.apache.doris.nereids.properties.PhysicalProperties;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalJoin;
 import org.apache.doris.nereids.trees.plans.logical.LogicalPlan;
+import org.apache.doris.nereids.trees.plans.logical.LogicalProject;
 import org.apache.doris.nereids.util.TreeStringUtils;
 import org.apache.doris.statistics.StatsDeriveResult;
 
@@ -320,6 +321,10 @@ public class Group {
 
     public boolean isJoinGroup() {
         return getLogicalExpression().getPlan() instanceof LogicalJoin;
+    }
+
+    public boolean isProjectGroup() {
+        return getLogicalExpression().getPlan() instanceof LogicalProject;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Memo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Memo.java
@@ -60,7 +60,7 @@ public class Memo {
     private final Map<GroupId, Group> groups = Maps.newLinkedHashMap();
     // we could not use Set, because Set does not have get method.
     private final Map<GroupExpression, GroupExpression> groupExpressions = Maps.newHashMap();
-    private final Group root;
+    private Group root;
 
     // FOR TEST ONLY
     public Memo() {
@@ -71,8 +71,22 @@ public class Memo {
         root = init(plan);
     }
 
+    public static long getStateId() {
+        return stateId;
+    }
+
     public Group getRoot() {
         return root;
+    }
+
+    /**
+     * This function used to update the root group when DPHyp change the root Group
+     * Note it only used in DPHyp
+     *
+     * @param root The new root Group
+     */
+    public void setRoot(Group root) {
+        this.root = root;
     }
 
     public List<Group> getGroups() {
@@ -81,10 +95,6 @@ public class Memo {
 
     public Map<GroupExpression, GroupExpression> getGroupExpressions() {
         return groupExpressions;
-    }
-
-    public static long getStateId() {
-        return stateId;
     }
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/Expression.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/Expression.java
@@ -143,6 +143,10 @@ public abstract class Expression extends AbstractTreeNode<Expression> implements
         return this instanceof Slot;
     }
 
+    public boolean isAlias() {
+        return this instanceof Alias;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/jobs/joinorder/JoinOrderJobTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/jobs/joinorder/JoinOrderJobTest.java
@@ -71,7 +71,22 @@ public class JoinOrderJobTest extends TestWithFeService {
 
     @Test
     protected void testSimpleSQL() {
-        String sql = "select count(*) from T1, T2, T3, T4 "
+        String sql = "select * from T1, T2, T3, T4 "
+                + "where "
+                + "T1.id = T2.id and "
+                + "T2.score = T3.score and "
+                + "T3.id = T4.id";
+        PlanChecker.from(connectContext)
+                .analyze(sql)
+                .rewrite()
+                .deriveStats()
+                .orderJoin()
+                .printlnTree();
+    }
+
+    @Test
+    protected void testSimpleSQLWithProject() {
+        String sql = "select T1.id from T1, T2, T3, T4 "
                 + "where "
                 + "T1.id = T2.id and "
                 + "T2.score = T3.score and "

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/sqltest/MultiJoinTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/sqltest/MultiJoinTest.java
@@ -51,7 +51,7 @@ public class MultiJoinTest extends SqlTestBase {
 
     @Test
     @Disabled
-        // TODO: MultiJoin And EliminateOuter
+    // TODO: MultiJoin And EliminateOuter
     void testEliminateBelowOuter() {
         String sql = "SELECT * FROM T1, T2 LEFT JOIN T3 ON T2.id = T3.id WHERE T1.id = T2.id";
         PlanChecker.from(connectContext)

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/sqltest/MultiJoinTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/sqltest/MultiJoinTest.java
@@ -51,7 +51,7 @@ public class MultiJoinTest extends SqlTestBase {
 
     @Test
     @Disabled
-    // TODO: MultiJoin And EliminateOuter
+        // TODO: MultiJoin And EliminateOuter
     void testEliminateBelowOuter() {
         String sql = "SELECT * FROM T1, T2 LEFT JOIN T3 ON T2.id = T3.id WHERE T1.id = T2.id";
         PlanChecker.from(connectContext)

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/util/HyperGraphBuilder.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/util/HyperGraphBuilder.java
@@ -46,9 +46,9 @@ import java.util.Optional;
 import java.util.Set;
 
 public class HyperGraphBuilder {
-    private List<Integer> rowCounts = new ArrayList<>();
-    private HashMap<BitSet, LogicalPlan> plans = new HashMap<>();
-    private HashMap<BitSet, List<Integer>> schemas = new HashMap<>();
+    private final List<Integer> rowCounts = new ArrayList<>();
+    private final HashMap<BitSet, LogicalPlan> plans = new HashMap<>();
+    private final HashMap<BitSet, List<Integer>> schemas = new HashMap<>();
 
     public HyperGraph build() {
         assert plans.size() == 1 : "there are cross join";
@@ -180,7 +180,8 @@ public class HyperGraphBuilder {
         cascadesContext.getJobScheduler().executeJobPool(cascadesContext);
         injectRowcount(cascadesContext.getMemo().getRoot());
         HyperGraph hyperGraph = new HyperGraph();
-        joinOrderJob.buildGraph(cascadesContext.getMemo().getRoot(), hyperGraph);
+        Set<Slot> requires = cascadesContext.getMemo().getRoot().getLogicalExpression().getPlan().getInputSlots();
+        joinOrderJob.buildGraph(cascadesContext.getMemo().getRoot(), hyperGraph, requires);
         return hyperGraph;
     }
 
@@ -215,9 +216,9 @@ public class HyperGraphBuilder {
         List<Expression> conditions = new ArrayList<>(join.getExpressions());
         Set<Slot> inputs = condition.getInputSlots();
         if (leftSlots.containsAll(inputs)) {
-            left = (LogicalJoin) attachCondition(condition, (LogicalJoin) left);
+            left = attachCondition(condition, (LogicalJoin) left);
         } else if (rightSlots.containsAll(inputs)) {
-            right = (LogicalJoin) attachCondition(condition, (LogicalJoin) right);
+            right = attachCondition(condition, (LogicalJoin) right);
         } else {
             conditions.add(condition);
         }


### PR DESCRIPTION
Signed-off-by: xiejiann <jianxie0@gmail.com>

# Proposed changes

Issue Number: close #xxx

For different project operators, we
     1. If it's a simple expression for column pruning, w ignore it
     2. If it's an alias that may be used in the join operator, we need to add it to the graph
     3. If it's another expression, we can ignore them and add it after optimizing
     4. If it's a project only associated with one table, it's seen as an endNode just like a table 

## Problem summary

In DPHyp, we must process the project operator above the join to avoid constructing multiple join clusters.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [x] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

