### PR TITLE
[chore](fe) update fe snapshot to 1.2 and fix auditloader compile error

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -130,7 +130,7 @@ BUILD_BROKER=0
 BUILD_AUDIT=0
 BUILD_META_TOOL='OFF'
 BUILD_SPARK_DPP=0
-BUILD_JAVA_UDF=1
+BUILD_JAVA_UDF=0
 BUILD_HIVE_UDF=0
 CLEAN=0
 HELP=0
@@ -153,10 +153,12 @@ else
             BUILD_FE=1
             BUILD_SPARK_DPP=1
             BUILD_HIVE_UDF=1
+            BUILD_JAVA_UDF=1
             shift
             ;;
         --be)
             BUILD_BE=1
+            BUILD_JAVA_UDF=1
             shift
             ;;
         --broker)

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -243,7 +243,7 @@ under the License.
         <mariadb-java-client.version>3.0.4</mariadb-java-client.version>
         <dlf-metastore-client-hive2.version>0.2.14</dlf-metastore-client-hive2.version>
         <hadoop.version>2.10.2</hadoop.version>
-        <revision>1.0-SNAPSHOT</revision>
+        <revision>1.2-SNAPSHOT</revision>
         <project.scm.id>github</project.scm.id>
     </properties>
     <profiles>

--- a/fe_plugins/pom.xml
+++ b/fe_plugins/pom.xml
@@ -68,7 +68,7 @@ under the License.
     </modules>
     <properties>
         <log4j2.version>2.18.0</log4j2.version>
-        <doris.version>1.0-SNAPSHOT</doris.version>
+        <doris.version>1.2-SNAPSHOT</doris.version>
         <project.scm.id>github</project.scm.id>
     </properties>
     <profiles>
@@ -101,7 +101,11 @@ under the License.
                 </property>
             </activation>
             <repositories>
-                <!-- for java-cup -->
+                <repository>
+                    <id>snapshots</id>
+                    <name>apache snapshots maven repo https</name>
+                    <url>https://repository.apache.org/content/repositories/snapshots/</url>
+                </repository>
                 <repository>
                     <id>cloudera-public</id>
                     <url>https://repository.cloudera.com/artifactory/public/</url>


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

This PR #14925 change some field of AuditEvent, so we need to upgrade the fe-core's SNAPSHOT to 1.2
because auditloader depends on fe-core

Already push the 1.2-SNAPSHOT to
https://repository.apache.org/content/repositories/snapshots/org/apache/doris/fe-core/1.2-SNAPSHOT/

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [x] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

