### PR TITLE
[fix](new file reader) system_properties forgot to init broker_addresses

### DIFF
--- a/be/src/vec/exec/format/csv/csv_reader.cpp
+++ b/be/src/vec/exec/format/csv/csv_reader.cpp
@@ -109,6 +109,7 @@ Status CsvReader::init_reader(bool is_load) {
     system_properties.system_type = _params.file_type;
     system_properties.properties = _params.properties;
     system_properties.hdfs_params = _params.hdfs_params;
+    system_properties.broker_addresses = _params.broker_addresses;
 
     FileDescription file_description;
     file_description.path = _range.path;

--- a/be/src/vec/exec/format/json/new_json_reader.cpp
+++ b/be/src/vec/exec/format/json/new_json_reader.cpp
@@ -291,6 +291,7 @@ Status NewJsonReader::_open_file_reader() {
     system_properties.system_type = _params.file_type;
     system_properties.properties = _params.properties;
     system_properties.hdfs_params = _params.hdfs_params;
+    system_properties.broker_addresses = _params.broker_addresses;
 
     FileDescription file_description;
     file_description.path = _range.path;

--- a/be/src/vec/exec/format/orc/vorc_reader.cpp
+++ b/be/src/vec/exec/format/orc/vorc_reader.cpp
@@ -143,6 +143,7 @@ Status OrcReader::init_reader(
         system_properties.system_type = _scan_params.file_type;
         system_properties.properties = _scan_params.properties;
         system_properties.hdfs_params = _scan_params.hdfs_params;
+        system_properties.broker_addresses = _scan_params.broker_addresses;
 
         FileDescription file_description;
         file_description.path = _scan_range.path;

--- a/be/src/vec/exec/format/parquet/vparquet_reader.cpp
+++ b/be/src/vec/exec/format/parquet/vparquet_reader.cpp
@@ -140,6 +140,7 @@ Status ParquetReader::_open_file() {
     system_properties.system_type = _scan_params.file_type;
     system_properties.properties = _scan_params.properties;
     system_properties.hdfs_params = _scan_params.hdfs_params;
+    system_properties.broker_addresses = _scan_params.broker_addresses;
 
     FileDescription file_description;
     file_description.path = _scan_range.path;


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

This bug would cause be core while broker load.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

