### PR TITLE
[fix](load) delta writer init failed might cause data inconsistency between multiple replicas

### DIFF
--- a/be/src/olap/delta_writer.cpp
+++ b/be/src/olap/delta_writer.cpp
@@ -322,7 +322,7 @@ Status DeltaWriter::close() {
         // if this delta writer is not initialized, but close() is called.
         // which means this tablet has no data loaded, but at least one tablet
         // in same partition has data loaded.
-        // so we have to also init this DeltaWriter, so that it can create a empty rowset
+        // so we have to also init this DeltaWriter, so that it can create an empty rowset
         // for this tablet when being closed.
         RETURN_NOT_OK(init());
     }
@@ -413,7 +413,7 @@ Status DeltaWriter::cancel() {
 
 Status DeltaWriter::cancel_with_status(const Status& st) {
     std::lock_guard<std::mutex> l(_lock);
-    if (!_is_init || _is_cancelled) {
+    if (_is_cancelled) {
         return Status::OK();
     }
     _mem_table.reset();

--- a/be/src/runtime/tablets_channel.cpp
+++ b/be/src/runtime/tablets_channel.cpp
@@ -127,6 +127,7 @@ Status TabletsChannel::close(
                 if (_broken_tablets.find(it.second->tablet_id()) != _broken_tablets.end()) {
                     LOG(WARNING) << "SHOULD NOT HAPPEN, tablet writer is broken but not cancelled"
                                  << ", tablet_id=" << it.first << ", transaction_id=" << _txn_id;
+                    continue;
                 }
                 need_wait_writers.insert(it.second);
             } else {


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

In the following case, data inconsistency would happen between multiple replicas
1. current delta writer only writes a few lines of data (which meas the `write()` method only called once)
2. writer failed when `init()`(which is called at the fist time we call `write()`), and current tablet is recorded in `_broken_tablets`
3. delta writer closed, and in the `close()` method, delta writer found it's not inited, treat such case as an empty load, it will try to init again, which would create an empty rowset.
4. tablet sink received the error report in rpc response, marked the replica as failed, but since the quorum replicas are succeed, so the following load commit  operation will succeed.
5. FE send publish version task to each be, the one with empty rowset will publish  version successfully.
6. We got 2 replica with data and 1 empty replica.

some related logs:
```
W1213 11:20:39.394577 44596 tablets_channel.cpp:486] tablet writer write failed, tablet_id=1810937, txn_id=3922018, err=6, errcode=-115, msg:    @     0x564106aedfb4  doris::Status::ConstructErrorStatus()
```

```
1810937_06.log:I1213 11:20:41.679987 308893 engine_publish_version_task.cpp:230] publish version successfully on tablet, table_id=1810887, tablet=1810937.41350314.9c4623d5c51c0ea5-88d29156b64b668a, transaction_id=3922018, version=27011, num_rows=6, res=OK
1810937_09.log:I1213 11:20:39.680902 44527 engine_publish_version_task.cpp:230] publish version successfully on tablet, table_id=1810887, tablet=1810937.41350314.744d1ca1d02c5584-33f949fb17d7f6b0, transaction_id=3922018, version=27011, num_rows=0, res=OK
1810937_199.log:I1213 11:20:41.678467 181209 engine_publish_version_task.cpp:230] publish version successfully on tablet, table_id=1810887, tablet=1810937.41350314.334bf755ba8a4c32-c9ab5db5baa7599c, transaction_id=3922018, version=27011, num_rows=6, res=OK
```


## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
8. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
9. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
10. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
11. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

