### PR TITLE
[fix](schema) Fix create table error if Colocate tables not equal to bucket num

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/ColocateGroupSchema.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/ColocateGroupSchema.java
@@ -30,6 +30,7 @@ import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 /*
@@ -110,6 +111,17 @@ public class ColocateGroupSchema implements Writable {
         if (!replicaAlloc.equals(this.replicaAlloc)) {
             ErrorReport.reportDdlException(ErrorCode.ERR_COLOCATE_TABLE_MUST_HAS_SAME_REPLICATION_ALLOCATION,
                     this.replicaAlloc);
+        }
+    }
+
+    public void checkDynamicPartition(Map<String, String> properties,
+                                      DistributionInfo distributionInfo) throws DdlException {
+        if (properties.get(DynamicPartitionProperty.BUCKETS) != null) {
+            HashDistributionInfo info = (HashDistributionInfo) distributionInfo;
+            if (info.getBucketNum() != Integer.parseInt(properties.get(DynamicPartitionProperty.BUCKETS))) {
+                ErrorReport.reportDdlException(
+                        ErrorCode.ERR_DYNAMIC_PARTITION_MUST_HAS_SAME_BUCKET_NUM_WITH_COLOCATE_TABLE, bucketsNum);
+            }
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/common/ErrorCode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/ErrorCode.java
@@ -1635,6 +1635,8 @@ public enum ErrorCode {
     ERR_COLOCATE_NOT_COLOCATE_TABLE(5064, new byte[]{'4', '2', '0', '0', '0'},
             "Table %s is not a colocated table"),
     ERR_INVALID_OPERATION(5065, new byte[]{'4', '2', '0', '0', '0'}, "Operation %s is invalid"),
+    ERR_DYNAMIC_PARTITION_MUST_HAS_SAME_BUCKET_NUM_WITH_COLOCATE_TABLE(5063, new byte[]{'4', '2', '0', '0', '0'},
+        "Dynamic partition buckets must equal the distribution buckets if creating a colocate table: %s"),
     ERROR_DYNAMIC_PARTITION_TIME_UNIT(5065, new byte[]{'4', '2', '0', '0', '0'},
             "Unsupported time unit %s. Expect HOUR/DAY/WEEK/MONTH."),
     ERROR_DYNAMIC_PARTITION_START_ZERO(5066, new byte[]{'4', '2', '0', '0', '0'},

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
@@ -1970,6 +1970,7 @@ public class InternalCatalog implements CatalogIf<Database> {
                 if (groupSchema != null) {
                     // group already exist, check if this table can be added to this group
                     groupSchema.checkColocateSchema(olapTable);
+                    groupSchema.checkDynamicPartition(properties, olapTable.getDefaultDistributionInfo());
                 }
                 // add table to this group, if group does not exist, create a new one
                 Env.getCurrentColocateIndex()


### PR DESCRIPTION
Proposed changes
Issue Number: close #14999 

Problem summary
使用 colocate_with 创建表时，会对 dynamic_partition_buckets 和 distribution buckets 做校验，若不相等会直接报错。

Checklist(Required)
Does it affect the original behavior:
 Yes
[ √] No
 I don't know
Has unit tests been added:
 Yes
 No
[ √] No Need
Has document been added or modified:
 Yes
[ √] No
 No Need
Does it need to update dependencies:
 Yes
[√ ] No
Are there any changes that cannot be rolled back:
 Yes (If Yes, please explain WHY)
[ √] No
Further comments
If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...