### PR TITLE
[fix](brokerload) be core dump caused by broker load orc format file nullptr pointer

### DIFF
--- a/be/src/io/fs/broker_file_reader.h
+++ b/be/src/io/fs/broker_file_reader.h
@@ -23,6 +23,7 @@
 #include <atomic>
 
 #include "io/fs/file_reader.h"
+#include "runtime/client_cache.h"
 namespace doris {
 namespace io {
 
@@ -53,8 +54,8 @@ private:
     const TNetworkAddress& _broker_addr;
     TBrokerFD _fd;
 
-    BrokerFileSystem* _fs;
     std::atomic<bool> _closed = false;
+    std::shared_ptr<BrokerServiceConnection> _client;
 };
 } // namespace io
 } // namespace doris


### PR DESCRIPTION
# Proposed changes

Issue Number: close #15459

affects master, introduced by #15175

## Problem summary

In `vorc_reader.cpp` file_system is destructed before file_reader, but file_system is used when file_reader is destructed, resulting in null pointer exception

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

