### PR TITLE
[fix](Nereids): just allow crossjoin empty condition.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/LogicalPlanBuilder.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/LogicalPlanBuilder.java
@@ -1020,8 +1020,10 @@ public class LogicalPlanBuilder extends DorisParserBaseVisitor<Object> {
                 joinType = JoinType.LEFT_OUTER_JOIN;
             } else if (join.joinType().RIGHT() != null) {
                 joinType = JoinType.RIGHT_OUTER_JOIN;
-            } else {
+            } else if (join.joinType().INNER() != null) {
                 joinType = JoinType.INNER_JOIN;
+            } else {
+                joinType = JoinType.CROSS_JOIN;
             }
 
             // TODO: natural join, lateral join, using join, union join
@@ -1037,6 +1039,11 @@ public class LogicalPlanBuilder extends DorisParserBaseVisitor<Object> {
                                     .stream().map(UnboundSlot::quoted).collect(
                                             Collectors.toList());
                     return new LogicalJoin(JoinType.USING_JOIN, ids, last, plan(join.relationPrimary()));
+                }
+            } else {
+                // keep same with original planner, allow cross/inner join
+                if (!joinType.isInnerOrCrossJoin()) {
+                    throw new ParseException("on mustn't be empty except for cross/inner join", join);
                 }
             }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/parser/NereidsParserTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/parser/NereidsParserTest.java
@@ -170,7 +170,7 @@ public class NereidsParserTest extends ParserTestBase {
         String innerJoin2 = "SELECT t1.a FROM t1 JOIN t2 ON t1.id = t2.id;";
         logicalPlan = nereidsParser.parseSingle(innerJoin2);
         logicalJoin = (LogicalJoin) logicalPlan.child(0);
-        Assertions.assertEquals(JoinType.INNER_JOIN, logicalJoin.getJoinType());
+        Assertions.assertEquals(JoinType.CROSS_JOIN, logicalJoin.getJoinType());
 
         String leftJoin1 = "SELECT t1.a FROM t1 LEFT JOIN t2 ON t1.id = t2.id;";
         logicalPlan = nereidsParser.parseSingle(leftJoin1);
@@ -216,6 +216,18 @@ public class NereidsParserTest extends ParserTestBase {
         logicalPlan = nereidsParser.parseSingle(crossJoin);
         logicalJoin = (LogicalJoin) logicalPlan.child(0);
         Assertions.assertEquals(JoinType.CROSS_JOIN, logicalJoin.getJoinType());
+    }
+
+    @Test
+    void parseJoinEmptyConditionError() {
+        parsePlan("select * from t1 LEFT JOIN t2")
+                .assertThrowsExactly(ParseException.class)
+                .assertMessageEquals("\n"
+                        + "on mustn't be empty except for cross/inner join(line 1, pos 17)\n"
+                        + "\n"
+                        + "== SQL ==\n"
+                        + "select * from t1 LEFT JOIN t2\n"
+                        + "-----------------^^^\n");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/analysis/AnalyzeSubQueryTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/analysis/AnalyzeSubQueryTest.java
@@ -27,7 +27,6 @@ import org.apache.doris.nereids.trees.expressions.EqualTo;
 import org.apache.doris.nereids.trees.expressions.ExprId;
 import org.apache.doris.nereids.trees.expressions.NamedExpressionUtil;
 import org.apache.doris.nereids.trees.expressions.SlotReference;
-import org.apache.doris.nereids.trees.plans.JoinType;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalPlan;
 import org.apache.doris.nereids.types.BigIntType;
 import org.apache.doris.nereids.util.FieldChecker;
@@ -132,7 +131,7 @@ public class AnalyzeSubQueryTest extends TestWithFeService implements PatternMat
                 .applyTopDown(new LogicalSubQueryAliasToLogicalProject())
                 .matchesFromRoot(
                     logicalProject(
-                        logicalJoin(
+                        crossLogicalJoin(
                             logicalProject(
                                 logicalOlapScan()
                             ),
@@ -147,7 +146,6 @@ public class AnalyzeSubQueryTest extends TestWithFeService implements PatternMat
                                 new SlotReference(new ExprId(1), "score", BigIntType.INSTANCE, true, ImmutableList.of("TT2"))))
                             )
                         )
-                        .when(FieldChecker.check("joinType", JoinType.INNER_JOIN))
                         .when(FieldChecker.check("otherJoinConjuncts",
                                 ImmutableList.of(new EqualTo(
                                         new SlotReference(new ExprId(2), "id", BigIntType.INSTANCE, true, ImmutableList.of("TT1")),
@@ -169,13 +167,12 @@ public class AnalyzeSubQueryTest extends TestWithFeService implements PatternMat
                 .applyTopDown(new LogicalSubQueryAliasToLogicalProject())
                 .matchesFromRoot(
                     logicalProject(
-                        logicalJoin(
+                        crossLogicalJoin(
                             logicalOlapScan(),
                             logicalProject(
                                 logicalOlapScan()
                             )
                         )
-                        .when(FieldChecker.check("joinType", JoinType.INNER_JOIN))
                         .when(FieldChecker.check("otherJoinConjuncts", ImmutableList.of(new EqualTo(
                                 new SlotReference(new ExprId(0), "id", BigIntType.INSTANCE, true, ImmutableList.of("default_cluster:test", "T1")),
                                 new SlotReference(new ExprId(2), "id", BigIntType.INSTANCE, true, ImmutableList.of("T2")))))

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/analysis/RegisterCTETest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/analysis/RegisterCTETest.java
@@ -236,15 +236,14 @@ public class RegisterCTETest extends TestWithFeService implements PatternMatchSu
                 .analyze(sql4)
                 .matchesFromRoot(
                     logicalProject(
-                        logicalJoin(
+                        crossLogicalJoin(
                             logicalSubQueryAlias(
                                 logicalProject().when(p -> p.getProjects().equals(ImmutableList.of(skAlias)))
                             ).when(a -> a.getAlias().equals("cte1")),
                             logicalSubQueryAlias(
                                 logicalProject().when(p -> p.getProjects().equals(ImmutableList.of(skInCTE2)))
                             ).when(a -> a.getAlias().equals("cte2"))
-                        ).when(FieldChecker.check("joinType", JoinType.INNER_JOIN))
-                            .when(j -> j.getOtherJoinConjuncts().equals(ImmutableList.of(new EqualTo(skInCTE1, skInCTE2))))
+                        ).when(j -> j.getOtherJoinConjuncts().equals(ImmutableList.of(new EqualTo(skInCTE1, skInCTE2))))
                     ).when(p -> p.getProjects().equals(ImmutableList.of(skInCTE1, skInCTE2)))
                 );
     }


### PR DESCRIPTION
# Proposed changes

original planner just allow cross join empty condition.
forbidden empty condition when not cross join

make when parse join is `join`, make joinType `cross join`

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [x] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [x] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

