### PR TITLE
[Enhancement](profile) lazy load profileContent string 

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/ProfileManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/ProfileManager.java
@@ -95,13 +95,20 @@ public class ProfileManager {
         }
 
         private final RuntimeProfile profile;
+        // cache the result of getProfileContent method
+        private volatile String profileContent;
         public Map<String, String> infoStrings = Maps.newHashMap();
         public MultiProfileTreeBuilder builder = null;
         public String errMsg = "";
 
         // lazy load profileContent cause sometimes profileContent is very large
         public String getProfileContent() {
-            return profile.toString();
+            if (profileContent != null) {
+                return profileContent;
+            }
+            // no need to lock cause the possibility of concurrent read is very low
+            profileContent = profile.toString();
+            return profileContent;
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/ProfileManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/ProfileManager.java
@@ -101,7 +101,7 @@ public class ProfileManager {
         public MultiProfileTreeBuilder builder = null;
         public String errMsg = "";
 
-        // lazy load profileContent cause sometimes profileContent is very large
+        // lazy load profileContent because sometimes profileContent is very large
         public String getProfileContent() {
             if (profileContent != null) {
                 return profileContent;

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/ProfileManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/ProfileManager.java
@@ -106,7 +106,7 @@ public class ProfileManager {
             if (profileContent != null) {
                 return profileContent;
             }
-            // no need to lock cause the possibility of concurrent read is very low
+            // no need to lock because the possibility of concurrent read is very low
             profileContent = profile.toString();
             return profileContent;
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/RuntimeProfile.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/RuntimeProfile.java
@@ -48,8 +48,6 @@ public class RuntimeProfile {
     public static String ROOT_COUNTER = "";
     private Counter counterTotalTime;
     private double localTimePercent;
-    // cache the result of toString method
-    private volatile String profileContent;
 
     private Map<String, String> infoStrings = Maps.newHashMap();
     private List<String> infoStringsDisplayOrder = Lists.newArrayList();
@@ -270,14 +268,9 @@ public class RuntimeProfile {
     }
 
     public String toString() {
-        if (profileContent != null) {
-            return profileContent;
-        }
-        // no need to lock because the possibility of concurrent invoke is very low
         StringBuilder builder = new StringBuilder();
         prettyPrint(builder, "");
-        profileContent = builder.toString();
-        return profileContent;
+        return builder.toString();
     }
 
     private void printChildCounters(String prefix, String counterName, StringBuilder builder) {

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/RuntimeProfile.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/RuntimeProfile.java
@@ -48,6 +48,8 @@ public class RuntimeProfile {
     public static String ROOT_COUNTER = "";
     private Counter counterTotalTime;
     private double localTimePercent;
+    // cache the result of toString method
+    private volatile String profileContent;
 
     private Map<String, String> infoStrings = Maps.newHashMap();
     private List<String> infoStringsDisplayOrder = Lists.newArrayList();
@@ -268,9 +270,14 @@ public class RuntimeProfile {
     }
 
     public String toString() {
+        if (profileContent != null) {
+            return profileContent;
+        }
+        // no need to lock because the possibility of concurrent invoke is very low
         StringBuilder builder = new StringBuilder();
         prettyPrint(builder, "");
-        return builder.toString();
+        profileContent = builder.toString();
+        return profileContent;
     }
 
     private void printChildCounters(String prefix, String counterName, StringBuilder builder) {


### PR DESCRIPTION
Sometimes the `profileContent` of `ProfileElement` is very large (more than 30MB), and this kind of huge string object may cause performance problems for gc. But we use them only when we invoke profile relevant restful apis (such as `/profile/{format}/{query_id}`, `/api/profile` and so on), so we need to lazy load them.

# Proposed changes

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

