### PR TITLE
[fix](nereids) binding group by key on agg.output if output is slot

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/BindSlotReference.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/BindSlotReference.java
@@ -293,8 +293,7 @@ public class BindSlotReference implements AnalysisRuleFactory {
                             .collect(Collectors.toSet());
 
                     boundSlots.addAll(outputSlots);
-                    SlotBinder binder = new SlotBinder(toScope(Lists.newArrayList(boundSlots)),
-                            agg, ctx.cascadesContext);
+                    SlotBinder binder = new SlotBinder(toScope(Lists.newArrayList(boundSlots)), ctx.cascadesContext);
 
                     List<Expression> groupBy = replacedGroupBy.stream()
                             .map(expression -> binder.bind(expression))

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/analysis/BindSlotReferenceTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/analysis/BindSlotReferenceTest.java
@@ -19,17 +19,24 @@ package org.apache.doris.nereids.rules.analysis;
 
 import org.apache.doris.nereids.analyzer.UnboundSlot;
 import org.apache.doris.nereids.exceptions.AnalysisException;
+import org.apache.doris.nereids.trees.expressions.Alias;
 import org.apache.doris.nereids.trees.expressions.NamedExpressionUtil;
+import org.apache.doris.nereids.trees.expressions.SlotReference;
+import org.apache.doris.nereids.trees.expressions.functions.agg.Count;
+import org.apache.doris.nereids.trees.expressions.literal.IntegerLiteral;
 import org.apache.doris.nereids.trees.plans.JoinType;
+import org.apache.doris.nereids.trees.plans.logical.LogicalAggregate;
 import org.apache.doris.nereids.trees.plans.logical.LogicalJoin;
 import org.apache.doris.nereids.trees.plans.logical.LogicalOlapScan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalProject;
+import org.apache.doris.nereids.trees.plans.logical.LogicalSubQueryAlias;
 import org.apache.doris.nereids.trees.plans.logical.RelationUtil;
 import org.apache.doris.nereids.util.MemoTestUtils;
 import org.apache.doris.nereids.util.PlanChecker;
 import org.apache.doris.nereids.util.PlanConstructor;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -64,5 +71,53 @@ class BindSlotReferenceTest {
         Assertions.assertTrue(exception.getMessage().contains("id is ambiguous: "));
         Assertions.assertTrue(exception.getMessage().contains("id#4"));
         Assertions.assertTrue(exception.getMessage().contains("id#0"));
+    }
+
+    /*
+    select t1.id from student t1 join on student t2 on t1.di=t2.id group by id;
+    group_by_key bind on t1.id, not t2.id
+     */
+    @Test
+    public void testGroupByOnJoin() {
+        LogicalOlapScan scan1 = new LogicalOlapScan(RelationUtil.newRelationId(), PlanConstructor.student);
+        LogicalSubQueryAlias sub1 = new LogicalSubQueryAlias("t1", scan1);
+        LogicalOlapScan scan2 = new LogicalOlapScan(RelationUtil.newRelationId(), PlanConstructor.student);
+        LogicalSubQueryAlias sub2 = new LogicalSubQueryAlias("t2", scan2);
+        LogicalJoin<LogicalSubQueryAlias<LogicalOlapScan>, LogicalSubQueryAlias<LogicalOlapScan>> join =
+                new LogicalJoin<>(JoinType.CROSS_JOIN, sub1, sub2);
+        LogicalAggregate<LogicalJoin> aggregate = new LogicalAggregate<>(
+                Lists.newArrayList(new UnboundSlot("id")), //group by
+                Lists.newArrayList(new UnboundSlot("t1", "id")), //output
+                join
+        );
+        PlanChecker checker = PlanChecker.from(MemoTestUtils.createConnectContext()).analyze(aggregate);
+        LogicalAggregate plan = (LogicalAggregate) checker.getCascadesContext().getMemo().copyOut();
+        SlotReference groupByKey = (SlotReference) plan.getGroupByExpressions().get(0);
+        SlotReference t1id = (SlotReference) ((LogicalJoin) plan.child()).left().getOutput().get(0);
+        SlotReference t2id = (SlotReference) ((LogicalJoin) plan.child()).right().getOutput().get(0);
+        Assertions.assertEquals(groupByKey.getExprId(), t1id.getExprId());
+        Assertions.assertNotEquals(t1id.getExprId(), t2id.getExprId());
+    }
+
+    /*
+    select count(1) from student t1 join on student t2 on t1.di=t2.id group by id;
+    group by key is ambiguous
+     */
+    @Test
+    public void testGroupByOnJoinAmbiguous() {
+        LogicalOlapScan scan1 = new LogicalOlapScan(RelationUtil.newRelationId(), PlanConstructor.student);
+        LogicalSubQueryAlias sub1 = new LogicalSubQueryAlias("t1", scan1);
+        LogicalOlapScan scan2 = new LogicalOlapScan(RelationUtil.newRelationId(), PlanConstructor.student);
+        LogicalSubQueryAlias sub2 = new LogicalSubQueryAlias("t2", scan2);
+        LogicalJoin<LogicalSubQueryAlias<LogicalOlapScan>, LogicalSubQueryAlias<LogicalOlapScan>> join =
+                new LogicalJoin<>(JoinType.CROSS_JOIN, sub1, sub2);
+        LogicalAggregate<LogicalJoin> aggregate = new LogicalAggregate<>(
+                Lists.newArrayList(new UnboundSlot("id")), //group by
+                Lists.newArrayList(new Alias(new Count(new IntegerLiteral(1)), "count(1)")), //output
+                join
+        );
+        AnalysisException exception = Assertions.assertThrows(AnalysisException.class,
+                () -> PlanChecker.from(MemoTestUtils.createConnectContext()).analyze(aggregate));
+        Assertions.assertTrue(exception.getMessage().contains("id is ambiguous: "));
     }
 }


### PR DESCRIPTION
# Proposed changes
case 1
`select count(1) from t1 join t2 on t1.a = t2.a group by a`
`group by a` is ambiguous

case 2
`select t1.a from t1 join t2 on t1.a = t2.a group by a`
`group by a` is bound on t1.a

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

