### PR TITLE
[fix](multi-catalog) fix get many same name db/table when show where

### DIFF
--- a/be/src/exec/schema_scan_node.cpp
+++ b/be/src/exec/schema_scan_node.cpp
@@ -87,6 +87,10 @@ Status SchemaScanNode::init(const TPlanNode& tnode, RuntimeState* state) {
         _scanner_param.table_structure = _pool->add(
                 new std::vector<TSchemaTableStructure>(tnode.schema_scan_node.table_structure));
     }
+
+    if (tnode.schema_scan_node.__isset.catalog) {
+        _scanner_param.catalog = _pool->add(new std::string(tnode.schema_scan_node.catalog));
+    }
     return Status::OK();
 }
 

--- a/be/src/exec/schema_scanner.h
+++ b/be/src/exec/schema_scanner.h
@@ -44,6 +44,7 @@ struct SchemaScannerParam {
     int32_t port;                            // frontend thrift port
     int64_t thread_id;
     const std::vector<TSchemaTableStructure>* table_structure;
+    const std::string* catalog;
 
     SchemaScannerParam()
             : db(nullptr),
@@ -53,7 +54,8 @@ struct SchemaScannerParam {
               user_ip(nullptr),
               current_user_ident(nullptr),
               ip(nullptr),
-              port(0) {}
+              port(0),
+              catalog(nullptr) {}
 };
 
 // virtual scanner for all schema table

--- a/be/src/exec/schema_scanner/schema_columns_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_columns_scanner.cpp
@@ -70,6 +70,9 @@ Status SchemaColumnsScanner::start(RuntimeState* state) {
     if (nullptr != _param->db) {
         db_params.__set_pattern(*(_param->db));
     }
+    if (nullptr != _param->catalog) {
+        db_params.__set_catalog(*(_param->catalog));
+    }
     if (nullptr != _param->current_user_ident) {
         db_params.__set_current_user_ident(*_param->current_user_ident);
     } else {

--- a/be/src/exec/schema_scanner/schema_files_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_files_scanner.cpp
@@ -81,6 +81,9 @@ Status SchemaFilesScanner::start(RuntimeState* state) {
     if (NULL != _param->db) {
         db_params.__set_pattern(*(_param->db));
     }
+    if (nullptr != _param->catalog) {
+        db_params.__set_catalog(*(_param->catalog));
+    }
     if (NULL != _param->current_user_ident) {
         db_params.__set_current_user_ident(*(_param->current_user_ident));
     } else {

--- a/be/src/exec/schema_scanner/schema_partitions_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_partitions_scanner.cpp
@@ -69,6 +69,9 @@ Status SchemaPartitionsScanner::start(RuntimeState* state) {
     if (NULL != _param->db) {
         db_params.__set_pattern(*(_param->db));
     }
+    if (nullptr != _param->catalog) {
+        db_params.__set_catalog(*(_param->catalog));
+    }
     if (NULL != _param->current_user_ident) {
         db_params.__set_current_user_ident(*(_param->current_user_ident));
     } else {

--- a/be/src/exec/schema_scanner/schema_schemata_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_schemata_scanner.cpp
@@ -46,6 +46,9 @@ Status SchemaSchemataScanner::start(RuntimeState* state) {
     if (nullptr != _param->wild) {
         db_params.__set_pattern(*(_param->wild));
     }
+    if (nullptr != _param->catalog) {
+        db_params.__set_catalog(*(_param->catalog));
+    }
     if (nullptr != _param->current_user_ident) {
         db_params.__set_current_user_ident(*(_param->current_user_ident));
     } else {

--- a/be/src/exec/schema_scanner/schema_tables_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_tables_scanner.cpp
@@ -64,6 +64,9 @@ Status SchemaTablesScanner::start(RuntimeState* state) {
     if (nullptr != _param->db) {
         db_params.__set_pattern(*(_param->db));
     }
+    if (nullptr != _param->catalog) {
+        db_params.__set_catalog(*(_param->catalog));
+    }
     if (nullptr != _param->current_user_ident) {
         db_params.__set_current_user_ident(*(_param->current_user_ident));
     } else {

--- a/be/src/exec/schema_scanner/schema_views_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_views_scanner.cpp
@@ -53,6 +53,9 @@ Status SchemaViewsScanner::start(RuntimeState* state) {
     if (nullptr != _param->db) {
         db_params.__set_pattern(*(_param->db));
     }
+    if (nullptr != _param->catalog) {
+        db_params.__set_catalog(*(_param->catalog));
+    }
     if (nullptr != _param->current_user_ident) {
         db_params.__set_current_user_ident(*(_param->current_user_ident));
     } else {

--- a/be/src/vec/exec/vschema_scan_node.cpp
+++ b/be/src/vec/exec/vschema_scan_node.cpp
@@ -97,6 +97,10 @@ Status VSchemaScanNode::init(const TPlanNode& tnode, RuntimeState* state) {
         _scanner_param.table_structure = _pool->add(
                 new std::vector<TSchemaTableStructure>(tnode.schema_scan_node.table_structure));
     }
+
+    if (tnode.schema_scan_node.__isset.catalog) {
+        _scanner_param.catalog = _pool->add(new std::string(tnode.schema_scan_node.catalog));
+    }
     return Status::OK();
 }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/Analyzer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/Analyzer.java
@@ -139,6 +139,7 @@ public class Analyzer {
     private final Map<TupleId, Integer> currentOutputColumn = Maps.newHashMap();
     // used for Information Schema Table Scan
     private String schemaDb;
+    private String schemaCatalog;
     private String schemaWild;
     private String schemaTable; // table used in DESCRIBE Table
 
@@ -2025,6 +2026,10 @@ public class Analyzer {
         return schemaDb;
     }
 
+    public String getSchemaCatalog() {
+        return schemaCatalog;
+    }
+
     public String getSchemaTable() {
         return schemaTable;
     }
@@ -2044,10 +2049,11 @@ public class Analyzer {
     }
 
     // for Schema Table Schema like SHOW TABLES LIKE "abc%"
-    public void setSchemaInfo(String db, String table, String wild) {
+    public void setSchemaInfo(String db, String table, String wild, String catalog) {
         schemaDb = db;
         schemaTable = table;
         schemaWild = wild;
+        schemaCatalog = catalog;
     }
 
     public String getTargetDbName(FunctionName fnName) {

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowColumnStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowColumnStmt.java
@@ -164,7 +164,7 @@ public class ShowColumnStmt extends ShowStmt {
         selectStmt = new SelectStmt(selectList,
                 new FromClause(Lists.newArrayList(new TableRef(TABLE_NAME, null))),
                 where, null, null, null, LimitElement.NO_LIMIT);
-        analyzer.setSchemaInfo(tableName.getDb(), tableName.getTbl(), null);
+        analyzer.setSchemaInfo(tableName.getDb(), tableName.getTbl(), null, tableName.getCtl());
 
         return selectStmt;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowDbStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowDbStmt.java
@@ -88,7 +88,11 @@ public class ShowDbStmt extends ShowStmt {
         selectStmt = new SelectStmt(selectList,
                 new FromClause(Lists.newArrayList(new TableRef(TABLE_NAME, null))),
                 where, null, null, null, LimitElement.NO_LIMIT);
-
+        if (catalogName != null) {
+            analyzer.setSchemaInfo(null, null, null, catalogName);
+        } else {
+            analyzer.setSchemaInfo(null, null, null, analyzer.getDefaultCatalog());
+        }
         return selectStmt;
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowTableStatusStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowTableStatusStmt.java
@@ -183,7 +183,7 @@ public class ShowTableStatusStmt extends ShowStmt {
         selectStmt = new SelectStmt(selectList,
                 new FromClause(Lists.newArrayList(new TableRef(TABLE_NAME, null))),
                 where, null, null, null, LimitElement.NO_LIMIT);
-        analyzer.setSchemaInfo(db, null, null);
+        analyzer.setSchemaInfo(db, null, null, analyzer.getDefaultCatalog());
 
         return selectStmt;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowTableStatusStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowTableStatusStmt.java
@@ -183,7 +183,8 @@ public class ShowTableStatusStmt extends ShowStmt {
         selectStmt = new SelectStmt(selectList,
                 new FromClause(Lists.newArrayList(new TableRef(TABLE_NAME, null))),
                 where, null, null, null, LimitElement.NO_LIMIT);
-        analyzer.setSchemaInfo(db, null, null, analyzer.getDefaultCatalog());
+        analyzer.setSchemaInfo(ClusterNamespace.getNameFromFullName(db), null, null,
+                                analyzer.getDefaultCatalog());
 
         return selectStmt;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowTableStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowTableStmt.java
@@ -114,7 +114,8 @@ public class ShowTableStmt extends ShowStmt {
                 new FromClause(Lists.newArrayList(new TableRef(TABLE_NAME, null))),
                 where, null, null, null, LimitElement.NO_LIMIT);
 
-        analyzer.setSchemaInfo(ClusterNamespace.getNameFromFullName(db), null, null);
+        analyzer.setSchemaInfo(ClusterNamespace.getNameFromFullName(db), null, null,
+                                analyzer.getDefaultCatalog());
 
         return selectStmt;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowVariablesStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowVariablesStmt.java
@@ -106,7 +106,7 @@ public class ShowVariablesStmt extends ShowStmt {
 
         // DB: type
         // table: thread id
-        analyzer.setSchemaInfo(type.toSql(), null, null);
+        analyzer.setSchemaInfo(type.toSql(), null, null, null);
         return selectStmt;
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/SchemaScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/SchemaScanNode.java
@@ -52,6 +52,7 @@ public class SchemaScanNode extends ScanNode {
     private String userIp;
     private String frontendIP;
     private int frontendPort;
+    private String schemaCatalog;
 
     /**
      * Constructs node to scan given data files of table 'tbl'.
@@ -77,6 +78,7 @@ public class SchemaScanNode extends ScanNode {
         userIp = analyzer.getContext().getRemoteIP();
         frontendIP = FrontendOptions.getLocalHostAddress();
         frontendPort = Config.rpc_port;
+        schemaCatalog = analyzer.getSchemaCatalog();
     }
 
     @Override
@@ -91,6 +93,9 @@ public class SchemaScanNode extends ScanNode {
             } else if (tableName.equalsIgnoreCase("SESSION_VARIABLES")) {
                 msg.schema_scan_node.setDb("SESSION");
             }
+        }
+        if (schemaCatalog != null) {
+            msg.schema_scan_node.setCatalog(schemaCatalog);
         }
         msg.schema_scan_node.show_hidden_cloumns = Util.showHiddenColumns();
 

--- a/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
@@ -172,7 +172,13 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         }
 
         Env env = Env.getCurrentEnv();
-        List<CatalogIf> catalogIfs = env.getCatalogMgr().listCatalogs();
+        List<CatalogIf> catalogIfs = Lists.newArrayList();
+        if (Strings.isNullOrEmpty(params.catalog)) {
+            catalogIfs = env.getCatalogMgr().listCatalogs();
+        } else {
+            catalogIfs.add(env.getCatalogMgr()
+                    .getCatalogOrException(params.catalog, catalog -> new TException("Unknown catalog " + catalog)));
+        }
         for (CatalogIf catalog : catalogIfs) {
             List<String> dbNames = catalog.getDbNames();
             LOG.debug("get db names: {}, in catalog: {}", dbNames, catalog.getName());

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -287,6 +287,7 @@ struct TGetDbsParams {
   2: optional string user   // deprecated
   3: optional string user_ip    // deprecated
   4: optional Types.TUserIdentity current_user_ident // to replace the user and user ip
+  5: optional string catalog
 }
 
 // getDbNames returns a list of database names and catalog names

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -496,6 +496,7 @@ struct TSchemaScanNode {
   11: optional Types.TUserIdentity current_user_ident   // to replace the user and user_ip
   12: optional bool show_hidden_cloumns = false
   13: optional list<TSchemaTableStructure> table_structure
+  14: optional string catalog
 }
 
 struct TMetaScanNode {


### PR DESCRIPTION
when show databases/tables/table status where xxx, it will change a selectStmt to select result from information_schema, it need catalog info to scan schema table, otherwise may get many database or table info from multi catalog.

for example
mysql> show databases where schema_name='test';
+----------+
| Database |
+----------+
| test     |
| test     |
+----------+

MySQL [internal.test]> show tables from test where table_name='test_dc';
+----------------+
| Tables_in_test |
+----------------+
| test_dc        |
| test_dc        |
+----------------+

# Proposed changes

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

