### PR TITLE
[fix](be)fix bug of VSetOperationNode::release_resource

### DIFF
--- a/be/src/vec/exec/vset_operation_node.cpp
+++ b/be/src/vec/exec/vset_operation_node.cpp
@@ -143,6 +143,7 @@ void VSetOperationNode<is_intersect>::release_resource(RuntimeState* state) {
         VExpr::close(exprs, state);
     }
     release_mem();
+    ExecNode::release_resource(state);
 }
 template <bool is_intersect>
 Status VSetOperationNode<is_intersect>::close(RuntimeState* state) {


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary
should call "ExecNode::release_resource(state)" if child class override the parent's method

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

