### PR TITLE
[Bug](function) forbid hll_union input not hll type param

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/FunctionCallExpr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/FunctionCallExpr.java
@@ -815,12 +815,13 @@ public class FunctionCallExpr extends Expr {
             }
         }
 
-        if ((fnName.getFunction().equalsIgnoreCase(FunctionSet.HLL_UNION_AGG)
-                || fnName.getFunction().equalsIgnoreCase(FunctionSet.HLL_CARDINALITY)
-                || fnName.getFunction().equalsIgnoreCase(FunctionSet.HLL_RAW_AGG))
+        if ((fnName.getFunction().equalsIgnoreCase("HLL_UNION_AGG")
+                || fnName.getFunction().equalsIgnoreCase("HLL_CARDINALITY")
+                || fnName.getFunction().equalsIgnoreCase("HLL_RAW_AGG")
+                || fnName.getFunction().equalsIgnoreCase("HLL_UNION"))
                 && !arg.type.isHllType()) {
             throw new AnalysisException(
-                    "HLL_UNION_AGG, HLL_RAW_AGG and HLL_CARDINALITY's params must be hll column");
+                    "HLL_UNION, HLL_UNION_AGG, HLL_RAW_AGG and HLL_CARDINALITY's params must be hll column");
         }
 
         if (fnName.getFunction().equalsIgnoreCase("min")
@@ -829,7 +830,7 @@ public class FunctionCallExpr extends Expr {
         } else if (fnName.getFunction().equalsIgnoreCase("DISTINCT_PC")
                 || fnName.getFunction().equalsIgnoreCase("DISTINCT_PCSA")
                 || fnName.getFunction().equalsIgnoreCase("NDV")
-                || fnName.getFunction().equalsIgnoreCase(FunctionSet.HLL_UNION_AGG)) {
+                || fnName.getFunction().equalsIgnoreCase("HLL_UNION_AGG")) {
             fnParams.setIsDistinct(false);
         }
 


### PR DESCRIPTION
# Proposed changes
```sql
select hll_union(`a`) from regression_test_index_p0.test_decimal_bitmap_index_multi_page;
```

hll_union will code dump when input decimal.

```cpp
start time: Tue Dec 27 14:44:38 CST 2022
=================================================================
==2319700==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x7f5b925ff010 at pc 0x55a5e28b579b bp 0x7f5dfc68afd0 sp 0x7f5dfc68afc8
READ of size 4 at 0x7f5b925ff010 thread T346 (FragmentMgrThre)
    #0 0x55a5e28b579a in doris::HyperLogLog::merge(doris::HyperLogLog const&) /mnt/disk1/xiaolei/incubator-doris/be/src/olap/hll.cpp:80:15
    #1 0x55a5e63a196c in doris::vectorized::AggregateFunctionHLLData<false>::add(doris::vectorized::IColumn const*, unsigned long) /mnt/disk1/xiaolei/incubator-doris/be/src/vec/aggregate_functions/aggregate_function_hll_union_agg.h:70:21
    #2 0x55a5e63a949e in doris::vectorized::AggregateFunctionHLLUnion<doris::vectorized::AggregateFunctionHLLUnionImpl<doris::vectorized::AggregateFunctionHLLData<false>>>::add(char*, doris::vectorized::IColumn const**, unsigned long, doris::vectorized::Arena*) const /mnt/disk1/xiaolei/incubator-doris/be/src/vec/aggregate_functions/aggregate_function_hll_union_agg.h:115:27
    #3 0x55a5e63aafef in doris::vectorized::IAggregateFunctionHelper<doris::vectorized::AggregateFunctionHLLUnion<doris::vectorized::AggregateFunctionHLLUnionImpl<doris::vectorized::AggregateFunctionHLLData<false>>>>::add_batch_single_place(unsigned long, char*, doris::vectorized::IColumn const**, doris::vectorized::Arena*) const /mnt/disk1/xiaolei/incubator-doris/be/src/vec/aggregate_functions/aggregate_function.h:266:48
    #4 0x55a5eaef8b4f in doris::vectorized::AggFnEvaluator::execute_single_add(doris::vectorized::Block*, char*, doris::vectorized::Arena*) /mnt/disk1/xiaolei/incubator-doris/be/src/vec/exprs/vectorized_agg_fn.cpp:159:16
    #5 0x55a5e7431fd0 in doris::vectorized::AggregationNode::_execute_without_key(doris::vectorized::Block*) /mnt/disk1/xiaolei/incubator-doris/be/src/vec/exec/vaggregation_node.cpp:720:35
    #6 0x55a5e763c4ee in doris::Status std::__invoke_impl<doris::Status, doris::Status (doris::vectorized::AggregationNode::*&)(doris::vectorized::Block*), doris::vectorized::AggregationNode*&, doris::vectorized::Block*>(std::__invoke_memfun_deref, doris::Status (doris::vectorized::AggregationNode::*&)(doris::vectorized::Block*), doris::vectorized::AggregationNode*&, doris::vectorized::Block*&&) /mnt/disk1/xiaolei/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:74:14
    #7 0x55a5e763c32f in std::enable_if<is_invocable_r_v<doris::Status, doris::Status (doris::vectorized::AggregationNode::*&)(doris::vectorized::Block*), doris::vectorized::AggregationNode*&, doris::vectorized::Block*>, doris::Status>::type std::__invoke_r<doris::Status, doris::Status (doris::vectorized::AggregationNode::*&)(doris::vectorized::Block*), doris::vectorized::AggregationNode*&, doris::vectorized::Block*>(doris::Status (doris::vectorized::AggregationNode::*&)(doris::vectorized::Block*), doris::vectorized::AggregationNode*&, doris::vectorized::Block*&&) /mnt/disk1/xiaolei/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:114:9
    #8 0x55a5e763c268 in doris::Status std::_Bind_result<doris::Status, doris::Status (doris::vectorized::AggregationNode::* (doris::vectorized::AggregationNode*, std::_Placeholder<1>))(doris::vectorized::Block*)>::__call<doris::Status, doris::vectorized::Block*&&, 0ul, 1ul>(std::tuple<doris::vectorized::Block*&&>&&, std::_Index_tuple<0ul, 1ul>) /mnt/disk1/xiaolei/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/functional:570:11
    #9 0x55a5e763c0bc in doris::Status std::_Bind_result<doris::Status, doris::Status (doris::vectorized::AggregationNode::* (doris::vectorized::AggregationNode*, std::_Placeholder<1>))(doris::vectorized::Block*)>::operator()<doris::vectorized::Block*>(doris::vectorized::Block*&&) /mnt/disk1/xiaolei/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/functional:629:17
    #10 0x55a5e763bfa7 in doris::Status std::__invoke_impl<doris::Status, std::_Bind_result<doris::Status, doris::Status (doris::vectorized::AggregationNode::* (doris::vectorized::AggregationNode*, std::_Placeholder<1>))(doris::vectorized::Block*)>&, doris::vectorized::Block*>(std::__invoke_other, std::_Bind_result<doris::Status, doris::Status (doris::vectorized::AggregationNode::* (doris::vectorized::AggregationNode*, std::_Placeholder<1>))(doris::vectorized::Block*)>&, doris::vectorized::Block*&&) /mnt/disk1/xiaolei/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61:14
    #11 0x55a5e763bf27 in std::enable_if<is_invocable_r_v<doris::Status, std::_Bind_result<doris::Status, doris::Status (doris::vectorized::AggregationNode::* (doris::vectorized::AggregationNode*, std::_Placeholder<1>))(doris::vectorized::Block*)>&, doris::vectorized::Block*>, doris::Status>::type std::__invoke_r<doris::Status, std::_Bind_result<doris::Status, doris::Status (doris::vectorized::AggregationNode::* (doris::vectorized::AggregationNode*, std::_Placeholder<1>))(doris::vectorized::Block*)>&, doris::vectorized::Block*>(std::_Bind_result<doris::Status, doris::Status (doris::vectorized::AggregationNode::* (doris::vectorized::AggregationNode*, std::_Placeholder<1>))(doris::vectorized::Block*)>&, doris::vectorized::Block*&&) /mnt/disk1/xiaolei/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:114:9
    #12 0x55a5e763bd77 in std::_Function_handler<doris::Status (doris::vectorized::Block*), std::_Bind_result<doris::Status, doris::Status (doris::vectorized::AggregationNode::* (doris::vectorized::AggregationNode*, std::_Placeholder<1>))(doris::vectorized::Block*)>>::_M_invoke(std::_Any_data const&, doris::vectorized::Block*&&) /mnt/disk1/xiaolei/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291:9
    #13 0x55a5e75ae313 in std::function<doris::Status (doris::vectorized::Block*)>::operator()(doris::vectorized::Block*) const /mnt/disk1/xiaolei/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:560:9
    #14 0x55a5e743ca66 in doris::vectorized::AggregationNode::sink(doris::RuntimeState*, doris::vectorized::Block*, bool) /mnt/disk1/xiaolei/incubator-doris/be/src/vec/exec/vaggregation_node.cpp:567:9
    #15 0x55a5e743c59e in doris::vectorized::AggregationNode::open(doris::RuntimeState*) /mnt/disk1/xiaolei/incubator-doris/be/src/vec/exec/vaggregation_node.cpp:501:9
    #16 0x55a5e40634a0 in doris::PlanFragmentExecutor::open_vectorized_internal() /mnt/disk1/xiaolei/incubator-doris/be/src/runtime/plan_fragment_executor.cpp:272:9
    #17 0x55a5e4060c0e in doris::PlanFragmentExecutor::open() /mnt/disk1/xiaolei/incubator-doris/be/src/runtime/plan_fragment_executor.cpp:244:18
    #18 0x55a5e3fd0bd4 in doris::FragmentExecState::execute() /mnt/disk1/xiaolei/incubator-doris/be/src/runtime/fragment_mgr.cpp:250:9
    #19 0x55a5e3fd5496 in doris::FragmentMgr::_exec_actual(std::shared_ptr<doris::FragmentExecState>, std::function<void (doris::RuntimeState*, doris::Status*)>) /mnt/disk1/xiaolei/incubator-doris/be/src/runtime/fragment_mgr.cpp:490:17
    #20 0x55a5e3fea6fb in doris::FragmentMgr::exec_plan_fragment(doris::TExecPlanFragmentParams const&, std::function<void (doris::RuntimeState*, doris::Status*)>)::$_3::operator()() const /mnt/disk1/xiaolei/incubator-doris/be/src/runtime/fragment_mgr.cpp:724:21
    #21 0x55a5e3fea584 in void std::__invoke_impl<void, doris::FragmentMgr::exec_plan_fragment(doris::TExecPlanFragmentParams const&, std::function<void (doris::RuntimeState*, doris::Status*)>)::$_3&>(std::__invoke_other, doris::FragmentMgr::exec_plan_fragment(doris::TExecPlanFragmentParams const&, std::function<void (doris::RuntimeState*, doris::Status*)>)::$_3&) /mnt/disk1/xiaolei/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61:14
    #22 0x55a5e3fea524 in std::enable_if<is_invocable_r_v<void, doris::FragmentMgr::exec_plan_fragment(doris::TExecPlanFragmentParams const&, std::function<void (doris::RuntimeState*, doris::Status*)>)::$_3&>, void>::type std::__invoke_r<void, doris::FragmentMgr::exec_plan_fragment(doris::TExecPlanFragmentParams const&, std::function<void (doris::RuntimeState*, doris::Status*)>)::$_3&>(doris::FragmentMgr::exec_plan_fragment(doris::TExecPlanFragmentParams const&, std::function<void (doris::RuntimeState*, doris::Status*)>)::$_3&) /mnt/disk1/xiaolei/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:111:2
    #23 0x55a5e3fea2dc in std::_Function_handler<void (), doris::FragmentMgr::exec_plan_fragment(doris::TExecPlanFragmentParams const&, std::function<void (doris::RuntimeState*, doris::Status*)>)::$_3>::_M_invoke(std::_Any_data const&) /mnt/disk1/xiaolei/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291:9
    #24 0x55a5e3e2ac82 in std::function<void ()>::operator()() const /mnt/disk1/xiaolei/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:560:9
    #25 0x55a5e47631a8 in doris::FunctionRunnable::run() /mnt/disk1/xiaolei/incubator-doris/be/src/util/threadpool.cpp:46:27
    #26 0x55a5e474fe0b in doris::ThreadPool::dispatch_thread() /mnt/disk1/xiaolei/incubator-doris/be/src/util/threadpool.cpp:535:24
    #27 0x55a5e4776af3 in void std::__invoke_impl<void, void (doris::ThreadPool::*&)(), doris::ThreadPool*&>(std::__invoke_memfun_deref, void (doris::ThreadPool::*&)(), doris::ThreadPool*&) /mnt/disk1/xiaolei/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:74:14
    #28 0x55a5e47769cc in std::__invoke_result<void (doris::ThreadPool::*&)(), doris::ThreadPool*&>::type std::__invoke<void (doris::ThreadPool::*&)(), doris::ThreadPool*&>(void (doris::ThreadPool::*&)(), doris::ThreadPool*&) /mnt/disk1/xiaolei/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:96:14
    #29 0x55a5e4776954 in void std::_Bind<void (doris::ThreadPool::* (doris::ThreadPool*))()>::__call<void, 0ul>(std::tuple<>&&, std::_Index_tuple<0ul>) /mnt/disk1/xiaolei/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/functional:420:11
    #30 0x55a5e47767fd in void std::_Bind<void (doris::ThreadPool::* (doris::ThreadPool*))()>::operator()<void>() /mnt/disk1/xiaolei/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/functional:503:17
    #31 0x55a5e4776714 in void std::__invoke_impl<void, std::_Bind<void (doris::ThreadPool::* (doris::ThreadPool*))()>&>(std::__invoke_other, std::_Bind<void (doris::ThreadPool::* (doris::ThreadPool*))()>&) /mnt/disk1/xiaolei/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61:14
    #32 0x55a5e47766b4 in std::enable_if<is_invocable_r_v<void, std::_Bind<void (doris::ThreadPool::* (doris::ThreadPool*))()>&>, void>::type std::__invoke_r<void, std::_Bind<void (doris::ThreadPool::* (doris::ThreadPool*))()>&>(std::_Bind<void (doris::ThreadPool::* (doris::ThreadPool*))()>&) /mnt/disk1/xiaolei/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:111:2
    #33 0x55a5e477635c in std::_Function_handler<void (), std::_Bind<void (doris::ThreadPool::* (doris::ThreadPool*))()>>::_M_invoke(std::_Any_data const&) /mnt/disk1/xiaolei/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291:9
    #34 0x55a5e3e2ac82 in std::function<void ()>::operator()() const /mnt/disk1/xiaolei/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:560:9
    #35 0x55a5e47285ae in doris::Thread::supervise_thread(void*) /mnt/disk1/xiaolei/incubator-doris/be/src/util/thread.cpp:454:5
    #36 0x7f5f9a976179 in start_thread pthread_create.c
    #37 0x7f5f9b210df2 in clone (/lib64/libc.so.6+0xfcdf2) (BuildId: 20ee73ce1b6ac38a52440bab82ec7e28f0f5c5b9)

0x7f5b925ff010 is located 6128 bytes to the left of 393216-byte region [0x7f5b92600800,0x7f5b92660800)
allocated by thread T120 (_scanner_scan) here:
    #0 0x55a5e20febee in malloc (/mnt/disk1/xiaolei/incubator-doris/output/be/lib/doris_be+0xb82ebee) (BuildId: 12cc664292240b3e)
    #1 0x55a5f40eb5eb in LZ4F_decompress (/mnt/disk1/xiaolei/incubator-doris/output/be/lib/doris_be+0x1d81b5eb) (BuildId: 12cc664292240b3e)

Thread T346 (FragmentMgrThre) created by T0 here:
    #0 0x55a5e20e7a9c in pthread_create (/mnt/disk1/xiaolei/incubator-doris/output/be/lib/doris_be+0xb817a9c) (BuildId: 12cc664292240b3e)
    #1 0x55a5e47275b4 in doris::Thread::start_thread(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, std::function<void ()> const&, unsigned long, scoped_refptr<doris::Thread>*) /mnt/disk1/xiaolei/incubator-doris/be/src/util/thread.cpp:408:15
    #2 0x55a5e4759e1d in doris::Status doris::Thread::create<void (doris::ThreadPool::*)(), doris::ThreadPool*>(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, void (doris::ThreadPool::* const&)(), doris::ThreadPool* const&, scoped_refptr<doris::Thread>*) /mnt/disk1/xiaolei/incubator-doris/be/src/util/thread.h:57:16
    #3 0x55a5e474d5cd in doris::ThreadPool::create_thread() /mnt/disk1/xiaolei/incubator-doris/be/src/util/threadpool.cpp:603:12
    #4 0x55a5e47458bb in doris::ThreadPool::init() /mnt/disk1/xiaolei/incubator-doris/be/src/util/threadpool.cpp:263:25
    #5 0x55a5e4745506 in doris::ThreadPoolBuilder::build(std::unique_ptr<doris::ThreadPool, std::default_delete<doris::ThreadPool>>*) const /mnt/disk1/xiaolei/incubator-doris/be/src/util/threadpool.cpp:78:5
    #6 0x55a5e3fd2ee9 in doris::FragmentMgr::FragmentMgr(doris::ExecEnv*) /mnt/disk1/xiaolei/incubator-doris/be/src/runtime/fragment_mgr.cpp:445:18
    #7 0x55a5e3e067ce in doris::ExecEnv::_init(std::vector<doris::StorePath, std::allocator<doris::StorePath>> const&) /mnt/disk1/xiaolei/incubator-doris/be/src/runtime/exec_env_init.cpp:135:25
    #8 0x55a5e3e04e07 in doris::ExecEnv::init(doris::ExecEnv*, std::vector<doris::StorePath, std::allocator<doris::StorePath>> const&) /mnt/disk1/xiaolei/incubator-doris/be/src/runtime/exec_env_init.cpp:77:17
    #9 0x55a5e213f69f in main /mnt/disk1/xiaolei/incubator-doris/be/src/service/doris_main.cpp:398:5
    #10 0x7f5f9b137492 in __libc_start_main (/lib64/libc.so.6+0x23492) (BuildId: 20ee73ce1b6ac38a52440bab82ec7e28f0f5c5b9)

Thread T120 (_scanner_scan) created by T0 here:
    #0 0x55a5e20e7a9c in pthread_create (/mnt/disk1/xiaolei/incubator-doris/output/be/lib/doris_be+0xb817a9c) (BuildId: 12cc664292240b3e)
    #1 0x55a5e47275b4 in doris::Thread::start_thread(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, std::function<void ()> const&, unsigned long, scoped_refptr<doris::Thread>*) /mnt/disk1/xiaolei/incubator-doris/be/src/util/thread.cpp:408:15
    #2 0x55a5e4759e1d in doris::Status doris::Thread::create<void (doris::ThreadPool::*)(), doris::ThreadPool*>(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, void (doris::ThreadPool::* const&)(), doris::ThreadPool* const&, scoped_refptr<doris::Thread>*) /mnt/disk1/xiaolei/incubator-doris/be/src/util/thread.h:57:16
    #3 0x55a5e474d5cd in doris::ThreadPool::create_thread() /mnt/disk1/xiaolei/incubator-doris/be/src/util/threadpool.cpp:603:12
    #4 0x55a5e47458bb in doris::ThreadPool::init() /mnt/disk1/xiaolei/incubator-doris/be/src/util/threadpool.cpp:263:25
    #5 0x55a5e4745506 in doris::ThreadPoolBuilder::build(std::unique_ptr<doris::ThreadPool, std::default_delete<doris::ThreadPool>>*) const /mnt/disk1/xiaolei/incubator-doris/be/src/util/threadpool.cpp:78:5
    #6 0x55a5e3e06232 in doris::ExecEnv::_init(std::vector<doris::StorePath, std::allocator<doris::StorePath>> const&) /mnt/disk1/xiaolei/incubator-doris/be/src/runtime/exec_env_init.cpp:121:14
    #7 0x55a5e3e04e07 in doris::ExecEnv::init(doris::ExecEnv*, std::vector<doris::StorePath, std::allocator<doris::StorePath>> const&) /mnt/disk1/xiaolei/incubator-doris/be/src/runtime/exec_env_init.cpp:77:17
    #8 0x55a5e213f69f in main /mnt/disk1/xiaolei/incubator-doris/be/src/service/doris_main.cpp:398:5
    #9 0x7f5f9b137492 in __libc_start_main (/lib64/libc.so.6+0x23492) (BuildId: 20ee73ce1b6ac38a52440bab82ec7e28f0f5c5b9)

SUMMARY: AddressSanitizer: heap-buffer-overflow /mnt/disk1/xiaolei/incubator-doris/be/src/olap/hll.cpp:80:15 in doris::HyperLogLog::merge(doris::HyperLogLog const&)
Shadow bytes around the buggy address:
  0x0febf24b7db0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0febf24b7dc0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0febf24b7dd0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0febf24b7de0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0febf24b7df0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
=>0x0febf24b7e00: fa fa[fa]fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0febf24b7e10: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0febf24b7e20: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0febf24b7e30: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0febf24b7e40: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0febf24b7e50: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==2319700==ABORTING
start time: Tue Dec 27 14:50:11 CST 2022

```
## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

