### PR TITLE
[improve](file cache) rename the var QueryContext to QueryFileCacheContext

### DIFF
--- a/be/src/io/cache/block/block_file_cache.cpp
+++ b/be/src/io/cache/block/block_file_cache.cpp
@@ -63,7 +63,8 @@ std::string IFileCache::get_path_in_local_cache(const Key& key) const {
     return fs::path(_cache_base_path) / key_str;
 }
 
-IFileCache::QueryContextHolderPtr IFileCache::get_query_context_holder(const TUniqueId& query_id) {
+IFileCache::QueryFileCacheContextHolderPtr IFileCache::get_query_context_holder(
+        const TUniqueId& query_id) {
     std::lock_guard cache_lock(_mutex);
 
     if (!_enable_file_cache_query_limit) {
@@ -73,11 +74,11 @@ IFileCache::QueryContextHolderPtr IFileCache::get_query_context_holder(const TUn
     /// if enable_filesystem_query_cache_limit is true,
     /// we create context query for current query.
     auto context = get_or_set_query_context(query_id, cache_lock);
-    return std::make_unique<QueryContextHolder>(query_id, this, context);
+    return std::make_unique<QueryFileCacheContextHolder>(query_id, this, context);
 }
 
-IFileCache::QueryContextPtr IFileCache::get_query_context(const TUniqueId& query_id,
-                                                          std::lock_guard<std::mutex>& cache_lock) {
+IFileCache::QueryFileCacheContextPtr IFileCache::get_query_context(
+        const TUniqueId& query_id, std::lock_guard<std::mutex>& cache_lock) {
     auto query_iter = _query_map.find(query_id);
     return (query_iter == _query_map.end()) ? nullptr : query_iter->second;
 }
@@ -91,7 +92,7 @@ void IFileCache::remove_query_context(const TUniqueId& query_id) {
     }
 }
 
-IFileCache::QueryContextPtr IFileCache::get_or_set_query_context(
+IFileCache::QueryFileCacheContextPtr IFileCache::get_or_set_query_context(
         const TUniqueId& query_id, std::lock_guard<std::mutex>& cache_lock) {
     if (query_id.lo == 0 && query_id.hi == 0) {
         return nullptr;
@@ -102,21 +103,23 @@ IFileCache::QueryContextPtr IFileCache::get_or_set_query_context(
         return context;
     }
 
-    auto query_context = std::make_shared<QueryContext>(_max_query_cache_size);
+    auto query_context = std::make_shared<QueryFileCacheContext>(_max_query_cache_size);
     auto query_iter = _query_map.emplace(query_id, query_context).first;
     return query_iter->second;
 }
 
-void IFileCache::QueryContext::remove(const Key& key, size_t offset, bool is_presistent,
-                                      size_t size, std::lock_guard<std::mutex>& cache_lock) {
+void IFileCache::QueryFileCacheContext::remove(const Key& key, size_t offset, bool is_presistent,
+                                               size_t size,
+                                               std::lock_guard<std::mutex>& cache_lock) {
     auto record = records.find({key, offset, is_presistent});
     DCHECK(record != records.end());
     lru_queue.remove(record->second, cache_lock);
     records.erase({key, offset, is_presistent});
 }
 
-void IFileCache::QueryContext::reserve(const Key& key, size_t offset, bool is_presistent,
-                                       size_t size, std::lock_guard<std::mutex>& cache_lock) {
+void IFileCache::QueryFileCacheContext::reserve(const Key& key, size_t offset, bool is_presistent,
+                                                size_t size,
+                                                std::lock_guard<std::mutex>& cache_lock) {
     auto queue_iter = lru_queue.add(key, offset, is_presistent, size, cache_lock);
     records.insert({{key, offset, is_presistent}, queue_iter});
 }

--- a/be/src/io/cache/block/block_file_cache_factory.cpp
+++ b/be/src/io/cache/block/block_file_cache_factory.cpp
@@ -81,9 +81,9 @@ CloudFileCachePtr FileCacheFactory::get_disposable_cache(const IFileCache::Key& 
     return _disposable_cache[KeyHash()(key) % _caches.size()].get();
 }
 
-std::vector<IFileCache::QueryContextHolderPtr> FileCacheFactory::get_query_context_holders(
+std::vector<IFileCache::QueryFileCacheContextHolderPtr> FileCacheFactory::get_query_context_holders(
         const TUniqueId& query_id) {
-    std::vector<IFileCache::QueryContextHolderPtr> holders;
+    std::vector<IFileCache::QueryFileCacheContextHolderPtr> holders;
     for (const auto& cache : _caches) {
         holders.push_back(cache->get_query_context_holder(query_id));
     }

--- a/be/src/io/cache/block/block_file_cache_factory.h
+++ b/be/src/io/cache/block/block_file_cache_factory.h
@@ -44,7 +44,7 @@ public:
 
     CloudFileCachePtr get_by_path(const IFileCache::Key& key);
     CloudFileCachePtr get_disposable_cache(const IFileCache::Key& key);
-    std::vector<IFileCache::QueryContextHolderPtr> get_query_context_holders(
+    std::vector<IFileCache::QueryFileCacheContextHolderPtr> get_query_context_holders(
             const TUniqueId& query_id);
     FileCacheFactory() = default;
     FileCacheFactory& operator=(const FileCacheFactory&) = delete;

--- a/be/src/io/cache/block/block_lru_file_cache.cpp
+++ b/be/src/io/cache/block/block_lru_file_cache.cpp
@@ -438,7 +438,7 @@ bool LRUFileCache::try_reserve(const Key& key, const TUniqueId& query_id, bool i
     return true;
 }
 
-bool LRUFileCache::try_reserve_for_main_list(const Key& key, QueryContextPtr query_context,
+bool LRUFileCache::try_reserve_for_main_list(const Key& key, QueryFileCacheContextPtr query_context,
                                              bool is_persistent, size_t offset, size_t size,
                                              std::lock_guard<std::mutex>& cache_lock) {
     LRUQueue* queue = is_persistent ? &_persistent_queue : &_queue;

--- a/be/src/io/cache/block/block_lru_file_cache.h
+++ b/be/src/io/cache/block/block_lru_file_cache.h
@@ -118,7 +118,7 @@ private:
     bool try_reserve(const Key& key, const TUniqueId& query_id, bool is_persistent, size_t offset,
                      size_t size, std::lock_guard<std::mutex>& cache_lock) override;
 
-    bool try_reserve_for_main_list(const Key& key, QueryContextPtr query_context,
+    bool try_reserve_for_main_list(const Key& key, QueryFileCacheContextPtr query_context,
                                    bool is_persistent, size_t offset, size_t size,
                                    std::lock_guard<std::mutex>& cache_lock);
 


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

QueryContext is just used in file cache. It will be confuse for others. And we may need a global QueryContext records all the states of a query statement not only file cache. So rename it to QueryFileCacheContext.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

