### PR TITLE
[fix](Nereids) topn arg check is not compatible with legacy planner

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/agg/TopN.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/agg/TopN.java
@@ -77,12 +77,12 @@ public class TopN extends AggregateFunction
 
     @Override
     public void checkLegalityBeforeTypeCoercion() {
-        if (!getArgument(1).isConstant() || !getArgumentType(1).isIntegerType()) {
+        if (!getArgument(1).isConstant() || !getArgumentType(1).isIntegerLikeType()) {
             throw new AnalysisException(
                     "topn requires second parameter must be a constant Integer Type: " + this.toSql());
         }
         if (arity() == 3) {
-            if (!getArgument(2).isConstant() || !getArgumentType(2).isIntegerType()) {
+            if (!getArgument(2).isConstant() || !getArgumentType(2).isIntegerLikeType()) {
                 throw new AnalysisException(
                         "topn requires the third parameter must be a constant Integer Type: " + this.toSql());
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/types/DataType.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/types/DataType.java
@@ -438,7 +438,7 @@ public abstract class DataType implements AbstractDataType {
     }
 
     public boolean isIntegerLikeType() {
-        return this instanceof IntegralType;
+        return this instanceof IntegralType && !(this instanceof LargeIntType);
     }
 
     public boolean isTinyIntType() {


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

