### PR TITLE
[fix] Memory leaks when compaction fails

### DIFF
--- a/be/src/olap/collect_iterator.cpp
+++ b/be/src/olap/collect_iterator.cpp
@@ -385,6 +385,7 @@ inline OLAPStatus CollectIterator::Level1Iterator::_merge_next(const RowCursor**
             return OLAP_ERR_DATA_EOF;
         }
     } else {
+        delete _cur_child;
         _cur_child = nullptr;
         LOG(WARNING) << "failed to get next from child, res=" << res;
         return res;


### PR DESCRIPTION
# Proposed changes

Issue Number: close #15427 

## Problem summary

```cpp
340 OLAPStatus CollectIterator::Level1Iterator::init() {
341     if (_children.empty()) {
342         return OLAP_SUCCESS;
343     }
344
345     // Only when there are multiple children that need to be merged
346     if (_merge && _children.size() > 1) {
347         std::shared_ptr<LevelIteratorComparator> cmp;
348         if (_sort_type == SortType::ZORDER) {
349             cmp = std::make_shared<LevelZorderIteratorComparator>(_reverse, _sequence_id_idx,  _sort_col_num);
350         } else {
351             cmp = std::make_shared<LevelIteratorComparator>(_reverse, _sequence_id_idx);
352         }
353         BaseComparator bcmp(cmp);
354         _heap.reset(new MergeHeap(bcmp));
355         for (auto child : _children) {
356             DCHECK(child != nullptr);
357             DCHECK(child->current_row() != nullptr);
358             _heap->push(child);
359         }
360         _cur_child = _heap->top();
361         // Clear _children earlier to release any related references
362         _children.clear();
363     } else {
364         _merge = false;
365         _heap.reset(nullptr);
366         _cur_child = *(_children.begin());
367     }
368     return OLAP_SUCCESS;
369 }
```

In function `CollectIterator::Level1Iterator::init`, `_children` are pushed into `_heap` and cleared in line 362 which means that the ownership of `_children` belongs to `_heap`.

```cpp
371 inline OLAPStatus CollectIterator::Level1Iterator::_merge_next(const RowCursor** row,
372                                                                bool* delete_flag) {
373     _heap->pop();
374     auto res = _cur_child->next(row, delete_flag);
375     if (LIKELY(res == OLAP_SUCCESS)) {
376         _heap->push(_cur_child);
377         _cur_child = _heap->top();
378     } else if (res == OLAP_ERR_DATA_EOF) {
379         // current child has been read, to read next
380         delete _cur_child;
381         if (!_heap->empty()) {
382             _cur_child = _heap->top();
383         } else {
384             _cur_child = nullptr;
385             return OLAP_ERR_DATA_EOF;
386         }
387     } else {
388         _cur_child = nullptr;
389         LOG(WARNING) << "failed to get next from child, res=" << res;
390         return res;
391     }
392
393     if (_cur_child->need_skip()) {
394         (*_merged_rows)++;
395         _cur_child->set_need_skip(false);
396         return _merge_next(row, delete_flag);
397     }
398     *row = _cur_child->current_row(delete_flag);
399     return OLAP_SUCCESS;
400 }
```

In `CollectIterator::Level1Iterator::_merge_next`, `_heap` pops the top element first and `_cur_child` references to the top. If we entered the branch line 388 (failed to call next before), we didn't free the memory of `_cur_child` which causes the issue with memory leak.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

