### PR TITLE
[Feature-WIP](inverted index)(bkd) bdk index'reader implementation which in inverted index using for numeric types

### DIFF
--- a/be/src/olap/rowset/segment_v2/column_reader.cpp
+++ b/be/src/olap/rowset/segment_v2/column_reader.cpp
@@ -397,8 +397,8 @@ Status ColumnReader::_load_inverted_index_index(const TabletIndex* index_meta) {
                     _file_reader->fs(), _file_reader->path().native(), index_meta->index_id()));
         }
     } else if (is_numeric_type(type)) {
-        // todo(wy): implement
-        return Status::Error<ErrorCode::NOT_IMPLEMENTED_ERROR>();
+        _inverted_index.reset(new BkdIndexReader(_file_reader->fs(), _file_reader->path().native(),
+                                                 index_meta->index_id()));
     } else {
         _inverted_index.reset();
     }

--- a/be/src/olap/rowset/segment_v2/inverted_index_reader.cpp
+++ b/be/src/olap/rowset/segment_v2/inverted_index_reader.cpp
@@ -502,9 +502,6 @@ void InvertedIndexVisitor::visit(int rowID) {
     } else {
         hits->add(rowID);
     }
-    if (0) {
-        std::wcout << L"visit docID=" << rowID << std::endl;
-    }
 }
 
 void InvertedIndexVisitor::visit(lucene::util::bkd::bkd_docid_set_iterator* iter,
@@ -524,10 +521,6 @@ void InvertedIndexVisitor::visit(lucene::util::bkd::bkd_docid_set_iterator* iter
 }
 
 void InvertedIndexVisitor::visit(int rowID, std::vector<uint8_t>& packedValue) {
-    if (0) {
-        int x = lucene::util::NumericUtils::sortableBytesToLong(packedValue, 0);
-        std::wcout << L"visit docID=" << rowID << L" x=" << x << std::endl;
-    }
     if (matches(packedValue.data())) {
         if (only_count) {
             num_hits++;

--- a/be/src/olap/rowset/segment_v2/inverted_index_reader.cpp
+++ b/be/src/olap/rowset/segment_v2/inverted_index_reader.cpp
@@ -19,13 +19,14 @@
 
 #include <CLucene/search/BooleanQuery.h>
 #include <CLucene/search/PhraseQuery.h>
+#include <CLucene/util/FutureArrays.h>
+#include <CLucene/util/NumericUtils.h>
 
 #include "common/config.h"
 #include "gutil/strings/strip.h"
 #include "io/fs/file_system.h"
 #include "olap/key_coder.h"
 #include "olap/rowset/segment_v2/inverted_index_compound_directory.h"
-#include "olap/rowset/segment_v2/inverted_index_compound_reader.h"
 #include "olap/rowset/segment_v2/inverted_index_desc.h"
 #include "olap/tablet_schema.h"
 #include "olap/utils.h"
@@ -288,6 +289,313 @@ Status StringTypeInvertedIndexReader::query(const std::string& column_name, cons
 
 InvertedIndexReaderType StringTypeInvertedIndexReader::type() {
     return InvertedIndexReaderType::STRING_TYPE;
+}
+
+BkdIndexReader::BkdIndexReader(io::FileSystemSPtr fs, const std::string& path,
+                               const uint32_t uniq_id)
+        : InvertedIndexReader(fs, path, uniq_id), compoundReader(nullptr) {
+    io::Path io_path(_path);
+    auto index_dir = io_path.parent_path();
+    auto index_file_name =
+            InvertedIndexDescriptor::get_index_file_name(io_path.filename(), _index_id);
+
+    // check index file existence
+    auto index_file = index_dir / index_file_name;
+    if (!indexExists(index_file)) {
+        LOG(WARNING) << "bkd index: " << index_file.string() << " not exist.";
+        return;
+    }
+    compoundReader = new DorisCompoundReader(
+            DorisCompoundDirectory::getDirectory(fs, index_dir.c_str()),
+            index_file_name.c_str());
+}
+
+Status BkdIndexReader::new_iterator(const TabletIndex* index_meta,
+                                    InvertedIndexIterator** iterator) {
+    *iterator = new InvertedIndexIterator(index_meta, this);
+    return Status::OK();
+}
+
+Status BkdIndexReader::bkd_query(const std::string& column_name, const void* query_value,
+                                 InvertedIndexQueryType query_type,
+                                 std::shared_ptr<lucene::util::bkd::bkd_reader>&& r,
+                                 InvertedIndexVisitor* visitor) {
+    lucene::util::bkd::bkd_reader* tmp_reader;
+    auto status = get_bkd_reader(tmp_reader);
+    if (!status.ok()) {
+        LOG(WARNING) << "get bkd reader for column " << column_name
+                     << " failed: " << status.code_as_string();
+        return status;
+    }
+    r.reset(tmp_reader);
+    char tmp[r->bytes_per_dim_];
+    switch (query_type) {
+    case InvertedIndexQueryType::EQUAL_QUERY: {
+        _value_key_coder->full_encode_ascending(query_value, &visitor->queryMax);
+        _value_key_coder->full_encode_ascending(query_value, &visitor->queryMin);
+        break;
+    }
+    case InvertedIndexQueryType::LESS_THAN_QUERY:
+    case InvertedIndexQueryType::LESS_EQUAL_QUERY: {
+        _value_key_coder->full_encode_ascending(query_value, &visitor->queryMax);
+        _type_info->set_to_min(tmp);
+        _value_key_coder->full_encode_ascending(tmp, &visitor->queryMin);
+        break;
+    }
+    case InvertedIndexQueryType::GREATER_THAN_QUERY:
+    case InvertedIndexQueryType::GREATER_EQUAL_QUERY: {
+        _value_key_coder->full_encode_ascending(query_value, &visitor->queryMin);
+        _type_info->set_to_max(tmp);
+        _value_key_coder->full_encode_ascending(tmp, &visitor->queryMax);
+        break;
+    }
+    default:
+        LOG(ERROR) << "invalid query type when query bkd index";
+        return Status::Error<ErrorCode::INVERTED_INDEX_NOT_SUPPORTED>();
+    }
+    visitor->set_reader(r.get());
+    return Status::OK();
+}
+
+Status BkdIndexReader::query(const std::string& column_name, const void* query_value,
+                             InvertedIndexQueryType query_type,
+                             InvertedIndexParserType analyser_type, roaring::Roaring* bit_map) {
+    uint64_t start = UnixMillis();
+    auto visitor = std::make_unique<InvertedIndexVisitor>(bit_map, query_type);
+    std::shared_ptr<lucene::util::bkd::bkd_reader> r;
+    try {
+        RETURN_IF_ERROR(bkd_query(column_name, query_value, query_type, std::move(r), visitor.get()));
+        r->intersect(visitor.get());
+    } catch (const CLuceneError& e) {
+        LOG(WARNING) << "BKD Query CLuceneError Occurred, error msg: " << e.what();
+        return Status::Error<ErrorCode::INVERTED_INDEX_CLUCENE_ERROR>();
+    }
+
+    LOG(INFO) << "BKD index search time taken: " << UnixMillis() - start << "ms "
+              << " column: " << column_name << " result: " << bit_map->cardinality()
+              << " reader stats: " << r->stats.to_string();
+    return Status::OK();
+}
+
+Status BkdIndexReader::get_bkd_reader(lucene::util::bkd::bkd_reader*& bkdReader) {
+    // bkd file reader
+    if (compoundReader == nullptr) {
+        LOG(WARNING) << "bkd index input file not found";
+        return Status::Error<ErrorCode::INVERTED_INDEX_FILE_NOT_FOUND>();
+    }
+    CLuceneError err;
+    lucene::store::IndexInput* data_in;
+    lucene::store::IndexInput* meta_in;
+    lucene::store::IndexInput* index_in;
+
+    if (!compoundReader->openInput(
+                InvertedIndexDescriptor::get_temporary_bkd_index_data_file_name().c_str(), data_in,
+                err) ||
+        !compoundReader->openInput(
+                InvertedIndexDescriptor::get_temporary_bkd_index_meta_file_name().c_str(), meta_in,
+                err) ||
+        !compoundReader->openInput(
+                InvertedIndexDescriptor::get_temporary_bkd_index_file_name().c_str(), index_in,
+                err)) {
+        LOG(WARNING) << "bkd index input error: " << err.what();
+        return Status::Error<ErrorCode::INVERTED_INDEX_FILE_NOT_FOUND>();
+    }
+
+    bkdReader = new lucene::util::bkd::bkd_reader(data_in);
+    if (0 == bkdReader->read_meta(meta_in)) {
+        return Status::EndOfFile("bkd index file is empty");
+    }
+
+    bkdReader->read_index(index_in);
+
+    _type_info = get_scalar_type_info((FieldType)bkdReader->type);
+    if (_type_info == nullptr) {
+        auto type = bkdReader->type;
+        delete bkdReader;
+        LOG(WARNING) << "unsupported typeinfo, type=" << type;
+        return Status::Error<ErrorCode::INVERTED_INDEX_NOT_SUPPORTED>();
+    }
+    _value_key_coder = get_key_coder(_type_info->type());
+    return Status::OK();
+}
+
+InvertedIndexReaderType BkdIndexReader::type() {
+    return InvertedIndexReaderType::BKD;
+}
+
+InvertedIndexVisitor::InvertedIndexVisitor(roaring::Roaring* h, InvertedIndexQueryType query_type,
+                                           bool only_count)
+        : hits(h), num_hits(0), only_count(only_count), query_type(query_type) {}
+
+bool InvertedIndexVisitor::matches(uint8_t* packedValue) {
+    for (int dim = 0; dim < reader->num_data_dims_; dim++) {
+        int offset = dim * reader->bytes_per_dim_;
+        if (query_type == InvertedIndexQueryType::LESS_THAN_QUERY) {
+            if (lucene::util::FutureArrays::CompareUnsigned(
+                        packedValue, offset, offset + reader->bytes_per_dim_,
+                        (const uint8_t*)queryMax.c_str(), offset,
+                        offset + reader->bytes_per_dim_) >= 0) {
+                // Doc's value is too high, in this dimension
+                return false;
+            }
+        } else if (query_type == InvertedIndexQueryType::GREATER_THAN_QUERY) {
+            if (lucene::util::FutureArrays::CompareUnsigned(
+                        packedValue, offset, offset + reader->bytes_per_dim_,
+                        (const uint8_t*)queryMin.c_str(), offset,
+                        offset + reader->bytes_per_dim_) <= 0) {
+                // Doc's value is too high, in this dimension
+                return false;
+            }
+        } else {
+            if (lucene::util::FutureArrays::CompareUnsigned(
+                        packedValue, offset, offset + reader->bytes_per_dim_,
+                        (const uint8_t*)queryMin.c_str(), offset,
+                        offset + reader->bytes_per_dim_) < 0) {
+                // Doc's value is too low, in this dimension
+                return false;
+            }
+            if (lucene::util::FutureArrays::CompareUnsigned(
+                        packedValue, offset, offset + reader->bytes_per_dim_,
+                        (const uint8_t*)queryMax.c_str(), offset,
+                        offset + reader->bytes_per_dim_) > 0) {
+                // Doc's value is too high, in this dimension
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
+void InvertedIndexVisitor::visit(std::vector<char>& docID, std::vector<uint8_t>& packedValue) {
+    if (!matches(packedValue.data())) {
+        return;
+    }
+    visit(roaring::Roaring::read(docID.data(), false));
+}
+
+void InvertedIndexVisitor::visit(Roaring* docID, std::vector<uint8_t>& packedValue) {
+    if (!matches(packedValue.data())) {
+        return;
+    }
+    visit(*docID);
+}
+
+void InvertedIndexVisitor::visit(roaring::Roaring&& r) {
+    if (only_count) {
+        num_hits += r.cardinality();
+    } else {
+        *hits |= r;
+    }
+}
+
+void InvertedIndexVisitor::visit(roaring::Roaring& r) {
+    if (only_count) {
+        num_hits += r.cardinality();
+    } else {
+        *hits |= r;
+    }
+}
+
+void InvertedIndexVisitor::visit(int rowID) {
+    if (only_count) {
+        num_hits++;
+    } else {
+        hits->add(rowID);
+    }
+    if (0) {
+        std::wcout << L"visit docID=" << rowID << std::endl;
+    }
+}
+
+void InvertedIndexVisitor::visit(lucene::util::bkd::bkd_docid_set_iterator* iter,
+                                 std::vector<uint8_t>& packedValue) {
+    if (!matches(packedValue.data())) {
+        return;
+    }
+    int32_t docID = iter->docid_set->nextDoc();
+    while (docID != lucene::util::bkd::bkd_docid_set::NO_MORE_DOCS) {
+        if (only_count) {
+            num_hits++;
+        } else {
+            hits->add(docID);
+        }
+        docID = iter->docid_set->nextDoc();
+    }
+}
+
+void InvertedIndexVisitor::visit(int rowID, std::vector<uint8_t>& packedValue) {
+    if (0) {
+        int x = lucene::util::NumericUtils::sortableBytesToLong(packedValue, 0);
+        std::wcout << L"visit docID=" << rowID << L" x=" << x << std::endl;
+    }
+    if (matches(packedValue.data())) {
+        if (only_count) {
+            num_hits++;
+        } else {
+            hits->add(rowID);
+        }
+    }
+}
+
+lucene::util::bkd::relation InvertedIndexVisitor::compare(std::vector<uint8_t>& minPacked,
+                                                          std::vector<uint8_t>& maxPacked) {
+    bool crosses = false;
+
+    for (int dim = 0; dim < reader->num_data_dims_; dim++) {
+        int offset = dim * reader->bytes_per_dim_;
+
+        if (query_type == InvertedIndexQueryType::LESS_THAN_QUERY) {
+            if (lucene::util::FutureArrays::CompareUnsigned(
+                        minPacked.data(), offset, offset + reader->bytes_per_dim_,
+                        (const uint8_t*)queryMax.c_str(), offset,
+                        offset + reader->bytes_per_dim_) >= 0) {
+                return lucene::util::bkd::relation::CELL_OUTSIDE_QUERY;
+            }
+        } else if (query_type == InvertedIndexQueryType::GREATER_THAN_QUERY) {
+            if (lucene::util::FutureArrays::CompareUnsigned(
+                        maxPacked.data(), offset, offset + reader->bytes_per_dim_,
+                        (const uint8_t*)queryMin.c_str(), offset,
+                        offset + reader->bytes_per_dim_) <= 0) {
+                return lucene::util::bkd::relation::CELL_OUTSIDE_QUERY;
+            }
+        } else {
+            if (lucene::util::FutureArrays::CompareUnsigned(
+                        minPacked.data(), offset, offset + reader->bytes_per_dim_,
+                        (const uint8_t*)queryMax.c_str(), offset,
+                        offset + reader->bytes_per_dim_) > 0 ||
+                lucene::util::FutureArrays::CompareUnsigned(
+                        maxPacked.data(), offset, offset + reader->bytes_per_dim_,
+                        (const uint8_t*)queryMin.c_str(), offset,
+                        offset + reader->bytes_per_dim_) < 0) {
+                return lucene::util::bkd::relation::CELL_OUTSIDE_QUERY;
+            }
+        }
+        if (query_type == InvertedIndexQueryType::LESS_THAN_QUERY ||
+            query_type == InvertedIndexQueryType::GREATER_THAN_QUERY) {
+            crosses |= lucene::util::FutureArrays::CompareUnsigned(
+                               minPacked.data(), offset, offset + reader->bytes_per_dim_,
+                               (const uint8_t*)queryMin.c_str(), offset,
+                               offset + reader->bytes_per_dim_) <= 0 ||
+                       lucene::util::FutureArrays::CompareUnsigned(
+                               maxPacked.data(), offset, offset + reader->bytes_per_dim_,
+                               (const uint8_t*)queryMax.c_str(), offset,
+                               offset + reader->bytes_per_dim_) >= 0;
+        } else {
+            crosses |= lucene::util::FutureArrays::CompareUnsigned(
+                               minPacked.data(), offset, offset + reader->bytes_per_dim_,
+                               (const uint8_t*)queryMin.c_str(), offset,
+                               offset + reader->bytes_per_dim_) < 0 ||
+                       lucene::util::FutureArrays::CompareUnsigned(
+                               maxPacked.data(), offset, offset + reader->bytes_per_dim_,
+                               (const uint8_t*)queryMax.c_str(), offset,
+                               offset + reader->bytes_per_dim_) > 0;
+        }
+    }
+    if (crosses) {
+        return lucene::util::bkd::relation::CELL_CROSSES_QUERY;
+    } else {
+        return lucene::util::bkd::relation::CELL_INSIDE_QUERY;
+    }
 }
 
 Status InvertedIndexIterator::read_from_inverted_index(const std::string& column_name,

--- a/be/src/olap/rowset/segment_v2/inverted_index_reader.cpp
+++ b/be/src/olap/rowset/segment_v2/inverted_index_reader.cpp
@@ -306,8 +306,7 @@ BkdIndexReader::BkdIndexReader(io::FileSystemSPtr fs, const std::string& path,
         return;
     }
     compoundReader = new DorisCompoundReader(
-            DorisCompoundDirectory::getDirectory(fs, index_dir.c_str()),
-            index_file_name.c_str());
+            DorisCompoundDirectory::getDirectory(fs, index_dir.c_str()), index_file_name.c_str());
 }
 
 Status BkdIndexReader::new_iterator(const TabletIndex* index_meta,
@@ -364,7 +363,8 @@ Status BkdIndexReader::query(const std::string& column_name, const void* query_v
     auto visitor = std::make_unique<InvertedIndexVisitor>(bit_map, query_type);
     std::shared_ptr<lucene::util::bkd::bkd_reader> r;
     try {
-        RETURN_IF_ERROR(bkd_query(column_name, query_value, query_type, std::move(r), visitor.get()));
+        RETURN_IF_ERROR(
+                bkd_query(column_name, query_value, query_type, std::move(r), visitor.get()));
         r->intersect(visitor.get());
     } catch (const CLuceneError& e) {
         LOG(WARNING) << "BKD Query CLuceneError Occurred, error msg: " << e.what();

--- a/be/src/olap/rowset/segment_v2/inverted_index_reader.h
+++ b/be/src/olap/rowset/segment_v2/inverted_index_reader.h
@@ -147,7 +147,8 @@ public:
     std::string queryMax;
 
 public:
-    InvertedIndexVisitor(roaring::Roaring* hits, InvertedIndexQueryType query_type, bool only_count = false);
+    InvertedIndexVisitor(roaring::Roaring* hits, InvertedIndexQueryType query_type,
+                         bool only_count = false);
     virtual ~InvertedIndexVisitor() = default;
 
     void set_reader(lucene::util::bkd::bkd_reader* r) { reader = r; };

--- a/be/src/olap/rowset/segment_v2/inverted_index_reader.h
+++ b/be/src/olap/rowset/segment_v2/inverted_index_reader.h
@@ -18,6 +18,8 @@
 #pragma once
 
 #include <CLucene.h>
+#include <CLucene/util/BitSet.h>
+#include <CLucene/util/bkd/bkd_reader.h>
 
 #include <roaring/roaring.hh>
 
@@ -29,9 +31,12 @@
 #include "olap/inverted_index_parser.h"
 #include "olap/olap_common.h"
 #include "olap/rowset/segment_v2/common.h"
+#include "olap/rowset/segment_v2/inverted_index_compound_reader.h"
 #include "olap/tablet_schema.h"
 
 namespace doris {
+class KeyCoder;
+class TypeInfo;
 
 namespace segment_v2 {
 
@@ -41,6 +46,7 @@ enum class InvertedIndexReaderType {
     UNKNOWN = -1,
     FULLTEXT = 0,
     STRING_TYPE = 1,
+    BKD = 2,
 };
 
 enum class InvertedIndexQueryType {
@@ -126,6 +132,74 @@ public:
         return Status::Error<ErrorCode::NOT_IMPLEMENTED_ERROR>();
     }
     InvertedIndexReaderType type() override;
+};
+
+class InvertedIndexVisitor : public lucene::util::bkd::bkd_reader::intersect_visitor {
+private:
+    roaring::Roaring* hits;
+    uint32_t num_hits;
+    bool only_count;
+    lucene::util::bkd::bkd_reader* reader;
+    InvertedIndexQueryType query_type;
+
+public:
+    std::string queryMin;
+    std::string queryMax;
+
+public:
+    InvertedIndexVisitor(roaring::Roaring* hits, InvertedIndexQueryType query_type, bool only_count = false);
+    virtual ~InvertedIndexVisitor() = default;
+
+    void set_reader(lucene::util::bkd::bkd_reader* r) { reader = r; };
+    lucene::util::bkd::bkd_reader* get_reader() { return reader; };
+
+    void visit(int rowID) override;
+    void visit(roaring::Roaring& r) override;
+    void visit(roaring::Roaring&& r) override;
+    void visit(roaring::Roaring* docID, std::vector<uint8_t>& packedValue) override;
+    void visit(std::vector<char>& docID, std::vector<uint8_t>& packedValue) override;
+    void visit(int rowID, std::vector<uint8_t>& packedValue) override;
+    void visit(lucene::util::bkd::bkd_docid_set_iterator* iter,
+               std::vector<uint8_t>& packedValue) override;
+    bool matches(uint8_t* packedValue);
+    lucene::util::bkd::relation compare(std::vector<uint8_t>& minPacked,
+                                        std::vector<uint8_t>& maxPacked) override;
+    uint32_t get_num_hits() const { return num_hits; }
+};
+
+class BkdIndexReader : public InvertedIndexReader {
+public:
+    explicit BkdIndexReader(io::FileSystemSPtr fs, const std::string& path, const uint32_t uniq_id);
+    ~BkdIndexReader() override {
+        if (compoundReader != nullptr) {
+            compoundReader->close();
+            delete compoundReader;
+            compoundReader = nullptr;
+        }
+    }
+
+    Status new_iterator(const TabletIndex* index_meta, InvertedIndexIterator** iterator) override;
+
+    Status query(const std::string& column_name, const void* query_value,
+                 InvertedIndexQueryType query_type, InvertedIndexParserType analyser_type,
+                 roaring::Roaring* bit_map) override;
+    Status try_query(const std::string& column_name, const void* query_value,
+                     InvertedIndexQueryType query_type, InvertedIndexParserType analyser_type,
+                     uint32_t* count) override {
+        return Status::Error<ErrorCode::NOT_IMPLEMENTED_ERROR>();
+    }
+    Status bkd_query(const std::string& column_name, const void* query_value,
+                     InvertedIndexQueryType query_type,
+                     std::shared_ptr<lucene::util::bkd::bkd_reader>&& r,
+                     InvertedIndexVisitor* visitor);
+
+    InvertedIndexReaderType type() override;
+    Status get_bkd_reader(lucene::util::bkd::bkd_reader*& reader);
+
+private:
+    const TypeInfo* _type_info {};
+    const KeyCoder* _value_key_coder {};
+    DorisCompoundReader* compoundReader;
 };
 
 class InvertedIndexIterator {


### PR DESCRIPTION
# Proposed changes
Step3 of [DSIP-023: Add inverted index for full text search](https://cwiki.apache.org/confluence/display/DORIS/DSIP-023%3A+Add+inverted+index+for+full+text+search?src=contextnavpagetreemode)
implementation of bkd index's reader which in inverted index using for numeric types
dependency pr: https://github.com/apache/doris/pull/14211 https://github.com/apache/doris/pull/15807 https://github.com/apache/doris/pull/15823

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

