### PR TITLE
[Bug](function) fix overflow on concat_ws

### DIFF
--- a/be/src/vec/functions/function_string.h
+++ b/be/src/vec/functions/function_string.h
@@ -893,21 +893,22 @@ private:
         const auto& src_array_offsets = array_column.get_offsets();
         size_t current_src_array_offset = 0;
 
-        auto& sep_offsets = *offsets_list[0];
-        auto& sep_chars = *chars_list[0];
-        auto& sep_nullmap = *null_list[0];
-        int sep_size = sep_offsets[0];
-        const char* sep_data = reinterpret_cast<const char*>(&sep_chars[0]);
-        std::string_view sep(sep_data, sep_size);
-
         // Concat string in array
         for (size_t i = 0; i < input_rows_count; ++i) {
+            auto& sep_offsets = *offsets_list[0];
+            auto& sep_chars = *chars_list[0];
+            auto& sep_nullmap = *null_list[0];
+
             if (sep_nullmap[i]) {
                 res_offset[i] = res_data.size();
                 current_src_array_offset += src_array_offsets[i] - src_array_offsets[i - 1];
                 continue;
             }
 
+            int sep_size = sep_offsets[i] - sep_offsets[i - 1];
+            const char* sep_data = reinterpret_cast<const char*>(&sep_chars[sep_offsets[i - 1]]);
+
+            std::string_view sep(sep_data, sep_size);
             buffer.clear();
             views.clear();
 
@@ -940,20 +941,20 @@ private:
                          const std::vector<const Chars*>& chars_list,
                          const std::vector<const ColumnUInt8::Container*>& null_list,
                          Chars& res_data, Offsets& res_offset) {
-        auto& sep_offsets = *offsets_list[0];
-        auto& sep_chars = *chars_list[0];
-        auto& sep_nullmap = *null_list[0];
-        int sep_size = sep_offsets[0];
-        const char* sep_data = reinterpret_cast<const char*>(&sep_chars[0]);
-        std::string_view sep(sep_data, sep_size);
-
         // Concat string
         for (size_t i = 0; i < input_rows_count; ++i) {
+            auto& sep_offsets = *offsets_list[0];
+            auto& sep_chars = *chars_list[0];
+            auto& sep_nullmap = *null_list[0];
             if (sep_nullmap[i]) {
                 res_offset[i] = res_data.size();
                 continue;
             }
 
+            int sep_size = sep_offsets[i] - sep_offsets[i - 1];
+            const char* sep_data = reinterpret_cast<const char*>(&sep_chars[sep_offsets[i - 1]]);
+
+            std::string_view sep(sep_data, sep_size);
             buffer.clear();
             views.clear();
             for (size_t j = 1; j < argument_size; ++j) {

--- a/be/src/vec/functions/function_string.h
+++ b/be/src/vec/functions/function_string.h
@@ -893,22 +893,21 @@ private:
         const auto& src_array_offsets = array_column.get_offsets();
         size_t current_src_array_offset = 0;
 
+        auto& sep_offsets = *offsets_list[0];
+        auto& sep_chars = *chars_list[0];
+        auto& sep_nullmap = *null_list[0];
+        int sep_size = sep_offsets[0];
+        const char* sep_data = reinterpret_cast<const char*>(&sep_chars[0]);
+        std::string_view sep(sep_data, sep_size);
+
         // Concat string in array
         for (size_t i = 0; i < input_rows_count; ++i) {
-            auto& sep_offsets = *offsets_list[0];
-            auto& sep_chars = *chars_list[0];
-            auto& sep_nullmap = *null_list[0];
-
             if (sep_nullmap[i]) {
                 res_offset[i] = res_data.size();
                 current_src_array_offset += src_array_offsets[i] - src_array_offsets[i - 1];
                 continue;
             }
 
-            int sep_size = sep_offsets[i] - sep_offsets[i - 1];
-            const char* sep_data = reinterpret_cast<const char*>(&sep_chars[sep_offsets[i - 1]]);
-
-            std::string_view sep(sep_data, sep_size);
             buffer.clear();
             views.clear();
 
@@ -941,20 +940,20 @@ private:
                          const std::vector<const Chars*>& chars_list,
                          const std::vector<const ColumnUInt8::Container*>& null_list,
                          Chars& res_data, Offsets& res_offset) {
+        auto& sep_offsets = *offsets_list[0];
+        auto& sep_chars = *chars_list[0];
+        auto& sep_nullmap = *null_list[0];
+        int sep_size = sep_offsets[0];
+        const char* sep_data = reinterpret_cast<const char*>(&sep_chars[0]);
+        std::string_view sep(sep_data, sep_size);
+
         // Concat string
         for (size_t i = 0; i < input_rows_count; ++i) {
-            auto& sep_offsets = *offsets_list[0];
-            auto& sep_chars = *chars_list[0];
-            auto& sep_nullmap = *null_list[0];
             if (sep_nullmap[i]) {
                 res_offset[i] = res_data.size();
                 continue;
             }
 
-            int sep_size = sep_offsets[i] - sep_offsets[i - 1];
-            const char* sep_data = reinterpret_cast<const char*>(&sep_chars[sep_offsets[i - 1]]);
-
-            std::string_view sep(sep_data, sep_size);
             buffer.clear();
             views.clear();
             for (size_t j = 1; j < argument_size; ++j) {

--- a/be/src/vec/functions/function_timestamp.cpp
+++ b/be/src/vec/functions/function_timestamp.cpp
@@ -17,6 +17,7 @@
 
 #include "runtime/runtime_state.h"
 #include "udf/udf_internal.h"
+#include "vec/columns/column_const.h"
 #include "vec/columns/column_nullable.h"
 #include "vec/columns/column_string.h"
 #include "vec/columns/column_vector.h"
@@ -397,14 +398,10 @@ struct UnixTimeStampImpl {
                                const ColumnNumbers& arguments, size_t result,
                                size_t input_rows_count) {
         auto col_result = ColumnVector<Int32>::create();
-        col_result->resize(input_rows_count);
-        // TODO: use a const column to store this value
-        auto& col_result_data = col_result->get_data();
-        auto res_value = context->impl()->state()->timestamp_ms() / 1000;
-        for (int i = 0; i < input_rows_count; i++) {
-            col_result_data[i] = res_value;
-        }
-        block.replace_by_position(result, std::move(col_result));
+        col_result->resize(1);
+        col_result->get_data()[0] = context->impl()->state()->timestamp_ms() / 1000;
+        auto col_const = ColumnConst::create(std::move(col_result), input_rows_count);
+        block.replace_by_position(result, std::move(col_const));
         return Status::OK();
     }
 };

--- a/be/src/vec/functions/function_utility.cpp
+++ b/be/src/vec/functions/function_utility.cpp
@@ -16,6 +16,7 @@
 // under the License.
 #include <thread>
 
+#include "vec/columns/column_const.h"
 #include "vec/data_types/data_type_number.h"
 #include "vec/data_types/data_type_string.h"
 #include "vec/functions/simple_function_factory.h"
@@ -103,7 +104,8 @@ public:
                         size_t result, size_t input_rows_count) override {
         auto res_column = ColumnString::create();
         res_column->insert_data(version.c_str(), version.length());
-        block.replace_by_position(result, std::move(res_column));
+        auto col_const = ColumnConst::create(std::move(res_column), input_rows_count);
+        block.replace_by_position(result, std::move(col_const));
         return Status::OK();
     }
 };


### PR DESCRIPTION
# Proposed changes

```sql
select
   /*+ SET_VAR(query_timeout = 600) */ ref_238.`sm_ship_mode_sk` as c0,
  version() as c1,
  coalesce(71,
    ref_179.`d_holidayfl`) as c2,
  ref_179.`d_year` as c3,
  ref_179.`d_weekdayfl` as c4,
  TO_BITMAP(
    cast(ref_179.`d_lastdayinweekfl` as int)) as c5,
  ref_238.`sm_type` as c6,
  subq_5.`c4` as c7,
  ref_179.`d_weeknuminyear` as c8,
  ref_238.`sm_ship_mode_id` as c9,
  ref_179.`d_lastdayinweekfl` as c10,
  version() as c11,
  reverse(
    cast(ref_179.`d_dayofweek` as varchar)) as c12,
  version() as c13,
  ref_179.`d_datekey` as c14,
  ref_238.`sm_code` as c15,
  ref_179.`d_year` as c16,
  subq_5.`c2` as c17,
  ref_179.`d_sellingseason` as c18,
  subq_5.`c4` as c19
from
  regression_test_primary_index_ssb_unique_load_zstd_p0_four.date as ref_179
    right join regression_test_tpcds_sf1_p1.ship_mode as ref_238
    on ((false)
    and (concat(
        cast(concat_ws(
          cast(version() as varchar),
          cast(null as varchar)) as varchar),
        cast(null as varchar),
        cast(null as varchar)) is not NULL))
    left join (select
          ref_247.`rectime` as c0,
          ref_241.`supplycost` as c1,
          ref_241.`comment` as c2,
          ref_247.`rectime` as c3,
          ref_241.`comment` as c4,
          ref_241.`availqty` as c5,
          version() as c6
        from
          regression_test_query_p0_limit.tpch_tiny_partsupp as ref_241
            inner join regression_test_query_p0_join.test_bucket_shuffle_join as ref_247
            on (ref_241.`availqty` = ref_247.`id` )
            inner join regression_test_correctness.t1 as ref_248
            on (ref_247.`id` = ref_248.`id1` )
        where false) as subq_5
    on (ref_179.`d_yearmonthnum` = subq_5.`c5` )
where ref_179.`d_lastdayinmonthfl` is not NULL
```

```cpp
0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /mnt/disk1/yuejing/projects/doris/be/src/common/signal_handler.h:420
1# 0x00007F0369358400 in /lib64/libc.so.6
2# __GI_raise in /lib64/libc.so.6
3# __GI_abort in /lib64/libc.so.6
4# _nl_load_domain.cold.0 in /lib64/libc.so.6
5# 0x00007F0369350A76 in /lib64/libc.so.6
6# doris::vectorized::PODArray<unsigned int, 4096ul, Allocator<false, false>, 15ul, 16ul>::operator[](long) const in /mnt/disk1/yuejing/projects/doris/output/be/lib/doris_be
7# doris::vectorized::FunctionStringConcatWs::_execute_string(unsigned long const&, unsigned long const&, fmt::v7::basic_memory_buffer<char, 500ul, std::allocator<char> >&, std::
vector<std::basic_string_view<char, std::char_traits<char> >, std::allocator<std::basic_string_view<char, std::char_traits<char> > > >&, std::vector<doris::vectorized::PODArray<un
signed int, 4096ul, Allocator<false, false>, 15ul, 16ul> const*, std::allocator<doris::vectorized::PODArray<unsigned int, 4096ul, Allocator<false, false>, 15ul, 16ul> const*> > co
nst&, std::vector<doris::vectorized::PODArray<unsigned char, 4096ul, Allocator<false, false>, 15ul, 16ul> const*, std::allocator<doris::vectorized::PODArray<unsigned char, 4096ul,
Allocator<false, false>, 15ul, 16ul> const*> > const&, std::vector<doris::vectorized::PODArray<unsigned char, 4096ul, Allocator<false, false>, 15ul, 16ul> const*, std::allocator<
doris::vectorized::PODArray<unsigned char, 4096ul, Allocator<false, false>, 15ul, 16ul> const*> > const&, doris::vectorized::PODArray<unsigned char, 4096ul, Allocator<false, false
>, 15ul, 16ul>&, doris::vectorized::PODArray<unsigned int, 4096ul, Allocator<false, false>, 15ul, 16ul>&) at /mnt/disk1/yuejing/projects/doris/be/src/vec/functions/function_string
.h:954
8# doris::vectorized::FunctionStringConcatWs::execute_impl(doris_udf::FunctionContext*, doris::vectorized::Block&, std::vector<unsigned long, std::allocator<unsigned long> > cons
t&, unsigned long, unsigned long) at /mnt/disk1/yuejing/projects/doris/be/src/vec/functions/function_string.h:856
9# doris::vectorized::DefaultExecutable::execute_impl(doris_udf::FunctionContext*, doris::vectorized::Block&, std::vector<unsigned long, std::allocator<unsigned long> > const&, u
nsigned long, unsigned long) at /mnt/disk1/yuejing/projects/doris/be/src/vec/functions/function.h:465
10# doris::vectorized::PreparedFunctionImpl::execute_without_low_cardinality_columns(doris_udf::FunctionContext*, doris::vectorized::Block&, std::vector<unsigned long, std::alloca
tor<unsigned long> > const&, unsigned long, unsigned long, bool) at /mnt/disk1/yuejing/projects/doris/be/src/vec/functions/function.cpp:251
11# doris::vectorized::PreparedFunctionImpl::execute(doris_udf::FunctionContext*, doris::vectorized::Block&, std::vector<unsigned long, std::allocator<unsigned long> > const&, uns
igned long, unsigned long, bool) at /mnt/disk1/yuejing/projects/doris/be/src/vec/functions/function.cpp:272
12# doris::vectorized::IFunctionBase::execute(doris_udf::FunctionContext*, doris::vectorized::Block&, std::vector<unsigned long, std::allocator<unsigned long> > const&, unsigned l
ong, unsigned long, bool) at /mnt/disk1/yuejing/projects/doris/be/src/vec/functions/function.h:136
13# doris::vectorized::VectorizedFnCall::execute(doris::vectorized::VExprContext*, doris::vectorized::Block*, int*) at /mnt/disk1/yuejing/projects/doris/be/src/vec/exprs/vectorize
d_fn_call.cpp:107
14# doris::vectorized::VectorizedFnCall::execute(doris::vectorized::VExprContext*, doris::vectorized::Block*, int*) at /mnt/disk1/yuejing/projects/doris/be/src/vec/exprs/vectorize
d_fn_call.cpp:100
15# doris::vectorized::VectorizedFnCall::execute(doris::vectorized::VExprContext*, doris::vectorized::Block*, int*) at /mnt/disk1/yuejing/projects/doris/be/src/vec/exprs/vectorize
d_fn_call.cpp:100
16# doris::vectorized::VectorizedFnCall::execute(doris::vectorized::VExprContext*, doris::vectorized::Block*, int*) at /mnt/disk1/yuejing/projects/doris/be/src/vec/exprs/vectorize
d_fn_call.cpp:100
17# doris::vectorized::VcompoundPred::execute(doris::vectorized::VExprContext*, doris::vectorized::Block*, int*) at /mnt/disk1/yuejing/projects/doris/be/src/vec/exprs/vcompound_pr
ed.h:56
18# doris::vectorized::VExprContext::execute(doris::vectorized::Block*, int*) at /mnt/disk1/yuejing/projects/doris/be/src/vec/exprs/vexpr_context.cpp:44
19# doris::Status doris::vectorized::VNestedLoopJoinNode::_do_filtering_and_update_visited_flags<true, false>(doris::vectorized::Block*, bool) at /mnt/disk1/yuejing/projects/doris
/be/src/vec/exec/join/vnested_loop_join_node.cpp:462
20# doris::Status doris::vectorized::VNestedLoopJoinNode::_generate_join_block_data<std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type)3>, true, false>(doris::Runt
imeState*, std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type)3>&) at /mnt/disk1/yuejing/projects/doris/be/src/vec/exec/join/vnested_loop_join_node.h:138
21# auto doris::vectorized::VNestedLoopJoinNode::push(doris::RuntimeState*, doris::vectorized::Block*, bool)::$_0::operator()<std::integral_constant<doris::TJoinOp::type, (doris::
TJoinOp::type)3>&, std::integral_constant<bool, true>, std::integral_constant<bool, false> >(std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type)3>&, std::integral_
constant<bool, true>, std::integral_constant<bool, false>) const at /mnt/disk1/yuejing/projects/doris/be/src/vec/exec/join/vnested_loop_join_node.cpp:201
22# doris::Status std::__invoke_impl<doris::Status, doris::vectorized::VNestedLoopJoinNode::push(doris::RuntimeState*, doris::vectorized::Block*, bool)::$_0&, std::integral_consta
nt<doris::TJoinOp::type, (doris::TJoinOp::type)3>&, std::integral_constant<bool, true>, std::integral_constant<bool, false> >(std::__invoke_other, doris::vectorized::VNestedLoopJo
inNode::push(doris::RuntimeState*, doris::vectorized::Block*, bool)::$_0&, std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type)3>&, std::integral_constant<bool, tru
e>&&, std::integral_constant<bool, false>&&) at /mnt/disk1/yuejing/projects/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61
23# std::__invoke_result<doris::vectorized::VNestedLoopJoinNode::push(doris::RuntimeState*, doris::vectorized::Block*, bool)::$_0&, std::integral_constant<doris::TJoinOp::type, (d
oris::TJoinOp::type)3>&, std::integral_constant<bool, true>, std::integral_constant<bool, false> >::type std::__invoke<doris::vectorized::VNestedLoopJoinNode::push(doris::RuntimeS
tate*, doris::vectorized::Block*, bool)::$_0&, std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type)3>&, std::integral_constant<bool, true>, std::integral_constant<b
ool, false> >(doris::vectorized::VNestedLoopJoinNode::push(doris::RuntimeState*, doris::vectorized::Block*, bool)::$_0&, std::integral_constant<doris::TJoinOp::type, (doris::TJoin
Op::type)3>&, std::integral_constant<bool, true>&&, std::integral_constant<bool, false>&&) at /mnt/disk1/yuejing/projects/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../..
/../include/c++/11/bits/invoke.h:96
24# std::_detail::variant::gen_vtable_impl<std::detail::variant::_Multi_array<std::detail::variant::_deduce_visit_result<doris::Status> (doris::vectorized::VNeste
dLoopJoinNode::push(doris::RuntimeState*, doris::vectorized::Block*, bool)::$_0&, std::variant<std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type)0>, std::integral
_constant<doris::TJoinOp::type, (doris::TJoinOp::type)2>, std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type)8>, std::integral_constant<doris::TJoinOp::type, (dori
s::TJoinOp::type)1>, std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type)4>, std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type)3>, std::integral_co
nstant<doris::TJoinOp::type, (doris::TJoinOp::type)5>, std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type)7>, std::integral_constant<doris::TJoinOp::type, (doris::
TJoinOp::type)9>, std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type)10> >&, std::variant<std::integral_constant<bool, false>, std::integral_constant<bool, true> >
&&, std::variant<std::integral_constant<bool, false>, std::integral_constant<bool, true> >&&)>, std::integer_sequence<unsigned long, 5ul, 1ul, 0ul> >::__visit_invoke(doris::vector
ized::VNestedLoopJoinNode::push(doris::RuntimeState*, doris::vectorized::Block*, bool)::$_0&, std::variant<std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type)0>, s
td::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type)2>, std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type)8>, std::integral_constant<doris::TJoinOp:
:type, (doris::TJoinOp::type)1>, std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type)4>, std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type)3>, std:
:integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type)5>, std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type)7>, std::integral_constant<doris::TJoinOp::ty
pe, (doris::TJoinOp::type)9>, std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type)10> >&, std::variant<std::integral_constant<bool, false>, std::integral_constant<b
ool, true> >&&, std::variant<std::integral_constant<bool, false>, std::integral_constant<bool, true> >&&) at /mnt/disk1/yuejing/projects/ldb_toolchain/bin/../lib/gcc/x86_64-linux-
gnu/11/../../../../include/c++/11/variant:1013
25# decltype(auto) std::_do_visit<std::detail::variant::_deduce_visit_result<doris::Status>, doris::vectorized::VNestedLoopJoinNode::push(doris::RuntimeState*, doris::vector
ized::Block*, bool)::$_0&, std::variant<std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type)0>, std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type)2
>, std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type)8>, std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type)1>, std::integral_constant<doris::TJoi
nOp::type, (doris::TJoinOp::type)4>, std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type)3>, std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type)5>,
std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type)7>, std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type)9>, std::integral_constant<doris::TJoinOp
::type, (doris::TJoinOp::type)10> >&, std::variant<std::integral_constant<bool, false>, std::integral_constant<bool, true> >, std::variant<std::integral_constant<bool, false>, std
::integral_constant<bool, true> > >(doris::vectorized::VNestedLoopJoinNode::push(doris::RuntimeState*, doris::vectorized::Block*, bool)::$_0&, std::variant<std::integral_constant<
doris::TJoinOp::type, (doris::TJoinOp::type)0>, std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type)2>, std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp
::type)8>, std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type)1>, std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type)4>, std::integral_constant<dor
is::TJoinOp::type, (doris::TJoinOp::type)3>, std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type)5>, std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::t
ype)7>, std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type)9>, std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type)10> >&, std::variant<std::integra
l_constant<bool, false>, std::integral_constant<bool, true> >&&, std::variant<std::integral_constant<bool, false>, std::integral_constant<bool, true> >&&) at /mnt/disk1/yuejing/pr
ojects/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/variant:1714
26# decltype(auto) std::visit<doris::vectorized::VNestedLoopJoinNode::push(doris::RuntimeState*, doris::vectorized::Block*, bool)::$_0&, std::variant<std::integral_constant<doris:
:TJoinOp::type, (doris::TJoinOp::type)0>, std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type)2>, std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type
)8>, std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type)1>, std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type)4>, std::integral_constant<doris::TJ
oinOp::type, (doris::TJoinOp::type)3>, std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type)5>, std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type)7>
, std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type)9>, std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type)10> >&, std::variant<std::integral_cons
tant<bool, false>, std::integral_constant<bool, true> >, std::variant<std::integral_constant<bool, false>, std::integral_constant<bool, true> > >(doris::vectorized::VNestedLoopJoi
nNode::push(doris::RuntimeState*, doris::vectorized::Block*, bool)::$_0&, std::variant<std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type)0>, std::integral_constan
t<doris::TJoinOp::type, (doris::TJoinOp::type)2>, std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type)8>, std::integral_constant<doris::TJoinOp::type, (doris::TJoin
Op::type)1>, std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type)4>, std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type)3>, std::integral_constant<d
oris::TJoinOp::type, (doris::TJoinOp::type)5>, std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type)7>, std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp:
:type)9>, std::integral_constant<doris::TJoinOp::type, (doris::TJoinOp::type)10> >&, std::variant<std::integral_constant<bool, false>, std::integral_constant<bool, true> >&&, std:
:variant<std::integral_constant<bool, false>, std::integral_constant<bool, true> >&&) at /mnt/disk1/yuejing/projects/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../i
nclude/c++/11/variant:1769
27# doris::vectorized::VNestedLoopJoinNode::push(doris::RuntimeState*, doris::vectorized::Block*, bool) at /mnt/disk1/yuejing/projects/doris/be/src/vec/exec/join/vnested_loop_join
_node.cpp:205
28# doris::vectorized::VNestedLoopJoinNode::get_next(doris::RuntimeState*, doris::vectorized::Block*, bool*) at /mnt/disk1/yuejing/projects/doris/be/src/vec/exec/join/vnested_loop
_join_node.cpp:234
29# doris::ExecNode::get_next_after_projects(doris::RuntimeState*, doris::vectorized::Block*, bool*) in /mnt/disk1/yuejing/projects/doris/output/be/lib/doris_be
30# doris::vectorized::HashJoinNode::get_next(doris::RuntimeState*, doris::vectorized::Block*, bool*) at /mnt/disk1/yuejing/projects/doris/be/src/vec/exec/join/vhash_join_node.cpp
:601
31# doris::ExecNode::get_next_after_projects(doris::RuntimeState*, doris::vectorized::Block*, bool*) in /mnt/disk1/yuejing/projects/doris/output/be/lib/doris_be
32# doris::PlanFragmentExecutor::get_vectorized_internal(doris::vectorized::Block*, bool*) at /mnt/disk1/yuejing/projects/doris/be/src/runtime/plan_fragment_executor.cpp:344
33# doris::PlanFragmentExecutor::open_vectorized_internal() at /mnt/disk1/yuejing/projects/doris/be/src/runtime/plan_fragment_executor.cpp:299
34# doris::PlanFragmentExecutor::open() at /mnt/disk1/yuejing/projects/doris/be/src/runtime/plan_fragment_executor.cpp:250
35# doris::FragmentExecState::execute() at /mnt/disk1/yuejing/projects/doris/be/src/runtime/fragment_mgr.cpp:251
36# doris::FragmentMgr::_exec_actual(std::shared_ptr<doris::FragmentExecState>, std::function<void (doris::RuntimeState*, doris::Status*)>) at /mnt/disk1/yuejing/projects/doris/be
/src/runtime/fragment_mgr.cpp:495
37# doris::FragmentMgr::exec_plan_fragment(doris::TExecPlanFragmentParams const&, std::function<void (doris::RuntimeState*, doris::Status*)>)::$_3::operator()() const at /mnt/disk
1/yuejing/projects/doris/be/src/runtime/fragment_mgr.cpp:732
38# void std::__invoke_impl<void, doris::FragmentMgr::exec_plan_fragment(doris::TExecPlanFragmentParams const&, std::function<void (doris::RuntimeState*, doris::Status*)>)::$_3&>(
std::__invoke_other, doris::FragmentMgr::exec_plan_fragment(doris::TExecPlanFragmentParams const&, std::function<void (doris::RuntimeState*, doris::Status*)>)::$_3&) at /mnt/disk1
/yuejing/projects/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61
39# std::enable_if<is_invocable_r_v<void, doris::FragmentMgr::exec_plan_fragment(doris::TExecPlanFragmentParams const&, std::function<void (doris::RuntimeState*, doris::Status*)>)
::$3&>, void>::type std::_invoke_r<void, doris::FragmentMgr::exec_plan_fragment(doris::TExecPlanFragmentParams const&, std::function<void (doris::RuntimeState*, doris::Status*)>
)::$_3&>(doris::FragmentMgr::exec_plan_fragment(doris::TExecPlanFragmentParams const&, std::function<void (doris::RuntimeState*, doris::Status*)>)::$_3&) at /mnt/disk1/yuejing/pro
jects/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:117
40# std::_Function_handler<void (), doris::FragmentMgr::exec_plan_fragment(doris::TExecPlanFragmentParams const&, std::function<void (doris::RuntimeState*, doris::Status*)>)::$_3>
::_M_invoke(std::_Any_data const&) at /mnt/disk1/yuejing/projects/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291
41# std::function<void ()>::operator()() const at /mnt/disk1/yuejing/projects/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:560
42# doris::FunctionRunnable::run() at /mnt/disk1/yuejing/projects/doris/be/src/util/threadpool.cpp:46
43# doris::ThreadPool::dispatch_thread() at /mnt/disk1/yuejing/projects/doris/be/src/util/threadpool.cpp:535
44# void std::_invoke_impl<void, void (doris::ThreadPool::&)(), doris::ThreadPool&>(std::_invoke_memfun_deref, void (doris::ThreadPool::&)(), doris::ThreadPool&) at /mnt/dis
k1/yuejing/projects/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:74
45# std::_invoke_result<void (doris::ThreadPool::&)(), doris::ThreadPool&>::type std::_invoke<void (doris::ThreadPool::&)(), doris::ThreadPool&>(void (doris::ThreadPool::*&)
(), doris::ThreadPool*&) at /mnt/disk1/yuejing/projects/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:96
46# void std::Bind<void (doris::ThreadPool::(doris::ThreadPool))()>::_call<void, , 0ul>(std::tuple<>&&, std::_Index_tuple<0ul>) at /mnt/disk1/yuejing/projects/ldb_toolchain/bi
n/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/functional:420
47# void std::_Bind<void (doris::ThreadPool::(doris::ThreadPool))()>::operator()<, void>() at /mnt/disk1/yuejing/projects/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../
../../include/c++/11/functional:503
48# void std::_invoke_impl<void, std::_Bind<void (doris::ThreadPool::(doris::ThreadPool))()>&>(std::_invoke_other, std::_Bind<void (doris::ThreadPool::(doris::ThreadPool))()
>&) at /mnt/disk1/yuejing/projects/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61
49# std::enable_if<is_invocable_r_v<void, std::Bind<void (doris::ThreadPool::(doris::ThreadPool))()>&>, void>::type std::_invoke_r<void, std::_Bind<void (doris::ThreadPool::*(
doris::ThreadPool*))()>&>(std::_Bind<void (doris::ThreadPool::(doris::ThreadPool))()>&) at /mnt/disk1/yuejing/projects/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../
../include/c++/11/bits/invoke.h:117
50# std::_Function_handler<void (), std::_Bind<void (doris::ThreadPool::(doris::ThreadPool))()> >::_M_invoke(std::_Any_data const&) at /mnt/disk1/yuejing/projects/ldb_toolchain/
bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291
51# std::function<void ()>::operator()() const at /mnt/disk1/yuejing/projects/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:560
52# doris::Thread::supervise_thread(void*) at /mnt/disk1/yuejing/projects/doris/be/src/util/thread.cpp:454
53# start_thread in /lib64/libpthread.so.0
54# _GI__clone in /lib64/libc.so.6
```

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

