### PR TITLE
[fix](cooldown) Fix core in remove_all_remote_rowsets

### DIFF
--- a/be/src/olap/data_dir.cpp
+++ b/be/src/olap/data_dir.cpp
@@ -837,22 +837,28 @@ void DataDir::perform_remote_rowset_gc() {
     for (auto& [key, val] : gc_kvs) {
         auto rowset_id = key.substr(REMOTE_ROWSET_GC_PREFIX.size());
         RemoteRowsetGcPB gc_pb;
-        gc_pb.ParseFromString(val);
+        if (!gc_pb.ParseFromString(val)) {
+            LOG(WARNING) << "malformed RemoteRowsetGcPB. rowset_id=" << rowset_id;
+            deleted_keys.push_back(std::move(key));
+            continue;
+        }
         auto fs = get_filesystem(gc_pb.resource_id());
         if (!fs) {
             LOG(WARNING) << "Cannot get file system: " << gc_pb.resource_id();
             continue;
         }
         DCHECK(fs->type() != io::FileSystemType::LOCAL);
-        Status st;
+        bool success = true;
         for (int i = 0; i < gc_pb.num_segments(); ++i) {
             auto seg_path = BetaRowset::remote_segment_path(gc_pb.tablet_id(), rowset_id, i);
-            st = fs->delete_file(seg_path);
+            // TODO(plat1ko): batch delete
+            auto st = fs->delete_file(seg_path);
             if (!st.ok()) {
-                LOG(WARNING) << "failed to perform remote rowset gc, err=" << st;
+                LOG(WARNING) << "failed to delete remote rowset. err=" << st;
+                success = false;
             }
         }
-        if (st.ok()) {
+        if (success) {
             deleted_keys.push_back(std::move(key));
         }
     }
@@ -870,20 +876,30 @@ void DataDir::perform_remote_tablet_gc() {
     };
     _meta->iterate(META_COLUMN_FAMILY_INDEX, REMOTE_TABLET_GC_PREFIX, traverse_remote_tablet_func);
     std::vector<std::string> deleted_keys;
-    for (auto& [key, resource] : tablet_gc_kvs) {
+    for (auto& [key, val] : tablet_gc_kvs) {
         auto tablet_id = key.substr(REMOTE_TABLET_GC_PREFIX.size());
-        auto fs = get_filesystem(resource);
-        if (!fs) {
-            LOG(WARNING) << "could not get file system. resource_id=" << resource;
+        RemoteTabletGcPB gc_pb;
+        if (!gc_pb.ParseFromString(val)) {
+            LOG(WARNING) << "malformed RemoteTabletGcPB. tablet_id=" << tablet_id;
+            deleted_keys.push_back(std::move(key));
             continue;
         }
-        auto st = fs->delete_directory(DATA_PREFIX + '/' + tablet_id);
-        LOG(INFO) << "perform remote tablet gc. tablet_id=" << tablet_id;
-        if (st.ok()) {
+        bool success = true;
+        for (auto& resource_id : gc_pb.resource_ids()) {
+            auto fs = get_filesystem(resource_id);
+            if (!fs) {
+                LOG(WARNING) << "could not get file system. resource_id=" << resource_id;
+                success = false;
+                continue;
+            }
+            auto st = fs->delete_directory(DATA_PREFIX + '/' + tablet_id);
+            if (!st.ok()) {
+                LOG(WARNING) << "failed to delete all remote rowset in tablet. err=" << st;
+                success = false;
+            }
+        }
+        if (success) {
             deleted_keys.push_back(std::move(key));
-        } else {
-            LOG(WARNING) << "failed to perform remote tablet gc. tablet_id=" << tablet_id
-                         << ", reason: " << st;
         }
     }
     for (const auto& key : deleted_keys) {

--- a/be/src/olap/tablet_meta.cpp
+++ b/be/src/olap/tablet_meta.cpp
@@ -588,8 +588,9 @@ void TabletMeta::to_meta_pb(TabletMetaPB* tablet_meta_pb) {
     if (_preferred_rowset_type == BETA_ROWSET) {
         tablet_meta_pb->set_preferred_rowset_type(_preferred_rowset_type);
     }
-
-    tablet_meta_pb->set_storage_policy_id(_storage_policy_id);
+    if (_storage_policy_id > 0) {
+        tablet_meta_pb->set_storage_policy_id(_storage_policy_id);
+    }
     tablet_meta_pb->set_enable_unique_key_merge_on_write(_enable_unique_key_merge_on_write);
 
     if (_enable_unique_key_merge_on_write) {

--- a/be/test/olap/test_data/header_without_inc_rs.txt
+++ b/be/test/olap/test_data/header_without_inc_rs.txt
@@ -106,6 +106,5 @@
     "preferred_rowset_type": "BETA_ROWSET",
     "tablet_type": "TABLET_TYPE_DISK",
     "replica_id": 0,
-    "enable_unique_key_merge_on_write": false,
-    "storage_policy_id": 0
+    "enable_unique_key_merge_on_write": false
 }

--- a/gensrc/proto/olap_file.proto
+++ b/gensrc/proto/olap_file.proto
@@ -115,11 +115,16 @@ message RowsetMetaPB {
     optional SegmentsOverlapPB segments_overlap_pb = 51 [default = OVERLAP_UNKNOWN];
 }
 
-// unused remote rowsets garbage collection kv value
+// kv value for reclaiming remote rowset
 message RemoteRowsetGcPB {
     required string resource_id = 1;
     required int64 tablet_id = 2;
     required int64 num_segments = 3;
+}
+
+// kv value for reclaiming all remote rowsets of tablet
+message RemoteTabletGcPB {
+    repeated string resource_ids = 1;
 }
 
 enum DataFileType {


### PR DESCRIPTION
# Proposed changes

Issue Number: close #10986 

## Problem summary

Fix core and support reclaiming rowsets in multiple resources in a tablet.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

