### PR TITLE
[fix](primary_index) not compare result in regression case: primary_index/test_pk_uk_case

### DIFF
--- a/regression-test/suites/primary_index/test_pk_uk_case.groovy
+++ b/regression-test/suites/primary_index/test_pk_uk_case.groovy
@@ -246,7 +246,7 @@ suite("test_pk_uk_case") {
         for (int i = 0; i < result0.size(); ++i) {
             for (j = 0; j < result0[0].size(); j++) {
                 logger.info("result: " + result0[i][j] + "|" + result1[i][j])
-                assertTrue(result0[0]==result1[0])
+                assertTrue(result0[i][j]==result1[i][j])
             }
         }       
 


### PR DESCRIPTION
# Proposed changes

@yixiutt PTAL

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

