### PR TITLE
[fix](load) fix that flush memtable concurrently may cause data inconsistency

### DIFF
--- a/be/src/olap/memtable_flush_executor.cpp
+++ b/be/src/olap/memtable_flush_executor.cpp
@@ -91,9 +91,9 @@ void FlushToken::_flush_memtable(MemTable* memtable, int64_t submit_task_time) {
     Status s = memtable->flush();
     if (!s) {
         LOG(WARNING) << "Flush memtable failed with res = " << s;
+        // If s is not ok, ignore the code, just use other code is ok
+        _flush_status.store(ErrorCode::INTERNAL_ERROR);
     }
-    // If s is not ok, ignore the code, just use other code is ok
-    _flush_status.store(s.ok() ? OK : ErrorCode::INTERNAL_ERROR);
     if (_flush_status.load() != OK) {
         return;
     }

--- a/be/src/olap/task/engine_publish_version_task.cpp
+++ b/be/src/olap/task/engine_publish_version_task.cpp
@@ -228,11 +228,10 @@ void TabletPublishTxnTask::handle() {
         return;
     }
     _engine_publish_version_task->add_succ_tablet_id(_tablet_info.tablet_id);
-    VLOG_NOTICE << "publish version successfully on tablet. tablet=" << _tablet->full_name()
-                << ", transaction_id=" << _transaction_id << ", version=" << _version.first
-                << ", res=" << publish_status;
-
-    return;
+    LOG(INFO) << "publish version successfully on tablet"
+              << ", table_id=" << _tablet->table_id() << ", tablet=" << _tablet->full_name()
+              << ", transaction_id=" << _transaction_id << ", version=" << _version.first
+              << ", num_rows=" << _rowset->num_rows() << ", res=" << publish_status;
 }
 
 } // namespace doris


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary
Problem: 
Inconsistent result occurs when `select count(*) from lineitem` executed multiple times in tpch_sf100_unique_p2_load_one_step regression case.

Why:
When flush memtable concurrently, the value of `_flush_status` will be overwritten by other threads even if it fails.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

