### PR TITLE
[fix](thirdparty) patch sqltypes.h in odbc to avoid conflict with clucene TCHAR

### DIFF
--- a/thirdparty/download-thirdparty.sh
+++ b/thirdparty/download-thirdparty.sh
@@ -286,6 +286,15 @@ fi
 cd -
 echo "Finished patching ${CYRUS_SASL_SOURCE}"
 
+#patch sqltypes.h, change TCAHR to TWCHAR to avoid conflict with clucene TCAHR
+cd "${TP_SOURCE_DIR}/${ODBC_SOURCE}"
+if [[ ! -f ${PATCHED_MARK} ]]; then
+    patch -p1 <"${TP_PATCH_DIR}/sqltypes.h.patch"
+    touch "${PATCHED_MARK}"
+fi
+cd -
+echo "Finished patching ${ODBC_SOURCE}"
+
 # rocksdb patch to fix compile error
 if [[ "${ROCKSDB_SOURCE}" == "rocksdb-5.14.2" ]]; then
     cd "${TP_SOURCE_DIR}/${ROCKSDB_SOURCE}"

--- a/thirdparty/patches/sqltypes.h.patch
+++ b/thirdparty/patches/sqltypes.h.patch
@@ -1,0 +1,28 @@
+--- a/include/sqltypes.h        2022-04-19 14:37:42.584467011 +0800
++++ b/include/sqltypes.h        2022-04-19 13:56:41.486446873 +0800
+@@ -82,13 +82,13 @@
+  * 	by the standard linux string header files.
+  */
+ #ifdef SQL_WCHART_CONVERT
+-typedef wchar_t             TCHAR;
++typedef wchar_t             TWCHAR;
+ #else
+-typedef signed short        TCHAR;
++typedef signed short        TWCHAR;
+ #endif
+ 
+ #else
+-typedef char				TCHAR;
++typedef char				TWCHAR;
+ #endif
+ 
+ typedef unsigned short		WORD;
+@@ -108,7 +108,7 @@
+ typedef WCHAR* 	            LPWSTR;
+ typedef const char*         LPCSTR;
+ typedef const WCHAR*        LPCWSTR;
+-typedef TCHAR*              LPTSTR;
++typedef TWCHAR*              LPTSTR;
+ typedef char*               LPSTR;
+ typedef DWORD*           	LPDWORD;
+ 


### PR DESCRIPTION
# Proposed changes
Fix conflit name TCHAR in odbc sqltypes.h and clucene clucene-config.h. Change TCHAR to TWCHAR in odbc sqltypes.h, because TCHAR in odbc is not found used in doris, but there are too many places to call clucene's TCHAR.

thirdparty/installed/include/sqltypes.h: 
`typedef char                            TCHAR;`

thirdparty/installed/include/CLucene/clucene-config.h: 
`typedef  wchar_t TCHAR;`

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

