### PR TITLE
[Improvement](FE) Support more types of log level for FE.

### DIFF
--- a/conf/fe.conf
+++ b/conf/fe.conf
@@ -34,7 +34,7 @@ JAVA_OPTS_FOR_JDK_9="-Xmx8192m -XX:SurvivorRatio=8 -XX:MaxTenuringThreshold=7 -X
 ## the lowercase properties are read by main program.
 ##
 
-# INFO, WARN, ERROR, FATAL
+# ALL, TRACE, DEBUG, INFO, WARN, ERROR, FATAL, OFF
 sys_log_level = INFO
 
 # store metadata, must be created before start FE.

--- a/fe/fe-core/src/main/java/org/apache/doris/common/Log4jConfig.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/Log4jConfig.java
@@ -19,6 +19,7 @@ package org.apache.doris.common;
 
 import org.apache.doris.httpv2.config.SpringLog4j2Config;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.LoggerContext;
@@ -29,7 +30,9 @@ import org.apache.logging.log4j.core.lookup.StrSubstitutor;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 //
 // don't use trace. use INFO, WARN, ERROR, FATAL
@@ -124,6 +127,9 @@ public class Log4jConfig extends XmlConfiguration {
     //     loggers, all logs will be printed to console.
     public static boolean foreground = false;
 
+    private static final Set<String> validLogLevels = ImmutableSet.of("ALL", "TRACE", "DEBUG", "INFO", "WARN", "ERROR",
+            "FATAL", "OFF");
+
     private static void reconfig() throws IOException {
         String newXmlConfTemplate = xmlConfTemplate;
 
@@ -132,11 +138,9 @@ public class Log4jConfig extends XmlConfiguration {
         String sysRollNum = String.valueOf(Config.sys_log_roll_num);
         String sysDeleteAge = String.valueOf(Config.sys_log_delete_age);
 
-        if (!(sysLogLevel.equalsIgnoreCase("INFO")
-                || sysLogLevel.equalsIgnoreCase("WARN")
-                || sysLogLevel.equalsIgnoreCase("ERROR")
-                || sysLogLevel.equalsIgnoreCase("FATAL"))) {
-            throw new IOException("sys_log_level config error");
+        if (!validLogLevels.contains(sysLogLevel.toUpperCase(Locale.ROOT))) {
+            throw new IOException("sys_log_level config error, valid log level should be one of "
+                    + validLogLevels + ", but meet " + sysLogLevel);
         }
 
         String sysLogRollPattern = "%d{yyyyMMdd}";


### PR DESCRIPTION
# Proposed changes
Currently, FE only supports these log levels: `INFO, WARN, ERROR, FATAL`. Sometimes we need more log levels, such as `DEBUG`.
This PR proposes to support all the types of built-in standard log levels for Log4j.(https://logging.apache.org/log4j/2.x/manual/customloglevels.html)

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

