### PR TITLE
[fix](planner)wrong result when has order by under join

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/planner/ExchangeNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/ExchangeNode.java
@@ -84,9 +84,10 @@ public class ExchangeNode extends PlanNode {
         if (inputNode.getFragment().isPartitioned()) {
             limit = inputNode.limit;
         }
-        offset = inputNode.offset;
+        if (!(inputNode instanceof ExchangeNode)) {
+            offset = inputNode.offset;
+        }
         computeTupleIds();
-
     }
 
     public boolean isMergingExchange() {

--- a/regression-test/suites/query_p0/limit/OffsetInSubqueryWithJoin.groovy
+++ b/regression-test/suites/query_p0/limit/OffsetInSubqueryWithJoin.groovy
@@ -1,0 +1,42 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_offset_in_subquery_with_join", "query") {
+    // define a sql table
+    def testTable = "test_offset_in_subquery_with_join"
+
+    sql """
+        drop table if exists ${testTable}
+    """
+
+    sql """
+        create table if not exists ${testTable}(id int) distributed by hash(id) properties('replication_num'='1')
+    """
+
+    sql """
+        insert into ${testTable} values (1), (1);
+    """
+
+    test {
+        sql "select * from $testTable where id in (select id from $testTable order by id limit 1, 1)"
+        result([
+                [1],
+                [1]
+        ])
+    }
+
+}


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

when we have order by under join, aggregate, etc. node. we do offset twice if there is a exchange node on the top of merging exchange node.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

