### PR TITLE
[fix](memtracker) Fix load channel memory tracker are not refreshed in time

### DIFF
--- a/be/src/common/daemon.cpp
+++ b/be/src/common/daemon.cpp
@@ -245,7 +245,7 @@ void Daemon::load_channel_tracker_refresh_thread() {
     // Refresh the memory statistics of the load channel tracker more frequently,
     // which helps to accurately control the memory of LoadChannelMgr.
     while (!_stop_background_threads_latch.wait_for(
-            std::chrono::seconds(config::load_channel_memory_refresh_sleep_time_ms))) {
+            std::chrono::milliseconds(config::load_channel_memory_refresh_sleep_time_ms))) {
         doris::ExecEnv::GetInstance()->load_channel_mgr()->refresh_mem_tracker();
     }
 }

--- a/be/src/common/daemon.cpp
+++ b/be/src/common/daemon.cpp
@@ -205,6 +205,9 @@ void Daemon::memory_maintenance_thread() {
     int64_t interval_milliseconds = config::memory_maintenance_sleep_time_ms;
     while (!_stop_background_threads_latch.wait_for(
             std::chrono::milliseconds(interval_milliseconds))) {
+        if (!MemInfo::initialized()) {
+            continue;
+        }
         // Refresh process memory metrics.
         doris::PerfCounters::refresh_proc_status();
         doris::MemInfo::refresh_proc_meminfo();
@@ -246,7 +249,9 @@ void Daemon::load_channel_tracker_refresh_thread() {
     // which helps to accurately control the memory of LoadChannelMgr.
     while (!_stop_background_threads_latch.wait_for(
             std::chrono::milliseconds(config::load_channel_memory_refresh_sleep_time_ms))) {
-        doris::ExecEnv::GetInstance()->load_channel_mgr()->refresh_mem_tracker();
+        if (ExecEnv::GetInstance()->initialized()) {
+            doris::ExecEnv::GetInstance()->load_channel_mgr()->refresh_mem_tracker();
+        }
     }
 }
 


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

A bug that mistook milliseconds for seconds

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

