### PR TITLE
[refractor](schema) refractor function Schema::get_column_by_field to make it simple

### DIFF
--- a/be/src/olap/schema.cpp
+++ b/be/src/olap/schema.cpp
@@ -114,15 +114,7 @@ vectorized::DataTypePtr Schema::get_data_type_ptr(const Field& field) {
 }
 
 vectorized::IColumn::MutablePtr Schema::get_column_by_field(const Field& field) {
-    auto data_type_ptr = vectorized::DataTypeFactory::instance().create_data_type(field);
-    vectorized::IColumn::MutablePtr col_ptr = data_type_ptr->create_column();
-
-    if (field.is_nullable()) {
-        return doris::vectorized::ColumnNullable::create(std::move(col_ptr),
-                                                         doris::vectorized::ColumnUInt8::create());
-    }
-
-    return col_ptr;
+    return get_data_type_ptr(field)->create_column();
 }
 
 vectorized::IColumn::MutablePtr Schema::get_predicate_column_nullable_ptr(const Field& field) {


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary
`DataTypeFactory::instance().create_data_type` will consider `Field.is_nullable`, may return type T or Nullable(T).
Then datatype `create_column`, will create Column or ColumnNullable(Column).

So we do not need to create ColumnNullable manually.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

