### PR TITLE
[chore](ut)add one option to skip build be when running ut

### DIFF
--- a/run-be-ut.sh
+++ b/run-be-ut.sh
@@ -64,7 +64,7 @@ Usage: $0 <options>
     $0 --run --filter=-*DeathTest.*                                 runs all non-death tests
     $0 --run --filter=FooTest.*-FooTest.Bar                         runs everything in test suite FooTest except FooTest.Bar
     $0 --run --filter=FooTest.*:BarTest.*-FooTest.Bar:BarTest.Foo   runs everything in test suite FooTest except FooTest.Bar and everything in test suite BarTest except BarTest.Foo
-    $0 --run --skipBuild                                            run tests without building
+    $0 --skipBuild --run                                            run tests without building
     $0 --clean                                                      clean and build tests
     $0 --clean --run                                                clean, build and run all tests
   "
@@ -80,7 +80,7 @@ eval set -- "${OPTS}"
 CLEAN=0
 RUN=0
 BUILD_BENCHMARK_TOOL='OFF'
-BUILD_BE=1
+SKIP_BUILD=0
 FILTER=""
 if [[ "$#" != 1 ]]; then
     while true; do
@@ -90,7 +90,7 @@ if [[ "$#" != 1 ]]; then
             shift
             ;;
         --skipBuild)
-            BUILD_BE=0
+            SKIP_BUILD=1
             shift
             ;;
         --run)
@@ -131,11 +131,11 @@ CMAKE_BUILD_TYPE="$(echo "${CMAKE_BUILD_TYPE}" | awk '{ print(toupper($0)) }')"
 echo "Get params:
     PARALLEL            -- ${PARALLEL}
     CLEAN               -- ${CLEAN}
-    skipBuild           -- ${BUILD_BE}
+    skipBuild           -- ${SKIP_BUILD}
 "
 
 CMAKE_BUILD_DIR="${DORIS_HOME}/be/ut_build_${CMAKE_BUILD_TYPE}"
-if [[ "${BUILD_BE}" -eq 1 ]]; then
+if [[ "${SKIP_BUILD}" -ne 1 ]]; then
 echo "Build Backend UT"
 
 if [[ "${CLEAN}" -eq 1 ]]; then

--- a/run-be-ut.sh
+++ b/run-be-ut.sh
@@ -136,68 +136,68 @@ echo "Get params:
 
 CMAKE_BUILD_DIR="${DORIS_HOME}/be/ut_build_${CMAKE_BUILD_TYPE}"
 if [[ "${SKIP_BUILD}" -ne 1 ]]; then
-echo "Build Backend UT"
+    echo "Build Backend UT"
 
-if [[ "${CLEAN}" -eq 1 ]]; then
-    rm -rf "${CMAKE_BUILD_DIR}"
-    rm -rf "${DORIS_HOME}/be/output"
-fi
-
-if [[ ! -d "${CMAKE_BUILD_DIR}" ]]; then
-    mkdir -p "${CMAKE_BUILD_DIR}"
-fi
-
-if [[ -z "${GLIBC_COMPATIBILITY}" ]]; then
-    if [[ "$(uname -s)" != 'Darwin' ]]; then
-        GLIBC_COMPATIBILITY='ON'
-    else
-        GLIBC_COMPATIBILITY='OFF'
+    if [[ "${CLEAN}" -eq 1 ]]; then
+        rm -rf "${CMAKE_BUILD_DIR}"
+        rm -rf "${DORIS_HOME}/be/output"
     fi
-fi
 
-if [[ -z "${USE_LIBCPP}" ]]; then
-    if [[ "$(uname -s)" != 'Darwin' ]]; then
-        USE_LIBCPP='OFF'
-    else
-        USE_LIBCPP='ON'
+    if [[ ! -d "${CMAKE_BUILD_DIR}" ]]; then
+        mkdir -p "${CMAKE_BUILD_DIR}"
     fi
-fi
 
-if [[ -z "${USE_MEM_TRACKER}" ]]; then
-    if [[ "$(uname -s)" != 'Darwin' ]]; then
-        USE_MEM_TRACKER='ON'
-    else
-        USE_MEM_TRACKER='OFF'
+    if [[ -z "${GLIBC_COMPATIBILITY}" ]]; then
+        if [[ "$(uname -s)" != 'Darwin' ]]; then
+            GLIBC_COMPATIBILITY='ON'
+        else
+            GLIBC_COMPATIBILITY='OFF'
+        fi
     fi
-fi
 
-if [[ -z "${USE_DWARF}" ]]; then
-    USE_DWARF='OFF'
-fi
+    if [[ -z "${USE_LIBCPP}" ]]; then
+        if [[ "$(uname -s)" != 'Darwin' ]]; then
+            USE_LIBCPP='OFF'
+        else
+            USE_LIBCPP='ON'
+        fi
+    fi
 
-MAKE_PROGRAM="$(which "${BUILD_SYSTEM}")"
-echo "-- Make program: ${MAKE_PROGRAM}"
-echo "-- Use ccache: ${CMAKE_USE_CCACHE}"
-echo "-- Extra cxx flags: ${EXTRA_CXX_FLAGS:-}"
+    if [[ -z "${USE_MEM_TRACKER}" ]]; then
+        if [[ "$(uname -s)" != 'Darwin' ]]; then
+            USE_MEM_TRACKER='ON'
+        else
+            USE_MEM_TRACKER='OFF'
+        fi
+    fi
 
-cd "${CMAKE_BUILD_DIR}"
-"${CMAKE_CMD}" -G "${GENERATOR}" \
-    -DCMAKE_MAKE_PROGRAM="${MAKE_PROGRAM}" \
-    -DCMAKE_BUILD_TYPE="${CMAKE_BUILD_TYPE}" \
-    -DMAKE_TEST=ON \
-    -DGLIBC_COMPATIBILITY="${GLIBC_COMPATIBILITY}" \
-    -DUSE_LIBCPP="${USE_LIBCPP}" \
-    -DBUILD_META_TOOL=OFF \
-    -DBUILD_BENCHMARK_TOOL="${BUILD_BENCHMARK_TOOL}" \
-    -DWITH_MYSQL=OFF \
-    -DUSE_DWARF="${USE_DWARF}" \
-    -DUSE_MEM_TRACKER="${USE_MEM_TRACKER}" \
-    -DUSE_JEMALLOC=OFF \
-    -DSTRICT_MEMORY_USE=OFF \
-    -DEXTRA_CXX_FLAGS="${EXTRA_CXX_FLAGS}" \
-    ${CMAKE_USE_CCACHE:+${CMAKE_USE_CCACHE}} \
-    "${DORIS_HOME}/be"
-"${BUILD_SYSTEM}" -j "${PARALLEL}"
+    if [[ -z "${USE_DWARF}" ]]; then
+        USE_DWARF='OFF'
+    fi
+
+    MAKE_PROGRAM="$(which "${BUILD_SYSTEM}")"
+    echo "-- Make program: ${MAKE_PROGRAM}"
+    echo "-- Use ccache: ${CMAKE_USE_CCACHE}"
+    echo "-- Extra cxx flags: ${EXTRA_CXX_FLAGS:-}"
+
+    cd "${CMAKE_BUILD_DIR}"
+    "${CMAKE_CMD}" -G "${GENERATOR}" \
+        -DCMAKE_MAKE_PROGRAM="${MAKE_PROGRAM}" \
+        -DCMAKE_BUILD_TYPE="${CMAKE_BUILD_TYPE}" \
+        -DMAKE_TEST=ON \
+        -DGLIBC_COMPATIBILITY="${GLIBC_COMPATIBILITY}" \
+        -DUSE_LIBCPP="${USE_LIBCPP}" \
+        -DBUILD_META_TOOL=OFF \
+        -DBUILD_BENCHMARK_TOOL="${BUILD_BENCHMARK_TOOL}" \
+        -DWITH_MYSQL=OFF \
+        -DUSE_DWARF="${USE_DWARF}" \
+        -DUSE_MEM_TRACKER="${USE_MEM_TRACKER}" \
+        -DUSE_JEMALLOC=OFF \
+        -DSTRICT_MEMORY_USE=OFF \
+        -DEXTRA_CXX_FLAGS="${EXTRA_CXX_FLAGS}" \
+        ${CMAKE_USE_CCACHE:+${CMAKE_USE_CCACHE}} \
+        "${DORIS_HOME}/be"
+    "${BUILD_SYSTEM}" -j "${PARALLEL}"
 fi
 
 if [[ "${RUN}" -ne 1 ]]; then


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx
Previously when we run be ut, it would always run building the whole binary. But sometimes I just change one conf in be.conf to test the UT, I think it would help when we just wanna run one UT without building it.
## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

