### PR TITLE
[deps](fe)Upgrade hadoop dependency to 2.10.2

### DIFF
--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -85,7 +85,7 @@ under the License.
             <dependency>
                 <groupId>org.apache.hadoop</groupId>
                 <artifactId>hadoop-mapreduce-client</artifactId>
-                <version>2.7.4</version>
+                <version>${hadoop.version}</version>
                 <scope>compile</scope>
             </dependency>
         </dependencies>
@@ -618,6 +618,12 @@ under the License.
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-hdfs</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-auth</artifactId>
+            <version>${hadoop.version}</version>
             <scope>provided</scope>
         </dependency>
 

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -219,7 +219,7 @@ under the License.
         <RoaringBitmap.version>0.8.13</RoaringBitmap.version>
         <spark.version>2.4.6</spark.version>
         <hive.version>2.3.7</hive.version>
-        <hadoop.version>2.8.0</hadoop.version>
+        <hadoop.version>2.10.2</hadoop.version>
         <!-- ATTN: avro version must be consistent with Iceberg version -->
         <!-- Please modify iceberg.version and avro.version together,
          you can find avro version info in iceberg mvn repository -->
@@ -308,7 +308,7 @@ under the License.
             <dependency>
                 <groupId>org.apache.hadoop</groupId>
                 <artifactId>hadoop-client</artifactId>
-                <version>2.8.0</version>
+                <version>${hadoop.version}</version>
                 <scope>compile</scope>
             </dependency>
             <dependency>

--- a/fs_brokers/apache_hdfs_broker/pom.xml
+++ b/fs_brokers/apache_hdfs_broker/pom.xml
@@ -69,7 +69,7 @@ under the License.
         <maven.compiler.target>1.8</maven.compiler.target>
         <log4j2.version>2.18.0</log4j2.version>
         <project.scm.id>github</project.scm.id>
-        <hadoop.version>2.9.1</hadoop.version>
+        <hadoop.version>2.10.2</hadoop.version>
     </properties>
     <profiles>
         <!-- for custom internal repository -->


### PR DESCRIPTION
Works fine after upgrade
``` sql
mysql> CREATE CATALOG hive PROPERTIES (     "type"="hms",     'hive.metastore.uris' = 'thrift://localhost:9083' );
Query OK, 0 rows affected (0.01 sec)

mysql> switch hive;
Query OK, 0 rows affected (0.01 sec)

mysql> use test_catalog;
Reading table information for completion of table and column names
You can turn off this feature to get a quicker startup with -A

Database changed
mysql> show databases;
+--------------+
| Database     |
+--------------+
| default      |
| test_catalog |
+--------------+
2 rows in set (0.01 sec)

mysql> show tables;
+------------------------+
| Tables_in_test_catalog |
+------------------------+
| test_user              |
| test_user_1            |
+------------------------+
2 rows in set (0.00 sec)

mysql> select * from test_user_1;
+---------+--------------+
| user_id | user_name    |
+---------+--------------+
|   10001 | zhangfeng    |
|   10002 | test         |
|   10003 | zhangjiafeng |
+---------+--------------+
3 rows in set (0.58 sec)
```

# Proposed changes

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

