### PR TITLE
[Bug](broker load) fix hll_hash(null) in broker load report incorrect Exception

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/DataDescription.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/DataDescription.java
@@ -486,7 +486,7 @@ public class DataDescription {
     private static void validateHllHash(List<String> args, Map<String, String> columnNameMap) throws AnalysisException {
         for (int i = 0; i < args.size(); ++i) {
             String argColumn = args.get(i);
-            if (!columnNameMap.containsKey(argColumn)) {
+            if (argColumn == null || !columnNameMap.containsKey(argColumn)) {
                 throw new AnalysisException("Column is not in sources, column: " + argColumn);
             }
             args.set(i, columnNameMap.get(argColumn));

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/DataDescriptionTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/DataDescriptionTest.java
@@ -20,6 +20,7 @@ package org.apache.doris.analysis;
 import org.apache.doris.analysis.BinaryPredicate.Operator;
 import org.apache.doris.catalog.Database;
 import org.apache.doris.catalog.Env;
+import org.apache.doris.catalog.FunctionSet;
 import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.jmockit.Deencapsulation;
@@ -39,6 +40,8 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -412,5 +415,14 @@ public class DataDescriptionTest {
                 + "(k1, k2, v1) "
                 + "SET (`k1` = bitmap_dict('day', `k2`))";
         Assert.assertEquals(sql, desc.toSql());
+    }
+
+    @Test(expected = AnalysisException.class)
+    public void testHllFunctionArgsNull() throws AnalysisException {
+        String functionName = FunctionSet.HLL_HASH;
+        List<String> args = new ArrayList<>();
+        args.add(null);
+
+        DataDescription.validateMappingFunction(functionName, args, new HashMap<String, String>(), null, false);
     }
 }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #16294 

## Problem summary

tested locally. problem is solved.

The main reason is that `columnNameMap` is a TreeMap instance. And an `NullPointerException` will be reported when the key of `TreeMap.contains(key)` is `null`. 

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

