### PR TITLE
[feature-wip](MTMV) Support mapping the partition rule of base table to the materialized view

### DIFF
--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -261,6 +261,14 @@ under the License.
             <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/org.junit.jupiter/junit-jupiter-params -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+
         <!-- https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-api -->
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>

--- a/fe/fe-core/src/main/cup/sql_parser.cup
+++ b/fe/fe-core/src/main/cup/sql_parser.cup
@@ -718,6 +718,7 @@ nonterminal AnalyticWindow opt_window_clause;
 nonterminal AnalyticWindow.Type window_type;
 nonterminal AnalyticWindow.Boundary window_boundary;
 nonterminal SlotRef column_ref;
+nonterminal ArrayList<SlotRef> column_ref_list;
 nonterminal FunctionCallExpr column_subscript;
 nonterminal FunctionCallExpr column_slice;
 nonterminal ArrayList<TableRef> table_ref_list, base_table_ref_list;
@@ -878,6 +879,7 @@ nonterminal MVRefreshInfo.BuildMode build_mv;
 nonterminal MVRefreshInfo.RefreshMethod opt_refresh_method;
 nonterminal MVRefreshTriggerInfo opt_refresh_trigger;
 nonterminal MVRefreshInfo opt_mv_refersh_info;
+nonterminal PartitionDesc opt_mv_partition;
 
 precedence nonassoc COMMA;
 precedence nonassoc STRING_LITERAL;
@@ -1688,11 +1690,23 @@ opt_mv_refersh_info ::=
 
 opt_mv_keys ::=
     {:
-        RESULT = new KeysDesc(KeysType.DUP_KEYS, Lists.newArrayList());
+        RESULT = null;
     :}
     | KW_KEY LPAREN ident_list:keys RPAREN
     {:
         RESULT = new KeysDesc(KeysType.DUP_KEYS, keys);
+    :}
+    ;
+
+opt_mv_partition ::=
+    /* Empty: no partition */
+    {:
+        RESULT = null;
+    :}
+    /* Column partition */
+    | KW_PARTITION KW_BY LPAREN column_ref_list:columns RPAREN
+    {:
+        RESULT = new ColumnPartitionDesc(columns);
     :}
     ;
 
@@ -1825,7 +1839,7 @@ create_stmt ::=
     | KW_CREATE KW_MATERIALIZED KW_VIEW ident:mvName build_mv:buildMethod
          opt_mv_refersh_info:refreshInfo
          opt_mv_keys:keyDesc
-         opt_partition:partitionDesc
+         opt_mv_partition:partitionDesc
          opt_distribution:distributionDesc
          opt_properties:properties
          KW_AS query_stmt:query
@@ -6174,6 +6188,20 @@ column_ref ::=
   {: RESULT = new SlotRef(new TableName(null, db, tbl), col); :}
   | ident:ctl DOT ident:db DOT ident:tbl DOT ident:col
   {: RESULT = new SlotRef(new TableName(ctl, db, tbl), col); :}
+  ;
+
+column_ref_list ::=
+  column_ref:ref
+  {:
+    ArrayList<SlotRef> refs = new ArrayList<SlotRef>();
+    refs.add(ref);
+    RESULT = refs;
+  :}
+  | column_ref_list:list COMMA column_ref:ref
+  {:
+    list.add(ref);
+    RESULT = list;
+  :}
   ;
 
 column_subscript ::=

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ColumnPartitionDesc.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ColumnPartitionDesc.java
@@ -1,0 +1,126 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.analysis;
+
+import org.apache.doris.catalog.Column;
+import org.apache.doris.catalog.OlapTable;
+import org.apache.doris.catalog.PartitionInfo;
+import org.apache.doris.common.AnalysisException;
+import org.apache.doris.common.DdlException;
+
+import com.google.common.collect.Lists;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * This class is used for {@link org.apache.doris.catalog.MaterializedView}.
+ * When we create a materialized view for multiple tables, we can specify the partition of the view
+ * which is as consistent as one of base tables.
+ */
+public class ColumnPartitionDesc extends PartitionDesc {
+    private final List<SlotRef> columns;
+
+    public ColumnPartitionDesc(List<SlotRef> columns)
+            throws AnalysisException {
+        this.columns = columns;
+    }
+
+    public void analyze(Analyzer analyzer, CreateMultiTableMaterializedViewStmt stmt) throws AnalysisException {
+        for (SlotRef column : columns) {
+            column.analyze(analyzer);
+        }
+        OlapTable olapTable = matchTable(stmt.getOlapTables());
+        PartitionDesc partitionDesc = olapTable.getPartitionInfo().toPartitionDesc(olapTable);
+        type = partitionDesc.getType();
+        partitionColNames = toMVPartitionColumnNames(olapTable.getName(), partitionDesc.getPartitionColNames(),
+                stmt.getQueryStmt());
+        singlePartitionDescs = partitionDesc.getSinglePartitionDescs();
+    }
+
+    private OlapTable matchTable(Map<String, OlapTable> olapTables) throws AnalysisException {
+        OlapTable matched = null;
+        for (SlotRef column : columns) {
+            OlapTable olapTable = olapTables.get(column.getTableName().getTbl());
+            if (olapTable != null) {
+                if (matched != null && !matched.getName().equals(olapTable.getName())) {
+                    throw new AnalysisException("The partition columns must be in the same table.");
+                } else if (matched == null) {
+                    matched = olapTable;
+                }
+            }
+        }
+        PartitionInfo partitionInfo = matched.getPartitionInfo();
+        List<Column> partitionColumns = partitionInfo.getPartitionColumns();
+        if (!columns.stream().map(SlotRef::getColumn).collect(Collectors.toList()).equals(partitionColumns)) {
+            throw new AnalysisException("The partition columns doesn't match the ones in base table "
+                    + matched.getName() + ".");
+        }
+        return matched;
+    }
+
+    private List<String> toMVPartitionColumnNames(String tableName, List<String> partitionColNames, QueryStmt queryStmt)
+            throws AnalysisException {
+        List<String> mvPartitionColumnNames = Lists.newArrayListWithCapacity(partitionColNames.size());
+        if (queryStmt instanceof SelectStmt) {
+            List<SelectListItem> items = ((SelectStmt) queryStmt).getSelectList().getItems();
+            for (String partitionColName : partitionColNames) {
+                String mvColumnName = null;
+                for (int i = 0; mvColumnName == null && i < items.size(); ++ i) {
+                    SelectListItem item = items.get(i);
+                    if (item.isStar()) {
+                        mvColumnName = partitionColName;
+                    } else if (item.getExpr() instanceof SlotRef) {
+                        SlotRef slotRef = (SlotRef) item.getExpr();
+                        if (slotRef.getTableName().getTbl().equals(tableName) && slotRef.getColumnName()
+                                .equals(partitionColName)) {
+                            mvColumnName = item.getAlias() == null ? partitionColName : item.getAlias();
+                        }
+                    }
+                }
+                if (mvColumnName != null) {
+                    mvPartitionColumnNames.add(mvColumnName);
+                } else {
+                    throw new AnalysisException(
+                            "Failed to map the partition column name " + partitionColName + " to mv column");
+                }
+            }
+        } else {
+            throw new AnalysisException("Only select statement is supported.");
+        }
+        return mvPartitionColumnNames;
+    }
+
+    @Override
+    public PartitionInfo toPartitionInfo(List<Column> schema, Map<String, Long> partitionNameToId, boolean isTemp)
+            throws DdlException, AnalysisException {
+        switch (type) {
+            case RANGE:
+                return new RangePartitionDesc(partitionColNames,
+                        singlePartitionDescs.stream().map(desc -> (AllPartitionDesc) desc)
+                                .collect(Collectors.toList())).toPartitionInfo(schema, partitionNameToId, isTemp);
+            case LIST:
+                return new ListPartitionDesc(partitionColNames,
+                        singlePartitionDescs.stream().map(desc -> (AllPartitionDesc) desc)
+                                .collect(Collectors.toList())).toPartitionInfo(schema, partitionNameToId, isTemp);
+            default:
+                throw new RuntimeException("Invalid partition type.");
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateMultiTableMaterializedViewStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateMultiTableMaterializedViewStmt.java
@@ -67,6 +67,9 @@ public class CreateMultiTableMaterializedViewStmt extends CreateTableStmt {
             analyzeSelectClause((SelectStmt) queryStmt);
         }
         tableName = new TableName(null, database.getFullName(), mvName);
+        if (partitionDesc != null) {
+            ((ColumnPartitionDesc) partitionDesc).analyze(analyzer, this);
+        }
         super.analyze(analyzer);
     }
 
@@ -92,7 +95,7 @@ public class CreateMultiTableMaterializedViewStmt extends CreateTableStmt {
                         column.getName(),
                         new TypeDef(column.getType()),
                         column.isKey(),
-                        column.getAggregationType(),
+                        null,
                         column.isAllowNull(),
                         new DefaultValue(column.getDefaultValue() != null, column.getDefaultValue()),
                         column.getComment())

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateTableStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateTableStmt.java
@@ -101,47 +101,47 @@ public class CreateTableStmt extends DdlStmt {
     }
 
     public CreateTableStmt(boolean ifNotExists,
-                           boolean isExternal,
-                           TableName tableName,
-                           List<ColumnDef> columnDefinitions,
-                           String engineName,
-                           KeysDesc keysDesc,
-                           PartitionDesc partitionDesc,
-                           DistributionDesc distributionDesc,
-                           Map<String, String> properties,
-                           Map<String, String> extProperties,
-                           String comment) {
+            boolean isExternal,
+            TableName tableName,
+            List<ColumnDef> columnDefinitions,
+            String engineName,
+            KeysDesc keysDesc,
+            PartitionDesc partitionDesc,
+            DistributionDesc distributionDesc,
+            Map<String, String> properties,
+            Map<String, String> extProperties,
+            String comment) {
         this(ifNotExists, isExternal, tableName, columnDefinitions, null, engineName, keysDesc, partitionDesc,
                 distributionDesc, properties, extProperties, comment, null);
     }
 
     public CreateTableStmt(boolean ifNotExists,
-                           boolean isExternal,
-                           TableName tableName,
-                           List<ColumnDef> columnDefinitions,
-                           String engineName,
-                           KeysDesc keysDesc,
-                           PartitionDesc partitionDesc,
-                           DistributionDesc distributionDesc,
-                           Map<String, String> properties,
-                           Map<String, String> extProperties,
-                           String comment, List<AlterClause> ops) {
+            boolean isExternal,
+            TableName tableName,
+            List<ColumnDef> columnDefinitions,
+            String engineName,
+            KeysDesc keysDesc,
+            PartitionDesc partitionDesc,
+            DistributionDesc distributionDesc,
+            Map<String, String> properties,
+            Map<String, String> extProperties,
+            String comment, List<AlterClause> ops) {
         this(ifNotExists, isExternal, tableName, columnDefinitions, null, engineName, keysDesc, partitionDesc,
                 distributionDesc, properties, extProperties, comment, ops);
     }
 
     public CreateTableStmt(boolean ifNotExists,
-                           boolean isExternal,
-                           TableName tableName,
-                           List<ColumnDef> columnDefinitions,
-                           List<IndexDef> indexDefs,
-                           String engineName,
-                           KeysDesc keysDesc,
-                           PartitionDesc partitionDesc,
-                           DistributionDesc distributionDesc,
-                           Map<String, String> properties,
-                           Map<String, String> extProperties,
-                           String comment, List<AlterClause> rollupAlterClauseList) {
+            boolean isExternal,
+            TableName tableName,
+            List<ColumnDef> columnDefinitions,
+            List<IndexDef> indexDefs,
+            String engineName,
+            KeysDesc keysDesc,
+            PartitionDesc partitionDesc,
+            DistributionDesc distributionDesc,
+            Map<String, String> properties,
+            Map<String, String> extProperties,
+            String comment, List<AlterClause> rollupAlterClauseList) {
         this.tableName = tableName;
         if (columnDefinitions == null) {
             this.columnDefs = Lists.newArrayList();
@@ -169,11 +169,11 @@ public class CreateTableStmt extends DdlStmt {
 
     // This is for iceberg/hudi table, which has no column schema
     public CreateTableStmt(boolean ifNotExists,
-                           boolean isExternal,
-                           TableName tableName,
-                           String engineName,
-                           Map<String, String> properties,
-                           String comment) {
+            boolean isExternal,
+            TableName tableName,
+            String engineName,
+            Map<String, String> properties,
+            String comment) {
         this.ifNotExists = ifNotExists;
         this.isExternal = isExternal;
         this.tableName = tableName;
@@ -418,7 +418,8 @@ public class CreateTableStmt extends DdlStmt {
         if (engineName.equals("olap")) {
             // analyze partition
             if (partitionDesc != null) {
-                if (partitionDesc instanceof ListPartitionDesc || partitionDesc instanceof RangePartitionDesc) {
+                if (partitionDesc instanceof ListPartitionDesc || partitionDesc instanceof RangePartitionDesc
+                        || partitionDesc instanceof ColumnPartitionDesc) {
                     partitionDesc.analyze(columnDefs, properties);
                 } else {
                     throw new AnalysisException("Currently only support range"
@@ -440,8 +441,9 @@ public class CreateTableStmt extends DdlStmt {
                         if (columnDef.getAggregateType() == AggregateType.REPLACE
                                 || columnDef.getAggregateType() == AggregateType.REPLACE_IF_NOT_NULL) {
                             throw new AnalysisException("Create aggregate keys table with value columns of which"
-                                + " aggregate type is " + columnDef.getAggregateType() + " should not contain random"
-                                + " distribution desc");
+                                    + " aggregate type is " + columnDef.getAggregateType()
+                                    + " should not contain random"
+                                    + " distribution desc");
                         }
                     }
                 }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/PartitionDesc.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/PartitionDesc.java
@@ -42,6 +42,8 @@ public class PartitionDesc {
 
     protected PartitionType type;
 
+    public PartitionDesc() {}
+
     public PartitionDesc(List<String> partitionColNames,
                          List<AllPartitionDesc> allPartitionDescs) throws AnalysisException {
         this.partitionColNames = partitionColNames;
@@ -154,7 +156,7 @@ public class PartitionDesc {
     }
 
     public PartitionInfo toPartitionInfo(List<Column> schema, Map<String, Long> partitionNameToId, boolean isTemp)
-            throws DdlException {
+            throws DdlException, AnalysisException {
         throw new NotImplementedException();
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/ListPartitionInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/ListPartitionInfo.java
@@ -17,6 +17,9 @@
 
 package org.apache.doris.catalog;
 
+import org.apache.doris.analysis.AllPartitionDesc;
+import org.apache.doris.analysis.ListPartitionDesc;
+import org.apache.doris.analysis.PartitionDesc;
 import org.apache.doris.analysis.PartitionKeyDesc;
 import org.apache.doris.analysis.PartitionValue;
 import org.apache.doris.analysis.SinglePartitionDesc;
@@ -25,6 +28,8 @@ import org.apache.doris.common.DdlException;
 import org.apache.doris.common.util.ListUtil;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 
 import java.io.DataInput;
 import java.io.DataOutput;
@@ -34,6 +39,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 public class ListPartitionInfo extends PartitionInfo {
 
@@ -226,5 +232,34 @@ public class ListPartitionInfo extends PartitionInfo {
         }
         sb.append(")");
         return sb.toString();
+    }
+
+    @Override
+    public PartitionDesc toPartitionDesc(OlapTable table) throws AnalysisException {
+        List<String> partitionColumnNames = partitionColumns.stream().map(Column::getName).collect(Collectors.toList());
+        List<AllPartitionDesc> allPartitionDescs = Lists.newArrayListWithCapacity(this.idToItem.size());
+
+        // sort list
+        List<Map.Entry<Long, PartitionItem>> entries = new ArrayList<>(this.idToItem.entrySet());
+        Collections.sort(entries, ListUtil.LIST_MAP_ENTRY_COMPARATOR);
+        for (Map.Entry<Long, PartitionItem> entry : entries) {
+            Partition partition = table.getPartition(entry.getKey());
+            String partitionName = partition.getName();
+
+            List<PartitionKey> partitionKeys = entry.getValue().getItems();
+            List<List<PartitionValue>> inValues = partitionKeys.stream().map(PartitionInfo::toPartitionValue)
+                    .collect(Collectors.toList());
+            PartitionKeyDesc partitionKeyDesc = PartitionKeyDesc.createIn(inValues);
+
+            Map<String, String> properties = Maps.newHashMap();
+            Optional.ofNullable(this.idToStoragePolicy.get(entry.getKey())).ifPresent(p -> {
+                if (!p.equals("")) {
+                    properties.put("STORAGE POLICY", p);
+                }
+            });
+
+            allPartitionDescs.add(new SinglePartitionDesc(false, partitionName, partitionKeyDesc, properties));
+        }
+        return new ListPartitionDesc(partitionColumnNames, allPartitionDescs);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/RangePartitionInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/RangePartitionInfo.java
@@ -17,7 +17,10 @@
 
 package org.apache.doris.catalog;
 
+import org.apache.doris.analysis.AllPartitionDesc;
+import org.apache.doris.analysis.PartitionDesc;
 import org.apache.doris.analysis.PartitionKeyDesc;
+import org.apache.doris.analysis.RangePartitionDesc;
 import org.apache.doris.analysis.SinglePartitionDesc;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.DdlException;
@@ -36,6 +39,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 public class RangePartitionInfo extends PartitionInfo {
 
@@ -293,5 +297,34 @@ public class RangePartitionInfo extends PartitionInfo {
         }
         sb.append(")");
         return sb.toString();
+    }
+
+    @Override
+    public PartitionDesc toPartitionDesc(OlapTable table) throws AnalysisException {
+        List<String> partitionColumnNames = partitionColumns.stream().map(Column::getName).collect(Collectors.toList());
+        List<AllPartitionDesc> allPartitionDescs = Lists.newArrayListWithCapacity(this.idToItem.size());
+
+        // sort range
+        List<Map.Entry<Long, PartitionItem>> entries = new ArrayList<>(this.idToItem.entrySet());
+        Collections.sort(entries, RangeUtils.RANGE_MAP_ENTRY_COMPARATOR);
+        for (Map.Entry<Long, PartitionItem> entry : entries) {
+            Partition partition = table.getPartition(entry.getKey());
+            String partitionName = partition.getName();
+
+            Range<PartitionKey> range = entry.getValue().getItems();
+            PartitionKeyDesc partitionKeyDesc = PartitionKeyDesc.createFixed(
+                    PartitionInfo.toPartitionValue(range.lowerEndpoint()),
+                    PartitionInfo.toPartitionValue(range.upperEndpoint()));
+
+            Map<String, String> properties = Maps.newHashMap();
+            Optional.ofNullable(this.idToStoragePolicy.get(entry.getKey())).ifPresent(p -> {
+                if (!p.equals("")) {
+                    properties.put("STORAGE POLICY", p);
+                }
+            });
+
+            allPartitionDescs.add(new SinglePartitionDesc(false, partitionName, partitionKeyDesc, properties));
+        }
+        return new RangePartitionDesc(partitionColumnNames, allPartitionDescs);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/TableIf.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/TableIf.java
@@ -164,6 +164,7 @@ public interface TableIf {
                     return "SYSTEM VIEW";
                 case INLINE_VIEW:
                 case VIEW:
+                case MATERIALIZED_VIEW:
                     return "VIEW";
                 case MYSQL:
                 case ODBC:

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
@@ -2242,7 +2242,7 @@ public class InternalCatalog implements CatalogIf<Database> {
         LOG.info("successfully create table[{}-{}]", tableName, tableId);
     }
 
-    private Table createEsTable(Database db, CreateTableStmt stmt) throws DdlException {
+    private Table createEsTable(Database db, CreateTableStmt stmt) throws DdlException, AnalysisException {
         String tableName = stmt.getTableName();
 
         // validate props to get column from es.

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/MultiTableMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/MultiTableMaterializedViewTest.java
@@ -41,6 +41,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.IOException;
 
@@ -50,26 +52,12 @@ public class MultiTableMaterializedViewTest extends TestWithFeService {
     protected void setUp() throws Exception {
         createDatabase("test");
         connectContext.setDatabase("default_cluster:test");
+        connectContext.getState().reset();
     }
 
     @AfterEach
     public void tearDown() {
         Env.getCurrentEnv().clear();
-    }
-
-    @Test
-    public void testCreate() throws Exception {
-        createTable("create table test.t1 (pk int, v1 int sum) aggregate key (pk) "
-                + "distributed by hash (pk) buckets 1 properties ('replication_num' = '1');");
-        createTable("create table test.t2 (pk int, v2 int sum) aggregate key (pk) "
-                + "distributed by hash (pk) buckets 1 properties ('replication_num' = '1');");
-
-        ExceptionChecker.expectThrowsNoException(() ->
-                connectContext.getEnv().createMultiTableMaterializedView(
-                    (CreateMultiTableMaterializedViewStmt) parseAndAnalyzeStmt("create materialized view mv "
-                        + "build immediate refresh complete key (pk_of_mv) distributed by hash (pk_of_mv) "
-                        + "properties ('replication_num' = '1') "
-                        + "as select test.t1.pk as pk_of_mv from test.t1, test.t2 where test.t1.pk = test.t2.pk")));
     }
 
     @Test
@@ -80,13 +68,13 @@ public class MultiTableMaterializedViewTest extends TestWithFeService {
                 + "distributed by hash (pk) buckets 1 properties ('replication_num' = '1');");
 
         String sql = "create materialized view mv build immediate refresh complete "
-                + "key (pk_of_mv) distributed by hash (pk_of_mv) "
-                + "as select test.t1.pk as pk_of_mv from test.t1, test.t2 where test.t1.pk = test.t2.pk";
+                + "key (mpk) distributed by hash (mpk) "
+                + "as select test.t1.pk as mpk from test.t1, test.t2 where test.t1.pk = test.t2.pk";
         testSerialization(sql);
 
         sql = "create materialized view mv1 build immediate refresh complete start with '1:00' next 1 day "
-                + "key (pk_of_mv) distributed by hash (pk_of_mv) "
-                + "as select test.t1.pk as pk_of_mv from test.t1, test.t2 where test.t1.pk = test.t2.pk";
+                + "key (mpk) distributed by hash (mpk) "
+                + "as select test.t1.pk as mpk from test.t1, test.t2 where test.t1.pk = test.t2.pk";
         testSerialization(sql);
     }
 
@@ -157,11 +145,11 @@ public class MultiTableMaterializedViewTest extends TestWithFeService {
                 + "distributed by hash (pk) buckets 1 properties ('replication_num' = '1');");
         createTable("create table test.t2 (pk int, v2 int sum) aggregate key (pk) "
                 + "distributed by hash (pk) buckets 1 properties ('replication_num' = '1');");
-        StmtExecutor executor = new StmtExecutor(connectContext, "create materialized view mv "
-                + "build immediate refresh complete key (pk_of_mv) distributed by hash (pk_of_mv) "
+        new StmtExecutor(connectContext, "create materialized view mv "
+                + "build immediate refresh complete key (mpk) distributed by hash (mpk) "
                 + "properties ('replication_num' = '1') "
-                + "as select test.t1.pk as pk_of_mv from test.t1, test.t2 where test.t1.pk = test.t2.pk");
-        ExceptionChecker.expectThrowsNoException(executor::execute);
+                + "as select test.t1.pk as mpk from test.t1, test.t2 where test.t1.pk = test.t2.pk").execute();
+        Assertions.assertNull(connectContext.getState().getErrorCode(), connectContext.getState().getErrorMessage());
 
         ShowExecutor showExecutor = new ShowExecutor(connectContext,
                 (ShowStmt) parseAndAnalyzeStmt("show create table mv"));
@@ -169,8 +157,8 @@ public class MultiTableMaterializedViewTest extends TestWithFeService {
         String result = resultSet.getResultRows().get(0).get(1);
         Assertions.assertTrue(result.contains("CREATE MATERIALIZED VIEW `mv`\n"
                 + "BUILD IMMEDIATE REFRESH COMPLETE ON DEMAND\n"
-                + "KEY(`pk_of_mv`)\n"
-                + "DISTRIBUTED BY HASH(`pk_of_mv`) BUCKETS 10"));
+                + "KEY(`mpk`)\n"
+                + "DISTRIBUTED BY HASH(`mpk`) BUCKETS 10"));
     }
 
     @Test
@@ -179,11 +167,11 @@ public class MultiTableMaterializedViewTest extends TestWithFeService {
                 + "distributed by hash (pk) buckets 1 properties ('replication_num' = '1');");
         createTable("create table test.t2 (pk int, v2 int sum) aggregate key (pk) "
                 + "distributed by hash (pk) buckets 1 properties ('replication_num' = '1');");
-        StmtExecutor executor = new StmtExecutor(connectContext, "create materialized view mv "
-                + "build immediate refresh complete key (pk_of_mv) distributed by hash (pk_of_mv) "
+        new StmtExecutor(connectContext, "create materialized view mv "
+                + "build immediate refresh complete key (mpk) distributed by hash (mpk) "
                 + "properties ('replication_num' = '1') "
-                + "as select test.t1.pk as pk_of_mv from test.t1, test.t2 where test.t1.pk = test.t2.pk");
-        ExceptionChecker.expectThrowsNoException(executor::execute);
+                + "as select test.t1.pk as mpk from test.t1, test.t2 where test.t1.pk = test.t2.pk").execute();
+        Assertions.assertNull(connectContext.getState().getErrorCode(), connectContext.getState().getErrorMessage());
 
         ExceptionChecker.expectThrowsWithMsg(DdlException.class, "is not TABLE",
                 () -> Env.getCurrentInternalCatalog()
@@ -192,5 +180,128 @@ public class MultiTableMaterializedViewTest extends TestWithFeService {
         ExceptionChecker.expectThrowsNoException(() -> connectContext.getEnv().dropMaterializedView(
                 (DropMaterializedViewStmt) parseAndAnalyzeStmt("drop materialized view mv")));
     }
-}
 
+    @ParameterizedTest
+    @ValueSource(strings = {"AGGREGATE", "UNIQUE", "DUPLICATE"})
+    public void testCreate(String keyType) throws Exception {
+        String aggregation = keyType.equals("AGGREGATE") ? "SUM" : "";
+        createTable("CREATE TABLE test.t1 ("
+                + "  pk INT,"
+                + "  v1 INT " + aggregation
+                + ") " + keyType + " KEY (pk)"
+                + "DISTRIBUTED BY HASH(pk) BUCKETS 1 PROPERTIES ('replication_num' = '1')");
+        createTable("CREATE TABLE test.t2 ("
+                + "  pk INT,"
+                + "  v2 INT " + aggregation
+                + ") " + keyType + " KEY (pk)"
+                + "DISTRIBUTED BY HASH(pk) BUCKETS 1 PROPERTIES ('replication_num' = '1')");
+        new StmtExecutor(connectContext, "CREATE MATERIALIZED VIEW mv "
+                + "BUILD IMMEDIATE REFRESH COMPLETE KEY (pk) DISTRIBUTED BY HASH(pk) "
+                + "PROPERTIES ('replication_num' = '1') "
+                + "AS SELECT t1.pk, v1, v2 FROM test.t1, test.t2 WHERE test.t1.pk = test.t2.pk").execute();
+        Assertions.assertNull(connectContext.getState().getErrorCode(), connectContext.getState().getErrorMessage());
+
+        connectContext.getEnv().dropMaterializedView(
+                (DropMaterializedViewStmt) parseAndAnalyzeStmt("DROP MATERIALIZED VIEW mv"));
+        new StmtExecutor(connectContext, "CREATE MATERIALIZED VIEW mv "
+                + "BUILD IMMEDIATE REFRESH COMPLETE DISTRIBUTED BY HASH(pk) "
+                + "PROPERTIES ('replication_num' = '1') "
+                + "AS SELECT t1.pk, v1, v2 FROM test.t1, test.t2 WHERE test.t1.pk = test.t2.pk").execute();
+        Assertions.assertNull(connectContext.getState().getErrorCode(), connectContext.getState().getErrorMessage());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"AGGREGATE", "UNIQUE", "DUPLICATE"})
+    public void testCreateWithAliases(String keyType) throws Exception {
+        String aggregation = keyType.equals("AGGREGATE") ? "SUM" : "";
+        createTable("CREATE TABLE test.t1 ("
+                + "  pk INT,"
+                + "  v1 INT " + aggregation
+                + ") " + keyType + " KEY (pk)"
+                + "DISTRIBUTED BY HASH(pk) BUCKETS 1 PROPERTIES ('replication_num' = '1')");
+        createTable("CREATE TABLE test.t2 ("
+                + "  pk INT,"
+                + "  v2 INT " + aggregation
+                + ") " + keyType + " KEY (pk)"
+                + "DISTRIBUTED BY HASH(pk) BUCKETS 1 PROPERTIES ('replication_num' = '1')");
+        new StmtExecutor(connectContext, "CREATE MATERIALIZED VIEW mv "
+                + "BUILD IMMEDIATE REFRESH COMPLETE KEY (mpk) DISTRIBUTED BY HASH(mpk) "
+                + "PROPERTIES ('replication_num' = '1') "
+                + "AS SELECT t1.pk AS mpk, v1, v2 FROM test.t1, test.t2 WHERE test.t1.pk = test.t2.pk").execute();
+        Assertions.assertNull(connectContext.getState().getErrorCode(), connectContext.getState().getErrorMessage());
+
+        connectContext.getEnv().dropMaterializedView(
+                (DropMaterializedViewStmt) parseAndAnalyzeStmt("DROP MATERIALIZED VIEW mv"));
+        new StmtExecutor(connectContext, "CREATE MATERIALIZED VIEW mv "
+                + "BUILD IMMEDIATE REFRESH COMPLETE DISTRIBUTED BY HASH(mpk) "
+                + "PROPERTIES ('replication_num' = '1') "
+                + "AS SELECT t1.pk as mpk, v1, v2 FROM test.t1, test.t2 WHERE test.t1.pk = test.t2.pk").execute();
+        Assertions.assertNull(connectContext.getState().getErrorCode(), connectContext.getState().getErrorMessage());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"AGGREGATE", "UNIQUE", "DUPLICATE"})
+    public void testCreateWithPartition(String keyType) throws Exception {
+        String aggregation = keyType.equals("AGGREGATE") ? "SUM" : "";
+        createTable("CREATE TABLE test.t1 ("
+                + "  pk INT NOT NULL,"
+                + "  v1 INT " + aggregation
+                + ") " + keyType + " KEY (pk)"
+                + "PARTITION BY RANGE(pk) ("
+                + "  PARTITION p1 VALUES LESS THAN ('10'),"
+                + "  PARTITION p2 VALUES LESS THAN ('20')"
+                + ")"
+                + "DISTRIBUTED BY HASH(pk) BUCKETS 1 PROPERTIES ('replication_num' = '1')");
+        createTable("CREATE TABLE test.t2 ("
+                + "  pk INT NOT NULL,"
+                + "  v2 INT " + aggregation
+                + ") " + keyType + " KEY (pk)"
+                + "PARTITION BY LIST(pk) ("
+                + "  PARTITION odd VALUES IN ('10', '30', '50', '70', '90'),"
+                + "  PARTITION even VALUES IN ('20', '40', '60', '80')"
+                + ")"
+                + "DISTRIBUTED BY HASH(pk) BUCKETS 1 PROPERTIES ('replication_num' = '1')");
+
+        new StmtExecutor(connectContext, "CREATE MATERIALIZED VIEW mv "
+                + "BUILD IMMEDIATE REFRESH COMPLETE KEY (pk) "
+                + "PARTITION BY (t1.pk)"
+                + "DISTRIBUTED BY HASH(pk) "
+                + "PROPERTIES ('replication_num' = '1') "
+                + "AS SELECT t1.pk, v1, v2 FROM test.t1, test.t2 WHERE test.t1.pk = test.t2.pk").execute();
+        Assertions.assertNull(connectContext.getState().getErrorCode(), connectContext.getState().getErrorMessage());
+
+        connectContext.getEnv().dropMaterializedView(
+                (DropMaterializedViewStmt) parseAndAnalyzeStmt("DROP MATERIALIZED VIEW mv"));
+        new StmtExecutor(connectContext, "CREATE MATERIALIZED VIEW mv "
+                + "BUILD IMMEDIATE REFRESH COMPLETE KEY (pk) "
+                + "PARTITION BY (t2.pk)"
+                + "DISTRIBUTED BY HASH(pk) "
+                + "PROPERTIES ('replication_num' = '1') "
+                + "AS SELECT t2.pk, v1, v2 FROM test.t1, test.t2 WHERE test.t1.pk = test.t2.pk").execute();
+        Assertions.assertNull(connectContext.getState().getErrorCode(), connectContext.getState().getErrorMessage());
+
+        connectContext.getEnv().dropMaterializedView(
+                (DropMaterializedViewStmt) parseAndAnalyzeStmt("DROP MATERIALIZED VIEW mv"));
+
+        connectContext.getState().reset();
+        new StmtExecutor(connectContext, "CREATE MATERIALIZED VIEW mv "
+                + "BUILD IMMEDIATE REFRESH COMPLETE KEY (pk) "
+                + "PARTITION BY (t1.pk)"
+                + "DISTRIBUTED BY HASH(pk) "
+                + "PROPERTIES ('replication_num' = '1') "
+                + "AS SELECT t2.pk, v1, v2 FROM test.t1, test.t2 WHERE test.t1.pk = test.t2.pk").execute();
+        Assertions.assertTrue(
+                connectContext.getState().getErrorMessage().contains("Failed to map the partition column name"));
+
+        connectContext.getState().reset();
+        new StmtExecutor(connectContext, "CREATE MATERIALIZED VIEW mv "
+                + "BUILD IMMEDIATE REFRESH COMPLETE KEY (pk) "
+                + "PARTITION BY (v1)"
+                + "DISTRIBUTED BY HASH(pk) "
+                + "PROPERTIES ('replication_num' = '1') "
+                + "AS SELECT t2.pk, v1, v2 FROM test.t1, test.t2 WHERE test.t1.pk = test.t2.pk").execute();
+        Assertions.assertTrue(
+                connectContext.getState().getErrorMessage()
+                        .contains("The partition columns doesn't match the ones in base table"));
+    }
+}

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -461,6 +461,13 @@ under the License.
                 <version>${junit.version}</version>
                 <scope>test</scope>
             </dependency>
+            <!-- https://mvnrepository.com/artifact/org.junit.jupiter/junit-jupiter-params -->
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-params</artifactId>
+                <version>${junit.version}</version>
+                <scope>test</scope>
+            </dependency>
             <!-- https://mvnrepository.com/artifact/org.apache.thrift/libthrift -->
             <dependency>
                 <groupId>org.apache.thrift</groupId>


### PR DESCRIPTION
# Proposed changes

Issue Number: close #14929

## Problem summary

When we create a materialized view for multiple tables, users may not figure out the partition rule for the materialized view, because the query result can be too complex. If the query result doesn't match one of the partition rules, the insertion will fail.

We can resolve this issue by mapping the partition rule of base table to the materialized view. As a result, users don't need specify the partition rules and query results are all valid because they are retrieved from the partitions of the base table.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [x] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

