### PR TITLE
[refactor] separate agg and flush in memtable

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -490,13 +490,12 @@ CONF_mInt64(load_channel_memory_refresh_sleep_time_ms, "100");
 // Alignment
 CONF_Int32(memory_max_alignment, "16");
 
-// write buffer size before flush
+// max write buffer size before flush, default 200MB
 CONF_mInt64(write_buffer_size, "209715200");
-
-// max buffer size used in memtable for the aggregated table
-CONF_mInt64(memtable_max_buffer_size, "419430400");
+// max buffer size used in memtable for the aggregated table, default 400MB
+CONF_mInt64(write_buffer_size_for_agg, "419430400");
 // write buffer size in push task for sparkload, default 1GB
-CONF_mInt64(flush_size_for_sparkload, "1073741824");
+CONF_mInt64(write_buffer_size_for_sparkload, "1073741824");
 
 // following 2 configs limit the memory consumption of load process on a Backend.
 // eg: memory limit to 80% of mem limit config but up to 100GB(default)

--- a/be/src/olap/delta_writer.cpp
+++ b/be/src/olap/delta_writer.cpp
@@ -170,10 +170,10 @@ Status DeltaWriter::write(const vectorized::Block* block, const std::vector<int>
     _total_received_rows += row_idxs.size();
     _mem_table->insert(block, row_idxs);
 
-    if (_mem_table->need_agg()) {
+    if (UNLIKELY(_mem_table->need_agg())) {
         _mem_table->shrink_memtable_by_agg();
     }
-    if (_mem_table->need_flush()) {
+    if (UNLIKELY(_mem_table->need_flush())) {
         auto s = _flush_memtable_async();
         _reset_mem_table();
         if (UNLIKELY(!s.ok())) {

--- a/be/src/olap/delta_writer.cpp
+++ b/be/src/olap/delta_writer.cpp
@@ -170,14 +170,14 @@ Status DeltaWriter::write(const vectorized::Block* block, const std::vector<int>
     _total_received_rows += row_idxs.size();
     _mem_table->insert(block, row_idxs);
 
-    if (_mem_table->need_to_agg()) {
+    if (_mem_table->need_agg()) {
         _mem_table->shrink_memtable_by_agg();
-        if (_mem_table->is_flush()) {
-            auto s = _flush_memtable_async();
-            _reset_mem_table();
-            if (UNLIKELY(!s.ok())) {
-                return s;
-            }
+    }
+    if (_mem_table->need_flush()) {
+        auto s = _flush_memtable_async();
+        _reset_mem_table();
+        if (UNLIKELY(!s.ok())) {
+            return s;
         }
     }
 

--- a/be/src/olap/memtable.cpp
+++ b/be/src/olap/memtable.cpp
@@ -296,13 +296,15 @@ void MemTable::shrink_memtable_by_agg() {
     _collect_vskiplist_results<false>();
 }
 
-bool MemTable::is_flush() const {
+bool MemTable::need_flush() const {
     return memory_usage() >= config::write_buffer_size;
 }
 
-bool MemTable::need_to_agg() {
-    return _keys_type == KeysType::DUP_KEYS ? is_flush()
-                                            : memory_usage() >= config::memtable_max_buffer_size;
+bool MemTable::need_agg() const {
+    if (keys_type() == KeysType::AGG_KEYS)
+        return memory_usage() >= config::write_buffer_size_for_agg;
+    
+    return false;
 }
 
 Status MemTable::_generate_delete_bitmap(int64_t atomic_num_segments_before_flush,

--- a/be/src/olap/memtable.cpp
+++ b/be/src/olap/memtable.cpp
@@ -301,9 +301,10 @@ bool MemTable::need_flush() const {
 }
 
 bool MemTable::need_agg() const {
-    if (keys_type() == KeysType::AGG_KEYS)
+    if (keys_type() == KeysType::AGG_KEYS) {
         return memory_usage() >= config::write_buffer_size_for_agg;
-    
+    }
+
     return false;
 }
 

--- a/be/src/olap/memtable.cpp
+++ b/be/src/olap/memtable.cpp
@@ -301,7 +301,7 @@ bool MemTable::need_flush() const {
 }
 
 bool MemTable::need_agg() const {
-    if (keys_type() == KeysType::AGG_KEYS) {
+    if (_keys_type == KeysType::AGG_KEYS) {
         return memory_usage() >= config::write_buffer_size_for_agg;
     }
 

--- a/be/src/olap/memtable.h
+++ b/be/src/olap/memtable.h
@@ -58,9 +58,9 @@ public:
 
     void shrink_memtable_by_agg();
 
-    bool is_flush() const;
+    bool need_flush() const;
 
-    bool need_to_agg();
+    bool need_agg() const;
 
     /// Flush
     Status flush();

--- a/be/src/olap/push_handler.cpp
+++ b/be/src/olap/push_handler.cpp
@@ -250,7 +250,7 @@ Status PushHandler::_convert_v2(TabletSharedPtr cur_tablet, RowsetSharedPtr* cur
             VLOG_NOTICE << "start to convert etl file to delta.";
             while (!reader->eof()) {
                 if (reader->mem_pool()->mem_tracker()->consumption() >
-                    config::flush_size_for_sparkload) {
+                    config::write_buffer_size_for_sparkload) {
                     RETURN_NOT_OK(rowset_writer->flush());
                     reader->mem_pool()->free_all();
                 }


### PR DESCRIPTION
# Proposed changes

refactor some of your code @spaces-X 
cc thanks

keys:
- separate need_to_agg and flush in memtable
- rename var and function

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

