### PR TITLE
[bugfix](vertical compaction) fix dcheck failed on MOW tablet

### DIFF
--- a/be/src/vec/olap/vertical_merge_iterator.cpp
+++ b/be/src/vec/olap/vertical_merge_iterator.cpp
@@ -430,12 +430,12 @@ Status VerticalHeapMergeIterator::next_batch(Block* block) {
 }
 
 Status VerticalHeapMergeIterator::init(const StorageReadOptions& opts) {
+    DCHECK(_origin_iters.size() == _iterator_init_flags.size());
+    _record_rowids = opts.record_rowids;
     if (_origin_iters.empty()) {
         return Status::OK();
     }
-    DCHECK(_origin_iters.size() == _iterator_init_flags.size());
     _schema = &(*_origin_iters.begin())->schema();
-    _record_rowids = opts.record_rowids;
 
     auto seg_order = 0;
     // Init contxt depends on _iterator_init_flags

--- a/regression-test/suites/compaction/test_vertical_compaction_uniq_keys.groovy
+++ b/regression-test/suites/compaction/test_vertical_compaction_uniq_keys.groovy
@@ -113,7 +113,7 @@ suite("test_vertical_compaction_uniq_keys") {
                 `max_dwell_time` INT DEFAULT "0" COMMENT "用户最大停留时间",
                 `min_dwell_time` INT DEFAULT "99999" COMMENT "用户最小停留时间")
             UNIQUE KEY(`user_id`, `date`, `datev2`, `datetimev2_1`, `datetimev2_2`, `city`, `age`, `sex`) DISTRIBUTED BY HASH(`user_id`)
-            PROPERTIES ( "replication_num" = "1" );
+            PROPERTIES ( "replication_num" = "1", "enable_unique_key_merge_on_write"="true" );
         """
 
         sql """ INSERT INTO ${tableName} VALUES


### PR DESCRIPTION
fix a dcheck error for vertical compaction on Merge-On-Write table。 When merge rowsets with empty segment, VerticalHeapMergeIterator::init return ok directly and _record_rowids not set, dcheck failed when _unique_key_next_block call current_block_row_locations。

# Proposed changes

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

