### PR TITLE
[improvement](vertical_compaction) reduce segments load in vertical merger

### DIFF
--- a/be/src/olap/row.h
+++ b/be/src/olap/row.h
@@ -209,7 +209,9 @@ uint32_t hash_row(const RowType& row, uint32_t seed) {
         FieldType type = row.schema()->column(cid)->type();
         // The approximation of float/double in a certain precision range, the binary of byte is not
         // a fixed value, so these two types are ignored in calculating hash code.
-        if (type == OLAP_FIELD_TYPE_FLOAT || type == OLAP_FIELD_TYPE_DOUBLE) {
+        // HLL type use flat map to store hash_set and it should be ignored
+        if (type == OLAP_FIELD_TYPE_FLOAT || type == OLAP_FIELD_TYPE_DOUBLE ||
+            type == OLAP_FIELD_TYPE_HLL) {
             continue;
         }
         seed = row.schema()->column(cid)->hash_code(row.cell(cid), seed);

--- a/be/src/vec/olap/vertical_block_reader.h
+++ b/be/src/vec/olap/vertical_block_reader.h
@@ -70,7 +70,8 @@ private:
     Status _init_collect_iter(const ReaderParams& read_params);
 
     Status _get_segment_iterators(const ReaderParams& read_params,
-                                  std::vector<RowwiseIterator*>* segment_iters);
+                                  std::vector<RowwiseIterator*>* segment_iters,
+                                  std::vector<bool>* iterator_init_flag);
 
     void _init_agg_state(const ReaderParams& read_params);
     void _append_agg_data(MutableColumns& columns);

--- a/be/src/vec/olap/vertical_merge_iterator.cpp
+++ b/be/src/vec/olap/vertical_merge_iterator.cpp
@@ -272,11 +272,15 @@ void VerticalMergeIteratorContext::copy_rows(Block* block, bool advanced) {
 }
 
 Status VerticalMergeIteratorContext::init(const StorageReadOptions& opts) {
+    if (LIKELY(_inited)) {
+        return Status::OK();
+    }
     _block_row_max = opts.block_row_max;
     RETURN_IF_ERROR(_load_next_block());
     if (valid()) {
         RETURN_IF_ERROR(advance());
     }
+    _inited = true;
     return Status::OK();
 }
 
@@ -340,7 +344,7 @@ Status VerticalHeapMergeIterator::next_batch(Block* block) {
     std::vector<RowSource> tmp_row_sources;
     while (_get_size(block) < _block_row_max) {
         if (_merge_heap.empty()) {
-            LOG(INFO) << "_merge_heap empty";
+            VLOG_NOTICE << "_merge_heap empty";
             break;
         }
 
@@ -380,6 +384,22 @@ Status VerticalHeapMergeIterator::next_batch(Block* block) {
         if (ctx->valid()) {
             _merge_heap.push(ctx);
         } else {
+            // push next iterator in same rowset into heap
+            auto cur_order = ctx->order();
+            while (cur_order + 1 < _iterator_init_flags.size() &&
+                   !_iterator_init_flags[cur_order + 1]) {
+                auto next_ctx = _ori_iter_ctx[cur_order + 1];
+                DCHECK(next_ctx);
+                RETURN_IF_ERROR(next_ctx->init(_opts));
+                if (!next_ctx->valid()) {
+                    // next_ctx is empty segment, move to next
+                    ++cur_order;
+                    delete next_ctx;
+                    continue;
+                }
+                _merge_heap.push(next_ctx);
+                break;
+            }
             // Release ctx earlier to reduce resource consumed
             delete ctx;
         }
@@ -395,41 +415,68 @@ Status VerticalHeapMergeIterator::init(const StorageReadOptions& opts) {
     if (_origin_iters.empty()) {
         return Status::OK();
     }
+    DCHECK(_origin_iters.size() == _iterator_init_flags.size());
     _schema = &(*_origin_iters.begin())->schema();
 
     auto seg_order = 0;
+    // Init contxt depends on _iterator_init_flags
+    // for example, the vector is [1,0,0,1,1], mean that order 0,3,4 iterator needs
+    // to be inited and [0-2] is in same rowset.
+    // Notice: if iterator[0] is empty it will be invalid when init succeed, but it
+    // will not be pushed into heap, we should init next one util we find a valid iter
+    // so this rowset can work in heap
+    bool pre_iter_invalid = false;
     for (auto iter : _origin_iters) {
-        auto ctx = std::make_unique<VerticalMergeIteratorContext>(iter, _ori_return_cols, seg_order,
-                                                                  _seq_col_idx);
-        RETURN_IF_ERROR(ctx->init(opts));
-        if (!ctx->valid()) {
-            continue;
+        VerticalMergeIteratorContext* ctx =
+                new VerticalMergeIteratorContext(iter, _ori_return_cols, seg_order, _seq_col_idx);
+        _ori_iter_ctx.push_back(ctx);
+        if (_iterator_init_flags[seg_order] || pre_iter_invalid) {
+            RETURN_IF_ERROR(ctx->init(opts));
+            if (!ctx->valid()) {
+                pre_iter_invalid = true;
+                ++seg_order;
+                delete ctx;
+                continue;
+            }
+            _merge_heap.push(ctx);
+            pre_iter_invalid = false;
         }
-        _merge_heap.push(ctx.release());
         ++seg_order;
     }
     _origin_iters.clear();
 
+    _opts = opts;
     _block_row_max = opts.block_row_max;
     return Status::OK();
 }
 
 //  ----------------  VerticalMaskMergeIterator  -------------  //
+Status VerticalMaskMergeIterator::check_all_iter_finished() {
+    for (auto iter : _origin_iter_ctx) {
+        if (iter->inited()) {
+            RETURN_IF_ERROR(iter->advance());
+            DCHECK(!iter->valid());
+        }
+    }
+    return Status::OK();
+}
 Status VerticalMaskMergeIterator::next_row(vectorized::IteratorRowRef* ref) {
     DCHECK(_row_sources_buf);
     auto st = _row_sources_buf->has_remaining();
     if (!st.ok()) {
         if (st.is<END_OF_FILE>()) {
-            for (auto iter : _origin_iter_ctx) {
-                RETURN_IF_ERROR(iter->advance());
-                DCHECK(!iter->valid());
-            }
+            RETURN_IF_ERROR(check_all_iter_finished());
         }
         return st;
     }
+
     auto row_source = _row_sources_buf->current();
     uint16_t order = row_source.get_source_num();
     auto& ctx = _origin_iter_ctx[order];
+    // init ctx and this ctx must be valid
+    RETURN_IF_ERROR(ctx->init(_opts));
+    DCHECK(ctx->valid());
+
     if (UNLIKELY(ctx->is_first_row())) {
         // first row in block, don't call ctx->advance
         // Except first row, we call advance first and than get cur row
@@ -455,6 +502,9 @@ Status VerticalMaskMergeIterator::unique_key_next_row(vectorized::IteratorRowRef
         auto row_source = _row_sources_buf->current();
         uint16_t order = row_source.get_source_num();
         auto& ctx = _origin_iter_ctx[order];
+        RETURN_IF_ERROR(ctx->init(_opts));
+        DCHECK(ctx->valid());
+
         if (UNLIKELY(ctx->is_first_row()) && !row_source.agg_flag()) {
             // first row in block, don't call ctx->advance
             // Except first row, we call advance first and than get cur row
@@ -471,11 +521,9 @@ Status VerticalMaskMergeIterator::unique_key_next_row(vectorized::IteratorRowRef
         }
         st = _row_sources_buf->has_remaining();
     }
+
     if (st.is<END_OF_FILE>()) {
-        for (auto iter : _origin_iter_ctx) {
-            RETURN_IF_ERROR(iter->advance());
-            DCHECK(!iter->valid());
-        }
+        RETURN_IF_ERROR(check_all_iter_finished());
     }
     return st;
 }
@@ -488,6 +536,8 @@ Status VerticalMaskMergeIterator::next_batch(Block* block) {
         uint16_t order = _row_sources_buf->current().get_source_num();
         DCHECK(order < _origin_iter_ctx.size());
         auto& ctx = _origin_iter_ctx[order];
+        RETURN_IF_ERROR(ctx->init(_opts));
+        DCHECK(ctx->valid());
 
         // find max same source count in cur ctx
         size_t limit = std::min(ctx->remain_rows(), _block_row_max - rows);
@@ -500,10 +550,7 @@ Status VerticalMaskMergeIterator::next_batch(Block* block) {
         st = _row_sources_buf->has_remaining();
     }
     if (st.is<END_OF_FILE>()) {
-        for (auto iter : _origin_iter_ctx) {
-            RETURN_IF_ERROR(iter->advance());
-            DCHECK(!iter->valid());
-        }
+        RETURN_IF_ERROR(check_all_iter_finished());
     }
     return st;
 }
@@ -513,16 +560,12 @@ Status VerticalMaskMergeIterator::init(const StorageReadOptions& opts) {
         return Status::OK();
     }
     _schema = &(*_origin_iters.begin())->schema();
+    _opts = opts;
 
     for (auto iter : _origin_iters) {
         auto ctx = std::make_unique<VerticalMergeIteratorContext>(iter, _ori_return_cols, -1, -1);
-        RETURN_IF_ERROR(ctx->init(opts));
-        if (!ctx->valid()) {
-            continue;
-        }
         _origin_iter_ctx.emplace_back(ctx.release());
     }
-
     _origin_iters.clear();
 
     _block_row_max = opts.block_row_max;
@@ -531,10 +574,12 @@ Status VerticalMaskMergeIterator::init(const StorageReadOptions& opts) {
 
 // interfaces to create vertical merge iterator
 std::shared_ptr<RowwiseIterator> new_vertical_heap_merge_iterator(
-        const std::vector<RowwiseIterator*>& inputs, size_t ori_return_cols, KeysType keys_type,
-        uint32_t seq_col_idx, RowSourcesBuffer* row_sources) {
-    return std::make_shared<VerticalHeapMergeIterator>(std::move(inputs), ori_return_cols,
-                                                       keys_type, seq_col_idx, row_sources);
+        std::vector<RowwiseIterator*> inputs, const std::vector<bool>& iterator_init_flag,
+        size_t ori_return_cols, KeysType keys_type, uint32_t seq_col_idx,
+        RowSourcesBuffer* row_sources) {
+    return std::make_shared<VerticalHeapMergeIterator>(std::move(inputs), iterator_init_flag,
+                                                       ori_return_cols, keys_type, seq_col_idx,
+                                                       row_sources);
 }
 
 std::shared_ptr<RowwiseIterator> new_vertical_mask_merge_iterator(


### PR DESCRIPTION

# Proposed changes

In vertical compaction, every segment iterator will be loaded into Heap and then traverse all data, this will cost a lot
of memory as every segment need to load a block. Actually, segments can be loaded on demand.If a rowset is none overlapping, then it's segment can be traversed one by one.

In this pr, I use a iterator_init_flags to indicate whether a segment should be loaded when build vertical merger.
For example, if i have 3 rowsets and each one have 3 segments,  and rowset 2 is none overlapping, then 9 segments
use a vector [1,1,1,1,0,0,1,1,1] to show that segments 0,1,2,3,6,7,8 should be loaded once build vertical merged
and segments 4,5 can be loaded one by one when segment 3 reached it's end

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

