### PR TITLE
[fix] 'SHOW ROLES' statement does not display global resource privilege in branch-1.1-lts (#14905)

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/RoleManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/RoleManager.java
@@ -134,16 +134,29 @@ public class RoleManager implements Writable {
             
             // global
             boolean hasGlobal = false;
+            PrivBitSet privBitSet = PrivBitSet.of();
             for (Map.Entry<TablePattern, PrivBitSet> entry : role.getTblPatternToPrivs().entrySet()) {
                 if (entry.getKey().getPrivLevel() == PrivLevel.GLOBAL) {
                     hasGlobal = true;
-                    info.add(entry.getValue().toString());
+                    privBitSet.or(entry.getValue());
                     // global priv should only has one
                     break;
                 }
             }
+
+            for (Map.Entry<ResourcePattern, PrivBitSet> entry : role.getResourcePatternToPrivs().entrySet()) {
+                if (entry.getKey().getPrivLevel() == PrivLevel.GLOBAL) {
+                    hasGlobal = true;
+                    privBitSet.or(entry.getValue());
+                    // global priv should only has one
+                    break;
+                }
+            }
+
             if (!hasGlobal) {
                 info.add(FeConstants.null_string);
+            } else {
+                info.add(privBitSet.toString());
             }
 
             // db


### PR DESCRIPTION
# Proposed changes

Issue Number: close #14905

## Problem summary

GRANT USAGE_PRIV ON RESOURCE * TO ROLE 'my_role';
SHOW ROLES
It does not display USAGE_PRIV in GlobalPrivs

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [X] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [X] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [X] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [X] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [X] No

## Further comments

