### PR TITLE
[Bug](function) fix core dump on reverse() when big string input

### DIFF
--- a/be/src/vec/functions/function_string.h
+++ b/be/src/vec/functions/function_string.h
@@ -2164,10 +2164,12 @@ struct ReverseImpl {
         for (ssize_t i = 0; i < rows_count; ++i) {
             auto src_str = reinterpret_cast<const char*>(&data[offsets[i - 1]]);
             int64_t src_len = offsets[i] - offsets[i - 1];
-            char dst[src_len];
+            string dst;
+            dst.resize(src_len);
             simd::VStringFunctions::reverse(StringVal((uint8_t*)src_str, src_len),
-                                            StringVal((uint8_t*)dst, src_len));
-            StringOP::push_value_string(std::string_view(dst, src_len), i, res_data, res_offsets);
+                                            StringVal((uint8_t*)dst.data(), src_len));
+            StringOP::push_value_string(std::string_view(dst.data(), src_len), i, res_data,
+                                        res_offsets);
         }
         return Status::OK();
     }


### PR DESCRIPTION
# Proposed changes

```sql
SELECT /*+ SET_VAR(query_timeout = 600) */ reverse(CAST(repeat(CAST(ref_0.`d_yearmonth` AS varchar), CAST(ref_0.`d_datekey` AS int)) AS varchar)) AS c0, max(CAST(ref_0.`d_lastdayinweekfl` AS int)) OVER (PARTITION BY ref_0.`d_daynuminyear`, ref_0.`d_sellingseason` ORDER BY ref_0.`d_lastdayinmonthfl`, ref_0.`d_daynuminyear`) AS c1
, ref_0.`d_monthnuminyear` AS c2
FROM regression_test_ssb_unique_load_zstd_p0_load_four_step.date ref_0
WHERE true
```
```cpp
start time: Tue 20 Dec 2022 02:30:07 PM CST
*** Query id: 648ee38a20a14f67-b8ac5691d88614ac ***
*** Aborted at 1671519461 (unix time) try "date -d @1671519461" if you are using GNU date ***
*** Current BE git commitID: 494eb895d ***
*** SIGSEGV invalid permissions for mapped object (@0x7fc0ce62efff) received by PID 685667 (TID 0x7fc0cee2e700) from PID 18446744072877174783; stack trace: ***
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /home/zcp/repo_center/doris_master/doris/be/src/common/signal_handler.h:420
 1# 0x00007FC1EA729BF9 in /usr/lib/jvm/java-1.11.0-openjdk-amd64/lib/server/libjvm.so
 2# JVM_handle_linux_signal in /usr/lib/jvm/java-1.11.0-openjdk-amd64/lib/server/libjvm.so
 3# 0x00007FC1EA72293C in /usr/lib/jvm/java-1.11.0-openjdk-amd64/lib/server/libjvm.so
 4# 0x00007FC1F08540C0 in /lib/x86_64-linux-gnu/libc.so.6
 5# doris::simd::VStringFunctions::reverse(doris_udf::StringVal const&, doris_udf::StringVal) at /home/zcp/repo_center/doris_master/doris/be/src/util/simd/vstring_function.h:143
 6# doris::vectorized::ReverseImpl::vector(doris::vectorized::PODArray<unsigned char, 4096ul, Allocator<false, false>, 15ul, 16ul> const&, doris::vectorized::PODArray<unsigned int, 4096ul, Allocator<false, false>, 15ul, 16ul> const&, doris::vectorized::PODArray<unsigned char, 4096ul, Allocator<false, false>, 15ul, 16ul>&, doris::vectorized::PODArray<unsigned int, 4096ul, Allocator<false, false>, 15ul, 16ul>&) at /home/zcp/repo_center/doris_master/doris/be/src/vec/functions/function_string.h:2168
 7# doris::vectorized::FunctionReverseCommon::execute_impl(doris_udf::FunctionContext*, doris::vectorized::Block&, std::vector<unsigned long, std::allocator<unsigned long> > const&, unsigned long, unsigned long) at /home/zcp/repo_center/doris_master/doris/be/src/vec/functions/function_reverse.h:52
 8# doris::vectorized::DefaultExecutable::execute_impl(doris_udf::FunctionContext*, doris::vectorized::Block&, std::vector<unsigned long, std::allocator<unsigned long> > const&, unsigned long, unsigned long) at /home/zcp/repo_center/doris_master/doris/be/src/vec/functions/function.h:465
 9# doris::vectorized::PreparedFunctionImpl::execute_without_low_cardinality_columns(doris_udf::FunctionContext*, doris::vectorized::Block&, std::vector<unsigned long, std::allocator<unsigned long> > const&, unsigned long, unsigned long, bool) at /home/zcp/repo_center/doris_master/doris/be/src/vec/functions/function.cpp:251
10# doris::vectorized::PreparedFunctionImpl::default_implementation_for_nulls(doris_udf::FunctionContext*, doris::vectorized::Block&, std::vector<unsigned long, std::allocator<unsigned long> > const&, unsigned long, unsigned long, bool, bool*) at /home/zcp/repo_center/doris_master/doris/be/src/vec/functions/function.cpp:221
11# doris::vectorized::PreparedFunctionImpl::execute_without_low_cardinality_columns(doris_udf::FunctionContext*, doris::vectorized::Block&, std::vector<unsigned long, std::allocator<unsigned long> > const&, unsigned long, unsigned long, bool) at /home/zcp/repo_center/doris_master/doris/be/src/vec/functions/function.cpp:242
12# doris::vectorized::PreparedFunctionImpl::execute(doris_udf::FunctionContext*, doris::vectorized::Block&, std::vector<unsigned long, std::allocator<unsigned long> > const&, unsigned long, unsigned long, bool) at /home/zcp/repo_center/doris_master/doris/be/src/vec/functions/function.cpp:273
13# doris::vectorized::IFunctionBase::execute(doris_udf::FunctionContext*, doris::vectorized::Block&, std::vector<unsigned long, std::allocator<unsigned long> > const&, unsigned long, unsigned long, bool) at /home/zcp/repo_center/doris_master/doris/be/src/vec/functions/function.h:136
14# doris::vectorized::VectorizedFnCall::execute(doris::vectorized::VExprContext*, doris::vectorized::Block*, int*) at /home/zcp/repo_center/doris_master/doris/be/src/vec/exprs/vectorized_fn_call.cpp:107
15# doris::vectorized::VExprContext::execute(doris::vectorized::Block*, int*) at /home/zcp/repo_center/doris_master/doris/be/src/vec/exprs/vexpr_context.cpp:44
16# doris::vectorized::VExprContext::get_output_block_after_execute_exprs(std::vector<doris::vectorized::VExprContext*, std::allocator<doris::vectorized::VExprContext*> > const&, doris::vectorized::Block const&, doris::Status&) at /home/zcp/repo_center/doris_master/doris/be/src/vec/exprs/vexpr_context.cpp:143
17# doris::vectorized::VMysqlResultWriter::append_block(doris::vectorized::Block&) at /home/zcp/repo_center/doris_master/doris/be/src/vec/sink/vmysql_result_writer.cpp:431
18# doris::vectorized::VResultSink::send(doris::RuntimeState*, doris::vectorized::Block*, bool) at /home/zcp/repo_center/doris_master/doris/be/src/vec/sink/vresult_sink.cpp:96
19# doris::PlanFragmentExecutor::open_vectorized_internal() at /home/zcp/repo_center/doris_master/doris/be/src/runtime/plan_fragment_executor.cpp:311
20# doris::PlanFragmentExecutor::open() at /home/zcp/repo_center/doris_master/doris/be/src/runtime/plan_fragment_executor.cpp:250
21# doris::FragmentExecState::execute() at /home/zcp/repo_center/doris_master/doris/be/src/runtime/fragment_mgr.cpp:250
22# doris::FragmentMgr::_exec_actual(std::shared_ptr<doris::FragmentExecState>, std::function<void (doris::RuntimeState*, doris::Status*)>) at /home/zcp/repo_center/doris_master/doris/be/src/runtime/fragment_mgr.cpp:490
23# doris::FragmentMgr::exec_plan_fragment(doris::TExecPlanFragmentParams const&, std::function<void (doris::RuntimeState*, doris::Status*)>)::{lambda()#1}::operator()() const at /home/zcp/repo_center/doris_master/doris/be/src/runtime/fragment_mgr.cpp:725
24# void std::__invoke_impl<void, doris::FragmentMgr::exec_plan_fragment(doris::TExecPlanFragmentParams const&, std::function<void (doris::RuntimeState*, doris::Status*)>)::{lambda()#1}&>(std::__invoke_other, doris::FragmentMgr::exec_plan_fragment(doris::TExecPlanFragmentParams const&, std::function<void (doris::RuntimeState*, doris::Status*)>)::{lambda()#1}&) at /var/local/ldb_toolchain/include/c++/11/bits/invoke.h:61
25# std::enable_if<is_invocable_r_v<void, doris::FragmentMgr::exec_plan_fragment(doris::TExecPlanFragmentParams const&, std::function<void (doris::RuntimeState*, doris::Status*)>)::{lambda()#1}&>, void>::type std::__invoke_r<void, doris::FragmentMgr::exec_plan_fragment(doris::TExecPlanFragmentParams const&, std::function<void (doris::RuntimeState*, doris::Status*)>)::{lambda()#1}&>(doris::FragmentMgr::exec_plan_fragment(doris::TExecPlanFragmentParams const&, std::function<void (doris::RuntimeState*, doris::Status*)>)::{lambda()#1}&) at /var/local/ldb_toolchain/include/c++/11/bits/invoke.h:117
26# std::_Function_handler<void (), doris::FragmentMgr::exec_plan_fragment(doris::TExecPlanFragmentParams const&, std::function<void (doris::RuntimeState*, doris::Status*)>)::{lambda()#1}>::_M_invoke(std::_Any_data const&) at /var/local/ldb_toolchain/include/c++/11/bits/std_function.h:292
27# std::function<void ()>::operator()() const at /var/local/ldb_toolchain/include/c++/11/bits/std_function.h:560
28# doris::FunctionRunnable::run() at /home/zcp/repo_center/doris_master/doris/be/src/util/threadpool.cpp:46
29# doris::ThreadPool::dispatch_thread() at /home/zcp/repo_center/doris_master/doris/be/src/util/threadpool.cpp:543
30# void std::__invoke_impl<void, void (doris::ThreadPool::*&)(), doris::ThreadPool*&>(std::__invoke_memfun_deref, void (doris::ThreadPool::*&)(), doris::ThreadPool*&) at /var/local/ldb_toolchain/include/c++/11/bits/invoke.h:74
31# std::__invoke_result<void (doris::ThreadPool::*&)(), doris::ThreadPool*&>::type std::__invoke<void (doris::ThreadPool::*&)(), doris::ThreadPool*&>(void (doris::ThreadPool::*&)(), doris::ThreadPool*&) at /var/local/ldb_toolchain/include/c++/11/bits/invoke.h:97
32# void std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>::__call<void, , 0ul>(std::tuple<>&&, std::_Index_tuple<0ul>) at /var/local/ldb_toolchain/include/c++/11/functional:422
33# void std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>::operator()<, void>() at /var/local/ldb_toolchain/include/c++/11/functional:505
34# void std::__invoke_impl<void, std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>&>(std::__invoke_other, std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>&) at /var/local/ldb_toolchain/include/c++/11/bits/invoke.h:61
35# std::enable_if<is_invocable_r_v<void, std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>&>, void>::type std::__invoke_r<void, std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>&>(std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>&) at /var/local/ldb_toolchain/include/c++/11/bits/invoke.h:117
36# std::_Function_handler<void (), std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()> >::_M_invoke(std::_Any_data const&) at /var/local/ldb_toolchain/include/c++/11/bits/std_function.h:292
37# std::function<void ()>::operator()() const at /var/local/ldb_toolchain/include/c++/11/bits/std_function.h:560
38# doris::Thread::supervise_thread(void*) at /home/zcp/repo_center/doris_master/doris/be/src/util/thread.cpp:455
39# start_thread at /build/glibc-sMfBJT/glibc-2.31/nptl/pthread_create.c:478
40# __clone in /lib/x86_64-linux-gnu/libc.so.6 
```

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

