### PR TITLE
Revert "[fix](compile) fix compile error caused by `mysql_scan_node.cpp` not being found when enabling `WITH_MYSQL` (#15277)"

### DIFF
--- a/be/src/exec/CMakeLists.txt
+++ b/be/src/exec/CMakeLists.txt
@@ -102,6 +102,13 @@ set(EXEC_FILES
     assert_num_rows_node.cpp
 
 )
+if (WITH_MYSQL)
+    set(EXEC_FILES
+        ${EXEC_FILES}
+        mysql_scan_node.cpp
+        mysql_scanner.cpp
+        )
+endif()
 
 if (WITH_LZO)
     set(EXEC_FILES ${EXEC_FILES}

--- a/be/src/vec/CMakeLists.txt
+++ b/be/src/vec/CMakeLists.txt
@@ -281,13 +281,6 @@ set(VEC_FILES
   exec/format/table/table_format_reader.cpp
   exec/format/table/iceberg_reader.cpp)
 
-if (WITH_MYSQL)
-    set(VEC_FILES
-            ${VEC_FILES}
-            exec/scan/mysql_scanner.cpp
-            )
-endif ()
-
 add_library(Vec STATIC
         ${VEC_FILES}
         )


### PR DESCRIPTION
This reverts commit 9d637531e903c33903a2898a3d5a1b32dd3d0018.