### PR TITLE
[improvement](string) set bigger limit for ColumnString chars length

### DIFF
--- a/be/src/vec/columns/column_string.h
+++ b/be/src/vec/columns/column_string.h
@@ -44,7 +44,7 @@ public:
 private:
     // currently Offsets is uint32, if chars.size() exceeds 4G, offset will overflow.
     // limit chars.size() and check the size when inserting data into ColumnString.
-    static constexpr size_t MAX_STRING_SIZE = 1024 * 1024 * 1024;
+    static constexpr size_t MAX_STRING_SIZE = 0xffffffff;
 
     friend class COWHelper<IColumn, ColumnString>;
     friend class OlapBlockDataConvertor;
@@ -63,7 +63,7 @@ private:
 
     void ALWAYS_INLINE check_chars_length(size_t length) const {
         if (UNLIKELY(length > MAX_STRING_SIZE)) {
-            LOG(FATAL) << "string column length is too large.";
+            LOG(FATAL) << "string column length is too large: " << length;
         }
     }
 


### PR DESCRIPTION
# Proposed changes

Issue Number: related to #15360

## Problem summary

Some test cases will exceed the old 1G limit for ColumnString chars length, set a larger limt.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

