### PR TITLE
[bugfix](vertical_compaction) fix base_compaction delete_sign handler

### DIFF
--- a/be/src/vec/olap/vertical_block_reader.cpp
+++ b/be/src/vec/olap/vertical_block_reader.cpp
@@ -393,8 +393,10 @@ Status VerticalBlockReader::_unique_key_next_block(Block* block, bool* eof) {
                 bool sign = (delete_data[i] == 0);
                 filter_data[i] = sign;
                 if (UNLIKELY(!sign)) {
-                    _row_sources_buffer->set_agg_flag(row_source_idx + i, true);
+                    _row_sources_buffer->set_agg_flag(row_source_idx, true);
                 }
+                // skip same rows filtered in vertical_merge_iterator
+                row_source_idx += _row_sources_buffer->continuous_agg_count(row_source_idx);
             }
 
             ColumnWithTypeAndName column_with_type_and_name {_delete_filter_column,

--- a/be/src/vec/olap/vertical_merge_iterator.cpp
+++ b/be/src/vec/olap/vertical_merge_iterator.cpp
@@ -98,6 +98,21 @@ void RowSourcesBuffer::set_agg_flag(uint64_t index, bool agg) {
     _buffer->get_data()[index] = ori.data();
 }
 
+size_t RowSourcesBuffer::continuous_agg_count(uint64_t index) {
+    size_t result = 1;
+    int start = index + 1;
+    int end = _buffer->size();
+    while (index < end) {
+        RowSource next(_buffer->get_element(start++));
+        if (next.agg_flag()) {
+            ++result;
+        } else {
+            break;
+        }
+    }
+    return result;
+}
+
 size_t RowSourcesBuffer::same_source_count(uint16_t source, size_t limit) {
     int result = 1;
     int start = _buf_idx + 1;

--- a/be/src/vec/olap/vertical_merge_iterator.h
+++ b/be/src/vec/olap/vertical_merge_iterator.h
@@ -103,6 +103,9 @@ public:
 
     size_t same_source_count(uint16_t source, size_t limit);
 
+    // return continous agg_flag=true count from index
+    size_t continuous_agg_count(uint64_t index);
+
 private:
     Status _create_buffer_file();
     Status _serialize();


### PR DESCRIPTION
In vertical base compaction, same rows will be filtered in verticam_merge_iterator, we should skip these filtered rows when set agg flag of delete sign. For example, schema is a,b,delete_sign, and data is 1,1,1
1,1,0
1,1,0
2,2,1
2,2
and Block we get in VerticalBlockReader is
1,1,1
2,2,1
and we should set agg flag idex 0,4 to true when handle delete sign, so we add a function continuous_agg_count to skip same rows filtered in VerticalMergeIterator.

# Proposed changes

Issue Number: close #16139

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

