### PR TITLE
[enhancement](gc) sub_file_cache checks the directory files when gc

### DIFF
--- a/be/src/io/cache/dummy_file_cache.cpp
+++ b/be/src/io/cache/dummy_file_cache.cpp
@@ -44,62 +44,20 @@ void DummyFileCache::_add_file_cache(const Path& data_file) {
 }
 
 void DummyFileCache::_load() {
-    // list all files
-    std::vector<Path> cache_file_names;
-    if (!io::global_local_filesystem()->list(_cache_dir, &cache_file_names).ok()) {
+    std::vector<Path> cache_names;
+    if (!_get_dir_file(_cache_dir, cache_names, _unfinished_files).ok()) {
         return;
     }
 
-    // separate DATA file and DONE file
-    std::set<Path> cache_names;
-    std::list<Path> done_names;
-    for (const auto& cache_file_name : cache_file_names) {
-        if (ends_with(cache_file_name.native(), CACHE_DONE_FILE_SUFFIX)) {
-            done_names.push_back(cache_file_name);
-        } else {
-            cache_names.insert(cache_file_name);
-        }
+    for (auto file : cache_names) {
+        _add_file_cache(file);
     }
-
-    // match DONE file with DATA file
-    for (auto iter = done_names.begin(); iter != done_names.end(); ++iter) {
-        Path cache_filename = StringReplace(iter->native(), CACHE_DONE_FILE_SUFFIX, "", true);
-        if (cache_names.find(cache_filename) != cache_names.end()) {
-            cache_names.erase(cache_filename);
-            _add_file_cache(cache_filename);
-        } else {
-            // not data file, but with DONE file
-            _unfinished_files.push_back(*iter);
-        }
-    }
-    // data file without DONE file
-    for (const auto& file : cache_names) {
-        _unfinished_files.push_back(file);
-    }
-}
-
-Status DummyFileCache::_clean_unfinished_cache() {
-    // remove cache file without done file
-    for (auto iter = _unfinished_files.begin(); iter != _unfinished_files.end(); ++iter) {
-        Path cache_file_path = _cache_dir / *iter;
-        LOG(INFO) << "Delete unfinished cache file: " << cache_file_path.native();
-        if (!io::global_local_filesystem()->delete_file(cache_file_path).ok()) {
-            LOG(ERROR) << "delete_file failed: " << cache_file_path.native();
-        }
-    }
-    std::vector<Path> cache_file_names;
-    if (io::global_local_filesystem()->list(_cache_dir, &cache_file_names).ok() &&
-        cache_file_names.size() == 0) {
-        if (global_local_filesystem()->delete_directory(_cache_dir).ok()) {
-            LOG(INFO) << "Delete empty dir: " << _cache_dir.native();
-        }
-    }
-    return Status::OK();
 }
 
 Status DummyFileCache::load_and_clean() {
     _load();
-    return _clean_unfinished_cache();
+    RETURN_IF_ERROR(_clean_unfinished_files(_unfinished_files));
+    return _check_and_delete_dir(_cache_dir);
 }
 
 Status DummyFileCache::clean_timeout_cache() {
@@ -113,13 +71,17 @@ Status DummyFileCache::clean_timeout_cache() {
     return Status::OK();
 }
 
+Status DummyFileCache::clean_cache_normal() {
+    return clean_timeout_cache();
+}
+
 Status DummyFileCache::clean_all_cache() {
     while (!_gc_lru_queue.empty()) {
         RETURN_IF_ERROR(_clean_cache_internal(_gc_lru_queue.top().file, nullptr));
         _gc_lru_queue.pop();
     }
     _cache_file_size = 0;
-    return Status::OK();
+    return _check_and_delete_dir(_cache_dir);
 }
 
 Status DummyFileCache::clean_one_cache(size_t* cleaned_size) {
@@ -129,12 +91,15 @@ Status DummyFileCache::clean_one_cache(size_t* cleaned_size) {
         _cache_file_size -= *cleaned_size;
         _gc_lru_queue.pop();
     }
+    if (_gc_lru_queue.empty()) {
+        RETURN_IF_ERROR(_check_and_delete_dir(_cache_dir));
+    }
     return Status::OK();
 }
 
 Status DummyFileCache::_clean_cache_internal(const Path& cache_file_path, size_t* cleaned_size) {
     Path done_file_path = cache_file_path.native() + CACHE_DONE_FILE_SUFFIX;
-    return _remove_file(cache_file_path, done_file_path, cleaned_size);
+    return _remove_cache_and_done(cache_file_path, done_file_path, cleaned_size);
 }
 
 } // namespace io

--- a/be/src/io/cache/dummy_file_cache.h
+++ b/be/src/io/cache/dummy_file_cache.h
@@ -52,7 +52,9 @@ public:
 
     io::FileReaderSPtr remote_file_reader() const override { return nullptr; }
 
-    Status clean_timeout_cache() override;
+    Status clean_timeout_cache();
+    
+    Status clean_cache_normal() override;
 
     Status clean_all_cache() override;
 
@@ -69,7 +71,6 @@ public:
     bool is_gc_finish() const override { return _gc_lru_queue.empty(); }
 
 private:
-    Status _clean_unfinished_cache();
     void _add_file_cache(const Path& data_file);
     void _load();
     Status _clean_cache_internal(const Path&, size_t*);
@@ -86,7 +87,7 @@ private:
     Path _cache_dir;
     int64_t _alive_time_sec;
 
-    std::list<Path> _unfinished_files;
+    std::vector<Path> _unfinished_files;
 };
 
 } // namespace io

--- a/be/src/io/cache/dummy_file_cache.h
+++ b/be/src/io/cache/dummy_file_cache.h
@@ -52,9 +52,7 @@ public:
 
     io::FileReaderSPtr remote_file_reader() const override { return nullptr; }
 
-    Status clean_timeout_cache();
-    
-    Status clean_cache_normal() override;
+    Status clean_timeout_cache() override;
 
     Status clean_all_cache() override;
 

--- a/be/src/io/cache/file_cache.h
+++ b/be/src/io/cache/file_cache.h
@@ -44,7 +44,7 @@ public:
 
     virtual io::FileReaderSPtr remote_file_reader() const = 0;
 
-    virtual Status clean_cache_normal() = 0;
+    virtual Status clean_timeout_cache() = 0;
 
     virtual Status clean_all_cache() = 0;
 
@@ -66,12 +66,12 @@ protected:
     Status _remove_cache_and_done(const Path& cache_file, const Path& cache_done_file,
                                   size_t* cleaned_size);
 
-    Status _get_dir_file(const Path& cache_dir, std::vector<Path>& cache_names,
-                         std::vector<Path>& unfinished_files);
+    Status _get_dir_files_and_remove_unfinished(const Path& cache_dir,
+                                                std::vector<Path>& cache_names);
 
     Status _clean_unfinished_files(const std::vector<Path>& unfinished_files);
 
-    Status _check_and_delete_dir(const Path& cache_dir);
+    Status _check_and_delete_empty_dir(const Path& cache_dir);
 
     template <typename T>
     struct SubFileLRUComparator {

--- a/be/src/io/cache/file_cache.h
+++ b/be/src/io/cache/file_cache.h
@@ -44,7 +44,7 @@ public:
 
     virtual io::FileReaderSPtr remote_file_reader() const = 0;
 
-    virtual Status clean_timeout_cache() = 0;
+    virtual Status clean_cache_normal() = 0;
 
     virtual Status clean_all_cache() = 0;
 
@@ -61,7 +61,17 @@ public:
     virtual int64_t get_oldest_match_time() const = 0;
 
 protected:
-    Status _remove_file(const Path& cache_file, const Path& cache_done_file, size_t* cleaned_size);
+    Status _remove_file(const Path& file, size_t* cleaned_size);
+
+    Status _remove_cache_and_done(const Path& cache_file, const Path& cache_done_file,
+                                  size_t* cleaned_size);
+
+    Status _get_dir_file(const Path& cache_dir, std::vector<Path>& cache_names,
+                         std::vector<Path>& unfinished_files);
+
+    Status _clean_unfinished_files(const std::vector<Path>& unfinished_files);
+
+    Status _check_and_delete_dir(const Path& cache_dir);
 
     template <typename T>
     struct SubFileLRUComparator {

--- a/be/src/io/cache/file_cache_manager.cpp
+++ b/be/src/io/cache/file_cache_manager.cpp
@@ -142,7 +142,7 @@ void FileCacheManager::_gc_unused_file_caches(std::list<FileCachePtr>& result) {
                 // load cache meta from disk and clean unfinished cache files
                 file_cache->load_and_clean();
                 // policy1: GC file cache by timeout
-                file_cache->clean_timeout_cache();
+                file_cache->clean_cache_normal();
 
                 result.push_back(file_cache);
             }
@@ -184,7 +184,7 @@ void FileCacheManager::gc_file_caches() {
                 continue;
             }
             // policy1: GC file cache by timeout
-            iter->second->clean_timeout_cache();
+            iter->second->clean_cache_normal();
             // sort file cache by last match time
             _add_file_cache_for_gc_by_disk(contexts, iter->second);
         }

--- a/be/src/io/cache/file_cache_manager.cpp
+++ b/be/src/io/cache/file_cache_manager.cpp
@@ -142,7 +142,7 @@ void FileCacheManager::_gc_unused_file_caches(std::list<FileCachePtr>& result) {
                 // load cache meta from disk and clean unfinished cache files
                 file_cache->load_and_clean();
                 // policy1: GC file cache by timeout
-                file_cache->clean_cache_normal();
+                file_cache->clean_timeout_cache();
 
                 result.push_back(file_cache);
             }
@@ -184,7 +184,7 @@ void FileCacheManager::gc_file_caches() {
                 continue;
             }
             // policy1: GC file cache by timeout
-            iter->second->clean_cache_normal();
+            iter->second->clean_timeout_cache();
             // sort file cache by last match time
             _add_file_cache_for_gc_by_disk(contexts, iter->second);
         }

--- a/be/src/io/cache/sub_file_cache.h
+++ b/be/src/io/cache/sub_file_cache.h
@@ -48,7 +48,7 @@ public:
 
     io::FileReaderSPtr remote_file_reader() const override { return _remote_file_reader; }
 
-    Status clean_cache_normal() override;
+    Status clean_timeout_cache() override;
 
     Status clean_all_cache() override;
 
@@ -68,9 +68,9 @@ private:
     Status _get_need_cache_offsets(size_t offset, size_t req_size,
                                    std::vector<size_t>* cache_offsets);
 
-    size_t _calc_cache_file_size();
-
     std::pair<Path, Path> _cache_path(size_t offset);
+
+    void _init();
 
 private:
     struct SubFileInfo {
@@ -91,6 +91,8 @@ private:
     std::map<size_t, int64_t> _last_match_times;
     // offset_begin -> local file reader
     std::map<size_t, io::FileReaderSPtr> _cache_file_readers;
+
+    std::once_flag init_flag;
 };
 
 } // namespace io

--- a/be/src/io/cache/sub_file_cache.h
+++ b/be/src/io/cache/sub_file_cache.h
@@ -48,7 +48,7 @@ public:
 
     io::FileReaderSPtr remote_file_reader() const override { return _remote_file_reader; }
 
-    Status clean_timeout_cache() override;
+    Status clean_cache_normal() override;
 
     Status clean_all_cache() override;
 

--- a/be/src/io/cache/whole_file_cache.h
+++ b/be/src/io/cache/whole_file_cache.h
@@ -48,15 +48,13 @@ public:
 
     io::FileReaderSPtr remote_file_reader() const override { return _remote_file_reader; }
 
-    Status clean_timeout_cache();
-
-    Status clean_cache_normal() override;
+    Status clean_timeout_cache() override;
 
     Status clean_all_cache() override;
 
     Status clean_one_cache(size_t* cleaned_size) override;
 
-    int64_t get_oldest_match_time() const override { return _gc_match_time; };
+    int64_t get_oldest_match_time() const override { return _gc_match_time; }
 
     bool is_gc_finish() const override;
 

--- a/be/src/io/cache/whole_file_cache.h
+++ b/be/src/io/cache/whole_file_cache.h
@@ -48,15 +48,17 @@ public:
 
     io::FileReaderSPtr remote_file_reader() const override { return _remote_file_reader; }
 
-    Status clean_timeout_cache() override;
+    Status clean_timeout_cache();
+
+    Status clean_cache_normal() override;
 
     Status clean_all_cache() override;
 
     Status clean_one_cache(size_t* cleaned_size) override;
 
-    int64_t get_oldest_match_time() const override { return _last_match_time; };
+    int64_t get_oldest_match_time() const override { return _gc_match_time; };
 
-    bool is_gc_finish() const override { return _cache_file_reader == nullptr; }
+    bool is_gc_finish() const override;
 
 private:
     Status _generate_cache_reader(size_t offset, size_t req_size);
@@ -70,9 +72,10 @@ private:
     int64_t _alive_time_sec;
     io::FileReaderSPtr _remote_file_reader;
 
-    int64_t _last_match_time;
+    int64_t _gc_match_time {0};
+    int64_t _last_match_time {0};
 
-    std::shared_mutex _cache_lock;
+    mutable std::shared_mutex _cache_lock;
     io::FileReaderSPtr _cache_file_reader;
 };
 


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

When be restarted, sub_file_cache may only open some of the files in the directory to memory. gc needs to check for files that are not in memory.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

