### PR TITLE
[fix](multi catalog)Fix convert_to_doris_type missing break for some cases.

### DIFF
--- a/be/src/vec/exec/format/parquet/schema_desc.cpp
+++ b/be/src/vec/exec/format/parquet/schema_desc.cpp
@@ -228,6 +228,7 @@ TypeDescriptor FieldDescriptor::convert_to_doris_type(tparquet::ConvertedType::t
     switch (convertedType) {
     case tparquet::ConvertedType::type::UTF8:
         type.type = TYPE_STRING;
+        break;
     case tparquet::ConvertedType::type::DECIMAL:
         type.type = TYPE_DECIMALV2;
         type.precision = 27;
@@ -250,6 +251,7 @@ TypeDescriptor FieldDescriptor::convert_to_doris_type(tparquet::ConvertedType::t
     case tparquet::ConvertedType::type::INT_16:
     case tparquet::ConvertedType::type::INT_32:
         type.type = TYPE_INT;
+        break;
     case tparquet::ConvertedType::type::UINT_32:
     case tparquet::ConvertedType::type::UINT_64:
     case tparquet::ConvertedType::type::INT_64:


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

Some cases of convert_to_doris_type are missing break, cause convert to wrong type.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

