### PR TITLE
[improvement](memory) Optimize the log of process memory insufficient and support regular GC cache

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -74,6 +74,10 @@ CONF_Int64(max_sys_mem_available_low_water_mark_bytes, "1717986918");
 // The size of the memory that gc wants to release each time, as a percentage of the mem limit.
 CONF_mString(process_minor_gc_size, "10%");
 CONF_mString(process_full_gc_size, "20%");
+// Some caches have their own gc threads, such as segment cache.
+// For caches that do not have a separate gc thread, perform regular gc in the memory maintenance thread.
+// Currently only storage page cache, chunk allocator, more in the future.
+CONF_mInt32(cache_gc_interval_s, "60");
 
 // If true, when the process does not exceed the soft mem limit, the query memory will not be limited;
 // when the process memory exceeds the soft mem limit, the query with the largest ratio between the currently
@@ -477,7 +481,7 @@ CONF_Bool(madvise_huge_pages, "false");
 CONF_Bool(mmap_buffers, "false");
 
 // Sleep time in milliseconds between memory maintenance iterations
-CONF_mInt64(memory_maintenance_sleep_time_ms, "500");
+CONF_mInt32(memory_maintenance_sleep_time_ms, "500");
 
 // Sleep time in milliseconds between load channel memory refresh iterations
 CONF_mInt64(load_channel_memory_refresh_sleep_time_ms, "100");

--- a/be/src/common/daemon.cpp
+++ b/be/src/common/daemon.cpp
@@ -185,7 +185,6 @@ void Daemon::memory_maintenance_thread() {
 
         // Refresh mem tracker each type metrics.
         doris::MemTrackerLimiter::refresh_global_counter();
-        doris::MemTrackerLimiter::enable_print_log_process_usage();
 
         // If system available memory is not enough, or the process memory exceeds the limit, reduce refresh interval.
         if (doris::MemInfo::sys_mem_available() <
@@ -193,7 +192,10 @@ void Daemon::memory_maintenance_thread() {
             doris::MemInfo::proc_mem_no_allocator_cache() >= doris::MemInfo::mem_limit()) {
             doris::MemTrackerLimiter::print_log_process_usage("process full gc", false);
             interval_milliseconds = std::min(100, config::memory_maintenance_sleep_time_ms);
-            doris::MemInfo::process_full_gc();
+            if (doris::MemInfo::process_full_gc()) {
+                // If there is not enough memory to be gc, the process memory usage will not be printed in the next continuous gc.
+                doris::MemTrackerLimiter::enable_print_log_process_usage();
+            }
             cache_gc_interval_ms = config::cache_gc_interval_s * 1000;
         } else if (doris::MemInfo::sys_mem_available() <
                            doris::MemInfo::sys_mem_available_warning_water_mark() ||
@@ -201,21 +203,26 @@ void Daemon::memory_maintenance_thread() {
                            doris::MemInfo::soft_mem_limit()) {
             doris::MemTrackerLimiter::print_log_process_usage("process minor gc", false);
             interval_milliseconds = std::min(200, config::memory_maintenance_sleep_time_ms);
-            doris::MemInfo::process_minor_gc();
+            if (doris::MemInfo::process_minor_gc()) {
+                doris::MemTrackerLimiter::enable_print_log_process_usage();
+            }
             cache_gc_interval_ms = config::cache_gc_interval_s * 1000;
         } else {
+            doris::MemTrackerLimiter::enable_print_log_process_usage();
             interval_milliseconds = config::memory_maintenance_sleep_time_ms;
             if (doris::config::memory_debug) {
-                doris::MemTrackerLimiter::print_log_process_usage("memory debug", false);
+                LOG_EVERY_N(WARNING, 20) << doris::MemTrackerLimiter::log_process_usage_str(
+                        "memory debug", false); // default 10s print once
             } else {
-                LOG_EVERY_N(INFO, 10) << MemTrackerLimiter::process_mem_log_str();
+                LOG_EVERY_N(INFO, 10)
+                        << MemTrackerLimiter::process_mem_log_str(); // default 5s print once
             }
             cache_gc_interval_ms -= interval_milliseconds;
             if (cache_gc_interval_ms < 0) {
                 cache_gc_freed_mem = 0;
                 doris::MemInfo::process_cache_gc(cache_gc_freed_mem);
                 LOG(INFO) << fmt::format("Process regular GC Cache, Free Memory {} Bytes",
-                                         cache_gc_freed_mem);
+                                         cache_gc_freed_mem); // default 6s print once
                 cache_gc_interval_ms = config::cache_gc_interval_s * 1000;
             }
         }

--- a/be/src/common/daemon.cpp
+++ b/be/src/common/daemon.cpp
@@ -185,6 +185,7 @@ void Daemon::memory_maintenance_thread() {
 
         // Refresh mem tracker each type metrics.
         doris::MemTrackerLimiter::refresh_global_counter();
+        doris::MemTrackerLimiter::enable_print_log_process_usage();
 
         // If system available memory is not enough, or the process memory exceeds the limit, reduce refresh interval.
         if (doris::MemInfo::sys_mem_available() <
@@ -204,7 +205,6 @@ void Daemon::memory_maintenance_thread() {
             cache_gc_interval_ms = config::cache_gc_interval_s * 1000;
         } else {
             interval_milliseconds = config::memory_maintenance_sleep_time_ms;
-            doris::MemTrackerLimiter::enable_print_log_process_usage();
             if (doris::config::memory_debug) {
                 doris::MemTrackerLimiter::print_log_process_usage("memory debug", false);
             } else {

--- a/be/src/runtime/memory/mem_tracker_limiter.cpp
+++ b/be/src/runtime/memory/mem_tracker_limiter.cpp
@@ -354,7 +354,7 @@ int64_t MemTrackerLimiter::free_top_overcommit_query(int64_t min_free_mem, Type 
                             "details see be.INFO.",
                             TypeString[type], TypeString[type], max_pq.top().second,
                             print_bytes(query_mem), BackendOptions::get_localhost(),
-                            PerfCounters::get_vm_rss_str(), print_bytes(MemInfo::soft_mem_limit()),
+                            PerfCounters::get_vm_rss_str(), MemInfo::soft_mem_limit_str(),
                             MemInfo::sys_mem_available_str(),
                             print_bytes(MemInfo::sys_mem_available_warning_water_mark())));
 

--- a/be/src/runtime/memory/mem_tracker_limiter.h
+++ b/be/src/runtime/memory/mem_tracker_limiter.h
@@ -136,6 +136,7 @@ public:
     void print_log_usage(const std::string& msg);
     void enable_print_log_usage() { _enable_print_log_usage = true; }
     static void enable_print_log_process_usage() { _enable_print_log_process_usage = true; }
+    static std::string log_process_usage_str(const std::string& msg, bool with_stacktrace = true);
     static void print_log_process_usage(const std::string& msg, bool with_stacktrace = true);
 
     // Log the memory usage when memory limit is exceeded.
@@ -157,6 +158,9 @@ public:
     }
     // only for Type::QUERY or Type::LOAD.
     static TUniqueId label_to_queryid(const std::string& label) {
+        if (label.rfind("Query#Id=", 0) != 0 && label.rfind("Load#Id=", 0) != 0) {
+            return TUniqueId();
+        }
         auto queryid = split(label, "#Id=")[1];
         TUniqueId querytid;
         parse_id(queryid, &querytid);

--- a/be/src/runtime/memory/mem_tracker_limiter.h
+++ b/be/src/runtime/memory/mem_tracker_limiter.h
@@ -165,12 +165,14 @@ public:
 
     static std::string process_mem_log_str() {
         return fmt::format(
-                "OS physical memory {}, process memory used {} limit {}, sys mem available {} low "
-                "water mark {}, refresh interval memory growth {} B",
+                "OS physical memory {}. Process memory usage {}, limit {}, soft limit {}. Sys "
+                "available memory {}, low water mark {}, warning water mark {}. Refresh interval "
+                "memory growth {} B",
                 PrettyPrinter::print(MemInfo::physical_mem(), TUnit::BYTES),
                 PerfCounters::get_vm_rss_str(), MemInfo::mem_limit_str(),
-                MemInfo::sys_mem_available_str(),
+                MemInfo::soft_mem_limit_str(), MemInfo::sys_mem_available_str(),
                 PrettyPrinter::print(MemInfo::sys_mem_available_low_water_mark(), TUnit::BYTES),
+                PrettyPrinter::print(MemInfo::sys_mem_available_warning_water_mark(), TUnit::BYTES),
                 MemInfo::refresh_interval_memory_growth);
     }
 

--- a/be/src/util/mem_info.cpp
+++ b/be/src/util/mem_info.cpp
@@ -47,6 +47,7 @@ int64_t MemInfo::_s_physical_mem = -1;
 int64_t MemInfo::_s_mem_limit = -1;
 std::string MemInfo::_s_mem_limit_str = "";
 int64_t MemInfo::_s_soft_mem_limit = -1;
+std::string MemInfo::_s_soft_mem_limit_str = "";
 
 int64_t MemInfo::_s_allocator_cache_mem = 0;
 std::string MemInfo::_s_allocator_cache_mem_str = "";
@@ -200,6 +201,7 @@ void MemInfo::init() {
     }
     _s_mem_limit_str = PrettyPrinter::print(_s_mem_limit, TUnit::BYTES);
     _s_soft_mem_limit = _s_mem_limit * config::soft_mem_limit_frac;
+    _s_soft_mem_limit_str = PrettyPrinter::print(_s_soft_mem_limit, TUnit::BYTES);
 
     _s_process_minor_gc_size =
             ParseUtil::parse_mem_spec(config::process_minor_gc_size, -1, _s_mem_limit, &is_percent);
@@ -236,7 +238,7 @@ void MemInfo::init() {
             config::max_sys_mem_available_low_water_mark_bytes);
     int64_t p2 = std::max<int64_t>(_s_vm_min_free_kbytes - _s_physical_mem * 0.01, 0);
     _s_sys_mem_available_low_water_mark = std::max<int64_t>(p1 - p2, 0);
-    _s_sys_mem_available_warning_water_mark = _s_sys_mem_available_low_water_mark + p1 * 2;
+    _s_sys_mem_available_warning_water_mark = _s_sys_mem_available_low_water_mark + p1;
 
     LOG(INFO) << "Physical Memory: " << PrettyPrinter::print(_s_physical_mem, TUnit::BYTES)
               << ", Mem Limit: " << _s_mem_limit_str
@@ -261,6 +263,7 @@ void MemInfo::init() {
     _s_mem_limit = ParseUtil::parse_mem_spec(config::mem_limit, -1, _s_physical_mem, &is_percent);
     _s_mem_limit_str = PrettyPrinter::print(_s_mem_limit, TUnit::BYTES);
     _s_soft_mem_limit = _s_mem_limit * config::soft_mem_limit_frac;
+    _s_soft_mem_limit_str = PrettyPrinter::print(_s_soft_mem_limit, TUnit::BYTES);
 
     LOG(INFO) << "Physical Memory: " << PrettyPrinter::print(_s_physical_mem, TUnit::BYTES);
     _s_initialized = true;

--- a/be/src/util/mem_info.h
+++ b/be/src/util/mem_info.h
@@ -114,6 +114,7 @@ public:
 
     static std::string debug_string();
 
+    static void process_cache_gc(int64_t& freed_mem);
     static void process_minor_gc();
     static void process_full_gc();
 

--- a/be/src/util/mem_info.h
+++ b/be/src/util/mem_info.h
@@ -111,6 +111,10 @@ public:
         DCHECK(_s_initialized);
         return _s_soft_mem_limit;
     }
+    static inline std::string soft_mem_limit_str() {
+        DCHECK(_s_initialized);
+        return _s_soft_mem_limit_str;
+    }
 
     static std::string debug_string();
 
@@ -128,6 +132,7 @@ private:
     static int64_t _s_mem_limit;
     static std::string _s_mem_limit_str;
     static int64_t _s_soft_mem_limit;
+    static std::string _s_soft_mem_limit_str;
 
     static int64_t _s_allocator_cache_mem;
     static std::string _s_allocator_cache_mem_str;

--- a/be/src/util/mem_info.h
+++ b/be/src/util/mem_info.h
@@ -119,8 +119,8 @@ public:
     static std::string debug_string();
 
     static void process_cache_gc(int64_t& freed_mem);
-    static void process_minor_gc();
-    static void process_full_gc();
+    static bool process_minor_gc();
+    static bool process_full_gc();
 
     // It is only used after the memory limit is exceeded. When multiple threads are waiting for the available memory of the process,
     // avoid multiple threads starting at the same time and causing OOM.


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

1. When the process memory is insufficient, print the process memory statistics in a more timely and detailed manner.

2. Support regular GC cache, currently only page cache and chunk allocator are included, because many people reported that the memory does not drop after the query ends.

3. Reduce system available memory warning water mark to reduce memory waste

4. Optimize soft mem limit logging

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
5. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
6. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

