### PR TITLE
[fix](pipeline) _valid_element_in_hash_tbl was not set correctly

### DIFF
--- a/be/src/vec/common/hash_table/hash_table.h
+++ b/be/src/vec/common/hash_table/hash_table.h
@@ -317,6 +317,7 @@ public:
 
     void increase_size_degree(doris::vectorized::UInt8 delta) {
         size_degree_ += delta;
+        DCHECK(size_degree_ <= 64);
         precalculated_mask = (1ULL << size_degree_) - 1;
         precalculated_max_fill = 1ULL << (size_degree_ - 1);
     }

--- a/be/src/vec/exec/vset_operation_node.cpp
+++ b/be/src/vec/exec/vset_operation_node.cpp
@@ -174,6 +174,8 @@ Status VSetOperationNode<is_intersect>::init(const TPlanNode& tnode, RuntimeStat
         _child_expr_lists.push_back(ctxs);
     }
 
+    _probe_finished_children_index.assign(_child_expr_lists.size(), false);
+
     return Status::OK();
 }
 
@@ -183,7 +185,6 @@ Status VSetOperationNode<is_intersect>::alloc_resource(RuntimeState* state) {
     for (const std::vector<VExprContext*>& exprs : _child_expr_lists) {
         RETURN_IF_ERROR(VExpr::open(exprs, state));
     }
-    _probe_finished_children_index.assign(_child_expr_lists.size(), false);
     _probe_columns.resize(_child_expr_lists[1].size());
     return Status::OK();
 }
@@ -202,21 +203,6 @@ Status VSetOperationNode<is_intersect>::open(RuntimeState* state) {
     for (int i = 1; i < _children.size(); ++i) {
         RETURN_IF_ERROR(child(i)->open(state));
         eos = false;
-        int probe_expr_ctxs_sz = _child_expr_lists[i].size();
-        _probe_columns.resize(probe_expr_ctxs_sz);
-
-        if constexpr (is_intersect) {
-            _valid_element_in_hash_tbl = 0;
-        } else {
-            std::visit(
-                    [&](auto&& arg) {
-                        using HashTableCtxType = std::decay_t<decltype(arg)>;
-                        if constexpr (!std::is_same_v<HashTableCtxType, std::monostate>) {
-                            _valid_element_in_hash_tbl = arg.hash_table.size();
-                        }
-                    },
-                    *_hash_table_variants);
-        }
 
         while (!eos) {
             release_block_memory(_probe_block, i);
@@ -370,6 +356,18 @@ Status VSetOperationNode<is_intersect>::sink(RuntimeState*, Block* block, bool e
         ++_build_block_index;
 
         if (eos) {
+            if constexpr (is_intersect) {
+                _valid_element_in_hash_tbl = 0;
+            } else {
+                std::visit(
+                        [&](auto&& arg) {
+                            using HashTableCtxType = std::decay_t<decltype(arg)>;
+                            if constexpr (!std::is_same_v<HashTableCtxType, std::monostate>) {
+                                _valid_element_in_hash_tbl = arg.hash_table.size();
+                            }
+                        },
+                        *_hash_table_variants);
+            }
             _build_finished = true;
         }
     }
@@ -492,6 +490,18 @@ template <bool is_intersect>
 Status VSetOperationNode<is_intersect>::finalize_probe(RuntimeState* /*state*/, int child_id) {
     if (child_id != (_children.size() - 1)) {
         refresh_hash_table();
+        if constexpr (is_intersect) {
+            _valid_element_in_hash_tbl = 0;
+        } else {
+            std::visit(
+                    [&](auto&& arg) {
+                        using HashTableCtxType = std::decay_t<decltype(arg)>;
+                        if constexpr (!std::is_same_v<HashTableCtxType, std::monostate>) {
+                            _valid_element_in_hash_tbl = arg.hash_table.size();
+                        }
+                    },
+                    *_hash_table_variants);
+        }
         _probe_columns.resize(_child_expr_lists[child_id + 1].size());
     } else {
         _can_read = true;


### PR DESCRIPTION
# Proposed changes

The value of `VSetOperatorionNode::_valid_element_in_hash_tbl` was not set correctly in pipeline engine.

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

