### PR TITLE
[testcase](index)change wait timeout from 1m to 2m in index_meta testcase

### DIFF
--- a/regression-test/suites/index_p0/test_index_meta.groovy
+++ b/regression-test/suites/index_p0/test_index_meta.groovy
@@ -20,21 +20,20 @@ import org.codehaus.groovy.runtime.IOGroovyMethods
 
 suite("index_meta", "p0") {
     // prepare test table
-    def timeout = 60000
+    def timeout = 120000
     def delta_time = 1000
     def alter_res = "null"
     def useTime = 0
     def wait_for_latest_op_on_table_finish = { table_name, OpTimeout ->
-        for(int t = delta_time; t <= OpTimeout; t += delta_time){
+        for(useTime = 0; useTime <= OpTimeout; useTime += delta_time){
             alter_res = sql """SHOW ALTER TABLE COLUMN WHERE TableName = "${table_name}" ORDER BY CreateTime DESC LIMIT 1;"""
             alter_res = alter_res.toString()
             if(alter_res.contains("FINISHED")) {
                  break
             }
-            useTime = t
             sleep(delta_time)
         }
-        assertTrue(useTime <= OpTimeout)
+        assertTrue(useTime <= OpTimeout, "wait_for_latest_op_on_table_finish timeout")
     }
 
     def tableName = "test_index_meta"


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

Sometimes, index_meta test case will fail because 1 minute timeout is reached for add index op when the test hosts are busy. Change wait timeout from 1m to 2m to reduce failure chance.

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [x] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

