### PR TITLE
[MTMV](opt) mtmv task use original query stmt so that user can set var more flexible

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/MaterializedView.java
@@ -71,7 +71,7 @@ public class MaterializedView extends OlapTable {
         type = TableType.MATERIALIZED_VIEW;
         buildMode = params.buildMode;
         refreshInfo = params.mvRefreshInfo;
-        query = params.queryStmt.toSql();
+        query = params.originQueryStmt;
     }
 
     public BuildMode getBuildMode() {

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTableFactory.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTableFactory.java
@@ -24,19 +24,18 @@ import org.apache.doris.analysis.MVRefreshInfo;
 import org.apache.doris.analysis.MVRefreshInfo.BuildMode;
 import org.apache.doris.analysis.QueryStmt;
 import org.apache.doris.catalog.TableIf.TableType;
+
+import com.google.common.base.Preconditions;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import com.google.common.base.Preconditions;
-
 import java.util.List;
-
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.Vector;
 
 public class OlapTableFactory {
     private static final Logger LOG = LogManager.getLogger(OlapTableFactory.class);
+
     public static class BuildParams {
         public long tableId;
         public String tableName;
@@ -174,7 +173,7 @@ public class OlapTableFactory {
             LOG.info("create mtmv, original_query:{}, stmt:{}", materializedViewParams.originQueryStmt, orignalStmt);
             if (orignalStmt.length() <= 0) {
                 LOG.warn("create mtmv fail, cause get query fail , sql:{}", orignalStmt);
-                throw new IllegalArgumentException("create mtmv fail cause get query fail, sql:"+orignalStmt);
+                throw new IllegalArgumentException("create mtmv fail cause get query fail, sql:" + orignalStmt);
             }
             return withBuildMode(createMVStmt.getBuildMode())
                     .withRefreshInfo(createMVStmt.getRefreshInfo())
@@ -182,23 +181,23 @@ public class OlapTableFactory {
         }
     }
 
-    public String getMvStmtQueryString(String str){
-        String regex="AS[\\s\\n]+select[\\s\\n]+";
-		Pattern pattern = Pattern.compile(regex, Pattern.CASE_INSENSITIVE);
-		Matcher matcher = pattern.matcher(str);
+    public String getMvStmtQueryString(String str) {
+        String regex = "AS[\\s\\n]+select[\\s\\n]+";
+        Pattern pattern = Pattern.compile(regex, Pattern.CASE_INSENSITIVE);
+        Matcher matcher = pattern.matcher(str);
         int startPos = -1;
         int endPos = -1;
-		while(matcher.find()) {
-			startPos = matcher.start();
-            endPos =  matcher.end();
+        while (matcher.find()) {
+            startPos = matcher.start();
+            endPos = matcher.end();
             break;
-		}
-        if(startPos>=0){
-            String ret =  "select " + str.substring(endPos);
-            Pattern patternNew = Pattern.compile(";+$"); 
-            Matcher matcherNew = patternNew.matcher(ret);      
-            return matcherNew.replaceAll("");      
-        }else{
+        }
+        if (startPos >= 0) {
+            String ret = "select " + str.substring(endPos);
+            Pattern patternNew = Pattern.compile(";+$");
+            Matcher matcherNew = patternNew.matcher(ret);
+            return matcherNew.replaceAll("");
+        } else {
             return "";
         }
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTableFactory.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTableFactory.java
@@ -182,7 +182,7 @@ public class OlapTableFactory {
     }
 
     public String getMvStmtQueryString(String str) {
-        String regex = "AS[\\s\\n]+select[\\s\\n]+";
+        String regex = "[\\s\\n]+AS[\\s\\n]+";
         Pattern pattern = Pattern.compile(regex, Pattern.CASE_INSENSITIVE);
         Matcher matcher = pattern.matcher(str);
         int startPos = -1;
@@ -193,7 +193,7 @@ public class OlapTableFactory {
             break;
         }
         if (startPos >= 0) {
-            String ret = "select " + str.substring(endPos);
+            String ret = str.substring(endPos);
             Pattern patternNew = Pattern.compile(";+$");
             Matcher matcherNew = patternNew.matcher(ret);
             return matcherNew.replaceAll("");

--- a/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVTaskProcessor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVTaskProcessor.java
@@ -33,8 +33,8 @@ import org.apache.doris.common.util.SqlParserUtils;
 import org.apache.doris.datasource.InternalCatalog;
 import org.apache.doris.mtmv.MTMVUtils.TaskState;
 import org.apache.doris.qe.ConnectContext;
-import org.apache.doris.qe.QueryState;
 import org.apache.doris.qe.OriginStatement;
+import org.apache.doris.qe.QueryState;
 import org.apache.doris.qe.StmtExecutor;
 import org.apache.doris.system.SystemInfoService;
 

--- a/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVTaskProcessor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVTaskProcessor.java
@@ -34,6 +34,7 @@ import org.apache.doris.datasource.InternalCatalog;
 import org.apache.doris.mtmv.MTMVUtils.TaskState;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.QueryState;
+import org.apache.doris.qe.OriginStatement;
 import org.apache.doris.qe.StmtExecutor;
 import org.apache.doris.system.SystemInfoService;
 
@@ -218,6 +219,7 @@ public class MTMVTaskProcessor {
         stmts = parse(ctx, originStmt);
         parsedStmt = stmts.get(0);
         try {
+            parsedStmt.setOrigStmt(new OriginStatement(originStmt, 0));
             StmtExecutor executor = new StmtExecutor(ctx, parsedStmt);
             ctx.setExecutor(executor);
             executor.execute();

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -446,7 +446,6 @@ public class StmtExecutor implements ProfileWriter {
             }
             // support select hint e.g. select /*+ SET_VAR(query_timeout=1) */ sleep(3);
             analyzeVariablesInStmt();
-            LOG.warn("fuck, query_timeout,{}",context.getSessionVariable().getQueryTimeoutS());
 
             if (!context.isTxnModel()) {
                 Span queryAnalysisSpan =

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -446,6 +446,7 @@ public class StmtExecutor implements ProfileWriter {
             }
             // support select hint e.g. select /*+ SET_VAR(query_timeout=1) */ sleep(3);
             analyzeVariablesInStmt();
+            LOG.warn("fuck, query_timeout,{}",context.getSessionVariable().getQueryTimeoutS());
 
             if (!context.isTxnModel()) {
                 Span queryAnalysisSpan =
@@ -647,6 +648,16 @@ public class StmtExecutor implements ProfileWriter {
         SessionVariable sessionVariable = context.getSessionVariable();
         if (parsedStmt != null && parsedStmt instanceof SelectStmt) {
             SelectStmt selectStmt = (SelectStmt) parsedStmt;
+            Map<String, String> optHints = selectStmt.getSelectList().getOptHints();
+            if (optHints != null) {
+                sessionVariable.setIsSingleSetVar(true);
+                for (String key : optHints.keySet()) {
+                    VariableMgr.setVar(sessionVariable, new SetVar(key, new StringLiteral(optHints.get(key))));
+                }
+            }
+        }
+        if (parsedStmt != null && parsedStmt instanceof InsertStmt) {
+            SelectStmt selectStmt = (SelectStmt)((InsertStmt) parsedStmt).getQueryStmt();
             Map<String, String> optHints = selectStmt.getSelectList().getOptHints();
             if (optHints != null) {
                 sessionVariable.setIsSingleSetVar(true);

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -645,24 +645,19 @@ public class StmtExecutor implements ProfileWriter {
      */
     private void analyzeVariablesInStmt() throws DdlException {
         SessionVariable sessionVariable = context.getSessionVariable();
+        Map<String, String> optHints = null;
         if (parsedStmt != null && parsedStmt instanceof SelectStmt) {
             SelectStmt selectStmt = (SelectStmt) parsedStmt;
-            Map<String, String> optHints = selectStmt.getSelectList().getOptHints();
-            if (optHints != null) {
-                sessionVariable.setIsSingleSetVar(true);
-                for (String key : optHints.keySet()) {
-                    VariableMgr.setVar(sessionVariable, new SetVar(key, new StringLiteral(optHints.get(key))));
-                }
-            }
+            optHints = selectStmt.getSelectList().getOptHints();
         }
         if (parsedStmt != null && parsedStmt instanceof InsertStmt) {
-            SelectStmt selectStmt = (SelectStmt)((InsertStmt) parsedStmt).getQueryStmt();
-            Map<String, String> optHints = selectStmt.getSelectList().getOptHints();
-            if (optHints != null) {
-                sessionVariable.setIsSingleSetVar(true);
-                for (String key : optHints.keySet()) {
-                    VariableMgr.setVar(sessionVariable, new SetVar(key, new StringLiteral(optHints.get(key))));
-                }
+            SelectStmt selectStmt = (SelectStmt) ((InsertStmt) parsedStmt).getQueryStmt();
+            optHints = selectStmt.getSelectList().getOptHints();
+        }
+        if (optHints != null) {
+            sessionVariable.setIsSingleSetVar(true);
+            for (String key : optHints.keySet()) {
+                VariableMgr.setVar(sessionVariable, new SetVar(key, new StringLiteral(optHints.get(key))));
             }
         }
     }


### PR DESCRIPTION
# Proposed changes
mtmv task use original query stmt so that user can set var more flexible, for example set  query_timeout, exec_mem_limit etc
though ``CREATE MATERIALIZED VIEW`` statement

```
CREATE MATERIALIZED VIEW  multi_mv
BUILD IMMEDIATE 
REFRESH COMPLETE 
start with "2022-10-27 19:35:00"
next  60 second
KEY(username)   
DISTRIBUTED BY HASH (username)  buckets 1
PROPERTIES ('replication_num' = '1') 
AS 
select  /*+set_var(query_timeout=1000)*/ t_user.username, t_user_pv.pv  from t_user, t_user_pv where t_user.id=t_user_pv.id;
```

mtmv task will  use the original stmt  when insert data to table 
```
select  /*+set_var(query_timeout=1000)*/ t_user.username, t_user_pv.pv  from t_user, t_user_pv where t_user.id=t_user_pv.id;
```
instead of 
```
select  t_user.username, t_user_pv.pv  from t_user, t_user_pv where t_user.id=t_user_pv.id;
```


## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

