### PR TITLE
[Fix](Table Valued function) fix the problem that can not catchthe exception thrown by the TableValuedFunctionRef constructor

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/SelectStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/SelectStmt.java
@@ -304,6 +304,7 @@ public class SelectStmt extends QueryStmt {
                 inlineStmt.getTables(analyzer, expandView, tableMap, parentViewNameSet);
             } else if (tblRef instanceof TableValuedFunctionRef) {
                 TableValuedFunctionRef tblFuncRef = (TableValuedFunctionRef) tblRef;
+                tblFuncRef.analyze(analyzer);
                 tableMap.put(tblFuncRef.getTableFunction().getTable().getId(),
                         tblFuncRef.getTableFunction().getTable());
             } else {

--- a/fe/fe-core/src/main/java/org/apache/doris/tablefunction/ExternalFileTableValuedFunction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/tablefunction/ExternalFileTableValuedFunction.java
@@ -135,13 +135,17 @@ public abstract class ExternalFileTableValuedFunction extends TableValuedFunctio
         return "";
     }
 
-    protected void parseFile() throws UserException {
+    protected void parseFile() throws AnalysisException {
         String path = getFilePath();
         BrokerDesc brokerDesc = getBrokerDesc();
-        BrokerUtil.parseFile(path, brokerDesc, fileStatuses);
+        try {
+            BrokerUtil.parseFile(path, brokerDesc, fileStatuses);
+        } catch (UserException e) {
+            throw new AnalysisException("parse file failed, path = " + path);
+        }
     }
 
-    protected void parseProperties(Map<String, String> validParams) throws UserException {
+    protected void parseProperties(Map<String, String> validParams) throws AnalysisException {
         String formatString = validParams.getOrDefault(FORMAT, "").toLowerCase();
         switch (formatString) {
             case "csv":
@@ -296,7 +300,7 @@ public abstract class ExternalFileTableValuedFunction extends TableValuedFunctio
             break;
         }
         if (firstFile == null) {
-            throw new AnalysisException("Can not get first file, please check s3 uri.");
+            throw new AnalysisException("Can not get first file, please check uri.");
         }
 
         // set TFileRangeDesc

--- a/fe/fe-core/src/main/java/org/apache/doris/tablefunction/HdfsTableValuedFunction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/tablefunction/HdfsTableValuedFunction.java
@@ -21,7 +21,6 @@ import org.apache.doris.analysis.BrokerDesc;
 import org.apache.doris.analysis.ExportStmt;
 import org.apache.doris.analysis.StorageBackend.StorageType;
 import org.apache.doris.common.AnalysisException;
-import org.apache.doris.common.UserException;
 import org.apache.doris.common.util.URI;
 import org.apache.doris.thrift.TFileType;
 
@@ -65,7 +64,7 @@ public class HdfsTableValuedFunction extends ExternalFileTableValuedFunction {
     private URI hdfsUri;
     private String filePath;
 
-    public HdfsTableValuedFunction(Map<String, String> params) throws UserException {
+    public HdfsTableValuedFunction(Map<String, String> params) throws AnalysisException {
         Map<String, String> fileFormatParams = new CaseInsensitiveMap();
         locationProperties = Maps.newHashMap();
         for (String key : params.keySet()) {

--- a/fe/fe-core/src/main/java/org/apache/doris/tablefunction/NumbersTableValuedFunction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/tablefunction/NumbersTableValuedFunction.java
@@ -22,7 +22,6 @@ import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.PrimitiveType;
 import org.apache.doris.common.AnalysisException;
-import org.apache.doris.common.UserException;
 import org.apache.doris.planner.DataGenScanNode;
 import org.apache.doris.planner.PlanNodeId;
 import org.apache.doris.planner.ScanNode;
@@ -64,9 +63,9 @@ public class NumbersTableValuedFunction extends DataGenTableValuedFunction {
     /**
      * Constructor.
      * @param params params from user
-     * @throws UserException exception
+     * @throws AnalysisException exception
      */
-    public NumbersTableValuedFunction(Map<String, String> params) throws UserException {
+    public NumbersTableValuedFunction(Map<String, String> params) throws AnalysisException {
         Map<String, String> validParams = Maps.newHashMap();
         for (String key : params.keySet()) {
             if (!PROPERTIES_SET.contains(key.toLowerCase())) {
@@ -78,17 +77,17 @@ public class NumbersTableValuedFunction extends DataGenTableValuedFunction {
         try {
             tabletsNum = Integer.parseInt(validParams.getOrDefault(BACKEND_NUM, "1"));
         } catch (NumberFormatException e) {
-            throw new UserException("can not parse `backend_num` param to natural number");
+            throw new AnalysisException("can not parse `backend_num` param to natural number");
         }
         String numberStr = validParams.get(NUMBER);
         if (!Strings.isNullOrEmpty(numberStr)) {
             try {
                 totalNumbers = Long.parseLong(numberStr);
             } catch (NumberFormatException e) {
-                throw new UserException("can not parse `number` param to natural number");
+                throw new AnalysisException("can not parse `number` param to natural number");
             }
         } else {
-            throw new UserException(
+            throw new AnalysisException(
                     "can not find `number` param, please specify `number`, like: numbers(\"number\" = \"10\")");
         }
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/tablefunction/S3TableValuedFunction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/tablefunction/S3TableValuedFunction.java
@@ -64,7 +64,7 @@ public class S3TableValuedFunction extends ExternalFileTableValuedFunction {
     private String virtualBucket;
     private boolean forceVirtualHosted;
 
-    public S3TableValuedFunction(Map<String, String> params) throws UserException {
+    public S3TableValuedFunction(Map<String, String> params) throws AnalysisException {
         Map<String, String> validParams = new CaseInsensitiveMap();
         for (String key : params.keySet()) {
             if (!PROPERTIES_SET.contains(key.toLowerCase()) && !FILE_FORMAT_PROPERTIES.contains(key.toLowerCase())) {
@@ -82,7 +82,11 @@ public class S3TableValuedFunction extends ExternalFileTableValuedFunction {
             forceVirtualHosted = !Boolean.valueOf(validParams.get(USE_PATH_STYLE)).booleanValue();
         }
 
-        s3uri = S3URI.create(validParams.get(S3_URI), forceVirtualHosted);
+        try {
+            s3uri = S3URI.create(validParams.get(S3_URI), forceVirtualHosted);
+        } catch (UserException e) {
+            throw new AnalysisException("parse s3 uri failed, uri = " + validParams.get(S3_URI));
+        }
         if (forceVirtualHosted) {
             // s3uri.getVirtualBucket() is: virtualBucket.endpoint, Eg:
             //          uri: http://my_bucket.cos.ap-beijing.myqcloud.com/file.txt

--- a/fe/fe-core/src/main/java/org/apache/doris/tablefunction/TableValuedFunctionIf.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/tablefunction/TableValuedFunctionIf.java
@@ -22,7 +22,6 @@ import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.FunctionGenTable;
 import org.apache.doris.catalog.TableIf;
 import org.apache.doris.common.AnalysisException;
-import org.apache.doris.common.UserException;
 import org.apache.doris.planner.PlanNodeId;
 import org.apache.doris.planner.ScanNode;
 
@@ -42,7 +41,7 @@ public abstract class TableValuedFunctionIf {
 
     // All table functions should be registered here
     public static TableValuedFunctionIf getTableFunction(String funcName, Map<String, String> params)
-                                                        throws UserException {
+                                                        throws AnalysisException {
         switch (funcName.toLowerCase()) {
             case NumbersTableValuedFunction.NAME:
                 return new NumbersTableValuedFunction(params);
@@ -51,7 +50,7 @@ public abstract class TableValuedFunctionIf {
             case HdfsTableValuedFunction.NAME:
                 return new HdfsTableValuedFunction(params);
             default:
-                throw new UserException("Could not find table function " + funcName);
+                throw new AnalysisException("Could not find table function " + funcName);
         }
     }
 


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

fix the problem that can not catchthe exception thrown by the TableValuedFunctionRef constructor

## Problem summary

Put the generation of `TableValuedFunctionIf` in the analye function, instead of the generation in the TableValuedFunctionRef constructor.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

