### PR TITLE
[chore](github) BE UT workflows support branch checks

### DIFF
--- a/.github/workflows/be-ut-clang.yml
+++ b/.github/workflows/be-ut-clang.yml
@@ -75,8 +75,14 @@ jobs:
           sudo dpkg-reconfigure --frontend noninteractive tzdata
 
           pushd thirdparty
-          curl -L https://github.com/apache/doris-thirdparty/releases/download/automation/doris-thirdparty-prebuilt-linux-x86_64.tar.xz \
-            -o doris-thirdparty-prebuilt-linux-x86_64.tar.xz
+          branch="${{ github.base_ref }}"
+          if [[ -z "${branch}" ]] || [[ "${branch}" == 'master' ]]; then
+            curl -L https://github.com/apache/doris-thirdparty/releases/download/automation/doris-thirdparty-prebuilt-linux-x86_64.tar.xz \
+              -o doris-thirdparty-prebuilt-linux-x86_64.tar.xz
+          else
+            curl -L "https://github.com/apache/doris-thirdparty/releases/download/automation-${branch/branch-/}/doris-thirdparty-prebuilt-linux-x86_64.tar.xz" \
+              -o doris-thirdparty-prebuilt-linux-x86_64.tar.xz
+          fi
           tar -xvf doris-thirdparty-prebuilt-linux-x86_64.tar.xz
           popd
 

--- a/.github/workflows/be-ut-mac.yml
+++ b/.github/workflows/be-ut-mac.yml
@@ -83,8 +83,14 @@ jobs:
           brew install "${cellars[@]}"
 
           pushd thirdparty
-          curl -L https://github.com/apache/doris-thirdparty/releases/download/automation/doris-thirdparty-prebuilt-darwin-x86_64.tar.xz \
-            -o doris-thirdparty-prebuilt-darwin-x86_64.tar.xz
+          branch="${{ github.base_ref }}"
+          if [[ -z "${branch}" ]] || [[ "${branch}" == 'master' ]]; then
+            curl -L https://github.com/apache/doris-thirdparty/releases/download/automation/doris-thirdparty-prebuilt-darwin-x86_64.tar.xz \
+              -o doris-thirdparty-prebuilt-darwin-x86_64.tar.xz
+          else
+            curl -L "https://github.com/apache/doris-thirdparty/releases/download/automation-${branch/branch-/}/doris-thirdparty-prebuilt-darwin-x86_64.tar.xz" \
+              -o doris-thirdparty-prebuilt-darwin-x86_64.tar.xz
+          fi
           tar -xvf doris-thirdparty-prebuilt-darwin-x86_64.tar.xz
           popd
 


### PR DESCRIPTION
# Proposed changes

~~Issue Number: close #xxx~~

## Problem summary

Apache Doris made the branch `branch-1.2-lts` protected. As a result, all pull requests for this branch should be checked before merging it.

However, the BE UT workflows doesn't support branch checks and they fail to check the pull requests for the branch `branch-1.2-lts`. The reason is that they download the wrong pre-built third-party libraries when they check the pull requests for `branch-1.2-lts`. This PR resolves this issue.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

