### PR TITLE
[fix](planner) move join reorder to the single node planner

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/SelectStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/SelectStmt.java
@@ -595,10 +595,6 @@ public class SelectStmt extends QueryStmt {
         if (needToSql) {
             sqlString = toSql();
         }
-        if (analyzer.enableStarJoinReorder()) {
-            LOG.debug("use old reorder logical in select stmt");
-            reorderTable(analyzer);
-        }
 
         resolveInlineViewRefs(analyzer);
 
@@ -790,7 +786,7 @@ public class SelectStmt extends QueryStmt {
         }
     }
 
-    protected void reorderTable(Analyzer analyzer) throws AnalysisException {
+    public void reorderTable(Analyzer analyzer) throws AnalysisException {
         List<Pair<TableRef, Long>> candidates = Lists.newArrayList();
         ArrayList<TableRef> originOrderBackUp = Lists.newArrayList(fromClause.getTableRefs());
         // New pair of table ref and row count

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/SingleNodePlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/SingleNodePlanner.java
@@ -1116,6 +1116,11 @@ public class SingleNodePlanner {
             return createConstantSelectPlan(selectStmt, analyzer);
         }
 
+        if (analyzer.enableStarJoinReorder()) {
+            LOG.debug("use old reorder logical in select stmt");
+            selectStmt.reorderTable(analyzer);
+        }
+
         // Slot materialization:
         // We need to mark all slots as materialized that are needed during the execution
         // of selectStmt, and we need to do that prior to creating plans for the TableRefs

--- a/fe/fe-core/src/test/java/org/apache/doris/statistics/AnalysisTaskExecutorTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/statistics/AnalysisTaskExecutorTest.java
@@ -67,23 +67,17 @@ public class AnalysisTaskExecutorTest extends TestWithFeService {
                 .build();
         OlapAnalysisTask analysisJob = new OlapAnalysisTask(analysisTaskScheduler, analysisJobInfo);
 
-        new Expectations() {
-            {
-                analysisTaskScheduler.getPendingTasks();
-                result = analysisJob;
+        new MockUp<AnalysisTaskScheduler>() {
+            public synchronized BaseAnalysisTask getPendingTasks() {
+                return analysisJob;
             }
         };
+
         AnalysisTaskExecutor analysisTaskExecutor = new AnalysisTaskExecutor(analysisTaskScheduler);
         BlockingQueue<AnalysisTaskWrapper> b = Deencapsulation.getField(analysisTaskExecutor, "jobQueue");
         AnalysisTaskWrapper analysisTaskWrapper = new AnalysisTaskWrapper(analysisTaskExecutor, analysisJob);
         Deencapsulation.setField(analysisTaskWrapper, "startTime", 5);
         b.put(analysisTaskWrapper);
-        new Expectations() {
-            {
-                analysisTaskWrapper.cancel();
-                times = 1;
-            }
-        };
         analysisTaskExecutor.start();
         BlockingCounter counter = Deencapsulation.getField(analysisTaskExecutor, "blockingCounter");
         int sleepTime = 500;


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

Reorder in analyze phase would produce a stmt which its corresponding SQL could not be analyzed correctly and cause an analyze exception that may be happened in the stmt rewrite, since the rewriter will reset and reanalyze the rewritten stmt.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

