### PR TITLE
[refactor] delete non vec load from memtable

### DIFF
--- a/be/src/olap/memtable.cpp
+++ b/be/src/olap/memtable.cpp
@@ -43,7 +43,6 @@ MemTable::MemTable(TabletSharedPtr tablet, Schema* schema, const TabletSchema* t
           _keys_type(_tablet->keys_type()),
           _schema(schema),
           _tablet_schema(tablet_schema),
-          _slot_descs(slot_descs),
           _insert_mem_tracker(insert_mem_tracker),
           _flush_mem_tracker(flush_mem_tracker),
           _schema_size(_schema->schema_size()),

--- a/be/src/olap/memtable.h
+++ b/be/src/olap/memtable.h
@@ -118,8 +118,6 @@ private:
     const KeysType _keys_type;
     Schema* _schema;
     const TabletSchema* _tablet_schema;
-    // the slot in _slot_descs are in order of tablet's schema
-    const std::vector<SlotDescriptor*>* _slot_descs;
 
     // TODO: change to unique_ptr of comparator
     std::shared_ptr<RowComparator> _row_comparator;

--- a/be/src/olap/memtable.h
+++ b/be/src/olap/memtable.h
@@ -50,12 +50,9 @@ public:
     ~MemTable();
 
     int64_t tablet_id() const { return _tablet->tablet_id(); }
-    KeysType keys_type() const { return _tablet->keys_type(); }
     size_t memory_usage() const {
         return _insert_mem_tracker->consumption() + _flush_mem_tracker->consumption();
     }
-
-    inline void insert(const Tuple* tuple) { (this->*_insert_fn)(tuple); }
     // insert tuple from (row_pos) to (row_pos+num_rows)
     void insert(const vectorized::Block* block, const std::vector<int>& row_idxs);
 
@@ -74,15 +71,6 @@ public:
 
 private:
     Status _do_flush(int64_t& duration_ns);
-
-    class RowCursorComparator : public RowComparator {
-    public:
-        RowCursorComparator(const Schema* schema);
-        int operator()(const char* left, const char* right) const override;
-
-    private:
-        const Schema* _schema;
-    };
 
     // row pos in _input_mutable_block
     struct RowInBlock {
@@ -115,34 +103,9 @@ private:
     };
 
 private:
-    using Table = SkipList<char*, RowComparator>;
-    using TableKey = Table::key_type;
     using VecTable = SkipList<RowInBlock*, RowInBlockComparator>;
 
-public:
-    /// The iterator of memtable, so that the data in this memtable
-    /// can be visited outside.
-    class Iterator {
-    public:
-        Iterator(MemTable* mem_table);
-        ~Iterator() = default;
-
-        void seek_to_first();
-        bool valid();
-        void next();
-        ContiguousRow get_current_row();
-
-    private:
-        MemTable* _mem_table;
-        Table::Iterator _it;
-    };
-
 private:
-    void _tuple_to_row(const Tuple* tuple, ContiguousRow* row, MemPool* mem_pool);
-    void _aggregate_two_row(const ContiguousRow& new_row, TableKey row_in_skiplist);
-    void _replace_row(const ContiguousRow& src_row, TableKey row_in_skiplist);
-    void _insert_dup(const Tuple* tuple);
-    void _insert_agg(const Tuple* tuple);
     // for vectorized
     void _insert_one_row_from_block(RowInBlock* row_in_block);
     void _aggregate_two_row_in_block(RowInBlock* new_row, RowInBlock* row_in_skiplist);
@@ -152,6 +115,7 @@ private:
 
 private:
     TabletSharedPtr _tablet;
+    const KeysType _keys_type;
     Schema* _schema;
     const TabletSchema* _tablet_schema;
     // the slot in _slot_descs are in order of tablet's schema
@@ -186,8 +150,6 @@ private:
     ObjectPool _agg_object_pool;
 
     size_t _schema_size;
-    std::unique_ptr<Table> _skip_list;
-    Table::Hint _hint;
 
     std::unique_ptr<VecTable> _vec_skip_list;
     VecTable::Hint _vec_hint;
@@ -204,9 +166,6 @@ private:
     // in unique or aggregate key model.
     int64_t _rows = 0;
     int64_t _merged_rows = 0;
-    void (MemTable::*_insert_fn)(const Tuple* tuple) = nullptr;
-    void (MemTable::*_aggregate_two_row_fn)(const ContiguousRow& new_row,
-                                            TableKey row_in_skiplist) = nullptr;
 
     //for vectorized
     vectorized::MutableBlock _input_mutable_block;

--- a/be/src/olap/rowset/beta_rowset_writer.h
+++ b/be/src/olap/rowset/beta_rowset_writer.h
@@ -56,7 +56,6 @@ public:
 
     // Return the file size flushed to disk in "flush_size"
     // This method is thread-safe.
-    Status flush_single_memtable(MemTable* memtable, int64_t* flush_size) override;
     Status flush_single_memtable(const vectorized::Block* block) override;
 
     RowsetSharedPtr build() override;

--- a/be/src/olap/rowset/rowset_writer.h
+++ b/be/src/olap/rowset/rowset_writer.h
@@ -64,9 +64,6 @@ public:
     }
     virtual Status final_flush() { return Status::Error<ErrorCode::NOT_IMPLEMENTED_ERROR>(); }
 
-    virtual Status flush_single_memtable(MemTable* memtable, int64_t* flush_size) {
-        return Status::Error<ErrorCode::NOT_IMPLEMENTED_ERROR>();
-    }
     virtual Status flush_single_memtable(const vectorized::Block* block) {
         return Status::Error<ErrorCode::NOT_IMPLEMENTED_ERROR>();
     }


### PR DESCRIPTION
1. delete non vec load from memtable totally.

2. remove function keys_type() in memtable.

cc, thanks @yiguolei @HappenLee
# Proposed changes

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

