### PR TITLE
[fix](Nereids) SimplifyArithmeticRule should add constant expr to the head of variables list

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rewrite/rules/SimplifyArithmeticRule.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rewrite/rules/SimplifyArithmeticRule.java
@@ -39,6 +39,8 @@ import java.util.Optional;
  * a + 1 + b - 2 - ((c - d) + 1) => a + b - c + d + (1 - 2 - 1)
  * After `FoldConstantRule`:
  * a + b - c + d + (1 - 2 - 1) => a + b - c + d - 2
+ *
+ * TODO: handle cases like: '1 - IA < 1' to 'IA > 0'
  */
 public class SimplifyArithmeticRule extends AbstractExpressionRewriteRule {
     public static final SimplifyArithmeticRule INSTANCE = new SimplifyArithmeticRule();
@@ -100,7 +102,12 @@ public class SimplifyArithmeticRule extends AbstractExpressionRewriteRule {
                 }
                 return Operand.of(true, expr);
             });
-            variables.add(Operand.of(!isOpposite, c.get().expression));
+            boolean firstVariableFlag = variables.isEmpty() || variables.get(0).flag;
+            if (isOpposite || firstVariableFlag) {
+                variables.add(Operand.of(!isOpposite, c.get().expression));
+            } else {
+                variables.add(0, Operand.of(!isOpposite, c.get().expression));
+            }
         }
 
         Optional<Operand> result = variables.stream().reduce((x, y) -> !y.flag

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/Expression.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/Expression.java
@@ -122,7 +122,7 @@ public abstract class Expression extends AbstractTreeNode<Expression> implements
     /**
      * Whether the expression is a constant.
      */
-    public final boolean isConstant() {
+    public boolean isConstant() {
         if (this instanceof LeafExpression) {
             return this instanceof Literal;
         } else {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/agg/Count.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/agg/Count.java
@@ -66,6 +66,11 @@ public class Count extends AggregateFunction implements AlwaysNotNullable, Custo
     }
 
     @Override
+    public boolean isConstant() {
+        return false;
+    }
+
+    @Override
     protected List<DataType> intermediateTypes() {
         return ImmutableList.of(BigIntType.INSTANCE);
     }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/rewrite/SimplifyArithmeticRuleTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/rewrite/SimplifyArithmeticRuleTest.java
@@ -36,6 +36,8 @@ public class SimplifyArithmeticRuleTest extends ExpressionRewriteTestHelper {
         assertRewriteAfterTypeCoercion("IA", "IA");
         assertRewriteAfterTypeCoercion("IA + 1", "IA + 1");
         assertRewriteAfterTypeCoercion("IA + IB", "IA + IB");
+        assertRewriteAfterTypeCoercion("1 * 3 / IA", "(3.0 / cast(IA as DOUBLE))");
+        assertRewriteAfterTypeCoercion("1 - IA", "1 - IA");
         assertRewriteAfterTypeCoercion("1 + 1", "2");
         assertRewriteAfterTypeCoercion("IA + 2 - 1", "cast(IA as bigint) + 1");
         assertRewriteAfterTypeCoercion("IA + 2 - (1 - 1)", "cast(IA as bigint) + 2");


### PR DESCRIPTION

# Proposed changes

Issue Number: close #xxx

## Problem summary

in the case of 'a / b', if a is constant, after apple SimplifyArithmeticRule, expression will be convert to 'b * a' by mistake.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

