### PR TITLE
[feature](remote)Add alter storage policy

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/alter/Alter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/Alter.java
@@ -46,15 +46,18 @@ import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.DataProperty;
 import org.apache.doris.catalog.Database;
 import org.apache.doris.catalog.Env;
+import org.apache.doris.catalog.Index;
 import org.apache.doris.catalog.MysqlTable;
 import org.apache.doris.catalog.OdbcTable;
 import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.catalog.OlapTable.OlapTableState;
 import org.apache.doris.catalog.Partition;
 import org.apache.doris.catalog.PartitionInfo;
+import org.apache.doris.catalog.Replica;
 import org.apache.doris.catalog.ReplicaAllocation;
 import org.apache.doris.catalog.Table;
 import org.apache.doris.catalog.TableIf.TableType;
+import org.apache.doris.catalog.Tablet;
 import org.apache.doris.catalog.View;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.DdlException;
@@ -187,8 +190,17 @@ public class Alter {
         if (currentAlterOps.checkTableStoragePolicy(alterClauses)) {
             String tableStoragePolicy = olapTable.getStoragePolicy();
             if (!tableStoragePolicy.equals("")) {
-                throw new DdlException("Do not support alter table's storage policy , this table ["
-                        + olapTable.getName() + "] has storage policy " + tableStoragePolicy);
+                for (Partition partition : olapTable.getAllPartitions()) {
+                    for (Tablet tablet : partition.getBaseIndex().getTablets()) {
+                        for (Replica replica : tablet.getReplicas()) {
+                            if (replica.getRowCount() > 0 || replica.getDataSize() > 0) {
+                                throw new DdlException("Do not support alter table's storage policy , this table ["
+                                        + olapTable.getName() + "] has storage policy " + tableStoragePolicy
+                                        + ", the table need to be empty.");
+                            }
+                        }
+                    }
+                }
             }
             String currentStoragePolicy = currentAlterOps.getTableStoragePolicy(alterClauses);
             // check currentStoragePolicy resource exist.

--- a/fe/fe-core/src/main/java/org/apache/doris/alter/Alter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/Alter.java
@@ -46,7 +46,6 @@ import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.DataProperty;
 import org.apache.doris.catalog.Database;
 import org.apache.doris.catalog.Env;
-import org.apache.doris.catalog.Index;
 import org.apache.doris.catalog.MysqlTable;
 import org.apache.doris.catalog.OdbcTable;
 import org.apache.doris.catalog.OlapTable;

--- a/regression-test/suites/cold_heat_separation/use_policy/alter_table_add_policy.groovy
+++ b/regression-test/suites/cold_heat_separation/use_policy/alter_table_add_policy.groovy
@@ -83,8 +83,8 @@ suite("add_table_policy_by_alter_table") {
     def alter_table_when_table_has_storage_policy_result = try_sql """
         ALTER TABLE create_table_not_have_policy set ("storage_policy" = "created_create_table_alter_policy");
     """
-    // errCode = 2, detailMessage = Do not support alter table's storage policy , this table [create_table_not_have_policy] has storage policy created_create_table_alter_policy
-    assertEquals(alter_table_when_table_has_storage_policy_result, null);
+    // OK
+    assertEquals(alter_table_when_table_has_storage_policy_result.size(), 1);
 
     if (!storage_exist.call("created_create_table_alter_policy_1")) {
         def create_s3_resource = try_sql """
@@ -113,8 +113,8 @@ suite("add_table_policy_by_alter_table") {
     def cannot_modify_exist_storage_policy_table_result = try_sql """
         ALTER TABLE create_table_not_have_policy set ("storage_policy" = "created_create_table_alter_policy_1");
     """
-    //  errCode = 2, detailMessage = Do not support alter table's storage policy , this table [create_table_not_have_policy] has storage policy created_create_table_alter_policy
-    assertEquals(cannot_modify_exist_storage_policy_table_result, null);
+    // OK
+    assertEquals(cannot_modify_exist_storage_policy_table_result.size(), 1);
 
     // you can change created_create_table_alter_policy's policy cooldown time, cooldown ttl property,
     // by alter storage policy


### PR DESCRIPTION
# Proposed changes

Issue Number: close #14331

## Problem summary

If storage policy need to be change, the table need to be empty, or else the data will be upload to remote, and it will be lost when storage polilcy is changed.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

