### PR TITLE
[Bug](function) enchance esquery error msg && forbid to_quantile_state

### DIFF
--- a/be/src/vec/functions/function_fake.cpp
+++ b/be/src/vec/functions/function_fake.cpp
@@ -17,11 +17,11 @@
 
 #include "vec/functions/function_fake.h"
 
-#include <boost/metaparse/string.hpp>
-#include <string_view>
-#include <type_traits>
-
+#include "vec/data_types/data_type_array.h"
 #include "vec/data_types/data_type_nullable.h"
+#include "vec/data_types/data_type_number.h"
+#include "vec/functions/function_helpers.h"
+#include "vec/functions/simple_function_factory.h"
 
 namespace doris::vectorized {
 
@@ -33,6 +33,7 @@ struct FunctionFakeBaseImpl {
         }
         return std::make_shared<ReturnType>();
     }
+    static std::string get_error_msg() { return "Fake function do not support execute"; }
 };
 
 struct FunctionExplode {
@@ -41,11 +42,19 @@ struct FunctionExplode {
         return make_nullable(
                 check_and_get_data_type<DataTypeArray>(arguments[0].get())->get_nested_type());
     }
+    static std::string get_error_msg() { return "Fake function do not support execute"; }
 };
 
-template <typename ReturnType, bool Nullable = false>
-void register_function_default(SimpleFunctionFactory& factory, const std::string& name) {
-    factory.register_function<FunctionFake<FunctionFakeBaseImpl<ReturnType, Nullable>>>(name);
+struct FunctionEsquery {
+    static DataTypePtr get_return_type_impl(const DataTypes& arguments) {
+        return FunctionFakeBaseImpl<DataTypeUInt8>::get_return_type_impl(arguments);
+    }
+    static std::string get_error_msg() { return "esquery only supported on es table"; }
+};
+
+template <typename FunctionImpl>
+void register_function(SimpleFunctionFactory& factory, const std::string& name) {
+    factory.register_function<FunctionFake<FunctionImpl>>(name);
 };
 
 template <typename FunctionImpl>
@@ -74,7 +83,7 @@ void register_table_function_expand_outer_default(SimpleFunctionFactory& factory
 };
 
 void register_function_fake(SimpleFunctionFactory& factory) {
-    register_function_default<DataTypeUInt8>(factory, "esquery");
+    register_function<FunctionEsquery>(factory, "esquery");
 
     register_table_function_expand_outer<FunctionExplode>(factory, "explode");
 

--- a/be/src/vec/functions/function_fake.h
+++ b/be/src/vec/functions/function_fake.h
@@ -18,14 +18,7 @@
 #pragma once
 
 #include "common/status.h"
-#include "vec/core/types.h"
-#include "vec/data_types/data_type_array.h"
-#include "vec/data_types/data_type_nullable.h"
-#include "vec/data_types/data_type_number.h"
-#include "vec/data_types/data_type_string.h"
-#include "vec/functions/function_helpers.h"
-#include "vec/functions/simple_function_factory.h"
-#include "vec/utils/util.hpp"
+#include "vec/functions/function.h"
 
 namespace doris::vectorized {
 // FunctionFake is use for some function call expr only work at prepare/open phase, do not support execute().
@@ -50,7 +43,7 @@ public:
 
     Status execute_impl(FunctionContext* context, Block& block, const ColumnNumbers& arguments,
                         size_t result, size_t input_rows_count) override {
-        return Status::NotSupported("Fake function {} do not support execute", name);
+        return Status::NotSupported(Impl::get_error_msg());
     }
 };
 

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/FunctionCallExpr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/FunctionCallExpr.java
@@ -853,6 +853,7 @@ public class FunctionCallExpr extends Expr {
             if (!getChild(1).isConstant()) {
                 throw new AnalysisException(fnName + "function's second argument should be constant");
             }
+            throw new AnalysisException(fnName + "not support on vectorized engine now.");
         }
 
         if ((fnName.getFunction().equalsIgnoreCase("HLL_UNION_AGG")


### PR DESCRIPTION
# Proposed changes

1. enchance `esquery` error msg.
```sql
mysql [regression_test_nereids_function_p0]>select esquery(kvchrs1, kvchrs1) from fn_test order by kvchrs1, kvchrs1;
ERROR 1105 (HY000): errCode = 2, detailMessage = [NOT_IMPLEMENTED_ERROR]esquery only supported on es table
```

2. forbidden `to_quantile_state` temporary to avoid core dump. waiting for #15868 get the ball rolling on implementation.

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
4. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
5. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
6. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
7. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

