### PR TITLE
[Fix](Load) Disable for the developer to import fast json in fe

### DIFF
--- a/fe/check/checkstyle/import-control.xml
+++ b/fe/check/checkstyle/import-control.xml
@@ -30,6 +30,7 @@ under the License.
     <disallow pkg="io.fabric8.zjsonpatch.internal.guava" />
     <disallow pkg="org.checkerframework.com.google" />
     <disallow pkg="org.apache.iceberg.relocated" />
+    <disallow pkg="com.alibaba.fastjson2" />
     <subpackage name="nereids">
         <allow pkg="org.junit.jupiter"/>
         <disallow pkg="org.junit"/>

--- a/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/MysqlLoadManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/MysqlLoadManager.java
@@ -82,7 +82,7 @@ public class MysqlLoadManager {
                             .getAsJsonObject();
                     if (!result.get("Status").getAsString().equalsIgnoreCase("Success")) {
                         LOG.warn("Execute stream load for mysql data load failed with message: " + request);
-                        throw new LoadException(result.get("Message").toString());
+                        throw new LoadException(result.get("Message").getAsString());
                     }
                     loadResult.incRecords(result.get("NumberLoadedRows").getAsLong());
                     loadResult.incSkipped(result.get("NumberFilteredRows").getAsInt());

--- a/fe/fe-core/src/test/java/org/apache/doris/clone/TabletRepairAndBalanceTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/clone/TabletRepairAndBalanceTest.java
@@ -586,7 +586,7 @@ public class TabletRepairAndBalanceTest {
                 tbl.checkReplicaAllocation();
                 break;
             } catch (UserException | NoSuchElementException e) {
-                // why use add no such element exception because hash map is not a thread safe struct.
+                // Why do we add no such element exception because hash map is not a thread safe struct.
                 // In this ut using a big loop to iterate the hash map,
                 // it will increase the probability of map to throw NoSuchElementException exception.
                 System.out.println(e.getMessage());

--- a/fe/fe-core/src/test/java/org/apache/doris/clone/TabletRepairAndBalanceTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/clone/TabletRepairAndBalanceTest.java
@@ -73,6 +73,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.Random;
 import java.util.Set;
 import java.util.UUID;
@@ -584,7 +585,10 @@ public class TabletRepairAndBalanceTest {
             try {
                 tbl.checkReplicaAllocation();
                 break;
-            } catch (UserException e) {
+            } catch (UserException | NoSuchElementException e) {
+                // why use add no such element exception because hash map is not a thread safe struct.
+                // In this ut using a big loop to iterate the hash map,
+                // it will increase the probability of map to throw NoSuchElementException exception.
                 System.out.println(e.getMessage());
             }
             Thread.sleep(1000);

--- a/fe/fe-core/src/test/java/org/apache/doris/common/util/AutoBucketUtilsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/common/util/AutoBucketUtilsTest.java
@@ -136,7 +136,7 @@ public class AutoBucketUtilsTest {
 
     @After
     public void tearDown() {
-        // Env.getCurrentEnv().clear();
+        Env.getCurrentEnv().clear();
         UtFrameUtils.cleanDorisFeDir(runningDirBase);
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/common/util/AutoBucketUtilsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/common/util/AutoBucketUtilsTest.java
@@ -136,7 +136,7 @@ public class AutoBucketUtilsTest {
 
     @After
     public void tearDown() {
-        Env.getCurrentEnv().clear();
+        // Env.getCurrentEnv().clear();
         UtFrameUtils.cleanDorisFeDir(runningDirBase);
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/statistics/HistogramTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/statistics/HistogramTest.java
@@ -23,9 +23,9 @@ import org.apache.doris.catalog.Type;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.statistics.util.StatisticsUtil;
 
-import com.alibaba.fastjson2.JSON;
-import com.alibaba.fastjson2.JSONArray;
-import com.alibaba.fastjson2.JSONObject;
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+import org.json.simple.JSONValue;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -95,18 +95,18 @@ class HistogramTest {
     @Test
     void testSerializeToJson() throws AnalysisException {
         String json = Histogram.serializeToJson(histogramUnderTest);
-        JSONObject histogramJson = JSON.parseObject(json);
+        JSONObject histogramJson = (JSONObject) JSONValue.parse(json);
 
-        int maxBucketSize = histogramJson.getIntValue("max_bucket_num");
+        int maxBucketSize = (int) histogramJson.get("max_bucket_num");
         Assertions.assertEquals(128, maxBucketSize);
 
-        int bucketSize = histogramJson.getIntValue("bucket_num");
+        int bucketSize = (int) histogramJson.get("bucket_num");
         Assertions.assertEquals(5, bucketSize);
 
-        float sampleRate = histogramJson.getFloat("sample_rate");
+        float sampleRate = (float) histogramJson.get("sample_rate");
         Assertions.assertEquals(1.0, sampleRate);
 
-        JSONArray jsonArray = histogramJson.getJSONArray("buckets");
+        JSONArray jsonArray = (JSONArray) histogramJson.get("buckets");
         Assertions.assertEquals(5, jsonArray.size());
 
         // test first bucket
@@ -118,13 +118,13 @@ class HistogramTest {
         boolean flag = false;
 
         for (int i = 0; i < jsonArray.size(); i++) {
-            JSONObject bucketJson = jsonArray.getJSONObject(i);
+            JSONObject bucketJson = (JSONObject) jsonArray.get(i);
             assert datatype != null;
             LiteralExpr lower = StatisticsUtil.readableValue(datatype, bucketJson.get("lower").toString());
             LiteralExpr upper = StatisticsUtil.readableValue(datatype, bucketJson.get("upper").toString());
-            int count = bucketJson.getIntValue("count");
-            int preSum = bucketJson.getIntValue("pre_sum");
-            int ndv = bucketJson.getIntValue("ndv");
+            int count = (int) bucketJson.get("count");
+            int preSum = (int) bucketJson.get("pre_sum");
+            int ndv = (int) bucketJson.get("ndv");
             if (expectedLower.equals(lower) && expectedUpper.equals(upper) && count == 9 && preSum == 0 && ndv == 1) {
                 flag = true;
                 break;

--- a/fe/fe-core/src/test/java/org/apache/doris/statistics/HistogramTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/statistics/HistogramTest.java
@@ -23,9 +23,9 @@ import org.apache.doris.catalog.Type;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.statistics.util.StatisticsUtil;
 
-import org.json.simple.JSONArray;
-import org.json.simple.JSONObject;
-import org.json.simple.JSONValue;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -95,18 +95,18 @@ class HistogramTest {
     @Test
     void testSerializeToJson() throws AnalysisException {
         String json = Histogram.serializeToJson(histogramUnderTest);
-        JSONObject histogramJson = (JSONObject) JSONValue.parse(json);
+        JsonObject histogramJson = JsonParser.parseString(json).getAsJsonObject();
 
-        int maxBucketSize = (int) histogramJson.get("max_bucket_num");
+        int maxBucketSize = histogramJson.get("max_bucket_num").getAsInt();
         Assertions.assertEquals(128, maxBucketSize);
 
-        int bucketSize = (int) histogramJson.get("bucket_num");
+        int bucketSize = histogramJson.get("bucket_num").getAsInt();
         Assertions.assertEquals(5, bucketSize);
 
-        float sampleRate = (float) histogramJson.get("sample_rate");
+        float sampleRate = histogramJson.get("sample_rate").getAsFloat();
         Assertions.assertEquals(1.0, sampleRate);
 
-        JSONArray jsonArray = (JSONArray) histogramJson.get("buckets");
+        JsonArray jsonArray = histogramJson.get("buckets").getAsJsonArray();
         Assertions.assertEquals(5, jsonArray.size());
 
         // test first bucket
@@ -118,13 +118,13 @@ class HistogramTest {
         boolean flag = false;
 
         for (int i = 0; i < jsonArray.size(); i++) {
-            JSONObject bucketJson = (JSONObject) jsonArray.get(i);
+            JsonObject bucketJson = jsonArray.get(i).getAsJsonObject();
             assert datatype != null;
-            LiteralExpr lower = StatisticsUtil.readableValue(datatype, bucketJson.get("lower").toString());
-            LiteralExpr upper = StatisticsUtil.readableValue(datatype, bucketJson.get("upper").toString());
-            int count = (int) bucketJson.get("count");
-            int preSum = (int) bucketJson.get("pre_sum");
-            int ndv = (int) bucketJson.get("ndv");
+            LiteralExpr lower = StatisticsUtil.readableValue(datatype, bucketJson.get("lower").getAsString());
+            LiteralExpr upper = StatisticsUtil.readableValue(datatype, bucketJson.get("upper").getAsString());
+            int count = bucketJson.get("count").getAsInt();
+            int preSum = bucketJson.get("pre_sum").getAsInt();
+            int ndv = bucketJson.get("ndv").getAsInt();
             if (expectedLower.equals(lower) && expectedUpper.equals(upper) && count == 9 && preSum == 0 && ndv == 1) {
                 flag = true;
                 break;


### PR DESCRIPTION
# Proposed changes
In the pull request #15511 , I use the fastjson to parse the json text.
But now the fastjson is not recommend to be used in doris.

> Canel is depend on fastjon, so we don't use it in code but still package it in lib.

## Problem summary
Add an import header check for fastjson to disable import fast json in fe for the doris developer.
And use gson instead of fastjson in mysql load.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

