### PR TITLE
[enhancement](tablet) Unify redundant `create_rowset_writer` methods

### DIFF
--- a/be/src/http/action/pad_rowset_action.cpp
+++ b/be/src/http/action/pad_rowset_action.cpp
@@ -86,8 +86,12 @@ Status PadRowsetAction::_pad_rowset(TabletSharedPtr tablet, const Version& versi
     }
 
     std::unique_ptr<RowsetWriter> writer;
-    RETURN_IF_ERROR(tablet->create_rowset_writer(version, VISIBLE, NONOVERLAPPING,
-                                                 tablet->tablet_schema(), -1, -1, &writer));
+    RowsetWriterContext ctx;
+    ctx.version = version;
+    ctx.rowset_state = VISIBLE;
+    ctx.segments_overlap = NONOVERLAPPING;
+    ctx.tablet_schema = tablet->tablet_schema();
+    RETURN_IF_ERROR(tablet->create_rowset_writer(ctx, &writer));
     auto rowset = writer->build();
     rowset->make_visible(version);
 

--- a/be/src/io/fs/local_file_system.cpp
+++ b/be/src/io/fs/local_file_system.cpp
@@ -144,7 +144,7 @@ Status LocalFileSystem::list(const Path& path, std::vector<Path>* files) {
 
 static FileSystemSPtr local_fs = std::make_shared<io::LocalFileSystem>("");
 
-FileSystemSPtr global_local_filesystem() {
+const FileSystemSPtr& global_local_filesystem() {
     return local_fs;
 }
 

--- a/be/src/io/fs/local_file_system.h
+++ b/be/src/io/fs/local_file_system.h
@@ -55,7 +55,7 @@ private:
     Path absolute_path(const Path& path) const;
 };
 
-FileSystemSPtr global_local_filesystem();
+const FileSystemSPtr& global_local_filesystem();
 
 } // namespace io
 } // namespace doris

--- a/be/src/olap/delta_writer.cpp
+++ b/be/src/olap/delta_writer.cpp
@@ -22,6 +22,7 @@
 #include "olap/data_dir.h"
 #include "olap/memtable.h"
 #include "olap/memtable_flush_executor.h"
+#include "olap/rowset/rowset_writer_context.h"
 #include "olap/schema.h"
 #include "olap/schema_change.h"
 #include "olap/storage_engine.h"
@@ -138,9 +139,13 @@ Status DeltaWriter::init() {
     // build tablet schema in request level
     _build_current_tablet_schema(_req.index_id, _req.ptable_schema_param,
                                  *_tablet->tablet_schema());
-
-    RETURN_NOT_OK(_tablet->create_rowset_writer(_req.txn_id, _req.load_id, PREPARED, OVERLAPPING,
-                                                _tablet_schema, &_rowset_writer));
+    RowsetWriterContext context;
+    context.txn_id = _req.txn_id;
+    context.load_id = _req.load_id;
+    context.rowset_state = PREPARED;
+    context.segments_overlap = OVERLAPPING;
+    context.tablet_schema = _tablet_schema;
+    RETURN_NOT_OK(_tablet->create_rowset_writer(context, &_rowset_writer));
     _schema.reset(new Schema(_tablet_schema));
     _reset_mem_table();
 

--- a/be/src/olap/merger.cpp
+++ b/be/src/olap/merger.cpp
@@ -22,6 +22,7 @@
 
 #include "olap/olap_define.h"
 #include "olap/row_cursor.h"
+#include "olap/storage_engine.h"
 #include "olap/tablet.h"
 #include "util/trace.h"
 #include "vec/olap/block_reader.h"

--- a/be/src/olap/push_handler.cpp
+++ b/be/src/olap/push_handler.cpp
@@ -197,8 +197,13 @@ Status PushHandler::_convert_v2(TabletSharedPtr cur_tablet, RowsetSharedPtr* cur
         // but it depends on thirparty implementation, so we conservatively
         // set this value to OVERLAP_UNKNOWN
         std::unique_ptr<RowsetWriter> rowset_writer;
-        res = cur_tablet->create_rowset_writer(_request.transaction_id, load_id, PREPARED,
-                                               OVERLAP_UNKNOWN, tablet_schema, &rowset_writer);
+        RowsetWriterContext context;
+        context.txn_id = _request.transaction_id;
+        context.load_id = load_id;
+        context.rowset_state = PREPARED;
+        context.segments_overlap = OVERLAP_UNKNOWN;
+        context.tablet_schema = tablet_schema;
+        res = cur_tablet->create_rowset_writer(context, &rowset_writer);
         if (!res.ok()) {
             LOG(WARNING) << "failed to init rowset writer, tablet=" << cur_tablet->full_name()
                          << ", txn_id=" << _request.transaction_id << ", res=" << res;
@@ -350,8 +355,13 @@ Status PushHandler::_convert(TabletSharedPtr cur_tablet, RowsetSharedPtr* cur_ro
 
         // 2. init RowsetBuilder of cur_tablet for current push
         std::unique_ptr<RowsetWriter> rowset_writer;
-        res = cur_tablet->create_rowset_writer(_request.transaction_id, load_id, PREPARED,
-                                               OVERLAP_UNKNOWN, tablet_schema, &rowset_writer);
+        RowsetWriterContext context;
+        context.txn_id = _request.transaction_id;
+        context.load_id = load_id;
+        context.rowset_state = PREPARED;
+        context.segments_overlap = OVERLAP_UNKNOWN;
+        context.tablet_schema = tablet_schema;        
+        res = cur_tablet->create_rowset_writer(context, &rowset_writer);
         if (!res.ok()) {
             LOG(WARNING) << "failed to init rowset writer, tablet=" << cur_tablet->full_name()
                          << ", txn_id=" << _request.transaction_id << ", res=" << res;

--- a/be/src/olap/push_handler.cpp
+++ b/be/src/olap/push_handler.cpp
@@ -360,7 +360,7 @@ Status PushHandler::_convert(TabletSharedPtr cur_tablet, RowsetSharedPtr* cur_ro
         context.load_id = load_id;
         context.rowset_state = PREPARED;
         context.segments_overlap = OVERLAP_UNKNOWN;
-        context.tablet_schema = tablet_schema;        
+        context.tablet_schema = tablet_schema;
         res = cur_tablet->create_rowset_writer(context, &rowset_writer);
         if (!res.ok()) {
             LOG(WARNING) << "failed to init rowset writer, tablet=" << cur_tablet->full_name()

--- a/be/src/olap/rowset/beta_rowset_writer.cpp
+++ b/be/src/olap/rowset/beta_rowset_writer.cpp
@@ -33,7 +33,7 @@
 #include "olap/rowset/beta_rowset.h"
 #include "olap/rowset/rowset_factory.h"
 #include "olap/rowset/segment_v2/segment_writer.h"
-//#include "olap/storage_engine.h"
+#include "olap/storage_engine.h"
 #include "runtime/exec_env.h"
 #include "runtime/memory/mem_tracker_limiter.h"
 

--- a/be/src/olap/rowset/beta_rowset_writer.cpp
+++ b/be/src/olap/rowset/beta_rowset_writer.cpp
@@ -81,14 +81,7 @@ BetaRowsetWriter::~BetaRowsetWriter() {
 Status BetaRowsetWriter::init(const RowsetWriterContext& rowset_writer_context) {
     _context = rowset_writer_context;
     _rowset_meta.reset(new RowsetMeta);
-    if (_context.fs == nullptr && _context.data_dir) {
-        _rowset_meta->set_fs(_context.data_dir->fs());
-    } else {
-        _rowset_meta->set_fs(_context.fs);
-    }
-    if (_context.fs != nullptr && _context.fs->resource_id().size() > 0) {
-        _rowset_meta->set_resource_id(_context.fs->resource_id());
-    }
+    _rowset_meta->set_fs(_context.fs);
     _rowset_meta->set_rowset_id(_context.rowset_id);
     _rowset_meta->set_partition_id(_context.partition_id);
     _rowset_meta->set_tablet_id(_context.tablet_id);

--- a/be/src/olap/rowset/beta_rowset_writer.h
+++ b/be/src/olap/rowset/beta_rowset_writer.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include "olap/rowset/rowset_writer.h"
+#include "segment_v2/segment.h"
 #include "vec/olap/vgeneric_iterators.h"
 
 namespace doris {

--- a/be/src/olap/rowset/rowset_meta.h
+++ b/be/src/olap/rowset/rowset_meta.h
@@ -87,10 +87,10 @@ public:
     }
 
     // This method may return nullptr.
-    io::FileSystemSPtr fs() {
+    const io::FileSystemSPtr& fs() {
         if (!_fs) {
             if (is_local()) {
-                return io::global_local_filesystem();
+                _fs = io::global_local_filesystem();
             } else {
                 _fs = io::FileSystemMap::instance()->get(resource_id());
                 LOG_IF(WARNING, !_fs) << "Cannot get file system: " << resource_id();
@@ -99,7 +99,12 @@ public:
         return _fs;
     }
 
-    void set_fs(io::FileSystemSPtr fs) { _fs = std::move(fs); }
+    void set_fs(io::FileSystemSPtr fs) {
+        if (fs && fs->type() != io::FileSystemType::LOCAL) {
+            _rowset_meta_pb.set_resource_id(fs->resource_id());
+        }
+        _fs = std::move(fs);
+    }
 
     const io::ResourceId& resource_id() const { return _rowset_meta_pb.resource_id(); }
 

--- a/be/src/olap/rowset/rowset_writer_context.h
+++ b/be/src/olap/rowset/rowset_writer_context.h
@@ -18,24 +18,21 @@
 #pragma once
 
 #include "gen_cpp/olap_file.pb.h"
-#include "olap/data_dir.h"
-#include "olap/storage_engine.h"
-#include "olap/tablet.h"
 #include "olap/tablet_schema.h"
+#include "io/fs/file_system.h"
 
 namespace doris {
 
 class RowsetWriterContextBuilder;
 using RowsetWriterContextBuilderSharedPtr = std::shared_ptr<RowsetWriterContextBuilder>;
+class DataDir;
 
 struct RowsetWriterContext {
     RowsetWriterContext()
             : tablet_id(0),
               tablet_schema_hash(0),
               partition_id(0),
-              rowset_type(ALPHA_ROWSET),
-              fs(nullptr),
-              tablet_schema(nullptr),
+              rowset_type(BETA_ROWSET),
               rowset_state(PREPARED),
               version(Version(0, 0)),
               txn_id(0),
@@ -45,33 +42,13 @@ struct RowsetWriterContext {
         load_id.set_lo(0);
     }
 
-    static RowsetWriterContext create(const Version& version, TabletSharedPtr new_tablet,
-                                      RowsetTypePB new_rowset_type,
-                                      SegmentsOverlapPB segments_overlap) {
-        RowsetWriterContext context;
-        context.rowset_id = StorageEngine::instance()->next_rowset_id();
-        context.tablet_uid = new_tablet->tablet_uid();
-        context.tablet_id = new_tablet->tablet_id();
-        context.partition_id = new_tablet->partition_id();
-        context.tablet_schema_hash = new_tablet->schema_hash();
-        context.rowset_type = new_rowset_type;
-        context.rowset_dir = new_tablet->tablet_path();
-        context.tablet_schema = new_tablet->tablet_schema();
-        context.data_dir = new_tablet->data_dir();
-        context.rowset_state = VISIBLE;
-        context.version = version;
-        context.segments_overlap = segments_overlap;
-
-        return context;
-    }
-
     RowsetId rowset_id;
     int64_t tablet_id;
     int64_t tablet_schema_hash;
     int64_t partition_id;
     RowsetTypePB rowset_type;
-    io::FileSystemSPtr fs = nullptr;
-    std::string rowset_dir = "";
+    io::FileSystemSPtr fs;
+    std::string rowset_dir;
     TabletSchemaSPtr tablet_schema;
     // PREPARED/COMMITTED for pending rowset
     // VISIBLE for non-pending rowset

--- a/be/src/olap/rowset/rowset_writer_context.h
+++ b/be/src/olap/rowset/rowset_writer_context.h
@@ -18,8 +18,8 @@
 #pragma once
 
 #include "gen_cpp/olap_file.pb.h"
-#include "olap/tablet_schema.h"
 #include "io/fs/file_system.h"
+#include "olap/tablet_schema.h"
 
 namespace doris {
 

--- a/be/src/olap/tablet.h
+++ b/be/src/olap/tablet.h
@@ -291,27 +291,10 @@ public:
         return _tablet_meta->tablet_schema(version);
     }
 
-    Status create_rowset_writer(const Version& version, const RowsetStatePB& rowset_state,
-                                const SegmentsOverlapPB& overlap, TabletSchemaSPtr tablet_schema,
-                                int64_t oldest_write_timestamp, int64_t newest_write_timestamp,
+    Status create_rowset_writer(RowsetWriterContext& context,
                                 std::unique_ptr<RowsetWriter>* rowset_writer);
 
-    Status create_rowset_writer(const Version& version, const RowsetStatePB& rowset_state,
-                                const SegmentsOverlapPB& overlap, TabletSchemaSPtr tablet_schema,
-                                int64_t oldest_write_timestamp, int64_t newest_write_timestamp,
-                                io::FileSystemSPtr fs,
-                                std::unique_ptr<RowsetWriter>* rowset_writer);
-
-    Status create_rowset_writer(const int64_t& txn_id, const PUniqueId& load_id,
-                                const RowsetStatePB& rowset_state, const SegmentsOverlapPB& overlap,
-                                TabletSchemaSPtr tablet_schema,
-                                std::unique_ptr<RowsetWriter>* rowset_writer);
-
-    Status create_vertical_rowset_writer(const Version& version, const RowsetStatePB& rowset_state,
-                                         const SegmentsOverlapPB& overlap,
-                                         TabletSchemaSPtr tablet_schema,
-                                         int64_t oldest_write_timestamp,
-                                         int64_t newest_write_timestamp,
+    Status create_vertical_rowset_writer(RowsetWriterContext& context,
                                          std::unique_ptr<RowsetWriter>* rowset_writer);
 
     Status create_rowset(RowsetMetaSharedPtr rowset_meta, RowsetSharedPtr* rowset);

--- a/be/test/olap/rowid_conversion_test.cpp
+++ b/be/test/olap/rowid_conversion_test.cpp
@@ -55,8 +55,6 @@ protected:
         }
         EXPECT_TRUE(FileUtils::create_dir(absolute_dir).ok());
         EXPECT_TRUE(FileUtils::create_dir(absolute_dir + "/tablet_path").ok());
-        _data_dir = std::make_unique<DataDir>(absolute_dir);
-        _data_dir->update_capacity();
         doris::EngineOptions options;
         k_engine = new StorageEngine(options);
         StorageEngine::_s_instance = k_engine;
@@ -130,10 +128,9 @@ protected:
         rowset_id.init(inc_id);
         rowset_writer_context->rowset_id = rowset_id;
         rowset_writer_context->rowset_type = BETA_ROWSET;
-        rowset_writer_context->data_dir = _data_dir.get();
         rowset_writer_context->rowset_state = VISIBLE;
         rowset_writer_context->tablet_schema = tablet_schema;
-        rowset_writer_context->rowset_dir = "tablet_path";
+        rowset_writer_context->rowset_dir = absolute_dir + "/tablet_path";
         rowset_writer_context->version = Version(inc_id, inc_id);
         rowset_writer_context->segments_overlap = overlap;
         rowset_writer_context->max_rows_per_segment = max_rows_per_segment;
@@ -463,7 +460,6 @@ protected:
 private:
     const std::string kTestDir = "/ut_dir/rowid_conversion_test";
     string absolute_dir;
-    std::unique_ptr<DataDir> _data_dir;
 };
 
 TEST_F(TestRowIdConversion, Basic) {

--- a/be/test/olap/rowid_conversion_test.cpp
+++ b/be/test/olap/rowid_conversion_test.cpp
@@ -32,6 +32,7 @@
 #include "olap/rowset/rowset_writer.h"
 #include "olap/rowset/rowset_writer_context.h"
 #include "olap/schema.h"
+#include "olap/storage_engine.h"
 #include "olap/tablet_schema.h"
 #include "olap/tablet_schema_helper.h"
 #include "util/file_utils.h"

--- a/be/test/vec/olap/vertical_compaction_test.cpp
+++ b/be/test/vec/olap/vertical_compaction_test.cpp
@@ -29,6 +29,7 @@
 #include "olap/rowset/rowset_writer.h"
 #include "olap/rowset/rowset_writer_context.h"
 #include "olap/schema.h"
+#include "olap/storage_engine.h"
 #include "olap/tablet_schema.h"
 #include "olap/tablet_schema_helper.h"
 #include "util/file_utils.h"

--- a/be/test/vec/olap/vertical_compaction_test.cpp
+++ b/be/test/vec/olap/vertical_compaction_test.cpp
@@ -55,8 +55,6 @@ protected:
         }
         EXPECT_TRUE(FileUtils::create_dir(absolute_dir).ok());
         EXPECT_TRUE(FileUtils::create_dir(absolute_dir + "/tablet_path").ok());
-        _data_dir = std::make_unique<DataDir>(absolute_dir);
-        _data_dir->update_capacity();
         doris::EngineOptions options;
         k_engine = new StorageEngine(options);
         StorageEngine::_s_instance = k_engine;
@@ -164,10 +162,9 @@ protected:
         rowset_id.init(inc_id);
         rowset_writer_context->rowset_id = rowset_id;
         rowset_writer_context->rowset_type = BETA_ROWSET;
-        rowset_writer_context->data_dir = _data_dir.get();
         rowset_writer_context->rowset_state = VISIBLE;
         rowset_writer_context->tablet_schema = tablet_schema;
-        rowset_writer_context->rowset_dir = "tablet_path";
+        rowset_writer_context->rowset_dir = absolute_dir + "/tablet_path";
         rowset_writer_context->version = Version(inc_id, inc_id);
         rowset_writer_context->segments_overlap = overlap;
         rowset_writer_context->max_rows_per_segment = max_rows_per_segment;
@@ -364,7 +361,6 @@ protected:
 private:
     const std::string kTestDir = "/ut_dir/vertical_compaction_test";
     string absolute_dir;
-    std::unique_ptr<DataDir> _data_dir;
 };
 
 TEST_F(VerticalCompactionTest, TestRowSourcesBuffer) {


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

1.  Unify redundant `create_rowset_writer` methods.
2. Set `resource_id` when setting `fs` in rowset meta

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
3. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
5. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
6. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

