### PR TITLE
[refractor](schema) refractor schema::get_predicate_column_ptr

### DIFF
--- a/be/src/olap/rowset/segment_v2/segment_iterator.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.cpp
@@ -15,8 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include "olap/rowset/segment_v2/segment_iterator.h"
-
 #include <memory>
 #include <set>
 #include <utility>
@@ -27,6 +25,7 @@
 #include "olap/olap_common.h"
 #include "olap/rowset/segment_v2/column_reader.h"
 #include "olap/rowset/segment_v2/segment.h"
+#include "olap/rowset/segment_v2/segment_iterator.h"
 #include "olap/short_key_index.h"
 #include "util/doris_metrics.h"
 #include "util/key_util.h"
@@ -1294,8 +1293,7 @@ Status SegmentIterator::next_batch(vectorized::Block* block) {
             auto cid = _schema.column_id(i);
             auto column_desc = _schema.column(cid);
             if (_is_pred_column[cid]) {
-                _current_return_columns[cid] =
-                        Schema::get_predicate_column_nullable_ptr(*column_desc);
+                _current_return_columns[cid] = Schema::get_predicate_column_ptr(*column_desc);
                 _current_return_columns[cid]->set_rowset_segment_id(
                         {_segment->rowset_id(), _segment->id()});
                 _current_return_columns[cid]->reserve(_opts.block_row_max);

--- a/be/src/olap/rowset/segment_v2/segment_iterator.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.cpp
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#include "olap/rowset/segment_v2/segment_iterator.h"
+
 #include <memory>
 #include <set>
 #include <utility>
@@ -25,7 +27,6 @@
 #include "olap/olap_common.h"
 #include "olap/rowset/segment_v2/column_reader.h"
 #include "olap/rowset/segment_v2/segment.h"
-#include "olap/rowset/segment_v2/segment_iterator.h"
 #include "olap/short_key_index.h"
 #include "util/doris_metrics.h"
 #include "util/key_util.h"

--- a/be/src/olap/schema.cpp
+++ b/be/src/olap/schema.cpp
@@ -16,6 +16,7 @@
 // under the License.
 
 #include "olap/schema.h"
+
 #include "olap/uint24.h"
 #include "vec/columns/column_complex.h"
 #include "vec/columns/column_dictionary.h"

--- a/be/src/olap/schema.cpp
+++ b/be/src/olap/schema.cpp
@@ -16,7 +16,6 @@
 // under the License.
 
 #include "olap/schema.h"
-
 #include "olap/uint24.h"
 #include "vec/columns/column_complex.h"
 #include "vec/columns/column_dictionary.h"
@@ -117,77 +116,80 @@ vectorized::IColumn::MutablePtr Schema::get_column_by_field(const Field& field) 
     return get_data_type_ptr(field)->create_column();
 }
 
-vectorized::IColumn::MutablePtr Schema::get_predicate_column_nullable_ptr(const Field& field) {
+vectorized::IColumn::MutablePtr Schema::get_predicate_column_ptr(const Field& field) {
     if (UNLIKELY(field.type() == OLAP_FIELD_TYPE_ARRAY)) {
         return get_data_type_ptr(field)->create_column();
     }
 
-    vectorized::IColumn::MutablePtr ptr = Schema::get_predicate_column_ptr(field.type());
+    vectorized::IColumn::MutablePtr ptr = nullptr;
+    switch (field.type()) {
+    case OLAP_FIELD_TYPE_BOOL:
+        ptr = doris::vectorized::PredicateColumnType<TYPE_BOOLEAN>::create();
+        break;
+    case OLAP_FIELD_TYPE_TINYINT:
+        ptr = doris::vectorized::PredicateColumnType<TYPE_TINYINT>::create();
+        break;
+    case OLAP_FIELD_TYPE_SMALLINT:
+        ptr = doris::vectorized::PredicateColumnType<TYPE_SMALLINT>::create();
+        break;
+    case OLAP_FIELD_TYPE_INT:
+        ptr = doris::vectorized::PredicateColumnType<TYPE_INT>::create();
+        break;
+    case OLAP_FIELD_TYPE_FLOAT:
+        ptr = doris::vectorized::PredicateColumnType<TYPE_FLOAT>::create();
+        break;
+    case OLAP_FIELD_TYPE_DOUBLE:
+        ptr = doris::vectorized::PredicateColumnType<TYPE_DOUBLE>::create();
+        break;
+    case OLAP_FIELD_TYPE_BIGINT:
+        ptr = doris::vectorized::PredicateColumnType<TYPE_BIGINT>::create();
+        break;
+    case OLAP_FIELD_TYPE_LARGEINT:
+        ptr = doris::vectorized::PredicateColumnType<TYPE_LARGEINT>::create();
+        break;
+    case OLAP_FIELD_TYPE_DATE:
+        ptr = doris::vectorized::PredicateColumnType<TYPE_DATE>::create();
+        break;
+    case OLAP_FIELD_TYPE_DATEV2:
+        ptr = doris::vectorized::PredicateColumnType<TYPE_DATEV2>::create();
+        break;
+    case OLAP_FIELD_TYPE_DATETIMEV2:
+        ptr = doris::vectorized::PredicateColumnType<TYPE_DATETIMEV2>::create();
+        break;
+    case OLAP_FIELD_TYPE_DATETIME:
+        ptr = doris::vectorized::PredicateColumnType<TYPE_DATETIME>::create();
+        break;
+    case OLAP_FIELD_TYPE_CHAR:
+    case OLAP_FIELD_TYPE_VARCHAR:
+    case OLAP_FIELD_TYPE_STRING:
+        if (config::enable_low_cardinality_optimize) {
+            ptr = doris::vectorized::ColumnDictionary<doris::vectorized::Int32>::create(
+                    field.type());
+        } else {
+            ptr = doris::vectorized::PredicateColumnType<TYPE_STRING>::create();
+        }
+        break;
+    case OLAP_FIELD_TYPE_DECIMAL:
+        ptr = doris::vectorized::PredicateColumnType<TYPE_DECIMALV2>::create();
+        break;
+    case OLAP_FIELD_TYPE_DECIMAL32:
+        ptr = doris::vectorized::PredicateColumnType<TYPE_DECIMAL32>::create();
+        break;
+    case OLAP_FIELD_TYPE_DECIMAL64:
+        ptr = doris::vectorized::PredicateColumnType<TYPE_DECIMAL64>::create();
+        break;
+    case OLAP_FIELD_TYPE_DECIMAL128I:
+        ptr = doris::vectorized::PredicateColumnType<TYPE_DECIMAL128I>::create();
+        break;
+    default:
+        LOG(FATAL) << "Unexpected type when choosing predicate column, type=" << field.type();
+    }
+
     if (field.is_nullable()) {
         return doris::vectorized::ColumnNullable::create(std::move(ptr),
                                                          doris::vectorized::ColumnUInt8::create());
     }
     return ptr;
-}
-
-vectorized::IColumn::MutablePtr Schema::get_predicate_column_ptr(FieldType type) {
-    switch (type) {
-    case OLAP_FIELD_TYPE_BOOL:
-        return doris::vectorized::PredicateColumnType<TYPE_BOOLEAN>::create();
-
-    case OLAP_FIELD_TYPE_TINYINT:
-        return doris::vectorized::PredicateColumnType<TYPE_TINYINT>::create();
-
-    case OLAP_FIELD_TYPE_SMALLINT:
-        return doris::vectorized::PredicateColumnType<TYPE_SMALLINT>::create();
-
-    case OLAP_FIELD_TYPE_INT:
-        return doris::vectorized::PredicateColumnType<TYPE_INT>::create();
-
-    case OLAP_FIELD_TYPE_FLOAT:
-        return doris::vectorized::PredicateColumnType<TYPE_FLOAT>::create();
-
-    case OLAP_FIELD_TYPE_DOUBLE:
-        return doris::vectorized::PredicateColumnType<TYPE_DOUBLE>::create();
-
-    case OLAP_FIELD_TYPE_BIGINT:
-        return doris::vectorized::PredicateColumnType<TYPE_BIGINT>::create();
-
-    case OLAP_FIELD_TYPE_LARGEINT:
-        return doris::vectorized::PredicateColumnType<TYPE_LARGEINT>::create();
-
-    case OLAP_FIELD_TYPE_DATE:
-        return doris::vectorized::PredicateColumnType<TYPE_DATE>::create();
-
-    case OLAP_FIELD_TYPE_DATEV2:
-        return doris::vectorized::PredicateColumnType<TYPE_DATEV2>::create();
-
-    case OLAP_FIELD_TYPE_DATETIMEV2:
-        return doris::vectorized::PredicateColumnType<TYPE_DATETIMEV2>::create();
-
-    case OLAP_FIELD_TYPE_DATETIME:
-        return doris::vectorized::PredicateColumnType<TYPE_DATETIME>::create();
-
-    case OLAP_FIELD_TYPE_CHAR:
-    case OLAP_FIELD_TYPE_VARCHAR:
-    case OLAP_FIELD_TYPE_STRING:
-        if (config::enable_low_cardinality_optimize) {
-            return doris::vectorized::ColumnDictionary<doris::vectorized::Int32>::create(type);
-        }
-        return doris::vectorized::PredicateColumnType<TYPE_STRING>::create();
-
-    case OLAP_FIELD_TYPE_DECIMAL:
-        return doris::vectorized::PredicateColumnType<TYPE_DECIMALV2>::create();
-    case OLAP_FIELD_TYPE_DECIMAL32:
-        return doris::vectorized::PredicateColumnType<TYPE_DECIMAL32>::create();
-    case OLAP_FIELD_TYPE_DECIMAL64:
-        return doris::vectorized::PredicateColumnType<TYPE_DECIMAL64>::create();
-    case OLAP_FIELD_TYPE_DECIMAL128I:
-        return doris::vectorized::PredicateColumnType<TYPE_DECIMAL128I>::create();
-
-    default:
-        LOG(FATAL) << "Unexpected type when choosing predicate column, type=" << type;
-    }
 }
 
 } // namespace doris

--- a/be/src/olap/schema.h
+++ b/be/src/olap/schema.h
@@ -112,9 +112,7 @@ public:
 
     static vectorized::IColumn::MutablePtr get_column_by_field(const Field& field);
 
-    static vectorized::IColumn::MutablePtr get_predicate_column_ptr(FieldType type);
-
-    static vectorized::IColumn::MutablePtr get_predicate_column_nullable_ptr(const Field& field);
+    static vectorized::IColumn::MutablePtr get_predicate_column_ptr(const Field& field);
 
     const std::vector<Field*>& columns() const { return _cols; }
 


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

remove function `Schema::get_predicate_column_nullable_ptr`
and merge nullable logic into `schema::get_predicate_column_ptr`

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

