### PR TITLE
[Bug](decimalv3) Fix wrong argument for min_by/max_by

### DIFF
--- a/be/src/vec/aggregate_functions/aggregate_function_min_max_by.cpp
+++ b/be/src/vec/aggregate_functions/aggregate_function_min_max_by.cpp
@@ -105,22 +105,22 @@ static IAggregateFunction* create_aggregate_function_min_max_by(const String& na
     }
     if (which.idx == TypeIndex::Decimal128) {
         return create_aggregate_function_min_max_by_impl<AggregateFunctionTemplate, Data,
-                                                         SingleValueDataFixed<DecimalV2Value>>(
+                                                         SingleValueDataDecimal<Decimal128>>(
                 argument_types);
     }
     if (which.idx == TypeIndex::Decimal32) {
         return create_aggregate_function_min_max_by_impl<AggregateFunctionTemplate, Data,
-                                                         SingleValueDataFixed<Int32>>(
+                                                         SingleValueDataDecimal<Decimal32>>(
                 argument_types);
     }
     if (which.idx == TypeIndex::Decimal64) {
         return create_aggregate_function_min_max_by_impl<AggregateFunctionTemplate, Data,
-                                                         SingleValueDataFixed<Int64>>(
+                                                         SingleValueDataDecimal<Decimal64>>(
                 argument_types);
     }
     if (which.idx == TypeIndex::Decimal128I) {
         return create_aggregate_function_min_max_by_impl<AggregateFunctionTemplate, Data,
-                                                         SingleValueDataFixed<Int128I>>(
+                                                         SingleValueDataDecimal<Decimal128I>>(
                 argument_types);
     }
     return nullptr;


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

