### PR TITLE
[feature](information_schema)add procs table to show all functions doris supports

### DIFF
--- a/be/src/exec/CMakeLists.txt
+++ b/be/src/exec/CMakeLists.txt
@@ -83,6 +83,7 @@ set(EXEC_FILES
     schema_scanner/schema_views_scanner.cpp
     schema_scanner/schema_statistics_scanner.cpp
     schema_scanner/schema_table_privileges_scanner.cpp
+    schema_scanner/schema_procs_scanner.cpp
     schema_scanner/schema_schema_privileges_scanner.cpp
     schema_scanner/schema_user_privileges_scanner.cpp
     schema_scanner/schema_files_scanner.cpp

--- a/be/src/exec/schema_scanner.cpp
+++ b/be/src/exec/schema_scanner.cpp
@@ -17,8 +17,6 @@
 
 #include "exec/schema_scanner.h"
 
-#include <gen_cpp/Descriptors_types.h>
-
 #include "exec/schema_scanner/schema_backends_scanner.h"
 #include "exec/schema_scanner/schema_charsets_scanner.h"
 #include "exec/schema_scanner/schema_collations_scanner.h"

--- a/be/src/exec/schema_scanner.cpp
+++ b/be/src/exec/schema_scanner.cpp
@@ -17,6 +17,8 @@
 
 #include "exec/schema_scanner.h"
 
+#include <gen_cpp/Descriptors_types.h>
+
 #include "exec/schema_scanner/schema_backends_scanner.h"
 #include "exec/schema_scanner/schema_charsets_scanner.h"
 #include "exec/schema_scanner/schema_collations_scanner.h"
@@ -24,6 +26,7 @@
 #include "exec/schema_scanner/schema_dummy_scanner.h"
 #include "exec/schema_scanner/schema_files_scanner.h"
 #include "exec/schema_scanner/schema_partitions_scanner.h"
+#include "exec/schema_scanner/schema_procs_scanner.h"
 #include "exec/schema_scanner/schema_rowsets_scanner.h"
 #include "exec/schema_scanner/schema_schema_privileges_scanner.h"
 #include "exec/schema_scanner/schema_schemata_scanner.h"
@@ -91,7 +94,8 @@ Status SchemaScanner::init(SchemaScannerParam* param, ObjectPool* pool) {
         return Status::InternalError("invalid parameter");
     }
 
-    if (_schema_table_type == TSchemaTableType::SCH_BACKENDS) {
+    if (_schema_table_type == TSchemaTableType::SCH_BACKENDS ||
+        _schema_table_type == TSchemaTableType::SCH_PROCS) {
         RETURN_IF_ERROR(create_columns(param->table_structure, pool));
     }
 
@@ -139,6 +143,8 @@ SchemaScanner* SchemaScanner::create(TSchemaTableType::type type) {
         return new (std::nothrow) SchemaRowsetsScanner();
     case TSchemaTableType::SCH_BACKENDS:
         return new (std::nothrow) SchemaBackendsScanner();
+    case TSchemaTableType::SCH_PROCS:
+        return new (std::nothrow) SchemaProcsScanner();
     default:
         return new (std::nothrow) SchemaDummyScanner();
         break;

--- a/be/src/exec/schema_scanner/schema_procs_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_procs_scanner.cpp
@@ -72,7 +72,7 @@ Status SchemaProcsScanner::fill_one_row(Tuple* tuple, MemPool* pool) {
     {
         // add arguments type
         std::string args;
-        for (auto t: _batch_data[_row_idx].arg_types) {
+        for (auto t : _batch_data[_row_idx].arg_types) {
             args += " " + thrift_to_string(t.types.data()->scalar_type.type);
         }
         vals[2] = std::move(args);
@@ -82,7 +82,8 @@ Status SchemaProcsScanner::fill_one_row(Tuple* tuple, MemPool* pool) {
         vals[3] = std::move(_batch_data[_row_idx].signature);
     }
     for (size_t idx = 0; idx < _column_num; idx++) {
-        RETURN_IF_ERROR(fill_one_col(&vals[idx], pool, tuple->get_slot(_tuple_desc->slots()[idx]->tuple_offset())));
+        RETURN_IF_ERROR(fill_one_col(&vals[idx], pool,
+                                     tuple->get_slot(_tuple_desc->slots()[idx]->tuple_offset())));
     }
     _row_idx++;
     return Status::OK();

--- a/be/src/exec/schema_scanner/schema_procs_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_procs_scanner.cpp
@@ -1,0 +1,147 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "exec/schema_scanner/schema_procs_scanner.h"
+
+#include <gen_cpp/Descriptors_types.h>
+#include <gen_cpp/FrontendService.h>
+#include <gen_cpp/HeartbeatService_types.h>
+#include <gen_cpp/Types_types.h>
+
+#include "common/config.h"
+#include "common/status.h"
+#include "runtime/client_cache.h"
+#include "runtime/exec_env.h"
+#include "runtime/primitive_type.h"
+#include "runtime/string_value.h"
+#include "util/thrift_rpc_helper.h"
+
+namespace doris {
+
+SchemaScanner::ColumnDesc SchemaProcsScanner::_s_procs_columns[] = {
+        //   name,       type,          size,     is_null
+        {"FuncName", TYPE_VARCHAR, sizeof(StringValue), false},
+        {"RetType", TYPE_VARCHAR, sizeof(StringValue), false},
+        {"ArgTypes", TYPE_VARCHAR, sizeof(StringValue), false},
+        {"Signature", TYPE_VARCHAR, sizeof(StringValue), false},
+};
+
+SchemaProcsScanner::SchemaProcsScanner()
+        : SchemaScanner(_s_procs_columns,
+                        sizeof(_s_procs_columns) / sizeof(SchemaScanner::ColumnDesc),
+                        TSchemaTableType::SCH_PROCS),
+          _row_idx(0) {}
+
+SchemaProcsScanner::~SchemaProcsScanner() = default;
+
+Status SchemaProcsScanner::start(RuntimeState* state) {
+    if (!_is_init) {
+        return Status::InternalError("used before initialized.");
+    }
+    RETURN_IF_ERROR(_fetch_procs_info());
+
+    return Status::OK();
+}
+
+Status SchemaProcsScanner::fill_one_row(Tuple* tuple, MemPool* pool) {
+    // set all bit to not null
+    memset((void*)tuple, 0, _tuple_desc->num_null_bytes());
+    std::string vals[_column_num];
+    {
+        // add function name
+        vals[0] = std::move(_batch_data[_row_idx].name.function_name);
+    }
+    {
+        // add return type
+        vals[1] = thrift_to_string(_batch_data[_row_idx].ret_type.types.data()->scalar_type.type);
+    }
+    {
+        // add arguments type
+        std::string args;
+        for (auto t: _batch_data[_row_idx].arg_types) {
+            args += " " + thrift_to_string(t.types.data()->scalar_type.type);
+        }
+        vals[2] = std::move(args);
+    }
+    {
+        // add signature
+        vals[3] = std::move(_batch_data[_row_idx].signature);
+    }
+    for (size_t idx = 0; idx < _column_num; idx++) {
+        RETURN_IF_ERROR(fill_one_col(&vals[idx], pool, tuple->get_slot(_tuple_desc->slots()[idx]->tuple_offset())));
+    }
+    _row_idx++;
+    return Status::OK();
+}
+
+Status SchemaProcsScanner::fill_one_col(const std::string* src, MemPool* pool, void* slot) {
+    if (nullptr == slot || nullptr == pool || nullptr == src) {
+        return Status::InternalError("input pointer is nullptr.");
+    }
+    StringValue* str_slot = reinterpret_cast<StringValue*>(slot);
+    str_slot->len = src->length();
+    str_slot->ptr = (char*)pool->allocate(str_slot->len);
+    if (nullptr == str_slot->ptr) {
+        return Status::InternalError("Allocate memcpy failed.");
+    }
+    memcpy(str_slot->ptr, src->c_str(), str_slot->len);
+    return Status::OK();
+}
+
+Status SchemaProcsScanner::get_next_row(Tuple* tuple, MemPool* pool, bool* eos) {
+    if (!_is_init) {
+        return Status::InternalError("Used before initialized.");
+    }
+    if (nullptr == tuple || nullptr == pool || nullptr == eos) {
+        return Status::InternalError("input pointer is nullptr.");
+    }
+
+    if (_row_idx >= _batch_data.size()) {
+        *eos = true;
+        return Status::OK();
+    }
+
+    *eos = false;
+
+    return fill_one_row(tuple, pool);
+}
+
+Status SchemaProcsScanner::_fetch_procs_info() {
+    TFetchProcsDataRequest request;
+    request.schema_table_name = TSchemaTableName::PROCS;
+    request.__isset.schema_table_name = true;
+    TNetworkAddress master_addr = ExecEnv::GetInstance()->master_info()->network_address;
+    TFetchProcsDataResult result;
+
+    RETURN_IF_ERROR(ThriftRpcHelper::rpc<FrontendServiceClient>(
+            master_addr.hostname, master_addr.port,
+            [&request, &result](FrontendServiceConnection& client) {
+                client->fetchProcsData(result, request);
+            },
+            config::txn_commit_rpc_timeout_ms));
+
+    Status status(result.status);
+    if (!status.ok()) {
+        LOG(WARNING) << "fetch procs from master failed, errmsg=" << status.get_error_msg();
+        return status;
+    }
+
+    _batch_data = std::move(result.data_batch);
+    return Status::OK();
+}
+
+} // namespace doris

--- a/be/src/exec/schema_scanner/schema_procs_scanner.h
+++ b/be/src/exec/schema_scanner/schema_procs_scanner.h
@@ -1,0 +1,42 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include "exec/schema_scanner.h"
+
+namespace doris {
+
+class SchemaProcsScanner : public SchemaScanner {
+public:
+    SchemaProcsScanner();
+    ~SchemaProcsScanner() override;
+
+    Status start(RuntimeState* state) override;
+    Status get_next_row(Tuple* tuple, MemPool* pool, bool* eos) override;
+
+private:
+    Status fill_one_row(Tuple* tuple, MemPool* pool);
+    Status _fetch_procs_info();
+    Status fill_one_col(const std::string* src, MemPool* pool, void* slot);
+
+    std::vector<TFunction> _batch_data;
+    size_t _row_idx;
+    static SchemaScanner::ColumnDesc _s_procs_columns[];
+};
+
+} // namespace doris

--- a/be/src/runtime/primitive_type.cpp
+++ b/be/src/runtime/primitive_type.cpp
@@ -457,6 +457,10 @@ std::string type_to_string(PrimitiveType t) {
     return "";
 }
 
+std::string thrift_to_string(TPrimitiveType::type ttype) {
+    return type_to_string(thrift_to_type(ttype));
+}
+
 std::string type_to_odbc_string(PrimitiveType t) {
     // ODBC driver requires types in lower case
     switch (t) {

--- a/be/src/runtime/primitive_type.h
+++ b/be/src/runtime/primitive_type.h
@@ -108,6 +108,7 @@ PrimitiveType thrift_to_type(TPrimitiveType::type ttype);
 TPrimitiveType::type to_thrift(PrimitiveType ptype);
 TColumnType to_tcolumn_type_thrift(TPrimitiveType::type ttype);
 std::string type_to_string(PrimitiveType t);
+std::string thrift_to_string(TPrimitiveType::type ttype);
 std::string type_to_odbc_string(PrimitiveType t);
 TTypeDesc gen_type_desc(const TPrimitiveType::type val);
 TTypeDesc gen_type_desc(const TPrimitiveType::type val, const std::string& name);

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/SchemaTableType.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/SchemaTableType.java
@@ -67,7 +67,8 @@ public enum SchemaTableType {
     SCH_CREATE_TABLE("CREATE_TABLE", "CREATE_TABLE", TSchemaTableType.SCH_CREATE_TABLE),
     SCH_INVALID("NULL", "NULL", TSchemaTableType.SCH_INVALID),
     SCH_ROWSETS("ROWSETS", "ROWSETS", TSchemaTableType.SCH_ROWSETS),
-    SCH_BACKENDS("BACKENDS", "BACKENDS", TSchemaTableType.SCH_BACKENDS);
+    SCH_BACKENDS("BACKENDS", "BACKENDS", TSchemaTableType.SCH_BACKENDS),
+    SCH_PROCS("PROCS", "PROCS", TSchemaTableType.SCH_PROCS);
 
     private static final String dbName = "INFORMATION_SCHEMA";
     private static SelectList fullSelectLists;

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/FunctionSet.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/FunctionSet.java
@@ -42,7 +42,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-public class FunctionSet<T> {
+public class FunctionSet {
     private static final Logger LOG = LogManager.getLogger(FunctionSet.class);
 
     // All of the registered user functions. The key is the user facing name (e.g. "myUdf"),

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/SchemaTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/SchemaTable.java
@@ -426,11 +426,18 @@ public class SchemaTable extends Table {
                             .column("Version", ScalarType.createVarchar(64))
                             .column("Status", ScalarType.createVarchar(1024))
                             .build()))
+            .put("procs",
+                    new SchemaTable(SystemIdGenerator.getNextId(), "procs", TableType.SCHEMA,
+                            builder().column("FuncName", ScalarType.createVarchar(64))
+                                    .column("RetType", ScalarType.createVarchar(32))
+                                    .column("ArgTypes", ScalarType.createVarchar(32))
+                                    .column("Signature", ScalarType.createVarchar(128)).build()))
             .build();
 
     public static List<TSchemaTableStructure> getTableStructure(String tableName) {
         List<TSchemaTableStructure> tSchemaTableStructureList = Lists.newArrayList();
         switch (tableName) {
+            case "procs":
             case "backends": {
                 Table table = TABLE_MAP.get(tableName);
                 for (Column column : table.getFullSchema()) {

--- a/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
@@ -73,6 +73,8 @@ import org.apache.doris.thrift.TDescribeTableParams;
 import org.apache.doris.thrift.TDescribeTableResult;
 import org.apache.doris.thrift.TExecPlanFragmentParams;
 import org.apache.doris.thrift.TFeResult;
+import org.apache.doris.thrift.TFetchProcsDataRequest;
+import org.apache.doris.thrift.TFetchProcsDataResult;
 import org.apache.doris.thrift.TFetchResourceResult;
 import org.apache.doris.thrift.TFetchSchemaTableDataRequest;
 import org.apache.doris.thrift.TFetchSchemaTableDataResult;
@@ -80,6 +82,8 @@ import org.apache.doris.thrift.TFinishTaskRequest;
 import org.apache.doris.thrift.TFrontendPingFrontendRequest;
 import org.apache.doris.thrift.TFrontendPingFrontendResult;
 import org.apache.doris.thrift.TFrontendPingFrontendStatusCode;
+import org.apache.doris.thrift.TFunction;
+import org.apache.doris.thrift.TFunctionName;
 import org.apache.doris.thrift.TGetDbsParams;
 import org.apache.doris.thrift.TGetDbsResult;
 import org.apache.doris.thrift.TGetStoragePolicy;
@@ -116,6 +120,7 @@ import org.apache.doris.thrift.TStatusCode;
 import org.apache.doris.thrift.TStreamLoadPutRequest;
 import org.apache.doris.thrift.TStreamLoadPutResult;
 import org.apache.doris.thrift.TTableStatus;
+import org.apache.doris.thrift.TTypeDesc;
 import org.apache.doris.thrift.TUpdateExportTaskStatusRequest;
 import org.apache.doris.thrift.TWaitingTxnStatusRequest;
 import org.apache.doris.thrift.TWaitingTxnStatusResult;
@@ -137,11 +142,13 @@ import org.apache.logging.log4j.Logger;
 import org.apache.thrift.TException;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.stream.Collectors;
 
 // Frontend service used to serve all request for this frontend through
 // thrift protocol
@@ -1103,6 +1110,33 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         return result;
     }
 
+    @Override
+    public TFetchProcsDataResult fetchProcsData(TFetchProcsDataRequest request) {
+        LOG.info("fetch procs data");
+        switch (request.getSchemaTableName()) {
+            case PROCS:
+                return getProcsData();
+            default:
+                break;
+        }
+        TFetchProcsDataResult result = new TFetchProcsDataResult();
+        result.setStatus(new TStatus(TStatusCode.INTERNAL_ERROR));
+        return result;
+    }
+
+    private TFetchProcsDataResult getProcsData() {
+        TFetchProcsDataResult result = new TFetchProcsDataResult();
+        List<TFunction> dataBatch = Env.getCurrentEnv().getBuiltinFunctions().stream().map(function -> {
+            List<TTypeDesc> retTypes = Arrays.stream(function.getArgs()).map(type -> type.toThrift())
+                    .collect(Collectors.toList());
+            return new TFunction(new TFunctionName(function.functionName()), function.getBinaryType(), retTypes,
+                    function.getReturnType().toThrift(), false).setSignature(function.signatureString());
+        }).collect(Collectors.toList());
+        result.setDataBatch(dataBatch);
+        result.setStatus(new TStatus(TStatusCode.OK));
+        return result;
+    }
+
     private TNetworkAddress getClientAddr() {
         ThriftServerContext connectionContext = ThriftServerEventProcessor.getConnectionContext();
         // For NonBlockingServer, we can not get client ip.
@@ -1141,45 +1175,41 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         result.setStatus(status);
 
         List<Policy> policyList = Env.getCurrentEnv().getPolicyMgr().getCopiedPoliciesByType(PolicyTypeEnum.STORAGE);
-        policyList.stream().filter(p -> p instanceof StoragePolicy).map(p -> (StoragePolicy) p).forEach(
-                iter -> {
-                    // default policy not init.
-                    if (iter.getStorageResource() == null) {
-                        return;
-                    }
-                    TGetStoragePolicy rEntry = new TGetStoragePolicy();
-                    rEntry.setPolicyName(iter.getPolicyName());
-                    //java 8 not support ifPresentOrElse
-                    final long[] ttlCoolDown = {-1};
-                    Optional.ofNullable(iter.getCooldownTtl()).ifPresent(ttl -> ttlCoolDown[0] = Integer.parseInt(ttl));
-                    rEntry.setCooldownTtl(ttlCoolDown[0]);
+        policyList.stream().filter(p -> p instanceof StoragePolicy).map(p -> (StoragePolicy) p).forEach(iter -> {
+            // default policy not init.
+            if (iter.getStorageResource() == null) {
+                return;
+            }
+            TGetStoragePolicy rEntry = new TGetStoragePolicy();
+            rEntry.setPolicyName(iter.getPolicyName());
+            //java 8 not support ifPresentOrElse
+            final long[] ttlCoolDown = {-1};
+            Optional.ofNullable(iter.getCooldownTtl()).ifPresent(ttl -> ttlCoolDown[0] = Integer.parseInt(ttl));
+            rEntry.setCooldownTtl(ttlCoolDown[0]);
 
-                    rEntry.setCooldownDatetime(
-                            iter.getCooldownTimestampMs() == -1 ? -1 : iter.getCooldownTimestampMs() / 100);
+            rEntry.setCooldownDatetime(iter.getCooldownTimestampMs() == -1 ? -1 : iter.getCooldownTimestampMs() / 100);
 
-                    Optional.ofNullable(iter.getMd5Checksum()).ifPresent(rEntry::setMd5Checksum);
-                    TS3StorageParam s3Info = new TS3StorageParam();
-                    Optional.ofNullable(iter.getStorageResource()).ifPresent(resource -> {
-                        Map<String, String> storagePolicyProperties = Env.getCurrentEnv().getResourceMgr()
-                                .getResource(resource).getCopiedProperties();
-                        s3Info.setS3Endpoint(storagePolicyProperties.get(S3Resource.S3_ENDPOINT));
-                        s3Info.setS3Region(storagePolicyProperties.get(S3Resource.S3_REGION));
-                        s3Info.setRootPath(storagePolicyProperties.get(S3Resource.S3_ROOT_PATH));
-                        s3Info.setS3Ak(storagePolicyProperties.get(S3Resource.S3_ACCESS_KEY));
-                        s3Info.setS3Sk(storagePolicyProperties.get(S3Resource.S3_SECRET_KEY));
-                        s3Info.setBucket(storagePolicyProperties.get(S3Resource.S3_BUCKET));
-                        s3Info.setS3MaxConn(
-                                Integer.parseInt(storagePolicyProperties.get(S3Resource.S3_MAX_CONNECTIONS)));
-                        s3Info.setS3RequestTimeoutMs(
-                                Integer.parseInt(storagePolicyProperties.get(S3Resource.S3_REQUEST_TIMEOUT_MS)));
-                        s3Info.setS3ConnTimeoutMs(
-                                Integer.parseInt(storagePolicyProperties.get(S3Resource.S3_CONNECTION_TIMEOUT_MS)));
-                    });
+            Optional.ofNullable(iter.getMd5Checksum()).ifPresent(rEntry::setMd5Checksum);
+            TS3StorageParam s3Info = new TS3StorageParam();
+            Optional.ofNullable(iter.getStorageResource()).ifPresent(resource -> {
+                Map<String, String> storagePolicyProperties = Env.getCurrentEnv().getResourceMgr().getResource(resource)
+                        .getCopiedProperties();
+                s3Info.setS3Endpoint(storagePolicyProperties.get(S3Resource.S3_ENDPOINT));
+                s3Info.setS3Region(storagePolicyProperties.get(S3Resource.S3_REGION));
+                s3Info.setRootPath(storagePolicyProperties.get(S3Resource.S3_ROOT_PATH));
+                s3Info.setS3Ak(storagePolicyProperties.get(S3Resource.S3_ACCESS_KEY));
+                s3Info.setS3Sk(storagePolicyProperties.get(S3Resource.S3_SECRET_KEY));
+                s3Info.setBucket(storagePolicyProperties.get(S3Resource.S3_BUCKET));
+                s3Info.setS3MaxConn(Integer.parseInt(storagePolicyProperties.get(S3Resource.S3_MAX_CONNECTIONS)));
+                s3Info.setS3RequestTimeoutMs(
+                        Integer.parseInt(storagePolicyProperties.get(S3Resource.S3_REQUEST_TIMEOUT_MS)));
+                s3Info.setS3ConnTimeoutMs(
+                        Integer.parseInt(storagePolicyProperties.get(S3Resource.S3_CONNECTION_TIMEOUT_MS)));
+            });
 
-                    rEntry.setS3StorageParam(s3Info);
-                    result.addToResultEntrys(rEntry);
-                }
-        );
+            rEntry.setS3StorageParam(s3Info);
+            result.addToResultEntrys(rEntry);
+        });
         if (!result.isSetResultEntrys()) {
             result.setResultEntrys(new ArrayList<>());
         }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/analysis/GenerateScalarFunction.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/analysis/GenerateScalarFunction.java
@@ -425,7 +425,7 @@ public class GenerateScalarFunction {
     }
 
     private Map<String, String> collectFunctionCodes() {
-        FunctionSet<Object> functionSet = new FunctionSet<>();
+        FunctionSet functionSet = new FunctionSet();
         functionSet.init();
 
         ArrayListMultimap<String, Function> functionMap = ArrayListMultimap.create();

--- a/gensrc/thrift/Descriptors.thrift
+++ b/gensrc/thrift/Descriptors.thrift
@@ -104,7 +104,8 @@ enum TSchemaTableType {
     SCH_VIEWS,
     SCH_INVALID,
     SCH_ROWSETS,
-    SCH_BACKENDS
+    SCH_BACKENDS,
+    SCH_PROCS
 }
 
 enum THdfsCompression {

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -691,6 +691,7 @@ struct TInitExternalCtlMetaResult {
 
 enum TSchemaTableName{
   BACKENDS = 0,
+  PROCS = 1,
 }
 
 struct TFetchSchemaTableDataRequest {
@@ -701,6 +702,15 @@ struct TFetchSchemaTableDataRequest {
 struct TFetchSchemaTableDataResult {
   1: required Status.TStatus status
   2: optional list<Data.TRow> data_batch;
+}
+
+struct TFetchProcsDataRequest {
+  1: optional TSchemaTableName schema_table_name
+}
+
+struct TFetchProcsDataResult {
+  1: required Status.TStatus status
+  2: optional list<Types.TFunction> data_batch;
 }
 
 service FrontendService {
@@ -741,4 +751,5 @@ service FrontendService {
     TInitExternalCtlMetaResult initExternalCtlMeta(1: TInitExternalCtlMetaRequest request)
 
     TFetchSchemaTableDataResult fetchSchemaTableData(1: TFetchSchemaTableDataRequest request)
+    TFetchProcsDataResult fetchProcsData(1: TFetchProcsDataRequest request)
 }

--- a/regression-test/suites/correctness/test_procs_table.groovy
+++ b/regression-test/suites/correctness/test_procs_table.groovy
@@ -1,0 +1,23 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// This suit test the `backends` information_schema table
+suite("test_procs_table") {
+    List<List<Object>> table =  sql """ select * from information_schema.procs limit 100; """
+    assertTrue(table.size() > 0) // row should > 0
+    assertTrue(table[0].size == 4) // column should be 23
+}


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx
Add one procs table similar as PostgreSQL's pg_procs internal table which can show all functions supported by the underlying database system. User would get result like the following picture once they select from Doris.
![image](https://user-images.githubusercontent.com/43750022/206120746-3c6ff6db-0d6b-4775-8060-4251d2fe066c.png)

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [x] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

