### PR TITLE
[Chore](refactor) some modify for pass c++20 standard

### DIFF
--- a/be/src/gutil/ref_counted.h
+++ b/be/src/gutil/ref_counted.h
@@ -94,9 +94,6 @@ public:
 
 protected:
     ~RefCounted() {}
-
-private:
-    DISALLOW_COPY_AND_ASSIGN(RefCounted<T>);
 };
 
 // Forward declaration.

--- a/be/src/http/web_page_handler.cpp
+++ b/be/src/http/web_page_handler.cpp
@@ -64,7 +64,8 @@ void WebPageHandler::register_template_page(const std::string& path, const strin
                                             bool is_on_nav_bar) {
     // Relative path which will be used to find .mustache file in _www_path
     std::string render_path = (path == "/") ? "/home" : path;
-    auto wrapped_cb = [=](const ArgumentMap& args, std::stringstream* output) {
+    auto wrapped_cb = [callback, render_path, this](const ArgumentMap& args,
+                                                    std::stringstream* output) {
         EasyJson ej;
         callback(args, &ej);
         render(render_path, ej, true /* is_styled */, output);

--- a/be/src/olap/compaction_permit_limiter.cpp
+++ b/be/src/olap/compaction_permit_limiter.cpp
@@ -28,14 +28,14 @@ bool CompactionPermitLimiter::request(int64_t permits) {
         // it's necessary to do compaction for this tablet because this tablet will not get "permits"
         // anyway. otherwise, compaction task for this tablet will not be executed forever.
         std::unique_lock<std::mutex> lock(_permits_mutex);
-        _permits_cv.wait(lock, [=] {
+        _permits_cv.wait(lock, [permits, this] {
             return _used_permits == 0 ||
                    _used_permits + permits <= config::total_permits_for_compaction_score;
         });
     } else {
         if (_used_permits + permits > config::total_permits_for_compaction_score) {
             std::unique_lock<std::mutex> lock(_permits_mutex);
-            _permits_cv.wait(lock, [=] {
+            _permits_cv.wait(lock, [permits, this] {
                 return _used_permits + permits <= config::total_permits_for_compaction_score;
             });
         }

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -835,7 +835,8 @@ void PInternalServiceImpl::request_slave_tablet_pull_rowset(
     int64_t brpc_port = request->brpc_port();
     std::string token = request->token();
     int64_t node_id = request->node_id();
-    _slave_replica_worker_pool.offer([=]() {
+    _slave_replica_worker_pool.offer([rowset_meta_pb, host, brpc_port, node_id, segments_size,
+                                      http_port, token, rowset_path, this]() {
         TabletSharedPtr tablet = StorageEngine::instance()->tablet_manager()->get_tablet(
                 rowset_meta_pb.tablet_id(), rowset_meta_pb.tablet_schema_hash());
         if (tablet == nullptr) {

--- a/be/src/util/semaphore.hpp
+++ b/be/src/util/semaphore.hpp
@@ -36,7 +36,7 @@ public:
 
     void wait() {
         std::unique_lock<std::mutex> lock(_mutex);
-        _cv.wait(lock, [=] { return _count > 0; });
+        _cv.wait(lock, [this] { return _count > 0; });
         --_count;
     }
 

--- a/be/src/util/trace.h
+++ b/be/src/util/trace.h
@@ -100,7 +100,7 @@ class Trace;
 // Construct a constant C string counter name which acts as a sort of
 // coarse-grained histogram for trace metrics.
 #define BUCKETED_COUNTER_NAME(prefix, duration_us) \
-    [=]() {                                        \
+    []() {                                         \
         if (duration_us >= 100 * 1000) {           \
             return prefix "_gt_100_ms";            \
         } else if (duration_us >= 10 * 1000) {     \

--- a/be/src/vec/aggregate_functions/aggregate_function_collect.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_collect.h
@@ -141,7 +141,7 @@ struct AggregateFunctionCollectListData<StringRef> {
     using ColVecType = ColumnString;
     MutableColumnPtr data;
 
-    AggregateFunctionCollectListData<ElementType>() { data = ColVecType::create(); }
+    AggregateFunctionCollectListData() { data = ColVecType::create(); }
 
     void add(const IColumn& column, size_t row_num) { data->insert_from(column, row_num); }
 

--- a/be/src/vec/aggregate_functions/aggregate_function_min_max_by.cpp
+++ b/be/src/vec/aggregate_functions/aggregate_function_min_max_by.cpp
@@ -21,6 +21,7 @@
 #include "vec/aggregate_functions/aggregate_function_simple_factory.h"
 #include "vec/aggregate_functions/factory_helpers.h"
 #include "vec/aggregate_functions/helpers.h"
+#include "vec/core/types.h"
 
 namespace doris::vectorized {
 
@@ -105,7 +106,7 @@ static IAggregateFunction* create_aggregate_function_min_max_by(const String& na
     }
     if (which.idx == TypeIndex::Decimal128) {
         return create_aggregate_function_min_max_by_impl<AggregateFunctionTemplate, Data,
-                                                         SingleValueDataFixed<DecimalV2Value>>(
+                                                         SingleValueDataDecimal<Decimal128>>(
                 argument_types);
     }
     if (which.idx == TypeIndex::Decimal32) {
@@ -120,7 +121,7 @@ static IAggregateFunction* create_aggregate_function_min_max_by(const String& na
     }
     if (which.idx == TypeIndex::Decimal128I) {
         return create_aggregate_function_min_max_by_impl<AggregateFunctionTemplate, Data,
-                                                         SingleValueDataFixed<Int128I>>(
+                                                         SingleValueDataDecimal<Decimal128I>>(
                 argument_types);
     }
     return nullptr;

--- a/be/src/vec/core/field.h
+++ b/be/src/vec/core/field.h
@@ -1060,13 +1060,26 @@ struct NearestFieldTypeImpl<AggregateFunctionStateData> {
     using Type = AggregateFunctionStateData;
 };
 
+template <>
+struct Field::TypeToEnum<PackedInt128> {
+    static const Types::Which value = Types::Int128;
+};
+
+template <>
+struct NearestFieldTypeImpl<PackedInt128> {
+    using Type = Int128;
+};
+
 template <typename T>
 decltype(auto) cast_to_nearest_field_type(T&& x) {
     using U = NearestFieldType<std::decay_t<T>>;
-    if constexpr (std::is_same_v<std::decay_t<T>, U>)
+    if constexpr (std::is_same_v<PackedInt128, std::decay_t<T>>) {
+        return U(x.value);
+    } else if constexpr (std::is_same_v<std::decay_t<T>, U>) {
         return std::forward<T>(x);
-    else
+    } else {
         return U(x);
+    }
 }
 
 /// This (rather tricky) code is to avoid ambiguity in expressions like

--- a/be/src/vec/runtime/vdatetime_value.h
+++ b/be/src/vec/runtime/vdatetime_value.h
@@ -728,19 +728,19 @@ public:
             std::conditional_t<std::is_same_v<T, DateTimeV2ValueType>, uint64_t, uint32_t>;
 
     // Constructor
-    DateV2Value<T>() : date_v2_value_(0, 0, 0, 0, 0, 0, 0) {}
+    DateV2Value() : date_v2_value_(0, 0, 0, 0, 0, 0, 0) {}
 
-    DateV2Value<T>(DateV2Value<T>& other) { int_val_ = other.to_date_int_val(); }
+    DateV2Value(DateV2Value<T>& other) { int_val_ = other.to_date_int_val(); }
 
-    DateV2Value<T>(const DateV2Value<T>& other) { int_val_ = other.to_date_int_val(); }
+    DateV2Value(const DateV2Value<T>& other) { int_val_ = other.to_date_int_val(); }
 
-    static DateV2Value<T> create_from_olap_date(uint64_t value) {
+    static DateV2Value create_from_olap_date(uint64_t value) {
         DateV2Value<T> date;
         date.from_olap_date(value);
         return date;
     }
 
-    static DateV2Value<T> create_from_olap_datetime(uint64_t value) {
+    static DateV2Value create_from_olap_datetime(uint64_t value) {
         DateV2Value<T> datetime;
         datetime.from_olap_datetime(value);
         return datetime;
@@ -1178,8 +1178,8 @@ private:
         underlying_value int_val_;
     };
 
-    DateV2Value<T>(uint16_t year, uint8_t month, uint8_t day, uint8_t hour, uint8_t minute,
-                   uint8_t second, uint32_t microsecond)
+    DateV2Value(uint16_t year, uint8_t month, uint8_t day, uint8_t hour, uint8_t minute,
+                uint8_t second, uint32_t microsecond)
             : date_v2_value_(year, month, day, hour, minute, second, microsecond) {}
 };
 


### PR DESCRIPTION
# Proposed changes
part of https://github.com/apache/doris/issues/9312
1. remove temlate argument on constructor
2. precate implicit capture of this Implicitly capturing `this` in a lamdba capture using `[=]` is deprecated on cpp20
3. fix some wrong template usage

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
4. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
5. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
6. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
7. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

