### PR TITLE
[fix](test) change remote_fragment_exec_timeout_ms in p0/p1 to 60 seconds

### DIFF
--- a/regression-test/pipeline/p0/conf/fe.conf
+++ b/regression-test/pipeline/p0/conf/fe.conf
@@ -67,5 +67,5 @@ sys_log_verbose_modules = org.apache.doris
 
 enable_outfile_to_local = true
 tablet_create_timeout_second=20
-remote_fragment_exec_timeout_ms=15000
+remote_fragment_exec_timeout_ms=60000
 use_fuzzy_session_variable=true

--- a/regression-test/pipeline/p1/conf/fe.conf
+++ b/regression-test/pipeline/p1/conf/fe.conf
@@ -68,5 +68,5 @@ priority_networks=172.19.0.0/24
 
 enable_outfile_to_local = true
 tablet_create_timeout_second=20
-remote_fragment_exec_timeout_ms=15000
+remote_fragment_exec_timeout_ms=60000
 use_fuzzy_session_variable=true


### PR DESCRIPTION
test_join case failed due to send fragment timeout frequently.

# Proposed changes

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

