### PR TITLE
[fix](index) fix that the last element of each batch will be read repeatedly for binary prefix page

### DIFF
--- a/be/src/olap/rowset/segment_v2/binary_prefix_page.cpp
+++ b/be/src/olap/rowset/segment_v2/binary_prefix_page.cpp
@@ -257,17 +257,19 @@ Status BinaryPrefixPageDecoder::next_batch(size_t* n, ColumnBlockView* dst) {
     RETURN_IF_ERROR(_copy_current_to_output(dst->pool(), out));
     i++;
     out++;
+    _cur_pos++;
 
     // read and copy remaining values
     for (; i < max_fetch; ++i) {
-        _cur_pos++;
         RETURN_IF_ERROR(_read_next_value_to_output(prev[i - 1], dst->pool(), out));
         out++;
+        _cur_pos++;
     }
 
     //must update _current_value
     _current_value.clear();
     _current_value.assign_copy((uint8_t*)prev[i - 1].data, prev[i - 1].size);
+    _read_next_value();
 
     *n = max_fetch;
     return Status::OK();

--- a/be/test/olap/rowset/segment_v2/binary_prefix_page_test.cpp
+++ b/be/test/olap/rowset/segment_v2/binary_prefix_page_test.cpp
@@ -90,6 +90,30 @@ public:
             EXPECT_EQ(std::to_string(i), values[i - 1000].to_string());
         }
 
+        ret = page_decoder->seek_to_position_in_page(0);
+        EXPECT_TRUE(ret.ok());
+        int n = 0;
+        while (true) {
+            //check values
+            MemPool pool;
+            auto type_info = get_scalar_type_info(OLAP_FIELD_TYPE_VARCHAR);
+            std::unique_ptr<ColumnVectorBatch> cvb;
+            size_t size = 6;
+            ColumnVectorBatch::create(size, false, type_info, nullptr, &cvb);
+            ColumnBlock column_block(cvb.get(), &pool);
+            ColumnBlockView block_view(&column_block);
+            ret = page_decoder->next_batch(&size, &block_view);
+            EXPECT_TRUE(ret.ok());
+            if (size == 0) {
+                break;
+            }
+            Slice* values = reinterpret_cast<Slice*>(column_block.data());
+            for (int i = 0; i < size; ++i) {
+                EXPECT_EQ(std::to_string(1000 + 6 * n + i), values[i].to_string());
+            }
+            n++;
+        }
+
         std::unique_ptr<ColumnVectorBatch> cvb2;
         ColumnVectorBatch::create(size, false, type_info, nullptr, &cvb2);
         ColumnBlock column_block2(cvb2.get(), &pool);


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

When reading several batches continuously, the last element of each batch will be read repeatedly for binary prefix page.

**For example:**
The data is: 1, 2, 3, 4, 5, 6, 7, 8, 9, 10
When batch size is 4, the result will be: 
    next_batch: 1, 2, 3, 4
    next_batch: 4, 5, 6, 7
    next_batch: 7, 8, 9, 10

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

