### PR TITLE
[Feature](bitmap)Support return bitmap/hll data in select statement in vectoriza…

### DIFF
--- a/be/src/runtime/result_writer.h
+++ b/be/src/runtime/result_writer.h
@@ -52,6 +52,10 @@ public:
 
     virtual bool output_object_data() const { return _output_object_data; }
 
+    void set_output_object_data(bool output_object_data) {
+        _output_object_data = output_object_data;
+    }
+
     static const std::string NULL_IN_CSV;
     virtual void set_header_info(const std::string& header_type, const std::string& header) {
         _header_type = header_type;

--- a/be/src/vec/columns/column.h
+++ b/be/src/vec/columns/column.h
@@ -527,6 +527,8 @@ public:
 
     virtual bool is_bitmap() const { return false; }
 
+    virtual bool is_hll() const { return false; }
+
     // true if column has null element
     virtual bool has_null() const { return false; }
 

--- a/be/src/vec/columns/column_complex.h
+++ b/be/src/vec/columns/column_complex.h
@@ -47,6 +47,7 @@ public:
     bool is_numeric() const override { return false; }
 
     bool is_bitmap() const override { return std::is_same_v<T, BitmapValue>; }
+    bool is_hll() const override { return std::is_same_v<T, HyperLogLog>; }
 
     size_t size() const override { return data.size(); }
 

--- a/be/src/vec/columns/column_nullable.h
+++ b/be/src/vec/columns/column_nullable.h
@@ -214,6 +214,7 @@ public:
 
     bool is_nullable() const override { return true; }
     bool is_bitmap() const override { return get_nested_column().is_bitmap(); }
+    bool is_hll() const override { return get_nested_column().is_hll(); }
     bool is_column_decimal() const override { return get_nested_column().is_column_decimal(); }
     bool is_column_string() const override { return get_nested_column().is_column_string(); }
     bool is_column_array() const override { return get_nested_column().is_column_array(); }

--- a/be/src/vec/sink/vmysql_result_writer.cpp
+++ b/be/src/vec/sink/vmysql_result_writer.cpp
@@ -93,13 +93,12 @@ Status VMysqlResultWriter::_add_one_column(const ColumnPtr& column_ptr,
 
             if constexpr (type == TYPE_OBJECT) {
                 if (column->is_bitmap() && output_object_data()) {
-                    vectorized::ColumnComplexType<BitmapValue>* tmp =
-                            (vectorized::ColumnComplexType<BitmapValue>*)column.get();
-                    BitmapValue bitmapValue = tmp->get_element(i);
-                    int size = bitmapValue.getSizeInBytes();
-                    char buf[size];
-                    bitmapValue.write(buf);
-                    buf_ret = _buffer.push_string(buf, size);
+                    const vectorized::ColumnComplexType<BitmapValue>* pColumnComplexType = assert_cast<const vectorized::ColumnComplexType<BitmapValue>*>(column.get());
+                    BitmapValue bitmapValue = pColumnComplexType->get_element(i);
+                    size_t size = bitmapValue.getSizeInBytes();
+                    std::unique_ptr<char[]> buf(new char[size]);
+                    bitmapValue.write(buf.get());
+                    buf_ret = _buffer.push_string(buf.get(), size);
                 } else {
                     buf_ret = _buffer.push_null();
                 }

--- a/be/src/vec/sink/vmysql_result_writer.cpp
+++ b/be/src/vec/sink/vmysql_result_writer.cpp
@@ -93,7 +93,9 @@ Status VMysqlResultWriter::_add_one_column(const ColumnPtr& column_ptr,
 
             if constexpr (type == TYPE_OBJECT) {
                 if (column->is_bitmap() && output_object_data()) {
-                    const vectorized::ColumnComplexType<BitmapValue>* pColumnComplexType = assert_cast<const vectorized::ColumnComplexType<BitmapValue>*>(column.get());
+                    const vectorized::ColumnComplexType<BitmapValue>* pColumnComplexType =
+                            assert_cast<const vectorized::ColumnComplexType<BitmapValue>*>(
+                                    column.get());
                     BitmapValue bitmapValue = pColumnComplexType->get_element(i);
                     size_t size = bitmapValue.getSizeInBytes();
                     std::unique_ptr<char[]> buf(new char[size]);

--- a/be/src/vec/sink/vmysql_result_writer.cpp
+++ b/be/src/vec/sink/vmysql_result_writer.cpp
@@ -99,7 +99,7 @@ Status VMysqlResultWriter::_add_one_column(const ColumnPtr& column_ptr,
                                     column.get());
                     BitmapValue bitmapValue = pColumnComplexType->get_element(i);
                     size_t size = bitmapValue.getSizeInBytes();
-                    std::unique_ptr<char[]> buf(new char[size]);
+                    std::unique_ptr<char[]> buf = std::make_unique<char[]>(size);
                     bitmapValue.write(buf.get());
                     buf_ret = _buffer.push_string(buf.get(), size);
                 } else if (column->is_hll() && output_object_data()) {
@@ -108,7 +108,7 @@ Status VMysqlResultWriter::_add_one_column(const ColumnPtr& column_ptr,
                                     column.get());
                     HyperLogLog hyperLogLog = pColumnComplexType->get_element(i);
                     size_t size = hyperLogLog.max_serialized_size();
-                    std::unique_ptr<char[]> buf(new char[size]);
+                    std::unique_ptr<char[]> buf = std::make_unique<char[]>(size);
                     hyperLogLog.serialize((uint8*)buf.get());
                     buf_ret = _buffer.push_string(buf.get(), size);
                 } else {

--- a/regression-test/suites/query_p1/return_binaray/test_return_binaray_hll.groovy
+++ b/regression-test/suites/query_p1/return_binaray/test_return_binaray_hll.groovy
@@ -1,3 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 suite("test_return_binary_hll") {
     def tableName="test_return_binary_hll"
     sql "drop table if exists ${tableName};"

--- a/regression-test/suites/query_p1/return_binaray/test_return_binaray_hll.groovy
+++ b/regression-test/suites/query_p1/return_binaray/test_return_binaray_hll.groovy
@@ -1,0 +1,33 @@
+suite("test_return_binary_hll") {
+    def tableName="test_return_binary_hll"
+    sql "drop table if exists ${tableName};"
+
+    sql """
+    CREATE TABLE `${tableName}` (
+        `dt` int(11) NULL,
+        `page` varchar(10) NULL,
+        `user_id` hll HLL_UNION NULL
+        ) ENGINE=OLAP
+        AGGREGATE KEY(`dt`, `page`)
+        COMMENT 'OLAP'
+        DISTRIBUTED BY HASH(`dt`) BUCKETS 1
+        PROPERTIES (
+        "replication_allocation" = "tag.location.default: 1",
+        "in_memory" = "false",
+        "storage_format" = "V2",
+        "disable_auto_compaction" = "false"
+        );
+    """
+    sql """
+        insert into ${tableName} values(1,1,hll_hash(1)),(1,1,hll_hash(2)),(1,1,hll_hash(3)),(1,1,hll_hash(23332));
+    """
+    sql "set enable_vectorized_engine=true;"
+    sql "set return_object_data_as_binary=false;"
+    def result1 = sql "select * from ${tableName}"
+    assertTrue(result1[0][2]==null);
+
+    sql "set enable_vectorized_engine=true;"
+    sql "set return_object_data_as_binary=true;"
+    def result2 = sql "select * from ${tableName}"
+    assertTrue(result2[0][2]!=null);
+}

--- a/regression-test/suites/query_p1/return_binaray/test_return_binary_bitmap.groovy
+++ b/regression-test/suites/query_p1/return_binaray/test_return_binary_bitmap.groovy
@@ -1,0 +1,33 @@
+suite("test_return_binary_bitmap") {
+    def tableName="test_return_binary_bitmap"
+    sql "drop table if exists ${tableName};"
+
+    sql """
+    CREATE TABLE `${tableName}` (
+        `dt` int(11) NULL,
+        `page` varchar(10) NULL,
+        `user_id` bitmap BITMAP_UNION NULL
+        ) ENGINE=OLAP
+        AGGREGATE KEY(`dt`, `page`)
+        COMMENT 'OLAP'
+        DISTRIBUTED BY HASH(`dt`) BUCKETS 1
+        PROPERTIES (
+        "replication_allocation" = "tag.location.default: 1",
+        "in_memory" = "false",
+        "storage_format" = "V2",
+        "disable_auto_compaction" = "false"
+        );
+    """
+    sql """
+        insert into ${tableName} values(1,1,to_bitmap(1)),(1,1,to_bitmap(2)),(1,1,to_bitmap(3)),(1,1,to_bitmap(23332));
+    """
+    sql "set enable_vectorized_engine=true;"
+    sql "set return_object_data_as_binary=false;"
+    def result1 = sql "select * from ${tableName}"
+    assertTrue(result1[0][2]==null);
+
+    sql "set enable_vectorized_engine=true;"
+    sql "set return_object_data_as_binary=true;"
+    def result2 = sql "select * from ${tableName}"
+    assertTrue(result2[0][2]!=null);
+}

--- a/regression-test/suites/query_p1/return_binaray/test_return_binary_bitmap.groovy
+++ b/regression-test/suites/query_p1/return_binaray/test_return_binary_bitmap.groovy
@@ -1,3 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 suite("test_return_binary_bitmap") {
     def tableName="test_return_binary_bitmap"
     sql "drop table if exists ${tableName};"


### PR DESCRIPTION
# Proposed changes

Support return bitmap data in select statement in vectorization mode


In the scenario of using Bitmap to circle people, users need to return the Bitmap results to the upper layer, which is parsing the contents of the Bitmap to deal with high QPS query scenarios

在使用bitmap圈人场景中，用户需要把bitmap结果返回到上层，上层在去解析bitmap的内容，以应对高qps的查询场景

MySQL [test_db]> set return_object_data_as_binary=true;

![image](https://user-images.githubusercontent.com/11487604/208808025-0a67431e-c393-4335-a131-74c611aad416.png)
![image](https://user-images.githubusercontent.com/11487604/208818747-a7e0c6e1-de7b-4763-baa3-0e1494058ddc.png)



Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

