### PR TITLE
[opt](planner) add session var: COMPACT_EQUAL_TO_IN_PREDICATE_THRESHOLD

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -204,6 +204,9 @@ public class SessionVariable implements Serializable, Writable {
 
     // percentage of EXEC_MEM_LIMIT
     public static final String BROADCAST_HASHTABLE_MEM_LIMIT_PERCENTAGE = "broadcast_hashtable_mem_limit_percentage";
+
+    public static final String  COMPACT_EQUAL_TO_IN_PREDICATE_COUNT = "compact_equal_to_in_predicate_count";
+
     public static final String NEREIDS_STAR_SCHEMA_SUPPORT = "nereids_star_schema_support";
 
     public static final String NEREIDS_CBO_PENALTY_FACTOR = "nereids_cbo_penalty_factor";
@@ -550,6 +553,9 @@ public class SessionVariable implements Serializable, Writable {
     @VariableMgr.VarAttr(name = NEREIDS_STAR_SCHEMA_SUPPORT)
     private boolean nereidsStarSchemaSupport = true;
 
+    @VariableMgr.VarAttr(name = COMPACT_EQUAL_TO_IN_PREDICATE_COUNT)
+    private int compactEqualToInPredicateCount = 2;
+
     @VariableMgr.VarAttr(name = NEREIDS_CBO_PENALTY_FACTOR)
     private double nereidsCboPenaltyFactor = 0.7;
     @VariableMgr.VarAttr(name = ENABLE_NEREIDS_TRACE)
@@ -690,6 +696,14 @@ public class SessionVariable implements Serializable, Writable {
 
     public void setBlockEncryptionMode(String blockEncryptionMode) {
         this.blockEncryptionMode = blockEncryptionMode;
+    }
+
+    public void setCompactEqualToInPredicateCount(int count) {
+        this.compactEqualToInPredicateCount = count;
+    }
+
+    public int getCompactEqualToInPredicateCount() {
+        return compactEqualToInPredicateCount;
     }
 
     public long getMaxExecMemByte() {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -205,7 +205,7 @@ public class SessionVariable implements Serializable, Writable {
     // percentage of EXEC_MEM_LIMIT
     public static final String BROADCAST_HASHTABLE_MEM_LIMIT_PERCENTAGE = "broadcast_hashtable_mem_limit_percentage";
 
-    public static final String  COMPACT_EQUAL_TO_IN_PREDICATE_COUNT = "compact_equal_to_in_predicate_count";
+    public static final String COMPACT_EQUAL_TO_IN_PREDICATE_THRESHOLD = "compact_equal_to_in_predicate_threshold";
 
     public static final String NEREIDS_STAR_SCHEMA_SUPPORT = "nereids_star_schema_support";
 
@@ -553,8 +553,8 @@ public class SessionVariable implements Serializable, Writable {
     @VariableMgr.VarAttr(name = NEREIDS_STAR_SCHEMA_SUPPORT)
     private boolean nereidsStarSchemaSupport = true;
 
-    @VariableMgr.VarAttr(name = COMPACT_EQUAL_TO_IN_PREDICATE_COUNT)
-    private int compactEqualToInPredicateCount = 2;
+    @VariableMgr.VarAttr(name = COMPACT_EQUAL_TO_IN_PREDICATE_THRESHOLD)
+    private int compactEqualToInPredicateThreshold = 2;
 
     @VariableMgr.VarAttr(name = NEREIDS_CBO_PENALTY_FACTOR)
     private double nereidsCboPenaltyFactor = 0.7;
@@ -698,12 +698,12 @@ public class SessionVariable implements Serializable, Writable {
         this.blockEncryptionMode = blockEncryptionMode;
     }
 
-    public void setCompactEqualToInPredicateCount(int count) {
-        this.compactEqualToInPredicateCount = count;
+    public void setCompactEqualToInPredicateThreshold(int threshold) {
+        this.compactEqualToInPredicateThreshold = threshold;
     }
 
-    public int getCompactEqualToInPredicateCount() {
-        return compactEqualToInPredicateCount;
+    public int getCompactEqualToInPredicateThreshold() {
+        return compactEqualToInPredicateThreshold;
     }
 
     public long getMaxExecMemByte() {

--- a/fe/fe-core/src/main/java/org/apache/doris/rewrite/CompactEqualsToInPredicateRule.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/rewrite/CompactEqualsToInPredicateRule.java
@@ -67,10 +67,10 @@ public class CompactEqualsToInPredicateRule implements ExprRewriteRule {
     expr in form of A or B or ...
      */
     private Pair<Boolean, Expr> compactEqualsToInPredicate(Expr expr) {
-        int compactCount = ConnectContext.get().getSessionVariable().getCompactEqualToInPredicateCount();
+        int compactThreshold = ConnectContext.get().getSessionVariable().getCompactEqualToInPredicateThreshold();
         boolean changed = false;
         List<Expr> disConjuncts = getDisconjuncts(expr);
-        if (disConjuncts.size() < compactCount) {
+        if (disConjuncts.size() < compactThreshold) {
             return Pair.of(false, expr);
         }
         Map<SlotRef, Set<Expr>> equalMap = new HashMap<>();
@@ -112,7 +112,7 @@ public class CompactEqualsToInPredicateRule implements ExprRewriteRule {
         for (Entry<SlotRef, Set<Expr>> entry : equalMap.entrySet()) {
             SlotRef slot = entry.getKey();
             InPredicate in = inPredMap.get(slot);
-            if (entry.getValue().size() >= compactCount || in != null) {
+            if (entry.getValue().size() >= compactThreshold || in != null) {
                 if (in == null) {
                     in = new InPredicate(entry.getKey(), Lists.newArrayList(entry.getValue()), false);
                     inPredMap.put(slot, in);

--- a/fe/fe-core/src/main/java/org/apache/doris/rewrite/CompactEqualsToInPredicateRule.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/rewrite/CompactEqualsToInPredicateRule.java
@@ -67,7 +67,12 @@ public class CompactEqualsToInPredicateRule implements ExprRewriteRule {
     expr in form of A or B or ...
      */
     private Pair<Boolean, Expr> compactEqualsToInPredicate(Expr expr) {
-        int compactThreshold = ConnectContext.get().getSessionVariable().getCompactEqualToInPredicateThreshold();
+        int compactThreshold;
+        if (ConnectContext.get() == null) {
+            compactThreshold = 2;
+        } else {
+            compactThreshold = ConnectContext.get().getSessionVariable().getCompactEqualToInPredicateThreshold();
+        }
         boolean changed = false;
         List<Expr> disConjuncts = getDisconjuncts(expr);
         if (disConjuncts.size() < compactThreshold) {

--- a/regression-test/data/performance_p0/redundant_conjuncts.out
+++ b/regression-test/data/performance_p0/redundant_conjuncts.out
@@ -23,7 +23,7 @@ PLAN FRAGMENT 0
 
   0:VOlapScanNode
      TABLE: default_cluster:regression_test_performance_p0.redundant_conjuncts(redundant_conjuncts), PREAGGREGATION: OFF. Reason: No AggregateInfo
-     PREDICATES: `k1` IN (2, 1)
+     PREDICATES: (`k1` = 1 OR `k1` = 2)
      partitions=0/1, tablets=0/0, tabletList=
      cardinality=0, avgRowSize=8.0, numNodes=1
 

--- a/regression-test/suites/performance_p0/redundant_conjuncts.groovy
+++ b/regression-test/suites/performance_p0/redundant_conjuncts.groovy
@@ -35,6 +35,7 @@ suite("redundant_conjuncts") {
     EXPLAIN SELECT v1 FROM redundant_conjuncts WHERE k1 = 1 AND k1 = 1;
     """
 
+    sql "set COMPACT_EQUAL_TO_IN_PREDICATE_COUNT = 100"
     qt_redundant_conjuncts_gnerated_by_extract_common_filter """
     EXPLAIN SELECT v1 FROM redundant_conjuncts WHERE k1 = 1 OR k1 = 2;
     """

--- a/regression-test/suites/performance_p0/redundant_conjuncts.groovy
+++ b/regression-test/suites/performance_p0/redundant_conjuncts.groovy
@@ -35,7 +35,7 @@ suite("redundant_conjuncts") {
     EXPLAIN SELECT v1 FROM redundant_conjuncts WHERE k1 = 1 AND k1 = 1;
     """
 
-    sql "set COMPACT_EQUAL_TO_IN_PREDICATE_COUNT = 100"
+    sql "set COMPACT_EQUAL_TO_IN_PREDICATE_THRESHOLD = 100"
     qt_redundant_conjuncts_gnerated_by_extract_common_filter """
     EXPLAIN SELECT v1 FROM redundant_conjuncts WHERE k1 = 1 OR k1 = 2;
     """


### PR DESCRIPTION
# Proposed changes
in previous pr, we compact equals like "a=1 or a=2 or a = 3 " in to "a in (1, 2, 3)"
this pr set a lower bound for the number of equals COMPACT_EQUAL_TO_IN_PREDICATE_THRESHOLD (default is 2)

for performance reason, we create a hashSet to collect literals, like {1,2,3}. and hence, the literals in "in-predicates" are in random order.

for regression test, if we need stable output of explain string, set COMPACT_EQUAL_TO_IN_PREDICATE_THRESHOLD to a large number to avoid compact rule.

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

