### PR TITLE
[deps](libhdfs3) update to 2.3.6 to fix kms aes 256 bug

### DIFF
--- a/dist/LICENSE-dist.txt
+++ b/dist/LICENSE-dist.txt
@@ -680,20 +680,19 @@ The Apache Software License, Version 2.0
     * Apache Directory LDAP API Utilities:
         - org.apache.directory.api:api-util:1.0.0-M20 (http://directory.apache.org/api-parent/api-util/)
     * Apache Hadoop Amazon Web Services support:
-        - org.apache.hadoop:hadoop-aws:2.7.3 (no url defined)
-        - org.apache.hadoop:hadoop-aws:2.8.0 (no url defined)
+        - org.apache.hadoop:hadoop-aws:3.3.3 (no url defined)
     * Apache Hadoop Annotations:
-        - org.apache.hadoop:hadoop-annotations:2.10.2 (no url defined)
+        - org.apache.hadoop:hadoop-annotations:3.3.3 (no url defined)
     * Apache Hadoop Auth:
-        - org.apache.hadoop:hadoop-auth:2.10.2 (no url defined)
+        - org.apache.hadoop:hadoop-auth:3.3.3 (no url defined)
     * Apache Hadoop Client:
-        - org.apache.hadoop:hadoop-client:2.10.2 (no url defined)
+        - org.apache.hadoop:hadoop-client:3.3.3 (no url defined)
     * Apache Hadoop Common:
-        - org.apache.hadoop:hadoop-common:2.10.2 (no url defined)
+        - org.apache.hadoop:hadoop-common:3.3.3 (no url defined)
     * Apache Hadoop HDFS:
-        - org.apache.hadoop:hadoop-hdfs:2.10.2 (no url defined)
+        - org.apache.hadoop:hadoop-hdfs:3.3.3 (no url defined)
     * Apache Hadoop HDFS Client:
-        - org.apache.hadoop:hadoop-hdfs-client:2.10.2 (no url defined)
+        - org.apache.hadoop:hadoop-hdfs-client:3.3.3 (no url defined)
     * Apache HttpClient:
         - org.apache.httpcomponents:httpclient:4.5.13 (http://hc.apache.org/httpcomponents-client)
     * Apache HttpCore:
@@ -881,33 +880,33 @@ The Apache Software License, Version 2.0
     * velocity:
         - org.apache.velocity:velocity-engine-core:2.3 (https://velocity.apache.org/engine/2.3/)        
     * Hive Common:
-        - org.apache.hive:hive-common:2.3.7 (https://hive.apache.org/hive-common)
+        - org.apache.hive:hive-common:3.1.3 (https://hive.apache.org/hive-common)
     * Hive Llap Client:
-        - org.apache.hive:hive-llap-client:2.3.7 (https://hive.apache.org/hive-llap-client)
+        - org.apache.hive:hive-llap-client:3.1.3 (https://hive.apache.org/hive-llap-client)
     * Hive Llap Common:
-        - org.apache.hive:hive-llap-common:2.3.7 (https://hive.apache.org/hive-llap-common)
+        - org.apache.hive:hive-llap-common:3.1.3 (https://hive.apache.org/hive-llap-common)
     * Hive Llap Tez:
-        - org.apache.hive:hive-llap-tez:2.3.7 (https://hive.apache.org/hive-llap-tez)
+        - org.apache.hive:hive-llap-tez:3.1.3 (https://hive.apache.org/hive-llap-tez)
     * Hive Metastore:
-        - org.apache.hive:hive-metastore:2.3.7 (https://hive.apache.org/hive-metastore)
+        - org.apache.hive:hive-metastore:3.1.3 (https://hive.apache.org/hive-metastore)
     * Hive Query Language:
-        - org.apache.hive:hive-exec:2.3.7 (https://hive.apache.org/hive-exec)
+        - org.apache.hive:hive-exec:3.1.3 (https://hive.apache.org/hive-exec)
     * Hive Serde:
-        - org.apache.hive:hive-serde:2.3.7 (https://hive.apache.org/hive-serde)
+        - org.apache.hive:hive-serde:3.1.3 (https://hive.apache.org/hive-serde)
     * Hive Service RPC:
-        - org.apache.hive:hive-service-rpc:2.3.7 (https://hive.apache.org/hive-service-rpc)
+        - org.apache.hive:hive-service-rpc:3.1.3 (https://hive.apache.org/hive-service-rpc)
     * Hive Shims:
-        - org.apache.hive:hive-shims:2.3.7 (https://hive.apache.org/hive-shims)
+        - org.apache.hive:hive-shims:3.1.3 (https://hive.apache.org/hive-shims)
     * Hive Shims 0.23:
-        - org.apache.hive.shims:hive-shims-0.23:2.3.7 (https://hive.apache.org/hive-shims-0.23)
+        - org.apache.hive.shims:hive-shims-0.23:3.1.3 (https://hive.apache.org/hive-shims-0.23)
     * Hive Shims Common:
-        - org.apache.hive.shims:hive-shims-common:2.3.7 (https://hive.apache.org/hive-shims-common)
+        - org.apache.hive.shims:hive-shims-common:3.1.3 (https://hive.apache.org/hive-shims-common)
     * Hive Shims Scheduler:
-        - org.apache.hive.shims:hive-shims-scheduler:2.3.7 (https://hive.apache.org/hive-shims-scheduler)
+        - org.apache.hive.shims:hive-shims-scheduler:3.1.3 (https://hive.apache.org/hive-shims-scheduler)
     * Hive Storage API:
         - org.apache.hive:hive-storage-api:2.4.0 (https://www.apache.org/hive-storage-api/)
     * Hive Vector-Code-Gen Utilities:
-        - org.apache.hive:hive-vector-code-gen:2.3.7 (https://hive.apache.org/hive-vector-code-gen)
+        - org.apache.hive:hive-vector-code-gen:3.1.3 (https://hive.apache.org/hive-vector-code-gen)
     * HttpClient:
         - commons-httpclient:commons-httpclient:3.0.1 (http://jakarta.apache.org/commons/httpclient/)
         - commons-httpclient:commons-httpclient:3.1 (http://jakarta.apache.org/httpcomponents/httpclient-3.x/)
@@ -947,15 +946,15 @@ The Apache Software License, Version 2.0
     * Jackson datatype: jdk8:
         - com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.13.1 (https://github.com/FasterXML/jackson-modules-java8/jackson-datatype-jdk8)
     * Jackson module: JAXB Annotations:
-        - com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.12.1 (https://github.com/FasterXML/jackson-modules-base)
+        - com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.12.3 (https://github.com/FasterXML/jackson-modules-base)
     * Jackson module: Paranamer:
         - com.fasterxml.jackson.module:jackson-module-paranamer:2.7.9 (https://github.com/FasterXML/jackson-modules-base)
     * Jackson-annotations:
-        - com.fasterxml.jackson.core:jackson-annotations:2.12.1 (http://github.com/FasterXML/jackson)
+        - com.fasterxml.jackson.core:jackson-annotations:2.12.3 (http://github.com/FasterXML/jackson)
     * Jackson-core:
-        - com.fasterxml.jackson.core:jackson-core:2.12.1 (https://github.com/FasterXML/jackson-core)
+        - com.fasterxml.jackson.core:jackson-core:2.12.3 (https://github.com/FasterXML/jackson-core)
     * Jackson-dataformat-YAML:
-        - com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.12.1 (https://github.com/FasterXML/jackson-dataformats-text)
+        - com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.12.3 (https://github.com/FasterXML/jackson-dataformats-text)
     * Jackson-module-parameter-names:
         - com.fasterxml.jackson.module:jackson-module-parameter-names:2.13.1 (https://github.com/FasterXML/jackson-modules-java8/jackson-module-parameter-names)
     * Jakarta Bean Validation API:
@@ -1531,10 +1530,10 @@ The Apache Software License, Version 2.0
     * aws sdk: 1.9.211
     * benchmark: 1.5.6
     * simdjson: 3.0.1
-    * libhdfs3: 2.3.0
-    * libhdfs3: commit 5fccd36
+    * libhdfs3: 2.3.6
     * opentelemetry-proto: 0.18.0
     * opentelemetry-cpp: 1.4.0
+    * clucenc: 2.4.4
 
 The MIT License -- licenses/LICENSE-MIT.txt
     * datatables: 1.12.1
@@ -1549,7 +1548,7 @@ LGPL -- licenes/LICENSE-LGPL.txt
 
 Other dependencies:
     * libevent: 2.1.12 -- license/LICENSE-libevent.txt
-    * openssl: 1.1.1m -- license/LICENSE-openssl.txt
+    * openssl: 1.1.1s -- license/LICENSE-openssl.txt
     * gflag: 2.2.2 -- license/LICENSE-gflag.txt
     * glog: 0.4.0 -- license/LICENSE-glog.txt
     * gtest: 1.11.0 -- license/LICENSE-gtest.txt
@@ -1570,7 +1569,7 @@ Other dependencies:
     * librdkafka: 1.8.2 -- license/LICENSE-librdkafka.txt
     * zstd: 1.5.2 -- license/LICENSE-zstd.txt
     * brotli: 1.0.9 -- license/LICENSE-brotli.txt
-    * bitshuffle: 0.3.5 -- license/LICENSE-bigshuffle.txt
+    * bitshuffle: 0.5.1 -- license/LICENSE-bigshuffle.txt
     * fmt: 7.1.3 -- license/LICENSE-fmt.txt
     * jemalloc: 5.2.1 -- license/LICENSE-jemolloc.txt
     * lzma@master -- license/LICENSE-lzma.txt

--- a/thirdparty/CHANGELOG.md
+++ b/thirdparty/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 This file contains version of the third-party dependency libraries in the build-env image. The docker build-env image is apache/doris, and the tag is `build-env-${version}`
 
+## v20230120
+- Modified: libhdfs3 2.3.5 -> 2.3.6
+
+## v20230117
+- Modified: bitshuffle 0.3.5 -> 0.5.1
+
+## v20230112
+- Added: clucene 2.4.4
+
+## v20230111
+- Fixed: libgsasl enable GSSAPI
+
+## v20230110
+- Modified: libhdfs3 2.3.4 -> 2.3.5
+
 ## v20230105
 - Modified: openssl 1.1.1m -> 1.1.1s fix CVE-2022-1292
 

--- a/thirdparty/vars.sh
+++ b/thirdparty/vars.sh
@@ -368,10 +368,10 @@ KRB5_SOURCE="krb5-1.19"
 KRB5_MD5SUM="aaf18447a5a014aa3b7e81814923f4c9"
 
 # hdfs3
-HDFS3_DOWNLOAD="https://github.com/apache/doris-thirdparty/archive/refs/tags/libhdfs3-v2.3.5.tar.gz"
-HDFS3_NAME="doris-thirdparty-libhdfs3-v2.3.5.tar.gz"
-HDFS3_SOURCE="doris-thirdparty-libhdfs3-v2.3.5"
-HDFS3_MD5SUM="8da623120add76f5595e5978b123e157"
+HDFS3_DOWNLOAD="https://github.com/apache/doris-thirdparty/archive/refs/tags/libhdfs3-v2.3.6.tar.gz"
+HDFS3_NAME="doris-thirdparty-libhdfs3-v2.3.6.tar.gz"
+HDFS3_SOURCE="doris-thirdparty-libhdfs3-v2.3.6"
+HDFS3_MD5SUM="179e492ee71b6dc484e8f44bc2865de9"
 
 #libdivide
 LIBDIVIDE_DOWNLOAD="https://github.com/ridiculousfish/libdivide/archive/5.0.tar.gz"


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

update libhdfs3 to 2.3.6 to fix kms aes 256 bug.
And update the licences and changelog

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [x] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

