### PR TITLE
[fix](broker-load) fix broker load with hdfs failed to get right file  type

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/planner/external/FileGroupInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/external/FileGroupInfo.java
@@ -99,6 +99,7 @@ public class FileGroupInfo {
         this.filesAdded = filesAdded;
         this.strictMode = strictMode;
         this.loadParallelism = loadParallelism;
+        this.fileType = brokerDesc.getFileType();
     }
 
     // for stream load

--- a/regression-test/suites/jdbc_p0/test_jdbc_query_mysql.groovy
+++ b/regression-test/suites/jdbc_p0/test_jdbc_query_mysql.groovy
@@ -266,14 +266,14 @@ suite("test_jdbc_query_mysql", "p0") {
         sql  """ drop table if exists ${exMysqlTable} """
         sql  """ drop table if exists ${inDorisTable} """
         sql  """ CREATE EXTERNAL TABLE `${exMysqlTable}` (
-                  `id` int(11) not NULL,
+                  `id` bigint not NULL,
                   `apply_id` varchar(32) NULL,
                   `begin_value` string NULL,
                   `operator` varchar(32) NULL,
                   `operator_name` varchar(32) NULL,
                   `state` varchar(8) NULL,
                   `sub_state` varchar(8) NULL,
-                  `state_count` smallint(5) NULL,
+                  `state_count` int NULL,
                   `create_time` datetime NULL
                 ) ENGINE=JDBC
                 COMMENT "JDBC Mysql 外部表"
@@ -894,7 +894,7 @@ suite("test_jdbc_query_mysql", "p0") {
         sql  """ drop table if exists ${exMysqlTypeTable} """
         sql  """
                CREATE EXTERNAL TABLE ${exMysqlTypeTable} (
-               `id` bigint NOT NULL,
+               `id` int NOT NULL,
                `count_value` varchar(100) NULL
                ) ENGINE=JDBC
                COMMENT "JDBC Mysql 外部表"
@@ -933,6 +933,26 @@ suite("test_jdbc_query_mysql", "p0") {
                                     t3 AS (SELECT max(x) OVER() FROM t2) SELECT * FROM t3 limit 3"""
         order_qt_sql111 """ SELECT rank() OVER () FROM (SELECT k8 FROM $jdbcMysql57Table1 LIMIT 10) as t LIMIT 3 """
         order_qt_sql112 """ SELECT k7, count(DISTINCT k8) FROM $jdbcMysql57Table1 WHERE k8 > 110 GROUP BY GROUPING SETS ((), (k7)) """
+
+        // test for type check
+        sql  """ drop table if exists ${exMysqlTypeTable} """
+        sql  """
+               CREATE EXTERNAL TABLE ${exMysqlTypeTable} (
+               `id` bigint NOT NULL,
+               `count_value` varchar(100) NULL
+               ) ENGINE=JDBC
+               COMMENT "JDBC Mysql 外部表"
+               PROPERTIES (
+                "resource" = "$jdbcResourceMysql57",
+                "table" = "ex_tb2",
+                "table_type"="mysql"
+               ); 
+        """
+
+        test {
+            sql """select * from ${exMysqlTypeTable} order by id"""
+            exception "Fail to convert jdbc type of java.lang.Integer to doris type BIGINT on column: id"
+        }
 
     }
 }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

Introduced from #14808, using broker load with hdfs will get "LOCAL" file type, but should be "HDFS"

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [x] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

