### PR TITLE
[bugfix](writer) add _is_closed state to DeltaWriter and avoid write/close core after close

### DIFF
--- a/be/src/common/status.h
+++ b/be/src/common/status.h
@@ -105,6 +105,7 @@ E(TOO_MANY_VERSION, -235);
 E(NOT_INITIALIZED, -236);
 E(ALREADY_CANCELLED, -237);
 E(TOO_MANY_SEGMENTS, -238);
+E(ALREADY_CLOSED, -239);
 E(CE_CMD_PARAMS_ERROR, -300);
 E(CE_BUFFER_TOO_SMALL, -301);
 E(CE_CMD_NOT_VALID, -302);
@@ -266,6 +267,7 @@ static constexpr bool capture_stacktrace() {
         && code != ErrorCode::TOO_MANY_SEGMENTS
         && code != ErrorCode::TOO_MANY_VERSION
         && code != ErrorCode::ALREADY_CANCELLED
+        && code != ErrorCode::ALREADY_CLOSED
         && code != ErrorCode::PUSH_TRANSACTION_ALREADY_EXIST
         && code != ErrorCode::BE_NO_SUITABLE_VERSION
         && code != ErrorCode::CUMULATIVE_NO_SUITABLE_VERSION

--- a/be/src/olap/delta_writer.cpp
+++ b/be/src/olap/delta_writer.cpp
@@ -170,8 +170,9 @@ Status DeltaWriter::write(const vectorized::Block* block, const std::vector<int>
     }
 
     if (_is_closed) {
-        LOG(WARNING) << "write block after closed";
-        return Status::Error<ALREADY_CANCELLED>();
+        LOG(WARNING) << "write block after closed tablet_id=" << _req.tablet_id
+                     << " load_id=" << _req.load_id << " txn_id=" << _req.txn_id;
+        return Status::Error<ALREADY_CLOSED>();
     }
 
     _total_received_rows += row_idxs.size();
@@ -290,8 +291,9 @@ Status DeltaWriter::close() {
     }
 
     if (_is_closed) {
-        LOG(WARNING) << "write block after closed";
-        return Status::Error<ALREADY_CANCELLED>();
+        LOG(WARNING) << "close after closed tablet_id=" << _req.tablet_id
+                     << " load_id=" << _req.load_id << " txn_id=" << _req.txn_id;
+        return Status::Error<ALREADY_CLOSED>();
     }
 
     auto s = _flush_memtable_async();

--- a/be/src/olap/delta_writer.h
+++ b/be/src/olap/delta_writer.h
@@ -125,6 +125,7 @@ private:
 
     bool _is_init = false;
     bool _is_cancelled = false;
+    bool _is_closed = false;
     Status _cancel_status;
     WriteRequest _req;
     TabletSharedPtr _tablet;


### PR DESCRIPTION
# Proposed changes

Issue Number: close #16450

## Problem summary

`DeltaWriter::close()` will reset `_mem_table` to nullptr. So if `DeltaWriter::write()` is called after `close()`, `_mem_table->insert()` will cause be core.

This PR add _is_closed status to delta_writer and return `Status::Error<ALREADY_CLOSED>` on write/close after close.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

