### PR TITLE
[fix](inbitmap) forbid having clause to include in bitmap.

### DIFF
--- a/regression-test/suites/query_p0/join/test_bitmap_filter.groovy
+++ b/regression-test/suites/query_p0/join/test_bitmap_filter.groovy
@@ -69,4 +69,9 @@ suite("test_bitmap_filter", "query_p0") {
         sql "select k1, k2 from ${tbl1} b1 where k1 in (select k2 from ${tbl2} b2 where b1.k2 = b2.k1) order by k1;"
         exception "In bitmap does not support correlated subquery"
     }
+
+    test {
+        sql "select k1, count(*) from ${tbl1} b1 group by k1 having k1 in (select k2 from ${tbl2} b2) order by k1;"
+        exception "HAVING clause dose not support in bitmap"
+    }
 }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

The having clause cannot use runtime filter, because in bitmap planning is nested loop join, if there is no bitmap filter, it needs to copy a lot of bitmap in the process of nested loop join, which causes extreme performance degradation.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

