### PR TITLE
[fix](struct-type) select of struct return wrong result

### DIFF
--- a/be/src/vec/columns/column_struct.h
+++ b/be/src/vec/columns/column_struct.h
@@ -216,6 +216,12 @@ public:
     const ColumnPtr& get_column_ptr(size_t idx) const { return columns[idx]; }
     ColumnPtr& get_column_ptr(size_t idx) { return columns[idx]; }
 
+    void clear() override {
+        for (auto col : columns) {
+            col->clear();
+        }
+    }
+
 private:
     int compare_at_impl(size_t n, size_t m, const IColumn& rhs, int nan_direction_hint) const;
 


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary
If we do not clear correctly, we always get the first value while select struct.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

