### PR TITLE
[fix](jdbc) fix create table like table of jdbc error

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
@@ -3112,7 +3112,8 @@ public class Env {
             addTableComment(jdbcTable, sb);
             sb.append("\nPROPERTIES (\n");
             sb.append("\"resource\" = \"").append(jdbcTable.getResourceName()).append("\",\n");
-            sb.append("\"table\" = \"").append(jdbcTable.getJdbcTable()).append("\"");
+            sb.append("\"table\" = \"").append(jdbcTable.getJdbcTable()).append("\",\n");
+            sb.append("\"table_type\" = \"").append(jdbcTable.getJdbcTypeName()).append("\"");
             sb.append("\n)");
         }
 

--- a/regression-test/suites/external_table_emr_p2/mysql/test_external_resource_mysql.groovy
+++ b/regression-test/suites/external_table_emr_p2/mysql/test_external_resource_mysql.groovy
@@ -26,6 +26,7 @@ suite("test_external_resource_mysql", "p2") {
         String mysqlResourceName = "jdbc_resource_mysql_57"
         String mysqlDatabaseName01 = "external_mysql_database01"
         String mysqlTableName01 = "external_mysql_table01"
+        String mysqlTableName02 = "external_mysql_table02"
 
         sql """drop resource if exists ${mysqlResourceName};"""
         sql """
@@ -58,11 +59,19 @@ suite("test_external_resource_mysql", "p2") {
         def res = sql """select count(*) from ${mysqlTableName01};"""
         logger.info("recoding select: " + res.toString())
 
+        sql """
+            CREATE EXTERNAL TABLE ${mysqlTableName02} LIKE ${mysqlTableName01};
+            """
+        res = sql """select count(*) from ${mysqlTableName02};"""
+        logger.info("recoding select: " + res.toString())    
+
         sql """drop table if exists ${mysqlTableName01}"""
+        sql """drop table if exists ${mysqlTableName02}"""
         sql """drop database if exists ${mysqlDatabaseName01};"""
 
     }
 }
+
 
 
 

--- a/regression-test/suites/external_table_emr_p2/mysql/test_external_resource_mysql.groovy
+++ b/regression-test/suites/external_table_emr_p2/mysql/test_external_resource_mysql.groovy
@@ -63,7 +63,7 @@ suite("test_external_resource_mysql", "p2") {
             CREATE EXTERNAL TABLE ${mysqlTableName02} LIKE ${mysqlTableName01};
             """
         res = sql """select count(*) from ${mysqlTableName02};"""
-        logger.info("recoding select: " + res.toString())    
+        logger.info("recoding select: " + res.toString())
 
         sql """drop table if exists ${mysqlTableName01}"""
         sql """drop table if exists ${mysqlTableName02}"""


### PR DESCRIPTION
when create table like table of jdbc, it will get error like 
'errCode = 2, detailMessage = Failed to execute CREATE TABLE LIKE baseall_mysql. Reason: errCode = 2, detailMessage = property table_type must be set'
this pr fix it.

# Proposed changes

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [x] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

