### PR TITLE
[Fix](Regression_test)add order by to increase test stability

### DIFF
--- a/regression-test/suites/correctness_p0/test_bucket_join_with_colocate_table.groovy
+++ b/regression-test/suites/correctness_p0/test_bucket_join_with_colocate_table.groovy
@@ -72,6 +72,6 @@
          ;
      """
 
-     order_qt_select """  select * from ${colocateTableName} right outer join ${rightTable} on ${colocateTableName}.c1 = ${rightTable}.k1; """
+     order_qt_select """  select * from ${colocateTableName} right outer join ${rightTable} on ${colocateTableName}.c1 = ${rightTable}.k1 order by c1; """
  }
 


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

change
select * from ${colocateTableName} right outer join ${rightTable} on ${colocateTableName}.c1 = ${rightTable}.k11
to
select * from ${colocateTableName} right outer join ${rightTable} on ${colocateTableName}.c1 = ${rightTable}.k1 order by c1;
to avoid failed running caused by order error when running regression test.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

