### PR TITLE
[Fix](Oracle External Table) fix that oracle external table can not insert batch values

### DIFF
--- a/be/src/exec/table_connector.cpp
+++ b/be/src/exec/table_connector.cpp
@@ -57,7 +57,14 @@ Status TableConnector::append(const std::string& table_name, vectorized::Block* 
                               TOdbcTableType::type table_type) {
     _insert_stmt_buffer.clear();
     std::u16string insert_stmt;
-    {
+    if (table_type == TOdbcTableType::ORACLE) {
+        SCOPED_TIMER(_convert_tuple_timer);
+        oracle_type_append(table_name, block, output_vexpr_ctxs, start_send_row, num_rows_sent,
+                           table_type);
+        // Translate utf8 string to utf16 to use unicode encoding
+        insert_stmt = utf8_to_u16string(_insert_stmt_buffer.data(),
+                                        _insert_stmt_buffer.data() + _insert_stmt_buffer.size());
+    } else {
         SCOPED_TIMER(_convert_tuple_timer);
         fmt::format_to(_insert_stmt_buffer, "INSERT INTO {} VALUES (", table_name);
 
@@ -91,6 +98,38 @@ Status TableConnector::append(const std::string& table_name, vectorized::Block* 
     }
     RETURN_IF_ERROR(exec_write_sql(insert_stmt, _insert_stmt_buffer));
     COUNTER_UPDATE(_sent_rows_counter, *num_rows_sent);
+    return Status::OK();
+}
+
+Status TableConnector::oracle_type_append(
+        const std::string& table_name, vectorized::Block* block,
+        const std::vector<vectorized::VExprContext*>& output_vexpr_ctxs, uint32_t start_send_row,
+        uint32_t* num_rows_sent, TOdbcTableType::type table_type) {
+    fmt::format_to(_insert_stmt_buffer, "INSERT ALL ");
+    int num_rows = block->rows();
+    int num_columns = block->columns();
+    for (int i = start_send_row; i < num_rows; ++i) {
+        (*num_rows_sent)++;
+        fmt::format_to(_insert_stmt_buffer, "INTO {} VALUES (", table_name);
+        // Construct insert statement of odbc/jdbc table
+        for (int j = 0; j < num_columns; ++j) {
+            if (j != 0) {
+                fmt::format_to(_insert_stmt_buffer, "{}", ", ");
+            }
+            auto& column_ptr = block->get_by_position(j).column;
+            auto& type_ptr = block->get_by_position(j).type;
+            RETURN_IF_ERROR(convert_column_data(
+                    column_ptr, type_ptr, output_vexpr_ctxs[j]->root()->type(), i, table_type));
+        }
+
+        if (i < num_rows - 1 && _insert_stmt_buffer.size() < INSERT_BUFFER_SIZE) {
+            fmt::format_to(_insert_stmt_buffer, "{}", ") ");
+        } else {
+            // batch exhausted or _insert_stmt_buffer is full, need to do real insert stmt
+            fmt::format_to(_insert_stmt_buffer, "{}", ") SELECT 1 FROM DUAL");
+            break;
+        }
+    }
     return Status::OK();
 }
 

--- a/be/src/exec/table_connector.h
+++ b/be/src/exec/table_connector.h
@@ -82,6 +82,15 @@ protected:
     RuntimeProfile::Counter* _result_send_timer = nullptr;
     // number of sent rows
     RuntimeProfile::Counter* _sent_rows_counter = nullptr;
+
+private:
+    // Because Oracle database do not support
+    // insert into tables values (...),(...);
+    // Here we do something special for Oracle.
+    Status oracle_type_append(const std::string& table_name, vectorized::Block* block,
+                              const std::vector<vectorized::VExprContext*>& output_vexpr_ctxs,
+                              uint32_t start_send_row, uint32_t* num_rows_sent,
+                              TOdbcTableType::type table_type);
 };
 
 } // namespace doris

--- a/be/src/vec/exec/scan/new_jdbc_scanner.h
+++ b/be/src/vec/exec/scan/new_jdbc_scanner.h
@@ -48,6 +48,8 @@ protected:
     RuntimeProfile::Counter* _connector_close_timer = nullptr;
 
 private:
+    void _update_profile();
+
     bool _is_init;
 
     bool _jdbc_eos;

--- a/be/src/vec/exec/vjdbc_connector.h
+++ b/be/src/vec/exec/vjdbc_connector.h
@@ -47,9 +47,16 @@ struct JdbcConnectorParam {
 
 class JdbcConnector : public TableConnector {
 public:
-    JdbcConnector(const JdbcConnectorParam& param);
+    struct JdbcStatistic {
+        int64_t _load_jar_timer = 0;
+        int64_t _init_connector_timer = 0;
+        int64_t _get_data_timer = 0;
+        int64_t _check_type_timer = 0;
+        int64_t _execte_read_timer = 0;
+        int64_t _connector_close_timer = 0;
+    };
 
-    JdbcConnector(NewJdbcScanner* jdbc_scanner, const JdbcConnectorParam& param);
+    JdbcConnector(const JdbcConnectorParam& param);
 
     ~JdbcConnector() override;
 
@@ -67,6 +74,8 @@ public:
     Status begin_trans() override; // should be call after connect and before query or init_to_write
     Status abort_trans() override; // should be call after transaction abort
     Status finish_trans() override; // should be call after transaction commit
+
+    JdbcStatistic& get_jdbc_statistic() { return _jdbc_statistic; }
 
     Status close() override;
 
@@ -89,7 +98,6 @@ private:
     Status _cast_string_to_array(const SlotDescriptor* slot_desc, Block* block, int column_index,
                                  int rows);
 
-    NewJdbcScanner* _jdbc_scanner;
     const JdbcConnectorParam& _conn_param;
     //java.sql.Types: https://docs.oracle.com/javase/7/docs/api/constant-values.html#java.sql.Types.INTEGER
     std::map<int, PrimitiveType> _arr_jdbc_map {
@@ -125,6 +133,8 @@ private:
     std::vector<DataTypePtr> _input_array_string_types;
     std::vector<MutableColumnPtr>
             str_array_cols; // for array type to save data like big string [1,2,3]
+
+    JdbcStatistic _jdbc_statistic;
 
 #define FUNC_VARI_DECLARE(RETURN_TYPE)                                \
     RETURN_TYPE _jobject_to_##RETURN_TYPE(JNIEnv* env, jobject jobj); \

--- a/fe/java-udf/src/main/java/org/apache/doris/udf/JdbcExecutor.java
+++ b/fe/java-udf/src/main/java/org/apache/doris/udf/JdbcExecutor.java
@@ -266,4 +266,3 @@ public class JdbcExecutor {
         }
     }
 }
-


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

This pr fix two bugs:
1. _jdbc_scanner may be nullptr in vjdbc_connector.cpp, so we use another method to count jdbc statistic. close #15914
2. In the batch insertion scenario, oracle database does not support syntax `insert into tables values (...),(...);` , what it supports is:
```sql
insert all
into table(col1,col2) values(c1v1, c2v1)
into table(col1,col2) values(c1v2, c2v2)
SELECT 1 FROM DUAL;
```



## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
4. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
5. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
6. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
7. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

