### PR TITLE
[fix](pipeline) remove the redundant override of the close function in set operators

### DIFF
--- a/be/src/pipeline/exec/set_probe_sink_operator.h
+++ b/be/src/pipeline/exec/set_probe_sink_operator.h
@@ -55,7 +55,6 @@ public:
     Status sink(RuntimeState* state, vectorized::Block* block, SourceState source_state) override;
     Status finalize(RuntimeState* state) override;
     Status open(RuntimeState* /*state*/) override { return Status::OK(); }
-    Status close(RuntimeState* /*state*/) override { return Status::OK(); }
 
 private:
     int _child_id;

--- a/be/src/pipeline/exec/set_sink_operator.h
+++ b/be/src/pipeline/exec/set_sink_operator.h
@@ -50,8 +50,6 @@ public:
 
     bool can_write() override { return true; }
 
-    Status close(RuntimeState* /*state*/) override { return Status::OK(); };
-
 private:
     vectorized::VSetOperationNode<is_intersect>* _set_node;
 };


### PR DESCRIPTION
# Proposed changes

```bash
raise 0x00007ffff762337f
abort 0x00007ffff760ddb5
<unknown> 0x000055556642d319
google::LogMessage::SendToLog() 0x000055556642392d
google::LogMessage::Flush() 0x0000555566423e2c
google::LogMessageFatal::~LogMessageFatal() 0x0000555566427349
doris::vectorized::VExprContext::~VExprContext vexpr_context.cpp:35
<lambda#1>::operator()(void *) const object_pool.h:40
<lambda#1>::__invoke(void *) object_pool.h:40
doris::ObjectPool::clear object_pool.h:53
doris::RuntimeState::~RuntimeState runtime_state.cpp:163
std::default_delete::operator() unique_ptr.h:85
std::unique_ptr::~unique_ptr unique_ptr.h:361
doris::pipeline::PipelineFragmentContext::~PipelineFragmentContext pipeline_fragment_context.h:44
__gnu_cxx::new_allocator::destroy<…> new_allocator.h:162
std::allocator_traits::destroy<…> alloc_traits.h:531
std::_Sp_counted_ptr_inplace::_M_dispose shared_ptr_base.h:528
std::_Sp_counted_base::_M_release shared_ptr_base.h:168
std::__shared_count::~__shared_count shared_ptr_base.h:702
std::__shared_ptr::~__shared_ptr shared_ptr_base.h:1149
std::shared_ptr::~shared_ptr shared_ptr.h:122
doris::pipeline::PipelineFragmentContext::close_a_pipeline pipeline_fragment_context.cpp:555
doris::pipeline::TaskScheduler::_try_close_task task_scheduler.cpp:312
doris::pipeline::TaskScheduler::_do_work task_scheduler.cpp:231
std::__invoke_impl<…> invoke.h:74
std::__invoke<…> invoke.h:96
std::_Bind<void (doris::pipeline::TaskScheduler::*(doris::pipeline::TaskScheduler*, unsigned long))(unsigned long)>::__call<void, , 0ul, 1ul>(std::tuple<>&&, std::_Index_tuple<0ul, 1ul>) functional:420
std::_Bind<void (doris::pipeline::TaskScheduler::*(doris::pipeline::TaskScheduler*, unsigned long))(unsigned long)>::operator()<, void>() functional:503
std::__invoke_impl<…>(std::__invoke_other, std::_Bind<…> &) invoke.h:61
std::__invoke_r<…>(std::_Bind<…> &) invoke.h:111
std::_Function_handler::_M_invoke(const std::_Any_data &) std_function.h:291
std::function::operator()() const std_function.h:560
doris::FunctionRunnable::run threadpool.cpp:46
doris::ThreadPool::dispatch_thread threadpool.cpp:535
std::__invoke_impl<…> invoke.h:74
std::__invoke<…> invoke.h:96
std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>::__call<void, , 0ul>(std::tuple<>&&, std::_Index_tuple<0ul>) functional:420
std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>::operator()<, void>() functional:503
std::__invoke_impl<…>(std::__invoke_other, std::_Bind<…> &) invoke.h:61
std::__invoke_r<…>(std::_Bind<…> &) invoke.h:111
std::_Function_handler::_M_invoke(const std::_Any_data &) std_function.h:291
std::function::operator()() const std_function.h:560
doris::Thread::supervise_thread thread.cpp:454
start_thread 0x00007ffff6e4e17a
clone 0x00007ffff76e8df3
```

## Problem summary

The sink/source operators will share the same VSetOperationNode, so it is better to use the close of the base class to release resources.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

