### PR TITLE
[bugfix](topn) fix topn runtime predicate getting value bug for decimal type

### DIFF
--- a/be/src/exec/olap_common.h
+++ b/be/src/exec/olap_common.h
@@ -45,7 +45,7 @@ std::string cast_to_string(T value, int scale) {
         std::stringstream ss;
         vectorized::write_text<int64_t>((int64_t)value, scale, ss);
         return ss.str();
-    } else if constexpr (primitive_type == TYPE_DECIMAL128I) {
+    } else if constexpr (primitive_type == TYPE_DECIMAL128I || primitive_type == TYPE_DECIMALV2) {
         std::stringstream ss;
         vectorized::write_text<int128_t>((int128_t)value, scale, ss);
         return ss.str();

--- a/be/src/exec/olap_common.h
+++ b/be/src/exec/olap_common.h
@@ -45,7 +45,7 @@ std::string cast_to_string(T value, int scale) {
         std::stringstream ss;
         vectorized::write_text<int64_t>((int64_t)value, scale, ss);
         return ss.str();
-    } else if constexpr (primitive_type == TYPE_DECIMAL128I || primitive_type == TYPE_DECIMALV2) {
+    } else if constexpr (primitive_type == TYPE_DECIMAL128I) {
         std::stringstream ss;
         vectorized::write_text<int128_t>((int128_t)value, scale, ss);
         return ss.str();

--- a/be/src/runtime/runtime_predicate.h
+++ b/be/src/runtime/runtime_predicate.h
@@ -147,30 +147,29 @@ private:
     }
 
     static std::string get_decimalv2_value(const Field& field) {
-        using ValueType = typename PrimitiveTypeTraits<TYPE_DECIMALV2>::CppType;
-        ValueType value;
+        // can NOT use PrimitiveTypeTraits<TYPE_DECIMAL128I>::CppType since
+        //   it is DecimalV2Value and Decimal128 can not convert to it implicitly
+        using ValueType = Decimal128::NativeType;
         auto v = field.get<DecimalField<Decimal128>>();
-        value.from_olap_decimal(v.get_value(), v.get_scale());
-        int scale = v.get_scale();
-        return cast_to_string<TYPE_DECIMALV2, ValueType>(value, scale);
+        return cast_to_string<TYPE_DECIMALV2, ValueType>(v.get_value(), v.get_scale());
     }
 
     static std::string get_decimal32_value(const Field& field) {
         using ValueType = typename PrimitiveTypeTraits<TYPE_DECIMAL32>::CppType;
-        ValueType value = field.get<ValueType>();
-        return cast_to_string<TYPE_DECIMAL32, ValueType>(value, 0);
+        auto v = field.get<DecimalField<Decimal32>>();
+        return cast_to_string<TYPE_DECIMAL32, ValueType>(v.get_value(), v.get_scale());
     }
 
     static std::string get_decimal64_value(const Field& field) {
         using ValueType = typename PrimitiveTypeTraits<TYPE_DECIMAL64>::CppType;
-        ValueType value = field.get<ValueType>();
-        return cast_to_string<TYPE_DECIMAL64, ValueType>(value, 0);
+        auto v = field.get<DecimalField<Decimal64>>();
+        return cast_to_string<TYPE_DECIMAL64, ValueType>(v.get_value(), v.get_scale());
     }
 
     static std::string get_decimal128_value(const Field& field) {
         using ValueType = typename PrimitiveTypeTraits<TYPE_DECIMAL128I>::CppType;
-        ValueType value = field.get<ValueType>();
-        return cast_to_string<TYPE_DECIMAL128I, ValueType>(value, 0);
+        auto v = field.get<DecimalField<Decimal128I>>();
+        return cast_to_string<TYPE_DECIMAL128I, ValueType>(v.get_value(), v.get_scale());
     }
 };
 

--- a/be/src/runtime/runtime_predicate.h
+++ b/be/src/runtime/runtime_predicate.h
@@ -147,11 +147,13 @@ private:
     }
 
     static std::string get_decimalv2_value(const Field& field) {
-        // can NOT use PrimitiveTypeTraits<TYPE_DECIMAL128I>::CppType since
+        // can NOT use PrimitiveTypeTraits<TYPE_DECIMALV2>::CppType since
         //   it is DecimalV2Value and Decimal128 can not convert to it implicitly
         using ValueType = Decimal128::NativeType;
         auto v = field.get<DecimalField<Decimal128>>();
-        return cast_to_string<TYPE_DECIMALV2, ValueType>(v.get_value(), v.get_scale());
+        // use TYPE_DECIMAL128I instead of TYPE_DECIMALV2 since v.get_scale()
+        //   is always 9 for DECIMALV2
+        return cast_to_string<TYPE_DECIMAL128I, ValueType>(v.get_value(), v.get_scale());
     }
 
     static std::string get_decimal32_value(const Field& field) {


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

Describe your changes.

The value pushed down for decimal type is wrong and cause datatype_p0/scalar_types/*_decimal_* test cases fail occasionally. This PR fix the bug getting the value.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

