### PR TITLE
[fix](load) add to error tablets when delta writer failed to close

### DIFF
--- a/be/src/runtime/tablets_channel.cpp
+++ b/be/src/runtime/tablets_channel.cpp
@@ -118,6 +118,9 @@ Status TabletsChannel::close(
                 if (!st.ok()) {
                     LOG(WARNING) << "close tablet writer failed, tablet_id=" << it.first
                                  << ", transaction_id=" << _txn_id << ", err=" << st;
+                    PTabletError* tablet_error = tablet_errors->Add();
+                    tablet_error->set_tablet_id(it.first);
+                    tablet_error->set_msg(st.to_string());
                     // just skip this tablet(writer) and continue to close others
                     continue;
                 }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

 The result of load should be failed when all tablets delta writer failed to close on single node. But the result returned to client is success. 
The reason is that the committed tablets and error tablets are both empty, so publish will be success.
We should add it to error tablets when delta writer failed to close, then the transaction will be failed.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

