### PR TITLE
[feature](struct-type) adjust the vexpr for struct type

### DIFF
--- a/be/src/vec/columns/column_struct.cpp
+++ b/be/src/vec/columns/column_struct.cpp
@@ -22,13 +22,6 @@
 
 namespace doris::vectorized {
 
-namespace ErrorCodes {
-extern const int ILLEGAL_COLUMN;
-extern const int NOT_IMPLEMENTED;
-extern const int CANNOT_INSERT_VALUE_OF_DIFFERENT_SIZE_INTO_TUPLE;
-extern const int LOGICAL_ERROR;
-} // namespace ErrorCodes
-
 std::string ColumnStruct::get_name() const {
     std::stringstream res;
     res << "Struct(";

--- a/be/src/vec/columns/column_struct.h
+++ b/be/src/vec/columns/column_struct.h
@@ -103,7 +103,6 @@ public:
     bool can_be_inside_nullable() const override { return true; }
     MutableColumnPtr clone_empty() const override;
     MutableColumnPtr clone_resized(size_t size) const override;
-
     size_t size() const override { return columns.at(0)->size(); }
 
     Field operator[](size_t n) const override;

--- a/be/src/vec/data_types/data_type_factory.hpp
+++ b/be/src/vec/data_types/data_type_factory.hpp
@@ -112,6 +112,14 @@ public:
                 return entity.second;
             }
         }
+        if (type_ptr->get_type_id() == TypeIndex::Struct) {
+            DataTypeFactory::instance().register_data_type(type_ptr->get_name(), type_ptr);
+            for (const auto& entity : _invert_data_type_map) {
+                if (entity.first->equals(*type_ptr)) {
+                    return entity.second;
+                }
+            }
+        }
         return _empty_string;
     }
 

--- a/be/src/vec/data_types/data_type_struct.h
+++ b/be/src/vec/data_types/data_type_struct.h
@@ -96,6 +96,9 @@ public:
     const char* deserialize(const char* buf, IColumn* column, int be_exec_version) const override;
     void to_pb_column_meta(PColumnMeta* col_meta) const override;
 
+    Status from_string(ReadBuffer& rb, IColumn* column) const override;
+    std::string to_string(const IColumn& column, size_t row_num) const override;
+    void to_string(const IColumn& column, size_t row_num, BufferWritable& ostr) const override;
     // bool is_parametric() const { return true; }
     // SerializationPtr do_get_default_serialization() const override;
     // SerializationPtr get_serialization(const SerializationInfo& info) const override;

--- a/be/src/vec/functions/function_cast.h
+++ b/be/src/vec/functions/function_cast.h
@@ -1512,6 +1512,16 @@ private:
             return &ConvertImplGenericToJsonb::execute;
         }
     }
+    // check struct value type and get to_type value
+    // TODO: need handle another type to cast struct
+    WrapperType create_struct_wrapper(const DataTypePtr& from_type,
+                                      const DataTypeStruct& to_type) const {
+        switch (from_type->get_type_id()) {
+        case TypeIndex::String:
+        default:
+            return &ConvertImplGenericFromString<ColumnString>::execute;
+        }
+    }
 
     WrapperType prepare_unpack_dictionaries(const DataTypePtr& from_type,
                                             const DataTypePtr& to_type) const {
@@ -1680,6 +1690,8 @@ private:
             return create_string_wrapper(from_type);
         case TypeIndex::Array:
             return create_array_wrapper(from_type, static_cast<const DataTypeArray&>(*to_type));
+        case TypeIndex::Struct:
+            return create_struct_wrapper(from_type, static_cast<const DataTypeStruct&>(*to_type));
         default:
             break;
         }
@@ -1725,7 +1737,6 @@ protected:
         // TODO(xy): support return struct type for factory
         auto type = DataTypeFactory::instance().get(type_col->get_value<String>());
         DCHECK(type != nullptr);
-
         bool need_to_be_nullable = false;
         // 1. from_type is nullable
         need_to_be_nullable |= arguments[0].type->is_nullable();

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/CastExpr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/CastExpr.java
@@ -318,9 +318,17 @@ public class CastExpr extends Expr {
                     type, Function.NullableMode.ALWAYS_NULLABLE,
                     Lists.newArrayList(Type.VARCHAR), false,
                     "doris::CastFunctions::cast_to_array_val", null, null, true);
+        } else if (type.isStructType()) {
+            fn = ScalarFunction.createBuiltin(getFnName(Type.STRUCT),
+                    type, Function.NullableMode.ALWAYS_NULLABLE,
+                    Lists.newArrayList(Type.VARCHAR), false,
+                    "doris::CastFunctions::cast_to_struct_val", null, null, true);
         }
 
         if (fn == null) {
+            if (type.isStructType() && childType.isStringType()) {
+                return;
+            }
             if (childType.isNull() && Type.canCastTo(childType, type)) {
                 return;
             } else {

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/TypeDef.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/TypeDef.java
@@ -129,7 +129,7 @@ public class TypeDef implements ParseNode {
         // check whether the sub-type is supported
         if (!parent.supportSubType(child)) {
             throw new AnalysisException(
-                    parent.getPrimitiveType() + "unsupported sub-type: " + child.toSql());
+                    parent.getPrimitiveType() + " unsupported sub-type: " + child.toSql());
         }
 
         if (child.getPrimitiveType().isStringType() && !child.isLengthSet()) {

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Column.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Column.java
@@ -188,17 +188,10 @@ public class Column implements Writable, GsonPostProcessable {
             c.setIsAllowNull(((ArrayType) type).getContainsNull());
             column.addChildrenColumn(c);
         } else if (type.isStructType()) {
-<<<<<<< HEAD
             ArrayList<StructField> fields = ((StructType) type).getFields();
             for (StructField field : fields) {
                 Column c = new Column(field.getName(), field.getType());
                 c.setIsAllowNull(field.getContainsNull());
-=======
-            ArrayList<StructField> fileds = ((StructType) type).getFields();
-            for (StructField field : fileds) {
-                Column c = new Column(COLUMN_STRUCT_CHILDREN, field.getType());
-                // c.setIsAllowNull(field.getContainsNull());
->>>>>>> [feature](struct-type) add children column when create table
                 column.addChildrenColumn(c);
             }
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Column.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Column.java
@@ -58,6 +58,7 @@ public class Column implements Writable, GsonPostProcessable {
     public static final String DELETE_SIGN = "__DORIS_DELETE_SIGN__";
     public static final String SEQUENCE_COL = "__DORIS_SEQUENCE_COL__";
     private static final String COLUMN_ARRAY_CHILDREN = "item";
+    private static final String COLUMN_STRUCT_CHILDREN = "field";
     public static final int COLUMN_UNIQUE_ID_INIT_VALUE = -1;
 
     @SerializedName(value = "name")
@@ -187,10 +188,17 @@ public class Column implements Writable, GsonPostProcessable {
             c.setIsAllowNull(((ArrayType) type).getContainsNull());
             column.addChildrenColumn(c);
         } else if (type.isStructType()) {
+<<<<<<< HEAD
             ArrayList<StructField> fields = ((StructType) type).getFields();
             for (StructField field : fields) {
                 Column c = new Column(field.getName(), field.getType());
                 c.setIsAllowNull(field.getContainsNull());
+=======
+            ArrayList<StructField> fileds = ((StructType) type).getFields();
+            for (StructField field : fileds) {
+                Column c = new Column(COLUMN_STRUCT_CHILDREN, field.getType());
+                // c.setIsAllowNull(field.getContainsNull());
+>>>>>>> [feature](struct-type) add children column when create table
                 column.addChildrenColumn(c);
             }
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/StructType.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/StructType.java
@@ -162,6 +162,11 @@ public class StructType extends Type {
     }
 
     @Override
+    public PrimitiveType getPrimitiveType() {
+        return PrimitiveType.STRUCT;
+    }
+
+    @Override
     public boolean equals(Object other) {
         if (!(other instanceof StructType)) {
             return false;

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/StructType.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/StructType.java
@@ -162,11 +162,6 @@ public class StructType extends Type {
     }
 
     @Override
-    public PrimitiveType getPrimitiveType() {
-        return PrimitiveType.STRUCT;
-    }
-
-    @Override
     public boolean equals(Object other) {
         if (!(other instanceof StructType)) {
             return false;

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Type.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Type.java
@@ -513,8 +513,11 @@ public abstract class Type {
             return false;
         } else if (targetType.isStructType() && sourceType.isStringType()) {
             return true;
+<<<<<<< HEAD
         } else if (sourceType.isStructType() && targetType.isStructType()) {
             return StructType.canCastTo((StructType) sourceType, (StructType) targetType);
+=======
+>>>>>>> [feature](struct-type) add children column when create table
         }
         return sourceType.isNull() || sourceType.getPrimitiveType().isCharFamily();
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Type.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Type.java
@@ -169,8 +169,20 @@ public abstract class Type {
         arraySubTypes.add(STRING);
 
         structSubTypes = Lists.newArrayList();
-        structSubTypes.add(INT);
+        structSubTypes.addAll(numericTypes);
+        structSubTypes.add(BOOLEAN);
+        structSubTypes.add(VARCHAR);
         structSubTypes.add(STRING);
+        structSubTypes.add(CHAR);
+        structSubTypes.add(DATE);
+        structSubTypes.add(DATETIME);
+        structSubTypes.add(DATEV2);
+        structSubTypes.add(DATETIMEV2);
+        structSubTypes.add(TIME);
+        structSubTypes.add(TIMEV2);
+        structSubTypes.add(DECIMAL32);
+        structSubTypes.add(DECIMAL64);
+        structSubTypes.add(DECIMAL128);
     }
 
     public static ArrayList<ScalarType> getIntegerTypes() {
@@ -513,11 +525,8 @@ public abstract class Type {
             return false;
         } else if (targetType.isStructType() && sourceType.isStringType()) {
             return true;
-<<<<<<< HEAD
         } else if (sourceType.isStructType() && targetType.isStructType()) {
             return StructType.canCastTo((StructType) sourceType, (StructType) targetType);
-=======
->>>>>>> [feature](struct-type) add children column when create table
         }
         return sourceType.isNull() || sourceType.getPrimitiveType().isCharFamily();
     }


### PR DESCRIPTION
# Proposed changes
1. this pr is used to adjust the vexpr for struct type when we import data.
2. load the json as below to the table which include the struct column.
{ "id" : 0, "s1" : { "name": "jack", "age": 20 } }]

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
5. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
6. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

