### PR TITLE
[fix](resource) HdfsStorage can get default.Fs from path or configuration

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/OutFileClause.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/OutFileClause.java
@@ -624,7 +624,6 @@ public class OutFileClause {
         } else if (filePath.toUpperCase().startsWith(HDFS_FILE_PREFIX.toUpperCase())) {
             brokerName = StorageBackend.StorageType.HDFS.name();
             storageType = StorageBackend.StorageType.HDFS;
-            filePath = filePath.substring(HDFS_FILE_PREFIX.length() - 1);
         } else {
             return;
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/OutFileClause.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/OutFileClause.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.analysis;
 
+import org.apache.doris.backup.HdfsStorage;
 import org.apache.doris.backup.S3Storage;
 import org.apache.doris.catalog.HdfsResource;
 import org.apache.doris.catalog.PrimitiveType;
@@ -649,6 +650,10 @@ public class OutFileClause {
         }
         if (storageType == StorageBackend.StorageType.S3) {
             S3Storage.checkS3(brokerProps);
+        } else if (storageType == StorageBackend.StorageType.HDFS) {
+            if (!brokerProps.containsKey(HdfsResource.HADOOP_FS_NAME)) {
+                brokerProps.put(HdfsResource.HADOOP_FS_NAME, HdfsStorage.getFsName(filePath));
+            }
         }
 
         brokerDesc = new BrokerDesc(brokerName, storageType, brokerProps);

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/OutFileClause.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/OutFileClause.java
@@ -17,7 +17,6 @@
 
 package org.apache.doris.analysis;
 
-import org.apache.doris.backup.HdfsStorage;
 import org.apache.doris.backup.S3Storage;
 import org.apache.doris.catalog.HdfsResource;
 import org.apache.doris.catalog.PrimitiveType;
@@ -650,8 +649,6 @@ public class OutFileClause {
         }
         if (storageType == StorageBackend.StorageType.S3) {
             S3Storage.checkS3(brokerProps);
-        } else if (storageType == StorageBackend.StorageType.HDFS) {
-            HdfsStorage.checkHDFS(brokerProps);
         }
 
         brokerDesc = new BrokerDesc(brokerName, storageType, brokerProps);

--- a/fe/fe-core/src/main/java/org/apache/doris/backup/HdfsStorage.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/backup/HdfsStorage.java
@@ -23,7 +23,6 @@ import org.apache.doris.catalog.HdfsResource;
 import org.apache.doris.common.UserException;
 import org.apache.doris.common.util.URI;
 
-import org.apache.commons.collections.map.CaseInsensitiveMap;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FSDataOutputStream;
@@ -49,6 +48,7 @@ import java.nio.file.FileVisitOption;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -58,7 +58,7 @@ import java.util.Map;
  */
 public class HdfsStorage extends BlobStorage {
     private static final Logger LOG = LogManager.getLogger(HdfsStorage.class);
-    private final Map<String, String> caseInsensitiveProperties;
+    private final Map<String, String> hdfsProperties;
 
     private final int readBufferSize = 128 << 10; // 128k
     private final int writeBufferSize = 128 << 10; // 128k
@@ -71,19 +71,26 @@ public class HdfsStorage extends BlobStorage {
      * @param properties parameters to access HDFS.
      */
     public HdfsStorage(Map<String, String> properties) {
-        caseInsensitiveProperties = new CaseInsensitiveMap();
+        hdfsProperties = new HashMap<>();
         setProperties(properties);
         setType(StorageBackend.StorageType.HDFS);
         setName(StorageBackend.StorageType.HDFS.name());
     }
 
+    public static String getFsName(String path) {
+        Path hdfsPath = new Path(path);
+        String fullPath = hdfsPath.toUri().toString();
+        String filePath = hdfsPath.toUri().getPath();
+        return fullPath.replace(filePath, "");
+    }
+
     @Override
     public FileSystem getFileSystem(String remotePath) throws UserException {
         if (dfsFileSystem == null) {
-            String username = caseInsensitiveProperties.get(HdfsResource.HADOOP_USER_NAME);
+            String username = hdfsProperties.get(HdfsResource.HADOOP_USER_NAME);
             Configuration conf = new HdfsConfiguration();
             boolean isSecurityEnabled = false;
-            for (Map.Entry<String, String> propEntry : caseInsensitiveProperties.entrySet()) {
+            for (Map.Entry<String, String> propEntry : hdfsProperties.entrySet()) {
                 conf.set(propEntry.getKey(), propEntry.getValue());
                 if (propEntry.getKey().equals(HdfsResource.HADOOP_SECURITY_AUTHENTICATION)
                         && propEntry.getValue().equals(AuthType.KERBEROS.getDesc())) {
@@ -95,8 +102,8 @@ public class HdfsStorage extends BlobStorage {
                 if (isSecurityEnabled) {
                     UserGroupInformation.setConfiguration(conf);
                     UserGroupInformation.loginUserFromKeytab(
-                            caseInsensitiveProperties.get(HdfsResource.HADOOP_KERBEROS_PRINCIPAL),
-                            caseInsensitiveProperties.get(HdfsResource.HADOOP_KERBEROS_KEYTAB));
+                            hdfsProperties.get(HdfsResource.HADOOP_KERBEROS_PRINCIPAL),
+                            hdfsProperties.get(HdfsResource.HADOOP_KERBEROS_KEYTAB));
                 }
                 if (username == null) {
                     dfsFileSystem = FileSystem.get(java.net.URI.create(remotePath), conf);
@@ -114,7 +121,7 @@ public class HdfsStorage extends BlobStorage {
     @Override
     public void setProperties(Map<String, String> properties) {
         super.setProperties(properties);
-        caseInsensitiveProperties.putAll(properties);
+        hdfsProperties.putAll(properties);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/HdfsResource.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/HdfsResource.java
@@ -27,8 +27,6 @@ import com.google.common.collect.Maps;
 import com.google.gson.annotations.SerializedName;
 
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 
 /**
@@ -56,7 +54,6 @@ public class HdfsResource extends Resource {
     public static String HADOOP_KERBEROS_KEYTAB = "hadoop.kerberos.keytab";
     public static String HADOOP_SHORT_CIRCUIT = "dfs.client.read.shortcircuit";
     public static String HADOOP_SOCKET_PATH = "dfs.domain.socket.path";
-    public static List<String> REQUIRED_FIELDS = Collections.singletonList(HADOOP_FS_NAME);
 
     @SerializedName(value = "properties")
     private Map<String, String> properties;
@@ -75,11 +72,6 @@ public class HdfsResource extends Resource {
 
     @Override
     protected void setProperties(Map<String, String> properties) throws DdlException {
-        for (String field : REQUIRED_FIELDS) {
-            if (!properties.containsKey(field)) {
-                throw new DdlException("Missing [" + field + "] in properties.");
-            }
-        }
         // `dfs.client.read.shortcircuit` and `dfs.domain.socket.path` should be both set to enable short circuit read.
         // We should disable short circuit read if they are not both set because it will cause performance down.
         if (!properties.containsKey(HADOOP_SHORT_CIRCUIT) || !properties.containsKey(HADOOP_SOCKET_PATH)) {

--- a/regression-test/data/external_catalog_p0/hive/test_hive_other.out
+++ b/regression-test/data/external_catalog_p0/hive/test_hive_other.out
@@ -671,3 +671,11 @@ zyLjAtVdXV	GrJRf8WvRR
 2022-11-25	2022-11-25	zj9uWRywHa	5F8hzYcY8G	2022-11-25
 2022-11-25	2022-11-25	zvs3b72ERY	zorbigHkYB	2022-11-25
 
+-- !student --
+124	lisi	13	f	abcdefh	13056781234
+123	zhangsan	12	m	abcdefg	13012345678
+
+-- !tvf_student --
+124	lisi	13	f	abcdefh	13056781234
+123	zhangsan	12	m	abcdefg	13012345678
+


### PR DESCRIPTION
# Proposed changes

## Problem summary
Fix three bugs:
1. External table is failed when query data
```
CREATE TABLE `student` (
  `id` int NOT NULL,
  `name` string NOT NULL
) ENGINE=HIVE
COMMENT "HIVE"
PROPERTIES (
'hive.metastore.uris' = 'thrift://yongkang:9083',
'database' = 'test1',
'table' = 'student'
); 

msyql> select * from student;
ERROR 1105 (HY000): errCode = 2, detailMessage = The properties of hdfs are invalid. fs.defaultFS is needed.
```
PR(https://github.com/apache/doris/pull/14842) has unified resource interface, the external table will use `HdfsStorage` to list file status. `HdfsStorage` was previously use by `OutFileClause` which would check `fs.defaultFS` property, but `fs.defaultFS` can be got from path, so the external catalog and external table don't need to set `fs.defaultFS`. This pr add same the logical to `OutFileClause` that get `fs.defaultFS` from file path.

2. `HdfsStorage` use `CaseInsensitiveMap` to save hdfs properties, which is case sensitive however, for example:
```
'dfs.nameservices'='HDFSxxx',
'dfs.ha.namenodes.HDFSxxx'='nn1,nn2',
```
If use `CaseInsensitiveMap`, we will get:
```
'dfs.nameservices'='HDFSxxx',
'dfs.ha.namenodes.hdfsxxx'='nn1,nn2',
```
'dfs.ha.namenodes.HDFSxxx' is lowercase to 'dfs.ha.namenodes.hdfsxxx', so the hdfs can't find namenode for 'HDFSxxx', causing failure like:
```
ERROR 1105 (HY000): errCode = 2, detailMessage = errCode = 2, detailMessage = errors while connect to hdfs://HDFSxxx

java.lang.IllegalArgumentException: java.net.UnknownHostException: HDFSxxx
	at org.apache.hadoop.security.SecurityUtil.buildTokenService(SecurityUtil.java:417) ~[hadoop-common-2.8.0.jar:?]
	at org.apache.hadoop.hdfs.NameNodeProxiesClient.createProxyWithClientProtocol(NameNodeProxiesClient.java:130) ~[hadoop-hdfs-client-2.8.0.jar:?]
	at org.apache.hadoop.hdfs.DFSClient.<init>(DFSClient.java:343) ~[hadoop-hdfs-client-2.8.0.jar:?]
	at org.apache.hadoop.hdfs.DFSClient.<init>(DFSClient.java:287) ~[hadoop-hdfs-client-2.8.0.jar:?]
	at org.apache.hadoop.hdfs.DistributedFileSystem.initialize(DistributedFileSystem.java:156) ~[hadoop-hdfs-client-2.8.0.jar:?]
	at org.apache.hadoop.fs.FileSystem.createFileSystem(FileSystem.java:2811) ~[hadoop-common-2.8.0.jar:?]
	at org.apache.hadoop.fs.FileSystem.access$200(FileSystem.java:100) ~[hadoop-common-2.8.0.jar:?]
	at org.apache.hadoop.fs.FileSystem$Cache.getInternal(FileSystem.java:2848) ~[hadoop-common-2.8.0.jar:?]
	at org.apache.hadoop.fs.FileSystem$Cache.get(FileSystem.java:2830) ~[hadoop-common-2.8.0.jar:?]
	at org.apache.hadoop.fs.FileSystem.get(FileSystem.java:389) ~[hadoop-common-2.8.0.jar:?]
	at org.apache.doris.backup.HdfsStorage.getFileSystem(HdfsStorage.java:102) ~[doris-fe.jar:1.0-SNAPSHOT]
	at org.apache.doris.backup.HdfsStorage.listLocatedStatus(HdfsStorage.java:490) ~[doris-fe.jar:1.0-SNAPSHOT]
	at org.apache.doris.catalog.HiveMetaStoreClientHelper.getHiveDataFiles(HiveMetaStoreClientHelper.java:192) ~[doris-fe.jar:1.0-SNAPSHOT]
```

3. `OutFileClause` remove the `hdfs:/` prefix of file path, causing the result is written in local file system in BE.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
4. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
5. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
6. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
7. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

