### PR TITLE
[chore](script) add build-for-release.sh

### DIFF
--- a/build-for-release.sh
+++ b/build-for-release.sh
@@ -29,7 +29,7 @@ export DORIS_HOME="${ROOT}"
 # Check args
 usage() {
     echo "
-Usage: $0 --version "version" <options>
+Usage: $0 --version version <options>
   Optional options:
      [no option]        build with avx2
      --noavx2           build without avx2
@@ -110,8 +110,8 @@ echo "Get params:
 "
 
 sh build.sh --clean &&
-USE_AVX2="${_USE_AVX2}" sh build.sh &&
-USE_AVX2="${_USE_AVX2}" sh build.sh --be --meta-tool &&
+    USE_AVX2="${_USE_AVX2}" sh build.sh &&
+    USE_AVX2="${_USE_AVX2}" sh build.sh --be --meta-tool
 
 echo "Begin to pack"
 ORI_OUTPUT="${ROOT}/output"
@@ -134,27 +134,27 @@ echo "FE:   ${OUTPUT_FE}"
 echo "BE:   ${OUTPUT_BE}"
 echo "JAR:  ${OUTPUT_DEPS}"
 
-rm -rf ${OUTPUT}
-mkdir -p ${OUTPUT_FE} ${OUTPUT_BE} ${OUTPUT_DEPS}
+rm -rf "${OUTPUT}"
+mkdir -p "${OUTPUT_FE}" "${OUTPUT_BE}" "${OUTPUT_DEPS}"
 
 # FE
-cp -R ${ORI_OUTPUT}/fe/* ${OUTPUT_FE}/
+cp -R "${ORI_OUTPUT}"/fe/* "${OUTPUT_FE}"/
 
 # DEPS
-cp ${ORI_OUTPUT}/be/lib/java-udf-jar-with-dependencies.jar ${OUTPUT_DEPS}/
-cp -R ${ORI_OUTPUT}/apache_hdfs_broker ${OUTPUT_DEPS}/apache_hdfs_broker
-cp -R ${ORI_OUTPUT}/audit_loader ${OUTPUT_DEPS}/audit_loader
+cp "${ORI_OUTPUT}"/be/lib/java-udf-jar-with-dependencies.jar "${OUTPUT_DEPS}"/
+cp -R "${ORI_OUTPUT}"/apache_hdfs_broker "${OUTPUT_DEPS}"/apache_hdfs_broker
+cp -R "${ORI_OUTPUT}"/audit_loader "${OUTPUT_DEPS}"/audit_loader
 
 # BE
-cp -R ${ORI_OUTPUT}/be/* ${OUTPUT_BE}/
-rm ${OUTPUT_BE}/lib/java-udf-jar-with-dependencies.jar
+cp -R "${ORI_OUTPUT}"/be/* "${OUTPUT_BE}"/
+rm "${OUTPUT_BE}"/lib/java-udf-jar-with-dependencies.jar
 
 if [[ "${TAR}" -eq 1 ]]; then
     echo "Begin to compress"
-    cd ${OUTPUT}
-    tar -cf - ${FE} | xz -T0 -z - > ${FE}.tar.xz
-    tar -cf - ${BE} | xz -T0 -z - > ${BE}.tar.xz
-    tar -cf - ${DEPS} | xz -T0 -z - > ${DEPS}.tar.xz
+    cd "${OUTPUT}"
+    tar -cf - "${FE}" | xz -T0 -z - >"${FE}".tar.xz
+    tar -cf - "${BE}" | xz -T0 -z - >"${BE}".tar.xz
+    tar -cf - "${DEPS}" | xz -T0 -z - >"${DEPS}".tar.xz
     cd -
 fi
 

--- a/build-for-release.sh
+++ b/build-for-release.sh
@@ -140,7 +140,7 @@ mkdir -p ${OUTPUT_FE} ${OUTPUT_BE} ${OUTPUT_DEPS}
 # FE
 cp -R ${ORI_OUTPUT}/fe/* ${OUTPUT_FE}/
 
-# Jar
+# DEPS
 cp ${ORI_OUTPUT}/be/lib/java-udf-jar-with-dependencies.jar ${OUTPUT_DEPS}/
 cp -R ${ORI_OUTPUT}/apache_hdfs_broker ${OUTPUT_DEPS}/apache_hdfs_broker
 cp -R ${ORI_OUTPUT}/audit_loader ${OUTPUT_DEPS}/audit_loader

--- a/build-for-release.sh
+++ b/build-for-release.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+##############################################################
+# This script is used to build for Apache Doris Release
+##############################################################
+
+set -eo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+
+export DORIS_HOME="${ROOT}"
+
+# Check args
+usage() {
+    echo "
+Usage: $0 --version "version" <options>
+  Optional options:
+     [no option]        build with avx2
+     --noavx2           build without avx2
+     --tar              pack the output
+
+  Eg.
+    $0 --version 1.2.0                      build with avx2
+    $0 --noavx2 --version 1.2.0             build without avx2
+    $0 --version 1.2.0 --tar                build with avx2 and pack the output
+  "
+    exit 1
+}
+
+if ! OPTS="$(getopt \
+    -n "$0" \
+    -o '' \
+    -l 'noavx2' \
+    -l 'tar' \
+    -l 'version:' \
+    -l 'help' \
+    -- "$@")"; then
+    usage
+fi
+
+eval set -- "${OPTS}"
+
+_USE_AVX2=1
+TAR=0
+VERSION=
+if [[ "$#" == 1 ]]; then
+    _USE_AVX2=1
+else
+    while true; do
+        case "$1" in
+        --noavx2)
+            _USE_AVX2=0
+            shift
+            ;;
+        --tar)
+            TAR=1
+            shift
+            ;;
+        --version)
+            VERSION="$2"
+            shift 2
+            ;;
+        --help)
+            HELP=1
+            shift
+            ;;
+        --)
+            shift
+            break
+            ;;
+        *)
+            echo "Internal error"
+            exit 1
+            ;;
+        esac
+    done
+fi
+
+if [[ "${HELP}" -eq 1 ]]; then
+    usage
+    exit
+fi
+
+if [[ -z ${VERSION} ]]; then
+    echo "Must specify version"
+    usage
+    exit 1
+fi
+
+echo "Get params:
+    VERSION         -- ${VERSION}
+    USE_AVX2        -- ${_USE_AVX2}
+    TAR             -- ${TAR}
+"
+
+sh build.sh --clean &&
+USE_AVX2="${_USE_AVX2}" sh build.sh &&
+USE_AVX2="${_USE_AVX2}" sh build.sh --be --meta-tool &&
+
+echo "Begin to pack"
+ORI_OUTPUT="${ROOT}/output"
+
+FE=apache-doris-fe-${VERSION}-bin-x86_64
+BE=apache-doris-be-${VERSION}-bin-x86_64
+DEPS=apache-doris-dependencies-${VERSION}-bin-x86_64
+
+OUTPUT="${ORI_OUTPUT}/apache-doris-${VERSION}-bin-x86_64"
+OUTPUT_FE="${OUTPUT}/${FE}"
+OUTPUT_DEPS="${OUTPUT}/${DEPS}"
+OUTPUT_BE="${OUTPUT}/${BE}"
+
+if [[ "${_USE_AVX2}" == "0" ]]; then
+    OUTPUT_BE="${OUTPUT_BE}-noavx2"
+fi
+
+echo "Pakage Name:"
+echo "FE:   ${OUTPUT_FE}"
+echo "BE:   ${OUTPUT_BE}"
+echo "JAR:  ${OUTPUT_DEPS}"
+
+rm -rf ${OUTPUT}
+mkdir -p ${OUTPUT_FE} ${OUTPUT_BE} ${OUTPUT_DEPS}
+
+# FE
+cp -R ${ORI_OUTPUT}/fe/* ${OUTPUT_FE}/
+
+# Jar
+cp ${ORI_OUTPUT}/be/lib/java-udf-jar-with-dependencies.jar ${OUTPUT_DEPS}/
+cp -R ${ORI_OUTPUT}/apache_hdfs_broker ${OUTPUT_DEPS}/apache_hdfs_broker
+cp -R ${ORI_OUTPUT}/audit_loader ${OUTPUT_DEPS}/audit_loader
+
+# BE
+cp -R ${ORI_OUTPUT}/be/* ${OUTPUT_BE}/
+rm ${OUTPUT_BE}/lib/java-udf-jar-with-dependencies.jar
+
+if [[ "${TAR}" -eq 1 ]]; then
+    echo "Begin to compress"
+    cd ${OUTPUT}
+    tar -cf - ${FE} | xz -T0 -z - > ${FE}.tar.xz
+    tar -cf - ${BE} | xz -T0 -z - > ${BE}.tar.xz
+    tar -cf - ${DEPS} | xz -T0 -z - > ${DEPS}.tar.xz
+    cd -
+fi
+
+echo "Output dir: ${OUTPUT}"
+exit 0

--- a/docs/en/docs/install/source-install/compilation-with-ldb-toolchain.md
+++ b/docs/en/docs/install/source-install/compilation-with-ldb-toolchain.md
@@ -125,3 +125,14 @@ $ USE_AVX2=0 sh build.sh
 If supported, execute `sh build.sh` directly.
 
 This script will compile the third-party libraries first and then the Doris components (FE, BE) later. The compiled output will be in the `output/` directory.
+
+## Precompile the three-party binaries
+
+The `build.sh` script will first compile the third-party dependencies. You can also directly download the precompiled three-party binaries:
+
+`https://github.com/apache/doris-thirdparty/releases`
+
+Here we provide precompiled third-party binaries for Linux X86(with AVX2) and MacOS(X86 Chip). If it is consistent with your compiling and running environment, you can download and use it directly.
+
+After downloading, you will get an `installed/` directory after decompression, copy this directory to the `thirdparty/` directory, and then run `build.sh`.
+

--- a/docs/zh-CN/docs/install/source-install/compilation-with-ldb-toolchain.md
+++ b/docs/zh-CN/docs/install/source-install/compilation-with-ldb-toolchain.md
@@ -119,9 +119,20 @@ $ cat /proc/cpuinfo | grep avx2
 不支持则使用以下命令进行编译
 
 ```
-$ USE_AVX2=0  sh build.sh
+$ USE_AVX2=0 sh build.sh
 ```
 
 若支持则直接执行 `sh build.sh` 即可
 
 该脚本会先编译第三方库，之后再编译 Doris 组件（FE、BE）。编译产出在 `output/` 目录下。
+
+## 预编译三方库
+
+`build.sh` 脚本会先编译第三方库。你也可以直接下载预编译好的三方库：
+
+`https://github.com/apache/doris-thirdparty/releases`
+
+这里我们提供了 Linux X86(with AVX2) 和 MacOS(X86芯片) 的预编译三方库。如果和你的编译运行环境一致，可以直接下载使用。
+
+下载好后，解压会得到一个 `installed/` 目录，将这个目录拷贝到 `thirdparty/` 目录下，之后运行 `build.sh` 即可。
+


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

Add `build-for-release.sh` for releasing.
eg:
`sh build-for-release.sh --version 1.2.0`

it will compile the source code and reorganize the output into 3 dirs:

```
apache-doris-be-${VERSION}-bin-x86_64
apache-doris-fe-${VERSION}-bin-x86_64
apache-doris-dependencies-${VERSION}-bin-x86_64
```

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [x] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

