### PR TITLE
[fix](merge-on-write) unique key mow tables should require distribution columns be key column

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateTableStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateTableStmt.java
@@ -436,7 +436,7 @@ public class CreateTableStmt extends DdlStmt {
             if (distributionDesc == null) {
                 throw new AnalysisException("Create olap table should contain distribution desc");
             }
-            distributionDesc.analyze(columnSet, columnDefs);
+            distributionDesc.analyze(columnSet, columnDefs, keysDesc);
             if (distributionDesc.type == DistributionInfo.DistributionInfoType.RANDOM) {
                 if (keysDesc.getKeysType() == KeysType.UNIQUE_KEYS) {
                     throw new AnalysisException("Create unique keys table should not contain random distribution desc");

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/DistributionDesc.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/DistributionDesc.java
@@ -40,7 +40,7 @@ public class DistributionDesc implements Writable {
 
     }
 
-    public void analyze(Set<String> colSet, List<ColumnDef> columnDefs) throws AnalysisException {
+    public void analyze(Set<String> colSet, List<ColumnDef> columnDefs, KeysDesc keysDesc) throws AnalysisException {
         throw new NotImplementedException();
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/HashDistributionDesc.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/HashDistributionDesc.java
@@ -17,7 +17,6 @@
 
 package org.apache.doris.analysis;
 
-import org.apache.doris.catalog.AggregateType;
 import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.DistributionInfo;
 import org.apache.doris.catalog.DistributionInfo.DistributionInfoType;
@@ -30,7 +29,6 @@ import org.apache.doris.common.io.Text;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
-import org.apache.twill.internal.Configs.Keys;
 
 import java.io.DataInput;
 import java.io.DataOutput;

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/RandomDistributionDesc.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/RandomDistributionDesc.java
@@ -42,7 +42,7 @@ public class RandomDistributionDesc extends DistributionDesc {
     }
 
     @Override
-    public void analyze(Set<String> colSet, List<ColumnDef> columnDefs) throws AnalysisException {
+    public void analyze(Set<String> colSet, List<ColumnDef> columnDefs, KeysDesc keysDesc) throws AnalysisException {
         if (numBucket <= 0) {
             throw new AnalysisException("Number of random distribution should be larger than zero.");
         }

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/CreateTableStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/CreateTableStmtTest.java
@@ -158,10 +158,18 @@ public class CreateTableStmtTest {
         col4.setIsKey(false);
         cols.add(col4);
         // test merge-on-write
-        CreateTableStmt stmt = new CreateTableStmt(false, false, tblName, cols, "olap",
+        CreateTableStmt stmt1 = new CreateTableStmt(false, false, tblName, cols, "olap",
                 new KeysDesc(KeysType.UNIQUE_KEYS, colsName), null,
-                new HashDistributionDesc(10, Lists.newArrayList("col1")), properties, null, "");
-        stmt.analyze(analyzer);
+                new HashDistributionDesc(10, Lists.newArrayList("col3")), properties, null, "");
+        expectedEx.expect(AnalysisException.class);
+        expectedEx.expectMessage("Distribution column[col3] is not key column");
+        stmt1.analyze(analyzer);
+
+        CreateTableStmt stmt2 = new CreateTableStmt(false, false, tblName, cols, "olap",
+                new KeysDesc(KeysType.UNIQUE_KEYS, colsName), null,
+                new HashDistributionDesc(10, Lists.newArrayList("col3")), properties, null, "");
+        stmt2.analyze(analyzer);
+
         Assert.assertEquals(col3.getAggregateType(), AggregateType.NONE);
         Assert.assertEquals(col4.getAggregateType(), AggregateType.NONE);
         // clear


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

