### PR TITLE
[fix](compile) fix the compile error when WITH_MYSQL is ON.

### DIFF
--- a/be/src/exec/exec_node.cpp
+++ b/be/src/exec/exec_node.cpp
@@ -47,6 +47,7 @@
 #include "vec/exec/vdata_gen_scan_node.h"
 #include "vec/exec/vempty_set_node.h"
 #include "vec/exec/vexchange_node.h"
+#include "vec/exec/vmysql_scan_node.h"
 #include "vec/exec/vrepeat_node.h"
 #include "vec/exec/vschema_scan_node.h"
 #include "vec/exec/vselect_node.h"


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

```
export WITH_MYSQL=ON

sh build.sh --be
```

```
FAILED: src/exec/CMakeFiles/Exec.dir/exec_node.cpp.o
ccache /home/disk3/lzl/icode/baidu/bdg/doris/palo-toolchain/ldb_toolchain/bin/clang++ -DBOOST_STACKTRACE_USE_BACKTRACE -DHAVE_INTTYPES_H -DHAVE_NETINET_IN_H -I/home/disk3/lzl/icode/baidu/bdg/doris/core/be/src -I/home/disk3/lzl/icode/baidu/bdg/doris/core/be/test -I/home/disk3/lzl/icode/baidu/bdg/doris/palo-toolchain/jdk1.8.0_131/include -I/home/disk3/lzl/icode/baidu/bdg/doris/palo-toolchain/jdk1.8.0_131/include/linux -isystem /home/disk3/lzl/icode/baidu/bdg/doris/core/be/../gensrc/build -isystem /home/disk3/lzl/icode/baidu/bdg/doris/core/thirdparty/installed/include -isystem /home/disk3/lzl/icode/baidu/bdg/doris/core/thirdparty/installed/gperftools/include -g -Wall -Wextra -pthread -Werror -Wno-unused-parameter -Wno-ignored-qualifiers -Wno-implicit-fallthrough -Wno-sign-compare -fstrict-aliasing -fno-omit-frame-pointer -std=gnu++17 -D__STDC_FORMAT_MACROS -DBOOST_DATE_TIME_POSIX_TIME_STD_CONFIG -DBOOST_SYSTEM_NO_DEPRECATED -DBRPC_ENABLE_CPU_PROFILER -DBOOST_UUID_RANDOM_PROVIDER_FORCE_POSIX=1 -msse4.2 -mavx2 -DS2_USE_GFLAGS -DS2_USE_GLOG -DDORIS_WITH_MYSQL -DDORIS_WITH_LZO -DUSE_MEM_TRACKER -DUSE_JEMALLOC -DENABLE_STACKTRACE -faligned-new  -O0  -g   -D OS_LINUX -fcolor-diagnostics -fno-limit-debug-info -Qunused-arguments -MD -MT src/exec/CMakeFiles/Exec.dir/exec_node.cpp.o -MF src/exec/CMakeFiles/Exec.dir/exec_node.cpp.o.d -o src/exec/CMakeFiles/Exec.dir/exec_node.cpp.o -c /home/disk3/lzl/icode/baidu/bdg/doris/core/be/src/exec/exec_node.cpp
/home/disk3/lzl/icode/baidu/bdg/doris/core/be/src/exec/exec_node.cpp:315:43: error: no type named 'VMysqlScanNode' in namespace 'doris::vectorized'
        *node = pool->add(new vectorized::VMysqlScanNode(pool, tnode, descs));
                              ~~~~~~~~~~~~^
1 error generated.
[181/533] Building CXX object src/service/CMakeFiles/Service.dir/internal_service.cpp.o
ninja: build stopped: subcommand failed.
```

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

