### PR TITLE
[fix](nereids)type coercion: in-pred handle null literal bug

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslator.java
@@ -1374,7 +1374,7 @@ public class PhysicalPlanTranslator extends DefaultPlanVisitor<PlanFragment, Pla
         for (int i = 0; i < outputs.size(); ++i) {
             Slot right = childOutputs.get(i);
             DataType tightestCommonType = outputs.get(i).getDataType();
-            Expression newRight = TypeCoercionUtils.castIfNotSameType(right, tightestCommonType);
+            Expression newRight = TypeCoercionUtils.castIfNotSameTypeAndNotNull(right, tightestCommonType);
             newChildOutputs.add(newRight);
         }
         return ImmutableList.copyOf(newChildOutputs);

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rewrite/rules/TypeCoercion.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rewrite/rules/TypeCoercion.java
@@ -38,7 +38,6 @@ import org.apache.doris.nereids.trees.expressions.typecoercion.ImplicitCastInput
 import org.apache.doris.nereids.types.BigIntType;
 import org.apache.doris.nereids.types.DataType;
 import org.apache.doris.nereids.types.DoubleType;
-import org.apache.doris.nereids.types.NullType;
 import org.apache.doris.nereids.types.coercion.AbstractDataType;
 import org.apache.doris.nereids.types.coercion.CharacterType;
 import org.apache.doris.nereids.types.coercion.FractionalType;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rewrite/rules/TypeCoercion.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rewrite/rules/TypeCoercion.java
@@ -37,6 +37,7 @@ import org.apache.doris.nereids.trees.expressions.typecoercion.ImplicitCastInput
 import org.apache.doris.nereids.types.BigIntType;
 import org.apache.doris.nereids.types.DataType;
 import org.apache.doris.nereids.types.DoubleType;
+import org.apache.doris.nereids.types.NullType;
 import org.apache.doris.nereids.types.coercion.AbstractDataType;
 import org.apache.doris.nereids.types.coercion.CharacterType;
 import org.apache.doris.nereids.types.coercion.FractionalType;
@@ -172,7 +173,8 @@ public class TypeCoercion extends AbstractExpressionRewriteRule {
         InPredicate newInPredicate = inPredicate.withChildren(rewrittenChildren);
 
         if (newInPredicate.getOptions().stream().map(Expression::getDataType)
-                .allMatch(dt -> dt.equals(newInPredicate.getCompareExpr().getDataType()))) {
+                .allMatch(dt -> dt.equals(NullType.INSTANCE)
+                        || dt.equals(newInPredicate.getCompareExpr().getDataType()))) {
             return newInPredicate;
         }
         Optional<DataType> optionalCommonType = TypeCoercionUtils.findWiderCommonType(newInPredicate.children()

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rewrite/rules/TypeCoercion.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rewrite/rules/TypeCoercion.java
@@ -112,8 +112,8 @@ public class TypeCoercion extends AbstractExpressionRewriteRule {
                 .filter(ct -> op.inputType().acceptsType(ct))
                 .filter(ct -> !left.getDataType().equals(ct) || !right.getDataType().equals(ct))
                 .map(commonType -> {
-                    Expression newLeft = TypeCoercionUtils.castIfNotSameType(left, commonType);
-                    Expression newRight = TypeCoercionUtils.castIfNotSameType(right, commonType);
+                    Expression newLeft = TypeCoercionUtils.castIfNotSameTypeAndNotNull(left, commonType);
+                    Expression newRight = TypeCoercionUtils.castIfNotSameTypeAndNotNull(right, commonType);
                     return op.withChildren(newLeft, newRight);
                 })
                 .orElse(op.withChildren(left, right));
@@ -132,8 +132,8 @@ public class TypeCoercion extends AbstractExpressionRewriteRule {
                 && (commonType.isBigIntType() || commonType.isLargeIntType())) {
             commonType = DoubleType.INSTANCE;
         }
-        Expression newLeft = TypeCoercionUtils.castIfNotSameType(left, commonType);
-        Expression newRight = TypeCoercionUtils.castIfNotSameType(right, commonType);
+        Expression newLeft = TypeCoercionUtils.castIfNotSameTypeAndNotNull(left, commonType);
+        Expression newRight = TypeCoercionUtils.castIfNotSameTypeAndNotNull(right, commonType);
         return divide.withChildren(newLeft, newRight);
     }
 
@@ -156,10 +156,10 @@ public class TypeCoercion extends AbstractExpressionRewriteRule {
                     List<Expression> newChildren
                             = newCaseWhen.getWhenClauses().stream()
                             .map(wc -> wc.withChildren(wc.getOperand(),
-                                    TypeCoercionUtils.castIfNotSameType(wc.getResult(), commonType)))
+                                    TypeCoercionUtils.castIfNotSameTypeAndNotNull(wc.getResult(), commonType)))
                             .collect(Collectors.toList());
                     newCaseWhen.getDefaultValue()
-                            .map(dv -> TypeCoercionUtils.castIfNotSameType(dv, commonType))
+                            .map(dv -> TypeCoercionUtils.castIfNotSameTypeAndNotNull(dv, commonType))
                             .ifPresent(newChildren::add);
                     return newCaseWhen.withChildren(newChildren);
                 })
@@ -183,7 +183,8 @@ public class TypeCoercion extends AbstractExpressionRewriteRule {
         return optionalCommonType
                 .map(commonType -> {
                     List<Expression> newChildren = newInPredicate.children().stream()
-                            .map(e -> TypeCoercionUtils.castIfNotSameType(e, commonType))
+                            .map(e -> TypeCoercionUtils.castIfNotSameTypeAndNotNull(e, commonType)
+                            )
                             .collect(Collectors.toList());
                     return newInPredicate.withChildren(newChildren);
                 })
@@ -238,7 +239,7 @@ public class TypeCoercion extends AbstractExpressionRewriteRule {
             DataType argType = child.getDataType();
             Optional<DataType> castType = castTypes.get(childIndex);
             if (castType.isPresent() && !castType.get().equals(argType)) {
-                return TypeCoercionUtils.castIfNotSameType(child, castType.get());
+                return TypeCoercionUtils.castIfNotSameTypeAndNotNull(child, castType.get());
             } else {
                 return child;
             }
@@ -248,8 +249,8 @@ public class TypeCoercion extends AbstractExpressionRewriteRule {
     @Override
     public Expression visitIntegralDivide(IntegralDivide integralDivide, ExpressionRewriteContext context) {
         DataType commonType = BigIntType.INSTANCE;
-        Expression newLeft = TypeCoercionUtils.castIfNotSameType(integralDivide.left(), commonType);
-        Expression newRight = TypeCoercionUtils.castIfNotSameType(integralDivide.right(), commonType);
+        Expression newLeft = TypeCoercionUtils.castIfNotSameTypeAndNotNull(integralDivide.left(), commonType);
+        Expression newRight = TypeCoercionUtils.castIfNotSameTypeAndNotNull(integralDivide.right(), commonType);
         return integralDivide.withChildren(newLeft, newRight);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/Expression.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/Expression.java
@@ -86,6 +86,9 @@ public abstract class Expression extends AbstractTreeNode<Expression> implements
         List<String> errorMessages = Lists.newArrayList();
         for (int i = 0; i < inputs.size(); i++) {
             Expression input = inputs.get(i);
+            if (input.equals(NullLiteral.INSTANCE)) {
+                continue;
+            }
             AbstractDataType inputType = inputTypes.get(i);
             if (!inputType.acceptsType(input.getDataType())) {
                 errorMessages.add(String.format(INPUT_CHECK_ERROR_MESSAGE,

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalSetOperation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalSetOperation.java
@@ -136,8 +136,9 @@ public abstract class LogicalSetOperation extends AbstractLogicalPlan implements
                 Optional<DataType> tightestCommonType =
                         TypeCoercionUtils.findTightestCommonType(null, left.getDataType(), right.getDataType());
                 if (tightestCommonType.isPresent()) {
-                    Expression newLeft = TypeCoercionUtils.castIfNotSameType(left, tightestCommonType.get());
-                    Expression newRight = TypeCoercionUtils.castIfNotSameType(right, tightestCommonType.get());
+                    Expression newLeft = TypeCoercionUtils.castIfNotSameTypeAndNotNull(left, tightestCommonType.get());
+                    Expression newRight = TypeCoercionUtils.castIfNotSameTypeAndNotNull(right,
+                            tightestCommonType.get());
                     newLeftOutputs.add(newLeft);
                     newRightOutpus.add(newRight);
                     hasPushed = true;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/util/TypeCoercionUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/util/TypeCoercionUtils.java
@@ -24,6 +24,7 @@ import org.apache.doris.nereids.trees.expressions.BinaryOperator;
 import org.apache.doris.nereids.trees.expressions.Cast;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.literal.Literal;
+import org.apache.doris.nereids.trees.expressions.literal.NullLiteral;
 import org.apache.doris.nereids.types.BigIntType;
 import org.apache.doris.nereids.types.BooleanType;
 import org.apache.doris.nereids.types.DataType;
@@ -362,8 +363,10 @@ public class TypeCoercionUtils {
     /**
      * cast input type if input's datatype is not same with dateType.
      */
-    public static Expression castIfNotSameType(Expression input, DataType dataType) {
-        if (input.getDataType().equals(dataType)) {
+    public static Expression castIfNotSameTypeAndNotNull(Expression input, DataType dataType) {
+        if (input instanceof NullLiteral) {
+            return input;
+        } else if (input.getDataType().equals(dataType)) {
             return input;
         } else {
             if (input instanceof Literal) {

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/rewrite/TypeCoercionTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/rewrite/TypeCoercionTest.java
@@ -118,6 +118,15 @@ public class TypeCoercionTest extends ExpressionRewriteTestHelper {
     }
 
     @Test
+    public void testInNull() {
+        //make sure Null literal is not casted to Integerf
+        InPredicate in = new InPredicate(new IntegerLiteral(1),
+                Lists.newArrayList(new IntegerLiteral(2),
+                        new NullLiteral()));
+        assertRewrite(in, in);
+    }
+
+    @Test
     public void testBinaryPredicate() {
         Expression left = new DecimalLiteral(new BigDecimal(2.4));
         Expression right = new TinyIntLiteral((byte) 2);

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/rewrite/TypeCoercionTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/rewrite/TypeCoercionTest.java
@@ -38,6 +38,7 @@ import org.apache.doris.nereids.trees.expressions.literal.DecimalLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.DoubleLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.IntegerLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.Literal;
+import org.apache.doris.nereids.trees.expressions.literal.NullLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.SmallIntLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.StringLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.TinyIntLiteral;
@@ -196,6 +197,17 @@ public class TypeCoercionTest extends ExpressionRewriteTestHelper {
 
         Expression actual2 = new Add(new IntegerLiteral(1), new Add(BooleanLiteral.TRUE, new StringLiteral("x")));
         Assertions.assertThrows(IllegalStateException.class, () -> assertRewrite(actual2, null));
+    }
+
+    /**
+     * 1 in (2, null)
+     * type coercion does not cast null to IntegerLiteral.
+     */
+    @Test
+    public void testInListNull() {
+        Expression inPredicate = new InPredicate(new IntegerLiteral(1),
+                Lists.newArrayList(new IntegerLiteral(2), new NullLiteral()));
+        assertRewrite(inPredicate, inPredicate);
     }
 
     private DataType checkAndGetDataType(Expression expression) {

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/ExpectedInputTypesTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/ExpectedInputTypesTest.java
@@ -137,9 +137,7 @@ public class ExpectedInputTypesTest {
 
         Divide nullType = new Divide(NullLiteral.INSTANCE, NullLiteral.INSTANCE);
         typeCheckResult = nullType.checkInputDataTypes();
-        Assertions.assertTrue(typeCheckResult.failed());
-        // this means has two type check error
-        Assertions.assertEquals(4, typeCheckResult.getMessage().split(",").length);
+        Assertions.assertTrue(typeCheckResult.success());
     }
 
     @Test
@@ -265,9 +263,7 @@ public class ExpectedInputTypesTest {
 
         Multiply nullType = new Multiply(NullLiteral.INSTANCE, NullLiteral.INSTANCE);
         typeCheckResult = nullType.checkInputDataTypes();
-        Assertions.assertTrue(typeCheckResult.failed());
-        // this means has two type check error
-        Assertions.assertEquals(4, typeCheckResult.getMessage().split(",").length);
+        Assertions.assertTrue(typeCheckResult.success());
     }
 
     @Test
@@ -334,9 +330,7 @@ public class ExpectedInputTypesTest {
 
         Subtract nullType = new Subtract(NullLiteral.INSTANCE, NullLiteral.INSTANCE);
         typeCheckResult = nullType.checkInputDataTypes();
-        Assertions.assertTrue(typeCheckResult.failed());
-        // this means has two type check error
-        Assertions.assertEquals(4, typeCheckResult.getMessage().split(",").length);
+        Assertions.assertTrue(typeCheckResult.success());
     }
 
     @Test
@@ -403,9 +397,7 @@ public class ExpectedInputTypesTest {
 
         Mod nullType = new Mod(NullLiteral.INSTANCE, NullLiteral.INSTANCE);
         typeCheckResult = nullType.checkInputDataTypes();
-        Assertions.assertTrue(typeCheckResult.failed());
-        // this means has two type check error
-        Assertions.assertEquals(4, typeCheckResult.getMessage().split(",").length);
+        Assertions.assertTrue(typeCheckResult.success());
     }
 
     @Test
@@ -472,9 +464,7 @@ public class ExpectedInputTypesTest {
 
         Add nullType = new Add(NullLiteral.INSTANCE, NullLiteral.INSTANCE);
         typeCheckResult = nullType.checkInputDataTypes();
-        Assertions.assertTrue(typeCheckResult.failed());
-        // this means has two type check error
-        Assertions.assertEquals(4, typeCheckResult.getMessage().split(",").length);
+        Assertions.assertTrue(typeCheckResult.success());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/util/TypeCoercionUtilsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/util/TypeCoercionUtilsTest.java
@@ -199,8 +199,8 @@ public class TypeCoercionUtilsTest {
     @Test
     public void testCastIfNotSameType() {
         Assertions.assertEquals(new DoubleLiteral(5L),
-                TypeCoercionUtils.castIfNotSameType(new DoubleLiteral(5L), DoubleType.INSTANCE));
+                TypeCoercionUtils.castIfNotSameTypeAndNotNull(new DoubleLiteral(5L), DoubleType.INSTANCE));
         Assertions.assertEquals(new Cast(new DoubleLiteral(5L), BooleanType.INSTANCE),
-                TypeCoercionUtils.castIfNotSameType(new DoubleLiteral(5L), BooleanType.INSTANCE));
+                TypeCoercionUtils.castIfNotSameTypeAndNotNull(new DoubleLiteral(5L), BooleanType.INSTANCE));
     }
 }


### PR DESCRIPTION
# Proposed changes
fix two bug about nullLiteral
1. fix type coercion bug
`1 in (2, null)`
in type coercion rewrite, nereids cast null to tiny int. This is wrong.

2. NullLiteral should be passed as a function parameter of any data type.
for example, sum(x) expects integerType as input parameter. But it also accept NullLiteral.
We do not need to cast nullLiteral to Integer and then pass it to sum()

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
4. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
5. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
6. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
7. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

