### PR TITLE
[bugfix](thirdparty) patch simdjson to avoid conflict with odbc macro BOOL

### DIFF
--- a/thirdparty/download-thirdparty.sh
+++ b/thirdparty/download-thirdparty.sh
@@ -395,3 +395,14 @@ if [[ ! -f "${PATCHED_MARK}" ]]; then
 fi
 cd -
 echo "Finished patching ${BRPC_SOURCE}"
+
+# patch jemalloc, change simdjson::dom::element_type::BOOL to BOOLEAN to avoid conflict with odbc macro BOOL
+if [[ "${SIMDJSON_SOURCE}" = "simdjson-1.0.2" ]]; then
+    cd "${TP_SOURCE_DIR}/${SIMDJSON_SOURCE}"
+    if [[ ! -f "${PATCHED_MARK}" ]]; then
+        patch -p1 <"${TP_PATCH_DIR}/simdjson-1.0.2.patch"
+        touch "${PATCHED_MARK}"
+    fi
+    cd -
+fi
+echo "Finished patching ${SIMDJSON_SOURCE}"

--- a/thirdparty/patches/simdjson-1.0.2.patch
+++ b/thirdparty/patches/simdjson-1.0.2.patch
@@ -1,0 +1,99 @@
+diff -ur a/fuzz/fuzz_dump.cpp b/fuzz/fuzz_dump.cpp
+--- a/fuzz/fuzz_dump.cpp	2021-10-28 07:29:42.000000000 +0800
++++ b/fuzz/fuzz_dump.cpp	2022-12-20 21:20:13.068613831 +0800
+@@ -48,7 +48,7 @@
+   case simdjson::dom::element_type::STRING:
+     os << element.get_string().value_unsafe() << endl;
+     break;
+-  case simdjson::dom::element_type::BOOL:
++  case simdjson::dom::element_type::BOOLEAN:
+     os << element.get_bool().value_unsafe() << endl;
+     break;
+   case simdjson::dom::element_type::NULL_VALUE:
+diff -ur a/include/simdjson/dom/element.h b/include/simdjson/dom/element.h
+--- a/include/simdjson/dom/element.h	2021-10-28 07:29:42.000000000 +0800
++++ b/include/simdjson/dom/element.h	2022-12-20 21:19:28.213840603 +0800
+@@ -27,7 +27,7 @@
+   UINT64 = 'u',    ///< uint64_t: any integer that fits in uint64_t but *not* int64_t
+   DOUBLE = 'd',    ///< double: Any number with a "." or "e" that fits in double.
+   STRING = '"',    ///< std::string_view
+-  BOOL = 't',      ///< bool
++  BOOLEAN = 't',      ///< bool
+   NULL_VALUE = 'n' ///< null
+ };
+ 
+diff -ur a/include/simdjson/dom/element-inl.h b/include/simdjson/dom/element-inl.h
+--- a/include/simdjson/dom/element-inl.h	2021-10-28 07:29:42.000000000 +0800
++++ b/include/simdjson/dom/element-inl.h	2022-12-20 21:23:03.064754395 +0800
+@@ -187,7 +187,7 @@
+ 
+ inline element_type element::type() const noexcept {
+   auto tape_type = tape.tape_ref_type();
+-  return tape_type == internal::tape_type::FALSE_VALUE ? element_type::BOOL : static_cast<element_type>(tape_type);
++  return tape_type == internal::tape_type::FALSE_VALUE ? element_type::BOOLEAN : static_cast<element_type>(tape_type);
+ }
+ 
+ inline simdjson_result<bool> element::get_bool() const noexcept {
+@@ -413,7 +413,7 @@
+       return out << "double";
+     case element_type::STRING:
+       return out << "string";
+-    case element_type::BOOL:
++    case element_type::BOOLEAN:
+       return out << "bool";
+     case element_type::NULL_VALUE:
+       return out << "null";
+diff -ur a/singleheader/simdjson.h b/singleheader/simdjson.h
+--- a/singleheader/simdjson.h	2021-10-28 07:29:42.000000000 +0800
++++ b/singleheader/simdjson.h	2022-12-20 21:19:55.295703686 +0800
+@@ -5167,7 +5167,7 @@
+   UINT64 = 'u',    ///< uint64_t: any integer that fits in uint64_t but *not* int64_t
+   DOUBLE = 'd',    ///< double: Any number with a "." or "e" that fits in double.
+   STRING = '"',    ///< std::string_view
+-  BOOL = 't',      ///< bool
++  BOOLEAN = 't',      ///< bool
+   NULL_VALUE = 'n' ///< null
+ };
+ 
+@@ -7008,7 +7008,7 @@
+ 
+ inline element_type element::type() const noexcept {
+   auto tape_type = tape.tape_ref_type();
+-  return tape_type == internal::tape_type::FALSE_VALUE ? element_type::BOOL : static_cast<element_type>(tape_type);
++  return tape_type == internal::tape_type::FALSE_VALUE ? element_type::BOOLEAN : static_cast<element_type>(tape_type);
+ }
+ 
+ inline simdjson_result<bool> element::get_bool() const noexcept {
+@@ -7234,7 +7234,7 @@
+       return out << "double";
+     case element_type::STRING:
+       return out << "string";
+-    case element_type::BOOL:
++    case element_type::BOOLEAN:
+       return out << "bool";
+     case element_type::NULL_VALUE:
+       return out << "null";
+diff -ur a/tests/dom/basictests.cpp b/tests/dom/basictests.cpp
+--- a/tests/dom/basictests.cpp	2021-10-28 07:29:42.000000000 +0800
++++ b/tests/dom/basictests.cpp	2022-12-20 21:18:54.684010105 +0800
+@@ -1499,7 +1499,7 @@
+     simdjson_result<dom::element> result = parser.parse(ALL_TYPES_JSON)[key];
+ 
+     return true
+-      && test_type(result, dom::element_type::BOOL)
++      && test_type(result, dom::element_type::BOOLEAN)
+       && test_cast_error<dom::array>(result, INCORRECT_TYPE)
+       && test_cast_error<dom::object>(result, INCORRECT_TYPE)
+       && test_cast_error<std::string_view>(result, INCORRECT_TYPE)
+diff -ur a/tests/dom/readme_examples.cpp b/tests/dom/readme_examples.cpp
+--- a/tests/dom/readme_examples.cpp	2021-10-28 07:29:42.000000000 +0800
++++ b/tests/dom/readme_examples.cpp	2022-12-20 21:19:06.757949077 +0800
+@@ -204,7 +204,7 @@
+       case dom::element_type::STRING:
+         cout << std::string_view(element) << endl;
+         break;
+-      case dom::element_type::BOOL:
++      case dom::element_type::BOOLEAN:
+         cout << bool(element) << endl;
+         break;
+       case dom::element_type::NULL_VALUE:


### PR DESCRIPTION
# Proposed changes

fix conflit name BOOL in odbc sqltypes.h and simdjson element.h. Change BOOL to BOOLEAN in simdjson.

- thirdparty/installed/include/sqltypes.h

> #define	BOOL				int


- thirdparty/src/simdjson-1.0.2/include/simdjson/dom/element.h

> enum class element_type {
>   ARRAY = '[',     ///< dom::array
>   OBJECT = '{',    ///< dom::object
>   INT64 = 'l',     ///< int64_t
>   UINT64 = 'u',    ///< uint64_t: any integer that fits in uint64_t but *not* int64_t
>   DOUBLE = 'd',    ///< double: Any number with a "." or "e" that fits in double.
>   STRING = '"',    ///< std::string_view
>   BOO = 't',      ///< bool
>   NULL_VALUE = 'n' ///< null
> };
> 

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [x] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

