### PR TITLE
[refactor](hashtable) simplify template args of partitioned hash table

### DIFF
--- a/be/src/vec/common/hash_table/hash_table.h
+++ b/be/src/vec/common/hash_table/hash_table.h
@@ -420,9 +420,9 @@ struct ZeroValueStorage<false, Cell> {
     const Cell* zero_value() const { return nullptr; }
 };
 
-template <typename Key, typename Cell, typename Hash, typename Grower, typename Allocator>
+template <typename Key, typename Cell, typename HashMethod, typename Grower, typename Allocator>
 class HashTable : private boost::noncopyable,
-                  protected Hash,
+                  protected HashMethod,
                   protected Allocator,
                   protected Cell::State,
                   protected ZeroValueStorage<Cell::need_zero_value_storage,
@@ -431,7 +431,7 @@ class HashTable : private boost::noncopyable,
 protected:
     friend class Reader;
 
-    template <typename, typename, typename, typename, typename, typename, size_t>
+    template <typename, size_t>
     friend class PartitionedHashTable;
 
     template <typename SubMaps>
@@ -610,6 +610,8 @@ protected:
 public:
     using key_type = Key;
     using value_type = typename Cell::value_type;
+    using mapped_type = value_type;
+    using Hash = HashMethod;
 
     // Use lookup_result_get_mapped/Key to work with these values.
     using LookupResult = Cell*;

--- a/be/src/vec/common/hash_table/partitioned_hash_map.h
+++ b/be/src/vec/common/hash_table/partitioned_hash_map.h
@@ -22,43 +22,32 @@
 #include "vec/common/hash_table/hash_map.h"
 #include "vec/common/hash_table/partitioned_hash_table.h"
 
-template <typename Key, typename Cell, typename Hash = DefaultHash<Key>,
-          typename Grower = PartitionedHashTableGrower<>, typename Allocator = HashTableAllocator,
-          template <typename...> typename ImplTable = HashMapTable>
-class PartitionedHashMapTable
-        : public PartitionedHashTable<Key, Cell, Hash, Grower, Allocator,
-                                      ImplTable<Key, Cell, Hash, Grower, Allocator>> {
+template <typename ImplTable>
+class PartitionedHashMapTable : public PartitionedHashTable<ImplTable> {
 public:
-    using Impl = ImplTable<Key, Cell, Hash, Grower, Allocator>;
-    using Base = PartitionedHashTable<Key, Cell, Hash, Grower, Allocator,
-                                      ImplTable<Key, Cell, Hash, Grower, Allocator>>;
+    using Impl = ImplTable;
+    using Base = PartitionedHashTable<ImplTable>;
+    using Key = typename ImplTable::key_type;
     using LookupResult = typename Impl::LookupResult;
 
     using Base::Base;
     using Base::prefetch;
 
-    using mapped_type = typename Cell::Mapped;
+    using mapped_type = typename Base::mapped_type;
 
-    typename Cell::Mapped& ALWAYS_INLINE operator[](const Key& x) {
+    auto& ALWAYS_INLINE operator[](const Key& x) {
         LookupResult it;
         bool inserted;
         this->emplace(x, it, inserted);
 
-        if (inserted) new (lookup_result_get_mapped(it)) mapped_type();
+        if (inserted) {
+            new (lookup_result_get_mapped(it)) mapped_type();
+        }
 
         return *lookup_result_get_mapped(it);
     }
 };
 
-template <typename Key, typename Mapped, typename Hash = DefaultHash<Key>,
-          typename Grower = PartitionedHashTableGrower<>, typename Allocator = HashTableAllocator,
-          template <typename...> typename ImplTable = HashMapTable>
-using PartitionedHashMap = PartitionedHashMapTable<Key, HashMapCell<Key, Mapped, Hash>, Hash,
-                                                   Grower, Allocator, ImplTable>;
-
-template <typename Key, typename Mapped, typename Hash = DefaultHash<Key>,
-          typename Grower = PartitionedHashTableGrower<>, typename Allocator = HashTableAllocator,
-          template <typename...> typename ImplTable = HashMapTable>
-using PartitionedHashMapWithSavedHash =
-        PartitionedHashMapTable<Key, HashMapCellWithSavedHash<Key, Mapped, Hash>, Hash, Grower,
-                                Allocator, ImplTable>;
+template <typename Key, typename Mapped, typename Hash = DefaultHash<Key>>
+using PartitionedHashMap =
+        PartitionedHashMapTable<HashMap<Key, Mapped, Hash, PartitionedHashTableGrower<>>>;


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary

The template arguments are too complex, we need to simplify them before adding the implementation of `PHMap`.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

