### PR TITLE
[Fix](Nereids)fix group_concat order bug and support more signatures.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/agg/GroupConcat.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/agg/GroupConcat.java
@@ -24,7 +24,9 @@ import org.apache.doris.nereids.trees.expressions.OrderExpression;
 import org.apache.doris.nereids.trees.expressions.functions.ExplicitlyCastableSignature;
 import org.apache.doris.nereids.trees.expressions.functions.PropagateNullable;
 import org.apache.doris.nereids.trees.expressions.visitor.ExpressionVisitor;
+import org.apache.doris.nereids.types.CharType;
 import org.apache.doris.nereids.types.DataType;
+import org.apache.doris.nereids.types.StringType;
 import org.apache.doris.nereids.types.VarcharType;
 import org.apache.doris.nereids.types.coercion.AnyDataType;
 import org.apache.doris.nereids.util.ExpressionUtils;
@@ -46,7 +48,17 @@ public class GroupConcat extends AggregateFunction
             FunctionSignature.ret(VarcharType.SYSTEM_DEFAULT)
                     .varArgs(VarcharType.SYSTEM_DEFAULT, AnyDataType.INSTANCE),
             FunctionSignature.ret(VarcharType.SYSTEM_DEFAULT)
-                    .varArgs(VarcharType.SYSTEM_DEFAULT, VarcharType.SYSTEM_DEFAULT, AnyDataType.INSTANCE)
+                    .varArgs(VarcharType.SYSTEM_DEFAULT, VarcharType.SYSTEM_DEFAULT, AnyDataType.INSTANCE),
+            FunctionSignature.ret(CharType.SYSTEM_DEFAULT).varArgs(CharType.SYSTEM_DEFAULT),
+            FunctionSignature.ret(CharType.SYSTEM_DEFAULT)
+                    .varArgs(CharType.SYSTEM_DEFAULT, AnyDataType.INSTANCE),
+            FunctionSignature.ret(CharType.SYSTEM_DEFAULT)
+                    .varArgs(CharType.SYSTEM_DEFAULT, CharType.SYSTEM_DEFAULT, AnyDataType.INSTANCE),
+            FunctionSignature.ret(StringType.INSTANCE).varArgs(StringType.INSTANCE),
+            FunctionSignature.ret(StringType.INSTANCE)
+                    .varArgs(StringType.INSTANCE, AnyDataType.INSTANCE),
+            FunctionSignature.ret(StringType.INSTANCE)
+                    .varArgs(StringType.INSTANCE, StringType.INSTANCE, AnyDataType.INSTANCE)
     );
 
     private final int nonOrderArguments;
@@ -55,8 +67,7 @@ public class GroupConcat extends AggregateFunction
      * constructor with 1 argument.
      */
     public GroupConcat(Expression arg, OrderExpression... orders) {
-        super("group_concat", ExpressionUtils.mergeArguments(arg, orders));
-        this.nonOrderArguments = 1;
+        this(false, arg, orders);
     }
 
     /**
@@ -71,8 +82,7 @@ public class GroupConcat extends AggregateFunction
      * constructor with 2 arguments.
      */
     public GroupConcat(Expression arg0, Expression arg1, OrderExpression... orders) {
-        super("group_concat", ExpressionUtils.mergeArguments(arg0, arg1, orders));
-        this.nonOrderArguments = 2;
+        this(false, arg0, arg1, orders);
     }
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/util/ExpressionUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/util/ExpressionUtils.java
@@ -467,17 +467,4 @@ public class ExpressionUtils {
                 .flatMap(expr -> expr.getInputSlots().stream())
                 .collect(ImmutableSet.toImmutableSet());
     }
-
-    /**
-     * cast push down in order expression
-     */
-    public static Expression pushDownCastInOrderExpression(Expression expression) {
-        if (expression instanceof Cast
-                && ((Cast) expression).child() instanceof OrderExpression) {
-            Cast cast = ((Cast) expression);
-            OrderExpression order = ((OrderExpression) cast.child());
-            return order.withChildren(cast.withChildren(order.getOrderKey().getExpr()));
-        }
-        return expression;
-    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/util/ExpressionUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/util/ExpressionUtils.java
@@ -28,7 +28,6 @@ import org.apache.doris.nereids.trees.expressions.InPredicate;
 import org.apache.doris.nereids.trees.expressions.IsNull;
 import org.apache.doris.nereids.trees.expressions.Not;
 import org.apache.doris.nereids.trees.expressions.Or;
-import org.apache.doris.nereids.trees.expressions.OrderExpression;
 import org.apache.doris.nereids.trees.expressions.Slot;
 import org.apache.doris.nereids.trees.expressions.SlotReference;
 import org.apache.doris.nereids.trees.expressions.literal.BooleanLiteral;


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

fix group_concat order bug and support more signatures.
now the function not only support varchar but also char, string.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

