### PR TITLE
[Fix](inverted index) fix add nulls bug for inverted fulltext index

### DIFF
--- a/be/src/olap/rowset/segment_v2/inverted_index_writer.cpp
+++ b/be/src/olap/rowset/segment_v2/inverted_index_writer.cpp
@@ -192,8 +192,7 @@ public:
             }
 
             for (int i = 0; i < count; ++i) {
-                auto empty_wide = lucene::util::Misc::_charToWide(empty_value.c_str());
-                _field->setValue(empty_wide, false);
+                new_fulltext_field(empty_value.c_str(), 0);
                 _index_writer->addDocument(_doc);
             }
         }


### PR DESCRIPTION
# Proposed changes

fix a bug for inverted index writer add_nulls function

## Problem summary

We found a problem with inverted index when parser=english, if there were nulls in columns when flushing inverted index for them, it can cause CLucene throwing an exception.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

