### PR TITLE
[Compile](lzo) fix lzo decompressor compiler error

### DIFF
--- a/be/src/exec/decompressor.h
+++ b/be/src/exec/decompressor.h
@@ -150,7 +150,7 @@ public:
 private:
     friend class Decompressor;
     LzopDecompressor()
-            : Decompressor(CompressType::LZOP), _header_info({0}), _is_header_loaded(false) {}
+            : Decompressor(CompressType::LZOP), _header_info(), _is_header_loaded(false) {}
     Status init() override;
 
 private:


### PR DESCRIPTION
# Proposed changes

Fixed it:

In file included from /mnt/disk1/baizhenbo/mycode/incubator-doris/be/src/exec/plain_text_line_reader.cpp:21:
/mnt/disk1/baizhenbo/mycode/incubator-doris/be/src/exec/decompressor.h:153:64: error: missing field 'lib_version' initializer [-Werror,-Wmissing-field-initializers]
            : Decompressor(CompressType::LZOP), _header_info({0}), _is_header_loaded(false) {}


Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

