### PR TITLE
[Improvement](decimal) do not log fatal if precision is invalid

### DIFF
--- a/be/src/vec/data_types/data_type_decimal.cpp
+++ b/be/src/vec/data_types/data_type_decimal.cpp
@@ -163,11 +163,13 @@ T DataTypeDecimal<T>::parse_from_string(const std::string& str) const {
 DataTypePtr create_decimal(UInt64 precision_value, UInt64 scale_value, bool use_v2) {
     if (precision_value < min_decimal_precision() ||
         precision_value > max_decimal_precision<Decimal128>()) {
-        LOG(FATAL) << "Wrong precision " << precision_value;
+        LOG(WARNING) << "Wrong precision " << precision_value;
+        return nullptr;
     }
 
     if (static_cast<UInt64>(scale_value) > precision_value) {
-        LOG(FATAL) << "Negative scales and scales larger than precision are not supported";
+        LOG(WARNING) << "Negative scales and scales larger than precision are not supported";
+        return nullptr;
     }
 
     if (use_v2) {

--- a/be/src/vec/exprs/vexpr.cpp
+++ b/be/src/vec/exprs/vexpr.cpp
@@ -165,6 +165,9 @@ Status VExpr::create_expr(doris::ObjectPool* pool, const doris::TExprNode& texpr
     default:
         return Status::InternalError("Unknown expr node type: {}", texpr_node.node_type);
     }
+    if (!(*expr)->data_type()) {
+        return Status::InvalidArgument("Unknown expr type: {}", texpr_node.node_type);
+    }
     return Status::OK();
 }
 


### PR DESCRIPTION
# Proposed changes

Do not crash if precision is invalid

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

