### PR TITLE
fix(sec): upgrade org.apache.hive:hive-exec to 3.1.3

### DIFF
--- a/regression-test/java-udf-src/pom.xml
+++ b/regression-test/java-udf-src/pom.xml
@@ -35,7 +35,7 @@ under the License.
         <dependency>
             <groupId>org.apache.hive</groupId>
             <artifactId>hive-exec</artifactId>
-            <version>2.3.5</version>
+            <version>3.1.3</version>
         </dependency>
     </dependencies>
 

--- a/samples/doris-demo/java-udf-demo/pom.xml
+++ b/samples/doris-demo/java-udf-demo/pom.xml
@@ -35,7 +35,7 @@ under the License.
         <dependency>
             <groupId>org.apache.hive</groupId>
             <artifactId>hive-exec</artifactId>
-            <version>2.3.5</version>
+            <version>3.1.3</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.apache.hive:hive-exec 2.3.5
- [CVE-2021-34538](https://www.oscs1024.com/hd/CVE-2021-34538)


### What did I do？
Upgrade org.apache.hive:hive-exec from 2.3.5 to 3.1.3 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS
Signed-off-by:pen4<948453219@qq.com>