### PR TITLE
[enhancement](load)  delete skiplist for duplicate table in memtable

### DIFF
--- a/be/src/olap/memtable.cpp
+++ b/be/src/olap/memtable.cpp
@@ -315,7 +315,6 @@ void MemTable::shrink_memtable_by_agg() {
 }
 
 bool MemTable::need_flush() const {
-bool MemTable::need_flush() const {
     return memory_usage() >= config::write_buffer_size;
 }
 

--- a/be/src/olap/memtable.h
+++ b/be/src/olap/memtable.h
@@ -166,7 +166,7 @@ private:
     int64_t _merged_rows = 0;
 
     // for vectorized
-    vectorized::MutableBlock _input_mutable_block; // temp store for aggregate table
+    vectorized::MutableBlock _input_mutable_block;     // temp store for aggregate table
     vectorized::MutableBlock _input_mutable_block_dup; // temp store for duplicate table
     vectorized::MutableBlock _output_mutable_block;
 

--- a/be/src/olap/memtable.h
+++ b/be/src/olap/memtable.h
@@ -165,13 +165,14 @@ private:
     int64_t _rows = 0;
     int64_t _merged_rows = 0;
 
-    //for vectorized
-    vectorized::MutableBlock _input_mutable_block;
+    // for vectorized
+    vectorized::MutableBlock _input_mutable_block; // temp store for aggregate table
+    vectorized::MutableBlock _input_mutable_block_dup; // temp store for duplicate table
     vectorized::MutableBlock _output_mutable_block;
 
     template <bool is_final>
-    void _collect_vskiplist_results();
-    bool _is_first_insertion;
+    void _collect_memtable_results();
+    bool _is_first_insert;
 
     void _init_agg_functions(const vectorized::Block* block);
     std::vector<vectorized::AggregateFunctionPtr> _agg_functions;


### PR DESCRIPTION
# Proposed changes

delete skiplist for dup table when data load.
## Problem summary

when load data, data will be insert into skiplist in memtable, for each row skiplist need to **Find** and **Sort**, which time cost is O(log(n)), I don't think it's a good way.

There are two ways to insert data into memtable:

1. insert into skiplist: **O(log(n))**, when need flush, the data is already sorted
2. insert into a block(append only): **O(1)**, when need flush, sort once.

this pr implement way2 for duplicate table: **append data to a block and sort when need flush.**

I don't know how good or bad it turned out
This pr needs to use the community's testing framework
So I submit first to see the result.

