### PR TITLE
[fix](fe)fix bug of the bucket shuffle join is not recognized

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/planner/DistributedPlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/DistributedPlanner.java
@@ -629,7 +629,7 @@ public class DistributedPlanner {
         OlapTable leftTable = leftScanNode.getOlapTable();
 
         //1 the left table has more than one partition or left table is not a stable colocate table
-        if (leftScanNode.getSelectedPartitionIds().size() > 1) {
+        if (leftScanNode.getSelectedPartitionIds().size() != 1) {
             ColocateTableIndex colocateIndex = Env.getCurrentColocateIndex();
             if (!leftTable.isColocateTable()
                     || colocateIndex.isGroupUnstable(colocateIndex.getGroup(leftTable.getId()))) {

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/DistributedPlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/DistributedPlanner.java
@@ -629,7 +629,7 @@ public class DistributedPlanner {
         OlapTable leftTable = leftScanNode.getOlapTable();
 
         //1 the left table has more than one partition or left table is not a stable colocate table
-        if (leftScanNode.getSelectedPartitionIds().size() != 1) {
+        if (leftScanNode.getSelectedPartitionIds().size() > 1) {
             ColocateTableIndex colocateIndex = Env.getCurrentColocateIndex();
             if (!leftTable.isColocateTable()
                     || colocateIndex.isGroupUnstable(colocateIndex.getGroup(leftTable.getId()))) {
@@ -656,7 +656,7 @@ public class DistributedPlanner {
                     continue;
                 }
 
-                SlotRef leftSlot = lhsJoinExpr.unwrapSlotRef();
+                SlotRef leftSlot = node.getChild(0).findSrcSlotRef(lhsJoinExpr.getSrcSlotRef());
                 if (leftSlot.getTable() instanceof OlapTable
                         && leftScanNode.desc.getSlots().contains(leftSlot.getDesc())) {
                     // table name in SlotRef is not the really name. `select * from test as t`

--- a/regression-test/suites/correctness_p0/test_bucket_shuffle_join.groovy
+++ b/regression-test/suites/correctness_p0/test_bucket_shuffle_join.groovy
@@ -1,0 +1,81 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_bucket_shuffle_join") {
+    sql """ DROP TABLE IF EXISTS `test_colo1` """
+    sql """ DROP TABLE IF EXISTS `test_colo2` """
+    sql """ DROP TABLE IF EXISTS `test_colo3` """
+    sql """
+        CREATE TABLE `test_colo1` (
+        `id` varchar(64) NULL,
+        `name` varchar(64) NULL,
+        `age` int NULL
+        ) ENGINE=OLAP
+        DUPLICATE KEY(`id`,`name`)
+        COMMENT 'OLAP'
+        DISTRIBUTED BY HASH(`id`,`name`) BUCKETS 4
+        PROPERTIES (
+        "replication_allocation" = "tag.location.default: 1",
+        "in_memory" = "false",
+        "storage_format" = "V2",
+        "disable_auto_compaction" = "false"
+        );
+    """
+    sql """
+        CREATE TABLE `test_colo2` (
+        `id` varchar(64) NULL,
+        `name` varchar(64) NULL,
+        `age` int NULL
+        ) ENGINE=OLAP
+        DUPLICATE KEY(`id`,`name`)
+        COMMENT 'OLAP'
+        DISTRIBUTED BY HASH(`id`,`name`) BUCKETS 5
+        PROPERTIES (
+        "replication_allocation" = "tag.location.default: 1",
+        "in_memory" = "false",
+        "storage_format" = "V2",
+        "disable_auto_compaction" = "false"
+        );
+    """
+
+    sql """
+        CREATE TABLE `test_colo3` (
+        `id` varchar(64) NULL,
+        `name` varchar(64) NULL,
+        `age` int NULL
+        ) ENGINE=OLAP
+        DUPLICATE KEY(`id`,`name`)
+        COMMENT 'OLAP'
+        DISTRIBUTED BY HASH(`id`,`name`) BUCKETS 6
+        PROPERTIES (
+        "replication_allocation" = "tag.location.default: 1",
+        "in_memory" = "false",
+        "storage_format" = "V2",
+        "disable_auto_compaction" = "false"
+        );
+    """
+
+    sql """insert into test_colo1 values('1','a',12);"""
+    sql """insert into test_colo2 values('1','a',12);"""
+    sql """insert into test_colo3 values('1','a',12);"""
+
+    explain {
+        sql("select a.id,a.name,b.id,b.name,c.id,c.name from test_colo1 a inner join test_colo2 b on a.id = b.id and a.name = b.name inner join test_colo3 c on a.id=c.id and a.name= c.name")
+        contains "4:VHASH JOIN\n  |  join op: INNER JOIN(BUCKET_SHUFFLE)"
+        contains "2:VHASH JOIN\n  |  join op: INNER JOIN(BUCKET_SHUFFLE)"
+    }
+}


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary
the bucket shuffle join is not recognized if there are more than 2 tables participate the join. This pr fix the problem

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

