### PR TITLE
[bugfix](disk balance) remove new rowset time check when add tablet

### DIFF
--- a/be/src/olap/tablet_manager.cpp
+++ b/be/src/olap/tablet_manager.cpp
@@ -157,7 +157,7 @@ Status TabletManager::_add_tablet_unlocked(TTabletId tablet_id, const TabletShar
     // here, the new rowset's file will also be dropped, so use keep files here
     bool keep_files = force ? true : false;
     if (force ||
-        (new_version > old_version || (new_version == old_version && new_time > old_time))) {
+        (new_version > old_version || (new_version == old_version && new_time >= old_time))) {
         // check if new tablet's meta is in store and add new tablet's meta to meta store
         res = _add_tablet_to_map_unlocked(tablet_id, tablet, update_meta, keep_files,
                                           true /*drop_old*/);


### PR DESCRIPTION
In disk balancer, new rowset create time is same as old one, and when add tablet, there has a creation time check that new_time must bigger than old time, so disk balancer will always failed.

# Proposed changes

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

