### PR TITLE
[optimize](multi-catalog) use dictionary encode&filter to process delete files

### DIFF
--- a/be/src/vec/columns/column_dictionary.h
+++ b/be/src/vec/columns/column_dictionary.h
@@ -211,6 +211,17 @@ public:
         LOG(FATAL) << "should not call replace_column_data_default in ColumnDictionary";
     }
 
+    /**
+     * Just insert dictionary data items, the items will append into _dict.
+     */
+    void insert_many_dict_data(const StringRef* dict_array, uint32_t dict_num) {
+        _dict.reserve(_dict.size() + dict_num);
+        for (uint32_t i = 0; i < dict_num; ++i) {
+            auto value = StringValue(dict_array[i].data, dict_array[i].size);
+            _dict.insert_value(value);
+        }
+    }
+
     void insert_many_dict_data(const int32_t* data_array, size_t start_index,
                                const StringRef* dict_array, size_t data_num,
                                uint32_t dict_num) override {

--- a/be/src/vec/exec/format/parquet/parquet_common.h
+++ b/be/src/vec/exec/format/parquet/parquet_common.h
@@ -178,11 +178,23 @@ public:
     }
 
 protected:
+    /**
+     * Decode dictionary-coded values into doris_column, ensure that doris_column is ColumnDictI32 type,
+     * and the coded values must be read into _indexes previously.
+     */
+    Status _decode_dict_values(MutableColumnPtr& doris_column, ColumnSelectVector& select_vector);
+
     int32_t _type_length;
     Slice* _data = nullptr;
     uint32_t _offset = 0;
     FieldSchema* _field_schema = nullptr;
     std::unique_ptr<DecodeParams> _decode_params = nullptr;
+
+    // For dictionary encoding
+    bool _has_dict = false;
+    std::unique_ptr<uint8_t[]> _dict = nullptr;
+    std::unique_ptr<RleBatchDecoder<uint32_t>> _index_batch_decoder = nullptr;
+    std::vector<uint32_t> _indexes;
 };
 
 template <typename DecimalPrimitiveType>
@@ -253,12 +265,9 @@ protected:
     if (!_has_dict) _offset += _type_length
 
     tparquet::Type::type _physical_type;
+
     // For dictionary encoding
-    bool _has_dict = false;
-    std::unique_ptr<uint8_t[]> _dict = nullptr;
     std::vector<char*> _dict_items;
-    std::unique_ptr<RleBatchDecoder<uint32_t>> _index_batch_decoder = nullptr;
-    std::vector<uint32_t> _indexes;
 };
 
 template <typename Numeric>
@@ -567,11 +576,7 @@ protected:
                                   ColumnSelectVector& select_vector);
 
     // For dictionary encoding
-    bool _has_dict = false;
-    std::unique_ptr<uint8_t[]> _dict = nullptr;
     std::vector<StringRef> _dict_items;
-    std::unique_ptr<RleBatchDecoder<uint32_t>> _index_batch_decoder = nullptr;
-    std::vector<uint32_t> _indexes;
 };
 
 template <typename DecimalPrimitiveType>

--- a/be/src/vec/exec/format/parquet/vparquet_column_chunk_reader.h
+++ b/be/src/vec/exec/format/parquet/vparquet_column_chunk_reader.h
@@ -168,6 +168,7 @@ private:
     Slice _page_data;
     std::unique_ptr<uint8_t[]> _decompress_buf;
     size_t _decompress_buf_size = 0;
+    bool _has_dict = false;
     Decoder* _page_decoder = nullptr;
     // Map: encoding -> Decoder
     // Plain or Dictionary encoding. If the dictionary grows too big, the encoding will fall back to the plain encoding

--- a/be/src/vec/exec/format/parquet/vparquet_reader.cpp
+++ b/be/src/vec/exec/format/parquet/vparquet_reader.cpp
@@ -155,7 +155,6 @@ Status ParquetReader::_open_file() {
                 _profile, system_properties, file_description, &_file_system, &_file_reader));
     }
     if (_file_metadata == nullptr) {
-        SCOPED_RAW_TIMER(&_statistics.parse_meta_time);
         if (_file_reader->size() == 0) {
             return Status::EndOfFile("Empty Parquet File");
         }
@@ -354,31 +353,31 @@ Status ParquetReader::get_columns(std::unordered_map<std::string, TypeDescriptor
 }
 
 Status ParquetReader::get_next_block(Block* block, size_t* read_rows, bool* eof) {
-    if (_current_group_reader == nullptr) {
+    if (_current_group_reader == nullptr || _row_group_eof) {
         if (_read_row_groups.size() > 0) {
             RETURN_IF_ERROR(_next_row_group_reader());
         } else {
+            _current_group_reader.reset(nullptr);
+            _row_group_eof = true;
             *read_rows = 0;
             *eof = true;
             return Status::OK();
         }
     }
     DCHECK(_current_group_reader != nullptr);
-    bool batch_eof = false;
     {
         SCOPED_RAW_TIMER(&_statistics.column_read_time);
         RETURN_IF_ERROR(
-                _current_group_reader->next_batch(block, _batch_size, read_rows, &batch_eof));
+                _current_group_reader->next_batch(block, _batch_size, read_rows, &_row_group_eof));
     }
-    if (batch_eof) {
+    if (_row_group_eof) {
         auto column_st = _current_group_reader->statistics();
         _column_statistics.merge(column_st);
         _statistics.lazy_read_filtered_rows += _current_group_reader->lazy_read_filtered_rows();
-        Status st = _next_row_group_reader();
-        if (st.is<ErrorCode::END_OF_FILE>()) {
+        if (_read_row_groups.size() == 0) {
             *eof = true;
-        } else if (!st.ok()) {
-            return st;
+        } else {
+            *eof = false;
         }
     }
     return Status::OK();
@@ -403,6 +402,7 @@ RowGroupReader::PositionDeleteContext ParquetReader::_get_position_delete_ctx(
 
 Status ParquetReader::_next_row_group_reader() {
     if (_read_row_groups.empty()) {
+        _row_group_eof = true;
         _current_group_reader.reset(nullptr);
         return Status::EndOfFile("No next RowGroupReader");
     }
@@ -419,6 +419,7 @@ Status ParquetReader::_next_row_group_reader() {
     _current_group_reader.reset(new RowGroupReader(_file_reader, _read_columns,
                                                    row_group_index.row_group_id, row_group, _ctz,
                                                    position_delete_ctx, _lazy_read_ctx));
+    _row_group_eof = false;
     return _current_group_reader->init(_file_metadata->schema(), candidate_row_ranges,
                                        _col_offsets);
 }

--- a/be/src/vec/exec/format/parquet/vparquet_reader.h
+++ b/be/src/vec/exec/format/parquet/vparquet_reader.h
@@ -156,7 +156,9 @@ private:
     io::FileReaderSPtr _file_reader = nullptr;
     std::shared_ptr<FileMetaData> _file_metadata;
     const tparquet::FileMetaData* _t_metadata;
-    std::unique_ptr<RowGroupReader> _current_group_reader;
+    std::unique_ptr<RowGroupReader> _current_group_reader = nullptr;
+    // read to the end of current reader
+    bool _row_group_eof = true;
     int32_t _total_groups;                  // num of groups(stripes) of a parquet(orc) file
     std::map<std::string, int> _map_column; // column-name <---> column-index
     std::unordered_map<std::string, ColumnValueRangeType>* _colname_to_value_range;

--- a/be/src/vec/exec/format/table/iceberg_reader.cpp
+++ b/be/src/vec/exec/format/table/iceberg_reader.cpp
@@ -26,10 +26,16 @@ namespace doris::vectorized {
 
 const int64_t MIN_SUPPORT_DELETE_FILES_VERSION = 2;
 const std::string ICEBERG_ROW_POS = "pos";
+const std::string ICEBERG_FILE_PATH = "file_path";
 
 IcebergTableReader::IcebergTableReader(GenericReader* file_format_reader, RuntimeProfile* profile,
-                                       RuntimeState* state, const TFileScanRangeParams& params)
-        : TableFormatReader(file_format_reader), _profile(profile), _state(state), _params(params) {
+                                       RuntimeState* state, const TFileScanRangeParams& params,
+                                       const TFileRangeDesc& range)
+        : TableFormatReader(file_format_reader),
+          _profile(profile),
+          _state(state),
+          _params(params),
+          _range(range) {
     static const char* iceberg_profile = "IcebergProfile";
     ADD_TIMER(_profile, iceberg_profile);
     _iceberg_profile.num_delete_files =
@@ -38,12 +44,8 @@ IcebergTableReader::IcebergTableReader(GenericReader* file_format_reader, Runtim
             ADD_CHILD_COUNTER(_profile, "NumDeleteRows", TUnit::UNIT, iceberg_profile);
     _iceberg_profile.delete_files_read_time =
             ADD_CHILD_TIMER(_profile, "DeleteFileReadTime", iceberg_profile);
-}
-
-IcebergTableReader::~IcebergTableReader() {
-    if (_data_path_conjunct_ctx != nullptr) {
-        _data_path_conjunct_ctx->close(_state);
-    }
+    _iceberg_profile.delete_rows_sort_time =
+            ADD_CHILD_TIMER(_profile, "DeleteRowsSortTime", iceberg_profile);
 }
 
 Status IcebergTableReader::get_next_block(Block* block, size_t* read_rows, bool* eof) {
@@ -76,15 +78,6 @@ Status IcebergTableReader::init_row_filters(const TFileRangeDesc& range) {
     }
     if (delete_file_type == POSITION_DELETE) {
         // position delete
-        SCOPED_TIMER(_iceberg_profile.delete_files_read_time);
-        auto row_desc = RowDescriptor(_state->desc_tbl(),
-                                      std::vector<TupleId>({table_desc.delete_table_tuple_id}),
-                                      std::vector<bool>({false}));
-        RETURN_IF_ERROR(VExpr::create_expr_tree(_state->obj_pool(), table_desc.file_select_conjunct,
-                                                &_data_path_conjunct_ctx));
-        RETURN_IF_ERROR(_data_path_conjunct_ctx->prepare(_state, row_desc));
-        RETURN_IF_ERROR(_data_path_conjunct_ctx->open(_state));
-
         ParquetReader* parquet_reader = (ParquetReader*)(_file_format_reader.get());
         RowRange whole_range = parquet_reader->get_whole_range();
         bool init_schema = false;
@@ -100,6 +93,7 @@ Status IcebergTableReader::init_row_filters(const TFileRangeDesc& range) {
                 delete_rows_iter++;
                 continue;
             }
+            SCOPED_TIMER(_iceberg_profile.delete_files_read_time);
             std::vector<int64_t>& delete_rows = *delete_rows_iter;
             TFileRangeDesc delete_range;
             delete_range.path = delete_file.path;
@@ -112,49 +106,90 @@ Status IcebergTableReader::init_row_filters(const TFileRangeDesc& range) {
                 delete_reader.get_parsed_schema(&delete_file_col_names, &delete_file_col_types);
                 init_schema = true;
             }
-            RETURN_IF_ERROR(delete_reader.init_reader(delete_file_col_names, nullptr,
-                                                      _data_path_conjunct_ctx, false));
+            std::string data_file_path = _range.path;
+            // the path in _range is remove the namenode prefix,
+            // and the file_path in delete file is full path, so we should add it back.
+            if (_params.__isset.hdfs_params && _params.hdfs_params.__isset.fs_name) {
+                std::string fs_name = _params.hdfs_params.fs_name;
+                if (!starts_with(data_file_path, fs_name)) {
+                    data_file_path = fs_name + data_file_path;
+                }
+            }
+            RETURN_IF_ERROR(
+                    delete_reader.init_reader(delete_file_col_names, nullptr, nullptr, false));
             std::unordered_map<std::string, std::tuple<std::string, const SlotDescriptor*>>
                     partition_columns;
             std::unordered_map<std::string, VExprContext*> missing_columns;
             delete_reader.set_fill_columns(partition_columns, missing_columns);
 
             bool eof = false;
+            // We can only know whether a parquet file is encoded in dictionary after reading the first block,
+            // so we assume it dictionary encoded first, and reset it false if error thrown.
+            bool dictionary_coded = true;
             while (!eof) {
                 Block block = Block();
                 for (int i = 0; i < delete_file_col_names.size(); ++i) {
                     DataTypePtr data_type = DataTypeFactory::instance().create_data_type(
-                            delete_file_col_types[i], true);
-                    MutableColumnPtr data_column = data_type->create_column();
-                    block.insert(ColumnWithTypeAndName(std::move(data_column), data_type,
-                                                       delete_file_col_names[i]));
+                            delete_file_col_types[i], false);
+                    if (delete_file_col_names[i] == ICEBERG_FILE_PATH && dictionary_coded) {
+                        // the dictionary data in ColumnDictI32 is referenced by StringValue, it does keep
+                        // the dictionary data in its life circle, so the upper caller should keep the
+                        // dictionary data alive after ColumnDictI32.
+                        MutableColumnPtr dict_column = ColumnDictI32::create();
+                        block.insert(ColumnWithTypeAndName(std::move(dict_column), data_type,
+                                                           delete_file_col_names[i]));
+                    } else {
+                        MutableColumnPtr data_column = data_type->create_column();
+                        block.insert(ColumnWithTypeAndName(std::move(data_column), data_type,
+                                                           delete_file_col_names[i]));
+                    }
                 }
                 eof = false;
                 size_t read_rows = 0;
-                RETURN_IF_ERROR(delete_reader.get_next_block(&block, &read_rows, &eof));
-                if (read_rows > 0) {
-                    auto& pos_type_column = block.get_by_name(ICEBERG_ROW_POS);
-                    ColumnPtr pos_column = pos_type_column.column;
-                    using ColumnType = typename PrimitiveTypeTraits<TYPE_BIGINT>::ColumnType;
-                    if (pos_type_column.type->is_nullable()) {
-                        pos_column = assert_cast<const ColumnNullable&>(*pos_column)
-                                             .get_nested_column_ptr();
+                Status st = delete_reader.get_next_block(&block, &read_rows, &eof);
+                if (!st.ok()) {
+                    if (st.to_string() == "[IO_ERROR]Not dictionary coded") {
+                        dictionary_coded = false;
+                        continue;
                     }
-                    const int64_t* src_data =
-                            assert_cast<const ColumnType&>(*pos_column).get_data().data();
-                    const int64_t* src_data_end = src_data + read_rows;
-                    const int64_t* cpy_start =
-                            std::lower_bound(src_data, src_data_end, whole_range.first_row);
-                    const int64_t* cpy_end =
-                            std::lower_bound(cpy_start, src_data_end, whole_range.last_row);
-                    int64_t cpy_count = cpy_end - cpy_start;
+                    return st;
+                }
+                if (read_rows > 0) {
+                    ColumnPtr path_column = block.get_by_name(ICEBERG_FILE_PATH).column;
+                    DCHECK_EQ(path_column->size(), read_rows);
+                    std::pair<int, int> path_range;
+                    if (dictionary_coded) {
+                        path_range = _binary_search(assert_cast<const ColumnDictI32&>(*path_column),
+                                                    data_file_path);
+                    } else {
+                        path_range = _binary_search(assert_cast<const ColumnString&>(*path_column),
+                                                    data_file_path);
+                    }
 
-                    if (cpy_count > 0) {
-                        int64_t origin_size = delete_rows.size();
-                        delete_rows.resize(origin_size + cpy_count);
-                        int64_t* dest_position = &delete_rows[origin_size];
-                        memcpy(dest_position, cpy_start, cpy_count * sizeof(int64_t));
-                        num_delete_rows += cpy_count;
+                    int skip_count = path_range.first;
+                    int valid_count = path_range.second;
+                    if (valid_count > 0) {
+                        // delete position
+                        ColumnPtr pos_column = block.get_by_name(ICEBERG_ROW_POS).column;
+                        CHECK_EQ(pos_column->size(), read_rows);
+                        using ColumnType = typename PrimitiveTypeTraits<TYPE_BIGINT>::ColumnType;
+                        const int64_t* src_data =
+                                assert_cast<const ColumnType&>(*pos_column).get_data().data() +
+                                skip_count;
+                        const int64_t* src_data_end = src_data + valid_count;
+                        const int64_t* cpy_start =
+                                std::lower_bound(src_data, src_data_end, whole_range.first_row);
+                        const int64_t* cpy_end =
+                                std::lower_bound(cpy_start, src_data_end, whole_range.last_row);
+                        int64_t cpy_count = cpy_end - cpy_start;
+
+                        if (cpy_count > 0) {
+                            int64_t origin_size = delete_rows.size();
+                            delete_rows.resize(origin_size + cpy_count);
+                            int64_t* dest_position = &delete_rows[origin_size];
+                            memcpy(dest_position, cpy_start, cpy_count * sizeof(int64_t));
+                            num_delete_rows += cpy_count;
+                        }
                     }
                 }
             }
@@ -168,6 +203,7 @@ Status IcebergTableReader::init_row_filters(const TFileRangeDesc& range) {
                     iter++;
                 }
             }
+            SCOPED_TIMER(_iceberg_profile.delete_rows_sort_time);
             _merge_sort(delete_rows_list, num_delete_rows);
             parquet_reader->set_delete_rows(&_delete_rows);
             COUNTER_UPDATE(_iceberg_profile.num_delete_rows, num_delete_rows);
@@ -176,6 +212,64 @@ Status IcebergTableReader::init_row_filters(const TFileRangeDesc& range) {
     // todo: equality delete
     COUNTER_UPDATE(_iceberg_profile.num_delete_files, files.size());
     return Status::OK();
+}
+
+std::pair<int, int> IcebergTableReader::_binary_search(const ColumnDictI32& file_path_column,
+                                                       const std::string& data_file_path) {
+    size_t read_rows = file_path_column.get_data().size();
+
+    int data_file_code = file_path_column.find_code(StringValue(data_file_path));
+    if (data_file_code == -2) { // -1 is null code
+        return std::make_pair(read_rows, 0);
+    }
+
+    const int* coded_path = file_path_column.get_data().data();
+    const int* coded_path_end = coded_path + read_rows;
+    const int* path_start = std::lower_bound(coded_path, coded_path_end, data_file_code);
+    const int* path_end = std::lower_bound(path_start, coded_path_end, data_file_code + 1);
+    int skip_count = path_start - coded_path;
+    int valid_count = path_end - path_start;
+
+    return std::make_pair(skip_count, valid_count);
+}
+
+std::pair<int, int> IcebergTableReader::_binary_search(const ColumnString& file_path_column,
+                                                       const std::string& data_file_path) {
+    const int read_rows = file_path_column.size();
+    if (read_rows == 0) {
+        return std::make_pair(0, 0);
+    }
+    StringRef data_file(data_file_path);
+
+    int left = 0;
+    int right = read_rows - 1;
+    if (file_path_column.get_data_at(left) > data_file ||
+        file_path_column.get_data_at(right) < data_file) {
+        return std::make_pair(read_rows, 0);
+    }
+    while (left < right) {
+        int mid = (left + right) / 2;
+        if (file_path_column.get_data_at(mid) < data_file) {
+            left = mid;
+        } else {
+            right = mid;
+        }
+    }
+    if (file_path_column.get_data_at(left) == data_file) {
+        int start = left;
+        int end = read_rows - 1;
+        while (start < end) {
+            int pivot = (start + end) / 2;
+            if (file_path_column.get_data_at(pivot) > data_file) {
+                end = pivot;
+            } else {
+                start = pivot;
+            }
+        }
+        return std::make_pair(left, end - left + 1);
+    } else {
+        return std::make_pair(read_rows, 0);
+    }
 }
 
 void IcebergTableReader::_merge_sort(std::list<std::vector<int64_t>>& delete_rows_list,

--- a/be/src/vec/exec/scan/vfile_scanner.cpp
+++ b/be/src/vec/exec/scan/vfile_scanner.cpp
@@ -494,8 +494,8 @@ Status VFileScanner::_get_next_reader() {
             if (range.__isset.table_format_params &&
                 range.table_format_params.table_format_type == "iceberg") {
                 IcebergTableReader* iceberg_reader = new IcebergTableReader(
-                        (GenericReader*)parquet_reader, _profile, _state, _params);
-                iceberg_reader->init_row_filters(range);
+                        (GenericReader*)parquet_reader, _profile, _state, _params, range);
+                RETURN_IF_ERROR(iceberg_reader->init_row_filters(range));
                 _cur_reader.reset((GenericReader*)iceberg_reader);
             } else {
                 _cur_reader.reset((GenericReader*)parquet_reader);

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/external/IcebergSplit.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/external/IcebergSplit.java
@@ -18,7 +18,6 @@
 package org.apache.doris.planner.external;
 
 import org.apache.doris.analysis.Analyzer;
-import org.apache.doris.analysis.BaseTableRef;
 
 import lombok.Data;
 import org.apache.hadoop.fs.Path;
@@ -34,7 +33,6 @@ public class IcebergSplit extends HiveSplit {
     private Analyzer analyzer;
     private String dataFilePath;
     private Integer formatVersion;
-    private BaseTableRef deleteTableRef;
     private List<IcebergDeleteFileFilter> deleteFileFilters;
 }
 

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -274,7 +274,9 @@ struct TIcebergFileDesc {
     2: optional i32 content;
     // When open a delete file, filter the data file path with the 'file_path' property
     3: optional list<TIcebergDeleteFileDesc> delete_files;
+    // Deprecated
     4: optional Types.TTupleId delete_table_tuple_id;
+    // Deprecated
     5: optional Exprs.TExpr file_select_conjunct;
 }
 


### PR DESCRIPTION
# Proposed changes

Use dictionary encode&filter to process delete files.

## Problem summary
**Optimize**
PR https://github.com/apache/doris/pull/14470 has used `Expr` to filter delete rows to match current data file, but the rows in the delete file are [sorted by file_path then position](https://iceberg.apache.org/spec/#position-delete-files) to optimize filtering rows while scanning, so this PR remove `Expr` and use binary search to filter delete rows.

In addition, delete files are likely to be encoded in dictionary, it's time-consuming to decode `file_path` columns into `ColumnString`, so this PR use `ColumnDictionary` to read `file_path` column.

After testing, the performance of iceberg v2's MOR is improved by 30%+.

**Fix Bug**
Lazy-read-block may not have the filter column, if the whole group is filtered by `Expr` and the batch_eof is generated from next batch.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

