### PR TITLE
[regression-test](MTMV) Make the case test_create_mtmv more robust (addendum)

### DIFF
--- a/regression-test/suites/mtmv_p0/test_create_mtmv.groovy
+++ b/regression-test/suites/mtmv_p0/test_create_mtmv.groovy
@@ -78,7 +78,7 @@ suite("test_create_mtmv") {
         state = show_task_result.last().get(index)
         println "The state of ${query} is ${state}"
         Thread.sleep(1000);
-    } while (state.equals('PENDING'))
+    } while (state.equals('PENDING') || state.equals('RUNNING'))
 
     assertEquals('SUCCESS', state)
     order_qt_select "SELECT * FROM ${mvName}"


### PR DESCRIPTION
# Proposed changes

~~Issue Number: close #xxx~~

## Problem summary

See #15866 , but the previous PR missed the state `RUNNING`.

```java
public enum TaskState {
    PENDING, RUNNING, FAILED, SUCCESS,
}
```

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [x] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

