### PR TITLE
[fix](nereids)translate is not null predicate mistake

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/ExpressionTranslator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/ExpressionTranslator.java
@@ -172,7 +172,7 @@ public class ExpressionTranslator extends DefaultExpressionVisitor<Expr, PlanTra
         } else if (not.child() instanceof InSubquery || not.child() instanceof Exists) {
             return new BoolLiteral(true);
         } else if (not.child() instanceof IsNull) {
-            return new IsNullPredicate(not.child().accept(this, context), true);
+            return new IsNullPredicate(((IsNull) not.child()).child().accept(this, context), true);
         } else {
             return new CompoundPredicate(CompoundPredicate.Operator.NOT,
                     not.child(0).accept(this, context), null);

--- a/regression-test/data/bloom_filter_p0/test_bloom_filter_is_not_null.out
+++ b/regression-test/data/bloom_filter_p0/test_bloom_filter_is_not_null.out
@@ -9,3 +9,13 @@ b
 -- !select_null --
 \N
 
+-- !select_all --
+\N
+b
+
+-- !select_not_null --
+b
+
+-- !select_null --
+\N
+

--- a/regression-test/suites/bloom_filter_p0/test_bloom_filter_is_not_null.groovy
+++ b/regression-test/suites/bloom_filter_p0/test_bloom_filter_is_not_null.groovy
@@ -33,7 +33,17 @@ suite("test_bloom_filter_is_not_null") {
 
     sql """INSERT INTO ${table_name} values (null), ('b')"""
 
+    sql 'set enable_nereids_planner=false'
     qt_select_all """select * from ${table_name} order by a"""
     qt_select_not_null """select * from ${table_name} WHERE a is not null"""
     qt_select_null """select * from ${table_name} WHERE a is null"""
+
+    sql 'set enable_nereids_planner=true'
+    sql 'set enable_fallback_to_original_planner=false'
+    qt_select_all """select * from ${table_name} order by a"""
+    qt_select_not_null """select * from ${table_name} WHERE a is not null"""
+    qt_select_null """select * from ${table_name} WHERE a is null"""
+
+    sql 'set enable_nereids_planner=false'
+    sql 'set enable_fallback_to_original_planner=true'
 }

--- a/regression-test/suites/bloom_filter_p0/test_bloom_filter_is_not_null.groovy
+++ b/regression-test/suites/bloom_filter_p0/test_bloom_filter_is_not_null.groovy
@@ -38,6 +38,7 @@ suite("test_bloom_filter_is_not_null") {
     qt_select_not_null """select * from ${table_name} WHERE a is not null"""
     qt_select_null """select * from ${table_name} WHERE a is null"""
 
+    sql 'set enable_vectorized_engine=true'
     sql 'set enable_nereids_planner=true'
     sql 'set enable_fallback_to_original_planner=false'
     qt_select_all """select * from ${table_name} order by a"""


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

the 'is not null' predicate is not translated correctly in ExpressionTranslator 

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

