### PR TITLE
[fix](planner) npe in RewriteBinaryPredicatesRule

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/rewrite/RewriteBinaryPredicatesRule.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/rewrite/RewriteBinaryPredicatesRule.java
@@ -27,7 +27,6 @@ import org.apache.doris.analysis.Expr;
 import org.apache.doris.analysis.IntLiteral;
 import org.apache.doris.analysis.LiteralExpr;
 import org.apache.doris.analysis.SlotRef;
-import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.Type;
 import org.apache.doris.common.AnalysisException;
 
@@ -123,8 +122,10 @@ public class RewriteBinaryPredicatesRule implements ExprRewriteRule {
         Expr expr1 = expr.getChild(1);
         if (expr0 instanceof CastExpr && (expr0.getType() == Type.DECIMALV2 || expr0.getType().isDecimalV3())
                 && expr0.getChild(0) instanceof SlotRef
-                && expr0.getChild(0).getType().getResultType() == Type.BIGINT && expr1 instanceof DecimalLiteral) {
-            return rewriteBigintSlotRefCompareDecimalLiteral(expr0, expr0.getChild(0).getType(), (DecimalLiteral) expr1, op);
+                && expr0.getChild(0).getType().getResultType() == Type.BIGINT
+                && expr1 instanceof DecimalLiteral) {
+            return rewriteBigintSlotRefCompareDecimalLiteral(expr0,
+                    expr0.getChild(0).getType(), (DecimalLiteral) expr1, op);
         }
         return expr;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/rewrite/RewriteBinaryPredicatesRule.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/rewrite/RewriteBinaryPredicatesRule.java
@@ -27,6 +27,7 @@ import org.apache.doris.analysis.Expr;
 import org.apache.doris.analysis.IntLiteral;
 import org.apache.doris.analysis.LiteralExpr;
 import org.apache.doris.analysis.SlotRef;
+import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.Type;
 import org.apache.doris.common.AnalysisException;
 
@@ -64,9 +65,8 @@ public class RewriteBinaryPredicatesRule implements ExprRewriteRule {
      * 11) "select * from T where t1> 2.0" is converted to "select * from T where t1> 2"
      * 12) "select * from T where t1> 2.1" is converted to "select * from T where t1> 2"
      */
-    private Expr rewriteBigintSlotRefCompareDecimalLiteral(Expr expr0, DecimalLiteral expr1,
+    private Expr rewriteBigintSlotRefCompareDecimalLiteral(Expr expr0, Type expr0ColumnType, DecimalLiteral expr1,
             BinaryPredicate.Operator op) {
-        Type columnType = expr0.getSrcSlotRef().getColumn().getType();
         try {
             // Convert childExpr to column type and compare the converted values. There are 3 possible situations:
             // case 1. The value of childExpr exceeds the range of the column type, then castTo() will throw an
@@ -74,7 +74,7 @@ public class RewriteBinaryPredicatesRule implements ExprRewriteRule {
             // case 2. childExpr is converted to column type, but the value of childExpr loses precision.
             //   For example, 2.1 is converted to 2;
             // case 3. childExpr is precisely converted to column type. For example, 2.0 is converted to 2.
-            LiteralExpr newExpr = (LiteralExpr) expr1.castTo(columnType);
+            LiteralExpr newExpr = (LiteralExpr) expr1.castTo(expr0ColumnType);
             int compResult = expr1.compareLiteral(newExpr);
             // case 2
             if (compResult != 0) {
@@ -99,11 +99,11 @@ public class RewriteBinaryPredicatesRule implements ExprRewriteRule {
                 }
             }
             // case 3
-            return new BinaryPredicate(op, expr0.castTo(columnType), newExpr);
+            return new BinaryPredicate(op, expr0.castTo(expr0ColumnType), newExpr);
         } catch (AnalysisException e) {
             // case 1
-            IntLiteral colTypeMinValue = IntLiteral.createMinValue(columnType);
-            IntLiteral colTypeMaxValue = IntLiteral.createMaxValue(columnType);
+            IntLiteral colTypeMinValue = IntLiteral.createMinValue(expr0ColumnType);
+            IntLiteral colTypeMaxValue = IntLiteral.createMaxValue(expr0ColumnType);
             if (op == Operator.NE || ((expr1).compareLiteral(colTypeMinValue) < 0 && (op == Operator.GE
                     || op == Operator.GT)) || ((expr1).compareLiteral(colTypeMaxValue) > 0 && (op == Operator.LE
                     || op == Operator.LT))) {
@@ -123,11 +123,8 @@ public class RewriteBinaryPredicatesRule implements ExprRewriteRule {
         Expr expr1 = expr.getChild(1);
         if (expr0 instanceof CastExpr && (expr0.getType() == Type.DECIMALV2 || expr0.getType().isDecimalV3())
                 && expr0.getChild(0) instanceof SlotRef
-                && expr0.getChild(0).getType().getResultType() == Type.BIGINT && expr1 instanceof DecimalLiteral
-                //expr0.getChild(0) should be a real column, not a function. refer to pr 16401
-                && expr0.getSrcSlotRef() != null
-                && expr0.getSrcSlotRef().getColumn() != null) {
-            return rewriteBigintSlotRefCompareDecimalLiteral(expr0, (DecimalLiteral) expr1, op);
+                && expr0.getChild(0).getType().getResultType() == Type.BIGINT && expr1 instanceof DecimalLiteral) {
+            return rewriteBigintSlotRefCompareDecimalLiteral(expr0, expr0.getChild(0).getType(), (DecimalLiteral) expr1, op);
         }
         return expr;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/rewrite/RewriteBinaryPredicatesRule.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/rewrite/RewriteBinaryPredicatesRule.java
@@ -123,7 +123,10 @@ public class RewriteBinaryPredicatesRule implements ExprRewriteRule {
         Expr expr1 = expr.getChild(1);
         if (expr0 instanceof CastExpr && (expr0.getType() == Type.DECIMALV2 || expr0.getType().isDecimalV3())
                 && expr0.getChild(0) instanceof SlotRef
-                && expr0.getChild(0).getType().getResultType() == Type.BIGINT && expr1 instanceof DecimalLiteral) {
+                && expr0.getChild(0).getType().getResultType() == Type.BIGINT && expr1 instanceof DecimalLiteral
+                //expr0.getChild(0) should be a real column, not a function. refer to pr 16401
+                && expr0.getSrcSlotRef() != null
+                && expr0.getSrcSlotRef().getColumn() != null) {
             return rewriteBigintSlotRefCompareDecimalLiteral(expr0, (DecimalLiteral) expr1, op);
         }
         return expr;


### PR DESCRIPTION
# Proposed changes
RewriteBinaryPredicatesRule rewrite expression like 
`cast(A decimal) > decimal` to `A > some_other_bigint`
in order to：
1. push down the rewrite predicate 
2. avoid convert column A to decimal

We get the datatype of `A` by `expr0.getSrcSlotRef().getColumn().getType()`.
However, when A is result of a function from sub-query, this rule is not applicable.
For example:
```
select * 
from (
       select TIMESTAMPDIFF(MINUTE,startTime,endTime) AS timediff 
        from CNC_SliceSate) T  
where timediff > 5.0;
```
we cannot push predicate down to OlapScan(CNC_SliceSate) to save effort.

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
4. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
5. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
6. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
7. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

