### PR TITLE
[fix](Nereids): move parentExpression in moveOwnership()

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/util/Utils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/util/Utils.java
@@ -219,7 +219,7 @@ public class Utils {
 
     public static <T> void replaceList(List<T> list, T oldItem, T newItem) {
         for (int i = 0; i < list.size(); i++) {
-            if (list.get(i) == oldItem) {
+            if (list.get(i).equals(oldItem)) {
                 list.set(i, newItem);
             }
         }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

original code forgot move `parentExpression`

## Checklist(Required)

1. Does it affect the original behavior: 
    - [x] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

