### PR TITLE
[fix](nereids) fix bug in CaseWhen.getDataType and add some missing case for findTightestCommonType

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/CaseWhen.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/CaseWhen.java
@@ -20,6 +20,7 @@ package org.apache.doris.nereids.trees.expressions;
 import org.apache.doris.nereids.exceptions.UnboundException;
 import org.apache.doris.nereids.trees.expressions.visitor.ExpressionVisitor;
 import org.apache.doris.nereids.types.DataType;
+import org.apache.doris.nereids.util.TypeCoercionUtils;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
@@ -78,7 +79,13 @@ public class CaseWhen extends Expression {
 
     @Override
     public DataType getDataType() {
-        return child(0).getDataType();
+        DataType outputType = child(0).getDataType();
+        for (Expression child : children) {
+            DataType tempType = outputType;
+            outputType = TypeCoercionUtils.findTightestCommonType(null,
+                            outputType, child.getDataType()).orElseGet(() -> tempType);
+        }
+        return outputType;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/util/TypeCoercionUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/util/TypeCoercionUtils.java
@@ -246,7 +246,19 @@ public class TypeCoercionUtils {
             tightestCommonType = DecimalV2Type.widerDecimalV2Type((DecimalV2Type) left, (DecimalV2Type) right);
         } else if (left instanceof FloatType && right instanceof DecimalV2Type
                 || left instanceof DecimalV2Type && right instanceof FloatType) {
-            tightestCommonType = DoubleType.INSTANCE;
+            //TODO: need refactor. let operator upgrade data type.
+            if (binaryOperator != null) {
+                // for arithmetic, like Float + Decimal, upgrade to Double
+                tightestCommonType = DoubleType.INSTANCE;
+            } else {
+                //of other case, like
+                //          case
+                //            when 1=1 then cast(1 as int)
+                //            when 1>1 then cast(1 as float)
+                //            else 0.0 end;
+                //do not upgrade data type, keep Float
+                tightestCommonType = FloatType.INSTANCE;
+            }
         } else if (canCompareDate(left, right)) {
             if (binaryOperator instanceof BinaryArithmetic) {
                 tightestCommonType = IntegerType.INSTANCE;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/util/TypeCoercionUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/util/TypeCoercionUtils.java
@@ -239,6 +239,14 @@ public class TypeCoercionUtils {
             } else if (left instanceof DateV2Type || right instanceof DateV2Type) {
                 tightestCommonType = DateV2Type.INSTANCE;
             }
+        } else if (left instanceof DoubleType && right instanceof DecimalV2Type
+                || left instanceof DecimalV2Type && right instanceof DoubleType) {
+            tightestCommonType = DoubleType.INSTANCE;
+        } else if (left instanceof DecimalV2Type && right instanceof DecimalV2Type) {
+            tightestCommonType = DecimalV2Type.widerDecimalV2Type((DecimalV2Type) left, (DecimalV2Type) right);
+        } else if (left instanceof FloatType && right instanceof DecimalV2Type
+                || left instanceof DecimalV2Type && right instanceof FloatType) {
+            tightestCommonType = FloatType.INSTANCE;
         } else if (canCompareDate(left, right)) {
             if (binaryOperator instanceof BinaryArithmetic) {
                 tightestCommonType = IntegerType.INSTANCE;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/util/TypeCoercionUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/util/TypeCoercionUtils.java
@@ -246,7 +246,7 @@ public class TypeCoercionUtils {
             tightestCommonType = DecimalV2Type.widerDecimalV2Type((DecimalV2Type) left, (DecimalV2Type) right);
         } else if (left instanceof FloatType && right instanceof DecimalV2Type
                 || left instanceof DecimalV2Type && right instanceof FloatType) {
-            tightestCommonType = FloatType.INSTANCE;
+            tightestCommonType = DoubleType.INSTANCE;
         } else if (canCompareDate(left, right)) {
             if (binaryOperator instanceof BinaryArithmetic) {
                 tightestCommonType = IntegerType.INSTANCE;

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/util/TypeCoercionUtilsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/util/TypeCoercionUtilsTest.java
@@ -146,7 +146,7 @@ public class TypeCoercionUtilsTest {
         testFindTightestCommonType(StringType.INSTANCE, StringType.INSTANCE, IntegerType.INSTANCE);
         testFindTightestCommonType(StringType.INSTANCE, IntegerType.INSTANCE, StringType.INSTANCE);
         testFindTightestCommonType(DecimalV2Type.SYSTEM_DEFAULT, DecimalV2Type.SYSTEM_DEFAULT, DecimalV2Type.createDecimalV2Type(2, 1));
-        testFindTightestCommonType(DoubleType.INSTANCE, FloatType.INSTANCE, DecimalV2Type.SYSTEM_DEFAULT);
+        testFindTightestCommonType(FloatType.INSTANCE, FloatType.INSTANCE, DecimalV2Type.SYSTEM_DEFAULT);
         testFindTightestCommonType(VarcharType.createVarcharType(10), CharType.createCharType(8), CharType.createCharType(10));
         testFindTightestCommonType(VarcharType.createVarcharType(10), VarcharType.createVarcharType(8), VarcharType.createVarcharType(10));
         testFindTightestCommonType(VarcharType.createVarcharType(10), VarcharType.createVarcharType(8), CharType.createCharType(10));

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/util/TypeCoercionUtilsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/util/TypeCoercionUtilsTest.java
@@ -146,7 +146,7 @@ public class TypeCoercionUtilsTest {
         testFindTightestCommonType(StringType.INSTANCE, StringType.INSTANCE, IntegerType.INSTANCE);
         testFindTightestCommonType(StringType.INSTANCE, IntegerType.INSTANCE, StringType.INSTANCE);
         testFindTightestCommonType(DecimalV2Type.SYSTEM_DEFAULT, DecimalV2Type.SYSTEM_DEFAULT, DecimalV2Type.createDecimalV2Type(2, 1));
-        testFindTightestCommonType(FloatType.INSTANCE, FloatType.INSTANCE, DecimalV2Type.SYSTEM_DEFAULT);
+        testFindTightestCommonType(DoubleType.INSTANCE, FloatType.INSTANCE, DecimalV2Type.SYSTEM_DEFAULT);
         testFindTightestCommonType(VarcharType.createVarcharType(10), CharType.createCharType(8), CharType.createCharType(10));
         testFindTightestCommonType(VarcharType.createVarcharType(10), VarcharType.createVarcharType(8), VarcharType.createVarcharType(10));
         testFindTightestCommonType(VarcharType.createVarcharType(10), VarcharType.createVarcharType(8), CharType.createCharType(10));

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/util/TypeCoercionUtilsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/util/TypeCoercionUtilsTest.java
@@ -145,7 +145,8 @@ public class TypeCoercionUtilsTest {
         testFindTightestCommonType(BigIntType.INSTANCE, IntegerType.INSTANCE, BigIntType.INSTANCE);
         testFindTightestCommonType(StringType.INSTANCE, StringType.INSTANCE, IntegerType.INSTANCE);
         testFindTightestCommonType(StringType.INSTANCE, IntegerType.INSTANCE, StringType.INSTANCE);
-        testFindTightestCommonType(DoubleType.INSTANCE, DecimalV2Type.SYSTEM_DEFAULT, DecimalV2Type.createDecimalV2Type(2, 1));
+        testFindTightestCommonType(DecimalV2Type.SYSTEM_DEFAULT, DecimalV2Type.SYSTEM_DEFAULT, DecimalV2Type.createDecimalV2Type(2, 1));
+        testFindTightestCommonType(FloatType.INSTANCE, FloatType.INSTANCE, DecimalV2Type.SYSTEM_DEFAULT);
         testFindTightestCommonType(VarcharType.createVarcharType(10), CharType.createCharType(8), CharType.createCharType(10));
         testFindTightestCommonType(VarcharType.createVarcharType(10), VarcharType.createVarcharType(8), VarcharType.createVarcharType(10));
         testFindTightestCommonType(VarcharType.createVarcharType(10), VarcharType.createVarcharType(8), CharType.createCharType(10));

--- a/regression-test/data/nereids_syntax_p0/test_query_between.out
+++ b/regression-test/data/nereids_syntax_p0/test_query_between.out
@@ -34,6 +34,7 @@ false
 -- !between11 --
 
 -- !between12 --
+6.333
 
 -- !between13 --
 123.123

--- a/regression-test/suites/nereids_syntax_p0/explain.groovy
+++ b/regression-test/suites/nereids_syntax_p0/explain.groovy
@@ -53,4 +53,15 @@ suite("nereids_explain") {
         sql("plan with s as (select * from supplier) select * from s as s1, s as s2")
         contains "*LogicalSubQueryAlias"
     }
+
+    explain {
+        sql """
+        verbose 
+        select case 
+            when 1=1 then cast(1 as int) 
+            when 1>1 then cast(1 as float)
+            else 0.0 end;
+            """
+        contains "SlotDescriptor{id=0, col=null, colUniqueId=null, type=FLOAT, nullable=false}"
+    }
 }

--- a/regression-test/suites/nereids_syntax_p0/test_query_between.groovy
+++ b/regression-test/suites/nereids_syntax_p0/test_query_between.groovy
@@ -36,6 +36,6 @@ suite("nereids_test_query_between", "query,p0") {
                 and \"9999-12-31 12:12:12\" order by k1, k2, k3, k4"""
     qt_between11 """select k10 from ${tableName} where k10 between \"2015-04-02\"
                 and \"9999-12-31\" order by k1, k2, k3, k4"""
-    qt_between12 "select k9 from ${tableName} where k9 between -1 and 6.333 order by k1, k2, k3, k4"
-    qt_between13 "select k5 from ${tableName} where k5 between 0 and 1243.5 order by k1, k2, k3, k4"
+    qt_between12 "select k9 from ${tableName} where k9 between -1 and 6.34 order by k1, k2, k3, k4"
+    qt_between13 "select k5 from ${tableName} where k5 between 0 and 1243.6 order by k1, k2, k3, k4"
 }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

