### PR TITLE
[fix](multi-catalog) add support for orc binary type

### DIFF
--- a/be/src/vec/data_types/data_type_factory.cpp
+++ b/be/src/vec/data_types/data_type_factory.cpp
@@ -98,6 +98,7 @@ DataTypePtr DataTypeFactory::create_data_type(const TypeDescriptor& col_desc, bo
     case TYPE_STRING:
     case TYPE_CHAR:
     case TYPE_VARCHAR:
+    case TYPE_BINARY:
         nested = std::make_shared<vectorized::DataTypeString>();
         break;
     case TYPE_JSONB:

--- a/be/src/vec/exec/format/orc/vorc_reader.cpp
+++ b/be/src/vec/exec/format/orc/vorc_reader.cpp
@@ -529,7 +529,7 @@ TypeDescriptor OrcReader::_convert_to_doris_type(const orc::Type* orc_type) {
     case orc::TypeKind::STRING:
         return TypeDescriptor(PrimitiveType::TYPE_STRING);
     case orc::TypeKind::BINARY:
-        return TypeDescriptor(PrimitiveType::TYPE_BINARY);
+        return TypeDescriptor(PrimitiveType::TYPE_STRING);
     case orc::TypeKind::TIMESTAMP:
         return TypeDescriptor(PrimitiveType::TYPE_DATETIMEV2);
     case orc::TypeKind::DECIMAL:

--- a/be/src/vec/exec/scan/vfile_scanner.cpp
+++ b/be/src/vec/exec/scan/vfile_scanner.cpp
@@ -210,11 +210,10 @@ Status VFileScanner::_init_src_block(Block* block) {
             data_type = DataTypeFactory::instance().create_data_type(it->second, true);
         }
         if (data_type == nullptr) {
-            return Status::NotSupported(
-                    fmt::format("Not support data type:{} for column: {}",
-                                (it == _name_to_col_type.end() ? slot->type().debug_string()
-                                                               : it->second.debug_string()),
-                                slot->col_name()));
+            return Status::NotSupported("Not support data type {} for column {}",
+                                        it == _name_to_col_type.end() ? slot->type().debug_string()
+                                                                      : it->second.debug_string(),
+                                        slot->col_name());
         }
         MutableColumnPtr data_column = data_type->create_column();
         _src_block.insert(

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/ScalarType.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/ScalarType.java
@@ -160,6 +160,8 @@ public class ScalarType extends Type {
                 return CHAR;
             case VARCHAR:
                 return createVarcharType();
+            case BINARY:
+                return createStringType();
             case JSONB:
                 return createJsonbType();
             case STRING:


### PR DESCRIPTION
# Proposed changes

## Problem summary
Fix three bugs:
1.  `DataTypeFactory::create_data_type` is missing the conversion of binary type, and `OrcReader` will failed with error like:
```
msg:errCode = 2, detailMessage = Not support arrow type: LO_ORDERPRIORITY BINARY
```
2. `ScalarType#createType` is missing the conversion of binary type, and `ExternalFileTableValuedFunction` will failed with error like:
```
ERROR 1105 (HY000): IllegalStateException, msg: java.lang.IllegalStateException: null
```
3. `fmt::format` can't generate right format string, and will be failed with error like:
```
terminate called after throwing an instance of 'fmt::v7::format_error'
  what():  argument not found
*** Query id: 0-0 ***
*** Aborted at 1671196995 (unix time) try "date -d @1671196995" if you are using GNU date ***
*** Current BE git commitID: 9831be623 ***
*** SIGABRT unkown detail explain (@0x2edd19) received by PID 3071257 (TID 0x7f9e481fd700) from PID 3071257; stack trace: ***
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /mnt/disk2/gaoxin/ws/doris/be/src/common/signal_handler.h:420
 1# 0x00007F9EAEE68090 in /lib/x86_64-linux-gnu/libc.so.6
 2# raise at ../sysdeps/unix/sysv/linux/raise.c:51
 3# abort at /build/glibc-SzIz7B/glibc-2.31/stdlib/abort.c:81
 4# __gnu_cxx::__verbose_terminate_handler() [clone .cold] in /mnt/disk1/lqf/doris-1.2/apache-doris-be-1.2.0-bin-x86_64/lib/doris_be
 5# __cxxabiv1::__terminate(void (*)()) in /mnt/disk1/lqf/doris-1.2/apache-doris-be-1.2.0-bin-x86_64/lib/doris_be
 6# 0x000055BFBCDF60A1 in /mnt/disk1/lqf/doris-1.2/apache-doris-be-1.2.0-bin-x86_64/lib/doris_be
 7# 0x000055BFBCDF61F5 in /mnt/disk1/lqf/doris-1.2/apache-doris-be-1.2.0-bin-x86_64/lib/doris_be
 8# fmt::v7::detail::error_handler::on_error(char const*) [clone .constprop.0] in /mnt/disk1/lqf/doris-1.2/apache-doris-be-1.2.0-bin-x86_64/lib/doris_be
 9# char const* fmt::v7::detail::parse_replacement_field<char, fmt::v7::detail::format_handler<fmt::v7::detail::buffer_appender<char>, char, fmt::v7::basic_format_context<fmt::v7::detail::buffer_appender<char>, char> >&>(char const*, char const*, fmt::v7::detail::format_handler<fmt::v7::detail::buffer_appender<char>, char, fmt::v7::basic_format_context<fmt::v7::detail::buffer_appender<char>, char> >&) in /mnt/disk1/lqf/doris-1.2/apache-doris-be-1.2.0-bin-x86_64/lib/doris_be
10# void fmt::v7::detail::vformat_to<char>(fmt::v7::detail::buffer<char>&, fmt::v7::basic_string_view<char>, fmt::v7::basic_format_args<fmt::v7::basic_format_context<fmt::v7::detail::buffer_appender<fmt::v7::type_identity<char>::type>, fmt::v7::type_identity<char>::type> >, fmt::v7::detail::locale_ref) in /mnt/disk1/lqf/doris-1.2/apache-doris-be-1.2.0-bin-x86_64/lib/doris_be
11# fmt::v7::detail::vformat[abi:cxx11](fmt::v7::basic_string_view<char>, fmt::v7::format_args) in /mnt/disk1/lqf/doris-1.2/apache-doris-be-1.2.0-bin-x86_64/lib/doris_be
12# doris::vectorized::VFileScanner::_init_src_block(doris::vectorized::Block*) at /mnt/disk2/gaoxin/ws/doris/be/src/vec/exec/scan/vfile_scanner.cpp:215
13# doris::vectorized::VFileScanner::_get_block_impl(doris::RuntimeState*, doris::vectorized::Block*, bool*) at /mnt/disk2/gaoxin/ws/doris/be/src/vec/exec/scan/vfile_scanner.cpp:143
14# doris::vectorized::VScanner::get_block(doris::RuntimeState*, doris::vectorized::Block*, bool*) at /mnt/disk2/gaoxin/ws/doris/be/src/vec/exec/scan/vscanner.cpp:53
```

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
5. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
6. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
7. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
8. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

