### PR TITLE
[chore](macOS) Resolve the issue with missing python program

### DIFF
--- a/be/src/vec/aggregate_functions/aggregate_function_sequence_match.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_sequence_match.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include <bitset>
+#include <stack>
 
 #include "common/logging.h"
 #include "vec/aggregate_functions/aggregate_function.h"

--- a/docs/en/community/developer-guide/fe-idea-dev.md
+++ b/docs/en/community/developer-guide/fe-idea-dev.md
@@ -87,12 +87,6 @@ under the License.
    ```
    mvn clean install -DskipTests
    ```
-
-   If it's MAC M1, run following command
-
-   ```
-   mvn clean install -DskipTests -Dos.arch=x86_64
-   ```
    
    You can also use IDE embedded GUI tools to run maven command to generate sources
 
@@ -101,13 +95,7 @@ under the License.
 If you are developing on the OS which lack of support to run `shell script` and `make` such as Windows, a workround here 
 is generate codes in Linux and copy them back. Using Docker should also be an option.
 
-5. If it's MAC M1, python may not be found, so create a soft link from python3 to python: 
-
-   ```
-   ln -s /usr/bin/python3 /usr/bin/python
-   ```
-
-6. If a help document has not been generated, go to the docs directory and run`sh build_help_zip.sh`，
+5. If a help document has not been generated, go to the docs directory and run`sh build_help_zip.sh`，
    Then copy help-resource.zip from build to fe/fe-core/target/classes
 
 ## 2. Debug

--- a/docs/zh-CN/community/developer-guide/fe-idea-dev.md
+++ b/docs/zh-CN/community/developer-guide/fe-idea-dev.md
@@ -83,27 +83,13 @@ JDK1.8+, IntelliJ IDEA
 
     ```
 
-    如果是mac m1版，则执行：
-
-    ```
-    cd fe && mvn clean install -DskipTests -Dos.arch=x86_64
-
-    ```
-
 或者通过图形界面运行 maven 命令生成
 
 ![](/images/gen_code.png)
 
 如果使用windows环境可能会有make命令和sh脚本无法执行的情况 可以通过拷贝linux上的 `fe/fe-core/target/generated-sources` 目录拷贝到相应的目录的方式实现，也可以通过docker 镜像挂载本地目录之后，在docker 内部生成自动生成代码，可以参照编译一节
 
-5. 如果是 mac m1 版，可能会找不到 python，则创建一个 python3 到 python 的软链：
-
-    ```
-    ln -s /usr/bin/python3 /usr/bin/python
-    ```
-
-
-6. 如果还未生成过help文档，需要跳转到docs目录，执行`sh build_help_zip.sh`，
+5. 如果还未生成过help文档，需要跳转到docs目录，执行`sh build_help_zip.sh`，
    然后将build中的help-resource.zip拷贝到fe/fe-core/target/classes中
 
 ## 2.调试

--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -863,6 +863,10 @@ under the License.
                             <goal>exec</goal>
                         </goals>
                         <configuration>
+                            <environmentVariables>
+                                <DORIS_HOME>${doris.home}</DORIS_HOME>
+                            </environmentVariables>
+                            <environmentScript>${doris.home}/env.sh</environmentScript>
                             <executable>make</executable>
                             <arguments>
                                 <argument>-C</argument>


### PR DESCRIPTION
# Proposed changes

Issue Number: close #14850 

## Problem summary

Python 2 is missing on some platform (e.g. macOS) by default due to it reached EOL. If we build the FE in IntelliJ Idea on macOS, some errors occur.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

