### PR TITLE
[enhancement](runtimefilter) no need wait for fragment because two phase exec fragment

### DIFF
--- a/be/src/runtime/fragment_mgr.cpp
+++ b/be/src/runtime/fragment_mgr.cpp
@@ -1063,13 +1063,6 @@ Status FragmentMgr::apply_filter(const PPublishFilterRequest* request,
     RuntimeFilterMgr* runtime_filter_mgr = nullptr;
     if (is_pipeline) {
         std::unique_lock<std::mutex> lock(_lock);
-
-        if (!_pipeline_map.count(tfragment_instance_id)) {
-            VLOG_NOTICE << "wait for fragment start execute, fragment-id:" << fragment_instance_id;
-            _cv.wait_for(lock, std::chrono::milliseconds(1000),
-                         [&] { return _pipeline_map.count(tfragment_instance_id); });
-        }
-
         auto iter = _pipeline_map.find(tfragment_instance_id);
         if (iter == _pipeline_map.end()) {
             VLOG_CRITICAL << "unknown.... fragment-id:" << fragment_instance_id;
@@ -1081,12 +1074,6 @@ Status FragmentMgr::apply_filter(const PPublishFilterRequest* request,
         runtime_filter_mgr = pip_context->get_runtime_state()->runtime_filter_mgr();
     } else {
         std::unique_lock<std::mutex> lock(_lock);
-        if (!_fragment_map.count(tfragment_instance_id)) {
-            VLOG_NOTICE << "wait for fragment start execute, fragment-id:" << fragment_instance_id;
-            _cv.wait_for(lock, std::chrono::milliseconds(1000),
-                         [&] { return _fragment_map.count(tfragment_instance_id); });
-        }
-
         auto iter = _fragment_map.find(tfragment_instance_id);
         if (iter == _fragment_map.end()) {
             VLOG_CRITICAL << "unknown.... fragment-id:" << fragment_instance_id;


### PR DESCRIPTION


# Proposed changes

1. call pthread condition wait may block brpc thread.
2. no need wait for fragment because two phase exec fragment already guarantee that the fragment instance exits when runtime filter comes. So that I remove the condition wait code.

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
3. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
5. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
6. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

