### PR TITLE
[fix](olap) dictionary cannot be sorted after inserting some null values

### DIFF
--- a/be/src/vec/columns/column_dictionary.h
+++ b/be/src/vec/columns/column_dictionary.h
@@ -240,6 +240,12 @@ public:
     }
 
     void convert_dict_codes_if_necessary() override {
+        // Avoid setting `_dict_sorted` to true when `_dict` is empty.
+        // Because `_dict` maybe keep empty after inserting some null rows.
+        if (_dict.empty()) {
+            return;
+        }
+
         if (!is_dict_sorted()) {
             _dict.sort();
             _dict_sorted = true;

--- a/regression-test/suites/query_p0/test_dict_with_null.groovy
+++ b/regression-test/suites/query_p0/test_dict_with_null.groovy
@@ -1,0 +1,46 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("dict_with_null", "query") {
+    def tableName = "test_dict_with_null"
+    sql "DROP TABLE IF EXISTS ${tableName}"
+    sql """
+        CREATE TABLE IF NOT EXISTS ${tableName} (
+          c_int INT,
+          c_string VARCHAR(10)
+        )
+        DISTRIBUTED BY HASH(c_int) BUCKETS 1
+        PROPERTIES (
+          "replication_num" = "1"
+        )
+    """
+
+    // Here insert all rows in one statement to make sure they are in one same segment.
+    // Insert 100 + 1 rows because `SegmentIterator` will read 100 rows in the first time.
+    // The first 100 rows are all null to make no record be inserted into dictionary at the first read time.
+    def insert_sql = "insert into ${tableName} values "
+    for (int i in 1..100) {
+        if (i != 1) {
+            insert_sql += ", "
+        }
+        insert_sql += "(${i}, null)"
+    }
+    insert_sql += ", (101, 'abc')"
+
+    sql insert_sql
+    sql "select * from test_dict_with_null where c_string > '0'"
+}


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

coredump:
```bash
#0  0x000055cf7bf6a1b8 in doris::vectorized::ColumnDictionary<int>::Dictionary::convert_code (code=@0x7f92ea19e098: 0, this=0x7f92ea117220) at /root/doris-1.2.1-rc01/be/src/vec/columns/column_dictionary.h:442
#1  doris::vectorized::ColumnDictionary<int>::convert_dict_codes_if_necessary (this=<optimized out>) at /root/doris-1.2.1-rc01/be/src/vec/columns/column_dictionary.h:250
#2  doris::vectorized::ColumnDictionary<int>::convert_dict_codes_if_necessary (this=0x7f92ea117200) at /root/doris-1.2.1-rc01/be/src/vec/columns/column_dictionary.h:242
#3  0x000055cf7c433a20 in doris::segment_v2::SegmentIterator::_convert_dict_code_for_predicate_if_necessary (this=this@entry=0x7f92ea11fc00) at /root/doris-1.2.1-rc01/be/src/olap/rowset/segment_v2/segment_iterator.cpp:1249
#4  0x000055cf7c43edca in doris::segment_v2::SegmentIterator::next_batch (this=0x7f92ea11fc00, block=<optimized out>) at /root/doris-1.2.1-rc01/be/src/olap/rowset/segment_v2/segment_iterator.cpp:1164
#5  0x000055cf7c7271da in doris::BetaRowsetReader::next_block (this=0x7f9178a83c00, block=0x7f91780da800) at /root/doris-1.2.1-rc01/be/src/olap/rowset/beta_rowset_reader.cpp:277
#6  0x000055cf8004af81 in doris::vectorized::VCollectIterator::Level0Iterator::next (this=0x7f92ea1001c0, block=0x7f91780da800) at /root/doris-1.2.1-rc01/be/src/vec/olap/vcollect_iterator.cpp:267
#7  0x000055cf8004a749 in doris::vectorized::VCollectIterator::Level1Iterator::_normal_next (this=0x7f92ea100260, block=0x7f91780da800) at /root/doris-1.2.1-rc01/be/src/vec/olap/vcollect_iterator.cpp:533
#8  0x000055cf8004ca6e in doris::vectorized::VCollectIterator::Level1Iterator::next (this=<optimized out>, block=<optimized out>) at /root/doris-1.2.1-rc01/be/src/vec/olap/vcollect_iterator.cpp:359
#9  0x000055cf80049d5a in doris::vectorized::VCollectIterator::next (this=this@entry=0x7f9178a7f1b8, block=<optimized out>) at /root/doris-1.2.1-rc01/be/src/vec/olap/vcollect_iterator.cpp:187
#10 0x000055cf80041395 in doris::vectorized::BlockReader::_direct_next_block (this=0x7f9178a7ee00, block=<optimized out>, mem_pool=<optimized out>, agg_pool=<optimized out>, eof=0x7f92f5ff65b6) at /root/doris-1.2.1-rc01/be/src/vec/olap/block_reader.cpp:167
#11 0x000055cf80047279 in doris::vectorized::BlockReader::next_block_with_aggregation (this=<optimized out>, block=<optimized out>, mem_pool=<optimized out>, agg_pool=<optimized out>, eof=<optimized out>) at /root/doris-1.2.1-rc01/be/src/vec/olap/block_reader.h:45
#12 0x000055cf8024302d in doris::vectorized::NewOlapScanner::_get_block_impl (this=0x7f9178a74c00, state=<optimized out>, block=0x7f91780da800, eof=0x7f92f5ff65b6) at /var/local/ldb-toolchain/include/c++/11/bits/unique_ptr.h:173
#13 0x000055cf80224f13 in doris::vectorized::VScanner::get_block (this=this@entry=0x7f9178a74c00, state=state@entry=0x7f93393fe300, block=block@entry=0x7f91780da800, eof=eof@entry=0x7f92f5ff65b6) at /root/doris-1.2.1-rc01/be/src/vec/exec/scan/vscanner.cpp:53
#14 0x000055cf8022239f in doris::vectorized::ScannerScheduler::_scanner_scan (this=<optimized out>, scheduler=<optimized out>, ctx=0x7f9178bb6800, scanner=0x7f9178a74c00) at /root/doris-1.2.1-rc01/be/src/vec/exec/scan/scanner_scheduler.cpp:234
#15 0x000055cf7ca75805 in std::function<void ()>::operator()() const (this=<optimized out>) at /var/local/ldb-toolchain/include/c++/11/bits/std_function.h:560
#16 doris::FunctionRunnable::run (this=<optimized out>) at /root/doris-1.2.1-rc01/be/src/util/threadpool.cpp:45
#17 doris::ThreadPool::dispatch_thread (this=0x7f9338457400) at /root/doris-1.2.1-rc01/be/src/util/threadpool.cpp:534
#18 0x000055cf7ca6bbef in std::function<void ()>::operator()() const (this=0x7f9337edd478) at /var/local/ldb-toolchain/include/c++/11/bits/std_function.h:560
#19 doris::Thread::supervise_thread (arg=0x7f9337edd460) at /root/doris-1.2.1-rc01/be/src/util/thread.cpp:454
#20 0x00007f93543d6ea5 in __pthread_mutex_unlock_full () from /lib64/libpthread.so.0
#21 0x0000000000000000 in ?? ()
```

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

