### PR TITLE
[fix](nereids): fix all bugs in `mergeGroup()`.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/NereidsPlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/NereidsPlanner.java
@@ -269,7 +269,9 @@ public class NereidsPlanner extends Planner {
 
             List<Plan> planChildren = Lists.newArrayList();
             for (int i = 0; i < groupExpression.arity(); i++) {
-                planChildren.add(chooseBestPlan(groupExpression.child(i), inputPropertiesList.get(i)));
+                planChildren.add(
+                        chooseBestPlan(cascadesContext.getMemo().getGroup(groupExpression.child(i).getGroupId()),
+                                inputPropertiesList.get(i)));
             }
 
             Plan plan = groupExpression.getPlan().withChildren(planChildren);

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/NereidsPlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/NereidsPlanner.java
@@ -269,9 +269,7 @@ public class NereidsPlanner extends Planner {
 
             List<Plan> planChildren = Lists.newArrayList();
             for (int i = 0; i < groupExpression.arity(); i++) {
-                planChildren.add(
-                        chooseBestPlan(cascadesContext.getMemo().getGroup(groupExpression.child(i).getGroupId()),
-                                inputPropertiesList.get(i)));
+                planChildren.add(chooseBestPlan(groupExpression.child(i), inputPropertiesList.get(i)));
             }
 
             Plan plan = groupExpression.getPlan().withChildren(planChildren);

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/cascades/ApplyRuleJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/cascades/ApplyRuleJob.java
@@ -58,7 +58,8 @@ public class ApplyRuleJob extends Job {
 
     @Override
     public void execute() throws AnalysisException {
-        if (groupExpression.hasApplied(rule)) {
+        if (groupExpression.hasApplied(rule)
+                || groupExpression.isUnused()) {
             return;
         }
         countJobExecutionTimesOfGroupExpressions(groupExpression);

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/cascades/CostAndEnforcerJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/cascades/CostAndEnforcerJob.java
@@ -104,6 +104,10 @@ public class CostAndEnforcerJob extends Job implements Cloneable {
      */
     @Override
     public void execute() {
+        if (groupExpression.isUnused()) {
+            return;
+        }
+
         countJobExecutionTimesOfGroupExpressions(groupExpression);
         // Do init logic of root plan/groupExpr of `subplan`, only run once per task.
         if (curChildIndex == -1) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/cascades/DeriveStatsJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/cascades/DeriveStatsJob.java
@@ -58,10 +58,10 @@ public class DeriveStatsJob extends Job {
 
     @Override
     public void execute() {
-        countJobExecutionTimesOfGroupExpressions(groupExpression);
-        if (groupExpression.isStatDerived()) {
+        if (groupExpression.isStatDerived() || groupExpression.isUnused()) {
             return;
         }
+        countJobExecutionTimesOfGroupExpressions(groupExpression);
         if (!deriveChildren && groupExpression.arity() > 0) {
             pushJob(new DeriveStatsJob(groupExpression, true, context));
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Group.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Group.java
@@ -232,37 +232,6 @@ public class Group {
         lowestCostPlans.putAll(needReplaceBestExpressions);
     }
 
-    /**
-     * delete groupExpression in lowestCostPlans.
-     */
-    public void deleteBestPlan(GroupExpression groupExpression) {
-        for (Iterator<Map.Entry<PhysicalProperties, Pair<Double, GroupExpression>>> iterator =
-                lowestCostPlans.entrySet().iterator(); iterator.hasNext(); ) {
-            Map.Entry<PhysicalProperties, Pair<Double, GroupExpression>> entry = iterator.next();
-            Pair<Double, GroupExpression> pair = entry.getValue();
-            GroupExpression bestExpression = pair.second;
-            if (bestExpression.equals(groupExpression)) {
-                iterator.remove();
-            }
-        }
-
-        // we need to delete the enforcer whose input property is satisfied by the deleted group expression.
-        for (Iterator<Map.Entry<PhysicalProperties, Pair<Double, GroupExpression>>> iterator =
-                lowestCostPlans.entrySet().iterator(); iterator.hasNext(); ) {
-            Map.Entry<PhysicalProperties, Pair<Double, GroupExpression>> entry = iterator.next();
-            PhysicalProperties requiredProperty = entry.getKey();
-            Pair<Double, GroupExpression> pair = entry.getValue();
-            GroupExpression bestExpression = pair.second;
-            // enforcer's child group is same with itself.
-            if (bestExpression.arity() == 1 && bestExpression.child(0) == bestExpression.getOwnerGroup()) {
-                // the enforcer need to be deleted when its input property can not be satisfied by the group
-                if (!lowestCostPlans.keySet().containsAll(bestExpression.getInputProperties(requiredProperty))) {
-                    iterator.remove();
-                }
-            }
-        }
-    }
-
     public StatsDeriveResult getStatistics() {
         return statistics;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/GroupExpression.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/GroupExpression.java
@@ -166,6 +166,9 @@ public class GroupExpression {
         this.statDerived = statDerived;
     }
 
+    /**
+     * Check this GroupExpression isUnused. See detail of `isUnused` in its comment.
+     */
     public boolean isUnused() {
         if (isUnused) {
             Preconditions.checkState(children.isEmpty() || ownerGroup == null);
@@ -241,21 +244,14 @@ public class GroupExpression {
      * Merge GroupExpression.
      */
     public void mergeTo(GroupExpression target) {
-        // LowestCostTable
-        this.getLowestCostTable()
-                .forEach((properties, pair) -> target.updateLowestCostTable(properties, pair.second, pair.first));
-        // requestPropertiesMap
-        target.requestPropertiesMap.putAll(this.requestPropertiesMap);
-        // ruleMasks
-        target.ruleMasks.or(this.ruleMasks);
-
-        // clear
+        this.mergeToNotOwnerRemove(target);
         this.ownerGroup.removeGroupExpression(this);
-        this.children.forEach(child -> child.removeParentExpression(this));
-        this.children.clear();
     }
 
-    public void move(GroupExpression target) {
+    /**
+     * Merge GroupExpression, but owner don't remove this GroupExpression.
+     */
+    public void mergeToNotOwnerRemove(GroupExpression target) {
         // LowestCostTable
         this.getLowestCostTable()
                 .forEach((properties, pair) -> target.updateLowestCostTable(properties, pair.second, pair.first));

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/GroupExpression.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/GroupExpression.java
@@ -66,6 +66,7 @@ public class GroupExpression {
     // value is the request physical properties
     private final Map<PhysicalProperties, PhysicalProperties> requestPropertiesMap;
 
+    // After mergeGroup(), source Group was cleaned up, but it may be in the Job Stack. So use this to mark and skip it.
     private boolean isUnused = false;
 
     public GroupExpression(Plan plan) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/GroupExpression.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/GroupExpression.java
@@ -224,17 +224,6 @@ public class GroupExpression {
         return lowestCostTable.get(property).first;
     }
 
-    /**
-     * Gets the input properties needed for a given required property
-     *
-     * @param property PhysicalPropertySet that needs to be satisfied
-     * @return List of children input physical properties required
-     */
-    public List<PhysicalProperties> getInputProperties(PhysicalProperties property) {
-        Preconditions.checkState(lowestCostTable.containsKey(property));
-        return lowestCostTable.get(property).second;
-    }
-
     public void putOutputPropertiesMap(PhysicalProperties outputPropertySet,
             PhysicalProperties requiredPropertySet) {
         this.requestPropertiesMap.put(requiredPropertySet, outputPropertySet);
@@ -261,7 +250,6 @@ public class GroupExpression {
         target.ruleMasks.or(this.ruleMasks);
 
         // clear
-        // this.ownerGroup.removeGroupExpression(this);
         this.children.forEach(child -> child.removeParentExpression(this));
         this.children.clear();
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/GroupExpression.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/GroupExpression.java
@@ -233,8 +233,8 @@ public class GroupExpression {
      * Merge GroupExpression.
      */
     public void mergeTo(GroupExpression target) {
-        this.mergeToNotOwnerRemove(target);
         this.ownerGroup.removeGroupExpression(this);
+        this.mergeToNotOwnerRemove(target);
     }
 
     /**
@@ -252,6 +252,7 @@ public class GroupExpression {
         // clear
         this.children.forEach(child -> child.removeParentExpression(this));
         this.children.clear();
+        this.ownerGroup = null;
     }
 
     public double getCost() {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Memo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Memo.java
@@ -474,10 +474,8 @@ public class Memo {
             }
         }
         if (!source.equals(destination)) {
-            // TODO: stats and other
             source.mergeTo(destination);
-            // groups.remove(source.getGroupId());
-            groups.put(source.getGroupId(), destination);
+            groups.remove(source.getGroupId());
         }
 
         needMergeGroupPairs.forEach(this::mergeGroup);

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Memo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Memo.java
@@ -446,7 +446,7 @@ public class Memo {
         }
         GROUP_MERGE_TRACER.log(GroupMergeEvent.of(source, destination, needReplaceChild));
 
-        Map<Group, Group> needMergeGroup = Maps.newHashMap();
+        Map<Group, Group> needMergeGroupPairs = Maps.newHashMap();
         for (GroupExpression reinsertGroupExpr : needReplaceChild) {
             // After change GroupExpression children, hashcode will change, so need to reinsert into map.
             groupExpressions.remove(reinsertGroupExpr);
@@ -467,10 +467,7 @@ public class Memo {
                     reinsertGroupExpr.mergeTo(existGroupExpr);
                 } else {
                     // reinsertGroupExpr & existGroupExpr aren't in same group, need to merge their OwnerGroup.
-                    if (reinsertGroupExpr.getPlan() instanceof PhysicalPlan) {
-                        reinsertGroupExpr.getOwnerGroup().deleteBestPlan(reinsertGroupExpr);
-                    }
-                    needMergeGroup.put(reinsertGroupExpr.getOwnerGroup(), existGroupExpr.getOwnerGroup());
+                    needMergeGroupPairs.put(reinsertGroupExpr.getOwnerGroup(), existGroupExpr.getOwnerGroup());
                 }
             } else {
                 groupExpressions.put(reinsertGroupExpr, reinsertGroupExpr);
@@ -483,7 +480,7 @@ public class Memo {
             groups.put(source.getGroupId(), destination);
         }
 
-        needMergeGroup.forEach(this::mergeGroup);
+        needMergeGroupPairs.forEach(this::mergeGroup);
         return destination;
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Memo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Memo.java
@@ -33,6 +33,7 @@ import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalOlapScan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalPlan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalProject;
+import org.apache.doris.nereids.trees.plans.physical.PhysicalPlan;
 import org.apache.doris.nereids.util.Utils;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.statistics.StatsDeriveResult;
@@ -444,22 +445,38 @@ public class Memo {
             }
         }
         GROUP_MERGE_TRACER.log(GroupMergeEvent.of(source, destination, needReplaceChild));
-        for (GroupExpression groupExpression : needReplaceChild) {
-            // After change GroupExpression children, the hashcode will change,
-            // so need to reinsert into map.
-            groupExpressions.remove(groupExpression);
-            Utils.replaceList(groupExpression.children(), source, destination);
 
-            GroupExpression that = groupExpressions.get(groupExpression);
-            if (that != null && that.getOwnerGroup() != null
-                    && !that.getOwnerGroup().equals(groupExpression.getOwnerGroup())) {
-                // remove groupExpression from its owner group to avoid adding it to that.getOwnerGroup()
-                // that.getOwnerGroup() already has this groupExpression.
-                Group ownerGroup = groupExpression.getOwnerGroup();
-                groupExpression.getOwnerGroup().removeGroupExpression(groupExpression);
-                mergeGroup(ownerGroup, that.getOwnerGroup());
+        Map<Group, Group> needMergeGroup = Maps.newHashMap();
+        for (GroupExpression reinsertGroupExpr : needReplaceChild) {
+            // After change GroupExpression children, hashcode will change, so need to reinsert into map.
+            groupExpressions.remove(reinsertGroupExpr);
+            Utils.replaceList(reinsertGroupExpr.children(), source, destination);
+
+            GroupExpression existGroupExpr = groupExpressions.get(reinsertGroupExpr);
+            if (existGroupExpr != null && existGroupExpr.getOwnerGroup() != null) {
+                // remove reinsertGroupExpr from its owner group to avoid adding it to existGroupExpr.getOwnerGroup()
+                // existGroupExpr.getOwnerGroup() already has this reinsertGroupExpr.
+                reinsertGroupExpr.setUnused(true);
+                if (existGroupExpr.getOwnerGroup() != null
+                        && existGroupExpr.getOwnerGroup().equals(reinsertGroupExpr.getOwnerGroup())) {
+                    // reinsertGroupExpr & existGroupExpr are in same Group,use existGroupExpr to
+                    // replace the bestExpression in the group
+                    if (reinsertGroupExpr.getPlan() instanceof PhysicalPlan) {
+                        reinsertGroupExpr.getOwnerGroup().replaceBestPlanGroupExpr(reinsertGroupExpr, existGroupExpr);
+                    }
+                    // existingGroupExpression merge the state of reinsertGroupExpr
+                    reinsertGroupExpr.mergeTo(existGroupExpr);
+                } else {
+                    // reinsertGroupExpr and existGroupExpr are not in the same group, need to merge them.
+                    if (reinsertGroupExpr.getPlan() instanceof PhysicalPlan) {
+                        reinsertGroupExpr.getOwnerGroup().deleteBestPlan(reinsertGroupExpr);
+                    }
+                    needMergeGroup.put(reinsertGroupExpr.getOwnerGroup(), existGroupExpr.getOwnerGroup());
+                    // TODO !!!!: reinsertGroupExpr need to merge to existGroupExpr???????
+                    reinsertGroupExpr.mergeTo(existGroupExpr);
+                }
             } else {
-                groupExpressions.put(groupExpression, groupExpression);
+                groupExpressions.put(reinsertGroupExpr, reinsertGroupExpr);
             }
         }
         if (!source.equals(destination)) {
@@ -467,6 +484,8 @@ public class Memo {
             source.mergeTo(destination);
             groups.remove(source.getGroupId());
         }
+
+        needMergeGroup.forEach(this::mergeGroup);
         return destination;
     }
 


### PR DESCRIPTION
# Proposed changes

fix all bugs in `mergeGroup()`

## Problem summary

bug:
- Removed Group (after merge) also may be in Job Stack.
- mergeGroup() should deal with separately the different condition (whether reinsertGroupExpr and existedGroupExpr are in same Group)
- Due to PhysicalEnforcer just in lowestCostPlans, isn't in `groupExpressions`, need to notice it.
- PhysicalEnforcer have a owner Group, but owner-Group's physicalExpression don't include it (due to avoid dead loop)
- we also should move/merge
  -  physical property in GroupExpression
  - lowestCostPlans in Group
- .... more detail bug

## Checklist(Required)

1. Does it affect the original behavior: 
    - [x] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

