### PR TITLE
[improvement](testcase) change order by sql in test_dup_mv_bitmap_hash.groovy to make result stable

### DIFF
--- a/regression-test/data/materialized_view_p0/test_dup_mv_bitmap_hash/test_dup_mv_bitmap_hash.out
+++ b/regression-test/data/materialized_view_p0/test_dup_mv_bitmap_hash/test_dup_mv_bitmap_hash.out
@@ -4,10 +4,17 @@
 1
 1
 
+-- !select_k1 --
+1
+2
+2
+3
+3
+
 -- !select_star --
 1	1	a
-2	2	bb
 2	2	b
+2	2	bb
 3	3	c
 3	3	c
 

--- a/regression-test/suites/materialized_view_p0/test_dup_mv_bitmap_hash/test_dup_mv_bitmap_hash.groovy
+++ b/regression-test/suites/materialized_view_p0/test_dup_mv_bitmap_hash/test_dup_mv_bitmap_hash.groovy
@@ -69,7 +69,9 @@ suite ("test_dup_mv_bitmap_hash") {
     sql "insert into d_table select 2,2,'bb';"
     sql "insert into d_table select 3,3,'c';"
 
-    qt_select_star "select * from d_table order by k1;"
+    qt_select_k1 "select k1 from d_table order by k1;"
+
+    qt_select_star "select * from d_table order by k1,k2,k3;"
 
     explain {
         sql("select k1,bitmap_union_count(bitmap_hash(k3)) from d_table group by k1;")


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

Describe your changes.

The result of original order by sql `select * from d_table order by k1` is not guaranteed to be stable since k1 has duplicate values.

This pr change the order by sql to `select k1 from d_table order by k1` and `select * from d_table order by k1,k2,k3`.

> mysql> select * from d_table;
+------+------+------+
| k1   | k2   | k3   |
+------+------+------+
|    2 |    2 | b    |
|    2 |    2 | bb   |
|    1 |    1 | a    |
|    3 |    3 | c    |
|    3 |    3 | c    |
+------+------+------+
5 rows in set (0.01 sec)

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [x] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

