### PR TITLE
[typo](docs) Fixed label_clean_interval_second's incorrect default value

### DIFF
--- a/docs/en/docs/admin-manual/config/fe-config.md
+++ b/docs/en/docs/admin-manual/config/fe-config.md
@@ -1999,7 +1999,7 @@ The max keep time of some kind of jobs. like schema change job and rollup job.
 
 ### label_clean_interval_second
 
-Default：4 * 3600  （4 hour）
+Default：1 * 3600  （1 hour）
 
 Load label cleaner will run every *label_clean_interval_second* to clean the outdated jobs.
 

--- a/docs/zh-CN/docs/admin-manual/config/fe-config.md
+++ b/docs/zh-CN/docs/admin-manual/config/fe-config.md
@@ -2029,7 +2029,7 @@ HOUR: log前缀是：yyyyMMddHH
 
 ### `label_clean_interval_second`
 
-默认值：4 * 3600  （4小时）
+默认值：1 * 3600  （1小时）
 
 load 标签清理器将每隔 `label_clean_interval_second` 运行一次以清理过时的作业。
 


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

Fixed label_clean_interval_second's incorrect default value. In code, the actual value is 1 * 3600.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

