### PR TITLE
[Improvement](topn) order by key topn query optimization

### DIFF
--- a/be/src/olap/iterators.h
+++ b/be/src/olap/iterators.h
@@ -175,6 +175,9 @@ public:
     virtual bool update_profile(RuntimeProfile* profile) { return false; }
     // return rows merged count by iterator
     virtual uint64_t merged_rows() const { return 0; }
+
+    // return if it's an empty iterator
+    virtual bool empty() const { return false; }
 };
 
 } // namespace doris

--- a/be/src/olap/reader.cpp
+++ b/be/src/olap/reader.cpp
@@ -420,7 +420,9 @@ Status TabletReader::_init_orderby_keys_param(const ReaderParams& read_params) {
     }
 
     // UNIQUE_KEYS will compare all keys as before
-    if (_tablet_schema->keys_type() == DUP_KEYS) {
+    if (_tablet_schema->keys_type() == DUP_KEYS ||
+           (_tablet_schema->keys_type() == UNIQUE_KEYS &&
+            _tablet->enable_unique_key_merge_on_write())) {
         // find index in vector _return_columns
         //   for the read_orderby_key_num_prefix_columns orderby keys
         for (uint32_t i = 0; i < read_params.read_orderby_key_num_prefix_columns; i++) {

--- a/be/src/olap/reader.cpp
+++ b/be/src/olap/reader.cpp
@@ -420,9 +420,8 @@ Status TabletReader::_init_orderby_keys_param(const ReaderParams& read_params) {
     }
 
     // UNIQUE_KEYS will compare all keys as before
-    if (_tablet_schema->keys_type() == DUP_KEYS ||
-           (_tablet_schema->keys_type() == UNIQUE_KEYS &&
-            _tablet->enable_unique_key_merge_on_write())) {
+    if (_tablet_schema->keys_type() == DUP_KEYS || (_tablet_schema->keys_type() == UNIQUE_KEYS &&
+                                                    _tablet->enable_unique_key_merge_on_write())) {
         // find index in vector _return_columns
         //   for the read_orderby_key_num_prefix_columns orderby keys
         for (uint32_t i = 0; i < read_params.read_orderby_key_num_prefix_columns; i++) {

--- a/be/src/olap/reader.cpp
+++ b/be/src/olap/reader.cpp
@@ -204,6 +204,8 @@ Status TabletReader::_capture_rs_readers(const ReaderParams& read_params,
     _reader_context.need_ordered_result = need_ordered_result;
     _reader_context.use_topn_opt = read_params.use_topn_opt;
     _reader_context.read_orderby_key_reverse = read_params.read_orderby_key_reverse;
+    _reader_context.read_orderby_key_limit = read_params.read_orderby_key_limit;
+    _reader_context.filter_block_vconjunct_ctx_ptr = read_params.filter_block_vconjunct_ctx_ptr;
     _reader_context.return_columns = &_return_columns;
     _reader_context.read_orderby_key_columns =
             _orderby_key_columns.size() > 0 ? &_orderby_key_columns : nullptr;

--- a/be/src/olap/reader.h
+++ b/be/src/olap/reader.h
@@ -28,6 +28,7 @@
 #include "olap/tablet.h"
 #include "olap/tablet_schema.h"
 #include "util/runtime_profile.h"
+#include "vec/exprs/vexpr_context.h"
 
 namespace doris {
 
@@ -120,6 +121,10 @@ public:
         bool read_orderby_key_reverse = false;
         // num of columns for orderby key
         size_t read_orderby_key_num_prefix_columns = 0;
+        // limit of rows for read_orderby_key
+        size_t read_orderby_key_limit = 0;
+        // filter_block arguments
+        vectorized::VExprContext** filter_block_vconjunct_ctx_ptr = nullptr;
 
         // for vertical compaction
         bool is_key_column_group = false;

--- a/be/src/olap/rowset/beta_rowset_reader.cpp
+++ b/be/src/olap/rowset/beta_rowset_reader.cpp
@@ -230,7 +230,7 @@ Status BetaRowsetReader::next_block(vectorized::Block* block) {
     if (_empty) {
         return Status::Error<END_OF_FILE>();
     }
-    
+
     do {
         auto s = _iterator->next_batch(block);
         if (!s.ok()) {

--- a/be/src/olap/rowset/beta_rowset_reader.cpp
+++ b/be/src/olap/rowset/beta_rowset_reader.cpp
@@ -162,15 +162,6 @@ Status BetaRowsetReader::get_segment_iterators(RowsetReaderContext* read_context
     _read_options.read_orderby_key_columns = read_context->read_orderby_key_columns;
     _read_options.io_ctx.reader_type = read_context->reader_type;
     _read_options.runtime_state = read_context->runtime_state;
-    if (read_context->read_orderby_key_limit > 0) {
-        size_t limit = read_context->read_orderby_key_limit;
-        if (read_context->predicates != nullptr) {
-            limit = limit * 2;
-        }
-        if (read_options.block_row_max > limit) {
-            read_options.block_row_max = limit;
-        }
-    }
 
     // load segments
     // use cache is true when do vertica compaction

--- a/be/src/olap/rowset/beta_rowset_reader.cpp
+++ b/be/src/olap/rowset/beta_rowset_reader.cpp
@@ -227,7 +227,9 @@ Status BetaRowsetReader::init(RowsetReaderContext* read_context) {
 
 Status BetaRowsetReader::next_block(vectorized::Block* block) {
     SCOPED_RAW_TIMER(&_stats->block_fetch_ns);
-    if (_empty) return Status::OLAPInternalError(OLAP_ERR_DATA_EOF);
+    if (_empty) {
+        return Status::Error<END_OF_FILE>();
+    }
     
     do {
         auto s = _iterator->next_batch(block);

--- a/be/src/olap/rowset/beta_rowset_reader.cpp
+++ b/be/src/olap/rowset/beta_rowset_reader.cpp
@@ -184,11 +184,6 @@ Status BetaRowsetReader::get_segment_iterators(RowsetReaderContext* read_context
         seg_iterators.push_back(std::move(iter));
     }
 
-    if (seg_iterators.empty() && read_context->is_vec) {
-        _empty = true;
-        return Status::OK();
-    }
-
     std::vector<RowwiseIterator*> iterators;
     for (auto& owned_it : seg_iterators) {
         auto st = owned_it->init(_read_options);

--- a/be/src/olap/rowset/beta_rowset_reader.h
+++ b/be/src/olap/rowset/beta_rowset_reader.h
@@ -84,6 +84,8 @@ private:
     SegmentCacheHandle _segment_cache_handle;
 
     StorageReadOptions _read_options;
+
+    bool _empty = false;
 };
 
 } // namespace doris

--- a/be/src/olap/rowset/rowset_reader_context.h
+++ b/be/src/olap/rowset/rowset_reader_context.h
@@ -22,6 +22,7 @@
 #include "olap/olap_common.h"
 #include "runtime/runtime_state.h"
 #include "vec/exprs/vexpr.h"
+#include "vec/exprs/vexpr_context.h"
 
 namespace doris {
 
@@ -42,6 +43,10 @@ struct RowsetReaderContext {
     bool read_orderby_key_reverse = false;
     // columns for orderby keys
     std::vector<uint32_t>* read_orderby_key_columns = nullptr;
+    // limit of rows for read_orderby_key
+    size_t read_orderby_key_limit = 0;
+    // filter_block arguments
+    vectorized::VExprContext** filter_block_vconjunct_ctx_ptr = nullptr;
     // projection columns: the set of columns rowset reader should return
     const std::vector<uint32_t>* return_columns = nullptr;
     TPushAggOp::type push_down_agg_type_opt = TPushAggOp::NONE;

--- a/be/src/olap/rowset/segment_v2/empty_segment_iterator.h
+++ b/be/src/olap/rowset/segment_v2/empty_segment_iterator.h
@@ -32,6 +32,7 @@ public:
     Status init(const StorageReadOptions& opts) override { return Status::OK(); }
     const Schema& schema() const override { return _schema; }
     Status next_batch(vectorized::Block* block) override;
+    bool empty() const override { return true; }
 
 private:
     const Schema& _schema;

--- a/be/src/olap/rowset/segment_v2/segment_iterator.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.cpp
@@ -970,14 +970,14 @@ void SegmentIterator::_vec_init_lazy_materialization() {
 
     // add runtime predicate to _col_predicates
     // should NOT add for order by key,
-    //  since key is already sorted and topn_next only need first N rows from each segment, 
+    //  since key is already sorted and topn_next only need first N rows from each segment,
     //  but runtime predicate will filter some rows and read more than N rows.
     // should add add for order by none-key column, since none-key column is not sorted and
     //  all rows should be read, so runtime predicate will reduce rows for topn node
     if (_opts.use_topn_opt &&
         !(_opts.read_orderby_key_columns != nullptr && !_opts.read_orderby_key_columns->empty())) {
-        auto & runtime_predicate =
-            _opts.runtime_state->get_query_fragments_ctx()->get_runtime_predicate();
+        auto& runtime_predicate =
+                _opts.runtime_state->get_query_fragments_ctx()->get_runtime_predicate();
         _runtime_predicate = runtime_predicate.get_predictate();
         if (_runtime_predicate) {
             _col_predicates.push_back(_runtime_predicate.get());

--- a/be/src/olap/rowset/segment_v2/segment_iterator.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.cpp
@@ -969,9 +969,15 @@ void SegmentIterator::_vec_init_lazy_materialization() {
     }
 
     // add runtime predicate to _col_predicates
-    if (_opts.use_topn_opt) {
-        auto& runtime_predicate =
-                _opts.runtime_state->get_query_fragments_ctx()->get_runtime_predicate();
+    // should NOT add for order by key,
+    //  since key is already sorted and topn_next only need first N rows from each segment, 
+    //  but runtime predicate will filter some rows and read more than N rows.
+    // should add add for order by none-key column, since none-key column is not sorted and
+    //  all rows should be read, so runtime predicate will reduce rows for topn node
+    if (_opts.use_topn_opt &&
+        !(_opts.read_orderby_key_columns != nullptr && !_opts.read_orderby_key_columns->empty())) {
+        auto & runtime_predicate =
+            _opts.runtime_state->get_query_fragments_ctx()->get_runtime_predicate();
         _runtime_predicate = runtime_predicate.get_predictate();
         if (_runtime_predicate) {
             _col_predicates.push_back(_runtime_predicate.get());

--- a/be/src/runtime/runtime_predicate.cpp
+++ b/be/src/runtime/runtime_predicate.cpp
@@ -147,6 +147,8 @@ Status RuntimePredicate::update(const Field& value, const String& col_name, bool
     // get value string from _orderby_extrem and push back to condition_values
     condition.condition_values.push_back(_get_value_fn(_orderby_extrem));
 
+    VLOG_DEBUG << "update runtime predicate condition " << condition;
+
     // update _predictate
     _predictate.reset(
             parse_to_predicate(_tablet_schema, condition, _predicate_mem_pool.get(), false));

--- a/be/src/runtime/runtime_predicate.cpp
+++ b/be/src/runtime/runtime_predicate.cpp
@@ -113,6 +113,11 @@ Status RuntimePredicate::init(const PrimitiveType type) {
 Status RuntimePredicate::update(const Field& value, const String& col_name, bool is_reverse) {
     std::unique_lock<std::shared_mutex> wlock(_rwlock);
 
+    // TODO why null
+    if (!_tablet_schema) {
+        return Status::OK();
+    }
+
     bool updated = false;
 
     if (UNLIKELY(_orderby_extrem.is_null())) {

--- a/be/src/vec/core/block.cpp
+++ b/be/src/vec/core/block.cpp
@@ -1006,7 +1006,9 @@ size_t MutableBlock::get_position_by_name(const std::string& name) const {
 std::string MutableBlock::dump_names() const {
     std::stringstream out;
     for (auto it = _names.begin(); it != _names.end(); ++it) {
-        if (it != _names.begin()) out << ", ";
+        if (it != _names.begin()) {
+            out << ", ";
+        }
         out << *it;
     }
     return out.str();

--- a/be/src/vec/core/block.h
+++ b/be/src/vec/core/block.h
@@ -453,6 +453,25 @@ public:
         }
         return 0;
     }
+
+    int compare_at(size_t n, size_t m, const std::vector<uint32_t>* compare_columns,
+                   const MutableBlock& rhs, int nan_direction_hint) const {
+        DCHECK_GE(columns(), compare_columns->size());
+        DCHECK_GE(rhs.columns(), compare_columns->size());
+
+        DCHECK_LE(n, rows());
+        DCHECK_LE(m, rhs.rows());
+        for (auto i : *compare_columns) {
+            DCHECK(get_datatype_by_position(i)->equals(*rhs.get_datatype_by_position(i)));
+            auto res = get_column_by_position(i)->compare_at(n, m, *(rhs.get_column_by_position(i)),
+                                                             nan_direction_hint);
+            if (res) {
+                return res;
+            }
+        }
+        return 0;
+    }
+
     template <typename T>
     void merge(T&& block) {
         if (_columns.size() == 0 && _data_types.size() == 0) {

--- a/be/src/vec/core/block.h
+++ b/be/src/vec/core/block.h
@@ -503,8 +503,8 @@ public:
     void swap(MutableBlock&& other) noexcept;
 
     void add_row(const Block* block, int row);
-    void add_rows(const Block* block, const int* row_begin, const int* row_end, bool align = false);
-    void add_rows(const Block* block, size_t row_begin, size_t length, bool align = false);
+    void add_rows(const Block* block, const int* row_begin, const int* row_end);
+    void add_rows(const Block* block, size_t row_begin, size_t length);
 
     std::string dump_data(size_t row_limit = 100) const;
 

--- a/be/src/vec/core/block.h
+++ b/be/src/vec/core/block.h
@@ -380,6 +380,10 @@ class MutableBlock {
 private:
     MutableColumns _columns;
     DataTypes _data_types;
+    Names _names;
+
+    using IndexByName = phmap::flat_hash_map<String, size_t>;
+    IndexByName index_by_name;
 
 public:
     static MutableBlock build_mutable_block(Block* block) {
@@ -392,13 +396,23 @@ public:
                  bool igore_trivial_slot = false);
 
     MutableBlock(Block* block)
-            : _columns(block->mutate_columns()), _data_types(block->get_data_types()) {}
+            : _columns(block->mutate_columns()),
+              _data_types(block->get_data_types()),
+              _names(block->get_names()) {
+        initialize_index_by_name();
+    }
     MutableBlock(Block&& block)
-            : _columns(block.mutate_columns()), _data_types(block.get_data_types()) {}
+            : _columns(block.mutate_columns()),
+              _data_types(block.get_data_types()),
+              _names(block.get_names()) {
+        initialize_index_by_name();
+    }
 
     void operator=(MutableBlock&& m_block) {
         _columns = std::move(m_block._columns);
         _data_types = std::move(m_block._data_types);
+        _names = std::move(m_block._names);
+        initialize_index_by_name();
     }
 
     size_t rows() const;
@@ -443,6 +457,7 @@ public:
     void merge(T&& block) {
         if (_columns.size() == 0 && _data_types.size() == 0) {
             _data_types = block.get_data_types();
+            _names = block.get_names();
             _columns.resize(block.columns());
             for (size_t i = 0; i < block.columns(); ++i) {
                 if (block.get_by_position(i).column) {
@@ -453,6 +468,7 @@ public:
                     _columns[i] = _data_types[i]->create_column();
                 }
             }
+            initialize_index_by_name();
         } else {
             DCHECK_EQ(_columns.size(), block.columns());
             for (int i = 0; i < _columns.size(); ++i) {
@@ -487,14 +503,15 @@ public:
     void swap(MutableBlock&& other) noexcept;
 
     void add_row(const Block* block, int row);
-    void add_rows(const Block* block, const int* row_begin, const int* row_end);
-    void add_rows(const Block* block, size_t row_begin, size_t length);
+    void add_rows(const Block* block, const int* row_begin, const int* row_end, bool align = false);
+    void add_rows(const Block* block, size_t row_begin, size_t length, bool align = false);
 
     std::string dump_data(size_t row_limit = 100) const;
 
     void clear() {
         _columns.clear();
         _data_types.clear();
+        _names.clear();
     }
 
     void clear_column_data() noexcept;
@@ -509,6 +526,18 @@ public:
 
         return res;
     }
+
+    Names& get_names() { return _names; }
+
+    bool has(const std::string& name) const;
+
+    size_t get_position_by_name(const std::string& name) const;
+
+    /** Get a list of column names separated by commas. */
+    std::string dump_names() const;
+
+private:
+    void initialize_index_by_name();
 };
 
 struct IteratorRowRef {

--- a/be/src/vec/exec/scan/new_olap_scanner.cpp
+++ b/be/src/vec/exec/scan/new_olap_scanner.cpp
@@ -330,7 +330,9 @@ Status NewOlapScanner::_init_tablet_reader_params(
 
     if (!_state->skip_storage_engine_merge()) {
         TOlapScanNode& olap_scan_node = ((NewOlapScanNode*)_parent)->_olap_scan_node;
-        if (olap_scan_node.__isset.sort_info && olap_scan_node.sort_info.is_asc_order.size() > 0) {
+        bool use_topn_opt = ((NewOlapScanNode*)_parent)->_olap_scan_node.use_topn_opt;
+        if (use_topn_opt && olap_scan_node.__isset.sort_info &&
+            olap_scan_node.sort_info.is_asc_order.size() > 0) {
             _limit = _parent->_limit_per_scanner;
             _tablet_reader_params.read_orderby_key = true;
             if (!olap_scan_node.sort_info.is_asc_order[0]) {
@@ -338,10 +340,12 @@ Status NewOlapScanner::_init_tablet_reader_params(
             }
             _tablet_reader_params.read_orderby_key_num_prefix_columns =
                     olap_scan_node.sort_info.is_asc_order.size();
+            _tablet_reader_params.read_orderby_key_limit = _limit;
+            _tablet_reader_params.filter_block_vconjunct_ctx_ptr = &_vconjunct_ctx;
         }
-    }
 
-    _tablet_reader_params.use_topn_opt = ((NewOlapScanNode*)_parent)->_olap_scan_node.use_topn_opt;
+        _tablet_reader_params.use_topn_opt = use_topn_opt;
+    }
 
     return Status::OK();
 }

--- a/be/src/vec/exec/scan/new_olap_scanner.cpp
+++ b/be/src/vec/exec/scan/new_olap_scanner.cpp
@@ -330,8 +330,7 @@ Status NewOlapScanner::_init_tablet_reader_params(
 
     if (!_state->skip_storage_engine_merge()) {
         TOlapScanNode& olap_scan_node = ((NewOlapScanNode*)_parent)->_olap_scan_node;
-        bool use_topn_opt = ((NewOlapScanNode*)_parent)->_olap_scan_node.use_topn_opt;
-        if (use_topn_opt && olap_scan_node.__isset.sort_info &&
+        if (olap_scan_node.__isset.sort_info &&
             olap_scan_node.sort_info.is_asc_order.size() > 0) {
             _limit = _parent->_limit_per_scanner;
             _tablet_reader_params.read_orderby_key = true;
@@ -344,7 +343,9 @@ Status NewOlapScanner::_init_tablet_reader_params(
             _tablet_reader_params.filter_block_vconjunct_ctx_ptr = &_vconjunct_ctx;
         }
 
-        _tablet_reader_params.use_topn_opt = use_topn_opt;
+        // runtime predicate push down optimization for topn
+        _tablet_reader_params.use_topn_opt =
+            ((NewOlapScanNode*)_parent)->_olap_scan_node.use_topn_opt;
     }
 
     return Status::OK();

--- a/be/src/vec/exec/scan/new_olap_scanner.cpp
+++ b/be/src/vec/exec/scan/new_olap_scanner.cpp
@@ -330,8 +330,7 @@ Status NewOlapScanner::_init_tablet_reader_params(
 
     if (!_state->skip_storage_engine_merge()) {
         TOlapScanNode& olap_scan_node = ((NewOlapScanNode*)_parent)->_olap_scan_node;
-        if (olap_scan_node.__isset.sort_info &&
-            olap_scan_node.sort_info.is_asc_order.size() > 0) {
+        if (olap_scan_node.__isset.sort_info && olap_scan_node.sort_info.is_asc_order.size() > 0) {
             _limit = _parent->_limit_per_scanner;
             _tablet_reader_params.read_orderby_key = true;
             if (!olap_scan_node.sort_info.is_asc_order[0]) {
@@ -345,7 +344,7 @@ Status NewOlapScanner::_init_tablet_reader_params(
 
         // runtime predicate push down optimization for topn
         _tablet_reader_params.use_topn_opt =
-            ((NewOlapScanNode*)_parent)->_olap_scan_node.use_topn_opt;
+                ((NewOlapScanNode*)_parent)->_olap_scan_node.use_topn_opt;
     }
 
     return Status::OK();

--- a/be/src/vec/olap/block_reader.cpp
+++ b/be/src/vec/olap/block_reader.cpp
@@ -75,8 +75,6 @@ Status BlockReader::_init_collect_iter(const ReaderParams& read_params,
     _vcollect_iter.init(this, _is_rowsets_overlapping, read_params.read_orderby_key,
                         read_params.read_orderby_key_reverse);
 
-    _vcollect_iter.init(this, read_params.read_orderby_key, read_params.read_orderby_key_reverse);
-
     _reader_context.batch_size = _batch_size;
     _reader_context.is_vec = true;
     _reader_context.push_down_agg_type_opt = read_params.push_down_agg_type_opt;

--- a/be/src/vec/olap/vcollect_iterator.cpp
+++ b/be/src/vec/olap/vcollect_iterator.cpp
@@ -375,7 +375,11 @@ Status VCollectIterator::topn_next(Block* block) {
 
 bool VCollectIterator::BlockRowposComparator::operator()(const size_t& lpos,
                                                          const size_t& rpos) const {
-    return _mutable_block->compare_at(lpos, rpos, _compare_columns, *_mutable_block, 0);
+    bool ret = _mutable_block->compare_at(lpos, rpos, _compare_columns, *_mutable_block, 0);
+    if (_is_reverse) {
+        ret = !ret;
+    }
+    return ret;
 }
 
 VCollectIterator::Level0Iterator::Level0Iterator(RowsetReaderSharedPtr rs_reader,

--- a/be/src/vec/olap/vcollect_iterator.cpp
+++ b/be/src/vec/olap/vcollect_iterator.cpp
@@ -242,8 +242,7 @@ Status VCollectIterator::_topn_next(Block* block) {
     MutableBlock mutable_block = vectorized::MutableBlock::build_mutable_block(&cloneBlock);
 
     size_t first_sort_column_idx = (*_reader->_reader_context.read_orderby_key_columns)[0];
-    const std::vector<uint32_t>* sort_columns =
-        _reader->_reader_context.read_orderby_key_columns;
+    const std::vector<uint32_t>* sort_columns = _reader->_reader_context.read_orderby_key_columns;
 
     BlockRowPosComparator row_pos_comparator(&mutable_block, sort_columns,
                                              _reader->_reader_context.read_orderby_key_reverse);
@@ -309,12 +308,10 @@ Status VCollectIterator::_topn_next(Block* block) {
 
                     int res = 0;
                     for (auto j : *sort_columns) {
-                        DCHECK(block->get_by_position(j)
-                                    .type->equals(*mutable_block.get_datatype_by_position(j)));
-                        res = block->get_by_position(j)
-                                    .column->compare_at(i, last_row_pos,
-                                                        *(mutable_block.get_column_by_position(j)),
-                                                        0);
+                        DCHECK(block->get_by_position(j).type->equals(
+                                *mutable_block.get_datatype_by_position(j)));
+                        res = block->get_by_position(j).column->compare_at(
+                                i, last_row_pos, *(mutable_block.get_column_by_position(j)), 0);
                         if (res) {
                             break;
                         }
@@ -361,8 +358,8 @@ Status VCollectIterator::_topn_next(Block* block) {
             }
 
             // update runtime_predicate
-            if (_reader->_reader_context.use_topn_opt &&
-                changed && sorted_row_pos.size() >= _topn_limit) {
+            if (_reader->_reader_context.use_topn_opt && changed &&
+                sorted_row_pos.size() >= _topn_limit) {
                 // get field value from column
                 size_t last_sorted_row = *sorted_row_pos.rbegin();
                 auto col_ptr = mutable_block.get_column_by_position(first_sort_column_idx).get();

--- a/be/src/vec/olap/vcollect_iterator.h
+++ b/be/src/vec/olap/vcollect_iterator.h
@@ -77,7 +77,8 @@ private:
 
     class BlockRowposComparator {
     public:
-        BlockRowposComparator(MutableBlock* mutable_block, size_t compare_column_idx, bool is_reverse)
+        BlockRowposComparator(MutableBlock* mutable_block, size_t compare_column_idx,
+                              bool is_reverse)
                 : _mutable_block(mutable_block),
                   _compare_column_idx(compare_column_idx),
                   _is_reverse(is_reverse) {}

--- a/be/src/vec/olap/vcollect_iterator.h
+++ b/be/src/vec/olap/vcollect_iterator.h
@@ -77,17 +77,17 @@ private:
 
     class BlockRowposComparator {
     public:
-        BlockRowposComparator(MutableBlock* mutable_block, size_t compare_column_idx,
-                              bool is_reverse)
+        BlockRowposComparator(MutableBlock* mutable_block,
+                              const std::vector<uint32_t>* compare_columns, bool is_reverse)
                 : _mutable_block(mutable_block),
-                  _compare_column_idx(compare_column_idx),
+                  _compare_columns(compare_columns),
                   _is_reverse(is_reverse) {}
 
         bool operator()(const size_t& lpos, const size_t& rpos) const;
 
     private:
         const MutableBlock* _mutable_block = nullptr;
-        const size_t _compare_column_idx = 0;
+        const std::vector<uint32_t>* _compare_columns;
         // reverse the compare order
         const bool _is_reverse = false;
     };

--- a/be/src/vec/olap/vcollect_iterator.h
+++ b/be/src/vec/olap/vcollect_iterator.h
@@ -71,6 +71,8 @@ public:
         return false;
     }
 
+    const inline bool use_topn_next() { return _topn_limit > 0; }
+
 private:
     // next for topn query
     Status topn_next(Block* block);

--- a/be/src/vec/olap/vcollect_iterator.h
+++ b/be/src/vec/olap/vcollect_iterator.h
@@ -71,15 +71,15 @@ public:
         return false;
     }
 
-    const inline bool use_topn_next() { return _topn_limit > 0; }
+    inline bool use_topn_next() const { return _topn_limit > 0; }
 
 private:
     // next for topn query
-    Status topn_next(Block* block);
+    Status _topn_next(Block* block);
 
-    class BlockRowposComparator {
+    class BlockRowPosComparator {
     public:
-        BlockRowposComparator(MutableBlock* mutable_block,
+        BlockRowPosComparator(MutableBlock* mutable_block,
                               const std::vector<uint32_t>* compare_columns, bool is_reverse)
                 : _mutable_block(mutable_block),
                   _compare_columns(compare_columns),

--- a/be/src/vec/olap/vcollect_iterator.h
+++ b/be/src/vec/olap/vcollect_iterator.h
@@ -72,6 +72,25 @@ public:
     }
 
 private:
+    // next for topn query
+    Status topn_next(Block* block);
+
+    class BlockRowposComparator {
+    public:
+        BlockRowposComparator(MutableBlock* mutable_block, size_t compare_column_idx, bool is_reverse)
+                : _mutable_block(mutable_block),
+                  _compare_column_idx(compare_column_idx),
+                  _is_reverse(is_reverse) {}
+
+        bool operator()(const size_t& lpos, const size_t& rpos) const;
+
+    private:
+        const MutableBlock* _mutable_block = nullptr;
+        const size_t _compare_column_idx = 0;
+        // reverse the compare order
+        const bool _is_reverse = false;
+    };
+
     // This interface is the actual implementation of the new version of iterator.
     // It currently contains two implementations, one is Level0Iterator,
     // which only reads data from the rowset reader, and the other is Level1Iterator,
@@ -291,6 +310,11 @@ private:
     bool _merge = true;
     // reverse the compare order
     bool _is_reverse = false;
+    // for topn next
+    size_t _topn_limit = 0;
+    bool _topn_eof = false;
+    std::vector<RowsetReaderSharedPtr> _rs_readers;
+
     // Hold reader point to access read params, such as fetch conditions.
     TabletReader* _reader = nullptr;
 

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/OlapScanNode.java
@@ -458,6 +458,16 @@ public class OlapScanNode extends ScanNode {
         return olapTable;
     }
 
+    public boolean isDupKeysOrMergeOnWrite() {
+        if (olapTable.getKeysType() == KeysType.DUP_KEYS
+                || (olapTable.getKeysType() == KeysType.UNIQUE_KEYS
+                        && olapTable.getEnableUniqueKeyMergeOnWrite())) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
     @Override
     protected String debugString() {
         MoreObjects.ToStringHelper helper = MoreObjects.toStringHelper(this);

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/OriginalPlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/OriginalPlanner.java
@@ -196,7 +196,7 @@ public class OriginalPlanner extends Planner {
 
         // check and set flag for topn detail query opt
         if (VectorizedUtil.isVectorized()) {
-            checkTopnOpt(singleNodePlan);
+            checkAndSetTopnOpt(singleNodePlan);
         }
 
         if (queryOptions.num_nodes == 1 || queryStmt.isPointQuery()) {
@@ -443,7 +443,7 @@ public class OriginalPlanner extends Planner {
      * 2. limit > 0
      * 3. first expression of order by is a table column
      */
-    private void checkTopnOpt(PlanNode node) {
+    private void checkAndSetTopnOpt(PlanNode node) {
         if (node instanceof SortNode && node.getChildren().size() == 1) {
             SortNode sortNode = (SortNode) node;
             PlanNode child = sortNode.getChild(0);

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/OriginalPlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/OriginalPlanner.java
@@ -453,8 +453,10 @@ public class OriginalPlanner extends Planner {
                 if (firstSortExpr instanceof SlotRef && !firstSortExpr.getType().isStringType()
                         && !firstSortExpr.getType().isFloatingPointType()) {
                     OlapScanNode scanNode = (OlapScanNode) child;
-                    sortNode.setUseTopnOpt(true);
-                    scanNode.setUseTopnOpt(true);
+                    if (scanNode.isDupKeysOrMergeOnWrite()) {
+                        sortNode.setUseTopnOpt(true);
+                        scanNode.setUseTopnOpt(true);
+                    }
                 }
             }
         }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

Describe your changes.

Optimize for order by key topn query like `SELECT * FROM table1 ORDER BY k1, k2 LIMIT n` in which k1 and k2 is the prefix of table sort key. 

This optimization is only for table with DUP_KEYS and UNQIUE_KEYS with merge on write.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [x] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

