### PR TITLE
[fix](storage-policy) fix some bug

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/AlterPolicyStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/AlterPolicyStmt.java
@@ -99,9 +99,9 @@ public class AlterPolicyStmt extends DdlStmt {
 
         if (properties.containsKey(StoragePolicy.COOLDOWN_TTL)) {
             hasCooldownTtl = true;
-            if (Integer.parseInt(properties.get(StoragePolicy.COOLDOWN_TTL)) < 0) {
-                throw new AnalysisException("cooldown_ttl must >= 0.");
-            }
+            // support 1h, 1hour to 3600s
+            properties.put(StoragePolicy.COOLDOWN_TTL, String.valueOf(
+                    StoragePolicy.getMsByCooldownTtl(properties.get(StoragePolicy.COOLDOWN_TTL)) / 1000));
         }
 
         if (hasCooldownDatetime && hasCooldownTtl) {

--- a/fe/fe-core/src/main/java/org/apache/doris/policy/StoragePolicy.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/policy/StoragePolicy.java
@@ -300,7 +300,7 @@ public class StoragePolicy extends Policy {
      * @param cooldownTtl cooldown ttl
      * @return millisecond for cooldownTtl
      */
-    private static long getMsByCooldownTtl(String cooldownTtl) throws AnalysisException {
+    public static long getMsByCooldownTtl(String cooldownTtl) throws AnalysisException {
         cooldownTtl = cooldownTtl.replace(TTL_DAY, TTL_DAY_SIMPLE).replace(TTL_HOUR, TTL_HOUR_SIMPLE);
         long cooldownTtlMs = 0;
         try {

--- a/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
@@ -1159,8 +1159,9 @@ public class FrontendServiceImpl implements FrontendService.Iface {
                     Optional.ofNullable(iter.getCooldownTtl()).ifPresent(ttl -> ttlCoolDown[0] = Integer.parseInt(ttl));
                     rEntry.setCooldownTtl(ttlCoolDown[0]);
 
+                    //timestamp : ms -> s
                     rEntry.setCooldownDatetime(
-                            iter.getCooldownTimestampMs() == -1 ? -1 : iter.getCooldownTimestampMs() / 100);
+                            iter.getCooldownTimestampMs() == -1 ? -1 : iter.getCooldownTimestampMs() / 1000);
 
                     Optional.ofNullable(iter.getMd5Checksum()).ifPresent(rEntry::setMd5Checksum);
                     TS3StorageParam s3Info = new TS3StorageParam();

--- a/fe/fe-core/src/main/java/org/apache/doris/task/NotifyUpdateStoragePolicyTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/task/NotifyUpdateStoragePolicyTask.java
@@ -44,8 +44,8 @@ public class NotifyUpdateStoragePolicyTask extends AgentTask {
 
         ret.policy_name = policyName;
         // cooldown_datetime in BE is in seconds
-        ret.cooldown_datetime = Long.parseLong(properties.get(StoragePolicy.COOLDOWN_DATETIME)) / 1000;
-        ret.cooldown_ttl = Long.parseLong(properties.get(StoragePolicy.COOLDOWN_TTL));
+        ret.setCooldownDatetime(Long.parseLong(properties.get(StoragePolicy.COOLDOWN_DATETIME)) / 1000);
+        ret.setCooldownTtl(Long.parseLong(properties.get(StoragePolicy.COOLDOWN_TTL)));
         ret.s3_storage_param = new TS3StorageParam();
         ret.s3_storage_param.s3_max_conn = Integer.parseInt(
                 properties.getOrDefault(S3Resource.S3_MAX_CONNECTIONS,


### PR DESCRIPTION
1. fix datetime ms transfter to s bug
2. fix alter storage policy notify be missing field(datetime, ttl)
3. support alter storage policy use "h, hour, d, day" as ttl filed

# Proposed changes

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

1. fix datetime ms transfter to s bug
![image](https://user-images.githubusercontent.com/3887565/210472023-93cbf04c-1e50-4cdc-8926-d19bd783c0fc.png)
![image](https://user-images.githubusercontent.com/3887565/210472090-56d69b84-0f52-45f8-b896-12343b548e55.png)
![image](https://user-images.githubusercontent.com/3887565/210472108-9de2d6a3-c288-428e-bbe7-70f60cb3f49d.png)

2.  fix alter storage policy notify be missing field(datetime, ttl)
before fix :  datetime and ttl not send to be
![image](https://user-images.githubusercontent.com/3887565/210472168-7afe7bbe-b20a-4d9e-a6ee-1d77caa2ec80.png)

3. support alter storage policy use "h, hour, d, day" as ttl filed
```
mysql> ALTER STORAGE POLICY test_policy PROPERTIES("cooldown_ttl" = "99999");
Query OK, 0 rows affected (0.01 sec)

mysql> ALTER STORAGE POLICY test_policy PROPERTIES("cooldown_ttl" = "10d");
Query OK, 0 rows affected (0.00 sec)
```