### PR TITLE
[fix](DOE) only return first batch data in ES 8.x

### DIFF
--- a/be/src/exec/es/es_scan_reader.cpp
+++ b/be/src/exec/es/es_scan_reader.cpp
@@ -76,8 +76,8 @@ ESScanReader::ESScanReader(const std::string& target,
         std::stringstream scratch;
         // just send a normal search  against the elasticsearch with additional terminate_after param to achieve terminate early effect when limit take effect
         if (_type.empty()) {
+            // `terminate_after` and `size` can not be used together in scroll request of ES 8.x
             scratch << _target << REQUEST_SEPARATOR << _index << "/_search?"
-                    << "terminate_after=" << props.at(KEY_TERMINATE_AFTER)
                     << REQUEST_PREFERENCE_PREFIX << _shards << "&" << filter_path;
         } else {
             scratch << _target << REQUEST_SEPARATOR << _index << REQUEST_SEPARATOR << _type
@@ -92,9 +92,10 @@ ESScanReader::ESScanReader(const std::string& target,
         // scroll request for scanning
         // add terminate_after for the first scroll to avoid decompress all postings list
         if (_type.empty()) {
+            // `terminate_after` and `size` can not be used together in scroll request of ES 8.x
             scratch << _target << REQUEST_SEPARATOR << _index << "/_search?"
                     << "scroll=" << _scroll_keep_alive << REQUEST_PREFERENCE_PREFIX << _shards
-                    << "&" << filter_path << "&terminate_after=" << batch_size_str;
+                    << "&" << filter_path;
         } else {
             scratch << _target << REQUEST_SEPARATOR << _index << REQUEST_SEPARATOR << _type
                     << "/_search?"


### PR DESCRIPTION
# Proposed changes

Issue Number: close #15717

## Problem summary

Do not use `terminate_after` and `size` together in scroll request of ES 8.x.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

