### PR TITLE
[fix](third-party) Pass search paths of dependencies to CLucene explicitly

### DIFF
--- a/thirdparty/build-thirdparty.sh
+++ b/thirdparty/build-thirdparty.sh
@@ -1566,9 +1566,17 @@ build_clucene() {
     cd "${BUILD_DIR}"
     rm -rf CMakeCache.txt CMakeFiles/
 
-    ${CMAKE_CMD} -G "${GENERATOR}" -DCMAKE_INSTALL_PREFIX="${TP_INSTALL_DIR}" -DBUILD_STATIC_LIBRARIES=ON \
-        -DBUILD_SHARED_LIBRARIES=OFF -DCMAKE_CXX_FLAGS="-fno-omit-frame-pointer ${warning_narrowing}" \
-        -DUSE_STAT64=0 -DUSE_AVX2="${USE_AVX2}" -DCMAKE_BUILD_TYPE="${BUILD_TYPE}" -DBUILD_CONTRIBS_LIB=ON ..
+    ${CMAKE_CMD} -G "${GENERATOR}" \
+        -DCMAKE_INSTALL_PREFIX="${TP_INSTALL_DIR}" \
+        -DBUILD_STATIC_LIBRARIES=ON \
+        -DBUILD_SHARED_LIBRARIES=OFF \
+        -DBOOST_ROOT="${TP_INSTALL_DIR}" \
+        -DZLIB_ROOT="${TP_INSTALL_DIR}" \
+        -DCMAKE_CXX_FLAGS="-fno-omit-frame-pointer ${warning_narrowing}" \
+        -DUSE_STAT64=0 \
+        -DUSE_AVX2="${USE_AVX2}" \
+        -DCMAKE_BUILD_TYPE="${BUILD_TYPE}" \
+        -DBUILD_CONTRIBS_LIB=ON ..
     ${BUILD_SYSTEM} -j "${PARALLEL}"
     ${BUILD_SYSTEM} install
 


### PR DESCRIPTION
# Proposed changes

~~Issue Number: close #xxx~~

## Problem summary

When building CLucene, CMake may find the wrong Boost and zlib. We should pass the search path to the build command for CLucene explicitly to find the correct dependencies.

```shell
-- old Boost_INCLUDE_DIR    :
-- Found Boost: /usr/lib64/boost/BoostConfig.cmake (found version "1.41.0")    # Should use the one in thirdparty/installed
Boost found
-- Boost_INCLUDE_DIR    : /usr/include
-- Found ZLIB: /devel/ldb_toolchain/usr/lib/libz.so (found version "1.2.11")    # Should use the one in thirdparty/installed
```

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [x] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [x] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

