### PR TITLE
[fix](array-type) fix the be core dump when insert '[1, 1, 1]' or '[true, true, true]'

### DIFF
--- a/be/src/exprs/cast_expr.cpp
+++ b/be/src/exprs/cast_expr.cpp
@@ -40,6 +40,8 @@ Expr* CastExpr::from_thrift(const TExprNode& node) {
         return new CastFloatExpr(node);
     case TPrimitiveType::DOUBLE:
         return new CastDoubleExpr(node);
+    case TPrimitiveType::VARCHAR:
+        return new ScalarFnCall(node);
     default:
         return nullptr;
     }

--- a/be/src/exprs/cast_expr.h
+++ b/be/src/exprs/cast_expr.h
@@ -22,6 +22,7 @@
 
 #include "common/object_pool.h"
 #include "exprs/expr.h"
+#include "exprs/scalar_fn_call.h"
 
 namespace doris {
 

--- a/be/src/exprs/scalar_fn_call.h
+++ b/be/src/exprs/scalar_fn_call.h
@@ -63,6 +63,7 @@ public:
 
 protected:
     friend class Expr;
+    friend class CastExpr;
 
     ScalarFnCall(const TExprNode& node);
     virtual Status prepare(RuntimeState* state, const RowDescriptor& desc,

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/CastExpr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/CastExpr.java
@@ -258,7 +258,8 @@ public class CastExpr extends Expr {
         msg.node_type = TExprNodeType.CAST_EXPR;
         msg.setOpcode(opcode);
         msg.setOutputColumn(outputColumn);
-        if (type.isNativeType() && getChild(0).getType().isNativeType()) {
+        if ((type.isNativeType() && getChild(0).getType().isNativeType())
+                || (type.isArrayType() && getChild(0).getType().isVarchar())) {
             msg.setChildType(getChild(0).getType().getPrimitiveType().toThrift());
         }
     }


### PR DESCRIPTION
# Proposed changes
1. this pr is used to fix the  be core dump when we run insert '[1, 1, 1]' or '[true, true, true]' under the non-vectorization scenario.
2. before the change, the be will core dump when we config fe as follow:
fe.conf :
enable_vectorized_load = false
enable_vectorized_engine = false
 mysql client :
set enable_vectorized_engine=false;
3. after the change, the be will be normal.

Issue Number: #7570

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
5. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
6. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
7. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

