### PR TITLE
[fix](spark load) not setting the file format cause null pointer exception

### DIFF
--- a/fe/spark-dpp/src/main/java/org/apache/doris/load/loadv2/dpp/SparkDpp.java
+++ b/fe/spark-dpp/src/main/java/org/apache/doris/load/loadv2/dpp/SparkDpp.java
@@ -627,7 +627,7 @@ public final class SparkDpp implements java.io.Serializable {
             srcColumnsWithColumnsFromPath.addAll(fileGroup.columnsFromPath);
         }
 
-        if (fileGroup.fileFormat.equalsIgnoreCase("parquet")) {
+        if ("parquet".equalsIgnoreCase(fileGroup.fileFormat)) {
             // parquet had its own schema, just use it; perhaps we could add some validation in future.
             Dataset<Row> dataFrame = spark.read().parquet(fileUrl);
             if (!CollectionUtils.isEmpty(columnValueFromPath)) {
@@ -639,7 +639,7 @@ public final class SparkDpp implements java.io.Serializable {
             return dataFrame;
         }
 
-        if (fileGroup.fileFormat.equalsIgnoreCase("orc")) {
+        if ("orc".equalsIgnoreCase(fileGroup.fileFormat)) {
             Dataset<Row> dataFrame = spark.read().orc(fileUrl);
             if (!CollectionUtils.isEmpty(columnValueFromPath)) {
                 for (int k = 0; k < columnValueFromPath.size(); k++) {


### PR DESCRIPTION

not setting the file format cause a null pointer exception，changing to constant equals variable avoids this problem

# Proposed changes

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

