### PR TITLE
(improvement)[bucket] Add auto bucket implement

### DIFF
--- a/fe/fe-core/src/main/cup/sql_parser.cup
+++ b/fe/fe-core/src/main/cup/sql_parser.cup
@@ -2915,12 +2915,16 @@ opt_distribution ::=
     /* Hash distributed */
     | KW_DISTRIBUTED KW_BY KW_HASH LPAREN ident_list:columns RPAREN opt_distribution_number:numDistribution
     {:
-        RESULT = new HashDistributionDesc(numDistribution, columns);
+        int bucketNum = (numDistribution == null ? -1 : numDistribution);
+        boolean is_auto_bucket = (numDistribution == null);
+        RESULT = new HashDistributionDesc(bucketNum, is_auto_bucket, columns);
     :}
     /* Random distributed */
     | KW_DISTRIBUTED KW_BY KW_RANDOM opt_distribution_number:numDistribution
     {:
-        RESULT = new RandomDistributionDesc(numDistribution);
+        int bucketNum = (numDistribution == null ? -1 : numDistribution);
+        boolean is_auto_bucket = (numDistribution == null);
+        RESULT = new RandomDistributionDesc(bucketNum, is_auto_bucket);
     :}
     ;
 
@@ -2947,7 +2951,7 @@ opt_distribution_number ::=
     :}
     | KW_BUCKETS KW_AUTO
     {:
-        RESULT = 0;
+        RESULT = null;
     :}
     ;
 

--- a/fe/fe-core/src/main/cup/sql_parser.cup
+++ b/fe/fe-core/src/main/cup/sql_parser.cup
@@ -616,7 +616,8 @@ terminal String
     KW_YEAR,
     KW_MTMV,
     KW_TYPECAST,
-    KW_HISTOGRAM;
+    KW_HISTOGRAM,
+    KW_AUTO;
 
 terminal COMMA, COLON, DOT, DOTDOTDOT, AT, STAR, LPAREN, RPAREN, SEMICOLON, LBRACKET, RBRACKET, DIVIDE, MOD, ADD, SUBTRACT;
 terminal BITAND, BITOR, BITXOR, BITNOT;
@@ -2943,6 +2944,10 @@ opt_distribution_number ::=
     | KW_BUCKETS INTEGER_LITERAL:numDistribution
     {:
         RESULT = numDistribution.intValue();
+    :}
+    | KW_BUCKETS KW_AUTO
+    {:
+        RESULT = 0;
     :}
     ;
 

--- a/fe/fe-core/src/main/cup/sql_parser.cup
+++ b/fe/fe-core/src/main/cup/sql_parser.cup
@@ -45,6 +45,7 @@ import org.apache.doris.catalog.StructField;
 import org.apache.doris.catalog.StructType;
 import org.apache.doris.catalog.View;
 import org.apache.doris.common.AnalysisException;
+import org.apache.doris.common.FeConstants;
 import org.apache.doris.common.Version;
 import org.apache.doris.mysql.MysqlPassword;
 import org.apache.doris.load.loadv2.LoadTask;
@@ -2942,8 +2943,8 @@ opt_rollup ::=
 opt_distribution_number ::=
     /* Empty */
     {:
-        /* If distribution number is null, default distribution number is 10. */
-        RESULT = 10;
+        /* If distribution number is null, default distribution number is FeConstants.default_bucket_num. */
+        RESULT = FeConstants.default_bucket_num;
     :}
     | KW_BUCKETS INTEGER_LITERAL:numDistribution
     {:

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateTableStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateTableStmt.java
@@ -100,9 +100,7 @@ public class CreateTableStmt extends DdlStmt {
     // properties["auto_bucket"] = "true"
     private static Map<String, String> maybeRewriteByAutoBucket(DistributionDesc distributionDesc,
             Map<String, String> properties) throws AnalysisException {
-        // after parse sql, distributionDesc.getBucketNum() == 0 that auto bucket is
-        // enable
-        if (distributionDesc == null || distributionDesc.getBuckets() != 0) {
+        if (distributionDesc == null || !distributionDesc.isAutoBucket()) {
             return properties;
         }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateTableStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateTableStmt.java
@@ -289,7 +289,7 @@ public class CreateTableStmt extends DdlStmt {
 
     @Override
     public void analyze(Analyzer analyzer) throws UserException, AnalysisException {
-        if (Strings.isNullOrEmpty(engineName) || engineName.equals("olap")) {
+        if (Strings.isNullOrEmpty(engineName) || engineName.equalsIgnoreCase("olap")) {
             this.properties = maybeRewriteByAutoBucket(distributionDesc, properties);
         }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateTableStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateTableStmt.java
@@ -112,7 +112,7 @@ public class CreateTableStmt extends DdlStmt {
         newProperties.put(PropertyAnalyzer.PROPERTIES_AUTO_BUCKET, "true");
 
         if (!newProperties.containsKey(PropertyAnalyzer.PROPERTIES_ESTIMATE_PARTITION_SIZE)) {
-            distributionDesc.setBuckets(11);
+            distributionDesc.setBuckets(FeConstants.default_bucket_num);
         } else {
             long partitionSize = ParseUtil
                     .analyzeDataVolumn(newProperties.get(PropertyAnalyzer.PROPERTIES_ESTIMATE_PARTITION_SIZE));

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateTableStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateTableStmt.java
@@ -96,8 +96,8 @@ public class CreateTableStmt extends DdlStmt {
         engineNames.add("jdbc");
     }
 
-    // if auto bucket auto bucket enable, rewrite distribution bucket num && set
-    // properties["auto_bucket"] = "true"
+    // if auto bucket auto bucket enable, rewrite distribution bucket num &&
+    // set properties[PropertyAnalyzer.PROPERTIES_AUTO_BUCKET] = "true"
     private static Map<String, String> maybeRewriteByAutoBucket(DistributionDesc distributionDesc,
             Map<String, String> properties) throws AnalysisException {
         if (distributionDesc == null || !distributionDesc.isAutoBucket()) {

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/DistributionDesc.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/DistributionDesc.java
@@ -35,9 +35,21 @@ import java.util.Set;
 
 public class DistributionDesc implements Writable {
     protected DistributionInfoType type;
+    protected int numBucket;
 
     public DistributionDesc() {
+    }
 
+    public DistributionDesc(int numBucket) {
+        this.numBucket = numBucket;
+    }
+
+    public int getBuckets() {
+        return numBucket;
+    }
+
+    public int setBuckets(int numBucket) {
+        return this.numBucket = numBucket;
     }
 
     public void analyze(Set<String> colSet, List<ColumnDef> columnDefs, KeysDesc keysDesc) throws AnalysisException {

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/DistributionDesc.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/DistributionDesc.java
@@ -22,17 +22,13 @@ import org.apache.doris.catalog.DistributionInfo;
 import org.apache.doris.catalog.DistributionInfo.DistributionInfoType;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.DdlException;
-import org.apache.doris.common.io.Text;
-import org.apache.doris.common.io.Writable;
 
 import org.apache.commons.lang.NotImplementedException;
 
-import java.io.DataOutput;
-import java.io.IOException;
 import java.util.List;
 import java.util.Set;
 
-public class DistributionDesc implements Writable {
+public class DistributionDesc {
     protected DistributionInfoType type;
     protected int numBucket;
     protected boolean autoBucket;
@@ -68,12 +64,5 @@ public class DistributionDesc implements Writable {
 
     public DistributionInfo toDistributionInfo(List<Column> columns) throws DdlException {
         throw new NotImplementedException();
-    }
-
-    @Override
-    public void write(DataOutput out) throws IOException {
-        Text.writeString(out, type.name());
-        out.writeInt(numBucket);
-        out.writeBoolean(autoBucket);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/DistributionDesc.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/DistributionDesc.java
@@ -27,7 +27,6 @@ import org.apache.doris.common.io.Writable;
 
 import org.apache.commons.lang.NotImplementedException;
 
-import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 import java.util.List;
@@ -36,12 +35,15 @@ import java.util.Set;
 public class DistributionDesc implements Writable {
     protected DistributionInfoType type;
     protected int numBucket;
-
-    public DistributionDesc() {
-    }
+    protected boolean autoBucket;
 
     public DistributionDesc(int numBucket) {
+        this(numBucket, false);
+    }
+
+    public DistributionDesc(int numBucket, boolean autoBucket) {
         this.numBucket = numBucket;
+        this.autoBucket = autoBucket;
     }
 
     public int getBuckets() {
@@ -50,6 +52,10 @@ public class DistributionDesc implements Writable {
 
     public int setBuckets(int numBucket) {
         return this.numBucket = numBucket;
+    }
+
+    public boolean isAutoBucket() {
+        return autoBucket;
     }
 
     public void analyze(Set<String> colSet, List<ColumnDef> columnDefs, KeysDesc keysDesc) throws AnalysisException {
@@ -64,27 +70,10 @@ public class DistributionDesc implements Writable {
         throw new NotImplementedException();
     }
 
-    public static DistributionDesc read(DataInput in) throws IOException {
-        DistributionInfoType type = DistributionInfoType.valueOf(Text.readString(in));
-        if (type == DistributionInfoType.HASH) {
-            DistributionDesc desc = new HashDistributionDesc();
-            desc.readFields(in);
-            return desc;
-        } else if (type == DistributionInfoType.RANDOM) {
-            DistributionDesc desc = new RandomDistributionDesc();
-            desc.readFields(in);
-            return desc;
-        } else {
-            throw new IOException("Unknown distribution type: " + type);
-        }
-    }
-
     @Override
     public void write(DataOutput out) throws IOException {
         Text.writeString(out, type.name());
-    }
-
-    public void readFields(DataInput in) throws IOException {
-        throw new NotImplementedException();
+        out.writeInt(numBucket);
+        out.writeBoolean(autoBucket);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/HashDistributionDesc.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/HashDistributionDesc.java
@@ -25,13 +25,10 @@ import org.apache.doris.catalog.KeysType;
 import org.apache.doris.catalog.PrimitiveType;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.DdlException;
-import org.apache.doris.common.io.Text;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 
-import java.io.DataOutput;
-import java.io.IOException;
 import java.util.List;
 import java.util.Set;
 
@@ -141,16 +138,5 @@ public class HashDistributionDesc extends DistributionDesc {
         HashDistributionInfo hashDistributionInfo =
                                 new HashDistributionInfo(numBucket, autoBucket, distributionColumns);
         return hashDistributionInfo;
-    }
-
-    @Override
-    public void write(DataOutput out) throws IOException {
-        super.write(out);
-
-        int count = distributionColumnNames.size();
-        out.writeInt(count);
-        for (String colName : distributionColumnNames) {
-            Text.writeString(out, colName);
-        }
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/HashDistributionDesc.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/HashDistributionDesc.java
@@ -37,7 +37,6 @@ import java.util.List;
 import java.util.Set;
 
 public class HashDistributionDesc extends DistributionDesc {
-    private int numBucket;
     private List<String> distributionColumnNames;
 
     public HashDistributionDesc() {
@@ -46,8 +45,8 @@ public class HashDistributionDesc extends DistributionDesc {
     }
 
     public HashDistributionDesc(int numBucket, List<String> distributionColumnNames) {
+        super(numBucket);
         type = DistributionInfoType.HASH;
-        this.numBucket = numBucket;
         this.distributionColumnNames = distributionColumnNames;
     }
 
@@ -55,14 +54,10 @@ public class HashDistributionDesc extends DistributionDesc {
         return distributionColumnNames;
     }
 
-    public int getBuckets() {
-        return numBucket;
-    }
-
     @Override
     public void analyze(Set<String> colSet, List<ColumnDef> columnDefs, KeysDesc keysDesc) throws AnalysisException {
         if (numBucket <= 0) {
-            throw new AnalysisException("Number of hash distribution should be larger than zero.");
+            throw new AnalysisException("Number of hash distribution should be greater than zero.");
         }
         if (distributionColumnNames == null || distributionColumnNames.size() == 0) {
             throw new AnalysisException("Number of hash column should be larger than zero.");

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/HashDistributionDesc.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/HashDistributionDesc.java
@@ -30,7 +30,6 @@ import org.apache.doris.common.io.Text;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 
-import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 import java.util.List;
@@ -39,13 +38,14 @@ import java.util.Set;
 public class HashDistributionDesc extends DistributionDesc {
     private List<String> distributionColumnNames;
 
-    public HashDistributionDesc() {
-        type = DistributionInfoType.HASH;
-        distributionColumnNames = Lists.newArrayList();
-    }
-
     public HashDistributionDesc(int numBucket, List<String> distributionColumnNames) {
         super(numBucket);
+        type = DistributionInfoType.HASH;
+        this.distributionColumnNames = distributionColumnNames;
+    }
+
+    public HashDistributionDesc(int numBucket, boolean autoBucket, List<String> distributionColumnNames) {
+        super(numBucket, autoBucket);
         type = DistributionInfoType.HASH;
         this.distributionColumnNames = distributionColumnNames;
     }
@@ -95,7 +95,11 @@ public class HashDistributionDesc extends DistributionDesc {
             i++;
         }
         stringBuilder.append(")\n");
-        stringBuilder.append("BUCKETS ").append(numBucket);
+        if (autoBucket) {
+            stringBuilder.append("BUCKETS AUTO");
+        } else {
+            stringBuilder.append("BUCKETS ").append(numBucket);
+        }
         return stringBuilder.toString();
     }
 
@@ -134,7 +138,8 @@ public class HashDistributionDesc extends DistributionDesc {
             }
         }
 
-        HashDistributionInfo hashDistributionInfo = new HashDistributionInfo(numBucket, distributionColumns);
+        HashDistributionInfo hashDistributionInfo =
+                                new HashDistributionInfo(numBucket, autoBucket, distributionColumns);
         return hashDistributionInfo;
     }
 
@@ -142,19 +147,10 @@ public class HashDistributionDesc extends DistributionDesc {
     public void write(DataOutput out) throws IOException {
         super.write(out);
 
-        out.writeInt(numBucket);
         int count = distributionColumnNames.size();
         out.writeInt(count);
         for (String colName : distributionColumnNames) {
             Text.writeString(out, colName);
-        }
-    }
-
-    public void readFields(DataInput in) throws IOException {
-        numBucket = in.readInt();
-        int count = in.readInt();
-        for (int i = 0; i < count; i++) {
-            distributionColumnNames.add(Text.readString(in));
         }
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/RandomDistributionDesc.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/RandomDistributionDesc.java
@@ -23,19 +23,17 @@ import org.apache.doris.catalog.DistributionInfo.DistributionInfoType;
 import org.apache.doris.catalog.RandomDistributionInfo;
 import org.apache.doris.common.AnalysisException;
 
-import java.io.DataInput;
-import java.io.DataOutput;
-import java.io.IOException;
 import java.util.List;
 import java.util.Set;
 
 public class RandomDistributionDesc extends DistributionDesc {
-    public RandomDistributionDesc() {
+    public RandomDistributionDesc(int numBucket) {
+        super(numBucket);
         type = DistributionInfoType.RANDOM;
     }
 
-    public RandomDistributionDesc(int numBucket) {
-        super(numBucket);
+    public RandomDistributionDesc(int numBucket, boolean autoBucket) {
+        super(numBucket, autoBucket);
         type = DistributionInfoType.RANDOM;
     }
 
@@ -50,23 +48,18 @@ public class RandomDistributionDesc extends DistributionDesc {
     public String toSql() {
         StringBuilder stringBuilder = new StringBuilder();
         stringBuilder.append("DISTRIBUTED BY RANDOM\n")
-                .append("BUCKETS ").append(numBucket);
+                .append("BUCKETS ");
+        if (autoBucket) {
+            stringBuilder.append("AUTO");
+        } else {
+            stringBuilder.append(numBucket);
+        }
         return stringBuilder.toString();
     }
 
     @Override
     public DistributionInfo toDistributionInfo(List<Column> columns) {
-        RandomDistributionInfo randomDistributionInfo = new RandomDistributionInfo(numBucket);
+        RandomDistributionInfo randomDistributionInfo = new RandomDistributionInfo(numBucket, autoBucket);
         return randomDistributionInfo;
-    }
-
-    @Override
-    public void write(DataOutput out) throws IOException {
-        super.write(out);
-        out.writeInt(numBucket);
-    }
-
-    public void readFields(DataInput in) throws IOException {
-        numBucket = in.readInt();
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/RandomDistributionDesc.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/RandomDistributionDesc.java
@@ -30,21 +30,19 @@ import java.util.List;
 import java.util.Set;
 
 public class RandomDistributionDesc extends DistributionDesc {
-    int numBucket;
-
     public RandomDistributionDesc() {
         type = DistributionInfoType.RANDOM;
     }
 
     public RandomDistributionDesc(int numBucket) {
+        super(numBucket);
         type = DistributionInfoType.RANDOM;
-        this.numBucket = numBucket;
     }
 
     @Override
     public void analyze(Set<String> colSet, List<ColumnDef> columnDefs, KeysDesc keysDesc) throws AnalysisException {
         if (numBucket <= 0) {
-            throw new AnalysisException("Number of random distribution should be larger than zero.");
+            throw new AnalysisException("Number of random distribution should be greater than zero.");
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/DistributionInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/DistributionInfo.java
@@ -40,12 +40,28 @@ public abstract class DistributionInfo implements Writable {
     @SerializedName(value = "type")
     protected DistributionInfoType type;
 
+    @SerializedName(value = "bucketNum")
+    protected int bucketNum;
+
+    @SerializedName(value = "autoBucket")
+    protected boolean autoBucket;
+
     public DistributionInfo() {
         // for persist
     }
 
     public DistributionInfo(DistributionInfoType type) {
+        this(type, 0, false);
+    }
+
+    public DistributionInfo(DistributionInfoType type, int bucketNum) {
+        this(type, bucketNum, false);
+    }
+
+    public DistributionInfo(DistributionInfoType type, int bucketNum, boolean autoBucket) {
         this.type = type;
+        this.bucketNum = bucketNum;
+        this.autoBucket = autoBucket;
     }
 
     public DistributionInfoType getType() {

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/DistributionInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/DistributionInfo.java
@@ -78,6 +78,10 @@ public abstract class DistributionInfo implements Writable {
         throw new NotImplementedException("not implemented");
     }
 
+    public void markAutoBucket() {
+        autoBucket = true;
+    }
+
     public DistributionDesc toDistributionDesc() {
         throw new NotImplementedException();
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
@@ -2956,8 +2956,6 @@ public class Env {
             }
 
             // estimate_partition_size
-            LOG.info("estimate partition size: {}, auto bucket: {}", olapTable.getEstimatePartitionSize(),
-                    olapTable.isAutoBucket());
             if (!olapTable.getEstimatePartitionSize().equals("")) {
                 sb.append(",\n\"").append(PropertyAnalyzer.PROPERTIES_ESTIMATE_PARTITION_SIZE).append("\" = \"");
                 sb.append(olapTable.getEstimatePartitionSize()).append("\"");

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
@@ -2955,6 +2955,14 @@ public class Env {
                 sb.append(olapTable.getCompressionType()).append("\"");
             }
 
+            // estimate_partition_size
+            LOG.info("estimate partition size: {}, auto bucket: {}", olapTable.getEstimatePartitionSize(),
+                    olapTable.isAutoBucket());
+            if (!olapTable.getEstimatePartitionSize().equals("")) {
+                sb.append(",\n\"").append(PropertyAnalyzer.PROPERTIES_ESTIMATE_PARTITION_SIZE).append("\" = \"");
+                sb.append(olapTable.getEstimatePartitionSize()).append("\"");
+            }
+
             // unique key table with merge on write
             if (olapTable.getKeysType() == KeysType.UNIQUE_KEYS && olapTable.getEnableUniqueKeyMergeOnWrite()) {
                 sb.append(",\n\"").append(PropertyAnalyzer.ENABLE_UNIQUE_KEY_MERGE_ON_WRITE).append("\" = \"");

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/HashDistributionInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/HashDistributionInfo.java
@@ -37,8 +37,6 @@ import java.util.Objects;
 public class HashDistributionInfo extends DistributionInfo {
     @SerializedName(value = "distributionColumns")
     private List<Column> distributionColumns;
-    @SerializedName(value = "bucketNum")
-    private int bucketNum;
 
     public HashDistributionInfo() {
         super();
@@ -46,9 +44,13 @@ public class HashDistributionInfo extends DistributionInfo {
     }
 
     public HashDistributionInfo(int bucketNum, List<Column> distributionColumns) {
-        super(DistributionInfoType.HASH);
+        super(DistributionInfoType.HASH, bucketNum);
         this.distributionColumns = distributionColumns;
-        this.bucketNum = bucketNum;
+    }
+
+    public HashDistributionInfo(int bucketNum, boolean autoBucket, List<Column> distributionColumns) {
+        super(DistributionInfoType.HASH, bucketNum, autoBucket);
+        this.distributionColumns = distributionColumns;
     }
 
     public List<Column> getDistributionColumns() {
@@ -65,6 +67,7 @@ public class HashDistributionInfo extends DistributionInfo {
         this.bucketNum = bucketNum;
     }
 
+    @Override
     public void write(DataOutput out) throws IOException {
         super.write(out);
         int columnCount = distributionColumns.size();
@@ -75,6 +78,7 @@ public class HashDistributionInfo extends DistributionInfo {
         out.writeInt(bucketNum);
     }
 
+    @Override
     public void readFields(DataInput in) throws IOException {
         super.readFields(in);
         int columnCount = in.readInt();
@@ -117,7 +121,7 @@ public class HashDistributionInfo extends DistributionInfo {
         for (Column col : distributionColumns) {
             distriColNames.add(col.getName());
         }
-        DistributionDesc distributionDesc = new HashDistributionDesc(bucketNum, distriColNames);
+        DistributionDesc distributionDesc = new HashDistributionDesc(bucketNum, autoBucket, distriColNames);
         return distributionDesc;
     }
 
@@ -133,7 +137,11 @@ public class HashDistributionInfo extends DistributionInfo {
         String colList = Joiner.on(", ").join(colNames);
         builder.append(colList);
 
-        builder.append(") BUCKETS ").append(bucketNum);
+        if (autoBucket) {
+            builder.append(") BUCKETS AUTO");
+        } else {
+            builder.append(") BUCKETS ").append(bucketNum);
+        }
         return builder.toString();
     }
 
@@ -148,7 +156,11 @@ public class HashDistributionInfo extends DistributionInfo {
         }
         builder.append("]; ");
 
-        builder.append("bucket num: ").append(bucketNum).append("; ");
+        if (autoBucket) {
+            builder.append("bucket num: auto;");
+        } else {
+            builder.append("bucket num: ").append(bucketNum).append(";");
+        }
 
         return builder.toString();
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
@@ -1638,7 +1638,21 @@ public class OlapTable extends Table {
         }
         tableProperty.modifyTableProperties(PropertyAnalyzer.PROPERTIES_AUTO_BUCKET,
                 Boolean.valueOf(isAutoBucket).toString());
-        tableProperty.buildAutoBucket();
+    }
+
+    public void setEstimatePartitionSize(String estimatePartitionSize) {
+        if (tableProperty == null) {
+            tableProperty = new TableProperty(new HashMap<>());
+        }
+        tableProperty.modifyTableProperties(PropertyAnalyzer.PROPERTIES_ESTIMATE_PARTITION_SIZE,
+                estimatePartitionSize);
+    }
+
+    public String getEstimatePartitionSize() {
+        if (tableProperty != null) {
+            return tableProperty.getEstimatePartitionSize();
+        }
+        return "";
     }
 
     public boolean getEnableLightSchemaChange() {

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
@@ -1282,6 +1282,9 @@ public class OlapTable extends Table {
         if (in.readBoolean()) {
             tableProperty = TableProperty.read(in);
         }
+        if (isAutoBucket()) {
+            defaultDistributionInfo.markAutoBucket();
+        }
 
         // temp partitions
         tempPartitions = TempPartitions.read(in);

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
@@ -594,8 +594,8 @@ public class OlapTable extends Table {
         if (full) {
             return indexIdToMeta.get(indexId).getSchema();
         } else {
-            return indexIdToMeta.get(indexId).getSchema().stream().filter(column ->
-                    column.isVisible()).collect(Collectors.toList());
+            return indexIdToMeta.get(indexId).getSchema().stream().filter(column -> column.isVisible())
+                    .collect(Collectors.toList());
         }
     }
 
@@ -1133,7 +1133,6 @@ public class OlapTable extends Table {
         return false;
     }
 
-
     @Override
     public void write(DataOutput out) throws IOException {
         super.write(out);
@@ -1626,6 +1625,22 @@ public class OlapTable extends Table {
         tableProperty.buildInMemory();
     }
 
+    public Boolean isAutoBucket() {
+        if (tableProperty != null) {
+            return tableProperty.isAutoBucket();
+        }
+        return false;
+    }
+
+    public void setIsAutoBucket(boolean isAutoBucket) {
+        if (tableProperty == null) {
+            tableProperty = new TableProperty(new HashMap<>());
+        }
+        tableProperty.modifyTableProperties(PropertyAnalyzer.PROPERTIES_AUTO_BUCKET,
+                Boolean.valueOf(isAutoBucket).toString());
+        tableProperty.buildAutoBucket();
+    }
+
     public boolean getEnableLightSchemaChange() {
         if (tableProperty != null) {
             return tableProperty.getUseSchemaLightChange();
@@ -1879,11 +1894,11 @@ public class OlapTable extends Table {
             return false;
         }
         List<Expr> partitionExps = aggregateInfo.getPartitionExprs() != null
-                ? aggregateInfo.getPartitionExprs() : groupingExps;
+                ? aggregateInfo.getPartitionExprs()
+                : groupingExps;
         DistributionInfo distribution = getDefaultDistributionInfo();
         if (distribution instanceof HashDistributionInfo) {
-            List<Column> distributeColumns =
-                    ((HashDistributionInfo) distribution).getDistributionColumns();
+            List<Column> distributeColumns = ((HashDistributionInfo) distribution).getDistributionColumns();
             PartitionInfo partitionInfo = getPartitionInfo();
             if (partitionInfo instanceof RangePartitionInfo) {
                 List<Column> rangeColumns = partitionInfo.getPartitionColumns();
@@ -1891,8 +1906,7 @@ public class OlapTable extends Table {
                     return false;
                 }
             }
-            List<SlotRef> partitionSlots =
-                    partitionExps.stream().map(Expr::unwrapSlotRef).collect(Collectors.toList());
+            List<SlotRef> partitionSlots = partitionExps.stream().map(Expr::unwrapSlotRef).collect(Collectors.toList());
             if (partitionSlots.contains(null)) {
                 return false;
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/RandomDistributionInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/RandomDistributionInfo.java
@@ -29,21 +29,21 @@ import java.util.Objects;
  * Random partition.
  */
 public class RandomDistributionInfo extends DistributionInfo {
-
-    private int bucketNum;
-
     public RandomDistributionInfo() {
         super();
     }
 
     public RandomDistributionInfo(int bucketNum) {
-        super(DistributionInfoType.RANDOM);
-        this.bucketNum = bucketNum;
+        super(DistributionInfoType.RANDOM, bucketNum);
+    }
+
+    public RandomDistributionInfo(int bucketNum, boolean autoBucket) {
+        super(DistributionInfoType.RANDOM, bucketNum, autoBucket);
     }
 
     @Override
     public DistributionDesc toDistributionDesc() {
-        DistributionDesc distributionDesc = new RandomDistributionDesc(bucketNum);
+        DistributionDesc distributionDesc = new RandomDistributionDesc(bucketNum, autoBucket);
         return distributionDesc;
     }
 
@@ -55,15 +55,21 @@ public class RandomDistributionInfo extends DistributionInfo {
     @Override
     public String toSql() {
         StringBuilder builder = new StringBuilder();
-        builder.append("DISTRIBUTED BY RANDOM BUCKETS ").append(bucketNum);
+        if (autoBucket) {
+            builder.append("DISTRIBUTED BY RANDOM() BUCKETS AUTO");
+        } else {
+            builder.append("DISTRIBUTED BY RANDOM() BUCKETS ").append(bucketNum);
+        }
         return builder.toString();
     }
 
+    @Override
     public void write(DataOutput out) throws IOException {
         super.write(out);
         out.writeInt(bucketNum);
     }
 
+    @Override
     public void readFields(DataInput in) throws IOException {
         super.readFields(in);
         bucketNum = in.readInt();

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/TableProperty.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/TableProperty.java
@@ -58,7 +58,6 @@ public class TableProperty implements Writable {
     private DynamicPartitionProperty dynamicPartitionProperty = new DynamicPartitionProperty(Maps.newHashMap());
     private ReplicaAllocation replicaAlloc = ReplicaAllocation.DEFAULT_ALLOCATION;
     private boolean isInMemory = false;
-    private boolean isAutoBucket = false;
 
     private String storagePolicy = "";
 
@@ -147,11 +146,6 @@ public class TableProperty implements Writable {
 
     public TableProperty buildInMemory() {
         isInMemory = Boolean.parseBoolean(properties.getOrDefault(PropertyAnalyzer.PROPERTIES_INMEMORY, "false"));
-        return this;
-    }
-
-    public TableProperty buildAutoBucket() {
-        isAutoBucket = Boolean.parseBoolean(properties.getOrDefault(PropertyAnalyzer.PROPERTIES_AUTO_BUCKET, "false"));
         return this;
     }
 
@@ -251,7 +245,11 @@ public class TableProperty implements Writable {
     }
 
     public boolean isAutoBucket() {
-        return isAutoBucket;
+        return Boolean.parseBoolean(properties.getOrDefault(PropertyAnalyzer.PROPERTIES_AUTO_BUCKET, "false"));
+    }
+
+    public String getEstimatePartitionSize() {
+        return properties.getOrDefault(PropertyAnalyzer.PROPERTIES_ESTIMATE_PARTITION_SIZE, "");
     }
 
     public TStorageFormat getStorageFormat() {

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/TableProperty.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/TableProperty.java
@@ -58,6 +58,7 @@ public class TableProperty implements Writable {
     private DynamicPartitionProperty dynamicPartitionProperty = new DynamicPartitionProperty(Maps.newHashMap());
     private ReplicaAllocation replicaAlloc = ReplicaAllocation.DEFAULT_ALLOCATION;
     private boolean isInMemory = false;
+    private boolean isAutoBucket = false;
 
     private String storagePolicy = "";
 
@@ -146,6 +147,11 @@ public class TableProperty implements Writable {
 
     public TableProperty buildInMemory() {
         isInMemory = Boolean.parseBoolean(properties.getOrDefault(PropertyAnalyzer.PROPERTIES_INMEMORY, "false"));
+        return this;
+    }
+
+    public TableProperty buildAutoBucket() {
+        isAutoBucket = Boolean.parseBoolean(properties.getOrDefault(PropertyAnalyzer.PROPERTIES_AUTO_BUCKET, "false"));
         return this;
     }
 
@@ -242,6 +248,10 @@ public class TableProperty implements Writable {
 
     public boolean isInMemory() {
         return isInMemory;
+    }
+
+    public boolean isAutoBucket() {
+        return isAutoBucket;
     }
 
     public TStorageFormat getStorageFormat() {

--- a/fe/fe-core/src/main/java/org/apache/doris/clone/DynamicPartitionScheduler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/DynamicPartitionScheduler.java
@@ -196,7 +196,7 @@ public class DynamicPartitionScheduler extends MasterDaemon {
             }
         });
         ArrayList<Long> parititonsSize = Lists.newArrayList();
-        for (Partition partition : table.getPartitions()) {
+        for (Partition partition : partitions) {
             parititonsSize.add(partition.getDataSize());
         }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/clone/DynamicPartitionScheduler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/DynamicPartitionScheduler.java
@@ -201,7 +201,9 @@ public class DynamicPartitionScheduler extends MasterDaemon {
 
         ArrayList<Long> partitionSizeArray = Lists.newArrayList();
         for (Partition partition : partitions) {
-            partitionSizeArray.add(partition.getDataSize());
+            if (partition.getVisibleVersion() >= 2) {
+                partitionSizeArray.add(partition.getDataSize());
+            }
         }
 
         // * 5 for uncompressed data

--- a/fe/fe-core/src/main/java/org/apache/doris/common/FeConstants.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/FeConstants.java
@@ -22,6 +22,10 @@ import org.apache.doris.persist.meta.FeMetaFormat;
 public class FeConstants {
     // Database and table's default configurations, we will never change them
     public static short default_replication_num = 3;
+
+    // The default value of bucket setting && auto bucket without estimate_partition_size
+    public static int default_bucket_num = 10;
+
     /*
      * Those two fields is responsible for determining the default key columns in duplicate table.
      * If user does not specify key of duplicate table in create table stmt,

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/AutoBucketUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/AutoBucketUtils.java
@@ -30,8 +30,9 @@ import org.apache.logging.log4j.Logger;
 public class AutoBucketUtils {
     private static Logger logger = LogManager.getLogger(AutoBucketUtils.class);
 
-    private static final long SIZE_100MB = 100 * 1024 * 1024L;
-    private static final long SIZE_1GB = 1 * 1024 * 1024 * 1024L;
+    static final long SIZE_100MB = 100 * 1024 * 1024L;
+    static final long SIZE_1GB = 1 * 1024 * 1024 * 1024L;
+    static final long SIZE_1TB = 1024 * SIZE_1GB;
 
     private static int getBENum() {
         SystemInfoService infoService = Env.getCurrentSystemInfo();

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/AutoBucketUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/AutoBucketUtils.java
@@ -54,7 +54,7 @@ public class AutoBucketUtils {
         int buckets = 0;
         for (Backend backend : backends.values()) {
             if (!backend.isLoadAvailable()) {
-                break;
+                continue;
             }
 
             ImmutableMap<String, DiskInfo> disks = backend.getDisks();

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/AutoBucketUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/AutoBucketUtils.java
@@ -86,12 +86,12 @@ public class AutoBucketUtils {
         int bucketsNumByBE = getBucketsNumByBEDisks();
         int bucketsNum = Math.min(128, Math.min(bucketsNumByPartitionSize, bucketsNumByBE));
         int beNum = getBENum();
-        logger.info("AutoBucketsUtil: bucketsNumByPartitionSize {}, bucketsNumByBE {}, bucketsNum {}, beNum {}",
+        logger.debug("AutoBucketsUtil: bucketsNumByPartitionSize {}, bucketsNumByBE {}, bucketsNum {}, beNum {}",
                 bucketsNumByPartitionSize, bucketsNumByBE, bucketsNum, beNum);
         if (bucketsNum < bucketsNumByPartitionSize && bucketsNum < beNum) {
             bucketsNum = beNum;
         }
-        logger.info("AutoBucketsUtil: final bucketsNum {}", bucketsNum);
+        logger.debug("AutoBucketsUtil: final bucketsNum {}", bucketsNum);
         return bucketsNum;
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/AutoBucketUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/AutoBucketUtils.java
@@ -1,0 +1,97 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.common.util;
+
+import org.apache.doris.catalog.DiskInfo;
+import org.apache.doris.catalog.DiskInfo.DiskState;
+import org.apache.doris.catalog.Env;
+import org.apache.doris.system.Backend;
+import org.apache.doris.system.SystemInfoService;
+
+import com.google.common.collect.ImmutableMap;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class AutoBucketUtils {
+    private static Logger logger = LogManager.getLogger(AutoBucketUtils.class);
+
+    private static final long SIZE_100MB = 100 * 1024 * 1024L;
+    private static final long SIZE_1GB = 1 * 1024 * 1024 * 1024L;
+
+    private static int getBENum() {
+        SystemInfoService infoService = Env.getCurrentSystemInfo();
+        ImmutableMap<Long, Backend> backends = infoService.getBackendsInCluster(null);
+
+        int activeBENum = 0;
+        for (Backend backend : backends.values()) {
+            if (backend.isAlive()) {
+                ++activeBENum;
+            }
+        }
+        return activeBENum;
+    }
+
+    private static int getBucketsNumByBEDisks() {
+        SystemInfoService infoService = Env.getCurrentSystemInfo();
+        ImmutableMap<Long, Backend> backends = infoService.getBackendsInCluster(null);
+
+        int buckets = 0;
+        for (Backend backend : backends.values()) {
+            if (!backend.isLoadAvailable()) {
+                break;
+            }
+
+            ImmutableMap<String, DiskInfo> disks = backend.getDisks();
+            for (DiskInfo diskInfo : disks.values()) {
+                if (diskInfo.getState() == DiskState.ONLINE && diskInfo.hasPathHash()) {
+                    buckets += (diskInfo.getAvailableCapacityB() - 1) / (50 * SIZE_1GB) + 1;
+                }
+            }
+        }
+        return buckets;
+    }
+
+    private static int convertParitionSizeToBucketsNum(long partitionSize) {
+        partitionSize /= 5; // for compression 5:1
+
+        // <= 100MB, 1 bucket
+        // <= 1GB, 2 buckets
+        // > 1GB, round to (size / 1G)
+        if (partitionSize <= SIZE_100MB) {
+            return 1;
+        } else if (partitionSize <= SIZE_1GB) {
+            return 2;
+        } else {
+            return (int) ((partitionSize - 1) / SIZE_1GB + 1);
+        }
+    }
+
+    public static int getBucketsNum(long partitionSize) {
+        int bucketsNumByPartitionSize = convertParitionSizeToBucketsNum(partitionSize);
+        int bucketsNumByBE = getBucketsNumByBEDisks();
+        int bucketsNum = Math.min(128, Math.min(bucketsNumByPartitionSize, bucketsNumByBE));
+        int beNum = getBENum();
+        logger.info("AutoBucketsUtil: bucketsNumByPartitionSize {}, bucketsNumByBE {}, bucketsNum {}, beNum {}",
+                bucketsNumByPartitionSize, bucketsNumByBE, bucketsNum, beNum);
+        if (bucketsNum < bucketsNumByPartitionSize && bucketsNum < beNum) {
+            bucketsNum = beNum;
+        }
+        logger.info("AutoBucketsUtil: final bucketsNum {}", bucketsNum);
+        return bucketsNum;
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/PropertyAnalyzer.java
@@ -549,6 +549,15 @@ public class PropertyAnalyzer {
         return defaultVal;
     }
 
+    public static String analyzeEstimatePartitionSize(Map<String, String> properties) {
+        String  estimatePartitionSize = "";
+        if (properties != null && properties.containsKey(PROPERTIES_ESTIMATE_PARTITION_SIZE)) {
+            estimatePartitionSize = properties.get(PROPERTIES_ESTIMATE_PARTITION_SIZE);
+            properties.remove(PROPERTIES_ESTIMATE_PARTITION_SIZE);
+        }
+        return estimatePartitionSize;
+    }
+
     public static String analyzeStoragePolicy(Map<String, String> properties) throws AnalysisException {
         String storagePolicy = "";
         if (properties != null && properties.containsKey(PROPERTIES_STORAGE_POLICY)) {

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/PropertyAnalyzer.java
@@ -92,7 +92,8 @@ public class PropertyAnalyzer {
 
     public static final String PROPERTIES_INMEMORY = "in_memory";
 
-    public static final String PROPERTIES_AUTO_BUCKET = "auto_bucket";
+    // _auto_bucket can only set in create table stmt rewrite bucket and can not be changed
+    public static final String PROPERTIES_AUTO_BUCKET = "_auto_bucket";
     public static final String PROPERTIES_ESTIMATE_PARTITION_SIZE = "estimate_partition_size";
 
     public static final String PROPERTIES_TABLET_TYPE = "tablet_type";

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/PropertyAnalyzer.java
@@ -92,6 +92,9 @@ public class PropertyAnalyzer {
 
     public static final String PROPERTIES_INMEMORY = "in_memory";
 
+    public static final String PROPERTIES_AUTO_BUCKET = "auto_bucket";
+    public static final String PROPERTIES_ESTIMATE_PARTITION_SIZE = "estimate_partition_size";
+
     public static final String PROPERTIES_TABLET_TYPE = "tablet_type";
 
     public static final String PROPERTIES_STRICT_RANGE = "strict_range";
@@ -131,7 +134,7 @@ public class PropertyAnalyzer {
     /**
      * check and replace members of DataProperty by properties.
      *
-     * @param properties key->value for members to change.
+     * @param properties      key->value for members to change.
      * @param oldDataProperty old DataProperty
      * @return new DataProperty
      * @throws AnalysisException property has invalid key->value
@@ -246,7 +249,8 @@ public class PropertyAnalyzer {
             throws AnalysisException {
         Short replicationNum = oldReplicationNum;
         String propKey = Strings.isNullOrEmpty(prefix)
-                ? PROPERTIES_REPLICATION_NUM : prefix + "." + PROPERTIES_REPLICATION_NUM;
+                ? PROPERTIES_REPLICATION_NUM
+                : prefix + "." + PROPERTIES_REPLICATION_NUM;
         if (properties != null && properties.containsKey(propKey)) {
             try {
                 replicationNum = Short.valueOf(properties.get(propKey));
@@ -348,7 +352,7 @@ public class PropertyAnalyzer {
     }
 
     public static Set<String> analyzeBloomFilterColumns(Map<String, String> properties, List<Column> columns,
-                                                        KeysType keysType) throws AnalysisException {
+            KeysType keysType) throws AnalysisException {
         Set<String> bfColumns = null;
         if (properties != null && properties.containsKey(PROPERTIES_BF_COLUMNS)) {
             bfColumns = Sets.newHashSet();
@@ -483,7 +487,7 @@ public class PropertyAnalyzer {
     }
 
     // analyzeCompressionType will parse the compression type from properties
-    public static TCompressionType analyzeCompressionType(Map<String, String> properties) throws  AnalysisException {
+    public static TCompressionType analyzeCompressionType(Map<String, String> properties) throws AnalysisException {
         String compressionType = "";
         if (properties != null && properties.containsKey(PROPERTIES_COMPRESSION)) {
             compressionType = properties.get(PROPERTIES_COMPRESSION);
@@ -760,7 +764,6 @@ public class PropertyAnalyzer {
         throw new AnalysisException(PropertyAnalyzer.ENABLE_UNIQUE_KEY_MERGE_ON_WRITE + " must be `true` or `false`");
     }
 
-
     /**
      * Check the type property of the catalog props.
      */
@@ -776,5 +779,3 @@ public class PropertyAnalyzer {
         }
     }
 }
-
-

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
@@ -1927,10 +1927,8 @@ public class InternalCatalog implements CatalogIf<Database> {
         olapTable.setIsAutoBucket(isAutoBucket);
 
         // set estimate partition size
-        LOG.info("begin to analyze estimate partition size, auto_bucket: {}", isAutoBucket);
         if (isAutoBucket) {
             String estimatePartitionSize = PropertyAnalyzer.analyzeEstimatePartitionSize(properties);
-            LOG.info("estimate partition size: {}", estimatePartitionSize);
             olapTable.setEstimatePartitionSize(estimatePartitionSize);
         }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
@@ -1921,15 +1921,23 @@ public class InternalCatalog implements CatalogIf<Database> {
 
         olapTable.setReplicationAllocation(replicaAlloc);
 
-        // set in memory
-        boolean isInMemory = PropertyAnalyzer.analyzeBooleanProp(properties, PropertyAnalyzer.PROPERTIES_INMEMORY,
-                false);
-        olapTable.setIsInMemory(isInMemory);
-
         // set auto bucket
         boolean isAutoBucket = PropertyAnalyzer.analyzeBooleanProp(properties, PropertyAnalyzer.PROPERTIES_AUTO_BUCKET,
                 false);
         olapTable.setIsAutoBucket(isAutoBucket);
+
+        // set estimate partition size
+        LOG.info("begin to analyze estimate partition size, auto_bucket: {}", isAutoBucket);
+        if (isAutoBucket) {
+            String estimatePartitionSize = PropertyAnalyzer.analyzeEstimatePartitionSize(properties);
+            LOG.info("estimate partition size: {}", estimatePartitionSize);
+            olapTable.setEstimatePartitionSize(estimatePartitionSize);
+        }
+
+        // set in memory
+        boolean isInMemory = PropertyAnalyzer.analyzeBooleanProp(properties, PropertyAnalyzer.PROPERTIES_INMEMORY,
+                false);
+        olapTable.setIsInMemory(isInMemory);
 
         // set storage policy
         String storagePolicy = PropertyAnalyzer.analyzeStoragePolicy(properties);

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
@@ -241,7 +241,6 @@ public class InternalCatalog implements CatalogIf<Database> {
         return INTERNAL_CATALOG_NAME;
     }
 
-
     @Override
     public List<String> getDbNames() {
         return Lists.newArrayList(fullNameToDb.keySet());
@@ -734,12 +733,12 @@ public class InternalCatalog implements CatalogIf<Database> {
             if (Strings.isNullOrEmpty(newPartitionName)) {
                 if (olapTable.getPartition(partitionName) != null) {
                     throw new DdlException("partition[" + partitionName + "] "
-                        + "already exist in table[" + tableName + "]");
+                            + "already exist in table[" + tableName + "]");
                 }
             } else {
                 if (olapTable.getPartition(newPartitionName) != null) {
                     throw new DdlException("partition[" + newPartitionName + "] "
-                        + "already exist in table[" + tableName + "]");
+                            + "already exist in table[" + tableName + "]");
                 }
             }
 
@@ -932,7 +931,7 @@ public class InternalCatalog implements CatalogIf<Database> {
     }
 
     public boolean unprotectDropTable(Database db, Table table, boolean isForceDrop, boolean isReplay,
-                                      long recycleTime) {
+            long recycleTime) {
         if (table.getType() == TableType.ELASTICSEARCH) {
             esRepository.deRegisterTable(table.getId());
         } else if (table.getType() == TableType.OLAP) {
@@ -964,7 +963,7 @@ public class InternalCatalog implements CatalogIf<Database> {
     }
 
     public void replayDropTable(Database db, long tableId, boolean isForceDrop,
-                                Long recycleTime) throws MetaNotFoundException {
+            Long recycleTime) throws MetaNotFoundException {
         Table table = db.getTableOrMetaException(tableId);
         db.writeLock();
         table.writeLock();
@@ -1002,10 +1001,10 @@ public class InternalCatalog implements CatalogIf<Database> {
             schemaHash = olapTable.getSchemaHashByIndexId(info.getIndexId());
         }
 
-        Replica replica =
-                new Replica(info.getReplicaId(), info.getBackendId(), info.getVersion(), schemaHash, info.getDataSize(),
-                        info.getRemoteDataSize(), info.getRowCount(), ReplicaState.NORMAL, info.getLastFailedVersion(),
-                        info.getLastSuccessVersion());
+        Replica replica = new Replica(info.getReplicaId(), info.getBackendId(), info.getVersion(), schemaHash,
+                info.getDataSize(),
+                info.getRemoteDataSize(), info.getRowCount(), ReplicaState.NORMAL, info.getLastFailedVersion(),
+                info.getLastSuccessVersion());
         tablet.addReplica(replica);
     }
 
@@ -1368,8 +1367,8 @@ public class InternalCatalog implements CatalogIf<Database> {
                 if (distributionInfo.getType() == DistributionInfoType.HASH) {
                     HashDistributionInfo hashDistributionInfo = (HashDistributionInfo) distributionInfo;
                     List<Column> newDistriCols = hashDistributionInfo.getDistributionColumns();
-                    List<Column> defaultDistriCols
-                            = ((HashDistributionInfo) defaultDistributionInfo).getDistributionColumns();
+                    List<Column> defaultDistriCols = ((HashDistributionInfo) defaultDistributionInfo)
+                            .getDistributionColumns();
                     if (!newDistriCols.equals(defaultDistriCols)) {
                         throw new DdlException(
                                 "Cannot assign hash distribution with different distribution cols. " + "default is: "
@@ -1629,7 +1628,7 @@ public class InternalCatalog implements CatalogIf<Database> {
                 olapTable.dropTempPartition(info.getPartitionName(), true);
             } else {
                 Partition partition = olapTable.dropPartition(info.getDbId(), info.getPartitionName(),
-                                info.isForceDrop());
+                        info.isForceDrop());
                 if (!info.isForceDrop() && partition != null && info.getRecycleTime() != 0) {
                     Env.getCurrentRecycleBin().setRecycleTimeByIdForReplay(partition.getId(), info.getRecycleTime());
                 }
@@ -1660,7 +1659,7 @@ public class InternalCatalog implements CatalogIf<Database> {
             DistributionInfo distributionInfo, TStorageMedium storageMedium, ReplicaAllocation replicaAlloc,
             Long versionInfo, Set<String> bfColumns, double bfFpp, Set<Long> tabletIdSet, List<Index> indexes,
             boolean isInMemory, TStorageFormat storageFormat, TTabletType tabletType, TCompressionType compressionType,
-            DataSortInfo dataSortInfo, boolean enableUniqueKeyMergeOnWrite,  String storagePolicy,
+            DataSortInfo dataSortInfo, boolean enableUniqueKeyMergeOnWrite, String storagePolicy,
             IdGeneratorBuffer idGeneratorBuffer, boolean disableAutoCompaction) throws DdlException {
         // create base index first.
         Preconditions.checkArgument(baseIndexId != -1);
@@ -1926,6 +1925,11 @@ public class InternalCatalog implements CatalogIf<Database> {
         boolean isInMemory = PropertyAnalyzer.analyzeBooleanProp(properties, PropertyAnalyzer.PROPERTIES_INMEMORY,
                 false);
         olapTable.setIsInMemory(isInMemory);
+
+        // set auto bucket
+        boolean isAutoBucket = PropertyAnalyzer.analyzeBooleanProp(properties, PropertyAnalyzer.PROPERTIES_AUTO_BUCKET,
+                false);
+        olapTable.setIsAutoBucket(isAutoBucket);
 
         // set storage policy
         String storagePolicy = PropertyAnalyzer.analyzeStoragePolicy(properties);

--- a/fe/fe-core/src/main/jflex/sql_scanner.flex
+++ b/fe/fe-core/src/main/jflex/sql_scanner.flex
@@ -479,6 +479,7 @@ import org.apache.doris.qe.SqlModeHelper;
         keywordMap.put("year", new Integer(SqlParserSymbols.KW_YEAR));
         keywordMap.put("mtmv", new Integer(SqlParserSymbols.KW_MTMV));
         keywordMap.put("histogram", new Integer(SqlParserSymbols.KW_HISTOGRAM));
+        keywordMap.put("auto", new Integer(SqlParserSymbols.KW_AUTO));
    }
     
   // map from token id to token description

--- a/fe/fe-core/src/test/java/org/apache/doris/common/util/AutoBucketUtilsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/common/util/AutoBucketUtilsTest.java
@@ -1,0 +1,236 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.common.util;
+
+import org.apache.doris.catalog.Env;
+import org.apache.doris.common.Config;
+import org.apache.doris.common.FeConstants;
+import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.qe.ResultSetMetaData;
+import org.apache.doris.qe.ShowResultSet;
+import org.apache.doris.system.Backend;
+import org.apache.doris.system.SystemInfoService;
+import org.apache.doris.thrift.TDisk;
+import org.apache.doris.thrift.TStorageMedium;
+import org.apache.doris.utframe.UtFrameUtils;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.UUID;
+
+public class AutoBucketUtilsTest {
+    private static String databaseName = "AutoBucketUtilsTest";
+    // use a unique dir so that it won't be conflict with other unit test which
+    // may also start a Mocked Frontend
+    private static String runningDirBase = "fe";
+    private static String runningDir = runningDirBase + "/mocked/AutoBucketUtilsTest/" + UUID.randomUUID().toString()
+            + "/";
+    private static List<Backend> backends = Lists.newArrayList();
+    private static Random random = new Random(System.currentTimeMillis());
+    private ConnectContext connectContext;
+
+    // // create backends by be num, disk num, disk capacity
+    private static void createBackends(int beNum, int diskNum, long diskCapacity) throws Exception {
+        UtFrameUtils.createDorisClusterWithMultiTag(runningDir, beNum);
+
+        // must set disk info, or the tablet scheduler won't work
+        backends = Env.getCurrentSystemInfo().getClusterBackends(SystemInfoService.DEFAULT_CLUSTER);
+        for (Backend be : backends) {
+            Map<String, TDisk> backendDisks = Maps.newHashMap();
+            for (int i = 0; i < diskNum; ++i) {
+                TDisk disk = new TDisk();
+                disk.setRootPath("/home/doris/" + UUID.randomUUID().toString());
+                disk.setDiskTotalCapacity(diskCapacity);
+                disk.setDataUsedCapacity(0);
+                disk.setUsed(true);
+                disk.setDiskAvailableCapacity(disk.disk_total_capacity - disk.data_used_capacity);
+                disk.setPathHash(random.nextLong());
+                disk.setStorageMedium(TStorageMedium.HDD);
+                backendDisks.put(disk.getRootPath(), disk);
+            }
+            be.updateDisks(backendDisks);
+        }
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        FeConstants.runningUnitTest = true;
+        FeConstants.tablet_checker_interval_ms = 1000;
+        FeConstants.default_scheduler_interval_millisecond = 100;
+        Config.tablet_repair_delay_factor_second = 1;
+        connectContext = UtFrameUtils.createDefaultCtx();
+    }
+
+    @After
+    public void tearDown() {
+        Env.getCurrentEnv().clear();
+        UtFrameUtils.cleanDorisFeDir(runningDirBase);
+    }
+
+    private static String genTableNameWithoutDatabase(String estimatePartitionSize) {
+        return "size_" + estimatePartitionSize;
+    }
+
+    private static String genTableName(String estimatePartitionSize) {
+        return databaseName + "." + genTableNameWithoutDatabase(estimatePartitionSize);
+    }
+
+    private static String genTableNameByTag(String estimatePartitionSize, String tag) {
+        return databaseName + "." + genTableNameWithoutDatabase(estimatePartitionSize) + "_" + tag;
+    }
+
+    private static String genCreateTableSql(String estimatePartitionSize) {
+        return "CREATE TABLE IF NOT EXISTS " + genTableName(estimatePartitionSize) + "\n"
+                + "(\n"
+                + "`user_id` LARGEINT NOT NULL\n"
+                + ")\n"
+                + "DISTRIBUTED BY HASH(`user_id`) BUCKETS AUTO\n"
+                + "PROPERTIES (\n"
+                + "\"estimate_partition_size\" = \"" + estimatePartitionSize + "\",\n"
+                + "\"replication_num\" = \"1\"\n"
+                + ")";
+    }
+
+    private void createTable(String sql) throws Exception {
+        // create database first
+        UtFrameUtils.createDatabase(connectContext, databaseName);
+        UtFrameUtils.createTable(connectContext, sql);
+    }
+
+    private void createTableBySize(String estimatePartitionSize) throws Exception {
+        createTable(genCreateTableSql(estimatePartitionSize));
+    }
+
+    private int getPartitionBucketNum(String tableName) throws Exception {
+        ShowResultSet result = UtFrameUtils.showPartitionsByName(connectContext, tableName);
+        ResultSetMetaData metaData = result.getMetaData();
+
+        for (int i = 0; i < metaData.getColumnCount(); ++i) {
+            if (metaData.getColumn(i).getName().equalsIgnoreCase("buckets")) {
+                return Integer.valueOf(result.getResultRows().get(0).get(i));
+            }
+        }
+
+        throw new Exception("No buckets column in show partitions result");
+    }
+
+    // also has checked create table && show partitions
+    @Test
+    public void testWithoutEstimatePartitionSize() throws Exception {
+        String tableName = genTableName("");
+        String sql = "CREATE TABLE IF NOT EXISTS " + tableName + "\n"
+                + "(\n"
+                + "`user_id` LARGEINT NOT NULL\n"
+                + ")\n"
+                + "DISTRIBUTED BY HASH(`user_id`) BUCKETS AUTO\n"
+                + "PROPERTIES (\n"
+                + "\"replication_num\" = \"1\"\n"
+                + ")";
+        String showResultExpected = "CREATE TABLE `" + genTableNameWithoutDatabase("") + "` (\n"
+                + "  `user_id` largeint(40) NOT NULL\n"
+                + ") ENGINE=OLAP\n"
+                + "DUPLICATE KEY(`user_id`)\n"
+                + "COMMENT 'OLAP'\n"
+                + "DISTRIBUTED BY HASH(`user_id`) BUCKETS AUTO\n"
+                + "PROPERTIES (\n"
+                + "\"replication_allocation\" = \"tag.location.default: 1\",\n"
+                + "\"in_memory\" = \"false\",\n"
+                + "\"storage_format\" = \"V2\",\n"
+                + "\"disable_auto_compaction\" = \"false\"\n"
+                + ");";
+
+        createBackends(1, 1, 2000000000);
+
+        createTable(sql);
+        ShowResultSet showCreateTableResult = UtFrameUtils.showCreateTableByName(connectContext, tableName);
+        Assert.assertEquals(showResultExpected, showCreateTableResult.getResultRows().get(0).get(1));
+        int bucketNum = getPartitionBucketNum(tableName);
+        Assert.assertEquals(FeConstants.default_bucket_num, bucketNum);
+    }
+
+    @Test
+    public void test100MB() throws Exception {
+        long estimatePartitionSize = AutoBucketUtils.SIZE_100MB;
+        createBackends(10, 3, 2000000000);
+        Assert.assertEquals(1, AutoBucketUtils.getBucketsNum(estimatePartitionSize));
+    }
+
+    @Test
+    public void test500MB() throws Exception {
+        long estimatePartitionSize = 5 * AutoBucketUtils.SIZE_100MB;
+        createBackends(10, 3, 2000000000);
+        Assert.assertEquals(1, AutoBucketUtils.getBucketsNum(estimatePartitionSize));
+    }
+
+    @Test
+    public void test1G() throws Exception {
+        long estimatePartitionSize = AutoBucketUtils.SIZE_1GB;
+        createBackends(3, 2, 500 * AutoBucketUtils.SIZE_1GB);
+        Assert.assertEquals(2, AutoBucketUtils.getBucketsNum(estimatePartitionSize));
+    }
+
+    @Test
+    public void test100G() throws Exception {
+        long estimatePartitionSize = 100 * AutoBucketUtils.SIZE_1GB;
+        createBackends(3, 2, 500 * AutoBucketUtils.SIZE_1GB);
+        Assert.assertEquals(20, AutoBucketUtils.getBucketsNum(estimatePartitionSize));
+    }
+
+    @Test
+    public void test500G_0() throws Exception {
+        long estimatePartitionSize = 500 * AutoBucketUtils.SIZE_1GB;
+        createBackends(3, 1, AutoBucketUtils.SIZE_1TB);
+        Assert.assertEquals(63, AutoBucketUtils.getBucketsNum(estimatePartitionSize));
+    }
+
+    @Test
+    public void test500G_1() throws Exception {
+        long estimatePartitionSize = 500 * AutoBucketUtils.SIZE_1GB;
+        createBackends(10, 3, 2 * AutoBucketUtils.SIZE_1TB);
+        Assert.assertEquals(100, AutoBucketUtils.getBucketsNum(estimatePartitionSize));
+    }
+
+    @Test
+    public void test500G_2() throws Exception {
+        long estimatePartitionSize = 500 * AutoBucketUtils.SIZE_1GB;
+        createBackends(1, 1, 100 * AutoBucketUtils.SIZE_1TB);
+        Assert.assertEquals(100, AutoBucketUtils.getBucketsNum(estimatePartitionSize));
+    }
+
+    @Test
+    public void test1T_0() throws Exception {
+        long estimatePartitionSize = AutoBucketUtils.SIZE_1TB;
+        createBackends(10, 3, 2 * AutoBucketUtils.SIZE_1TB);
+        Assert.assertEquals(128, AutoBucketUtils.getBucketsNum(estimatePartitionSize));
+    }
+
+    @Test
+    public void test1T_1() throws Exception {
+        long estimatePartitionSize = AutoBucketUtils.SIZE_1TB;
+        createBackends(200, 7, 4 * AutoBucketUtils.SIZE_1TB);
+        Assert.assertEquals(200, AutoBucketUtils.getBucketsNum(estimatePartitionSize));
+    }
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/common/util/AutoBucketUtilsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/common/util/AutoBucketUtilsTest.java
@@ -35,6 +35,8 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import mockit.Expectations;
 import mockit.Mocked;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.core.StringContains;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -197,24 +199,14 @@ public class AutoBucketUtilsTest {
                 + "PROPERTIES (\n"
                 + "\"replication_num\" = \"1\"\n"
                 + ")";
-        String showResultExpected = "CREATE TABLE `" + genTableNameWithoutDatabase("") + "` (\n"
-                + "  `user_id` largeint(40) NOT NULL\n"
-                + ") ENGINE=OLAP\n"
-                + "DUPLICATE KEY(`user_id`)\n"
-                + "COMMENT 'OLAP'\n"
-                + "DISTRIBUTED BY HASH(`user_id`) BUCKETS AUTO\n"
-                + "PROPERTIES (\n"
-                + "\"replication_allocation\" = \"tag.location.default: 1\",\n"
-                + "\"in_memory\" = \"false\",\n"
-                + "\"storage_format\" = \"V2\",\n"
-                + "\"disable_auto_compaction\" = \"false\"\n"
-                + ");";
 
         createClusterWithBackends(1, 1, 2000000000);
 
         createTable(sql);
         ShowResultSet showCreateTableResult = UtFrameUtils.showCreateTableByName(connectContext, tableName);
-        Assert.assertEquals(showResultExpected, showCreateTableResult.getResultRows().get(0).get(1));
+        String showCreateTableResultSql = showCreateTableResult.getResultRows().get(0).get(1);
+        MatcherAssert.assertThat(showCreateTableResultSql,
+                StringContains.containsString("DISTRIBUTED BY HASH(`user_id`) BUCKETS AUTO\n"));
         int bucketNum = getPartitionBucketNum(tableName);
         Assert.assertEquals(FeConstants.default_bucket_num, bucketNum);
     }

--- a/regression-test/suites/autobucket/test_autobucket.groovy
+++ b/regression-test/suites/autobucket/test_autobucket.groovy
@@ -1,0 +1,41 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_autobucket") {
+    sql "drop table if exists autobucket_test"
+    result = sql """
+        CREATE TABLE `autobucket_test` (
+          `user_id` largeint(40) NOT NULL
+        ) ENGINE=OLAP
+        DUPLICATE KEY(`user_id`)
+        COMMENT 'OLAP'
+        DISTRIBUTED BY HASH(`user_id`) BUCKETS AUTO
+        PROPERTIES (
+        "replication_allocation" = "tag.location.default: 1"
+        )
+        """
+
+    result = sql "show create table autobucket_test"
+    assertTrue(result.toString().containsIgnoreCase("BUCKETS AUTO"))
+
+    result = sql "show partitions from autobucket_test"
+    logger.info("${result}")
+    // XXX: buckets at pos(8), next maybe impl by sql meta
+    assertEquals(Integer.valueOf(result.get(0).get(8)), 10)
+
+    sql "drop table if exists autobucket_test"
+}


### PR DESCRIPTION
# Proposed changes

## Problem summary

用户经常设置不合适的bucket，导致各种问题，这里提供一种方式，来自动设置分桶数。暂时而言只对olap表生效

## 实现思路
根据数据量，计算分桶数。
对于分区表，可以根据历史分区的数据量、机器数、盘数，确定一个分桶。
主要问题是初始桶数不好确定。
这里提供两种方式：
1. 根据机器数、盘数，确定一个分桶数
2. 用户可以提供一个数据量的经验值，根据这个值，确定分桶数。

### 详细设计
1. 建表
```
create table tbl1
(...)
[PARTITION BY RANGE(...)]
DISTRIBUTED BY HASH(k1) BUCKETS AUTO
properties(
    "estimate_partition_size" = "100G"
)
```

- BUCKETS AUTO 表示自动设定buckets
- estimate_partition_size：可选参数，提供一个单分区初始数据量。

2. 分桶计算逻辑
初始分桶计算
- 没有给 estimate_partition_size
这种基本上不太靠谱。使用了default_bucket_num(10)。
- 给了 estimate_partition_size

这里我们先假设给的是单副本文本格式的数据量
1. 先根据数据量得出一个桶数：N
    首先数据量除以5（按5比1的压缩比算）
    < 100MB : 1
    < 1G: 2
    > 1G:  每1G一个分桶。

2. 根据桶数和盘数的乘机得出一个桶数 M
    每个BE节点算1
    磁盘容量，每50G算1
    
4. min(M, N, 128)，如果这个值小于N，也小于机器数。取机器数。

举例：
```
1. 先根据数据量得出一个桶数：N
    首先数据量除以5（按5比1的压缩比算）
    < 100MB : 1
    < 1G: 2
    > 1G:  每1G一个分桶。

2. 根据BE数和盘数的乘机得出一个桶数 M
    每个BE节点算1
    磁盘容量，每50G算1
    
3. min(M, N, 128)，如果这个值小于N，也小于机器数。
取机器数。这里就是

举例：
1. 100MB，10台机器，2T * 3盘 = 1
数据量: 1
BE磁盘: 10 * 40 * 3 = 1200
min计算: 1
最终: 1

2. 1G, 3台机器，500GB * 2盘 = 2
数据量: 2
BE磁盘: 3 * 10 * 2 = 60
min计算: 2
最终: 2

3. 100G，3台机器，500GB * 2盘 = 20
数据量: 20
BE磁盘: 3 * 10 * 2 = 60
min计算: 20
最终: 20

4. 500G，3台机器，1T * 1盘 = 60
数据量: 100
BE磁盘: 3 * 21 * 1 = 63
min计算: 63
最终: 63

5. 500G，10台机器，2T * 3盘 = 128
数据量: 500
BE磁盘: 10 * 41 * 3 = 1230
min计算: 100
最终: 100

6. 1T，10台机器，2T * 3盘 = 128 
数据量: 200
BE磁盘: 10 * 41 * 3 = 1230
min计算: 128
最终: 128

7. 500G，1台机器，100TB * 1盘 = 128
数据量: 100
BE磁盘: 1 * 2048 * 1 = 2048
min计算: 100
最终: 100

8. 1TB, 200台机器，4T * 7盘 = 200
数据量: 205
BE磁盘: 200 * 80 * 7 = 112000
min计算: 128
最终: 200
```

计算未来分桶
仅针对分区表。
根据最多前7个分区的数据量的指数平均值，作为estimate_partition_size，进行评估。
需要判断历史分区的趋势：
    比如前五个分区，每个都比前一个大，说明数据再增长，则此时不能求平均值，而应该取趋势值。
    仅考虑递增和递减的情况。其他情况，求平均。

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [x] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

