### PR TITLE
[fix](compile) compile failed in Mac with clang14

### DIFF
--- a/thirdparty/build-thirdparty.sh
+++ b/thirdparty/build-thirdparty.sh
@@ -681,7 +681,7 @@ build_hyperscan() {
     mkdir -p "${BUILD_DIR}"
     cd "${BUILD_DIR}"
 
-    "${CMAKE_CMD}" -G "${GENERATOR}" -DBUILD_SHARED_LIBS=0 \
+    "${CMAKE_CMD}" -G "${GENERATOR}" -DBUILD_SHARED_LIBS=0 -DCMAKE_BUILD_TYPE=RELWITHDEBINFO \
         -DBOOST_ROOT="${BOOST_SOURCE}" -DCMAKE_INSTALL_PREFIX="${TP_INSTALL_DIR}" -DBUILD_EXAMPLES=OFF ..
     "${BUILD_SYSTEM}" -j "${PARALLEL}" install
     strip_lib libhs.a

--- a/thirdparty/build-thirdparty.sh
+++ b/thirdparty/build-thirdparty.sh
@@ -449,7 +449,7 @@ build_gflags() {
     rm -rf CMakeCache.txt CMakeFiles/
 
     "${CMAKE_CMD}" -G "${GENERATOR}" -DCMAKE_INSTALL_PREFIX="${TP_INSTALL_DIR}" \
-        -DCMAKE_POSITION_INDEPENDENT_CODE=On ../
+        -DCMAKE_BUILD_TYPE=Release -DCMAKE_POSITION_INDEPENDENT_CODE=On ../
 
     "${BUILD_SYSTEM}" -j "${PARALLEL}"
     "${BUILD_SYSTEM}" install

--- a/thirdparty/build-thirdparty.sh
+++ b/thirdparty/build-thirdparty.sh
@@ -681,7 +681,7 @@ build_hyperscan() {
     mkdir -p "${BUILD_DIR}"
     cd "${BUILD_DIR}"
 
-    "${CMAKE_CMD}" -G "${GENERATOR}" -DBUILD_SHARED_LIBS=0 -DCMAKE_BUILD_TYPE=RELWITHDEBINFO \
+    "${CMAKE_CMD}" -G "${GENERATOR}" -DBUILD_SHARED_LIBS=0 -DCMAKE_BUILD_TYPE=RelWithDebInfo \
         -DBOOST_ROOT="${BOOST_SOURCE}" -DCMAKE_INSTALL_PREFIX="${TP_INSTALL_DIR}" -DBUILD_EXAMPLES=OFF ..
     "${BUILD_SYSTEM}" -j "${PARALLEL}" install
     strip_lib libhs.a

--- a/thirdparty/patches/vectorscan-5.4.7.patch
+++ b/thirdparty/patches/vectorscan-5.4.7.patch
@@ -1,9 +1,9 @@
 diff --git CMakeLists.txt CMakeLists.txt
-index cb4ba8067..04c5f50e9 100644
+index cb4ba80..9a106e5 100644
 --- CMakeLists.txt
 +++ CMakeLists.txt
 @@ -170,7 +170,7 @@ if (CMAKE_COMPILER_IS_GNUCC AND NOT CROSS_COMPILE)
- 
+
      # arg1 might exist if using ccache
      string (STRIP "${CMAKE_C_COMPILER_ARG1}" CC_ARG1)
 -    set (EXEC_ARGS ${CC_ARG1} -c -Q --help=target -${ARCH_FLAG}=native -mtune=native)
@@ -11,21 +11,8 @@ index cb4ba8067..04c5f50e9 100644
      execute_process(COMMAND ${CMAKE_C_COMPILER} ${EXEC_ARGS}
          OUTPUT_VARIABLE _GCC_OUTPUT)
      string(FIND "${_GCC_OUTPUT}" "${ARCH_FLAG}" POS)
-@@ -451,6 +451,12 @@ if (CXX_UNUSED_CONST_VAR)
-     set(EXTRA_CXX_FLAGS "${EXTRA_CXX_FLAGS} -Wno-unused-const-variable")
- endif()
- 
-+# clang-14 complains about unused-but-set variable.
-+CHECK_CXX_COMPILER_FLAG("-Wunused-but-set-variable" CXX_UNUSED_BUT_SET_VAR)
-+if (CXX_UNUSED_BUT_SET_VAR)
-+    set(EXTRA_CXX_FLAGS "${EXTRA_CXX_FLAGS} -Wno-unused-but-set-variable")
-+endif()
-+
- # gcc 6 complains about type attributes that get ignored, like alignment
- CHECK_CXX_COMPILER_FLAG("-Wignored-attributes" CXX_IGNORED_ATTR)
- if (CXX_IGNORED_ATTR)
 diff --git cmake/build_wrapper.sh cmake/build_wrapper.sh
-index 895610c00..becfbf4c3 100755
+index 895610c..becfbf4 100755
 --- cmake/build_wrapper.sh
 +++ cmake/build_wrapper.sh
 @@ -17,11 +17,11 @@ KEEPSYMS=$(mktemp -p /tmp keep.syms.XXXXX)

--- a/thirdparty/patches/vectorscan-5.4.7.patch
+++ b/thirdparty/patches/vectorscan-5.4.7.patch
@@ -1,9 +1,9 @@
 diff --git CMakeLists.txt CMakeLists.txt
-index cb4ba80..9a106e5 100644
+index cb4ba8067..04c5f50e9 100644
 --- CMakeLists.txt
 +++ CMakeLists.txt
 @@ -170,7 +170,7 @@ if (CMAKE_COMPILER_IS_GNUCC AND NOT CROSS_COMPILE)
-
+ 
      # arg1 might exist if using ccache
      string (STRIP "${CMAKE_C_COMPILER_ARG1}" CC_ARG1)
 -    set (EXEC_ARGS ${CC_ARG1} -c -Q --help=target -${ARCH_FLAG}=native -mtune=native)
@@ -11,8 +11,21 @@ index cb4ba80..9a106e5 100644
      execute_process(COMMAND ${CMAKE_C_COMPILER} ${EXEC_ARGS}
          OUTPUT_VARIABLE _GCC_OUTPUT)
      string(FIND "${_GCC_OUTPUT}" "${ARCH_FLAG}" POS)
+@@ -451,6 +451,12 @@ if (CXX_UNUSED_CONST_VAR)
+     set(EXTRA_CXX_FLAGS "${EXTRA_CXX_FLAGS} -Wno-unused-const-variable")
+ endif()
+ 
++# clang-14 complains about unused-but-set variable.
++CHECK_CXX_COMPILER_FLAG("-Wunused-but-set-variable" CXX_UNUSED_BUT_SET_VAR)
++if (CXX_UNUSED_BUT_SET_VAR)
++    set(EXTRA_CXX_FLAGS "${EXTRA_CXX_FLAGS} -Wno-unused-but-set-variable")
++endif()
++
+ # gcc 6 complains about type attributes that get ignored, like alignment
+ CHECK_CXX_COMPILER_FLAG("-Wignored-attributes" CXX_IGNORED_ATTR)
+ if (CXX_IGNORED_ATTR)
 diff --git cmake/build_wrapper.sh cmake/build_wrapper.sh
-index 895610c..becfbf4 100755
+index 895610c00..becfbf4c3 100755
 --- cmake/build_wrapper.sh
 +++ cmake/build_wrapper.sh
 @@ -17,11 +17,11 @@ KEEPSYMS=$(mktemp -p /tmp keep.syms.XXXXX)


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

HOW to reproduce?
Add `export CMAKE_BUILD_TYPE=DEBUG` in custom_env.sh. Then build thirdparty in MAC.

There will be too problem:
1. build vectorscan with DEBUG type, will got `unused-but-set-variable` error:
doris/thirdparty/src/vectorscan-vectorscan-5.4.7/src/nfa/mcclellancompile.cpp:1485:13: error: variable 'total_daddy' set but not used [-Werror,-Wunused-but-set-variable]
        u16 total_daddy = 0;
2. gflags will output libgflags_debug.a instead of libgflags.a while build with DEBUG type. Then we will got error can not find library gflags error.

To avoid these errors, we set CMAKE_BUILD_TYPE while build `vectorscan` and `gflags`.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
5. Does it need to update dependencies:
    - [x] Yes
    - [ ] No
6. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

