### PR TITLE
[fix](csv-reader) fix be crash when reading invalid value

### DIFF
--- a/be/src/vec/core/block.cpp
+++ b/be/src/vec/core/block.cpp
@@ -320,6 +320,19 @@ size_t Block::rows() const {
     return 0;
 }
 
+std::string Block::each_col_size() {
+    std::stringstream ss;
+    for (const auto& elem : data) {
+        if (elem.column) {
+            ss << elem.column->size() << " | ";
+        } else {
+            ss << "-1 | ";
+        }
+    }
+    return ss.str();
+}
+
+
 void Block::set_num_rows(size_t length) {
     if (rows() > length) {
         for (auto& elem : data) {

--- a/be/src/vec/core/block.cpp
+++ b/be/src/vec/core/block.cpp
@@ -332,7 +332,6 @@ std::string Block::each_col_size() {
     return ss.str();
 }
 
-
 void Block::set_num_rows(size_t length) {
     if (rows() > length) {
         for (auto& elem : data) {

--- a/be/src/vec/core/block.h
+++ b/be/src/vec/core/block.h
@@ -180,6 +180,8 @@ public:
     /// Returns number of rows from first column in block, not equal to nullptr. If no columns, returns 0.
     size_t rows() const;
 
+    std::string each_col_size();
+
     // Cut the rows in block, use in LIMIT operation
     void set_num_rows(size_t length);
 


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

when reading text format hive table with invalid value format, be may crash

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

