### PR TITLE
[bug](jdbc) fix error of jdbc with datetime type in oracle

### DIFF
--- a/be/src/vec/exec/scan/new_jdbc_scanner.h
+++ b/be/src/vec/exec/scan/new_jdbc_scanner.h
@@ -33,6 +33,7 @@ public:
 
 public:
     Status prepare(RuntimeState* state, VExprContext** vconjunct_ctx_ptr);
+
 protected:
     Status _get_block_impl(RuntimeState* state, Block* block, bool* eos) override;
 

--- a/be/src/vec/exec/scan/new_jdbc_scanner.h
+++ b/be/src/vec/exec/scan/new_jdbc_scanner.h
@@ -33,7 +33,6 @@ public:
 
 public:
     Status prepare(RuntimeState* state, VExprContext** vconjunct_ctx_ptr);
-
 protected:
     Status _get_block_impl(RuntimeState* state, Block* block, bool* eos) override;
 

--- a/docs/en/docs/admin-manual/config/fe-config.md
+++ b/docs/en/docs/admin-manual/config/fe-config.md
@@ -2572,3 +2572,13 @@ Default：x@8
 #### `proxy_auth_enable`
 
 Default：false
+
+#### `enable_func_pushdown`
+
+Default：true
+
+IsMutable：true
+
+MasterOnly：false
+
+Whether to push the filter conditions with functions down to MYSQL, when exectue query of ODBC、JDBC external tables

--- a/docs/en/docs/ecosystem/external-table/jdbc-of-doris.md
+++ b/docs/en/docs/ecosystem/external-table/jdbc-of-doris.md
@@ -204,7 +204,7 @@ There are different data types among different databases. Here is a list of the 
 |   DATE   | DATETIME |
 | SMALLINT | SMALLINT |
 |   INT    |   INT    |
-|   REAL   |   FLOAT  |
+|   REAL   |   DOUBLE |
 |   FLOAT  |   DOUBLE |
 |  NUMBER  | DECIMAL  |
 

--- a/docs/zh-CN/docs/admin-manual/config/fe-config.md
+++ b/docs/zh-CN/docs/admin-manual/config/fe-config.md
@@ -2572,3 +2572,13 @@ SmallFileMgr 中存储的最大文件数
 #### `proxy_auth_enable`
 
 默认值：false
+
+#### `enable_func_pushdown`
+
+默认值：true
+
+是否可以动态配置：true
+
+是否为 Master FE 节点独有的配置项：false
+
+在ODBC、JDBC的MYSQL外部表查询时，是否将带函数的过滤条件下推到MYSQL中执行

--- a/docs/zh-CN/docs/ecosystem/external-table/jdbc-of-doris.md
+++ b/docs/zh-CN/docs/ecosystem/external-table/jdbc-of-doris.md
@@ -206,7 +206,7 @@ PROPERTIES (
 |   DATE   | DATETIME |
 | SMALLINT | SMALLINT |
 |   INT    |   INT    |
-|   REAL   |   FLOAT  |
+|   REAL   |   DOUBLE |
 |   FLOAT  |   DOUBLE |
 |  NUMBER  | DECIMAL  |
 

--- a/fe/fe-core/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/Config.java
@@ -1920,5 +1920,12 @@ public class Config extends ConfigBase {
      */
     @ConfField(mutable = false, masterOnly = true)
     public static boolean enable_fqdn_mode = false;
+
+    /**
+     * This is used whether to push down function to MYSQL in external Table with query sql
+     * like odbc, jdbc for mysql table
+     */
+    @ConfField(mutable = true)
+    public static boolean enable_func_pushdown = true;
 }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/JdbcScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/JdbcScanNode.java
@@ -102,7 +102,7 @@ public class JdbcScanNode extends ScanNode {
         ArrayList<Expr> conjunctsList = Expr.cloneList(conjuncts, sMap);
         for (Expr p : conjunctsList) {
             if (OdbcScanNode.shouldPushDownConjunct(jdbcType, p)) {
-                String filter = p.toMySql();
+                String filter = OdbcScanNode.conjunctExprToString(jdbcType, p);
                 filters.add(filter);
                 conjuncts.remove(p);
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/OdbcScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/OdbcScanNode.java
@@ -18,6 +18,7 @@
 package org.apache.doris.planner;
 
 import org.apache.doris.analysis.Analyzer;
+import org.apache.doris.analysis.BinaryPredicate;
 import org.apache.doris.analysis.DateLiteral;
 import org.apache.doris.analysis.Expr;
 import org.apache.doris.analysis.ExprSubstitutionMap;
@@ -27,6 +28,8 @@ import org.apache.doris.analysis.SlotRef;
 import org.apache.doris.analysis.TupleDescriptor;
 import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.OdbcTable;
+import org.apache.doris.catalog.Type;
+import org.apache.doris.common.Config;
 import org.apache.doris.common.UserException;
 import org.apache.doris.statistics.StatisticalType;
 import org.apache.doris.statistics.StatsRecursiveDerive;
@@ -54,7 +57,6 @@ public class OdbcScanNode extends ScanNode {
 
     // Now some database have different function call like doris, now doris do not
     // push down the function call except MYSQL
-    // TODO: maybe add a config to decide whether to pushdown the function of MYSQL
     public static boolean shouldPushDownConjunct(TOdbcTableType tableType, Expr expr) {
         if (!tableType.equals(TOdbcTableType.MYSQL)) {
             List<FunctionCallExpr> fnExprList = Lists.newArrayList();
@@ -62,14 +64,25 @@ public class OdbcScanNode extends ScanNode {
             if (!fnExprList.isEmpty()) {
                 return false;
             }
-            //oracle date type is not push down https://github.com/apache/doris/discussions/15069
-            //TODO: Now not sure how to rewrite the needed expr and doesn't affect other normal
-            //if we could rewrite the expr according to the format, then can pushdown this.
-            if (tableType.equals(TOdbcTableType.ORACLE) && expr.contains(DateLiteral.class)) {
-                return false;
+        }
+        return Config.enable_func_pushdown;
+    }
+
+    public static String conjunctExprToString(TOdbcTableType tableType, Expr expr) {
+        if (tableType.equals(TOdbcTableType.ORACLE) && expr.contains(DateLiteral.class)
+                && (expr instanceof BinaryPredicate)) {
+            ArrayList<Expr> children = expr.getChildren();
+            // k1 OP '2022-12-10 20:55:59'  changTo ---> k1 OP to_date('{}','yyyy-mm-dd hh24:mi:ss')
+            // oracle datetime push down is different: https://github.com/apache/doris/discussions/15069
+            if (children.get(1).isConstant() && (children.get(1).getType().equals(Type.DATETIME) || children
+                    .get(1).getType().equals(Type.DATETIMEV2))) {
+                String filter = children.get(0).toSql();
+                filter += ((BinaryPredicate) expr).getOp().toString();
+                filter += "to_date('" + children.get(1).getStringValue() + "','yyyy-mm-dd hh24:mi:ss')";
+                return filter;
             }
         }
-        return true;
+        return expr.toMySql();
     }
 
     private final List<String> columns = new ArrayList<String>();
@@ -190,7 +203,7 @@ public class OdbcScanNode extends ScanNode {
         ArrayList<Expr> odbcConjuncts = Expr.cloneList(conjuncts, sMap);
         for (Expr p : odbcConjuncts) {
             if (shouldPushDownConjunct(odbcType, p)) {
-                String filter = p.toMySql();
+                String filter = conjunctExprToString(odbcType, p);
                 filters.add(filter);
                 conjuncts.remove(p);
             }


### PR DESCRIPTION
# Proposed changes
in #15092,  forbid push down filter with DATETIME  type in oracle
because oracle will report error, now change the datetime value with to_date func.

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

