### PR TITLE
[fix](memory) Fix request jemallloc metrics wait lock `je_malloc_mutex_lock_slow`

### DIFF
--- a/be/src/common/daemon.cpp
+++ b/be/src/common/daemon.cpp
@@ -181,6 +181,7 @@ void Daemon::memory_maintenance_thread() {
         // Refresh allocator memory metrics.
 #if !defined(ADDRESS_SANITIZER) && !defined(LEAK_SANITIZER) && !defined(THREAD_SANITIZER)
         doris::MemInfo::refresh_allocator_mem();
+        DorisMetrics::instance()->system_metrics()->update_allocator_metrics();
 #endif
         doris::MemInfo::refresh_proc_mem_no_allocator_cache();
 

--- a/be/src/runtime/memory/jemalloc_hook.cpp
+++ b/be/src/runtime/memory/jemalloc_hook.cpp
@@ -28,6 +28,9 @@
 
 extern "C" {
 void* doris_malloc(size_t size) __THROW {
+    // Both je_nallocx and je_malloc will use the lock je_malloc_mutex_lock_slow,
+    // so enabling the jemalloc hook will double the lock usage.
+    // In extreme cases this will affect performance, consider turning off mem hook
     TRY_CONSUME_MEM_TRACKER(je_nallocx(size, 0), nullptr);
     void* ptr = je_malloc(size);
     if (UNLIKELY(ptr == nullptr)) {

--- a/be/src/util/system_metrics.cpp
+++ b/be/src/util/system_metrics.cpp
@@ -430,6 +430,9 @@ void SystemMetrics::_install_memory_metrics(MetricEntity* entity) {
 void SystemMetrics::_update_memory_metrics() {
     _memory_metrics->memory_allocated_bytes->set_value(PerfCounters::get_vm_rss());
     get_metrics_from_proc_vmstat();
+}
+
+void SystemMetrics::update_allocator_metrics() {
 #if defined(ADDRESS_SANITIZER) || defined(LEAK_SANITIZER) || defined(THREAD_SANITIZER)
     LOG(INFO) << "Memory tracking is not available with address sanitizer builds.";
 #elif defined(USE_JEMALLOC)

--- a/be/src/util/system_metrics.h
+++ b/be/src/util/system_metrics.h
@@ -55,6 +55,7 @@ public:
                                          int64_t interval_sec);
     void update_max_network_send_bytes_rate(int64_t max_send_bytes_rate);
     void update_max_network_receive_bytes_rate(int64_t max_receive_bytes_rate);
+    void update_allocator_metrics();
 
 private:
     void _install_cpu_metrics();


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

![image](https://user-images.githubusercontent.com/13197424/216555132-bb5f9c21-2ed1-411c-a757-d01cdbc2038b.png)
![image](https://user-images.githubusercontent.com/13197424/216555859-69178e4c-062e-4ec0-8aeb-3cbc6255a33d.png)
`MetricRegistry::trigger_all_hooks` holds the metrics lock and is stuck in `get_je_metrics`, `to_prometheus` is waiting for `MetricRegistry::trigger_all_hooks` to release the lock, so `get_je_metrics` is no longer called in `MetricRegistry::trigger_all_hooks`.


## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

