### PR TITLE
[fix](meta) fix bug that backend tag may change to default after upgrading to 1.2

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/system/Backend.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/system/Backend.java
@@ -573,13 +573,12 @@ public class Backend implements Writable {
             // When first upgrade from old version, tags may be null
             tagMap = Maps.newHashMap();
         }
-        if (!tagMap.containsKey(Tag.TYPE_LOCATION)) {
+        if (!locationTag.value.equals(tagMap.get(Tag.TYPE_LOCATION))) {
             // ATTN: here we use Tag.TYPE_LOCATION directly, not locationTag.type,
             // because we need to make sure the previous tag must be a location type tag,
             // and if not, convert it to location type.
             tagMap.put(Tag.TYPE_LOCATION, locationTag.value);
         }
-        locationTag = Tag.createNotCheck(Tag.TYPE_LOCATION, tagMap.get(Tag.TYPE_LOCATION));
     }
 
     public static Backend read(DataInput in) throws IOException {


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

When upgrading from 1.1.x to 1.2.x, the tag of backend may change to `location:default`,
no matter what you set before.
This PR fix this issue

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

