### PR TITLE
[fix](multi-catalog) fix recursive get schema cache bug

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Column.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Column.java
@@ -63,6 +63,9 @@ public class Column implements Writable, GsonPostProcessable {
     private static final String COLUMN_ARRAY_CHILDREN = "item";
     public static final int COLUMN_UNIQUE_ID_INIT_VALUE = -1;
 
+    public static final Column UNSUPPORTED_COLUMN = new Column("unknown",
+            Type.UNSUPPORTED, true, null, true, null, "invalid", true, null, -1, null);
+
     @SerializedName(value = "name")
     private String name;
     @SerializedName(value = "type")

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/external/EsExternalTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/external/EsExternalTable.java
@@ -20,6 +20,8 @@ package org.apache.doris.catalog.external;
 import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.EsTable;
 import org.apache.doris.datasource.EsExternalCatalog;
+import org.apache.doris.external.elasticsearch.EsRestClient;
+import org.apache.doris.external.elasticsearch.EsUtil;
 import org.apache.doris.thrift.TEsTable;
 import org.apache.doris.thrift.TTableDescriptor;
 import org.apache.doris.thrift.TTableType;
@@ -74,6 +76,12 @@ public class EsExternalTable extends ExternalTable {
                 getName(), "");
         tTableDescriptor.setEsTable(tEsTable);
         return tTableDescriptor;
+    }
+
+    @Override
+    public List<Column> initSchema() {
+        EsRestClient restClient = ((EsExternalCatalog) catalog).getEsRestClient();
+        return EsUtil.genColumnsFromEs(restClient, name, null, ((EsExternalCatalog) catalog).enableMappingEsId());
     }
 
     private EsTable toEsTable() {

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/external/ExternalTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/external/ExternalTable.java
@@ -310,6 +310,10 @@ public class ExternalTable implements TableIf, Writable, GsonPostProcessable {
         return 1;
     }
 
+    public List<Column> initSchema() {
+        throw new NotImplementedException("implement in sub class");
+    }
+
     @Override
     public void write(DataOutput out) throws IOException {
         String json = GsonUtils.GSON.toJson(this);

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/external/ExternalTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/external/ExternalTable.java
@@ -310,6 +310,13 @@ public class ExternalTable implements TableIf, Writable, GsonPostProcessable {
         return 1;
     }
 
+    /**
+     * Should only be called in ExternalCatalog's getSchema(),
+     * which is called from schema cache.
+     * If you want to get schema of this table, use getFullSchema()
+     *
+     * @return
+     */
     public List<Column> initSchema() {
         throw new NotImplementedException("implement in sub class");
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/external/JdbcExternalTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/external/JdbcExternalTable.java
@@ -70,6 +70,11 @@ public class JdbcExternalTable extends ExternalTable {
         return jdbcTable.toThrift();
     }
 
+    @Override
+    public List<Column> initSchema() {
+        return ((JdbcExternalCatalog) catalog).getJdbcClient().getColumnsFromJdbc(dbName, name);
+    }
+
     private JdbcTable toJdbcTable() {
         List<Column> schema = getFullSchema();
         JdbcExternalCatalog jdbcCatalog = (JdbcExternalCatalog) catalog;
@@ -85,5 +90,4 @@ public class JdbcExternalTable extends ExternalTable {
         jdbcTable.setCheckSum(jdbcCatalog.getCheckSum());
         return jdbcTable;
     }
-
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/EsExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/EsExternalCatalog.java
@@ -17,12 +17,10 @@
 
 package org.apache.doris.datasource;
 
-import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.EsResource;
 import org.apache.doris.catalog.external.EsExternalDatabase;
 import org.apache.doris.external.elasticsearch.EsRestClient;
-import org.apache.doris.external.elasticsearch.EsUtil;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -155,11 +153,5 @@ public class EsExternalCatalog extends ExternalCatalog {
     @Override
     public boolean tableExist(SessionContext ctx, String dbName, String tblName) {
         return esRestClient.existIndex(this.esRestClient.getClient(), tblName);
-    }
-
-    @Override
-    public List<Column> getSchema(String dbName, String tblName) {
-        makeSureInitialized();
-        return EsUtil.genColumnsFromEs(getEsRestClient(), tblName, null, enableMappingEsId());
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/HMSExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/HMSExternalCatalog.java
@@ -18,14 +18,11 @@
 package org.apache.doris.datasource;
 
 import org.apache.doris.catalog.AuthType;
-import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.HMSResource;
 import org.apache.doris.catalog.HdfsResource;
-import org.apache.doris.catalog.HiveMetaStoreClientHelper;
 import org.apache.doris.catalog.external.ExternalDatabase;
 import org.apache.doris.catalog.external.HMSExternalDatabase;
-import org.apache.doris.catalog.external.HMSExternalTable;
 import org.apache.doris.common.Config;
 import org.apache.doris.datasource.hive.PooledHiveMetaStoreClient;
 import org.apache.doris.datasource.hive.event.MetastoreNotificationFetchException;
@@ -35,18 +32,14 @@ import com.google.common.collect.Maps;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.api.CurrentNotificationEventId;
-import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.metastore.api.NotificationEventResponse;
 import org.apache.hadoop.security.UserGroupInformation;
-import org.apache.iceberg.Schema;
-import org.apache.iceberg.Table;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 /**
  * External catalog for hive metastore compatible data sources.
@@ -172,42 +165,6 @@ public class HMSExternalCatalog extends ExternalCatalog {
     public PooledHiveMetaStoreClient getClient() {
         makeSureInitialized();
         return client;
-    }
-
-    @Override
-    public List<Column> getSchema(String dbName, String tblName) {
-        makeSureInitialized();
-        List<FieldSchema> schema = getClient().getSchema(dbName, tblName);
-        Optional<ExternalDatabase> db = getDb(dbName);
-        if (db.isPresent()) {
-            Optional table = db.get().getTable(tblName);
-            if (table.isPresent()) {
-                HMSExternalTable hmsTable = (HMSExternalTable) table.get();
-                if (hmsTable.getDlaType().equals(HMSExternalTable.DLAType.ICEBERG)) {
-                    return getIcebergSchema(hmsTable, schema);
-                }
-            }
-        }
-        List<Column> tmpSchema = Lists.newArrayListWithCapacity(schema.size());
-        for (FieldSchema field : schema) {
-            tmpSchema.add(new Column(field.getName(),
-                    HiveMetaStoreClientHelper.hiveTypeToDorisType(field.getType()), true, null,
-                    true, field.getComment(), true, -1));
-        }
-        return tmpSchema;
-    }
-
-    private List<Column> getIcebergSchema(HMSExternalTable table, List<FieldSchema> hmsSchema) {
-        Table icebergTable = HiveMetaStoreClientHelper.getIcebergTable(table);
-        Schema schema = icebergTable.schema();
-        List<Column> tmpSchema = Lists.newArrayListWithCapacity(hmsSchema.size());
-        for (FieldSchema field : hmsSchema) {
-            tmpSchema.add(new Column(field.getName(),
-                    HiveMetaStoreClientHelper.hiveTypeToDorisType(field.getType()), true, null,
-                    true, field.getComment(), true,
-                    schema.caseInsensitiveFindField(field.getName()).fieldId()));
-        }
-        return tmpSchema;
     }
 
     public void setLastSyncedEventId(long lastSyncedEventId) {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/JdbcExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/JdbcExternalCatalog.java
@@ -17,7 +17,6 @@
 
 package org.apache.doris.datasource;
 
-import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.JdbcResource;
 import org.apache.doris.catalog.external.ExternalDatabase;
@@ -162,11 +161,5 @@ public class JdbcExternalCatalog extends ExternalCatalog {
     public boolean tableExist(SessionContext ctx, String dbName, String tblName) {
         makeSureInitialized();
         return jdbcClient.isTableExist(dbName, tblName);
-    }
-
-    @Override
-    public List<Column> getSchema(String dbName, String tblName) {
-        makeSureInitialized();
-        return jdbcClient.getColumnsFromJdbc(dbName, tblName);
     }
 }

--- a/regression-test/data/external_table_emr_p2/hive/test_external_github.out
+++ b/regression-test/data/external_table_emr_p2/hive/test_external_github.out
@@ -1925,8 +1925,8 @@ gin-gonic/gin	3246
 flutter/flutter	3160
 facebook/rocksdb	3156
 antirez/redis	3101
-istio/istio	3094
 ansible/ansible	3094
+istio/istio	3094
 torvalds/linux	3092
 minio/minio	3068
 cockroachdb/cockroach	3006
@@ -1958,8 +1958,8 @@ tensorflow/models	2355
 getsentry/sentry	2354
 dgraph-io/dgraph	2338
 TheAlgorithms/Python	2320
-mholt/caddy	2317
 astaxie/build-web-application-with-golang	2317
+mholt/caddy	2317
 
 -- !46 --
 facebook/react	121976
@@ -4327,8 +4327,8 @@ gin-gonic/gin	3246
 flutter/flutter	3160
 facebook/rocksdb	3156
 antirez/redis	3101
-istio/istio	3094
 ansible/ansible	3094
+istio/istio	3094
 torvalds/linux	3092
 minio/minio	3068
 cockroachdb/cockroach	3006
@@ -4360,8 +4360,8 @@ tensorflow/models	2355
 getsentry/sentry	2354
 dgraph-io/dgraph	2338
 TheAlgorithms/Python	2320
-mholt/caddy	2317
 astaxie/build-web-application-with-golang	2317
+mholt/caddy	2317
 
 -- !46 --
 facebook/react	121976

--- a/regression-test/suites/external_table_emr_p2/hive/test_external_github.groovy
+++ b/regression-test/suites/external_table_emr_p2/hive/test_external_github.groovy
@@ -431,7 +431,7 @@ suite("test_external_github", "p2") {
             WHERE (event_type = 'WatchEvent') AND (repo_name IN ('ClickHouse/ClickHouse', 'yandex/ClickHouse'))
         )) AND (repo_name NOT IN ('ClickHouse/ClickHouse', 'yandex/ClickHouse'))
         GROUP BY repo_name
-        ORDER BY stars DESC
+        ORDER BY stars DESC, repo_name asc
         LIMIT 50"""
     def starsFromHeavyGithubUsers1 = """SELECT /*+SET_VAR(exec_mem_limit=21474836480, query_timeout=600) */
             repo_name,


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

Introduced from #16111
Error:
```
java.lang.IllegalStateException: Recursive load of SchemaCache
```

This is because when calling `getFullSchema()` of ExternalCatalog.
it will call
```
getFullSchema() -> schemaCache.loadSchema() -> catalog.getSchema() ->
HMSTable.getDlaType() -> HMSTable.makesureInitialized() -> initPartitionColumns() -> getFullSchema();
```
Which is recursive.

I refactor this logic by moving `getSchema()` logic into `ExternalTable` and rename it to `initSchema()` to avoid this.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

