### PR TITLE
[fix](MTMV) Use current db to identify the MTMV tasks and jobs

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowMTMVJobStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowMTMVJobStmt.java
@@ -29,8 +29,10 @@ import com.google.common.base.Strings;
 public class ShowMTMVJobStmt extends ShowStmt {
 
     private final String jobName; // optional
-    private String dbName; // optional
+    private final String dbName; // optional
     private final TableName mvName; // optional
+
+    private String analyzedDbName;
 
     public ShowMTMVJobStmt() {
         this.jobName = null;
@@ -51,11 +53,11 @@ public class ShowMTMVJobStmt extends ShowStmt {
     }
 
     public boolean isShowAllJobs() {
-        return dbName == null && mvName == null && jobName == null;
+        return analyzedDbName == null && mvName == null && jobName == null;
     }
 
     public boolean isShowAllJobsFromDb() {
-        return dbName != null && mvName == null;
+        return analyzedDbName != null && mvName == null;
     }
 
     public boolean isShowAllJobsOnMv() {
@@ -67,13 +69,7 @@ public class ShowMTMVJobStmt extends ShowStmt {
     }
 
     public String getDbName() {
-        if (dbName != null) {
-            return dbName;
-        } else if (mvName != null) {
-            return mvName.getDb();
-        } else {
-            return null;
-        }
+        return analyzedDbName;
     }
 
     public String getMVName() {
@@ -90,8 +86,17 @@ public class ShowMTMVJobStmt extends ShowStmt {
         if (dbName != null && mvName != null && mvName.getDb() != null && !dbName.equals(mvName.getDb())) {
             throw new UserException("Database name should be same when they both been set.");
         }
-        if (!Strings.isNullOrEmpty(dbName)) {
-            dbName = ClusterNamespace.getFullName(getClusterName(), dbName);
+        analyzedDbName = dbName;
+        if (Strings.isNullOrEmpty(analyzedDbName)) {
+            if (mvName != null) {
+                analyzedDbName = mvName.getDb();
+            }
+            if (Strings.isNullOrEmpty(analyzedDbName)) {
+                analyzedDbName = analyzer.getDefaultDb();
+            }
+        }
+        if (!Strings.isNullOrEmpty(analyzedDbName)) {
+            analyzedDbName = ClusterNamespace.getFullName(getClusterName(), analyzedDbName);
         }
     }
 
@@ -114,11 +119,11 @@ public class ShowMTMVJobStmt extends ShowStmt {
         StringBuilder sb = new StringBuilder();
         sb.append("SHOW MTMV JOB");
 
-        if (jobName != null) {
+        if (!Strings.isNullOrEmpty(jobName)) {
             sb.append(" FOR ");
             sb.append(getJobName());
         }
-        if (dbName != null) {
+        if (!Strings.isNullOrEmpty(dbName)) {
             sb.append(" FROM ");
             sb.append(ClusterNamespace.getNameFromFullName(dbName));
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowMTMVTaskStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowMTMVTaskStmt.java
@@ -28,8 +28,10 @@ import com.google.common.base.Strings;
 
 public class ShowMTMVTaskStmt extends ShowStmt {
     private final String taskId; // optional
-    private String dbName; // optional
+    private final String dbName; // optional
     private final TableName mvName; // optional
+
+    private String analyzedDbName;
 
     public ShowMTMVTaskStmt() {
         this.taskId = null;
@@ -50,11 +52,11 @@ public class ShowMTMVTaskStmt extends ShowStmt {
     }
 
     public boolean isShowAllTasks() {
-        return dbName == null && mvName == null && taskId == null;
+        return analyzedDbName == null && mvName == null && taskId == null;
     }
 
     public boolean isShowAllTasksFromDb() {
-        return dbName != null && mvName == null;
+        return analyzedDbName != null && mvName == null;
     }
 
     public boolean isShowAllTasksOnMv() {
@@ -66,13 +68,7 @@ public class ShowMTMVTaskStmt extends ShowStmt {
     }
 
     public String getDbName() {
-        if (dbName != null) {
-            return dbName;
-        } else if (mvName != null) {
-            return mvName.getDb();
-        } else {
-            return null;
-        }
+        return analyzedDbName;
     }
 
     public String getMVName() {
@@ -89,8 +85,17 @@ public class ShowMTMVTaskStmt extends ShowStmt {
         if (dbName != null && mvName != null && mvName.getDb() != null && !dbName.equals(mvName.getDb())) {
             throw new UserException("Database name should be same when they both been set.");
         }
-        if (!Strings.isNullOrEmpty(dbName)) {
-            dbName = ClusterNamespace.getFullName(getClusterName(), dbName);
+        analyzedDbName = dbName;
+        if (Strings.isNullOrEmpty(analyzedDbName)) {
+            if (mvName != null) {
+                analyzedDbName = mvName.getDb();
+            }
+            if (Strings.isNullOrEmpty(analyzedDbName)) {
+                analyzedDbName = analyzer.getDefaultDb();
+            }
+        }
+        if (!Strings.isNullOrEmpty(analyzedDbName)) {
+            analyzedDbName = ClusterNamespace.getFullName(getClusterName(), analyzedDbName);
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVJobManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVJobManager.java
@@ -33,6 +33,7 @@ import org.apache.doris.mtmv.metadata.MTMVTask;
 import org.apache.doris.persist.gson.GsonUtils;
 
 import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import org.apache.logging.log4j.LogManager;
@@ -324,7 +325,7 @@ public class MTMVJobManager {
 
     public List<MTMVJob> showJobs(String dbName) {
         List<MTMVJob> jobList = Lists.newArrayList();
-        if (dbName == null) {
+        if (Strings.isNullOrEmpty(dbName)) {
             jobList.addAll(nameToJobMap.values());
         } else {
             jobList.addAll(nameToJobMap.values().stream().filter(u -> u.getDBName().equals(dbName))

--- a/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVTaskManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVTaskManager.java
@@ -29,6 +29,7 @@ import org.apache.doris.mtmv.metadata.MTMVJob;
 import org.apache.doris.mtmv.metadata.MTMVTask;
 import org.apache.doris.qe.ConnectContext;
 
+import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Queues;
@@ -278,7 +279,7 @@ public class MTMVTaskManager {
 
     public List<MTMVTask> showTasks(String dbName) {
         List<MTMVTask> taskList = Lists.newArrayList();
-        if (dbName == null) {
+        if (Strings.isNullOrEmpty(dbName)) {
             for (Queue<MTMVTaskExecutor> pTaskQueue : getPendingTaskMap().values()) {
                 taskList.addAll(pTaskQueue.stream().map(MTMVTaskExecutor::getTask).collect(Collectors.toList()));
             }

--- a/fe/fe-core/src/test/java/org/apache/doris/mtmv/ShowMTMVJobStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/mtmv/ShowMTMVJobStmtTest.java
@@ -24,17 +24,18 @@ import org.apache.doris.analysis.TableName;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.UserException;
 
+import com.google.common.base.Strings;
 import org.junit.Assert;
 import org.junit.Test;
 
 public class ShowMTMVJobStmtTest {
     @Test
     public void testNormal() throws UserException, AnalysisException {
-        final Analyzer analyzer =  AccessTestUtil.fetchBlockAnalyzer();
+        final Analyzer analyzer =  AccessTestUtil.fetchEmptyDbAnalyzer();
         ShowMTMVJobStmt stmt = new ShowMTMVJobStmt();
         stmt.analyze(analyzer);
         Assert.assertNull(stmt.getJobName());
-        Assert.assertNull(stmt.getDbName());
+        Assert.assertTrue(Strings.isNullOrEmpty(stmt.getDbName()));
         Assert.assertNull(stmt.getMVName());
         Assert.assertEquals(13, stmt.getMetaData().getColumnCount());
         Assert.assertEquals("SHOW MTMV JOB", stmt.toSql());
@@ -42,14 +43,14 @@ public class ShowMTMVJobStmtTest {
         stmt = new ShowMTMVJobStmt("job1");
         stmt.analyze(analyzer);
         Assert.assertNotNull(stmt.getJobName());
-        Assert.assertNull(stmt.getDbName());
+        Assert.assertTrue(Strings.isNullOrEmpty(stmt.getDbName()));
         Assert.assertNull(stmt.getMVName());
         Assert.assertEquals("SHOW MTMV JOB FOR job1", stmt.toSql());
 
         stmt = new ShowMTMVJobStmt("db1", null);
         stmt.analyze(analyzer);
         Assert.assertNull(stmt.getJobName());
-        Assert.assertNotNull(stmt.getDbName());
+        Assert.assertFalse(Strings.isNullOrEmpty(stmt.getDbName()));
         Assert.assertNull(stmt.getMVName());
         Assert.assertEquals("SHOW MTMV JOB FROM db1", stmt.toSql());
 
@@ -57,7 +58,7 @@ public class ShowMTMVJobStmtTest {
         stmt = new ShowMTMVJobStmt(null, tableName);
         stmt.analyze(analyzer);
         Assert.assertNull(stmt.getJobName());
-        Assert.assertNull(stmt.getDbName());
+        Assert.assertTrue(Strings.isNullOrEmpty(stmt.getDbName()));
         Assert.assertNotNull(stmt.getMVName());
         Assert.assertEquals("SHOW MTMV JOB ON `mv1`", stmt.toSql());
 
@@ -65,7 +66,7 @@ public class ShowMTMVJobStmtTest {
         stmt = new ShowMTMVJobStmt(null, tableName);
         stmt.analyze(analyzer);
         Assert.assertNull(stmt.getJobName());
-        Assert.assertNotNull(stmt.getDbName());
+        Assert.assertFalse(Strings.isNullOrEmpty(stmt.getDbName()));
         Assert.assertNotNull(stmt.getMVName());
         Assert.assertEquals("SHOW MTMV JOB ON `db2`.`mv1`", stmt.toSql());
 
@@ -73,7 +74,7 @@ public class ShowMTMVJobStmtTest {
         stmt = new ShowMTMVJobStmt("db1", tableName);
         stmt.analyze(analyzer);
         Assert.assertNull(stmt.getJobName());
-        Assert.assertNotNull(stmt.getDbName());
+        Assert.assertFalse(Strings.isNullOrEmpty(stmt.getDbName()));
         Assert.assertNotNull(stmt.getMVName());
         Assert.assertEquals("SHOW MTMV JOB FROM db1 ON `mv1`", stmt.toSql());
     }
@@ -85,5 +86,20 @@ public class ShowMTMVJobStmtTest {
 
         ShowMTMVJobStmt stmt = new ShowMTMVJobStmt("db1", tableName);
         stmt.analyze(analyzer);
+    }
+
+
+    @Test
+    public void testDefaultDb() throws UserException {
+        final Analyzer analyzer =  AccessTestUtil.fetchBlockAnalyzer();
+        ShowMTMVJobStmt stmt = new ShowMTMVJobStmt();
+        stmt.analyze(analyzer);
+        Assert.assertNull(stmt.getJobName());
+        Assert.assertEquals("testCluster:testDb", stmt.getDbName());
+        Assert.assertNull(stmt.getMVName());
+        Assert.assertEquals(13, stmt.getMetaData().getColumnCount());
+        Assert.assertEquals("SHOW MTMV JOB", stmt.toSql());
+        Assert.assertFalse(stmt.isShowAllJobs());
+        Assert.assertTrue(stmt.isShowAllJobsFromDb());
     }
 }


### PR DESCRIPTION
# Proposed changes

## Problem summary
`Show MTMV JOB/Task` will list all the job and task among different database in spite of the  current database.

Now use current db to identify the mtmv task and job. Only the user who did not use a database can list all job and tasks among differents databases.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [x] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

