### PR TITLE
[Feature](inverted index) implementation of inverted index writer for numeric types, using bkd index

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -880,6 +880,8 @@ CONF_mDouble(inverted_index_ram_buffer_size, "512");
 CONF_Int32(query_bkd_inverted_index_limit_percent, "5"); // 5%
 // dict path for chinese analyzer
 CONF_String(inverted_index_dict_path, "${DORIS_HOME}/dict");
+// tree depth for bkd index
+CONF_Int32(max_depth_in_bkd_tree, "32");
 #ifdef BE_TEST
 // test s3
 CONF_String(test_s3_resource, "resource");


### PR DESCRIPTION
# Proposed changes

 Step3 of [DSIP-023: Add inverted index for full text search](https://cwiki.apache.org/confluence/display/DORIS/DSIP-023%3A+Add+inverted+index+for+full+text+search?src=contextnavpagetreemode)
 implementation of inverted index writer for numeric types, using bkd index
dependency pr: https://github.com/apache/doris/pull/14207 https://github.com/apache/doris/pull/15807 https://github.com/apache/doris/pull/15821

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

