### PR TITLE
Revert "[enhancement](rewrite) Remove unused wide common factors to improve scan performance in ExtractCommonFactorsRule"

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/rewrite/ExtractCommonFactorsRule.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/rewrite/ExtractCommonFactorsRule.java
@@ -20,7 +20,6 @@ package org.apache.doris.rewrite;
 import org.apache.doris.analysis.Analyzer;
 import org.apache.doris.analysis.BinaryPredicate;
 import org.apache.doris.analysis.CompoundPredicate;
-import org.apache.doris.analysis.CompoundPredicate.Operator;
 import org.apache.doris.analysis.Expr;
 import org.apache.doris.analysis.InPredicate;
 import org.apache.doris.analysis.LiteralExpr;
@@ -29,7 +28,6 @@ import org.apache.doris.analysis.TableName;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.planner.PlanNode;
 import org.apache.doris.qe.ConnectContext;
-import org.apache.doris.rewrite.ExprRewriter.ClauseType;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.BoundType;
@@ -76,7 +74,7 @@ public class ExtractCommonFactorsRule implements ExprRewriteRule {
             return null;
         } else if (expr instanceof CompoundPredicate
                 && ((CompoundPredicate) expr).getOp() == CompoundPredicate.Operator.OR) {
-            Expr rewrittenExpr = extractCommonFactors(exprFormatting((CompoundPredicate) expr), analyzer, clauseType);
+            Expr rewrittenExpr = extractCommonFactors(exprFormatting((CompoundPredicate) expr), analyzer);
             if (rewrittenExpr != null) {
                 return rewrittenExpr;
             }
@@ -114,7 +112,7 @@ public class ExtractCommonFactorsRule implements ExprRewriteRule {
      * 4. Construct new expr:
      * @return: a and b' and (b or (e and f))
      */
-    private Expr extractCommonFactors(List<List<Expr>> exprs, Analyzer analyzer, ExprRewriter.ClauseType clauseType) {
+    private Expr extractCommonFactors(List<List<Expr>> exprs, Analyzer analyzer) {
         if (exprs.size() < 2) {
             return null;
         }
@@ -169,11 +167,9 @@ public class ExtractCommonFactorsRule implements ExprRewriteRule {
         }
 
         // 3. find merge cross the clause
-        if (analyzer.getContext() != null && clauseType == ClauseType.WHERE_CLAUSE
-                && analyzer.getContext().getSessionVariable().isExtractWideRangeExpr()) {
+        if (analyzer.getContext() != null && analyzer.getContext().getSessionVariable().isExtractWideRangeExpr()) {
             Expr wideCommonExpr = findWideRangeExpr(clearExprs);
-            if (wideCommonExpr != null && !(wideCommonExpr instanceof CompoundPredicate
-                    && ((CompoundPredicate) wideCommonExpr).getOp() == Operator.OR)) {
+            if (wideCommonExpr != null) {
                 commonFactorList.add(wideCommonExpr);
             }
         }

--- a/fe/fe-core/src/test/java/org/apache/doris/rewrite/ExtractCommonFactorsRuleFunctionTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/rewrite/ExtractCommonFactorsRuleFunctionTest.java
@@ -84,13 +84,6 @@ public class ExtractCommonFactorsRuleFunctionTest {
     }
 
     @Test
-    public void testWideCommonFactorsWithOrPredicate() throws Exception {
-        String query = "select * from tb1 where tb1.k1 > 1000 or tb1.k1 < 200 or tb1.k1 = 300";
-        String planString = dorisAssert.query(query).explainQuery();
-        Assert.assertTrue(planString.contains("PREDICATES: (`tb1`.`k1` > 1000 OR `tb1`.`k1` < 200 OR `tb1`.`k1` = 300)"));
-    }
-
-    @Test
     public void testWideCommonFactorsWithEqualPredicate() throws Exception {
         String query = "select * from tb1, tb2 where (tb1.k1=1 and tb2.k1=1) or (tb1.k1 =2 and tb2.k1=2)";
         String planString = dorisAssert.query(query).explainQuery();


### PR DESCRIPTION
This reverts commit 1f2c06dd6e81c6e12ec73b4030288a3d236bfead.

# Proposed changes

This reverts PR(https://github.com/apache/doris/pull/14381). PR(https://github.com/apache/doris/pull/14381) causes the predicates `(n1.n_name = 'FRANCE' and n2.n_name = 'GERMANY') or (n1.n_name = 'GERMANY' and n2.n_name = 'FRANCE')` of tpch-100g-q7-query are not pushed down into scan node, resulting in a performance reduction of more than three times for tpch-100g-q7-query.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

