### PR TITLE
[fix](brokerload) fix be core dump casued by broker load

### DIFF
--- a/be/src/io/fs/broker_file_reader.h
+++ b/be/src/io/fs/broker_file_reader.h
@@ -59,7 +59,6 @@ private:
 
     std::shared_ptr<BrokerFileSystem> _fs;
     std::atomic<bool> _closed = false;
-    std::shared_ptr<BrokerServiceConnection> _client;
 };
 } // namespace io
 } // namespace doris


### PR DESCRIPTION
# Proposed changes

Issue Number: close #15846

## Problem summary

The BrokerFileReader is refactored in #15622, but the _client is not initialized

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

