### PR TITLE
[fix](s3 outfile) Add the `use_path_style` parameter for s3 outfile

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/OutFileClause.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/OutFileClause.java
@@ -429,6 +429,10 @@ public class OutFileClause {
             }
         }
         if (storageType == StorageBackend.StorageType.S3) {
+            if (properties.containsKey(S3Storage.USE_PATH_STYLE)) {
+                brokerProps.put(S3Storage.USE_PATH_STYLE, properties.get(S3Storage.USE_PATH_STYLE));
+                processedPropKeys.add(S3Storage.USE_PATH_STYLE);
+            }
             S3Storage.checkS3(new CaseInsensitiveMap(brokerProps));
         } else if (storageType == StorageBackend.StorageType.HDFS) {
             HDFSStorage.checkHDFS(new CaseInsensitiveMap(brokerProps));


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

Currently, outfile did not support `use_path_style` parameter and use `virtual-host style` by default, however some Object-storage may only support `path_style` access mode.

This pr add the `use_path_style` parameter for s3 outfile, so that different object-storage can use different access mode.

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

