### PR TITLE
[fix](Nereids) Generate is missing on alias query

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/LogicalPlanBuilder.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/LogicalPlanBuilder.java
@@ -450,7 +450,11 @@ public class LogicalPlanBuilder extends DorisParserBaseVisitor<Object> {
 
     @Override
     public LogicalPlan visitAliasedQuery(AliasedQueryContext ctx) {
-        return withTableAlias(visitQuery(ctx.query()), ctx.tableAlias());
+        LogicalPlan plan = withTableAlias(visitQuery(ctx.query()), ctx.tableAlias());
+        for (LateralViewContext lateralViewContext : ctx.lateralView()) {
+            plan = withGenerate(plan, lateralViewContext);
+        }
+        return plan;
     }
 
     @Override

--- a/regression-test/data/nereids_syntax_p0/lateral_view.out
+++ b/regression-test/data/nereids_syntax_p0/lateral_view.out
@@ -89,3 +89,37 @@
 3	1	["abc", "def"]	valid
 3	2	["abc", "def"]	valid
 
+-- !alias_query --
+0	1	["abc", "def"]	[1.1,2.2]
+0	1	["abc", "def"]	[1.1,2.2]
+0	2	["abc", "def"]	[1.1,2.2]
+0	2	["abc", "def"]	[1.1,2.2]
+0	1	["abc", "def"]	[1.1,2.2]
+0	1	["abc", "def"]	[1.1,2.2]
+0	2	["abc", "def"]	[1.1,2.2]
+0	2	["abc", "def"]	[1.1,2.2]
+0	1	valid	[1.1,2.2]
+0	1	valid	[1.1,2.2]
+0	2	valid	[1.1,2.2]
+0	2	valid	[1.1,2.2]
+1	1	valid	[1.1,2.2]
+1	1	valid	[1.1,2.2]
+1	2	valid	[1.1,2.2]
+1	2	valid	[1.1,2.2]
+0	1	["abc", "def"]	valid
+0	2	["abc", "def"]	valid
+0	1	["abc", "def"]	valid
+0	2	["abc", "def"]	valid
+1	1	["abc", "def"]	valid
+1	2	["abc", "def"]	valid
+1	1	["abc", "def"]	valid
+1	2	["abc", "def"]	valid
+2	1	["abc", "def"]	valid
+2	2	["abc", "def"]	valid
+2	1	["abc", "def"]	valid
+2	2	["abc", "def"]	valid
+3	1	["abc", "def"]	valid
+3	2	["abc", "def"]	valid
+3	1	["abc", "def"]	valid
+3	2	["abc", "def"]	valid
+

--- a/regression-test/suites/nereids_syntax_p0/lateral_view.groovy
+++ b/regression-test/suites/nereids_syntax_p0/lateral_view.groovy
@@ -63,4 +63,12 @@ suite("nereids_lateral_view") {
           LATERAL VIEW explode_json_array_int(c3) lv3 AS clv3
           LATERAL VIEW explode_json_array_double_outer(c4) lv4 AS clv4
     """
+
+    qt_alias_query """
+        SELECT clv1, clv3, c2, c4 FROM (SELECT * FROM nlv_test) tmp
+          LATERAL VIEW explode_numbers(c1) lv1 AS clv1
+          LATERAL VIEW explode_json_array_string_outer(c2) lv2 AS clv2
+          LATERAL VIEW explode_json_array_int(c3) lv3 AS clv3
+          LATERAL VIEW explode_json_array_double_outer(c4) lv4 AS clv4
+    """
 }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

support syntax as:
```sql
SELECT * FROM (SELECT * FROM tbl) tmp LATERAL VIEW explode(c1) gtmp AS ce;
```

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

