### PR TITLE
[bugfix](compaction) fix missing key_bounds in vertical compaction

### DIFF
--- a/be/src/olap/merger.cpp
+++ b/be/src/olap/merger.cpp
@@ -239,7 +239,7 @@ Status Merger::vertical_compact_one_group(
         stats_output->merged_rows = reader.merged_rows();
         stats_output->filtered_rows = reader.filtered_rows();
     }
-    RETURN_IF_ERROR(dst_rowset_writer->flush_columns());
+    RETURN_IF_ERROR(dst_rowset_writer->flush_columns(is_key));
 
     return Status::OK();
 }

--- a/be/src/olap/rowset/rowset_writer.h
+++ b/be/src/olap/rowset/rowset_writer.h
@@ -59,7 +59,9 @@ public:
     // explicit flush all buffered rows into segment file.
     // note that `add_row` could also trigger flush when certain conditions are met
     virtual Status flush() = 0;
-    virtual Status flush_columns() { return Status::Error<ErrorCode::NOT_IMPLEMENTED_ERROR>(); }
+    virtual Status flush_columns(bool is_key) {
+        return Status::Error<ErrorCode::NOT_IMPLEMENTED_ERROR>();
+    }
     virtual Status final_flush() { return Status::Error<ErrorCode::NOT_IMPLEMENTED_ERROR>(); }
 
     virtual Status flush_single_memtable(MemTable* memtable, int64_t* flush_size) {

--- a/be/src/olap/rowset/vertical_beta_rowset_writer.cpp
+++ b/be/src/olap/rowset/vertical_beta_rowset_writer.cpp
@@ -115,13 +115,13 @@ Status VerticalBetaRowsetWriter::_flush_columns(
     return Status::OK();
 }
 
-Status VerticalBetaRowsetWriter::flush_columns() {
+Status VerticalBetaRowsetWriter::flush_columns(bool is_key) {
     if (_segment_writers.empty()) {
         return Status::OK();
     }
 
     DCHECK(_segment_writers[_cur_writer_idx]);
-    RETURN_IF_ERROR(_flush_columns(&_segment_writers[_cur_writer_idx]));
+    RETURN_IF_ERROR(_flush_columns(&_segment_writers[_cur_writer_idx], is_key));
     _cur_writer_idx = 0;
     return Status::OK();
 }

--- a/be/src/olap/rowset/vertical_beta_rowset_writer.h
+++ b/be/src/olap/rowset/vertical_beta_rowset_writer.h
@@ -32,7 +32,7 @@ public:
                        bool is_key, uint32_t max_rows_per_segment);
 
     // flush last segment's column
-    Status flush_columns();
+    Status flush_columns(bool is_key);
 
     // flush when all column finished, flush column footer
     Status final_flush();


### PR DESCRIPTION
When flush last segment of every column, missing set segment key bound for rowset meta so that rowset tree init error.

# Proposed changes

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

