### PR TITLE
[fix](pipeline) query blocked by waiting for shared hash table

### DIFF
--- a/be/src/pipeline/exec/hashjoin_build_sink.h
+++ b/be/src/pipeline/exec/hashjoin_build_sink.h
@@ -39,7 +39,9 @@ public:
 class HashJoinBuildSink final : public StreamingOperator<HashJoinBuildSinkBuilder> {
 public:
     HashJoinBuildSink(OperatorBuilderBase* operator_builder, ExecNode* node);
-    bool can_write() override { return true; };
+    bool can_write() override { return _node->can_sink_write(); }
+    bool need_data_from_source() const override { return _node->should_build_hash_table(); }
+    std::string get_name() const override { return "HashJoinBuildSink"; }
 };
 
 } // namespace pipeline

--- a/be/src/pipeline/exec/operator.h
+++ b/be/src/pipeline/exec/operator.h
@@ -206,6 +206,11 @@ public:
         return Status::NotSupported(error_msg.str());
     }
 
+    virtual bool need_data_from_source() const {
+        DCHECK(is_sink());
+        return true;
+    }
+
     /**
      * pending_finish means we have called `close` and there are still some work to do before finishing.
      * Now it is a pull-based pipeline and operators pull data from its child by this method.

--- a/be/src/pipeline/pipeline_task.h
+++ b/be/src/pipeline/pipeline_task.h
@@ -128,13 +128,13 @@ public:
 
     bool is_pending_finish() { return _source->is_pending_finish() || _sink->is_pending_finish(); }
 
-    bool source_can_read() { return _source->can_read(); }
+    bool source_can_read();
 
     bool runtime_filters_are_ready_or_timeout() {
         return _source->runtime_filters_are_ready_or_timeout();
     }
 
-    bool sink_can_write() { return _sink->can_write(); }
+    bool sink_can_write();
 
     Status finalize();
 
@@ -170,6 +170,8 @@ private:
     Status open();
     void _init_profile();
 
+    void _close_operators_if_need();
+
     uint32_t _index;
     PipelinePtr _pipeline;
     bool _dependency_finish = false;
@@ -180,6 +182,7 @@ private:
 
     bool _prepared;
     bool _opened;
+    bool _operators_closed = false;
     RuntimeState* _state;
     int _previous_schedule_id = -1;
     uint32_t _schedule_time = 0;

--- a/be/src/vec/exec/join/vhash_join_node.cpp
+++ b/be/src/vec/exec/join/vhash_join_node.cpp
@@ -723,6 +723,13 @@ Status HashJoinNode::_materialize_build_side(RuntimeState* state) {
     return Status::OK();
 }
 
+bool HashJoinNode::can_sink_write() const {
+    if (_should_build_hash_table) {
+        return true;
+    }
+    return _shared_hash_table_context && _shared_hash_table_context->signaled;
+}
+
 Status HashJoinNode::sink(doris::RuntimeState* state, vectorized::Block* in_block, bool eos) {
     SCOPED_TIMER(_build_timer);
 

--- a/be/src/vec/exec/join/vhash_join_node.h
+++ b/be/src/vec/exec/join/vhash_join_node.h
@@ -211,8 +211,9 @@ public:
     Status pull(RuntimeState* state, vectorized::Block* output_block, bool* eos) override;
     Status push(RuntimeState* state, vectorized::Block* input_block, bool eos) override;
     void prepare_for_next() override;
-
     void debug_string(int indentation_level, std::stringstream* out) const override;
+    bool can_sink_write() const;
+    bool should_build_hash_table() const { return _should_build_hash_table; }
 
 private:
     using VExprContexts = std::vector<VExprContext*>;


### PR DESCRIPTION
# Proposed changes

`SharedHashTableController::wait_for_signal` will block the `HashJoinBuildSink` operator and the query will be blocked if there are too many instances waiting for shared hash table.

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

