### PR TITLE
[fix](nereids)upgrade signature datatype bug

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/FunctionCallExpr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/FunctionCallExpr.java
@@ -32,7 +32,6 @@ import org.apache.doris.catalog.ScalarFunction;
 import org.apache.doris.catalog.ScalarType;
 import org.apache.doris.catalog.Type;
 import org.apache.doris.common.AnalysisException;
-import org.apache.doris.common.Config;
 import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.ErrorReport;
 import org.apache.doris.common.util.VectorizedUtil;
@@ -1326,15 +1325,7 @@ public class FunctionCallExpr extends Expr {
                 for (int i = 0; i < argTypes.length - orderByElements.size(); ++i) {
                     // For varargs, we must compare with the last type in callArgs.argTypes.
                     int ix = Math.min(args.length - 1, i);
-                    if (!argTypes[i].matchesType(args[ix]) && Config.enable_date_conversion
-                            && !argTypes[i].isDateType() && (args[ix].isDate() || args[ix].isDatetime())) {
-                        uncheckedCastChild(ScalarType.getDefaultDateType(args[ix]), i);
-                    } else if (!argTypes[i].matchesType(args[ix])
-                            && Config.enable_decimal_conversion
-                            && argTypes[i].isDecimalV3() && args[ix].isDecimalV2()) {
-                        uncheckedCastChild(ScalarType.createDecimalV3Type(argTypes[i].getPrecision(),
-                                ((ScalarType) argTypes[i]).getScalarScale()), i);
-                    } else if (fnName.getFunction().equalsIgnoreCase("money_format")
+                    if (fnName.getFunction().equalsIgnoreCase("money_format")
                             && children.get(0).getType().isDecimalV3() && args[ix].isDecimalV3()) {
                         continue;
                     } else if (!argTypes[i].matchesType(args[ix]) && !(
@@ -1392,38 +1383,6 @@ public class FunctionCallExpr extends Expr {
             }
         } else {
             this.type = fn.getReturnType();
-        }
-
-        Type[] childTypes = collectChildReturnTypes();
-        if ((this.type.isDate() || this.type.isDatetime()) && Config.enable_date_conversion
-                && fn.getArgs().length == childTypes.length) {
-            boolean implicitCastToDate = false;
-            for (int i = 0; i < fn.getArgs().length; i++) {
-                implicitCastToDate = Type.canCastTo(childTypes[i], fn.getArgs()[i]);
-                if (implicitCastToDate) {
-                    break;
-                }
-            }
-            if (implicitCastToDate) {
-                this.type = ScalarType.getDefaultDateType(fn.getReturnType());
-                fn.setReturnType(ScalarType.getDefaultDateType(fn.getReturnType()));
-            }
-        }
-
-        if (this.type.isDecimalV2() && Config.enable_decimal_conversion
-                && fn.getArgs().length == childTypes.length) {
-            boolean implicitCastToDecimalV3 = false;
-            for (int i = 0; i < fn.getArgs().length; i++) {
-                implicitCastToDecimalV3 = Type.canCastTo(childTypes[i], fn.getArgs()[i]);
-                if (implicitCastToDecimalV3) {
-                    break;
-                }
-            }
-            if (implicitCastToDecimalV3) {
-                this.type = ScalarType.createDecimalV3Type(fn.getReturnType().getPrecision(),
-                        ((ScalarType) fn.getReturnType()).getScalarScale());
-                fn.setReturnType(this.type);
-            }
         }
 
         if (this.type.isDecimalV2()) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/ComputeSignature.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/ComputeSignature.java
@@ -106,8 +106,6 @@ public interface ComputeSignature extends FunctionTrait, ImplicitCastInputTypes 
         // function class, like 'If' function and 'Substring' function.
         return ComputeSignatureChain.from(this, signature, getArguments())
                 .then(ComputeSignatureHelper::implementAbstractReturnType)
-                .then(ComputeSignatureHelper::upgradeDateOrDateTimeToV2)
-                .then(ComputeSignatureHelper::upgradeDecimalV2ToV3)
                 .then(ComputeSignatureHelper::normalizeDecimalV2)
                 .then(ComputeSignatureHelper::computePrecision)
                 .then(ComputeSignatureHelper::dynamicComputePropertiesOfArray)

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/ComputeSignatureHelper.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/ComputeSignatureHelper.java
@@ -19,16 +19,12 @@ package org.apache.doris.nereids.trees.expressions.functions;
 
 import org.apache.doris.catalog.FunctionSignature;
 import org.apache.doris.catalog.FunctionSignature.TripleFunction;
-import org.apache.doris.catalog.ScalarType;
-import org.apache.doris.catalog.Type;
-import org.apache.doris.common.Config;
 import org.apache.doris.nereids.exceptions.AnalysisException;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.types.ArrayType;
 import org.apache.doris.nereids.types.DataType;
 import org.apache.doris.nereids.types.DateType;
 import org.apache.doris.nereids.types.DecimalV2Type;
-import org.apache.doris.nereids.types.coercion.AbstractDataType;
 import org.apache.doris.nereids.types.coercion.FollowToArgumentType;
 import org.apache.doris.nereids.util.ResponsibilityChain;
 
@@ -46,29 +42,6 @@ public class ComputeSignatureHelper {
                 return signature.withReturnType(arguments.get(argumentIndex).getDataType());
             }
             throw new AnalysisException("Not implemented abstract return type: " + signature.returnType);
-        }
-        return signature;
-    }
-
-    /** upgradeDateOrDateTimeToV2 */
-    public static FunctionSignature upgradeDateOrDateTimeToV2(
-            FunctionSignature signature, List<Expression> arguments) {
-        Type type = signature.returnType.toCatalogDataType();
-        if ((type.isDate() || type.isDatetime()) && Config.enable_date_conversion) {
-            Type legacyReturnType = ScalarType.getDefaultDateType(type);
-            signature = signature.withReturnType(DataType.fromCatalogType(legacyReturnType));
-        }
-        return signature;
-    }
-
-    /** upgradeDecimalV2ToV3 */
-    public static FunctionSignature upgradeDecimalV2ToV3(
-            FunctionSignature signature, List<Expression> arguments) {
-        AbstractDataType returnType = signature.returnType;
-        Type type = returnType.toCatalogDataType();
-        if ((type.isDate() || type.isDatetime()) && Config.enable_date_conversion) {
-            Type legacyReturnType = ScalarType.getDefaultDateType(returnType.toCatalogDataType());
-            signature = signature.withReturnType(DataType.fromCatalogType(legacyReturnType));
         }
         return signature;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/DaysAdd.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/DaysAdd.java
@@ -18,6 +18,7 @@
 package org.apache.doris.nereids.trees.expressions.functions.scalar;
 
 import org.apache.doris.catalog.FunctionSignature;
+import org.apache.doris.common.Config;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.functions.AlwaysNullable;
 import org.apache.doris.nereids.trees.expressions.functions.ExplicitlyCastableSignature;
@@ -38,11 +39,19 @@ import java.util.List;
  * ScalarFunction 'days_add'.
  */
 public class DaysAdd extends ScalarFunction implements BinaryExpression, ExplicitlyCastableSignature, AlwaysNullable {
-    public static final List<FunctionSignature> SIGNATURES = ImmutableList.of(
-            FunctionSignature.ret(DateTimeType.INSTANCE).args(DateTimeType.INSTANCE, IntegerType.INSTANCE),
+    //When enable_date_conversion is true, we prefer to V2 signature.
+    // This preference follows original planner. refer to ScalarType.getDefaultDateType()
+    public static final List<FunctionSignature> SIGNATURES = Config.enable_date_conversion ? ImmutableList.of(
             FunctionSignature.ret(DateTimeV2Type.SYSTEM_DEFAULT)
                     .args(DateTimeV2Type.SYSTEM_DEFAULT, IntegerType.INSTANCE),
+            FunctionSignature.ret(DateV2Type.INSTANCE).args(DateV2Type.INSTANCE, IntegerType.INSTANCE),
+            FunctionSignature.ret(DateTimeType.INSTANCE).args(DateTimeType.INSTANCE, IntegerType.INSTANCE),
+            FunctionSignature.ret(DateType.INSTANCE).args(DateType.INSTANCE, IntegerType.INSTANCE)
+    ) : ImmutableList.of(
+            FunctionSignature.ret(DateTimeType.INSTANCE).args(DateTimeType.INSTANCE, IntegerType.INSTANCE),
             FunctionSignature.ret(DateType.INSTANCE).args(DateType.INSTANCE, IntegerType.INSTANCE),
+            FunctionSignature.ret(DateTimeV2Type.SYSTEM_DEFAULT)
+                    .args(DateTimeV2Type.SYSTEM_DEFAULT, IntegerType.INSTANCE),
             FunctionSignature.ret(DateV2Type.INSTANCE).args(DateV2Type.INSTANCE, IntegerType.INSTANCE)
     );
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/DaysSub.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/DaysSub.java
@@ -18,6 +18,7 @@
 package org.apache.doris.nereids.trees.expressions.functions.scalar;
 
 import org.apache.doris.catalog.FunctionSignature;
+import org.apache.doris.common.Config;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.functions.AlwaysNullable;
 import org.apache.doris.nereids.trees.expressions.functions.ExplicitlyCastableSignature;
@@ -38,11 +39,19 @@ import java.util.List;
  * ScalarFunction 'days_add'.
  */
 public class DaysSub extends ScalarFunction implements BinaryExpression, ExplicitlyCastableSignature, AlwaysNullable {
-    public static final List<FunctionSignature> SIGNATURES = ImmutableList.of(
-            FunctionSignature.ret(DateTimeType.INSTANCE).args(DateTimeType.INSTANCE, IntegerType.INSTANCE),
+    //When enable_date_conversion is true, we prefer to V2 signature.
+    // This preference follows original planner. refer to ScalarType.getDefaultDateType()
+    public static final List<FunctionSignature> SIGNATURES = Config.enable_date_conversion ? ImmutableList.of(
             FunctionSignature.ret(DateTimeV2Type.SYSTEM_DEFAULT)
                     .args(DateTimeV2Type.SYSTEM_DEFAULT, IntegerType.INSTANCE),
+            FunctionSignature.ret(DateV2Type.INSTANCE).args(DateV2Type.INSTANCE, IntegerType.INSTANCE),
+            FunctionSignature.ret(DateTimeType.INSTANCE).args(DateTimeType.INSTANCE, IntegerType.INSTANCE),
+            FunctionSignature.ret(DateType.INSTANCE).args(DateType.INSTANCE, IntegerType.INSTANCE)
+    ) : ImmutableList.of(
+            FunctionSignature.ret(DateTimeType.INSTANCE).args(DateTimeType.INSTANCE, IntegerType.INSTANCE),
             FunctionSignature.ret(DateType.INSTANCE).args(DateType.INSTANCE, IntegerType.INSTANCE),
+            FunctionSignature.ret(DateTimeV2Type.SYSTEM_DEFAULT)
+                    .args(DateTimeV2Type.SYSTEM_DEFAULT, IntegerType.INSTANCE),
             FunctionSignature.ret(DateV2Type.INSTANCE).args(DateV2Type.INSTANCE, IntegerType.INSTANCE)
     );
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/Timestamp.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/Timestamp.java
@@ -18,6 +18,7 @@
 package org.apache.doris.nereids.trees.expressions.functions.scalar;
 
 import org.apache.doris.catalog.FunctionSignature;
+import org.apache.doris.common.Config;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.functions.AlwaysNullable;
 import org.apache.doris.nereids.trees.expressions.functions.ExplicitlyCastableSignature;
@@ -36,8 +37,12 @@ import java.util.List;
  */
 public class Timestamp extends ScalarFunction
         implements UnaryExpression, ExplicitlyCastableSignature, AlwaysNullable {
-
-    public static final List<FunctionSignature> SIGNATURES = ImmutableList.of(
+    //When enable_date_conversion is true, we prefer to V2 signature.
+    // This preference follows original planner. refer to ScalarType.getDefaultDateType()
+    public static final List<FunctionSignature> SIGNATURES = Config.enable_date_conversion ? ImmutableList.of(
+            FunctionSignature.ret(DateTimeV2Type.SYSTEM_DEFAULT).args(DateTimeV2Type.SYSTEM_DEFAULT),
+            FunctionSignature.ret(DateTimeType.INSTANCE).args(DateTimeType.INSTANCE)
+    ) : ImmutableList.of(
             FunctionSignature.ret(DateTimeType.INSTANCE).args(DateTimeType.INSTANCE),
             FunctionSignature.ret(DateTimeV2Type.SYSTEM_DEFAULT).args(DateTimeV2Type.SYSTEM_DEFAULT)
     );


### PR DESCRIPTION
# Proposed changes
ComputeSignatureHelper.upgradeDateOrDateTimeToV2()
we upgrate return date type, but forget to upgrade arguments datatype.

The same problem in upgradeDecimalV2ToV3()

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

