### PR TITLE
[branch-1.1-lts](unique key) disable concurrent flush memtable for unique key

### DIFF
--- a/be/src/olap/delta_writer.cpp
+++ b/be/src/olap/delta_writer.cpp
@@ -149,8 +149,9 @@ OLAPStatus DeltaWriter::init() {
     _reset_mem_table();
 
     // create flush handler
-    RETURN_NOT_OK(_storage_engine->memtable_flush_executor()->create_flush_token(&_flush_token,
-            writer_context.rowset_type, _req.is_high_priority));
+    bool should_serial = _tablet->keys_type() == KeysType::UNIQUE_KEYS;
+    RETURN_NOT_OK(_storage_engine->memtable_flush_executor()->create_flush_token(
+            &_flush_token, writer_context.rowset_type, should_serial, _req.is_high_priority));
 
     _is_init = true;
     return OLAP_SUCCESS;

--- a/be/src/olap/memtable_flush_executor.h
+++ b/be/src/olap/memtable_flush_executor.h
@@ -101,9 +101,9 @@ public:
     // because it needs path hash of each data dir.
     void init(const std::vector<DataDir*>& data_dirs);
 
-    OLAPStatus create_flush_token(
-            std::unique_ptr<FlushToken>* flush_token,
-            RowsetTypePB rowset_type, bool is_high_priority);
+    OLAPStatus create_flush_token(std::unique_ptr<FlushToken>* flush_token,
+                                  RowsetTypePB rowset_type, bool should_serial,
+                                  bool is_high_priority);
 
 private:
     std::unique_ptr<ThreadPool> _flush_pool;


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

