### PR TITLE
[Feature](profile) set sql and defaultDb fields in show-load-profile.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/BrokerLoadJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/BrokerLoadJob.java
@@ -323,14 +323,19 @@ public class BrokerLoadJob extends BulkLoadJob {
         summaryProfile.addInfoString(ProfileManager.QUERY_TYPE, "Load");
         summaryProfile.addInfoString(ProfileManager.QUERY_STATE, "N/A");
         summaryProfile.addInfoString(ProfileManager.USER, "N/A");
-        summaryProfile.addInfoString(ProfileManager.DEFAULT_DB, "N/A");
-        summaryProfile.addInfoString(ProfileManager.SQL_STATEMENT, "N/A");
+        summaryProfile.addInfoString(ProfileManager.DEFAULT_DB, getDefaultDb());
+        summaryProfile.addInfoString(ProfileManager.SQL_STATEMENT, this.getOriginStmt().originStmt);
         summaryProfile.addInfoString(ProfileManager.IS_CACHED, "N/A");
 
         // Add the summary profile to the first
         jobProfile.addFirstChild(summaryProfile);
         jobProfile.computeTimeInChildProfile();
         ProfileManager.getInstance().pushProfile(jobProfile);
+    }
+
+    private String getDefaultDb() {
+        Database database = Env.getCurrentEnv().getInternalCatalog().getDb(this.dbId).orElse(null);
+        return database == null ? "N/A" : database.getFullName();
     }
 
     private void updateLoadingStatus(BrokerLoadingTaskAttachment attachment) {

--- a/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/BulkLoadJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/BulkLoadJob.java
@@ -301,6 +301,10 @@ public abstract class BulkLoadJob extends LoadJob {
         }
     }
 
+    public OriginStatement getOriginStmt() {
+        return this.originStmt;
+    }
+
     public void readFields(DataInput in) throws IOException {
         super.readFields(in);
         brokerDesc = BrokerDesc.read(in);


### PR DESCRIPTION
# Proposed changes

When execute `show load profile '/'`, the value of `SQL` and `DefaultDb` columns are all 'N/A', but we can fill these fields，the result of this pr is as follows:

Execute `show load profile '/'\G`:

```sql
MySQL [test_d]> show load profile '/'\G
*************************** 1. row ***************************
   QueryId: 652326
      User: N/A
 DefaultDb: default_cluster:test_d
       SQL: LOAD LABEL `default_cluster:test_d`.`xxx`  (APPEND DATA INFILE ('hdfs://xxx/user/hive/warehouse/xxx.db/xxx/*')  INTO TABLE xxx FORMAT AS 'ORC' (c1, c2, c3) SET (`c1` = `c1`, `c2` = `c2`, `c3` = `c3`))  WITH BROKER broker_xxx (xxx)  PROPERTIES ("max_filter_ratio" = "0", "timeout" = "30000")
 QueryType: Load
 StartTime: 2023-01-12 18:33:34
   EndTime: 2023-01-12 18:33:46
 TotalTime: 11s613ms
QueryState: N/A
1 row in set (0.01 sec)
```


## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

