### PR TITLE
[fix](func) fix core dump when the pattern of the regexp_extract_all function does not contain subpatterns

### DIFF
--- a/be/src/vec/functions/function_regexp.cpp
+++ b/be/src/vec/functions/function_regexp.cpp
@@ -204,6 +204,10 @@ struct RegexpExtractAllImpl {
                 }
                 scoped_re.reset(re);
             }
+            if (re->NumberOfCapturingGroups() == 0) {
+                StringOP::push_empty_string(i, result_data, result_offset);
+                continue;
+            }
             const auto& str = str_col->get_data_at(i);
             int max_matches = 1 + re->NumberOfCapturingGroups();
             std::vector<re2::StringPiece> res_matches;

--- a/docs/en/docs/sql-manual/sql-functions/string-functions/regexp/regexp_extract_all.md
+++ b/docs/en/docs/sql-manual/sql-functions/string-functions/regexp/regexp_extract_all.md
@@ -30,7 +30,7 @@ under the License.
 
 `VARCHAR regexp_extract_all (VARCHAR str, VARCHAR pattern)`
 
-Regularly matches a string str and extracts the first sub-pattern matching part of pattern. The pattern needs to exactly match a part of str in order to return an array of strings for the part of the pattern that needs to be matched. If there is no match, the empty string is returned.
+Regularly matches a string str and extracts the first sub-pattern matching part of pattern. The pattern needs to exactly match a part of str in order to return an array of strings for the part of the pattern that needs to be matched. If there is no match or the pattern has no sub-pattern, the empty string is returned.
 
 ### example
 

--- a/docs/zh-CN/docs/sql-manual/sql-functions/string-functions/regexp/regexp_extract_all.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/string-functions/regexp/regexp_extract_all.md
@@ -28,7 +28,7 @@ under the License.
 
 `VARCHAR regexp_extract_all(VARCHAR str, VARCHAR pattern)`
 
-对字符串 str 进行正则匹配，抽取符合 pattern 的第一个子模式匹配部分。需要 pattern 完全匹配 str 中的某部分，这样才能返回 pattern 部分中需匹配部分的字符串数组。如果没有匹配，返回空字符串。
+对字符串 str 进行正则匹配，抽取符合 pattern 的第一个子模式匹配部分。需要 pattern 完全匹配 str 中的某部分，这样才能返回 pattern 部分中需匹配部分的字符串数组。如果没有匹配或者pattern没有子模式，返回空字符串。
 
 ### example
 

--- a/regression-test/data/query_p0/sql_functions/string_functions/test_string_function_regexp.out
+++ b/regression-test/data/query_p0/sql_functions/string_functions/test_string_function_regexp.out
@@ -31,6 +31,9 @@ d
 ['abc','def','ghi']
 
 -- !sql --
+
+
+-- !sql --
 a-b-c
 
 -- !sql --

--- a/regression-test/suites/query_p0/sql_functions/string_functions/test_string_function_regexp.groovy
+++ b/regression-test/suites/query_p0/sql_functions/string_functions/test_string_function_regexp.groovy
@@ -46,6 +46,7 @@ suite("test_string_function_regexp") {
     qt_sql "SELECT regexp_extract_all('x=a3&x=18abc&x=2&y=3&x=4&x=17bcd', 'x=([0-9]+)([a-z]+)');"
     qt_sql "SELECT regexp_extract_all('http://a.m.baidu.com/i41915i73660.htm', 'i([0-9]+)');"
     qt_sql "SELECT regexp_extract_all('abc=111, def=222, ghi=333', '(\"[^\"]+\"|\\\\w+)=(\"[^\"]+\"|\\\\w+)');"
+    qt_sql "select regexp_extract_all('xxfs','f');"
 
     qt_sql "SELECT regexp_replace('a b c', \" \", \"-\");"
     qt_sql "SELECT regexp_replace('a b c','(b)','<\\\\1>');"


### PR DESCRIPTION

# Proposed changes

Issue Number: close #16352

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

