### PR TITLE
[feature](file reader) Merge stream_load_pipe to the new file reader

### DIFF
--- a/be/src/io/CMakeLists.txt
+++ b/be/src/io/CMakeLists.txt
@@ -45,6 +45,7 @@ set(IO_FILES
     fs/hdfs_file_reader.cpp
     fs/broker_file_system.cpp
     fs/broker_file_reader.cpp
+    fs/stream_load_pipe_reader.cpp
     cache/dummy_file_cache.cpp
     cache/file_cache.cpp
     cache/file_cache_manager.cpp

--- a/be/src/io/fs/stream_load_pipe_reader.cpp
+++ b/be/src/io/fs/stream_load_pipe_reader.cpp
@@ -1,0 +1,210 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "stream_load_pipe_reader.h"
+
+#include <gen_cpp/internal_service.pb.h>
+
+#include "runtime/thread_context.h"
+#include "util/bit_util.h"
+
+namespace doris {
+namespace io {
+StreamLoadPipeReader::StreamLoadPipeReader(size_t max_buffered_bytes, size_t min_chunk_size,
+                                           int64_t total_length, bool use_proto)
+        : _buffered_bytes(0),
+          _proto_buffered_bytes(0),
+          _max_buffered_bytes(max_buffered_bytes),
+          _min_chunk_size(min_chunk_size),
+          _total_length(total_length),
+          _use_proto(use_proto) {}
+
+StreamLoadPipeReader::~StreamLoadPipeReader() {
+    SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER(ExecEnv::GetInstance()->orphan_mem_tracker());
+    while (!_buf_queue.empty()) {
+        _buf_queue.pop_front();
+    }
+}
+
+Status StreamLoadPipeReader::read_at(size_t /*offset*/, Slice result, const IOContext& /*io_ctx*/,
+                                     size_t* bytes_read) {
+    SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER(ExecEnv::GetInstance()->orphan_mem_tracker());
+    *bytes_read = 0;
+    size_t bytes_req = result.size;
+    char* to = result.data;
+    if (UNLIKELY(bytes_req == 0)) {
+        return Status::OK();
+    }
+    while (*bytes_read < bytes_req) {
+        std::unique_lock<std::mutex> l(_lock);
+        while (!_cancelled && !_finished && _buf_queue.empty()) {
+            _get_cond.wait(l);
+        }
+        // cancelled
+        if (_cancelled) {
+            return Status::InternalError("cancelled: {}", _cancelled_reason);
+        }
+        // finished
+        if (_buf_queue.empty()) {
+            DCHECK(_finished);
+            // break the while loop
+            bytes_req = *bytes_read;
+            return Status::OK();
+        }
+        auto buf = _buf_queue.front();
+        int64_t copy_size = std::min(bytes_req - *bytes_read, buf->remaining());
+        buf->get_bytes(to + *bytes_read, copy_size);
+        *bytes_read += copy_size;
+        if (!buf->has_remaining()) {
+            _buf_queue.pop_front();
+            _buffered_bytes -= buf->limit;
+            _put_cond.notify_one();
+        }
+    }
+    DCHECK(*bytes_read == bytes_req)
+            << "*bytes_read=" << *bytes_read << ", bytes_req=" << bytes_req;
+    return Status::OK();
+}
+
+Status StreamLoadPipeReader::append_and_flush(const char* data, size_t size,
+                                              size_t proto_byte_size) {
+    ByteBufferPtr buf = ByteBuffer::allocate(BitUtil::RoundUpToPowerOfTwo(size + 1));
+    buf->put_bytes(data, size);
+    buf->flip();
+    return _append(buf, proto_byte_size);
+}
+
+Status StreamLoadPipeReader::append(const char* data, size_t size) {
+    size_t pos = 0;
+    if (_write_buf != nullptr) {
+        if (size < _write_buf->remaining()) {
+            _write_buf->put_bytes(data, size);
+            return Status::OK();
+        } else {
+            pos = _write_buf->remaining();
+            _write_buf->put_bytes(data, pos);
+
+            _write_buf->flip();
+            RETURN_IF_ERROR(_append(_write_buf));
+            _write_buf.reset();
+        }
+    }
+    // need to allocate a new chunk, min chunk is 64k
+    size_t chunk_size = std::max(_min_chunk_size, size - pos);
+    chunk_size = BitUtil::RoundUpToPowerOfTwo(chunk_size);
+    _write_buf = ByteBuffer::allocate(chunk_size);
+    _write_buf->put_bytes(data + pos, size - pos);
+    return Status::OK();
+}
+
+Status StreamLoadPipeReader::append(const ByteBufferPtr& buf) {
+    if (_write_buf != nullptr) {
+        _write_buf->flip();
+        RETURN_IF_ERROR(_append(_write_buf));
+        _write_buf.reset();
+    }
+    return _append(buf);
+}
+
+// read the next buffer from _buf_queue
+Status StreamLoadPipeReader::_read_next_buffer(std::unique_ptr<uint8_t[]>* data, int64_t* length) {
+    std::unique_lock<std::mutex> l(_lock);
+    while (!_cancelled && !_finished && _buf_queue.empty()) {
+        _get_cond.wait(l);
+    }
+    // cancelled
+    if (_cancelled) {
+        return Status::InternalError("cancelled: {}", _cancelled_reason);
+    }
+    // finished
+    if (_buf_queue.empty()) {
+        DCHECK(_finished);
+        data->reset();
+        *length = 0;
+        return Status::OK();
+    }
+    auto buf = _buf_queue.front();
+    *length = buf->remaining();
+    data->reset(new uint8_t[*length]);
+    buf->get_bytes((char*)(data->get()), *length);
+    _buf_queue.pop_front();
+    _buffered_bytes -= buf->limit;
+    if (_use_proto) {
+        PDataRow** ptr = reinterpret_cast<PDataRow**>(data->get());
+        _proto_buffered_bytes -= (sizeof(PDataRow*) + (*ptr)->GetCachedSize());
+    }
+    _put_cond.notify_one();
+    return Status::OK();
+}
+
+Status StreamLoadPipeReader::_append(const ByteBufferPtr& buf, size_t proto_byte_size) {
+    {
+        std::unique_lock<std::mutex> l(_lock);
+        // if _buf_queue is empty, we append this buf without size check
+        if (_use_proto) {
+            while (!_cancelled && !_buf_queue.empty() &&
+                   (_proto_buffered_bytes + proto_byte_size > _max_buffered_bytes)) {
+                _put_cond.wait(l);
+            }
+        } else {
+            while (!_cancelled && !_buf_queue.empty() &&
+                   _buffered_bytes + buf->remaining() > _max_buffered_bytes) {
+                _put_cond.wait(l);
+            }
+        }
+        if (_cancelled) {
+            return Status::InternalError("cancelled: {}", _cancelled_reason);
+        }
+        _buf_queue.push_back(buf);
+        if (_use_proto) {
+            _proto_buffered_bytes += proto_byte_size;
+        } else {
+            _buffered_bytes += buf->remaining();
+        }
+    }
+    _get_cond.notify_one();
+    return Status::OK();
+}
+
+// called when producer finished
+Status StreamLoadPipeReader::finish() {
+    if (_write_buf != nullptr) {
+        _write_buf->flip();
+        _append(_write_buf);
+        _write_buf.reset();
+    }
+    {
+        std::lock_guard<std::mutex> l(_lock);
+        _finished = true;
+    }
+    _get_cond.notify_all();
+    return Status::OK();
+}
+
+// called when producer/consumer failed
+void StreamLoadPipeReader::cancel(const std::string& reason) {
+    {
+        std::lock_guard<std::mutex> l(_lock);
+        _cancelled = true;
+        _cancelled_reason = reason;
+    }
+    _get_cond.notify_all();
+    _put_cond.notify_all();
+}
+
+} // namespace io
+} // namespace doris

--- a/be/src/io/fs/stream_load_pipe_reader.cpp
+++ b/be/src/io/fs/stream_load_pipe_reader.cpp
@@ -30,7 +30,6 @@ StreamLoadPipeReader::StreamLoadPipeReader(size_t max_buffered_bytes, size_t min
           _proto_buffered_bytes(0),
           _max_buffered_bytes(max_buffered_bytes),
           _min_chunk_size(min_chunk_size),
-          _total_length(total_length),
           _use_proto(use_proto) {}
 
 StreamLoadPipeReader::~StreamLoadPipeReader() {

--- a/be/src/io/fs/stream_load_pipe_reader.h
+++ b/be/src/io/fs/stream_load_pipe_reader.h
@@ -82,7 +82,7 @@ private:
     // The default is -1, which means that the data arrives in a stream
     // and the length is unknown.
     // size_t is unsigned, so use int64_t
-    int64_t _total_length = -1;
+    // int64_t _total_length = -1;
     bool _use_proto = false;
     std::deque<ByteBufferPtr> _buf_queue;
     std::condition_variable _put_cond;

--- a/be/src/io/fs/stream_load_pipe_reader.h
+++ b/be/src/io/fs/stream_load_pipe_reader.h
@@ -1,0 +1,97 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <condition_variable>
+#include <deque>
+
+#include "io/fs/file_reader.h"
+#include "runtime/message_body_sink.h"
+
+namespace doris {
+namespace io {
+
+const size_t kMaxPipeBufferedBytes = 4 * 1024 * 1024;
+
+class StreamLoadPipeReader : public MessageBodySink, public FileReader {
+public:
+    StreamLoadPipeReader(size_t max_buffered_bytes = kMaxPipeBufferedBytes,
+                         size_t min_chunk_size = 64 * 1024, int64_t total_length = -1,
+                         bool use_proto = false);
+
+    ~StreamLoadPipeReader() override;
+
+    Status append_and_flush(const char* data, size_t size, size_t proto_byte_size = 0);
+
+    Status append(const char* data, size_t size) override;
+
+    Status append(const ByteBufferPtr& buf) override;
+
+    Status read_at(size_t offset, Slice result, const IOContext& io_ctx,
+                   size_t* bytes_read) override;
+
+    const Path& path() const override { return _path; }
+
+    size_t size() const override { return 0; }
+
+    // called when consumer finished
+    Status close() override {
+        cancel("closed");
+        return Status::OK();
+    }
+
+    bool closed() const override { return _cancelled; }
+
+    // called when producer finished
+    Status finish() override;
+
+    // called when producer/consumer failed
+    void cancel(const std::string& reason) override;
+
+private:
+    // read the next buffer from _buf_queue
+    Status _read_next_buffer(std::unique_ptr<uint8_t[]>* data, int64_t* length);
+
+    Status _append(const ByteBufferPtr& buf, size_t proto_byte_size = 0);
+
+    // Blocking queue
+    std::mutex _lock;
+    size_t _buffered_bytes;
+    size_t _proto_buffered_bytes;
+    size_t _max_buffered_bytes;
+    size_t _min_chunk_size;
+    // The total amount of data expected to be read.
+    // In some scenarios, such as loading json format data through stream load,
+    // the data needs to be completely read before it can be parsed,
+    // so the total size of the data needs to be known.
+    // The default is -1, which means that the data arrives in a stream
+    // and the length is unknown.
+    // size_t is unsigned, so use int64_t
+    int64_t _total_length = -1;
+    bool _use_proto = false;
+    std::deque<ByteBufferPtr> _buf_queue;
+    std::condition_variable _put_cond;
+    std::condition_variable _get_cond;
+
+    ByteBufferPtr _write_buf;
+
+    // no use, only for compatibility with the `Path` interface
+    Path _path = "";
+};
+} // namespace io
+} // namespace doris

--- a/be/src/runtime/CMakeLists.txt
+++ b/be/src/runtime/CMakeLists.txt
@@ -84,6 +84,7 @@ set(RUNTIME_FILES
     stream_load/stream_load_executor.cpp
     stream_load/stream_load_recorder.cpp
     stream_load/load_stream_mgr.cpp
+    stream_load/new_load_stream_mgr.cpp
     routine_load/data_consumer.cpp
     routine_load/data_consumer_group.cpp
     routine_load/data_consumer_pool.cpp

--- a/be/src/runtime/exec_env.h
+++ b/be/src/runtime/exec_env.h
@@ -51,6 +51,7 @@ class FragmentMgr;
 class ResultCache;
 class LoadPathMgr;
 class LoadStreamMgr;
+class NewLoadStreamMgr;
 class MemTrackerLimiter;
 class MemTracker;
 class StorageEngine;
@@ -168,6 +169,7 @@ public:
     BufferPool* buffer_pool() { return _buffer_pool; }
     LoadChannelMgr* load_channel_mgr() { return _load_channel_mgr; }
     LoadStreamMgr* load_stream_mgr() { return _load_stream_mgr; }
+    NewLoadStreamMgr* new_load_stream_mgr() { return _new_load_stream_mgr; }
     SmallFileMgr* small_file_mgr() { return _small_file_mgr; }
     StoragePolicyMgr* storage_policy_mgr() { return _storage_policy_mgr; }
 
@@ -250,6 +252,7 @@ private:
     BrokerMgr* _broker_mgr = nullptr;
     LoadChannelMgr* _load_channel_mgr = nullptr;
     LoadStreamMgr* _load_stream_mgr = nullptr;
+    NewLoadStreamMgr* _new_load_stream_mgr = nullptr;
     BrpcClientCache<PBackendService_Stub>* _internal_client_cache = nullptr;
     BrpcClientCache<PFunctionService_Stub>* _function_client_cache = nullptr;
 

--- a/be/src/runtime/exec_env_init.cpp
+++ b/be/src/runtime/exec_env_init.cpp
@@ -45,6 +45,7 @@
 #include "runtime/routine_load/routine_load_task_executor.h"
 #include "runtime/small_file_mgr.h"
 #include "runtime/stream_load/load_stream_mgr.h"
+#include "runtime/stream_load/new_load_stream_mgr.h"
 #include "runtime/stream_load/stream_load_executor.h"
 #include "runtime/thread_resource_mgr.h"
 #include "runtime/tmp_file_mgr.h"
@@ -144,6 +145,7 @@ Status ExecEnv::_init(const std::vector<StorePath>& store_paths) {
     _broker_mgr = new BrokerMgr(this);
     _load_channel_mgr = new LoadChannelMgr();
     _load_stream_mgr = new LoadStreamMgr();
+    _new_load_stream_mgr = new NewLoadStreamMgr();
     _internal_client_cache = new BrpcClientCache<PBackendService_Stub>();
     _function_client_cache = new BrpcClientCache<PFunctionService_Stub>();
     _stream_load_executor = new StreamLoadExecutor(this);

--- a/be/src/runtime/routine_load/kafka_consumer_pipe_reader.h
+++ b/be/src/runtime/routine_load/kafka_consumer_pipe_reader.h
@@ -30,7 +30,6 @@ public:
     ~KafkaConsumerPipeReader() override = default;
 
     Status append_with_line_delimiter(const char* data, size_t size) {
-        LOG(INFO) << "--ftw: kafka reader";
         Status st = append(data, size);
         if (!st.ok()) {
             return st;
@@ -41,10 +40,7 @@ public:
         return st;
     }
 
-    Status append_json(const char* data, size_t size) {
-        LOG(INFO) << "--ftw: kafka append json";
-        return append_and_flush(data, size);
-    }
+    Status append_json(const char* data, size_t size) { return append_and_flush(data, size); }
 };
 } // namespace io
 } // end namespace doris

--- a/be/src/runtime/routine_load/kafka_consumer_pipe_reader.h
+++ b/be/src/runtime/routine_load/kafka_consumer_pipe_reader.h
@@ -1,0 +1,50 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include "io/fs/stream_load_pipe_reader.h"
+
+namespace doris {
+namespace io {
+class KafkaConsumerPipeReader : public StreamLoadPipeReader {
+public:
+    KafkaConsumerPipeReader(size_t max_buffered_bytes = 1024 * 1024,
+                            size_t min_chunk_size = 64 * 1024)
+            : StreamLoadPipeReader(max_buffered_bytes, min_chunk_size) {}
+
+    ~KafkaConsumerPipeReader() override = default;
+
+    Status append_with_line_delimiter(const char* data, size_t size) {
+        LOG(INFO) << "--ftw: kafka reader";
+        Status st = append(data, size);
+        if (!st.ok()) {
+            return st;
+        }
+
+        // append the line delimiter
+        st = append("\n", 1);
+        return st;
+    }
+
+    Status append_json(const char* data, size_t size) {
+        LOG(INFO) << "--ftw: kafka append json";
+        return append_and_flush(data, size);
+    }
+};
+} // namespace io
+} // end namespace doris

--- a/be/src/runtime/stream_load/new_load_stream_mgr.cpp
+++ b/be/src/runtime/stream_load/new_load_stream_mgr.cpp
@@ -1,0 +1,33 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "runtime/stream_load/new_load_stream_mgr.h"
+
+namespace doris {
+
+DEFINE_GAUGE_METRIC_PROTOTYPE_2ARG(new_stream_load_pipe_count, MetricUnit::NOUNIT);
+
+NewLoadStreamMgr::NewLoadStreamMgr() {
+    // Each StreamLoadPipeReader has a limited buffer size (default 1M), it's not needed to count the
+    // actual size of all StreamLoadPipeReader.
+    REGISTER_HOOK_METRIC(new_stream_load_pipe_count, [this]() { return _stream_map.size(); });
+}
+
+NewLoadStreamMgr::~NewLoadStreamMgr() {
+    DEREGISTER_HOOK_METRIC(new_stream_load_pipe_count);
+}
+} // namespace doris

--- a/be/src/runtime/stream_load/new_load_stream_mgr.h
+++ b/be/src/runtime/stream_load/new_load_stream_mgr.h
@@ -21,19 +21,20 @@
 #include <mutex>
 #include <unordered_map>
 
-#include "runtime/stream_load/stream_load_pipe.h" // for StreamLoadPipe
+#include "io/fs/stream_load_pipe_reader.h"
 #include "util/doris_metrics.h"
-#include "util/uid_util.h" // for std::hash for UniqueId
+#include "util/uid_util.h"
 
 namespace doris {
 
 // used to register all streams in process so that other module can get this stream
-class LoadStreamMgr {
+// TODO(ftw): should be renamed to `LoadStreamMgr` after new file reader is ready.
+class NewLoadStreamMgr {
 public:
-    LoadStreamMgr();
-    ~LoadStreamMgr();
+    NewLoadStreamMgr();
+    ~NewLoadStreamMgr();
 
-    Status put(const UniqueId& id, std::shared_ptr<StreamLoadPipe> stream) {
+    Status put(const UniqueId& id, std::shared_ptr<io::StreamLoadPipeReader> stream) {
         std::lock_guard<std::mutex> l(_lock);
         auto it = _stream_map.find(id);
         if (it != std::end(_stream_map)) {
@@ -44,7 +45,7 @@ public:
         return Status::OK();
     }
 
-    std::shared_ptr<StreamLoadPipe> get(const UniqueId& id) {
+    std::shared_ptr<io::StreamLoadPipeReader> get(const UniqueId& id) {
         std::lock_guard<std::mutex> l(_lock);
         auto it = _stream_map.find(id);
         if (it == std::end(_stream_map)) {
@@ -66,7 +67,6 @@ public:
 
 private:
     std::mutex _lock;
-    std::unordered_map<UniqueId, std::shared_ptr<StreamLoadPipe>> _stream_map;
+    std::unordered_map<UniqueId, std::shared_ptr<io::StreamLoadPipeReader>> _stream_map;
 };
-
 } // namespace doris

--- a/be/src/runtime/stream_load/stream_load_executor.h
+++ b/be/src/runtime/stream_load/stream_load_executor.h
@@ -27,7 +27,6 @@ class ExecEnv;
 class StreamLoadContext;
 class Status;
 class TTxnCommitAttachment;
-class StreamLoadPipe;
 
 class StreamLoadExecutor {
 public:

--- a/be/src/runtime/stream_load/stream_load_pipe.h
+++ b/be/src/runtime/stream_load/stream_load_pipe.h
@@ -46,9 +46,11 @@ public:
               _total_length(total_length),
               _use_proto(use_proto) {}
 
-    virtual ~StreamLoadPipe() {
+    ~StreamLoadPipe() override {
         SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER(ExecEnv::GetInstance()->orphan_mem_tracker());
-        while (!_buf_queue.empty()) _buf_queue.pop_front();
+        while (!_buf_queue.empty()) {
+            _buf_queue.pop_front();
+        }
     }
 
     Status open() override { return Status::OK(); }

--- a/be/src/util/doris_metrics.h
+++ b/be/src/util/doris_metrics.h
@@ -185,6 +185,7 @@ public:
     UIntGauge* routine_load_task_count;
     UIntGauge* small_file_cache_count;
     UIntGauge* stream_load_pipe_count;
+    UIntGauge* new_stream_load_pipe_count;
     UIntGauge* brpc_endpoint_stub_count;
     UIntGauge* brpc_function_endpoint_stub_count;
     UIntGauge* tablet_writer_count;

--- a/be/src/vec/exec/format/file_reader/new_file_factory.cpp
+++ b/be/src/vec/exec/format/file_reader/new_file_factory.cpp
@@ -32,6 +32,7 @@
 #include "io/s3_writer.h"
 #include "runtime/exec_env.h"
 #include "runtime/stream_load/load_stream_mgr.h"
+#include "runtime/stream_load/new_load_stream_mgr.h"
 #include "util/s3_util.h"
 
 namespace doris {
@@ -142,9 +143,9 @@ Status NewFileFactory::create_file_reader(RuntimeProfile* /*profile*/,
 
 // file scan node/stream load pipe
 Status NewFileFactory::create_pipe_reader(const TUniqueId& load_id,
-                                          std::shared_ptr<FileReader>& file_reader) {
-    file_reader = ExecEnv::GetInstance()->load_stream_mgr()->get(load_id);
-    if (!file_reader) {
+                                          io::FileReaderSPtr* file_reader) {
+    *file_reader = ExecEnv::GetInstance()->new_load_stream_mgr()->get(load_id);
+    if (!(*file_reader)) {
         return Status::InternalError("unknown stream load id: {}", UniqueId(load_id).to_string());
     }
     return Status::OK();

--- a/be/src/vec/exec/format/file_reader/new_file_factory.h
+++ b/be/src/vec/exec/format/file_reader/new_file_factory.h
@@ -74,8 +74,7 @@ public:
                                      io::FileReaderSPtr* file_reader);
 
     // Create FileReader for stream load pipe
-    static Status create_pipe_reader(const TUniqueId& load_id,
-                                     std::shared_ptr<FileReader>& file_reader);
+    static Status create_pipe_reader(const TUniqueId& load_id, io::FileReaderSPtr* file_reader);
 
     // TODO(ftw): should be delete after new_hdfs_file_reader ready
     static Status create_hdfs_reader(const THdfsParams& hdfs_params, const std::string& path,

--- a/be/src/vec/exec/format/json/new_json_reader.cpp
+++ b/be/src/vec/exec/format/json/new_json_reader.cpp
@@ -301,8 +301,6 @@ Status NewJsonReader::_open_line_reader() {
     int64_t size = _range.size;
     if (_range.start_offset != 0) {
         // When we fetch range doesn't start from 0, size will += 1.
-
-        // TODO(ftw): check what if file_reader is stream_pipe? Is `size+=1` is correct?
         size += 1;
         _skip_first_line = true;
     } else {

--- a/regression-test/suites/jdbc_catalog_p0/test_mysql_jdbc_catalog.groovy
+++ b/regression-test/suites/jdbc_catalog_p0/test_mysql_jdbc_catalog.groovy
@@ -49,7 +49,6 @@ suite("test_mysql_jdbc_catalog", "p0") {
 
         sql """drop catalog if exists ${catalog_name} """
 
-        // if use 'com.mysql.cj.jdbc.Driver' here, it will report: ClassNotFound
         sql """ CREATE CATALOG ${catalog_name} PROPERTIES (
                 "type"="jdbc",
                 "jdbc.user"="root",


### PR DESCRIPTION
# Proposed changes

Issue Number: close #15456 
Currently, there are two sets of file readers in Doris, this pr rewrites the old stream_load_pipe with the new file reader.

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

