### PR TITLE
[fix](load) fix that flush memtable concurrently may cause data inconsistency

### DIFF
--- a/be/src/olap/memtable_flush_executor.cpp
+++ b/be/src/olap/memtable_flush_executor.cpp
@@ -69,7 +69,11 @@ void FlushToken::_flush_memtable(std::shared_ptr<MemTable> memtable, int64_t sub
 
     MonotonicStopWatch timer;
     timer.start();
-    _flush_status.store(memtable->flush());
+    OLAPStatus s = memtable->flush();
+    if (s != OLAP_SUCCESS) {
+        LOG(WARNING) << "Flush memtable failed with res = " << s;
+        _flush_status.store(s);
+    }
     if (_flush_status.load() != OLAP_SUCCESS) {
         return;
     }


### PR DESCRIPTION

# Proposed changes

Issue Number: close #xxx

## Problem summary

cherry-pick from: #15005 

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

