### PR TITLE
[enhance](planner)add parenthesis `()` for expr automatically if necessary

### DIFF
--- a/fe/fe-core/src/main/cup/sql_parser.cup
+++ b/fe/fe-core/src/main/cup/sql_parser.cup
@@ -6098,7 +6098,6 @@ non_pred_expr ::=
   {: RESULT = e; :}
   | LPAREN non_pred_expr:e RPAREN
   {:
-    e.setPrintSqlInParens(true);
     RESULT = e;
   :}
   /* TODO(zc): add other trim function */
@@ -6367,7 +6366,6 @@ predicate ::=
   {: RESULT = p; :}
   | LPAREN predicate:p RPAREN
   {:
-    p.setPrintSqlInParens(true);
     RESULT = p;
   :}
   ;

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/CompoundPredicate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/CompoundPredicate.java
@@ -85,19 +85,48 @@ public class CompoundPredicate extends Predicate {
     @Override
     public String toSqlImpl() {
         if (children.size() == 1) {
-            Preconditions.checkState(op == Operator.NOT);
-            return "NOT " + getChild(0).toSql();
+            if (getChild(0) instanceof CompoundPredicate) {
+                return "NOT (" + getChild(0).toSql() + ")";
+            } else {
+                return getChild(0).toSql();
+            }
+
         } else {
-            return getChild(0).toSql() + " " + op.toString() + " " + getChild(1).toSql();
+            String left = getChild(0).toSql();
+            String right = getChild(1).toSql();
+            if (op == Operator.AND) {
+                if (CompoundPredicate.isOr(getChild(0))) {
+                    left = "(" + left + ")";
+                }
+                if (CompoundPredicate.isOr(getChild(1))) {
+                    right = "(" + right + ")";
+                }
+            }
+            return left + " " + op.toString() + " " + right;
         }
     }
 
     @Override
     public String toDigestImpl() {
         if (children.size() == 1) {
-            return "NOT " + getChild(0).toDigest();
+            if (getChild(0) instanceof CompoundPredicate) {
+                return "NOT (" + getChild(0).toDigest() + ")";
+            } else {
+                return getChild(0).toDigest();
+            }
+
         } else {
-            return getChild(0).toDigest() + " " + op.toString() + " " + getChild(1).toDigest();
+            String left = getChild(0).toDigest();
+            String right = getChild(1).toDigest();
+            if (op == Operator.AND) {
+                if (CompoundPredicate.isOr(getChild(0))) {
+                    left = "(" + left + ")";
+                }
+                if (CompoundPredicate.isOr(getChild(1))) {
+                    right = "(" + right + ")";
+                }
+            }
+            return left + " " + op.toString() + " " + right;
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/Expr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/Expr.java
@@ -279,10 +279,6 @@ public abstract class Expr extends TreeNode<Expr> implements ParseNode, Cloneabl
     // Cached value of IsConstant(), set during analyze() and valid if isAnalyzed_ is true.
     private boolean isConstant;
 
-    // Flag to indicate whether to wrap this expr's toSql() in parenthesis. Set by parser.
-    // Needed for properly capturing expr precedences in the SQL string.
-    protected boolean printSqlInParens = false;
-
     protected Expr() {
         super();
         type = Type.INVALID;
@@ -304,7 +300,6 @@ public abstract class Expr extends TreeNode<Expr> implements ParseNode, Cloneabl
         outputScale = other.outputScale;
         isConstant = other.isConstant;
         fn = other.fn;
-        printSqlInParens = other.printSqlInParens;
         children = Expr.cloneList(other.children);
     }
 
@@ -384,14 +379,6 @@ public abstract class Expr extends TreeNode<Expr> implements ParseNode, Cloneabl
 
     public Function getFn() {
         return fn;
-    }
-
-    public boolean getPrintSqlInParens() {
-        return printSqlInParens;
-    }
-
-    public void setPrintSqlInParens(boolean b) {
-        printSqlInParens = b;
     }
 
     /**
@@ -909,7 +896,7 @@ public abstract class Expr extends TreeNode<Expr> implements ParseNode, Cloneabl
     }
 
     public String toSql() {
-        return (printSqlInParens) ? "(" + toSqlImpl() + ")" : toSqlImpl();
+        return toSqlImpl();
     }
 
     public void setDisableTableName(boolean value) {
@@ -927,7 +914,7 @@ public abstract class Expr extends TreeNode<Expr> implements ParseNode, Cloneabl
     }
 
     public String toDigest() {
-        return (printSqlInParens) ? "(" + toDigestImpl() + ")" : toDigestImpl();
+        return toDigestImpl();
     }
 
     /**
@@ -1755,7 +1742,6 @@ public abstract class Expr extends TreeNode<Expr> implements ParseNode, Cloneabl
             Expr right = pushNegationToOperands(root.getChild(1));
             CompoundPredicate compoundPredicate =
                     new CompoundPredicate(((CompoundPredicate) root).getOp(), left, right);
-            compoundPredicate.setPrintSqlInParens(root.getPrintSqlInParens());
             return compoundPredicate;
         }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/rewrite/ExtractCommonFactorsRule.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/rewrite/ExtractCommonFactorsRule.java
@@ -200,7 +200,6 @@ public class ExtractCommonFactorsRule implements ExprRewriteRule {
             result = new CompoundPredicate(CompoundPredicate.Operator.AND,
                     makeCompound(commonFactorList, CompoundPredicate.Operator.AND),
                     makeCompoundRemaining(remainingOrClause, CompoundPredicate.Operator.OR, analyzer, clauseType));
-            result.setPrintSqlInParens(true);
         } else {
             result = makeCompoundRemaining(remainingOrClause, CompoundPredicate.Operator.OR, analyzer, clauseType);
         }
@@ -436,7 +435,6 @@ public class ExtractCommonFactorsRule implements ExprRewriteRule {
         for (int i = 2; i < exprs.size(); ++i) {
             result = new CompoundPredicate(op, result.clone(), exprs.get(i));
         }
-        result.setPrintSqlInParens(true);
         return result;
     }
 
@@ -464,7 +462,6 @@ public class ExtractCommonFactorsRule implements ExprRewriteRule {
         for (int i = 2; i < exprs.size(); i++) {
             result = new CompoundPredicate(op, result.clone(), exprs.get(i));
         }
-        result.setPrintSqlInParens(true);
         return result;
     }
 
@@ -504,16 +501,10 @@ public class ExtractCommonFactorsRule implements ExprRewriteRule {
                 Expr left = and.getChild(0);
                 if (left instanceof CompoundPredicate) {
                     left = apply(and.getChild(0), analyzer, clauseType);
-                    if (CompoundPredicate.isOr(left)) {
-                        left.setPrintSqlInParens(true);
-                    }
                 }
                 Expr right = and.getChild(1);
                 if (right instanceof CompoundPredicate) {
                     right = apply(and.getChild(1), analyzer, clauseType);
-                    if (CompoundPredicate.isOr(right)) {
-                        right.setPrintSqlInParens(true);
-                    }
                 }
                 notMergedExprs.add(new CompoundPredicate(Operator.AND, left, right));
             } else if (!(predicate instanceof BinaryPredicate) && !(predicate instanceof InPredicate)) {

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/SelectStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/SelectStmtTest.java
@@ -330,16 +330,18 @@ public class SelectStmtTest {
         SelectStmt stmt2 = (SelectStmt) UtFrameUtils.parseAndAnalyzeStmt(sql2, ctx);
         stmt2.rewriteExprs(new Analyzer(ctx.getEnv(), ctx).getExprRewriter());
         String fragment3 =
-                "(((`t1`.`k4` >= 50 AND `t1`.`k4` <= 300) AND `t2`.`k2` IN ('United States', 'United States1') "
-                        + "AND `t2`.`k3` IN ('CO', 'IL', 'MN', 'OH', 'MT', 'NM', 'TX', 'MO', 'MI')) "
-                        + "AND `t1`.`k1` = `t2`.`k3` AND `t2`.`k2` = 'United States' "
-                        + "AND `t2`.`k3` IN ('CO', 'IL', 'MN') AND `t1`.`k4` >= 100 AND `t1`.`k4` <= 200 "
+                "WHERE `t1`.`k4` >= 50 AND `t1`.`k4` <= 300 AND `t2`.`k2` IN ('United States', 'United States1') "
+                        + "AND `t2`.`k3` IN ('CO', 'IL', 'MN', 'OH', 'MT', 'NM', 'TX', 'MO', 'MI') "
+                        + "AND (`t1`.`k1` = `t2`.`k3` "
+                        + "AND `t2`.`k2` = 'United States' AND `t2`.`k3` IN ('CO', 'IL', 'MN') "
+                        + "AND `t1`.`k4` >= 100 AND `t1`.`k4` <= 200 "
                         + "OR "
-                        + "`t1`.`k1` = `t2`.`k1` AND `t2`.`k2` = 'United States1' "
-                        + "AND `t2`.`k3` IN ('OH', 'MT', 'NM') AND `t1`.`k4` >= 150 AND `t1`.`k4` <= 300 "
+                        + "`t1`.`k1` = `t2`.`k1` "
+                        + "AND `t2`.`k2` = 'United States1' AND `t2`.`k3` IN ('OH', 'MT', 'NM') "
+                        + "AND `t1`.`k4` >= 150 AND `t1`.`k4` <= 300 "
                         + "OR "
-                        + "`t1`.`k1` = `t2`.`k1` AND `t2`.`k2` = 'United States' "
-                        + "AND `t2`.`k3` IN ('TX', 'MO', 'MI') "
+                        + "`t1`.`k1` = `t2`.`k1` "
+                        + "AND `t2`.`k2` = 'United States' AND `t2`.`k3` IN ('TX', 'MO', 'MI') "
                         + "AND `t1`.`k4` >= 50 AND `t1`.`k4` <= 250)";
         Assert.assertTrue(stmt2.toSql().contains(fragment3));
 

--- a/fe/fe-core/src/test/java/org/apache/doris/planner/QueryPlanTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/planner/QueryPlanTest.java
@@ -1031,17 +1031,17 @@ public class QueryPlanTest extends TestWithFeService {
 
     @Test
     public void testOrCompoundPredicateFold() throws Exception {
-        String queryStr = "explain select * from baseall where (k1 > 1) or (k1 > 1 and k2 < 1)";
+        String queryStr = "explain select * from baseall where k1 > 1 or k1 > 1 and k2 < 1";
         String explainString = getSQLPlanOrErrorMsg(queryStr);
-        Assert.assertTrue(explainString.contains("PREDICATES: (`k1` > 1)\n"));
+        Assert.assertTrue(explainString.contains("PREDICATES: `k1` > 1\n"));
 
-        queryStr = "explain select * from  baseall where (k1 > 1 and k2 < 1) or  (k1 > 1)";
+        queryStr = "explain select * from  baseall where (k1 > 1 and k2 < 1) or (k1 > 1)";
         explainString = getSQLPlanOrErrorMsg(queryStr);
         Assert.assertTrue(explainString.contains("PREDICATES: `k1` > 1\n"));
 
         queryStr = "explain select * from  baseall where (k1 > 1) or (k1 > 1)";
         explainString = getSQLPlanOrErrorMsg(queryStr);
-        Assert.assertTrue(explainString.contains("PREDICATES: (`k1` > 1)\n"));
+        Assert.assertTrue(explainString.contains("PREDICATES: `k1` > 1\n"));
     }
 
     @Test
@@ -2263,7 +2263,7 @@ public class QueryPlanTest extends TestWithFeService {
         Assert.assertTrue(explainString.contains(
                 "PREDICATES: `query_id` = `client_ip` "
                         + "AND (`stmt_id` IN (1, 2, 3) OR `user` = 'abc' AND `state` IN ('a', 'b', 'c', 'd')) "
-                        + "OR (`db` NOT IN ('x', 'y'))\n"));
+                        + "OR `db` NOT IN ('x', 'y')\n"));
 
         //ExtractCommonFactorsRule may generate more expr, test the rewriteOrToIn applied on generated exprs
         sql = "select * from test1 where (stmt_id=1 and state='a') or (stmt_id=2 and state='b')";

--- a/fe/fe-core/src/test/java/org/apache/doris/planner/RepeatNodeTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/planner/RepeatNodeTest.java
@@ -67,9 +67,9 @@ public class RepeatNodeTest extends TestWithFeService {
         String sql2 = "select (id + 1) id_, name, sum(cost) from mycost group by grouping sets((id_, name),());";
         String explainString2 = getSQLPlanOrErrorMsg("explain " + sql2);
         System.out.println(explainString2);
-        Assertions.assertTrue(explainString2.contains("exprs: (`id` + 1), `name`, `cost`"));
+        Assertions.assertTrue(explainString2.contains("exprs: `id` + 1, `name`, `cost`"));
         Assertions.assertTrue(
-                explainString2.contains(" output slots: `(`id` + 1)`, ``name``, ``cost``, ``GROUPING_ID``"));
+                explainString2.contains(" output slots: ``id` + 1`, ``name``, ``cost``, ``GROUPING_ID``"));
 
         String sql3 = "select 1 as id_, name, sum(cost) from mycost group by grouping sets((id_, name),());";
         String explainString3 = getSQLPlanOrErrorMsg("explain " + sql3);


### PR DESCRIPTION
# Proposed changes
in order to print parenthesis in Expr, coder have to call `expr.setPrintSqlInParens(true);`
This is error-prone. if user forget to call it, the print of Expr is wrong. 
For example, `a and (b or c)`  =>  `a and b or c`

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

