### PR TITLE
[fix](segcompaction) fix segcompaction failed for newly created segment

### DIFF
--- a/be/src/olap/rowset/beta_rowset_writer.cpp
+++ b/be/src/olap/rowset/beta_rowset_writer.cpp
@@ -383,12 +383,12 @@ void BetaRowsetWriter::compact_segments(SegCompactionCandidatesSharedPtr segment
 }
 
 Status BetaRowsetWriter::_load_noncompacted_segments(
-        std::vector<segment_v2::SegmentSharedPtr>* segments) {
+        std::vector<segment_v2::SegmentSharedPtr>* segments, size_t num) {
     auto fs = _rowset_meta->fs();
     if (!fs) {
         return Status::Error<INIT_FAILED>();
     }
-    for (int seg_id = _segcompacted_point; seg_id < _num_segment; ++seg_id) {
+    for (int seg_id = _segcompacted_point; seg_id < num; ++seg_id) {
         auto seg_path =
                 BetaRowset::segment_file_path(_context.rowset_dir, _context.rowset_id, seg_id);
         auto cache_path =
@@ -415,7 +415,8 @@ Status BetaRowsetWriter::_load_noncompacted_segments(
 Status BetaRowsetWriter::_find_longest_consecutive_small_segment(
         SegCompactionCandidatesSharedPtr segments) {
     std::vector<segment_v2::SegmentSharedPtr> all_segments;
-    RETURN_NOT_OK(_load_noncompacted_segments(&all_segments));
+    // subtract one to skip last (maybe active) segment
+    RETURN_NOT_OK(_load_noncompacted_segments(&all_segments, _num_segment - 1));
 
     if (VLOG_DEBUG_IS_ON) {
         vlog_buffer.clear();
@@ -473,7 +474,7 @@ Status BetaRowsetWriter::_get_segcompaction_candidates(SegCompactionCandidatesSh
         VLOG_DEBUG << "segcompaction last few segments";
         // currently we only rename remaining segments to reduce wait time
         // so that transaction can be committed ASAP
-        RETURN_NOT_OK(_load_noncompacted_segments(segments.get()));
+        RETURN_NOT_OK(_load_noncompacted_segments(segments.get(), _num_segment));
         for (int i = 0; i < segments->size(); ++i) {
             RETURN_NOT_OK(_rename_compacted_segment_plain(_segcompacted_point++));
         }

--- a/be/src/olap/rowset/beta_rowset_writer.h
+++ b/be/src/olap/rowset/beta_rowset_writer.h
@@ -110,7 +110,8 @@ private:
     Status _delete_original_segments(uint32_t begin, uint32_t end);
     Status _rename_compacted_segments(int64_t begin, int64_t end);
     Status _rename_compacted_segment_plain(uint64_t seg_id);
-    Status _load_noncompacted_segments(std::vector<segment_v2::SegmentSharedPtr>* segments);
+    Status _load_noncompacted_segments(std::vector<segment_v2::SegmentSharedPtr>* segments,
+                                       size_t num);
     Status _find_longest_consecutive_small_segment(SegCompactionCandidatesSharedPtr segments);
     Status _get_segcompaction_candidates(SegCompactionCandidatesSharedPtr& segments, bool is_last);
     Status _wait_flying_segcompaction();

--- a/be/test/olap/segcompaction_test.cpp
+++ b/be/test/olap/segcompaction_test.cpp
@@ -253,6 +253,7 @@ TEST_F(SegCompactionTest, SegCompactionThenRead) {
         ls.push_back("10047_3.dat");
         ls.push_back("10047_4.dat");
         ls.push_back("10047_5.dat");
+        ls.push_back("10047_6.dat");
         EXPECT_TRUE(check_dir(ls));
     }
 


### PR DESCRIPTION
Currently, newly created segment could be chosen to be compaction candidate, which is prone to bugs and segment file open failures. We should skip last (maybe active) segment while doing segcompaction.

Signed-off-by: freemandealer <freeman.zhang1992@gmail.com>

# Proposed changes

Issue Number: close #15022

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

