### PR TITLE
[fix](pipeline) disable sharing hashtable for broadcast join for pipeline engine

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -1340,7 +1340,10 @@ public class SessionVariable implements Serializable, Writable {
         tResult.setEnablePipelineEngine(enablePipelineEngine);
         tResult.setReturnObjectDataAsBinary(returnObjectDataAsBinary);
         tResult.setTrimTailingSpacesForExternalTableQuery(trimTailingSpacesForExternalTableQuery);
-        tResult.setEnableShareHashTableForBroadcastJoin(enableShareHashTableForBroadcastJoin);
+
+        // TODO: enable share hashtable for broadcast after switching completely to pipeline engine.
+        tResult.setEnableShareHashTableForBroadcastJoin(
+                enablePipelineEngine ? false : enableShareHashTableForBroadcastJoin);
 
         tResult.setBatchSize(batchSize);
         tResult.setDisableStreamPreaggregations(disableStreamPreaggregations);


### PR DESCRIPTION
# Proposed changes

`SharedHashTableController::wait_for_signal` will block the HashJoinBuildSink operator and the query will be blocked if there are too many instances waiting for the shared hash table.

So this PR disables sharing hash table temporarily for pipeline engine.

## Problem Summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

