### PR TITLE
[Fix](multi catalog)Check orc file reader is not null before using it.

### DIFF
--- a/be/src/vec/exec/format/orc/vorc_reader.cpp
+++ b/be/src/vec/exec/format/orc/vorc_reader.cpp
@@ -96,10 +96,12 @@ OrcReader::~OrcReader() {
 void OrcReader::close() {
     if (!_closed) {
         if (_profile != nullptr) {
-            auto& fst = _file_reader->statistics();
-            COUNTER_UPDATE(_orc_profile.read_time, fst.read_time);
-            COUNTER_UPDATE(_orc_profile.read_calls, fst.read_calls);
-            COUNTER_UPDATE(_orc_profile.read_bytes, fst.read_bytes);
+            if (_file_reader != nullptr) {
+                auto& fst = _file_reader->statistics();
+                COUNTER_UPDATE(_orc_profile.read_time, fst.read_time);
+                COUNTER_UPDATE(_orc_profile.read_calls, fst.read_calls);
+                COUNTER_UPDATE(_orc_profile.read_bytes, fst.read_bytes);
+            }
             COUNTER_UPDATE(_orc_profile.column_read_time, _statistics.column_read_time);
             COUNTER_UPDATE(_orc_profile.get_batch_time, _statistics.get_batch_time);
             COUNTER_UPDATE(_orc_profile.parse_meta_time, _statistics.parse_meta_time);


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

The external table file path cache may out of date, which will cause orc reader to visit non-exist files. In this case, orc file reader is nullptr. This pr is to check the reader before using it to avoid core dump of visiting nullptr.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

