### PR TITLE
[Enhancement](Nereids)add more clear message when run select * except incorrectly.

### DIFF
--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -843,6 +843,10 @@ under the License.
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>org.apache.doris</groupId>
+            <artifactId>fe-common</artifactId>
+        </dependency>
 
     </dependencies>
     <build>

--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -843,10 +843,6 @@ under the License.
                 </exclusion>
             </exclusions>
         </dependency>
-        <dependency>
-            <groupId>org.apache.doris</groupId>
-            <artifactId>fe-common</artifactId>
-        </dependency>
 
     </dependencies>
     <build>

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectProcessor.java
@@ -313,7 +313,7 @@ public class ConnectProcessor {
                     && ctx.getSessionVariable().isEnableNereidsPlanner()
                     && !ctx.getSessionVariable().enableFallbackToOriginalPlanner) {
                 Exception exception = new Exception(
-                        String.format("Nereids cannot parse the SQL, and fallback disabled. caused by: %s",
+                        String.format("Nereids cannot parse the SQL, and fallback disabled. caused by: %s\n\n",
                                 nereidsParseException.getMessage()), nereidsParseException);
                 // audit it and break
                 handleQueryException(exception, auditStmt, null, null);

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectProcessor.java
@@ -313,10 +313,8 @@ public class ConnectProcessor {
                     && ctx.getSessionVariable().isEnableNereidsPlanner()
                     && !ctx.getSessionVariable().enableFallbackToOriginalPlanner) {
                 Exception exception = new Exception(
-                        String.format("Nereids cannot parse the SQL, and fallback disabled.\n\n%s",
+                        String.format("Nereids cannot parse the SQL, and fallback disabled. caused by: %s",
                                 nereidsParseException.getMessage()), nereidsParseException);
-                        String.format("nereids cannot anaylze sql, and fall-back disabled: %s, caused by %s",
-                        parsedStmt.toSql(), nereidsParseException.getMessage()), nereidsParseException);
                 // audit it and break
                 handleQueryException(exception, auditStmt, null, null);
                 break;

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectProcessor.java
@@ -315,6 +315,8 @@ public class ConnectProcessor {
                 Exception exception = new Exception(
                         String.format("Nereids cannot parse the SQL, and fallback disabled.\n\n%s",
                                 nereidsParseException.getMessage()), nereidsParseException);
+                        String.format("nereids cannot anaylze sql, and fall-back disabled: %s, caused by %s",
+                        parsedStmt.toSql(), nereidsParseException.getMessage()), nereidsParseException);
                 // audit it and break
                 handleQueryException(exception, auditStmt, null, null);
                 break;

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectProcessor.java
@@ -313,7 +313,7 @@ public class ConnectProcessor {
                     && ctx.getSessionVariable().isEnableNereidsPlanner()
                     && !ctx.getSessionVariable().enableFallbackToOriginalPlanner) {
                 Exception exception = new Exception(
-                        String.format("Nereids cannot parse the SQL, and fallback disabled. caused by: %s\n\n",
+                        String.format("Nereids cannot parse the SQL, and fallback disabled. caused by: \n\n%s",
                                 nereidsParseException.getMessage()), nereidsParseException);
                 // audit it and break
                 handleQueryException(exception, auditStmt, null, null);


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

add more clear message when run select * except incorrectly. Now we can see the parseException when nereids parse error.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

