### PR TITLE
[BugFix](JdbcResource) fix that JdbcResource  does not support the jdbcurl of `Oracle` and `SQLServer`

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/JdbcResource.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/JdbcResource.java
@@ -24,7 +24,6 @@ import org.apache.doris.common.DdlException;
 import org.apache.doris.common.FeConstants;
 import org.apache.doris.common.proc.BaseProcResult;
 import org.apache.doris.common.util.Util;
-import org.apache.doris.external.jdbc.JdbcClientException;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
@@ -61,10 +60,16 @@ import java.util.Map;
 public class JdbcResource extends Resource {
     private static final Logger LOG = LogManager.getLogger(JdbcResource.class);
 
+    public static final String JDBC_MYSQL = "jdbc:mysql";
+    public static final String JDBC_MARIADB = "jdbc:mariadb";
+    public static final String JDBC_POSTGRESQL = "jdbc:postgresql";
+    public static final String JDBC_ORACLE = "jdbc:oracle";
+    public static final String JDBC_SQLSERVER = "jdbc:sqlserver";
+
     public static final String MYSQL = "MYSQL";
     public static final String POSTGRESQL = "POSTGRESQL";
-    // private static final String ORACLE = "ORACLE";
-    // private static final String SQLSERVER = "SQLSERVER";
+    public static final String ORACLE = "ORACLE";
+    private static final String SQLSERVER = "SQLSERVER";
 
     public static final String JDBC_PROPERTIES_PREFIX = "jdbc.";
     public static final String JDBC_URL = "jdbc_url";
@@ -220,21 +225,20 @@ public class JdbcResource extends Resource {
         }
     }
 
-    public static String parseDbType(String url) {
-        if (url.startsWith("jdbc:mysql") || url.startsWith("jdbc:mariadb")) {
+    public static String parseDbType(String url) throws DdlException {
+        if (url.startsWith(JDBC_MYSQL) || url.startsWith(JDBC_MARIADB)) {
             return MYSQL;
-        } else if (url.startsWith("jdbc:postgresql")) {
+        } else if (url.startsWith(JDBC_POSTGRESQL)) {
             return POSTGRESQL;
+        } else if (url.startsWith(JDBC_ORACLE)) {
+            return ORACLE;
+        } else if (url.startsWith(JDBC_SQLSERVER)) {
+            return SQLSERVER;
         }
-        // else if (url.startsWith("jdbc:oracle")) {
-        //     return ORACLE;
-        // }
-        // else if (url.startsWith("jdbc:sqlserver")) {
-        //     return SQLSERVER;
-        throw new JdbcClientException("Unsupported jdbc database type, please check jdbcUrl: " + url);
+        throw new DdlException("Unsupported jdbc database type, please check jdbcUrl: " + url);
     }
 
-    public static String handleJdbcUrl(String jdbcUrl) {
+    public static String handleJdbcUrl(String jdbcUrl) throws DdlException {
         // delete all space in jdbcUrl
         String newJdbcUrl = jdbcUrl.replaceAll(" ", "");
         String dbType = parseDbType(newJdbcUrl);

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/JdbcExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/JdbcExternalCatalog.java
@@ -77,7 +77,7 @@ public class JdbcExternalCatalog extends ExternalCatalog {
     }
 
     public String getDatabaseTypeName() {
-        return JdbcResource.parseDbType(getJdbcUrl());
+        return jdbcClient.getDbType();
     }
 
     public String getJdbcUser() {

--- a/fe/fe-core/src/main/java/org/apache/doris/external/jdbc/JdbcClient.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/external/jdbc/JdbcClient.java
@@ -45,6 +45,7 @@ import java.util.List;
 @Getter
 public class JdbcClient {
     private static final Logger LOG = LogManager.getLogger(JdbcClient.class);
+
     private static final int HTTP_TIMEOUT_MS = 10000;
 
     private String dbType;
@@ -63,9 +64,9 @@ public class JdbcClient {
         this.jdbcUser = user;
         this.jdbcPasswd = password;
         this.jdbcUrl = jdbcUrl;
+        this.dbType = parseDbType(jdbcUrl);
         this.driverUrl = driverUrl;
         this.driverClass = driverClass;
-        this.dbType = JdbcResource.parseDbType(jdbcUrl);
 
         ClassLoader oldClassLoader = Thread.currentThread().getContextClassLoader();
         try {
@@ -495,5 +496,19 @@ public class JdbcClient {
                     true, null, -1));
         }
         return dorisTableSchema;
+    }
+
+    private String parseDbType(String url) {
+        if (url.startsWith(JdbcResource.JDBC_MYSQL) || url.startsWith(JdbcResource.JDBC_MARIADB)) {
+            return JdbcResource.MYSQL;
+        } else if (url.startsWith(JdbcResource.JDBC_POSTGRESQL)) {
+            return JdbcResource.POSTGRESQL;
+        } else if (url.startsWith(JdbcResource.JDBC_ORACLE)) {
+            return JdbcResource.ORACLE;
+        }
+        // else if (url.startsWith("jdbc:sqlserver")) {
+        //     return SQLSERVER;
+        // }
+        throw new JdbcClientException("Unsupported jdbc database type, please check jdbcUrl: " + url);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/JdbcScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/JdbcScanNode.java
@@ -54,12 +54,6 @@ public class JdbcScanNode extends ScanNode {
     private String tableName;
     private TOdbcTableType jdbcType;
 
-    public JdbcScanNode(PlanNodeId id, TupleDescriptor desc, JdbcTable tbl) {
-        super(id, desc, "SCAN JDBC", StatisticalType.JDBC_SCAN_NODE);
-        jdbcType = tbl.getJdbcTableType();
-        tableName = OdbcTable.databaseProperName(jdbcType, tbl.getJdbcTable());
-    }
-
     public JdbcScanNode(PlanNodeId id, TupleDescriptor desc, boolean isJdbcExternalTable) {
         super(id, desc, "JdbcScanNode", StatisticalType.JDBC_SCAN_NODE);
         JdbcTable tbl = null;


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

Actually, `JdbcResource` should support `Oracle` jdbcurl and `SQLServer` jdbcurl for jdbc external table.


## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

