### PR TITLE
[fix](csv-reader) fix new csv reader's performance issue

### DIFF
--- a/be/src/vec/exec/format/csv/csv_reader.cpp
+++ b/be/src/vec/exec/format/csv/csv_reader.cpp
@@ -167,9 +167,23 @@ Status CsvReader::init_reader(bool is_load) {
 
     _is_load = is_load;
     if (!_is_load) {
-        // For query task, we need to save the mapping from table schema to file column
+        // For query task, there are 2 slot mapping.
+        // One is from file slot to values in line.
+        //      eg, the file_slot_descs is k1, k3, k5, and values in line are k1, k2, k3, k4, k5
+        //      the _col_idxs will save: 0, 2, 4
+        // The other is from file slot to columns in output block
+        //      eg, the file_slot_descs is k1, k3, k5, and columns in block are p1, k1, k3, k5
+        //      where "p1" is the partition col which does not exist in file
+        //      the _file_slot_idx_map will save: 1, 2, 3
         DCHECK(_params.__isset.column_idxs);
         _col_idxs = _params.column_idxs;
+        int idx = 0;
+        for (const auto& slot_info : _params.required_slots) {
+            if (slot_info.is_file_slot) {
+                _file_slot_idx_map.push_back(idx);
+            }
+            idx++;
+        }
     } else {
         // For load task, the column order is same as file column order
         int i = 0;
@@ -177,6 +191,7 @@ Status CsvReader::init_reader(bool is_load) {
             _col_idxs.push_back(i++);
         }
     }
+
 
     _line_reader_eof = false;
     return Status::OK();
@@ -317,16 +332,11 @@ Status CsvReader::_fill_dest_columns(const Slice& line, Block* block,
     if (_is_load) {
         for (int i = 0; i < _file_slot_descs.size(); ++i) {
             auto src_slot_desc = _file_slot_descs[i];
-            // int col_idx = _col_idxs[i];
+            int col_idx = _col_idxs[i];
             // col idx is out of range, fill with null.
-            const Slice& value = i < _split_values.size() ? _split_values[i] : _s_null_slice;
-            // IColumn* col_ptr =
-            //         const_cast<IColumn*>(block->get_by_name(src_slot_desc->col_name()).column.get());
-            // _text_converter->write_vec_column(src_slot_desc, col_ptr, value.data, value.size, true,
-            //                                   false);
-
-            _text_converter->write_string_column(src_slot_desc, &columns[i], value.data,
-                                                 value.size);
+            const Slice& value = col_idx < _split_values.size() ? _split_values[col_idx] : _s_null_slice;
+            // For load task, we always read "string" from file, so use "write_string_column"
+            _text_converter->write_string_column(src_slot_desc, &columns[i], value.data, value.size);
         }
     } else {
         // if _split_values.size > _file_slot_descs.size()
@@ -335,12 +345,10 @@ Status CsvReader::_fill_dest_columns(const Slice& line, Block* block,
             auto src_slot_desc = _file_slot_descs[i];
             int col_idx = _col_idxs[i];
             // col idx is out of range, fill with null.
-            const Slice& value =
-                    col_idx < _split_values.size() ? _split_values[col_idx] : _s_null_slice;
-            IColumn* col_ptr = const_cast<IColumn*>(
-                    block->get_by_name(src_slot_desc->col_name()).column.get());
-            _text_converter->write_vec_column(src_slot_desc, col_ptr, value.data, value.size, true,
-                                              false);
+            const Slice& value = col_idx < _split_values.size() ? _split_values[col_idx] : _s_null_slice;
+            IColumn* col_ptr = const_cast<IColumn*>(block->get_by_position(_file_slot_idx_map[i]).column.get());
+            // For query task, we will convert values to final column type, so use "write_vec_column"
+            _text_converter->write_vec_column(src_slot_desc, col_ptr, value.data, value.size, true, false);
         }
     }
     ++(*rows);

--- a/be/src/vec/exec/format/csv/csv_reader.cpp
+++ b/be/src/vec/exec/format/csv/csv_reader.cpp
@@ -192,7 +192,6 @@ Status CsvReader::init_reader(bool is_load) {
         }
     }
 
-
     _line_reader_eof = false;
     return Status::OK();
 }
@@ -334,9 +333,11 @@ Status CsvReader::_fill_dest_columns(const Slice& line, Block* block,
             auto src_slot_desc = _file_slot_descs[i];
             int col_idx = _col_idxs[i];
             // col idx is out of range, fill with null.
-            const Slice& value = col_idx < _split_values.size() ? _split_values[col_idx] : _s_null_slice;
+            const Slice& value =
+                    col_idx < _split_values.size() ? _split_values[col_idx] : _s_null_slice;
             // For load task, we always read "string" from file, so use "write_string_column"
-            _text_converter->write_string_column(src_slot_desc, &columns[i], value.data, value.size);
+            _text_converter->write_string_column(src_slot_desc, &columns[i], value.data,
+                                                 value.size);
         }
     } else {
         // if _split_values.size > _file_slot_descs.size()
@@ -345,10 +346,13 @@ Status CsvReader::_fill_dest_columns(const Slice& line, Block* block,
             auto src_slot_desc = _file_slot_descs[i];
             int col_idx = _col_idxs[i];
             // col idx is out of range, fill with null.
-            const Slice& value = col_idx < _split_values.size() ? _split_values[col_idx] : _s_null_slice;
-            IColumn* col_ptr = const_cast<IColumn*>(block->get_by_position(_file_slot_idx_map[i]).column.get());
+            const Slice& value =
+                    col_idx < _split_values.size() ? _split_values[col_idx] : _s_null_slice;
+            IColumn* col_ptr = const_cast<IColumn*>(
+                    block->get_by_position(_file_slot_idx_map[i]).column.get());
             // For query task, we will convert values to final column type, so use "write_vec_column"
-            _text_converter->write_vec_column(src_slot_desc, col_ptr, value.data, value.size, true, false);
+            _text_converter->write_vec_column(src_slot_desc, col_ptr, value.data, value.size, true,
+                                              false);
         }
     }
     ++(*rows);

--- a/be/src/vec/exec/format/csv/csv_reader.h
+++ b/be/src/vec/exec/format/csv/csv_reader.h
@@ -78,6 +78,11 @@ private:
     const TFileScanRangeParams& _params;
     const TFileRangeDesc& _range;
     const std::vector<SlotDescriptor*>& _file_slot_descs;
+    // Only for query task, save the file slot to columns in block map.
+    // eg, there are 3 cols in "_file_slot_descs" named: k1, k2, k3
+    // and this 3 columns in block are k2, k3, k1,
+    // the _file_slot_idx_map will save: 2, 0, 1
+    std::vector<int> _file_slot_idx_map;
     // Only for query task, save the columns' index which need to be read.
     // eg, there are 3 cols in "_file_slot_descs" named: k1, k2, k3
     // and the corresponding position in file is 0, 3, 5.

--- a/be/src/vec/exec/format/csv/csv_reader.h
+++ b/be/src/vec/exec/format/csv/csv_reader.h
@@ -56,7 +56,8 @@ public:
 private:
     // used for stream/broker load of csv file.
     Status _create_decompressor();
-    Status _fill_dest_columns(const Slice& line, Block* block, size_t* rows);
+    Status _fill_dest_columns(const Slice& line, Block* block,
+                              std::vector<MutableColumnPtr>& columns, size_t* rows);
     Status _line_split_to_values(const Slice& line, bool* success);
     void _split_line(const Slice& line);
     Status _check_array_format(std::vector<Slice>& split_values, bool* is_success);

--- a/be/src/vec/exec/scan/vfile_scanner.h
+++ b/be/src/vec/exec/scan/vfile_scanner.h
@@ -68,6 +68,7 @@ protected:
     std::map<std::string, int> _file_slot_name_map;
     // col names from _file_slot_descs
     std::vector<std::string> _file_col_names;
+
     // Partition source slot descriptors
     std::vector<SlotDescriptor*> _partition_slot_descs;
     // Partition slot id to index in _partition_slot_descs


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

#14604 fix the bug but introduce a performance issue.
This PR fix the performance issue when loading csv.

For clickbench load time, from 600s -> 470s

TODO:
Still slower than origin broker scan node, which is about 420s.
Will improve later.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

