### PR TITLE
[improvement](pipeline) Support sharing hash table for broadcast join

### DIFF
--- a/be/src/pipeline/CMakeLists.txt
+++ b/be/src/pipeline/CMakeLists.txt
@@ -58,7 +58,8 @@ set(PIPELINE_FILES
         exec/union_sink_operator.cpp
         exec/union_source_operator.cpp
         exec/data_queue.cpp
-        exec/select_operator.cpp)
+        exec/select_operator.cpp
+        exec/empty_source_operator.cpp)
 
 add_library(Pipeline STATIC
         ${PIPELINE_FILES}

--- a/be/src/pipeline/exec/empty_source_operator.cpp
+++ b/be/src/pipeline/exec/empty_source_operator.cpp
@@ -15,32 +15,11 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#pragma once
+#include "empty_source_operator.h"
 
-#include "operator.h"
+namespace doris::pipeline {
+OperatorPtr EmptySourceOperatorBuilder::build_operator() {
+    return std::make_shared<EmptySourceOperator>(this);
+}
 
-namespace doris {
-namespace vectorized {
-class HashJoinNode;
-class VExprContext;
-class Block;
-} // namespace vectorized
-
-namespace pipeline {
-
-class HashJoinBuildSinkBuilder final : public OperatorBuilder<vectorized::HashJoinNode> {
-public:
-    HashJoinBuildSinkBuilder(int32_t, ExecNode*);
-
-    OperatorPtr build_operator() override;
-    bool is_sink() const override { return true; };
-};
-
-class HashJoinBuildSink final : public StreamingOperator<HashJoinBuildSinkBuilder> {
-public:
-    HashJoinBuildSink(OperatorBuilderBase* operator_builder, ExecNode* node);
-    bool can_write() override { return _node->can_sink_write(); };
-};
-
-} // namespace pipeline
-} // namespace doris
+} // namespace doris::pipeline

--- a/be/src/pipeline/exec/empty_source_operator.h
+++ b/be/src/pipeline/exec/empty_source_operator.h
@@ -1,0 +1,62 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include "operator.h"
+
+namespace doris::vectorized {
+class VExchangeNode;
+}
+
+namespace doris::pipeline {
+
+class EmptySourceOperatorBuilder final : public OperatorBuilderBase {
+public:
+    EmptySourceOperatorBuilder(int32_t id, const RowDescriptor& row_descriptor)
+            : OperatorBuilderBase(id, "EmptySourceOperator"), _row_descriptor(row_descriptor) {}
+
+    bool is_source() const override { return true; }
+
+    OperatorPtr build_operator() override;
+
+    const RowDescriptor& row_desc() override { return _row_descriptor; }
+
+private:
+    RowDescriptor _row_descriptor;
+};
+
+class EmptySourceOperator final : public OperatorBase {
+public:
+    EmptySourceOperator(OperatorBuilderBase* builder) : OperatorBase(builder) {}
+    bool can_read() override { return true; }
+    bool is_pending_finish() const override { return false; }
+
+    Status prepare(RuntimeState*) override { return Status::OK(); }
+
+    Status open(RuntimeState*) override { return Status::OK(); }
+
+    Status get_block(RuntimeState* /*runtime_state*/, vectorized::Block* /*block*/,
+                     SourceState& result_state) override {
+        result_state = SourceState::FINISHED;
+        return Status::OK();
+    }
+
+    Status sink(RuntimeState*, vectorized::Block*, SourceState) override { return Status::OK(); }
+};
+
+} // namespace doris::pipeline

--- a/be/src/pipeline/exec/operator.h
+++ b/be/src/pipeline/exec/operator.h
@@ -168,7 +168,7 @@ public:
     /**
      * Release all resources once this operator done its work.
      */
-    virtual Status close(RuntimeState* state) = 0;
+    virtual Status close(RuntimeState* state);
 
     Status set_child(OperatorPtr child) {
         if (is_source()) {

--- a/be/src/runtime/fragment_mgr.h
+++ b/be/src/runtime/fragment_mgr.h
@@ -119,15 +119,16 @@ private:
 
     bool _is_scan_node(const TPlanNodeType::type& type);
 
+    void _setup_shared_hashtable_for_broadcast_join(const TExecPlanFragmentParams& params,
+                                                    RuntimeState* state,
+                                                    QueryFragmentsCtx* fragments_ctx);
+
     // This is input params
     ExecEnv* _exec_env;
 
     std::mutex _lock;
 
     std::condition_variable _cv;
-
-    std::mutex _lock_for_shared_hash_table;
-    std::condition_variable _cv_for_sharing_hashtable;
 
     // Make sure that remove this before no data reference FragmentExecState
     std::unordered_map<TUniqueId, std::shared_ptr<FragmentExecState>> _fragment_map;

--- a/be/src/vec/exec/join/vhash_join_node.h
+++ b/be/src/vec/exec/join/vhash_join_node.h
@@ -214,6 +214,15 @@ public:
 
     void debug_string(int indentation_level, std::stringstream* out) const override;
 
+    bool can_sink_write() const {
+        if (_should_build_hash_table) {
+            return true;
+        }
+        return _shared_hash_table_context && _shared_hash_table_context->signaled;
+    }
+
+    bool should_build_hash_table() const { return _should_build_hash_table; }
+
 private:
     using VExprContexts = std::vector<VExprContext*>;
     // probe expr

--- a/be/src/vec/runtime/shared_hash_table_controller.cpp
+++ b/be/src/vec/runtime/shared_hash_table_controller.cpp
@@ -22,10 +22,28 @@
 namespace doris {
 namespace vectorized {
 
+void SharedHashTableController::set_builder_and_consumers(TUniqueId builder,
+                                                          const std::vector<TUniqueId>& consumers,
+                                                          int node_id) {
+    // Only need to set builder and consumers with pipeline engine enabled.
+    DCHECK(_pipeline_engine_enabled);
+    std::lock_guard<std::mutex> lock(_mutex);
+    DCHECK(_builder_fragment_ids.find(node_id) == _builder_fragment_ids.cend());
+    _builder_fragment_ids.insert({node_id, builder});
+    _ref_fragments[node_id].assign(consumers.cbegin(), consumers.cend());
+}
+
 bool SharedHashTableController::should_build_hash_table(const TUniqueId& fragment_instance_id,
                                                         int my_node_id) {
     std::lock_guard<std::mutex> lock(_mutex);
     auto it = _builder_fragment_ids.find(my_node_id);
+    if (_pipeline_engine_enabled) {
+        if (it != _builder_fragment_ids.cend()) {
+            return it->second == fragment_instance_id;
+        }
+        return false;
+    }
+
     if (it == _builder_fragment_ids.cend()) {
         _builder_fragment_ids.insert({my_node_id, fragment_instance_id});
         return true;

--- a/be/src/vec/runtime/shared_hash_table_controller.h
+++ b/be/src/vec/runtime/shared_hash_table_controller.h
@@ -64,15 +64,21 @@ using SharedHashTableContextPtr = std::shared_ptr<SharedHashTableContext>;
 
 class SharedHashTableController {
 public:
+    /// set hash table builder's fragment instance id and consumers' fragment instance id
+    void set_builder_and_consumers(TUniqueId builder, const std::vector<TUniqueId>& consumers,
+                                   int node_id);
     TUniqueId get_builder_fragment_instance_id(int my_node_id);
     SharedHashTableContextPtr get_context(int my_node_id);
     void signal(int my_node_id);
     Status wait_for_signal(RuntimeState* state, const SharedHashTableContextPtr& context);
     bool should_build_hash_table(const TUniqueId& fragment_instance_id, int my_node_id);
+    void set_pipeline_engine_enabled(bool enabled) { _pipeline_engine_enabled = enabled; }
 
 private:
+    bool _pipeline_engine_enabled = false;
     std::mutex _mutex;
     std::condition_variable _cv;
+    std::map<int, std::vector<TUniqueId>> _ref_fragments;
     std::map<int /*node id*/, TUniqueId /*fragment instance id*/> _builder_fragment_ids;
     std::map<int /*node id*/, SharedHashTableContextPtr> _shared_contexts;
 };

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/DistributedPlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/DistributedPlanner.java
@@ -385,6 +385,7 @@ public class DistributedPlanner {
             node.setChild(0, leftChildFragment.getPlanRoot());
             connectChildFragment(node, 1, leftChildFragment, rightChildFragment);
             leftChildFragment.setPlanRoot(node);
+            rightChildFragment.setRightChildOfBroadcastHashJoin(true);
             return leftChildFragment;
         } else {
             node.setDistributionMode(HashJoinNode.DistributionMode.PARTITIONED);

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/PlanFragment.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/PlanFragment.java
@@ -145,6 +145,8 @@ public class PlanFragment extends TreeNode<PlanFragment> {
     // has colocate plan node
     private boolean hasColocatePlanNode = false;
 
+    private boolean isRightChildOfBroadcastHashJoin = false;
+
     /**
      * C'tor for fragment with specific partition; the output is by default broadcast.
      */
@@ -423,6 +425,14 @@ public class PlanFragment extends TreeNode<PlanFragment> {
 
     public boolean isTransferQueryStatisticsWithEveryBatch() {
         return transferQueryStatisticsWithEveryBatch;
+    }
+
+    public boolean isRightChildOfBroadcastHashJoin() {
+        return isRightChildOfBroadcastHashJoin;
+    }
+
+    public void setRightChildOfBroadcastHashJoin(boolean value) {
+        isRightChildOfBroadcastHashJoin = value;
     }
 
     public int getFragmentSequenceNum() {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -1341,10 +1341,7 @@ public class SessionVariable implements Serializable, Writable {
         tResult.setEnablePipelineEngine(enablePipelineEngine);
         tResult.setReturnObjectDataAsBinary(returnObjectDataAsBinary);
         tResult.setTrimTailingSpacesForExternalTableQuery(trimTailingSpacesForExternalTableQuery);
-
-        // TODO: enable share hashtable for broadcast after switching completely to pipeline engine.
-        tResult.setEnableShareHashTableForBroadcastJoin(
-                enablePipelineEngine ? false : enableShareHashTableForBroadcastJoin);
+        tResult.setEnableShareHashTableForBroadcastJoin(enableShareHashTableForBroadcastJoin);
 
         tResult.setBatchSize(batchSize);
         tResult.setDisableStreamPreaggregations(disableStreamPreaggregations);

--- a/gensrc/thrift/PaloInternalService.thrift
+++ b/gensrc/thrift/PaloInternalService.thrift
@@ -376,6 +376,10 @@ struct TExecPlanFragmentParams {
   // it will wait for the FE to send the "start execution" command before it is actually executed.
   // Otherwise, the fragment will start executing directly on the BE side.
   20: optional bool need_wait_execution_trigger = false;
+
+  21: optional bool build_hash_table_for_broadcast_join = false;
+
+  22: optional list<Types.TUniqueId> instances_sharing_hash_table;
 }
 
 struct TExecPlanFragmentParamsList {


### PR DESCRIPTION
# Proposed changes

1. FE chooses one instance to build hash table.
2. Add `EmptySourceOperator` to adapt for `HashJoinBuildSink` which doesn't need to build hash table.

## Problem Summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
3. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
5. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
6. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

