### PR TITLE
[enhance](planner)convert 'or' into 'in-predicate'

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/BinaryPredicate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/BinaryPredicate.java
@@ -218,6 +218,13 @@ public class BinaryPredicate extends Predicate implements Writable {
     }
 
     @Override
+    public String toString() {
+        StringBuilder builder = new StringBuilder();
+        builder.append(children.get(0)).append(" ").append(op).append(" ").append(children.get(1));
+        return builder.toString();
+    }
+
+    @Override
     public Expr negate() {
         Operator newOp = null;
         switch (op) {

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/CompoundPredicate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/CompoundPredicate.java
@@ -198,6 +198,13 @@ public class CompoundPredicate extends Predicate {
         return new CompoundPredicate(Operator.AND, rhs, lhs);
     }
 
+    public static Expr createDisjunction(Expr lhs, Expr rhs) {
+        if (rhs == null) {
+            return lhs;
+        }
+        return new CompoundPredicate(Operator.OR, rhs, lhs);
+    }
+
     /**
      * Creates a conjunctive predicate from a list of exprs.
      */
@@ -209,6 +216,26 @@ public class CompoundPredicate extends Predicate {
                 continue;
             }
             conjunctivePred = new CompoundPredicate(CompoundPredicate.Operator.AND, expr, conjunctivePred);
+        }
+        return conjunctivePred;
+    }
+
+    /**
+     * Creates a disjunctive predicate from a list of exprs in reverse order.
+     * Usually we collect disjunctions from "a or b or c" in list [a, b, c]
+     * and we prefer that createDisjunctivePredicate([a, b, c]) to create "a or b or c", keeping the original order
+     */
+    public static Expr createDisjunctivePredicate(List<Expr> conjuncts) {
+        Expr conjunctivePred = null;
+        int count = conjuncts.size();
+        //in reverse order, but do not change conjuncts
+        for (int i = 0; i < count; i++) {
+            Expr expr = conjuncts.get(count - i - 1);
+            if (conjunctivePred == null) {
+                conjunctivePred = expr;
+                continue;
+            }
+            conjunctivePred = new CompoundPredicate(CompoundPredicate.Operator.OR, expr, conjunctivePred);
         }
         return conjunctivePred;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/CompoundPredicate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/CompoundPredicate.java
@@ -229,6 +229,11 @@ public class CompoundPredicate extends Predicate {
         return result;
     }
 
+    public static boolean isOr(Expr expr) {
+        return expr instanceof CompoundPredicate
+                && ((CompoundPredicate) expr).getOp() == Operator.OR;
+    }
+
     @Override
     public Expr getResultValue() throws AnalysisException {
         recursiveResetChildrenResult();

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/CompoundPredicate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/CompoundPredicate.java
@@ -280,8 +280,6 @@ public class CompoundPredicate extends Predicate {
 
     @Override
     public String toString() {
-        StringBuilder builder = new StringBuilder();
-        builder.append(getChild(0)).append(" ").append(op).append(" ").append(getChild(1));
-        return builder.toString();
+        return toSqlImpl();
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/CompoundPredicate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/CompoundPredicate.java
@@ -198,13 +198,6 @@ public class CompoundPredicate extends Predicate {
         return new CompoundPredicate(Operator.AND, rhs, lhs);
     }
 
-    public static Expr createDisjunction(Expr lhs, Expr rhs) {
-        if (rhs == null) {
-            return lhs;
-        }
-        return new CompoundPredicate(Operator.OR, rhs, lhs);
-    }
-
     /**
      * Creates a conjunctive predicate from a list of exprs.
      */
@@ -221,23 +214,19 @@ public class CompoundPredicate extends Predicate {
     }
 
     /**
-     * Creates a disjunctive predicate from a list of exprs in reverse order.
-     * Usually we collect disjunctions from "a or b or c" in list [a, b, c]
-     * and we prefer that createDisjunctivePredicate([a, b, c]) to create "a or b or c", keeping the original order
+     * Creates a disjunctive predicate from a list of exprs,
+     * reserve the expr order
      */
-    public static Expr createDisjunctivePredicate(List<Expr> conjuncts) {
-        Expr conjunctivePred = null;
-        int count = conjuncts.size();
-        //in reverse order, but do not change conjuncts
-        for (int i = 0; i < count; i++) {
-            Expr expr = conjuncts.get(count - i - 1);
-            if (conjunctivePred == null) {
-                conjunctivePred = expr;
+    public static Expr createDisjunctivePredicate(List<Expr> disjunctions) {
+        Expr result = null;
+        for (Expr expr : disjunctions) {
+            if (result == null) {
+                result = expr;
                 continue;
             }
-            conjunctivePred = new CompoundPredicate(CompoundPredicate.Operator.OR, expr, conjunctivePred);
+            result = new CompoundPredicate(CompoundPredicate.Operator.OR, result, expr);
         }
-        return conjunctivePred;
+        return result;
     }
 
     @Override
@@ -287,5 +276,12 @@ public class CompoundPredicate extends Predicate {
     @Override
     public void finalizeImplForNereids() throws AnalysisException {
 
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder builder = new StringBuilder();
+        builder.append(getChild(0)).append(" ").append(op).append(" ").append(getChild(1));
+        return builder.toString();
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/LiteralExpr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/LiteralExpr.java
@@ -262,4 +262,9 @@ public abstract class LiteralExpr extends Expr implements Comparable<LiteralExpr
     public void finalizeImplForNereids() throws AnalysisException {
 
     }
+
+    @Override
+    public String toString() {
+        return getStringValue();
+    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/SlotRef.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/SlotRef.java
@@ -486,4 +486,16 @@ public class SlotRef extends Expr {
     public void finalizeImplForNereids() throws AnalysisException {
 
     }
+
+    @Override
+    public String toString() {
+        StringBuilder builder = new StringBuilder();
+        if (tblName != null) {
+            builder.append(tblName).append(".");
+        }
+        if (label != null) {
+            builder.append(label);
+        }
+        return builder.toString();
+    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/rewrite/ExtractCommonFactorsRule.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/rewrite/ExtractCommonFactorsRule.java
@@ -496,7 +496,13 @@ public class ExtractCommonFactorsRule implements ExprRewriteRule {
                     && ((CompoundPredicate) predicate).getOp() == Operator.AND) {
                 CompoundPredicate and = (CompoundPredicate) predicate;
                 Expr left = apply(and.getChild(0), analyzer, clauseType);
+                if (CompoundPredicate.isOr(left)) {
+                    left.setPrintSqlInParens(true);
+                }
                 Expr right = apply(and.getChild(1), analyzer, clauseType);
+                if (CompoundPredicate.isOr(right)) {
+                    right.setPrintSqlInParens(true);
+                }
                 notMergedExprs.add(new CompoundPredicate(Operator.AND, left, right));
             } else if (!(predicate instanceof BinaryPredicate) && !(predicate instanceof InPredicate)) {
                 notMergedExprs.add(predicate);

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/SelectStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/SelectStmtTest.java
@@ -289,7 +289,6 @@ public class SelectStmtTest {
         String betweenExpanded3 = "`t1`.`k4` >= 50 AND `t1`.`k4` <= 250";
 
         String rewrittenSql = stmt.toSql();
-        System.out.println(rewrittenSql);
         Assert.assertTrue(rewrittenSql.contains(commonExpr1));
         Assert.assertEquals(rewrittenSql.indexOf(commonExpr1), rewrittenSql.lastIndexOf(commonExpr1));
         Assert.assertTrue(rewrittenSql.contains(commonExpr2));
@@ -331,25 +330,17 @@ public class SelectStmtTest {
         SelectStmt stmt2 = (SelectStmt) UtFrameUtils.parseAndAnalyzeStmt(sql2, ctx);
         stmt2.rewriteExprs(new Analyzer(ctx.getEnv(), ctx).getExprRewriter());
         String fragment3 =
-                "((`t1`.`k4` >= 50 AND `t1`.`k4` <= 300) "
-                        + "AND (`t2`.`k2` = 'United States' OR `t2`.`k2` = 'United States1') "
-                        + "AND `t2`.`k3` IN ('CO', 'IL', 'MN', 'OH', 'MT', 'NM', 'TX', 'MO', 'MI')"
-                        + ") "
-
+                "(((`t1`.`k4` >= 50 AND `t1`.`k4` <= 300) AND `t2`.`k2` IN ('United States', 'United States1') "
+                        + "AND `t2`.`k3` IN ('CO', 'IL', 'MN', 'OH', 'MT', 'NM', 'TX', 'MO', 'MI')) "
                         + "AND `t1`.`k1` = `t2`.`k3` AND `t2`.`k2` = 'United States' "
-                        + "AND `t2`.`k3` IN ('CO', 'IL', 'MN') "
-                        + "AND `t1`.`k4` >= 100 AND `t1`.`k4` <= 200 "
-
+                        + "AND `t2`.`k3` IN ('CO', 'IL', 'MN') AND `t1`.`k4` >= 100 AND `t1`.`k4` <= 200 "
                         + "OR "
                         + "`t1`.`k1` = `t2`.`k1` AND `t2`.`k2` = 'United States1' "
-                        + "AND `t2`.`k3` IN ('OH', 'MT', 'NM') "
-                        + "AND `t1`.`k4` >= 150 AND `t1`.`k4` <= 300 "
-
+                        + "AND `t2`.`k3` IN ('OH', 'MT', 'NM') AND `t1`.`k4` >= 150 AND `t1`.`k4` <= 300 "
                         + "OR "
-                        + "`t1`.`k1` = `t2`.`k1` "
-                        + "AND `t2`.`k2` = 'United States' "
+                        + "`t1`.`k1` = `t2`.`k1` AND `t2`.`k2` = 'United States' "
                         + "AND `t2`.`k3` IN ('TX', 'MO', 'MI') "
-                        + "AND `t1`.`k4` >= 50 AND `t1`.`k4` <= 250";
+                        + "AND `t1`.`k4` >= 50 AND `t1`.`k4` <= 250)";
         Assert.assertTrue(stmt2.toSql().contains(fragment3));
 
         String sql3 = "select\n"

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/SelectStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/SelectStmtTest.java
@@ -330,13 +330,26 @@ public class SelectStmtTest {
                 + ")";
         SelectStmt stmt2 = (SelectStmt) UtFrameUtils.parseAndAnalyzeStmt(sql2, ctx);
         stmt2.rewriteExprs(new Analyzer(ctx.getEnv(), ctx).getExprRewriter());
-        String fragment3 = "((`t1`.`k1` = `t2`.`k3` AND `t2`.`k2` = 'United States'"
-                + " AND `t2`.`k3` IN ('CO', 'IL', 'MN') "
-                + "AND `t1`.`k4` >= 100 AND `t1`.`k4` <= 200) "
-                + "OR (`t1`.`k1` = `t2`.`k1` AND `t2`.`k2` = 'United States1' "
-                + "AND `t2`.`k3` IN ('OH', 'MT', 'NM') AND `t1`.`k4` >= 150 AND `t1`.`k4` <= 300) "
-                + "OR (`t1`.`k1` = `t2`.`k1` AND `t2`.`k2` = 'United States' AND `t2`.`k3` IN ('TX', 'MO', 'MI') "
-                + "AND `t1`.`k4` >= 50 AND `t1`.`k4` <= 250))";
+        String fragment3 =
+                "((`t1`.`k4` >= 50 AND `t1`.`k4` <= 300) "
+                        + "AND (`t2`.`k2` = 'United States' OR `t2`.`k2` = 'United States1') "
+                        + "AND `t2`.`k3` IN ('CO', 'IL', 'MN', 'OH', 'MT', 'NM', 'TX', 'MO', 'MI')"
+                        + ") "
+
+                        + "AND `t1`.`k1` = `t2`.`k3` AND `t2`.`k2` = 'United States' "
+                        + "AND `t2`.`k3` IN ('CO', 'IL', 'MN') "
+                        + "AND `t1`.`k4` >= 100 AND `t1`.`k4` <= 200 "
+
+                        + "OR "
+                        + "`t1`.`k1` = `t2`.`k1` AND `t2`.`k2` = 'United States1' "
+                        + "AND `t2`.`k3` IN ('OH', 'MT', 'NM') "
+                        + "AND `t1`.`k4` >= 150 AND `t1`.`k4` <= 300 "
+
+                        + "OR "
+                        + "`t1`.`k1` = `t2`.`k1` "
+                        + "AND `t2`.`k2` = 'United States' "
+                        + "AND `t2`.`k3` IN ('TX', 'MO', 'MI') "
+                        + "AND `t1`.`k4` >= 50 AND `t1`.`k4` <= 250";
         Assert.assertTrue(stmt2.toSql().contains(fragment3));
 
         String sql3 = "select\n"
@@ -396,7 +409,7 @@ public class SelectStmtTest {
         SelectStmt stmt7 = (SelectStmt) UtFrameUtils.parseAndAnalyzeStmt(sql7, ctx);
         stmt7.rewriteExprs(new Analyzer(ctx.getEnv(), ctx).getExprRewriter());
         Assert.assertTrue(stmt7.toSql()
-                .contains("`t2`.`k1` IS NOT NULL OR (`t1`.`k1` IS NOT NULL " + "AND `t1`.`k2` IS NOT NULL)"));
+                .contains("`t2`.`k1` IS NOT NULL OR `t1`.`k1` IS NOT NULL AND `t1`.`k2` IS NOT NULL"));
 
         String sql8 = "select\n"
                 + "   avg(t1.k4)\n"
@@ -408,13 +421,13 @@ public class SelectStmtTest {
         SelectStmt stmt8 = (SelectStmt) UtFrameUtils.parseAndAnalyzeStmt(sql8, ctx);
         stmt8.rewriteExprs(new Analyzer(ctx.getEnv(), ctx).getExprRewriter());
         Assert.assertTrue(stmt8.toSql()
-                .contains("`t2`.`k1` IS NOT NULL AND `t1`.`k1` IS NOT NULL" + " AND `t1`.`k1` IS NOT NULL"));
+                .contains("`t2`.`k1` IS NOT NULL AND `t1`.`k1` IS NOT NULL AND `t1`.`k1` IS NOT NULL"));
 
         String sql9 = "select * from db1.tbl1 where (k1='shutdown' and k4<1) or (k1='switchOff' and k4>=1)";
         SelectStmt stmt9 = (SelectStmt) UtFrameUtils.parseAndAnalyzeStmt(sql9, ctx);
         stmt9.rewriteExprs(new Analyzer(ctx.getEnv(), ctx).getExprRewriter());
         Assert.assertTrue(
-                stmt9.toSql().contains("(`k1` = 'shutdown' AND `k4` < 1)" + " OR (`k1` = 'switchOff' AND `k4` >= 1)"));
+                stmt9.toSql().contains("`k1` = 'shutdown' AND `k4` < 1 OR `k1` = 'switchOff' AND `k4` >= 1"));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/planner/QueryPlanTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/planner/QueryPlanTest.java
@@ -2220,40 +2220,61 @@ public class QueryPlanTest extends TestWithFeService {
         Assert.assertTrue(explainString.contains("PREAGGREGATION: ON"));
     }
 
+    /*
+    NOTE:
+    explainString.contains("PREDICATES: xxx\n")
+    add '\n' at the end of line to ensure there are no other predicates
+     */
     @Test
     public void testRewriteOrToIn() throws Exception {
         connectContext.setDatabase("default_cluster:test");
         String sql = "SELECT * from test1 where query_time = 1 or query_time = 2 or query_time in (3, 4)";
         String explainString = UtFrameUtils.getSQLPlanOrErrorMsg(connectContext, "EXPLAIN " + sql);
-        Assert.assertTrue(explainString.contains("PREDICATES: `query_time` IN (1, 2, 3, 4)"));
+        Assert.assertTrue(explainString.contains("PREDICATES: `query_time` IN (1, 2, 3, 4)\n"));
 
         sql = "SELECT * from test1 where (query_time = 1 or query_time = 2) and query_time in (3, 4)";
         explainString = UtFrameUtils.getSQLPlanOrErrorMsg(connectContext, "EXPLAIN " + sql);
-        Assert.assertTrue(explainString.contains("PREDICATES: `query_time` IN (1, 2), `query_time` IN (3, 4)"));
+        Assert.assertTrue(explainString.contains("PREDICATES: `query_time` IN (1, 2), `query_time` IN (3, 4)\n"));
 
         sql = "SELECT * from test1 where (query_time = 1 or query_time = 2 or scan_bytes = 2) and scan_bytes in (2, 3)";
         explainString = UtFrameUtils.getSQLPlanOrErrorMsg(connectContext, "EXPLAIN " + sql);
-        Assert.assertTrue(explainString.contains("PREDICATES: (`query_time` = 1 OR `query_time` = 2 OR `scan_bytes` = 2), `scan_bytes` IN (2, 3)"));
+        Assert.assertTrue(explainString.contains("PREDICATES: `query_time` IN (1, 2) OR `scan_bytes` = 2, `scan_bytes` IN (2, 3)\n"));
 
         sql = "SELECT * from test1 where (query_time = 1 or query_time = 2) and (scan_bytes = 2 or scan_bytes = 3)";
         explainString = UtFrameUtils.getSQLPlanOrErrorMsg(connectContext, "EXPLAIN " + sql);
-        Assert.assertTrue(explainString.contains("PREDICATES: `query_time` IN (1, 2), `scan_bytes` IN (2, 3)"));
+        Assert.assertTrue(explainString.contains("PREDICATES: `query_time` IN (1, 2), `scan_bytes` IN (2, 3)\n"));
 
         sql = "SELECT * from test1 where query_time = 1 or query_time = 2 or query_time = 3 or query_time = 1";
         explainString = UtFrameUtils.getSQLPlanOrErrorMsg(connectContext, "EXPLAIN " + sql);
-        Assert.assertTrue(explainString.contains("PREDICATES: `query_time` IN (1, 2, 3)"));
+        Assert.assertTrue(explainString.contains("PREDICATES: `query_time` IN (1, 2, 3)\n"));
 
         sql = "SELECT * from test1 where query_time = 1 or query_time = 2 or query_time in (3, 2)";
         explainString = UtFrameUtils.getSQLPlanOrErrorMsg(connectContext, "EXPLAIN " + sql);
-        Assert.assertTrue(explainString.contains("PREDICATES: `query_time` IN (1, 2, 3)"));
+        Assert.assertTrue(explainString.contains("PREDICATES: `query_time` IN (1, 2, 3)\n"));
 
         connectContext.getSessionVariable().setRewriteOrToInPredicateThreshold(100);
         sql = "SELECT * from test1 where query_time = 1 or query_time = 2 or query_time in (3, 4)";
         explainString = UtFrameUtils.getSQLPlanOrErrorMsg(connectContext, "EXPLAIN " + sql);
-        Assert.assertTrue(explainString.contains("PREDICATES: (`query_time` = 1 OR `query_time` = 2 OR `query_time` IN (3, 4))"));
+        Assert.assertTrue(explainString.contains("PREDICATES: `query_time` = 1 OR `query_time` = 2 OR `query_time` IN (3, 4)\n"));
+        connectContext.getSessionVariable().setRewriteOrToInPredicateThreshold(2);
 
         sql = "SELECT * from test1 where (query_time = 1 or query_time = 2) and query_time in (3, 4)";
         explainString = UtFrameUtils.getSQLPlanOrErrorMsg(connectContext, "EXPLAIN " + sql);
-        Assert.assertTrue(explainString.contains("PREDICATES: (`query_time` = 1 OR `query_time` = 2), `query_time` IN (3, 4)"));
+        Assert.assertTrue(explainString.contains("PREDICATES: `query_time` IN (1, 2), `query_time` IN (3, 4)\n"));
+
+        //test we can handle `!=` and `not in`
+        sql = "select * from test1 where (query_time = 1 or query_time = 2 or query_time!= 3 or query_time not in (5, 6))";
+        explainString = UtFrameUtils.getSQLPlanOrErrorMsg(connectContext, "EXPLAIN " + sql);
+        Assert.assertTrue(explainString.contains("PREDICATES: `query_time` IN (1, 2) OR `query_time` != 3 OR `query_time` NOT IN (5, 6)\n"));
+
+        //test we can handle merge 2 or more columns
+        sql = "select * from test1 where (query_time = 1 or query_time = 2 or scan_rows = 3 or scan_rows = 4)";
+        explainString = UtFrameUtils.getSQLPlanOrErrorMsg(connectContext, "EXPLAIN " + sql);
+        Assert.assertTrue(explainString.contains("PREDICATES: `query_time` IN (1, 2) OR `scan_rows` IN (3, 4)"));
+
+        //merge in-pred or in-pred
+        sql = "select * from test1 where (query_time = 1 or query_time = 2 or query_time = 3 or query_time = 4)";
+        explainString = UtFrameUtils.getSQLPlanOrErrorMsg(connectContext, "EXPLAIN " + sql);
+        Assert.assertTrue(explainString.contains("PREDICATES: `query_time` IN (1, 2, 3, 4)\n"));
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/planner/QueryPlanTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/planner/QueryPlanTest.java
@@ -2288,5 +2288,13 @@ public class QueryPlanTest extends TestWithFeService {
                 "PREDICATES: `query_id` = `client_ip` "
                         + "AND (`stmt_id` IN (1, 2, 3) OR `user` = 'abc' AND `state` IN ('a', 'b', 'c', 'd')) "
                         + "OR (`db` NOT IN ('x', 'y'))\n"));
+
+        //ExtractCommonFactorsRule may generate more expr, test the rewriteOrToIn applied on generated exprs
+        sql = "select * from test1 where (stmt_id=1 and state='a') or (stmt_id=2 and state='b')";
+        explainString = UtFrameUtils.getSQLPlanOrErrorMsg(connectContext, "EXPLAIN " + sql);
+        Assert.assertTrue(explainString.contains(
+                "PREDICATES: `state` IN ('a', 'b'), `stmt_id` IN (1, 2),"
+                        + " `stmt_id` = 1 AND `state` = 'a' OR `stmt_id` = 2 AND `state` = 'b'\n"
+        ));
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/planner/QueryPlanTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/planner/QueryPlanTest.java
@@ -2286,7 +2286,7 @@ public class QueryPlanTest extends TestWithFeService {
         explainString = UtFrameUtils.getSQLPlanOrErrorMsg(connectContext, "EXPLAIN " + sql);
         Assert.assertTrue(explainString.contains(
                 "PREDICATES: `query_id` = `client_ip` "
-                        + "AND `stmt_id` IN (1, 2, 3) OR `user` = 'abc' AND `state` IN ('a', 'b', 'c', 'd') "
+                        + "AND (`stmt_id` IN (1, 2, 3) OR `user` = 'abc' AND `state` IN ('a', 'b', 'c', 'd')) "
                         + "OR (`db` NOT IN ('x', 'y'))\n"));
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/rewrite/ExtractCommonFactorsRuleFunctionTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/rewrite/ExtractCommonFactorsRuleFunctionTest.java
@@ -94,8 +94,8 @@ public class ExtractCommonFactorsRuleFunctionTest {
     public void testWideCommonFactorsWithEqualPredicate() throws Exception {
         String query = "select * from tb1, tb2 where (tb1.k1=1 and tb2.k1=1) or (tb1.k1 =2 and tb2.k1=2)";
         String planString = dorisAssert.query(query).explainQuery();
-        Assert.assertTrue(planString.contains("(`tb1`.`k1` = 1 OR `tb1`.`k1` = 2)"));
-        Assert.assertTrue(planString.contains("(`tb2`.`k1` = 1 OR `tb2`.`k1` = 2)"));
+        Assert.assertTrue(planString.contains("`tb1`.`k1` IN (1, 2)"));
+        Assert.assertTrue(planString.contains("`tb2`.`k1` IN (1, 2)"));
         Assert.assertTrue(planString.contains("NESTED LOOP JOIN"));
     }
 
@@ -246,10 +246,10 @@ public class ExtractCommonFactorsRuleFunctionTest {
         Assert.assertTrue(planString.contains("`l_partkey` = `p_partkey`"));
         Assert.assertTrue(planString.contains("`l_shipmode` IN ('AIR', 'AIR REG')"));
         Assert.assertTrue(planString.contains("`l_shipinstruct` = 'DELIVER IN PERSON'"));
-        Assert.assertTrue(planString.contains("((`l_quantity` >= 9 AND `l_quantity` <= 19) "
-                + "OR (`l_quantity` >= 20 AND `l_quantity` <= 36))"));
+        Assert.assertTrue(planString.contains("`l_quantity` >= 9 AND `l_quantity` <= 19 "
+                + "OR `l_quantity` >= 20 AND `l_quantity` <= 36"));
         Assert.assertTrue(planString.contains("`p_size` >= 1"));
-        Assert.assertTrue(planString.contains("(`p_brand` = 'Brand#11' OR `p_brand` = 'Brand#21' OR `p_brand` = 'Brand#32')"));
+        Assert.assertTrue(planString.contains("`p_brand` IN ('Brand#11', 'Brand#21', 'Brand#32')"));
         Assert.assertTrue(planString.contains("`p_size` <= 15"));
         Assert.assertTrue(planString.contains("`p_container` IN ('SM CASE', 'SM BOX', 'SM PACK', 'SM PKG', 'MED BAG', "
                 + "'MED BOX', 'MED PKG', 'MED PACK', 'LG CASE', 'LG BOX', 'LG PACK', 'LG PKG')"));

--- a/fe/fe-core/src/test/java/org/apache/doris/rewrite/ExtractCommonFactorsRuleFunctionTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/rewrite/ExtractCommonFactorsRuleFunctionTest.java
@@ -87,7 +87,7 @@ public class ExtractCommonFactorsRuleFunctionTest {
     public void testWideCommonFactorsWithOrPredicate() throws Exception {
         String query = "select * from tb1 where tb1.k1 > 1000 or tb1.k1 < 200 or tb1.k1 = 300";
         String planString = dorisAssert.query(query).explainQuery();
-        Assert.assertTrue(planString.contains("PREDICATES: (`tb1`.`k1` > 1000 OR `tb1`.`k1` < 200 OR `tb1`.`k1` = 300)"));
+        Assert.assertTrue(planString.contains("PREDICATES: `tb1`.`k1` = 300 OR `tb1`.`k1` > 1000 OR `tb1`.`k1` < 200"));
     }
 
     @Test

--- a/regression-test/data/performance_p0/redundant_conjuncts.out
+++ b/regression-test/data/performance_p0/redundant_conjuncts.out
@@ -23,7 +23,7 @@ PLAN FRAGMENT 0
 
   0:VOlapScanNode
      TABLE: default_cluster:regression_test_performance_p0.redundant_conjuncts(redundant_conjuncts), PREAGGREGATION: OFF. Reason: No AggregateInfo
-     PREDICATES: (`k1` = 1 OR `k1` = 2)
+     PREDICATES: `k1` = 1 OR `k1` = 2
      partitions=0/1, tablets=0/0, tabletList=
      cardinality=0, avgRowSize=8.0, numNodes=1
 


### PR DESCRIPTION
# Proposed changes
in previous [PR 12872](https://github.com/apache/doris/pull/12872), we convert multi equals on same slot into `in predicate`. for example, `a =1 or a = 2` => `a in (1, 2)`

This pr makes 4 changes about convert or to in:
1. fix a bug: `Not IN`  is merged with equal. `a =1 or a not in (2, 3)` => `a in (1, 2, 3)`
2. extends this rule on more cases
- merge for more than one slot: 'a =1 or a = 2 or b = 3 or b = 4' => `a in (1, 2) or b in (3, 4)`
- merge skip not-equal and not-in: 'a =1 or a = 2 or b !=3 or c not in (1, 2)' => 'a in (1, 2) or b!=3 or c not in (1,2)`
3. rewrite recursively. 
4. OrToIn is implemented in ExtractCommonFactorsRule. This rule will generate new exprs. OrToIn should apply on such generated exprs. for example `(a=1 and b=2) or (a=3 and b=4)` => `(a=1 or a=3) and (b=2 or b=4) and [(a=1 and b=2) or (a=3 and b=4)]` => `a in (1,3) and b in (2 ,4) and [(a=1 and b=2) or (a=3 and b=4)]` 

In addition, this pr add toString() for some Expr.

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
6. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
7. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
8. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
9. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

