### PR TITLE
[Fix](Nereids)fix group by binding error, resulting in incorrect results

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/logical/NormalizeAggregate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/logical/NormalizeAggregate.java
@@ -65,9 +65,9 @@ public class NormalizeAggregate extends OneRewriteRuleFactory implements Normali
                     aggregate.getOutputExpressions(), Alias.class::isInstance);
             Set<Expression> needToSlots = collectGroupByAndArgumentsOfAggregateFunctions(aggregate);
             NormalizeToSlotContext groupByAndArgumentToSlotContext =
-                    NormalizeToSlotContext.buildContext(existsAliases, needToSlots);
+                    NormalizeToSlotContext.buildContext(existsAliases, needToSlots, aggregate);
             Set<NamedExpression> bottomProjects =
-                    groupByAndArgumentToSlotContext.pushDownToNamedExpression(needToSlots);
+                    groupByAndArgumentToSlotContext.pushDownToNamedExpression(needToSlots, aggregate);
             Plan normalizedChild = bottomProjects.isEmpty()
                     ? aggregate.child()
                     : new LogicalProject<>(ImmutableList.copyOf(bottomProjects), aggregate.child());
@@ -78,7 +78,7 @@ public class NormalizeAggregate extends OneRewriteRuleFactory implements Normali
             // some expression on the aggregate functions, e.g. `sum(value) + 1`, we should replace
             // the sum(value) to slot and move the `slot + 1` to the upper project later.
             List<NamedExpression> normalizeOutputPhase1 = groupByAndArgumentToSlotContext
-                    .normalizeToUseSlotRef(aggregate.getOutputExpressions());
+                    .normalizeToUseSlotRef(aggregate.getOutputExpressions(), true);
             Set<AggregateFunction> normalizedAggregateFunctions =
                     ExpressionUtils.collect(normalizeOutputPhase1, AggregateFunction.class::isInstance);
 
@@ -87,13 +87,14 @@ public class NormalizeAggregate extends OneRewriteRuleFactory implements Normali
             // now reuse the exists alias for the aggregate functions,
             // or create new alias for the aggregate functions
             NormalizeToSlotContext aggregateFunctionToSlotContext =
-                    NormalizeToSlotContext.buildContext(existsAliases, normalizedAggregateFunctions);
+                    NormalizeToSlotContext.buildContext(existsAliases, normalizedAggregateFunctions, aggregate);
 
             Set<NamedExpression> normalizedAggregateFunctionsWithAlias =
-                    aggregateFunctionToSlotContext.pushDownToNamedExpression(normalizedAggregateFunctions);
+                    aggregateFunctionToSlotContext.pushDownToNamedExpression(normalizedAggregateFunctions, aggregate);
 
             List<Slot> normalizedGroupBy =
-                    (List) groupByAndArgumentToSlotContext.normalizeToUseSlotRef(aggregate.getGroupByExpressions());
+                    (List) groupByAndArgumentToSlotContext
+                            .normalizeToUseSlotRef(aggregate.getGroupByExpressions(), false);
 
             // we can safely add all groupBy and aggregate functions to output, because we will
             // add a project on it, and the upper project can protect the scope of visible of slot
@@ -107,7 +108,7 @@ public class NormalizeAggregate extends OneRewriteRuleFactory implements Normali
 
             // replace aggregate function to slot
             List<NamedExpression> upperProjects =
-                    aggregateFunctionToSlotContext.normalizeToUseSlotRef(normalizeOutputPhase1);
+                    aggregateFunctionToSlotContext.normalizeToUseSlotRef(normalizeOutputPhase1, true);
             return new LogicalProject<>(upperProjects, normalizedAggregate);
         }).toRule(RuleType.NORMALIZE_AGGREGATE);
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/logical/NormalizeToSlot.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/logical/NormalizeToSlot.java
@@ -21,6 +21,8 @@ import org.apache.doris.nereids.trees.expressions.Alias;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.NamedExpression;
 import org.apache.doris.nereids.trees.expressions.Slot;
+import org.apache.doris.nereids.trees.expressions.functions.scalar.ScalarFunction;
+import org.apache.doris.nereids.trees.plans.Plan;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -29,6 +31,7 @@ import com.google.common.collect.Maps;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.BiFunction;
 import javax.annotation.Nullable;
@@ -39,14 +42,17 @@ public interface NormalizeToSlot {
     /** NormalizeSlotContext */
     class NormalizeToSlotContext {
         private final Map<Expression, NormalizeToSlotTriplet> normalizeToSlotMap;
+        private final Plan currentPlan;
 
-        public NormalizeToSlotContext(Map<Expression, NormalizeToSlotTriplet> normalizeToSlotMap) {
+        public NormalizeToSlotContext(
+                Map<Expression, NormalizeToSlotTriplet> normalizeToSlotMap, Plan currentPlan) {
             this.normalizeToSlotMap = normalizeToSlotMap;
+            this.currentPlan = currentPlan;
         }
 
         /** buildContext */
         public static NormalizeToSlotContext buildContext(
-                Set<Alias> existsAliases, Set<? extends Expression> sourceExpressions) {
+                Set<Alias> existsAliases, Set<? extends Expression> sourceExpressions, Plan currentPlan) {
             Map<Expression, NormalizeToSlotTriplet> normalizeToSlotMap = Maps.newLinkedHashMap();
 
             Map<Expression, Alias> existsAliasMap = Maps.newLinkedHashMap();
@@ -62,26 +68,55 @@ public interface NormalizeToSlot {
                         NormalizeToSlotTriplet.toTriplet(expression, existsAliasMap.get(expression));
                 normalizeToSlotMap.put(expression, normalizeToSlotTriplet);
             }
-            return new NormalizeToSlotContext(normalizeToSlotMap);
+            return new NormalizeToSlotContext(normalizeToSlotMap, currentPlan);
         }
 
         /** normalizeToUseSlotRef, no custom normalize */
-        public <E extends Expression> List<E> normalizeToUseSlotRef(List<E> expressions) {
-            return normalizeToUseSlotRef(expressions, (context, expr) -> expr);
+        public <E extends Expression> List<E> normalizeToUseSlotRef(
+                List<E> expressions, boolean isOutput) {
+            return normalizeToUseSlotRef(expressions, (context, expr) -> expr, isOutput);
         }
 
         /** normalizeToUseSlotRef */
         public <E extends Expression> List<E> normalizeToUseSlotRef(List<E> expressions,
-                BiFunction<NormalizeToSlotContext, Expression, Expression> customNormalize) {
+                BiFunction<NormalizeToSlotContext, Expression, Expression> customNormalize,
+                boolean isOutput) {
             return expressions.stream()
                     .map(expr -> (E) expr.rewriteDownShortCircuit(child -> {
                         Expression newChild = customNormalize.apply(this, child);
                         if (newChild != null && newChild != child) {
                             return newChild;
                         }
+                        if (child instanceof ScalarFunction && !isOutput) {
+                            return getSlotFromChildOutputsWhichEqualName(currentPlan, child);
+                        }
+                        if (child instanceof ScalarFunction && isOutput
+                                && collectSlotFromChildOutputsWhichEqualName(currentPlan, child).isPresent()) {
+                            NormalizeToSlotTriplet normalizeToSlotTriplet = normalizeToSlotMap.get(child);
+                            return normalizeToSlotTriplet == null ? child : normalizeToSlotTriplet.originExpr;
+                        }
                         NormalizeToSlotTriplet normalizeToSlotTriplet = normalizeToSlotMap.get(child);
                         return normalizeToSlotTriplet == null ? child : normalizeToSlotTriplet.remainExpr;
                     })).collect(ImmutableList.toImmutableList());
+        }
+
+        private Expression getSlotFromChildOutputsWhichEqualName(Plan repeat, Expression child) {
+            NormalizeToSlotTriplet normalizeToSlotTriplet = normalizeToSlotMap.get(child);
+            Optional<Slot> slot = collectSlotFromChildOutputsWhichEqualName(repeat, child);
+            if (slot.isPresent()) {
+                return slot.get();
+            }
+            return normalizeToSlotTriplet == null ? child : normalizeToSlotTriplet.remainExpr;
+        }
+
+        private Optional<Slot> collectSlotFromChildOutputsWhichEqualName(
+                Plan repeat, Expression child) {
+            NormalizeToSlotTriplet normalizeToSlotTriplet = normalizeToSlotMap.get(child);
+            String asName = normalizeToSlotTriplet == null
+                    ? child.toSql() : normalizeToSlotTriplet.remainExpr.getName();
+            return repeat.child(0).getOutput().stream()
+                    .filter(s -> s.getName().equals(asName))
+                    .findFirst();
         }
 
         /**
@@ -90,14 +125,25 @@ public interface NormalizeToSlot {
          * groupByExpressions: k1#0, k2#1 + 1;
          * bottom: k1#0, (k2#1 + 1) AS (k2 + 1)#2;
          */
-        public Set<NamedExpression> pushDownToNamedExpression(Collection<? extends Expression> needToPushExpressions) {
+        public Set<NamedExpression> pushDownToNamedExpression(
+                Collection<? extends Expression> needToPushExpressions, Plan current) {
             return needToPushExpressions.stream()
+                    .filter(e -> filterScalarFunWithSameAliasNameInChildOutput(e, current))
                     .map(expr -> {
                         NormalizeToSlotTriplet normalizeToSlotTriplet = normalizeToSlotMap.get(expr);
                         return normalizeToSlotTriplet == null
                                 ? (NamedExpression) expr
                                 : normalizeToSlotTriplet.pushedExpr;
                     }).collect(ImmutableSet.toImmutableSet());
+        }
+
+        private boolean filterScalarFunWithSameAliasNameInChildOutput(
+                Expression expression, Plan current) {
+            if (expression instanceof ScalarFunction) {
+                Optional<Slot> slot = collectSlotFromChildOutputsWhichEqualName(current, expression);
+                return !slot.isPresent();
+            }
+            return true;
         }
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/GroupingSetsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/GroupingSetsTest.java
@@ -183,4 +183,53 @@ public class GroupingSetsTest extends TestWithFeService {
         PlanChecker.from(connectContext)
                 .checkPlannerResult("select if(k1 = 1, 2, k1) k_if from t1");
     }
+
+    @Test
+    public void test1() {
+        PlanChecker.from(connectContext)
+                .checkPlannerResult("select coalesce(col1, 'all') as col1, count(*) as cnt from"
+                        + " (select null as col1 union all select 'a' as col1 ) t group by grouping sets ((col1),());");
+    }
+
+    @Test
+    public void test1_1() {
+        PlanChecker.from(connectContext)
+                .checkPlannerResult("select coalesce(col1, 'all') as col2, count(*) as cnt from"
+                        + " (select null as col1 union all select 'a' as col1 ) t group by grouping sets ((col1),());");
+    }
+
+    @Test
+    public void test1_2() {
+        PlanChecker.from(connectContext)
+                .checkPlannerResult("select coalesce(col1, 'all') as col2, count(*) as cnt from"
+                        + " (select null as col1 union all select 'a' as col1 ) t group by grouping sets ((col2),());");
+    }
+
+    @Test
+    public void test2() {
+        PlanChecker.from(connectContext)
+                .checkPlannerResult("select if(1 = null, 'all', 2) as col1, count(*) as cnt from"
+                        + " (select null as col1 union all select 'a' as col1 ) t group by grouping sets ((col1),());");
+    }
+
+    @Test
+    public void test2_1() {
+        PlanChecker.from(connectContext)
+                .checkPlannerResult("select if(col1 = null, 'all', 2) as col1, count(*) as cnt from"
+                        + " (select null as col1 union all select 'a' as col1 ) t group by grouping sets ((col1),());");
+    }
+
+    @Test
+    public void test2_2() {
+        PlanChecker.from(connectContext)
+                .checkPlannerResult("select if(col1 = null, 'all', 2) as col2, count(*) as cnt from"
+                        + " (select null as col1 union all select 'a' as col1 ) t group by grouping sets ((col1),());");
+    }
+
+    @Test
+    public void test2_3() {
+        PlanChecker.from(connectContext)
+                .checkPlannerResult("select if(col1 = null, 'all', 2) as col2, count(*) as cnt from"
+                        + " (select null as col1 union all select 'a' as col1 ) t group by grouping sets ((col2),());");
+    }
 }

--- a/regression-test/data/nereids_syntax_p0/grouping_sets.out
+++ b/regression-test/data/nereids_syntax_p0/grouping_sets.out
@@ -224,3 +224,37 @@
 3
 4
 
+-- !select1 --
+a	1
+all	1
+all	2
+
+-- !select2 --
+a	1
+all	1
+all	2
+
+-- !select3 --
+\N	2
+a	1
+all	1
+
+-- !select4 --
+2	1
+2	1
+2	2
+
+-- !select5 --
+2	1
+2	1
+2	2
+
+-- !select6 --
+2	1
+2	1
+2	2
+
+-- !select7 --
+2	1
+2	1
+2	2

--- a/regression-test/suites/nereids_syntax_p0/grouping_sets.groovy
+++ b/regression-test/suites/nereids_syntax_p0/grouping_sets.groovy
@@ -232,4 +232,32 @@ suite("test_nereids_grouping_sets") {
             ) T
         ) T2;
     """
+
+    order_qt_select1 """
+        select coalesce(col1, 'all') as col1, count(*) as cnt from (select null as col1 union all select 'a' as col1 ) t group by grouping sets ((col1),());
+    """
+
+    order_qt_select2 """
+        select coalesce(col1, 'all') as col2, count(*) as cnt from (select null as col1 union all select 'a' as col1 ) t group by grouping sets ((col1),());
+    """
+
+    order_qt_select3 """
+        select coalesce(col1, 'all') as col2, count(*) as cnt from (select null as col1 union all select 'a' as col1 ) t group by grouping sets ((col2),());
+    """
+
+    order_qt_select4 """
+        select if(1 = null, 'all', 2) as col1, count(*) as cnt from (select null as col1 union all select 'a' as col1 ) t group by grouping sets ((col1),());
+    """
+
+    order_qt_select5 """
+        select if(col1 = null, 'all', 2) as col1, count(*) as cnt from (select null as col1 union all select 'a' as col1 ) t group by grouping sets ((col1),());
+    """
+
+    order_qt_select6 """
+        select if(1 = null, 'all', 2) as col2, count(*) as cnt from (select null as col1 union all select 'a' as col1 ) t group by grouping sets ((col1),());
+    """
+
+    order_qt_select7 """
+        select if(col1 = null, 'all', 2) as col2, count(*) as cnt from (select null as col1 union all select 'a' as col1 ) t group by grouping sets ((col1),());
+    """
 }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

Original: group by is bound to the outputExpression of the current node.

Problem: When the name of the new reference of outputExpression is the same as the child's output column, the child's output column should be used for group by, but at this time, the new reference of the node's outputExpression will be used for group by, resulting in an error

Now: Give priority to the child's output for group by binding. If the child does not have a corresponding column, use the outputExpression of this node for binding

eg:
```
select coalesce(col1, 'all') as col1, count(*) as cnt from (select  null as col1  union all  select  'a' as col1 ) t group by grouping sets ((col1),());
```

before: wrong result
```
+------+------+
| col1 | cnt  |
+------+------+
| all  |    1 |
| a    |    1 |
| NULL |    2 |
+------+------+
```

now: right result
```
+------+------+
| col1 | cnt  |
+------+------+
| all  |    1 |
| a    |    1 |
| all  |    2 |
+------+------+
```

before
```
+----------------------------------------------------------+
| Explain String                                           |
+----------------------------------------------------------+
| PLAN FRAGMENT 0                                          |
|   OUTPUT EXPRS:                                          |
|     col1[#8]                                             |
|     cnt[#9]                                              |
|   PARTITION: UNPARTITIONED                               |
|                                                          |
|   VRESULT SINK                                           |
|                                                          |
|   4:VEXCHANGE                                            |
|                                                          |
| PLAN FRAGMENT 1                                          |
|                                                          |
|   PARTITION: HASH_PARTITIONED: col1[#3], GROUPING_ID[#4] |
|                                                          |
|   STREAM DATA SINK                                       |
|     EXCHANGE ID: 04                                      |
|     UNPARTITIONED                                        |
|                                                          |
|   3:VAGGREGATE (update finalize)                         |
|   |  output: count(*)[#7]                                |
|   |  group by: col1[#3], GROUPING_ID[#4]                 |
|   |  cardinality=2                                       |
|   |  projections: col1[#5], cnt[#7]                      |
|   |  project output tuple id: 5                          |
|   |                                                      |
|   2:VEXCHANGE                                            |
|                                                          |
| PLAN FRAGMENT 2                                          |
|                                                          |
|   PARTITION: UNPARTITIONED                               |
|                                                          |
|   STREAM DATA SINK                                       |
|     EXCHANGE ID: 02                                      |
|     HASH_PARTITIONED: col1[#3], GROUPING_ID[#4]          |
|                                                          |
|   1:VREPEAT_NODE                                         |
|   |  repeat: repeat 1 lines [[3], []]                    |
|   |  exprs: col1[#1]                                     |
|   |  output slots: `null`, `GROUPING_ID`                 |
|   |                                                      |
|   0:VUNION                                               |
|      constant exprs:                                     |
|          NULL                                            |
|          'a'                                             |
|      projections: coalesce(col1[#0], 'all')              |
|      project output tuple id: 1                          |
+----------------------------------------------------------+
```
now
```
+----------------------------------------------------------+
| Explain String                                           |
+----------------------------------------------------------+
| PLAN FRAGMENT 0                                          |
|   OUTPUT EXPRS:                                          |
|     col1[#7]                                             |
|     cnt[#8]                                              |
|   PARTITION: UNPARTITIONED                               |
|                                                          |
|   VRESULT SINK                                           |
|                                                          |
|   4:VEXCHANGE                                            |
|                                                          |
| PLAN FRAGMENT 1                                          |
|                                                          |
|   PARTITION: HASH_PARTITIONED: col1[#2], GROUPING_ID[#3] |
|                                                          |
|   STREAM DATA SINK                                       |
|     EXCHANGE ID: 04                                      |
|     UNPARTITIONED                                        |
|                                                          |
|   3:VAGGREGATE (update finalize)                         |
|   |  output: count(*)[#6]                                |
|   |  group by: col1[#2], GROUPING_ID[#3]                 |
|   |  cardinality=2                                       |
|   |  projections: coalesce(col1[#4], 'all'), cnt[#6]     |
|   |  project output tuple id: 4                          |
|   |                                                      |
|   2:VEXCHANGE                                            |
|                                                          |
| PLAN FRAGMENT 2                                          |
|                                                          |
|   PARTITION: UNPARTITIONED                               |
|                                                          |
|   STREAM DATA SINK                                       |
|     EXCHANGE ID: 02                                      |
|     HASH_PARTITIONED: col1[#2], GROUPING_ID[#3]          |
|                                                          |
|   1:VREPEAT_NODE                                         |
|   |  repeat: repeat 1 lines [[2], []]                    |
|   |  exprs: col1[#0]                                     |
|   |  output slots: `null`, `GROUPING_ID`                 |
|   |                                                      |
|   0:VUNION                                               |
|      constant exprs:                                     |
|          NULL                                            |
|          'a'                                             |
+----------------------------------------------------------+
```


## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [x] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

