### PR TITLE
[fix](struct-type) fix insert null and explain for struct type

### DIFF
--- a/be/src/olap/rowset/segment_v2/column_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/column_writer.cpp
@@ -658,11 +658,9 @@ Status StructColumnWriter::append_data(const uint8_t** ptr, size_t num_rows) {
                                                        num_rows));
     }
     if (is_nullable()) {
-        uint8_t null_sign = 0;
-        const uint8_t* null_sign_ptr = &null_sign;
-        for (size_t i = 0; i < num_rows; ++i) {
-            RETURN_IF_ERROR(_null_writer->append_data(&null_sign_ptr, 1));
-        }
+        std::vector<vectorized::UInt8> null_signs(num_rows, 0);
+        const uint8_t* null_sign_ptr = null_signs.data();
+        RETURN_IF_ERROR(_null_writer->append_data(&null_sign_ptr, num_rows));
     }
     return Status::OK();
 }
@@ -707,7 +705,15 @@ Status StructColumnWriter::write_ordinal_index() {
 }
 
 Status StructColumnWriter::append_nulls(size_t num_rows) {
-    return Status::NotSupported("struct writer not support append nulls");
+    for (auto& column_writer : _sub_column_writers) {
+        RETURN_IF_ERROR(column_writer->append_nulls(num_rows));
+    }
+    if (is_nullable()) {
+        std::vector<vectorized::UInt8> null_signs(num_rows, 1);
+        const uint8_t* null_sign_ptr = null_signs.data();
+        RETURN_IF_ERROR(_null_writer->append_data(&null_sign_ptr, num_rows));
+    }
+    return Status::OK();
 }
 
 Status StructColumnWriter::finish_current_page() {

--- a/be/src/olap/rowset/segment_v2/column_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/column_writer.cpp
@@ -648,6 +648,13 @@ Status StructColumnWriter::write_inverted_index() {
     return Status::OK();
 }
 
+Status StructColumnWriter::append_nullable(const uint8_t* null_map, const uint8_t** ptr,
+                                           size_t num_rows) {
+    RETURN_IF_ERROR(append_data(ptr, num_rows));
+    RETURN_IF_ERROR(_null_writer->append_data(&null_map, num_rows));
+    return Status::OK();
+}
+
 Status StructColumnWriter::append_data(const uint8_t** ptr, size_t num_rows) {
     auto results = reinterpret_cast<const uint64_t*>(*ptr);
     for (size_t i = 0; i < _num_sub_column_writers; ++i) {

--- a/be/src/olap/rowset/segment_v2/column_writer.h
+++ b/be/src/olap/rowset/segment_v2/column_writer.h
@@ -113,7 +113,7 @@ public:
     Status append_nullable(const uint8_t* nullmap, const void* data, size_t num_rows);
 
     // use only in vectorized load
-    Status append_nullable(const uint8_t* null_map, const uint8_t** data, size_t num_rows);
+    virtual Status append_nullable(const uint8_t* null_map, const uint8_t** data, size_t num_rows);
 
     virtual Status append_nulls(size_t num_rows) = 0;
 
@@ -274,6 +274,7 @@ public:
 
     Status init() override;
 
+    Status append_nullable(const uint8_t* null_map, const uint8_t** data, size_t num_rows) override;
     Status append_data(const uint8_t** ptr, size_t num_rows) override;
 
     uint64_t estimate_buffer_size() override;

--- a/be/src/vec/columns/column.h
+++ b/be/src/vec/columns/column.h
@@ -539,7 +539,9 @@ public:
     virtual bool is_dummy() const { return false; }
 
     /// Clear data of column, just like vector clear
-    virtual void clear() {};
+    virtual void clear() {
+        LOG(FATAL) << fmt::format("clear not impl for column {}", get_name());
+    }
 
     /** Memory layout properties.
       *

--- a/be/src/vec/columns/column.h
+++ b/be/src/vec/columns/column.h
@@ -539,9 +539,7 @@ public:
     virtual bool is_dummy() const { return false; }
 
     /// Clear data of column, just like vector clear
-    virtual void clear() {
-        LOG(FATAL) << fmt::format("clear not impl for column {}", get_name());
-    }
+    virtual void clear() {};
 
     /** Memory layout properties.
       *

--- a/be/src/vec/data_types/data_type_struct.cpp
+++ b/be/src/vec/data_types/data_type_struct.cpp
@@ -272,7 +272,7 @@ bool DataTypeStruct::equals(const IDataType& rhs) const {
     }
 
     for (size_t i = 0; i < size; ++i) {
-        if (!elems[i]->equals(*rhs_tuple.elems[i]) || names[i] != rhs_tuple.names[i]) {
+        if (!elems[i]->equals(*rhs_tuple.elems[i])) {
             return false;
         }
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/StructLiteral.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/StructLiteral.java
@@ -58,7 +58,7 @@ public class StructLiteral extends LiteralExpr {
     @Override
     protected String toSqlImpl() {
         List<String> list = new ArrayList<>(children.size());
-        children.forEach(v -> list.add(v.toDigestImpl()));
+        children.forEach(v -> list.add(v.toSqlImpl()));
         return "STRUCT(" + StringUtils.join(list, ", ") + ")";
     }
 


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

1. support insert null for struct type;
2. fix explain const exprs for strut type got wrong result;
```
> explain insert into example3 values(20,{12345678,12345679}),(21,{12345678,12345679});
+------------------------------------------+
| Explain String                           |
+------------------------------------------+
| PLAN FRAGMENT 0                          |
|   OUTPUT EXPRS:                          |
|     <slot 2> 20                          |
|     <slot 3> STRUCT(12345678, 12345679)  |
|   PARTITION: UNPARTITIONED               |
|                                          |
|   OLAP TABLE SINK                        |
|     TUPLE ID: 0                          |
|     RANDOM                               |
|                                          |
|   0:VUNION                               |
|      constant exprs:                     |
|          20 | STRUCT(12345678, 12345679) |
|          21 | STRUCT(12345678, 12345679) |
+------------------------------------------+
```

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
4. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
5. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
6. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
7. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

