### PR TITLE
[fix](multi catalog)Set column defualt value for query.

### DIFF
--- a/be/src/vec/exec/scan/vfile_scanner.cpp
+++ b/be/src/vec/exec/scan/vfile_scanner.cpp
@@ -655,8 +655,27 @@ Status VFileScanner::_init_expr_ctxes() {
         }
     }
 
+    // set column name to default value expr map
+    for (auto slot_desc : _real_tuple_desc->slots()) {
+        if (!slot_desc->is_materialized()) {
+            continue;
+        }
+        vectorized::VExprContext* ctx = nullptr;
+        auto it = _params.default_value_of_src_slot.find(slot_desc->id());
+        if (it != std::end(_params.default_value_of_src_slot)) {
+            if (!it->second.nodes.empty()) {
+                RETURN_IF_ERROR(
+                        vectorized::VExpr::create_expr_tree(_state->obj_pool(), it->second, &ctx));
+                RETURN_IF_ERROR(ctx->prepare(_state, *_default_val_row_desc));
+                RETURN_IF_ERROR(ctx->open(_state));
+            }
+            // if expr is empty, the default value will be null
+            _col_default_value_ctx.emplace(slot_desc->col_name(), ctx);
+        }
+    }
+
     if (_is_load) {
-        // follow desc expr map and src default value expr map is only for load task.
+        // follow desc expr map is only for load task.
         bool has_slot_id_map = _params.__isset.dest_sid_to_src_sid_without_trans;
         int idx = 0;
         for (auto slot_desc : _output_tuple_desc->slots()) {
@@ -693,24 +712,6 @@ Status VFileScanner::_init_expr_ctxes() {
                                                          full_src_index_map[_src_slot_it->first]);
                     _src_slot_descs_order_by_dest.emplace_back(_src_slot_it->second);
                 }
-            }
-        }
-
-        for (auto slot_desc : _real_tuple_desc->slots()) {
-            if (!slot_desc->is_materialized()) {
-                continue;
-            }
-            vectorized::VExprContext* ctx = nullptr;
-            auto it = _params.default_value_of_src_slot.find(slot_desc->id());
-            if (it != std::end(_params.default_value_of_src_slot)) {
-                if (!it->second.nodes.empty()) {
-                    RETURN_IF_ERROR(vectorized::VExpr::create_expr_tree(_state->obj_pool(),
-                                                                        it->second, &ctx));
-                    RETURN_IF_ERROR(ctx->prepare(_state, *_default_val_row_desc));
-                    RETURN_IF_ERROR(ctx->open(_state));
-                }
-                // if expr is empty, the default value will be null
-                _col_default_value_ctx.emplace(slot_desc->col_name(), ctx);
             }
         }
     }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

Current column default value is used only for load task. But in the case of Iceberg schema change, query task is also possible to read the default value for columns not exist in old schema. This pr is to support default value for query task.

Manually tested the broker load and external emr regression cases.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

