### PR TITLE
[Bug](schema scanner) Fix wrong type in schema scanner

### DIFF
--- a/be/src/exec/schema_scanner/schema_columns_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_columns_scanner.cpp
@@ -193,9 +193,10 @@ std::string SchemaColumnsScanner::type_to_string(TColumnDesc& desc) {
     case TPrimitiveType::DECIMAL64:
     case TPrimitiveType::DECIMAL128I: {
         fmt::memory_buffer debug_string_buffer;
-        fmt::format_to(debug_string_buffer, "decimalv3({}, {})",
-                       desc.__isset.columnPrecision ? desc.columnPrecision : "UNKNOWN",
-                       desc.__isset.columnScale ? desc.columnScale : "UNKNOWN");
+        fmt::format_to(
+                debug_string_buffer, "decimalv3({}, {})",
+                desc.__isset.columnPrecision ? std::to_string(desc.columnPrecision) : "UNKNOWN",
+                desc.__isset.columnScale ? std::to_string(desc.columnScale) : "UNKNOWN");
         return fmt::to_string(debug_string_buffer);
     }
     case TPrimitiveType::DATEV2:
@@ -203,7 +204,7 @@ std::string SchemaColumnsScanner::type_to_string(TColumnDesc& desc) {
     case TPrimitiveType::DATETIMEV2: {
         fmt::memory_buffer debug_string_buffer;
         fmt::format_to(debug_string_buffer, "datetimev2({})",
-                       desc.__isset.columnScale ? desc.columnScale : "UNKNOWN");
+                       desc.__isset.columnScale ? std::to_string(desc.columnScale) : "UNKNOWN");
         return fmt::to_string(debug_string_buffer);
     }
     case TPrimitiveType::HLL: {

--- a/be/src/exec/schema_scanner/schema_columns_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_columns_scanner.cpp
@@ -149,7 +149,7 @@ std::string SchemaColumnsScanner::type_to_string(TColumnDesc& desc) {
     case TPrimitiveType::BIGINT:
         return "bigint(20)";
     case TPrimitiveType::LARGEINT:
-        return "bigint(20) unsigned";
+        return "largeint";
     case TPrimitiveType::FLOAT:
         return "float";
     case TPrimitiveType::DOUBLE:
@@ -185,6 +185,38 @@ std::string SchemaColumnsScanner::type_to_string(TColumnDesc& desc) {
             stream << desc.columnScale;
         } else {
             stream << 9;
+        }
+        stream << ")";
+        return stream.str();
+    }
+    case TPrimitiveType::DECIMAL32:
+    case TPrimitiveType::DECIMAL64:
+    case TPrimitiveType::DECIMAL128I: {
+        std::stringstream stream;
+        stream << "decimalv3(";
+        if (desc.__isset.columnPrecision) {
+            stream << desc.columnPrecision;
+        } else {
+            stream << "UNKNOWN";
+        }
+        stream << ",";
+        if (desc.__isset.columnScale) {
+            stream << desc.columnScale;
+        } else {
+            stream << "UNKNOWN";
+        }
+        stream << ")";
+        return stream.str();
+    }
+    case TPrimitiveType::DATEV2:
+        return "datev2";
+    case TPrimitiveType::DATETIMEV2: {
+        std::stringstream stream;
+        stream << "datetimev2(";
+        if (desc.__isset.columnScale) {
+            stream << desc.columnScale;
+        } else {
+            stream << "UNKNOWN";
         }
         stream << ")";
         return stream.str();

--- a/be/src/exec/schema_scanner/schema_columns_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_columns_scanner.cpp
@@ -192,34 +192,19 @@ std::string SchemaColumnsScanner::type_to_string(TColumnDesc& desc) {
     case TPrimitiveType::DECIMAL32:
     case TPrimitiveType::DECIMAL64:
     case TPrimitiveType::DECIMAL128I: {
-        std::stringstream stream;
-        stream << "decimalv3(";
-        if (desc.__isset.columnPrecision) {
-            stream << desc.columnPrecision;
-        } else {
-            stream << "UNKNOWN";
-        }
-        stream << ",";
-        if (desc.__isset.columnScale) {
-            stream << desc.columnScale;
-        } else {
-            stream << "UNKNOWN";
-        }
-        stream << ")";
-        return stream.str();
+        fmt::memory_buffer debug_string_buffer;
+        fmt::format_to(debug_string_buffer, "decimalv3({}, {})",
+                       desc.__isset.columnPrecision ? desc.columnPrecision : "UNKNOWN",
+                       desc.__isset.columnScale ? desc.columnScale : "UNKNOWN");
+        return fmt::to_string(debug_string_buffer);
     }
     case TPrimitiveType::DATEV2:
         return "datev2";
     case TPrimitiveType::DATETIMEV2: {
-        std::stringstream stream;
-        stream << "datetimev2(";
-        if (desc.__isset.columnScale) {
-            stream << desc.columnScale;
-        } else {
-            stream << "UNKNOWN";
-        }
-        stream << ")";
-        return stream.str();
+        fmt::memory_buffer debug_string_buffer;
+        fmt::format_to(debug_string_buffer, "datetimev2({})",
+                       desc.__isset.columnScale ? desc.columnScale : "UNKNOWN");
+        return fmt::to_string(debug_string_buffer);
     }
     case TPrimitiveType::HLL: {
         return "hll";


### PR DESCRIPTION
# Proposed changes

Before:
![image](https://user-images.githubusercontent.com/37700562/211497973-820e31db-ef55-4843-b487-cf753f014ee8.png)

After:
![image](https://user-images.githubusercontent.com/37700562/211498101-14210128-bddc-428d-b4f9-ca0175534bf1.png)


## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

