### PR TITLE
[Fix](Nereids)fix incorrectly push down cast expression in hash join conjunctions

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/util/ExpressionUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/util/ExpressionUtils.java
@@ -466,4 +466,11 @@ public class ExpressionUtils {
                 .flatMap(expr -> expr.getInputSlots().stream())
                 .collect(ImmutableSet.toImmutableSet());
     }
+
+    public static boolean checkTypeSkipCast(Expression expression, Class<? extends Expression> cls) {
+        while (expression instanceof Cast) {
+            expression = ((Cast) expression).child();
+        }
+        return cls.isInstance(expression);
+    }
 }

--- a/regression-test/suites/nereids_syntax_p0/join.groovy
+++ b/regression-test/suites/nereids_syntax_p0/join.groovy
@@ -223,12 +223,13 @@ suite("join") {
     logger.info(explainStr)
     assertTrue(
         //if analyze finished
-            (explainStr.contains("4:VAGGREGATE (update serialize)") && explainStr.contains("6:VAGGREGATE (merge finalize)")
+            explainStr.contains("4:VAGGREGATE (update serialize)") && explainStr.contains("6:VAGGREGATE (merge finalize)")
+                    && explainStr.contains("wtid[#8] = CAST(wtid[#3] AS CHARACTER)") && explainStr.contains("projections: wtid[#5], wfid[#6]")
                     ||
         //analyze not finished
                     explainStr.contains("7:VAGGREGATE (update finalize)") && explainStr.contains("5:VAGGREGATE (update finalize)")
                     && explainStr.contains("4:VEXCHANGE") && explainStr.contains("3:VHASH JOIN")
-            ) && explainStr.contains("wtid[#8] = CAST(wtid[#3] AS CHARACTER)") && explainStr.contains("projections: wtid[#5], wfid[#6]")
+
     )
 
     test {

--- a/regression-test/suites/nereids_syntax_p0/join.groovy
+++ b/regression-test/suites/nereids_syntax_p0/join.groovy
@@ -229,7 +229,6 @@ suite("join") {
         //analyze not finished
                     explainStr.contains("7:VAGGREGATE (update finalize)") && explainStr.contains("5:VAGGREGATE (update finalize)")
                     && explainStr.contains("4:VEXCHANGE") && explainStr.contains("3:VHASH JOIN")
-
     )
 
     test {

--- a/regression-test/suites/nereids_syntax_p0/join.groovy
+++ b/regression-test/suites/nereids_syntax_p0/join.groovy
@@ -223,14 +223,12 @@ suite("join") {
     logger.info(explainStr)
     assertTrue(
         //if analyze finished
-        explainStr.contains("4:VAGGREGATE (update serialize)") 
-        && explainStr.contains("6:VAGGREGATE (merge finalize)") 
-        ||
+            (explainStr.contains("4:VAGGREGATE (update serialize)") && explainStr.contains("6:VAGGREGATE (merge finalize)")
+                    ||
         //analyze not finished
-        explainStr.contains("7:VAGGREGATE (update finalize)") 
-        && explainStr.contains("5:VAGGREGATE (update finalize)") 
-        && explainStr.contains("4:VEXCHANGE")
-        && explainStr.contains("3:VHASH JOIN")
+                    explainStr.contains("7:VAGGREGATE (update finalize)") && explainStr.contains("5:VAGGREGATE (update finalize)")
+                    && explainStr.contains("4:VEXCHANGE") && explainStr.contains("3:VHASH JOIN")
+            ) && explainStr.contains("wtid[#8] = CAST(wtid[#3] AS CHARACTER)") && explainStr.contains("projections: wtid[#5], wfid[#6]")
     )
 
     test {


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

fix incorrectly push down cast expression in hash join conjunctions
now conjunctions like: cast(k1 as type) = k2 will not be push down and create unnecessary project.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [x] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

