### PR TITLE
[fix](jdbc) fix logger error of statusLogger unrecognized

### DIFF
--- a/be/src/util/jni-util.cpp
+++ b/be/src/util/jni-util.cpp
@@ -71,10 +71,11 @@ void FindOrCreateJavaVM() {
     if (rv == 0) {
         auto classpath = GetDorisJNIClasspath();
         std::string heap_size = fmt::format("-Xmx{}", config::jvm_max_heap_size);
-
+        std::string log_path = fmt::format("-DlogPath={}/log/udf-jdbc.log", getenv("DORIS_HOME"));
         JavaVMOption options[] = {
                 {const_cast<char*>(classpath.c_str()), nullptr},
                 {const_cast<char*>(heap_size.c_str()), nullptr},
+                {const_cast<char*>(log_path.c_str()), nullptr},
 #ifdef __APPLE__
                 // On macOS, we should disable MaxFDLimit, otherwise the RLIMIT_NOFILE
                 // will be assigned the minimum of OPEN_MAX (10240) and rlim_cur (See src/hotspot/os/bsd/os_bsd.cpp)

--- a/fe/java-udf/pom.xml
+++ b/fe/java-udf/pom.xml
@@ -82,9 +82,9 @@ under the License.
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <configuration>
-                    <descriptorRefs>
-                        <descriptorRef>jar-with-dependencies</descriptorRef>
-                    </descriptorRefs>
+                    <descriptors>
+                        <descriptor>src/main/resources/package.xml</descriptor>
+                    </descriptors>
                     <archive>
                         <manifest>
                             <mainClass></mainClass>

--- a/fe/java-udf/src/main/resources/log4j.properties
+++ b/fe/java-udf/src/main/resources/log4j.properties
@@ -1,0 +1,9 @@
+log4j.rootLogger=INFO, RollingFile
+log4j.appender.RollingFile=org.apache.log4j.RollingFileAppender
+log4j.appender.RollingFile.Threshold=INFO
+log4j.appender.RollingFile.File=${logPath}
+log4j.appender.RollingFile.Append=true
+log4j.appender.RollingFile.MaxFileSize=10MB
+log4j.appender.RollingFile.MaxBackupIndex=5
+log4j.appender.RollingFile.layout=org.apache.log4j.PatternLayout
+log4j.appender.RollingFile.layout.ConversionPattern= %d{yyyy-MM-dd HH:mm:ss} %5p %t %-5l - %m%n

--- a/fe/java-udf/src/main/resources/log4j.properties
+++ b/fe/java-udf/src/main/resources/log4j.properties
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+
+#   http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 log4j.rootLogger=INFO, RollingFile
 log4j.appender.RollingFile=org.apache.log4j.RollingFileAppender
 log4j.appender.RollingFile.Threshold=INFO

--- a/fe/java-udf/src/main/resources/package.xml
+++ b/fe/java-udf/src/main/resources/package.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.0.0 http://maven.apache.org/xsd/assembly-2.0.0.xsd">
+    <id>jar-with-dependencies</id>
+    <formats>
+        <format>jar</format>
+    </formats>
+    <includeBaseDirectory>false</includeBaseDirectory>
+    <dependencySets>
+        <dependencySet>
+            <outputDirectory>/</outputDirectory>
+            <useProjectArtifact>true</useProjectArtifact>
+            <unpack>true</unpack>
+            <scope>runtime</scope>
+            <unpackOptions>
+                <excludes>
+                    <exclude>**/Log4j2Plugins.dat</exclude>
+                </excludes>
+            </unpackOptions>
+        </dependencySet>
+    </dependencySets>
+</assembly>

--- a/fe/java-udf/src/main/resources/package.xml
+++ b/fe/java-udf/src/main/resources/package.xml
@@ -1,4 +1,22 @@
 <?xml version="1.0" encoding="UTF-8" ?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
 <assembly xmlns="http://maven.apache.org/ASSEMBLY/2.0.0"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.0.0 http://maven.apache.org/xsd/assembly-2.0.0.xsd">


### PR DESCRIPTION
# Proposed changes
1.enable Java UDF can use Log4j to file.
2.fix logger error of statusLogger unrecognized

`ERROR StatusLogger Unrecognized format specifier [d]
ERROR StatusLogger Unrecognized conversion specifier [d] starting at position 16 in conversion pattern.
ERROR StatusLogger Unrecognized format specifier [thread]
ERROR StatusLogger Unrecognized conversion specifier [thread] starting at position 25 in conversion pattern.
ERROR StatusLogger Unrecognized format specifier [level]
ERROR StatusLogger Unrecognized conversion specifier [level] starting at position 35 in conversion pattern.`

Issue Number: close #14677 

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

