### PR TITLE
[improvement](test) add --conf option for run-regression-test.sh for custom config file

### DIFF
--- a/run-regression-test.sh
+++ b/run-regression-test.sh
@@ -128,7 +128,7 @@ export MVN_CMD
 CONF_DIR="${DORIS_HOME}/regression-test/conf"
 if [[ -n "${CUSTOM_CONFIG_FILE}" ]] && [[ -f "${CUSTOM_CONFIG_FILE}" ]]; then
     CONFIG_FILE="${CUSTOM_CONFIG_FILE}"
-    echo "Using custom config file $CONFIG_FILE"
+    echo "Using custom config file ${CONFIG_FILE}"
 else
     CONFIG_FILE="${CONF_DIR}/regression-conf.groovy"
 fi

--- a/run-regression-test.sh
+++ b/run-regression-test.sh
@@ -90,6 +90,11 @@ else
             TEAMCITY=1
             shift
             ;;
+        --conf)
+            CUSTOM_CONFIG_FILE="$2"
+            shift
+            shift
+            ;;
         --run)
             RUN=1
             shift
@@ -121,7 +126,12 @@ fi
 export MVN_CMD
 
 CONF_DIR="${DORIS_HOME}/regression-test/conf"
-CONFIG_FILE="${CONF_DIR}/regression-conf.groovy"
+if [[ -n "${CUSTOM_CONFIG_FILE}" ]] && [[ -f "${CUSTOM_CONFIG_FILE}" ]]; then
+    CONFIG_FILE="${CUSTOM_CONFIG_FILE}"
+    echo "Using custom config file $CONFIG_FILE"
+else
+    CONFIG_FILE="${CONF_DIR}/regression-conf.groovy"
+fi
 LOG_CONFIG_FILE="${CONF_DIR}/logback.xml"
 
 FRAMEWORK_SOURCE_DIR="${DORIS_HOME}/regression-test/framework"


### PR DESCRIPTION
# Proposed changes

Developers need to change port in regression-test/conf/regression-conf.groovy to run regression test locally if they share the same machine and use different ports. It's not convenient may lead to mistake commit for regression-conf.groovy.

This PR add --conf option for run-regression-test.sh for custom config file. It can be used as follows: 

` sh run-regression-test.sh --run --conf my-regression-conf.groovy -d tpch_sf1_p0 `

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

