### PR TITLE
[improvement](query)optimize select stmt with limit 0 

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -1107,13 +1107,13 @@ public class StmtExecutor implements ProfileWriter {
         }
 
         // handle select .. from xx  limit 0
-        if(parsedStmt instanceof SelectStmt){
+        if (parsedStmt instanceof SelectStmt) {
             SelectStmt parsedSelectStmt = (SelectStmt) parsedStmt;
-            if(parsedSelectStmt.getLimit() == 0){
+            if (parsedSelectStmt.getLimit() == 0) {
                 LOG.info("ignore handle limit 0 ,sql:{}", parsedSelectStmt.toSql());
                 sendFields(queryStmt.getColLabels(), exprToType(queryStmt.getResultExprs()));
                 context.getState().setEof();
-                return ;
+                return;
             }
         }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -1108,13 +1108,13 @@ public class StmtExecutor implements ProfileWriter {
 
         // handle select .. from xx  limit 0
         if (parsedStmt instanceof SelectStmt) {
-            SelectStmt parsedSelectStmt = (SelectStmt) parsedStmt;
-            if (parsedSelectStmt.getLimit() == 0) {
-                LOG.info("ignore handle limit 0 ,sql:{}", parsedSelectStmt.toSql());
-                sendFields(queryStmt.getColLabels(), exprToType(queryStmt.getResultExprs()));
-                context.getState().setEof();
-                return;
-            }
+            // SelectStmt parsedSelectStmt = (SelectStmt) parsedStmt;
+            // if (parsedSelectStmt.getLimit() == 0) {
+            //     LOG.info("ignore handle limit 0 ,sql:{}", parsedSelectStmt.toSql());
+            //     sendFields(queryStmt.getColLabels(), exprToType(queryStmt.getResultExprs()));
+            //     context.getState().setEof();
+            //     return;
+            // }
         }
 
         sendResult(isOutfileQuery, false, queryStmt, channel, null, null);

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -1105,6 +1105,18 @@ public class StmtExecutor implements ProfileWriter {
             handleCacheStmt(cacheAnalyzer, channel, (SelectStmt) queryStmt);
             return;
         }
+
+        // handle select .. from xx  limit 0
+        if(parsedStmt instanceof SelectStmt){
+            SelectStmt parsedSelectStmt = (SelectStmt) parsedStmt;
+            if(parsedSelectStmt.getLimit() == 0){
+                LOG.info("ignore handle limit 0 ,sql:{}", parsedSelectStmt.toSql());
+                sendFields(queryStmt.getColLabels(), exprToType(queryStmt.getResultExprs()));
+                context.getState().setEof();
+                return ;
+            }
+        }
+
         sendResult(isOutfileQuery, false, queryStmt, channel, null, null);
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -1108,13 +1108,13 @@ public class StmtExecutor implements ProfileWriter {
 
         // handle select .. from xx  limit 0
         if (parsedStmt instanceof SelectStmt) {
-            // SelectStmt parsedSelectStmt = (SelectStmt) parsedStmt;
-            // if (parsedSelectStmt.getLimit() == 0) {
-            //     LOG.info("ignore handle limit 0 ,sql:{}", parsedSelectStmt.toSql());
-            //     sendFields(queryStmt.getColLabels(), exprToType(queryStmt.getResultExprs()));
-            //     context.getState().setEof();
-            //     return;
-            // }
+            SelectStmt parsedSelectStmt = (SelectStmt) parsedStmt;
+            if (parsedSelectStmt.getLimit() == 0) {
+                LOG.info("ignore handle limit 0 ,sql:{}", parsedSelectStmt.toSql());
+                sendFields(queryStmt.getColLabels(), exprToType(queryStmt.getResultExprs()));
+                context.getState().setEof();
+                return;
+            }
         }
 
         sendResult(isOutfileQuery, false, queryStmt, channel, null, null);


### PR DESCRIPTION
# Proposed changes
In some scenarios of automatic report generation platform, field and type information is frequently obtained through select followed by limit 0
select * from .. limit 0
Doris has two problems in processing
1、Limit 0 SQL will also be sent to the be node for meaningless queries
2、When there are multiple nested scenes, it will lead to some strange cores

Some optimizations have been made for this purpose. The sql of limit 0 is not sent to be any more. It is returned directly after carrying the meta information on the fe side

在一些自动化报表生成平台场景会频繁通过select 接一个limit 0的方式来获取字段和类型的信息
    select * from ..  limit 0 
![image](https://user-images.githubusercontent.com/11487604/206621209-d70f0170-a22b-474e-b77d-10cf338136fe.png)

doris在处理时存在两个问题
1、limit 0 的sql也会发到be节点，做无意义的查询
2、在里面有多层嵌套场景下，会导致be一些奇怪的core
为此做了一些优化，limit 0 的sql不在发送到be，在fe侧携带meta信息后直接返回



Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

