### PR TITLE
[fix](object)  fix bitmap/hll data size

### DIFF
--- a/be/src/vec/sink/vmysql_result_writer.cpp
+++ b/be/src/vec/sink/vmysql_result_writer.cpp
@@ -98,7 +98,7 @@ Status VMysqlResultWriter::_add_one_column(const ColumnPtr& column_ptr,
                             assert_cast<const vectorized::ColumnComplexType<BitmapValue>*>(
                                     column.get());
                     BitmapValue bitmapValue = pColumnComplexType->get_element(i);
-                    size_t size = bitmapValue.getSizeInBytes();
+                    int64_t size = bitmapValue.getSizeInBytes();
                     std::unique_ptr<char[]> buf = std::make_unique<char[]>(size);
                     bitmapValue.write(buf.get());
                     buf_ret = _buffer.push_string(buf.get(), size);
@@ -107,7 +107,7 @@ Status VMysqlResultWriter::_add_one_column(const ColumnPtr& column_ptr,
                             assert_cast<const vectorized::ColumnComplexType<HyperLogLog>*>(
                                     column.get());
                     HyperLogLog hyperLogLog = pColumnComplexType->get_element(i);
-                    size_t size = hyperLogLog.max_serialized_size();
+                    int64_t size = hyperLogLog.max_serialized_size();
                     std::unique_ptr<char[]> buf = std::make_unique<char[]>(size);
                     hyperLogLog.serialize((uint8*)buf.get());
                     buf_ret = _buffer.push_string(buf.get(), size);


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary
bitmap/hll data size is wrong when  length over 2G 
change type size_t -> int64_t

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

