### PR TITLE
[fix](memtracker) Fix high frequency load slow lock in memtracker

### DIFF
--- a/be/src/runtime/thread_context.h
+++ b/be/src/runtime/thread_context.h
@@ -344,8 +344,6 @@ private:
     do {                                                                    \
         if (doris::thread_context_ptr.init) {                               \
             doris::thread_context()->thread_mem_tracker_mgr->consume(size); \
-        } else {                                                            \
-            doris::ThreadMemTrackerMgr::consume_no_attach(size);            \
         }                                                                   \
     } while (0)
 // NOTE, The LOG cannot be printed in the mem hook. If the LOG statement triggers the mem hook LOG,
@@ -360,16 +358,12 @@ private:
             } else {                                                                       \
                 doris::thread_context()->thread_mem_tracker_mgr->consume(size);            \
             }                                                                              \
-        } else {                                                                           \
-            doris::ThreadMemTrackerMgr::consume_no_attach(size);                           \
         }                                                                                  \
     } while (0)
 #define RELEASE_MEM_TRACKER(size)                                            \
     do {                                                                     \
         if (doris::thread_context_ptr.init) {                                \
             doris::thread_context()->thread_mem_tracker_mgr->consume(-size); \
-        } else {                                                             \
-            doris::ThreadMemTrackerMgr::consume_no_attach(-size);            \
         }                                                                    \
     } while (0)
 #else


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

Global lock stuck in memtracker when bthread is frequently created

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

