### PR TITLE
[fix](inverted index) fix some bug about fulltext match query with compound conditions

### DIFF
--- a/be/src/olap/rowset/segment_v2/segment_iterator.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.cpp
@@ -466,8 +466,12 @@ Status SegmentIterator::_execute_predicates_except_leafnode_of_andnode(vectorize
     } else if (_is_literal_node(node_type)) {
         auto v_literal_expr = dynamic_cast<doris::vectorized::VLiteral*>(expr);
         _column_predicate_info->query_value = v_literal_expr->value();
-    } else if (node_type == TExprNodeType::BINARY_PRED) {
-        _column_predicate_info->query_op = expr->fn().name.function_name;
+    } else if (node_type == TExprNodeType::BINARY_PRED || node_type == TExprNodeType::MATCH_PRED) {
+        if (node_type == TExprNodeType::MATCH_PRED) {
+            _column_predicate_info->query_op = "match";
+        } else {
+            _column_predicate_info->query_op = expr->fn().name.function_name;
+        }
         // get child condition result in compound condtions
         auto pred_result_sign = _gen_predicate_result_sign(_column_predicate_info.get());
         _column_predicate_info.reset(new ColumnPredicateInfo());
@@ -536,9 +540,13 @@ bool SegmentIterator::_check_apply_by_inverted_index(ColumnPredicate* pred) {
     int32_t unique_id = _schema.unique_id(pred->column_id());
     if (_inverted_index_iterators.count(unique_id) < 1 ||
         _inverted_index_iterators[unique_id] == nullptr ||
-        (pred->type() != PredicateType::MATCH && handle_by_fulltext)) {
+        (pred->type() != PredicateType::MATCH && handle_by_fulltext) ||
+        pred->type() == PredicateType::IS_NULL || pred->type() == PredicateType::IS_NOT_NULL ||
+        pred->type() == PredicateType::BF) {
         // 1. this column without inverted index
         // 2. equal or range qeury for fulltext index
+        // 3. is_null or is_not_null predicate
+        // 4. bloom filter predicate
         return false;
     }
     return true;

--- a/be/src/vec/functions/function.h
+++ b/be/src/vec/functions/function.h
@@ -532,7 +532,14 @@ public:
     bool can_fast_execute() const override {
         return function->get_name() == "eq" || function->get_name() == "ne" ||
                function->get_name() == "lt" || function->get_name() == "gt" ||
-               function->get_name() == "le" || function->get_name() == "ge";
+               function->get_name() == "le" || function->get_name() == "ge" ||
+               function->get_name() == "match_any" || function->get_name() == "match_all" ||
+               function->get_name() == "match_phrase" ||
+               function->get_name() == "match_element_eq" ||
+               function->get_name() == "match_element_lt" ||
+               function->get_name() == "match_element_gt" ||
+               function->get_name() == "match_element_le" ||
+               function->get_name() == "match_element_ge";
     }
 
     bool is_deterministic_in_scope_of_query() const override {


### PR DESCRIPTION
# Proposed changes
when execute query with compound conditions, filter out predicates not supported by inverted index, and correct match predicate result sign in block

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

