### PR TITLE
[fix](nereids) bind slot using exactly match 

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/BindSlotReference.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/BindSlotReference.java
@@ -629,6 +629,24 @@ public class BindSlotReference implements AnalysisRuleFactory {
                     }
                     return bounded.get(0);
                 default:
+                    /*
+                    select t1.k k, t2.k
+                    from t1 join t2 order by k
+
+                    't1.k k' is denoted by alias_k, its full name is 'k'
+                    'order by k' is denoted as order_k, it full name is 'k'
+                    't2.k' in select list, its full name is 't2.k'
+
+                    order_k can be bound on alias_k and t2.k
+                    alias_k is exactly matched, since its full name is exactly match full name of order_k
+                    t2.k is not exactly matched, since t2.k's full name is larger than order_k
+                     */
+                    List<Slot> exactMatch = bounded.stream()
+                            .filter( bound -> unboundSlot.getNameParts().size() == bound.getQualifier().size() + 1)
+                            .collect(Collectors.toList());
+                    if (exactMatch.size() == 1) {
+                        return exactMatch.get(0);
+                    }
                     throw new AnalysisException(String.format("%s is ambiguous: %s.",
                             unboundSlot.toSql(),
                             bounded.stream()

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/BindSlotReference.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/BindSlotReference.java
@@ -642,7 +642,7 @@ public class BindSlotReference implements AnalysisRuleFactory {
                     t2.k is not exactly matched, since t2.k's full name is larger than order_k
                      */
                     List<Slot> exactMatch = bounded.stream()
-                            .filter( bound -> unboundSlot.getNameParts().size() == bound.getQualifier().size() + 1)
+                            .filter(bound -> unboundSlot.getNameParts().size() == bound.getQualifier().size() + 1)
                             .collect(Collectors.toList());
                     if (exactMatch.size() == 1) {
                         return exactMatch.get(0);

--- a/regression-test/data/nereids_syntax_p0/bind_priority.out
+++ b/regression-test/data/nereids_syntax_p0/bind_priority.out
@@ -26,3 +26,13 @@ all	2
 3
 2
 
+-- !bind_order_to_project_alias --
+4	5
+5	4
+6	6
+
+-- !bind_order_to_project_alias --
+5	4
+4	5
+6	6
+

--- a/regression-test/suites/nereids_syntax_p0/bind_priority.groovy
+++ b/regression-test/suites/nereids_syntax_p0/bind_priority.groovy
@@ -56,9 +56,9 @@ suite("bind_priority") {
         exception "Unexpected exception: cannot bind GROUP BY KEY: v"
     }
 
-    sql "drop table if exists t"
+    sql "drop table if exists bind_priority_tbl"
     sql """
-        CREATE TABLE `t` (
+        CREATE TABLE bind_priority_tbl (
             `a` int(11) NOT NULL,
             `b` int(11) NOT NULL
         ) ENGINE=OLAP
@@ -74,11 +74,43 @@ suite("bind_priority") {
         );
     """
 
-    sql"insert into t values(1,5),(2, 6),(3,4);"
+    sql"insert into bind_priority_tbl values(1,5),(2, 6),(3,4);"
 
-    qt_bind_sort_scan "select a as b from t order by t.b;"
+    qt_bind_sort_scan "select a as b from bind_priority_tbl order by bind_priority_tbl.b;"
 
-    qt_bind_sort_alias "select a as b from t order by b;"
+    qt_bind_sort_alias "select a as b from bind_priority_tbl order by b;"
 
-    qt_bind_sort_aliasAndScan "select a as b from t order by t.b + b;"
+    qt_bind_sort_aliasAndScan "select a as b from bind_priority_tbl order by bind_priority_tbl.b + b;"
+
+    sql "drop table if exists bind_priority_tbl2"
+    sql """
+        CREATE TABLE bind_priority_tbl2 (
+            `a` int(11) NOT NULL,
+            `b` int(11) NOT NULL
+        ) ENGINE=OLAP
+        DUPLICATE KEY(`a`)
+        COMMENT 'OLAP'
+        DISTRIBUTED BY HASH(`a`) BUCKETS 1
+        PROPERTIES (
+        "replication_allocation" = "tag.location.default: 1",
+        "in_memory" = "false",
+        "storage_format" = "V2",
+        "light_schema_change" = "true",
+        "disable_auto_compaction" = "false"
+        );
+    """
+    sql "insert into bind_priority_tbl2 values(3,5),(2, 6),(1,4);"
+    
+    qt_bind_order_to_project_alias """
+            select bind_priority_tbl.b b, bind_priority_tbl2.b
+            from bind_priority_tbl join bind_priority_tbl2 on bind_priority_tbl.a=bind_priority_tbl2.a 
+            order by b;
+        """
+
+
+    qt_bind_order_to_project_alias """
+        select bind_priority_tbl.b, bind_priority_tbl2.b b
+        from bind_priority_tbl join bind_priority_tbl2 on bind_priority_tbl.a=bind_priority_tbl2.a 
+        order by b;
+        """
 }


### PR DESCRIPTION
# Proposed changes
example:
unbound slot `k`
bounded {`k`, `t.k`}

In previous binding algorithm, there are 2 candidate bindings,
in which bounded `k` is exactly matched unbound slot `k`, it has higher priority than that of `t1.k`

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

