### PR TITLE
[fix](multi-catalog) fix show data on external catalog

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowDataStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowDataStmt.java
@@ -99,6 +99,8 @@ public class ShowDataStmt extends ShowStmt {
             // disallow external catalog
             Util.prohibitExternalCatalog(tableName.getCtl(), this.getClass().getSimpleName());
             dbName = tableName.getDb();
+        } else {
+            Util.prohibitExternalCatalog(analyzer.getDefaultCatalog(), this.getClass().getSimpleName());
         }
 
         Database db = Env.getCurrentInternalCatalog().getDbOrAnalysisException(dbName);


### PR DESCRIPTION
Signed-off-by: nextdreamblue <zxw520blue1@163.com>

# Proposed changes

Issue Number: close #xxx

## Problem summary

if switch external catalog, and use a database that has same name with one database of internal catalog, query 'show data', will get data info from internal catalog.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

