### PR TITLE
[Fix](inverted index) fix compilation error for inverted index compound directory

### DIFF
--- a/be/src/olap/rowset/segment_v2/inverted_index_compound_directory.cpp
+++ b/be/src/olap/rowset/segment_v2/inverted_index_compound_directory.cpp
@@ -245,14 +245,10 @@ bool DorisCompoundDirectory::FSIndexInput::open(const io::FileSystemSPtr& fs, co
     if (h->_reader) {
         //Store the file length
         h->_length = h->_reader->size();
-        // if (handle->_length == -1)
-        if (h->_reader->size() < 0) {
-            error.set(CL_ERR_IO, "fileStat error");
-        } else {
-            h->_fpos = 0;
-            ret = _CLNEW FSIndexInput(h, buffer_size);
-            return true;
-        }
+        h->_fpos = 0;
+        ret = _CLNEW FSIndexInput(h, buffer_size);
+        return true;
+
     } else {
         int err = errno;
         if (err == ENOENT) {


### PR DESCRIPTION
# Proposed changes

fix compilation error for inverted index compound directory

```
be/src/olap/rowset/segment_v2/inverted_index_compound_directory.cpp:249:32: error: comparison of unsigned expression in '< 0' is always false [-Werror=type-limits]
  249 |         if (h->_reader->size() < 0) {
      |             ~~~~~~~~~~~~~~~~~~~^~~
```

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

