### PR TITLE
[fix] fix dereference to nullptr in Tablet::calc_delete_bitmap

### DIFF
--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -2013,7 +2013,7 @@ Status Tablet::calc_delete_bitmap(RowsetId rowset_id,
                     }
                 }
 
-                if (!specified_rowset_ids->empty()) {
+                if (specified_rowset_ids != nullptr && !specified_rowset_ids->empty()) {
                     auto st = lookup_row_key(*key, specified_rowset_ids, &loc,
                                              dummy_version.first - 1);
                     CHECK(st.ok() || st.is<NOT_FOUND>() || st.is<ALREADY_EXIST>());


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

