### PR TITLE
[Fix](topn) fix wrong nullable cast for RowId column and use heapsort…

### DIFF
--- a/be/src/vec/common/sort/heap_sorter.cpp
+++ b/be/src/vec/common/sort/heap_sorter.cpp
@@ -48,7 +48,7 @@ Status HeapSorter::append_block(Block* block) {
                 if (column_id < 0) {
                     continue;
                 }
-                if (convert_nullable_flags[i]) {
+                if (i < convert_nullable_flags.size() && convert_nullable_flags[i]) {
                     auto column_ptr = make_nullable(block->get_by_position(column_id).column);
                     new_block.insert({column_ptr,
                                       make_nullable(block->get_by_position(column_id).type), ""});

--- a/be/src/vec/common/sort/sorter.cpp
+++ b/be/src/vec/common/sort/sorter.cpp
@@ -250,7 +250,7 @@ Status Sorter::partial_sort(Block& src_block, Block& dest_block) {
             if (column_id < 0) {
                 continue;
             }
-            if (convert_nullable_flags[i]) {
+            if (i < convert_nullable_flags.size() && convert_nullable_flags[i]) {
                 auto column_ptr = make_nullable(src_block.get_by_position(column_id).column);
                 new_block.insert(
                         {column_ptr, make_nullable(src_block.get_by_position(column_id).type), ""});

--- a/be/src/vec/exec/vsort_node.cpp
+++ b/be/src/vec/exec/vsort_node.cpp
@@ -44,7 +44,8 @@ Status VSortNode::init(const TPlanNode& tnode, RuntimeState* state) {
     // exclude cases which incoming blocks has string column which is sensitive to operations like
     // `filter` and `memcpy`
     if (_limit > 0 && _limit + _offset < HeapSorter::HEAP_SORT_THRESHOLD &&
-        (tnode.sort_node.use_topn_opt || !row_desc.has_varlen_slots())) {
+        (tnode.sort_node.sort_info.use_two_phase_read || tnode.sort_node.use_topn_opt ||
+         !row_desc.has_varlen_slots())) {
         _sorter.reset(new HeapSorter(_vsort_exec_exprs, _limit, _offset, _pool, _is_asc_order,
                                      _nulls_first, row_desc));
         _reuse_mem = false;

--- a/be/src/vec/utils/util.hpp
+++ b/be/src/vec/utils/util.hpp
@@ -35,7 +35,7 @@ public:
     }
 
     static ColumnsWithTypeAndName create_columns_with_type_and_name(
-            const RowDescriptor& row_desc, bool ignore_trivial_slot = false) {
+            const RowDescriptor& row_desc, bool ignore_trivial_slot = true) {
         ColumnsWithTypeAndName columns_with_type_and_name;
         for (const auto& tuple_desc : row_desc.tuple_descriptors()) {
             for (const auto& slot_desc : tuple_desc->slots()) {
@@ -50,7 +50,7 @@ public:
     }
 
     static ColumnsWithTypeAndName create_empty_block(const RowDescriptor& row_desc,
-                                                     bool ignore_trivial_slot = false) {
+                                                     bool ignore_trivial_slot = true) {
         ColumnsWithTypeAndName columns_with_type_and_name;
         for (const auto& tuple_desc : row_desc.tuple_descriptors()) {
             for (const auto& slot_desc : tuple_desc->slots()) {


### PR DESCRIPTION
…er for two phase read

convert_nullable_flags does not contain nullable info for RowID column, but valid_column_ids contain RowID column, nullable falg will be undefined for RowID column

# Proposed changes

Issue Number: close #16398

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

