### PR TITLE
[fix](InBitmap) Check whether the in bitmap contains correlated subqueries

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/StmtRewriter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/StmtRewriter.java
@@ -1113,6 +1113,10 @@ public class StmtRewriter {
         Expr subquerySubstitute = slotRef;
         if (exprWithSubquery instanceof InPredicate) {
             if (slotRef.getType().isBitmapType()) {
+                if (isCorrelated) {
+                    throw new AnalysisException(
+                            "In bitmap does not support correlated subquery: " + exprWithSubquery.toSql());
+                }
                 Expr pred = new BitmapFilterPredicate(exprWithSubquery.getChild(0), slotRef,
                         ((InPredicate) exprWithSubquery).isNotIn());
                 pred.analyze(analyzer);

--- a/regression-test/suites/query_p0/join/test_bitmap_filter.groovy
+++ b/regression-test/suites/query_p0/join/test_bitmap_filter.groovy
@@ -16,12 +16,11 @@
 // under the License.
 
 suite("test_bitmap_filter", "query_p0") {
-    def tbl1 = "bigtable"
+    def tbl1 = "test_query_db.bigtable"
     def tbl2 = "bitmap_table"
-    def tbl3 = "baseall"
+    def tbl3 = "test_query_db.baseall"
 
     sql "set runtime_filter_type = 16"
-    sql "use test_query_db"
     sql "DROP TABLE IF EXISTS ${tbl2}"
     sql """
     CREATE TABLE ${tbl2} (
@@ -50,4 +49,9 @@ suite("test_bitmap_filter", "query_p0") {
     qt_sql5 "select k1, k2 from ${tbl1} where k1 in (select k2 from ${tbl2}) and k2 not in (select k3 from ${tbl2}) order by k1;"
 
     qt_sql6 "select k2, count(k2) from ${tbl1} where k1 in (select k2 from ${tbl2}) group by k2 order by k2;"
+
+    test {
+        sql "select k1, k2 from ${tbl1} b1 where k1 in (select k2 from ${tbl2} b2 where b1.k2 = b2.k1) order by k1;"
+        exception "In bitmap does not support correlated subquery"
+    }
 }


### PR DESCRIPTION

1. Currently in bitmap does not support correlated subquery, like: `a.k1 in (select bitmap_col from b where a.k2 = b.k2)`.

# Proposed changes

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

