### PR TITLE
[refactor](Nereids) remove trick datatype code in Expression

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/Add.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/Add.java
@@ -44,7 +44,7 @@ public class Add extends BinaryArithmetic {
 
     @Override
     public DataType getDataType() {
-        return left().getDataType().promotion();
+        return super.getDataType().promotion();
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/BinaryArithmetic.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/BinaryArithmetic.java
@@ -23,7 +23,6 @@ import org.apache.doris.nereids.trees.expressions.functions.PropagateNullable;
 import org.apache.doris.nereids.trees.expressions.typecoercion.ImplicitCastInputTypes;
 import org.apache.doris.nereids.trees.expressions.visitor.ExpressionVisitor;
 import org.apache.doris.nereids.types.DataType;
-import org.apache.doris.nereids.util.TypeCoercionUtils;
 
 /**
  * binary arithmetic operator. Such as +, -, *, /.
@@ -43,17 +42,7 @@ public abstract class BinaryArithmetic extends BinaryOperator implements Propaga
 
     @Override
     public DataType getDataType() throws UnboundException {
-        if (left().getDataType().equals(right().getDataType())) {
-            return left().getDataType();
-        } else {
-            try {
-                return TypeCoercionUtils.findCommonNumericsType(left().getDataType(), right().getDataType());
-            } catch (Exception e) {
-                return TypeCoercionUtils.findTightestCommonType(this,
-                                left().getDataType(), right().getDataType())
-                        .orElseGet(() -> left().getDataType());
-            }
-        }
+        return left().getDataType();
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/CaseWhen.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/CaseWhen.java
@@ -21,7 +21,6 @@ import org.apache.doris.nereids.exceptions.UnboundException;
 import org.apache.doris.nereids.trees.expressions.functions.ExpressionTrait;
 import org.apache.doris.nereids.trees.expressions.visitor.ExpressionVisitor;
 import org.apache.doris.nereids.types.DataType;
-import org.apache.doris.nereids.util.TypeCoercionUtils;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
@@ -78,13 +77,7 @@ public class CaseWhen extends Expression {
 
     @Override
     public DataType getDataType() {
-        DataType outputType = child(0).getDataType();
-        for (Expression child : children) {
-            DataType tempType = outputType;
-            outputType = TypeCoercionUtils.findTightestCommonType(null,
-                    outputType, child.getDataType()).orElse(tempType);
-        }
-        return outputType;
+        return child(0).getDataType();
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/Multiply.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/Multiply.java
@@ -22,7 +22,6 @@ import org.apache.doris.nereids.trees.expressions.visitor.ExpressionVisitor;
 import org.apache.doris.nereids.types.DataType;
 import org.apache.doris.nereids.types.coercion.AbstractDataType;
 import org.apache.doris.nereids.types.coercion.NumericType;
-import org.apache.doris.nereids.util.TypeCoercionUtils;
 
 import com.google.common.base.Preconditions;
 
@@ -45,12 +44,7 @@ public class Multiply extends BinaryArithmetic {
 
     @Override
     public DataType getDataType() {
-        DataType rightType = child(0).getDataType();
-        DataType leftType = child(1).getDataType();
-        DataType outputType = TypeCoercionUtils.findTightestCommonType(this,
-                rightType, leftType).orElseGet(() -> rightType);
-        outputType = outputType.promotion();
-        return outputType;
+        return super.getDataType().promotion();
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/Subtract.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/Subtract.java
@@ -44,7 +44,7 @@ public class Subtract extends BinaryArithmetic {
 
     @Override
     public DataType getDataType() {
-        return left().getDataType().promotion();
+        return super.getDataType().promotion();
     }
 
     @Override


### PR DESCRIPTION
# Proposed changes

Since we already do typeCoercion bottom-up in binding step.
The trick codes of dataType in Expression are useless.
This PR try to remove them.


## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

