### PR TITLE
[efficiency](chore) do not build ui sparkdpp and hive udf while building fe

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -46,6 +46,7 @@ Usage: $0 <options>
      --audit            build audit loader. Default ON.
      --spark-dpp        build Spark DPP application. Default ON.
      --hive-udf         build Hive UDF library for Spark Load. Default ON.
+     --ui               build UI. Default ON.
      --clean            clean and build target
      -j                 build Backend parallel
 
@@ -132,6 +133,7 @@ BUILD_META_TOOL='OFF'
 BUILD_SPARK_DPP=0
 BUILD_JAVA_UDF=0
 BUILD_HIVE_UDF=0
+BUILD_UI=0
 CLEAN=0
 HELP=0
 PARAMETER_COUNT="$#"
@@ -146,14 +148,13 @@ if [[ "$#" == 1 ]]; then
     BUILD_SPARK_DPP=1
     BUILD_HIVE_UDF=1
     BUILD_JAVA_UDF=1
+    BUILD_UI=1
     CLEAN=0
 else
     while true; do
         case "$1" in
         --fe)
             BUILD_FE=1
-            BUILD_SPARK_DPP=1
-            BUILD_HIVE_UDF=1
             BUILD_JAVA_UDF=1
             shift
             ;;
@@ -180,6 +181,10 @@ else
             ;;
         --hive-udf)
             BUILD_HIVE_UDF=1
+            shift
+            ;;
+        --ui)
+            BUILD_UI=1
             shift
             ;;
         --clean)
@@ -340,6 +345,7 @@ echo "Get params:
     BUILD_SPARK_DPP     -- ${BUILD_SPARK_DPP}
     BUILD_JAVA_UDF      -- ${BUILD_JAVA_UDF}
     BUILD_HIVE_UDF      -- ${BUILD_HIVE_UDF}
+    BUILD_UI            -- ${BUILD_UI}
     PARALLEL            -- ${PARALLEL}
     CLEAN               -- ${CLEAN}
     WITH_MYSQL          -- ${WITH_MYSQL}
@@ -474,7 +480,7 @@ function build_ui() {
 }
 
 # FE UI must be built before building FE
-if [[ "${BUILD_FE}" -eq 1 ]]; then
+if [[ "${BUILD_UI}" -eq 1 ]]; then
     build_ui
 fi
 


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

It is time consuming to build ui, spark dpp and hive udf when building fe.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

