### PR TITLE
[bugfix](datetimev2) fix coredump when load datatime  data to doris

### DIFF
--- a/be/src/runtime/types.h
+++ b/be/src/runtime/types.h
@@ -73,6 +73,8 @@ struct TypeDescriptor {
         if (type == TYPE_DECIMALV2) {
             precision = 27;
             scale = 9;
+        } else if (type == TYPE_DATETIMEV2) {
+            scale = 6;
         }
     }
 

--- a/be/src/vec/data_types/data_type_decimal.h
+++ b/be/src/vec/data_types/data_type_decimal.h
@@ -118,8 +118,7 @@ public:
 
     static constexpr size_t max_precision() { return max_decimal_precision<T>(); }
 
-    DataTypeDecimal(UInt32 precision_ = 27, UInt32 scale_ = 9)
-            : precision(precision_), scale(scale_) {
+    DataTypeDecimal(UInt32 precision = 27, UInt32 scale = 9) : precision(precision), scale(scale) {
         if (UNLIKELY(precision < 1 || precision > max_precision())) {
             LOG(FATAL) << fmt::format("Precision {} is out of bounds", precision);
         }

--- a/be/src/vec/data_types/data_type_time_v2.cpp
+++ b/be/src/vec/data_types/data_type_time_v2.cpp
@@ -92,7 +92,7 @@ std::string DataTypeDateTimeV2::to_string(const IColumn& column, size_t row_num)
             binary_cast<UInt64, DateV2Value<DateTimeV2ValueType>>(int_val);
 
     char buf[64];
-    char* pos = val.to_string(buf, scale_);
+    char* pos = val.to_string(buf, _scale);
     return std::string(buf, pos - buf - 1);
 }
 
@@ -105,7 +105,7 @@ void DataTypeDateTimeV2::to_string(const IColumn& column, size_t row_num,
             binary_cast<UInt64, DateV2Value<DateTimeV2ValueType>>(int_val);
 
     char buf[64];
-    char* pos = value.to_string(buf, scale_);
+    char* pos = value.to_string(buf, _scale);
     // DateTime to_string the end is /0
     ostr.write(buf, pos - buf - 1);
 }

--- a/be/src/vec/data_types/data_type_time_v2.h
+++ b/be/src/vec/data_types/data_type_time_v2.h
@@ -57,13 +57,13 @@ class DataTypeDateTimeV2 final : public DataTypeNumberBase<UInt64> {
 public:
     static constexpr bool is_parametric = true;
 
-    DataTypeDateTimeV2(UInt32 scale = 0) : scale_(scale) {
+    DataTypeDateTimeV2(UInt32 scale = 0) : _scale(scale) {
         if (UNLIKELY(scale > 6)) {
             LOG(FATAL) << fmt::format("Scale {} is out of bounds", scale);
         }
     }
 
-    DataTypeDateTimeV2(const DataTypeDateTimeV2& rhs) : scale_(rhs.scale_) {}
+    DataTypeDateTimeV2(const DataTypeDateTimeV2& rhs) : _scale(rhs._scale) {}
     TypeIndex get_type_id() const override { return TypeIndex::DateTimeV2; }
     const char* get_family_name() const override { return "DateTimeV2"; }
     std::string do_get_name() const override { return "DateTimeV2"; }
@@ -77,7 +77,7 @@ public:
 
     MutableColumnPtr create_column() const override;
 
-    const UInt32 get_scale() const { return scale_; }
+    const UInt32 get_scale() const { return _scale; }
 
     static void cast_to_date(const UInt64 from, Int64& to);
     static void cast_to_date_time(const UInt64 from, Int64& to);
@@ -86,7 +86,7 @@ public:
     static void cast_from_date_time(const Int64 from, UInt64& to);
 
 private:
-    UInt32 scale_;
+    UInt32 _scale;
 };
 
 template <typename DataType>


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

this bug is because of date_time_v2  will check scale when constructed

https://github.com/apache/doris/blob/5c5b7a5c6fb91d7425b6284d3efd26c5f3ac7960/be/src/vec/data_types/data_type_time_v2.h#L62

this is introduced by #11198
## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

