### PR TITLE
[typo](docs) fix error path in ssb/tpch docs

### DIFF
--- a/docs/en/docs/benchmark/ssb.md
+++ b/docs/en/docs/benchmark/ssb.md
@@ -175,7 +175,7 @@ With the `-s 100` parameter, the resulting dataset size is:
 
 Before import the script, you need to write the FE’s ip port and other information in the `doris-cluster.conf` file.
 
-The file location is at the same level as `load-ssb-dimension-data.sh`.
+The file location is at `${DORIS_HOME}/tools/ssb-tools/load-ssb-dimension-data.sh`.
 
 The content of the file includes FE's ip, HTTP port, user name, password and the DB name of the data to be imported:
 

--- a/docs/en/docs/benchmark/ssb.md
+++ b/docs/en/docs/benchmark/ssb.md
@@ -175,7 +175,7 @@ With the `-s 100` parameter, the resulting dataset size is:
 
 Before import the script, you need to write the FE’s ip port and other information in the `doris-cluster.conf` file.
 
-The file location is at `${DORIS_HOME}/tools/ssb-tools/load-ssb-dimension-data.sh`.
+The file is located under `${DORIS_HOME}/tools/ssb-tools/conf/`.
 
 The content of the file includes FE's ip, HTTP port, user name, password and the DB name of the data to be imported:
 

--- a/docs/en/docs/benchmark/tpch.md
+++ b/docs/en/docs/benchmark/tpch.md
@@ -158,7 +158,7 @@ sh gen-tpch-data.sh
 
 Before import the script, you need to write the FE’s ip port and other information in the `doris-cluster.conf` file.
 
-The file location is at `${DORIS_HOME}/tools/tpch-tools/conf/load-tpch-data.sh`.
+The file is located under `${DORIS_HOME}/tools/tpch-tools/conf/` .
 
 The content of the file includes FE's ip, HTTP port, user name, password and the DB name of the data to be imported:
 

--- a/docs/en/docs/benchmark/tpch.md
+++ b/docs/en/docs/benchmark/tpch.md
@@ -158,7 +158,7 @@ sh gen-tpch-data.sh
 
 Before import the script, you need to write the FE’s ip port and other information in the `doris-cluster.conf` file.
 
-The file location is at the same level as `load-tpch-data.sh`.
+The file location is at `${DORIS_HOME}/tools/tpch-tools/conf/load-tpch-data.sh`.
 
 The content of the file includes FE's ip, HTTP port, user name, password and the DB name of the data to be imported:
 

--- a/docs/zh-CN/docs/benchmark/ssb.md
+++ b/docs/zh-CN/docs/benchmark/ssb.md
@@ -176,7 +176,7 @@ sh gen-ssb-data.sh -s 100 -c 100
 
 在调用导入脚本前，需要将 FE 的 ip 端口等信息写在 `doris-cluster.conf` 文件中。
 
-文件位置和 `load-ssb-dimension-data.sh` 平级。
+文件位置在 `${DORIS_HOME}/tools/ssb-tools/load-ssb-dimension-data.sh` 。
 
 文件内容包括 FE 的 ip，HTTP 端口，用户名，密码以及待导入数据的 DB 名称：
 

--- a/docs/zh-CN/docs/benchmark/ssb.md
+++ b/docs/zh-CN/docs/benchmark/ssb.md
@@ -176,7 +176,7 @@ sh gen-ssb-data.sh -s 100 -c 100
 
 在调用导入脚本前，需要将 FE 的 ip 端口等信息写在 `doris-cluster.conf` 文件中。
 
-文件位置在 `${DORIS_HOME}/tools/ssb-tools/load-ssb-dimension-data.sh` 。
+文件位置在 `${DORIS_HOME}/tools/tpch-tools/conf/` 目录下 。
 
 文件内容包括 FE 的 ip，HTTP 端口，用户名，密码以及待导入数据的 DB 名称：
 

--- a/docs/zh-CN/docs/benchmark/tpch.md
+++ b/docs/zh-CN/docs/benchmark/tpch.md
@@ -159,7 +159,7 @@ sh gen-tpch-data.sh
 
 在调用导入脚本前，需要将 FE 的 ip 端口等信息写在 `doris-cluster.conf` 文件中。
 
-文件位置在 `${DORIS_HOME}/tools/tpch-tools/conf/load-tpch-data.sh`。
+文件位置在 `${DORIS_HOME}/tools/ssb-tools/conf/` 目录下。
 
 文件内容包括 FE 的 ip，HTTP 端口，用户名，密码以及待导入数据的 DB 名称：
 

--- a/docs/zh-CN/docs/benchmark/tpch.md
+++ b/docs/zh-CN/docs/benchmark/tpch.md
@@ -159,7 +159,7 @@ sh gen-tpch-data.sh
 
 在调用导入脚本前，需要将 FE 的 ip 端口等信息写在 `doris-cluster.conf` 文件中。
 
-文件位置和 `load-tpch-data.sh` 平级。
+文件位置在 `${DORIS_HOME}/tools/tpch-tools/conf/load-tpch-data.sh`。
 
 文件内容包括 FE 的 ip，HTTP 端口，用户名，密码以及待导入数据的 DB 名称：
 


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx
I found out that the config file path inside `tpch-benchmark` along with `ssb-benchmark` is not consistent with the `load_data.sh`. In the sh file's content, the config file should lie under conf directory. It's so misleading...
![image](https://user-images.githubusercontent.com/43750022/213456593-fb554056-50e2-4fee-ade5-14a3ff6d8c57.png)

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
3. Has document been added or modified:
    - [x] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

