### PR TITLE
[bug](function) fix mask_first_n function can't handle const value

### DIFF
--- a/be/src/vec/functions/function_string.h
+++ b/be/src/vec/functions/function_string.h
@@ -420,8 +420,8 @@ public:
         int n = -1;
 
         auto res = ColumnString::create();
-        const ColumnString& source_column =
-                assert_cast<const ColumnString&>(*block.get_by_position(arguments[0]).column);
+        auto col = block.get_by_position(arguments[0]).column->convert_to_full_column_if_const();
+        const ColumnString& source_column = assert_cast<const ColumnString&>(*col);
 
         if (arguments.size() == 2) {
             auto& col = *block.get_by_position(arguments[1]).column;

--- a/be/src/vec/functions/function_string.h
+++ b/be/src/vec/functions/function_string.h
@@ -435,7 +435,7 @@ public:
             FunctionMask::vector_mask(source_column, *res, FunctionMask::DEFAULT_UPPER_MASK,
                                       FunctionMask::DEFAULT_LOWER_MASK,
                                       FunctionMask::DEFAULT_NUMBER_MASK);
-        } else if (n > 0) {
+        } else if (n >= 0) {
             vector(source_column, n, *res);
         }
 

--- a/regression-test/data/nereids_function_p0/scalar_function/L-Q.out
+++ b/regression-test/data/nereids_function_p0/scalar_function/L-Q.out
@@ -525,6 +525,39 @@ xxxxxxn
 xxxxxxn
 
 -- !sql --
+\N
+xarchar11
+xarchar11
+xxxchar11
+xxxxxxxnn
+xarchar12
+xarchar12
+xxxchar12
+xxxchar12
+xxxchar13
+xxxxxxr13
+xxxchar13
+xxxxxxxnn
+
+-- !sql --
+\N
+xtring1
+xtring1
+xxxing1
+xxxxxxn
+xtring2
+xtring2
+xxxing2
+xxxing2
+xxxing3
+xxxxxx3
+xxxing3
+xxxxxxn
+
+-- !sql_mask_const --
+xxxnnn
+
+-- !sql --
 xxxx
 xxxxxxxnn
 xxxxxxxnn
@@ -552,6 +585,36 @@ xxxxxxn
 xxxxxxn
 xxxxxxn
 xxxxxxn
+xxxxxxn
+
+-- !sql --
+\N
+varchar1n
+varchar1n
+varchaxnn
+xxxxxxxnn
+varchar1n
+varchar1n
+varchaxnn
+varchaxnn
+varchaxnn
+varxxxxnn
+varchaxnn
+xxxxxxxnn
+
+-- !sql --
+\N
+stringn
+stringn
+strixxn
+xxxxxxn
+stringn
+stringn
+strixxn
+strixxn
+strixxn
+sxxxxxn
+strixxn
 xxxxxxn
 
 -- !sql --

--- a/regression-test/suites/nereids_function_p0/scalar_function/L-Q.groovy
+++ b/regression-test/suites/nereids_function_p0/scalar_function/L-Q.groovy
@@ -65,14 +65,13 @@ suite("nereids_scalar_fn_3") {
     qt_sql "select mask(kstr) from fn_test order by kstr"
     qt_sql "select mask_first_n(kvchrs1) from fn_test order by kvchrs1"
     qt_sql "select mask_first_n(kstr) from fn_test order by kstr"
-    // core
-    // qt_sql "select mask_first_n(kvchrs1, kint) from fn_test order by kvchrs1, kint"
-    // qt_sql "select mask_first_n(kstr, kint) from fn_test order by kstr, kint"
+    qt_sql "select mask_first_n(kvchrs1, kint) from fn_test order by kvchrs1, kint"
+    qt_sql "select mask_first_n(kstr, kint) from fn_test order by kstr, kint"
+    qt_sql_mask_const "select mask_first_n('asd123', 54);"
     qt_sql "select mask_last_n(kvchrs1) from fn_test order by kvchrs1"
     qt_sql "select mask_last_n(kstr) from fn_test order by kstr"
-    // core
-    // qt_sql "select mask_last_n(kvchrs1, kint) from fn_test order by kvchrs1, kint"
-    // qt_sql "select mask_last_n(kstr, kint) from fn_test order by kstr, kint"
+    qt_sql "select mask_last_n(kvchrs1, kint) from fn_test order by kvchrs1, kint"
+    qt_sql "select mask_last_n(kstr, kint) from fn_test order by kstr, kint"
     qt_sql "select md5(kvchrs1) from fn_test order by kvchrs1"
     qt_sql "select md5(kstr) from fn_test order by kstr"
     // cannot find function


### PR DESCRIPTION
test sql:
`select mask_first_n('aa', 54) from fn_test;`

error:
`F0201 10:34:01.775910 1401464 assert_cast.h:50] Bad cast from type:doris::vectorized::ColumnConst to doris::vectorized::ColumnString`

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

