### PR TITLE
[fix](compile) compile error while with DORIS_WITH_MYSQL

### DIFF
--- a/be/src/exec/exec_node.cpp
+++ b/be/src/exec/exec_node.cpp
@@ -38,6 +38,7 @@
 #include "exec/hash_join_node.h"
 #include "exec/intersect_node.h"
 #include "exec/merge_node.h"
+#include "exec/mysql_scan_node.h"
 #include "exec/odbc_scan_node.h"
 #include "exec/olap_scan_node.h"
 #include "exec/partitioned_aggregation_node.h"


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

Can not find MysqlScanNode while compile with DORIS_WITH_MYSQL.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

