### PR TITLE
[Bug](FE) fix compile error due to code refactor

### DIFF
--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/analysis/CheckAnalysisTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/analysis/CheckAnalysisTest.java
@@ -53,6 +53,7 @@ public class CheckAnalysisTest {
         Plan plan = new LogicalOneRowRelation(
                 ImmutableList.of(new Alias(new Not(new IntegerLiteral(2)), "not_2")));
         CheckAnalysis checkAnalysis = new CheckAnalysis();
-        Assertions.assertThrows(AnalysisException.class, () -> checkAnalysis.build().transform(plan, cascadesContext));
+        Assertions.assertThrows(AnalysisException.class, () ->
+                checkAnalysis.buildRules().forEach(rule -> rule.transform(plan, cascadesContext)));
     }
 }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx
#15157  and  #14827 together would bring fe compile error due to `failed to find symbol` cause there is no `build()` in CheckAnalysis, it's `buildRules()` instead. 
## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

