### PR TITLE
[fix](pipeline) incorrect result when disabling sharing hash table

### DIFF
--- a/be/src/vec/sink/vdata_stream_sender.h
+++ b/be/src/vec/sink/vdata_stream_sender.h
@@ -370,7 +370,7 @@ public:
         }
         if (eos || block->column_metas_size()) {
             RETURN_IF_ERROR(_buffer->add_block(
-                    {this, block ? std::make_unique<PBlock>(std::move(*block)) : nullptr, eos}));
+                    {this, block ? std::make_unique<PBlock>(*block) : nullptr, eos}));
         }
         return Status::OK();
     }


### PR DESCRIPTION
# Proposed changes

Incorrect result of regression-test case `ssb_unique_sql_zstd_p0/sql/q3.1.sql`, with session variables:
1. enable_share_hash_table_for_broadcast_join = false
2. parallel_fragment_exec_instance_num = 2
3. enable_local_exchange = 0
4. enable_pipeline_engine = 1



## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
6. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
7. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
8. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
9. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

