### PR TITLE
[Performance] Optimize performance of like expr using strstr()

### DIFF
--- a/be/src/runtime/string_search.hpp
+++ b/be/src/runtime/string_search.hpp
@@ -41,13 +41,11 @@ public:
             return -1;
         }
 
-        auto it = std::search(str->ptr, str->ptr + str->len,
-                              std::default_searcher(_pattern->ptr, _pattern->ptr + _pattern->len));
-        if (it == str->ptr + str->len) {
+        char* occurence = std::strstr(str->ptr, _pattern->ptr);
+        if (occurence == nullptr) {
             return -1;
-        } else {
-            return it - str->ptr;
         }
+        return occurence - str->ptr;
     }
 
 private:

--- a/be/src/vec/functions/like.cpp
+++ b/be/src/vec/functions/like.cpp
@@ -76,7 +76,7 @@ Status FunctionLikeBase::constant_substring_fn(LikeSearchState* state, const Str
         *result = true;
         return Status::OK();
     }
-    StringValue pattern_value = StringValue::from_string_val(val.ptr);
+    StringValue pattern_value(val.ptr, val.len);
     *result = state->substring_pattern.search(&pattern_value) != -1;
     return Status::OK();
 }


### PR DESCRIPTION
## Problem summary

Optimize performance of like expr using `std::strstr()` instead of `std::search()`.