### PR TITLE
[fix](olap) Incorrect reserving size for PredicateColumn converted from ColumnDictionary

### DIFF
--- a/be/src/vec/columns/column_dictionary.h
+++ b/be/src/vec/columns/column_dictionary.h
@@ -293,7 +293,7 @@ public:
             convert_dict_codes_if_necessary();
         }
         auto res = vectorized::PredicateColumnType<TYPE_STRING>::create();
-        res->reserve(_codes.size());
+        res->reserve(_codes.capacity());
         for (size_t i = 0; i < _codes.size(); ++i) {
             auto& code = reinterpret_cast<T&>(_codes[i]);
             auto value = _dict.get_value(code);


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

```bash
#0  0x000055958d894807 in doris::vectorized::PODArray<doris::StringValue, 4096ul, Allocator<false, false>, 15ul, 16ul>::push_back_without_reserve<doris::StringValue&> (x=<synthetic pointer>..., this=0x7fdd34240550) at /root/doris/be/src/runtime/string_value.h:90
#1  doris::vectorized::PredicateColumnType<(doris::PrimitiveType)23>::insert_string_value (length=<optimized out>, data_ptr=0x559594d7ef70 <doris::MemPool::k_zero_length_region_> "\273w\252f", this=0x7fdd34240540) at /root/doris/be/src/vec/columns/predicate_column.h:191
#2  doris::vectorized::PredicateColumnType<(doris::PrimitiveType)23>::insert_data (this=0x7fdd34240540, data_ptr=0x559594d7ef70 <doris::MemPool::k_zero_length_region_> "\273w\252f", length=<optimized out>) at /root/doris/be/src/vec/columns/predicate_column.h:215
#3  0x000055958f124fd2 in doris::vectorized::ColumnNullable::insert_data (this=0x7fdd34235830, pos=<optimized out>, length=<optimized out>) at /root/doris/be/src/vec/columns/column_nullable.cpp:159
#4  0x000055958dcee0b6 in doris::vectorized::IColumn::insert_many_data (data_num=1, length=0, pos=0x559594d7ef70 <doris::MemPool::k_zero_length_region_> "\273w\252f", this=0x7fdd34235830) at /root/doris/be/src/vec/columns/column.h:272
#5  doris::segment_v2::DefaultValueColumnIterator::insert_default_data (type_info=<optimized out>, type_size=<optimized out>, mem_value=<optimized out>, dst=..., n=1) at /root/doris/be/src/olap/rowset/segment_v2/column_reader.cpp:1090
#6  0x000055958dcee44a in doris::segment_v2::DefaultValueColumnIterator::_insert_many_default (n=<optimized out>, dst=..., this=<optimized out>) at /root/doris/be/src/olap/rowset/segment_v2/column_reader.cpp:1118
#7  doris::segment_v2::DefaultValueColumnIterator::_insert_many_default (n=<optimized out>, dst=..., this=<optimized out>) at /root/doris/be/src/olap/rowset/segment_v2/column_reader.cpp:1114
#8  doris::segment_v2::DefaultValueColumnIterator::next_batch (this=<optimized out>, n=<optimized out>, dst=..., has_null=<optimized out>) at /root/doris/be/src/olap/rowset/segment_v2/column_reader.cpp:1104
#9  0x000055958dd62d52 in doris::segment_v2::ColumnIterator::next_batch (dst=..., n=0x7fdcef3ddd28, this=<optimized out>) at /root/doris/be/src/olap/rowset/segment_v2/column_reader.h:254
#10 doris::segment_v2::SegmentIterator::_read_columns (this=this@entry=0x7fdb4d590c00, column_ids=..., column_block=..., nrows=nrows@entry=1) at /root/doris/be/src/olap/rowset/segment_v2/segment_iterator.cpp:923
#11 0x000055958dd63069 in doris::segment_v2::SegmentIterator::_read_columns_by_index (this=this@entry=0x7fdb4d590c00, nrows_read_limit=100, nrows_read=@0x7fdb4d590f88: 0, set_block_rowid=true) at /root/doris/be/src/olap/rowset/segment_v2/segment_iterator.cpp:986
#12 0x000055958dd6ad60 in doris::segment_v2::SegmentIterator::next_batch (this=0x7fdb4d590c00, block=<optimized out>) at /root/doris/be/src/olap/rowset/segment_v2/segment_iterator.cpp:1143
#13 0x000055958e0531da in doris::BetaRowsetReader::next_block (this=0x7fdd29beaa00, block=0x7fdb4f277620) at /root/doris/be/src/olap/rowset/beta_rowset_reader.cpp:277
#14 0x0000559591976f81 in doris::vectorized::VCollectIterator::Level0Iterator::next (this=0x7fdb4c08c200, block=0x7fdb4f277620) at /root/doris/be/src/vec/olap/vcollect_iterator.cpp:267
#15 0x0000559591976749 in doris::vectorized::VCollectIterator::Level1Iterator::_normal_next (this=0x7fdb4c08c2a0, block=0x7fdb4f277620) at /root/doris/be/src/vec/olap/vcollect_iterator.cpp:533
#16 0x0000559591978a6e in doris::vectorized::VCollectIterator::Level1Iterator::next (this=<optimized out>, block=<optimized out>) at /root/doris/be/src/vec/olap/vcollect_iterator.cpp:359
#17 0x0000559591975d5a in doris::vectorized::VCollectIterator::next (this=this@entry=0x7fdb3ca441b8, block=<optimized out>) at /root/doris/be/src/vec/olap/vcollect_iterator.cpp:187
#18 0x000055959196d395 in doris::vectorized::BlockReader::_direct_next_block (this=0x7fdb3ca43e00, block=<optimized out>, mem_pool=<optimized out>, agg_pool=<optimized out>, eof=0x7fdcef3de596) at /root/doris/be/src/vec/olap/block_reader.cpp:167
#19 0x0000559591973279 in doris::vectorized::BlockReader::next_block_with_aggregation (this=<optimized out>, block=<optimized out>, mem_pool=<optimized out>, agg_pool=<optimized out>, eof=<optimized out>) at /root/doris/be/src/vec/olap/block_reader.h:45
#20 0x0000559591b6f02d in doris::vectorized::NewOlapScanner::_get_block_impl (this=0x7fdb4f304800, state=<optimized out>, block=0x7fdb4f277620, eof=0x7fdcef3de596) at /var/local/ldb-toolchain/include/c++/11/bits/unique_ptr.h:173
#21 0x0000559591b50f13 in doris::vectorized::VScanner::get_block (this=this@entry=0x7fdb4f304800, state=state@entry=0x7fdb4e7f8e00, block=block@entry=0x7fdb4f277620, eof=eof@entry=0x7fdcef3de596) at /root/doris/be/src/vec/exec/scan/vscanner.cpp:53
#22 0x0000559591b4e39f in doris::vectorized::ScannerScheduler::_scanner_scan (this=<optimized out>, scheduler=<optimized out>, ctx=0x7fdb4f220a00, scanner=0x7fdb4f304800) at /root/doris/be/src/vec/exec/scan/scanner_scheduler.cpp:234
#23 0x000055958e3a1805 in std::function<void ()>::operator()() const (this=<optimized out>) at /var/local/ldb-toolchain/include/c++/11/bits/std_function.h:560
#24 doris::FunctionRunnable::run (this=<optimized out>) at /root/doris/be/src/util/threadpool.cpp:45
#25 doris::ThreadPool::dispatch_thread (this=0x7fdd53e8fe00) at /root/doris/be/src/util/threadpool.cpp:534
#26 0x000055958e397bef in std::function<void ()>::operator()() const (this=0x7fdd34d8ff78) at /var/local/ldb-toolchain/include/c++/11/bits/std_function.h:560
#27 doris::Thread::supervise_thread (arg=0x7fdd34d8ff60) at /root/doris/be/src/util/thread.cpp:454
```

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

