### PR TITLE
[fix](brokerload) fix broker load parquet format file finished but no data actually

### DIFF
--- a/be/src/io/file_factory.cpp
+++ b/be/src/io/file_factory.cpp
@@ -170,7 +170,7 @@ Status FileFactory::create_file_reader(RuntimeProfile* /*profile*/,
     }
     case TFileType::FILE_BROKER: {
         RETURN_IF_ERROR(create_broker_reader(system_properties.broker_addresses[0],
-                                             system_properties.properties, file_description.path,
+                                             system_properties.properties, file_description,
                                              &file_system_ptr, file_reader));
         break;
     }
@@ -232,12 +232,12 @@ Status FileFactory::create_s3_reader(const std::map<std::string, std::string>& p
 
 Status FileFactory::create_broker_reader(const TNetworkAddress& broker_addr,
                                          const std::map<std::string, std::string>& prop,
-                                         const std::string& path,
+                                         const FileDescription& file_description,
                                          io::FileSystem** broker_file_system,
                                          io::FileReaderSPtr* reader) {
-    *broker_file_system = new io::BrokerFileSystem(broker_addr, prop);
+    *broker_file_system = new io::BrokerFileSystem(broker_addr, prop, file_description.file_size);
     RETURN_IF_ERROR((dynamic_cast<io::BrokerFileSystem*>(*broker_file_system))->connect());
-    RETURN_IF_ERROR((*broker_file_system)->open_file(path, reader));
+    RETURN_IF_ERROR((*broker_file_system)->open_file(file_description.path, reader));
     return Status::OK();
 }
 } // namespace doris

--- a/be/src/io/file_factory.h
+++ b/be/src/io/file_factory.h
@@ -95,7 +95,8 @@ public:
 
     static Status create_broker_reader(const TNetworkAddress& broker_addr,
                                        const std::map<std::string, std::string>& prop,
-                                       const std::string& path, io::FileSystem** hdfs_file_system,
+                                       const FileDescription& file_description,
+                                       io::FileSystem** hdfs_file_system,
                                        io::FileReaderSPtr* reader);
 
     static TFileType::type convert_storage_type(TStorageBackendType::type type) {

--- a/be/src/io/fs/broker_file_system.h
+++ b/be/src/io/fs/broker_file_system.h
@@ -25,7 +25,8 @@ namespace io {
 class BrokerFileSystem final : public RemoteFileSystem {
 public:
     BrokerFileSystem(const TNetworkAddress& broker_addr,
-                     const std::map<std::string, std::string>& broker_prop);
+                     const std::map<std::string, std::string>& broker_prop, size_t file_size);
+
     ~BrokerFileSystem() override = default;
 
     Status create_file(const Path& /*path*/, FileWriterPtr* /*writer*/) override {
@@ -67,6 +68,7 @@ public:
 private:
     const TNetworkAddress& _broker_addr;
     const std::map<std::string, std::string>& _broker_prop;
+    size_t _file_size;
 
     std::shared_ptr<BrokerServiceConnection> _client;
 };


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

affects master, introduced by #15175

## Problem summary

broker `openReader` interface cannot get the file size, resulting in the file size being incorrectly set to 0

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

