### PR TITLE
[chore](config) set config enable_write_index_searcher_cache default to false, and set config inverted_index_searcher_cache_limit default to 5%

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -882,9 +882,9 @@ CONF_Bool(enable_file_cache_query_limit, "false");
 // cache entry stay time after lookup, default 1h
 CONF_mInt32(index_cache_entry_stay_time_after_lookup_s, "3600");
 // inverted index searcher cache size
-CONF_String(inverted_index_searcher_cache_limit, "10%");
+CONF_String(inverted_index_searcher_cache_limit, "5%");
 // set `true` to enable insert searcher into cache when write inverted index data
-CONF_Bool(enable_write_index_searcher_cache, "true");
+CONF_Bool(enable_write_index_searcher_cache, "fasle");
 CONF_Bool(enable_inverted_index_cache_check_timestamp, "true");
 
 // inverted index


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary
`index_searcher_cache` is cache file descriptor of inverted index,  if open file descriptor limit of the Linux system is set too small and config `inverted_index_searcher_cache_limit ` is too big, during high pressure load maybe cause "Too many open files".

So set config `enable_write_index_searcher_cache ` default to `false`,  and reduce config `inverted_index_searcher_cache_limit ` default to `5%`.

It is recommended to open `enable_write_index_searcher_cache` when the query pressure is greater than the write pressure.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

