### PR TITLE
[Fix](MTMV)Support master and follow change in multi fe for mtmv

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
@@ -854,8 +854,6 @@ public class Env {
             // If not using bdb, we need to notify the FE type transfer manually.
             notifyNewFETypeTransfer(FrontendNodeType.MASTER);
         }
-        // 7. start mtmv jobManager
-        mtmvJobManager.start();
     }
 
     // wait until FE is ready.
@@ -1412,7 +1410,8 @@ public class Env {
         if (Config.enable_hms_events_incremental_sync) {
             metastoreEventsProcessor.start();
         }
-
+        // start mtmv jobManager
+        mtmvJobManager.start();
     }
 
     // start threads that should running on all FE
@@ -1462,6 +1461,9 @@ public class Env {
         startNonMasterDaemonThreads();
 
         MetricRepo.init();
+
+        // stop mtmv scheduler
+        mtmvJobManager.stop();
     }
 
     // Set global variable 'lower_case_table_names' only when the cluster is initialized.

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
@@ -1309,10 +1309,6 @@ public class Env {
         // start other daemon threads that should running on all FE
         startNonMasterDaemonThreads();
 
-        // start mtmv jobManager
-        LOG.info("Start mtmv job manager.");
-        mtmvJobManager.start();
-
         MetricRepo.init();
 
         canRead.set(true);
@@ -1414,6 +1410,8 @@ public class Env {
         if (Config.enable_hms_events_incremental_sync) {
             metastoreEventsProcessor.start();
         }
+        // start mtmv jobManager
+        mtmvJobManager.start();
     }
 
     // start threads that should running on all FE

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
@@ -1309,6 +1309,10 @@ public class Env {
         // start other daemon threads that should running on all FE
         startNonMasterDaemonThreads();
 
+        // start mtmv jobManager
+        LOG.info("Start mtmv job manager.");
+        mtmvJobManager.start();
+
         MetricRepo.init();
 
         canRead.set(true);
@@ -1410,8 +1414,6 @@ public class Env {
         if (Config.enable_hms_events_incremental_sync) {
             metastoreEventsProcessor.start();
         }
-        // start mtmv jobManager
-        mtmvJobManager.start();
     }
 
     // start threads that should running on all FE

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
@@ -956,7 +956,7 @@ public class InternalCatalog implements CatalogIf<Database> {
         if (table instanceof MaterializedView && Config.enable_mtmv_scheduler_framework) {
             List<Long> dropIds = Env.getCurrentEnv().getMTMVJobManager().showJobs(db.getFullName(), table.getName())
                     .stream().map(MTMVJob::getId).collect(Collectors.toList());
-            Env.getCurrentEnv().getMTMVJobManager().dropJobs(dropIds, false);
+            Env.getCurrentEnv().getMTMVJobManager().dropJobs(dropIds, isReplay);
             LOG.info("Drop related {} mv job.", dropIds.size());
         }
         LOG.info("finished dropping table[{}] in db[{}]", table.getName(), db.getFullName());

--- a/fe/fe-core/src/main/java/org/apache/doris/journal/JournalEntity.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/journal/JournalEntity.java
@@ -744,7 +744,7 @@ public class JournalEntity implements Writable {
                 isRead = true;
                 break;
             }
-            case OperationType.OP_ALTER_MTMV_JOB: {
+            case OperationType.OP_CHANGE_MTMV_JOB: {
                 data = ChangeMTMVJob.read(in);
                 isRead = true;
                 break;
@@ -759,7 +759,7 @@ public class JournalEntity implements Writable {
                 isRead = true;
                 break;
             }
-            case OperationType.OP_ALTER_MTMV_TASK: {
+            case OperationType.OP_CHANGE_MTMV_TASK: {
                 data = ChangeMTMVTask.read(in);
                 isRead = true;
                 break;

--- a/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVJobManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVJobManager.java
@@ -127,13 +127,16 @@ public class MTMVJobManager {
     private void registerJobs() {
         LOG.info("registerJobs = " + nameToJobMap.size());
         for (MTMVJob job : nameToJobMap.values()) {
-            if (job.getState() != JobState.ACTIVE) {
+            if (!job.getState().equals(JobState.ACTIVE)) {
                 continue;
             }
             LOG.info("register single job");
             if (job.getTriggerMode() == TriggerMode.PERIODICAL) {
                 LOG.info("register single1 job");
                 JobSchedule schedule = job.getSchedule();
+                LOG.info("delay seconds = " + MTMVUtils.getDelaySeconds(job));
+                LOG.info("getPeriod = " + schedule.getPeriod());
+                LOG.info("getTimeUnit = " + schedule.getTimeUnit());
                 ScheduledFuture<?> future = periodScheduler.scheduleAtFixedRate(() -> submitJobTask(job.getName()),
                         MTMVUtils.getDelaySeconds(job), schedule.getPeriod(), schedule.getTimeUnit());
                 periodFutureMap.put(job.getId(), future);
@@ -239,6 +242,7 @@ public class MTMVJobManager {
 
     public MTMVUtils.TaskSubmitStatus submitJobTask(String jobName, MTMVTaskExecuteParams param) {
         MTMVJob job = nameToJobMap.get(jobName);
+        LOG.info("Submit a job task");
         if (job == null) {
             return MTMVUtils.TaskSubmitStatus.FAILED;
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVJobManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVJobManager.java
@@ -135,10 +135,10 @@ public class MTMVJobManager {
                 LOG.info("register single1 job");
                 JobSchedule schedule = job.getSchedule();
                 LOG.info("delay seconds = " + MTMVUtils.getDelaySeconds(job));
-                LOG.info("getPeriod = " + schedule.getPeriod());
+                LOG.info("getPeriod = " + schedule.getSecondPeriod());
                 LOG.info("getTimeUnit = " + schedule.getTimeUnit());
                 ScheduledFuture<?> future = periodScheduler.scheduleAtFixedRate(() -> submitJobTask(job.getName()),
-                        MTMVUtils.getDelaySeconds(job), schedule.getPeriod(), schedule.getTimeUnit());
+                        MTMVUtils.getDelaySeconds(job), schedule.getSecondPeriod(), TimeUnit.SECONDS);
                 periodFutureMap.put(job.getId(), future);
             } else if (job.getTriggerMode() == TriggerMode.ONCE) {
                 LOG.info("register single2 job");
@@ -174,7 +174,7 @@ public class MTMVJobManager {
                     // log job before submit any task.
                     Env.getCurrentEnv().getEditLog().logCreateScheduleJob(job);
                     ScheduledFuture<?> future = periodScheduler.scheduleAtFixedRate(() -> submitJobTask(job.getName()),
-                            MTMVUtils.getDelaySeconds(job), schedule.getPeriod(), schedule.getTimeUnit());
+                            MTMVUtils.getDelaySeconds(job), schedule.getSecondPeriod(), TimeUnit.SECONDS);
                     periodFutureMap.put(job.getId(), future);
                 }
             } else if (job.getTriggerMode() == TriggerMode.ONCE) {

--- a/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVJobManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVJobManager.java
@@ -175,8 +175,11 @@ public class MTMVJobManager {
                     periodFutureMap.put(job.getId(), future);
                 }
             } else if (job.getTriggerMode() == TriggerMode.ONCE) {
-                job.setState(JobState.ACTIVE);
-                job.setExpireTime(MTMVUtils.getNowTimeStamp() + Config.scheduler_mtmv_job_expired);
+                // only change once job state from unknown to active. if job is completed, only put it in map
+                if (job.getState() == JobState.UNKNOWN) {
+                    job.setState(JobState.ACTIVE);
+                    job.setExpireTime(MTMVUtils.getNowTimeStamp() + Config.scheduler_mtmv_job_expired);
+                }
                 nameToJobMap.put(job.getName(), job);
                 idToJobMap.put(job.getId(), job);
                 if (!isReplay) {
@@ -185,7 +188,10 @@ public class MTMVJobManager {
                     submitJobTask(job.getName(), executeOption);
                 }
             } else if (job.getTriggerMode() == TriggerMode.MANUAL) {
-                job.setState(JobState.ACTIVE);
+                // only change once job state from unknown to active. if job is completed, only put it in map
+                if (job.getState() == JobState.UNKNOWN) {
+                    job.setState(JobState.ACTIVE);
+                }
                 nameToJobMap.put(job.getName(), job);
                 idToJobMap.put(job.getId(), job);
                 if (!isReplay) {

--- a/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVJobManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVJobManager.java
@@ -108,7 +108,7 @@ public class MTMVJobManager {
                 } finally {
                     unlock();
                 }
-            }, 0, 1, TimeUnit.DAYS);
+            }, 0, 1, TimeUnit.MINUTES);
 
             taskManager.startTaskScheduler();
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVJobManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVJobManager.java
@@ -79,6 +79,7 @@ public class MTMVJobManager {
     }
 
     public void start() {
+        LOG.info("start isStarted = " + isStarted.get());
         if (isStarted.compareAndSet(false, true)) {
             taskManager.clearUnfinishedTasks();
 
@@ -115,6 +116,7 @@ public class MTMVJobManager {
     }
 
     public void stop() {
+        LOG.info("stop isStarted = " + isStarted.get());
         if (isStarted.compareAndSet(true, false)) {
             periodScheduler.shutdown();
             cleanerScheduler.shutdown();
@@ -123,16 +125,20 @@ public class MTMVJobManager {
     }
 
     private void registerJobs() {
+        LOG.info("registerJobs = " + nameToJobMap.size());
         for (MTMVJob job : nameToJobMap.values()) {
             if (job.getState() != JobState.ACTIVE) {
                 continue;
             }
+            LOG.info("register single job");
             if (job.getTriggerMode() == TriggerMode.PERIODICAL) {
+                LOG.info("register single1 job");
                 JobSchedule schedule = job.getSchedule();
                 ScheduledFuture<?> future = periodScheduler.scheduleAtFixedRate(() -> submitJobTask(job.getName()),
                         MTMVUtils.getDelaySeconds(job), schedule.getPeriod(), schedule.getTimeUnit());
                 periodFutureMap.put(job.getId(), future);
             } else if (job.getTriggerMode() == TriggerMode.ONCE) {
+                LOG.info("register single2 job");
                 if (job.getRetryPolicy() == TaskRetryPolicy.ALWAYS || job.getRetryPolicy() == TaskRetryPolicy.TIMES) {
                     MTMVTaskExecuteParams executeOption = new MTMVTaskExecuteParams();
                     submitJobTask(job.getName(), executeOption);

--- a/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVTaskExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVTaskExecutor.java
@@ -125,6 +125,10 @@ public class MTMVTaskExecutor implements Comparable<MTMVTaskExecutor> {
         return task;
     }
 
+    public void setTask(MTMVTask task) {
+        this.task = task;
+    }
+
     public MTMVTask initTask(String taskId, Long createTime) {
         MTMVTask task = new MTMVTask();
         task.setTaskId(taskId);

--- a/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVTaskExecutorPool.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVTaskExecutorPool.java
@@ -81,7 +81,7 @@ public class MTMVTaskExecutorPool {
 
             ChangeMTMVTask changeTask = new ChangeMTMVTask(taskExecutor.getJob().getId(), task, TaskState.RUNNING,
                     task.getState());
-            Env.getCurrentEnv().getEditLog().logAlterScheduleTask(changeTask);
+            Env.getCurrentEnv().getEditLog().logChangeMTMVTask(changeTask);
         });
         taskExecutor.setFuture(future);
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVTaskManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVTaskManager.java
@@ -67,7 +67,7 @@ public class MTMVTaskManager {
     // keep track of all the completed tasks
     private final Deque<MTMVTask> historyQueue = Queues.newLinkedBlockingDeque();
 
-    private final ScheduledExecutorService taskScheduler = Executors.newScheduledThreadPool(1);
+    private ScheduledExecutorService taskScheduler = Executors.newScheduledThreadPool(1);
 
     private final MTMVJobManager mtmvJobManager;
 
@@ -76,6 +76,9 @@ public class MTMVTaskManager {
     }
 
     public void startTaskScheduler() {
+        if (taskScheduler.isShutdown()) {
+            taskScheduler = Executors.newScheduledThreadPool(1);
+        }
         taskScheduler.scheduleAtFixedRate(() -> {
             if (!tryLock()) {
                 return;
@@ -89,6 +92,10 @@ public class MTMVTaskManager {
                 unlock();
             }
         }, 0, 1, TimeUnit.SECONDS);
+    }
+
+    public void stopTaskScheduler() {
+        taskScheduler.shutdown();
     }
 
     public MTMVUtils.TaskSubmitStatus submitTask(MTMVTaskExecutor taskExecutor, MTMVTaskExecuteParams params) {

--- a/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVTaskManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVTaskManager.java
@@ -99,6 +99,7 @@ public class MTMVTaskManager {
     }
 
     public MTMVUtils.TaskSubmitStatus submitTask(MTMVTaskExecutor taskExecutor, MTMVTaskExecuteParams params) {
+        LOG.info("submit a task");
         // duplicate submit
         if (taskExecutor.getTask() != null) {
             return MTMVUtils.TaskSubmitStatus.FAILED;
@@ -118,6 +119,7 @@ public class MTMVTaskManager {
         }
 
         String taskId = UUID.randomUUID().toString();
+        LOG.info("task id = " + taskId);
         MTMVTask task = taskExecutor.initTask(taskId, MTMVUtils.getNowTimeStamp());
         task.setPriority(params.getPriority());
         Env.getCurrentEnv().getEditLog().logCreateScheduleTask(task);

--- a/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVTaskManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVTaskManager.java
@@ -332,7 +332,7 @@ public class MTMVTaskManager {
                     return;
                 }
                 MTMVTaskExecutor taskExecutor = MTMVUtils.buildTask(job);
-                taskExecutor.initTask(task.getTaskId(), task.getCreateTime());
+                taskExecutor.setTask(task);
                 arrangeToPendingTask(taskExecutor);
                 break;
             case RUNNING:

--- a/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVUtils.java
@@ -85,7 +85,6 @@ public class MTMVUtils {
         return getDelaySeconds(job, LocalDateTime.now());
     }
 
-    // this method only for test
     public static long getDelaySeconds(MTMVJob job, LocalDateTime now) {
         long lastModifyTime = job.getLastModifyTime();
         long nextTime = 0;

--- a/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVUtils.java
@@ -117,10 +117,10 @@ public class MTMVUtils {
         switch (strTimeUnit.toUpperCase()) {
             case "SECOND":
                 return TimeUnit.SECONDS;
+            case "MINUTE":
+                return TimeUnit.MINUTES;
             case "HOUR":
                 return TimeUnit.HOURS;
-            case "DAY":
-                return TimeUnit.DAYS;
             default:
                 return TimeUnit.DAYS;
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/mtmv/metadata/MTMVJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mtmv/metadata/MTMVJob.java
@@ -259,8 +259,8 @@ public class MTMVJob implements Writable, Comparable {
         }
 
         public String toString() {
-            return " (START " + LocalDateTime.ofInstant(Instant.ofEpochSecond(startTime), ZoneId.systemDefault())
-                    + " EVERY(" + period + " " + timeUnit + "))";
+            return "START " + LocalDateTime.ofInstant(Instant.ofEpochSecond(startTime), ZoneId.systemDefault())
+                    + " EVERY(" + period + " " + timeUnit + ")";
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/EditLog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/EditLog.java
@@ -881,7 +881,7 @@ public class EditLog {
                     env.getMTMVJobManager().replayCreateJob(job);
                     break;
                 }
-                case OperationType.OP_ALTER_MTMV_JOB: {
+                case OperationType.OP_CHANGE_MTMV_JOB: {
                     final ChangeMTMVJob changeJob = (ChangeMTMVJob) journal.getData();
                     env.getMTMVJobManager().replayUpdateJob(changeJob);
                     break;
@@ -896,7 +896,7 @@ public class EditLog {
                     env.getMTMVJobManager().replayCreateJobTask(task);
                     break;
                 }
-                case OperationType.OP_ALTER_MTMV_TASK: {
+                case OperationType.OP_CHANGE_MTMV_TASK: {
                     final ChangeMTMVTask changeTask = (ChangeMTMVTask) journal.getData();
                     env.getMTMVJobManager().replayUpdateTask(changeTask);
                     break;
@@ -1613,27 +1613,27 @@ public class EditLog {
         logEdit(id, log);
     }
 
-    public void logCreateScheduleJob(MTMVJob job) {
+    public void logCreateMTMVJob(MTMVJob job) {
         logEdit(OperationType.OP_CREATE_MTMV_JOB, job);
     }
 
-    public void logDropScheduleJob(List<Long> jobIds) {
+    public void logDropMTMVJob(List<Long> jobIds) {
         logEdit(OperationType.OP_DROP_MTMV_JOB, new DropMTMVJob(jobIds));
     }
 
-    public void logChangeScheduleJob(ChangeMTMVJob changeJob) {
-        logEdit(OperationType.OP_ALTER_MTMV_JOB, changeJob);
+    public void logChangeMTMVJob(ChangeMTMVJob changeJob) {
+        logEdit(OperationType.OP_CHANGE_MTMV_JOB, changeJob);
     }
 
-    public void logCreateScheduleTask(MTMVTask task) {
+    public void logCreateMTMVTask(MTMVTask task) {
         logEdit(OperationType.OP_CREATE_MTMV_TASK, task);
     }
 
-    public void logAlterScheduleTask(ChangeMTMVTask changeTaskRecord) {
-        logEdit(OperationType.OP_ALTER_MTMV_TASK, changeTaskRecord);
+    public void logChangeMTMVTask(ChangeMTMVTask changeTaskRecord) {
+        logEdit(OperationType.OP_CHANGE_MTMV_TASK, changeTaskRecord);
     }
 
-    public void logAlterScheduleTask(List<String> taskIds) {
+    public void logDropMTMVTasks(List<String> taskIds) {
         logEdit(OperationType.OP_DROP_MTMV_TASK, new DropMTMVTask(taskIds));
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/OperationType.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/OperationType.java
@@ -251,11 +251,11 @@ public class OperationType {
     // scheduler job and task 330-350
     public static final short OP_CREATE_MTMV_JOB = 330;
     public static final short OP_DROP_MTMV_JOB = 331;
-    public static final short OP_ALTER_MTMV_JOB = 332;
+    public static final short OP_CHANGE_MTMV_JOB = 332;
 
     public static final short OP_CREATE_MTMV_TASK = 340;
     public static final short OP_DROP_MTMV_TASK = 341;
-    public static final short OP_ALTER_MTMV_TASK = 342;
+    public static final short OP_CHANGE_MTMV_TASK = 342;
 
     public static final short OP_DROP_EXTERNAL_TABLE = 350;
     public static final short OP_DROP_EXTERNAL_DB = 351;

--- a/regression-test/suites/mtmv_p0/test_create_mtmv.groovy
+++ b/regression-test/suites/mtmv_p0/test_create_mtmv.groovy
@@ -16,16 +16,12 @@
 // under the License.
 
 suite("test_create_mtmv") {
-    def dbName = "db_mtmv"
     def tableName = "t_user"
     def tableNamePv = "t_user_pv"
     def mvName = "multi_mv"
     sql """
         ADMIN SET FRONTEND CONFIG("enable_mtmv_scheduler_framework"="true");
         """
-    sql "DROP DATABASE IF EXISTS ${dbName};"
-    sql "CREATE DATABASE ${dbName};"
-    sql "USE ${dbName};"
 
     sql """
         CREATE TABLE IF NOT EXISTS `${tableName}` (
@@ -42,7 +38,7 @@ suite("test_create_mtmv") {
         INSERT INTO ${tableName} VALUES("2022-10-26",1,"clz"),("2022-10-28",2,"zhangsang"),("2022-10-29",3,"lisi");
     """
     sql """
-        create table ${tableNamePv}(
+        create table IF NOT EXISTS ${tableNamePv}(
             event_day DATE,
             id BIGINT,
             pv BIGINT
@@ -66,9 +62,9 @@ suite("test_create_mtmv") {
         SELECT ${tableName}.username, ${tableNamePv}.pv FROM ${tableName}, ${tableNamePv} WHERE ${tableName}.id=${tableNamePv}.id;
     """
 
-    def show_task_meta = sql_meta "SHOW MTMV TASK FROM ${dbName}"
+    def show_task_meta = sql_meta "SHOW MTMV TASK ON ${mvName}"
     def index = show_task_meta.indexOf(['State', 'CHAR'])
-    def query = "SHOW MTMV TASK FROM ${dbName}"
+    def query = "SHOW MTMV TASK ON ${mvName}"
     def show_task_result
     def state
     do {
@@ -89,15 +85,22 @@ suite("test_create_mtmv") {
     sql """
         CREATE MATERIALIZED VIEW ${mvName}
         BUILD IMMEDIATE REFRESH COMPLETE
-        start with "2022-11-03 00:00:00" next 1 MINUTE  
+        start with "2022-11-03 00:00:00" next 1 DAY
         KEY(username)   
         DISTRIBUTED BY HASH (username)  buckets 1
         PROPERTIES ('replication_num' = '1') 
         AS 
         SELECT ${tableName}.username, ${tableNamePv}.pv FROM ${tableName}, ${tableNamePv} WHERE ${tableName}.id=${tableNamePv}.id;
     """
+    // wait task to be finished to avoid task leak in suite.
+    do {
+        show_task_result = sql "${query}"
+        state = show_task_result.last().get(index)
+        println "The state of ${query} is ${state}"
+        Thread.sleep(1000);
+    } while (state.equals('PENDING') || state.equals('RUNNING'))
 
-    def show_job_result = sql "SHOW MTMV JOB FROM ${dbName}"
+    def show_job_result = sql "SHOW MTMV JOB ON ${mvName}"
     assertEquals 1, show_job_result.size()
 
     sql """


### PR DESCRIPTION
# Proposed changes

Support master and follow change in multi fe for mtmv

## Problem summary
In this PR, I fix these issue here:
1. Start the mtmv only in master node, if master change to follower, it will stop the scheduler.
2. Fix a double meta write here
3. Rename some edit log function and variables
4. If a mv both have PeriodicalJob and immediate job and PeriodicalJob will be trigger right now, scheduler will ignore the immediate job.
5. Fix expired time bugs, and make sure it will be clean among all the fes.
6. `cleanerScheduler` interval from 1 day to 1 minute.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
7. Has unit tests been added:
    - [x] Yes
    - [ ] No
    - [ ] No Need
8. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
9. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
10. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

