### PR TITLE
[fix](fe)add session variable group_concat_max_len

### DIFF
--- a/docs/en/docs/advanced/variables.md
+++ b/docs/en/docs/advanced/variables.md
@@ -553,3 +553,6 @@ Translated with www.DeepL.com/Translator (free version)
 * `validate_password_policy`
 
 	Password strength verification policy. Defaults to `NONE` or `0`, i.e. no verification. Can be set to `STRONG` or `2`. When set to `STRONG` or `2`, when setting a password via the `ALTER USER` or `SET PASSWORD` commands, the password must contain any of "uppercase letters", "lowercase letters", "numbers" and "special characters". 3 items, and the length must be greater than or equal to 8. Special characters include: `~!@#$%^&*()_+|<>,.?/:;'[]{}"`.
+
+* `group_concat_max_len`
+    For compatible purpose. This variable has no effect, just enable some BI tools can query or set this session variable sucessfully.

--- a/docs/zh-CN/docs/advanced/variables.md
+++ b/docs/zh-CN/docs/advanced/variables.md
@@ -542,4 +542,7 @@ SELECT /*+ SET_VAR(query_timeout = 1, enable_partition_cache=true) */ sleep(3);
 * `validate_password_policy`
 
 	密码强度校验策略。默认为 `NONE` 或 `0`，即不做校验。可以设置为 `STRONG` 或 `2`。当设置为 `STRONG` 或 `2` 时，通过 `ALTER USER` 或 `SET PASSWORD` 命令设置密码时，密码必须包含“大写字母”，“小写字母”，“数字”和“特殊字符”中的3项，并且长度必须大于等于8。特殊字符包括：`~!@#$%^&*()_+|<>,.?/:;'[]{}"`。
+
+* `group_concat_max_len`
+    为了兼容某些BI工具能正确获取和设置该变量，变量值实际并没有作用。
 	

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -251,7 +251,7 @@ public class SessionVariable implements Serializable, Writable {
             = "enable_share_hash_table_for_broadcast_join";
 
     public static final String REPEAT_MAX_NUM = "repeat_max_num";
-    
+
     public static final String GROUP_CONCAT_MAX_LEN = "group_concat_max_len";
 
     // session origin value
@@ -649,7 +649,7 @@ public class SessionVariable implements Serializable, Writable {
 
     @VariableMgr.VarAttr(name = REPEAT_MAX_NUM)
     public int repeatMaxNum = 10000;
-    
+
     @VariableMgr.VarAttr(name = GROUP_CONCAT_MAX_LEN)
     public int groupConcatMaxLen = 2147483646;
 

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -251,6 +251,8 @@ public class SessionVariable implements Serializable, Writable {
             = "enable_share_hash_table_for_broadcast_join";
 
     public static final String REPEAT_MAX_NUM = "repeat_max_num";
+    
+    public static final String GROUP_CONCAT_MAX_LEN = "group_concat_max_len";
 
     // session origin value
     public Map<Field, String> sessionOriginValue = new HashMap<Field, String>();
@@ -647,6 +649,9 @@ public class SessionVariable implements Serializable, Writable {
 
     @VariableMgr.VarAttr(name = REPEAT_MAX_NUM)
     public int repeatMaxNum = 10000;
+    
+    @VariableMgr.VarAttr(name = GROUP_CONCAT_MAX_LEN)
+    public int groupConcatMaxLen = 2147483646;
 
     // If this fe is in fuzzy mode, then will use initFuzzyModeVariables to generate some variables,
     // not the default value set in the code.

--- a/regression-test/suites/correctness_p0/test_show_dummy_variables.groovy
+++ b/regression-test/suites/correctness_p0/test_show_dummy_variables.groovy
@@ -1,0 +1,22 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_show_dummy_variables") {
+
+    def ret = sql"""show variables like '%group_concat%';"""
+    assertTrue(ret.toString().contains("group_concat_max_len"))
+}


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

some bi tools may query the session variable "group_concat_max_len", this pr simply add it with no effect. This is to make the bi tools work.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

