### PR TITLE
[Bug](s2geo)  avoid some core dump on s2geo && enable ut of s2geo

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -864,8 +864,6 @@ CONF_Bool(enable_fuzzy_mode, "false");
 
 CONF_Int32(pipeline_executor_size, "0");
 
-CONF_Double(s2geo_eps, "0.000000001");
-
 #ifdef BE_TEST
 // test s3
 CONF_String(test_s3_resource, "resource");

--- a/be/src/geo/geo_functions.cpp
+++ b/be/src/geo/geo_functions.cpp
@@ -24,7 +24,10 @@
 
 namespace doris {
 
-void GeoFunctions::init() {}
+void GeoFunctions::init() {
+    // set s2debug to false to avoid crash
+    FLAGS_s2debug = false;
+}
 
 DoubleVal GeoFunctions::st_distance_sphere(FunctionContext* ctx, const DoubleVal& x_lng,
                                            const DoubleVal& x_lat, const DoubleVal& y_lng,

--- a/be/test/geo/geo_functions_test.cpp
+++ b/be/test/geo/geo_functions_test.cpp
@@ -22,10 +22,8 @@
 
 #include <vector>
 
-#include "common/logging.h"
 #include "geo/geo_types.h"
 #include "geo/wkt_parse.h"
-#include "geo/wkt_parse_ctx.h"
 #include "testutil/function_utils.h"
 #include "udf/udf.h"
 #include "udf/udf_internal.h"
@@ -182,7 +180,7 @@ TEST_F(GeoFunctionsTest, st_line) {
         GeoFunctions::st_from_wkt_close(ctx, FunctionContext::FRAGMENT_LOCAL);
     }
 }
-/*
+
 TEST_F(GeoFunctionsTest, st_polygon) {
     FunctionUtils utils;
     FunctionContext* ctx = utils.get_fn_ctx();
@@ -216,7 +214,7 @@ TEST_F(GeoFunctionsTest, st_polygon) {
         GeoFunctions::st_from_wkt_close(ctx, FunctionContext::FRAGMENT_LOCAL);
     }
 }
-*/
+
 TEST_F(GeoFunctionsTest, st_circle) {
     FunctionUtils utils;
     FunctionContext* ctx = utils.get_fn_ctx();
@@ -275,7 +273,7 @@ TEST_F(GeoFunctionsTest, st_poly_line_fail) {
         GeoFunctions::st_from_wkt_close(ctx, FunctionContext::FRAGMENT_LOCAL);
     }
 }
-/*
+
 TEST_F(GeoFunctionsTest, st_contains) {
     FunctionUtils utils;
     FunctionContext* ctx = utils.get_fn_ctx();
@@ -325,5 +323,5 @@ TEST_F(GeoFunctionsTest, st_contains_cached) {
     EXPECT_TRUE(res.val);
     GeoFunctions::st_contains_close(ctx, FunctionContext::FRAGMENT_LOCAL);
 }
-*/
+
 } // namespace doris

--- a/be/test/geo/geo_types_test.cpp
+++ b/be/test/geo/geo_types_test.cpp
@@ -22,8 +22,6 @@
 #include "common/logging.h"
 #include "geo/geo_types.h"
 #include "geo/wkt_parse.h"
-#include "geo/wkt_parse_ctx.h"
-#include "s2/s2debug.h"
 
 namespace doris {
 
@@ -93,7 +91,7 @@ TEST_F(GeoTypesTest, linestring) {
         EXPECT_EQ(nullptr, line2);
     }
 }
-/*
+
 TEST_F(GeoTypesTest, polygon_contains) {
     const char* wkt = "POLYGON ((10 10, 50 10, 50 10, 50 50, 50 50, 10 50, 10 10))";
     GeoParseStatus status;
@@ -128,7 +126,7 @@ TEST_F(GeoTypesTest, polygon_contains) {
         EXPECT_EQ(nullptr, shape);
     }
 }
-*/
+
 TEST_F(GeoTypesTest, polygon_parse_fail) {
     {
         const char* wkt = "POLYGON ((10 10, 50 10, 50 50, 10 50), (10 10 01))";
@@ -152,7 +150,7 @@ TEST_F(GeoTypesTest, polygon_parse_fail) {
         EXPECT_EQ(nullptr, polygon.get());
     }
 }
-/*
+
 TEST_F(GeoTypesTest, polygon_hole_contains) {
     const char* wkt =
             "POLYGON ((10 10, 50 10, 50 50, 10 50, 10 10), (20 20, 40 20, 40 40, 20 40, 20 20))";
@@ -180,7 +178,7 @@ TEST_F(GeoTypesTest, polygon_hole_contains) {
         EXPECT_TRUE(res);
     }
 }
-*/
+
 TEST_F(GeoTypesTest, circle) {
     GeoCircle circle;
     auto res = circle.init(110.123, 64, 1000);

--- a/be/test/vec/function/function_geo_test.cpp
+++ b/be/test/vec/function/function_geo_test.cpp
@@ -22,9 +22,7 @@
 
 #include "function_test_util.h"
 #include "geo/geo_types.h"
-#include "vec/core/field.h"
 #include "vec/core/types.h"
-#include "vec/data_types/data_type_nullable.h"
 #include "vec/data_types/data_type_string.h"
 
 namespace doris::vectorized {
@@ -137,7 +135,7 @@ TEST(VGeoFunctionsTest, function_geo_st_distance_sphere) {
         check_function<DataTypeFloat64, true>(func_name, input_types, data_set);
     }
 }
-/*
+
 TEST(VGeoFunctionsTest, function_geo_st_contains) {
     std::string func_name = "st_contains";
     {
@@ -172,7 +170,7 @@ TEST(VGeoFunctionsTest, function_geo_st_contains) {
         check_function<DataTypeUInt8, true>(func_name, input_types, data_set);
     }
 }
-*/
+
 TEST(VGeoFunctionsTest, function_geo_st_circle) {
     std::string func_name = "st_circle";
     {
@@ -246,7 +244,6 @@ TEST(VGeoFunctionsTest, function_geo_st_linefromtext) {
     }
 }
 
-/*
 TEST(VGeoFunctionsTest, function_geo_st_polygon) {
     std::string func_name = "st_polygon";
     {
@@ -284,5 +281,5 @@ TEST(VGeoFunctionsTest, function_geo_st_polygonfromtext) {
         check_function<DataTypeString, true>(func_name, input_types, data_set);
     }
 }
-*/
+
 } // namespace doris::vectorized


### PR DESCRIPTION
# Proposed changes

avoid some core dump on s2geo && enable ut of s2geo
fix https://github.com/apache/doris/pull/15002
## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

