### PR TITLE
[fix](join) crash caused by canceling query (Cherry-pick from #16311)

### DIFF
--- a/be/src/vec/exec/join/vhash_join_node.cpp
+++ b/be/src/vec/exec/join/vhash_join_node.cpp
@@ -1081,7 +1081,8 @@ std::vector<uint16_t> HashJoinNode::_convert_block_to_null(Block& block) {
 
 HashJoinNode::~HashJoinNode() {
     if (_shared_hashtable_controller && _should_build_hash_table) {
-        _shared_hashtable_controller->signal(id());
+        // signal at here is abnormal
+        _shared_hashtable_controller->signal(id(), Status::Cancelled("signaled in destructor"));
     }
 }
 

--- a/be/src/vec/runtime/shared_hash_table_controller.cpp
+++ b/be/src/vec/runtime/shared_hash_table_controller.cpp
@@ -42,6 +42,17 @@ SharedHashTableContextPtr SharedHashTableController::get_context(int my_node_id)
     return _shared_contexts[my_node_id];
 }
 
+void SharedHashTableController::signal(int my_node_id, Status status) {
+    std::lock_guard<std::mutex> lock(_mutex);
+    auto it = _shared_contexts.find(my_node_id);
+    if (it != _shared_contexts.cend()) {
+        it->second->signaled = true;
+        it->second->status = status;
+        _shared_contexts.erase(it);
+    }
+    _cv.notify_all();
+}
+
 void SharedHashTableController::signal(int my_node_id) {
     std::lock_guard<std::mutex> lock(_mutex);
     auto it = _shared_contexts.find(my_node_id);

--- a/be/src/vec/runtime/shared_hash_table_controller.h
+++ b/be/src/vec/runtime/shared_hash_table_controller.h
@@ -67,6 +67,7 @@ public:
     TUniqueId get_builder_fragment_instance_id(int my_node_id);
     SharedHashTableContextPtr get_context(int my_node_id);
     void signal(int my_node_id);
+    void signal(int my_node_id, Status status);
     Status wait_for_signal(RuntimeState* state, const SharedHashTableContextPtr& context);
     bool should_build_hash_table(const TUniqueId& fragment_instance_id, int my_node_id);
 


### PR DESCRIPTION
If the query was canceled,
the status in shared context may be `OK` with other fields not set.

# Proposed changes

Issue Number: close #xxx

## Problem summary

Cherry-pick from #16311

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

