### PR TITLE
[fix](Nereids) join satisfy in hash distribution is not correct

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/DistributionSpecHash.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/DistributionSpecHash.java
@@ -189,11 +189,23 @@ public class DistributionSpecHash extends DistributionSpec {
 
         // If the required property is from join and this property is not enforced, we only need to check to contain
         // And more checking is in ChildrenPropertiesRegulator
-        if (requiredHash.shuffleType == shuffleType.JOIN && this.shuffleType != shuffleType.ENFORCED) {
-            return containsSatisfy(requiredHash.getOrderedShuffledColumns());
+        if (requiredHash.shuffleType == ShuffleType.JOIN && this.shuffleType != ShuffleType.ENFORCED) {
+            return joinSatisfy(requiredHash.getOrderedShuffledColumns());
         }
 
         return equalsSatisfy(requiredHash.getOrderedShuffledColumns());
+    }
+
+    private boolean joinSatisfy(List<ExprId> required) {
+        BitSet containsBit = new BitSet(orderedShuffledColumns.size());
+        for (ExprId exprId : required) {
+            if (exprIdToEquivalenceSet.containsKey(exprId)) {
+                containsBit.set(exprIdToEquivalenceSet.get(exprId));
+            } else {
+                return false;
+            }
+        }
+        return containsBit.nextClearBit(0) >= orderedShuffledColumns.size();
     }
 
     private boolean containsSatisfy(List<ExprId> required) {

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/properties/DistributionSpecHashTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/properties/DistributionSpecHashTest.java
@@ -276,6 +276,21 @@ public class DistributionSpecHashTest {
                 join3Map
         );
 
+        Map<ExprId, Integer> join4Map = Maps.newHashMap();
+        join4Map.put(new ExprId(2), 0);
+        join4Map.put(new ExprId(1), 1);
+        join4Map.put(new ExprId(3), 2);
+        DistributionSpecHash join4 = new DistributionSpecHash(
+                Lists.newArrayList(new ExprId(2), new ExprId(1), new ExprId(3)),
+                ShuffleType.JOIN,
+                1,
+                Sets.newHashSet(1L),
+                Lists.newArrayList(Sets.newHashSet(new ExprId(2)),
+                        Sets.newHashSet(new ExprId(1)),
+                        Sets.newHashSet(new ExprId(3))),
+                join4Map
+        );
+
         DistributionSpecHash natural = new DistributionSpecHash(
                 Lists.newArrayList(new ExprId(1), new ExprId(2)),
                 ShuffleType.NATURAL,
@@ -311,6 +326,7 @@ public class DistributionSpecHashTest {
         Assertions.assertFalse(join3.satisfy(join1));
         // other shuffle type with same order
         Assertions.assertTrue(natural.satisfy(join2));
+        Assertions.assertFalse(natural.satisfy(join4));
         Assertions.assertTrue(aggregate.satisfy(join2));
         Assertions.assertTrue(enforce.satisfy(join2));
         // other shuffle type contain all set but order is not same


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

when required type is JOIN, all required exprid should in current hash distributed key list

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

