### PR TITLE
[fix](inverted index) fulltext match query should not prune by zone map

### DIFF
--- a/be/src/olap/rowset/segment_v2/segment_iterator.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.cpp
@@ -367,6 +367,12 @@ Status SegmentIterator::_get_row_ranges_from_conditions(RowRanges* condition_row
     RowRanges zone_map_row_ranges = RowRanges::create_single(num_rows());
     // second filter data by zone map
     for (auto& cid : cids) {
+        if (_inverted_index_iterators[_schema.unique_id(cid)] != nullptr &&
+            _inverted_index_iterators[_schema.unique_id(cid)]->get_inverted_index_reader_type() ==
+                    InvertedIndexReaderType::FULLTEXT) {
+            // fulltext match query should not prune by zone map
+            continue;
+        }
         // get row ranges by zone map of this column,
         RowRanges column_row_ranges = RowRanges::create_single(num_rows());
         DCHECK(_opts.col_id_to_predicates.count(cid) > 0);


### PR DESCRIPTION
# Proposed changes
zone map prune data by min/max value, should not prune by zone map when fulltext match term is substring in a string type column's value, otherwise, some data meeting the conditions will be pruned.

such like:
- test data:

|  col_1   |
|  ----  |
| hello world |
| say hello world |
| zero |

- match query:
```
select * from tb where col_1 match 'world';
```
`hello world` and `say hello world` should be returned to the user instead of being pruned by zone map.

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

