### PR TITLE
[Improvement](thrift) optimize thrift messages

### DIFF
--- a/be/src/exec/data_sink.cpp
+++ b/be/src/exec/data_sink.cpp
@@ -177,6 +177,146 @@ Status DataSink::create_data_sink(ObjectPool* pool, const TDataSink& thrift_sink
     return Status::OK();
 }
 
+Status DataSink::create_data_sink(ObjectPool* pool, const TDataSink& thrift_sink,
+                                  const std::vector<TExpr>& output_exprs,
+                                  const TPipelineParams& params, const size_t& local_param_idx,
+                                  const RowDescriptor& row_desc, RuntimeState* state,
+                                  std::unique_ptr<DataSink>* sink, DescriptorTbl& desc_tbl) {
+    DataSink* tmp_sink = nullptr;
+    TPipelineLocalParams local_params = params.local_params[local_param_idx];
+    switch (thrift_sink.type) {
+    case TDataSinkType::DATA_STREAM_SINK: {
+        if (!thrift_sink.__isset.stream_sink) {
+            return Status::InternalError("Missing data stream sink.");
+        }
+        bool send_query_statistics_with_every_batch =
+                params.__isset.send_query_statistics_with_every_batch
+                        ? params.send_query_statistics_with_every_batch
+                        : false;
+        // TODO: figure out good buffer size based on size of output row
+        tmp_sink = new vectorized::VDataStreamSender(
+                state, pool, local_params.sender_id, row_desc, thrift_sink.stream_sink,
+                params.destinations, 16 * 1024, send_query_statistics_with_every_batch);
+        // RETURN_IF_ERROR(sender->prepare(state->obj_pool(), thrift_sink.stream_sink));
+        sink->reset(tmp_sink);
+        break;
+    }
+    case TDataSinkType::RESULT_SINK: {
+        if (!thrift_sink.__isset.result_sink) {
+            return Status::InternalError("Missing data buffer sink.");
+        }
+
+        // TODO: figure out good buffer size based on size of output row
+        tmp_sink = new doris::vectorized::VResultSink(row_desc, output_exprs,
+                                                      thrift_sink.result_sink, 4096);
+        sink->reset(tmp_sink);
+        break;
+    }
+    case TDataSinkType::RESULT_FILE_SINK: {
+        if (!thrift_sink.__isset.result_file_sink) {
+            return Status::InternalError("Missing result file sink.");
+        }
+
+        // TODO: figure out good buffer size based on size of output row
+        bool send_query_statistics_with_every_batch =
+                params.__isset.send_query_statistics_with_every_batch
+                        ? params.send_query_statistics_with_every_batch
+                        : false;
+        // Result file sink is not the top sink
+        if (params.__isset.destinations && params.destinations.size() > 0) {
+            tmp_sink = new doris::vectorized::VResultFileSink(
+                    pool, local_params.sender_id, row_desc, thrift_sink.result_file_sink,
+                    params.destinations, 16 * 1024, send_query_statistics_with_every_batch,
+                    output_exprs, desc_tbl);
+        } else {
+            tmp_sink = new doris::vectorized::VResultFileSink(
+                    pool, row_desc, thrift_sink.result_file_sink, 16 * 1024,
+                    send_query_statistics_with_every_batch, output_exprs);
+        }
+
+        sink->reset(tmp_sink);
+        break;
+    }
+    case TDataSinkType::MEMORY_SCRATCH_SINK: {
+        if (!thrift_sink.__isset.memory_scratch_sink) {
+            return Status::InternalError("Missing data buffer sink.");
+        }
+
+        tmp_sink = new vectorized::MemoryScratchSink(row_desc, output_exprs,
+                                                     thrift_sink.memory_scratch_sink, pool);
+        sink->reset(tmp_sink);
+        break;
+    }
+    case TDataSinkType::MYSQL_TABLE_SINK: {
+#ifdef DORIS_WITH_MYSQL
+        if (!thrift_sink.__isset.mysql_table_sink) {
+            return Status::InternalError("Missing data buffer sink.");
+        }
+        doris::vectorized::VMysqlTableSink* vmysql_tbl_sink =
+                new doris::vectorized::VMysqlTableSink(pool, row_desc, output_exprs);
+        sink->reset(vmysql_tbl_sink);
+        break;
+#else
+        return Status::InternalError(
+                "Don't support MySQL table, you should rebuild Doris with WITH_MYSQL option ON");
+#endif
+    }
+    case TDataSinkType::ODBC_TABLE_SINK: {
+        if (!thrift_sink.__isset.odbc_table_sink) {
+            return Status::InternalError("Missing data odbc sink.");
+        }
+        sink->reset(new vectorized::VOdbcTableSink(pool, row_desc, output_exprs));
+        break;
+    }
+
+    case TDataSinkType::JDBC_TABLE_SINK: {
+        if (!thrift_sink.__isset.jdbc_table_sink) {
+            return Status::InternalError("Missing data jdbc sink.");
+        }
+        if (config::enable_java_support) {
+            sink->reset(new vectorized::VJdbcTableSink(pool, row_desc, output_exprs));
+        } else {
+            return Status::InternalError(
+                    "Jdbc table sink is not enabled, you can change be config "
+                    "enable_java_support to true and restart be.");
+        }
+        break;
+    }
+
+    case TDataSinkType::EXPORT_SINK: {
+        RETURN_ERROR_IF_NON_VEC;
+        break;
+    }
+    case TDataSinkType::OLAP_TABLE_SINK: {
+        Status status;
+        DCHECK(thrift_sink.__isset.olap_table_sink);
+        sink->reset(new stream_load::VOlapTableSink(pool, row_desc, output_exprs, &status));
+        RETURN_IF_ERROR(status);
+        break;
+    }
+
+    default: {
+        std::stringstream error_msg;
+        std::map<int, const char*>::const_iterator i =
+                _TDataSinkType_VALUES_TO_NAMES.find(thrift_sink.type);
+        const char* str = "Unknown data sink type ";
+
+        if (i != _TDataSinkType_VALUES_TO_NAMES.end()) {
+            str = i->second;
+        }
+
+        error_msg << str << " not implemented.";
+        return Status::InternalError(error_msg.str());
+    }
+    }
+
+    if (*sink != nullptr) {
+        RETURN_IF_ERROR((*sink)->init(thrift_sink));
+    }
+
+    return Status::OK();
+}
+
 Status DataSink::init(const TDataSink& thrift_sink) {
     return Status::OK();
 }

--- a/be/src/exec/data_sink.cpp
+++ b/be/src/exec/data_sink.cpp
@@ -179,11 +179,12 @@ Status DataSink::create_data_sink(ObjectPool* pool, const TDataSink& thrift_sink
 
 Status DataSink::create_data_sink(ObjectPool* pool, const TDataSink& thrift_sink,
                                   const std::vector<TExpr>& output_exprs,
-                                  const TPipelineParams& params, const size_t& local_param_idx,
-                                  const RowDescriptor& row_desc, RuntimeState* state,
-                                  std::unique_ptr<DataSink>* sink, DescriptorTbl& desc_tbl) {
+                                  const TPipelineFragmentParams& params,
+                                  const size_t& local_param_idx, const RowDescriptor& row_desc,
+                                  RuntimeState* state, std::unique_ptr<DataSink>* sink,
+                                  DescriptorTbl& desc_tbl) {
     DataSink* tmp_sink = nullptr;
-    TPipelineLocalParams local_params = params.local_params[local_param_idx];
+    const auto& local_params = params.local_params[local_param_idx];
     switch (thrift_sink.type) {
     case TDataSinkType::DATA_STREAM_SINK: {
         if (!thrift_sink.__isset.stream_sink) {

--- a/be/src/exec/data_sink.h
+++ b/be/src/exec/data_sink.h
@@ -78,6 +78,12 @@ public:
                                    const RowDescriptor& row_desc, RuntimeState* state,
                                    std::unique_ptr<DataSink>* sink, DescriptorTbl& desc_tbl);
 
+    static Status create_data_sink(ObjectPool* pool, const TDataSink& thrift_sink,
+                                   const std::vector<TExpr>& output_exprs,
+                                   const TPipelineParams& params, const size_t& local_param_idx,
+                                   const RowDescriptor& row_desc, RuntimeState* state,
+                                   std::unique_ptr<DataSink>* sink, DescriptorTbl& desc_tbl);
+
     // Returns the runtime profile for the sink.
     virtual RuntimeProfile* profile() = 0;
 

--- a/be/src/exec/data_sink.h
+++ b/be/src/exec/data_sink.h
@@ -80,9 +80,10 @@ public:
 
     static Status create_data_sink(ObjectPool* pool, const TDataSink& thrift_sink,
                                    const std::vector<TExpr>& output_exprs,
-                                   const TPipelineParams& params, const size_t& local_param_idx,
-                                   const RowDescriptor& row_desc, RuntimeState* state,
-                                   std::unique_ptr<DataSink>* sink, DescriptorTbl& desc_tbl);
+                                   const TPipelineFragmentParams& params,
+                                   const size_t& local_param_idx, const RowDescriptor& row_desc,
+                                   RuntimeState* state, std::unique_ptr<DataSink>* sink,
+                                   DescriptorTbl& desc_tbl);
 
     // Returns the runtime profile for the sink.
     virtual RuntimeProfile* profile() = 0;

--- a/be/src/pipeline/pipeline_fragment_context.cpp
+++ b/be/src/pipeline/pipeline_fragment_context.cpp
@@ -88,11 +88,12 @@ using apache::thrift::TException;
 namespace doris::pipeline {
 
 PipelineFragmentContext::PipelineFragmentContext(
-        const TUniqueId& query_id, const TUniqueId& instance_id, int backend_num,
-        std::shared_ptr<QueryFragmentsCtx> query_ctx, ExecEnv* exec_env,
+        const TUniqueId& query_id, const TUniqueId& instance_id, const int fragment_id,
+        int backend_num, std::shared_ptr<QueryFragmentsCtx> query_ctx, ExecEnv* exec_env,
         std::function<void(RuntimeState*, Status*)> call_back)
         : _query_id(query_id),
-          _fragment_id(instance_id),
+          _fragment_instance_id(instance_id),
+          _fragment_id(fragment_id),
           _backend_num(backend_num),
           _exec_env(exec_env),
           _cancel_reason(PPlanFragmentCancelReason::INTERNAL_ERROR),
@@ -125,7 +126,7 @@ void PipelineFragmentContext::cancel(const PPlanFragmentCancelReason& reason,
         _query_ctx->set_ready_to_execute(true);
 
         // must close stream_mgr to avoid dead lock in Exchange Node
-        _exec_env->vstream_mgr()->cancel(_fragment_id);
+        _exec_env->vstream_mgr()->cancel(_fragment_instance_id);
         // Cancel the result queue manager used by spark doris connector
         // TODO pipeline incomp
         // _exec_env->result_queue_mgr()->update_queue_status(id, Status::Aborted(msg));
@@ -272,8 +273,164 @@ Status PipelineFragmentContext::prepare(const doris::TExecPlanFragmentParams& re
     return Status::OK();
 }
 
+Status PipelineFragmentContext::prepare(const doris::TPipelineParams& request, const size_t idx) {
+    if (_prepared) {
+        return Status::InternalError("Already prepared");
+    }
+    TPipelineLocalParams local_params = request.local_params[idx];
+    _runtime_profile.reset(new RuntimeProfile("PipelineContext"));
+    _start_timer = ADD_TIMER(_runtime_profile, "StartTime");
+    COUNTER_UPDATE(_start_timer, _fragment_watcher.elapsed_time());
+    _prepare_timer = ADD_TIMER(_runtime_profile, "PrepareTime");
+    SCOPED_TIMER(_prepare_timer);
+
+    auto* fragment_context = this;
+    OpentelemetryTracer tracer = telemetry::get_noop_tracer();
+    if (opentelemetry::trace::Tracer::GetCurrentSpan()->GetContext().IsValid()) {
+        tracer = telemetry::get_tracer(print_id(_query_id));
+    }
+    START_AND_SCOPE_SPAN(tracer, span, "PipelineFragmentExecutor::prepare");
+
+    LOG_INFO("PipelineFragmentContext::prepare")
+            .tag("query_id", _query_id)
+            .tag("instance_id", local_params.fragment_instance_id)
+            .tag("backend_num", local_params.backend_num)
+            .tag("pthread_id", (uintptr_t)pthread_self());
+
+    // 1. init _runtime_state
+    _runtime_state =
+            std::make_unique<RuntimeState>(local_params, request.query_id, request.query_options,
+                                           _query_ctx->query_globals, _exec_env);
+    _runtime_state->set_query_fragments_ctx(_query_ctx.get());
+    _runtime_state->set_query_mem_tracker(_query_ctx->query_mem_tracker);
+    _runtime_state->set_tracer(std::move(tracer));
+
+    // TODO should be combine with plan_fragment_executor.prepare funciton
+    SCOPED_ATTACH_TASK(get_runtime_state());
+    _runtime_state->runtime_filter_mgr()->init();
+    _runtime_state->set_be_number(local_params.backend_num);
+
+    if (request.__isset.backend_id) {
+        _runtime_state->set_backend_id(request.backend_id);
+    }
+    if (request.__isset.import_label) {
+        _runtime_state->set_import_label(request.import_label);
+    }
+    if (request.__isset.db_name) {
+        _runtime_state->set_db_name(request.db_name);
+    }
+    if (request.__isset.load_job_id) {
+        _runtime_state->set_load_job_id(request.load_job_id);
+    }
+
+    if (request.query_options.__isset.is_report_success) {
+        fragment_context->set_is_report_success(request.query_options.is_report_success);
+    }
+
+    auto* desc_tbl = _query_ctx->desc_tbl;
+    _runtime_state->set_desc_tbl(desc_tbl);
+
+    // 2. Create ExecNode to build pipeline with PipelineFragmentContext
+    RETURN_IF_ERROR(ExecNode::create_tree(_runtime_state.get(), _runtime_state->obj_pool(),
+                                          request.fragment.plan, *desc_tbl, &_root_plan));
+
+    // Set senders of exchange nodes before pipeline build
+    std::vector<ExecNode*> exch_nodes;
+    _root_plan->collect_nodes(TPlanNodeType::EXCHANGE_NODE, &exch_nodes);
+    for (ExecNode* exch_node : exch_nodes) {
+        DCHECK_EQ(exch_node->type(), TPlanNodeType::EXCHANGE_NODE);
+        int num_senders = find_with_default(request.per_exch_num_senders, exch_node->id(), 0);
+        DCHECK_GT(num_senders, 0);
+        static_cast<vectorized::VExchangeNode*>(exch_node)->set_num_senders(num_senders);
+    }
+
+    // All prepare work do in exec node tree
+    RETURN_IF_ERROR(_root_plan->prepare(_runtime_state.get()));
+    // set scan ranges
+    std::vector<ExecNode*> scan_nodes;
+    std::vector<TScanRangeParams> no_scan_ranges;
+    _root_plan->collect_scan_nodes(&scan_nodes);
+    VLOG_CRITICAL << "scan_nodes.size()=" << scan_nodes.size();
+    VLOG_CRITICAL << "params.per_node_scan_ranges.size()="
+                  << local_params.per_node_scan_ranges.size();
+
+    _root_plan->try_do_aggregate_serde_improve();
+    // set scan range in ScanNode
+    for (int i = 0; i < scan_nodes.size(); ++i) {
+        // TODO(cmy): this "if...else" should be removed once all ScanNode are derived from VScanNode.
+        ExecNode* node = scan_nodes[i];
+        if (typeid(*node) == typeid(vectorized::NewOlapScanNode) ||
+            typeid(*node) == typeid(vectorized::NewFileScanNode) // ||
+//            typeid(*node) == typeid(vectorized::NewOdbcScanNode) ||
+//            typeid(*node) == typeid(vectorized::NewEsScanNode)
+#ifdef LIBJVM
+//            || typeid(*node) == typeid(vectorized::NewJdbcScanNode)
+#endif
+        ) {
+            auto* scan_node = static_cast<vectorized::VScanNode*>(scan_nodes[i]);
+            const std::vector<TScanRangeParams>& scan_ranges = find_with_default(
+                    local_params.per_node_scan_ranges, scan_node->id(), no_scan_ranges);
+            scan_node->set_scan_ranges(scan_ranges);
+        } else {
+            ScanNode* scan_node = static_cast<ScanNode*>(scan_nodes[i]);
+            const std::vector<TScanRangeParams>& scan_ranges = find_with_default(
+                    local_params.per_node_scan_ranges, scan_node->id(), no_scan_ranges);
+            scan_node->set_scan_ranges(scan_ranges);
+            VLOG_CRITICAL << "scan_node_Id=" << scan_node->id() << " size=" << scan_ranges.size();
+        }
+    }
+
+    _runtime_state->set_per_fragment_instance_idx(local_params.sender_id);
+    _runtime_state->set_num_per_fragment_instances(request.num_senders);
+
+    if (request.fragment.__isset.output_sink) {
+        RETURN_IF_ERROR(DataSink::create_data_sink(
+                _runtime_state->obj_pool(), request.fragment.output_sink,
+                request.fragment.output_exprs, request, idx, _root_plan->row_desc(),
+                _runtime_state.get(), &_sink, *desc_tbl));
+    }
+
+    _root_pipeline = fragment_context->add_pipeline();
+    RETURN_IF_ERROR(_build_pipelines(_root_plan, _root_pipeline));
+    if (_sink) {
+        RETURN_IF_ERROR(_create_sink(request.fragment.output_sink));
+    }
+    RETURN_IF_ERROR(_build_pipeline_tasks(request));
+    if (_sink) {
+        _runtime_state->runtime_profile()->add_child(_sink->profile(), true, nullptr);
+    }
+    _runtime_state->runtime_profile()->add_child(_root_plan->runtime_profile(), true, nullptr);
+    _runtime_state->runtime_profile()->add_child(_runtime_profile.get(), true, nullptr);
+
+    _prepared = true;
+    return Status::OK();
+}
+
 Status PipelineFragmentContext::_build_pipeline_tasks(
         const doris::TExecPlanFragmentParams& request) {
+    for (PipelinePtr& pipeline : _pipelines) {
+        // if sink
+        auto sink = pipeline->sink()->build_operator();
+        // TODO pipeline 1 need to add new interface for exec node and operator
+        sink->init(request.fragment.output_sink);
+
+        Operators operators;
+        RETURN_IF_ERROR(pipeline->build_operators(operators));
+        auto task = std::make_unique<PipelineTask>(pipeline, 0, _runtime_state.get(), operators,
+                                                   sink, this, pipeline->pipeline_profile());
+        sink->set_child(task->get_root());
+        _tasks.emplace_back(std::move(task));
+        _runtime_profile->add_child(pipeline->pipeline_profile(), true, nullptr);
+    }
+
+    for (auto& task : _tasks) {
+        RETURN_IF_ERROR(task->prepare(_runtime_state.get()));
+    }
+    _total_tasks = _tasks.size();
+    return Status::OK();
+}
+
+Status PipelineFragmentContext::_build_pipeline_tasks(const doris::TPipelineParams& request) {
     for (PipelinePtr& pipeline : _pipelines) {
         // if sink
         auto sink = pipeline->sink()->build_operator();
@@ -651,7 +808,8 @@ void PipelineFragmentContext::send_report(bool done) {
     params.protocol_version = FrontendServiceVersion::V1;
     params.__set_query_id(_query_id);
     params.__set_backend_num(_backend_num);
-    params.__set_fragment_instance_id(_fragment_id);
+    params.__set_fragment_instance_id(_fragment_instance_id);
+    params.__set_fragment_id(_fragment_id);
     exec_status.set_t_status(&params);
     params.__set_done(true);
 
@@ -736,8 +894,8 @@ void PipelineFragmentContext::send_report(bool done) {
             coord->reportExecStatus(res, params);
         } catch (TTransportException& e) {
             LOG(WARNING) << "Retrying ReportExecStatus. query id: " << print_id(_query_id)
-                         << ", instance id: " << print_id(_fragment_id) << " to " << coord_addr
-                         << ", err: " << e.what();
+                         << ", instance id: " << print_id(_fragment_instance_id) << " to "
+                         << coord_addr << ", err: " << e.what();
             rpc_status = coord.reopen();
 
             if (!rpc_status.ok()) {

--- a/be/src/pipeline/pipeline_fragment_context.cpp
+++ b/be/src/pipeline/pipeline_fragment_context.cpp
@@ -273,11 +273,12 @@ Status PipelineFragmentContext::prepare(const doris::TExecPlanFragmentParams& re
     return Status::OK();
 }
 
-Status PipelineFragmentContext::prepare(const doris::TPipelineParams& request, const size_t idx) {
+Status PipelineFragmentContext::prepare(const doris::TPipelineFragmentParams& request,
+                                        const size_t idx) {
     if (_prepared) {
         return Status::InternalError("Already prepared");
     }
-    TPipelineLocalParams local_params = request.local_params[idx];
+    const auto& local_params = request.local_params[idx];
     _runtime_profile.reset(new RuntimeProfile("PipelineContext"));
     _start_timer = ADD_TIMER(_runtime_profile, "StartTime");
     COUNTER_UPDATE(_start_timer, _fragment_watcher.elapsed_time());
@@ -430,7 +431,8 @@ Status PipelineFragmentContext::_build_pipeline_tasks(
     return Status::OK();
 }
 
-Status PipelineFragmentContext::_build_pipeline_tasks(const doris::TPipelineParams& request) {
+Status PipelineFragmentContext::_build_pipeline_tasks(
+        const doris::TPipelineFragmentParams& request) {
     for (PipelinePtr& pipeline : _pipelines) {
         // if sink
         auto sink = pipeline->sink()->build_operator();

--- a/be/src/pipeline/pipeline_fragment_context.h
+++ b/be/src/pipeline/pipeline_fragment_context.h
@@ -38,15 +38,15 @@ class PipelineTask;
 class PipelineFragmentContext : public std::enable_shared_from_this<PipelineFragmentContext> {
 public:
     PipelineFragmentContext(const TUniqueId& query_id, const TUniqueId& instance_id,
-                            int backend_num, std::shared_ptr<QueryFragmentsCtx> query_ctx,
-                            ExecEnv* exec_env,
+                            const int fragment_id, int backend_num,
+                            std::shared_ptr<QueryFragmentsCtx> query_ctx, ExecEnv* exec_env,
                             std::function<void(RuntimeState*, Status*)> call_back);
 
     ~PipelineFragmentContext();
 
     PipelinePtr add_pipeline();
 
-    TUniqueId get_fragment_id() { return _fragment_id; }
+    TUniqueId get_fragment_instance_id() { return _fragment_instance_id; }
 
     RuntimeState* get_runtime_state() { return _runtime_state.get(); }
 
@@ -56,6 +56,8 @@ public:
     int32_t next_operator_builder_id() { return _next_operator_builder_id++; }
 
     Status prepare(const doris::TExecPlanFragmentParams& request);
+
+    Status prepare(const doris::TPipelineParams& request, const size_t idx);
 
     Status submit();
 
@@ -93,7 +95,8 @@ public:
 private:
     // Id of this query
     TUniqueId _query_id;
-    TUniqueId _fragment_id;
+    TUniqueId _fragment_instance_id;
+    int _fragment_id;
 
     int _backend_num;
 
@@ -142,6 +145,7 @@ private:
     Status _create_sink(const TDataSink& t_data_sink);
     Status _build_pipelines(ExecNode*, PipelinePtr);
     Status _build_pipeline_tasks(const doris::TExecPlanFragmentParams& request);
+    Status _build_pipeline_tasks(const doris::TPipelineParams& request);
 
     template <bool is_intersect>
     Status _build_operators_for_set_operation_node(ExecNode*, PipelinePtr);

--- a/be/src/pipeline/pipeline_fragment_context.h
+++ b/be/src/pipeline/pipeline_fragment_context.h
@@ -57,7 +57,7 @@ public:
 
     Status prepare(const doris::TExecPlanFragmentParams& request);
 
-    Status prepare(const doris::TPipelineParams& request, const size_t idx);
+    Status prepare(const doris::TPipelineFragmentParams& request, const size_t idx);
 
     Status submit();
 
@@ -145,7 +145,7 @@ private:
     Status _create_sink(const TDataSink& t_data_sink);
     Status _build_pipelines(ExecNode*, PipelinePtr);
     Status _build_pipeline_tasks(const doris::TExecPlanFragmentParams& request);
-    Status _build_pipeline_tasks(const doris::TPipelineParams& request);
+    Status _build_pipeline_tasks(const doris::TPipelineFragmentParams& request);
 
     template <bool is_intersect>
     Status _build_operators_for_set_operation_node(ExecNode*, PipelinePtr);

--- a/be/src/pipeline/task_scheduler.cpp
+++ b/be/src/pipeline/task_scheduler.cpp
@@ -106,7 +106,7 @@ void BlockedTaskScheduler::_schedule() {
                 LOG(WARNING) << "Timeout, query_id="
                              << print_id(task->query_fragments_context()->query_id)
                              << ", instance_id="
-                             << print_id(task->fragment_context()->get_fragment_id());
+                             << print_id(task->fragment_context()->get_fragment_instance_id());
 
                 task->fragment_context()->cancel(PPlanFragmentCancelReason::TIMEOUT);
 

--- a/be/src/runtime/fragment_mgr.cpp
+++ b/be/src/runtime/fragment_mgr.cpp
@@ -530,6 +530,11 @@ Status FragmentMgr::exec_plan_fragment(const TExecPlanFragmentParams& params) {
     }
 }
 
+Status FragmentMgr::exec_plan_fragment(const TPipelineParams& params) {
+    // TODO
+    return exec_plan_fragment(params, empty_function);
+}
+
 Status FragmentMgr::start_query_execution(const PExecPlanFragmentStartRequest* request) {
     std::lock_guard<std::mutex> lock(_lock);
     TUniqueId query_id;
@@ -586,7 +591,7 @@ void FragmentMgr::remove_pipeline_context(
     auto query_id = f_context->get_query_id();
     auto* q_context = f_context->get_query_context();
     bool all_done = q_context->countdown();
-    _pipeline_map.erase(f_context->get_fragment_id());
+    _pipeline_map.erase(f_context->get_fragment_instance_id());
     if (all_done) {
         _fragments_ctx_map.erase(query_id);
     }
@@ -750,7 +755,7 @@ Status FragmentMgr::exec_plan_fragment(const TExecPlanFragmentParams& params, Fi
                                                    fragments_ctx.get());
         std::shared_ptr<pipeline::PipelineFragmentContext> context =
                 std::make_shared<pipeline::PipelineFragmentContext>(
-                        fragments_ctx->query_id, fragment_instance_id, params.backend_num,
+                        fragments_ctx->query_id, fragment_instance_id, -1, params.backend_num,
                         fragments_ctx, _exec_env, cb);
         {
             SCOPED_RAW_TIMER(&duration_ns);
@@ -777,6 +782,157 @@ Status FragmentMgr::exec_plan_fragment(const TExecPlanFragmentParams& params, Fi
     return Status::OK();
 }
 
+Status FragmentMgr::exec_plan_fragment(const TPipelineParams& params, FinishCallback cb) {
+    auto tracer = telemetry::is_current_span_valid() ? telemetry::get_tracer("tracer")
+                                                     : telemetry::get_noop_tracer();
+    VLOG_ROW << "exec_plan_fragment params is "
+             << apache::thrift::ThriftDebugString(params).c_str();
+    // sometimes TExecPlanFragmentParams debug string is too long and glog
+    // will truncate the log line, so print query options seperately for debuggin purpose
+    VLOG_ROW << "query options is "
+             << apache::thrift::ThriftDebugString(params.query_options).c_str();
+    START_AND_SCOPE_SPAN(tracer, span, "FragmentMgr::exec_plan_fragment");
+
+    std::shared_ptr<FragmentExecState> exec_state;
+    std::shared_ptr<QueryFragmentsCtx> fragments_ctx;
+    if (params.is_simplified_param) {
+        // Get common components from _fragments_ctx_map
+        std::lock_guard<std::mutex> lock(_lock);
+        auto search = _fragments_ctx_map.find(params.query_id);
+        if (search == _fragments_ctx_map.end()) {
+            return Status::InternalError(
+                    "Failed to get query fragments context. Query may be "
+                    "timeout or be cancelled. host: {}",
+                    BackendOptions::get_localhost());
+        }
+        fragments_ctx = search->second;
+    } else {
+        // This may be a first fragment request of the query.
+        // Create the query fragments context.
+        fragments_ctx.reset(new QueryFragmentsCtx(params.fragment_num_on_host, _exec_env));
+        fragments_ctx->query_id = params.query_id;
+        RETURN_IF_ERROR(DescriptorTbl::create(&(fragments_ctx->obj_pool), params.desc_tbl,
+                                              &(fragments_ctx->desc_tbl)));
+        fragments_ctx->coord_addr = params.coord;
+        LOG(INFO) << "query_id: "
+                  << UniqueId(fragments_ctx->query_id.hi, fragments_ctx->query_id.lo)
+                  << " coord_addr " << fragments_ctx->coord_addr
+                  << " total fragment num on current host: " << params.fragment_num_on_host;
+        fragments_ctx->query_globals = params.query_globals;
+
+        if (params.__isset.resource_info) {
+            fragments_ctx->user = params.resource_info.user;
+            fragments_ctx->group = params.resource_info.group;
+            fragments_ctx->set_rsc_info = true;
+        }
+
+        fragments_ctx->get_shared_hash_table_controller()->set_pipeline_engine_enabled(true);
+        fragments_ctx->timeout_second = params.query_options.query_timeout;
+        _set_scan_concurrency(params, fragments_ctx.get());
+
+        bool has_query_mem_tracker =
+                params.query_options.__isset.mem_limit && (params.query_options.mem_limit > 0);
+        int64_t bytes_limit = has_query_mem_tracker ? params.query_options.mem_limit : -1;
+        if (bytes_limit > MemInfo::mem_limit()) {
+            VLOG_NOTICE << "Query memory limit " << PrettyPrinter::print(bytes_limit, TUnit::BYTES)
+                        << " exceeds process memory limit of "
+                        << PrettyPrinter::print(MemInfo::mem_limit(), TUnit::BYTES)
+                        << ". Using process memory limit instead";
+            bytes_limit = MemInfo::mem_limit();
+        }
+        if (params.query_options.query_type == TQueryType::SELECT) {
+            fragments_ctx->query_mem_tracker = std::make_shared<MemTrackerLimiter>(
+                    MemTrackerLimiter::Type::QUERY,
+                    fmt::format("Query#Id={}", print_id(fragments_ctx->query_id)), bytes_limit);
+        } else if (params.query_options.query_type == TQueryType::LOAD) {
+            fragments_ctx->query_mem_tracker = std::make_shared<MemTrackerLimiter>(
+                    MemTrackerLimiter::Type::LOAD,
+                    fmt::format("Load#Id={}", print_id(fragments_ctx->query_id)), bytes_limit);
+        } else { // EXTERNAL
+            fragments_ctx->query_mem_tracker = std::make_shared<MemTrackerLimiter>(
+                    MemTrackerLimiter::Type::LOAD,
+                    fmt::format("External#Id={}", print_id(fragments_ctx->query_id)), bytes_limit);
+        }
+        if (params.query_options.__isset.is_report_success &&
+            params.query_options.is_report_success) {
+            fragments_ctx->query_mem_tracker->enable_print_log_usage();
+        }
+        {
+            // Find _fragments_ctx_map again, in case some other request has already
+            // create the query fragments context.
+            std::lock_guard<std::mutex> lock(_lock);
+            auto search = _fragments_ctx_map.find(params.query_id);
+            if (search == _fragments_ctx_map.end()) {
+                _fragments_ctx_map.insert(std::make_pair(fragments_ctx->query_id, fragments_ctx));
+                LOG(INFO) << "Register query/load memory tracker, query/load id: "
+                          << print_id(fragments_ctx->query_id)
+                          << " limit: " << PrettyPrinter::print(bytes_limit, TUnit::BYTES);
+            } else {
+                // Already has a query fragments context, use it
+                fragments_ctx = search->second;
+            }
+        }
+    }
+
+    for (size_t i = 0; i < params.local_params.size(); i++) {
+        TPipelineLocalParams local_params = params.local_params[i];
+
+        const TUniqueId& fragment_instance_id = local_params.fragment_instance_id;
+        {
+            std::lock_guard<std::mutex> lock(_lock);
+            auto iter = _fragment_map.find(fragment_instance_id);
+            if (iter != _fragment_map.end()) {
+                // Duplicated
+                continue;
+            }
+        }
+
+        fragments_ctx->fragment_ids.push_back(fragment_instance_id);
+
+        exec_state.reset(new FragmentExecState(fragments_ctx->query_id, fragment_instance_id,
+                                               local_params.backend_num, _exec_env, fragments_ctx));
+        if (params.__isset.need_wait_execution_trigger && params.need_wait_execution_trigger) {
+            // set need_wait_execution_trigger means this instance will not actually being executed
+            // until the execPlanFragmentStart RPC trigger to start it.
+            exec_state->set_need_wait_execution_trigger();
+        }
+
+        int64_t duration_ns = 0;
+        if (!params.__isset.need_wait_execution_trigger || !params.need_wait_execution_trigger) {
+            fragments_ctx->set_ready_to_execute_only();
+        }
+        _setup_shared_hashtable_for_broadcast_join(
+                params, local_params, exec_state->executor()->runtime_state(), fragments_ctx.get());
+        std::shared_ptr<pipeline::PipelineFragmentContext> context =
+                std::make_shared<pipeline::PipelineFragmentContext>(
+                        fragments_ctx->query_id, fragment_instance_id, params.fragment_id,
+                        local_params.backend_num, fragments_ctx, _exec_env, cb);
+        {
+            SCOPED_RAW_TIMER(&duration_ns);
+            auto prepare_st = context->prepare(params, i);
+            g_fragmentmgr_prepare_latency << (duration_ns / 1000);
+            if (!prepare_st.ok()) {
+                context->close_if_prepare_failed();
+                return prepare_st;
+            }
+        }
+
+        std::shared_ptr<RuntimeFilterMergeControllerEntity> handler;
+        _runtimefilter_controller.add_entity(params, local_params, &handler,
+                                             context->get_runtime_state());
+        context->set_merge_controller_handler(handler);
+
+        {
+            std::lock_guard<std::mutex> lock(_lock);
+            _pipeline_map.insert(std::make_pair(fragment_instance_id, context));
+            _cv.notify_all();
+        }
+        RETURN_IF_ERROR(context->submit());
+    }
+
+    return Status::OK();
+}
+
 void FragmentMgr::_set_scan_concurrency(const TExecPlanFragmentParams& params,
                                         QueryFragmentsCtx* fragments_ctx) {
 #ifndef BE_TEST
@@ -785,6 +941,50 @@ void FragmentMgr::_set_scan_concurrency(const TExecPlanFragmentParams& params,
     if (params.query_options.__isset.resource_limit &&
         params.query_options.resource_limit.__isset.cpu_limit) {
         fragments_ctx->set_thread_token(params.query_options.resource_limit.cpu_limit, false);
+    }
+#endif
+}
+
+void FragmentMgr::_set_scan_concurrency(const TPipelineParams& params,
+                                        QueryFragmentsCtx* fragments_ctx) {
+#ifndef BE_TEST
+    // set thread token
+    // the thread token will be set if
+    // 1. the cpu_limit is set, or
+    // 2. the limit is very small ( < 1024)
+    // If the token is set, the scan task will use limited_scan_pool in scanner scheduler.
+    // Otherwise, the scan task will use local/remote scan pool in scanner scheduler
+    int concurrency = 1;
+    bool is_serial = false;
+    bool need_token = false;
+    if (params.query_options.__isset.resource_limit &&
+        params.query_options.resource_limit.__isset.cpu_limit) {
+        concurrency = params.query_options.resource_limit.cpu_limit;
+        need_token = true;
+    } else {
+        concurrency = config::doris_scanner_thread_pool_thread_num;
+    }
+    if (params.__isset.fragment && params.fragment.__isset.plan &&
+        params.fragment.plan.nodes.size() > 0) {
+        for (auto& node : params.fragment.plan.nodes) {
+            // Only for SCAN NODE
+            if (!_is_scan_node(node.node_type)) {
+                continue;
+            }
+            if (node.__isset.conjuncts && !node.conjuncts.empty()) {
+                // If the scan node has where predicate, do not set concurrency
+                continue;
+            }
+            if (node.limit > 0 && node.limit < 1024) {
+                concurrency = 1;
+                is_serial = true;
+                need_token = true;
+                break;
+            }
+        }
+    }
+    if (need_token) {
+        fragments_ctx->set_thread_token(concurrency, is_serial);
     }
 #endif
 }
@@ -1100,6 +1300,33 @@ void FragmentMgr::_setup_shared_hashtable_for_broadcast_join(const TExecPlanFrag
         if (params.build_hash_table_for_broadcast_join) {
             fragments_ctx->get_shared_hash_table_controller()->set_builder_and_consumers(
                     params.params.fragment_instance_id, params.instances_sharing_hash_table,
+                    node.node_id);
+        }
+    }
+}
+
+void FragmentMgr::_setup_shared_hashtable_for_broadcast_join(
+        const TPipelineParams& params, const TPipelineLocalParams& local_params,
+        RuntimeState* state, QueryFragmentsCtx* fragments_ctx) {
+    if (!params.query_options.__isset.enable_share_hash_table_for_broadcast_join ||
+        !params.query_options.enable_share_hash_table_for_broadcast_join) {
+        return;
+    }
+
+    if (!params.__isset.fragment || !params.fragment.__isset.plan ||
+        params.fragment.plan.nodes.empty()) {
+        return;
+    }
+    for (auto& node : params.fragment.plan.nodes) {
+        if (node.node_type != TPlanNodeType::HASH_JOIN_NODE ||
+            !node.hash_join_node.__isset.is_broadcast_join ||
+            !node.hash_join_node.is_broadcast_join) {
+            continue;
+        }
+
+        if (local_params.build_hash_table_for_broadcast_join) {
+            fragments_ctx->get_shared_hash_table_controller()->set_builder_and_consumers(
+                    local_params.fragment_instance_id, params.instances_sharing_hash_table,
                     node.node_id);
         }
     }

--- a/be/src/runtime/fragment_mgr.cpp
+++ b/be/src/runtime/fragment_mgr.cpp
@@ -530,7 +530,7 @@ Status FragmentMgr::exec_plan_fragment(const TExecPlanFragmentParams& params) {
     }
 }
 
-Status FragmentMgr::exec_plan_fragment(const TPipelineParams& params) {
+Status FragmentMgr::exec_plan_fragment(const TPipelineFragmentParams& params) {
     // TODO
     return exec_plan_fragment(params, empty_function);
 }
@@ -782,7 +782,7 @@ Status FragmentMgr::exec_plan_fragment(const TExecPlanFragmentParams& params, Fi
     return Status::OK();
 }
 
-Status FragmentMgr::exec_plan_fragment(const TPipelineParams& params, FinishCallback cb) {
+Status FragmentMgr::exec_plan_fragment(const TPipelineFragmentParams& params, FinishCallback cb) {
     auto tracer = telemetry::is_current_span_valid() ? telemetry::get_tracer("tracer")
                                                      : telemetry::get_noop_tracer();
     VLOG_ROW << "exec_plan_fragment params is "
@@ -875,7 +875,7 @@ Status FragmentMgr::exec_plan_fragment(const TPipelineParams& params, FinishCall
     }
 
     for (size_t i = 0; i < params.local_params.size(); i++) {
-        TPipelineLocalParams local_params = params.local_params[i];
+        const auto& local_params = params.local_params[i];
 
         const TUniqueId& fragment_instance_id = local_params.fragment_instance_id;
         {
@@ -945,7 +945,7 @@ void FragmentMgr::_set_scan_concurrency(const TExecPlanFragmentParams& params,
 #endif
 }
 
-void FragmentMgr::_set_scan_concurrency(const TPipelineParams& params,
+void FragmentMgr::_set_scan_concurrency(const TPipelineFragmentParams& params,
                                         QueryFragmentsCtx* fragments_ctx) {
 #ifndef BE_TEST
     // set thread token
@@ -1306,7 +1306,7 @@ void FragmentMgr::_setup_shared_hashtable_for_broadcast_join(const TExecPlanFrag
 }
 
 void FragmentMgr::_setup_shared_hashtable_for_broadcast_join(
-        const TPipelineParams& params, const TPipelineLocalParams& local_params,
+        const TPipelineFragmentParams& params, const TPipelineInstanceParams& local_params,
         RuntimeState* state, QueryFragmentsCtx* fragments_ctx) {
     if (!params.query_options.__isset.enable_share_hash_table_for_broadcast_join ||
         !params.query_options.enable_share_hash_table_for_broadcast_join) {

--- a/be/src/runtime/fragment_mgr.h
+++ b/be/src/runtime/fragment_mgr.h
@@ -72,7 +72,7 @@ public:
     // execute one plan fragment
     Status exec_plan_fragment(const TExecPlanFragmentParams& params);
 
-    Status exec_plan_fragment(const TPipelineParams& params);
+    Status exec_plan_fragment(const TPipelineFragmentParams& params);
 
     void remove_pipeline_context(
             std::shared_ptr<pipeline::PipelineFragmentContext> pipeline_context);
@@ -80,7 +80,7 @@ public:
     // TODO(zc): report this is over
     Status exec_plan_fragment(const TExecPlanFragmentParams& params, FinishCallback cb);
 
-    Status exec_plan_fragment(const TPipelineParams& params, FinishCallback cb);
+    Status exec_plan_fragment(const TPipelineFragmentParams& params, FinishCallback cb);
 
     Status start_query_execution(const PExecPlanFragmentStartRequest* request);
 
@@ -122,7 +122,8 @@ private:
     void _set_scan_concurrency(const TExecPlanFragmentParams& params,
                                QueryFragmentsCtx* fragments_ctx);
 
-    void _set_scan_concurrency(const TPipelineParams& params, QueryFragmentsCtx* fragments_ctx);
+    void _set_scan_concurrency(const TPipelineFragmentParams& params,
+                               QueryFragmentsCtx* fragments_ctx);
 
     bool _is_scan_node(const TPlanNodeType::type& type);
 
@@ -130,8 +131,8 @@ private:
                                                     RuntimeState* state,
                                                     QueryFragmentsCtx* fragments_ctx);
 
-    void _setup_shared_hashtable_for_broadcast_join(const TPipelineParams& params,
-                                                    const TPipelineLocalParams& local_params,
+    void _setup_shared_hashtable_for_broadcast_join(const TPipelineFragmentParams& params,
+                                                    const TPipelineInstanceParams& local_params,
                                                     RuntimeState* state,
                                                     QueryFragmentsCtx* fragments_ctx);
 

--- a/be/src/runtime/fragment_mgr.h
+++ b/be/src/runtime/fragment_mgr.h
@@ -72,11 +72,15 @@ public:
     // execute one plan fragment
     Status exec_plan_fragment(const TExecPlanFragmentParams& params);
 
+    Status exec_plan_fragment(const TPipelineParams& params);
+
     void remove_pipeline_context(
             std::shared_ptr<pipeline::PipelineFragmentContext> pipeline_context);
 
     // TODO(zc): report this is over
     Status exec_plan_fragment(const TExecPlanFragmentParams& params, FinishCallback cb);
+
+    Status exec_plan_fragment(const TPipelineParams& params, FinishCallback cb);
 
     Status start_query_execution(const PExecPlanFragmentStartRequest* request);
 
@@ -118,9 +122,16 @@ private:
     void _set_scan_concurrency(const TExecPlanFragmentParams& params,
                                QueryFragmentsCtx* fragments_ctx);
 
+    void _set_scan_concurrency(const TPipelineParams& params, QueryFragmentsCtx* fragments_ctx);
+
     bool _is_scan_node(const TPlanNodeType::type& type);
 
     void _setup_shared_hashtable_for_broadcast_join(const TExecPlanFragmentParams& params,
+                                                    RuntimeState* state,
+                                                    QueryFragmentsCtx* fragments_ctx);
+
+    void _setup_shared_hashtable_for_broadcast_join(const TPipelineParams& params,
+                                                    const TPipelineLocalParams& local_params,
                                                     RuntimeState* state,
                                                     QueryFragmentsCtx* fragments_ctx);
 

--- a/be/src/runtime/runtime_filter_mgr.cpp
+++ b/be/src/runtime/runtime_filter_mgr.cpp
@@ -310,6 +310,37 @@ Status RuntimeFilterMergeController::add_entity(
     return Status::OK();
 }
 
+Status RuntimeFilterMergeController::add_entity(
+        const TPipelineParams& params, const TPipelineLocalParams& local_params,
+        std::shared_ptr<RuntimeFilterMergeControllerEntity>* handle, RuntimeState* state) {
+    if (!local_params.__isset.runtime_filter_params ||
+        local_params.runtime_filter_params.rid_to_runtime_filter.size() == 0) {
+        return Status::OK();
+    }
+
+    runtime_filter_merge_entity_closer entity_closer =
+            std::bind(runtime_filter_merge_entity_close, this, std::placeholders::_1);
+
+    UniqueId query_id(params.query_id);
+    std::string query_id_str = query_id.to_string();
+    UniqueId fragment_instance_id = UniqueId(local_params.fragment_instance_id);
+    uint32_t shard = _get_controller_shard_idx(query_id);
+    std::lock_guard<std::mutex> guard(_controller_mutex[shard]);
+    auto iter = _filter_controller_map[shard].find(query_id_str);
+
+    if (iter == _filter_controller_map[shard].end()) {
+        *handle = std::shared_ptr<RuntimeFilterMergeControllerEntity>(
+                new RuntimeFilterMergeControllerEntity(state), entity_closer);
+        _filter_controller_map[shard][query_id_str] = *handle;
+        const TRuntimeFilterParams& filter_params = local_params.runtime_filter_params;
+        RETURN_IF_ERROR(handle->get()->init(query_id, fragment_instance_id, filter_params,
+                                            params.query_options));
+    } else {
+        *handle = _filter_controller_map[shard][query_id_str].lock();
+    }
+    return Status::OK();
+}
+
 Status RuntimeFilterMergeController::acquire(
         UniqueId query_id, std::shared_ptr<RuntimeFilterMergeControllerEntity>* handle) {
     uint32_t shard = _get_controller_shard_idx(query_id);

--- a/be/src/runtime/runtime_filter_mgr.cpp
+++ b/be/src/runtime/runtime_filter_mgr.cpp
@@ -311,7 +311,7 @@ Status RuntimeFilterMergeController::add_entity(
 }
 
 Status RuntimeFilterMergeController::add_entity(
-        const TPipelineParams& params, const TPipelineLocalParams& local_params,
+        const TPipelineFragmentParams& params, const TPipelineInstanceParams& local_params,
         std::shared_ptr<RuntimeFilterMergeControllerEntity>* handle, RuntimeState* state) {
     if (!local_params.__isset.runtime_filter_params ||
         local_params.runtime_filter_params.rid_to_runtime_filter.size() == 0) {

--- a/be/src/runtime/runtime_filter_mgr.h
+++ b/be/src/runtime/runtime_filter_mgr.h
@@ -169,7 +169,8 @@ public:
     Status add_entity(const TExecPlanFragmentParams& params,
                       std::shared_ptr<RuntimeFilterMergeControllerEntity>* handle,
                       RuntimeState* state);
-    Status add_entity(const TPipelineParams& params, const TPipelineLocalParams& local_params,
+    Status add_entity(const TPipelineFragmentParams& params,
+                      const TPipelineInstanceParams& local_params,
                       std::shared_ptr<RuntimeFilterMergeControllerEntity>* handle,
                       RuntimeState* state);
     // thread safe

--- a/be/src/runtime/runtime_filter_mgr.h
+++ b/be/src/runtime/runtime_filter_mgr.h
@@ -169,6 +169,9 @@ public:
     Status add_entity(const TExecPlanFragmentParams& params,
                       std::shared_ptr<RuntimeFilterMergeControllerEntity>* handle,
                       RuntimeState* state);
+    Status add_entity(const TPipelineParams& params, const TPipelineLocalParams& local_params,
+                      std::shared_ptr<RuntimeFilterMergeControllerEntity>* handle,
+                      RuntimeState* state);
     // thread safe
     // increase a reference count
     // if a query-id is not exist

--- a/be/src/runtime/runtime_state.cpp
+++ b/be/src/runtime/runtime_state.cpp
@@ -95,6 +95,33 @@ RuntimeState::RuntimeState(const TPlanFragmentExecParams& fragment_exec_params,
     DCHECK(status.ok());
 }
 
+RuntimeState::RuntimeState(const TPipelineLocalParams& pipeline_params, const TUniqueId& query_id,
+                           const TQueryOptions& query_options, const TQueryGlobals& query_globals,
+                           ExecEnv* exec_env)
+        : _profile("Fragment " + print_id(pipeline_params.fragment_instance_id)),
+          _obj_pool(new ObjectPool()),
+          _runtime_filter_mgr(new RuntimeFilterMgr(query_id, this)),
+          _data_stream_recvrs_pool(new ObjectPool()),
+          _unreported_error_idx(0),
+          _query_id(query_id),
+          _is_cancelled(false),
+          _per_fragment_instance_idx(0),
+          _num_rows_load_total(0),
+          _num_rows_load_filtered(0),
+          _num_rows_load_unselected(0),
+          _num_print_error_rows(0),
+          _num_bytes_load_total(0),
+          _normal_row_number(0),
+          _error_row_number(0),
+          _error_log_file(nullptr) {
+    if (pipeline_params.__isset.runtime_filter_params) {
+        _runtime_filter_mgr->set_runtime_filter_params(pipeline_params.runtime_filter_params);
+    }
+    Status status =
+            init(pipeline_params.fragment_instance_id, query_options, query_globals, exec_env);
+    DCHECK(status.ok());
+}
+
 RuntimeState::RuntimeState(const TQueryGlobals& query_globals)
         : _profile("<unnamed>"),
           _obj_pool(new ObjectPool()),

--- a/be/src/runtime/runtime_state.cpp
+++ b/be/src/runtime/runtime_state.cpp
@@ -95,9 +95,9 @@ RuntimeState::RuntimeState(const TPlanFragmentExecParams& fragment_exec_params,
     DCHECK(status.ok());
 }
 
-RuntimeState::RuntimeState(const TPipelineLocalParams& pipeline_params, const TUniqueId& query_id,
-                           const TQueryOptions& query_options, const TQueryGlobals& query_globals,
-                           ExecEnv* exec_env)
+RuntimeState::RuntimeState(const TPipelineInstanceParams& pipeline_params,
+                           const TUniqueId& query_id, const TQueryOptions& query_options,
+                           const TQueryGlobals& query_globals, ExecEnv* exec_env)
         : _profile("Fragment " + print_id(pipeline_params.fragment_instance_id)),
           _obj_pool(new ObjectPool()),
           _runtime_filter_mgr(new RuntimeFilterMgr(query_id, this)),

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -58,6 +58,10 @@ public:
                  const TQueryOptions& query_options, const TQueryGlobals& query_globals,
                  ExecEnv* exec_env);
 
+    RuntimeState(const TPipelineLocalParams& pipeline_params, const TUniqueId& query_id,
+                 const TQueryOptions& query_options, const TQueryGlobals& query_globals,
+                 ExecEnv* exec_env);
+
     // RuntimeState for executing expr in fe-support.
     RuntimeState(const TQueryGlobals& query_globals);
 

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -58,7 +58,7 @@ public:
                  const TQueryOptions& query_options, const TQueryGlobals& query_globals,
                  ExecEnv* exec_env);
 
-    RuntimeState(const TPipelineLocalParams& pipeline_params, const TUniqueId& query_id,
+    RuntimeState(const TPipelineInstanceParams& pipeline_params, const TUniqueId& query_id,
                  const TQueryOptions& query_options, const TQueryGlobals& query_globals,
                  ExecEnv* exec_env);
 

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -282,14 +282,14 @@ Status PInternalServiceImpl::_exec_plan_fragment(const std::string& ser_request,
         }
         return Status::OK();
     } else if (version == PFragmentRequestVersion::VERSION_3) {
-        TPipelineParamsList t_request;
+        TPipelineFragmentParamsList t_request;
         {
             const uint8_t* buf = (const uint8_t*)ser_request.data();
             uint32_t len = ser_request.size();
             RETURN_IF_ERROR(deserialize_thrift_msg(buf, &len, compact, &t_request));
         }
 
-        for (const TPipelineParams& params : t_request.params_list) {
+        for (const TPipelineFragmentParams& params : t_request.params_list) {
             RETURN_IF_ERROR(_exec_env->fragment_mgr()->exec_plan_fragment(params));
         }
         return Status::OK();

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -281,6 +281,18 @@ Status PInternalServiceImpl::_exec_plan_fragment(const std::string& ser_request,
             RETURN_IF_ERROR(_exec_env->fragment_mgr()->exec_plan_fragment(params));
         }
         return Status::OK();
+    } else if (version == PFragmentRequestVersion::VERSION_3) {
+        TPipelineParamsList t_request;
+        {
+            const uint8_t* buf = (const uint8_t*)ser_request.data();
+            uint32_t len = ser_request.size();
+            RETURN_IF_ERROR(deserialize_thrift_msg(buf, &len, compact, &t_request));
+        }
+
+        for (const TPipelineParams& params : t_request.params_list) {
+            RETURN_IF_ERROR(_exec_env->fragment_mgr()->exec_plan_fragment(params));
+        }
+        return Status::OK();
     } else {
         return Status::InternalError("invalid version");
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/ScalarFunction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/ScalarFunction.java
@@ -22,6 +22,7 @@ import org.apache.doris.analysis.FunctionName;
 import org.apache.doris.common.io.IOUtils;
 import org.apache.doris.common.io.Text;
 import org.apache.doris.common.util.URI;
+import org.apache.doris.common.util.VectorizedUtil;
 import org.apache.doris.thrift.TFunction;
 import org.apache.doris.thrift.TFunctionBinaryType;
 import org.apache.doris.thrift.TScalarFunction;
@@ -408,12 +409,16 @@ public class ScalarFunction extends Function {
     public TFunction toThrift(Type realReturnType, Type[] realArgTypes) {
         TFunction fn = super.toThrift(realReturnType, realArgTypes);
         fn.setScalarFn(new TScalarFunction());
-        fn.getScalarFn().setSymbol(symbolName);
-        if (prepareFnSymbol != null) {
-            fn.getScalarFn().setPrepareFnSymbol(prepareFnSymbol);
-        }
-        if (closeFnSymbol != null) {
-            fn.getScalarFn().setCloseFnSymbol(closeFnSymbol);
+        if (getBinaryType() != TFunctionBinaryType.BUILTIN || !VectorizedUtil.optRpcForPipeline()) {
+            fn.getScalarFn().setSymbol(symbolName);
+            if (prepareFnSymbol != null) {
+                fn.getScalarFn().setPrepareFnSymbol(prepareFnSymbol);
+            }
+            if (closeFnSymbol != null) {
+                fn.getScalarFn().setCloseFnSymbol(closeFnSymbol);
+            }
+        } else {
+            fn.getScalarFn().setSymbol("");
         }
         return fn;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/VectorizedUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/VectorizedUtil.java
@@ -41,4 +41,13 @@ public class VectorizedUtil {
         }
         return connectContext.getSessionVariable().enablePipelineEngine();
     }
+
+    public static boolean optRpcForPipeline() {
+        ConnectContext connectContext = ConnectContext.get();
+        if (connectContext == null) {
+            return false;
+        }
+        return connectContext.getSessionVariable().enablePipelineEngine()
+                && connectContext.getSessionVariable().enableRpcOptForPipeline();
+    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
@@ -82,6 +82,9 @@ import org.apache.doris.thrift.TExecPlanFragmentParamsList;
 import org.apache.doris.thrift.TFileRangeDesc;
 import org.apache.doris.thrift.TNetworkAddress;
 import org.apache.doris.thrift.TPaloScanRange;
+import org.apache.doris.thrift.TPipelineLocalParams;
+import org.apache.doris.thrift.TPipelineParams;
+import org.apache.doris.thrift.TPipelineParamsList;
 import org.apache.doris.thrift.TPlanFragmentDestination;
 import org.apache.doris.thrift.TPlanFragmentExecParams;
 import org.apache.doris.thrift.TQueryGlobals;
@@ -195,12 +198,15 @@ public class Coordinator {
     private final List<PlanFragment> fragments;
 
     private Map<Long, BackendExecStates> beToExecStates = Maps.newHashMap();
+    private Map<Long, PipelineExecContexts> beToPipelineExecCtxs = Maps.newHashMap();
 
     // backend execute state
     private final List<BackendExecState> backendExecStates = Lists.newArrayList();
+    private final Map<Integer, PipelineExecContext> pipelineExecContexts = new HashMap<>();
     // backend which state need to be checked when joining this coordinator.
     // It is supposed to be the subset of backendExecStates.
     private final List<BackendExecState> needCheckBackendExecStates = Lists.newArrayList();
+    private final List<PipelineExecContext> needCheckPipelineExecContexts = Lists.newArrayList();
     private ResultReceiver receiver;
     private final List<ScanNode> scanNodes;
     // number of instances of this query, equals to
@@ -241,6 +247,8 @@ public class Coordinator {
     private boolean enableShareHashTableForBroadcastJoin = false;
 
     private boolean enablePipelineEngine = false;
+
+    private boolean enableRpcOptForPipeline = false;
 
     // Runtime filter merge instance address and ID
     public TNetworkAddress runtimeFilterMergeAddr;
@@ -318,6 +326,8 @@ public class Coordinator {
         this.returnedAllResults = false;
         this.enableShareHashTableForBroadcastJoin = context.getSessionVariable().enableShareHashTableForBroadcastJoin;
         this.enablePipelineEngine = context.getSessionVariable().enablePipelineEngine;
+        this.enableRpcOptForPipeline = context.getSessionVariable().enablePipelineEngine
+                && context.getSessionVariable().enableRpcOptForPipeline;
         initQueryOptions(context);
 
         setFromUserProperty(analyzer);
@@ -464,12 +474,14 @@ public class Coordinator {
         lock.lock();
         try {
             this.backendExecStates.clear();
+            this.pipelineExecContexts.clear();
             this.queryStatus.setStatus(new Status());
             if (this.exportFiles == null) {
                 this.exportFiles = Lists.newArrayList();
             }
             this.exportFiles.clear();
             this.needCheckBackendExecStates.clear();
+            this.needCheckPipelineExecContexts.clear();
         } finally {
             lock.unlock();
         }
@@ -485,8 +497,15 @@ public class Coordinator {
 
     public Map<String, Integer> getBeToInstancesNum() {
         Map<String, Integer> result = Maps.newTreeMap();
-        for (BackendExecStates states : beToExecStates.values()) {
-            result.put(states.brpcAddr.hostname.concat(":").concat("" + states.brpcAddr.port), states.states.size());
+        if (enableRpcOptForPipeline) {
+            for (PipelineExecContexts ctxs : beToPipelineExecCtxs.values()) {
+                result.put(ctxs.brpcAddr.hostname.concat(":").concat("" + ctxs.brpcAddr.port), ctxs.ctxs.size());
+            }
+        } else {
+            for (BackendExecStates states : beToExecStates.values()) {
+                result.put(states.brpcAddr.hostname.concat(":").concat("" + states.brpcAddr.port),
+                        states.states.size());
+            }
         }
         return result;
     }
@@ -623,7 +642,11 @@ public class Coordinator {
             profileDoneSignal.addMark(instanceId, -1L /* value is meaningless */);
         }
         if (!isPointQuery) {
-            sendFragment();
+            if (enableRpcOptForPipeline) {
+                sendPipelineCtx();
+            } else {
+                sendFragment();
+            }
         } else {
             OlapScanNode planRoot = (OlapScanNode) fragments.get(0).getPlanRoot();
             Preconditions.checkState(planRoot.getScanTabletIds().size() == 1);
@@ -778,6 +801,118 @@ public class Coordinator {
         }
     }
 
+    private void sendPipelineCtx() throws TException, RpcException, UserException {
+        lock();
+        try {
+            Multiset<TNetworkAddress> hostCounter = HashMultiset.create();
+            for (FragmentExecParams params : fragmentExecParamsMap.values()) {
+                for (FInstanceExecParam fi : params.instanceExecParams) {
+                    hostCounter.add(fi.host);
+                }
+            }
+
+            int backendIdx = 0;
+            int profileFragmentId = 0;
+            beToPipelineExecCtxs.clear();
+            // If #fragments >=2, use twoPhaseExecution with exec_plan_fragments_prepare and exec_plan_fragments_start,
+            // else use exec_plan_fragments directly.
+            // we choose #fragments >=2 because in some cases
+            // we need ensure that A fragment is already prepared to receive data before B fragment sends data.
+            // For example: select * from numbers("10","w") will generate ExchangeNode and TableValuedFunctionScanNode,
+            // we should ensure TableValuedFunctionScanNode does not send data until ExchangeNode is ready to receive.
+            boolean twoPhaseExecution = fragments.size() >= 2;
+            for (PlanFragment fragment : fragments) {
+                FragmentExecParams params = fragmentExecParamsMap.get(fragment.getFragmentId());
+
+                // 1. set up exec states
+                int instanceNum = params.instanceExecParams.size();
+                Preconditions.checkState(instanceNum > 0);
+                Map<TNetworkAddress, TPipelineParams> tParams = params.toTPipelineParams(backendIdx);
+
+                boolean needCheckBackendState = false;
+                if (queryOptions.getQueryType() == TQueryType.LOAD && profileFragmentId == 0) {
+                    // this is a load process, and it is the first fragment.
+                    // we should add all BackendExecState of this fragment to needCheckBackendExecStates,
+                    // so that we can check these backends' state when joining this Coordinator
+                    needCheckBackendState = true;
+                }
+
+                // 3. group BackendExecState by BE. So that we can use one RPC to send all fragment instances of a BE.
+
+                for (Map.Entry<TNetworkAddress, TPipelineParams> entry : tParams.entrySet()) {
+                    PipelineExecContext pipelineExecContext =
+                            new PipelineExecContext(fragment.getFragmentId(),
+                                    profileFragmentId, entry.getValue(), this.addressToBackendID, entry.getKey());
+                    // Each tParam will set the total number of Fragments that need to be executed on the same BE,
+                    // and the BE will determine whether all Fragments have been executed based on this information.
+                    // Notice. load fragment has a small probability that FragmentNumOnHost is 0, for unknown reasons.
+                    entry.getValue().setFragmentNumOnHost(hostCounter.count(pipelineExecContext.address));
+                    entry.getValue().setBackendId(pipelineExecContext.backend.getId());
+                    entry.getValue().setNeedWaitExecutionTrigger(twoPhaseExecution);
+                    entry.getValue().setFragmentId(fragment.getFragmentId().asInt());
+
+                    pipelineExecContexts.put(fragment.getFragmentId().asInt(), pipelineExecContext);
+                    if (needCheckBackendState) {
+                        needCheckPipelineExecContexts.add(pipelineExecContext);
+                        if (LOG.isDebugEnabled()) {
+                            LOG.debug("add need check backend {} for fragment, {} job: {}",
+                                    pipelineExecContext.backend.getId(), fragment.getFragmentId().asInt(), jobId);
+                        }
+                    }
+
+                    PipelineExecContexts ctxs = beToPipelineExecCtxs.get(pipelineExecContext.backend.getId());
+                    if (ctxs == null) {
+                        ctxs = new PipelineExecContexts(pipelineExecContext.backend.getId(),
+                                pipelineExecContext.brpcAddress, twoPhaseExecution);
+                        beToPipelineExecCtxs.putIfAbsent(pipelineExecContext.backend.getId(), ctxs);
+                    }
+                    ctxs.addContext(pipelineExecContext);
+
+                    ++backendIdx;
+                }
+
+                profileFragmentId += 1;
+            } // end for fragments
+
+            // 4. send and wait fragments rpc
+            List<Triple<PipelineExecContexts, BackendServiceProxy, Future<InternalService.PExecPlanFragmentResult>>>
+                    futures = Lists.newArrayList();
+            Context parentSpanContext = Context.current();
+            for (PipelineExecContexts ctxs : beToPipelineExecCtxs.values()) {
+                Span span = Telemetry.getNoopSpan();
+                if (ConnectContext.get() != null) {
+                    span = ConnectContext.get().getTracer().spanBuilder("execRemoteFragmentsAsync")
+                            .setParent(parentSpanContext).setSpanKind(SpanKind.CLIENT).startSpan();
+                }
+                ctxs.scopedSpan = new ScopedSpan(span);
+                ctxs.unsetFields();
+                BackendServiceProxy proxy = BackendServiceProxy.getInstance();
+                futures.add(ImmutableTriple.of(ctxs, proxy, ctxs.execRemoteFragmentsAsync(proxy)));
+            }
+            waitPipelineRpc(futures, this.timeoutDeadline - System.currentTimeMillis(), "send fragments");
+
+            if (twoPhaseExecution) {
+                // 5. send and wait execution start rpc
+                futures.clear();
+                for (PipelineExecContexts ctxs : beToPipelineExecCtxs.values()) {
+                    Span span = Telemetry.getNoopSpan();
+                    if (ConnectContext.get() != null) {
+                        span = ConnectContext.get().getTracer().spanBuilder("execPlanFragmentStartAsync")
+                                .setParent(parentSpanContext).setSpanKind(SpanKind.CLIENT).startSpan();
+                    }
+                    ctxs.scopedSpan = new ScopedSpan(span);
+                    BackendServiceProxy proxy = BackendServiceProxy.getInstance();
+                    futures.add(ImmutableTriple.of(ctxs, proxy, ctxs.execPlanFragmentStartAsync(proxy)));
+                }
+                waitPipelineRpc(futures, this.timeoutDeadline - System.currentTimeMillis(), "send execution start");
+            }
+
+            attachInstanceProfileToFragmentProfile();
+        } finally {
+            unlock();
+        }
+    }
+
     private void waitRpc(List<Triple<BackendExecStates, BackendServiceProxy, Future<PExecPlanFragmentResult>>> futures,
                          long leftTimeMs,
             String operation) throws RpcException, UserException {
@@ -788,6 +923,73 @@ public class Coordinator {
 
         long timeoutMs = Math.min(leftTimeMs, Config.remote_fragment_exec_timeout_ms);
         for (Triple<BackendExecStates, BackendServiceProxy, Future<PExecPlanFragmentResult>> triple : futures) {
+            TStatusCode code;
+            String errMsg = null;
+            Exception exception = null;
+            Span span = triple.getLeft().scopedSpan.getSpan();
+            try {
+                PExecPlanFragmentResult result = triple.getRight().get(timeoutMs, TimeUnit.MILLISECONDS);
+                code = TStatusCode.findByValue(result.getStatus().getStatusCode());
+                if (code != TStatusCode.OK) {
+                    if (!result.getStatus().getErrorMsgsList().isEmpty()) {
+                        errMsg = result.getStatus().getErrorMsgsList().get(0);
+                    } else {
+                        errMsg = operation + " failed. backend id: " + triple.getLeft().beId;
+                    }
+                }
+            } catch (ExecutionException e) {
+                exception = e;
+                code = TStatusCode.THRIFT_RPC_ERROR;
+                triple.getMiddle().removeProxy(triple.getLeft().brpcAddr);
+            } catch (InterruptedException e) {
+                exception = e;
+                code = TStatusCode.INTERNAL_ERROR;
+            } catch (TimeoutException e) {
+                exception = e;
+                errMsg = "timeout when waiting for " + operation + " RPC. Wait(sec): " + timeoutMs / 1000;
+                code = TStatusCode.TIMEOUT;
+            }
+
+            try {
+                if (code != TStatusCode.OK) {
+                    if (exception != null && errMsg == null) {
+                        errMsg = operation + " failed. " + exception.getMessage();
+                    }
+                    queryStatus.setStatus(errMsg);
+                    cancelInternal(Types.PPlanFragmentCancelReason.INTERNAL_ERROR);
+                    switch (code) {
+                        case TIMEOUT:
+                            MetricRepo.BE_COUNTER_QUERY_RPC_FAILED.getOrAdd(triple.getLeft().brpcAddr.hostname)
+                                    .increase(1L);
+                            throw new RpcException(triple.getLeft().brpcAddr.hostname, errMsg, exception);
+                        case THRIFT_RPC_ERROR:
+                            MetricRepo.BE_COUNTER_QUERY_RPC_FAILED.getOrAdd(triple.getLeft().brpcAddr.hostname)
+                                    .increase(1L);
+                            SimpleScheduler.addToBlacklist(triple.getLeft().beId, errMsg);
+                            throw new RpcException(triple.getLeft().brpcAddr.hostname, errMsg, exception);
+                        default:
+                            throw new UserException(errMsg, exception);
+                    }
+                }
+            } catch (Exception e) {
+                span.recordException(e);
+                throw e;
+            } finally {
+                triple.getLeft().scopedSpan.endSpan();
+            }
+        }
+    }
+
+    private void waitPipelineRpc(List<Triple<PipelineExecContexts, BackendServiceProxy,
+            Future<PExecPlanFragmentResult>>> futures, long leftTimeMs,
+            String operation) throws RpcException, UserException {
+        if (leftTimeMs <= 0) {
+            throw new UserException("timeout before waiting for " + operation + " RPC. Elapse(sec): " + (
+                    (System.currentTimeMillis() - timeoutDeadline) / 1000 + queryOptions.query_timeout));
+        }
+
+        long timeoutMs = Math.min(leftTimeMs, Config.remote_fragment_exec_timeout_ms);
+        for (Triple<PipelineExecContexts, BackendServiceProxy, Future<PExecPlanFragmentResult>> triple : futures) {
             TStatusCode code;
             String errMsg = null;
             Exception exception = null;
@@ -1062,8 +1264,14 @@ public class Coordinator {
     }
 
     private void cancelRemoteFragmentsAsync(Types.PPlanFragmentCancelReason cancelReason) {
-        for (BackendExecState backendExecState : backendExecStates) {
-            backendExecState.cancelFragmentInstance(cancelReason);
+        if (enableRpcOptForPipeline) {
+            for (PipelineExecContext ctx : pipelineExecContexts.values()) {
+                ctx.cancelFragmentInstance(cancelReason);
+            }
+        } else {
+            for (BackendExecState backendExecState : backendExecStates) {
+                backendExecState.cancelFragmentInstance(cancelReason);
+            }
         }
     }
 
@@ -1867,63 +2075,117 @@ public class Coordinator {
     }
 
     public void updateFragmentExecStatus(TReportExecStatusParams params) {
-        if (params.backend_num >= backendExecStates.size()) {
-            LOG.warn("unknown backend number: {}, expected less than: {}",
-                    params.backend_num, backendExecStates.size());
-            return;
-        }
+        if (enableRpcOptForPipeline) {
+            PipelineExecContext ctx = pipelineExecContexts.get(params.getFragmentId());
+            if (!ctx.updateProfile(params)) {
+                return;
+            }
 
-        BackendExecState execState = backendExecStates.get(params.backend_num);
-        if (!execState.updateProfile(params)) {
-            return;
-        }
+            // print fragment instance profile
+            if (LOG.isDebugEnabled()) {
+                StringBuilder builder = new StringBuilder();
+                ctx.printProfile(builder);
+                LOG.debug("profile for query_id={} instance_id={}\n{}",
+                        DebugUtil.printId(queryId),
+                        DebugUtil.printId(params.getFragmentInstanceId()),
+                        builder.toString());
+            }
 
-        // print fragment instance profile
-        if (LOG.isDebugEnabled()) {
-            StringBuilder builder = new StringBuilder();
-            execState.printProfile(builder);
-            LOG.debug("profile for query_id={} instance_id={}\n{}",
-                    DebugUtil.printId(queryId),
-                    DebugUtil.printId(params.getFragmentInstanceId()),
-                    builder.toString());
-        }
+            Status status = new Status(params.status);
+            // for now, abort the query if we see any error except if the error is cancelled
+            // and returned_all_results_ is true.
+            // (UpdateStatus() initiates cancellation, if it hasn't already been initiated)
+            if (!(returnedAllResults && status.isCancelled()) && !status.ok()) {
+                LOG.warn("one instance report fail, query_id={} instance_id={}, error message: {}",
+                        DebugUtil.printId(queryId), DebugUtil.printId(params.getFragmentInstanceId()),
+                        status.getErrorMsg());
+                updateStatus(status, params.getFragmentInstanceId());
+            }
+            if (ctx.doneFlags.get(params.getFragmentInstanceId())) {
+                if (params.isSetDeltaUrls()) {
+                    updateDeltas(params.getDeltaUrls());
+                }
+                if (params.isSetLoadCounters()) {
+                    updateLoadCounters(params.getLoadCounters());
+                }
+                if (params.isSetTrackingUrl()) {
+                    trackingUrl = params.getTrackingUrl();
+                }
+                if (params.isSetExportFiles()) {
+                    updateExportFiles(params.getExportFiles());
+                }
+                if (params.isSetCommitInfos()) {
+                    updateCommitInfos(params.getCommitInfos());
+                }
+                if (params.isSetErrorTabletInfos()) {
+                    updateErrorTabletInfos(params.getErrorTabletInfos());
+                }
+                profileDoneSignal.markedCountDown(params.getFragmentInstanceId(), -1L);
+            }
 
-        Status status = new Status(params.status);
-        // for now, abort the query if we see any error except if the error is cancelled
-        // and returned_all_results_ is true.
-        // (UpdateStatus() initiates cancellation, if it hasn't already been initiated)
-        if (!(returnedAllResults && status.isCancelled()) && !status.ok()) {
-            LOG.warn("one instance report fail, query_id={} instance_id={}, error message: {}",
-                    DebugUtil.printId(queryId), DebugUtil.printId(params.getFragmentInstanceId()),
-                    status.getErrorMsg());
-            updateStatus(status, params.getFragmentInstanceId());
-        }
-        if (execState.done) {
-            if (params.isSetDeltaUrls()) {
-                updateDeltas(params.getDeltaUrls());
+            if (params.isSetLoadedRows()) {
+                Env.getCurrentEnv().getLoadManager().updateJobProgress(
+                        jobId, params.getBackendId(), params.getQueryId(), params.getFragmentInstanceId(),
+                        params.getLoadedRows(), params.getLoadedBytes(), params.isDone());
             }
-            if (params.isSetLoadCounters()) {
-                updateLoadCounters(params.getLoadCounters());
+        } else {
+            if (params.backend_num >= backendExecStates.size()) {
+                LOG.warn("unknown backend number: {}, expected less than: {}",
+                        params.backend_num, backendExecStates.size());
+                return;
             }
-            if (params.isSetTrackingUrl()) {
-                trackingUrl = params.getTrackingUrl();
+            BackendExecState execState = backendExecStates.get(params.backend_num);
+            if (!execState.updateProfile(params)) {
+                return;
             }
-            if (params.isSetExportFiles()) {
-                updateExportFiles(params.getExportFiles());
-            }
-            if (params.isSetCommitInfos()) {
-                updateCommitInfos(params.getCommitInfos());
-            }
-            if (params.isSetErrorTabletInfos()) {
-                updateErrorTabletInfos(params.getErrorTabletInfos());
-            }
-            profileDoneSignal.markedCountDown(params.getFragmentInstanceId(), -1L);
-        }
 
-        if (params.isSetLoadedRows()) {
-            Env.getCurrentEnv().getLoadManager().updateJobProgress(
-                    jobId, params.getBackendId(), params.getQueryId(), params.getFragmentInstanceId(),
-                    params.getLoadedRows(), params.getLoadedBytes(), params.isDone());
+            // print fragment instance profile
+            if (LOG.isDebugEnabled()) {
+                StringBuilder builder = new StringBuilder();
+                execState.printProfile(builder);
+                LOG.debug("profile for query_id={} instance_id={}\n{}",
+                        DebugUtil.printId(queryId),
+                        DebugUtil.printId(params.getFragmentInstanceId()),
+                        builder.toString());
+            }
+
+            Status status = new Status(params.status);
+            // for now, abort the query if we see any error except if the error is cancelled
+            // and returned_all_results_ is true.
+            // (UpdateStatus() initiates cancellation, if it hasn't already been initiated)
+            if (!(returnedAllResults && status.isCancelled()) && !status.ok()) {
+                LOG.warn("one instance report fail, query_id={} instance_id={}, error message: {}",
+                        DebugUtil.printId(queryId), DebugUtil.printId(params.getFragmentInstanceId()),
+                        status.getErrorMsg());
+                updateStatus(status, params.getFragmentInstanceId());
+            }
+            if (execState.done) {
+                if (params.isSetDeltaUrls()) {
+                    updateDeltas(params.getDeltaUrls());
+                }
+                if (params.isSetLoadCounters()) {
+                    updateLoadCounters(params.getLoadCounters());
+                }
+                if (params.isSetTrackingUrl()) {
+                    trackingUrl = params.getTrackingUrl();
+                }
+                if (params.isSetExportFiles()) {
+                    updateExportFiles(params.getExportFiles());
+                }
+                if (params.isSetCommitInfos()) {
+                    updateCommitInfos(params.getCommitInfos());
+                }
+                if (params.isSetErrorTabletInfos()) {
+                    updateErrorTabletInfos(params.getErrorTabletInfos());
+                }
+                profileDoneSignal.markedCountDown(params.getFragmentInstanceId(), -1L);
+            }
+
+            if (params.isSetLoadedRows()) {
+                Env.getCurrentEnv().getLoadManager().updateJobProgress(
+                        jobId, params.getBackendId(), params.getQueryId(), params.getFragmentInstanceId(),
+                        params.getLoadedRows(), params.getLoadedBytes(), params.isDone());
+            }
         }
     }
 
@@ -1932,8 +2194,14 @@ public class Coordinator {
     }
 
     public void endProfile(boolean waitProfileDone) {
-        if (backendExecStates.isEmpty()) {
-            return;
+        if (enableRpcOptForPipeline) {
+            if (pipelineExecContexts.isEmpty()) {
+                return;
+            }
+        } else {
+            if (backendExecStates.isEmpty()) {
+                return;
+            }
         }
 
         // Wait for all backends to finish reporting when writing profile last time.
@@ -1994,11 +2262,21 @@ public class Coordinator {
      * return true if all of them are OK. Otherwise, return false.
      */
     private boolean checkBackendState() {
-        for (BackendExecState backendExecState : needCheckBackendExecStates) {
-            if (!backendExecState.isBackendStateHealthy()) {
-                queryStatus = new Status(TStatusCode.INTERNAL_ERROR, "backend "
-                        + backendExecState.backend.getId() + " is down");
-                return false;
+        if (enableRpcOptForPipeline) {
+            for (PipelineExecContext ctx : needCheckPipelineExecContexts) {
+                if (!ctx.isBackendStateHealthy()) {
+                    queryStatus = new Status(TStatusCode.INTERNAL_ERROR, "backend "
+                            + ctx.backend.getId() + " is down");
+                    return false;
+                }
+            }
+        } else {
+            for (BackendExecState backendExecState : needCheckBackendExecStates) {
+                if (!backendExecState.isBackendStateHealthy()) {
+                    queryStatus = new Status(TStatusCode.INTERNAL_ERROR, "backend "
+                            + backendExecState.backend.getId() + " is down");
+                    return false;
+                }
             }
         }
         return true;
@@ -2387,6 +2665,165 @@ public class Coordinator {
         }
     }
 
+    public class PipelineExecContext {
+        TPipelineParams rpcParams;
+        PlanFragmentId fragmentId;
+        boolean initiated;
+        volatile boolean done;
+        volatile Map<TUniqueId, Boolean> doneFlags = new HashMap<TUniqueId, Boolean>();
+        boolean hasCanceled;
+        volatile Map<TUniqueId, Boolean> cancelFlags = new HashMap<TUniqueId, Boolean>();
+        int cancelProgress = 0;
+        int profileFragmentId;
+        RuntimeProfile profile;
+        TNetworkAddress brpcAddress;
+        TNetworkAddress address;
+        Backend backend;
+        long lastMissingHeartbeatTime = -1;
+        long profileReportProgress = 0;
+        private final int numInstances;
+
+        public PipelineExecContext(PlanFragmentId fragmentId, int profileFragmentId,
+                TPipelineParams rpcParams, Map<TNetworkAddress, Long> addressToBackendID, TNetworkAddress addr) {
+            this.profileFragmentId = profileFragmentId;
+            this.fragmentId = fragmentId;
+            this.rpcParams = rpcParams;
+            this.numInstances = rpcParams.local_params.size();
+            for (int i = 0; i < this.numInstances; i++) {
+                this.doneFlags.put(rpcParams.local_params.get(i).fragment_instance_id, false);
+            }
+            this.initiated = false;
+            this.done = false;
+
+            this.address = addr;
+            this.backend = idToBackend.get(addressToBackendID.get(address));
+            this.brpcAddress = new TNetworkAddress(backend.getHost(), backend.getBrpcPort());
+
+            String name = "Fragment " + profileFragmentId + " (host=" + address + ")";
+            this.profile = new RuntimeProfile(name);
+            this.hasCanceled = false;
+            for (int i = 0; i < this.numInstances; i++) {
+                this.cancelFlags.put(rpcParams.local_params.get(i).fragment_instance_id, false);
+            }
+            this.lastMissingHeartbeatTime = backend.getLastMissingHeartbeatTime();
+        }
+
+        /**
+         * Some information common to all Fragments does not need to be sent repeatedly.
+         * Therefore, when we confirm that a certain BE has accepted the information,
+         * we will delete the information in the subsequent Fragment to avoid repeated sending.
+         * This information can be obtained from the cache of BE.
+         */
+        public void unsetFields() {
+            this.rpcParams.unsetDescTbl();
+            this.rpcParams.unsetCoord();
+            this.rpcParams.unsetQueryGlobals();
+            this.rpcParams.unsetResourceInfo();
+            this.rpcParams.setIsSimplifiedParam(true);
+        }
+
+        // update profile.
+        // return true if profile is updated. Otherwise, return false.
+        public synchronized boolean updateProfile(TReportExecStatusParams params) {
+            if (this.done) {
+                // duplicate packet
+                return false;
+            }
+            if (params.isSetProfile()) {
+                profile.update(params.profile);
+            }
+            if (params.done) {
+                this.doneFlags.replace(params.fragment_instance_id, true);
+                profileReportProgress++;
+            }
+            if (profileReportProgress == numInstances) {
+                this.done = true;
+            }
+            return true;
+        }
+
+        public synchronized void printProfile(StringBuilder builder) {
+            this.profile.computeTimeInProfile();
+            this.profile.prettyPrint(builder, "");
+        }
+
+        // cancel all fragment instances.
+        // return true if cancel success. Otherwise, return false
+        public synchronized boolean cancelFragmentInstance(Types.PPlanFragmentCancelReason cancelReason) {
+            if (!this.initiated) {
+                return false;
+            }
+            // don't cancel if it is already finished
+            if (this.done) {
+                return false;
+            }
+            if (this.hasCanceled) {
+                return false;
+            }
+            for (TPipelineLocalParams localParam : rpcParams.local_params) {
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("cancelRemoteFragments initiated={} done={} hasCanceled={} backend: {},"
+                                    + " fragment instance id={}, reason: {}",
+                            this.initiated, this.done, this.hasCanceled, backend.getId(),
+                            DebugUtil.printId(localParam.fragment_instance_id), cancelReason.name());
+                }
+                if (cancelFlags.get(localParam.fragment_instance_id)) {
+                    continue;
+                }
+                try {
+                    Span span = ConnectContext.get() != null
+                            ? ConnectContext.get().getTracer().spanBuilder("cancelPlanFragmentAsync")
+                            .setParent(Context.current()).setSpanKind(SpanKind.CLIENT).startSpan()
+                            : Telemetry.getNoopSpan();
+                    try (Scope scope = span.makeCurrent()) {
+                        BackendServiceProxy.getInstance().cancelPlanFragmentAsync(brpcAddress,
+                                localParam.fragment_instance_id, cancelReason);
+                    } catch (RpcException e) {
+                        span.recordException(e);
+                        LOG.warn("cancel plan fragment get a exception, address={}:{}", brpcAddress.getHostname(),
+                                brpcAddress.getPort());
+                        SimpleScheduler.addToBlacklist(addressToBackendID.get(brpcAddress), e.getMessage());
+                    } finally {
+                        span.end();
+                    }
+                } catch (Exception e) {
+                    LOG.warn("catch a exception", e);
+                    return false;
+                }
+            }
+            this.hasCanceled = true;
+            for (int i = 0; i < this.numInstances; i++) {
+                this.cancelFlags.replace(rpcParams.local_params.get(i).fragment_instance_id, true);
+            }
+            cancelProgress = numInstances;
+            return true;
+        }
+
+        public synchronized boolean computeTimeInProfile(int maxFragmentId) {
+            if (this.profileFragmentId < 0 || this.profileFragmentId > maxFragmentId) {
+                LOG.warn("profileFragmentId {} should be in [0, {})", profileFragmentId, maxFragmentId);
+                return false;
+            }
+            profile.computeTimeInProfile();
+            return true;
+        }
+
+        public boolean isBackendStateHealthy() {
+            if (backend.getLastMissingHeartbeatTime() > lastMissingHeartbeatTime && !backend.isAlive()) {
+                LOG.warn("backend {} is down while joining the coordinator. job id: {}",
+                        backend.getId(), jobId);
+                return false;
+            }
+            return true;
+        }
+
+        public List<QueryStatisticsItem.FragmentInstanceInfo> buildFragmentInstanceInfo() {
+            return this.rpcParams.local_params.stream().map(it -> new FragmentInstanceInfo.Builder()
+                    .instanceId(it.fragment_instance_id).fragmentId(String.valueOf(fragmentId))
+                    .address(this.address).build()).collect(Collectors.toList());
+        }
+    }
+
     /**
      * A set of BackendExecState for same Backend
      */
@@ -2430,6 +2867,103 @@ public class Coordinator {
                 for (BackendExecState state : states) {
                     state.initiated = true;
                     paramsList.addToParamsList(state.rpcParams);
+                }
+                return proxy.execPlanFragmentsAsync(brpcAddr, paramsList, twoPhaseExecution);
+            } catch (RpcException e) {
+                // DO NOT throw exception here, return a complete future with error code,
+                // so that the following logic will cancel the fragment.
+                return futureWithException(e);
+            }
+        }
+
+        public Future<InternalService.PExecPlanFragmentResult> execPlanFragmentStartAsync(BackendServiceProxy proxy)
+                throws TException {
+            try {
+                PExecPlanFragmentStartRequest.Builder builder = PExecPlanFragmentStartRequest.newBuilder();
+                PUniqueId qid = PUniqueId.newBuilder().setHi(queryId.hi).setLo(queryId.lo).build();
+                builder.setQueryId(qid);
+                return proxy.execPlanFragmentStartAsync(brpcAddr, builder.build());
+            } catch (RpcException e) {
+                // DO NOT throw exception here, return a complete future with error code,
+                // so that the following logic will cancel the fragment.
+                return futureWithException(e);
+            }
+        }
+
+        @NotNull
+        private Future<PExecPlanFragmentResult> futureWithException(RpcException e) {
+            return new Future<PExecPlanFragmentResult>() {
+                @Override
+                public boolean cancel(boolean mayInterruptIfRunning) {
+                    return false;
+                }
+
+                @Override
+                public boolean isCancelled() {
+                    return false;
+                }
+
+                @Override
+                public boolean isDone() {
+                    return true;
+                }
+
+                @Override
+                public PExecPlanFragmentResult get() {
+                    PExecPlanFragmentResult result = PExecPlanFragmentResult.newBuilder().setStatus(
+                            Types.PStatus.newBuilder().addErrorMsgs(e.getMessage())
+                                    .setStatusCode(TStatusCode.THRIFT_RPC_ERROR.getValue()).build()).build();
+                    return result;
+                }
+
+                @Override
+                public PExecPlanFragmentResult get(long timeout, TimeUnit unit) {
+                    return get();
+                }
+            };
+        }
+    }
+
+    public class PipelineExecContexts {
+        long beId;
+        TNetworkAddress brpcAddr;
+        List<PipelineExecContext> ctxs = Lists.newArrayList();
+        boolean twoPhaseExecution = false;
+        ScopedSpan scopedSpan = new ScopedSpan();
+
+        public PipelineExecContexts(long beId, TNetworkAddress brpcAddr, boolean twoPhaseExecution) {
+            this.beId = beId;
+            this.brpcAddr = brpcAddr;
+            this.twoPhaseExecution = twoPhaseExecution;
+        }
+
+        public void addContext(PipelineExecContext ctx) {
+            this.ctxs.add(ctx);
+        }
+
+        /**
+         * The BackendExecState in states are all send to the same BE.
+         * So only the first BackendExecState need to carry some common fields, such as DescriptorTbl,
+         * the other BackendExecState does not need those fields. Unset them to reduce size.
+         */
+        public void unsetFields() {
+            boolean first = true;
+            for (PipelineExecContext ctx : ctxs) {
+                if (first) {
+                    first = false;
+                    continue;
+                }
+                ctx.unsetFields();
+            }
+        }
+
+        public Future<InternalService.PExecPlanFragmentResult> execRemoteFragmentsAsync(BackendServiceProxy proxy)
+                throws TException {
+            try {
+                TPipelineParamsList paramsList = new TPipelineParamsList();
+                for (PipelineExecContext cts : ctxs) {
+                    cts.initiated = true;
+                    paramsList.addToParamsList(cts.rpcParams);
                 }
                 return proxy.execPlanFragmentsAsync(brpcAddr, paramsList, twoPhaseExecution);
             } catch (RpcException e) {
@@ -2560,6 +3094,77 @@ public class Coordinator {
             return paramsList;
         }
 
+        Map<TNetworkAddress, TPipelineParams> toTPipelineParams(int backendNum) {
+            long memLimit = queryOptions.getMemLimit();
+            // 2. update memory limit for colocate join
+            if (colocateFragmentIds.contains(fragment.getFragmentId().asInt())) {
+                int rate = Math.min(Config.query_colocate_join_memory_limit_penalty_factor, instanceExecParams.size());
+                memLimit = queryOptions.getMemLimit() / rate;
+            }
+
+            Map<TNetworkAddress, TPipelineParams> res = new HashMap();
+            for (int i = 0; i < instanceExecParams.size(); ++i) {
+                final FInstanceExecParam instanceExecParam = instanceExecParams.get(i);
+                if (!res.containsKey(instanceExecParam.host)) {
+                    TPipelineParams params = new TPipelineParams();
+
+                    // Set global param
+                    params.setProtocolVersion(PaloInternalServiceVersion.V1);
+                    params.setDescTbl(descTable);
+                    params.setResourceInfo(tResourceInfo);
+                    params.setQueryId(queryId);
+                    params.setPerExchNumSenders(perExchNumSenders);
+                    params.setDestinations(destinations);
+                    params.setNumSenders(instanceExecParams.size());
+                    params.setCoord(coordAddress);
+                    params.setQueryGlobals(queryGlobals);
+                    params.setQueryOptions(queryOptions);
+                    params.query_options.setMemLimit(memLimit);
+                    params.setSendQueryStatisticsWithEveryBatch(
+                            fragment.isTransferQueryStatisticsWithEveryBatch());
+                    params.setFragment(fragment.toThrift());
+                    params.setLocalParams(Lists.newArrayList());
+                    res.put(instanceExecParam.host, params);
+                }
+                TPipelineParams params = res.get(instanceExecParam.host);
+                TPipelineLocalParams localParams = new TPipelineLocalParams();
+
+                localParams.setBuildHashTableForBroadcastJoin(instanceExecParam.buildHashTableForBroadcastJoin);
+                localParams.setFragmentInstanceId(instanceExecParam.instanceId);
+                Map<Integer, List<TScanRangeParams>> scanRanges = instanceExecParam.perNodeScanRanges;
+                if (scanRanges == null) {
+                    scanRanges = Maps.newHashMap();
+                }
+                localParams.setPerNodeScanRanges(scanRanges);
+                localParams.setSenderId(i);
+                localParams.setBackendNum(backendNum++);
+                localParams.setRuntimeFilterParams(new TRuntimeFilterParams());
+                localParams.runtime_filter_params.setRuntimeFilterMergeAddr(runtimeFilterMergeAddr);
+                if (instanceExecParam.instanceId.equals(runtimeFilterMergeInstanceId)) {
+                    for (Map.Entry<RuntimeFilterId, List<FRuntimeFilterTargetParam>> entry
+                            : ridToTargetParam.entrySet()) {
+                        List<TRuntimeFilterTargetParams> targetParams = Lists.newArrayList();
+                        for (FRuntimeFilterTargetParam targetParam : entry.getValue()) {
+                            targetParams.add(new TRuntimeFilterTargetParams(targetParam.targetFragmentInstanceId,
+                                    targetParam.targetFragmentInstanceAddr));
+                        }
+                        localParams.runtime_filter_params.putToRidToTargetParam(entry.getKey().asInt(), targetParams);
+                    }
+                    for (Map.Entry<RuntimeFilterId, Integer> entry : ridToBuilderNum.entrySet()) {
+                        localParams.runtime_filter_params.putToRuntimeFilterBuilderNum(
+                                entry.getKey().asInt(), entry.getValue());
+                    }
+                    for (RuntimeFilter rf : assignedRuntimeFilters) {
+                        localParams.runtime_filter_params.putToRidToRuntimeFilter(
+                                rf.getFilterId().asInt(), rf.toThrift());
+                    }
+                }
+                params.getLocalParams().add(localParams);
+            }
+
+            return res;
+        }
+
         // Append range information
         // [tablet_id(version),tablet_id(version)]
         public void appendScanRange(StringBuilder sb, List<TScanRangeParams> params) {
@@ -2662,13 +3267,26 @@ public class Coordinator {
                 Lists.newArrayList();
         lock();
         try {
-            for (int index = 0; index < fragments.size(); index++) {
-                for (BackendExecState backendExecState : backendExecStates) {
-                    if (fragments.get(index).getFragmentId() != backendExecState.fragmentId) {
-                        continue;
+            if (enableRpcOptForPipeline) {
+                for (int index = 0; index < fragments.size(); index++) {
+                    for (PipelineExecContext ctx : pipelineExecContexts.values()) {
+                        if (fragments.get(index).getFragmentId() != ctx.fragmentId) {
+                            continue;
+                        }
+                        final List<QueryStatisticsItem.FragmentInstanceInfo> info = ctx.buildFragmentInstanceInfo();
+                        result.addAll(info);
                     }
-                    final QueryStatisticsItem.FragmentInstanceInfo info = backendExecState.buildFragmentInstanceInfo();
-                    result.add(info);
+                }
+            } else {
+                for (int index = 0; index < fragments.size(); index++) {
+                    for (BackendExecState backendExecState : backendExecStates) {
+                        if (fragments.get(index).getFragmentId() != backendExecState.fragmentId) {
+                            continue;
+                        }
+                        final QueryStatisticsItem.FragmentInstanceInfo info =
+                                backendExecState.buildFragmentInstanceInfo();
+                        result.add(info);
+                    }
                 }
             }
         } finally {
@@ -2678,11 +3296,20 @@ public class Coordinator {
     }
 
     private void attachInstanceProfileToFragmentProfile() {
-        for (BackendExecState backendExecState : backendExecStates) {
-            if (!backendExecState.computeTimeInProfile(fragmentProfile.size())) {
-                return;
+        if (enableRpcOptForPipeline) {
+            for (PipelineExecContext ctx : pipelineExecContexts.values()) {
+                if (!ctx.computeTimeInProfile(fragmentProfile.size())) {
+                    return;
+                }
+                fragmentProfile.get(ctx.profileFragmentId).addChild(ctx.profile);
             }
-            fragmentProfile.get(backendExecState.profileFragmentId).addChild(backendExecState.profile);
+        } else {
+            for (BackendExecState backendExecState : backendExecStates) {
+                if (!backendExecState.computeTimeInProfile(fragmentProfile.size())) {
+                    return;
+                }
+                fragmentProfile.get(backendExecState.profileFragmentId).addChild(backendExecState.profile);
+            }
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
@@ -82,9 +82,9 @@ import org.apache.doris.thrift.TExecPlanFragmentParamsList;
 import org.apache.doris.thrift.TFileRangeDesc;
 import org.apache.doris.thrift.TNetworkAddress;
 import org.apache.doris.thrift.TPaloScanRange;
-import org.apache.doris.thrift.TPipelineInstanceParams;
 import org.apache.doris.thrift.TPipelineFragmentParams;
 import org.apache.doris.thrift.TPipelineFragmentParamsList;
+import org.apache.doris.thrift.TPipelineInstanceParams;
 import org.apache.doris.thrift.TPlanFragmentDestination;
 import org.apache.doris.thrift.TPlanFragmentExecParams;
 import org.apache.doris.thrift.TQueryGlobals;
@@ -2684,7 +2684,8 @@ public class Coordinator {
         private final int numInstances;
 
         public PipelineExecContext(PlanFragmentId fragmentId, int profileFragmentId,
-                TPipelineFragmentParams rpcParams, Map<TNetworkAddress, Long> addressToBackendID, TNetworkAddress addr) {
+                TPipelineFragmentParams rpcParams, Map<TNetworkAddress, Long> addressToBackendID,
+                TNetworkAddress addr) {
             this.profileFragmentId = profileFragmentId;
             this.fragmentId = fragmentId;
             this.rpcParams = rpcParams;

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -170,6 +170,7 @@ public class SessionVariable implements Serializable, Writable {
     public static final String ENABLE_VECTORIZED_ENGINE = "enable_vectorized_engine";
 
     public static final String ENABLE_PIPELINE_ENGINE = "enable_pipeline_engine";
+    public static final String ENABLE_RPC_OPT_FOR_PIPELINE = "enable_rpc_opt_for_pipeline";
 
     public static final String ENABLE_SINGLE_DISTINCT_COLUMN_OPT = "enable_single_distinct_column_opt";
 
@@ -488,6 +489,9 @@ public class SessionVariable implements Serializable, Writable {
 
     @VariableMgr.VarAttr(name = ENABLE_PIPELINE_ENGINE, fuzzy = true)
     public boolean enablePipelineEngine = false;
+
+    @VariableMgr.VarAttr(name = ENABLE_RPC_OPT_FOR_PIPELINE)
+    public boolean enableRpcOptForPipeline = true;
 
     @VariableMgr.VarAttr(name = ENABLE_PARALLEL_OUTFILE)
     public boolean enableParallelOutfile = false;
@@ -1236,6 +1240,10 @@ public class SessionVariable implements Serializable, Writable {
 
     public boolean enablePipelineEngine() {
         return enablePipelineEngine;
+    }
+
+    public boolean enableRpcOptForPipeline() {
+        return enableRpcOptForPipeline;
     }
 
     public void setEnablePipelineEngine(boolean enablePipelineEngine) {

--- a/fe/fe-core/src/main/java/org/apache/doris/rpc/BackendServiceProxy.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/rpc/BackendServiceProxy.java
@@ -25,7 +25,7 @@ import org.apache.doris.proto.Types;
 import org.apache.doris.thrift.TExecPlanFragmentParamsList;
 import org.apache.doris.thrift.TFoldConstantParams;
 import org.apache.doris.thrift.TNetworkAddress;
-import org.apache.doris.thrift.TPipelineParamsList;
+import org.apache.doris.thrift.TPipelineFragmentParamsList;
 import org.apache.doris.thrift.TUniqueId;
 
 import com.google.common.collect.Maps;
@@ -141,7 +141,7 @@ public class BackendServiceProxy {
     }
 
     public Future<InternalService.PExecPlanFragmentResult> execPlanFragmentsAsync(TNetworkAddress address,
-            TPipelineParamsList params, boolean twoPhaseExecution) throws TException, RpcException {
+            TPipelineFragmentParamsList params, boolean twoPhaseExecution) throws TException, RpcException {
         InternalService.PExecPlanFragmentRequest.Builder builder =
                 InternalService.PExecPlanFragmentRequest.newBuilder();
         if (Config.use_compact_thrift_rpc) {
@@ -152,7 +152,7 @@ public class BackendServiceProxy {
             builder.setRequest(ByteString.copyFrom(new TSerializer().serialize(params))).build();
             builder.setCompact(false);
         }
-        // VERSION 3 means we send TPipelineParamsList
+        // VERSION 3 means we send TPipelineFragmentParamsList
         builder.setVersion(InternalService.PFragmentRequestVersion.VERSION_3);
 
         final InternalService.PExecPlanFragmentRequest pRequest = builder.build();

--- a/fe/fe-core/src/main/java/org/apache/doris/rpc/BackendServiceProxy.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/rpc/BackendServiceProxy.java
@@ -25,6 +25,7 @@ import org.apache.doris.proto.Types;
 import org.apache.doris.thrift.TExecPlanFragmentParamsList;
 import org.apache.doris.thrift.TFoldConstantParams;
 import org.apache.doris.thrift.TNetworkAddress;
+import org.apache.doris.thrift.TPipelineParamsList;
 import org.apache.doris.thrift.TUniqueId;
 
 import com.google.common.collect.Maps;
@@ -121,6 +122,38 @@ public class BackendServiceProxy {
         }
         // VERSION 2 means we send TExecPlanFragmentParamsList, not single TExecPlanFragmentParams
         builder.setVersion(InternalService.PFragmentRequestVersion.VERSION_2);
+
+        final InternalService.PExecPlanFragmentRequest pRequest = builder.build();
+        MetricRepo.BE_COUNTER_QUERY_RPC_ALL.getOrAdd(address.hostname).increase(1L);
+        MetricRepo.BE_COUNTER_QUERY_RPC_SIZE.getOrAdd(address.hostname).increase((long) pRequest.getSerializedSize());
+        try {
+            final BackendServiceClient client = getProxy(address);
+            if (twoPhaseExecution) {
+                return client.execPlanFragmentPrepareAsync(pRequest);
+            } else {
+                return client.execPlanFragmentAsync(pRequest);
+            }
+        } catch (Throwable e) {
+            LOG.warn("Execute plan fragment catch a exception, address={}:{}", address.getHostname(), address.getPort(),
+                    e);
+            throw new RpcException(address.hostname, e.getMessage());
+        }
+    }
+
+    public Future<InternalService.PExecPlanFragmentResult> execPlanFragmentsAsync(TNetworkAddress address,
+            TPipelineParamsList params, boolean twoPhaseExecution) throws TException, RpcException {
+        InternalService.PExecPlanFragmentRequest.Builder builder =
+                InternalService.PExecPlanFragmentRequest.newBuilder();
+        if (Config.use_compact_thrift_rpc) {
+            builder.setRequest(
+                    ByteString.copyFrom(new TSerializer(new TCompactProtocol.Factory()).serialize(params)));
+            builder.setCompact(true);
+        } else {
+            builder.setRequest(ByteString.copyFrom(new TSerializer().serialize(params))).build();
+            builder.setCompact(false);
+        }
+        // VERSION 3 means we send TPipelineParamsList
+        builder.setVersion(InternalService.PFragmentRequestVersion.VERSION_3);
 
         final InternalService.PExecPlanFragmentRequest pRequest = builder.build();
         MetricRepo.BE_COUNTER_QUERY_RPC_ALL.getOrAdd(address.hostname).increase(1L);

--- a/gensrc/proto/internal_service.proto
+++ b/gensrc/proto/internal_service.proto
@@ -192,6 +192,7 @@ message PTabletWriterCancelResult {
 enum PFragmentRequestVersion {
     VERSION_1 = 1;  // only one TExecPlanFragmentParams in request
     VERSION_2 = 2;  // multi TExecPlanFragmentParams in request
+    VERSION_3 = 3;  // multi TPipelineParams in request
 };
 
 message PExecPlanFragmentRequest {

--- a/gensrc/proto/internal_service.proto
+++ b/gensrc/proto/internal_service.proto
@@ -192,7 +192,7 @@ message PTabletWriterCancelResult {
 enum PFragmentRequestVersion {
     VERSION_1 = 1;  // only one TExecPlanFragmentParams in request
     VERSION_2 = 2;  // multi TExecPlanFragmentParams in request
-    VERSION_3 = 3;  // multi TPipelineParams in request
+    VERSION_3 = 3;  // multi TPipelineFragmentParams in request
 };
 
 message PExecPlanFragmentRequest {

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -408,6 +408,8 @@ struct TReportExecStatusParams {
   17: optional i64 loaded_bytes
 
   18: optional list<Types.TErrorTabletInfo> errorTabletInfos
+
+  19: optional i32 fragment_id
 }
 
 struct TFeResult {

--- a/gensrc/thrift/PaloInternalService.thrift
+++ b/gensrc/thrift/PaloInternalService.thrift
@@ -554,7 +554,7 @@ struct TExportStatusResult {
     3: optional list<string> files
 }
 
-struct TPipelineLocalParams {
+struct TPipelineInstanceParams {
   1: required Types.TUniqueId fragment_instance_id
   2: optional bool build_hash_table_for_broadcast_join = false;
   3: required map<Types.TPlanNodeId, list<TScanRangeParams>> per_node_scan_ranges
@@ -564,7 +564,7 @@ struct TPipelineLocalParams {
 }
 
 // ExecPlanFragment
-struct TPipelineParams {
+struct TPipelineFragmentParams {
   1: required PaloInternalServiceVersion protocol_version
   2: required Types.TUniqueId query_id
   3: optional i32 fragment_id
@@ -589,9 +589,9 @@ struct TPipelineParams {
   21: optional bool is_simplified_param = false;
   22: optional TGlobalDict global_dict  // scan node could use the global dict to encode the string value to an integer
   23: optional Planner.TPlanFragment fragment
-  24: list<TPipelineLocalParams> local_params
+  24: list<TPipelineInstanceParams> local_params
 }
 
-struct TPipelineParamsList {
-    1: optional list<TPipelineParams> params_list;
+struct TPipelineFragmentParamsList {
+    1: optional list<TPipelineFragmentParams> params_list;
 }

--- a/gensrc/thrift/PaloInternalService.thrift
+++ b/gensrc/thrift/PaloInternalService.thrift
@@ -553,3 +553,45 @@ struct TExportStatusResult {
     2: required Types.TExportState state
     3: optional list<string> files
 }
+
+struct TPipelineLocalParams {
+  1: required Types.TUniqueId fragment_instance_id
+  2: optional bool build_hash_table_for_broadcast_join = false;
+  3: required map<Types.TPlanNodeId, list<TScanRangeParams>> per_node_scan_ranges
+  4: optional i32 sender_id
+  5: optional TRuntimeFilterParams runtime_filter_params
+  6: optional i32 backend_num
+}
+
+// ExecPlanFragment
+struct TPipelineParams {
+  1: required PaloInternalServiceVersion protocol_version
+  2: required Types.TUniqueId query_id
+  3: optional i32 fragment_id
+  4: required map<Types.TPlanNodeId, i32> per_exch_num_senders
+  5: optional Descriptors.TDescriptorTable desc_tbl
+  6: optional Types.TResourceInfo resource_info
+  7: list<TPlanFragmentDestination> destinations
+  8: optional i32 num_senders
+  9: optional bool send_query_statistics_with_every_batch
+  10: optional Types.TNetworkAddress coord
+  11: optional TQueryGlobals query_globals
+  12: optional TQueryOptions query_options
+  // load job related
+  13: optional string import_label
+  14: optional string db_name
+  15: optional i64 load_job_id
+  16: optional TLoadErrorHubInfo load_error_hub_info
+  17: optional i32 fragment_num_on_host
+  18: optional i64 backend_id
+  19: optional bool need_wait_execution_trigger = false
+  20: optional list<Types.TUniqueId> instances_sharing_hash_table
+  21: optional bool is_simplified_param = false;
+  22: optional TGlobalDict global_dict  // scan node could use the global dict to encode the string value to an integer
+  23: optional Planner.TPlanFragment fragment
+  24: list<TPipelineLocalParams> local_params
+}
+
+struct TPipelineParamsList {
+    1: optional list<TPipelineParams> params_list;
+}


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

Now we use a thrift message per fragment instance. However, there are many same messages between instances in a fragment. So this PR aims to extract the same messages and we only need to send thrift message once for a fragment

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

