### PR TITLE
[Pipeline] Fix PipScannerContext::can_finish return wrong status

### DIFF
--- a/be/src/pipeline/exec/scan_operator.cpp
+++ b/be/src/pipeline/exec/scan_operator.cpp
@@ -25,10 +25,10 @@ namespace doris::pipeline {
 OPERATOR_CODE_GENERATOR(ScanOperator, SourceOperator)
 
 bool ScanOperator::can_read() {
-    if (_node->_eos || _node->_scanner_ctx->done() || _node->_scanner_ctx->can_finish()) {
+    if (_node->_eos || _node->_scanner_ctx->done() || _node->_scanner_ctx->no_schedule()) {
         // _eos: need eos
         // _scanner_ctx->done(): need finish
-        // _scanner_ctx->can_finish(): should be scheduled
+        // _scanner_ctx->no_schedule(): should schedule _scanner_ctx
         return true;
     } else {
         return !_node->_scanner_ctx->empty_in_queue(); // there are some blocks to process
@@ -36,7 +36,7 @@ bool ScanOperator::can_read() {
 }
 
 bool ScanOperator::is_pending_finish() const {
-    return _node->_scanner_ctx && !_node->_scanner_ctx->can_finish();
+    return _node->_scanner_ctx && !_node->_scanner_ctx->no_schedule();
 }
 
 bool ScanOperator::runtime_filters_are_ready_or_timeout() {

--- a/be/src/pipeline/pipeline_task.cpp
+++ b/be/src/pipeline/pipeline_task.cpp
@@ -28,8 +28,17 @@ void PipelineTask::_init_profile() {
     auto* task_profile = new RuntimeProfile(ss.str());
     _parent_profile->add_child(task_profile, true, nullptr);
     _task_profile.reset(task_profile);
-    _sink_timer = ADD_TIMER(_task_profile, "SinkTime");
-    _get_block_timer = ADD_TIMER(_task_profile, "GetBlockTime");
+    _task_cpu_timer = ADD_TIMER(_task_profile, "TaskCpuTime");
+
+    static const char* exec_time = "ExecuteTime";
+    _exec_timer = ADD_TIMER(_task_profile, exec_time);
+    _prepare_timer = ADD_CHILD_TIMER(_task_profile, "PrepareTime", exec_time);
+    _open_timer = ADD_CHILD_TIMER(_task_profile, "OpenTime", exec_time);
+    _get_block_timer = ADD_CHILD_TIMER(_task_profile, "GetBlockTime", exec_time);
+    _sink_timer = ADD_CHILD_TIMER(_task_profile, "SinkTime", exec_time);
+    _finalize_timer = ADD_CHILD_TIMER(_task_profile, "FinalizeTime", exec_time);
+    _close_timer = ADD_CHILD_TIMER(_task_profile, "CloseTime", exec_time);
+
     _wait_source_timer = ADD_TIMER(_task_profile, "WaitSourceTime");
     _wait_sink_timer = ADD_TIMER(_task_profile, "WaitSinkTime");
     _wait_worker_timer = ADD_TIMER(_task_profile, "WaitWorkerTime");
@@ -39,12 +48,16 @@ void PipelineTask::_init_profile() {
     _block_by_sink_counts = ADD_COUNTER(_task_profile, "NumBlockedBySinkTimes", TUnit::UNIT);
     _schedule_counts = ADD_COUNTER(_task_profile, "NumScheduleTimes", TUnit::UNIT);
     _yield_counts = ADD_COUNTER(_task_profile, "NumYieldTimes", TUnit::UNIT);
+    _core_change_times = ADD_COUNTER(_task_profile, "CoreChangeTimes", TUnit::UNIT);
 }
 
 Status PipelineTask::prepare(RuntimeState* state) {
     DCHECK(_sink);
     DCHECK(_cur_state == NOT_READY);
     _init_profile();
+    SCOPED_TIMER(_task_profile->total_time_counter());
+    SCOPED_CPU_TIMER(_task_cpu_timer);
+    SCOPED_TIMER(_prepare_timer);
     RETURN_IF_ERROR(_sink->prepare(state));
     for (auto& o : _operators) {
         RETURN_IF_ERROR(o->prepare(state));
@@ -94,6 +107,9 @@ bool PipelineTask::has_dependency() {
 }
 
 Status PipelineTask::open() {
+    SCOPED_TIMER(_task_profile->total_time_counter());
+    SCOPED_CPU_TIMER(_task_cpu_timer);
+    SCOPED_TIMER(_open_timer);
     for (auto& o : _operators) {
         RETURN_IF_ERROR(o->open(_state));
     }
@@ -105,8 +121,10 @@ Status PipelineTask::open() {
 }
 
 Status PipelineTask::execute(bool* eos) {
-    SCOPED_ATTACH_TASK(runtime_state());
     SCOPED_TIMER(_task_profile->total_time_counter());
+    SCOPED_CPU_TIMER(_task_cpu_timer);
+    SCOPED_TIMER(_exec_timer);
+    SCOPED_ATTACH_TASK(runtime_state());
     int64_t time_spent = 0;
     // The status must be runnable
     *eos = false;
@@ -170,15 +188,23 @@ Status PipelineTask::execute(bool* eos) {
 }
 
 Status PipelineTask::finalize() {
+    SCOPED_TIMER(_task_profile->total_time_counter());
+    SCOPED_CPU_TIMER(_task_cpu_timer);
+    SCOPED_TIMER(_finalize_timer);
     return _sink->finalize(_state);
 }
 
 Status PipelineTask::close() {
-    auto s = _sink->close(_state);
-    for (auto& op : _operators) {
-        auto tem = op->close(_state);
-        if (!tem.ok() && s.ok()) {
-            s = tem;
+    int64_t close_ns = 0;
+    Status s;
+    {
+        SCOPED_RAW_TIMER(&close_ns);
+        s = _sink->close(_state);
+        for (auto& op : _operators) {
+            auto tem = op->close(_state);
+            if (!tem.ok() && s.ok()) {
+                s = tem;
+            }
         }
     }
     if (_opened) {
@@ -187,6 +213,8 @@ Status PipelineTask::close() {
         COUNTER_UPDATE(_wait_sink_timer, _wait_sink_watcher.elapsed_time());
         COUNTER_UPDATE(_wait_worker_timer, _wait_worker_watcher.elapsed_time());
         COUNTER_UPDATE(_wait_schedule_timer, _wait_schedule_watcher.elapsed_time());
+        COUNTER_UPDATE(_close_timer, close_ns);
+        COUNTER_UPDATE(_task_profile->total_time_counter(), close_ns);
     }
     return s;
 }

--- a/be/src/pipeline/pipeline_task.h
+++ b/be/src/pipeline/pipeline_task.h
@@ -150,7 +150,15 @@ public:
 
     int get_previous_core_id() const { return _previous_schedule_id; }
 
-    void set_previous_core_id(int id) { _previous_schedule_id = id; }
+    void set_previous_core_id(int id) {
+        if (id == _previous_schedule_id) {
+            return;
+        }
+        if (_previous_schedule_id != -1) {
+            COUNTER_UPDATE(_core_change_times, 1);
+        }
+        _previous_schedule_id = id;
+    }
 
     bool has_dependency();
 
@@ -190,8 +198,14 @@ private:
 
     RuntimeProfile* _parent_profile;
     std::unique_ptr<RuntimeProfile> _task_profile;
-    RuntimeProfile::Counter* _sink_timer;
+    RuntimeProfile::Counter* _task_cpu_timer;
+    RuntimeProfile::Counter* _prepare_timer;
+    RuntimeProfile::Counter* _open_timer;
+    RuntimeProfile::Counter* _exec_timer;
     RuntimeProfile::Counter* _get_block_timer;
+    RuntimeProfile::Counter* _sink_timer;
+    RuntimeProfile::Counter* _finalize_timer;
+    RuntimeProfile::Counter* _close_timer;
     RuntimeProfile::Counter* _block_counts;
     RuntimeProfile::Counter* _block_by_source_counts;
     RuntimeProfile::Counter* _block_by_sink_counts;
@@ -206,5 +220,6 @@ private:
     MonotonicStopWatch _wait_schedule_watcher;
     RuntimeProfile::Counter* _wait_schedule_timer;
     RuntimeProfile::Counter* _yield_counts;
+    RuntimeProfile::Counter* _core_change_times;
 };
 } // namespace doris::pipeline

--- a/be/src/vec/exec/scan/pip_scanner_context.h
+++ b/be/src/vec/exec/scan/pip_scanner_context.h
@@ -35,10 +35,14 @@ public:
 
     void _update_block_queue_empty() override { _blocks_queue_empty = _blocks_queue.empty(); }
 
+    Status get_block_from_queue(vectorized::Block** block, bool* eos, bool wait = false) override {
+        return vectorized::ScannerContext::get_block_from_queue(block, eos, false);
+    }
+
     // We should make those method lock free.
     bool done() override { return _is_finished || _should_stop || _status_error; }
-    bool can_finish() override {
-        return _num_running_scanners == 0 && _num_scheduling_ctx == 0 && _is_finished;
+    bool no_schedule() override {
+        return _num_running_scanners == 0 && _num_scheduling_ctx == 0;
     }
     bool empty_in_queue() override { return _blocks_queue_empty; }
 

--- a/be/src/vec/exec/scan/pip_scanner_context.h
+++ b/be/src/vec/exec/scan/pip_scanner_context.h
@@ -37,7 +37,9 @@ public:
 
     // We should make those method lock free.
     bool done() override { return _is_finished || _should_stop || _status_error; }
-    bool can_finish() override { return _num_running_scanners == 0 && _num_scheduling_ctx == 0; }
+    bool can_finish() override {
+        return _num_running_scanners == 0 && _num_scheduling_ctx == 0 && _is_finished;
+    }
     bool empty_in_queue() override { return _blocks_queue_empty; }
 
 private:

--- a/be/src/vec/exec/scan/pip_scanner_context.h
+++ b/be/src/vec/exec/scan/pip_scanner_context.h
@@ -41,9 +41,7 @@ public:
 
     // We should make those method lock free.
     bool done() override { return _is_finished || _should_stop || _status_error; }
-    bool no_schedule() override {
-        return _num_running_scanners == 0 && _num_scheduling_ctx == 0;
-    }
+    bool no_schedule() override { return _num_running_scanners == 0 && _num_scheduling_ctx == 0; }
     bool empty_in_queue() override { return _blocks_queue_empty; }
 
 private:

--- a/be/src/vec/exec/scan/scanner_context.h
+++ b/be/src/vec/exec/scan/scanner_context.h
@@ -78,7 +78,7 @@ public:
     // Get next block from blocks queue. Called by ScanNode
     // Set eos to true if there is no more data to read.
     // And if eos is true, the block returned must be nullptr.
-    Status get_block_from_queue(vectorized::Block** block, bool* eos, bool wait = true);
+    virtual Status get_block_from_queue(vectorized::Block** block, bool* eos, bool wait = true);
 
     // When a scanner complete a scan, this method will be called
     // to return the scanner to the list for next scheduling.
@@ -118,7 +118,7 @@ public:
 
     void clear_and_join();
 
-    virtual bool can_finish();
+    virtual bool no_schedule();
 
     std::string debug_string();
 

--- a/be/src/vec/exec/vbroker_scan_node.h
+++ b/be/src/vec/exec/vbroker_scan_node.h
@@ -89,7 +89,7 @@ private:
     std::condition_variable _queue_reader_cond;
     std::condition_variable _queue_writer_cond;
 
-    int _num_running_scanners;
+    std::atomic<int> _num_running_scanners;
 
     std::atomic<bool> _scan_finished;
 


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary
Now in `ScannerContext::push_back_scanner_and_reschedule`, `_num_running_scanners--` is before `_num_scheduling_ctx++`.
In`PipScannerContext::can_finish`, we check `_num_running_scanners == 0 && _num_scheduling_ctx == 0` without obtaining `_transfer_lock`.
In follow case, `PipScannerContext::can_finish` will return wrong result.
1. _num_running_scanners--
2. Check _num_running_scanners == 0 && _num_scheduling_ctx == 0` return true.
3. _num_scheduling_ctx++

So, we can set `_num_running_scanners--` in the last of this func.

Describe your changes.

1. `PipScannerContext::get_block_from_queue` not block.
2.  Set `_num_running_scanners--` in the last of `ScannerContext::push_back_scanner_and_reschedule`.


## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
3. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
5. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
6. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
7. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

