### PR TITLE
[Pipeline](Exec) disable work steal of hash join build

### DIFF
--- a/be/src/pipeline/pipeline_fragment_context.cpp
+++ b/be/src/pipeline/pipeline_fragment_context.cpp
@@ -459,6 +459,7 @@ Status PipelineFragmentContext::_build_pipelines(ExecNode* node, PipelinePtr cur
         OperatorBuilderPtr join_sink =
                 std::make_shared<HashJoinBuildSinkBuilder>(next_operator_builder_id(), join_node);
         RETURN_IF_ERROR(new_pipe->set_sink(join_sink));
+        new_pipe->disable_task_steal();
 
         RETURN_IF_ERROR(_build_pipelines(node->child(0), cur_pipe));
         OperatorBuilderPtr join_source = std::make_shared<HashJoinProbeOperatorBuilder>(

--- a/be/src/pipeline/task_queue.cpp
+++ b/be/src/pipeline/task_queue.cpp
@@ -20,12 +20,15 @@
 namespace doris {
 namespace pipeline {
 
-PipelineTask* SubWorkTaskQueue::try_take() {
+PipelineTask* SubWorkTaskQueue::try_take(bool is_steal) {
     if (_queue.empty()) {
         return nullptr;
     }
-    ++_schedule_time;
     auto task = _queue.front();
+    if (!task->can_steal() && is_steal) {
+        return nullptr;
+    }
+    ++_schedule_time;
     _queue.pop();
     return task;
 }
@@ -52,7 +55,7 @@ void WorkTaskQueue::close() {
     _wait_task.notify_all();
 }
 
-PipelineTask* WorkTaskQueue::try_take_unprotected() {
+PipelineTask* WorkTaskQueue::try_take_unprotected(bool is_steal) {
     if (_total_task_size == 0 || _closed) {
         return nullptr;
     }
@@ -76,7 +79,7 @@ PipelineTask* WorkTaskQueue::try_take_unprotected() {
         }
     }
 
-    auto task = _sub_queues[idx].try_take();
+    auto task = _sub_queues[idx].try_take(is_steal);
     if (task) {
         _total_task_size--;
     }
@@ -93,15 +96,15 @@ int WorkTaskQueue::_compute_level(PipelineTask* task) {
     return SUB_QUEUE_LEVEL - 1;
 }
 
-PipelineTask* WorkTaskQueue::try_take() {
+PipelineTask* WorkTaskQueue::try_take(bool is_steal) {
     // TODO other efficient lock? e.g. if get lock fail, return null_ptr
     std::unique_lock<std::mutex> lock(_work_size_mutex);
-    return try_take_unprotected();
+    return try_take_unprotected(is_steal);
 }
 
 PipelineTask* WorkTaskQueue::take(uint32_t timeout_ms) {
     std::unique_lock<std::mutex> lock(_work_size_mutex);
-    auto task = try_take_unprotected();
+    auto task = try_take_unprotected(false);
     if (task) {
         return task;
     } else {
@@ -110,7 +113,7 @@ PipelineTask* WorkTaskQueue::take(uint32_t timeout_ms) {
         } else {
             _wait_task.wait(lock);
         }
-        return try_take_unprotected();
+        return try_take_unprotected(false);
     }
 }
 
@@ -138,7 +141,7 @@ void TaskQueue::close() {
 PipelineTask* TaskQueue::try_take(size_t core_id) {
     PipelineTask* task;
     while (!_closed) {
-        task = _async_queue[core_id].try_take();
+        task = _async_queue[core_id].try_take(false);
         if (task) {
             break;
         }
@@ -166,7 +169,7 @@ PipelineTask* TaskQueue::steal_take(size_t core_id) {
             next_id = 0;
         }
         DCHECK(next_id < _core_size);
-        auto task = _async_queue[next_id].try_take();
+        auto task = _async_queue[next_id].try_take(true);
         if (task) {
             return task;
         }

--- a/be/src/pipeline/task_queue.h
+++ b/be/src/pipeline/task_queue.h
@@ -29,7 +29,7 @@ class SubWorkTaskQueue {
 public:
     void push_back(PipelineTask* task) { _queue.emplace(task); }
 
-    PipelineTask* try_take();
+    PipelineTask* try_take(bool is_steal);
 
     void set_factor_for_normal(double factor_for_normal) { _factor_for_normal = factor_for_normal; }
 
@@ -53,9 +53,9 @@ public:
 
     void close();
 
-    PipelineTask* try_take_unprotected();
+    PipelineTask* try_take_unprotected(bool is_steal);
 
-    PipelineTask* try_take();
+    PipelineTask* try_take(bool is_steal);
 
     PipelineTask* take(uint32_t timeout_ms = 0);
 


### PR DESCRIPTION
# Proposed changes

Opt the cache miss of hash join build side in pipe exe engine

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

