### PR TITLE
[Exec][Pipeline] Remove AggContext's lock

### DIFF
--- a/be/src/pipeline/exec/agg_context.cpp
+++ b/be/src/pipeline/exec/agg_context.cpp
@@ -62,10 +62,10 @@ Status AggContext::get_block(std::unique_ptr<vectorized::Block>* block) {
     if (_is_canceled) {
         return Status::InternalError("AggContext canceled");
     }
-    if (_cur_bytes_in_queue > 0) {
-        int block_size_t = 0;
-        std::unique_lock<std::mutex> l(_transfer_lock);
+    if (_cur_blocks_in_queue > 0) {
+        int block_size_t;
         {
+            std::unique_lock<std::mutex> l(_transfer_lock);
             auto [block_ptr, block_size] = std::move(_blocks_queue.front());
             block_size_t = block_size;
             *block = std::move(block_ptr);

--- a/be/src/pipeline/exec/agg_context.cpp
+++ b/be/src/pipeline/exec/agg_context.cpp
@@ -25,6 +25,16 @@
 namespace doris {
 namespace pipeline {
 
+AggContext::AggContext()
+        : _is_finished(false),
+          _is_canceled(false),
+          _cur_bytes_in_queue(0),
+          _cur_blocks_in_queue(0) {}
+
+AggContext::~AggContext() {
+    DCHECK(_is_finished);
+}
+
 std::unique_ptr<vectorized::Block> AggContext::get_free_block() {
     {
         std::lock_guard<std::mutex> l(_free_blocks_lock);
@@ -45,20 +55,24 @@ void AggContext::return_free_block(std::unique_ptr<vectorized::Block> block) {
 }
 
 bool AggContext::has_data_or_finished() {
-    std::unique_lock<std::mutex> l(_transfer_lock);
-    return !_blocks_queue.empty() || _is_finished;
+    return _cur_blocks_in_queue > 0 || _is_finished;
 }
 
 Status AggContext::get_block(std::unique_ptr<vectorized::Block>* block) {
-    std::unique_lock<std::mutex> l(_transfer_lock);
     if (_is_canceled) {
         return Status::InternalError("AggContext canceled");
     }
-    if (!_blocks_queue.empty()) {
-        auto [block_ptr, block_size] = std::move(_blocks_queue.front());
-        *block = std::move(block_ptr);
-        _blocks_queue.pop_front();
-        _cur_bytes_in_queue -= block_size;
+    if (_cur_bytes_in_queue > 0) {
+        int block_size_t = 0;
+        std::unique_lock<std::mutex> l(_transfer_lock);
+        {
+            auto [block_ptr, block_size] = std::move(_blocks_queue.front());
+            block_size_t = block_size;
+            *block = std::move(block_ptr);
+            _blocks_queue.pop_front();
+        }
+        _cur_bytes_in_queue -= block_size_t;
+        _cur_blocks_in_queue -= 1;
     } else {
         if (_is_finished) {
             _data_exhausted = true;
@@ -68,8 +82,7 @@ Status AggContext::get_block(std::unique_ptr<vectorized::Block>* block) {
 }
 
 bool AggContext::has_enough_space_to_push() {
-    std::unique_lock<std::mutex> l(_transfer_lock);
-    return _cur_bytes_in_queue < MAX_BYTE_OF_QUEUE / 2;
+    return _cur_bytes_in_queue.load() < MAX_BYTE_OF_QUEUE / 2;
 }
 
 void AggContext::push_block(std::unique_ptr<vectorized::Block> block) {
@@ -77,28 +90,27 @@ void AggContext::push_block(std::unique_ptr<vectorized::Block> block) {
         return;
     }
     auto block_size = block->allocated_bytes();
-    std::unique_lock<std::mutex> l(_transfer_lock);
-    _blocks_queue.emplace_back(std::move(block), block_size);
     _cur_bytes_in_queue += block_size;
-
-    _max_bytes_in_queue = std::max(_max_bytes_in_queue, _cur_bytes_in_queue);
-    _max_size_of_queue = std::max(_max_size_of_queue, (int64)_blocks_queue.size());
+    {
+        std::unique_lock<std::mutex> l(_transfer_lock);
+        _blocks_queue.emplace_back(std::move(block), block_size);
+        _max_bytes_in_queue = std::max(_max_bytes_in_queue, _cur_bytes_in_queue.load());
+        _max_size_of_queue = std::max(_max_size_of_queue, (int64)_blocks_queue.size());
+    }
+    _cur_blocks_in_queue += 1;
 }
 
 void AggContext::set_finish() {
-    std::unique_lock<std::mutex> l(_transfer_lock);
     _is_finished = true;
 }
 
 void AggContext::set_canceled() {
-    std::unique_lock<std::mutex> l(_transfer_lock);
     DCHECK(!_is_finished);
     _is_canceled = true;
     _is_finished = true;
 }
 
 bool AggContext::is_finish() {
-    std::unique_lock<std::mutex> l(_transfer_lock);
     return _is_finished;
 }
 

--- a/be/src/pipeline/exec/agg_context.h
+++ b/be/src/pipeline/exec/agg_context.h
@@ -27,8 +27,8 @@ namespace pipeline {
 
 class AggContext {
 public:
-    AggContext() = default;
-    ~AggContext() { DCHECK(_is_finished); }
+    AggContext();
+    ~AggContext();
 
     std::unique_ptr<vectorized::Block> get_free_block();
 
@@ -57,12 +57,13 @@ private:
     std::mutex _transfer_lock;
     std::list<std::pair<std::unique_ptr<vectorized::Block>, size_t>> _blocks_queue;
 
-    bool _data_exhausted = false;
-    bool _is_finished = false;
-    bool _is_canceled = false;
+    bool _data_exhausted = false; // only used by streaming agg source operator
+    std::atomic<bool> _is_finished;
+    std::atomic<bool> _is_canceled;
 
     // int64_t just for counter of profile
-    int64_t _cur_bytes_in_queue = 0;
+    std::atomic<int64_t> _cur_bytes_in_queue;
+    std::atomic<uint32_t> _cur_blocks_in_queue;
     int64_t _max_bytes_in_queue = 0;
     int64_t _max_size_of_queue = 0;
     static constexpr int64_t MAX_BYTE_OF_QUEUE = 1024l * 1024 * 1024 / 10;


### PR DESCRIPTION
# Proposed changes
Remove the lock of `AggContext` when checking full or checking empty.

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

