### PR TITLE
[Improvement](topn) runtime prune for topn query

### DIFF
--- a/be/src/olap/iterators.h
+++ b/be/src/olap/iterators.h
@@ -26,6 +26,7 @@
 #include "olap/tablet_schema.h"
 #include "vec/core/block.h"
 #include "vec/exprs/vexpr.h"
+#include "runtime/runtime_state.h"
 
 namespace doris {
 
@@ -100,6 +101,8 @@ public:
     std::vector<uint32_t>* read_orderby_key_columns = nullptr;
     IOContext io_ctx;
     vectorized::VExpr* remaining_vconjunct_root = nullptr;
+    // runtime state
+    RuntimeState* runtime_state = nullptr;
 };
 
 class RowwiseIterator {

--- a/be/src/olap/iterators.h
+++ b/be/src/olap/iterators.h
@@ -95,6 +95,8 @@ public:
 
     TabletSchemaSPtr tablet_schema = nullptr;
     bool record_rowids = false;
+    // flag for enable topn opt
+    bool use_topn_opt = false;
     // used for special optimization for query : ORDER BY key DESC LIMIT n
     bool read_orderby_key_reverse = false;
     // columns for orderby keys

--- a/be/src/olap/iterators.h
+++ b/be/src/olap/iterators.h
@@ -24,9 +24,9 @@
 #include "olap/column_predicate.h"
 #include "olap/olap_common.h"
 #include "olap/tablet_schema.h"
+#include "runtime/runtime_state.h"
 #include "vec/core/block.h"
 #include "vec/exprs/vexpr.h"
-#include "runtime/runtime_state.h"
 
 namespace doris {
 

--- a/be/src/olap/reader.cpp
+++ b/be/src/olap/reader.cpp
@@ -524,8 +524,8 @@ void TabletReader::_init_conditions_param_except_leafnode_of_andnode(
     }
 
     if (read_params.use_topn_opt) {
-        auto & runtime_predicate =
-            read_params.runtime_state->get_query_fragments_ctx()->get_runtime_predicate();
+        auto& runtime_predicate =
+                read_params.runtime_state->get_query_fragments_ctx()->get_runtime_predicate();
         runtime_predicate.set_tablet_schema(_tablet_schema);
     }
 }

--- a/be/src/olap/reader.cpp
+++ b/be/src/olap/reader.cpp
@@ -203,6 +203,7 @@ Status TabletReader::_capture_rs_readers(const ReaderParams& read_params,
     _reader_context.version = read_params.version;
     _reader_context.tablet_schema = _tablet_schema;
     _reader_context.need_ordered_result = need_ordered_result;
+    _reader_context.use_topn_opt = read_params.use_topn_opt;
     _reader_context.read_orderby_key_reverse = read_params.read_orderby_key_reverse;
     _reader_context.return_columns = &_return_columns;
     _reader_context.read_orderby_key_columns =
@@ -522,7 +523,7 @@ void TabletReader::_init_conditions_param_except_leafnode_of_andnode(
         }
     }
 
-    if (read_params.reader_type == READER_QUERY) {
+    if (read_params.use_topn_opt) {
         auto & runtime_predicate =
             read_params.runtime_state->get_query_fragments_ctx()->get_runtime_predicate();
         runtime_predicate.set_tablet_schema(_tablet_schema);

--- a/be/src/olap/reader.cpp
+++ b/be/src/olap/reader.cpp
@@ -521,6 +521,12 @@ void TabletReader::_init_conditions_param_except_leafnode_of_andnode(
             _col_preds_except_leafnode_of_andnode.push_back(predicate);
         }
     }
+
+    if (read_params.reader_type == READER_QUERY) {
+        auto & runtime_predicate =
+            read_params.runtime_state->get_query_fragments_ctx()->get_runtime_predicate();
+        runtime_predicate.set_tablet_schema(_tablet_schema);
+    }
 }
 
 ColumnPredicate* TabletReader::_parse_to_predicate(

--- a/be/src/olap/reader.h
+++ b/be/src/olap/reader.h
@@ -96,6 +96,8 @@ public:
 
         // used for compaction to record row ids
         bool record_rowids = false;
+        // flag for enable topn opt
+        bool use_topn_opt = false;
         // used for special optimization for query : ORDER BY key LIMIT n
         bool read_orderby_key = false;
         // used for special optimization for query : ORDER BY key DESC LIMIT n

--- a/be/src/olap/rowset/beta_rowset_reader.cpp
+++ b/be/src/olap/rowset/beta_rowset_reader.cpp
@@ -147,6 +147,7 @@ Status BetaRowsetReader::get_segment_iterators(RowsetReaderContext* read_context
     _read_options.use_page_cache = read_context->use_page_cache;
     _read_options.tablet_schema = read_context->tablet_schema;
     _read_options.record_rowids = read_context->record_rowids;
+    _read_options.use_topn_opt = read_context->use_topn_opt;
     _read_options.read_orderby_key_reverse = read_context->read_orderby_key_reverse;
     _read_options.read_orderby_key_columns = read_context->read_orderby_key_columns;
     _read_options.io_ctx.reader_type = read_context->reader_type;

--- a/be/src/olap/rowset/beta_rowset_reader.cpp
+++ b/be/src/olap/rowset/beta_rowset_reader.cpp
@@ -150,6 +150,7 @@ Status BetaRowsetReader::get_segment_iterators(RowsetReaderContext* read_context
     _read_options.read_orderby_key_reverse = read_context->read_orderby_key_reverse;
     _read_options.read_orderby_key_columns = read_context->read_orderby_key_columns;
     _read_options.io_ctx.reader_type = read_context->reader_type;
+    _read_options.runtime_state = read_context->runtime_state;
 
     // load segments
     RETURN_NOT_OK(SegmentLoader::instance()->load_segments(

--- a/be/src/olap/rowset/rowset_reader_context.h
+++ b/be/src/olap/rowset/rowset_reader_context.h
@@ -34,6 +34,8 @@ struct RowsetReaderContext {
     ReaderType reader_type = READER_QUERY;
     Version version {-1, -1};
     TabletSchemaSPtr tablet_schema = nullptr;
+    // flag for enable topn opt
+    bool use_topn_opt = false;
     // whether rowset should return ordered rows.
     bool need_ordered_result = true;
     // used for special optimization for query : ORDER BY key DESC LIMIT n

--- a/be/src/olap/rowset/segment_v2/segment.cpp
+++ b/be/src/olap/rowset/segment_v2/segment.cpp
@@ -115,8 +115,8 @@ Status Segment::new_iterator(const Schema& schema, const StorageReadOptions& rea
         auto query_ctx = read_options.runtime_state->get_query_fragments_ctx();
         auto runtime_predicate = query_ctx->get_runtime_predicate().get_predictate();
         if (runtime_predicate) {
-            int32_t uid = read_options.tablet_schema->column(
-                            runtime_predicate->column_id()).unique_id();
+            int32_t uid =
+                    read_options.tablet_schema->column(runtime_predicate->column_id()).unique_id();
             AndBlockColumnPredicate and_predicate;
             auto single_predicate = new SingleColumnBlockPredicate(runtime_predicate.get());
             and_predicate.add_column_predicate(single_predicate);

--- a/be/src/olap/rowset/segment_v2/segment.cpp
+++ b/be/src/olap/rowset/segment_v2/segment.cpp
@@ -111,7 +111,7 @@ Status Segment::new_iterator(const Schema& schema, const StorageReadOptions& rea
         }
     }
 
-    if (read_options.runtime_state) {
+    if (read_options.use_topn_opt) {
         auto query_ctx = read_options.runtime_state->get_query_fragments_ctx();
         auto runtime_predicate = query_ctx->get_runtime_predicate().get_predictate();
         if (runtime_predicate) {

--- a/be/src/olap/rowset/segment_v2/segment_iterator.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.cpp
@@ -910,6 +910,16 @@ void SegmentIterator::_vec_init_lazy_materialization() {
         }
     }
 
+    // add runtime predicate to _col_predicates
+    if (_opts.runtime_state && _opts.runtime_state->get_query_fragments_ctx()) {
+        auto & runtime_predicate =
+            _opts.runtime_state->get_query_fragments_ctx()->get_runtime_predicate();
+        _runtime_predicate = runtime_predicate.get_predictate();
+        if (_runtime_predicate) {
+            _col_predicates.push_back(_runtime_predicate.get());
+        }
+    }
+
     if (!_col_predicates.empty() || !del_cond_id_set.empty()) {
         std::set<ColumnId> short_cir_pred_col_id_set; // using set for distinct cid
         std::set<ColumnId> vec_pred_col_id_set;

--- a/be/src/olap/rowset/segment_v2/segment_iterator.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.cpp
@@ -319,7 +319,7 @@ Status SegmentIterator::_get_row_ranges_by_column_conditions() {
     RETURN_IF_ERROR(_apply_inverted_index());
 
     std::shared_ptr<doris::ColumnPredicate> runtime_predicate = nullptr;
-    if (_opts.runtime_state) {
+    if (_opts.use_topn_opt) {
         auto query_ctx = _opts.runtime_state->get_query_fragments_ctx();
         runtime_predicate = query_ctx->get_runtime_predicate().get_predictate();
     }
@@ -379,7 +379,7 @@ Status SegmentIterator::_get_row_ranges_from_conditions(RowRanges* condition_row
     }
 
     std::shared_ptr<doris::ColumnPredicate> runtime_predicate = nullptr;
-    if (_opts.runtime_state) {
+    if (_opts.use_topn_opt) {
         auto query_ctx = _opts.runtime_state->get_query_fragments_ctx();
         runtime_predicate = query_ctx->get_runtime_predicate().get_predictate();
         if (runtime_predicate) {
@@ -938,7 +938,7 @@ void SegmentIterator::_vec_init_lazy_materialization() {
     }
 
     // add runtime predicate to _col_predicates
-    if (_opts.runtime_state && _opts.runtime_state->get_query_fragments_ctx()) {
+    if (_opts.use_topn_opt) {
         auto & runtime_predicate =
             _opts.runtime_state->get_query_fragments_ctx()->get_runtime_predicate();
         _runtime_predicate = runtime_predicate.get_predictate();

--- a/be/src/olap/rowset/segment_v2/segment_iterator.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.cpp
@@ -383,19 +383,18 @@ Status SegmentIterator::_get_row_ranges_from_conditions(RowRanges* condition_row
         auto query_ctx = _opts.runtime_state->get_query_fragments_ctx();
         runtime_predicate = query_ctx->get_runtime_predicate().get_predictate();
         if (runtime_predicate) {
-            int32_t cid = _opts.tablet_schema->column(
-                            runtime_predicate->column_id()).unique_id();
+            int32_t cid = _opts.tablet_schema->column(runtime_predicate->column_id()).unique_id();
             AndBlockColumnPredicate and_predicate;
             auto single_predicate = new SingleColumnBlockPredicate(runtime_predicate.get());
             and_predicate.add_column_predicate(single_predicate);
 
             RowRanges column_rp_row_ranges = RowRanges::create_single(num_rows());
             RETURN_IF_ERROR(_column_iterators[_schema.unique_id(cid)]->get_row_ranges_by_zone_map(
-                &and_predicate, nullptr, &column_rp_row_ranges));
+                    &and_predicate, nullptr, &column_rp_row_ranges));
 
             // intersect different columns's row ranges to get final row ranges by zone map
             RowRanges::ranges_intersection(zone_map_row_ranges, column_rp_row_ranges,
-                                        &zone_map_row_ranges);
+                                           &zone_map_row_ranges);
         }
     }
 
@@ -939,8 +938,8 @@ void SegmentIterator::_vec_init_lazy_materialization() {
 
     // add runtime predicate to _col_predicates
     if (_opts.use_topn_opt) {
-        auto & runtime_predicate =
-            _opts.runtime_state->get_query_fragments_ctx()->get_runtime_predicate();
+        auto& runtime_predicate =
+                _opts.runtime_state->get_query_fragments_ctx()->get_runtime_predicate();
         _runtime_predicate = runtime_predicate.get_predictate();
         if (_runtime_predicate) {
             _col_predicates.push_back(_runtime_predicate.get());

--- a/be/src/olap/rowset/segment_v2/segment_iterator.h
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.h
@@ -315,6 +315,8 @@ private:
     std::vector<roaring::Roaring> _pred_except_leafnode_of_andnode_evaluate_result;
     std::unique_ptr<ColumnPredicateInfo> _column_predicate_info;
 
+    std::shared_ptr<ColumnPredicate> _runtime_predicate {nullptr};
+
     // row schema of the key to seek
     // only used in `_get_row_ranges_by_keys`
     std::unique_ptr<Schema> _seek_schema;

--- a/be/src/runtime/CMakeLists.txt
+++ b/be/src/runtime/CMakeLists.txt
@@ -41,6 +41,7 @@ set(RUNTIME_FILES
     row_batch.cpp
     runtime_state.cpp
     runtime_filter_mgr.cpp
+    runtime_predicate.cpp
     string_value.cpp
     jsonb_value.cpp
     thread_context.cpp

--- a/be/src/runtime/primitive_type.cpp
+++ b/be/src/runtime/primitive_type.cpp
@@ -632,4 +632,41 @@ int get_slot_size(PrimitiveType type) {
     return 0;
 }
 
+PrimitiveType get_primitive_type(vectorized::TypeIndex v_type) {
+    switch (v_type) {
+    case vectorized::TypeIndex::Int8:
+        return PrimitiveType::TYPE_TINYINT;
+    case vectorized::TypeIndex::Int16:
+        return PrimitiveType::TYPE_SMALLINT;
+    case vectorized::TypeIndex::Int32:
+        return PrimitiveType::TYPE_INT;
+    case vectorized::TypeIndex::Int64:
+        return PrimitiveType::TYPE_BIGINT;
+    case vectorized::TypeIndex::Float32:
+        return PrimitiveType::TYPE_FLOAT;
+    case vectorized::TypeIndex::Float64:
+        return PrimitiveType::TYPE_DOUBLE;
+    case vectorized::TypeIndex::Decimal32:
+        return PrimitiveType::TYPE_DECIMALV2;
+    case vectorized::TypeIndex::Array:
+        return PrimitiveType::TYPE_ARRAY;
+    case vectorized::TypeIndex::String:
+        return PrimitiveType::TYPE_STRING;
+    case vectorized::TypeIndex::Date:
+        return PrimitiveType::TYPE_DATE;
+    case vectorized::TypeIndex::DateTime:
+        return PrimitiveType::TYPE_DATETIME;
+    case vectorized::TypeIndex::DateV2:
+        return PrimitiveType::TYPE_DATEV2;
+    case vectorized::TypeIndex::DateTimeV2:
+        return PrimitiveType::TYPE_DATETIMEV2;
+    case vectorized::TypeIndex::Tuple:
+        return PrimitiveType::TYPE_STRUCT;
+    // TODO add vectorized::more types
+    default:
+        LOG(FATAL) << "unknow data_type: " << getTypeName(v_type);
+        return PrimitiveType::INVALID_TYPE;
+    }
+}
+
 } // namespace doris

--- a/be/src/runtime/primitive_type.cpp
+++ b/be/src/runtime/primitive_type.cpp
@@ -632,41 +632,4 @@ int get_slot_size(PrimitiveType type) {
     return 0;
 }
 
-PrimitiveType get_primitive_type(vectorized::TypeIndex v_type) {
-    switch (v_type) {
-    case vectorized::TypeIndex::Int8:
-        return PrimitiveType::TYPE_TINYINT;
-    case vectorized::TypeIndex::Int16:
-        return PrimitiveType::TYPE_SMALLINT;
-    case vectorized::TypeIndex::Int32:
-        return PrimitiveType::TYPE_INT;
-    case vectorized::TypeIndex::Int64:
-        return PrimitiveType::TYPE_BIGINT;
-    case vectorized::TypeIndex::Float32:
-        return PrimitiveType::TYPE_FLOAT;
-    case vectorized::TypeIndex::Float64:
-        return PrimitiveType::TYPE_DOUBLE;
-    case vectorized::TypeIndex::Decimal32:
-        return PrimitiveType::TYPE_DECIMALV2;
-    case vectorized::TypeIndex::Array:
-        return PrimitiveType::TYPE_ARRAY;
-    case vectorized::TypeIndex::String:
-        return PrimitiveType::TYPE_STRING;
-    case vectorized::TypeIndex::Date:
-        return PrimitiveType::TYPE_DATE;
-    case vectorized::TypeIndex::DateTime:
-        return PrimitiveType::TYPE_DATETIME;
-    case vectorized::TypeIndex::DateV2:
-        return PrimitiveType::TYPE_DATEV2;
-    case vectorized::TypeIndex::DateTimeV2:
-        return PrimitiveType::TYPE_DATETIMEV2;
-    case vectorized::TypeIndex::Tuple:
-        return PrimitiveType::TYPE_STRUCT;
-    // TODO add vectorized::more types
-    default:
-        LOG(FATAL) << "unknow data_type: " << getTypeName(v_type);
-        return PrimitiveType::INVALID_TYPE;
-    }
-}
-
 } // namespace doris

--- a/be/src/runtime/primitive_type.h
+++ b/be/src/runtime/primitive_type.h
@@ -96,6 +96,10 @@ constexpr bool has_variable_type(PrimitiveType type) {
            type == TYPE_QUANTILE_STATE || type == TYPE_STRING;
 }
 
+// NOTICE:signed integers always return bigint
+// used for adapt data in varaint column's subcolumns
+PrimitiveType get_primitive_type(vectorized::TypeIndex v_type);
+
 // Returns the byte size of 'type'  Returns 0 for variable length types.
 int get_byte_size(PrimitiveType type);
 // Returns the byte size of type when in a tuple

--- a/be/src/runtime/primitive_type.h
+++ b/be/src/runtime/primitive_type.h
@@ -96,10 +96,6 @@ constexpr bool has_variable_type(PrimitiveType type) {
            type == TYPE_QUANTILE_STATE || type == TYPE_STRING;
 }
 
-// NOTICE:signed integers always return bigint
-// used for adapt data in varaint column's subcolumns
-PrimitiveType get_primitive_type(vectorized::TypeIndex v_type);
-
 // Returns the byte size of 'type'  Returns 0 for variable length types.
 int get_byte_size(PrimitiveType type);
 // Returns the byte size of type when in a tuple

--- a/be/src/runtime/query_fragments_ctx.h
+++ b/be/src/runtime/query_fragments_ctx.h
@@ -28,6 +28,7 @@
 #include "runtime/datetime_value.h"
 #include "runtime/exec_env.h"
 #include "runtime/memory/mem_tracker_limiter.h"
+#include "runtime/runtime_predicate.h"
 #include "util/pretty_printer.h"
 #include "util/threadpool.h"
 #include "vec/runtime/shared_hash_table_controller.h"
@@ -118,6 +119,8 @@ public:
         return _shared_hash_table_controller;
     }
 
+    vectorized::RuntimePredicate& get_runtime_predicate() { return _runtime_predicate; }
+
 public:
     TUniqueId query_id;
     DescriptorTbl* desc_tbl;
@@ -161,6 +164,8 @@ private:
     std::atomic<bool> _is_cancelled {false};
 
     std::shared_ptr<vectorized::SharedHashTableController> _shared_hash_table_controller;
+
+    vectorized::RuntimePredicate _runtime_predicate;
 };
 
 } // namespace doris

--- a/be/src/runtime/runtime_predicate.cpp
+++ b/be/src/runtime/runtime_predicate.cpp
@@ -99,7 +99,7 @@ Status RuntimePredicate::init(const PrimitiveType type) {
         break;
     }
     case PrimitiveType::TYPE_DECIMAL128I: {
-        _get_value_fn = get_decimalv3_value;
+        _get_value_fn = get_decimal128_value;
         break;
     }
     default:

--- a/be/src/runtime/runtime_predicate.cpp
+++ b/be/src/runtime/runtime_predicate.cpp
@@ -104,8 +104,8 @@ Status RuntimePredicate::_init(const TypeIndex type) {
     return Status::OK();
 }
 
-Status RuntimePredicate::update(const Field& value, const String& col_name,
-                                const TypeIndex type, bool is_reverse) {
+Status RuntimePredicate::update(const Field& value, const String& col_name, const TypeIndex type,
+                                bool is_reverse) {
     std::unique_lock<std::shared_mutex> wlock(_rwlock);
 
     // init will only be called once

--- a/be/src/runtime/runtime_predicate.cpp
+++ b/be/src/runtime/runtime_predicate.cpp
@@ -96,6 +96,10 @@ Status RuntimePredicate::_init(const TypeIndex type) {
         _get_value_fn = get_decimal64_value;
         break;
     }
+    case TypeIndex::Decimal128I: {
+        _get_value_fn = get_decimalv3_value;
+        break;
+    }
     default:
         return Status::InvalidArgument("unsupported runtime predicate type {}", type);
     }

--- a/be/src/runtime/runtime_predicate.cpp
+++ b/be/src/runtime/runtime_predicate.cpp
@@ -164,10 +164,6 @@ Status RuntimePredicate::update(std::vector<Field>& values, const String& col_na
     condition.condition_values.push_back(str_value);
 
     _predictate.reset(parse_to_predicate(_tablet_schema, condition, _predicate_mem_pool.get(), false));
-    
-    LOG(INFO) << "xk debug reset predictate type=" << (_predictate->type() == PredicateType::GE)
-              << " " << (_predictate->type() == PredicateType::LE)
-              << " column_id=" << _predictate->column_id() << " condition=" << condition;
 
     return Status::OK();
 }

--- a/be/src/runtime/runtime_predicate.cpp
+++ b/be/src/runtime/runtime_predicate.cpp
@@ -16,6 +16,7 @@
 // under the License.
 
 #include "runtime/runtime_predicate.h"
+#include "olap/predicate_creator.h"
 
 
 namespace doris {

--- a/be/src/runtime/runtime_predicate.cpp
+++ b/be/src/runtime/runtime_predicate.cpp
@@ -48,7 +48,9 @@ Status RuntimePredicate::update(std::vector<Field>& values, const String& col_na
         }
     }
 
-    if (!updated) return Status::OK();
+    if (!updated) {
+        return Status::OK();
+    }
 
     TCondition condition;
     condition.__set_column_name(col_name);

--- a/be/src/runtime/runtime_predicate.cpp
+++ b/be/src/runtime/runtime_predicate.cpp
@@ -1,0 +1,141 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "runtime/runtime_predicate.h"
+
+
+namespace doris {
+
+namespace vectorized {
+
+Status RuntimePredicate::update(std::vector<vectorized::Field>& values, const String& col_name,
+                const PrimitiveType type, bool is_reverse) {
+    std::unique_lock<std::shared_mutex> wlock(_rwlock);
+
+    if (!_predicate_mem_pool) {
+        _predicate_mem_pool.reset(new MemPool());
+    }
+
+    bool updated = false;
+
+    if (UNLIKELY(_orderby_extrems.size() == 0)) {
+        _orderby_extrems.push_back(values[0]);
+        updated = true;
+    } else if (is_reverse) {
+        if (values[0] > _orderby_extrems[0]) {
+            _orderby_extrems[0] = values[0];
+            updated = true;
+        }
+    } else {
+        if (values[0] < _orderby_extrems[0]) {
+            _orderby_extrems[0] = values[0];
+            updated = true;
+        }
+    }
+
+    if (!updated)
+        return Status::OK();
+
+    TCondition condition;
+    condition.__set_column_name(col_name);
+    condition.__set_column_unique_id(_tablet_schema->column(col_name).unique_id());
+    condition.__set_condition_op(is_reverse ? ">=" : "<=");
+
+    int scale = 0;
+    String s;
+
+    switch (type) {
+    case TYPE_DATEV2: {
+        using ValueType = typename PrimitiveTypeTraits<TYPE_DATEV2>::CppType;
+        // ValueType value;
+        // value.from_olap_date(_orderby_extrems[0].get<UInt32>());
+        ValueType value =
+            binary_cast<UInt32, ValueType>(_orderby_extrems[0].get<UInt32>());
+        condition.condition_values.push_back(
+            cast_to_string<TYPE_DATEV2, ValueType>(value, scale));
+        break;
+    }
+    case TYPE_DATETIMEV2: {
+        using ValueType = typename PrimitiveTypeTraits<TYPE_DATETIMEV2>::CppType;
+        // ValueType value;
+        // value.from_olap_datetime(_orderby_extrems[0].get<UInt64>());
+        ValueType value =
+            binary_cast<UInt64, ValueType>(_orderby_extrems[0].get<UInt64>());
+        condition.condition_values.push_back(
+            cast_to_string<TYPE_DATETIMEV2, ValueType>(value, scale));
+        break;
+    }
+    case TYPE_DATE: {
+        using ValueType = typename PrimitiveTypeTraits<TYPE_DATE>::CppType;
+        ValueType value;
+        Int64 v = _orderby_extrems[0].get<Int64>();
+        VecDateTimeValue* p = (VecDateTimeValue*)&v;
+        value.from_olap_date(p->to_olap_date());
+        value.cast_to_date();
+        condition.condition_values.push_back(
+            cast_to_string<TYPE_DATE, ValueType>(value, scale));
+        break;
+    }
+    case TYPE_DATETIME: {
+        using ValueType = typename PrimitiveTypeTraits<TYPE_DATETIME>::CppType;
+        ValueType value;
+        Int64 v = _orderby_extrems[0].get<Int64>();
+        VecDateTimeValue* p = (VecDateTimeValue*)&v;
+        value.from_olap_datetime(p->to_olap_datetime());
+        value.to_datetime();
+        condition.condition_values.push_back(
+            cast_to_string<TYPE_DATETIME, ValueType>(value, scale));
+        break;
+    }
+    case TYPE_DECIMALV2: {
+        using ValueType = typename PrimitiveTypeTraits<TYPE_DECIMALV2>::CppType;
+        ValueType value;
+        auto v = _orderby_extrems[0].get<DecimalField<Decimal128>>();
+        value.from_olap_decimal(v.get_value(), v.get_scale());
+        scale = v.get_scale();
+        condition.condition_values.push_back(
+            cast_to_string<TYPE_DECIMALV2, ValueType>(value, scale));
+        break;
+    }
+    case TYPE_CHAR:
+    case TYPE_VARCHAR:
+    case TYPE_STRING: {
+        // using ValueType = typename PrimitiveTypeTraits<TYPE_STRING>::CppType;
+        // ValueType value;
+        // s = _orderby_extrems[0].get<String>();
+        // value.replace((char*)s.c_str(), s.length());
+        // condition.condition_values.push_back(
+        //     cast_to_string<TYPE_STRING, ValueType>(value, scale));
+        condition.condition_values.push_back(_orderby_extrems[0].get<String>());
+        break;
+    }
+    default:
+        // value = _orderby_extrems[0].get<ValueType>();
+        break;
+    }
+
+    _predictate.reset(parse_to_predicate(_tablet_schema, condition, _predicate_mem_pool.get(), false));
+    
+    LOG(INFO) << "xk debug reset predictate type=" << (_predictate->type() == PredicateType::GE)
+              << " " << (_predictate->type() == PredicateType::LE)
+              << " column_id=" << _predictate->column_id() << " condition=" << condition;
+
+    return Status::OK();
+}
+
+} // namespace vectorized
+} // namespace doris

--- a/be/src/runtime/runtime_predicate.cpp
+++ b/be/src/runtime/runtime_predicate.cpp
@@ -16,15 +16,15 @@
 // under the License.
 
 #include "runtime/runtime_predicate.h"
-#include "olap/predicate_creator.h"
 
+#include "olap/predicate_creator.h"
 
 namespace doris {
 
 namespace vectorized {
 
 Status RuntimePredicate::update(std::vector<Field>& values, const String& col_name,
-                const TypeIndex type, bool is_reverse) {
+                                const TypeIndex type, bool is_reverse) {
     std::unique_lock<std::shared_mutex> wlock(_rwlock);
 
     if (!_predicate_mem_pool) {
@@ -48,8 +48,7 @@ Status RuntimePredicate::update(std::vector<Field>& values, const String& col_na
         }
     }
 
-    if (!updated)
-        return Status::OK();
+    if (!updated) return Status::OK();
 
     TCondition condition;
     condition.__set_column_name(col_name);
@@ -108,13 +107,13 @@ Status RuntimePredicate::update(std::vector<Field>& values, const String& col_na
     case TypeIndex::DateV2: {
         using ValueType = typename PrimitiveTypeTraits<TYPE_DATEV2>::CppType;
         str_value = cast_to_string<TYPE_DATEV2, ValueType>(
-            binary_cast<UInt32, ValueType>(field.get<UInt32>()), scale);
+                binary_cast<UInt32, ValueType>(field.get<UInt32>()), scale);
         break;
     }
     case TypeIndex::DateTimeV2: {
         using ValueType = typename PrimitiveTypeTraits<TYPE_DATETIMEV2>::CppType;
         str_value = cast_to_string<TYPE_DATETIMEV2, ValueType>(
-            binary_cast<UInt64, ValueType>(field.get<UInt64>()), scale);
+                binary_cast<UInt64, ValueType>(field.get<UInt64>()), scale);
         break;
     }
     case TypeIndex::Date: {
@@ -164,7 +163,8 @@ Status RuntimePredicate::update(std::vector<Field>& values, const String& col_na
 
     condition.condition_values.push_back(str_value);
 
-    _predictate.reset(parse_to_predicate(_tablet_schema, condition, _predicate_mem_pool.get(), false));
+    _predictate.reset(
+            parse_to_predicate(_tablet_schema, condition, _predicate_mem_pool.get(), false));
 
     return Status::OK();
 }

--- a/be/src/runtime/runtime_predicate.h
+++ b/be/src/runtime/runtime_predicate.h
@@ -64,6 +64,107 @@ private:
     std::shared_ptr<ColumnPredicate> _predictate {nullptr};
     TabletSchemaSPtr _tablet_schema;
     std::unique_ptr<MemPool> _predicate_mem_pool;
+    std::function<std::string(const Field&)> _get_value_fn;
+    bool _inited = false;
+
+    Status _init(const TypeIndex type);
+
+    static std::string get_bool_value(const Field& field) {
+        using ValueType = typename PrimitiveTypeTraits<TYPE_BOOLEAN>::CppType;
+        return cast_to_string<TYPE_BOOLEAN, ValueType>(field.get<ValueType>(), 0);
+    }
+
+    static std::string get_tinyint_value(const Field& field) {
+        using ValueType = typename PrimitiveTypeTraits<TYPE_TINYINT>::CppType;
+        return cast_to_string<TYPE_TINYINT, ValueType>(field.get<ValueType>(), 0);
+    }
+
+    static std::string get_smallint_value(const Field& field) {
+        using ValueType = typename PrimitiveTypeTraits<TYPE_SMALLINT>::CppType;
+        return cast_to_string<TYPE_SMALLINT, ValueType>(field.get<ValueType>(), 0);
+    }
+    
+    static std::string get_int_value(const Field& field) {
+        using ValueType = typename PrimitiveTypeTraits<TYPE_INT>::CppType;
+        return cast_to_string<TYPE_INT, ValueType>(field.get<ValueType>(), 0);
+    }
+
+    static std::string get_bigint_value(const Field& field) {
+        using ValueType = typename PrimitiveTypeTraits<TYPE_BIGINT>::CppType;
+        return cast_to_string<TYPE_BIGINT, ValueType>(field.get<ValueType>(), 0);
+    }
+
+    static std::string get_largeint_value(const Field& field) {
+        using ValueType = typename PrimitiveTypeTraits<TYPE_LARGEINT>::CppType;
+        return cast_to_string<TYPE_LARGEINT, ValueType>(field.get<ValueType>(), 0);
+    }
+
+    static std::string get_float_value(const Field& field) {
+        using ValueType = typename PrimitiveTypeTraits<TYPE_FLOAT>::CppType;
+        return cast_to_string<TYPE_FLOAT, ValueType>(field.get<ValueType>(), 0);
+    }
+
+    static std::string get_double_value(const Field& field) {
+        using ValueType = typename PrimitiveTypeTraits<TYPE_DOUBLE>::CppType;
+        return cast_to_string<TYPE_DOUBLE, ValueType>(field.get<ValueType>(), 0);
+    }
+
+    static std::string get_string_value(const Field& field) {
+        return field.get<String>();
+    }
+
+    static std::string get_date_value(const Field& field) {
+        using ValueType = typename PrimitiveTypeTraits<TYPE_DATE>::CppType;
+        ValueType value;
+        Int64 v = field.get<Int64>();
+        VecDateTimeValue* p = (VecDateTimeValue*)&v;
+        value.from_olap_date(p->to_olap_date());
+        value.cast_to_date();
+        return cast_to_string<TYPE_DATE, ValueType>(value, 0);
+    }
+    
+    static std::string get_datetime_value(const Field& field) {
+        using ValueType = typename PrimitiveTypeTraits<TYPE_DATETIME>::CppType;
+        ValueType value;
+        Int64 v = field.get<Int64>();
+        VecDateTimeValue* p = (VecDateTimeValue*)&v;
+        value.from_olap_datetime(p->to_olap_datetime());
+        value.to_datetime();
+        return cast_to_string<TYPE_DATETIME, ValueType>(value, 0);
+    }
+
+    static std::string get_datev2_value(const Field& field) {
+        using ValueType = typename PrimitiveTypeTraits<TYPE_DATEV2>::CppType;
+        return cast_to_string<TYPE_DATEV2, ValueType>(
+                binary_cast<UInt32, ValueType>(field.get<UInt32>()), 0);
+    }
+    
+    static std::string get_datetimev2_value(const Field& field) {
+        using ValueType = typename PrimitiveTypeTraits<TYPE_DATETIMEV2>::CppType;
+        return cast_to_string<TYPE_DATETIMEV2, ValueType>(
+                binary_cast<UInt64, ValueType>(field.get<UInt64>()), 0);
+    }
+    
+    static std::string get_decimalv2_value(const Field& field) {
+        using ValueType = typename PrimitiveTypeTraits<TYPE_DECIMALV2>::CppType;
+        ValueType value;
+        auto v = field.get<DecimalField<Decimal128>>();
+        value.from_olap_decimal(v.get_value(), v.get_scale());
+        int scale = v.get_scale();
+        return cast_to_string<TYPE_DECIMALV2, ValueType>(value, scale);
+    }
+
+    static std::string get_decimal32_value(const Field& field) {
+        using ValueType = typename PrimitiveTypeTraits<TYPE_DECIMAL32>::CppType;
+        ValueType value = field.get<ValueType>();
+        return cast_to_string<TYPE_DECIMAL32, ValueType>(value, 0);
+    }
+    
+    static std::string get_decimal64_value(const Field& field) {
+        using ValueType = typename PrimitiveTypeTraits<TYPE_DECIMAL64>::CppType;
+        ValueType value = field.get<ValueType>();
+        return cast_to_string<TYPE_DECIMAL64, ValueType>(value, 0);
+    }
 };
 
 } // namespace vectorized

--- a/be/src/runtime/runtime_predicate.h
+++ b/be/src/runtime/runtime_predicate.h
@@ -57,8 +57,8 @@ public:
         return _predictate;
     }
 
-    Status update(std::vector<vectorized::Field>& values, const String& col_name,
-                  const PrimitiveType type, bool is_reverse);
+    Status update(std::vector<Field>& values, const String& col_name,
+                  const TypeIndex type, bool is_reverse);
 
 private:
     mutable std::shared_mutex _rwlock;

--- a/be/src/runtime/runtime_predicate.h
+++ b/be/src/runtime/runtime_predicate.h
@@ -45,6 +45,13 @@ class RuntimePredicate {
 public:
     RuntimePredicate() = default;
 
+    Status init(const PrimitiveType type);
+
+    bool inited() {
+        std::unique_lock<std::shared_mutex> wlock(_rwlock);
+        return _inited;
+    };
+
     void set_tablet_schema(TabletSchemaSPtr tablet_schema) {
         std::unique_lock<std::shared_mutex> wlock(_rwlock);
         _tablet_schema = tablet_schema;
@@ -55,19 +62,16 @@ public:
         return _predictate;
     }
 
-    Status update(const Field& value, const String& col_name, const TypeIndex type,
-                  bool is_reverse);
+    Status update(const Field& value, const String& col_name, bool is_reverse);
 
 private:
     mutable std::shared_mutex _rwlock;
-    Field _orderby_extrem;
+    Field _orderby_extrem {Field::Types::Null};
     std::shared_ptr<ColumnPredicate> _predictate {nullptr};
     TabletSchemaSPtr _tablet_schema;
     std::unique_ptr<MemPool> _predicate_mem_pool;
     std::function<std::string(const Field&)> _get_value_fn;
     bool _inited = false;
-
-    Status _init(const TypeIndex type);
 
     static std::string get_bool_value(const Field& field) {
         using ValueType = typename PrimitiveTypeTraits<TYPE_BOOLEAN>::CppType;

--- a/be/src/runtime/runtime_predicate.h
+++ b/be/src/runtime/runtime_predicate.h
@@ -163,6 +163,12 @@ private:
         ValueType value = field.get<ValueType>();
         return cast_to_string<TYPE_DECIMAL64, ValueType>(value, 0);
     }
+
+    static std::string get_decimalv3_value(const Field& field) {
+        using ValueType = typename PrimitiveTypeTraits<TYPE_DECIMAL128I>::CppType;
+        ValueType value = field.get<ValueType>();
+        return cast_to_string<TYPE_DECIMAL128I, ValueType>(value, 0);
+    }
 };
 
 } // namespace vectorized

--- a/be/src/runtime/runtime_predicate.h
+++ b/be/src/runtime/runtime_predicate.h
@@ -83,7 +83,7 @@ private:
         using ValueType = typename PrimitiveTypeTraits<TYPE_SMALLINT>::CppType;
         return cast_to_string<TYPE_SMALLINT, ValueType>(field.get<ValueType>(), 0);
     }
-    
+
     static std::string get_int_value(const Field& field) {
         using ValueType = typename PrimitiveTypeTraits<TYPE_INT>::CppType;
         return cast_to_string<TYPE_INT, ValueType>(field.get<ValueType>(), 0);
@@ -109,9 +109,7 @@ private:
         return cast_to_string<TYPE_DOUBLE, ValueType>(field.get<ValueType>(), 0);
     }
 
-    static std::string get_string_value(const Field& field) {
-        return field.get<String>();
-    }
+    static std::string get_string_value(const Field& field) { return field.get<String>(); }
 
     static std::string get_date_value(const Field& field) {
         using ValueType = typename PrimitiveTypeTraits<TYPE_DATE>::CppType;
@@ -122,7 +120,7 @@ private:
         value.cast_to_date();
         return cast_to_string<TYPE_DATE, ValueType>(value, 0);
     }
-    
+
     static std::string get_datetime_value(const Field& field) {
         using ValueType = typename PrimitiveTypeTraits<TYPE_DATETIME>::CppType;
         ValueType value;
@@ -138,13 +136,13 @@ private:
         return cast_to_string<TYPE_DATEV2, ValueType>(
                 binary_cast<UInt32, ValueType>(field.get<UInt32>()), 0);
     }
-    
+
     static std::string get_datetimev2_value(const Field& field) {
         using ValueType = typename PrimitiveTypeTraits<TYPE_DATETIMEV2>::CppType;
         return cast_to_string<TYPE_DATETIMEV2, ValueType>(
                 binary_cast<UInt64, ValueType>(field.get<UInt64>()), 0);
     }
-    
+
     static std::string get_decimalv2_value(const Field& field) {
         using ValueType = typename PrimitiveTypeTraits<TYPE_DECIMALV2>::CppType;
         ValueType value;
@@ -159,7 +157,7 @@ private:
         ValueType value = field.get<ValueType>();
         return cast_to_string<TYPE_DECIMAL32, ValueType>(value, 0);
     }
-    
+
     static std::string get_decimal64_value(const Field& field) {
         using ValueType = typename PrimitiveTypeTraits<TYPE_DECIMAL64>::CppType;
         ValueType value = field.get<ValueType>();

--- a/be/src/runtime/runtime_predicate.h
+++ b/be/src/runtime/runtime_predicate.h
@@ -167,7 +167,7 @@ private:
         return cast_to_string<TYPE_DECIMAL64, ValueType>(value, 0);
     }
 
-    static std::string get_decimalv3_value(const Field& field) {
+    static std::string get_decimal128_value(const Field& field) {
         using ValueType = typename PrimitiveTypeTraits<TYPE_DECIMAL128I>::CppType;
         ValueType value = field.get<ValueType>();
         return cast_to_string<TYPE_DECIMAL128I, ValueType>(value, 0);

--- a/be/src/runtime/runtime_predicate.h
+++ b/be/src/runtime/runtime_predicate.h
@@ -36,7 +36,7 @@
 #include "exec/olap_common.h"
 #include "olap/tablet_schema.h"
 #include "olap/column_predicate.h"
-#include "olap/predicate_creator.h"
+// #include "olap/predicate_creator.h"
 
 
 namespace doris {

--- a/be/src/runtime/runtime_predicate.h
+++ b/be/src/runtime/runtime_predicate.h
@@ -43,7 +43,7 @@ namespace vectorized {
 
 class RuntimePredicate {
 public:
-    RuntimePredicate() {}
+    RuntimePredicate() = default;
 
     void set_tablet_schema(TabletSchemaSPtr tablet_schema) {
         std::unique_lock<std::shared_mutex> wlock(_rwlock);

--- a/be/src/runtime/runtime_predicate.h
+++ b/be/src/runtime/runtime_predicate.h
@@ -18,26 +18,24 @@
 #pragma once
 
 #include <atomic>
-#include <string>
 #include <mutex>
 #include <shared_mutex>
+#include <string>
 
 #include "common/config.h"
 #include "common/object_pool.h"
+#include "exec/olap_common.h"
 #include "gen_cpp/PaloInternalService_types.h" // for TQueryOptions
 #include "gen_cpp/Types_types.h"               // for TUniqueId
+#include "olap/column_predicate.h"
+#include "olap/tablet_schema.h"
 #include "runtime/datetime_value.h"
 #include "runtime/exec_env.h"
 #include "runtime/mem_pool.h"
 #include "util/threadpool.h"
-#include "vec/core/types.h"
 #include "vec/core/field.h"
-
-#include "exec/olap_common.h"
-#include "olap/tablet_schema.h"
-#include "olap/column_predicate.h"
+#include "vec/core/types.h"
 // #include "olap/predicate_creator.h"
-
 
 namespace doris {
 
@@ -45,7 +43,7 @@ namespace vectorized {
 
 class RuntimePredicate {
 public:
-    RuntimePredicate() { }
+    RuntimePredicate() {}
 
     void set_tablet_schema(TabletSchemaSPtr tablet_schema) {
         std::unique_lock<std::shared_mutex> wlock(_rwlock);
@@ -57,8 +55,8 @@ public:
         return _predictate;
     }
 
-    Status update(std::vector<Field>& values, const String& col_name,
-                  const TypeIndex type, bool is_reverse);
+    Status update(std::vector<Field>& values, const String& col_name, const TypeIndex type,
+                  bool is_reverse);
 
 private:
     mutable std::shared_mutex _rwlock;

--- a/be/src/runtime/runtime_predicate.h
+++ b/be/src/runtime/runtime_predicate.h
@@ -55,12 +55,12 @@ public:
         return _predictate;
     }
 
-    Status update(std::vector<Field>& values, const String& col_name, const TypeIndex type,
+    Status update(const Field& value, const String& col_name, const TypeIndex type,
                   bool is_reverse);
 
 private:
     mutable std::shared_mutex _rwlock;
-    std::vector<vectorized::Field> _orderby_extrems;
+    Field _orderby_extrem;
     std::shared_ptr<ColumnPredicate> _predictate {nullptr};
     TabletSchemaSPtr _tablet_schema;
     std::unique_ptr<MemPool> _predicate_mem_pool;

--- a/be/src/runtime/runtime_predicate.h
+++ b/be/src/runtime/runtime_predicate.h
@@ -1,0 +1,72 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <atomic>
+#include <string>
+#include <mutex>
+#include <shared_mutex>
+
+#include "common/config.h"
+#include "common/object_pool.h"
+#include "gen_cpp/PaloInternalService_types.h" // for TQueryOptions
+#include "gen_cpp/Types_types.h"               // for TUniqueId
+#include "runtime/datetime_value.h"
+#include "runtime/exec_env.h"
+#include "runtime/mem_pool.h"
+#include "util/threadpool.h"
+#include "vec/core/types.h"
+#include "vec/core/field.h"
+
+#include "exec/olap_common.h"
+#include "olap/tablet_schema.h"
+#include "olap/column_predicate.h"
+#include "olap/predicate_creator.h"
+
+
+namespace doris {
+
+namespace vectorized {
+
+class RuntimePredicate {
+public:
+    RuntimePredicate() { }
+
+    void set_tablet_schema(TabletSchemaSPtr tablet_schema) {
+        std::unique_lock<std::shared_mutex> wlock(_rwlock);
+        _tablet_schema = tablet_schema;
+    }
+
+    std::shared_ptr<ColumnPredicate> get_predictate() {
+        std::shared_lock<std::shared_mutex> rlock(_rwlock);
+        return _predictate;
+    }
+
+    Status update(std::vector<vectorized::Field>& values, const String& col_name,
+                  const PrimitiveType type, bool is_reverse);
+
+private:
+    mutable std::shared_mutex _rwlock;
+    std::vector<vectorized::Field> _orderby_extrems;
+    std::shared_ptr<ColumnPredicate> _predictate {nullptr};
+    TabletSchemaSPtr _tablet_schema;
+    std::unique_ptr<MemPool> _predicate_mem_pool;
+};
+
+} // namespace vectorized
+} // namespace doris

--- a/be/src/runtime/runtime_predicate.h
+++ b/be/src/runtime/runtime_predicate.h
@@ -35,7 +35,6 @@
 #include "util/threadpool.h"
 #include "vec/core/field.h"
 #include "vec/core/types.h"
-// #include "olap/predicate_creator.h"
 
 namespace doris {
 

--- a/be/src/vec/common/sort/heap_sorter.cpp
+++ b/be/src/vec/common/sort/heap_sorter.cpp
@@ -141,6 +141,17 @@ Status HeapSorter::get_next(RuntimeState* state, Block* block, bool* eos) {
     return Status::OK();
 }
 
+Field HeapSorter::get_top_value() {
+    Field field;
+    // get field from first sort column of top row
+    if (_heap->size() >= _heap_size) {
+        auto & top = _heap->top();
+        top.sort_columns()[0]->get(top.row_id(), field);
+    }
+
+    return field;
+}
+
 void HeapSorter::_do_filter(HeapSortCursorBlockView& block_view, size_t num_rows) {
     const auto& top_cursor = _heap->top();
     const int cursor_rid = top_cursor.row_id();

--- a/be/src/vec/common/sort/heap_sorter.cpp
+++ b/be/src/vec/common/sort/heap_sorter.cpp
@@ -142,7 +142,7 @@ Status HeapSorter::get_next(RuntimeState* state, Block* block, bool* eos) {
 }
 
 Field HeapSorter::get_top_value() {
-    Field field;
+    Field field {Field::Types::Null};
     // get field from first sort column of top row
     if (_heap->size() >= _heap_size) {
         auto& top = _heap->top();

--- a/be/src/vec/common/sort/heap_sorter.cpp
+++ b/be/src/vec/common/sort/heap_sorter.cpp
@@ -145,7 +145,7 @@ Field HeapSorter::get_top_value() {
     Field field;
     // get field from first sort column of top row
     if (_heap->size() >= _heap_size) {
-        auto & top = _heap->top();
+        auto& top = _heap->top();
         top.sort_columns()[0]->get(top.row_id(), field);
     }
 

--- a/be/src/vec/common/sort/heap_sorter.h
+++ b/be/src/vec/common/sort/heap_sorter.h
@@ -71,6 +71,8 @@ public:
 
     size_t data_size() const override;
 
+    Field get_top_value() override;
+
     static constexpr size_t HEAP_SORT_THRESHOLD = 1024;
 
 private:

--- a/be/src/vec/common/sort/sorter.h
+++ b/be/src/vec/common/sort/sorter.h
@@ -79,7 +79,7 @@ public:
 
     // for topn runtime predicate
     const SortDescription& get_sort_description() { return _sort_description; }
-    virtual Field get_top_value() { return Field{Field::Types::Null}; }
+    virtual Field get_top_value() { return Field {Field::Types::Null}; }
 
 protected:
     Status partial_sort(Block& src_block, Block& dest_block);

--- a/be/src/vec/common/sort/sorter.h
+++ b/be/src/vec/common/sort/sorter.h
@@ -77,6 +77,10 @@ public:
 
     virtual size_t data_size() const = 0;
 
+    // for topn runtime predicate
+    const SortDescription& get_sort_description() { return _sort_description; }
+    virtual Field get_top_value() { return {}; }
+
 protected:
     Status partial_sort(Block& src_block, Block& dest_block);
 

--- a/be/src/vec/common/sort/sorter.h
+++ b/be/src/vec/common/sort/sorter.h
@@ -79,7 +79,7 @@ public:
 
     // for topn runtime predicate
     const SortDescription& get_sort_description() { return _sort_description; }
-    virtual Field get_top_value() { return {}; }
+    virtual Field get_top_value() { return Field{Field::Types::Null}; }
 
 protected:
     Status partial_sort(Block& src_block, Block& dest_block);

--- a/be/src/vec/core/field.h
+++ b/be/src/vec/core/field.h
@@ -366,6 +366,9 @@ public:
 
     Field() : which(Types::Null) {}
 
+    // set Types::Null explictly and avoid other types
+    Field(Types::Which w) : which(w) { DCHECK_EQ(Types::Null, which); }
+
     /** Despite the presence of a template constructor, this constructor is still needed,
       *  since, in its absence, the compiler will still generate the default constructor.
       */

--- a/be/src/vec/exec/scan/new_olap_scanner.cpp
+++ b/be/src/vec/exec/scan/new_olap_scanner.cpp
@@ -294,6 +294,9 @@ Status NewOlapScanner::_init_tablet_reader_params(
                     olap_scan_node.sort_info.is_asc_order.size();
         }
     }
+
+    _tablet_reader_params.use_topn_opt = ((NewOlapScanNode*)_parent)->_olap_scan_node.use_topn_opt;
+
     return Status::OK();
 }
 

--- a/be/src/vec/exec/vsort_node.cpp
+++ b/be/src/vec/exec/vsort_node.cpp
@@ -104,8 +104,8 @@ Status VSortNode::sink(RuntimeState* state, vectorized::Block* input_block, bool
                 auto type = remove_nullable(col.type)->get_type_id();
                 bool is_reverse = sort_description[0].direction < 0;
                 auto query_ctx = _runtime_state->get_query_fragments_ctx();
-                RETURN_IF_ERROR(query_ctx->get_runtime_predicate().update(new_top, col.name,
-                                                                          type, is_reverse));
+                RETURN_IF_ERROR(query_ctx->get_runtime_predicate().update(new_top, col.name, type,
+                                                                          is_reverse));
                 old_top = std::move(new_top);
             }
         }

--- a/be/src/vec/exec/vsort_node.cpp
+++ b/be/src/vec/exec/vsort_node.cpp
@@ -38,7 +38,6 @@ Status VSortNode::init(const TPlanNode& tnode, RuntimeState* state) {
     RETURN_IF_ERROR(_vsort_exec_exprs.init(tnode.sort_node.sort_info, _pool));
     _is_asc_order = tnode.sort_node.sort_info.is_asc_order;
     _nulls_first = tnode.sort_node.sort_info.nulls_first;
-    _use_topn_opt = tnode.sort_node.use_topn_opt;
     const auto& row_desc = child(0)->row_desc();
     // If `limit` is smaller than HEAP_SORT_THRESHOLD, we consider using heap sort in priority.
     // To do heap sorting, each income block will be filtered by heap-top row. There will be some
@@ -46,10 +45,35 @@ Status VSortNode::init(const TPlanNode& tnode, RuntimeState* state) {
     // exclude cases which incoming blocks has string column which is sensitive to operations like
     // `filter` and `memcpy`
     if (_limit > 0 && _limit + _offset < HeapSorter::HEAP_SORT_THRESHOLD &&
-        (_use_topn_opt || !row_desc.has_varlen_slots())) {
+        (tnode.sort_node.use_topn_opt || !row_desc.has_varlen_slots())) {
         _sorter.reset(new HeapSorter(_vsort_exec_exprs, _limit, _offset, _pool, _is_asc_order,
                                      _nulls_first, row_desc));
         _reuse_mem = false;
+        _use_topn_opt = tnode.sort_node.use_topn_opt;
+        // init runtime predicate
+        if (_use_topn_opt) {
+            auto query_ctx = state->get_query_fragments_ctx();
+            auto first_sort_expr_node =
+                tnode.sort_node.sort_info.sort_tuple_slot_exprs[0].nodes[0];
+            if (first_sort_expr_node.node_type == TExprNodeType::SLOT_REF) {
+                auto first_sort_slot = first_sort_expr_node.slot_ref;
+                for (auto tuple_desc : row_desc.tuple_descriptors()) {
+                    if (tuple_desc->id() != first_sort_slot.tuple_id) {
+                        continue;
+                    }
+                    for (auto slot : tuple_desc->slots()) {
+                        if (slot->id() == first_sort_slot.slot_id) {
+                            RETURN_IF_ERROR(
+                                query_ctx->get_runtime_predicate().init(slot->type().type));
+                            break;
+                        }
+                    }
+                }
+            }
+            if (!query_ctx->get_runtime_predicate().inited()) {
+                return Status::InternalError("runtime predicate is not properly initialized");
+            }
+        }
     } else if (_limit > 0 && row_desc.has_varlen_slots() &&
                _limit + _offset < TopNSorter::TOPN_SORT_THRESHOLD) {
         _sorter.reset(new TopNSorter(_vsort_exec_exprs, _limit, _offset, _pool, _is_asc_order,
@@ -95,16 +119,15 @@ Status VSortNode::sink(RuntimeState* state, vectorized::Block* input_block, bool
         RETURN_IF_CANCELLED(state);
         RETURN_IF_ERROR(state->check_query_state("vsort, while sorting input."));
 
-        // runtime predicate
+        // update runtime predicate
         if (_use_topn_opt) {
             Field new_top = _sorter->get_top_value();
             if (!new_top.is_null() && new_top != old_top) {
                 auto& sort_description = _sorter->get_sort_description();
                 auto col = input_block->get_by_position(sort_description[0].column_number);
-                auto type = remove_nullable(col.type)->get_type_id();
                 bool is_reverse = sort_description[0].direction < 0;
                 auto query_ctx = _runtime_state->get_query_fragments_ctx();
-                RETURN_IF_ERROR(query_ctx->get_runtime_predicate().update(new_top, col.name, type,
+                RETURN_IF_ERROR(query_ctx->get_runtime_predicate().update(new_top, col.name,
                                                                           is_reverse));
                 old_top = std::move(new_top);
             }

--- a/be/src/vec/exec/vsort_node.cpp
+++ b/be/src/vec/exec/vsort_node.cpp
@@ -137,13 +137,14 @@ Status VSortNode::open(RuntimeState* state) {
             if (_use_topn_opt) {
                 Field new_top = _sorter->get_top_value();
                 if (!new_top.is_null() && new_top != old_top) {
-                    auto & sort_description = _sorter->get_sort_description();
+                    auto& sort_description = _sorter->get_sort_description();
                     auto col = upstream_block->get_by_position(sort_description[0].column_number);
                     auto type = remove_nullable(col.type)->get_type_id();
                     bool is_reverse = sort_description[0].direction < 0;
                     auto query_ctx = _runtime_state->get_query_fragments_ctx();
                     std::vector<vectorized::Field> values = {new_top};
-                    RETURN_IF_ERROR(query_ctx->get_runtime_predicate().update(values, col.name, type, is_reverse));
+                    RETURN_IF_ERROR(query_ctx->get_runtime_predicate().update(values, col.name,
+                                                                              type, is_reverse));
                     old_top = std::move(new_top);
                 }
             }

--- a/be/src/vec/exec/vsort_node.cpp
+++ b/be/src/vec/exec/vsort_node.cpp
@@ -104,9 +104,8 @@ Status VSortNode::sink(RuntimeState* state, vectorized::Block* input_block, bool
                 auto type = remove_nullable(col.type)->get_type_id();
                 bool is_reverse = sort_description[0].direction < 0;
                 auto query_ctx = _runtime_state->get_query_fragments_ctx();
-                std::vector<vectorized::Field> values = {new_top};
-                RETURN_IF_ERROR(query_ctx->get_runtime_predicate().update(values, col.name,
-                                                                            type, is_reverse));
+                RETURN_IF_ERROR(query_ctx->get_runtime_predicate().update(new_top, col.name,
+                                                                          type, is_reverse));
                 old_top = std::move(new_top);
             }
         }

--- a/be/src/vec/exec/vsort_node.cpp
+++ b/be/src/vec/exec/vsort_node.cpp
@@ -53,8 +53,7 @@ Status VSortNode::init(const TPlanNode& tnode, RuntimeState* state) {
         // init runtime predicate
         if (_use_topn_opt) {
             auto query_ctx = state->get_query_fragments_ctx();
-            auto first_sort_expr_node =
-                tnode.sort_node.sort_info.sort_tuple_slot_exprs[0].nodes[0];
+            auto first_sort_expr_node = tnode.sort_node.sort_info.sort_tuple_slot_exprs[0].nodes[0];
             if (first_sort_expr_node.node_type == TExprNodeType::SLOT_REF) {
                 auto first_sort_slot = first_sort_expr_node.slot_ref;
                 for (auto tuple_desc : row_desc.tuple_descriptors()) {
@@ -64,7 +63,7 @@ Status VSortNode::init(const TPlanNode& tnode, RuntimeState* state) {
                     for (auto slot : tuple_desc->slots()) {
                         if (slot->id() == first_sort_slot.slot_id) {
                             RETURN_IF_ERROR(
-                                query_ctx->get_runtime_predicate().init(slot->type().type));
+                                    query_ctx->get_runtime_predicate().init(slot->type().type));
                             break;
                         }
                     }
@@ -127,8 +126,8 @@ Status VSortNode::sink(RuntimeState* state, vectorized::Block* input_block, bool
                 auto col = input_block->get_by_position(sort_description[0].column_number);
                 bool is_reverse = sort_description[0].direction < 0;
                 auto query_ctx = _runtime_state->get_query_fragments_ctx();
-                RETURN_IF_ERROR(query_ctx->get_runtime_predicate().update(new_top, col.name,
-                                                                          is_reverse));
+                RETURN_IF_ERROR(
+                        query_ctx->get_runtime_predicate().update(new_top, col.name, is_reverse));
                 old_top = std::move(new_top);
             }
         }

--- a/be/src/vec/exec/vsort_node.cpp
+++ b/be/src/vec/exec/vsort_node.cpp
@@ -44,8 +44,7 @@ Status VSortNode::init(const TPlanNode& tnode, RuntimeState* state) {
     // `memcpy` operations. To ensure heap sort will not incur performance fallback, we should
     // exclude cases which incoming blocks has string column which is sensitive to operations like
     // `filter` and `memcpy`
-    if (_limit > 0 && _limit + _offset < HeapSorter::HEAP_SORT_THRESHOLD &&
-        !row_desc.has_varlen_slots()) {
+    if (_limit > 0 && _limit + _offset < HeapSorter::HEAP_SORT_THRESHOLD) {
         _sorter.reset(new HeapSorter(_vsort_exec_exprs, _limit, _offset, _pool, _is_asc_order,
                                      _nulls_first, row_desc));
         _reuse_mem = false;
@@ -74,6 +73,7 @@ Status VSortNode::prepare(RuntimeState* state) {
     _sort_blocks_memory_usage = ADD_COUNTER(memory_usage, "SortBlocks", TUnit::BYTES);
 
     RETURN_IF_ERROR(_vsort_exec_exprs.prepare(state, child(0)->row_desc(), _row_descriptor));
+    _runtime_state = state;
     return Status::OK();
 }
 
@@ -114,6 +114,7 @@ Status VSortNode::open(RuntimeState* state) {
     // The final merge is done on-demand as rows are requested in get_next().
     bool eos = false;
     std::unique_ptr<Block> upstream_block(new Block());
+    Field old_top;
     do {
         RETURN_IF_ERROR_AND_CHECK_SPAN(
                 child(0)->get_next_after_projects(
@@ -125,6 +126,32 @@ Status VSortNode::open(RuntimeState* state) {
                 child(0)->get_next_span(), eos);
         SCOPED_CONSUME_MEM_TRACKER(mem_tracker_growh());
         RETURN_IF_ERROR(sink(state, upstream_block.get(), eos));
+
+        if (upstream_block->rows() != 0) {
+            RETURN_IF_ERROR(_sorter->append_block(upstream_block.get()));
+            RETURN_IF_CANCELLED(state);
+            RETURN_IF_ERROR(state->check_query_state("vsort, while sorting input."));
+
+            // runtime predicate
+            // SCOPED_TIMER(_update_runtime_predicate_timer);
+            if (_limit % 2 == 0) {
+            Field new_top = _sorter->get_top_value();
+            if (!new_top.is_null() && new_top != old_top) {
+                auto & sort_description = _sorter->get_sort_description();
+                auto col = upstream_block->get_by_position(sort_description[0].column_number);
+                auto type = get_primitive_type(remove_nullable(col.type)->get_type_id());
+                bool is_reverse = sort_description[0].direction < 0;
+                auto query_ctx = _runtime_state->get_query_fragments_ctx();
+                std::vector<vectorized::Field> values = {new_top};
+                RETURN_IF_ERROR(query_ctx->get_runtime_predicate().update(values, col.name, type, is_reverse));
+                old_top = std::move(new_top);
+            }
+            }
+
+            if (!reuse_mem) {
+                upstream_block.reset(new Block());
+            }
+        }
     } while (!eos);
 
     child(0)->close(state);

--- a/be/src/vec/exec/vsort_node.cpp
+++ b/be/src/vec/exec/vsort_node.cpp
@@ -45,7 +45,8 @@ Status VSortNode::init(const TPlanNode& tnode, RuntimeState* state) {
     // `memcpy` operations. To ensure heap sort will not incur performance fallback, we should
     // exclude cases which incoming blocks has string column which is sensitive to operations like
     // `filter` and `memcpy`
-    if (_limit > 0 && _limit + _offset < HeapSorter::HEAP_SORT_THRESHOLD) {
+    if (_limit > 0 && _limit + _offset < HeapSorter::HEAP_SORT_THRESHOLD &&
+        (_use_topn_opt || !row_desc.has_varlen_slots())) {
         _sorter.reset(new HeapSorter(_vsort_exec_exprs, _limit, _offset, _pool, _is_asc_order,
                                      _nulls_first, row_desc));
         _reuse_mem = false;

--- a/be/src/vec/exec/vsort_node.cpp
+++ b/be/src/vec/exec/vsort_node.cpp
@@ -98,7 +98,6 @@ Status VSortNode::prepare(RuntimeState* state) {
     _sort_blocks_memory_usage = ADD_COUNTER(memory_usage, "SortBlocks", TUnit::BYTES);
 
     RETURN_IF_ERROR(_vsort_exec_exprs.prepare(state, child(0)->row_desc(), _row_descriptor));
-    _runtime_state = state;
     return Status::OK();
 }
 
@@ -125,7 +124,7 @@ Status VSortNode::sink(RuntimeState* state, vectorized::Block* input_block, bool
                 auto& sort_description = _sorter->get_sort_description();
                 auto col = input_block->get_by_position(sort_description[0].column_number);
                 bool is_reverse = sort_description[0].direction < 0;
-                auto query_ctx = _runtime_state->get_query_fragments_ctx();
+                auto query_ctx = state->get_query_fragments_ctx();
                 RETURN_IF_ERROR(
                         query_ctx->get_runtime_predicate().update(new_top, col.name, is_reverse));
                 old_top = std::move(new_top);

--- a/be/src/vec/exec/vsort_node.cpp
+++ b/be/src/vec/exec/vsort_node.cpp
@@ -126,8 +126,6 @@ Status VSortNode::open(RuntimeState* state) {
                                   _children[0], std::placeholders::_1, std::placeholders::_2,
                                   std::placeholders::_3)),
                 child(0)->get_next_span(), eos);
-        SCOPED_CONSUME_MEM_TRACKER(mem_tracker_growh());
-        RETURN_IF_ERROR(sink(state, upstream_block.get(), eos));
 
         if (upstream_block->rows() != 0) {
             RETURN_IF_ERROR(_sorter->append_block(upstream_block.get()));
@@ -154,6 +152,9 @@ Status VSortNode::open(RuntimeState* state) {
                 upstream_block.reset(new Block());
             }
         }
+
+        SCOPED_CONSUME_MEM_TRACKER(mem_tracker_growh());
+        RETURN_IF_ERROR(sink(state, upstream_block.get(), eos));
     } while (!eos);
 
     child(0)->close(state);

--- a/be/src/vec/exec/vsort_node.cpp
+++ b/be/src/vec/exec/vsort_node.cpp
@@ -150,7 +150,7 @@ Status VSortNode::open(RuntimeState* state) {
                 }
             }
 
-            if (!reuse_mem) {
+            if (!_reuse_mem) {
                 upstream_block.reset(new Block());
             }
         }

--- a/be/src/vec/exec/vsort_node.cpp
+++ b/be/src/vec/exec/vsort_node.cpp
@@ -140,7 +140,7 @@ Status VSortNode::open(RuntimeState* state) {
                 if (!new_top.is_null() && new_top != old_top) {
                     auto & sort_description = _sorter->get_sort_description();
                     auto col = upstream_block->get_by_position(sort_description[0].column_number);
-                    auto type = get_primitive_type(remove_nullable(col.type)->get_type_id());
+                    auto type = remove_nullable(col.type)->get_type_id();
                     bool is_reverse = sort_description[0].direction < 0;
                     auto query_ctx = _runtime_state->get_query_fragments_ctx();
                     std::vector<vectorized::Field> values = {new_top};

--- a/be/src/vec/exec/vsort_node.h
+++ b/be/src/vec/exec/vsort_node.h
@@ -72,6 +72,8 @@ private:
     RuntimeProfile::Counter* _sort_blocks_memory_usage;
 
     bool _use_topn_opt = false;
+    // topn top value
+    Field old_top;
 
     bool _reuse_mem;
 

--- a/be/src/vec/exec/vsort_node.h
+++ b/be/src/vec/exec/vsort_node.h
@@ -71,7 +71,9 @@ private:
 
     RuntimeProfile::Counter* _sort_blocks_memory_usage;
 
-    bool _reuse_mem;
+    bool _use_topn_opt = false;
+
+    bool reuse_mem;
 
     std::unique_ptr<Sorter> _sorter;
 

--- a/be/src/vec/exec/vsort_node.h
+++ b/be/src/vec/exec/vsort_node.h
@@ -73,15 +73,13 @@ private:
 
     bool _use_topn_opt = false;
     // topn top value
-    Field old_top;
+    Field old_top {Field::Types::Null};
 
     bool _reuse_mem;
 
     std::unique_ptr<Sorter> _sorter;
 
     static constexpr size_t ACCUMULATED_PARTIAL_SORT_THRESHOLD = 256;
-
-    RuntimeState* _runtime_state = nullptr;
 };
 
 } // namespace doris::vectorized

--- a/be/src/vec/exec/vsort_node.h
+++ b/be/src/vec/exec/vsort_node.h
@@ -73,7 +73,7 @@ private:
 
     bool _use_topn_opt = false;
 
-    bool reuse_mem;
+    bool _reuse_mem;
 
     std::unique_ptr<Sorter> _sorter;
 

--- a/be/src/vec/exec/vsort_node.h
+++ b/be/src/vec/exec/vsort_node.h
@@ -76,6 +76,8 @@ private:
     std::unique_ptr<Sorter> _sorter;
 
     static constexpr size_t ACCUMULATED_PARTIAL_SORT_THRESHOLD = 256;
+
+    RuntimeState* _runtime_state = nullptr;
 };
 
 } // namespace doris::vectorized

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/OlapScanNode.java
@@ -156,6 +156,8 @@ public class OlapScanNode extends ScanNode {
     // It's limit for scanner instead of scanNode so we add a new limit.
     private long sortLimit = -1;
 
+    private boolean useTopnOpt = false;
+
     private TPushAggOp pushDownAggNoGroupingOp = null;
 
     // List of tablets will be scanned by current olap_scan_node
@@ -248,6 +250,14 @@ public class OlapScanNode extends ScanNode {
 
     public void setSortLimit(long sortLimit) {
         this.sortLimit = sortLimit;
+    }
+
+    public boolean getUseTopnOpt() {
+        return useTopnOpt;
+    }
+
+    public void setUseTopnOpt(boolean useTopnOpt) {
+        this.useTopnOpt = useTopnOpt;
     }
 
     public Collection<Long> getSelectedPartitionIds() {
@@ -953,6 +963,9 @@ public class OlapScanNode extends ScanNode {
         if (sortLimit != -1) {
             output.append(prefix).append("SORT LIMIT: ").append(sortLimit).append("\n");
         }
+        if (useTopnOpt) {
+            output.append(prefix).append("TOPN OPT\n");
+        }
         if (!conjuncts.isEmpty()) {
             output.append(prefix).append("PREDICATES: ").append(getExplainString(conjuncts)).append("\n");
         }
@@ -1024,6 +1037,7 @@ public class OlapScanNode extends ScanNode {
         if (sortLimit != -1) {
             msg.olap_scan_node.setSortLimit(sortLimit);
         }
+        msg.olap_scan_node.setUseTopnOpt(useTopnOpt);
         msg.olap_scan_node.setKeyType(olapTable.getKeysType().toThrift());
         msg.olap_scan_node.setTableName(olapTable.getName());
         msg.olap_scan_node.setEnableUniqueKeyMergeOnWrite(olapTable.getEnableUniqueKeyMergeOnWrite());

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/OriginalPlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/OriginalPlanner.java
@@ -380,10 +380,16 @@ public class OriginalPlanner extends Planner {
             SortNode sortNode = (SortNode) node;
             PlanNode child = sortNode.getChild(0);
             if (child instanceof OlapScanNode && sortNode.getLimit() > 0
-                    && sortNode.getSortInfo().getOrderingExprs().get(0) instanceof SlotRef) {
-                OlapScanNode scanNode = (OlapScanNode) child;
-                sortNode.setUseTopnOpt(true);
-                scanNode.setUseTopnOpt(true);
+                    && sortNode.getSortInfo().getOrderingExprs().size() > 0) {
+                Expr firstSortExpr = sortNode.getSortInfo().getOrderingExprs().get(0);
+                if (firstSortExpr instanceof SlotRef) {
+                    SlotRef slot = (SlotRef) firstSortExpr;
+                    if (!slot.getColumn().getType().isStringType()) {
+                        OlapScanNode scanNode = (OlapScanNode) child;
+                        sortNode.setUseTopnOpt(true);
+                        scanNode.setUseTopnOpt(true);
+                    }
+                }
             }
         }
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/OriginalPlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/OriginalPlanner.java
@@ -382,13 +382,10 @@ public class OriginalPlanner extends Planner {
             if (child instanceof OlapScanNode && sortNode.getLimit() > 0
                     && sortNode.getSortInfo().getOrderingExprs().size() > 0) {
                 Expr firstSortExpr = sortNode.getSortInfo().getOrderingExprs().get(0);
-                if (firstSortExpr instanceof SlotRef) {
-                    SlotRef slot = (SlotRef) firstSortExpr;
-                    if (!slot.getColumn().getType().isStringType()) {
-                        OlapScanNode scanNode = (OlapScanNode) child;
-                        sortNode.setUseTopnOpt(true);
-                        scanNode.setUseTopnOpt(true);
-                    }
+                if (firstSortExpr instanceof SlotRef && !firstSortExpr.getType().isStringType()) {
+                    OlapScanNode scanNode = (OlapScanNode) child;
+                    sortNode.setUseTopnOpt(true);
+                    scanNode.setUseTopnOpt(true);
                 }
             }
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/OriginalPlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/OriginalPlanner.java
@@ -380,8 +380,8 @@ public class OriginalPlanner extends Planner {
             SortNode sortNode = (SortNode) node;
             PlanNode child = sortNode.getChild(0);
             if (child instanceof OlapScanNode && sortNode.getLimit() > 0
-                    && sortNode.getSortInfo().getOrderingExprs().size() > 0) {
-                Expr firstSortExpr = sortNode.getSortInfo().getOrderingExprs().get(0);
+                    && sortNode.getSortInfo().getMaterializedOrderingExprs().size() > 0) {
+                Expr firstSortExpr = sortNode.getSortInfo().getMaterializedOrderingExprs().get(0);
                 if (firstSortExpr instanceof SlotRef && !firstSortExpr.getType().isStringType()) {
                     OlapScanNode scanNode = (OlapScanNode) child;
                     sortNode.setUseTopnOpt(true);

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/OriginalPlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/OriginalPlanner.java
@@ -196,7 +196,9 @@ public class OriginalPlanner extends Planner {
         singleNodePlan.finalize(analyzer);
 
         // check and set flag for topn detail query opt
-        checkTopnOpt(singleNodePlan);
+        if (VectorizedUtil.isVectorized()) {
+            checkTopnOpt(singleNodePlan);
+        }
 
         if (queryOptions.num_nodes == 1) {
             // single-node execution; we're almost done

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/SortNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/SortNode.java
@@ -62,6 +62,7 @@ public class SortNode extends PlanNode {
     List<Expr> resolvedTupleExprs;
     private final SortInfo info;
     private final boolean  useTopN;
+    private boolean useTopnOpt;
 
     private boolean  isDefaultLimit;
     // if true, the output of this node feeds an AnalyticNode
@@ -133,6 +134,14 @@ public class SortNode extends PlanNode {
         return info;
     }
 
+    public boolean getUseTopnOpt() {
+        return useTopnOpt;
+    }
+
+    public void setUseTopnOpt(boolean useTopnOpt) {
+        this.useTopnOpt = useTopnOpt;
+    }
+
     @Override
     public void setCompactData(boolean on) {
         this.compactData = on;
@@ -159,6 +168,10 @@ public class SortNode extends PlanNode {
             output.append(isAsc.next() ? "ASC" : "DESC");
         }
         output.append("\n");
+
+        if (useTopnOpt) {
+            output.append(detailPrefix + "TOPN OPT\n");
+        }
         output.append(detailPrefix).append("offset: ").append(offset).append("\n");
         return output.toString();
     }
@@ -273,6 +286,7 @@ public class SortNode extends PlanNode {
 
         msg.sort_node = sortNode;
         msg.sort_node.setOffset(offset);
+        msg.sort_node.setUseTopnOpt(useTopnOpt);
     }
 
     @Override

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -555,6 +555,7 @@ struct TOlapScanNode {
   10: optional i64 sort_limit
   11: optional bool enable_unique_key_merge_on_write
   12: optional TPushAggOp push_down_agg_type_opt
+  13: optional bool use_topn_opt
 }
 
 struct TEqJoinCondition {
@@ -732,6 +733,7 @@ struct TSortNode {
 
   // Indicates whether the imposed limit comes DEFAULT_ORDER_BY_LIMIT.           
   6: optional bool is_default_limit                                              
+  7: optional bool use_topn_opt
 }
 
 enum TAnalyticWindowType {


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

Describe your changes.

This PR optimize topn query like `SELECT * FROM tableX ORDER BY columnA ASC/DESC LIMIT N`.

Sort node use the intermediate result of topn to generate a predicate dynamically for the ORDER BY column, eg. columnA in the example query. Then scan node use the predicate to filter segment file, page, rows to reduce the data to be read dramatically.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

