### PR TITLE
[fix](broker) Fix bug that heavy broker load may failed due to BrokerException which indicate the fd is not owned by client

### DIFF
--- a/fs_brokers/apache_hdfs_broker/src/main/java/org/apache/doris/broker/hdfs/BrokerFileSystem.java
+++ b/fs_brokers/apache_hdfs_broker/src/main/java/org/apache/doris/broker/hdfs/BrokerFileSystem.java
@@ -31,7 +31,7 @@ public class BrokerFileSystem {
     private ReentrantLock lock;
     private FileSystemIdentity identity;
     private FileSystem dfsFileSystem;
-    private long lastAccessTimestamp;
+    private volatile long lastAccessTimestamp;
     private long createTimestamp;
     private UUID fileSystemId;
 


### PR DESCRIPTION
# Proposed changes

Issue Number: close #16348 

if broker is under heavy load, ping broker maybe timeout, but data transfer is normal, then lastPingTimestamp
cannot be updated in time would cause the following exception "org.apache.doris.broker.hdfs.BrokerException: the fd is not owned by client null", so here need to update access time when access ClientResourceContext

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

