### PR TITLE
 [cherry-pick](bitmap)Support return bitmap data in select statem…

### DIFF
--- a/be/src/runtime/result_writer.h
+++ b/be/src/runtime/result_writer.h
@@ -52,6 +52,10 @@ public:
 
     virtual bool output_object_data() const { return _output_object_data; }
 
+    void set_output_object_data(bool output_object_data) {
+        _output_object_data = output_object_data;
+    }
+
     static const std::string NULL_IN_CSV;
     virtual void set_header_info(const std::string& header_type, const std::string& header) {
         _header_type = header_type;

--- a/be/src/vec/columns/column.h
+++ b/be/src/vec/columns/column.h
@@ -527,6 +527,8 @@ public:
 
     virtual bool is_bitmap() const { return false; }
 
+    virtual bool is_hll() const { return false; }
+
     // true if column has null element
     virtual bool has_null() const { return false; }
 

--- a/be/src/vec/columns/column_complex.h
+++ b/be/src/vec/columns/column_complex.h
@@ -47,6 +47,7 @@ public:
     bool is_numeric() const override { return false; }
 
     bool is_bitmap() const override { return std::is_same_v<T, BitmapValue>; }
+    bool is_hll() const override { return std::is_same_v<T, HyperLogLog>; }
 
     size_t size() const override { return data.size(); }
 

--- a/be/src/vec/columns/column_nullable.h
+++ b/be/src/vec/columns/column_nullable.h
@@ -214,6 +214,7 @@ public:
 
     bool is_nullable() const override { return true; }
     bool is_bitmap() const override { return get_nested_column().is_bitmap(); }
+    bool is_hll() const override { return get_nested_column().is_hll(); }
     bool is_column_decimal() const override { return get_nested_column().is_column_decimal(); }
     bool is_column_string() const override { return get_nested_column().is_column_string(); }
     bool is_column_array() const override { return get_nested_column().is_column_array(); }

--- a/be/src/vec/exec/format/parquet/vparquet_column_reader.h
+++ b/be/src/vec/exec/format/parquet/vparquet_column_reader.h
@@ -107,8 +107,7 @@ public:
     virtual Status read_column_data(ColumnPtr& doris_column, DataTypePtr& type,
                                     ColumnSelectVector& select_vector, size_t batch_size,
                                     size_t* read_rows, bool* eof) = 0;
-    static Status create(FileReader* file, FieldSchema* field,
-                         const tparquet::RowGroup& row_group,
+    static Status create(FileReader* file, FieldSchema* field, const tparquet::RowGroup& row_group,
                          const std::vector<RowRange>& row_ranges, cctz::time_zone* ctz,
                          std::unique_ptr<ParquetColumnReader>& reader, size_t max_buf_size);
     void init_column_metadata(const tparquet::ColumnChunk& chunk);

--- a/regression-test/suites/query_p1/return_binaray/test_return_binaray_hll.groovy
+++ b/regression-test/suites/query_p1/return_binaray/test_return_binaray_hll.groovy
@@ -1,0 +1,50 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_return_binary_hll") {
+    def tableName="test_return_binary_hll"
+    sql "drop table if exists ${tableName};"
+
+    sql """
+    CREATE TABLE `${tableName}` (
+        `dt` int(11) NULL,
+        `page` varchar(10) NULL,
+        `user_id` hll HLL_UNION NULL
+        ) ENGINE=OLAP
+        AGGREGATE KEY(`dt`, `page`)
+        COMMENT 'OLAP'
+        DISTRIBUTED BY HASH(`dt`) BUCKETS 1
+        PROPERTIES (
+        "replication_allocation" = "tag.location.default: 1",
+        "in_memory" = "false",
+        "storage_format" = "V2",
+        "disable_auto_compaction" = "false"
+        );
+    """
+    sql """
+        insert into ${tableName} values(1,1,hll_hash(1)),(1,1,hll_hash(2)),(1,1,hll_hash(3)),(1,1,hll_hash(23332));
+    """
+    sql "set enable_vectorized_engine=true;"
+    sql "set return_object_data_as_binary=false;"
+    def result1 = sql "select * from ${tableName}"
+    assertTrue(result1[0][2]==null);
+
+    sql "set enable_vectorized_engine=true;"
+    sql "set return_object_data_as_binary=true;"
+    def result2 = sql "select * from ${tableName}"
+    assertTrue(result2[0][2]!=null);
+}

--- a/regression-test/suites/query_p1/return_binaray/test_return_binary_bitmap.groovy
+++ b/regression-test/suites/query_p1/return_binaray/test_return_binary_bitmap.groovy
@@ -1,0 +1,50 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_return_binary_bitmap") {
+    def tableName="test_return_binary_bitmap"
+    sql "drop table if exists ${tableName};"
+
+    sql """
+    CREATE TABLE `${tableName}` (
+        `dt` int(11) NULL,
+        `page` varchar(10) NULL,
+        `user_id` bitmap BITMAP_UNION NULL
+        ) ENGINE=OLAP
+        AGGREGATE KEY(`dt`, `page`)
+        COMMENT 'OLAP'
+        DISTRIBUTED BY HASH(`dt`) BUCKETS 1
+        PROPERTIES (
+        "replication_allocation" = "tag.location.default: 1",
+        "in_memory" = "false",
+        "storage_format" = "V2",
+        "disable_auto_compaction" = "false"
+        );
+    """
+    sql """
+        insert into ${tableName} values(1,1,to_bitmap(1)),(1,1,to_bitmap(2)),(1,1,to_bitmap(3)),(1,1,to_bitmap(23332));
+    """
+    sql "set enable_vectorized_engine=true;"
+    sql "set return_object_data_as_binary=false;"
+    def result1 = sql "select * from ${tableName}"
+    assertTrue(result1[0][2]==null);
+
+    sql "set enable_vectorized_engine=true;"
+    sql "set return_object_data_as_binary=true;"
+    def result2 = sql "select * from ${tableName}"
+    assertTrue(result2[0][2]!=null);
+}


### PR DESCRIPTION
…ent in vectorization (#15224)

Support return bitmap data in select statement in vectorization mode

In the scenario of using Bitmap to circle people, users need to return the Bitmap results to the upper layer, which is parsing the contents of the Bitmap to deal with high QPS query scenarios

# Proposed changes

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

