### PR TITLE
[enhancement](remote) support local cache GC at the granularity of cache files

### DIFF
--- a/be/src/io/cache/dummy_file_cache.cpp
+++ b/be/src/io/cache/dummy_file_cache.cpp
@@ -36,7 +36,7 @@ void DummyFileCache::_add_file_cache(const Path& data_file) {
     time_t m_time = 0;
     if (io::global_local_filesystem()->file_size(cache_file, &file_size).ok() &&
         FileUtils::mtime(cache_file.native(), &m_time).ok()) {
-        _gc_lru_queue.push({cache_file, 0, m_time});
+        _gc_lru_queue.push({cache_file, m_time});
         _cache_file_size += file_size;
     } else {
         _unfinished_files.push_back(cache_file);

--- a/be/src/io/cache/dummy_file_cache.h
+++ b/be/src/io/cache/dummy_file_cache.h
@@ -19,6 +19,7 @@
 
 #include <future>
 #include <memory>
+#include <queue>
 
 #include "common/status.h"
 #include "io/cache/file_cache.h"
@@ -55,22 +56,22 @@ public:
 
     Status clean_all_cache() override;
 
+    Status clean_one_cache(size_t* cleaned_size) override;
+
     Status load_and_clean();
 
     bool is_dummy_file_cache() override { return true; }
 
 private:
     Status _clean_unfinished_cache();
-    void _update_last_mtime(const Path& done_file);
     void _add_file_cache(const Path& data_file);
     void _load();
-    Status _clean_cache_internal();
+    Status _clean_cache_internal(const Path&, size_t*);
 
 private:
     Path _cache_dir;
     int64_t _alive_time_sec;
 
-    std::map<Path, int64_t> _file_sizes;
     std::list<Path> _unfinished_files;
 };
 

--- a/be/src/io/cache/dummy_file_cache.h
+++ b/be/src/io/cache/dummy_file_cache.h
@@ -62,6 +62,12 @@ public:
 
     bool is_dummy_file_cache() override { return true; }
 
+    int64_t get_oldest_match_time() const override {
+        return _gc_lru_queue.empty() ? 0 : _gc_lru_queue.top().last_match_time;
+    };
+
+    bool is_gc_finish() const override { return _gc_lru_queue.empty(); }
+
 private:
     Status _clean_unfinished_cache();
     void _add_file_cache(const Path& data_file);
@@ -69,6 +75,14 @@ private:
     Status _clean_cache_internal(const Path&, size_t*);
 
 private:
+    struct DummyFileInfo {
+        Path file;
+        int64_t last_match_time;
+    };
+    using DummyGcQueue = std::priority_queue<DummyFileInfo, std::vector<DummyFileInfo>,
+                                             SubFileLRUComparator<DummyFileInfo>>;
+    DummyGcQueue _gc_lru_queue;
+
     Path _cache_dir;
     int64_t _alive_time_sec;
 

--- a/be/src/io/cache/file_cache.h
+++ b/be/src/io/cache/file_cache.h
@@ -59,7 +59,7 @@ public:
                                    size_t offset = 0);
 
     int64_t get_oldest_match_time() const {
-            return _gc_lru_queue.empty() ? 0 : _gc_lru_queue.top().last_match_time;
+        return _gc_lru_queue.empty() ? 0 : _gc_lru_queue.top().last_match_time;
     };
 
 protected:

--- a/be/src/io/cache/file_cache_manager.cpp
+++ b/be/src/io/cache/file_cache_manager.cpp
@@ -193,7 +193,7 @@ void FileCacheManager::gc_file_caches() {
     // policy2: GC file cache by disk size
     if (gc_conf_size > 0) {
         for (size_t i = 0; i < contexts.size(); ++i) {
-            auto context = contexts[i];
+            auto& context = contexts[i];
             FileCachePtr file_cache;
             while ((file_cache = context.top()) != nullptr) {
                 {

--- a/be/src/io/cache/file_cache_manager.h
+++ b/be/src/io/cache/file_cache_manager.h
@@ -33,7 +33,9 @@ public:
     GCContextPerDisk() : _conf_max_size(0), _used_size(0) {}
     void init(const std::string& path, int64_t max_size);
     bool try_add_file_cache(FileCachePtr cache, int64_t file_size);
-    void get_gc_file_caches(std::list<FileCachePtr>&);
+    FileCachePtr top();
+    Status gc_top();
+    void pop();
 
 private:
     std::string _disk_path;

--- a/be/src/io/cache/sub_file_cache.cpp
+++ b/be/src/io/cache/sub_file_cache.cpp
@@ -17,6 +17,12 @@
 
 #include "io/cache/sub_file_cache.h"
 
+#include <glog/logging.h>
+
+#include <algorithm>
+#include <utility>
+#include <vector>
+
 #include "common/config.h"
 #include "io/fs/local_file_system.h"
 #include "olap/iterators.h"
@@ -115,14 +121,17 @@ Status SubFileCache::read_at(size_t offset, Slice result, const IOContext& io_ct
             _last_match_times[*iter] = time(nullptr);
         }
     }
-    update_last_match_time();
     return Status::OK();
 }
 
+std::pair<Path, Path> SubFileCache::_cache_path(size_t offset) {
+    return {_cache_dir / fmt::format("{}_{}", SUB_FILE_CACHE_PREFIX, offset),
+            _cache_dir /
+                    fmt::format("{}_{}{}", SUB_FILE_CACHE_PREFIX, offset, CACHE_DONE_FILE_SUFFIX)};
+}
+
 Status SubFileCache::_generate_cache_reader(size_t offset, size_t req_size) {
-    Path cache_file = _cache_dir / fmt::format("{}_{}", SUB_FILE_CACHE_PREFIX, offset);
-    Path cache_done_file = _cache_dir / fmt::format("{}_{}{}", SUB_FILE_CACHE_PREFIX, offset,
-                                                    CACHE_DONE_FILE_SUFFIX);
+    auto [cache_file, cache_done_file] = _cache_path(offset);
     bool done_file_exist = false;
     RETURN_NOT_OK_STATUS_WITH_WARN(
             io::global_local_filesystem()->exists(cache_done_file, &done_file_exist),
@@ -134,8 +143,9 @@ Status SubFileCache::_generate_cache_reader(size_t offset, size_t req_size) {
         ThreadPoolToken* thread_token =
                 ExecEnv::GetInstance()->get_serial_download_cache_thread_token();
         if (thread_token != nullptr) {
-            auto st = thread_token->submit_func([this, &download_st, cache_done_file, cache_file,
-                                                 offset, req_size] {
+            auto st = thread_token->submit_func([this, &download_st,
+                                                 cache_done_file = cache_done_file,
+                                                 cache_file = cache_file, offset, req_size] {
                 auto func = [this, cache_done_file, cache_file, offset, req_size] {
                     bool done_file_exist = false;
                     // Judge again whether cache_done_file exists, it is possible that the cache
@@ -180,7 +190,6 @@ Status SubFileCache::_generate_cache_reader(size_t offset, size_t req_size) {
     RETURN_IF_ERROR(io::global_local_filesystem()->open_file(cache_file, &cache_reader));
     _cache_file_readers.emplace(offset, cache_reader);
     _last_match_times.emplace(offset, time(nullptr));
-    update_last_match_time();
     LOG(INFO) << "Create cache file from remote file successfully: "
               << _remote_file_reader->path().native() << "(" << offset << ", " << req_size
               << ") -> " << cache_file.native();
@@ -199,6 +208,8 @@ Status SubFileCache::_get_need_cache_offsets(size_t offset, size_t req_size,
 }
 
 Status SubFileCache::clean_timeout_cache() {
+    GcQueue gc_queue;
+    _gc_lru_queue.swap(gc_queue);
     std::vector<size_t> timeout_keys;
     {
         std::shared_lock<std::shared_mutex> rlock(_cache_map_lock);
@@ -206,6 +217,9 @@ Status SubFileCache::clean_timeout_cache() {
              iter != _last_match_times.cend(); ++iter) {
             if (time(nullptr) - iter->second > _alive_time_sec) {
                 timeout_keys.emplace_back(iter->first);
+            } else {
+                auto [cache_file, done_file] = _cache_path(iter->first);
+                _gc_lru_queue.push({cache_file, iter->first, iter->second});
             }
         }
     }
@@ -213,9 +227,10 @@ Status SubFileCache::clean_timeout_cache() {
         std::unique_lock<std::shared_mutex> wrlock(_cache_map_lock);
         for (std::vector<size_t>::const_iterator iter = timeout_keys.cbegin();
              iter != timeout_keys.cend(); ++iter) {
-            RETURN_IF_ERROR(_clean_cache_internal(*iter));
+            size_t cleaned_size = 0;
+            RETURN_IF_ERROR(_clean_cache_internal(*iter, &cleaned_size));
+            _cache_file_size -= cleaned_size;
         }
-        _cache_file_size = _calc_cache_file_size();
     }
     return Status::OK();
 }
@@ -224,40 +239,41 @@ Status SubFileCache::clean_all_cache() {
     std::unique_lock<std::shared_mutex> wrlock(_cache_map_lock);
     for (std::map<size_t, int64_t>::const_iterator iter = _last_match_times.cbegin();
          iter != _last_match_times.cend(); ++iter) {
-        RETURN_IF_ERROR(_clean_cache_internal(iter->first));
+        RETURN_IF_ERROR(_clean_cache_internal(iter->first, nullptr));
     }
-    _cache_file_size = _calc_cache_file_size();
+    _cache_file_size = 0;
     return Status::OK();
 }
 
-Status SubFileCache::_clean_cache_internal(size_t offset) {
+Status SubFileCache::clean_one_cache(size_t* cleaned_size) {
+    if (!_gc_lru_queue.empty()) {
+        const auto& cache = _gc_lru_queue.top();
+        {
+            std::unique_lock<std::shared_mutex> wrlock(_cache_map_lock);
+            if (auto it = _last_match_times.find(cache.offset);
+                it != _last_match_times.end() && it->second == cache.last_match_time) {
+                RETURN_IF_ERROR(_clean_cache_internal(cache.offset, cleaned_size));
+                _cache_file_size -= *cleaned_size;
+                _gc_lru_queue.pop();
+            }
+        }
+        decltype(_last_match_times.begin()) it;
+        while (!_gc_lru_queue.empty() &&
+               (it = _last_match_times.find(_gc_lru_queue.top().offset)) !=
+                       _last_match_times.end() &&
+               it->second != _gc_lru_queue.top().last_match_time) {
+            _gc_lru_queue.pop();
+        }
+    }
+    return Status::OK();
+}
+
+Status SubFileCache::_clean_cache_internal(size_t offset, size_t* cleaned_size) {
     if (_cache_file_readers.find(offset) != _cache_file_readers.end()) {
         _cache_file_readers.erase(offset);
     }
-    _cache_file_size = 0;
-    Path cache_file = _cache_dir / fmt::format("{}_{}", SUB_FILE_CACHE_PREFIX, offset);
-    Path done_file = _cache_dir /
-                     fmt::format("{}_{}{}", SUB_FILE_CACHE_PREFIX, offset, CACHE_DONE_FILE_SUFFIX);
-    bool done_file_exist = false;
-    RETURN_NOT_OK_STATUS_WITH_WARN(
-            io::global_local_filesystem()->exists(done_file, &done_file_exist),
-            "Check local done file exist failed.");
-    if (done_file_exist) {
-        RETURN_NOT_OK_STATUS_WITH_WARN(
-                io::global_local_filesystem()->delete_file(done_file),
-                fmt::format("Delete local done file failed: {}", done_file.native()));
-    }
-    bool cache_file_exist = false;
-    RETURN_NOT_OK_STATUS_WITH_WARN(
-            io::global_local_filesystem()->exists(cache_file, &cache_file_exist),
-            "Check local cache file exist failed.");
-    if (cache_file_exist) {
-        RETURN_NOT_OK_STATUS_WITH_WARN(
-                io::global_local_filesystem()->delete_file(cache_file),
-                fmt::format("Delete local cache file failed: {}", cache_file.native()));
-    }
-    LOG(INFO) << "Delete local cache file successfully: " << cache_file.native();
-    return Status::OK();
+    auto [cache_file, done_file] = _cache_path(offset);
+    return _remove_file(cache_file, done_file, cleaned_size);
 }
 
 size_t SubFileCache::_calc_cache_file_size() {

--- a/be/src/io/cache/sub_file_cache.cpp
+++ b/be/src/io/cache/sub_file_cache.cpp
@@ -208,7 +208,7 @@ Status SubFileCache::_get_need_cache_offsets(size_t offset, size_t req_size,
 }
 
 Status SubFileCache::clean_timeout_cache() {
-    GcQueue gc_queue;
+    SubGcQueue gc_queue;
     _gc_lru_queue.swap(gc_queue);
     std::vector<size_t> timeout_keys;
     {
@@ -219,7 +219,7 @@ Status SubFileCache::clean_timeout_cache() {
                 timeout_keys.emplace_back(iter->first);
             } else {
                 auto [cache_file, done_file] = _cache_path(iter->first);
-                _gc_lru_queue.push({cache_file, iter->first, iter->second});
+                _gc_lru_queue.push({iter->first, iter->second});
             }
         }
     }

--- a/be/src/io/cache/sub_file_cache.h
+++ b/be/src/io/cache/sub_file_cache.h
@@ -52,15 +52,19 @@ public:
 
     Status clean_all_cache() override;
 
+    Status clean_one_cache(size_t* cleaned_size) override;
+
 private:
     Status _generate_cache_reader(size_t offset, size_t req_size);
 
-    Status _clean_cache_internal(size_t offset);
+    Status _clean_cache_internal(size_t offset, size_t* cleaned_size);
 
     Status _get_need_cache_offsets(size_t offset, size_t req_size,
                                    std::vector<size_t>* cache_offsets);
 
     size_t _calc_cache_file_size();
+
+    std::pair<Path, Path> _cache_path(size_t offset);
 
 private:
     Path _cache_dir;

--- a/be/src/io/cache/sub_file_cache.h
+++ b/be/src/io/cache/sub_file_cache.h
@@ -79,6 +79,7 @@ private:
     };
     using SubGcQueue = std::priority_queue<SubFileInfo, std::vector<SubFileInfo>,
                                            SubFileLRUComparator<SubFileInfo>>;
+    // used by gc thread, and currently has no lock protection
     SubGcQueue _gc_lru_queue;
 
     Path _cache_dir;

--- a/be/src/io/cache/whole_file_cache.cpp
+++ b/be/src/io/cache/whole_file_cache.cpp
@@ -51,7 +51,6 @@ Status WholeFileCache::read_at(size_t offset, Slice result, const IOContext& io_
                    << ", bytes read: " << bytes_read << " vs required size: " << result.size;
         return Status::OLAPInternalError(OLAP_ERR_OS_ERROR);
     }
-    update_last_match_time();
     return Status::OK();
 }
 
@@ -134,44 +133,39 @@ Status WholeFileCache::_generate_cache_reader(size_t offset, size_t req_size) {
 }
 
 Status WholeFileCache::clean_timeout_cache() {
+    GcQueue gc_queue;
+    _gc_lru_queue.swap(gc_queue);
+    std::unique_lock<std::shared_mutex> wrlock(_cache_lock);
     if (time(nullptr) - _last_match_time > _alive_time_sec) {
-        _clean_cache_internal();
+        _clean_cache_internal(nullptr);
+    } else {
+        Path cache_file = _cache_dir / WHOLE_FILE_CACHE_NAME;
+        _gc_lru_queue.push({cache_file, 0, _last_match_time});
     }
     return Status::OK();
 }
 
 Status WholeFileCache::clean_all_cache() {
-    _clean_cache_internal();
+    std::unique_lock<std::shared_mutex> wrlock(_cache_lock);
+    return _clean_cache_internal(nullptr);
+}
+
+Status WholeFileCache::clean_one_cache(size_t* cleaned_size) {
+    std::unique_lock<std::shared_mutex> wrlock(_cache_lock);
+    if (!_gc_lru_queue.empty()) {
+        RETURN_IF_ERROR(_clean_cache_internal(cleaned_size));
+        _gc_lru_queue.pop();
+    }
     return Status::OK();
 }
 
-Status WholeFileCache::_clean_cache_internal() {
-    std::unique_lock<std::shared_mutex> wrlock(_cache_lock);
+Status WholeFileCache::_clean_cache_internal(size_t* cleaned_size) {
     _cache_file_reader.reset();
     _cache_file_size = 0;
     Path cache_file = _cache_dir / WHOLE_FILE_CACHE_NAME;
     Path done_file =
             _cache_dir / fmt::format("{}{}", WHOLE_FILE_CACHE_NAME, CACHE_DONE_FILE_SUFFIX);
-    bool done_file_exist = false;
-    RETURN_NOT_OK_STATUS_WITH_WARN(
-            io::global_local_filesystem()->exists(done_file, &done_file_exist),
-            "Check local done file exist failed.");
-    if (done_file_exist) {
-        RETURN_NOT_OK_STATUS_WITH_WARN(
-                io::global_local_filesystem()->delete_file(done_file),
-                fmt::format("Delete local done file failed: {}", done_file.native()));
-    }
-    bool cache_file_exist = false;
-    RETURN_NOT_OK_STATUS_WITH_WARN(
-            io::global_local_filesystem()->exists(cache_file, &cache_file_exist),
-            "Check local cache file exist failed.");
-    if (cache_file_exist) {
-        RETURN_NOT_OK_STATUS_WITH_WARN(
-                io::global_local_filesystem()->delete_file(cache_file),
-                fmt::format("Delete local cache file failed: {}", cache_file.native()));
-    }
-    LOG(INFO) << "Delete local cache file successfully: " << cache_file.native();
-    return Status::OK();
+    return _remove_file(cache_file, done_file, cleaned_size);
 }
 
 } // namespace io

--- a/be/src/io/cache/whole_file_cache.h
+++ b/be/src/io/cache/whole_file_cache.h
@@ -54,6 +54,10 @@ public:
 
     Status clean_one_cache(size_t* cleaned_size) override;
 
+    int64_t get_oldest_match_time() const override { return _last_match_time; };
+
+    bool is_gc_finish() const override { return _cache_file_reader == nullptr; }
+
 private:
     Status _generate_cache_reader(size_t offset, size_t req_size);
 

--- a/be/src/io/cache/whole_file_cache.h
+++ b/be/src/io/cache/whole_file_cache.h
@@ -52,15 +52,21 @@ public:
 
     Status clean_all_cache() override;
 
+    Status clean_one_cache(size_t* cleaned_size) override;
+
 private:
     Status _generate_cache_reader(size_t offset, size_t req_size);
 
-    Status _clean_cache_internal();
+    Status _clean_cache_internal(size_t* cleaned_size);
+
+    void update_last_match_time() { _last_match_time = time(nullptr); }
 
 private:
     Path _cache_dir;
     int64_t _alive_time_sec;
     io::FileReaderSPtr _remote_file_reader;
+
+    int64_t _last_match_time;
 
     std::shared_mutex _cache_lock;
     io::FileReaderSPtr _cache_file_reader;


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

The current local cache gc at the granularity of segment, under 'sub_file_cache' may cause some old subfiles can not be gc in time. to solve this problem this pr supports gc at the granularity of cache files.


The idea is to use a two-level lru queue, with the first level queue at the segment granularity and the second level queue at the sub-cache file granularity. Each time clean up the second level queue top file in the first level queue top element.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

