### PR TITLE
[enhancement](profile) add read columns to scanner profile

### DIFF
--- a/be/src/olap/rowset/beta_rowset_reader.cpp
+++ b/be/src/olap/rowset/beta_rowset_reader.cpp
@@ -42,25 +42,7 @@ void BetaRowsetReader::reset_read_options() {
     _read_options.key_ranges.clear();
 }
 
-static std::string read_columns_to_string(RowsetReaderContext* read_context,
-                                          const std::vector<uint32_t>& read_columns) {
-    std::string read_columns_string;
-    read_columns_string += "[";
-    for (auto it = read_columns.cbegin(); it != read_columns.cend(); it++) {
-        if (it != read_columns.cbegin()) {
-            read_columns_string += ", ";
-        }
-        read_columns_string += read_context->tablet_schema->columns().at(*it).name();
-    }
-    read_columns_string += "]";
-    return read_columns_string;
-}
-
 bool BetaRowsetReader::update_profile(RuntimeProfile* profile) {
-    // add read_columns in scanner_profile
-    profile->add_info_string("ReadColumns",
-                             read_columns_to_string(_context, _input_schema->column_ids()));
-
     if (_iterator != nullptr) {
         return _iterator->update_profile(profile);
     }

--- a/be/src/olap/rowset/beta_rowset_reader.h
+++ b/be/src/olap/rowset/beta_rowset_reader.h
@@ -64,12 +64,7 @@ public:
 
     Status get_segment_num_rows(std::vector<uint32_t>* segment_num_rows) override;
 
-    bool update_profile(RuntimeProfile* profile) override {
-        if (_iterator != nullptr) {
-            return _iterator->update_profile(profile);
-        }
-        return false;
-    }
+    bool update_profile(RuntimeProfile* profile) override;
 
 private:
     bool _should_push_down_value_predicates() const;

--- a/be/src/vec/exec/scan/scanner_context.cpp
+++ b/be/src/vec/exec/scan/scanner_context.cpp
@@ -181,22 +181,37 @@ Status ScannerContext::_close_and_clear_scanners() {
         std::stringstream scanner_rows_read;
         scanner_statistics << "[";
         scanner_rows_read << "[";
+        bool is_first_scanner_statistics = true;
+        bool is_first_scanner_rows_read = true;
         for (auto finished_scanner_time : _finished_scanner_runtime) {
-            scanner_statistics << PrettyPrinter::print(finished_scanner_time, TUnit::TIME_NS)
-                               << ", ";
+            if (!is_first_scanner_statistics) {
+                scanner_statistics << ", ";
+            }
+            scanner_statistics << PrettyPrinter::print(finished_scanner_time, TUnit::TIME_NS);
+            is_first_scanner_statistics = false;
         }
         for (auto finished_scanner_rows : _finished_scanner_rows_read) {
+            if (!is_first_scanner_rows_read) {
+                scanner_rows_read << ", ";
+            }
             scanner_rows_read << PrettyPrinter::print(finished_scanner_rows, TUnit::UNIT) << ", ";
+            is_first_scanner_rows_read = false;
         }
         // Only unfinished scanners here
         for (auto scanner : _scanners) {
             // Scanners are in ObjPool in ScanNode,
             // so no need to delete them here.
             // Add per scanner running time before close them
-            scanner_statistics << PrettyPrinter::print(scanner->get_time_cost_ns(), TUnit::TIME_NS)
-                               << ", ";
-            scanner_rows_read << PrettyPrinter::print(scanner->get_rows_read(), TUnit::UNIT)
-                              << ", ";
+            if (!is_first_scanner_statistics) {
+                scanner_statistics << ", ";
+            }
+            scanner_statistics << PrettyPrinter::print(scanner->get_time_cost_ns(), TUnit::TIME_NS);
+            is_first_scanner_statistics = false;
+            if (!is_first_scanner_rows_read) {
+                scanner_rows_read << ", ";
+            }
+            scanner_rows_read << PrettyPrinter::print(scanner->get_rows_read(), TUnit::UNIT);
+            is_first_scanner_rows_read = false;
         }
         scanner_statistics << "]";
         scanner_rows_read << "]";

--- a/be/src/vec/exec/scan/scanner_context.cpp
+++ b/be/src/vec/exec/scan/scanner_context.cpp
@@ -181,37 +181,22 @@ Status ScannerContext::_close_and_clear_scanners() {
         std::stringstream scanner_rows_read;
         scanner_statistics << "[";
         scanner_rows_read << "[";
-        bool is_first_scanner_statistics = true;
-        bool is_first_scanner_rows_read = true;
         for (auto finished_scanner_time : _finished_scanner_runtime) {
-            if (!is_first_scanner_statistics) {
-                scanner_statistics << ", ";
-            }
-            scanner_statistics << PrettyPrinter::print(finished_scanner_time, TUnit::TIME_NS);
-            is_first_scanner_statistics = false;
+            scanner_statistics << PrettyPrinter::print(finished_scanner_time, TUnit::TIME_NS)
+                               << ", ";
         }
         for (auto finished_scanner_rows : _finished_scanner_rows_read) {
-            if (!is_first_scanner_rows_read) {
-                scanner_rows_read << ", ";
-            }
             scanner_rows_read << PrettyPrinter::print(finished_scanner_rows, TUnit::UNIT) << ", ";
-            is_first_scanner_rows_read = false;
         }
         // Only unfinished scanners here
         for (auto scanner : _scanners) {
             // Scanners are in ObjPool in ScanNode,
             // so no need to delete them here.
             // Add per scanner running time before close them
-            if (!is_first_scanner_statistics) {
-                scanner_statistics << ", ";
-            }
-            scanner_statistics << PrettyPrinter::print(scanner->get_time_cost_ns(), TUnit::TIME_NS);
-            is_first_scanner_statistics = false;
-            if (!is_first_scanner_rows_read) {
-                scanner_rows_read << ", ";
-            }
-            scanner_rows_read << PrettyPrinter::print(scanner->get_rows_read(), TUnit::UNIT);
-            is_first_scanner_rows_read = false;
+            scanner_statistics << PrettyPrinter::print(scanner->get_time_cost_ns(), TUnit::TIME_NS)
+                               << ", ";
+            scanner_rows_read << PrettyPrinter::print(scanner->get_rows_read(), TUnit::UNIT)
+                              << ", ";
         }
         scanner_statistics << "]";
         scanner_rows_read << "]";


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

add ReadColumns in profile

eg:
```
mysql> select city, sum(cost) as total_cost from example_tbl group by city;
```
```
VScanner:
-  ReadColumns:  [city,  cost]
-  PerScannerRunningTime:  [92.198us,  ]
-  PerScannerRowsRead:  [6,  ]
-  BlockConvertTime:  0ns
-  BlockFetchTime:  86.382us
-  ReaderInitTime:  0ns
-  RowsDelFiltered:  0
```
## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

