### PR TITLE
[fix](nereids)FoldConstantRuleOnFe bug: npe if function do not have child, like current_date

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rewrite/rules/FoldConstantRuleOnFE.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rewrite/rules/FoldConstantRuleOnFE.java
@@ -218,6 +218,10 @@ public class FoldConstantRuleOnFE extends AbstractExpressionRewriteRule {
 
     @Override
     public Expression visitBoundFunction(BoundFunction boundFunction, ExpressionRewriteContext context) {
+        //functions, like current_date, do not have arg
+        if (boundFunction.getArguments().isEmpty()) {
+            return boundFunction;
+        }
         List<Expression> newArgs = boundFunction.getArguments().stream().map(arg -> process(arg, context))
                 .collect(Collectors.toList());
         if (ExpressionUtils.isAllLiteral(newArgs)) {


### PR DESCRIPTION
# Proposed changes
FoldConstantRuleOnFe missed one type of function, which do not have input arguments, like current_date

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

