### PR TITLE
[fix](join) crash caused by canceling query

### DIFF
--- a/be/src/vec/runtime/shared_hash_table_controller.cpp
+++ b/be/src/vec/runtime/shared_hash_table_controller.cpp
@@ -60,6 +60,17 @@ SharedHashTableContextPtr SharedHashTableController::get_context(int my_node_id)
     return _shared_contexts[my_node_id];
 }
 
+void SharedHashTableController::signal(int my_node_id, Status status) {
+    std::lock_guard<std::mutex> lock(_mutex);
+    auto it = _shared_contexts.find(my_node_id);
+    if (it != _shared_contexts.cend()) {
+        it->second->signaled = true;
+        it->second->status = status;
+        _shared_contexts.erase(it);
+    }
+    _cv.notify_all();
+}
+
 void SharedHashTableController::signal(int my_node_id) {
     std::lock_guard<std::mutex> lock(_mutex);
     auto it = _shared_contexts.find(my_node_id);

--- a/be/src/vec/runtime/shared_hash_table_controller.h
+++ b/be/src/vec/runtime/shared_hash_table_controller.h
@@ -70,6 +70,7 @@ public:
     TUniqueId get_builder_fragment_instance_id(int my_node_id);
     SharedHashTableContextPtr get_context(int my_node_id);
     void signal(int my_node_id);
+    void signal(int my_node_id, Status status);
     Status wait_for_signal(RuntimeState* state, const SharedHashTableContextPtr& context);
     bool should_build_hash_table(const TUniqueId& fragment_instance_id, int my_node_id);
     void set_pipeline_engine_enabled(bool enabled) { _pipeline_engine_enabled = enabled; }


### PR DESCRIPTION
If the query was canceled,
the status in shared context may be `OK` with other fields not set.

# Proposed changes

Issue Number: close #xxx

## Problem summary

```bash
#0  0x00007f562fd3f67b in kill () from /lib64/libc.so.6
#1  0x000055c63560698d in doris::signal::(anonymous namespace)::InvokeDefaultSignalHandler (signal_number=11)
    at /mnt/disk2/tengjianping/doris-master/be/src/common/signal_handler.h:341
#2  0x000055c635606cc6 in doris::signal::(anonymous namespace)::FailureSignalHandler (signal_number=11, signal_info=0x7e8b5b3ea2f0, 
    ucontext=0x7e8b5b3ea1c0) at /mnt/disk2/tengjianping/doris-master/be/src/common/signal_handler.h:435
#3  0x00007f533c5311a2 in os::Linux::chained_handler(int, siginfo*, void*) ()
   from /mnt/disk2/tengjianping/local/jdk1.8.0_131/jre/lib/amd64/server/libjvm.so
#4  0x00007f533c537826 in JVM_handle_linux_signal () from /mnt/disk2/tengjianping/local/jdk1.8.0_131/jre/lib/amd64/server/libjvm.so
#5  0x00007f533c52de13 in signalHandler(int, siginfo*, void*) ()
   from /mnt/disk2/tengjianping/local/jdk1.8.0_131/jre/lib/amd64/server/libjvm.so
#6  <signal handler called>
#7  0x000055c63a069eef in __gnu_cxx::__normal_iterator<doris::vectorized::Block const*, std::vector<doris::vectorized::Block, std::allocator<doris::vectorized::Block> > >::__normal_iterator (this=0x7e8b5b3eaee0, __i=<error reading variable>)
    at /mnt/disk2/tengjianping/local/ldb_toolchain/include/c++/11/bits/stl_iterator.h:1008
#8  0x000055c63a068596 in std::vector<doris::vectorized::Block, std::allocator<doris::vectorized::Block> >::end (this=0x0)
    at /mnt/disk2/tengjianping/local/ldb_toolchain/include/c++/11/bits/stl_vector.h:839
#9  0x000055c63a082f83 in std::vector<doris::vectorized::Block, std::allocator<doris::vectorized::Block> >::empty (this=0x0)
    at /mnt/disk2/tengjianping/local/ldb_toolchain/include/c++/11/bits/stl_vector.h:1008
#10 0x000055c63a874532 in doris::vectorized::HashJoinNode::sink (this=0x61c0004af080, state=0x61c0004ae880, in_block=0x0, eos=true)
    at /mnt/disk2/tengjianping/doris-master/be/src/vec/exec/join/vhash_join_node.cpp:865
#11 0x000055c63a86a88a in doris::vectorized::HashJoinNode::_materialize_build_side (this=0x61c0004af080, state=0x61c0004ae880)
    at /mnt/disk2/tengjianping/doris-master/be/src/vec/exec/join/vhash_join_node.cpp:724
#12 0x000055c63b224646 in doris::vectorized::VJoinNodeBase::open (this=0x61c0004af080, state=0x61c0004ae880)
    at /mnt/disk2/tengjianping/doris-master/be/src/vec/exec/join/vjoin_node_base.cpp:199
#13 0x000055c63a8688d3 in doris::vectorized::HashJoinNode::open (this=0x61c0004af080, state=0x61c0004ae880)
    at /mnt/disk2/tengjianping/doris-master/be/src/vec/exec/join/vhash_join_node.cpp:664
#14 0x000055c63a00c542 in doris::vectorized::VSortNode::open (this=0x618001e34880, state=0x61c0004ae880)
    at /mnt/disk2/tengjianping/doris-master/be/src/vec/exec/vsort_node.cpp:145
#15 0x000055c636ec926e in doris::PlanFragmentExecutor::open_vectorized_internal (this=0x61700078dcf0)
    at /mnt/disk2/tengjianping/doris-master/be/src/runtime/plan_fragment_executor.cpp:263
#16 0x000055c636ec88d0 in doris::PlanFragmentExecutor::open (this=0x61700078dcf0)
    at /mnt/disk2/tengjianping/doris-master/be/src/runtime/plan_fragment_executor.cpp:238
#17 0x000055c636e421e2 in doris::FragmentExecState::execute (this=0x61700078dc80)
    at /mnt/disk2/tengjianping/doris-master/be/src/runtime/fragment_mgr.cpp:250
#18 0x000055c636e4a552 in doris::FragmentMgr::_exec_actual(std::shared_ptr<doris::FragmentExecState>, std::function<void (doris::RuntimeState*, doris::Status*)>) (this=0x627000003900, exec_state=..., cb=...) at /mnt/disk2/tengjianping/doris-master/be/src/runtime/fragment_mgr.cpp:490
#19 0x000055c636e4cd79 in operator() (__closure=0x608004e09aa0) at /mnt/disk2/tengjianping/doris-master/be/src/runtime/fragment_mgr.cpp:746
--Type <RET> for more, q to quit, c to continue without paging--c
#20 0x000055c636e5dd48 in std::__invoke_impl<void, doris::FragmentMgr::exec_plan_fragment(const doris::TExecPlanFragmentParams&, doris::FragmentMgr::FinishCallback)::<lambda()>&>(std::__invoke_other, struct {...} &) (__f=...) at /mnt/disk2/tengjianping/local/ldb_toolchain/include/c++/11/bits/invoke.h:61
#21 0x000055c636e5d824 in std::__invoke_r<void, doris::FragmentMgr::exec_plan_fragment(const doris::TExecPlanFragmentParams&, doris::FragmentMgr::FinishCallback)::<lambda()>&>(struct {...} &) (__fn=...) at /mnt/disk2/tengjianping/local/ldb_toolchain/include/c++/11/bits/invoke.h:111
#22 0x000055c636e5cc48 in std::_Function_handler<void(), doris::FragmentMgr::exec_plan_fragment(const doris::TExecPlanFragmentParams&, doris::FragmentMgr::FinishCallback)::<lambda()> >::_M_invoke(const std::_Any_data &) (__functor=...) at /mnt/disk2/tengjianping/local/ldb_toolchain/include/c++/11/bits/std_function.h:291
#23 0x000055c6370c7270 in std::function<void ()>::operator()() const (this=0x6060464bfc58) at /mnt/disk2/tengjianping/local/ldb_toolchain/include/c++/11/bits/std_function.h:560
#24 0x000055c6376372fa in doris::FunctionRunnable::run (this=0x6060464bfc50) at /mnt/disk2/tengjianping/doris-master/be/src/util/threadpool.cpp:46
#25 0x000055c6376323ec in doris::ThreadPool::dispatch_thread (this=0x6140000c1c40) at /mnt/disk2/tengjianping/doris-master/be/src/util/threadpool.cpp:535
#26 0x000055c6376543d2 in std::__invoke_impl<void, void (doris::ThreadPool::*&)(), doris::ThreadPool*&> (__f=@0x6030004b8a70: (void (doris::ThreadPool::*)(doris::ThreadPool * const)) 0x55c6376310ae <doris::ThreadPool::dispatch_thread()>, __t=@0x6030004b8a80: 0x6140000c1c40) at /mnt/disk2/tengjianping/local/ldb_toolchain/include/c++/11/bits/invoke.h:74
#27 0x000055c637653c71 in std::__invoke<void (doris::ThreadPool::*&)(), doris::ThreadPool*&> (__fn=@0x6030004b8a70: (void (doris::ThreadPool::*)(doris::ThreadPool * const)) 0x55c6376310ae <doris::ThreadPool::dispatch_thread()>) at /mnt/disk2/tengjianping/local/ldb_toolchain/include/c++/11/bits/invoke.h:96
#28 0x000055c637653010 in std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>::__call<void, , 0ul>(std::tuple<>&&, std::_Index_tuple<0ul>) (this=0x6030004b8a70, __args=...) at /mnt/disk2/tengjianping/local/ldb_toolchain/include/c++/11/functional:420
#29 0x000055c637651b21 in std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>::operator()<, void>() (this=0x6030004b8a70) at /mnt/disk2/tengjianping/local/ldb_toolchain/include/c++/11/functional:503
#30 0x000055c63764e712 in std::__invoke_impl<void, std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>&>(std::__invoke_other, std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>&) (__f=...) at /mnt/disk2/tengjianping/local/ldb_toolchain/include/c++/11/bits/invoke.h:61
#31 0x000055c63764bbca in std::__invoke_r<void, std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>&>(std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>&) (__fn=...) at /mnt/disk2/tengjianping/local/ldb_toolchain/include/c++/11/bits/invoke.h:111
#32 0x000055c637646ec9 in std::_Function_handler<void (), std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()> >::_M_invoke(std::_Any_data const&) (__functor=...) at /mnt/disk2/tengjianping/local/ldb_toolchain/include/c++/11/bits/std_function.h:291
#33 0x000055c6370c7270 in std::function<void ()>::operator()() const (this=0x6110000b9a58) at /mnt/disk2/tengjianping/local/ldb_toolchain/include/c++/11/bits/std_function.h:560
#34 0x000055c637611eb8 in doris::Thread::supervise_thread (arg=0x6110000b9a40) at /mnt/disk2/tengjianping/doris-master/be/src/util/thread.cpp:453
#35 0x00007f563045717a in start_thread () from /lib64/libpthread.so.0
#36 0x00007f562fe04df3 in clone () from /lib64/libc.so.6
```

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

