### PR TITLE
[fix](QueryDetail) fix QueryDetail may be incorrect and null pointer exception

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectProcessor.java
@@ -209,11 +209,14 @@ public class ConnectProcessor {
                 }
             }
             ctx.getAuditEventBuilder().setIsQuery(true);
-            ctx.getQueryDetail().setEventTime(endTime);
-            ctx.getQueryDetail().setEndTime(endTime);
-            ctx.getQueryDetail().setLatency(elapseMs);
-            ctx.getQueryDetail().setState(QueryDetail.QueryMemState.FINISHED);
-            QueryDetailQueue.addOrUpdateQueryDetail(ctx.getQueryDetail());
+            if (ctx.getQueryDetail() != null) {
+                ctx.getQueryDetail().setEventTime(endTime);
+                ctx.getQueryDetail().setEndTime(endTime);
+                ctx.getQueryDetail().setLatency(elapseMs);
+                ctx.getQueryDetail().setState(QueryDetail.QueryMemState.FINISHED);
+                QueryDetailQueue.addOrUpdateQueryDetail(ctx.getQueryDetail());
+                ctx.setQueryDetail(null);
+            }
         } else {
             ctx.getAuditEventBuilder().setIsQuery(false);
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -1075,6 +1075,12 @@ public class StmtExecutor implements ProfileWriter {
         context.getMysqlChannel().reset();
         Queriable queryStmt = (Queriable) parsedStmt;
 
+        if (queryStmt.isExplain()) {
+            String explainString = planner.getExplainString(queryStmt.getExplainOptions());
+            handleExplainStmt(explainString);
+            return;
+        }
+
         QueryDetail queryDetail = new QueryDetail(context.getStartTime(),
                 DebugUtil.printId(context.queryId()),
                 context.getStartTime(), -1, -1,
@@ -1083,12 +1089,6 @@ public class StmtExecutor implements ProfileWriter {
                 originStmt.originStmt);
         context.setQueryDetail(queryDetail);
         QueryDetailQueue.addOrUpdateQueryDetail(queryDetail);
-
-        if (queryStmt.isExplain()) {
-            String explainString = planner.getExplainString(queryStmt.getExplainOptions());
-            handleExplainStmt(explainString);
-            return;
-        }
 
         // handle selects that fe can do without be, so we can make sql tools happy, especially the setup step.
         if (parsedStmt instanceof SelectStmt && ((SelectStmt) parsedStmt).getTableRefs().isEmpty()) {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -1075,12 +1075,6 @@ public class StmtExecutor implements ProfileWriter {
         context.getMysqlChannel().reset();
         Queriable queryStmt = (Queriable) parsedStmt;
 
-        if (queryStmt.isExplain()) {
-            String explainString = planner.getExplainString(queryStmt.getExplainOptions());
-            handleExplainStmt(explainString);
-            return;
-        }
-
         QueryDetail queryDetail = new QueryDetail(context.getStartTime(),
                 DebugUtil.printId(context.queryId()),
                 context.getStartTime(), -1, -1,
@@ -1089,6 +1083,12 @@ public class StmtExecutor implements ProfileWriter {
                 originStmt.originStmt);
         context.setQueryDetail(queryDetail);
         QueryDetailQueue.addOrUpdateQueryDetail(queryDetail);
+
+        if (queryStmt.isExplain()) {
+            String explainString = planner.getExplainString(queryStmt.getExplainOptions());
+            handleExplainStmt(explainString);
+            return;
+        }
 
         // handle selects that fe can do without be, so we can make sql tools happy, especially the setup step.
         if (parsedStmt instanceof SelectStmt && ((SelectStmt) parsedStmt).getTableRefs().isEmpty()) {


### PR DESCRIPTION

# Proposed changes

Issue Number: close #14937

## Problem summary

If sql throws an exception during the analysis phase, it will not update the QueryDetail, which will cause the QueryDetail in the ConnectContext to be inaccurate, and if this happens during the connection, there will be a null pointer exception causing the connection to fail.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

