### PR TITLE
[improvement](memory) load support overcommit memory

### DIFF
--- a/be/src/runtime/memory/mem_tracker_limiter.h
+++ b/be/src/runtime/memory/mem_tracker_limiter.h
@@ -106,7 +106,7 @@ public:
     bool limit_exceeded() const { return _limit >= 0 && _limit < consumption(); }
 
     Status check_limit(int64_t bytes = 0);
-    bool is_overcommit_tracker() { return type() == Type::QUERY || type() == Type::LOAD; }
+    bool is_overcommit_tracker() const { return type() == Type::QUERY || type() == Type::LOAD; }
 
     // Returns the maximum consumption that can be made without exceeding the limit on
     // this tracker limiter.

--- a/be/src/runtime/runtime_state.cpp
+++ b/be/src/runtime/runtime_state.cpp
@@ -263,7 +263,8 @@ Status RuntimeState::set_mem_limit_exceeded(const std::string& msg) {
 Status RuntimeState::check_query_state(const std::string& msg) {
     // TODO: it would be nice if this also checked for cancellation, but doing so breaks
     // cases where we use Status::Cancelled("Cancelled") to indicate that the limit was reached.
-    if (thread_context()->thread_mem_tracker()->limit_exceeded()) {
+    if (thread_context()->thread_mem_tracker()->limit_exceeded() &&
+        !config::enable_query_memroy_overcommit) {
         RETURN_LIMIT_EXCEEDED(this, msg);
     }
     return query_status();

--- a/be/src/util/mem_info.cpp
+++ b/be/src/util/mem_info.cpp
@@ -137,14 +137,13 @@ void MemInfo::process_full_gc() {
         return;
     }
     if (config::enable_query_memroy_overcommit) {
-        freed_mem += MemTrackerLimiter::free_top_overcommit_query(
-                _s_process_full_gc_size - freed_mem, MemTrackerLimiter::Type::LOAD);
+        freed_mem +=
+                MemTrackerLimiter::free_top_overcommit_load(_s_process_full_gc_size - freed_mem);
         if (freed_mem > _s_process_full_gc_size) {
             return;
         }
     }
-    freed_mem += MemTrackerLimiter::free_top_memory_query(_s_process_full_gc_size - freed_mem,
-                                                          MemTrackerLimiter::Type::LOAD);
+    freed_mem += MemTrackerLimiter::free_top_memory_load(_s_process_full_gc_size - freed_mem);
 }
 
 #ifndef __APPLE__


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

Overcommit memory means that when the memory is sufficient, it no longer checks whether the memory of query/load exceeds the exec mem limit.

Instead, when the process memory exceeds the limit or the available system memory is insufficient, cancel the top overcommit query in minor gc, and cancel top memory query in full gc.

Previously only query supported overcommit memory, this pr supports load, including insert into and stream load.

Detailed explanation, I will update the memory document in these two days~
https://github.com/apache/doris/blob/15bd56cd43a40869871972a0e708b0094ba7c39e/docs/zh-CN/docs/admin-manual/maint-monitor/memory-management/memory-limit-exceeded-analysis.md

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

