### PR TITLE
[fix](multi-catalog)Make ES catalog and resource compatible

### DIFF
--- a/docs/zh-CN/docs/lakehouse/multi-catalog/es.md
+++ b/docs/zh-CN/docs/lakehouse/multi-catalog/es.md
@@ -53,7 +53,7 @@ CREATE CATALOG es PROPERTIES (
 参数 | 是否必须 | 默认值 | 说明 
 --- | --- | --- | --- 
 `hosts` | 是 | | ES 地址，可以是一个或多个，也可以是 ES 的负载均衡地址 |
-`username` | 否 |  空 | ES 用户名 |
+`user` | 否 |  空 | ES 用户名 |
 `password` | 否 | 空 | 对应用户的密码信息 |
 `doc_value_scan` | 否 | true | 是否开启通过 ES/Lucene 列式存储获取查询字段的值 |
 `keyword_sniff` | 否 | true | 是否对 ES 中字符串分词类型 text.fields 进行探测，通过 keyword 进行查询。设置为 false 会按照分词后的内容匹配 |

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/EsResource.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/EsResource.java
@@ -85,7 +85,7 @@ public class EsResource extends Resource {
     @Override
     protected void setProperties(Map<String, String> properties) throws DdlException {
         valid(properties, false);
-        this.properties = properties;
+        this.properties = processCompatibleProperties(properties);
     }
 
     public static void valid(Map<String, String> properties, boolean isAlter) throws DdlException {
@@ -124,15 +124,24 @@ public class EsResource extends Resource {
         }
     }
 
+    private Map<String, String> processCompatibleProperties(Map<String, String> props) {
+        // Compatible with ES catalog properties
+        Map<String, String> properties = Maps.newHashMap(props);
+        if (properties.containsKey("username")) {
+            properties.put(EsResource.USER, properties.remove("username"));
+        }
+        return properties;
+    }
+
     @Override
     public Map<String, String> getCopiedProperties() {
-        return Maps.newHashMap(properties);
+        return Maps.newHashMap(processCompatibleProperties(properties));
     }
 
     @Override
     protected void getProcNodeData(BaseProcResult result) {
         String lowerCaseType = type.name().toLowerCase();
-        for (Map.Entry<String, String> entry : properties.entrySet()) {
+        for (Map.Entry<String, String> entry : processCompatibleProperties(properties).entrySet()) {
             result.addRow(Lists.newArrayList(name, lowerCaseType, entry.getKey(), entry.getValue()));
         }
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/external/elasticsearch/EsRestClient.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/external/elasticsearch/EsRestClient.java
@@ -258,6 +258,8 @@ public class EsRestClient {
             try (Response response = executeResponse(httpClient, path)) {
                 if (response.isSuccessful()) {
                     return response.body().string();
+                } else {
+                    LOG.warn("request response code: {}, body: {}", response.code(), response.body().string());
                 }
             } catch (IOException e) {
                 LOG.warn("request node [{}] [{}] failures {}, try next nodes", currentNode, path, e);


### PR DESCRIPTION
# Proposed changes

close #16099 

1. Make ES resource compatible with `username` property. Keep the same behavior with ES catalog.
2. Change ES catalog `username` to `user` to avoid confusion.
3. Add log in ESRestClient and make debug easier.


## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
4. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
5. Has document been added or modified:
    - [x] Yes
    - [ ] No
    - [ ] No Need
6. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
7. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

