### PR TITLE
[improvement](multi-catalog)Support invalid/not invalid option for refresh catalog and db.

### DIFF
--- a/fe/fe-core/src/main/cup/sql_parser.cup
+++ b/fe/fe-core/src/main/cup/sql_parser.cup
@@ -1137,13 +1137,13 @@ refresh_stmt ::=
     {:
         RESULT = new RefreshTableStmt(tbl);
     :}
-    | KW_REFRESH KW_DATABASE ident:db
+    | KW_REFRESH KW_DATABASE ident:db opt_properties:properties
     {:
-        RESULT = new RefreshDbStmt(db);
+        RESULT = new RefreshDbStmt(db, properties);
     :}
-    | KW_REFRESH KW_DATABASE ident:ctl DOT ident:db
+    | KW_REFRESH KW_DATABASE ident:ctl DOT ident:db opt_properties:properties
     {:
-        RESULT = new RefreshDbStmt(ctl, db);
+        RESULT = new RefreshDbStmt(ctl, db, properties);
     :}
     | KW_REFRESH KW_MATERIALIZED KW_VIEW table_name:mv
     {:
@@ -1153,9 +1153,9 @@ refresh_stmt ::=
     {:
         RESULT = new RefreshMaterializedViewStmt(mv, MVRefreshInfo.RefreshMethod.COMPLETE);
     :}
-    | KW_REFRESH KW_CATALOG ident:catalogName
+    | KW_REFRESH KW_CATALOG ident:catalogName opt_properties:properties
     {:
-        RESULT = new RefreshCatalogStmt(catalogName);
+        RESULT = new RefreshCatalogStmt(catalogName, properties);
     :}
     ;
 

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/RefreshCatalogStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/RefreshCatalogStmt.java
@@ -27,20 +27,30 @@ import org.apache.doris.datasource.InternalCatalog;
 import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.qe.ConnectContext;
 
+import java.util.Map;
+
 /**
  * RefreshCatalogStmt
  * Manually refresh the catalog metadata.
  */
 public class RefreshCatalogStmt extends DdlStmt {
+    private static final String INVALID_CACHE = "invalid_cache";
 
     private final String catalogName;
+    private Map<String, String> properties;
+    private boolean invalidCache = false;
 
-    public RefreshCatalogStmt(String catalogName) {
+    public RefreshCatalogStmt(String catalogName, Map<String, String> properties) {
         this.catalogName = catalogName;
+        this.properties = properties;
     }
 
     public String getCatalogName() {
         return catalogName;
+    }
+
+    public boolean isInvalidCache() {
+        return invalidCache;
     }
 
     @Override
@@ -56,6 +66,9 @@ public class RefreshCatalogStmt extends DdlStmt {
             ErrorReport.reportAnalysisException(ErrorCode.ERR_CATALOG_ACCESS_DENIED,
                     analyzer.getQualifiedUser(), catalogName);
         }
+        String invalidConfig = properties == null ? null : properties.get(INVALID_CACHE);
+        // Default is to invalid cache.
+        invalidCache = invalidConfig == null ? true : invalidConfig.equalsIgnoreCase("true");
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/RefreshDbStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/RefreshDbStmt.java
@@ -31,19 +31,26 @@ import com.google.common.base.Strings;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.Map;
+
 public class RefreshDbStmt extends DdlStmt {
     private static final Logger LOG = LogManager.getLogger(RefreshDbStmt.class);
+    private static final String INVALID_CACHE = "invalid_cache";
 
     private String catalogName;
     private String dbName;
+    private Map<String, String> properties;
+    private boolean invalidCache = false;
 
-    public RefreshDbStmt(String dbName) {
+    public RefreshDbStmt(String dbName, Map<String, String> properties) {
         this.dbName = dbName;
+        this.properties = properties;
     }
 
-    public RefreshDbStmt(String catalogName, String dbName) {
+    public RefreshDbStmt(String catalogName, String dbName, Map<String, String> properties) {
         this.catalogName = catalogName;
         this.dbName = dbName;
+        this.properties = properties;
     }
 
     public String getDbName() {
@@ -52,6 +59,10 @@ public class RefreshDbStmt extends DdlStmt {
 
     public String getCatalogName() {
         return catalogName;
+    }
+
+    public boolean isInvalidCache() {
+        return invalidCache;
     }
 
     @Override
@@ -82,6 +93,9 @@ public class RefreshDbStmt extends DdlStmt {
             ErrorReport.reportAnalysisException(
                     ErrorCode.ERR_DBACCESS_DENIED_ERROR, analyzer.getQualifiedUser(), dbName);
         }
+        String invalidConfig = properties == null ? null : properties.get(INVALID_CACHE);
+        // Default is to invalid cache.
+        invalidCache = invalidConfig == null ? true : invalidConfig.equalsIgnoreCase("true");
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/RefreshManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/RefreshManager.java
@@ -76,7 +76,7 @@ public class RefreshManager {
             refreshInternalCtlIcebergDb(dbName, env);
         } else {
             // Process external catalog db refresh
-            refreshExternalCtlDb(dbName, catalog);
+            refreshExternalCtlDb(dbName, catalog, stmt.isInvalidCache());
         }
         LOG.info("Successfully refresh db: {}", dbName);
     }
@@ -107,7 +107,7 @@ public class RefreshManager {
         env.getIcebergTableCreationRecordMgr().registerDb(db);
     }
 
-    private void refreshExternalCtlDb(String dbName, CatalogIf catalog) throws DdlException {
+    private void refreshExternalCtlDb(String dbName, CatalogIf catalog, boolean invalidCache) throws DdlException {
         if (!(catalog instanceof ExternalCatalog)) {
             throw new DdlException("Only support refresh ExternalCatalog Database");
         }
@@ -116,10 +116,11 @@ public class RefreshManager {
         if (db == null) {
             throw new DdlException("Database " + dbName + " does not exist in catalog " + catalog.getName());
         }
-        ((ExternalDatabase) db).setUnInitialized();
+        ((ExternalDatabase) db).setUnInitialized(invalidCache);
         ExternalObjectLog log = new ExternalObjectLog();
         log.setCatalogId(catalog.getId());
         log.setDbId(db.getId());
+        log.setInvalidCache(invalidCache);
         Env.getCurrentEnv().getEditLog().logRefreshExternalDb(log);
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/external/ExternalDatabase.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/external/ExternalDatabase.java
@@ -65,6 +65,7 @@ public class ExternalDatabase<T extends ExternalTable> implements DatabaseIf<T>,
     @SerializedName(value = "initialized")
     protected boolean initialized = false;
     protected ExternalCatalog extCatalog;
+    protected boolean invalidCacheInInit = true;
 
     /**
      * No args constructor for persist.
@@ -93,9 +94,12 @@ public class ExternalDatabase<T extends ExternalTable> implements DatabaseIf<T>,
     public void setTableExtCatalog(ExternalCatalog extCatalog) {
     }
 
-    public void setUnInitialized() {
+    public void setUnInitialized(boolean invalidCache) {
         this.initialized = false;
-        Env.getCurrentEnv().getExtMetaCacheMgr().invalidateDbCache(extCatalog.getId(), name);
+        this.invalidCacheInInit = invalidCache;
+        if (invalidCache) {
+            Env.getCurrentEnv().getExtMetaCacheMgr().invalidateDbCache(extCatalog.getId(), name);
+        }
     }
 
     public boolean isInitialized() {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/CatalogFactory.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/CatalogFactory.java
@@ -54,6 +54,7 @@ public class CatalogFactory {
             log.setNewCatalogName(((AlterCatalogNameStmt) stmt).getNewCatalogName());
         } else if (stmt instanceof RefreshCatalogStmt) {
             log.setCatalogId(catalogId);
+            log.setInvalidCache(((RefreshCatalogStmt) stmt).isInvalidCache());
         } else {
             throw new RuntimeException("Unknown stmt for catalog manager " + stmt.getClass().getSimpleName());
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/CatalogLog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/CatalogLog.java
@@ -53,6 +53,9 @@ public class CatalogLog implements Writable {
     @SerializedName(value = "newProps")
     private Map<String, String> newProps;
 
+    @SerializedName(value = "invalidCache")
+    private boolean invalidCache;
+
     @Override
     public void write(DataOutput out) throws IOException {
         Text.writeString(out, GsonUtils.GSON.toJson(this));

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/CatalogMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/CatalogMgr.java
@@ -110,12 +110,12 @@ public class CatalogMgr implements Writable, GsonPostProcessable {
         return catalog;
     }
 
-    private void unprotectedRefreshCatalog(long catalogId) {
+    private void unprotectedRefreshCatalog(long catalogId, boolean invalidCache) {
         CatalogIf catalog = idToCatalog.get(catalogId);
         if (catalog != null) {
             String catalogName = catalog.getName();
             if (!catalogName.equals(InternalCatalog.INTERNAL_CATALOG_NAME)) {
-                ((ExternalCatalog) catalog).setUninitialized();
+                ((ExternalCatalog) catalog).setUninitialized(invalidCache);
             }
         }
     }
@@ -409,7 +409,7 @@ public class CatalogMgr implements Writable, GsonPostProcessable {
     public void replayRefreshCatalog(CatalogLog log) throws DdlException {
         writeLock();
         try {
-            unprotectedRefreshCatalog(log.getCatalogId());
+            unprotectedRefreshCatalog(log.getCatalogId(), log.isInvalidCache());
         } finally {
             writeUnlock();
         }
@@ -465,7 +465,7 @@ public class CatalogMgr implements Writable, GsonPostProcessable {
         try {
             ExternalCatalog catalog = (ExternalCatalog) idToCatalog.get(log.getCatalogId());
             ExternalDatabase db = catalog.getDbForReplay(log.getDbId());
-            db.setUnInitialized();
+            db.setUnInitialized(log.isInvalidCache());
         } finally {
             writeUnlock();
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/EsExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/EsExternalCatalog.java
@@ -134,7 +134,7 @@ public class EsExternalCatalog extends ExternalCatalog {
         initCatalogLog.setCatalogId(id);
         initCatalogLog.setType(InitCatalogLog.Type.ES);
         if (dbNameToId != null && dbNameToId.containsKey(DEFAULT_DB)) {
-            idToDb.get(dbNameToId.get(DEFAULT_DB)).setUnInitialized();
+            idToDb.get(dbNameToId.get(DEFAULT_DB)).setUnInitialized(invalidCacheInInit);
             initCatalogLog.addRefreshDb(dbNameToId.get(DEFAULT_DB));
         } else {
             dbNameToId = Maps.newConcurrentMap();

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalCatalog.java
@@ -69,6 +69,7 @@ public abstract class ExternalCatalog implements CatalogIf<ExternalDatabase>, Wr
     // db name does not contains "default_cluster"
     protected Map<String, Long> dbNameToId = Maps.newConcurrentMap();
     private boolean objectCreated = false;
+    protected boolean invalidCacheInInit = true;
 
     private ExternalSchemaCache schemaCache;
 
@@ -129,8 +130,15 @@ public abstract class ExternalCatalog implements CatalogIf<ExternalDatabase>, Wr
     // init schema related objects
     protected abstract void init();
 
-    public void setUninitialized() {
+    public void setUninitialized(boolean invalidCache) {
         this.initialized = false;
+        this.invalidCacheInInit = invalidCache;
+        if (invalidCache) {
+            Env.getCurrentEnv().getExtMetaCacheMgr().invalidateCatalogCache(id);
+        }
+    }
+
+    public void updateDbList() {
         Env.getCurrentEnv().getExtMetaCacheMgr().invalidateCatalogCache(id);
     }
 
@@ -209,7 +217,7 @@ public abstract class ExternalCatalog implements CatalogIf<ExternalDatabase>, Wr
         Map<Long, ExternalDatabase> tmpIdToDb = Maps.newConcurrentMap();
         for (int i = 0; i < log.getRefreshCount(); i++) {
             ExternalDatabase db = getDbForReplay(log.getRefreshDbIds().get(i));
-            db.setUnInitialized();
+            db.setUnInitialized(invalidCacheInInit);
             tmpDbNameToId.put(db.getFullName(), db.getId());
             tmpIdToDb.put(db.getId(), db);
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalObjectLog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalObjectLog.java
@@ -43,6 +43,9 @@ public class ExternalObjectLog implements Writable {
     @SerializedName(value = "tableId")
     private long tableId;
 
+    @SerializedName(value = "invalidCache")
+    private boolean invalidCache;
+
     @Override
     public void write(DataOutput out) throws IOException {
         Text.writeString(out, GsonUtils.GSON.toJson(this));

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/HMSExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/HMSExternalCatalog.java
@@ -72,7 +72,7 @@ public class HMSExternalCatalog extends ExternalCatalog {
                 dbId = dbNameToId.get(dbName);
                 tmpDbNameToId.put(dbName, dbId);
                 ExternalDatabase db = idToDb.get(dbId);
-                db.setUnInitialized();
+                db.setUnInitialized(invalidCacheInInit);
                 tmpIdToDb.put(dbId, db);
                 initCatalogLog.addRefreshDb(dbId);
             } else {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/JdbcExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/JdbcExternalCatalog.java
@@ -122,7 +122,7 @@ public class JdbcExternalCatalog extends ExternalCatalog {
                 dbId = dbNameToId.get(dbName);
                 tmpDbNameToId.put(dbName, dbId);
                 ExternalDatabase db = idToDb.get(dbId);
-                db.setUnInitialized();
+                db.setUnInitialized(invalidCacheInInit);
                 tmpIdToDb.put(dbId, db);
                 initCatalogLog.addRefreshDb(dbId);
             } else {


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

Current refresh catalog/db operation always invalid all the related cache. In some cases, it is not necessary, for example, create a new db in external data source. This pr is to support refresh without invalidate cache.

refresh catalog hive properties("invalid_cache" = "false");
refresh database hive.db1 properties("invalid_cache" = "false");

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

