### PR TITLE
[enhancement](k8s) Support fqdn mode for fe in k8s enviroment

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/FeMetaVersion.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/FeMetaVersion.java
@@ -54,9 +54,11 @@ public final class FeMetaVersion {
     public static final int VERSION_116 = 116;
     // add user and comment to load job
     public static final int VERSION_117 = 117;
-    // note: when increment meta version, should assign the latest version to VERSION_CURRENT
+    // change frontend meta to json, add hostname to MasterInfo
+    public static final int VERSION_118 = 118;
 
-    public static final int VERSION_CURRENT = VERSION_117;
+    // note: when increment meta version, should assign the latest version to VERSION_CURRENT
+    public static final int VERSION_CURRENT = VERSION_118;
 
     // all logs meta version should >= the minimum version, so that we could remove many if clause, for example
     // if (FE_METAVERSION < VERSION_94) ...

--- a/fe/fe-core/src/main/java/org/apache/doris/alter/SystemHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/SystemHandler.java
@@ -153,16 +153,20 @@ public class SystemHandler extends AlterHandler {
 
         } else if (alterClause instanceof AddObserverClause) {
             AddObserverClause clause = (AddObserverClause) alterClause;
-            Env.getCurrentEnv().addFrontend(FrontendNodeType.OBSERVER, clause.getHost(), clause.getPort());
+            Env.getCurrentEnv().addFrontend(FrontendNodeType.OBSERVER, clause.getIp(), clause.getHostName(),
+                    clause.getPort());
         } else if (alterClause instanceof DropObserverClause) {
             DropObserverClause clause = (DropObserverClause) alterClause;
-            Env.getCurrentEnv().dropFrontend(FrontendNodeType.OBSERVER, clause.getHost(), clause.getPort());
+            Env.getCurrentEnv().dropFrontend(FrontendNodeType.OBSERVER, clause.getIp(), clause.getHostName(),
+                    clause.getPort());
         } else if (alterClause instanceof AddFollowerClause) {
             AddFollowerClause clause = (AddFollowerClause) alterClause;
-            Env.getCurrentEnv().addFrontend(FrontendNodeType.FOLLOWER, clause.getHost(), clause.getPort());
+            Env.getCurrentEnv().addFrontend(FrontendNodeType.FOLLOWER, clause.getIp(), clause.getHostName(),
+                    clause.getPort());
         } else if (alterClause instanceof DropFollowerClause) {
             DropFollowerClause clause = (DropFollowerClause) alterClause;
-            Env.getCurrentEnv().dropFrontend(FrontendNodeType.FOLLOWER, clause.getHost(), clause.getPort());
+            Env.getCurrentEnv().dropFrontend(FrontendNodeType.FOLLOWER, clause.getIp(), clause.getHostName(),
+                    clause.getPort());
         } else if (alterClause instanceof ModifyBrokerClause) {
             ModifyBrokerClause clause = (ModifyBrokerClause) alterClause;
             Env.getCurrentEnv().getBrokerMgr().execute(clause);

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/FrontendClause.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/FrontendClause.java
@@ -22,11 +22,11 @@ import org.apache.doris.catalog.Env;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.ErrorReport;
-import org.apache.doris.common.Pair;
 import org.apache.doris.ha.FrontendNodeType;
 import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.system.SystemInfoService;
+import org.apache.doris.system.SystemInfoService.HostInfo;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
@@ -36,7 +36,8 @@ import java.util.Map;
 
 public class FrontendClause extends AlterClause {
     protected String hostPort;
-    protected String host;
+    protected String ip;
+    protected String hostName;
     protected int port;
     protected FrontendNodeType role;
 
@@ -46,8 +47,12 @@ public class FrontendClause extends AlterClause {
         this.role = role;
     }
 
-    public String getHost() {
-        return host;
+    public String getIp() {
+        return ip;
+    }
+
+    public String getHostName() {
+        return hostName;
     }
 
     public int getPort() {
@@ -61,10 +66,11 @@ public class FrontendClause extends AlterClause {
                                                 analyzer.getQualifiedUser());
         }
 
-        Pair<String, Integer> pair = SystemInfoService.validateHostAndPort(hostPort);
-        this.host = pair.first;
-        this.port = pair.second;
-        Preconditions.checkState(!Strings.isNullOrEmpty(host));
+        HostInfo pair = SystemInfoService.getIpHostAndPort(hostPort, true);
+        this.ip = pair.getIp();
+        this.hostName = pair.getHostName();
+        this.port = pair.getPort();
+        Preconditions.checkState(!Strings.isNullOrEmpty(ip));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/common/proc/FrontendsProcNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/proc/FrontendsProcNode.java
@@ -24,6 +24,7 @@ import org.apache.doris.common.util.NetUtils;
 import org.apache.doris.common.util.TimeUtils;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.system.Frontend;
+import org.apache.doris.system.SystemInfoService.HostInfo;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
@@ -86,11 +87,11 @@ public class FrontendsProcNode implements ProcNodeInterface {
         List<InetSocketAddress> allFe = env.getHaProtocol().getElectableNodes(true /* include leader */);
         allFe.addAll(env.getHaProtocol().getObserverNodes());
         List<Pair<String, Integer>> allFeHosts = convertToHostPortPair(allFe);
-        List<Pair<String, Integer>> helperNodes = env.getHelperNodes();
+        List<HostInfo> helperNodes = env.getHelperNodes();
 
         // Because the `show frontend` stmt maybe forwarded from other FE.
         // if we only get self node from currrent catalog, the "CurrentConnected" field will always points to Msater FE.
-        String selfNode = Env.getCurrentEnv().getSelfNode().first;
+        String selfNode = Env.getCurrentEnv().getSelfNode().getIp();
         if (ConnectContext.get() != null && !Strings.isNullOrEmpty(ConnectContext.get().getCurrentConnectedFEIp())) {
             selfNode = ConnectContext.get().getCurrentConnectedFEIp();
         }
@@ -99,13 +100,13 @@ public class FrontendsProcNode implements ProcNodeInterface {
 
             List<String> info = new ArrayList<String>();
             info.add(fe.getNodeName());
-            info.add(fe.getHost());
+            info.add(fe.getIp());
 
-            info.add(NetUtils.getHostnameByIp(fe.getHost()));
+            info.add(NetUtils.getHostnameByIp(fe.getIp()));
             info.add(Integer.toString(fe.getEditLogPort()));
             info.add(Integer.toString(Config.http_port));
 
-            if (fe.getHost().equals(env.getSelfNode().first)) {
+            if (fe.getIp().equals(env.getSelfNode().getIp())) {
                 info.add(Integer.toString(Config.query_port));
                 info.add(Integer.toString(Config.rpc_port));
             } else {
@@ -114,7 +115,7 @@ public class FrontendsProcNode implements ProcNodeInterface {
             }
 
             info.add(fe.getRole().name());
-            InetSocketAddress socketAddress = new InetSocketAddress(fe.getHost(), fe.getEditLogPort());
+            InetSocketAddress socketAddress = new InetSocketAddress(fe.getIp(), fe.getEditLogPort());
             //An ipv6 address may have different format, so we compare InetSocketAddress objects instead of IP Strings.
             //e.g.  fdbd:ff1:ce00:1c26::d8 and fdbd:ff1:ce00:1c26:0:0:d8
             info.add(String.valueOf(socketAddress.equals(master)));
@@ -122,7 +123,7 @@ public class FrontendsProcNode implements ProcNodeInterface {
             info.add(Integer.toString(env.getClusterId()));
             info.add(String.valueOf(isJoin(allFeHosts, fe)));
 
-            if (fe.getHost().equals(env.getSelfNode().first)) {
+            if (fe.getIp().equals(env.getSelfNode().getIp())) {
                 info.add("true");
                 info.add(Long.toString(env.getEditLog().getMaxJournalId()));
             } else {
@@ -134,19 +135,19 @@ public class FrontendsProcNode implements ProcNodeInterface {
             info.add(fe.getHeartbeatErrMsg());
             info.add(fe.getVersion());
             // To indicate which FE we currently connected
-            info.add(fe.getHost().equals(selfNode) ? "Yes" : "No");
+            info.add(fe.getIp().equals(selfNode) ? "Yes" : "No");
 
             infos.add(info);
         }
     }
 
-    private static boolean isHelperNode(List<Pair<String, Integer>> helperNodes, Frontend fe) {
-        return helperNodes.stream().anyMatch(p -> p.first.equals(fe.getHost()) && p.second == fe.getEditLogPort());
+    private static boolean isHelperNode(List<HostInfo> helperNodes, Frontend fe) {
+        return helperNodes.stream().anyMatch(p -> p.getIp().equals(fe.getIp()) && p.getPort() == fe.getEditLogPort());
     }
 
     private static boolean isJoin(List<Pair<String, Integer>> allFeHosts, Frontend fe) {
         for (Pair<String, Integer> pair : allFeHosts) {
-            if (fe.getHost().equals(pair.first) && fe.getEditLogPort() == pair.second) {
+            if (fe.getIp().equals(pair.first) && fe.getEditLogPort() == pair.second) {
                 return true;
             }
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/common/telemetry/Telemetry.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/telemetry/Telemetry.java
@@ -70,7 +70,7 @@ public class Telemetry {
             throw new Exception("unknown value " + Config.trace_exporter + " of trace_exporter in fe.conf");
         }
 
-        String serviceName = "FRONTEND:" + Env.getCurrentEnv().getSelfNode().first;
+        String serviceName = "FRONTEND:" + Env.getCurrentEnv().getSelfNode().getIp();
         Resource serviceNameResource = Resource.create(
                 Attributes.of(AttributeKey.stringKey("service.name"), serviceName));
         // Send a batch of spans if ScheduleDelay time or MaxExportBatchSize is reached

--- a/fe/fe-core/src/main/java/org/apache/doris/ha/BDBHA.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/ha/BDBHA.java
@@ -221,6 +221,23 @@ public class BDBHA implements HAProtocol {
         return true;
     }
 
+    public boolean updateNodeAddress(String nodeName, String newHostName, int port) {
+        ReplicationGroupAdmin replicationGroupAdmin = environment.getReplicationGroupAdmin();
+        if (replicationGroupAdmin == null) {
+            return false;
+        }
+        try {
+            replicationGroupAdmin.updateAddress(nodeName, newHostName, port);
+        } catch (MemberNotFoundException e) {
+            LOG.error("the updating electable node is not found {}", nodeName, e);
+            return false;
+        } catch (MasterStateException e) {
+            LOG.error("the updating electable node is master {}", nodeName, e);
+            return false;
+        }
+        return true;
+    }
+
     // When new Follower FE is added to the cluster, it should also be added to the
     // helper sockets in
     // ReplicationGroupAdmin, in order to fix the following case:

--- a/fe/fe-core/src/main/java/org/apache/doris/ha/MasterInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/ha/MasterInfo.java
@@ -17,6 +17,8 @@
 
 package org.apache.doris.ha;
 
+import org.apache.doris.catalog.Env;
+import org.apache.doris.common.FeMetaVersion;
 import org.apache.doris.common.io.Text;
 import org.apache.doris.common.io.Writable;
 
@@ -27,17 +29,20 @@ import java.io.IOException;
 public class MasterInfo implements Writable {
 
     private String ip;
+    private String hostName;
     private int httpPort;
     private int rpcPort;
 
     public MasterInfo() {
         this.ip = "";
+        this.hostName = "";
         this.httpPort = 0;
         this.rpcPort = 0;
     }
 
-    public MasterInfo(String ip, int httpPort, int rpcPort) {
+    public MasterInfo(String ip, String hostName, int httpPort, int rpcPort) {
         this.ip = ip;
+        this.hostName = hostName;
         this.httpPort = httpPort;
         this.rpcPort = rpcPort;
     }
@@ -48,6 +53,14 @@ public class MasterInfo implements Writable {
 
     public void setIp(String ip) {
         this.ip = ip;
+    }
+
+    public String getHostName() {
+        return hostName;
+    }
+
+    public void setHostName(String hostName) {
+        this.hostName = hostName;
     }
 
     public int getHttpPort() {
@@ -71,12 +84,16 @@ public class MasterInfo implements Writable {
         Text.writeString(out, ip);
         out.writeInt(httpPort);
         out.writeInt(rpcPort);
+        Text.writeString(out, hostName);
     }
 
     public void readFields(DataInput in) throws IOException {
         ip = Text.readString(in);
         httpPort = in.readInt();
         rpcPort = in.readInt();
+        if (Env.getCurrentEnvJournalVersion() >= FeMetaVersion.VERSION_118) {
+            hostName = Text.readString(in);
+        }
     }
 
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/meta/MetaService.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/meta/MetaService.java
@@ -54,13 +54,14 @@ public class MetaService extends RestBaseController {
 
     private static final String VERSION = "version";
     private static final String HOST = "host";
+    private static final String HOSTNAME = "hostname";
     private static final String PORT = "port";
 
     private File imageDir = MetaHelper.getMasterImageDir();
 
     private boolean isFromValidFe(HttpServletRequest request) {
         String clientHost = request.getRemoteHost();
-        Frontend fe = Env.getCurrentEnv().getFeByHost(clientHost);
+        Frontend fe = Env.getCurrentEnv().getFeByIp(clientHost);
         if (fe == null) {
             LOG.warn("request is not from valid FE. client: {}", clientHost);
             return false;
@@ -184,12 +185,15 @@ public class MetaService extends RestBaseController {
     @RequestMapping(path = "/role", method = RequestMethod.GET)
     public Object role(HttpServletRequest request, HttpServletResponse response) throws DdlException {
         checkFromValidFe(request);
-
+        // For upgrade compatibility, the host parameter name remains the same
+        // and the new hostname parameter is added.
+        // host = ip
         String host = request.getParameter(HOST);
+        String hostname = request.getParameter(HOSTNAME);
         String portString = request.getParameter(PORT);
         if (!Strings.isNullOrEmpty(host) && !Strings.isNullOrEmpty(portString)) {
             int port = Integer.parseInt(portString);
-            Frontend fe = Env.getCurrentEnv().checkFeExist(host, port);
+            Frontend fe = Env.getCurrentEnv().checkFeExist(host, hostname, port);
             if (fe == null) {
                 response.setHeader("role", FrontendNodeType.UNKNOWN.name());
             } else {

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/manager/ClusterAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/manager/ClusterAction.java
@@ -60,7 +60,7 @@ public class ClusterAction extends RestBaseController {
         Map<String, List<String>> result = Maps.newHashMap();
         List<String> frontends = Env.getCurrentEnv().getFrontends(null)
                 .stream().filter(Frontend::isAlive)
-                .map(Frontend::getHost)
+                .map(Frontend::getIp)
                 .collect(Collectors.toList());
 
         result.put("mysql", frontends.stream().map(ip -> ip + ":" + Config.query_port).collect(Collectors.toList()));

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/manager/HttpUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/manager/HttpUtils.java
@@ -49,7 +49,7 @@ public class HttpUtils {
 
     static List<Pair<String, Integer>> getFeList() {
         return Env.getCurrentEnv().getFrontends(null)
-                .stream().filter(Frontend::isAlive).map(fe -> Pair.of(fe.getHost(), Config.http_port))
+                .stream().filter(Frontend::isAlive).map(fe -> Pair.of(fe.getIp(), Config.http_port))
                 .collect(Collectors.toList());
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/manager/NodeAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/manager/NodeAction.java
@@ -21,7 +21,6 @@ import org.apache.doris.catalog.Env;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.ConfigBase;
-import org.apache.doris.common.DdlException;
 import org.apache.doris.common.MarkedCountDownLatch;
 import org.apache.doris.common.Pair;
 import org.apache.doris.common.ThreadPoolManager;
@@ -230,7 +229,7 @@ public class NodeAction extends RestBaseController {
     }
 
     private static List<String> getFeList() {
-        return Env.getCurrentEnv().getFrontends(null).stream().map(fe -> fe.getHost() + ":" + Config.http_port)
+        return Env.getCurrentEnv().getFrontends(null).stream().map(fe -> fe.getIp() + ":" + Config.http_port)
                 .collect(Collectors.toList());
     }
 
@@ -483,7 +482,7 @@ public class NodeAction extends RestBaseController {
         List<Map<String, String>> failedTotal = Lists.newArrayList();
         List<NodeConfigs> nodeConfigList = parseSetConfigNodes(requestBody, failedTotal);
         List<Pair<String, Integer>> aliveFe = Env.getCurrentEnv().getFrontends(null).stream().filter(Frontend::isAlive)
-                .map(fe -> Pair.of(fe.getHost(), Config.http_port)).collect(Collectors.toList());
+                .map(fe -> Pair.of(fe.getIp(), Config.http_port)).collect(Collectors.toList());
         checkNodeIsAlive(nodeConfigList, aliveFe, failedTotal);
 
         Map<String, String> header = Maps.newHashMap();
@@ -646,9 +645,6 @@ public class NodeAction extends RestBaseController {
         }
         try {
             String role = reqInfo.getRole();
-            String[] split = reqInfo.getHostPort().split(":");
-            String host = split[0];
-            int port = Integer.parseInt(split[1]);
             Env currentEnv = Env.getCurrentEnv();
             FrontendNodeType frontendNodeType;
             if (FrontendNodeType.FOLLOWER.name().equals(role)) {
@@ -656,13 +652,14 @@ public class NodeAction extends RestBaseController {
             } else {
                 frontendNodeType = FrontendNodeType.OBSERVER;
             }
+            HostInfo info = SystemInfoService.getIpHostAndPort(reqInfo.getHostPort(), true);
             if ("ADD".equals(action)) {
-                currentEnv.addFrontend(frontendNodeType, host, port);
+                currentEnv.addFrontend(frontendNodeType, info.getIp(), info.getHostName(), info.getPort());
             } else if ("DROP".equals(action)) {
-                currentEnv.dropFrontend(frontendNodeType, host, port);
+                currentEnv.dropFrontend(frontendNodeType, info.getIp(), info.getHostName(), info.getPort());
             }
-        } catch (DdlException ddlException) {
-            return ResponseEntityBuilder.okWithCommonError(ddlException.getMessage());
+        } catch (UserException userException) {
+            return ResponseEntityBuilder.okWithCommonError(userException.getMessage());
         }
         return ResponseEntityBuilder.ok();
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/manager/QueryProfileAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/manager/QueryProfileAction.java
@@ -175,7 +175,7 @@ public class QueryProfileAction extends RestBaseController {
 
         // add node information
         for (List<String> query : queries) {
-            query.add(1, Env.getCurrentEnv().getSelfNode().first + ":" + Config.http_port);
+            query.add(1, Env.getCurrentEnv().getSelfNode().getIp() + ":" + Config.http_port);
         }
 
         if (!Strings.isNullOrEmpty(search)) {

--- a/fe/fe-core/src/main/java/org/apache/doris/journal/JournalEntity.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/journal/JournalEntity.java
@@ -337,9 +337,9 @@ public class JournalEntity implements Writable {
             }
             case OperationType.OP_ADD_FRONTEND:
             case OperationType.OP_ADD_FIRST_FRONTEND:
+            case OperationType.OP_MODIFY_FRONTEND:
             case OperationType.OP_REMOVE_FRONTEND: {
-                data = new Frontend();
-                ((Frontend) data).readFields(in);
+                data = Frontend.read(in);
                 isRead = true;
                 break;
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/journal/bdbje/BDBEnvironment.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/journal/bdbje/BDBEnvironment.java
@@ -183,7 +183,6 @@ public class BDBEnvironment {
                 // start state change listener
                 StateChangeListener listener = new BDBStateChangeListener();
                 replicatedEnvironment.setStateChangeListener(listener);
-
                 // open epochDB. the first parameter null means auto-commit
                 epochDB = replicatedEnvironment.openDatabase(null, "epochDB", dbConfig);
                 break;

--- a/fe/fe-core/src/main/java/org/apache/doris/journal/bdbje/BDBJEJournal.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/journal/bdbje/BDBJEJournal.java
@@ -18,7 +18,7 @@
 package org.apache.doris.journal.bdbje;
 
 import org.apache.doris.catalog.Env;
-import org.apache.doris.common.Pair;
+import org.apache.doris.common.Config;
 import org.apache.doris.common.io.DataOutputBuffer;
 import org.apache.doris.common.io.Writable;
 import org.apache.doris.common.util.Util;
@@ -27,6 +27,7 @@ import org.apache.doris.journal.JournalCursor;
 import org.apache.doris.journal.JournalEntity;
 import org.apache.doris.metric.MetricRepo;
 import org.apache.doris.persist.OperationType;
+import org.apache.doris.system.SystemInfoService.HostInfo;
 
 import com.sleepycat.bind.tuple.TupleBinding;
 import com.sleepycat.je.Database;
@@ -80,9 +81,17 @@ public class BDBJEJournal implements Journal { // CHECKSTYLE IGNORE THIS LINE: B
      */
     private void initBDBEnv(String nodeName) {
         environmentPath = Env.getServingEnv().getBdbDir();
-        Pair<String, Integer> selfNode = Env.getServingEnv().getSelfNode();
+        HostInfo selfNode = Env.getServingEnv().getSelfNode();
         selfNodeName = nodeName;
-        selfNodeHostPort = selfNode.first + ":" + selfNode.second;
+        if (Config.enable_fqdn_mode) {
+            // We use the hostname as the address of the bdbje node,
+            // so that we do not need to update bdbje when the IP changes.
+            // WARNING:However, it is necessary to ensure that the hostname of the node
+            // can be resolved and accessed by other nodes.
+            selfNodeHostPort = selfNode.getHostName() + ":" + selfNode.getPort();
+        } else {
+            selfNodeHostPort = selfNode.getIp() + ":" + selfNode.getPort();
+        }
     }
 
     /*
@@ -299,8 +308,11 @@ public class BDBJEJournal implements Journal { // CHECKSTYLE IGNORE THIS LINE: B
         if (bdbEnvironment == null) {
             File dbEnv = new File(environmentPath);
             bdbEnvironment = new BDBEnvironment();
-            Pair<String, Integer> helperNode = Env.getServingEnv().getHelperNode();
-            String helperHostPort = helperNode.first + ":" + helperNode.second;
+            HostInfo helperNode = Env.getServingEnv().getHelperNode();
+            String helperHostPort = helperNode.getIp() + ":" + helperNode.getPort();
+            if (Config.enable_fqdn_mode) {
+                helperHostPort = helperNode.getHostName() + ":" + helperNode.getPort();
+            }
             try {
                 bdbEnvironment.setup(dbEnv, selfNodeName, selfNodeHostPort, helperHostPort,
                         Env.getServingEnv().isElectable());
@@ -358,14 +370,14 @@ public class BDBJEJournal implements Journal { // CHECKSTYLE IGNORE THIS LINE: B
         // the files
         // ATTN: here we use `getServingEnv()`, because only serving catalog has
         // helper nodes.
-        Pair<String, Integer> helperNode = Env.getServingEnv().getHelperNode();
+        HostInfo helperNode = Env.getServingEnv().getHelperNode();
         NetworkRestore restore = new NetworkRestore();
         NetworkRestoreConfig config = new NetworkRestoreConfig();
         config.setRetainLogFiles(false);
         restore.execute(insufficientLogEx, config);
         bdbEnvironment.close();
         bdbEnvironment.setup(new File(environmentPath), selfNodeName, selfNodeHostPort,
-                helperNode.first + ":" + helperNode.second, Env.getServingEnv().isElectable());
+                helperNode.getIp() + ":" + helperNode.getPort(), Env.getServingEnv().isElectable());
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/master/Checkpoint.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/master/Checkpoint.java
@@ -185,7 +185,7 @@ public class Checkpoint extends MasterDaemon {
         if (!allFrontends.isEmpty()) {
             otherNodesCount = allFrontends.size() - 1; // skip master itself
             for (Frontend fe : allFrontends) {
-                String host = fe.getHost();
+                String host = fe.getIp();
                 if (host.equals(Env.getServingEnv().getMasterIp())) {
                     // skip master itself
                     continue;
@@ -227,7 +227,7 @@ public class Checkpoint extends MasterDaemon {
                 long deleteVersion = storage.getLatestValidatedImageSeq();
                 if (successPushed > 0) {
                     for (Frontend fe : allFrontends) {
-                        String host = fe.getHost();
+                        String host = fe.getIp();
                         if (host.equals(Env.getServingEnv().getMasterIp())) {
                             // skip master itself
                             continue;

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/EditLog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/EditLog.java
@@ -402,6 +402,11 @@ public class EditLog {
                     env.replayAddFrontend(fe);
                     break;
                 }
+                case OperationType.OP_MODIFY_FRONTEND: {
+                    Frontend fe = (Frontend) journal.getData();
+                    env.replayModifyFrontend(fe);
+                    break;
+                }
                 case OperationType.OP_REMOVE_FRONTEND: {
                     Frontend fe = (Frontend) journal.getData();
                     env.replayDropFrontend(fe);
@@ -1234,6 +1239,10 @@ public class EditLog {
 
     public void logAddFirstFrontend(Frontend fe) {
         logEdit(OperationType.OP_ADD_FIRST_FRONTEND, fe);
+    }
+
+    public void logModifyFrontend(Frontend fe) {
+        logEdit(OperationType.OP_MODIFY_FRONTEND, fe);
     }
 
     public void logRemoveFrontend(Frontend fe) {

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/OperationType.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/OperationType.java
@@ -150,6 +150,8 @@ public class OperationType {
     public static final short OP_DROP_REPOSITORY = 90;
     public static final short OP_MODIFY_BACKEND = 91;
 
+    public static final short OP_MODIFY_FRONTEND = 92;
+
     //colocate table
     public static final short OP_COLOCATE_ADD_TABLE = 94;
     public static final short OP_COLOCATE_REMOVE_TABLE = 95;

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -491,7 +491,7 @@ public class StmtExecutor implements ProfileWriter {
                         // If goes here, which means we can't find a valid Master FE(some error happens).
                         // To avoid endless forward, throw exception here.
                         throw new UserException("The statement has been forwarded to master FE("
-                                + Env.getCurrentEnv().getSelfNode().first + ") and failed to execute"
+                                + Env.getCurrentEnv().getSelfNode().getIp() + ") and failed to execute"
                                 + " because Master FE is not ready. You may need to check FE's status");
                     }
                     forwardToMaster();

--- a/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
@@ -780,7 +780,7 @@ public class FrontendServiceImpl implements FrontendService.Iface {
     public TMasterOpResult forward(TMasterOpRequest params) throws TException {
         TNetworkAddress clientAddr = getClientAddr();
         if (clientAddr != null) {
-            Frontend fe = Env.getCurrentEnv().getFeByHost(clientAddr.getHostname());
+            Frontend fe = Env.getCurrentEnv().getFeByIp(clientAddr.getHostname());
             if (fe == null) {
                 LOG.warn("reject request from invalid host. client: {}", clientAddr);
                 throw new TException("request from invalid host was rejected.");

--- a/fe/fe-core/src/main/java/org/apache/doris/system/FQDNManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/system/FQDNManager.java
@@ -19,6 +19,7 @@ package org.apache.doris.system;
 
 import org.apache.doris.catalog.Env;
 import org.apache.doris.common.ClientPool;
+import org.apache.doris.common.DdlException;
 import org.apache.doris.common.FeConstants;
 import org.apache.doris.common.util.MasterDaemon;
 import org.apache.doris.thrift.TNetworkAddress;
@@ -40,10 +41,36 @@ public class FQDNManager extends MasterDaemon {
     }
 
     /**
-     * At each round: check if ip of be has already been changed
+     * At each round: check if ip of be or fe has already been changed
      */
     @Override
     protected void runAfterCatalogReady() {
+        updateBeIp();
+        updateFeIp();
+    }
+
+    private void updateFeIp() {
+        for (Frontend fe : Env.getCurrentEnv().getFrontends(null /* all */)) {
+            if (fe.getHostName() != null) {
+                try {
+                    InetAddress inetAddress = InetAddress.getByName(fe.getHostName());
+                    if (!fe.getIp().equalsIgnoreCase(inetAddress.getHostAddress())) {
+                        String oldIp = fe.getIp();
+                        String newIp = inetAddress.getHostAddress();
+                        Env.getCurrentEnv().modifyFrontendIp(fe.getNodeName(), newIp);
+                        LOG.info("ip for {} of fe has been changed from {} to {}",
+                                fe.getHostName(), oldIp, fe.getIp());
+                    }
+                } catch (UnknownHostException e) {
+                    LOG.warn("unknown host name for fe, {}", fe.getHostName(), e);
+                } catch (DdlException e) {
+                    LOG.warn("fail to update ip for fe, {}", fe.getHostName(), e);
+                }
+            }
+        }
+    }
+
+    private void updateBeIp() {
         for (Backend be : nodeMgr.getIdToBackend().values()) {
             if (be.getHostName() != null) {
                 try {

--- a/fe/fe-core/src/main/java/org/apache/doris/system/Frontend.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/system/Frontend.java
@@ -19,20 +19,32 @@ package org.apache.doris.system;
 
 import org.apache.doris.catalog.Env;
 import org.apache.doris.common.Config;
+import org.apache.doris.common.FeMetaVersion;
 import org.apache.doris.common.io.Text;
 import org.apache.doris.common.io.Writable;
 import org.apache.doris.ha.BDBHA;
 import org.apache.doris.ha.FrontendNodeType;
+import org.apache.doris.persist.gson.GsonUtils;
 import org.apache.doris.system.HeartbeatResponse.HbStatus;
+
+import com.google.gson.annotations.SerializedName;
 
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 
 public class Frontend implements Writable {
+    @SerializedName("role")
     private FrontendNodeType role;
+    // nodeName = ip:port_timestamp
+    @SerializedName("nodeName")
     private String nodeName;
-    private String host;
+    @SerializedName("ip")
+    private volatile String ip;
+    // used for getIpByHostname
+    @SerializedName("hostName")
+    private String hostName;
+    @SerializedName("editLogPort")
     private int editLogPort;
     private String version;
 
@@ -47,10 +59,15 @@ public class Frontend implements Writable {
 
     public Frontend() {}
 
-    public Frontend(FrontendNodeType role, String nodeName, String host, int editLogPort) {
+    public Frontend(FrontendNodeType role, String nodeName, String ip, int editLogPort) {
+        this(role, nodeName, ip, null, editLogPort);
+    }
+
+    public Frontend(FrontendNodeType role, String nodeName, String ip, String hostName, int editLogPort) {
         this.role = role;
         this.nodeName = nodeName;
-        this.host = host;
+        this.ip = ip;
+        this.hostName = hostName;
         this.editLogPort = editLogPort;
     }
 
@@ -58,12 +75,20 @@ public class Frontend implements Writable {
         return this.role;
     }
 
-    public String getHost() {
-        return this.host;
+    public String getIp() {
+        return this.ip;
     }
 
     public String getVersion() {
         return version;
+    }
+
+    public String getHostName() {
+        return hostName;
+    }
+
+    public void setHostName(String hostName) {
+        this.hostName = hostName;
     }
 
     public String getNodeName() {
@@ -131,10 +156,8 @@ public class Frontend implements Writable {
 
     @Override
     public void write(DataOutput out) throws IOException {
-        Text.writeString(out, role.name());
-        Text.writeString(out, host);
-        out.writeInt(editLogPort);
-        Text.writeString(out, nodeName);
+        String json = GsonUtils.GSON.toJson(this);
+        Text.writeString(out, json);
     }
 
     public void readFields(DataInput in) throws IOException {
@@ -144,22 +167,31 @@ public class Frontend implements Writable {
             // we changed REPLICA to FOLLOWER
             role = FrontendNodeType.FOLLOWER;
         }
-        host = Text.readString(in);
+        ip = Text.readString(in);
         editLogPort = in.readInt();
         nodeName = Text.readString(in);
     }
 
     public static Frontend read(DataInput in) throws IOException {
-        Frontend frontend = new Frontend();
-        frontend.readFields(in);
-        return frontend;
+        if (Env.getCurrentEnvJournalVersion() < FeMetaVersion.VERSION_118) {
+            Frontend frontend = new Frontend();
+            frontend.readFields(in);
+            return frontend;
+        }
+        String json = Text.readString(in);
+        return GsonUtils.GSON.fromJson(json, Frontend.class);
     }
 
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();
         sb.append("name: ").append(nodeName).append(", role: ").append(role.name());
-        sb.append(", ").append(host).append(":").append(editLogPort);
+        sb.append(", hostname: ").append(hostName);
+        sb.append(", ").append(ip).append(":").append(editLogPort);
         return sb.toString();
+    }
+
+    public void setIp(String ip) {
+        this.ip = ip;
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/system/HeartbeatMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/system/HeartbeatMgr.java
@@ -29,6 +29,7 @@ import org.apache.doris.persist.HbPackage;
 import org.apache.doris.resource.Tag;
 import org.apache.doris.service.FrontendOptions;
 import org.apache.doris.system.HeartbeatResponse.HbStatus;
+import org.apache.doris.system.SystemInfoService.HostInfo;
 import org.apache.doris.thrift.FrontendService;
 import org.apache.doris.thrift.HeartbeatService;
 import org.apache.doris.thrift.TBackendInfo;
@@ -293,7 +294,9 @@ public class HeartbeatMgr extends MasterDaemon {
 
         @Override
         public HeartbeatResponse call() {
-            if (fe.getHost().equals(Env.getCurrentEnv().getSelfNode().first)) {
+            HostInfo selfNode = Env.getCurrentEnv().getSelfNode();
+            if (fe.getIp().equals(selfNode.getIp())
+                    || (fe.getHostName() != null && fe.getHostName().equals(selfNode.getHostName()))) {
                 // heartbeat to self
                 if (Env.getCurrentEnv().isReady()) {
                     return new FrontendHbResponse(fe.getNodeName(), Config.query_port, Config.rpc_port,
@@ -309,7 +312,7 @@ public class HeartbeatMgr extends MasterDaemon {
 
         private HeartbeatResponse getHeartbeatResponse() {
             FrontendService.Client client = null;
-            TNetworkAddress addr = new TNetworkAddress(fe.getHost(), Config.rpc_port);
+            TNetworkAddress addr = new TNetworkAddress(fe.getIp(), Config.rpc_port);
             boolean ok = false;
             try {
                 client = ClientPool.frontendHeartbeatPool.borrowObject(addr);

--- a/fe/fe-core/src/main/java/org/apache/doris/system/SystemInfoService.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/system/SystemInfoService.java
@@ -61,6 +61,7 @@ import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
@@ -127,6 +128,33 @@ public class SystemInfoService {
             return res;
         }
 
+        public boolean isSame(HostInfo other) {
+            if (other.getPort() != port) {
+                return false;
+            }
+            if (hostName != null && hostName.equals(other.getHostName())) {
+                return true;
+            }
+            if (ip != null && ip.equals(other.getIp())) {
+                return true;
+            }
+            return false;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            HostInfo that = (HostInfo) o;
+            return Objects.equals(ip, that.getIp())
+                    && Objects.equals(hostName, that.getHostName())
+                    && Objects.equals(port, that.getPort());
+        }
+
         @Override
         public String toString() {
             return "HostInfo{"
@@ -168,8 +196,8 @@ public class SystemInfoService {
             if (!Config.enable_fqdn_mode) {
                 hostInfo.setHostName(null);
             }
-            if (Config.enable_fqdn_mode && hostInfo.getHostName() == null) {
-                throw new DdlException("backend's hostName should not be null while enable_fqdn_mode is true");
+            if (Config.enable_fqdn_mode && StringUtils.isEmpty(hostInfo.getHostName())) {
+                throw new DdlException("backend's hostName should not be empty while enable_fqdn_mode is true");
             }
             // check is already exist
             if (getBackendWithHeartbeatPort(hostInfo.getIp(), hostInfo.getHostName(), hostInfo.getPort()) != null) {
@@ -355,20 +383,20 @@ public class SystemInfoService {
         return null;
     }
 
-    public Backend getBackendWithBePort(String host, int bePort) {
+    public Backend getBackendWithBePort(String ip, int bePort) {
         ImmutableMap<Long, Backend> idToBackend = idToBackendRef;
         for (Backend backend : idToBackend.values()) {
-            if (backend.getIp().equals(host) && backend.getBePort() == bePort) {
+            if (backend.getIp().equals(ip) && backend.getBePort() == bePort) {
                 return backend;
             }
         }
         return null;
     }
 
-    public Backend getBackendWithHttpPort(String host, int httpPort) {
+    public Backend getBackendWithHttpPort(String ip, int httpPort) {
         ImmutableMap<Long, Backend> idToBackend = idToBackendRef;
         for (Backend backend : idToBackend.values()) {
-            if (backend.getIp().equals(host) && backend.getHttpPort() == httpPort) {
+            if (backend.getIp().equals(ip) && backend.getHttpPort() == httpPort) {
                 return backend;
             }
         }

--- a/fe/fe-core/src/test/java/org/apache/doris/system/HeartbeatMgrTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/system/HeartbeatMgrTest.java
@@ -20,11 +20,11 @@ package org.apache.doris.system;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.FsBroker;
 import org.apache.doris.common.GenericPool;
-import org.apache.doris.common.Pair;
 import org.apache.doris.ha.FrontendNodeType;
 import org.apache.doris.system.HeartbeatMgr.BrokerHeartbeatHandler;
 import org.apache.doris.system.HeartbeatMgr.FrontendHeartbeatHandler;
 import org.apache.doris.system.HeartbeatResponse.HbStatus;
+import org.apache.doris.system.SystemInfoService.HostInfo;
 import org.apache.doris.thrift.FrontendService;
 import org.apache.doris.thrift.TBrokerOperationStatus;
 import org.apache.doris.thrift.TBrokerOperationStatusCode;
@@ -55,7 +55,7 @@ public class HeartbeatMgrTest {
             {
                 env.getSelfNode();
                 minTimes = 0;
-                result = Pair.of("192.168.1.3", 9010); // not self
+                result = new HostInfo("192.168.1.3", null, 9010); // not self
 
                 env.isReady();
                 minTimes = 0;


### PR DESCRIPTION
# Proposed changes


## Problem summary

大体逻辑沿用#9172

### 关键改动点：
1. FE的nodename从ip_port_timestamp改为hostname_port_timestamp，如下图中的fe3就是这个实例在k8s中的域名：<img width="468" alt="image" src="https://user-images.githubusercontent.com/3899678/215979268-9be561be-9546-4ca3-a138-f9ce14936b49.png">
**原因**：为了避免IP变更后，其它FE实例的IP使用了该IP，比如FE3的原始IP为172.18.0.4，动态变更为172.18.0.50，而后新增了一个FE4，它的IP为172.18.0.4，这时如果还使用ip_port_timestamp形式，则无法直观的从name中区分彼此。
**风险点**：可能影响依赖Name解析ip、port的外部程序，无法识别正确的IP。

2. FDQNManager定期便利所有的FE，检查域名对应的IP是否已经改变，如果改变：
2.1 ~~通过BDBHA的updateAddress方法通知所有peers，保证bdbje层面的一致性。~~【现在直接以域名作为BDBJE的address，不需要更改IP时再更新】
2.2 改变master自身内存记录的IP
2.3 通过editlog同步给其它FE，改变其它follower内存中记录的FE ip信息。
3.  Frontend的meta持久化方式改为了json格式，方便后续字段的变更。
4. deploy manger K8s支持IP变更（delete pod后stateful自动加回，ip跟原始的不一致）

### Changes:

1. The nodename of FE changes from ip_port_timestamp to hostname_port_timestamp, as shown in the following figure, fe3 is the hostname of this instance in k8s:
<img width="468" alt="image" src="https://user-images.githubusercontent.com/3899678/215979268-9be561be-9546-4ca3-a138-f9ce14936b49.png">

**Reason**: To avoid the scenario that other FE instances use the changed IP after IP change, for example, the original IP of FE3 is 172.18.0.4, changed dynamically to 172.18.0.50, and later a new FE4 is added with IP 172.18.0.4, if the ip_port_timestamp form is still used, the existing program cannot distinguish each other from the name.

**Risk**: The external program that relies on Name resolution for IP and port recognition may be affected and cannot recognize the correct IP.

2. FDQNManager regularly visits all FEs to check if the IP corresponding to the hostname has changed. If changed:
2.1 Notify all peers through the updateAddress method of BDBHA to ensure consistency at the bdbje level.
2.2 Change the IP information recorded in memory by the master itself
2.3 Synchronize to other FEs through the editlog to change the IP information recorded in memory by other followers.
3. The persistence method of Frontend meta is changed to json format for ease of future field changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [x] Yes
    - [ ] No
    - [ ] I don't know
5. Has unit tests been added:
    - [x] Yes
    - [ ] No
    - [ ] No Need
6. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
7. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
8. Are there any changes that cannot be rolled back:
    - [x] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

