### PR TITLE
[bug](jdbc) fix jdbc insert decimalv3 be core dump

### DIFF
--- a/be/src/exec/table_connector.cpp
+++ b/be/src/exec/table_connector.cpp
@@ -274,7 +274,8 @@ Status TableConnector::convert_column_data(const vectorized::ColumnPtr& column_p
     case TYPE_DECIMAL32:
     case TYPE_DECIMAL64:
     case TYPE_DECIMAL128I: {
-        auto val = type_ptr->to_string(*column, row);
+        auto decimal_type = remove_nullable(type_ptr);
+        auto val = decimal_type->to_string(*column, row);
         fmt::format_to(_insert_stmt_buffer, "{}", val);
         break;
     }


### PR DESCRIPTION
# Proposed changes
 *** Query id: bd140aca583140d9-aa826a4ce54283d6 ***
*** Aborted at 1675233072 (unix time) try "date -d @1675233072" if you are using GNU date ***
*** Current BE git commitID: fdb6eff6d ***
*** SIGSEGV unkown detail explain (@0x0) received by PID 1771670 (TID 1771894 OR 0x7f98dc05c700) from PID 0; stack trace: ***
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /mnt/disk1/ftw/projects/doris/be/src/common/signal_handler.h:428
 1# os::Linux::chained_handler(int, siginfo*, void*) in /mnt/disk1/ftw/tools/jdk1.8.0_131/jre/lib/amd64/server/libjvm.so
 2# JVM_handle_linux_signal in /mnt/disk1/ftw/tools/jdk1.8.0_131/jre/lib/amd64/server/libjvm.so
 3# signalHandler(int, siginfo*, void*) in /mnt/disk1/ftw/tools/jdk1.8.0_131/jre/lib/amd64/server/libjvm.so
 4# 0x00007F9938A11C20 in /lib64/libpthread.so.0
 5# doris::vectorized::DataTypeNullable::to_string[abi:cxx11](doris::vectorized::IColumn const&, unsigned long) const at /mnt/disk1/ftw/projects/doris/be/src/vec/data_types/data_type_nullable.cpp:48
 6# doris::TableConnector::convert_column_data(COW<doris::vectorized::IColumn>::immutable_ptr<doris::vectorized::IColumn> const&, std::shared_ptr<doris::vectorized::IDataType const> const&, doris::TypeDescriptor const&, int, doris::TOdbcTableType::type) at /mnt/disk1/ftw/projects/doris/be/src/exec/table_connector.cpp:279
 7# doris::TableConnector::append(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, doris::vectorized::Block*, std::vector<doris::vectorized::VExprContext*, std::allocator<doris::vectorized::VExprContext*> > const&, unsigned int, unsigned int*, doris::TOdbcTableType::type) at /mnt/disk1/ftw/projects/doris/be/src/runtime/types.h:39
 8# doris::vectorized::VJdbcTableSink::send(doris::RuntimeState*, doris::vectorized::Block*, bool) at /mnt/disk1/ftw/projects/doris/be/src/vec/sink/vjdbc_table_sink.cpp:83
 9# doris::PlanFragmentExecutor::open_vectorized_internal() at /mnt/disk1/ftw/projects/doris/be/src/runtime/plan_fragment_executor.cpp:298
10# doris::PlanFragmentExecutor::open() at /mnt/disk1/ftw/projects/doris/be/src/runtime/plan_fragment_executor.cpp:241
11# doris::FragmentExecState::execute() at /mnt/disk1/ftw/projects/doris/be/src/runtime/fragment_mgr.cpp:250
12# doris::FragmentMgr::_exec_actual(std::shared_ptr<doris::FragmentExecState>, std::function<void (doris::RuntimeState*, doris::Status*)>) at /mnt/disk1/ftw/projects/doris/be/src/runtime/fragment_mgr.cpp:490
13# std::_Function_handler<void (), doris::FragmentMgr::exec_plan_fragment(doris::TExecPlanFragmentParams const&, std::function<void (doris::RuntimeState*, doris::Status*)>)::{lambda()#1}>::_M_invoke(std::_Any_data const&) at /mnt/disk1/ftw/tools/ldb_toolchain/include/c++/11/bits/std_function.h:291
14# doris::ThreadPool::dispatch_thread() at /mnt/disk1/ftw/projects/doris/be/src/util/threadpool.cpp:543
15# doris::Thread::supervise_thread(void*) at /mnt/disk1/ftw/projects/doris/be/src/util/thread.cpp:454
16# start_thread in /lib64/libpthread.so.0
17# __GI___clone in /lib64/libc.so.6 
Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

