### PR TITLE
[improvement](filecache) add profile for file cache

### DIFF
--- a/be/src/exec/exec_node.cpp
+++ b/be/src/exec/exec_node.cpp
@@ -47,6 +47,7 @@
 #include "vec/exec/vdata_gen_scan_node.h"
 #include "vec/exec/vempty_set_node.h"
 #include "vec/exec/vexchange_node.h"
+#include "vec/exec/vmysql_scan_node.h"
 #include "vec/exec/vrepeat_node.h"
 #include "vec/exec/vschema_scan_node.h"
 #include "vec/exec/vselect_node.h"

--- a/be/src/vec/exec/scan/vfile_scanner.cpp
+++ b/be/src/vec/exec/scan/vfile_scanner.cpp
@@ -25,6 +25,7 @@
 #include "common/logging.h"
 #include "common/utils.h"
 #include "exec/text_converter.hpp"
+#include "io/cache/block/block_file_cache_profile.h"
 #include "olap/iterators.h"
 #include "runtime/descriptors.h"
 #include "runtime/raw_value.h"
@@ -750,6 +751,11 @@ Status VFileScanner::close(RuntimeState* state) {
 
     if (_push_down_expr) {
         _push_down_expr->close(state);
+    }
+
+    if (config::enable_file_cache) {
+        io::FileCacheProfileReporter cache_profile(_profile);
+        cache_profile.update(_file_cache_statistics.get());
     }
 
     RETURN_IF_ERROR(VScanner::close(state));


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary
Add profile for file cache:
```
VFILE_SCAN_NODE  (id=0):(Active:  3s902ms,  %  non-child:  76.27%)
    -  UseSpecificThreadToken:  False
    -  AcuireRuntimeFilterTime:  6.152us
    -  FileCache:  0ns
        -  IOHitCacheNum:  161
        -  IOTotalNum:  835
        -  ReadFromFileCacheBytes:  3.94  MB
        -  ReadFromWriteCacheBytes:  0.00  
        -  ReadTotalBytes:  29.52  MB
        -  SkipCacheBytes:  0.00  
        -  WriteInFileCacheBytes:  29.88  MB
        -  WriteInFileCacheNum:  3.118K  (3118)
    -  FileReadBytes:  9.31  MB
    -  FileReadCalls:  169
    -  FileReadTime:  3s535ms
```

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

