### PR TITLE
[chore](regression-test) Remove array config in regression test

### DIFF
--- a/regression-test/suites/delete_p0/test_array_column_delete.groovy
+++ b/regression-test/suites/delete_p0/test_array_column_delete.groovy
@@ -18,8 +18,6 @@
 suite("test_array_column_delete") {
     def tableName = "test_array_column_delete"
 
-    sql "ADMIN SET FRONTEND CONFIG ('enable_array_type' = 'true')"
-
     sql """ DROP TABLE IF EXISTS ${tableName}; """
     sql """ CREATE TABLE IF NOT EXISTS ${tableName} (id INT NULL, c_array ARRAY<INT> NULL) ENGINE=OLAP DUPLICATE KEY(id) DISTRIBUTED BY HASH(id) BUCKETS 4 PROPERTIES ( "replication_allocation" = "tag.location.default: 1","in_memory" = "false","storage_format" = "V2") """
     sql """ insert into ${tableName} values(1, NULL),(2,[12,3]),(3,[]),(4,NULL),(5,NULL) """

--- a/regression-test/suites/nereids_p0/sql_functions/array_functions/test_array_functions_of_array_difference.groovy
+++ b/regression-test/suites/nereids_p0/sql_functions/array_functions/test_array_functions_of_array_difference.groovy
@@ -20,8 +20,6 @@ suite("test_array_functions_of_array_difference") {
     sql "SET enable_vectorized_engine=true"
     sql "SET enable_fallback_to_original_planner=false" 
     def tableName = "test_array_functions_of_array_difference"
-    // open enable_array_type
-    sql "ADMIN SET FRONTEND CONFIG ('enable_array_type' = 'true')"
     // array functions only supported in vectorized engine
     sql """DROP TABLE IF EXISTS ${tableName}"""
     sql """ 

--- a/regression-test/suites/query_p0/sql_functions/array_functions/test_array_functions_of_array_difference.groovy
+++ b/regression-test/suites/query_p0/sql_functions/array_functions/test_array_functions_of_array_difference.groovy
@@ -18,8 +18,6 @@
 suite("test_array_functions_of_array_difference") {
     def tableName = "test_array_functions_of_array_difference"
     // open enable_array_type
-    sql "ADMIN SET FRONTEND CONFIG ('enable_array_type' = 'true')"
-    // array functions only supported in vectorized engine
     sql """DROP TABLE IF EXISTS ${tableName}"""
     sql """ 
             CREATE TABLE IF NOT EXISTS ${tableName} (

--- a/regression-test/suites/query_p0/sql_functions/array_functions/test_array_functions_of_array_difference.groovy
+++ b/regression-test/suites/query_p0/sql_functions/array_functions/test_array_functions_of_array_difference.groovy
@@ -17,7 +17,7 @@
 
 suite("test_array_functions_of_array_difference") {
     def tableName = "test_array_functions_of_array_difference"
-    // open enable_array_type
+    // array functions only supported in vectorized engine
     sql """DROP TABLE IF EXISTS ${tableName}"""
     sql """ 
             CREATE TABLE IF NOT EXISTS ${tableName} (


### PR DESCRIPTION
# Proposed changes

The fe config "enable_array_type" is not used, this commit removes it from regression test.

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

