### PR TITLE
[Fix](Nereids)fix be core when select constant expression

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/Expression.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/Expression.java
@@ -55,12 +55,30 @@ public abstract class Expression extends AbstractTreeNode<Expression> implements
         super(Optional.empty(), children);
     }
 
+    /**
+     * check input data types
+     */
     public TypeCheckResult checkInputDataTypes() {
         if (this instanceof ExpectsInputTypes) {
             ExpectsInputTypes expectsInputTypes = (ExpectsInputTypes) this;
             return checkInputDataTypes(children, expectsInputTypes.expectedInputTypes());
+        } else {
+            List<String> errorMessages = Lists.newArrayList();
+            // check all of its children recursively.
+            for (int i = 0; i < this.children.size(); ++i) {
+                Expression expression = this.children.get(i);
+                TypeCheckResult childResult = expression.checkInputDataTypes();
+                if (childResult != TypeCheckResult.SUCCESS) {
+                    errorMessages.add(String.format("argument %d type check fail: %s",
+                            i + 1, childResult.getMessage()));
+                }
+            }
+            if (errorMessages.isEmpty()) {
+                return TypeCheckResult.SUCCESS;
+            } else {
+                return new TypeCheckResult(false, StringUtils.join(errorMessages, ", "));
+            }
         }
-        return TypeCheckResult.SUCCESS;
     }
 
     private TypeCheckResult checkInputDataTypes(List<Expression> inputs, List<AbstractDataType> inputTypes) {

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/analysis/CheckAnalysisTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/analysis/CheckAnalysisTest.java
@@ -18,13 +18,18 @@
 package org.apache.doris.nereids.rules.analysis;
 
 import org.apache.doris.nereids.CascadesContext;
+import org.apache.doris.nereids.exceptions.AnalysisException;
+import org.apache.doris.nereids.trees.expressions.Alias;
 import org.apache.doris.nereids.trees.expressions.And;
+import org.apache.doris.nereids.trees.expressions.Not;
 import org.apache.doris.nereids.trees.expressions.literal.BooleanLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.IntegerLiteral;
 import org.apache.doris.nereids.trees.plans.GroupPlan;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalFilter;
+import org.apache.doris.nereids.trees.plans.logical.LogicalOneRowRelation;
 
+import com.google.common.collect.ImmutableList;
 import mockit.Mocked;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -40,5 +45,13 @@ public class CheckAnalysisTest {
         Plan plan = new LogicalFilter<>(new And(new IntegerLiteral(1), BooleanLiteral.TRUE), groupPlan);
         CheckAnalysis checkAnalysis = new CheckAnalysis();
         Assertions.assertThrows(RuntimeException.class, () -> checkAnalysis.build().transform(plan, cascadesContext));
+    }
+
+    @Test
+    public void testCheckNotWithChildrenWithErrorType() {
+        Plan plan = new LogicalOneRowRelation(
+                ImmutableList.of(new Alias(new Not(new IntegerLiteral(2)), "not_2")));
+        CheckAnalysis checkAnalysis = new CheckAnalysis();
+        Assertions.assertThrows(AnalysisException.class, () -> checkAnalysis.build().transform(plan, cascadesContext));
     }
 }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

fix be core when select !2

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [x] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

