### PR TITLE
[fix](nereids) bind sort key priority problem

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/BindRelation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/BindRelation.java
@@ -43,6 +43,7 @@ import org.apache.doris.nereids.trees.plans.logical.RelationUtil;
 import org.apache.doris.qe.ConnectContext;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
 import org.apache.commons.collections.CollectionUtils;
 
 import java.util.Collections;
@@ -113,7 +114,8 @@ public class BindRelation extends OneAnalysisRuleFactory {
         String dbName = cascadesContext.getConnectContext().getDatabase();
         TableIf table = getTable(catalogName, dbName, tableName, cascadesContext.getConnectContext().getEnv());
         // TODO: should generate different Scan sub class according to table's type
-        return getLogicalPlan(table, unboundRelation, dbName, cascadesContext);
+        List<String> tableQualifier = Lists.newArrayList(catalogName, dbName, tableName);
+        return getLogicalPlan(table, unboundRelation, tableQualifier, cascadesContext);
     }
 
     private LogicalPlan bindWithDbNameFromNamePart(CascadesContext cascadesContext, UnboundRelation unboundRelation) {
@@ -127,7 +129,8 @@ public class BindRelation extends OneAnalysisRuleFactory {
         }
         String tableName = nameParts.get(1);
         TableIf table = getTable(catalogName, dbName, tableName, connectContext.getEnv());
-        return getLogicalPlan(table, unboundRelation, dbName, cascadesContext);
+        List<String> tableQualifier = Lists.newArrayList(catalogName, dbName, tableName);
+        return getLogicalPlan(table, unboundRelation, tableQualifier, cascadesContext);
     }
 
     private LogicalPlan bindWithCatalogNameFromNamePart(CascadesContext cascadesContext,
@@ -141,11 +144,13 @@ public class BindRelation extends OneAnalysisRuleFactory {
         }
         String tableName = nameParts.get(2);
         TableIf table = getTable(catalogName, dbName, tableName, connectContext.getEnv());
-        return getLogicalPlan(table, unboundRelation, dbName, cascadesContext);
+        List<String> tableQualifier = Lists.newArrayList(catalogName, dbName, tableName);
+        return getLogicalPlan(table, unboundRelation, tableQualifier, cascadesContext);
     }
 
-    private LogicalPlan getLogicalPlan(TableIf table, UnboundRelation unboundRelation, String dbName,
+    private LogicalPlan getLogicalPlan(TableIf table, UnboundRelation unboundRelation, List<String> tableQualifier,
                                        CascadesContext cascadesContext) {
+        String dbName = tableQualifier.get(1); //[catalogName, dbName, tableName]
         switch (table.getType()) {
             case OLAP:
                 List<Long> partIds = getPartitionIds(table, unboundRelation);
@@ -158,7 +163,7 @@ public class BindRelation extends OneAnalysisRuleFactory {
                 }
             case VIEW:
                 Plan viewPlan = parseAndAnalyzeView(((View) table).getDdlSql(), cascadesContext);
-                return new LogicalSubQueryAlias<>(unboundRelation.getNameParts(), viewPlan);
+                return new LogicalSubQueryAlias<>(tableQualifier, viewPlan);
             case HMS_EXTERNAL_TABLE:
                 return new LogicalFileScan(cascadesContext.getStatementContext().getNextRelationId(),
                     (HMSExternalTable) table, ImmutableList.of(dbName));

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/BindRelation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/BindRelation.java
@@ -107,7 +107,7 @@ public class BindRelation extends OneAnalysisRuleFactory {
                     && ((LogicalSubQueryAlias<?>) ctePlan).getAlias().equals(tableName)) {
                 return ctePlan;
             }
-            return new LogicalSubQueryAlias<>(tableName, ctePlan);
+            return new LogicalSubQueryAlias<>(unboundRelation.getNameParts(), ctePlan);
         }
         String catalogName = cascadesContext.getConnectContext().getCurrentCatalog().getName();
         String dbName = cascadesContext.getConnectContext().getDatabase();
@@ -158,7 +158,7 @@ public class BindRelation extends OneAnalysisRuleFactory {
                 }
             case VIEW:
                 Plan viewPlan = parseAndAnalyzeView(((View) table).getDdlSql(), cascadesContext);
-                return new LogicalSubQueryAlias<>(table.getName(), viewPlan);
+                return new LogicalSubQueryAlias<>(unboundRelation.getNameParts(), viewPlan);
             case HMS_EXTERNAL_TABLE:
                 return new LogicalFileScan(cascadesContext.getStatementContext().getNextRelationId(),
                     (HMSExternalTable) table, ImmutableList.of(dbName));

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/BindSlotReference.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/BindSlotReference.java
@@ -362,8 +362,8 @@ public class BindSlotReference implements AnalysisRuleFactory {
                     Set<Slot> projectOutput = sort.child().getOutputSet();
                     SlotBinder strictBinderOnProject = new SlotBinder(toScope(Lists.newArrayList(projectOutput)),
                             sort, true, ctx.cascadesContext);
-                    SlotBinder looseBinderOnProject = new SlotBinder(toScope(Lists.newArrayList(projectOutput)),
-                            sort, false, ctx.cascadesContext);
+                    //SlotBinder looseBinderOnProject = new SlotBinder(toScope(Lists.newArrayList(projectOutput)),
+                    //        sort, false, ctx.cascadesContext);
 
                     Set<Slot> projectChildrenOutput = sort.child().children().stream()
                             .flatMap(plan -> plan.getOutputSet().stream())
@@ -371,16 +371,16 @@ public class BindSlotReference implements AnalysisRuleFactory {
                     SlotBinder strictBinderOnProjectChild = new SlotBinder(
                             toScope(Lists.newArrayList(projectChildrenOutput)),
                             sort, true, ctx.cascadesContext);
-                    SlotBinder looseBinderOnProjectChild = new SlotBinder(
-                            toScope(Lists.newArrayList(projectChildrenOutput)),
-                            sort, false, ctx.cascadesContext);
+                    //SlotBinder looseBinderOnProjectChild = new SlotBinder(
+                    //        toScope(Lists.newArrayList(projectChildrenOutput)),
+                    //        sort, false, ctx.cascadesContext);
                     List<OrderKey> sortItemList = sort.getOrderKeys()
                             .stream()
                             .map(orderKey -> {
                                 Expression item = strictBinderOnProject.bind(orderKey.getExpr());
                                 item = strictBinderOnProjectChild.bind(item);
-                                item = looseBinderOnProjectChild.bind(item);
-                                item = looseBinderOnProject.bind(item);
+                                //item = looseBinderOnProjectChild.bind(item);
+                                //item = looseBinderOnProject.bind(item);
                                 return new OrderKey(item, orderKey.isAsc(), orderKey.isNullFirst());
                             }).collect(Collectors.toList());
 
@@ -564,7 +564,7 @@ public class BindSlotReference implements AnalysisRuleFactory {
         private boolean strict;
 
         public SlotBinder(Scope scope, Plan plan, CascadesContext cascadesContext) {
-            this(scope, plan, false, cascadesContext);
+            this(scope, plan, true, cascadesContext);
         }
 
         public SlotBinder(Scope scope, Plan plan, boolean strict, CascadesContext cascadesContext) {
@@ -599,9 +599,9 @@ public class BindSlotReference implements AnalysisRuleFactory {
             if (!foundInThisScope && getScope().getOuterScope().isPresent()) {
                 boundedOpt = Optional.of(bindSlot(unboundSlot,
                         getScope()
-                        .getOuterScope()
-                        .get()
-                        .getSlots()));
+                                .getOuterScope()
+                                .get()
+                                .getSlots()));
             }
             List<Slot> bounded = boundedOpt.get();
             switch (bounded.size()) {
@@ -634,7 +634,7 @@ public class BindSlotReference implements AnalysisRuleFactory {
                     return bindQualifiedStar(qualifier);
                 default:
                     throw new AnalysisException("Not supported qualifier: "
-                        + StringUtils.join(qualifier, "."));
+                            + StringUtils.join(qualifier, "."));
             }
         }
 
@@ -648,14 +648,15 @@ public class BindSlotReference implements AnalysisRuleFactory {
                         List<String> boundSlotQualifier = boundSlot.getQualifier();
                         switch (boundSlotQualifier.size()) {
                             // bound slot is `column` and no qualified
-                            case 0: return false;
+                            case 0:
+                                return false;
                             case 1: // bound slot is `table`.`column`
                                 return qualifierStar.get(0).equalsIgnoreCase(boundSlotQualifier.get(0));
                             case 2:// bound slot is `db`.`table`.`column`
                                 return qualifierStar.get(0).equalsIgnoreCase(boundSlotQualifier.get(1));
                             default:
                                 throw new AnalysisException("Not supported qualifier: "
-                                    + StringUtils.join(qualifierStar, "."));
+                                        + StringUtils.join(qualifierStar, "."));
                         }
                     case 2: // db.table.*
                         boundSlotQualifier = boundSlot.getQualifier();
@@ -669,11 +670,11 @@ public class BindSlotReference implements AnalysisRuleFactory {
                                         && qualifierStar.get(1).equalsIgnoreCase(boundSlotQualifier.get(1));
                             default:
                                 throw new AnalysisException("Not supported qualifier: "
-                                    + StringUtils.join(qualifierStar, ".") + ".*");
+                                        + StringUtils.join(qualifierStar, ".") + ".*");
                         }
                     default:
                         throw new AnalysisException("Not supported name: "
-                            + StringUtils.join(qualifierStar, ".") + ".*");
+                                + StringUtils.join(qualifierStar, ".") + ".*");
                 }
             }).collect(Collectors.toList());
 
@@ -683,42 +684,29 @@ public class BindSlotReference implements AnalysisRuleFactory {
         private List<Slot> bindSlot(UnboundSlot unboundSlot, List<Slot> boundSlots) {
             return boundSlots.stream().filter(boundSlot -> {
                 List<String> nameParts = unboundSlot.getNameParts();
-                if (nameParts.size() == 1) {
-
+                int qualifierSize = boundSlot.getQualifier().size();
+                int namePartsSize = nameParts.size();
+                if (namePartsSize > qualifierSize + 1) {
+                    return false;
+                }
+                if (namePartsSize == 1) {
                     return nameParts.get(0).equalsIgnoreCase(boundSlot.getName());
-                } else if (nameParts.size() <= 3) {
-                    int size = nameParts.size();
-                    // if nameParts.size() == 3, nameParts.get(0) is cluster name.
-                    return handleNamePartsTwoOrThree(boundSlot, nameParts.subList(size - 2, size));
+                }
+                if (namePartsSize == 2) {
+                    String qualifierDbName = boundSlot.getQualifier().get(qualifierSize - 1);
+                    return qualifierDbName.equalsIgnoreCase(nameParts.get(0))
+                            && boundSlot.getName().equalsIgnoreCase(nameParts.get(1));
+                } else if (nameParts.size() == 3) {
+                    String qualifierDbName = boundSlot.getQualifier().get(qualifierSize - 1);
+                    String qualifierClusterName = boundSlot.getQualifier().get(qualifierSize - 2);
+                    return qualifierClusterName.equalsIgnoreCase(nameParts.get(0))
+                            && qualifierDbName.equalsIgnoreCase(nameParts.get(1))
+                            && boundSlot.getName().equalsIgnoreCase(nameParts.get(2));
                 }
                 //TODO: handle name parts more than three.
                 throw new AnalysisException("Not supported name: "
                         + StringUtils.join(nameParts, "."));
             }).collect(Collectors.toList());
-        }
-
-        private boolean handleNamePartsTwoOrThree(Slot boundSlot, List<String> nameParts) {
-            List<String> qualifier = boundSlot.getQualifier();
-            if (strict && qualifier.size() < nameParts.size()) {
-                return false;
-            }
-            String name = boundSlot.getName();
-            switch (qualifier.size()) {
-                case 2:
-                    // qualifier is `db`.`table`
-                    return nameParts.get(0).equalsIgnoreCase(qualifier.get(1))
-                            && nameParts.get(1).equalsIgnoreCase(name);
-                case 1:
-                    // qualifier is `table`
-                    return nameParts.get(0).equalsIgnoreCase(qualifier.get(0))
-                            && nameParts.get(1).equalsIgnoreCase(name);
-                case 0:
-                    // has no qualifiers
-                    return nameParts.get(1).equalsIgnoreCase(name);
-                default:
-                    throw new AnalysisException("Not supported qualifier: "
-                            + StringUtils.join(qualifier, "."));
-            }
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalSubQueryAlias.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalSubQueryAlias.java
@@ -40,23 +40,31 @@ import java.util.Optional;
  * @param <CHILD_TYPE> param
  */
 public class LogicalSubQueryAlias<CHILD_TYPE extends Plan> extends LogicalUnary<CHILD_TYPE> {
-    private final String alias;
+    private final List<String> qualifier;
 
     private final Optional<List<String>> columnAliases;
 
     public LogicalSubQueryAlias(String tableAlias, CHILD_TYPE child) {
-        this(tableAlias, Optional.empty(), Optional.empty(), Optional.empty(), child);
+        this(ImmutableList.of(tableAlias), Optional.empty(), Optional.empty(), Optional.empty(), child);
+    }
+
+    public LogicalSubQueryAlias(List<String> qualifier, CHILD_TYPE child) {
+        this(qualifier, Optional.empty(), Optional.empty(), Optional.empty(), child);
     }
 
     public LogicalSubQueryAlias(String tableAlias, Optional<List<String>> columnAliases, CHILD_TYPE child) {
-        this(tableAlias, columnAliases, Optional.empty(), Optional.empty(), child);
+        this(ImmutableList.of(tableAlias), columnAliases, Optional.empty(), Optional.empty(), child);
     }
 
-    public LogicalSubQueryAlias(String tableAlias, Optional<List<String>> columnAliases,
+    public LogicalSubQueryAlias(List<String> qualifier, Optional<List<String>> columnAliases, CHILD_TYPE child) {
+        this(qualifier, columnAliases, Optional.empty(), Optional.empty(), child);
+    }
+
+    public LogicalSubQueryAlias(List<String> qualifier, Optional<List<String>> columnAliases,
                                 Optional<GroupExpression> groupExpression,
                                 Optional<LogicalProperties> logicalProperties, CHILD_TYPE child) {
         super(PlanType.LOGICAL_SUBQUERY_ALIAS, groupExpression, logicalProperties, child);
-        this.alias = tableAlias;
+        this.qualifier = ImmutableList.copyOf(Objects.requireNonNull(qualifier));
         this.columnAliases = columnAliases;
     }
 
@@ -67,7 +75,6 @@ public class LogicalSubQueryAlias<CHILD_TYPE extends Plan> extends LogicalUnary<
                 ? this.columnAliases.get()
                 : ImmutableList.of();
         ImmutableList.Builder<Slot> currentOutput = ImmutableList.builder();
-        String qualifier = alias;
         for (int i = 0; i < childOutput.size(); i++) {
             Slot originSlot = childOutput.get(i);
             String columnAlias;
@@ -77,7 +84,7 @@ public class LogicalSubQueryAlias<CHILD_TYPE extends Plan> extends LogicalUnary<
                 columnAlias = originSlot.getName();
             }
             Slot qualified = originSlot
-                    .withQualifier(ImmutableList.of(qualifier))
+                    .withQualifier(qualifier)
                     .withName(columnAlias);
             currentOutput.add(qualified);
         }
@@ -85,7 +92,7 @@ public class LogicalSubQueryAlias<CHILD_TYPE extends Plan> extends LogicalUnary<
     }
 
     public String getAlias() {
-        return alias;
+        return qualifier.get(qualifier.size() - 1);
     }
 
     public Optional<List<String>> getColumnAliases() {
@@ -96,12 +103,12 @@ public class LogicalSubQueryAlias<CHILD_TYPE extends Plan> extends LogicalUnary<
     public String toString() {
         if (columnAliases.isPresent()) {
             return Utils.toSqlString("LogicalSubQueryAlias",
-                "alias", alias,
+                "qualifier", qualifier,
                 "columnAliases", StringUtils.join(columnAliases.get(), ",")
             );
         }
         return Utils.toSqlString("LogicalSubQueryAlias",
-                "alias", alias
+                "qualifier", qualifier
         );
     }
 
@@ -114,18 +121,18 @@ public class LogicalSubQueryAlias<CHILD_TYPE extends Plan> extends LogicalUnary<
             return false;
         }
         LogicalSubQueryAlias that = (LogicalSubQueryAlias) o;
-        return alias.equals(that.alias);
+        return qualifier.equals(that.qualifier);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(alias);
+        return Objects.hash(qualifier);
     }
 
     @Override
     public LogicalSubQueryAlias<Plan> withChildren(List<Plan> children) {
         Preconditions.checkArgument(children.size() == 1);
-        return new LogicalSubQueryAlias<>(alias, columnAliases, children.get(0));
+        return new LogicalSubQueryAlias<>(qualifier, columnAliases, children.get(0));
     }
 
     @Override
@@ -140,13 +147,13 @@ public class LogicalSubQueryAlias<CHILD_TYPE extends Plan> extends LogicalUnary<
 
     @Override
     public LogicalSubQueryAlias<CHILD_TYPE> withGroupExpression(Optional<GroupExpression> groupExpression) {
-        return new LogicalSubQueryAlias<>(alias, columnAliases, groupExpression,
+        return new LogicalSubQueryAlias<>(qualifier, columnAliases, groupExpression,
                 Optional.of(getLogicalProperties()), child());
     }
 
     @Override
     public LogicalSubQueryAlias<CHILD_TYPE> withLogicalProperties(Optional<LogicalProperties> logicalProperties) {
-        return new LogicalSubQueryAlias<>(alias, columnAliases, Optional.empty(),
+        return new LogicalSubQueryAlias<>(qualifier, columnAliases, Optional.empty(),
                 logicalProperties, child());
     }
 }

--- a/regression-test/data/nereids_syntax_p0/bind_priority.out
+++ b/regression-test/data/nereids_syntax_p0/bind_priority.out
@@ -11,3 +11,18 @@ all	2
 -- !select --
 0
 
+-- !bind_sort_scan --
+3
+1
+2
+
+-- !bind_sort_alias --
+1
+2
+3
+
+-- !bind_sort_aliasAndScan --
+1
+3
+2
+


### PR DESCRIPTION
# Proposed changes
## Problem summary
1. add strict mode for SlotBinder. in strict mode, binding must matches qualifier
2. for sort key binding, we first use strict mode, then loose mode

## cases:
table t (int a, int b)
case1. `select a as b from t order by t.b`
case2. `select a as b from t order by b`
case3. `select a as b from t order by t.b + b`

## TODO:

1. bind on grandson

currently, 
sort
 +---project
      +-----grandSon

sort key can be bound on project.output and grandSon.output. 
But there are some cases in which sort key should be bound on the output of grandSon's children.
For example grandSon is 
t1 join ( t2 join t3)
and order key is t3.x

2. similar problems in group by 
case1. `select a as b from t group by t.b`
case2. `select a as b from t group by b`
case3. `select a as b from t group by t.b + b`

Issue Number: close #xxx

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
4. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
5. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
6. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
7. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

