### PR TITLE
[Pipeline] Add MLFQ when schedule

### DIFF
--- a/be/src/pipeline/CMakeLists.txt
+++ b/be/src/pipeline/CMakeLists.txt
@@ -25,6 +25,7 @@ set(PIPELINE_FILES
         pipeline.cpp
         pipeline_fragment_context.cpp
         pipeline_task.cpp
+        task_queue.cpp
         task_scheduler.cpp
         exec/operator.cpp
         exec/scan_operator.cpp

--- a/be/src/pipeline/exec/operator.h
+++ b/be/src/pipeline/exec/operator.h
@@ -226,6 +226,7 @@ public:
 
     RuntimeProfile* runtime_profile() { return _runtime_profile.get(); }
     std::string debug_string() const;
+    int32_t id() const { return _operator_builder->id(); }
 
 protected:
     std::unique_ptr<MemTracker> _mem_tracker;

--- a/be/src/pipeline/exec/operator.h
+++ b/be/src/pipeline/exec/operator.h
@@ -262,7 +262,8 @@ public:
 
     Status prepare(RuntimeState* state) override {
         RETURN_IF_ERROR(_sink->prepare(state));
-        _runtime_profile.reset(new RuntimeProfile(_operator_builder->get_name()));
+        _runtime_profile.reset(new RuntimeProfile(
+                fmt::format("{} (id={})", _operator_builder->get_name(), _operator_builder->id())));
         _sink->profile()->insert_child_head(_runtime_profile.get(), true);
         _mem_tracker = std::make_unique<MemTracker>("DataSinkOperator:" + _runtime_profile->name(),
                                                     _runtime_profile.get());
@@ -316,7 +317,8 @@ public:
     std::string get_name() const override { return "StreamingOperator"; }
 
     Status prepare(RuntimeState* state) override {
-        _runtime_profile.reset(new RuntimeProfile(_operator_builder->get_name()));
+        _runtime_profile.reset(new RuntimeProfile(
+                fmt::format("{} (id={})", _operator_builder->get_name(), _operator_builder->id())));
         _node->runtime_profile()->insert_child_head(_runtime_profile.get(), true);
         _mem_tracker = std::make_unique<MemTracker>(get_name() + ": " + _runtime_profile->name(),
                                                     _runtime_profile.get());

--- a/be/src/pipeline/exec/streaming_aggregation_sink_operator.cpp
+++ b/be/src/pipeline/exec/streaming_aggregation_sink_operator.cpp
@@ -67,7 +67,6 @@ Status StreamingAggSinkOperator::close(RuntimeState* state) {
     COUNTER_SET(_queue_size_counter, _agg_context->max_size_of_queue());
     COUNTER_SET(_queue_byte_size_counter, _agg_context->max_bytes_in_queue());
     return StreamingOperator::close(state);
-    ;
 }
 
 StreamingAggSinkOperatorBuilder::StreamingAggSinkOperatorBuilder(

--- a/be/src/pipeline/pipeline.h
+++ b/be/src/pipeline/pipeline.h
@@ -63,7 +63,7 @@ public:
 
     Status build_operators(Operators&);
 
-    RuntimeProfile* runtime_profile() { return _pipeline_profile.get(); }
+    RuntimeProfile* pipeline_profile() { return _pipeline_profile.get(); }
 
 private:
     void _init_profile();

--- a/be/src/pipeline/pipeline_fragment_context.cpp
+++ b/be/src/pipeline/pipeline_fragment_context.cpp
@@ -133,11 +133,11 @@ Status PipelineFragmentContext::prepare(const doris::TExecPlanFragmentParams& re
     if (_prepared) {
         return Status::InternalError("Already prepared");
     }
-        _runtime_profile.reset(new RuntimeProfile("PipelineContext"));
-        _start_timer = ADD_TIMER(_runtime_profile, "StartTime");
-        COUNTER_UPDATE(_start_timer, _fragment_watcher.elapsed_time());
-        _prepare_timer = ADD_TIMER(_runtime_profile, "PrepareTime");
-        SCOPED_TIMER(_prepare_timer);
+    _runtime_profile.reset(new RuntimeProfile("PipelineContext"));
+    _start_timer = ADD_TIMER(_runtime_profile, "StartTime");
+    COUNTER_UPDATE(_start_timer, _fragment_watcher.elapsed_time());
+    _prepare_timer = ADD_TIMER(_runtime_profile, "PrepareTime");
+    SCOPED_TIMER(_prepare_timer);
 
     auto* fragment_context = this;
     OpentelemetryTracer tracer = telemetry::get_noop_tracer();
@@ -592,7 +592,6 @@ std::string PipelineFragmentContext::to_http_path(const std::string& file_name) 
 // TODO pipeline dump copy from FragmentExecState::coordinator_callback
 // TODO pipeline this callback should be placed in a thread pool
 void PipelineFragmentContext::send_report(bool done) {
-
     Status exec_status = Status::OK();
     {
         std::lock_guard<std::mutex> l(_status_lock);

--- a/be/src/pipeline/pipeline_fragment_context.h
+++ b/be/src/pipeline/pipeline_fragment_context.h
@@ -103,11 +103,13 @@ private:
 
     Pipelines _pipelines;
     PipelineId _next_pipeline_id = 0;
-    std::atomic<int> _closed_pipeline_cnt;
+    std::atomic_int _closed_tasks = 0;
+    // After prepared, `_total_tasks` is equal to the size of `_tasks`.
+    // When submit fail, `_total_tasks` is equal to the number of tasks submitted.
+    std::atomic_int _total_tasks = 0;
+    std::vector<std::unique_ptr<PipelineTask>> _tasks;
 
     int32_t _next_operator_builder_id = 10000;
-
-    std::vector<std::unique_ptr<PipelineTask>> _tasks;
 
     PipelinePtr _root_pipeline;
 
@@ -126,8 +128,8 @@ private:
     std::shared_ptr<RuntimeFilterMergeControllerEntity> _merge_controller_handler;
 
     MonotonicStopWatch _fragment_watcher;
-    //    RuntimeProfile::Counter* _start_timer;
-    //    RuntimeProfile::Counter* _prepare_timer;
+    RuntimeProfile::Counter* _start_timer;
+    RuntimeProfile::Counter* _prepare_timer;
 
     Status _create_sink(const TDataSink& t_data_sink);
     Status _build_pipelines(ExecNode*, PipelinePtr);
@@ -136,6 +138,8 @@ private:
     template <bool is_intersect>
     Status _build_operators_for_set_operation_node(ExecNode*, PipelinePtr);
     std::function<void(RuntimeState*, Status*)> _call_back;
+    void _close_action();
+    std::once_flag _close_once_flag;
 };
 } // namespace pipeline
 } // namespace doris

--- a/be/src/pipeline/pipeline_task.cpp
+++ b/be/src/pipeline/pipeline_task.cpp
@@ -52,9 +52,9 @@ Status PipelineTask::prepare(RuntimeState* state) {
     fmt::memory_buffer operator_ids_str;
     for (size_t i = 0; i < _operators.size(); i++) {
         if (i == 0) {
-            fmt::format_to(operator_ids_str, fmt::format("[{}", op->id()));
+            fmt::format_to(operator_ids_str, fmt::format("[{}", _operators[i]->id()));
         } else {
-            fmt::format_to(operator_ids_str, fmt::format(", {}", op->id()));
+            fmt::format_to(operator_ids_str, fmt::format(", {}", _operators[i]->id()));
         }
     }
     fmt::format_to(operator_ids_str, "]");

--- a/be/src/pipeline/pipeline_task.cpp
+++ b/be/src/pipeline/pipeline_task.cpp
@@ -46,6 +46,20 @@ Status PipelineTask::prepare(RuntimeState* state) {
     for (auto& o : _operators) {
         RETURN_IF_ERROR(o->prepare(state));
     }
+
+    _task_profile->add_info_string("SinkId", fmt::format("{}", _sink->id()));
+    bool first = true;
+    fmt::memory_buffer operator_ids_str;
+    for (size_t i = 0; i < _operators.size(); i++) {
+        if (i == 0) {
+            fmt::format_to(operator_ids_str, fmt::format("[{}", op->id()));
+        } else {
+            fmt::format_to(operator_ids_str, fmt::format(", {}", op->id()));
+        }
+    }
+    fmt::format_to(operator_ids_str, "]");
+    _task_profile->add_info_string("OperatorIds(source2root)", fmt::to_string(operator_ids_str));
+
     _block.reset(new doris::vectorized::Block());
 
     // We should make sure initial state for task are runnable so that we can do some preparation jobs (e.g. initialize runtime filters).

--- a/be/src/pipeline/pipeline_task.cpp
+++ b/be/src/pipeline/pipeline_task.cpp
@@ -48,7 +48,6 @@ Status PipelineTask::prepare(RuntimeState* state) {
     }
 
     _task_profile->add_info_string("SinkId", fmt::format("{}", _sink->id()));
-    bool first = true;
     fmt::memory_buffer operator_ids_str;
     for (size_t i = 0; i < _operators.size(); i++) {
         if (i == 0) {

--- a/be/src/pipeline/pipeline_task.h
+++ b/be/src/pipeline/pipeline_task.h
@@ -113,8 +113,11 @@ public:
     // must be call after all pipeline task is finish to release resource
     Status close();
 
-    void start_worker_watcher() { _wait_worker_watcher.start(); }
-    void stop_worker_watcher() { _wait_worker_watcher.stop(); }
+    void put_in_runnable_queue() {
+        _schedule_time++;
+        _wait_worker_watcher.start();
+    }
+    void pop_out_runnable_queue() { _wait_worker_watcher.stop(); }
     void start_schedule_watcher() { _wait_schedule_watcher.start(); }
     void stop_schedule_watcher() { _wait_schedule_watcher.stop(); }
 
@@ -157,6 +160,8 @@ public:
 
     RuntimeState* runtime_state() { return _state; }
 
+    const uint32_t total_schedule_time() const { return _schedule_time; }
+
     static constexpr auto THREAD_TIME_SLICE = 100'000'000L;
 
 private:
@@ -175,6 +180,7 @@ private:
     bool _opened;
     RuntimeState* _state;
     int _previous_schedule_id = -1;
+    uint32_t _schedule_time = 0;
     PipelineTaskState _cur_state;
     SourceState _data_state;
     std::unique_ptr<doris::vectorized::Block> _block;

--- a/be/src/pipeline/task_queue.cpp
+++ b/be/src/pipeline/task_queue.cpp
@@ -1,0 +1,193 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "task_queue.h"
+
+namespace doris {
+namespace pipeline {
+
+PipelineTask* SubWorkTaskQueue::try_take() {
+    if (_queue.empty()) {
+        return nullptr;
+    }
+    ++_schedule_time;
+    auto task = _queue.front();
+    _queue.pop();
+    return task;
+}
+
+////////////////////  WorkTaskQueue ////////////////////
+
+WorkTaskQueue::WorkTaskQueue() : _closed(false) {
+    double factor = 1;
+    for (int i = 0; i < SUB_QUEUE_LEVEL; ++i) {
+        _sub_queues[i].set_factor_for_normal(factor);
+        factor *= LEVEL_QUEUE_TIME_FACTOR;
+    }
+
+    int i = 0;
+    _task_schedule_limit[i] = BASE_LIMIT * (i + 1);
+    for (i = 1; i < SUB_QUEUE_LEVEL - 1; ++i) {
+        _task_schedule_limit[i] = _task_schedule_limit[i - 1] + BASE_LIMIT * (i + 1);
+    }
+}
+
+void WorkTaskQueue::close() {
+    std::unique_lock<std::mutex> lock(_work_size_mutex);
+    _closed = true;
+    _wait_task.notify_all();
+}
+
+PipelineTask* WorkTaskQueue::try_take_unprotected() {
+    if (_total_task_size == 0 || _closed) {
+        return nullptr;
+    }
+    double normal_schedule_times[SUB_QUEUE_LEVEL];
+    double min_schedule_time = 0;
+    int idx = -1;
+    for (int i = 0; i < SUB_QUEUE_LEVEL; ++i) {
+        normal_schedule_times[i] = _sub_queues[i].schedule_time_after_normal();
+        if (!_sub_queues[i].empty()) {
+            if (idx == -1 || normal_schedule_times[i] < min_schedule_time) {
+                idx = i;
+                min_schedule_time = normal_schedule_times[i];
+            }
+        }
+    }
+    DCHECK(idx != -1);
+    // update empty queue's schedule time, to avoid too high priority
+    for (int i = 0; i < SUB_QUEUE_LEVEL; ++i) {
+        if (_sub_queues[i].empty() &&
+            normal_schedule_times[i] < min_schedule_time) {
+            _sub_queues[i]._schedule_time = min_schedule_time / _sub_queues[i]._factor_for_normal;
+        }
+    }
+
+    auto task = _sub_queues[idx].try_take();
+    if (task) {
+        _total_task_size--;
+    }
+    return task;
+}
+
+int WorkTaskQueue::_compute_level(PipelineTask* task) {
+    uint32_t schedule_time = task->total_schedule_time();
+    for (int i = 0; i < SUB_QUEUE_LEVEL - 1; ++i) {
+        if (schedule_time <= _task_schedule_limit[i]) {
+            return i;
+        }
+    }
+    return SUB_QUEUE_LEVEL - 1;
+}
+
+PipelineTask* WorkTaskQueue::try_take() {
+    // TODO other efficient lock? e.g. if get lock fail, return null_ptr
+    std::unique_lock<std::mutex> lock(_work_size_mutex);
+    return try_take_unprotected();
+}
+
+PipelineTask* WorkTaskQueue::take(uint32_t timeout_ms) {
+    std::unique_lock<std::mutex> lock(_work_size_mutex);
+    auto task = try_take_unprotected();
+    if (task) {
+        return task;
+    } else {
+        if (timeout_ms > 0) {
+            _wait_task.wait_for(lock, std::chrono::milliseconds(timeout_ms));
+        } else {
+            _wait_task.wait(lock);
+        }
+        return try_take_unprotected();
+    }
+}
+
+Status WorkTaskQueue::push(PipelineTask* task) {
+    if (_closed) {
+        return Status::InternalError("WorkTaskQueue closed");
+    }
+    auto level = _compute_level(task);
+    std::unique_lock<std::mutex> lock(_work_size_mutex);
+    _sub_queues[level].push_back(task);
+    _total_task_size++;
+    _wait_task.notify_one();
+    return Status::OK();
+}
+
+////////////////// TaskQueue ////////////
+
+void TaskQueue::close() {
+    _closed = true;
+    for (int i = 0; i < _core_size; ++i) {
+        _async_queue[i].close();
+    }
+}
+
+PipelineTask* TaskQueue::try_take(size_t core_id) {
+    PipelineTask* task;
+    while (!_closed) {
+        task = _async_queue[core_id].try_take();
+        if (task) {
+            break;
+        }
+        task = steal_take(core_id);
+        if (task) {
+            break;
+        }
+        task = _async_queue[core_id].take(WAIT_CORE_TASK_TIMEOUT_MS /* timeout_ms */);
+        if (task) {
+            break;
+        }
+    }
+    if (task) {
+        task->pop_out_runnable_queue();
+    }
+    return task;
+}
+
+PipelineTask* TaskQueue::steal_take(size_t core_id) {
+    DCHECK(core_id < _core_size);
+    size_t next_id = core_id;
+    for (size_t i = 1; i < _core_size; ++i) {
+        ++next_id;
+        if (next_id == _core_size) {
+            next_id = 0;
+        }
+        DCHECK(next_id < _core_size);
+        auto task = _async_queue[core_id].try_take();
+        if (task) {
+            return task;
+        }
+    }
+    return nullptr;
+}
+
+Status TaskQueue::push_back(PipelineTask* task) {
+    int core_id = task->get_previous_core_id();
+    if (core_id < 0) {
+        core_id = _next_core.fetch_add(1) % _core_size;
+    }
+    return push_back(task, core_id);
+}
+
+Status TaskQueue::push_back(PipelineTask* task, size_t core_id) {
+    DCHECK(core_id < _core_size);
+    task->put_in_runnable_queue();
+    return _async_queue[core_id].push(task);
+}
+
+} // namespace pipeline
+} // namespace doris

--- a/be/src/pipeline/task_queue.cpp
+++ b/be/src/pipeline/task_queue.cpp
@@ -71,8 +71,7 @@ PipelineTask* WorkTaskQueue::try_take_unprotected() {
     DCHECK(idx != -1);
     // update empty queue's schedule time, to avoid too high priority
     for (int i = 0; i < SUB_QUEUE_LEVEL; ++i) {
-        if (_sub_queues[i].empty() &&
-            normal_schedule_times[i] < min_schedule_time) {
+        if (_sub_queues[i].empty() && normal_schedule_times[i] < min_schedule_time) {
             _sub_queues[i]._schedule_time = min_schedule_time / _sub_queues[i]._factor_for_normal;
         }
     }

--- a/be/src/pipeline/task_queue.h
+++ b/be/src/pipeline/task_queue.h
@@ -1,0 +1,115 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+#pragma once
+
+#include <queue>
+
+#include "pipeline_task.h"
+
+namespace doris {
+namespace pipeline {
+
+class SubWorkTaskQueue {
+    friend class WorkTaskQueue;
+
+public:
+    void push_back(PipelineTask* task) { _queue.emplace(task); }
+
+    PipelineTask* try_take();
+
+    void set_factor_for_normal(double factor_for_normal) { _factor_for_normal = factor_for_normal; }
+
+    double schedule_time_after_normal() { return _schedule_time * _factor_for_normal; }
+
+    bool empty() { return _queue.empty(); }
+
+private:
+    std::queue<PipelineTask*> _queue;
+    // factor for normalization
+    double _factor_for_normal = 1;
+    // the value cal the queue task time consume, the WorkTaskQueue
+    // use it to find the min queue to take task work
+    std::atomic<uint64_t> _schedule_time = 0;
+};
+
+// Each thread have private MLFQ
+class WorkTaskQueue {
+public:
+    explicit WorkTaskQueue();
+
+    void close();
+
+    PipelineTask* try_take_unprotected();
+
+    PipelineTask* try_take();
+
+    PipelineTask* take(uint32_t timeout_ms = 0);
+
+    Status push(PipelineTask* task);
+
+    // Get the each thread task size to do
+    size_t size() { return _total_task_size; }
+
+private:
+    static constexpr auto LEVEL_QUEUE_TIME_FACTOR = 1.5;
+    static constexpr size_t SUB_QUEUE_LEVEL = 5;
+    // 3, 6, 9, 12
+    static constexpr uint32_t BASE_LIMIT = 3;
+    SubWorkTaskQueue _sub_queues[SUB_QUEUE_LEVEL];
+    uint32_t _task_schedule_limit[SUB_QUEUE_LEVEL - 1];
+    std::mutex _work_size_mutex;
+    std::condition_variable _wait_task;
+    std::atomic<size_t> _total_task_size = 0;
+    bool _closed;
+
+    int _compute_level(PipelineTask* task);
+};
+
+// Need consider NUMA architecture
+class TaskQueue {
+public:
+    explicit TaskQueue(size_t core_size) : _core_size(core_size), _closed(false) {
+        _async_queue.reset(new WorkTaskQueue[core_size]);
+    }
+
+    ~TaskQueue() = default;
+
+    void close();
+
+    // Get the task by core id.
+    // TODO: To think the logic is useful?
+    PipelineTask* try_take(size_t core_id);
+
+    PipelineTask* steal_take(size_t core_id);
+
+    // TODO combine these methods to `push_back(task, core_id = -1)`
+    Status push_back(PipelineTask* task);
+
+    Status push_back(PipelineTask* task, size_t core_id);
+
+    int cores() const { return _core_size; }
+
+private:
+    std::unique_ptr<WorkTaskQueue[]> _async_queue;
+    size_t _core_size;
+    std::atomic<size_t> _next_core = 0;
+    std::atomic<bool> _closed;
+    static constexpr auto WAIT_CORE_TASK_TIMEOUT_MS = 200;
+};
+
+} // namespace pipeline
+} // namespace doris

--- a/be/src/pipeline/task_scheduler.h
+++ b/be/src/pipeline/task_scheduler.h
@@ -17,202 +17,23 @@
 
 #pragma once
 
-#include <queue>
-
 #include "common/status.h"
 #include "pipeline.h"
 #include "pipeline_task.h"
+#include "task_queue.h"
 #include "util/threadpool.h"
 
 namespace doris::pipeline {
 
-class SubWorkTaskQueue {
-    friend class WorkTaskQueue;
-
-public:
-    void add_total_time(const uint64_t duration) { _total_consume_time.fetch_add(duration); }
-
-    void push_back(PipelineTask* task) { _queue.emplace(task); }
-
-    PipelineTask* try_take() {
-        if (_queue.empty()) {
-            return nullptr;
-        }
-        auto task = _queue.front();
-        _queue.pop();
-        return task;
-    }
-
-    void set_factor_for_normal(double factor_for_normal) { _factor_for_normal = factor_for_normal; }
-
-    // TODO pipeline 1 may overflow here ?
-    double total_consume_time() { return _total_consume_time.load() / _factor_for_normal; }
-
-    bool empty() { return _queue.empty(); }
-
-private:
-    std::queue<PipelineTask*> _queue;
-    // factor for normalization
-    double _factor_for_normal = 1;
-    // TODO pipeline whether need to set to zero
-    // the value cal the queue task time consume, the WorkTaskQueue
-    // use it to find the min queue to take task work
-    std::atomic<uint64_t> _total_consume_time = 0;
-};
-
-// Each thread have private muti level queue
-class WorkTaskQueue {
-public:
-    explicit WorkTaskQueue() : _closed(false) {
-        double factor = 1;
-        for (int i = SUB_QUEUE_LEVEL - 1; i >= 0; --i) {
-            _sub_queues[i].set_factor_for_normal(factor);
-            factor *= LEVEL_QUEUE_TIME_FACTOR;
-        }
-    }
-
-    void close() {
-        std::unique_lock<std::mutex> lock(_work_size_mutex);
-        _closed = true;
-        _wait_task.notify_all();
-    }
-
-    PipelineTask* try_take_unprotected() {
-        if (_total_task_size == 0 || _closed) {
-            return nullptr;
-        }
-        double min_consume_time = _sub_queues[0].total_consume_time();
-        int idx = 0;
-        for (int i = 1; i < SUB_QUEUE_LEVEL; ++i) {
-            if (!_sub_queues[i].empty()) {
-                double consume_time = _sub_queues[i].total_consume_time();
-                if (idx == -1 || consume_time < min_consume_time) {
-                    idx = i;
-                    min_consume_time = consume_time;
-                }
-            }
-        }
-        auto task = _sub_queues[idx].try_take();
-        if (task) {
-            _total_task_size--;
-        }
-        return task;
-    }
-
-    PipelineTask* try_take() {
-        std::unique_lock<std::mutex> lock(_work_size_mutex);
-        return try_take_unprotected();
-    }
-
-    PipelineTask* take() {
-        std::unique_lock<std::mutex> lock(_work_size_mutex);
-        while (!_closed) {
-            auto task = try_take_unprotected();
-            if (task) {
-                return task;
-            } else {
-                _wait_task.wait(lock);
-            }
-        }
-        DCHECK(_closed);
-        return nullptr;
-    }
-
-    void push(PipelineTask* task) {
-        size_t level = _compute_level(task);
-        std::unique_lock<std::mutex> lock(_work_size_mutex);
-        _sub_queues[level].push_back(task);
-        _total_task_size++;
-        _wait_task.notify_one();
-    }
-
-    // Get the each thread task size to do
-    size_t size() { return _total_task_size; }
-
-private:
-    static constexpr auto LEVEL_QUEUE_TIME_FACTOR = 1.2;
-    static constexpr size_t SUB_QUEUE_LEVEL = 5;
-    SubWorkTaskQueue _sub_queues[SUB_QUEUE_LEVEL];
-    std::mutex _work_size_mutex;
-    std::condition_variable _wait_task;
-    std::atomic<size_t> _total_task_size = 0;
-    bool _closed;
-
-private:
-    size_t _compute_level(PipelineTask* task) { return 0; }
-};
-
-// Need consider NUMA architecture
-class TaskQueue {
-public:
-    explicit TaskQueue(size_t core_size) : _core_size(core_size) {
-        _async_queue.reset(new WorkTaskQueue[core_size]);
-    }
-
-    ~TaskQueue() = default;
-
-    void close() {
-        for (int i = 0; i < _core_size; ++i) {
-            _async_queue[i].close();
-        }
-    }
-
-    // Get the task by core id. TODO: To think the logic is useful?
-    PipelineTask* try_take(size_t core_id) { return _async_queue[core_id].try_take(); }
-
-    // not block， steal task by other core queue
-    PipelineTask* steal_take(size_t core_id) {
-        DCHECK(core_id < _core_size);
-        size_t next_id = core_id;
-        for (size_t i = 1; i < _core_size; ++i) {
-            ++next_id;
-            if (next_id == _core_size) {
-                next_id = 0;
-            }
-            DCHECK(next_id < _core_size);
-            auto task = try_take(next_id);
-            if (task) {
-                return task;
-            }
-        }
-        return nullptr;
-    }
-
-    // TODO pipeline 1 add timeout interface, other queue may have new task
-    PipelineTask* take(size_t core_id) { return _async_queue[core_id].take(); }
-
-    void push_back(PipelineTask* task) {
-        int core_id = task->get_previous_core_id();
-        if (core_id < 0) {
-            core_id = _next_core.fetch_add(1) % _core_size;
-        }
-        push_back(task, core_id);
-    }
-
-    void push_back(PipelineTask* task, size_t core_id) {
-        DCHECK(core_id < _core_size);
-        task->start_worker_watcher();
-        _async_queue[core_id].push(task);
-    }
-
-    int cores() const { return _core_size; }
-
-private:
-    std::unique_ptr<WorkTaskQueue[]> _async_queue;
-    size_t _core_size;
-    std::atomic<size_t> _next_core = 0;
-};
-
 class BlockedTaskScheduler {
 public:
-    explicit BlockedTaskScheduler(std::shared_ptr<TaskQueue> task_queue)
-            : _task_queue(std::move(task_queue)), _started(false), _shutdown(false) {}
+    explicit BlockedTaskScheduler(std::shared_ptr<TaskQueue> task_queue);
 
     ~BlockedTaskScheduler() = default;
 
     Status start();
     void shutdown();
-    void add_blocked_task(PipelineTask* task);
+    Status add_blocked_task(PipelineTask* task);
 
 private:
     std::shared_ptr<TaskQueue> _task_queue;
@@ -262,7 +83,6 @@ private:
     std::shared_ptr<BlockedTaskScheduler> _blocked_task_scheduler;
     std::atomic<bool> _shutdown;
 
-private:
     void _do_work(size_t index);
     void _try_close_task(PipelineTask* task, PipelineTaskState state);
 };

--- a/be/src/runtime/fragment_mgr.cpp
+++ b/be/src/runtime/fragment_mgr.cpp
@@ -760,13 +760,7 @@ Status FragmentMgr::exec_plan_fragment(const TExecPlanFragmentParams& params, Fi
             _pipeline_map.insert(std::make_pair(fragment_instance_id, context));
             _cv.notify_all();
         }
-        auto st = context->submit();
-        if (!st.ok()) {
-            context->cancel(PPlanFragmentCancelReason::INTERNAL_ERROR, "submit context fail");
-            remove_pipeline_context(context);
-            return Status::InternalError("Submit pipeline failed. err = {}, BE: {}", st.to_string(),
-                                         BackendOptions::get_localhost());
-        }
+        return context->submit();
     }
 
     return Status::OK();


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

dataset ssb flat sf 20

q1:
```SELECT sum(LO_EXTENDEDPRICE * LO_DISCOUNT) AS revenue
FROM lineorder_flat
WHERE LO_ORDERDATE >= 19930101 and LO_ORDERDATE <= 19931231 AND LO_DISCOUNT BETWEEN 1 AND 3 AND LO_QUANTITY < 25;
```

q2:
```SELECT sum(LO_EXTENDEDPRICE * LO_DISCOUNT) AS revenue
FROM lineorder_flat
WHERE weekofyear(LO_ORDERDATE) = 6 AND LO_ORDERDATE >= 19940101 and LO_ORDERDATE <= 19941231
  AND LO_DISCOUNT BETWEEN 5 AND 7 AND LO_QUANTITY BETWEEN 26 AND 35;
```

q3:
```SELECT
    C_CITY,
    S_CITY,
    (LO_ORDERDATE DIV 10000) AS year,
    sum(LO_REVENUE) AS revenue
FROM lineorder_flat
WHERE C_CITY in ( 'UNITED KI1' ,'UNITED KI5') AND S_CITY in ( 'UNITED KI1' ,'UNITED KI5') AND LO_ORDERDATE  >= 19920101 AND LO_ORDERDATE <= 19971231
GROUP BY
    C_CITY,
    S_CITY,
    year
ORDER BY
    year ASC,
    revenue DESC;
```

q4:
```SELECT
    C_CITY,
    S_CITY,
    (LO_ORDERDATE DIV 10000) AS year,
    sum(LO_REVENUE) AS revenue
FROM lineorder_flat
WHERE C_CITY in ('UNITED KI1', 'UNITED KI5') AND S_CITY in ( 'UNITED KI1',  'UNITED KI5') AND  LO_ORDERDATE  >= 19971201 AND LO_ORDERDATE <= 19971231
GROUP BY
    C_CITY,
    S_CITY,
    year
ORDER BY
    year ASC,
    revenue DESC;
```
parallel_fragment_exec_instance_num: 4
concurrency: 1


big query:
```select count (1) from (SELECT     p_color,     sum(LO_REVENUE) AS revenue FROM lineorder_flat GROUP BY       cube  (p_container, p_color, p_type,  c_nation, p_category)  ) t
```
parallel_fragment_exec_instance_num: 4
concurrency: 12


Describe your changes.
no pipeline:

query  | query time     |  query time with big query   |        query time increase times
-- | -- | -- | --
q1 | 58.0   | 241.0 | 4.16
q2 | 54.0     | 332.0 | 6.19
q3 | 64.0     | 825.0 | 12.89
q4 | 27.0     | 132.0 | 4.89



before use mlfq:
query  | query time     |  query time with big query   |        query time increase times
-- | -- | -- | --
q1       |    124.0              |     6554.0                |                        52.85
q2      |     104.0        |          2341.0                  |                       22.51
q3       |    280.0        |          8174.0                  |                       29.19
q4        |   45.0          |          2596.0                 |                       57.69

aflter use mlfq as pipeline task queue:
query  | query time     |  query time with big query   |        query time increase times
-- | -- | -- | --
q1       |    89.0         |          1416.0 | 15.91
q2      |    68.0           |      1692.0 | 24.88
q3      |    149.0         |         1266.0 | 8.50
q4       |   50.0           |         406.0 | 8.12






## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

