### PR TITLE
[Feature](Nereids) Support bitmap for materialized index.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslator.java
@@ -437,7 +437,10 @@ public class PhysicalPlanTranslator extends DefaultPlanVisitor<PlanFragment, Pla
     @Override
     public PlanFragment visitPhysicalOlapScan(PhysicalOlapScan olapScan, PlanTranslatorContext context) {
         // Create OlapScanNode
-        List<Slot> slotList = olapScan.getOutput();
+        List<Slot> slotList = new ImmutableList.Builder<Slot>()
+                .addAll(olapScan.getOutput())
+                .addAll(olapScan.getNonUserVisibleOutput())
+                .build();
         OlapTable olapTable = olapScan.getTable();
         TupleDescriptor tupleDescriptor = generateTupleDesc(slotList, olapTable, context);
         tupleDescriptor.setTable(olapTable);

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/batch/NereidsRewriteJobExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/batch/NereidsRewriteJobExecutor.java
@@ -29,6 +29,7 @@ import org.apache.doris.nereids.rules.mv.SelectMaterializedIndexWithAggregate;
 import org.apache.doris.nereids.rules.mv.SelectMaterializedIndexWithoutAggregate;
 import org.apache.doris.nereids.rules.rewrite.logical.BuildAggForUnion;
 import org.apache.doris.nereids.rules.rewrite.logical.ColumnPruning;
+import org.apache.doris.nereids.rules.rewrite.logical.CountDistinctRewrite;
 import org.apache.doris.nereids.rules.rewrite.logical.EliminateAggregate;
 import org.apache.doris.nereids.rules.rewrite.logical.EliminateFilter;
 import org.apache.doris.nereids.rules.rewrite.logical.EliminateGroupByConstant;
@@ -95,6 +96,7 @@ public class NereidsRewriteJobExecutor extends BatchRulesJob {
                 .add(topDownBatch(ImmutableList.of(new EliminateLimit())))
                 .add(topDownBatch(ImmutableList.of(new EliminateFilter())))
                 .add(topDownBatch(ImmutableList.of(new PruneOlapScanPartition())))
+                .add(topDownBatch(ImmutableList.of(new CountDistinctRewrite())))
                 .add(topDownBatch(ImmutableList.of(new SelectMaterializedIndexWithAggregate())))
                 .add(topDownBatch(ImmutableList.of(new SelectMaterializedIndexWithoutAggregate())))
                 .add(topDownBatch(ImmutableList.of(new PruneOlapScanTablet())))

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/RuleType.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/RuleType.java
@@ -158,6 +158,7 @@ public enum RuleType {
     HIDE_ONE_ROW_RELATION_UNDER_UNION(RuleTypeClass.REWRITE),
     MERGE_SET_OPERATION(RuleTypeClass.REWRITE),
     BUILD_AGG_FOR_UNION(RuleTypeClass.REWRITE),
+    COUNT_DISTINCT_REWRITE(RuleTypeClass.REWRITE),
     REWRITE_SENTINEL(RuleTypeClass.REWRITE),
 
     // limit push down

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/CheckAfterRewrite.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/CheckAfterRewrite.java
@@ -31,6 +31,7 @@ import org.apache.commons.lang.StringUtils;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * some check need to do after analyze whole plan.
@@ -49,8 +50,7 @@ public class CheckAfterRewrite extends OneAnalysisRuleFactory {
                 .flatMap(expr -> expr.getInputSlots().stream())
                 .collect(Collectors.toSet());
         Set<Slot> childrenOutput = plan.children().stream()
-                .map(Plan::getOutput)
-                .flatMap(List::stream)
+                .flatMap(child -> Stream.concat(child.getOutput().stream(), child.getNonUserVisibleOutput().stream()))
                 .collect(Collectors.toSet());
         notFromChildren.removeAll(childrenOutput);
         notFromChildren = removeValidVirtualSlots(notFromChildren, childrenOutput);

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/mv/AbstractSelectMaterializedIndexRule.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/mv/AbstractSelectMaterializedIndexRule.java
@@ -35,6 +35,7 @@ import org.apache.doris.nereids.util.ExpressionUtils;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
+import org.apache.commons.collections.CollectionUtils;
 
 import java.util.Comparator;
 import java.util.List;
@@ -61,21 +62,14 @@ public abstract class AbstractSelectMaterializedIndexRule {
         }
     }
 
-    /**
-     * 1. indexes have all the required columns.
-     * 2. find matching key prefix most.
-     * 3. sort by row count, column count and index id.
-     */
-    protected List<Long> filterAndOrder(
-            Stream<MaterializedIndex> candidates,
+    protected boolean containAllRequiredColumns(
+            MaterializedIndex index,
             LogicalOlapScan scan,
-            Set<Slot> requiredScanOutput,
-            List<Expression> predicates) {
-
+            Set<Slot> requiredScanOutput) {
         OlapTable table = scan.getTable();
         // Scan slot exprId -> slot name
-        Map<ExprId, String> exprIdToName = scan.getOutput()
-                .stream()
+        Map<ExprId, String> exprIdToName = Stream.concat(
+                        scan.getOutput().stream(), scan.getNonUserVisibleOutput().stream())
                 .collect(Collectors.toMap(NamedExpression::getExprId, NamedExpression::getName));
 
         // get required column names in metadata.
@@ -84,22 +78,32 @@ public abstract class AbstractSelectMaterializedIndexRule {
                 .map(slot -> exprIdToName.get(slot.getExprId()))
                 .collect(Collectors.toSet());
 
-        // 1. filter index contains all the required columns by column name.
-        List<MaterializedIndex> containAllRequiredColumns = candidates
-                .filter(index -> table.getSchemaByIndexId(index.getId(), true)
-                        .stream()
-                        .map(Column::getName)
-                        .collect(Collectors.toSet())
-                        .containsAll(requiredColumnNames)
-                ).collect(Collectors.toList());
+        return table.getSchemaByIndexId(index.getId(), true).stream()
+                .map(Column::getName)
+                .collect(Collectors.toSet())
+                .containsAll(requiredColumnNames);
+    }
 
-        // 2. find matching key prefix most.
-        List<MaterializedIndex> matchingKeyPrefixMost = matchPrefixMost(scan, containAllRequiredColumns, predicates,
-                exprIdToName);
+    /**
+     * 1. find matching key prefix most.
+     * 2. sort by row count, column count and index id.
+     */
+    protected long selectBestIndex(
+            List<MaterializedIndex> candidates,
+            LogicalOlapScan scan,
+            List<Expression> predicates) {
+        OlapTable table = scan.getTable();
+        // Scan slot exprId -> slot name
+        Map<ExprId, String> exprIdToName = scan.getOutput()
+                .stream()
+                .collect(Collectors.toMap(NamedExpression::getExprId, NamedExpression::getName));
+
+        // find matching key prefix most.
+        List<MaterializedIndex> matchingKeyPrefixMost = matchPrefixMost(scan, candidates, predicates, exprIdToName);
 
         List<Long> partitionIds = scan.getSelectedPartitionIds();
-        // 3. sort by row count, column count and index id.
-        return matchingKeyPrefixMost.stream()
+        // sort by row count, column count and index id.
+        List<Long> sortedIndexIds = matchingKeyPrefixMost.stream()
                 .map(MaterializedIndex::getId)
                 .sorted(Comparator
                         // compare by row count
@@ -111,6 +115,8 @@ public abstract class AbstractSelectMaterializedIndexRule {
                         // compare by index id
                         .thenComparing(rid -> (Long) rid))
                 .collect(Collectors.toList());
+
+        return CollectionUtils.isEmpty(sortedIndexIds) ? scan.getTable().getBaseIndexId() : sortedIndexIds.get(0);
     }
 
     protected List<MaterializedIndex> matchPrefixMost(

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/mv/SelectMaterializedIndexWithAggregate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/mv/SelectMaterializedIndexWithAggregate.java
@@ -472,7 +472,7 @@ public class SelectMaterializedIndexWithAggregate extends AbstractSelectMaterial
         @Override
         public PreAggStatus visitCount(Count count, CheckContext context) {
             // Now count(distinct key_column) is only supported for aggregate-keys and unique-keys OLAP table.
-            if (count.isDistinct()) {
+            if (count.isDistinct() && count.arity() == 1) {
                 Optional<ExprId> exprIdOpt = extractSlotId(count.child(0));
                 if (exprIdOpt.isPresent() && context.exprIdToKeyColumn.containsKey(exprIdOpt.get())) {
                     return PreAggStatus.on();
@@ -714,7 +714,7 @@ public class SelectMaterializedIndexWithAggregate extends AbstractSelectMaterial
          */
         @Override
         public Expression visitCount(Count count, RewriteContext context) {
-            if (count.isDistinct()) {
+            if (count.isDistinct() && count.arity() == 1) {
                 Optional<Slot> slotOpt = ExpressionUtils.extractSlotOrCastOnSlot(count.child(0));
 
                 // count distinct a value column.

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/mv/SelectMaterializedIndexWithoutAggregate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/mv/SelectMaterializedIndexWithoutAggregate.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.nereids.rules.mv;
 
+import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.MaterializedIndex;
 import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.nereids.rules.Rule;
@@ -124,24 +125,34 @@ public class SelectMaterializedIndexWithoutAggregate extends AbstractSelectMater
                 List<MaterializedIndex> candidates = table.getVisibleIndex().stream()
                         .filter(index -> index.getId() == baseIndexId
                                 || table.getKeyColumnsByIndexId(index.getId()).size() == baseIndexKeySize)
+                        .filter(index -> containAllRequiredColumns(index, scan, requiredScanOutputSupplier.get()))
                         .collect(Collectors.toList());
+
                 PreAggStatus preAgg = PreAggStatus.off("No aggregate on scan.");
                 if (candidates.size() == 1) {
                     // `candidates` only have base index.
-                    return scan.withMaterializedIndexSelected(preAgg, ImmutableList.of(baseIndexId));
+                    return scan.withMaterializedIndexSelected(preAgg, baseIndexId);
                 } else {
                     return scan.withMaterializedIndexSelected(preAgg,
-                            filterAndOrder(candidates.stream(), scan, requiredScanOutputSupplier.get(),
-                                    predicatesSupplier.get()));
+                            selectBestIndex(candidates, scan, predicatesSupplier.get()));
                 }
             case DUP_KEYS:
                 // Set pre-aggregation to `on` to keep consistency with legacy logic.
+                List<MaterializedIndex> candidate = scan.getTable().getVisibleIndex().stream()
+                        .filter(index -> !indexHasAggregate(index, scan))
+                        .filter(index -> containAllRequiredColumns(index, scan,
+                                requiredScanOutputSupplier.get()))
+                        .collect(Collectors.toList());
                 return scan.withMaterializedIndexSelected(PreAggStatus.on(),
-                        filterAndOrder(scan.getTable().getVisibleIndex().stream(), scan,
-                                requiredScanOutputSupplier.get(),
-                                predicatesSupplier.get()));
+                        selectBestIndex(candidate, scan, predicatesSupplier.get()));
             default:
                 throw new RuntimeException("Not supported keys type: " + scan.getTable().getKeysType());
         }
+    }
+
+    private boolean indexHasAggregate(MaterializedIndex index, LogicalOlapScan scan) {
+        return scan.getTable().getSchemaByIndexId(index.getId())
+                .stream()
+                .anyMatch(Column::isAggregated);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/logical/CountDistinctRewrite.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/logical/CountDistinctRewrite.java
@@ -25,7 +25,6 @@ import org.apache.doris.nereids.trees.expressions.NamedExpression;
 import org.apache.doris.nereids.trees.expressions.functions.agg.BitmapUnionCount;
 import org.apache.doris.nereids.trees.expressions.functions.agg.Count;
 import org.apache.doris.nereids.trees.expressions.visitor.DefaultExpressionRewriter;
-import org.apache.doris.nereids.trees.plans.logical.LogicalAggregate;
 
 import com.google.common.collect.ImmutableList;
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/logical/CountDistinctRewrite.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/logical/CountDistinctRewrite.java
@@ -46,8 +46,7 @@ public class CountDistinctRewrite extends OneRewriteRuleFactory {
                     .map(CountDistinctRewriter::rewrite)
                     .map(NamedExpression.class::cast)
                     .collect(ImmutableList.toImmutableList());
-            return new LogicalAggregate<>(agg.getGroupByExpressions(), output,
-                    agg.isNormalized(), agg.getSourceRepeat(), agg.child());
+            return agg.withAggOutput(output);
         }).toRule(RuleType.COUNT_DISTINCT_REWRITE);
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/logical/CountDistinctRewrite.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/logical/CountDistinctRewrite.java
@@ -1,0 +1,72 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.rules.rewrite.logical;
+
+import org.apache.doris.nereids.rules.Rule;
+import org.apache.doris.nereids.rules.RuleType;
+import org.apache.doris.nereids.rules.rewrite.OneRewriteRuleFactory;
+import org.apache.doris.nereids.trees.expressions.Expression;
+import org.apache.doris.nereids.trees.expressions.NamedExpression;
+import org.apache.doris.nereids.trees.expressions.functions.agg.BitmapUnionCount;
+import org.apache.doris.nereids.trees.expressions.functions.agg.Count;
+import org.apache.doris.nereids.trees.expressions.visitor.DefaultExpressionRewriter;
+import org.apache.doris.nereids.trees.plans.logical.LogicalAggregate;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+
+/**
+ * Rewrite count distinct for bitmap and hll type value.
+ * <p>
+ * count(distinct bitmap_col) -> bitmap_union_count(bitmap col)
+ * todo: add support for HLL type.
+ */
+public class CountDistinctRewrite extends OneRewriteRuleFactory {
+    @Override
+    public Rule build() {
+        return logicalAggregate().then(agg -> {
+            List<NamedExpression> output = agg.getOutputExpressions()
+                    .stream()
+                    .map(CountDistinctRewriter::rewrite)
+                    .map(NamedExpression.class::cast)
+                    .collect(ImmutableList.toImmutableList());
+            return new LogicalAggregate<>(agg.getGroupByExpressions(), output,
+                    agg.isNormalized(), agg.getSourceRepeat(), agg.child());
+        }).toRule(RuleType.COUNT_DISTINCT_REWRITE);
+    }
+
+    private static class CountDistinctRewriter extends DefaultExpressionRewriter<Void> {
+        private static final CountDistinctRewriter INSTANCE = new CountDistinctRewriter();
+
+        public static Expression rewrite(Expression expr) {
+            return expr.accept(INSTANCE, null);
+        }
+
+        @Override
+        public Expression visitCount(Count count, Void context) {
+            if (count.isDistinct() && count.arity() == 1) {
+                Expression child = count.child(0);
+                if (child.getDataType().isBitmap()) {
+                    return new BitmapUnionCount(child);
+                }
+            }
+            return count;
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/agg/BitmapUnionCount.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/agg/BitmapUnionCount.java
@@ -22,6 +22,7 @@ import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.functions.AlwaysNotNullable;
 import org.apache.doris.nereids.trees.expressions.functions.ExplicitlyCastableSignature;
 import org.apache.doris.nereids.trees.expressions.shape.UnaryExpression;
+import org.apache.doris.nereids.trees.expressions.visitor.ExpressionVisitor;
 import org.apache.doris.nereids.types.BigIntType;
 import org.apache.doris.nereids.types.BitmapType;
 import org.apache.doris.nereids.types.DataType;
@@ -61,5 +62,10 @@ public class BitmapUnionCount extends AggregateFunction
     @Override
     public List<FunctionSignature> getSignatures() {
         return SIGNATURES;
+    }
+
+    @Override
+    public <R, C> R accept(ExpressionVisitor<R, C> visitor, C context) {
+        return visitor.visitBitmapUnionCount(this, context);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/visitor/AggregateFunctionVisitor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/visitor/AggregateFunctionVisitor.java
@@ -19,6 +19,7 @@ package org.apache.doris.nereids.trees.expressions.visitor;
 
 import org.apache.doris.nereids.trees.expressions.functions.agg.AggregateFunction;
 import org.apache.doris.nereids.trees.expressions.functions.agg.Avg;
+import org.apache.doris.nereids.trees.expressions.functions.agg.BitmapUnionCount;
 import org.apache.doris.nereids.trees.expressions.functions.agg.Count;
 import org.apache.doris.nereids.trees.expressions.functions.agg.GroupBitAnd;
 import org.apache.doris.nereids.trees.expressions.functions.agg.GroupBitOr;
@@ -71,5 +72,9 @@ public interface AggregateFunctionVisitor<R, C> {
 
     default R visitSum(Sum sum, C context) {
         return visitAggregateFunction(sum, context);
+    }
+
+    default R visitBitmapUnionCount(BitmapUnionCount bitmapUnionCount, C context) {
+        return visitAggregateFunction(bitmapUnionCount, context);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/AbstractPlan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/AbstractPlan.java
@@ -140,6 +140,11 @@ public abstract class AbstractPlan extends AbstractTreeNode<Plan> implements Pla
     }
 
     @Override
+    public List<Slot> getNonUserVisibleOutput() {
+        return getLogicalProperties().getNonUserVisibleOutput();
+    }
+
+    @Override
     public Set<Slot> getOutputSet() {
         return getLogicalProperties().getOutputSet();
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/FakePlan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/FakePlan.java
@@ -23,6 +23,8 @@ import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.Slot;
 import org.apache.doris.nereids.trees.plans.visitor.PlanVisitor;
 
+import com.google.common.collect.ImmutableList;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -85,6 +87,11 @@ public class FakePlan implements Plan {
     @Override
     public List<Slot> getOutput() {
         return new ArrayList<>();
+    }
+
+    @Override
+    public List<Slot> getNonUserVisibleOutput() {
+        return ImmutableList.of();
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/Plan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/Plan.java
@@ -87,6 +87,8 @@ public interface Plan extends TreeNode<Plan> {
      */
     List<Slot> getOutput();
 
+    List<Slot> getNonUserVisibleOutput();
+
     /**
      * Get output slot set of the plan.
      */
@@ -112,6 +114,10 @@ public interface Plan extends TreeNode<Plan> {
 
     default List<Slot> computeOutput() {
         throw new IllegalStateException("Not support compute output for " + getClass().getName());
+    }
+
+    default List<Slot> computeNonUserVisibleOutput() {
+        return ImmutableList.of();
     }
 
     String treeString();

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/Command.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/Command.java
@@ -84,6 +84,11 @@ public interface Command extends LogicalPlan {
     }
 
     @Override
+    default List<Slot> getNonUserVisibleOutput() {
+        throw new RuntimeException("Command do not implement getNonUserVisibleOutput");
+    }
+
+    @Override
     default String treeString() {
         throw new RuntimeException("Command do not implement treeString");
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/AbstractLogicalPlan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/AbstractLogicalPlan.java
@@ -51,7 +51,7 @@ public abstract class AbstractLogicalPlan extends AbstractPlan implements Logica
         if (hasUnboundChild || hasUnboundExpression()) {
             return UnboundLogicalProperties.INSTANCE;
         } else {
-            return new LogicalProperties(this::computeOutput);
+            return new LogicalProperties(this::computeOutput, this::computeNonUserVisibleOutput);
         }
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalOlapScan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalOlapScan.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.nereids.trees.plans.logical;
 
+import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.Database;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.OlapTable;
@@ -24,6 +25,8 @@ import org.apache.doris.catalog.Table;
 import org.apache.doris.nereids.exceptions.AnalysisException;
 import org.apache.doris.nereids.memo.GroupExpression;
 import org.apache.doris.nereids.properties.LogicalProperties;
+import org.apache.doris.nereids.trees.expressions.Slot;
+import org.apache.doris.nereids.trees.expressions.SlotReference;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PlanType;
 import org.apache.doris.nereids.trees.plans.PreAggStatus;
@@ -36,26 +39,59 @@ import org.apache.doris.nereids.util.Utils;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
-import org.apache.commons.collections.CollectionUtils;
 
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Logical OlapScan.
  */
 public class LogicalOlapScan extends LogicalRelation implements CatalogRelation, OlapScan {
 
-    private final long selectedIndexId;
-    private final List<Long> selectedTabletIds;
-    private final boolean partitionPruned;
-    private final boolean tabletPruned;
+    ///////////////////////////////////////////////////////////////////////////
+    // Members for materialized index.
+    ///////////////////////////////////////////////////////////////////////////
 
-    private final List<Long> candidateIndexIds;
+    /**
+     * The select materialized index id to read data from.
+     */
+    private final long selectedIndexId;
+
+    /**
+     * Status to indicate materialized index id is selected or not.
+     */
     private final boolean indexSelected;
 
+    /**
+     * Status to indicate using pre-aggregation or not.
+     */
     private final PreAggStatus preAggStatus;
+
+    ///////////////////////////////////////////////////////////////////////////
+    // Members for tablet ids.
+    ///////////////////////////////////////////////////////////////////////////
+
+    /**
+     * Selected tablet ids to read data from.
+     */
+    private final ImmutableList<Long> selectedTabletIds;
+
+    /**
+     * Status to indicate tablets are pruned or not.
+     */
+    private final boolean tabletPruned;
+
+    ///////////////////////////////////////////////////////////////////////////
+    // Members for partition ids.
+    ///////////////////////////////////////////////////////////////////////////
+    /**
+     * Status to indicate partitions are pruned or not.
+     * todo: should be pulled up to base class?
+     */
+    private final boolean partitionPruned;
 
     public LogicalOlapScan(RelationId id, OlapTable table) {
         this(id, table, ImmutableList.of());
@@ -63,14 +99,15 @@ public class LogicalOlapScan extends LogicalRelation implements CatalogRelation,
 
     public LogicalOlapScan(RelationId id, OlapTable table, List<String> qualifier) {
         this(id, table, qualifier, Optional.empty(), Optional.empty(),
-                table.getPartitionIds(), false, ImmutableList.of(), false,
-                ImmutableList.of(), false, PreAggStatus.on());
+                table.getPartitionIds(), false,
+                ImmutableList.of(), false,
+                -1, false, PreAggStatus.on());
     }
 
     public LogicalOlapScan(RelationId id, Table table, List<String> qualifier) {
         this(id, table, qualifier, Optional.empty(), Optional.empty(),
                 ((OlapTable) table).getPartitionIds(), false, ImmutableList.of(), false,
-                ImmutableList.of(), false, PreAggStatus.on());
+                -1, false, PreAggStatus.on());
     }
 
     /**
@@ -80,17 +117,13 @@ public class LogicalOlapScan extends LogicalRelation implements CatalogRelation,
             Optional<GroupExpression> groupExpression, Optional<LogicalProperties> logicalProperties,
             List<Long> selectedPartitionIds, boolean partitionPruned,
             List<Long> selectedTabletIds, boolean tabletPruned,
-            List<Long> candidateIndexIds, boolean indexSelected, PreAggStatus preAggStatus) {
+            long selectedIndexId, boolean indexSelected, PreAggStatus preAggStatus) {
         super(id, PlanType.LOGICAL_OLAP_SCAN, table, qualifier,
                 groupExpression, logicalProperties, selectedPartitionIds);
-        // TODO: use CBO manner to select best index id, according to index's statistics info,
-        //   revisit this after rollup and materialized view selection are fully supported.
-        this.selectedIndexId = CollectionUtils.isEmpty(candidateIndexIds)
-                ? getTable().getBaseIndexId() : candidateIndexIds.get(0);
         this.selectedTabletIds = ImmutableList.copyOf(selectedTabletIds);
         this.partitionPruned = partitionPruned;
         this.tabletPruned = tabletPruned;
-        this.candidateIndexIds = ImmutableList.copyOf(candidateIndexIds);
+        this.selectedIndexId = selectedIndexId <= 0 ? getTable().getBaseIndexId() : selectedIndexId;
         this.indexSelected = indexSelected;
         this.preAggStatus = preAggStatus;
     }
@@ -113,7 +146,7 @@ public class LogicalOlapScan extends LogicalRelation implements CatalogRelation,
         return Utils.toSqlString("LogicalOlapScan",
                 "qualified", qualifiedName(),
                 "output", getOutput(),
-                "candidateIndexIds", candidateIndexIds,
+                "indexName", getSelectedMaterializedIndexName().orElse("<index_not_selected>"),
                 "selectedIndexId", selectedIndexId,
                 "preAgg", preAggStatus
         );
@@ -127,46 +160,53 @@ public class LogicalOlapScan extends LogicalRelation implements CatalogRelation,
         if (o == null || getClass() != o.getClass() || !super.equals(o)) {
             return false;
         }
-        return Objects.equals(selectedPartitionIds, ((LogicalOlapScan) o).selectedPartitionIds)
-                && Objects.equals(candidateIndexIds, ((LogicalOlapScan) o).candidateIndexIds)
-                && Objects.equals(selectedTabletIds, ((LogicalOlapScan) o).selectedTabletIds);
+        return Objects.equals(id, ((LogicalOlapScan) o).id)
+                && Objects.equals(selectedPartitionIds, ((LogicalOlapScan) o).selectedPartitionIds)
+                && Objects.equals(partitionPruned, ((LogicalOlapScan) o).partitionPruned)
+                && Objects.equals(selectedIndexId, ((LogicalOlapScan) o).selectedIndexId)
+                && Objects.equals(indexSelected, ((LogicalOlapScan) o).indexSelected)
+                && Objects.equals(selectedTabletIds, ((LogicalOlapScan) o).selectedTabletIds)
+                && Objects.equals(tabletPruned, ((LogicalOlapScan) o).tabletPruned);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, selectedPartitionIds, candidateIndexIds, selectedTabletIds);
+        return Objects.hash(id,
+                selectedPartitionIds, partitionPruned,
+                selectedIndexId, indexSelected,
+                selectedTabletIds, tabletPruned);
     }
 
     @Override
     public Plan withGroupExpression(Optional<GroupExpression> groupExpression) {
         return new LogicalOlapScan(id, table, qualifier, groupExpression, Optional.of(getLogicalProperties()),
                 selectedPartitionIds, partitionPruned, selectedTabletIds, tabletPruned,
-                candidateIndexIds, indexSelected, preAggStatus);
+                selectedIndexId, indexSelected, preAggStatus);
     }
 
     @Override
     public LogicalOlapScan withLogicalProperties(Optional<LogicalProperties> logicalProperties) {
         return new LogicalOlapScan(id, table, qualifier, Optional.empty(), logicalProperties,
                 selectedPartitionIds, partitionPruned, selectedTabletIds, tabletPruned,
-                candidateIndexIds, indexSelected, preAggStatus);
+                selectedIndexId, indexSelected, preAggStatus);
     }
 
     public LogicalOlapScan withSelectedPartitionIds(List<Long> selectedPartitionIds) {
         return new LogicalOlapScan(id, table, qualifier, Optional.empty(), Optional.of(getLogicalProperties()),
                 selectedPartitionIds, true, selectedTabletIds, tabletPruned,
-                candidateIndexIds, indexSelected, preAggStatus);
+                selectedIndexId, indexSelected, preAggStatus);
     }
 
-    public LogicalOlapScan withMaterializedIndexSelected(PreAggStatus preAgg, List<Long> candidateIndexIds) {
+    public LogicalOlapScan withMaterializedIndexSelected(PreAggStatus preAgg, long indexId) {
         return new LogicalOlapScan(id, table, qualifier, Optional.empty(), Optional.of(getLogicalProperties()),
                 selectedPartitionIds, partitionPruned, selectedTabletIds, tabletPruned,
-                candidateIndexIds, true, preAgg);
+                indexId, true, preAgg);
     }
 
     public LogicalOlapScan withSelectedTabletIds(List<Long> selectedTabletIds) {
         return new LogicalOlapScan(id, table, qualifier, Optional.empty(), Optional.of(getLogicalProperties()),
                 selectedPartitionIds, partitionPruned, selectedTabletIds, true,
-                candidateIndexIds, indexSelected, preAggStatus);
+                selectedIndexId, indexSelected, preAggStatus);
     }
 
     @Override
@@ -203,5 +243,24 @@ public class LogicalOlapScan extends LogicalRelation implements CatalogRelation,
     public Optional<String> getSelectedMaterializedIndexName() {
         return indexSelected ? Optional.ofNullable(((OlapTable) table).getIndexNameById(selectedIndexId))
                 : Optional.empty();
+    }
+
+    @Override
+    public List<Slot> computeNonUserVisibleOutput() {
+        Set<String> baseSchemaColNames = table.getBaseSchema().stream()
+                .map(Column::getName)
+                .collect(Collectors.toSet());
+
+        OlapTable olapTable = (OlapTable) table;
+        // extra columns in materialized index, such as `mv_bitmap_union_xxx`
+        return olapTable.getVisibleIndexIdToMeta().values()
+                .stream()
+                .filter(index -> index.getIndexId() != ((OlapTable) table).getBaseIndexId())
+                .flatMap(index -> index.getSchema()
+                        .stream()
+                        .filter(col -> !baseSchemaColNames.contains(col.getName()))
+                )
+                .map(col -> SlotReference.fromColumn(col, qualified()))
+                .collect(ImmutableList.toImmutableList());
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/types/DataType.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/types/DataType.java
@@ -445,6 +445,10 @@ public abstract class DataType implements AbstractDataType {
         return this instanceof DateTimeV2Type;
     }
 
+    public boolean isBitmap() {
+        return this instanceof BitmapType;
+    }
+
     public DataType promotion() {
         if (PROMOTION_MAP.containsKey(this.getClass())) {
             return PROMOTION_MAP.get(this.getClass()).get();

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/PlanToStringTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/PlanToStringTest.java
@@ -81,7 +81,8 @@ public class PlanToStringTest {
         LogicalOlapScan plan = PlanConstructor.newLogicalOlapScan(0, "table", 0);
         Assertions.assertTrue(
                 plan.toString().matches("LogicalOlapScan \\( qualified=db\\.table, "
-                        + "output=\\[id#\\d+, name#\\d+], candidateIndexIds=\\[], selectedIndexId=-1, preAgg=ON \\)"));
+                        + "output=\\[id#\\d+, name#\\d+], indexName=<index_not_selected>, "
+                        + "selectedIndexId=-1, preAgg=ON \\)"));
     }
 
     @Test


### PR DESCRIPTION
# Proposed changes

This PR adds the rewriting and matching logic for the bitmap_union column in materialized index.

If a materialized index has bitmap_union column, we try to rewrite count distinct or bitmap_union_count to the bitmap_union column in materialized index.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

