### PR TITLE
[debug](ParquetReader) print file path in error message if read parquet failed

### DIFF
--- a/be/src/vec/exec/format/parquet/vparquet_reader.cpp
+++ b/be/src/vec/exec/format/parquet/vparquet_reader.cpp
@@ -402,8 +402,12 @@ Status ParquetReader::get_next_block(Block* block, size_t* read_rows, bool* eof)
     DCHECK(_current_group_reader != nullptr);
     {
         SCOPED_RAW_TIMER(&_statistics.column_read_time);
-        RETURN_IF_ERROR(
-                _current_group_reader->next_batch(block, _batch_size, read_rows, &_row_group_eof));
+        Status batch_st =
+                _current_group_reader->next_batch(block, _batch_size, read_rows, &_row_group_eof);
+        if (!batch_st.ok()) {
+            return Status::InternalError("Read parquet file {} failed, reason = {}",
+                                         _scan_range.path, batch_st.to_string());
+        }
     }
     if (_row_group_eof) {
         auto column_st = _current_group_reader->statistics();


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

Print file path in error message if reading parquet file failed.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

