### PR TITLE
[enhance](nereids) show exprid in slot descriptor

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/PlanTranslatorContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/PlanTranslatorContext.java
@@ -159,6 +159,14 @@ public class PlanTranslatorContext {
             Optional<Column> column = slotReference.getColumn();
             column.ifPresent(slotDescriptor::setColumn);
         }
+
+        slotDescriptor.setNereidsExpressionId(slotReference.getExprId().asInt());
+        String caption = slotReference.toSql();
+        if (caption.startsWith("expr_")) {
+            caption = caption.substring("expr_".length());
+        }
+        slotDescriptor.setNereidsExpressionCaption(caption);
+
         slotDescriptor.setType(slotReference.getDataType().toCatalogDataType());
         slotDescriptor.setIsMaterialized(true);
         SlotRef slotRef;

--- a/regression-test/suites/nereids_syntax_p0/explain.groovy
+++ b/regression-test/suites/nereids_syntax_p0/explain.groovy
@@ -62,7 +62,7 @@ suite("nereids_explain") {
             when 1>1 then cast(1 as float)
             else 0.0 end;
             """
-        contains "SlotDescriptor{id=0, col=null, colUniqueId=null, type=FLOAT, nullable=false}"
+        contains "SlotDescriptor{id=0, col=CASE  WHEN (1 = 1) THEN cast(1 as INT) WHEN (1 > 1) THEN cast(1 as FLOAT) ELSE 0.0 END#0, colUniqueId=null, type=FLOAT, nullable=false}"
     }
 
     def explainStr = sql("select sum(if(lo_tax=1,lo_tax,0)) from lineorder where false").toString()


### PR DESCRIPTION
# Proposed changes
This pr makes `explain verbose` more readable
we print slot descriptor with its name and Expression ID.

Let's take some examples to illustrate its benifit.
### 1. link expression with its slot descriptor
`explain verbose select * from t1 X join t1 Y  on X.a=Y.a;`
here is a fragment of explain. 
```
   3:VHASH JOIN   
         join op: INNER JOIN(BROADCAST)[]
        equal join conjunct: a[#2] = a[#0]  
```
it is not easy to see what is the datatype of a[#2] from tuple descriptor table
Now we have 
```
| Tuples:                                                                   |
| TupleDescriptor{id=0, tbl=t1, byteSize=8}                                 |
|   SlotDescriptor{id=0, col=a#2, colUniqueId=0, type=INT, nullable=false}  |
|   SlotDescriptor{id=1, col=b#3, colUniqueId=1, type=INT, nullable=false}  |
|                                                                           |
| TupleDescriptor{id=1, tbl=t1, byteSize=8}                                 |
|   SlotDescriptor{id=2, col=a#0, colUniqueId=0, type=INT, nullable=false}  |
|   SlotDescriptor{id=3, col=b#1, colUniqueId=1, type=INT, nullable=false}
```
it is easy to see that `a[#2]` and `a[#0]` correspond to slot0 and slot2 respectively.

### helps to detect slot date type error 
![image](https://user-images.githubusercontent.com/1747806/213440574-1f617132-5425-4050-b08f-a1cff78da681.png)
with exprId, we could track how a slot transfers from one tuple to another tuple.
from above pic, we see that slot165 comes from slot155 not slot157, and its nullable value is wrong.

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
3. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
5. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
6. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

