### PR TITLE
[fix](udf) fix create udf function with uppercase database name can't recognize

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/FunctionName.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/FunctionName.java
@@ -53,9 +53,6 @@ public class FunctionName implements Writable {
     public FunctionName(String db, String fn) {
         this.db = db;
         this.fn = fn.toLowerCase();
-        if (this.db != null) {
-            this.db = this.db.toLowerCase();
-        }
     }
 
     public FunctionName(String fn) {


### PR DESCRIPTION
> when create function with database, eg: create function MYTEST.addfunc(int) ....

> it's will change MYTEST to lowercase mytest, so can't use this function in other database

# Proposed changes

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

