### PR TITLE
[enhencement](Nereids) remove constant expr constraint on OneRowRelation

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalOneRowRelation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalOneRowRelation.java
@@ -29,7 +29,6 @@ import org.apache.doris.nereids.trees.plans.visitor.PlanVisitor;
 import org.apache.doris.nereids.util.Utils;
 import org.apache.doris.statistics.StatsDeriveResult;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
@@ -45,19 +44,17 @@ public class PhysicalOneRowRelation extends PhysicalLeaf implements OneRowRelati
     private final boolean buildUnionNode;
 
     public PhysicalOneRowRelation(List<NamedExpression> projects, boolean buildUnionNode,
-                                  LogicalProperties logicalProperties) {
+            LogicalProperties logicalProperties) {
         this(projects, buildUnionNode, Optional.empty(), logicalProperties, null, null);
     }
 
     private PhysicalOneRowRelation(List<NamedExpression> projects,
-                                   boolean buildUnionNode,
-                                   Optional<GroupExpression> groupExpression,
+            boolean buildUnionNode,
+            Optional<GroupExpression> groupExpression,
             LogicalProperties logicalProperties, PhysicalProperties physicalProperties,
             StatsDeriveResult statsDeriveResult) {
         super(PlanType.PHYSICAL_ONE_ROW_RELATION, groupExpression, logicalProperties, physicalProperties,
                 statsDeriveResult);
-        Preconditions.checkArgument(projects.stream().allMatch(Expression::isConstant),
-                "OneRowRelation must consist of some constant expression");
         this.projects = ImmutableList.copyOf(Objects.requireNonNull(projects, "projects can not be null"));
         this.buildUnionNode = buildUnionNode;
     }


### PR DESCRIPTION
# Proposed changes

Now, function will fail in OneRowRelation.

like:
```sql
select bitmap_to_string(bitmap_and(bitmap_from_string('1,2,3'), bitmap_from_string('1,2'), bitmap_from_string('1,2,3,4,5'),bitmap_empty()));
```

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

