### PR TITLE
[Fix](multi catalog)Skip non-vectorized init code for NewFileScanNode.

### DIFF
--- a/be/src/exec/exec_node.cpp
+++ b/be/src/exec/exec_node.cpp
@@ -123,7 +123,8 @@ Status ExecNode::init(const TPlanNode& tnode, RuntimeState* state) {
         RETURN_IF_ERROR(doris::vectorized::VExpr::create_expr_tree(_pool, tnode.vconjunct,
                                                                    _vconjunct_ctx_ptr.get()));
     }
-    if (typeid(*this) != typeid(doris::vectorized::NewOlapScanNode)) {
+    if (typeid(*this) != typeid(doris::vectorized::NewOlapScanNode) &&
+        typeid(*this) != typeid(doris::vectorized::NewFileScanNode)) {
         RETURN_IF_ERROR(Expr::create_expr_trees(_pool, tnode.conjuncts, &_conjunct_ctxs));
     }
 
@@ -166,7 +167,8 @@ Status ExecNode::prepare(RuntimeState* state) {
     // For vectorized olap scan node, the conjuncts is prepared in _vconjunct_ctx_ptr.
     // And _conjunct_ctxs is useless.
     // TODO: Should be removed when non-vec engine is removed.
-    if (typeid(*this) != typeid(doris::vectorized::NewOlapScanNode)) {
+    if (typeid(*this) != typeid(doris::vectorized::NewOlapScanNode) &&
+        typeid(*this) != typeid(doris::vectorized::NewFileScanNode)) {
         RETURN_IF_ERROR(Expr::prepare(_conjunct_ctxs, state, _row_descriptor));
     }
     RETURN_IF_ERROR(vectorized::VExpr::prepare(_projections, state, intermediate_row_desc()));
@@ -184,7 +186,8 @@ Status ExecNode::alloc_resource(doris::RuntimeState* state) {
         RETURN_IF_ERROR((*_vconjunct_ctx_ptr)->open(state));
     }
     RETURN_IF_ERROR(vectorized::VExpr::open(_projections, state));
-    if (typeid(*this) != typeid(doris::vectorized::NewOlapScanNode)) {
+    if (typeid(*this) != typeid(doris::vectorized::NewOlapScanNode) &&
+        typeid(*this) != typeid(doris::vectorized::NewFileScanNode)) {
         return Expr::open(_conjunct_ctxs, state);
     } else {
         return Status::OK();
@@ -220,7 +223,8 @@ void ExecNode::release_resource(doris::RuntimeState* state) {
         if (_vconjunct_ctx_ptr) {
             (*_vconjunct_ctx_ptr)->close(state);
         }
-        if (typeid(*this) != typeid(doris::vectorized::NewOlapScanNode)) {
+        if (typeid(*this) != typeid(doris::vectorized::NewOlapScanNode) &&
+            typeid(*this) != typeid(doris::vectorized::NewFileScanNode)) {
             Expr::close(_conjunct_ctxs, state);
         }
         vectorized::VExpr::close(_projections, state);


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

The new nereids planner is for vectorized code, skip the non-vectorized init code for NewFileScanNode, so that the new planner could support HMS external table.

Manually test on TPCH 1G cases.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

