### PR TITLE
[fix](regression p0) add the alias function hist to histogram and fix p0

### DIFF
--- a/be/src/vec/aggregate_functions/aggregate_function_histogram.cpp
+++ b/be/src/vec/aggregate_functions/aggregate_function_histogram.cpp
@@ -83,6 +83,7 @@ AggregateFunctionPtr create_aggregate_function_histogram(const std::string& name
 
 void register_aggregate_function_histogram(AggregateFunctionSimpleFactory& factory) {
     factory.register_function("histogram", create_aggregate_function_histogram);
+    factory.register_alias("histogram", "hist");
 }
 
 } // namespace doris::vectorized

--- a/docs/en/docs/sql-manual/sql-functions/aggregate-functions/histogram.md
+++ b/docs/en/docs/sql-manual/sql-functions/aggregate-functions/histogram.md
@@ -28,7 +28,7 @@ under the License.
 ### description
 #### Syntax
 
-`histogram(expr)`
+`histogram(expr[, DOUBLE sample_rate, INT max_bucket_num])`
 
 The histogram function is used to describe the distribution of the data. It uses an "equal height" bucking strategy, and divides the data into buckets according to the value of the data. It describes each bucket with some simple data, such as the number of values that fall in the bucket. It is mainly used by the optimizer to estimate the range query.
 
@@ -37,6 +37,8 @@ The result of the function returns an empty or Json string.
 Parameter description：
 - sample_rate：Optional. The proportion of sample data used to generate the histogram. The default is 0.2.
 - max_bucket_num：Optional. Limit the number of histogram buckets. The default value is 128.
+
+Alias function: `hist(expr[, DOUBLE sample_rate, INT max_bucket_num])`
 
 ### notice
 
@@ -108,4 +110,4 @@ Field description：
 
 ### keywords
 
-HISTOGRAM
+HISTOGRAM, HIST

--- a/docs/zh-CN/docs/sql-manual/sql-functions/aggregate-functions/histogram.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/aggregate-functions/histogram.md
@@ -38,6 +38,8 @@ histogram（直方图）函数用于描述数据分布情况，它使用“等�
 - sample_rate：可选项。用于生成直方图的抽样数据比例，默认值 0.2。
 - max_bucket_num：可选项。用于限制直方图桶（bucket）的数量，默认值 128。
 
+别名函数：`hist(expr[, DOUBLE sample_rate, INT max_bucket_num])`
+
 ### notice
 
 ```
@@ -110,4 +112,4 @@ MySQL [test]> SELECT histogram(c_string, 0.5, 2) FROM histogram_test;
 
 ### keywords
 
-HISTOGRAM
+HISTOGRAM, HIST

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/FunctionSet.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/FunctionSet.java
@@ -935,6 +935,7 @@ public class FunctionSet<T> {
     public static final String COLLECT_LIST = "collect_list";
     public static final String COLLECT_SET = "collect_set";
     public static final String HISTOGRAM = "histogram";
+    public static final String HIST = "hist";
 
     private static final Map<Type, String> ORTHOGONAL_BITMAP_INTERSECT_INIT_SYMBOL =
             ImmutableMap.<Type, String>builder()
@@ -2608,9 +2609,11 @@ public class FunctionSet<T> {
                             .createBuiltin("topn_weighted", Lists.newArrayList(t, Type.BIGINT, Type.INT, Type.INT),
                                     new ArrayType(t), t,
                                     "", "", "", "", "", true, false, true, true));
+            addBuiltin(AggregateFunction.createBuiltin(HIST, Lists.newArrayList(t), Type.VARCHAR, t,
+                    "", "", "", "", "", true, false, true, true));
             addBuiltin(AggregateFunction.createBuiltin(HISTOGRAM, Lists.newArrayList(t), Type.VARCHAR, t,
                     "", "", "", "", "", true, false, true, true));
-            addBuiltin(AggregateFunction.createBuiltin(HISTOGRAM, Lists.newArrayList(t, Type.DOUBLE, Type.INT), Type.VARCHAR, t,
+            addBuiltin(AggregateFunction.createBuiltin(HIST, Lists.newArrayList(t, Type.DOUBLE, Type.INT), Type.VARCHAR, t,
                                     "", "", "", "", "", true, false, true, true));
             addBuiltin(AggregateFunction.createBuiltin(HISTOGRAM, Lists.newArrayList(t, Type.DOUBLE, Type.INT), Type.VARCHAR, t,
                     "", "", "", "", "", true, false, true, true));

--- a/regression-test/suites/query_p0/sql_functions/aggregate_functions/test_aggregate_histogram.groovy
+++ b/regression-test/suites/query_p0/sql_functions/aggregate_functions/test_aggregate_histogram.groovy
@@ -105,23 +105,23 @@ suite("test_aggregate_histogram") {
     // Test without GROUP BY
     qt_select """
         SELECT
-            histogram(c_bool, 1.0, 1), 
-            histogram(c_tinyint, 1.0, 1), 
-            histogram(c_smallint, 1.0, 1), 
-            histogram(c_bigint, 1.0, 1), 
-            histogram(c_largeint, 1.0, 1), 
-            histogram(c_float, 1.0, 1), 
-            histogram(c_double, 1.0, 1), 
-            histogram(c_decimal, 1.0, 1), 
-            histogram(c_decimalv3, 1.0, 1), 
-            histogram(c_char, 1.0, 1), 
-            histogram(c_varchar, 1.0, 1), 
-            histogram(c_string, 1.0, 1), 
-            histogram(c_date, 1.0, 1), 
-            histogram(c_datev2, 1.0, 1), 
-            histogram(c_date_time, 1.0, 1), 
-            histogram(c_date_timev2, 1.0, 1), 
-            histogram(c_string_not_null, 1.0, 1)
+            `histogram`(c_bool, 1.0, 1), 
+            `histogram`(c_tinyint, 1.0, 1), 
+            `histogram`(c_smallint, 1.0, 1), 
+            `histogram`(c_bigint, 1.0, 1), 
+            `histogram`(c_largeint, 1.0, 1), 
+            `histogram`(c_float, 1.0, 1), 
+            `histogram`(c_double, 1.0, 1), 
+            `histogram`(c_decimal, 1.0, 1), 
+            `histogram`(c_decimalv3, 1.0, 1), 
+            `histogram`(c_char, 1.0, 1), 
+            `histogram`(c_varchar, 1.0, 1), 
+            `histogram`(c_string, 1.0, 1), 
+            `histogram`(c_date, 1.0, 1), 
+            `histogram`(c_datev2, 1.0, 1), 
+            `histogram`(c_date_time, 1.0, 1), 
+            `histogram`(c_date_timev2, 1.0, 1), 
+            `histogram`(c_string_not_null, 1.0, 1)
         FROM
             ${tableName}
     """
@@ -130,23 +130,23 @@ suite("test_aggregate_histogram") {
     qt_select """
         SELECT
             c_id, 
-            histogram(c_bool, 1.0, 1), 
-            histogram(c_tinyint, 1.0, 1), 
-            histogram(c_smallint, 1.0, 1), 
-            histogram(c_bigint, 1.0, 1), 
-            histogram(c_largeint, 1.0, 1), 
-            histogram(c_float, 1.0, 1), 
-            histogram(c_double, 1.0, 1), 
-            histogram(c_decimal, 1.0, 1), 
-            histogram(c_decimalv3, 1.0, 1), 
-            histogram(c_char, 1.0, 1), 
-            histogram(c_varchar, 1.0, 1), 
-            histogram(c_string, 1.0, 1), 
-            histogram(c_date, 1.0, 1), 
-            histogram(c_datev2, 1.0, 1), 
-            histogram(c_date_time, 1.0, 1), 
-            histogram(c_date_timev2, 1.0, 1), 
-            histogram(c_string_not_null, 1.0, 1)
+            hist(c_bool, 1.0, 1), 
+            hist(c_tinyint, 1.0, 1), 
+            hist(c_smallint, 1.0, 1), 
+            hist(c_bigint, 1.0, 1), 
+            hist(c_largeint, 1.0, 1), 
+            hist(c_float, 1.0, 1), 
+            hist(c_double, 1.0, 1), 
+            hist(c_decimal, 1.0, 1), 
+            hist(c_decimalv3, 1.0, 1), 
+            hist(c_char, 1.0, 1), 
+            hist(c_varchar, 1.0, 1), 
+            hist(c_string, 1.0, 1), 
+            hist(c_date, 1.0, 1), 
+            hist(c_datev2, 1.0, 1), 
+            hist(c_date_time, 1.0, 1), 
+            hist(c_date_timev2, 1.0, 1), 
+            hist(c_string_not_null, 1.0, 1)
         FROM
             ${tableName}
         GROUP BY
@@ -159,23 +159,23 @@ suite("test_aggregate_histogram") {
         CREATE TABLE ${tableCTAS1} PROPERTIES("replication_num" = "1") AS
         SELECT
             1, 
-            histogram(c_bool, 1.0, 2), 
-            histogram(c_tinyint, 1.0, 2), 
-            histogram(c_smallint, 1.0, 2), 
-            histogram(c_bigint, 1.0, 2), 
-            histogram(c_largeint, 1.0, 2), 
-            histogram(c_float, 1.0, 2), 
-            histogram(c_double, 1.0, 2), 
-            histogram(c_decimal, 1.0, 2), 
-            histogram(c_decimalv3, 1.0, 2), 
-            histogram(c_char, 1.0, 2), 
-            histogram(c_varchar, 1.0, 2), 
-            histogram(c_string, 1.0, 2), 
-            histogram(c_date, 1.0, 2), 
-            histogram(c_datev2, 1.0, 2), 
-            histogram(c_date_time, 1.0, 2), 
-            histogram(c_date_timev2, 1.0, 2), 
-            histogram(c_string_not_null, 1.0, 2)
+            hist(c_bool, 1.0, 2), 
+            hist(c_tinyint, 1.0, 2), 
+            hist(c_smallint, 1.0, 2), 
+            hist(c_bigint, 1.0, 2), 
+            hist(c_largeint, 1.0, 2), 
+            hist(c_float, 1.0, 2), 
+            hist(c_double, 1.0, 2), 
+            hist(c_decimal, 1.0, 2), 
+            hist(c_decimalv3, 1.0, 2), 
+            hist(c_char, 1.0, 2), 
+            hist(c_varchar, 1.0, 2), 
+            hist(c_string, 1.0, 2), 
+            hist(c_date, 1.0, 2), 
+            hist(c_datev2, 1.0, 2), 
+            hist(c_date_time, 1.0, 2), 
+            hist(c_date_timev2, 1.0, 2), 
+            hist(c_string_not_null, 1.0, 2)
         FROM
             ${tableName}
     """
@@ -184,23 +184,23 @@ suite("test_aggregate_histogram") {
         CREATE TABLE ${tableCTAS2} PROPERTIES("replication_num" = "1") AS
         SELECT
             1, 
-            histogram(c_bool, 1.0, 1), 
-            histogram(c_tinyint, 1.0, 1), 
-            histogram(c_smallint, 1.0, 1), 
-            histogram(c_bigint, 1.0, 1), 
-            histogram(c_largeint, 1.0, 1), 
-            histogram(c_float, 1.0, 1), 
-            histogram(c_double, 1.0, 1), 
-            histogram(c_decimal, 1.0, 1), 
-            histogram(c_decimalv3, 1.0, 1), 
-            histogram(c_char, 1.0, 1), 
-            histogram(c_varchar, 1.0, 1), 
-            histogram(c_string, 1.0, 1), 
-            histogram(c_date, 1.0, 1), 
-            histogram(c_datev2, 1.0, 1), 
-            histogram(c_date_time, 1.0, 1), 
-            histogram(c_date_timev2, 1.0, 1), 
-            histogram(c_string_not_null, 1.0, 1)
+            hist(c_bool, 1.0, 1), 
+            hist(c_tinyint, 1.0, 1), 
+            hist(c_smallint, 1.0, 1), 
+            hist(c_bigint, 1.0, 1), 
+            hist(c_largeint, 1.0, 1), 
+            hist(c_float, 1.0, 1), 
+            hist(c_double, 1.0, 1), 
+            hist(c_decimal, 1.0, 1), 
+            hist(c_decimalv3, 1.0, 1), 
+            hist(c_char, 1.0, 1), 
+            hist(c_varchar, 1.0, 1), 
+            hist(c_string, 1.0, 1), 
+            hist(c_date, 1.0, 1), 
+            hist(c_datev2, 1.0, 1), 
+            hist(c_date_time, 1.0, 1), 
+            hist(c_date_timev2, 1.0, 1), 
+            hist(c_string_not_null, 1.0, 1)
         FROM
             ${tableName}
     """


### PR DESCRIPTION
# Proposed changes

1. Add the alias function hist to histogram and add modify sql doc

```
histogram(expr[, DOUBLE sample_rate, INT max_bucket_num])
hist(expr[, DOUBLE sample_rate, INT max_bucket_num])
```

2. Fix p0 bad case

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

