### PR TITLE
[fix](scanner scheduler) fix coredump of ScannerScheduler::_scanner_scan

### DIFF
--- a/be/src/vec/exec/scan/scanner_scheduler.cpp
+++ b/be/src/vec/exec/scan/scanner_scheduler.cpp
@@ -249,6 +249,13 @@ void ScannerScheduler::_scanner_scan(ScannerScheduler* scheduler, ScannerContext
             eos = true;
         }
 
+        if (UNLIKELY(!status.ok())) {
+            LOG(WARNING) << "Scan thread read VOlapScanner failed: " << status.to_string();
+            // Add block ptr in blocks, prevent mem leak in read failed
+            blocks.push_back(block);
+            break;
+        }
+
         raw_bytes_read += block->bytes();
         num_rows_in_block += block->rows();
         if (UNLIKELY(block->rows() == 0)) {

--- a/be/src/vec/exec/scan/scanner_scheduler.cpp
+++ b/be/src/vec/exec/scan/scanner_scheduler.cpp
@@ -235,7 +235,7 @@ void ScannerScheduler::_scanner_scan(ScannerScheduler* scheduler, ScannerContext
         VLOG_ROW << "VOlapScanNode input rows: " << block->rows() << ", eos: " << eos;
         // The VFileScanner for external table may try to open not exist files,
         // Because FE file cache for external table may out of date.
-        if (!status.ok() && (typeid(*scanner) == typeid(doris::vectorized::VFileScanner) &&
+        if (!status.ok() && (typeid(*scanner) != typeid(doris::vectorized::VFileScanner) ||
                              !status.is<ErrorCode::NOT_FOUND>())) {
             LOG(WARNING) << "Scan thread read VOlapScanner failed: " << status.to_string();
             // Add block ptr in blocks, prevent mem leak in read failed
@@ -247,13 +247,6 @@ void ScannerScheduler::_scanner_scan(ScannerScheduler* scheduler, ScannerContext
             // Set status to OK.
             status = Status::OK();
             eos = true;
-        }
-
-        if (UNLIKELY(!status.ok())) {
-            LOG(WARNING) << "Scan thread read VOlapScanner failed: " << status.to_string();
-            // Add block ptr in blocks, prevent mem leak in read failed
-            blocks.push_back(block);
-            break;
         }
 
         raw_bytes_read += block->bytes();

--- a/regression-test/suites/query_p0/sql_functions/string_functions/test_split_part.groovy
+++ b/regression-test/suites/query_p0/sql_functions/string_functions/test_split_part.groovy
@@ -1,0 +1,30 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_split_part") {
+  test {
+    sql """
+      select
+          name
+      from
+          tpch_tiny_nation
+      where
+          split_part("bCKHDX07at", "5.7.37", cast(name as int)) is not null;
+    """
+    exception "errCode = 2, detailMessage = [RUNTIME_ERROR]Argument at index 3 for function split_part must be constant"
+  }
+}


### PR DESCRIPTION
# Proposed changes

Issue Number: close #15198

## Problem summary

Introduced by #14997
`ScannerScheduler::_scanner_scan` missed checking returned Status of `scanner->get_block`, when `scanner->get_block` failed some column is NULL, which caused coredump when calling `block->bytes()`.

The sql mentioned in issue returns `Status::RuntimeError` in `FunctionSubstringIndex:: execute_impl`:
```
class FunctionSubstringIndex : public IFunction {
   Status execute_impl(FunctionContext* context, Block& block, const ColumnNumbers& arguments,
                            size_t result, size_t input_rows_count) override {

        for (size_t i = 1; i <= 2; i++) {
            ColumnPtr columnPtr = remove_nullable(block.get_by_position(arguments[i]).column);

            if (!is_column_const(*columnPtr)) {
                return Status::RuntimeError("Argument at index {} for function {} must be constant",
                                            i + 1, get_name());
            }
        }
    }
}
```


## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

