### PR TITLE
[improvement](signal) add tid during core dump,the tid is equal to thread id in be.INFO

### DIFF
--- a/be/src/common/signal_handler.h
+++ b/be/src/common/signal_handler.h
@@ -307,7 +307,15 @@ void DumpSignalInfo(int signal_number, siginfo_t* siginfo) {
     formatter.AppendString(")");
     formatter.AppendString(" received by PID ");
     formatter.AppendUint64(static_cast<uint64>(getpid()), 10);
-    formatter.AppendString(" (TID 0x");
+    formatter.AppendString(" (TID ");
+    uint64_t tid;
+#ifdef __APPLE__
+    pthread_threadid_np(nullptr, &tid);
+#else
+    tid = syscall(SYS_gettid);
+#endif
+    formatter.AppendUint64(tid, 10);
+    formatter.AppendString(" OR 0x");
     // We assume pthread_t is an integral number or a pointer, rather
     // than a complex struct.  In some environments, pthread_self()
     // returns an uint64 but in some other environments pthread_self()


### PR DESCRIPTION


# Proposed changes

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

