### PR TITLE
[fix](tvf) use virtual-hosted style when s3('uri'='s3://xxx')

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/tablefunction/S3TableValuedFunction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/tablefunction/S3TableValuedFunction.java
@@ -75,8 +75,8 @@ public class S3TableValuedFunction extends ExternalFileTableValuedFunction {
 
         String originUri = validParams.getOrDefault(S3_URI, "");
         if (originUri.toLowerCase().startsWith("s3")) {
-            // s3 protocol
-            forceVirtualHosted = false;
+            // s3 protocol, default virtual-hosted style
+            forceVirtualHosted = true;
         } else {
             // not s3 protocol, forceVirtualHosted is determined by USE_PATH_STYLE.
             forceVirtualHosted = !Boolean.valueOf(validParams.get(USE_PATH_STYLE)).booleanValue();


### PR DESCRIPTION
Signed-off-by: nextdreamblue <zxw520blue1@163.com>

# Proposed changes

Issue Number: close #xxx

## Problem summary

when S3 tvf, the S3 SDK uses the virtual-hosted style by default, but the code set forceVirtualHosted=false when uri='s3://bucket.endpoint/file' and will get error like 'parse file failed, path = s3://file'


## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

