### PR TITLE
[Bug](Compile) fix compile error due to incorrect method name

### DIFF
--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/logical/InferPredicatesTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/logical/InferPredicatesTest.java
@@ -548,11 +548,11 @@ public class InferPredicatesTest extends TestWithFeService implements PatternMat
                         logicalJoin(
                             logicalFilter(
                                     logicalOlapScan()
-                            ).when(filter -> filter.getPredicates().toSql().contains("id > 1")),
+                            ).when(filter -> filter.getPredicate().toSql().contains("id > 1")),
                             logicalProject(
                                     logicalFilter(
                                             logicalOlapScan()
-                                    ).when(filter -> filter.getPredicates().toSql().contains("sid > 1"))
+                                    ).when(filter -> filter.getPredicate().toSql().contains("sid > 1"))
                             )
                         )
                 );


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

There was one function name change in #14807 (from getPredicates to getPredicate), but #15292 still took the primitive method name which would bring compile error like the following picture.
![img_v2_ad452953-0d76-4d93-a89b-a381d5adfcdg](https://user-images.githubusercontent.com/43750022/209497725-1119ef90-c7c0-4f3c-845f-97ce494c9ecb.jpg)

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

