### PR TITLE
[fix](planner) create view generate wrong sql when sql contains multi count distinct

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/BaseViewStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/BaseViewStmt.java
@@ -117,6 +117,7 @@ public class BaseViewStmt extends DdlStmt {
 
         Analyzer tmpAnalyzer = new Analyzer(analyzer);
         List<String> colNames = cols.stream().map(c -> c.getColName()).collect(Collectors.toList());
+        cloneStmt.setNeedToSql(true);
         cloneStmt.substituteSelectList(tmpAnalyzer, colNames);
 
         try (ToSqlContext toSqlContext = ToSqlContext.getOrNewThreadLocalContext()) {

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/SelectStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/SelectStmt.java
@@ -2013,7 +2013,7 @@ public class SelectStmt extends QueryStmt {
                 if (i != 0) {
                     strBuilder.append(", ");
                 }
-                if (needToSql) {
+                if (needToSql && CollectionUtils.isNotEmpty(originalExpr)) {
                     strBuilder.append(originalExpr.get(i).toSql());
                 } else {
                     strBuilder.append(resultExprs.get(i).toSql());
@@ -2187,6 +2187,9 @@ public class SelectStmt extends QueryStmt {
             // Resolve and replace non-InlineViewRef table refs with a BaseTableRef or ViewRef.
             TableRef tblRef = fromClause.get(i);
             tblRef = analyzer.resolveTableRef(tblRef);
+            if (tblRef instanceof InlineViewRef) {
+                ((InlineViewRef) tblRef).setNeedToSql(needToSql);
+            }
             Preconditions.checkNotNull(tblRef);
             fromClause.set(i, tblRef);
             tblRef.setLeftTblRef(leftTblRef);
@@ -2215,6 +2218,9 @@ public class SelectStmt extends QueryStmt {
                 }
                 resultExprs.add(item.getExpr());
             }
+        }
+        if (needToSql) {
+            originalExpr = Expr.cloneList(resultExprs);
         }
         // substitute group by
         if (groupByClause != null) {

--- a/regression-test/suites/ddl_p0/test_create_view.groovy
+++ b/regression-test/suites/ddl_p0/test_create_view.groovy
@@ -1,0 +1,72 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_create_view") {
+
+    sql """DROP TABLE IF EXISTS count_distinct"""
+    sql """
+        CREATE TABLE IF NOT EXISTS count_distinct
+        (
+            RQ DATE NOT NULL  COMMENT "日期",
+            v1 VARCHAR(100) NOT NULL  COMMENT "字段1",
+            v2 VARCHAR(100) NOT NULL  COMMENT "字段2",
+            v3 VARCHAR(100) REPLACE_IF_NOT_NULL  COMMENT "字段3"
+        )
+        AGGREGATE KEY(RQ,v1,v2)
+        PARTITION BY RANGE(RQ)
+        (
+            PARTITION p20220908 VALUES LESS THAN ('2022-09-09')
+        )
+        DISTRIBUTED BY HASH(v1,v2) BUCKETS 3
+        PROPERTIES(
+        "replication_num" = "1",
+        "dynamic_partition.enable" = "true",
+        "dynamic_partition.time_unit" = "DAY",
+        "dynamic_partition.start" = "-3",
+        "dynamic_partition.end" = "3",
+        "dynamic_partition.prefix" = "p",
+        "dynamic_partition.buckets" = "3"
+        );
+    """
+    sql """
+    CREATE VIEW IF NOT EXISTS test_count_distinct
+    (
+        RQ comment "日期",
+        v1 comment "v1",
+        v2 comment "v2",
+        v3 comment "v3"
+    )
+    AS
+    select aa.RQ as RQ, aa.v1 as v1,aa.v2 as v2 , bb.v3 as v3  from
+    (
+        select RQ, count(distinct v1) as v1 , count(distinct  v2 ) as v2
+        from count_distinct  
+        group by RQ
+    ) aa
+    LEFT JOIN
+    (
+        select RQ, max(v3) as v3 
+        from count_distinct  
+        group by RQ
+    ) bb
+    on aa.RQ = bb.RQ;
+    """
+
+    sql """select * from test_count_distinct"""
+    sql """DROP VIEW IF EXISTS test_count_distinct"""
+    sql """DROP TABLE IF EXISTS count_distinct"""
+}


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

If sql in create view has more than one count distinct, and write column name explicitly.
We will generate sql contains function multi_count_distinct.
It cannot be analyzed and all query containing this view will fail.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [x] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [x] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

