### PR TITLE
[enhance](nereids) tightestCommonType of datetime and datev2 is datev2

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/util/TypeCoercionUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/util/TypeCoercionUtils.java
@@ -234,10 +234,10 @@ public class TypeCoercionUtils {
                 tightestCommonType = left;
             } else if (right instanceof DateTimeV2Type) {
                 tightestCommonType = right;
-            } else if (left instanceof DateTimeType || right instanceof DateTimeType) {
-                tightestCommonType = DateTimeType.INSTANCE;
             } else if (left instanceof DateV2Type || right instanceof DateV2Type) {
                 tightestCommonType = DateV2Type.INSTANCE;
+            } else if (left instanceof DateTimeType || right instanceof DateTimeType) {
+                tightestCommonType = DateTimeType.INSTANCE;
             }
         } else if (canCompareDate(left, right)) {
             if (binaryOperator instanceof BinaryArithmetic) {


### PR DESCRIPTION
# Proposed changes
in original planner,  tightestCommonType of datetime and datev2 is datev2.
make nereids compatible with original planner.

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

