### PR TITLE
[fix](create-table) wrong judgement about partition column type

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/PartitionDesc.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/PartitionDesc.java
@@ -108,6 +108,10 @@ public class PartitionDesc {
                         throw new AnalysisException("String Type should not be used in partition column["
                                 + columnDef.getName() + "].");
                     }
+                    if (columnDef.getType().isComplexType()) {
+                        throw new AnalysisException("Complex type column can't be partition column: "
+                                + columnDef.getType().toString());
+                    }
                     if (!ConnectContext.get().getSessionVariable().isAllowPartitionColumnNullable()
                             && columnDef.isAllowNull()) {
                         throw new AnalysisException("The partition column must be NOT NULL");

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/RangePartitionDesc.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/RangePartitionDesc.java
@@ -84,6 +84,10 @@ public class RangePartitionDesc extends PartitionDesc {
             boolean find = false;
             for (Column column : schema) {
                 if (column.getName().equalsIgnoreCase(colName)) {
+                    if (column.getType().isComplexType()) {
+                        throw new DdlException("Complex type column can't be partition column: "
+                                + column.getType().toString());
+                    }
                     try {
                         RangePartitionInfo.checkPartitionColumn(column);
                     } catch (AnalysisException e) {
@@ -93,10 +97,6 @@ public class RangePartitionDesc extends PartitionDesc {
                     partitionColumns.add(column);
                     find = true;
                     break;
-                }
-                if (column.getType().isComplexType()) {
-                    throw new DdlException("Complex type column can't be partition column: "
-                            + column.getType().toString());
                 }
             }
             if (!find) {

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/CreateTableTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/CreateTableTest.java
@@ -644,5 +644,46 @@ public class CreateTableTest {
                     + ") distributed by hash(k1) buckets 1\n"
                     + "properties(\"replication_num\" = \"1\");");
         });
+
+        ExceptionChecker.expectThrowsNoException(() -> {
+            createTable("create table test.test_array( \n"
+                    + "task_insert_time BIGINT NOT NULL DEFAULT \"0\" COMMENT \"\" , \n"
+                    + "task_project ARRAY<VARCHAR(64)>  DEFAULT NULL COMMENT \"\" ,\n"
+                    + "route_key DATEV2 NOT NULL COMMENT \"range分区键\"\n"
+                    + ") \n"
+                    + "DUPLICATE KEY(`task_insert_time`)  \n"
+                    + " COMMENT \"\"\n"
+                    + "PARTITION BY RANGE(route_key) \n"
+                    + "(PARTITION `p202209` VALUES LESS THAN (\"2022-10-01\"),\n"
+                    + "PARTITION `p202210` VALUES LESS THAN (\"2022-11-01\"),\n"
+                    + "PARTITION `p202211` VALUES LESS THAN (\"2022-12-01\")) \n"
+                    + "DISTRIBUTED BY HASH(`task_insert_time` ) BUCKETS 32 \n"
+                    + "PROPERTIES\n"
+                    + "(\n"
+                    + "    \"replication_num\" = \"1\",    \n"
+                    + "    \"light_schema_change\" = \"true\"    \n"
+                    + ");");
+        });
+
+        ExceptionChecker.expectThrowsWithMsg(AnalysisException.class, "Complex type column can't be partition column",
+                () -> {
+                    createTable("create table test.test_array2( \n"
+                            + "task_insert_time BIGINT NOT NULL DEFAULT \"0\" COMMENT \"\" , \n"
+                            + "task_project ARRAY<VARCHAR(64)>  DEFAULT NULL COMMENT \"\" ,\n"
+                            + "route_key DATEV2 NOT NULL COMMENT \"range分区键\"\n"
+                            + ") \n"
+                            + "DUPLICATE KEY(`task_insert_time`)  \n"
+                            + " COMMENT \"\"\n"
+                            + "PARTITION BY RANGE(task_project) \n"
+                            + "(PARTITION `p202209` VALUES LESS THAN (\"2022-10-01\"),\n"
+                            + "PARTITION `p202210` VALUES LESS THAN (\"2022-11-01\"),\n"
+                            + "PARTITION `p202211` VALUES LESS THAN (\"2022-12-01\")) \n"
+                            + "DISTRIBUTED BY HASH(`task_insert_time` ) BUCKETS 32 \n"
+                            + "PROPERTIES\n"
+                            + "(\n"
+                            + "    \"replication_num\" = \"1\",    \n"
+                            + "    \"light_schema_change\" = \"true\"    \n"
+                            + ");");
+                });
     }
 }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

The following stmt should be success, but return error: `complex type cannt be partition column：ARRAY<VARCHAR(64)>`

```
create table test_array( 
task_insert_time BIGINT NOT NULL DEFAULT "0" COMMENT "" , 
task_project ARRAY<VARCHAR(64)>  DEFAULT NULL COMMENT "" ,
route_key DATEV2 NOT NULL COMMENT "range分区键"
) 
DUPLICATE KEY(`task_insert_time`)  
 COMMENT ""
PARTITION BY RANGE(route_key) 
(PARTITION `p202209` VALUES LESS THAN ("2022-10-01"),
PARTITION `p202210` VALUES LESS THAN ("2022-11-01"),
PARTITION `p202211` VALUES LESS THAN ("2022-12-01")) 
DISTRIBUTED BY HASH(`task_insert_time` ) BUCKETS 32 
PROPERTIES
(
    "replication_num" = "1",    
    "light_schema_change" = "true"    
);
```

This PR fix this

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [x] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

