### PR TITLE
[Fix](Nereids) Group by binding should be consistent with the behavior of the old optimizer

### DIFF
--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/GroupingSetsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/GroupingSetsTest.java
@@ -232,4 +232,10 @@ public class GroupingSetsTest extends TestWithFeService {
                 .checkPlannerResult("select if(col1 = null, 'all', 2) as col2, count(*) as cnt from"
                         + " (select null as col1 union all select 'a' as col1 ) t group by grouping sets ((col2),());");
     }
+
+    @Test
+    public void testGroup() {
+        PlanChecker.from(connectContext)
+                .checkPlannerResult("select b.k2 as k2 from t1 a left join (select k2 from t1) b on a.k2 = b.k2 group by k2");
+    }
 }


### PR DESCRIPTION


# Proposed changes

Issue Number: close #15328

## Problem summary

The behavior of group by binding is consistent with the old optimizer, and it will be changed to the SQL standard in the future. It will be obtained from the child first, and then obtained from the output of the operator.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [x] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

