### PR TITLE
[fix](regression-test) Fix the build for Java UDF Case

### DIFF
--- a/regression-test/java-udf-src/pom.xml
+++ b/regression-test/java-udf-src/pom.xml
@@ -30,6 +30,13 @@ under the License.
         <maven.compiler.target>8</maven.compiler.target>
     </properties>
 
+    <repositories>
+        <repository>
+            <id>MapR</id>
+            <url>https://repository.mapr.com/nexus/content/groups/mapr-public/conjars</url>
+        </repository>
+    </repositories>
+
     <dependencies>
         <!-- https://mvnrepository.com/artifact/org.apache.hive/hive-exec -->
         <dependency>
@@ -68,6 +75,7 @@ under the License.
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.10.1</version>
                 <configuration>
                     <source>8</source>
                     <target>8</target>


### PR DESCRIPTION
# Proposed changes

Issue Number: close #15850 

## Problem summary

After opening the project in Intellij Idea, we can see the cause. It is because Apache Maven of which the version is 3.8.1 or newer blocks http repositories by default. Therefore, we can fix this issue by adding a https repository which contains this package in `pom.xml`.

```shell
org.pentaho:pentaho-aggdesigner-algorithm:pom:5.1.5-jhyde failed to transfer from http://0.0.0.0/ during a previous attempt. This failure was cached in the local repository and resolution is not reattempted until the update interval of maven-default-http-blocker has elapsed or updates are forced. Original error: Could not transfer artifact org.pentaho:pentaho-aggdesigner-algorithm:pom:5.1.5-jhyde from/to maven-default-http-blocker (http://0.0.0.0/): Blocked mirror for repositories: [datanucleus (http://www.datanucleus.org/downloads/maven2, default, releases), glassfish-repository (http://maven.glassfish.org/content/groups/glassfish, default, disabled), glassfish-repo-archive (http://maven.glassfish.org/content/groups/glassfish, default, disabled), apache.snapshots (http://repository.apache.org/snapshots, default, snapshots)]

Since Maven 3.8.1 http repositories are blocked.

Possible solutions:
- Check that Maven settings.xml does not contain http repositories
- Check that Maven pom files do not contain http repository http://www.datanucleus.org/downloads/maven2
- Check that Maven pom files do not contain http repository http://maven.glassfish.org/content/groups/glassfish
- Check that Maven pom files do not contain http repository http://maven.glassfish.org/content/groups/glassfish
- Check that Maven pom files do not contain http repository http://repository.apache.org/snapshots
- Add a mirror(s) for http://www.datanucleus.org/downloads/maven2, http://maven.glassfish.org/content/groups/glassfish, http://maven.glassfish.org/content/groups/glassfish, http://repository.apache.org/snapshots that allows http url in the Maven settings.xml
- Downgrade Maven to version 3.8.1 or earlier in settings
```

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

