### PR TITLE
[pipeline](opt) opt the exec performance of pipe exec engine

### DIFF
--- a/be/src/pipeline/exec/operator.h
+++ b/be/src/pipeline/exec/operator.h
@@ -276,7 +276,6 @@ public:
 
     Status sink(RuntimeState* state, vectorized::Block* in_block,
                 SourceState source_state) override {
-        SCOPED_TIMER(_runtime_profile->total_time_counter());
         if (in_block->rows() > 0) {
             return _sink->send(state, in_block, source_state == SourceState::FINISHED);
         }

--- a/be/src/pipeline/exec/set_probe_sink_operator.cpp
+++ b/be/src/pipeline/exec/set_probe_sink_operator.cpp
@@ -45,11 +45,6 @@ Status SetProbeSinkOperator<is_intersect>::sink(RuntimeState* state, vectorized:
 }
 
 template <bool is_intersect>
-Status SetProbeSinkOperator<is_intersect>::finalize(RuntimeState* state) {
-    return this->_node->finalize_probe(state, _child_id);
-}
-
-template <bool is_intersect>
 bool SetProbeSinkOperator<is_intersect>::can_write() {
     DCHECK_GT(_child_id, 0);
     return this->_node->is_child_finished(_child_id - 1);

--- a/be/src/pipeline/exec/set_probe_sink_operator.h
+++ b/be/src/pipeline/exec/set_probe_sink_operator.h
@@ -53,7 +53,6 @@ public:
     bool can_write() override;
 
     Status sink(RuntimeState* state, vectorized::Block* block, SourceState source_state) override;
-    Status finalize(RuntimeState* state) override;
     Status open(RuntimeState* /*state*/) override { return Status::OK(); }
 
 private:

--- a/be/src/pipeline/pipeline_task.cpp
+++ b/be/src/pipeline/pipeline_task.cpp
@@ -131,7 +131,7 @@ Status PipelineTask::execute(bool* eos) {
     }
 
     while (!_fragment_context->is_canceled()) {
-        if (!_source->can_read() && _data_state != SourceState::MORE_DATA) {
+        if (_data_state != SourceState::MORE_DATA && !_source->can_read()) {
             set_state(BLOCKED_FOR_SOURCE);
             break;
         }

--- a/be/src/vec/exec/vset_operation_node.cpp
+++ b/be/src/vec/exec/vset_operation_node.cpp
@@ -219,7 +219,6 @@ Status VSetOperationNode<is_intersect>::open(RuntimeState* state) {
 
             RETURN_IF_ERROR(sink_probe(state, i, &_probe_block, eos));
         }
-        finalize_probe(state, i);
     }
     return st;
 }
@@ -227,6 +226,7 @@ Status VSetOperationNode<is_intersect>::open(RuntimeState* state) {
 template <bool is_intersect>
 Status VSetOperationNode<is_intersect>::get_next(RuntimeState* state, Block* output_block,
                                                  bool* eos) {
+    SCOPED_TIMER(_runtime_profile->total_time_counter());
     INIT_AND_SCOPE_GET_NEXT_SPAN(state->get_tracer(), _get_next_span, "VExceptNode::get_next");
     return pull(state, output_block, eos);
 }
@@ -348,7 +348,6 @@ void VSetOperationNode<is_intersect>::hash_table_init() {
 
 template <bool is_intersect>
 Status VSetOperationNode<is_intersect>::sink(RuntimeState*, Block* block, bool eos) {
-    SCOPED_TIMER(_build_timer);
     constexpr static auto BUILD_BLOCK_MAX_SIZE = 4 * 1024UL * 1024UL * 1024UL;
 
     if (block->rows() != 0) {
@@ -406,6 +405,7 @@ Status VSetOperationNode<is_intersect>::pull(RuntimeState* state, Block* output_
 //build a hash table from child(0)
 template <bool is_intersect>
 Status VSetOperationNode<is_intersect>::hash_table_build(RuntimeState* state) {
+    SCOPED_TIMER(_build_timer);
     RETURN_IF_ERROR(child(0)->open(state));
     Block block;
     MutableBlock mutable_block(child(0)->row_desc().tuple_descriptors());
@@ -470,8 +470,8 @@ void VSetOperationNode<is_intersect>::add_result_columns(RowRefListWithFlags& va
 }
 
 template <bool is_intersect>
-Status VSetOperationNode<is_intersect>::sink_probe(RuntimeState* /*state*/, int child_id,
-                                                   Block* block, bool eos) {
+Status VSetOperationNode<is_intersect>::sink_probe(RuntimeState* state, int child_id, Block* block,
+                                                   bool eos) {
     SCOPED_TIMER(_probe_timer);
     CHECK(_build_finished) << "cannot sink probe data before build finished";
     if (child_id > 1) {
@@ -479,25 +479,23 @@ Status VSetOperationNode<is_intersect>::sink_probe(RuntimeState* /*state*/, int 
                 << fmt::format("child with id: {} should be probed first", child_id);
     }
     auto probe_rows = block->rows();
-
-    if (probe_rows == 0) {
-        return Status::OK();
+    if (probe_rows > 0) {
+        RETURN_IF_ERROR(extract_probe_column(*block, _probe_columns, child_id));
+        RETURN_IF_ERROR(std::visit(
+                [&](auto&& arg) -> Status {
+                    using HashTableCtxType = std::decay_t<decltype(arg)>;
+                    if constexpr (!std::is_same_v<HashTableCtxType, std::monostate>) {
+                        HashTableProbe<HashTableCtxType, is_intersect> process_hashtable_ctx(
+                                this, probe_rows);
+                        return process_hashtable_ctx.mark_data_in_hashtable(arg);
+                    } else {
+                        LOG(FATAL) << "FATAL: uninited hash table";
+                    }
+                },
+                *_hash_table_variants));
     }
 
-    RETURN_IF_ERROR(extract_probe_column(*block, _probe_columns, child_id));
-
-    return std::visit(
-            [&](auto&& arg) -> Status {
-                using HashTableCtxType = std::decay_t<decltype(arg)>;
-                if constexpr (!std::is_same_v<HashTableCtxType, std::monostate>) {
-                    HashTableProbe<HashTableCtxType, is_intersect> process_hashtable_ctx(
-                            this, probe_rows);
-                    return process_hashtable_ctx.mark_data_in_hashtable(arg);
-                } else {
-                    LOG(FATAL) << "FATAL: uninited hash table";
-                }
-            },
-            *_hash_table_variants);
+    return eos ? finalize_probe(state, child_id) : Status::OK();
 }
 
 template <bool is_intersect>
@@ -563,10 +561,6 @@ Status VSetOperationNode<is_intersect>::extract_build_column(Block& block,
 template <bool is_intersect>
 Status VSetOperationNode<is_intersect>::extract_probe_column(Block& block, ColumnRawPtrs& raw_ptrs,
                                                              int child_id) {
-    if (block.rows() == 0) {
-        return Status::OK();
-    }
-
     for (size_t i = 0; i < _child_expr_lists[child_id].size(); ++i) {
         int result_col_id = -1;
         RETURN_IF_ERROR(_child_expr_lists[child_id][i]->execute(&block, &result_col_id));

--- a/be/src/vec/runtime/vdata_stream_recvr.h
+++ b/be/src/vec/runtime/vdata_stream_recvr.h
@@ -93,6 +93,8 @@ public:
         return _num_buffered_bytes + batch_size > _total_buffer_limit;
     }
 
+    bool is_closed() const { return _is_closed; }
+
 private:
     class SenderQueue;
     class PipSenderQueue;
@@ -247,10 +249,13 @@ public:
         materialize_block_inplace(*nblock);
 
         size_t block_size = nblock->bytes();
+        auto block_mem_size = nblock->allocated_bytes();
         {
             std::unique_lock<std::mutex> l(_lock);
             _block_queue.emplace_back(block_size, nblock);
         }
+        COUNTER_UPDATE(_recvr->_local_bytes_received_counter, block_size);
+        _recvr->_blocks_memory_usage->add(block_mem_size);
         _update_block_queue_empty();
         _data_arrival_cv.notify_one();
 

--- a/be/src/vec/sink/vdata_stream_sender.cpp
+++ b/be/src/vec/sink/vdata_stream_sender.cpp
@@ -78,7 +78,12 @@ Status Channel::init(RuntimeState* state) {
     }
 
     if (state->query_options().__isset.enable_local_exchange) {
-        _enable_local_exchange = state->query_options().enable_local_exchange;
+        _is_local &= state->query_options().enable_local_exchange;
+    }
+
+    if (_is_local) {
+        _local_recvr = _parent->state()->exec_env()->vstream_mgr()->find_recvr(
+                _fragment_instance_id, _dest_node_id);
     }
 
     // In bucket shuffle join will set fragment_instance_id (-1, -1)
@@ -92,7 +97,7 @@ Status Channel::init(RuntimeState* state) {
 Status Channel::send_current_block(bool eos) {
     // FIXME: Now, local exchange will cause the performance problem is in a multi-threaded scenario
     // so this feature is turned off here by default. We need to re-examine this logic
-    if (_enable_local_exchange && is_local()) {
+    if (is_local()) {
         return send_local_block(eos);
     }
     SCOPED_CONSUME_MEM_TRACKER(_parent->_mem_tracker.get());
@@ -107,18 +112,15 @@ Status Channel::send_current_block(bool eos) {
 
 Status Channel::send_local_block(bool eos) {
     SCOPED_TIMER(_parent->_local_send_timer);
-    std::shared_ptr<VDataStreamRecvr> recvr =
-            _parent->state()->exec_env()->vstream_mgr()->find_recvr(_fragment_instance_id,
-                                                                    _dest_node_id);
     Block block = _mutable_block->to_block();
     _mutable_block->set_muatable_columns(block.clone_empty_columns());
-    if (recvr != nullptr) {
+    if (_recvr_is_valid()) {
         COUNTER_UPDATE(_parent->_local_bytes_send_counter, block.bytes());
         COUNTER_UPDATE(_parent->_local_sent_rows, block.rows());
         COUNTER_UPDATE(_parent->_blocks_sent_counter, 1);
-        recvr->add_block(&block, _parent->_sender_id, true);
+        _local_recvr->add_block(&block, _parent->_sender_id, true);
         if (eos) {
-            recvr->remove_sender(_parent->_sender_id, _be_number);
+            _local_recvr->remove_sender(_parent->_sender_id, _be_number);
         }
     }
     return Status::OK();
@@ -126,14 +128,11 @@ Status Channel::send_local_block(bool eos) {
 
 Status Channel::send_local_block(Block* block) {
     SCOPED_TIMER(_parent->_local_send_timer);
-    std::shared_ptr<VDataStreamRecvr> recvr =
-            _parent->state()->exec_env()->vstream_mgr()->find_recvr(_fragment_instance_id,
-                                                                    _dest_node_id);
-    if (recvr != nullptr) {
+    if (_recvr_is_valid()) {
         COUNTER_UPDATE(_parent->_local_bytes_send_counter, block->bytes());
         COUNTER_UPDATE(_parent->_local_sent_rows, block->rows());
         COUNTER_UPDATE(_parent->_blocks_sent_counter, 1);
-        recvr->add_block(block, _parent->_sender_id, false);
+        _local_recvr->add_block(block, _parent->_sender_id, false);
     }
     return Status::OK();
 }
@@ -461,15 +460,15 @@ Status VDataStreamSender::prepare(RuntimeState* state) {
                                profile()->total_time_counter()),
             "");
     _local_bytes_send_counter = ADD_COUNTER(profile(), "LocalBytesSent", TUnit::BYTES);
-    for (int i = 0; i < _channels.size(); ++i) {
-        RETURN_IF_ERROR(_channels[i]->init(state));
-    }
     return Status::OK();
 }
 
 Status VDataStreamSender::open(RuntimeState* state) {
     START_AND_SCOPE_SPAN(state->get_tracer(), span, "VDataStreamSender::open");
     DCHECK(state != nullptr);
+    for (int i = 0; i < _channels.size(); ++i) {
+        RETURN_IF_ERROR(_channels[i]->init(state));
+    }
     SCOPED_CONSUME_MEM_TRACKER(_mem_tracker.get());
     RETURN_IF_ERROR(VExpr::open(_partition_expr_ctxs, state));
     for (auto iter : _partition_infos) {

--- a/be/src/vec/sink/vdata_stream_sender.h
+++ b/be/src/vec/sink/vdata_stream_sender.h
@@ -263,16 +263,15 @@ public:
     void ch_roll_pb_block();
 
     bool can_write() {
-        if (!_enable_local_exchange || !is_local()) {
+        if (!is_local()) {
             return true;
         }
-        std::shared_ptr<VDataStreamRecvr> recvr =
-                _parent->state()->exec_env()->vstream_mgr()->find_recvr(_fragment_instance_id,
-                                                                        _dest_node_id);
-        return recvr == nullptr || !recvr->exceeds_limit(0);
+        return !_local_recvr || _local_recvr->is_closed() || !_local_recvr->exceeds_limit(0);
     }
 
 protected:
+    bool _recvr_is_valid() { return _local_recvr && !_local_recvr->is_closed(); }
+
     Status _wait_last_brpc() {
         SCOPED_TIMER(_parent->_brpc_wait_timer);
         if (_closure == nullptr) {
@@ -331,7 +330,7 @@ protected:
 
     size_t _capacity;
     bool _is_local;
-
+    std::shared_ptr<VDataStreamRecvr> _local_recvr;
     // serialized blocks for broadcasting; we need two so we can write
     // one while the other one is still being sent.
     // Which is for same reason as `_cur_pb_block`, `_pb_block1` and `_pb_block2`
@@ -339,8 +338,6 @@ protected:
     PBlock* _ch_cur_pb_block = nullptr;
     PBlock _ch_pb_block1;
     PBlock _ch_pb_block2;
-
-    bool _enable_local_exchange = true;
 };
 
 template <typename Channels>
@@ -392,7 +389,7 @@ public:
 
     // send _mutable_block
     Status send_current_block(bool eos) override {
-        if (_enable_local_exchange && is_local()) {
+        if (is_local()) {
             return send_local_block(eos);
         }
 


### PR DESCRIPTION
# Proposed changes

Before

```
mysql> select count() from (       select l_orderkey from lineitem where l_linenumber % 3 = 0       except       select l_orderkey from lineitem where l_partkey % 7 = 0  except select l_orderkey from lineitem where l_partkey % 5 = 0 )a;
+----------+
| count()  |
+----------+
| 18658876 |
+----------+
1 row in set (6.66 sec)
```

After
```
mysql> select count() from (       select l_orderkey from lineitem where l_linenumber % 3 = 0       except       select l_orderkey from lineitem where l_partkey % 7 = 0  except select l_orderkey from lineitem where l_partkey % 5 = 0 )a;
+----------+
| count()  |
+----------+
| 18658876 |
+----------+
1 row in set (5.74 sec)
```


## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

