### PR TITLE
[chore](build) Fix linkage errors on macOS (arm64)

### DIFF
--- a/thirdparty/build-thirdparty.sh
+++ b/thirdparty/build-thirdparty.sh
@@ -1549,15 +1549,21 @@ build_concurrentqueue() {
 
 #clucene
 build_clucene() {
-    if [[ -z ${USE_AVX2} ]]; then
-        USE_AVX2=1
+    if [[ "$(uname -m)" == 'x86_64' ]]; then
+        USE_AVX2="${USE_AVX2:-1}"
+    else
+        USE_AVX2="${USE_AVX2:-0}"
     fi
+
     if [[ -z ${BUILD_TYPE} ]]; then
         BUILD_TYPE=Release
     fi
+
     check_if_source_exist "${CLUCENE_SOURCE}"
     cd "${TP_SOURCE_DIR}/${CLUCENE_SOURCE}"
-    mkdir -p "${BUILD_DIR}" && cd "${BUILD_DIR}"
+
+    mkdir -p "${BUILD_DIR}"
+    cd "${BUILD_DIR}"
     rm -rf CMakeCache.txt CMakeFiles/
 
     ${CMAKE_CMD} -G "${GENERATOR}" -DCMAKE_INSTALL_PREFIX="${TP_INSTALL_DIR}" -DBUILD_STATIC_LIBRARIES=ON \


### PR DESCRIPTION
# Proposed changes

Issue Number: close #15923

## Problem summary

macOS with Apple Silicon chip doesn't support AVX2 instructions, we should build [CLucene](https://github.com/apache/doris-thirdparty/tree/clucene) without AVX2 support.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [x] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

