### PR TITLE
[feature-wip](MTMV) Support setting variables in query statement

### DIFF
--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -612,11 +612,6 @@ under the License.
                 </exclusion>
             </exclusions>
         </dependency>
-        <!-- https://mvnrepository.com/artifact/io.netty/netty-all -->
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-all</artifactId>
-        </dependency>
         <dependency>
             <groupId>org.apache.hive</groupId>
             <artifactId>hive-exec</artifactId>
@@ -674,11 +669,6 @@ under the License.
                     <groupId>com.fasterxml.jackson.core</groupId>
                 </exclusion>               
             </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-            <version>2.14.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.hadoop</groupId>

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/QueryStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/QueryStmt.java
@@ -167,6 +167,7 @@ public abstract class QueryStmt extends StatementBase implements Queriable {
 
     protected boolean toSQLWithSelectList;
     protected boolean isPointQuery;
+    protected boolean toSQLWithHint;
 
     QueryStmt(ArrayList<OrderByElement> orderByElements, LimitElement limitElement) {
         this.orderByElements = orderByElements;
@@ -817,5 +818,10 @@ public abstract class QueryStmt extends StatementBase implements Queriable {
 
     public boolean isPointQuery() {
         return isPointQuery;
+    }
+
+    public String toSqlWithHint() {
+        toSQLWithHint = true;
+        return toSql();
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/SelectStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/SelectStmt.java
@@ -56,6 +56,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections.MapUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -2004,6 +2005,15 @@ public class SelectStmt extends QueryStmt {
 
         // Select list
         strBuilder.append("SELECT ");
+
+        if (toSQLWithHint && MapUtils.isNotEmpty(selectList.getOptHints())) {
+            strBuilder.append("/*+ SET_VAR(");
+            strBuilder.append(
+                    selectList.getOptHints().entrySet().stream().map(entry -> entry.getKey() + "=" + entry.getValue())
+                            .collect(Collectors.joining(", ")));
+            strBuilder.append(") */ ");
+        }
+
         if (selectList.isDistinct()) {
             strBuilder.append("DISTINCT ");
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/MaterializedView.java
@@ -77,7 +77,7 @@ public class MaterializedView extends OlapTable {
         type = TableType.MATERIALIZED_VIEW;
         buildMode = params.buildMode;
         refreshInfo = params.mvRefreshInfo;
-        query = params.queryStmt.toSql();
+        query = params.queryStmt.toSqlWithHint();
     }
 
     public BuildMode getBuildMode() {

--- a/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVTaskProcessor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVTaskProcessor.java
@@ -65,14 +65,16 @@ public class MTMVTaskProcessor {
             String createStatement = generateCreateStatement(mv.clone(temporaryMVName));
             if (!executeSQL(context, createStatement)) {
                 throw new RuntimeException(
-                        "Failed to create the temporary materialized view, sql=" + createStatement + ".");
+                        "Failed to create the temporary materialized view, sql=" + createStatement + ", cause="
+                                + context.getCtx().getState().getErrorMessage() + ".");
             }
 
             // Step 2: insert data to the temporary materialized view.
             String insertSelectStatement = generateInsertSelectStmt(context, temporaryMVName);
             if (!executeSQL(context, insertSelectStatement)) {
                 throw new RuntimeException(
-                        "Failed to insert data to the temporary materialized view, sql=" + insertSelectStatement + ".");
+                        "Failed to insert data to the temporary materialized view, sql=" + insertSelectStatement
+                                + ", cause=" + context.getCtx().getState().getErrorMessage() + ".");
             }
             String insertInfoMessage = context.getCtx().getState().getInfoMessage();
 
@@ -81,7 +83,7 @@ public class MTMVTaskProcessor {
             if (!executeSQL(context, swapStatement)) {
                 throw new RuntimeException(
                         "Failed to swap the temporary materialized view with the original materialized view, sql="
-                                + swapStatement + ".");
+                                + swapStatement + ", cause=" + context.getCtx().getState().getErrorMessage() + ".");
             }
 
             context.getTask().setMessage(insertInfoMessage);

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -655,9 +655,13 @@ public class StmtExecutor implements ProfileWriter {
      * @throws DdlException
      */
     private void analyzeVariablesInStmt() throws DdlException {
+        analyzeVariablesInStmt(parsedStmt);
+    }
+
+    private void analyzeVariablesInStmt(StatementBase statement) throws DdlException {
         SessionVariable sessionVariable = context.getSessionVariable();
-        if (parsedStmt != null && parsedStmt instanceof SelectStmt) {
-            SelectStmt selectStmt = (SelectStmt) parsedStmt;
+        if (statement instanceof SelectStmt) {
+            SelectStmt selectStmt = (SelectStmt) statement;
             Map<String, String> optHints = selectStmt.getSelectList().getOptHints();
             if (optHints != null) {
                 sessionVariable.setIsSingleSetVar(true);
@@ -1506,6 +1510,8 @@ public class StmtExecutor implements ProfileWriter {
             handleExplainStmt(explainString);
             return;
         }
+
+        analyzeVariablesInStmt(insertStmt.getQueryStmt());
 
         long createTime = System.currentTimeMillis();
         Throwable throwable = null;


### PR DESCRIPTION
## Use case

```shell
mysql> CREATE TABLE t_user (
    ->   event_day DATE,
    ->   id bigint,
    ->   username varchar(20)
    -> )
    -> DISTRIBUTED BY HASH(id) BUCKETS 10
    -> PROPERTIES ('replication_num' = '1');
Query OK, 0 rows affected (0.07 sec)

mysql> CREATE TABLE t_user_pv(
    ->   event_day DATE,
    ->   id bigint,
    ->   pv bigint
    -> )
    -> DISTRIBUTED BY HASH(id) BUCKETS 10
    -> PROPERTIES ('replication_num' = '1');
Query OK, 0 rows affected (0.09 sec)

mysql> CREATE MATERIALIZED VIEW mv
    -> BUILD IMMEDIATE REFRESH COMPLETE
    -> KEY (username)
    -> DISTRIBUTED BY HASH(username) BUCKETS 10
    -> PROPERTIES ('replication_num' = '1')
    -> AS SELECT /*+ SET_VAR(exec_mem_limit=1048576, query_timeout=3600) */ t1.username ,t2.pv FROM t_user t1 LEFT JOIN t_user_pv t2 on t1.id = t2.id;
Query OK, 0 rows affected (0.10 sec)
```

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [x] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

