### PR TITLE
[Bug](CTAS): Ctas rollback ignore some case

### DIFF
--- a/docs/en/docs/advanced/variables.md
+++ b/docs/en/docs/advanced/variables.md
@@ -580,3 +580,7 @@ Translated with www.DeepL.com/Translator (free version)
 * `topn_opt_limit_threshold`
 
     Set threshold for limit of topn query (eg. SELECT * FROM t ORDER BY k LIMIT n). If n <= threshold, topn optimizations(runtime predicate pushdown, two phase result fetch and read order by key) will enable automatically, otherwise disable. Default value is 1024.
+
+* `drop_table_if_ctas_failed`
+
+    Controls whether create table as select deletes created tables when a insert error occurs, the default value is true.

--- a/docs/zh-CN/docs/advanced/variables.md
+++ b/docs/zh-CN/docs/advanced/variables.md
@@ -558,7 +558,7 @@ SELECT /*+ SET_VAR(query_timeout = 1, enable_partition_cache=true) */ sleep(3);
 
 *   `group_by_and_having_use_alias_first`
 
-       指定group by和having语句是否优先使用列的别名，而非从From语句里寻找列的名字。默认为false。
+    指定group by和having语句是否优先使用列的别名，而非从From语句里寻找列的名字。默认为false。
 
 * `enable_file_cache`
 
@@ -567,3 +567,7 @@ SELECT /*+ SET_VAR(query_timeout = 1, enable_partition_cache=true) */ sleep(3);
 * `topn_opt_limit_threshold`
 
     设置topn优化的limit阈值 (例如：SELECT * FROM t ORDER BY k LIMIT n). 如果limit的n小于等于阈值，topn相关优化（动态过滤下推、两阶段获取结果、按key的顺序读数据）会自动启用，否则会禁用。默认值是1024。
+
+* `drop_table_if_ctas_failed`
+
+    控制create table as select在写入发生错误时是否删除已创建的表，默认为true。

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -265,6 +265,7 @@ public class SessionVariable implements Serializable, Writable {
     public static final String ENABLE_FILE_CACHE = "enable_file_cache";
 
     public static final String GROUP_BY_AND_HAVING_USE_ALIAS_FIRST = "group_by_and_having_use_alias_first";
+    public static final String ENABLE_CTAS_ERROR_DROP_TABLE = "enable_ctas_error_drop_table";
 
     // session origin value
     public Map<Field, String> sessionOriginValue = new HashMap<Field, String>();
@@ -697,6 +698,10 @@ public class SessionVariable implements Serializable, Writable {
     // Whether enable block file cache. Only take effect when BE config item enable_file_cache is true.
     @VariableMgr.VarAttr(name = ENABLE_FILE_CACHE, needForward = true)
     public boolean enableFileCache = true;
+
+    // Whether drop table when create table as select insert data appear error.
+    @VariableMgr.VarAttr(name = ENABLE_CTAS_ERROR_DROP_TABLE)
+    public boolean enableCtasErrorDropTable = true;
 
     // If this fe is in fuzzy mode, then will use initFuzzyModeVariables to generate some variables,
     // not the default value set in the code.
@@ -1436,6 +1441,10 @@ public class SessionVariable implements Serializable, Writable {
 
     public void setFragmentTransmissionCompressionCodec(String codec) {
         this.fragmentTransmissionCompressionCodec = codec;
+    }
+
+    public boolean isEnableCtasErrorDropTable() {
+        return enableCtasErrorDropTable;
     }
 
     public void checkExternalSortBytesThreshold(String externalSortBytesThreshold) {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -265,7 +265,7 @@ public class SessionVariable implements Serializable, Writable {
     public static final String ENABLE_FILE_CACHE = "enable_file_cache";
 
     public static final String GROUP_BY_AND_HAVING_USE_ALIAS_FIRST = "group_by_and_having_use_alias_first";
-    public static final String ENABLE_CTAS_ERROR_DROP_TABLE = "enable_ctas_error_drop_table";
+    public static final String DROP_TABLE_IF_CTAS_FAILED = "drop_table_if_ctas_failed";
 
     // session origin value
     public Map<Field, String> sessionOriginValue = new HashMap<Field, String>();
@@ -700,8 +700,8 @@ public class SessionVariable implements Serializable, Writable {
     public boolean enableFileCache = true;
 
     // Whether drop table when create table as select insert data appear error.
-    @VariableMgr.VarAttr(name = ENABLE_CTAS_ERROR_DROP_TABLE)
-    public boolean enableCtasErrorDropTable = true;
+    @VariableMgr.VarAttr(name = DROP_TABLE_IF_CTAS_FAILED, needForward = true)
+    public boolean dropTableIfCtasFailed = true;
 
     // If this fe is in fuzzy mode, then will use initFuzzyModeVariables to generate some variables,
     // not the default value set in the code.
@@ -1443,8 +1443,8 @@ public class SessionVariable implements Serializable, Writable {
         this.fragmentTransmissionCompressionCodec = codec;
     }
 
-    public boolean isEnableCtasErrorDropTable() {
-        return enableCtasErrorDropTable;
+    public boolean isDropTableIfCtasFailed() {
+        return dropTableIfCtasFailed;
     }
 
     public void checkExternalSortBytesThreshold(String externalSortBytesThreshold) {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -1965,7 +1965,6 @@ public class StmtExecutor implements ProfileWriter {
                     handleCtasRollback(ctasStmt.getCreateTableStmt().getDbTbl());
                 }
             } catch (Exception e) {
-                e.printStackTrace();
                 LOG.warn("CTAS insert data error, stmt={}", ctasStmt.toSql(), e);
                 handleCtasRollback(ctasStmt.getCreateTableStmt().getDbTbl());
             }
@@ -1973,7 +1972,7 @@ public class StmtExecutor implements ProfileWriter {
     }
 
     private void handleCtasRollback(TableName table) {
-        if (context.getSessionVariable().isEnableCtasErrorDropTable()) {
+        if (context.getSessionVariable().isDropTableIfCtasFailed()) {
             // insert error drop table
             DropTableStmt dropTableStmt = new DropTableStmt(true, table, true);
             try {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -1973,14 +1973,15 @@ public class StmtExecutor implements ProfileWriter {
     }
 
     private void handleCtasRollback(TableName table) {
-        // insert error drop table
-        DropTableStmt dropTableStmt = new DropTableStmt(true, table, true);
-        try {
-            DdlExecutor.execute(context.getEnv(), dropTableStmt);
-        } catch (Exception ex) {
-            LOG.warn("CTAS drop table error, stmt={}", parsedStmt.toSql(), ex);
-            context.getState().setError(ErrorCode.ERR_UNKNOWN_ERROR,
-                    "Unexpected exception: " + ex.getMessage());
+        if (context.getSessionVariable().isEnableCtasErrorDropTable()) {
+            // insert error drop table
+            DropTableStmt dropTableStmt = new DropTableStmt(true, table, true);
+            try {
+                DdlExecutor.execute(context.getEnv(), dropTableStmt);
+            } catch (Exception ex) {
+                LOG.warn("CTAS drop table error, stmt={}", parsedStmt.toSql(), ex);
+                context.getState().setError(ErrorCode.ERR_UNKNOWN_ERROR, "Unexpected exception: " + ex.getMessage());
+            }
         }
     }
 


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

Currently, some error are catched due to table can not drop when execute ctas, I add a sessionVarible to control drop or not table.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [x] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

