### PR TITLE
[fix](meta) Persist storage_medium property for OlapTable and allow partition to inherit it

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
@@ -2010,4 +2010,7 @@ public class OlapTable extends Table {
         return idToPartition.keySet();
     }
 
+    public TStorageMedium getStorageMedium() {
+        return tableProperty.getStorageMedium();
+    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/TableProperty.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/TableProperty.java
@@ -27,10 +27,12 @@ import org.apache.doris.persist.OperationType;
 import org.apache.doris.persist.gson.GsonUtils;
 import org.apache.doris.thrift.TCompressionType;
 import org.apache.doris.thrift.TStorageFormat;
+import org.apache.doris.thrift.TStorageMedium;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.Maps;
 import com.google.gson.annotations.SerializedName;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -301,6 +303,15 @@ public class TableProperty implements Writable {
     public String getSequenceMapCol() {
         return properties.get(PropertyAnalyzer.PROPERTIES_FUNCTION_COLUMN + "."
                 + PropertyAnalyzer.PROPERTIES_SEQUENCE_COL);
+    }
+
+    public TStorageMedium getStorageMedium() {
+        String s = properties.get(PropertyAnalyzer.PROPERTIES_STORAGE_MEDIUM);
+        if (StringUtils.isNotEmpty(s)) {
+            return TStorageMedium.valueOf(s);
+        } else {
+            return DataProperty.DEFAULT_STORAGE_MEDIUM;
+        }
     }
 
     public void buildReplicaAllocation() {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
@@ -1356,6 +1356,11 @@ public class InternalCatalog implements CatalogIf<Database> {
                         olapTable.storeRowColumn().toString());
             }
 
+            if (!properties.containsKey(PropertyAnalyzer.PROPERTIES_STORAGE_MEDIUM)) {
+                properties.put(PropertyAnalyzer.PROPERTIES_STORAGE_MEDIUM,
+                        olapTable.getStorageMedium().name());
+            }
+
             singlePartitionDesc.analyze(partitionInfo.getPartitionColumns().size(), properties);
             partitionInfo.createAndCheckPartitionItem(singlePartitionDesc, isTempPartition);
 
@@ -2131,10 +2136,11 @@ public class InternalCatalog implements CatalogIf<Database> {
             } else if (partitionInfo.getType() == PartitionType.RANGE
                     || partitionInfo.getType() == PartitionType.LIST) {
                 try {
-                    // just for remove entries in stmt.getProperties(),
-                    // and then check if there still has unknown properties
-                    PropertyAnalyzer.analyzeDataProperty(stmt.getProperties(),
-                            new DataProperty(DataProperty.DEFAULT_STORAGE_MEDIUM));
+                    // remove entries in stmt.getProperties, and then check if there still has unknown properties
+                    DataProperty dataProperty = PropertyAnalyzer.analyzeDataProperty(stmt.getProperties(),
+                        new DataProperty(DataProperty.DEFAULT_STORAGE_MEDIUM));
+                    olapTable.getTableProperty().modifyTableProperties(PropertyAnalyzer.PROPERTIES_STORAGE_MEDIUM,
+                            dataProperty.getStorageMedium().name());
                     if (partitionInfo.getType() == PartitionType.RANGE) {
                         DynamicPartitionUtil.checkAndSetDynamicPartitionProperty(olapTable, properties, db);
 


### PR DESCRIPTION
 Persist storage_medium property for OlapTable and allow partition to inherit it

# Proposed changes
Currently, 'storage_medium' property in create table statement, is not persisted as table properties. 

- If we set a partitioned table's storage_medium to SSD, the newly added partition will use cluster's default storage_medium(HDD if ont set).
- If we set an un-partitioned table's storage_medium to SSD,  Doris creates a inner partition that use default storage_medium(HDD if ont set) for the table. That cause the storage_medium for un-partitioned table is not effective.

This PR persist storage_medium property for OlapTable and allow partition to inherit this table property. 



Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

