### PR TITLE
[fix](Nereids) all slot in grouping sets in repeat node should be nullable

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/NormalizeRepeat.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/NormalizeRepeat.java
@@ -223,7 +223,6 @@ public class NormalizeRepeat extends OneAnalysisRuleFactory {
         }
 
         List<Expression> groupingSetExpressions = ExpressionUtils.flatExpressions(repeat.getGroupingSets());
-        Set<Expression> commonGroupingSetExpressions = repeat.getCommonGroupingSetExpressions();
 
         // nullable will be different from grouping set and output expressions,
         // so we can not use the slot in grouping set，but use the equivalent slot in output expressions.
@@ -236,9 +235,7 @@ public class NormalizeRepeat extends OneAnalysisRuleFactory {
                 expression = outputs.get(outputs.indexOf(expression));
             }
             if (groupingSetExpressions.contains(expression)) {
-                boolean isCommonGroupingSetExpression = commonGroupingSetExpressions.contains(expression);
-                pushDownTriplet = toGroupingSetExpressionPushDownTriplet(
-                        isCommonGroupingSetExpression, expression, existsAliasMap.get(expression));
+                pushDownTriplet = toGroupingSetExpressionPushDownTriplet(expression, existsAliasMap.get(expression));
             } else {
                 pushDownTriplet = Optional.of(
                         NormalizeToSlotTriplet.toTriplet(expression, existsAliasMap.get(expression)));
@@ -252,10 +249,10 @@ public class NormalizeRepeat extends OneAnalysisRuleFactory {
     }
 
     private Optional<NormalizeToSlotTriplet> toGroupingSetExpressionPushDownTriplet(
-            boolean isCommonGroupingSetExpression, Expression expression, @Nullable Alias existsAlias) {
+            Expression expression, @Nullable Alias existsAlias) {
         NormalizeToSlotTriplet originTriplet = NormalizeToSlotTriplet.toTriplet(expression, existsAlias);
         SlotReference remainSlot = (SlotReference) originTriplet.remainExpr;
-        Slot newSlot = remainSlot.withCommonGroupingSetExpression(isCommonGroupingSetExpression);
+        Slot newSlot = remainSlot.withNullable(true);
         return Optional.of(new NormalizeToSlotTriplet(expression, newSlot, originTriplet.pushedExpr));
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/SlotReference.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/SlotReference.java
@@ -186,12 +186,4 @@ public class SlotReference extends Slot {
     public Slot withName(String name) {
         return new SlotReference(exprId, name, dataType, nullable, qualifier, column);
     }
-
-    /** withCommonGroupingSetExpression */
-    public Slot withCommonGroupingSetExpression(boolean isCommonGroupingSetExpression) {
-        if (!isCommonGroupingSetExpression) {
-            return withNullable(true);
-        }
-        return this;
-    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/algebra/Repeat.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/algebra/Repeat.java
@@ -76,7 +76,6 @@ public interface Repeat<CHILD_PLAN extends Plan> extends Aggregate<CHILD_PLAN> {
      */
     default Set<Expression> getCommonGroupingSetExpressions() {
         List<List<Expression>> groupingSets = getGroupingSets();
-        Sets.newLinkedHashSet();
         Iterator<List<Expression>> iterator = groupingSets.iterator();
         Set<Expression> commonGroupingExpressions = Sets.newLinkedHashSet(iterator.next());
         while (iterator.hasNext()) {


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

according to be's code, all slot in grouping set should be nullable.
reference to [be code](https://github.com/apache/doris/blob/be3482e6d6d7812509fd92601ce88b488dcddcf6/be/src/vec/exec/vrepeat_node.cpp#L113)


## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

