### PR TITLE
[fix](partition cache) fix can not hit partition cache

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/OlapScanNode.java
@@ -148,7 +148,6 @@ public class OlapScanNode extends ScanNode {
     private long selectedTabletsNum = 0;
     private long totalTabletsNum = 0;
     private long selectedIndexId = -1;
-    private int selectedPartitionNum = 0;
     private Collection<Long> selectedPartitionIds = Lists.newArrayList();
     private long totalBytes = 0;
 
@@ -248,7 +247,7 @@ public class OlapScanNode extends ScanNode {
     }
 
     public Integer getSelectedPartitionNum() {
-        return selectedPartitionNum;
+        return selectedPartitionIds.size();
     }
 
     public Long getSelectedTabletsNum() {
@@ -513,7 +512,6 @@ public class OlapScanNode extends ScanNode {
      * Init OlapScanNode, ONLY used for Nereids. Should NOT use this function in anywhere else.
      */
     public void init() throws UserException {
-        selectedPartitionNum = selectedPartitionIds.size();
         try {
             getScanRangeLocations();
         } catch (AnalysisException e) {
@@ -766,7 +764,6 @@ public class OlapScanNode extends ScanNode {
                     .filter(id -> olapTable.getPartition(id).hasData())
                     .collect(Collectors.toList());
         }
-        selectedPartitionNum = selectedPartitionIds.size();
 
         for (long id : selectedPartitionIds) {
             Partition partition = olapTable.getPartition(id);
@@ -800,7 +797,7 @@ public class OlapScanNode extends ScanNode {
     }
 
     private void getScanRangeLocations() throws UserException {
-        if (selectedPartitionIds.size() == 0) {
+        if (selectedPartitionIds.isEmpty()) {
             desc.setCardinality(0);
             return;
         }
@@ -1062,7 +1059,7 @@ public class OlapScanNode extends ScanNode {
             output.append(getRuntimeFilterExplainString(false));
         }
 
-        output.append(prefix).append(String.format("partitions=%s/%s, tablets=%s/%s", selectedPartitionNum,
+        output.append(prefix).append(String.format("partitions=%s/%s, tablets=%s/%s", getSelectedPartitionNum(),
                 olapTable.getPartitions().size(), selectedTabletsNum, totalTabletsNum));
         // We print up to 3 tablet, and we print "..." if the number is more than 3
         if (scanTabletIds.size() > 3) {
@@ -1142,7 +1139,6 @@ public class OlapScanNode extends ScanNode {
         olapScanNode.numInstances = 1;
 
         olapScanNode.selectedIndexId = olapScanNode.olapTable.getBaseIndexId();
-        olapScanNode.selectedPartitionNum = 1;
         olapScanNode.selectedTabletsNum = 1;
         olapScanNode.totalTabletsNum = 1;
         olapScanNode.setIsPreAggregation(false, "Export job");

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/cache/CacheAnalyzer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/cache/CacheAnalyzer.java
@@ -208,12 +208,6 @@ public class CacheAnalyzer {
                 LOG.debug("query contains non-olap table. queryid {}", DebugUtil.printId(queryId));
                 return CacheMode.None;
             }
-            if (enablePartitionCache() && ((OlapScanNode) node).getSelectedPartitionNum() > 1
-                    && selectStmt.hasGroupByClause()) {
-                LOG.debug("more than one partition scanned when qeury has agg, partition cache cannot use, queryid {}",
-                        DebugUtil.printId(queryId));
-                return CacheMode.None;
-            }
             CacheTable cTable = getSelectedPartitionLastUpdateTime((OlapScanNode) node);
             tblTimeList.add(cTable);
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/cache/PartitionCache.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/cache/PartitionCache.java
@@ -108,7 +108,6 @@ public class PartitionCache extends Cache {
             MetricRepo.COUNTER_CACHE_HIT_PARTITION.increase(1L);
         }
 
-        range.setTooNewByID(latestTable.latestPartitionId);
         //build rewrite sql
         this.hitRange = range.buildDiskPartitionRange(newRangeList);
         if (newRangeList != null && newRangeList.size() > 0) {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/cache/PartitionRange.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/cache/PartitionRange.java
@@ -61,6 +61,12 @@ public class PartitionRange {
         private long partitionId;
         private PartitionKeyType cacheKey;
         private boolean fromCache;
+        // Use the tooNew field to mark that the data in the partition field is too new,
+        // and do not update the cached data to avoid resource waste caused by frequent updates.
+        // But when a partition contains multiple partition values, it will cause various
+        // strange problems. For example, the partition name is p202205, and the partition range is
+        // [types: [DATE]; keys: [2022-05-01]; ..types: [DATE]; keys: [2022-06-01]
+        // Therefore, this field is not used temporarily
         private boolean tooNew;
 
         public Partition getPartition() {


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx
When the number of selected partition queried is greater than 1 and there is a group by statement, the PartitionCache will not be hit.
Even the examples provided on the official website and `PartitionCacheTest` UT cannot be hit, and PartitionCache is basically unavailable.


## Problem summary

Reproduce:
```sql
create table appevent (
  `eventdate` date NULL,
  `bu_name` varchar(50) NULL,
  `client_type` varchar(50) NULL,
  `userid` varchar(50) NULL
) ENGINE=OLAP
DUPLICATE KEY(`eventdate`)
PARTITION BY RANGE(`eventdate`)
(PARTITION p20230101 VALUES [('2023-01-01'), ('2023-01-02')),
PARTITION p20230102 VALUES [('2023-01-02'), ('2023-01-03')),
PARTITION p20230103 VALUES [('2023-01-03'), ('2023-01-04')),
PARTITION p20230104 VALUES [('2023-01-04'), ('2023-01-05')),
PARTITION p20230105 VALUES [('2023-01-05'), ('2023-01-06')))
DISTRIBUTED BY HASH(`bu_name`) BUCKETS 3
PROPERTIES (
"replication_allocation" = "tag.location.default: 3",
"in_memory" = "false",
"storage_format" = "V2"
)

insert into appevent values('2023-01-01', 'bu1', 'ios', 'user01');
insert into appevent values('2023-01-02', 'bu1', 'ios', 'user01');
insert into appevent values('2023-01-03', 'bu1', 'ios', 'user01');
insert into appevent values('2023-01-04', 'bu1', 'ios', 'user01');
insert into appevent values('2023-01-05', 'bu1', 'ios', 'user01');


SELECT 
    eventdate,count(userid) 
FROM 
    testdb.appevent 
WHERE 
    eventdate>="2023-01-01" AND eventdate<="2023-01-05" 
GROUP BY 
    eventdate 
ORDER BY 
    eventdate;
```

The following logic is triggered when querying:
```java
if (enablePartitionCache() && ((OlapScanNode) node).getSelectedPartitionNum() > 1
        && selectStmt.hasGroupByClause()) {
    LOG.debug("more than one partition scanned when qeury has agg, partition cache cannot use, queryid {}",
            DebugUtil.printId(queryId));
    return CacheMode.None;
}
```


## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

