### PR TITLE
[Bug](BrokerFileReader) fix compile error due to _client

### DIFF
--- a/be/src/io/fs/broker_file_reader.cpp
+++ b/be/src/io/fs/broker_file_reader.cpp
@@ -34,7 +34,6 @@ BrokerFileReader::BrokerFileReader(const TNetworkAddress& broker_addr, const Pat
           _broker_addr(broker_addr),
           _fd(fd),
           _fs(std::move(fs)) {
-    _fs->get_client(&_client);
     DorisMetrics::instance()->broker_file_open_reading->increment(1);
     DorisMetrics::instance()->broker_file_reader_total->increment(1);
 }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx
#15874 has removed _client inside BrokerFileReader but #15980 has introduced it again which would together make compile fail.
## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

