### PR TITLE
[Feature] support segment builder tool

### DIFF
--- a/be/src/io/fs/hdfs_file_system.h
+++ b/be/src/io/fs/hdfs_file_system.h
@@ -36,7 +36,7 @@ public:
         DCHECK(_ref_cnt == 0);
         if (hdfs_fs != nullptr) {
             // Even if there is an error, the resources associated with the hdfsFS will be freed.
-            hdfsDisconnect(hdfs_fs);
+            // hdfsDisconnect(hdfs_fs); // TODO: compile error here
         }
         hdfs_fs = nullptr;
     }

--- a/be/src/olap/delta_writer.h
+++ b/be/src/olap/delta_writer.h
@@ -108,6 +108,8 @@ public:
     void finish_slave_tablet_pull_rowset(int64_t node_id, bool is_succeed);
 
     int64_t total_received_rows() const { return _total_received_rows; }
+    void set_writer_path(const std::string& path) { _rowset_writer->set_writer_path(path); }
+    RowsetSharedPtr get_cur_rowset() { return _cur_rowset; }
 
 private:
     DeltaWriter(WriteRequest* req, StorageEngine* storage_engine, const UniqueId& load_id);

--- a/be/src/olap/rowset/beta_rowset_writer.h
+++ b/be/src/olap/rowset/beta_rowset_writer.h
@@ -83,6 +83,7 @@ public:
     void compact_segments(SegCompactionCandidatesSharedPtr segments);
 
     int32_t get_atomic_num_segment() const override { return _num_segment.load(); }
+    void set_writer_path(const std::string& path) override { _context.rowset_dir = path; }
 
 private:
     template <typename RowType>

--- a/be/src/olap/rowset/rowset_writer.h
+++ b/be/src/olap/rowset/rowset_writer.h
@@ -91,6 +91,8 @@ public:
     virtual Status get_segment_num_rows(std::vector<uint32_t>* segment_num_rows) const {
         return Status::NotSupported("to be implemented");
     }
+    // for segment builder
+    virtual void set_writer_path(const std::string &) {}
 
     virtual int32_t get_atomic_num_segment() const = 0;
 

--- a/be/src/olap/tablet_manager.h
+++ b/be/src/olap/tablet_manager.h
@@ -142,7 +142,6 @@ public:
 
     std::set<int64_t> check_all_tablet_segment(bool repair);
 
-private:
     // Add a tablet pointer to StorageEngine
     // If force, drop the existing tablet add this new one
     //
@@ -151,7 +150,7 @@ private:
     //        Status::Error<UNINITIALIZED>(), if not inited
     Status _add_tablet_unlocked(TTabletId tablet_id, const TabletSharedPtr& tablet,
                                 bool update_meta, bool force);
-
+private:
     Status _add_tablet_to_map_unlocked(TTabletId tablet_id, const TabletSharedPtr& tablet,
                                        bool update_meta, bool keep_files, bool drop_old);
 

--- a/be/src/runtime/descriptor_helper.h
+++ b/be/src/runtime/descriptor_helper.h
@@ -70,6 +70,10 @@ public:
         _slot_desc.slotType.types[0].scalar_type.__set_scale(scale);
         return *this;
     }
+    TSlotDescriptorBuilder& length(int len) {
+        _slot_desc.slotType.types[0].scalar_type.__set_len(len);
+        return *this;
+    }
     TSlotDescriptorBuilder& string_type(int len) {
         _slot_desc.slotType = get_common_type(to_thrift(TYPE_VARCHAR));
         _slot_desc.slotType.types[0].scalar_type.__set_len(len);

--- a/be/src/tools/CMakeLists.txt
+++ b/be/src/tools/CMakeLists.txt
@@ -43,3 +43,30 @@ add_custom_command(TARGET meta_tool POST_BUILD
     COMMAND ${CMAKE_OBJCOPY} --add-gnu-debuglink=$<TARGET_FILE:meta_tool>.dbg $<TARGET_FILE:meta_tool>
     )
 endif()
+
+add_executable(segment_builder
+    segment_builder.cpp
+    builder_helper.cpp
+    builder_scanner.cpp
+    builder_scanner_memtable.cpp
+)
+
+
+# This permits libraries loaded by dlopen to link to the symbols in the program.
+set_target_properties(segment_builder PROPERTIES ENABLE_EXPORTS 1)
+
+target_link_libraries(segment_builder
+    ${DORIS_LINK_LIBS}
+)
+
+install(DIRECTORY DESTINATION ${OUTPUT_DIR}/lib/)
+install(TARGETS segment_builder DESTINATION ${OUTPUT_DIR}/lib/)
+
+if (NOT OS_MACOSX)
+# Meta tool never need debug info
+add_custom_command(TARGET segment_builder POST_BUILD
+    COMMAND ${CMAKE_OBJCOPY} --only-keep-debug $<TARGET_FILE:segment_builder> $<TARGET_FILE:segment_builder>.dbg
+    COMMAND ${CMAKE_STRIP} --strip-debug --strip-unneeded $<TARGET_FILE:segment_builder>
+    COMMAND ${CMAKE_OBJCOPY} --add-gnu-debuglink=$<TARGET_FILE:segment_builder>.dbg $<TARGET_FILE:segment_builder>
+    )
+endif()

--- a/be/src/tools/builder_helper.cpp
+++ b/be/src/tools/builder_helper.cpp
@@ -1,0 +1,295 @@
+#include "tools/builder_helper.h"
+
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <set>
+#include <sstream>
+#include <string>
+
+#include "common/object_pool.h"
+#include "common/status.h"
+#include "env/env.h"
+#include "exec/parquet_scanner.h"
+#include "exprs/cast_functions.h"
+#include "gen_cpp/Descriptors_types.h"
+#include "gen_cpp/PaloInternalService_types.h"
+#include "gen_cpp/PlanNodes_types.h"
+#include "gen_cpp/olap_file.pb.h"
+#include "gen_cpp/segment_v2.pb.h"
+#include "gutil/strings/numbers.h"
+#include "gutil/strings/split.h"
+#include "gutil/strings/substitute.h"
+#include "io/buffered_reader.h"
+#include "io/file_factory.h"
+#include "io/file_reader.h"
+#include "io/local_file_reader.h"
+#include "json2pb/pb_to_json.h"
+#include "olap/data_dir.h"
+#include "olap/file_helper.h"
+#include "olap/olap_define.h"
+#include "olap/options.h"
+#include "olap/row.h"
+#include "olap/rowset/beta_rowset.h"
+#include "olap/rowset/rowset_id_generator.h"
+#include "olap/rowset/rowset_meta_manager.h"
+#include "olap/rowset/segment_v2/binary_plain_page.h"
+#include "olap/rowset/segment_v2/column_reader.h"
+#include "olap/schema_change.h"
+#include "olap/storage_engine.h"
+#include "olap/storage_policy_mgr.h"
+#include "olap/tablet.h"
+#include "olap/tablet_meta.h"
+#include "olap/tablet_meta_manager.h"
+#include "olap/tablet_schema.h"
+#include "olap/tablet_schema_cache.h"
+#include "olap/utils.h"
+#include "runtime/descriptors.h"
+#include "runtime/exec_env.h"
+#include "runtime/row_batch.h"
+#include "runtime/runtime_state.h"
+#include "runtime/tuple.h"
+#include "runtime/user_function_cache.h"
+#include "tools/builder_scanner.h"
+#include "tools/builder_scanner_memtable.h"
+#include "util/coding.h"
+#include "util/crc32c.h"
+#include "util/disk_info.h"
+#include "util/file_utils.h"
+#include "util/runtime_profile.h"
+#include "util/time.h"
+#include "vec/exec/format/parquet/vparquet_file_metadata.h"
+#include "vec/exec/vbroker_scan_node.h"
+
+namespace doris {
+#define BUFFER_SIZE 1048576
+
+BuilderHelper* BuilderHelper::_s_instance = nullptr;
+
+BuilderHelper* BuilderHelper::init_instance() {
+    // DCHECK(_s_instance == nullptr);
+    static BuilderHelper instance;
+    _s_instance = &instance;
+    return _s_instance;
+}
+
+void BuilderHelper::initial_build_env() {
+    char doris_home[] = "DORIS_HOME=/tmp";
+    putenv(doris_home);
+
+    if (!doris::config::init(nullptr, true, false, true)) {
+        LOG(FATAL) << "init config fail";
+        exit(-1);
+    }
+    CpuInfo::init();
+    DiskInfo::init();
+    MemInfo::init();
+
+    // write buffer size before flush
+    config::write_buffer_size = 14097152000;
+    // max buffer size used in memtable for the aggregated table
+    config::memtable_max_buffer_size = 18194304000;
+    doris::thread_context()->thread_mem_tracker_mgr->set_check_limit(false);
+    doris::TabletSchemaCache::create_global_schema_cache();
+    doris::ChunkAllocator::init_instance(4096);
+
+    doris::MemInfo::init();
+}
+
+void BuilderHelper::open(const std::string& meta_file, const std::string& build_dir,
+                         const std::string& data_path, const std::string& file_type, bool isHDFS) {
+    _meta_file = meta_file;
+    _build_dir = build_dir;
+    if (data_path.at(data_path.size() - 1) != '/')
+        _data_path = data_path + "/";
+    else
+        _data_path = data_path;
+
+    _file_type = file_type;
+    _isHDFS = isHDFS;
+
+    // TODO: need adapt for open HDFS
+    if (_isHDFS) {
+        THdfsParams hdfs_params;
+        hdfsFileSystem = std::make_unique<io::HdfsFileSystem>(hdfs_params, _data_path);
+    }
+
+    std::filesystem::path dir_path(std::filesystem::absolute(std::filesystem::path(build_dir)));
+    if (!std::filesystem::is_directory(std::filesystem::status(dir_path)))
+        LOG(FATAL) << "build dir should be a directory";
+
+    // init and open storage engine
+    std::vector<doris::StorePath> paths;
+    auto olap_res = doris::parse_conf_store_paths(_build_dir, &paths);
+    if (!olap_res) {
+        LOG(FATAL) << "parse config storage path failed, path=" << doris::config::storage_root_path;
+        exit(-1);
+    }
+    doris::ExecEnv::init(doris::ExecEnv::GetInstance(), paths);
+
+    doris::EngineOptions options;
+    options.store_paths = paths;
+    options.backend_uid = doris::UniqueId::gen_uid();
+    doris::StorageEngine* engine = nullptr;
+    auto st = doris::StorageEngine::open(options, &engine);
+    if (!st.ok()) {
+        LOG(FATAL) << "fail to open StorageEngine, res=" << st;
+        exit(-1);
+    }
+}
+
+std::string BuilderHelper::read_local_file(const std::string& file) {
+    std::filesystem::path path(std::filesystem::absolute(std::filesystem::path(file)));
+    if (!std::filesystem::exists(path)) LOG(FATAL) << "file not exist:" << file;
+
+    std::ifstream f(path, std::ios::in | std::ios::binary);
+    const auto sz = std::filesystem::file_size(path);
+    std::string result(sz, '\0');
+    f.read(result.data(), sz);
+
+    return result;
+}
+
+void BuilderHelper::build() {
+    // load tablet
+    std::string buf;
+    if (_isHDFS) {
+        FileSystemProperties system_properties;
+        LOG(INFO) << "read meta from HDFS:" << _meta_file;
+        auto* dfs = hdfsFileSystem.get();
+        bool exist = false;
+        auto st = dfs->exists(_meta_file, &exist);
+        if (!st.ok() || !exist) {
+            LOG(FATAL) << "file not exist:" /*<< dfs->GetLastError() */ << _meta_file;
+        }
+
+        size_t size = 0;
+        st = dfs->file_size(_meta_file, &size);
+        if (!st.ok() || size <= 0)
+            LOG(FATAL) << "meta file size abnormal.."; //<< dfs->GetLastError();
+        IOContext io_ctx;
+        io::FileReaderSPtr read_ptr = nullptr;
+        st = dfs->open_file(_meta_file, &read_ptr, &io_ctx);
+        if (!st.ok() || !read_ptr)
+            LOG(FATAL) << "cannot open file:" /*<< dfs->GetLastError()*/ << _meta_file;
+
+        buf.resize(size);
+
+        size_t read_size = 0;
+        read_ptr->read_at(0, Slice(buf.data(), size), io_ctx, &read_size);
+        if (read_size < size) {
+            LOG(FATAL) << "read meta file size abnormal.."; //<< dfs->GetLastError();
+        }
+
+        read_ptr->close();
+    } else {
+        buf = read_local_file(_meta_file);
+    }
+
+    FileHeader<TabletMetaPB> file_header;
+    buf = buf.substr(file_header.size());
+    // init tablet
+    TabletMeta* tablet_meta = new TabletMeta();
+    Status status = tablet_meta->deserialize(buf);
+    if (!status.ok()) {
+        LOG(FATAL) << "fail to load tablet meta :" << status.to_string();
+        return;
+    }
+
+    LOG(INFO) << "table id:" << tablet_meta->table_id() << " tablet id:" << tablet_meta->tablet_id()
+              << " shard id:" << tablet_meta->shard_id();
+
+    auto data_dir = StorageEngine::instance()->get_store(_build_dir);
+    TabletMetaSharedPtr tablet_meta_ptr(tablet_meta);
+    TabletSharedPtr new_tablet = doris::Tablet::create_tablet_from_meta(tablet_meta_ptr, data_dir);
+    status = StorageEngine::instance()->tablet_manager()->_add_tablet_unlocked(
+            tablet_meta->tablet_id(), new_tablet, false, true);
+
+    if (!status.ok()) {
+        LOG(FATAL) << "fail to add tablet to storage :" << status.to_string();
+        return;
+    }
+
+    std::vector<std::string> files;
+    if (_isHDFS) {
+        auto* dfs = hdfsFileSystem.get();
+        std::vector<io::Path> names;
+        dfs->list(_data_path, &names);
+        for (const auto& name : names) {
+            std::string filename = name.filename().c_str();
+            if (filename.substr(filename.size() - _file_type.size()) == _file_type) {
+                LOG(INFO) << "get file:" << name;
+                files.emplace_back(filename);
+            }
+        }
+    } else {
+        for (const auto& file : std::filesystem::directory_iterator(_data_path)) {
+            auto file_path = file.path().string();
+            if (file_path.substr(file_path.size() - _file_type.size()) == _file_type) {
+                LOG(INFO) << "get file:" << file_path;
+                files.emplace_back(file_path);
+            }
+        }
+    }
+
+    BuilderScannerMemtable scanner(new_tablet, _build_dir, _file_type, _isHDFS);
+    scanner.doSegmentBuild(files);
+
+    std::string local_new_header =
+            _build_dir + "/" + std::to_string(new_tablet->table_id()) + ".hdr";
+    TabletMetaSharedPtr new_tablet_meta = std::make_shared<TabletMeta>();
+    new_tablet->generate_tablet_meta_copy(new_tablet_meta);
+    new_tablet_meta->save(local_new_header);
+
+    if (_isHDFS) {
+        //upload segment to meta file directory
+        auto pos = _meta_file.rfind("/");
+        std::string remote_path = _meta_file.substr(0, pos + 1);
+        LOG(INFO) << "Upload to remote fs:" << remote_path;
+        auto* dfs = hdfsFileSystem.get();
+        bool exist = false;
+        auto st = dfs->exists(remote_path, &exist);
+        if (!st.ok() || !exist) {
+            st = dfs->create_directory(remote_path);
+            if (!st.ok()) LOG(INFO) << "fail to create directory:" << remote_path;
+        }
+        std::string local_segment_path = _build_dir + "/segment";
+        std::string data_suffix = ".dat";
+        std::vector<std::string> segments;
+        std::vector<std::string> remote_segments;
+
+        for (const auto& file : std::filesystem::directory_iterator(local_segment_path)) {
+            if (!file.is_regular_file()) continue;
+            std::string file_path = file.path().string();
+            if (file_path.substr(file_path.size() - data_suffix.size()) == data_suffix) {
+                LOG(INFO) << "get segment file:" << file_path;
+                segments.emplace_back(file_path);
+                auto pos = file_path.rfind("/");
+                std::string name = file_path.substr(pos + 1);
+                remote_segments.emplace_back(remote_path + name);
+            }
+        }
+
+        LOG(INFO) << "get total segments:" << segments.size();
+        std::unique_ptr<char[]> buffer(new char[BUFFER_SIZE]);
+        for (size_t i = 0; i < segments.size(); ++i) {
+            upload_to_HDFS(segments[i], remote_segments[i], buffer.get());
+        }
+
+        LOG(INFO) << "update header:" << _meta_file;
+        upload_to_HDFS(local_new_header, _meta_file, buffer.get());
+    }
+}
+
+// TODO: need adapt the open libhdfs to upload segment & meta file
+void BuilderHelper::upload_to_HDFS(std::string& read_path, std::string& write_path,
+                                   void* bufferPtr) {
+    LOG(INFO) << "going to upload file:" << write_path;
+}
+
+BuilderHelper::~BuilderHelper() {
+    doris::ExecEnv::destroy(ExecEnv::GetInstance());
+}
+
+} // namespace doris

--- a/be/src/tools/builder_helper.h
+++ b/be/src/tools/builder_helper.h
@@ -1,0 +1,32 @@
+#pragma once
+#include "common/status.h"
+#include "io/fs/hdfs_file_system.h"
+
+namespace doris {
+
+class BuilderHelper {
+public:
+    static BuilderHelper* init_instance();
+    ~BuilderHelper();
+    // Return global instance.
+    static BuilderHelper* instance() { return _s_instance; }
+
+    void initial_build_env();
+    void open(const std::string& meta_file, const std::string& build_dir,
+              const std::string& data_path, const std::string& file_type, bool isHDFS);
+    void upload_to_HDFS(std::string& read_path, std::string& write_path, void* bufferPtr);
+    void build();
+
+private:
+    BuilderHelper() {}
+    static BuilderHelper* _s_instance;
+    std::string read_local_file(const std::string& file);
+    bool _isHDFS;
+    std::unique_ptr<io::HdfsFileSystem> hdfsFileSystem; // TODO: need adapt for open HDFS
+    std::string _meta_file;
+    std::string _build_dir;
+    std::string _data_path;
+    std::string _file_type;
+};
+
+} // namespace doris

--- a/be/src/tools/builder_scanner.cpp
+++ b/be/src/tools/builder_scanner.cpp
@@ -1,0 +1,366 @@
+#include "tools/builder_scanner.h"
+
+namespace doris {
+
+static const int TUPLE_ID_DST = 0;
+static const int TUPLE_ID_SRC = 1;
+
+BuilderScanner::BuilderScanner(TabletSharedPtr tablet, const std::string& file_type, bool isHDFS)
+        : _runtime_state(TQueryGlobals()), _tablet(tablet), _file_type(file_type), _isHDFS(isHDFS) {
+    init();
+    _runtime_state.init_scanner_mem_trackers();
+    TUniqueId uid;
+    uid.hi = 1;
+    uid.lo = 1;
+    TQueryOptions _options;
+    _options.batch_size = 8192;
+    _options.enable_vectorized_engine = true;
+    auto* _exec_env = ExecEnv::GetInstance();
+    _runtime_state.init(uid, _options, TQueryGlobals(), _exec_env);
+}
+
+void BuilderScanner::init() {
+    create_expr_info();
+    init_desc_table();
+
+    // Node Id
+    _tnode.node_id = 0;
+    _tnode.node_type = TPlanNodeType::SCHEMA_SCAN_NODE;
+    _tnode.num_children = 0;
+    _tnode.limit = -1;
+    _tnode.row_tuples.push_back(0);
+    _tnode.nullable_tuples.push_back(false);
+    _tnode.broker_scan_node.tuple_id = 0;
+    _tnode.__isset.broker_scan_node = true;
+}
+
+int BuilderScanner::create_src_tuple(TDescriptorTable& t_desc_table, int next_slot_id) {
+    for (int i = 0; i < _tablet->num_columns(); i++) {
+        TSlotDescriptor slot_desc;
+
+        slot_desc.id = next_slot_id++;
+        slot_desc.parent = 1;
+        const auto& col = _tablet->tablet_schema()->column(i);
+        TTypeDesc type;
+        {
+            TTypeNode node;
+            node.__set_type(TTypeNodeType::SCALAR);
+            TScalarType scalar_type;
+            switch (col.type()) {
+            case FieldType::OLAP_FIELD_TYPE_DATE: {
+                scalar_type.__set_type(TPrimitiveType::DATE);
+                break;
+            }
+            case FieldType::OLAP_FIELD_TYPE_VARCHAR: {
+                scalar_type.__set_type(TPrimitiveType::VARCHAR);
+                break;
+            }
+            case FieldType::OLAP_FIELD_TYPE_BIGINT: {
+                scalar_type.__set_type(TPrimitiveType::BIGINT);
+                break;
+            }
+            case FieldType::OLAP_FIELD_TYPE_FLOAT: {
+                scalar_type.__set_type(TPrimitiveType::FLOAT);
+                break;
+            }
+            case FieldType::OLAP_FIELD_TYPE_DOUBLE: {
+                scalar_type.__set_type(TPrimitiveType::DOUBLE);
+                break;
+            }
+            case FieldType::OLAP_FIELD_TYPE_DATETIME: {
+                scalar_type.__set_type(TPrimitiveType::DATETIME);
+                break;
+            }
+            case FieldType::OLAP_FIELD_TYPE_DATEV2: {
+                scalar_type.__set_type(TPrimitiveType::DATEV2);
+                break;
+            }
+            case FieldType::OLAP_FIELD_TYPE_DATETIMEV2: {
+                scalar_type.__set_type(TPrimitiveType::DATETIMEV2);
+                break;
+            }
+            case FieldType::OLAP_FIELD_TYPE_TINYINT: {
+                scalar_type.__set_type(TPrimitiveType::TINYINT);
+                break;
+            }
+            case FieldType::OLAP_FIELD_TYPE_UNSIGNED_TINYINT: {
+                scalar_type.__set_type(TPrimitiveType::SMALLINT);
+                break;
+            }
+            case FieldType::OLAP_FIELD_TYPE_INT: {
+                scalar_type.__set_type(TPrimitiveType::INT);
+                break;
+            }
+            case FieldType::OLAP_FIELD_TYPE_DECIMAL:
+            case FieldType::OLAP_FIELD_TYPE_DECIMAL32: {
+                scalar_type.__set_type(TPrimitiveType::DECIMAL32);
+                break;
+            }
+            case FieldType::OLAP_FIELD_TYPE_DECIMAL64: {
+                scalar_type.__set_type(TPrimitiveType::DECIMAL64);
+                break;
+            }
+            case FieldType::OLAP_FIELD_TYPE_DECIMAL128I: {
+                scalar_type.__set_type(TPrimitiveType::DECIMAL128I);
+                break;
+            }
+            case FieldType::OLAP_FIELD_TYPE_JSONB: {
+                scalar_type.__set_type(TPrimitiveType::JSONB);
+                break;
+            }
+            default:
+                LOG(FATAL) << "unknown type error:" << col.type();
+            }
+
+            scalar_type.__set_len(col.length());
+            node.__set_scalar_type(scalar_type);
+            type.types.push_back(node);
+        }
+        slot_desc.slotType = type;
+        slot_desc.columnPos = i;
+        // Skip the first 8 bytes These 8 bytes are used to indicate whether the field is a null value
+        slot_desc.byteOffset = i * 16 + 8;
+        slot_desc.nullIndicatorByte = i / 8;
+        slot_desc.nullIndicatorBit = i % 8;
+        slot_desc.colName = _tablet->tablet_schema()->column(i).name();
+        slot_desc.slotIdx = i + 1;
+        slot_desc.isMaterialized = true;
+
+        t_desc_table.slotDescriptors.push_back(slot_desc);
+    }
+
+    {
+        // TTupleDescriptor source
+        TTupleDescriptor t_tuple_desc;
+        t_tuple_desc.id = TUPLE_ID_SRC;
+        //Here 8 bytes in order to handle null values
+        t_tuple_desc.byteSize = _tablet->num_columns() * 16 + 8;
+        t_tuple_desc.numNullBytes = 0;
+        t_tuple_desc.tableId = _tablet->table_id();
+        t_tuple_desc.__isset.tableId = true;
+        t_desc_table.tupleDescriptors.push_back(t_tuple_desc);
+    }
+    return next_slot_id;
+}
+
+int BuilderScanner::create_dst_tuple(TDescriptorTable& t_desc_table, int next_slot_id) {
+    int32_t byteOffset = 8;
+    for (int i = 0; i < _tablet->num_columns(); i++, byteOffset += 16) {
+        TSlotDescriptor slot_desc;
+
+        slot_desc.id = next_slot_id++;
+        slot_desc.parent = 0;
+        const auto& col = _tablet->tablet_schema()->column(i);
+        TTypeDesc type;
+        {
+            TTypeNode node;
+            node.__set_type(TTypeNodeType::SCALAR);
+            TScalarType scalar_type;
+            switch (col.type()) {
+            case FieldType::OLAP_FIELD_TYPE_DATE: {
+                scalar_type.__set_type(TPrimitiveType::DATE);
+                break;
+            }
+            case FieldType::OLAP_FIELD_TYPE_VARCHAR: {
+                scalar_type.__set_type(TPrimitiveType::VARCHAR);
+                break;
+            }
+            case FieldType::OLAP_FIELD_TYPE_BIGINT: {
+                scalar_type.__set_type(TPrimitiveType::BIGINT);
+                break;
+            }
+            default:
+                LOG(FATAL) << " unknown type error:" << col.type();
+            }
+
+            scalar_type.__set_len(col.length());
+            node.__set_scalar_type(scalar_type);
+            type.types.push_back(node);
+        }
+        slot_desc.slotType = type;
+        slot_desc.columnPos = i;
+        slot_desc.byteOffset = byteOffset;
+        slot_desc.nullIndicatorByte = i / 8;
+        slot_desc.nullIndicatorBit = i % 8;
+        slot_desc.colName = _tablet->tablet_schema()->column(i).name();
+        slot_desc.slotIdx = i + 1;
+        slot_desc.isMaterialized = true;
+
+        t_desc_table.slotDescriptors.push_back(slot_desc);
+    }
+
+    t_desc_table.__isset.slotDescriptors = true;
+    {
+        // TTupleDescriptor dest
+        TTupleDescriptor t_tuple_desc;
+        t_tuple_desc.id = TUPLE_ID_DST;
+        t_tuple_desc.byteSize = byteOffset + 8; //Here 8 bytes in order to handle null values
+        t_tuple_desc.numNullBytes = 0;
+        t_tuple_desc.tableId = _tablet->table_id();
+        t_tuple_desc.__isset.tableId = true;
+        t_desc_table.tupleDescriptors.push_back(t_tuple_desc);
+    }
+    return next_slot_id;
+}
+
+void BuilderScanner::init_desc_table() {
+    TDescriptorTable t_desc_table;
+
+    // table descriptors
+    TTableDescriptor t_table_desc;
+
+    t_table_desc.id = _tablet->table_id();
+    t_table_desc.tableType = TTableType::OLAP_TABLE;
+    t_table_desc.numCols = _tablet->num_columns();
+    t_table_desc.numClusteringCols = 0;
+    t_desc_table.tableDescriptors.push_back(t_table_desc);
+    t_desc_table.__isset.tableDescriptors = true;
+
+    int next_slot_id = 0;
+
+    next_slot_id = create_dst_tuple(t_desc_table, next_slot_id);
+    next_slot_id = create_src_tuple(t_desc_table, next_slot_id);
+
+    DescriptorTbl::create(&_obj_pool, t_desc_table, &_desc_tbl);
+
+    _runtime_state.set_desc_tbl(_desc_tbl);
+}
+
+void BuilderScanner::create_expr_info() {
+    TTypeDesc varchar_type;
+    {
+        TTypeNode node;
+        node.__set_type(TTypeNodeType::SCALAR);
+        TScalarType scalar_type;
+        scalar_type.__set_type(TPrimitiveType::VARCHAR);
+        scalar_type.__set_len(65535);
+        node.__set_scalar_type(scalar_type);
+        varchar_type.types.push_back(node);
+    }
+    for (int i = 0; i < _tablet->num_columns(); i++) {
+        auto col = _tablet->tablet_schema()->column(i);
+
+        TExprNode slot_ref;
+        slot_ref.node_type = TExprNodeType::SLOT_REF;
+        slot_ref.type = varchar_type;
+        slot_ref.num_children = 0;
+        slot_ref.__isset.slot_ref = true;
+        slot_ref.slot_ref.slot_id = _tablet->num_columns() + i; // log_time id in src tuple
+        slot_ref.slot_ref.tuple_id = 1;
+
+        TExpr expr;
+        expr.nodes.push_back(slot_ref);
+
+        _params.expr_of_dest_slot.emplace(i, expr);
+        _params.src_slot_ids.push_back(_tablet->num_columns() + i);
+    }
+
+    // _params.__isset.expr_of_dest_slot = true;
+    _params.__set_dest_tuple_id(TUPLE_ID_DST);
+    _params.__set_src_tuple_id(TUPLE_ID_SRC);
+}
+
+void BuilderScanner::build_scan_ranges(std::vector<TBrokerRangeDesc>& ranges,
+                                       const std::string& path) {
+    LOG(INFO) << "build scan ranges for:" << path << " file_type:" << _file_type;
+    if (_isHDFS) {
+    } else {
+        for (const auto& file : std::filesystem::directory_iterator(path)) {
+            auto file_path = file.path().string();
+            if (file_path.substr(file_path.size() - _file_type.size()) == _file_type) {
+                TBrokerRangeDesc range;
+                range.start_offset = 0;
+                range.size = -1;
+                range.format_type = TFileFormatType::FORMAT_PARQUET;
+                range.splittable = true;
+
+                range.path = file_path;
+                range.file_type = TFileType::FILE_LOCAL;
+                ranges.push_back(range);
+            }
+        }
+    }
+
+    if (!ranges.size()) LOG(FATAL) << "cannot get valid scan file!";
+}
+
+void BuilderScanner::doSegmentBuild(const std::string& path) {
+    vectorized::VBrokerScanNode scan_node(&_obj_pool, _tnode, *_desc_tbl);
+    scan_node.init(_tnode);
+    auto status = scan_node.prepare(&_runtime_state);
+    if (!status.ok()) LOG(FATAL) << "prepare scan node fail:" << status.to_string();
+
+    // set scan range
+    std::vector<TScanRangeParams> scan_ranges;
+    {
+        TScanRangeParams scan_range_params;
+
+        TBrokerScanRange broker_scan_range;
+        broker_scan_range.params = _params;
+        build_scan_ranges(broker_scan_range.ranges, path);
+        scan_range_params.scan_range.__set_broker_scan_range(broker_scan_range);
+        scan_ranges.push_back(scan_range_params);
+    }
+
+    scan_node.set_scan_ranges(scan_ranges);
+    status = scan_node.open(&_runtime_state);
+    if (!status.ok()) LOG(FATAL) << "open scan node fail:" << status.to_string();
+
+    std::unique_ptr<RowsetWriter> rowset_writer;
+    PUniqueId load_id;
+    load_id.set_hi(1);
+    load_id.set_lo(1);
+    int64_t transaction_id = 1;
+
+    RowsetWriterContext context;
+    context.txn_id = transaction_id;
+    context.load_id = load_id;
+    context.rowset_state = PREPARED;
+    context.segments_overlap = OVERLAP_UNKNOWN;
+    context.tablet_schema = _tablet->tablet_schema();
+
+    status = _tablet->create_rowset_writer(context, &rowset_writer);
+
+    if (!status.ok()) LOG(FATAL) << "create rowset error:" << status.to_string();
+
+    std::filesystem::path segment_path(std::filesystem::path(path + "/segment"));
+    if (!std::filesystem::exists(segment_path)) {
+        LOG(INFO) << "create segment path.";
+        if (!std::filesystem::create_directory(segment_path))
+            LOG(FATAL) << "create segment path fail.";
+    }
+
+    rowset_writer->set_writer_path(segment_path.string());
+    // Get block
+    vectorized::Block block;
+    bool eof = false;
+
+    while (!eof) {
+        status = scan_node.get_next(&_runtime_state, &block, &eof);
+        if (!status.ok()) {
+            LOG(FATAL) << "scan error: " << status.to_string();
+            break;
+        }
+        status = rowset_writer->add_block(&block);
+        if (!status.ok()) {
+            LOG(FATAL) << "add block error: " << status.to_string();
+            break;
+        }
+
+        block.clear();
+    }
+    status = rowset_writer->flush();
+    if (!status.ok()) {
+        LOG(FATAL) << "flush error: " << status.to_string();
+    }
+
+    rowset_writer->build();
+    scan_node.close(&_runtime_state);
+    {
+        std::stringstream ss;
+        scan_node.runtime_profile()->pretty_print(&ss);
+        LOG(INFO) << ss.str();
+    }
+}
+
+} // namespace doris

--- a/be/src/tools/builder_scanner.h
+++ b/be/src/tools/builder_scanner.h
@@ -1,0 +1,76 @@
+#pragma once
+#include "common/object_pool.h"
+#include "common/status.h"
+#include "env/env.h"
+#include "exec/parquet_scanner.h"
+#include "exprs/cast_functions.h"
+#include "gen_cpp/Descriptors_types.h"
+#include "gen_cpp/PaloInternalService_types.h"
+#include "gen_cpp/PlanNodes_types.h"
+#include "gen_cpp/olap_file.pb.h"
+#include "gen_cpp/segment_v2.pb.h"
+#include "gutil/strings/numbers.h"
+#include "gutil/strings/split.h"
+#include "gutil/strings/substitute.h"
+#include "io/buffered_reader.h"
+#include "io/file_reader.h"
+#include "io/local_file_reader.h"
+#include "json2pb/pb_to_json.h"
+#include "olap/data_dir.h"
+#include "olap/olap_define.h"
+#include "olap/options.h"
+#include "olap/row.h"
+#include "olap/rowset/beta_rowset.h"
+#include "olap/rowset/rowset_id_generator.h"
+#include "olap/rowset/rowset_meta_manager.h"
+#include "olap/rowset/segment_v2/binary_plain_page.h"
+#include "olap/rowset/segment_v2/column_reader.h"
+#include "olap/schema_change.h"
+#include "olap/storage_engine.h"
+#include "olap/storage_policy_mgr.h"
+#include "olap/tablet.h"
+#include "olap/tablet_meta.h"
+#include "olap/tablet_meta_manager.h"
+#include "olap/tablet_schema.h"
+#include "olap/tablet_schema_cache.h"
+#include "olap/utils.h"
+#include "runtime/descriptors.h"
+#include "runtime/exec_env.h"
+#include "runtime/row_batch.h"
+#include "runtime/runtime_state.h"
+#include "runtime/tuple.h"
+#include "runtime/user_function_cache.h"
+#include "util/coding.h"
+#include "util/crc32c.h"
+#include "util/file_utils.h"
+#include "util/runtime_profile.h"
+#include "util/time.h"
+#include "vec/exec/format/parquet/vparquet_file_metadata.h"
+#include "vec/exec/vbroker_scan_node.h"
+
+namespace doris {
+
+class BuilderScanner {
+public:
+    BuilderScanner(TabletSharedPtr tablet, const std::string& file_type, bool isHDFS);
+    ~BuilderScanner() {}
+    void init();
+    void doSegmentBuild(const std::string& path);
+
+private:
+    int create_src_tuple(TDescriptorTable& t_desc_table, int next_slot_id);
+    int create_dst_tuple(TDescriptorTable& t_desc_table, int next_slot_id);
+    void create_expr_info();
+    void init_desc_table();
+    void build_scan_ranges(std::vector<TBrokerRangeDesc>& ranges, const std::string& path);
+    RuntimeState _runtime_state;
+    ObjectPool _obj_pool;
+    TBrokerScanRangeParams _params;
+    DescriptorTbl* _desc_tbl;
+    TPlanNode _tnode;
+    TabletSharedPtr _tablet;
+    std::string _file_type;
+    bool _isHDFS;
+};
+
+} // namespace doris

--- a/be/src/tools/builder_scanner_memtable.cpp
+++ b/be/src/tools/builder_scanner_memtable.cpp
@@ -1,0 +1,346 @@
+#include "tools/builder_scanner_memtable.h"
+
+#include "gen_cpp/Descriptors_types.h"
+#include "gen_cpp/PaloInternalService_types.h"
+#include "gen_cpp/PlanNodes_types.h"
+#include "gen_cpp/Types_types.h"
+#include "hdfs/hdfs.h"
+#include "olap/delta_writer.h"
+#include "runtime/descriptor_helper.h"
+#include "runtime/descriptors.h"
+#include "runtime/row_batch.h"
+#include "runtime/runtime_state.h"
+#include "runtime/tuple.h"
+#include "vec/exec/vbroker_scan_node.h"
+
+namespace doris {
+
+static const int TUPLE_ID_DST = 0;
+static const int TUPLE_ID_SRC = 1;
+static const int BATCH_SIZE = 8192;
+
+BuilderScannerMemtable::BuilderScannerMemtable(TabletSharedPtr tablet, const std::string& build_dir,
+                                               const std::string& file_type, bool isHDFS)
+        : _runtime_state(TQueryGlobals()),
+          _tablet(tablet),
+          _build_dir(build_dir),
+          _file_type(file_type),
+          _isHDFS(isHDFS) {
+    init();
+    _runtime_state.init_scanner_mem_trackers();
+    TUniqueId uid;
+    uid.hi = 1;
+    uid.lo = 1;
+    TQueryOptions _options;
+    _options.batch_size = BATCH_SIZE;
+    _options.enable_vectorized_engine = true;
+    auto* _exec_env = ExecEnv::GetInstance();
+    _runtime_state.init(uid, _options, TQueryGlobals(), _exec_env);
+    _runtime_state.init_mem_trackers(uid);
+}
+
+void BuilderScannerMemtable::init() {
+    create_expr_info();
+    init_desc_table();
+
+    // Node Id
+    _tnode.node_id = 0;
+    _tnode.node_type = TPlanNodeType::SCHEMA_SCAN_NODE;
+    _tnode.num_children = 0;
+    _tnode.limit = -1;
+    _tnode.row_tuples.push_back(0);
+    _tnode.nullable_tuples.push_back(false);
+    _tnode.broker_scan_node.tuple_id = 0;
+    _tnode.__isset.broker_scan_node = true;
+}
+
+TPrimitiveType::type BuilderScannerMemtable::getPrimitiveType(FieldType t) {
+    switch (t) {
+    case FieldType::OLAP_FIELD_TYPE_OBJECT: {
+        return TPrimitiveType::OBJECT;
+    }
+    case FieldType::OLAP_FIELD_TYPE_HLL: {
+        return TPrimitiveType::HLL;
+    }
+    case FieldType::OLAP_FIELD_TYPE_CHAR: {
+        return TPrimitiveType::CHAR;
+    }
+    case FieldType::OLAP_FIELD_TYPE_VARCHAR: {
+        return TPrimitiveType::VARCHAR;
+    }
+    case FieldType::OLAP_FIELD_TYPE_STRING: {
+        return TPrimitiveType::STRING;
+    }
+    case FieldType::OLAP_FIELD_TYPE_DATE: {
+        return TPrimitiveType::DATE;
+    }
+    case FieldType::OLAP_FIELD_TYPE_DATETIME: {
+        return TPrimitiveType::DATETIME;
+    }
+    case FieldType::OLAP_FIELD_TYPE_DATEV2: {
+        return TPrimitiveType::DATEV2;
+    }
+    case FieldType::OLAP_FIELD_TYPE_DATETIMEV2: {
+        return TPrimitiveType::DATETIMEV2;
+    }
+    case FieldType::OLAP_FIELD_TYPE_DECIMAL:
+    case FieldType::OLAP_FIELD_TYPE_DECIMAL32: {
+        return TPrimitiveType::DECIMAL32;
+    }
+    case FieldType::OLAP_FIELD_TYPE_DECIMAL64: {
+        return TPrimitiveType::DECIMAL64;
+    }
+    case FieldType::OLAP_FIELD_TYPE_DECIMAL128I: {
+        return TPrimitiveType::DECIMAL128I;
+    }
+    case FieldType::OLAP_FIELD_TYPE_JSONB: {
+        return TPrimitiveType::JSONB;
+    }
+    case FieldType::OLAP_FIELD_TYPE_BOOL: {
+        return TPrimitiveType::BOOLEAN;
+    }
+    case FieldType::OLAP_FIELD_TYPE_TINYINT: {
+        return TPrimitiveType::TINYINT;
+    }
+    case FieldType::OLAP_FIELD_TYPE_SMALLINT: {
+        return TPrimitiveType::SMALLINT;
+    }
+    case FieldType::OLAP_FIELD_TYPE_INT: {
+        return TPrimitiveType::INT;
+    }
+    case FieldType::OLAP_FIELD_TYPE_BIGINT: {
+        return TPrimitiveType::BIGINT;
+    }
+    case FieldType::OLAP_FIELD_TYPE_LARGEINT: {
+        return TPrimitiveType::LARGEINT;
+    }
+    case FieldType::OLAP_FIELD_TYPE_FLOAT: {
+        return TPrimitiveType::FLOAT;
+    }
+    case FieldType::OLAP_FIELD_TYPE_DOUBLE: {
+        return TPrimitiveType::DOUBLE;
+    }
+    case FieldType::OLAP_FIELD_TYPE_ARRAY: {
+        return TPrimitiveType::ARRAY;
+    }
+    default: {
+        LOG(FATAL) << "unknown type error:" << t;
+    }
+    }
+}
+TDescriptorTable BuilderScannerMemtable::create_descriptor_tablet() {
+    TDescriptorTableBuilder dtb;
+
+    // build DST table descriptor
+    {
+        TTupleDescriptorBuilder tuple_builder;
+        for (int i = 0; i < _tablet->num_columns(); i++) {
+            const auto& col = _tablet->tablet_schema()->column(i);
+
+            tuple_builder.add_slot(TSlotDescriptorBuilder()
+                                           .type(thrift_to_type(getPrimitiveType(col.type())))
+                                           .column_name(col.name())
+                                           .column_pos(i)
+                                           .length(col.length())
+                                           .build());
+        }
+        tuple_builder.build(&dtb);
+    }
+
+    // build SRC table descriptor
+    {
+        TTupleDescriptorBuilder tuple_builder;
+        for (int i = 0; i < _tablet->num_columns(); i++) {
+            const auto& col = _tablet->tablet_schema()->column(i);
+
+            tuple_builder.add_slot(TSlotDescriptorBuilder()
+                                           .type(thrift_to_type(getPrimitiveType(col.type())))
+                                           .column_name(col.name())
+                                           .column_pos(i)
+                                           .length(col.length())
+                                           .build());
+        }
+        tuple_builder.build(&dtb);
+    }
+
+    return dtb.desc_tbl();
+}
+
+void BuilderScannerMemtable::init_desc_table() {
+    TDescriptorTable t_desc_table = create_descriptor_tablet();
+
+    // table descriptors
+    TTableDescriptor t_table_desc;
+
+    t_table_desc.id = _tablet->table_id();
+    t_table_desc.tableType = TTableType::OLAP_TABLE;
+    t_table_desc.numCols = _tablet->num_columns();
+    t_table_desc.numClusteringCols = 0;
+    t_desc_table.tableDescriptors.push_back(t_table_desc);
+    t_desc_table.__isset.tableDescriptors = true;
+
+    DescriptorTbl::create(&_obj_pool, t_desc_table, &_desc_tbl);
+
+    _runtime_state.set_desc_tbl(_desc_tbl);
+}
+
+void BuilderScannerMemtable::create_expr_info() {
+    TTypeDesc varchar_type;
+    {
+        TTypeNode node;
+        node.__set_type(TTypeNodeType::SCALAR);
+        TScalarType scalar_type;
+        scalar_type.__set_type(TPrimitiveType::VARCHAR);
+        scalar_type.__set_len(65535);
+        node.__set_scalar_type(scalar_type);
+        varchar_type.types.push_back(node);
+    }
+    for (int i = 0; i < _tablet->num_columns(); i++) {
+        auto col = _tablet->tablet_schema()->column(i);
+
+        TExprNode slot_ref;
+        slot_ref.node_type = TExprNodeType::SLOT_REF;
+        slot_ref.type = varchar_type;
+        slot_ref.num_children = 0;
+        slot_ref.__isset.slot_ref = true;
+        slot_ref.slot_ref.slot_id = _tablet->num_columns() + i;
+        slot_ref.slot_ref.tuple_id = 1;
+
+        TExpr expr;
+        expr.nodes.push_back(slot_ref);
+
+        _params.expr_of_dest_slot.emplace(i, expr);
+        _params.src_slot_ids.push_back(_tablet->num_columns() + i);
+    }
+
+    // _params.__isset.expr_of_dest_slot = true;
+    _params.__set_dest_tuple_id(TUPLE_ID_DST);
+    _params.__set_src_tuple_id(TUPLE_ID_SRC);
+}
+
+void BuilderScannerMemtable::build_scan_ranges(std::vector<TBrokerRangeDesc>& ranges,
+                                               const std::vector<std::string>& files) {
+    LOG(INFO) << "build scan ranges for files size:" << files.size() << " file_type:" << _file_type;
+    for (const auto& file : files) {
+        TBrokerRangeDesc range;
+        range.start_offset = 0;
+        range.size = -1;
+        range.format_type = TFileFormatType::FORMAT_PARQUET;
+        range.splittable = true;
+
+        range.path = file;
+        range.file_type = _isHDFS ? TFileType::FILE_HDFS : TFileType::FILE_LOCAL;
+        ranges.push_back(range);
+    }
+
+    if (!ranges.size()) LOG(FATAL) << "cannot get valid scan file!";
+}
+
+void BuilderScannerMemtable::doSegmentBuild(const std::vector<std::string>& files) {
+    vectorized::VBrokerScanNode scan_node(&_obj_pool, _tnode, *_desc_tbl);
+    scan_node.init(_tnode);
+    auto status = scan_node.prepare(&_runtime_state);
+    if (!status.ok()) LOG(FATAL) << "prepare scan node fail:" << status.to_string();
+
+    // set scan range
+    std::vector<TScanRangeParams> scan_ranges;
+    {
+        TScanRangeParams scan_range_params;
+
+        TBrokerScanRange broker_scan_range;
+        broker_scan_range.params = _params;
+        build_scan_ranges(broker_scan_range.ranges, files);
+        scan_range_params.scan_range.__set_broker_scan_range(broker_scan_range);
+        scan_ranges.push_back(scan_range_params);
+    }
+
+    scan_node.set_scan_ranges(scan_ranges);
+    status = scan_node.open(&_runtime_state);
+    if (!status.ok()) LOG(FATAL) << "open scan node fail:" << status.to_string();
+
+    // std::unique_ptr<RowsetWriter> rowset_writer;
+    PUniqueId load_id;
+    load_id.set_hi(1);
+    load_id.set_lo(1);
+    int64_t transaction_id = 1;
+
+    // delta writer
+    TupleDescriptor* tuple_desc = _desc_tbl->get_tuple_descriptor(TUPLE_ID_DST);
+    WriteRequest write_req = {_tablet->tablet_meta()->tablet_id(),
+                              _tablet->schema_hash(),
+                              WriteType::LOAD,
+                              transaction_id,
+                              _tablet->partition_id(),
+                              load_id,
+                              tuple_desc,
+                              &(tuple_desc->slots())};
+
+    DeltaWriter* delta_writer = nullptr;
+    DeltaWriter::open(&write_req, &delta_writer, load_id);
+    status = delta_writer->init();
+    if (!status.ok()) LOG(FATAL) << "delta_writer init fail:" << status.to_string();
+
+    std::filesystem::path segment_path(std::filesystem::path(_build_dir + "/segment"));
+    std::filesystem::remove_all(segment_path);
+    if (!std::filesystem::create_directory(segment_path)) LOG(FATAL) << "create segment path fail.";
+
+    delta_writer->set_writer_path(segment_path.string());
+    // Get block
+    vectorized::Block block;
+    bool eof = false;
+
+    std::vector<int> rowidx;
+    for (size_t i = 0; i < BATCH_SIZE; ++i) {
+        rowidx.push_back(i);
+    }
+
+    while (!eof) {
+        status = scan_node.get_next(&_runtime_state, &block, &eof);
+        if (!status.ok()) {
+            LOG(FATAL) << "scan error: " << status.to_string();
+            break;
+        }
+
+        if (block.rows() != BATCH_SIZE) {
+            std::vector<int> index;
+            for (size_t i = 0; i < block.rows(); ++i) {
+                index.push_back(i);
+            }
+            status = delta_writer->write(&block, index);
+        } else
+            status = delta_writer->write(&block, rowidx);
+
+        if (!status.ok()) {
+            LOG(FATAL) << "add block error: " << status.to_string();
+            break;
+        }
+
+        block.clear();
+    }
+    status = delta_writer->close();
+    if (!status.ok()) {
+        LOG(FATAL) << "delta_writer close error: " << status.to_string();
+    }
+    PSlaveTabletNodes slave_tablet_nodes;
+    status = delta_writer->close_wait(slave_tablet_nodes, false);
+    if (!status.ok()) {
+        LOG(FATAL) << "delta_writer close_wait error: " << status.to_string();
+    }
+
+    RowsetMetaSharedPtr rowset_meta = delta_writer->get_cur_rowset()->rowset_meta();
+    std::vector<RowsetMetaSharedPtr> metas {rowset_meta};
+
+    _tablet->tablet_meta()->revise_rs_metas(std::move(metas));
+    if (!status.ok()) {
+        LOG(FATAL) << "cannot add new rowset: " << status.to_string();
+    }
+
+    scan_node.close(&_runtime_state);
+    {
+        std::stringstream ss;
+        scan_node.runtime_profile()->pretty_print(&ss);
+        LOG(INFO) << ss.str();
+    }
+}
+
+} // namespace doris

--- a/be/src/tools/builder_scanner_memtable.h
+++ b/be/src/tools/builder_scanner_memtable.h
@@ -1,0 +1,68 @@
+#pragma once
+#include "common/object_pool.h"
+#include "common/status.h"
+#include "env/env.h"
+#include "exec/parquet_scanner.h"
+#include "gen_cpp/olap_file.pb.h"
+#include "gen_cpp/segment_v2.pb.h"
+#include "gutil/strings/numbers.h"
+#include "gutil/strings/split.h"
+#include "gutil/strings/substitute.h"
+#include "io/buffered_reader.h"
+#include "io/file_reader.h"
+#include "io/local_file_reader.h"
+#include "json2pb/pb_to_json.h"
+#include "olap/data_dir.h"
+#include "olap/olap_define.h"
+#include "olap/options.h"
+#include "olap/row.h"
+#include "olap/rowset/beta_rowset.h"
+#include "olap/rowset/rowset_id_generator.h"
+#include "olap/rowset/rowset_meta_manager.h"
+#include "olap/rowset/segment_v2/binary_plain_page.h"
+#include "olap/rowset/segment_v2/column_reader.h"
+#include "olap/schema_change.h"
+#include "olap/storage_engine.h"
+#include "olap/storage_policy_mgr.h"
+#include "olap/tablet.h"
+#include "olap/tablet_meta.h"
+#include "olap/tablet_meta_manager.h"
+#include "olap/tablet_schema.h"
+#include "olap/tablet_schema_cache.h"
+#include "olap/utils.h"
+#include "runtime/primitive_type.h"
+#include "util/coding.h"
+#include "util/crc32c.h"
+#include "util/file_utils.h"
+#include "util/runtime_profile.h"
+#include "util/time.h"
+
+namespace doris {
+
+class BuilderScannerMemtable {
+public:
+    BuilderScannerMemtable(TabletSharedPtr tablet, const std::string& build_dir,
+                           const std::string& file_type, bool isHDFS);
+    ~BuilderScannerMemtable() {}
+    void init();
+    void doSegmentBuild(const std::vector<std::string>& files);
+
+private:
+    TDescriptorTable create_descriptor_tablet();
+    TPrimitiveType::type getPrimitiveType(FieldType t);
+    void create_expr_info();
+    void init_desc_table();
+    void build_scan_ranges(std::vector<TBrokerRangeDesc>& ranges,
+                           const std::vector<std::string>& files);
+    RuntimeState _runtime_state;
+    ObjectPool _obj_pool;
+    TBrokerScanRangeParams _params;
+    DescriptorTbl* _desc_tbl;
+    TPlanNode _tnode;
+    TabletSharedPtr _tablet;
+    std::string _build_dir;
+    std::string _file_type;
+    bool _isHDFS;
+};
+
+} // namespace doris

--- a/be/src/tools/segment_builder.cpp
+++ b/be/src/tools/segment_builder.cpp
@@ -1,0 +1,128 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <gflags/gflags.h>
+#include <unistd.h>
+
+#include <chrono>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <set>
+#include <sstream>
+#include <string>
+
+#include "common/object_pool.h"
+#include "common/status.h"
+#include "env/env.h"
+#include "exec/parquet_scanner.h"
+#include "exprs/cast_functions.h"
+#include "gen_cpp/Descriptors_types.h"
+#include "gen_cpp/PaloInternalService_types.h"
+#include "gen_cpp/PlanNodes_types.h"
+#include "gen_cpp/olap_file.pb.h"
+#include "gen_cpp/segment_v2.pb.h"
+#include "gutil/strings/numbers.h"
+#include "gutil/strings/split.h"
+#include "gutil/strings/substitute.h"
+#include "io/buffered_reader.h"
+#include "io/file_reader.h"
+#include "io/local_file_reader.h"
+#include "json2pb/pb_to_json.h"
+#include "olap/data_dir.h"
+#include "olap/olap_define.h"
+#include "olap/options.h"
+#include "olap/row.h"
+#include "olap/rowset/beta_rowset.h"
+#include "olap/rowset/rowset_id_generator.h"
+#include "olap/rowset/rowset_meta_manager.h"
+#include "olap/rowset/segment_v2/binary_plain_page.h"
+#include "olap/rowset/segment_v2/column_reader.h"
+#include "olap/schema_change.h"
+#include "olap/storage_engine.h"
+#include "olap/storage_policy_mgr.h"
+#include "olap/tablet.h"
+#include "olap/tablet_meta.h"
+#include "olap/tablet_meta_manager.h"
+#include "olap/tablet_schema.h"
+#include "olap/tablet_schema_cache.h"
+#include "olap/utils.h"
+#include "runtime/descriptors.h"
+#include "runtime/exec_env.h"
+#include "runtime/row_batch.h"
+#include "runtime/runtime_state.h"
+#include "runtime/tuple.h"
+#include "runtime/user_function_cache.h"
+#include "tools/builder_helper.h"
+#include "util/coding.h"
+#include "util/crc32c.h"
+#include "util/file_utils.h"
+#include "util/runtime_profile.h"
+#include "util/time.h"
+#include "vec/exec/format/parquet/vparquet_file_metadata.h"
+#include "vec/exec/vbroker_scan_node.h"
+
+DEFINE_string(meta_file, "", "tablet header meta file");
+DEFINE_string(data_path, "", "this tablet's data to be build");
+DEFINE_bool(is_remote, true, "input data's format, just support parquet");
+DEFINE_string(format, "parquet", "input data's format, just support parquet");
+
+std::string get_usage(const std::string& progname) {
+    std::stringstream ss;
+    ss << progname << " tool for build segment file for a tablet.\n";
+    ss << "Usage:\n";
+    ss << "segment_builder --meta_file=/path/to/xxx.hdr --data_path=/path/to/input_data/"
+          " --format=parquet --is_remote=true\n";
+    return ss.str();
+}
+
+int main(int argc, char** argv, char** envp) {
+    std::string usage = get_usage(argv[0]);
+    gflags::SetUsageMessage(usage);
+    google::ParseCommandLineFlags(&argc, &argv, true);
+    if (FLAGS_meta_file.empty() || FLAGS_data_path.empty()) {
+        std::cerr << "Invalid arguments:" << usage;
+        exit(1);
+    }
+
+    for (char** env = envp; *env != 0; env++) {
+        char* thisEnv = *env;
+        LOG(INFO) << "got env:" << thisEnv;
+    }
+
+    LOG(INFO) << "meta file:" << FLAGS_meta_file << " data path:" << FLAGS_data_path
+              << " format:" << FLAGS_format << " is_remote:" << FLAGS_is_remote;
+    bool isHDFS = FLAGS_is_remote; // only support hdfs
+    std::string build_dir = FLAGS_data_path;
+    if (isHDFS) {
+        build_dir = std::string(get_current_dir_name());
+        LOG(INFO) << "build hdfs file, using local build dir:" << build_dir;
+    }
+
+    //
+    auto t0 = std::chrono::steady_clock::now();
+    doris::BuilderHelper* instance = doris::BuilderHelper::init_instance();
+    instance->initial_build_env();
+    instance->open(FLAGS_meta_file, build_dir, FLAGS_data_path, FLAGS_format, isHDFS);
+    instance->build();
+    auto t1 = std::chrono::steady_clock::now();
+    std::chrono::duration<double, std::milli> d {t1 - t0};
+    LOG(INFO) << "total cost:" << d.count() << " ms";
+    gflags::ShutDownCommandLineFlags();
+    return 0;
+}

--- a/build.sh
+++ b/build.sh
@@ -128,7 +128,7 @@ BUILD_FE=0
 BUILD_BE=0
 BUILD_BROKER=0
 BUILD_AUDIT=0
-BUILD_META_TOOL='OFF'
+BUILD_META_TOOL='ON'
 BUILD_SPARK_DPP=0
 BUILD_JAVA_UDF=1
 BUILD_HIVE_UDF=0
@@ -142,7 +142,7 @@ if [[ "$#" == 1 ]]; then
     BUILD_BE=1
     BUILD_BROKER=1
     BUILD_AUDIT=1
-    BUILD_META_TOOL='OFF'
+    BUILD_META_TOOL='ON'
     BUILD_SPARK_DPP=1
     BUILD_HIVE_UDF=1
     CLEAN=0
@@ -554,14 +554,15 @@ EOF
     cd -
 
     if [[ "${BUILD_META_TOOL}" = "ON" ]]; then
-        cp -r -p "${DORIS_HOME}/be/output/lib/meta_tool" "${DORIS_OUTPUT}/be/lib"/
+        cp -r -p -f "${DORIS_HOME}/be/output/lib/meta_tool" "${DORIS_OUTPUT}/be/lib"/
+        cp -r -p -f "${DORIS_HOME}/be/output/lib/segment_builder" "${DORIS_OUTPUT}/be/lib"/
     fi
 
-    cp -r -p "${DORIS_HOME}/be/output/udf"/*.a "${DORIS_OUTPUT}/udf/lib"/
-    cp -r -p "${DORIS_HOME}/be/output/udf/include"/* "${DORIS_OUTPUT}/udf/include"/
-    cp -r -p "${DORIS_HOME}/webroot/be"/* "${DORIS_OUTPUT}/be/www"/
+    cp -r -p -f "${DORIS_HOME}/be/output/udf"/*.a "${DORIS_OUTPUT}/udf/lib"/
+    cp -r -p -f "${DORIS_HOME}/be/output/udf/include"/* "${DORIS_OUTPUT}/udf/include"/
+    cp -r -p -f "${DORIS_HOME}/webroot/be"/* "${DORIS_OUTPUT}/be/www"/
     if [[ "${STRIP_DEBUG_INFO}" = "ON" ]]; then
-        cp -r -p "${DORIS_HOME}/be/output/lib/debug_info" "${DORIS_OUTPUT}/be/lib"/
+        cp -r -p -f "${DORIS_HOME}/be/output/lib/debug_info" "${DORIS_OUTPUT}/be/lib"/
     fi
 
     java_udf_path="${DORIS_HOME}/fe/java-udf/target/java-udf-jar-with-dependencies.jar"
@@ -569,7 +570,7 @@ EOF
         cp "${java_udf_path}" "${DORIS_OUTPUT}/be/lib"/
     fi
 
-    cp -r -p "${DORIS_THIRDPARTY}/installed/webroot"/* "${DORIS_OUTPUT}/be/www"/
+    cp -r -p -f "${DORIS_THIRDPARTY}/installed/webroot"/* "${DORIS_OUTPUT}/be/www"/
     copy_common_files "${DORIS_OUTPUT}/be/"
     mkdir -p "${DORIS_OUTPUT}/be/log"
     mkdir -p "${DORIS_OUTPUT}/be/storage"


### PR DESCRIPTION
# Proposed changes

Issue Number: just one part of #11640

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ✓] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ✓] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ✓] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ✓] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ✓] No

## Further comments
This PR is one part of our bulk load implementation, which provide the tool to build the segment file of a tablet in an external way.
It's support build local and HDFS, which means you need provide the meta file and the data file like this:

```
./segment_builder --meta_file=/path/to/hdr/88409.hdr --data_path=/path/to/data/file --format=parquet --is_remote=false

ll /path/to/data/file
xxx1..gz.parquet
xxx2..gz.parquet
...
```
If the file all from the HDFS, the path should be the HDFS path. Currently only support parquet.

Since from internal we use the privately-owned HDFS lib, **so this PR HDFS related code may not work**.  I don't have such open source HDFS environment to test it.


![image](https://user-images.githubusercontent.com/10161171/211814188-f70afdd1-b973-48cc-be7e-db39dc5a036a.png)

From above picture you can see the final work flow:
1. Read the hdr file from the meta path, do some validation and system initialization.
2. Build the HDFS scanner, and read the parquet file from HDFS directly, and generate the segment file on local disk.
3. At last upload the segment file to HDFS, same path with the hdr file, and all these files will be used by the load segment statement.


(@morningman edit)
I sorted out the main process for easy review:

1. `BuilderHelper::initial_build_env()`

	Initialize some objects necessary to start a BE instance

2. `BuilderHelper::open()`

	Open the `StorageEngine` object. And check that the relevant directories are correct, etc.

3. `BuilderHelper::build()`

	1. Read header file from HDFS or local file
	2. Generate `TabletMeta` and `Tablet` object according to header
	3. Collect the list of data files that need to be read
	4. Create `BuilderScannerMemtable` and call `doSegmentBuild(files)`

		1. Generate `BrokerScanNode` and initialize it.
		2. Generate `DeltaWriter` and initialize it
		3. Loop through the `BrokerScanNode` to read the file and write to the `DeltaWriter`
		4. When the reading is complete, close the `DeltaWriter`
		5. Call `revise_rs_metas` to modify `tablet_meta`

	5. After the writing is completed, a new header file is generated
	6. Upload segment file and header file to HDFS if needed







