### PR TITLE
[fix](load) fix new_load_scan_node load finished but no data actually caused by wrong file size

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/planner/external/FileGroupInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/external/FileGroupInfo.java
@@ -307,6 +307,7 @@ public class FileGroupInfo {
             rangeDesc.setPath(fileStatus.path);
             rangeDesc.setStartOffset(curFileOffset);
             rangeDesc.setSize(rangeBytes);
+            rangeDesc.setFileSize(fileStatus.size);
             rangeDesc.setColumnsFromPath(columnsFromPath);
         } else {
             // for stream load
@@ -316,10 +317,10 @@ public class FileGroupInfo {
                 Preconditions.checkState(fileGroup.getFilePaths().size() == 1);
                 rangeDesc.setPath(fileGroup.getFilePaths().get(0));
                 rangeDesc.setStartOffset(0);
-                rangeDesc.setSize(fileStatus.size);
             }
             rangeDesc.setLoadId(loadId);
             rangeDesc.setSize(fileStatus.size);
+            rangeDesc.setFileSize(fileStatus.size);
         }
         return rangeDesc;
     }


### PR DESCRIPTION


# Proposed changes

Issue Number: close #15210

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

