### PR TITLE
[improvement](fuzzy) print fuzzy session variable in FE audit log

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/plugin/AuditEvent.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/plugin/AuditEvent.java
@@ -92,6 +92,8 @@ public class AuditEvent {
     public String sqlDigest = "";
     @AuditField(value = "TraceId")
     public String traceId = "";
+    @AuditField(value = "FuzzyVariables")
+    public String fuzzyVariables = "";
 
     public static class AuditEventBuilder {
 
@@ -211,6 +213,11 @@ public class AuditEvent {
 
         public AuditEventBuilder setTraceId(String traceId) {
             auditEvent.traceId = traceId;
+            return this;
+        }
+
+        public AuditEventBuilder setFuzzyVariables(String variables) {
+            auditEvent.fuzzyVariables = variables;
             return this;
         }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectProcessor.java
@@ -273,7 +273,9 @@ public class ConnectProcessor {
                 .setReturnRows(ctx.getReturnRows())
                 .setStmtId(ctx.getStmtId())
                 .setQueryId(ctx.queryId() == null ? "NaN" : DebugUtil.printId(ctx.queryId()))
-                .setTraceId(spanContext.isValid() ? spanContext.getTraceId() : "");
+                .setTraceId(spanContext.isValid() ? spanContext.getTraceId() : "")
+                .setFuzzyVariables(ctx.getSessionVariable().printFuzzyVariables());
+
 
         if (ctx.getState().isQuery()) {
             MetricRepo.COUNTER_QUERY_ALL.increase(1L);

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/FuzzyVarHandlers.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/FuzzyVarHandlers.java
@@ -36,6 +36,7 @@ public class FuzzyVarHandlers {
         }
     }
 
+    // Randomly return true or false
     static class FuzzyRandomBool implements VarHandler {
         @Override
         public void handle(Field f, Object obj, Random random) throws Exception {
@@ -44,6 +45,7 @@ public class FuzzyVarHandlers {
         }
     }
 
+    // For partitioned_hash_join_rows_threshold and partitioned_hash_agg_rows_threshold
     static class FuzzyPartitionedHashNodeRowsThreshold implements VarHandler {
         @Override
         public void handle(Field f, Object obj, Random random) throws Exception {
@@ -52,6 +54,7 @@ public class FuzzyVarHandlers {
         }
     }
 
+    // for parallel_fragment_exec_instance_num
     static class FuzzyParallelExecNum implements VarHandler {
         @Override
         public void handle(Field f, Object obj, Random random) throws Exception {
@@ -66,6 +69,7 @@ public class FuzzyVarHandlers {
         }
     }
 
+    // for external_sort_bytes_threshold
     static class FuzzyExternalSortBytesThreshold implements VarHandler {
         @Override
         public void handle(Field f, Object obj, Random random) throws Exception {
@@ -89,6 +93,7 @@ public class FuzzyVarHandlers {
         }
     }
 
+    // Return true if the config "pull_request_id" is odd
     static class FuzzyPullRequestIdTrue implements VarHandler {
         @Override
         public void handle(Field f, Object obj, Random random) throws Exception {
@@ -97,6 +102,7 @@ public class FuzzyVarHandlers {
         }
     }
 
+    // Return true if the config "pull_request_id" is even
     static class FuzzyPullRequestIdFalse implements VarHandler {
         @Override
         public void handle(Field f, Object obj, Random random) throws Exception {
@@ -105,6 +111,7 @@ public class FuzzyVarHandlers {
         }
     }
 
+    // for rewrite_or_to_in_predicate_threshold
     static class FuzzyRewriteOrToInPredicateThreshold implements VarHandler {
         @Override
         public void handle(Field f, Object obj, Random random) throws Exception {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/FuzzyVarHandlers.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/FuzzyVarHandlers.java
@@ -1,0 +1,137 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.qe;
+
+import org.apache.doris.common.Config;
+
+import java.lang.reflect.Field;
+import java.util.Random;
+
+/**
+ * Handler for fuzzy variable
+ */
+public class FuzzyVarHandlers {
+    public interface VarHandler {
+        void handle(Field field, Object obj, Random random) throws Exception;
+    }
+
+    static class DefaultVarHandler implements VarHandler {
+        @Override
+        public void handle(Field field, Object obj, Random random) throws Exception {
+        }
+    }
+
+    static class FuzzyRandomBool implements VarHandler {
+        @Override
+        public void handle(Field f, Object obj, Random random) throws Exception {
+            boolean val = random.nextBoolean();
+            setField(obj, f, String.valueOf(val));
+        }
+    }
+
+    static class FuzzyPartitionedHashNodeRowsThreshold implements VarHandler {
+        @Override
+        public void handle(Field f, Object obj, Random random) throws Exception {
+            int val = random.nextBoolean() ? 8 : 1048576;
+            setField(obj, f, String.valueOf(val));
+        }
+    }
+
+    static class FuzzyParallelExecNum implements VarHandler {
+        @Override
+        public void handle(Field f, Object obj, Random random) throws Exception {
+            int val = random.nextInt(8) + 1;
+            switch (f.getType().getSimpleName()) {
+                case "int":
+                    f.setInt(obj, val);
+                    break;
+                default:
+                    throw new Exception("invalid field type: " + f.getType() + ", var: " + f.getName());
+            }
+        }
+    }
+
+    static class FuzzyExternalSortBytesThreshold implements VarHandler {
+        @Override
+        public void handle(Field f, Object obj, Random random) throws Exception {
+            int randomInt = random.nextInt(4);
+            long val;
+            switch (randomInt) {
+                case 0:
+                    val = 0;
+                    break;
+                case 1:
+                    val = 1;
+                    break;
+                case 2:
+                    val = 1024 * 1024;
+                    break;
+                default:
+                    val = 100 * 1024 * 1024 * 1024;
+                    break;
+            }
+            setField(obj, f, String.valueOf(val));
+        }
+    }
+
+    static class FuzzyPullRequestIdTrue implements VarHandler {
+        @Override
+        public void handle(Field f, Object obj, Random random) throws Exception {
+            boolean val = Config.pull_request_id % 2 == 1;
+            setField(obj, f, String.valueOf(val));
+        }
+    }
+
+    static class FuzzyPullRequestIdFalse implements VarHandler {
+        @Override
+        public void handle(Field f, Object obj, Random random) throws Exception {
+            boolean val = Config.pull_request_id % 2 != 1;
+            setField(obj, f, String.valueOf(val));
+        }
+    }
+
+    static class FuzzyRewriteOrToInPredicateThreshold implements VarHandler {
+        @Override
+        public void handle(Field f, Object obj, Random random) throws Exception {
+            int randomInt = random.nextInt(4);
+            int val;
+            if (randomInt % 2 == 0) {
+                val = 100000;
+            } else {
+                val = 2;
+            }
+            setField(obj, f, String.valueOf(val));
+        }
+    }
+
+    static void setField(Object instance, Field f, String val) throws Exception {
+        switch (f.getType().getSimpleName()) {
+            case "boolean":
+                f.setBoolean(instance, Boolean.valueOf(val));
+                break;
+            case "int":
+                f.setInt(instance, Integer.valueOf(val));
+                break;
+            case "long":
+                f.setLong(instance, Long.valueOf(val));
+                break;
+            default:
+                throw new Exception("invalid field type: " + f.getType() + ", var: " + f.getName());
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -727,7 +727,7 @@ public class SessionVariable implements Serializable, Writable {
         List<String> res = Lists.newArrayList();
         for (Field field : SessionVariable.class.getDeclaredFields()) {
             VarAttr attr = field.getAnnotation(VarAttr.class);
-            if (attr == null || attr.fuzzy().getSimpleName() == DefaultVarHandler.class.getSimpleName()) {
+            if (attr == null || attr.fuzzy().getSimpleName().equals(DefaultVarHandler.class.getSimpleName())) {
                 continue;
             }
             field.setAccessible(true);

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -576,7 +576,8 @@ public class SessionVariable implements Serializable, Writable {
     @VariableMgr.VarAttr(name = NEREIDS_STAR_SCHEMA_SUPPORT)
     private boolean nereidsStarSchemaSupport = true;
 
-    @VariableMgr.VarAttr(name = REWRITE_OR_TO_IN_PREDICATE_THRESHOLD, fuzzy = FuzzyRewriteOrToInPredicateThreshold.class)
+    @VariableMgr.VarAttr(name = REWRITE_OR_TO_IN_PREDICATE_THRESHOLD,
+            fuzzy = FuzzyRewriteOrToInPredicateThreshold.class)
     private int rewriteOrToInPredicateThreshold = 2;
 
     @VariableMgr.VarAttr(name = NEREIDS_CBO_PENALTY_FACTOR)

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -30,6 +30,7 @@ import org.apache.doris.qe.FuzzyVarHandlers.FuzzyPartitionedHashNodeRowsThreshol
 import org.apache.doris.qe.FuzzyVarHandlers.FuzzyPullRequestIdFalse;
 import org.apache.doris.qe.FuzzyVarHandlers.FuzzyPullRequestIdTrue;
 import org.apache.doris.qe.FuzzyVarHandlers.FuzzyRandomBool;
+import org.apache.doris.qe.FuzzyVarHandlers.FuzzyRewriteOrToInPredicateThreshold;
 import org.apache.doris.qe.VariableMgr.VarAttr;
 import org.apache.doris.thrift.TQueryOptions;
 import org.apache.doris.thrift.TResourceLimit;
@@ -575,7 +576,7 @@ public class SessionVariable implements Serializable, Writable {
     @VariableMgr.VarAttr(name = NEREIDS_STAR_SCHEMA_SUPPORT)
     private boolean nereidsStarSchemaSupport = true;
 
-    @VariableMgr.VarAttr(name = REWRITE_OR_TO_IN_PREDICATE_THRESHOLD)
+    @VariableMgr.VarAttr(name = REWRITE_OR_TO_IN_PREDICATE_THRESHOLD, fuzzy = FuzzyRewriteOrToInPredicateThreshold.class)
     private int rewriteOrToInPredicateThreshold = 2;
 
     @VariableMgr.VarAttr(name = NEREIDS_CBO_PENALTY_FACTOR)

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -23,10 +23,18 @@ import org.apache.doris.common.io.Writable;
 import org.apache.doris.common.util.TimeUtils;
 import org.apache.doris.nereids.metrics.Event;
 import org.apache.doris.nereids.metrics.EventSwitchParser;
+import org.apache.doris.qe.FuzzyVarHandlers.DefaultVarHandler;
+import org.apache.doris.qe.FuzzyVarHandlers.FuzzyExternalSortBytesThreshold;
+import org.apache.doris.qe.FuzzyVarHandlers.FuzzyParallelExecNum;
+import org.apache.doris.qe.FuzzyVarHandlers.FuzzyPartitionedHashNodeRowsThreshold;
+import org.apache.doris.qe.FuzzyVarHandlers.FuzzyPullRequestIdFalse;
+import org.apache.doris.qe.FuzzyVarHandlers.FuzzyPullRequestIdTrue;
+import org.apache.doris.qe.FuzzyVarHandlers.FuzzyRandomBool;
 import org.apache.doris.qe.VariableMgr.VarAttr;
 import org.apache.doris.thrift.TQueryOptions;
 import org.apache.doris.thrift.TResourceLimit;
 
+import com.google.common.base.Joiner;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
@@ -401,7 +409,7 @@ public class SessionVariable implements Serializable, Writable {
     @VariableMgr.VarAttr(name = BATCH_SIZE)
     public int batchSize = 4064;
 
-    @VariableMgr.VarAttr(name = DISABLE_STREAMING_PREAGGREGATIONS)
+    @VariableMgr.VarAttr(name = DISABLE_STREAMING_PREAGGREGATIONS, fuzzy = FuzzyRandomBool.class)
     public boolean disableStreamPreaggregations = false;
 
     @VariableMgr.VarAttr(name = DISABLE_COLOCATE_PLAN)
@@ -420,7 +428,7 @@ public class SessionVariable implements Serializable, Writable {
      * the parallel exec instance num for one Fragment in one BE
      * 1 means disable this feature
      */
-    @VariableMgr.VarAttr(name = PARALLEL_FRAGMENT_EXEC_INSTANCE_NUM)
+    @VariableMgr.VarAttr(name = PARALLEL_FRAGMENT_EXEC_INSTANCE_NUM, fuzzy = FuzzyParallelExecNum.class)
     public int parallelExecInstanceNum = 1;
 
     @VariableMgr.VarAttr(name = ENABLE_INSERT_STRICT, needForward = true)
@@ -479,7 +487,7 @@ public class SessionVariable implements Serializable, Writable {
     @VariableMgr.VarAttr(name = ENABLE_VECTORIZED_ENGINE)
     public boolean enableVectorizedEngine = true;
 
-    @VariableMgr.VarAttr(name = ENABLE_PIPELINE_ENGINE)
+    @VariableMgr.VarAttr(name = ENABLE_PIPELINE_ENGINE, fuzzy = FuzzyPullRequestIdTrue.class)
     public boolean enablePipelineEngine = false;
 
     @VariableMgr.VarAttr(name = ENABLE_PARALLEL_OUTFILE)
@@ -494,7 +502,6 @@ public class SessionVariable implements Serializable, Writable {
     @VariableMgr.VarAttr(name = TRIM_TAILING_SPACES_FOR_EXTERNAL_TABLE_QUERY, needForward = true)
     public boolean trimTailingSpacesForExternalTableQuery = false;
 
-
     // the maximum size in bytes for a table that will be broadcast to all be nodes
     // when performing a join, By setting this value to -1 broadcasting can be disabled.
     // Default value is 1Gto
@@ -504,7 +511,7 @@ public class SessionVariable implements Serializable, Writable {
     @VariableMgr.VarAttr(name = ENABLE_COST_BASED_JOIN_REORDER)
     private boolean enableJoinReorderBasedCost = false;
 
-    @VariableMgr.VarAttr(name = ENABLE_FOLD_CONSTANT_BY_BE)
+    @VariableMgr.VarAttr(name = ENABLE_FOLD_CONSTANT_BY_BE, fuzzy = FuzzyPullRequestIdTrue.class)
     private boolean enableFoldConstantByBe = false;
 
     @VariableMgr.VarAttr(name = RUNTIME_FILTER_MODE)
@@ -605,7 +612,7 @@ public class SessionVariable implements Serializable, Writable {
     @VariableMgr.VarAttr(name = ENABLE_FUNCTION_PUSHDOWN)
     public boolean enableFunctionPushdown;
 
-    @VariableMgr.VarAttr(name = ENABLE_LOCAL_EXCHANGE)
+    @VariableMgr.VarAttr(name = ENABLE_LOCAL_EXCHANGE, fuzzy = FuzzyRandomBool.class)
     public boolean enableLocalExchange = true;
 
     /**
@@ -652,14 +659,16 @@ public class SessionVariable implements Serializable, Writable {
     public boolean internalSession = false;
 
     // Use partitioned hash join if build side row count >= the threshold . 0 - the threshold is not set.
-    @VariableMgr.VarAttr(name = PARTITIONED_HASH_JOIN_ROWS_THRESHOLD)
+    @VariableMgr.VarAttr(name = PARTITIONED_HASH_JOIN_ROWS_THRESHOLD,
+            fuzzy = FuzzyPartitionedHashNodeRowsThreshold.class)
     public int partitionedHashJoinRowsThreshold = 0;
 
     // Use partitioned hash join if build side row count >= the threshold . 0 - the threshold is not set.
-    @VariableMgr.VarAttr(name = PARTITIONED_HASH_AGG_ROWS_THRESHOLD)
+    @VariableMgr.VarAttr(name = PARTITIONED_HASH_AGG_ROWS_THRESHOLD,
+            fuzzy = FuzzyPartitionedHashNodeRowsThreshold.class)
     public int partitionedHashAggRowsThreshold = 0;
 
-    @VariableMgr.VarAttr(name = ENABLE_SHARE_HASH_TABLE_FOR_BROADCAST_JOIN)
+    @VariableMgr.VarAttr(name = ENABLE_SHARE_HASH_TABLE_FOR_BROADCAST_JOIN, fuzzy = FuzzyRandomBool.class)
     public boolean enableShareHashTableForBroadcastJoin = true;
 
     @VariableMgr.VarAttr(name = REPEAT_MAX_NUM, needForward = true)
@@ -671,7 +680,8 @@ public class SessionVariable implements Serializable, Writable {
     // If the memory consumption of sort node exceed this limit, will trigger spill to disk;
     // Set to 0 to disable; min: 128M
     public static final long MIN_EXTERNAL_SORT_BYTES_THRESHOLD = 134217728;
-    @VariableMgr.VarAttr(name = EXTERNAL_SORT_BYTES_THRESHOLD, checker = "checkExternalSortBytesThreshold")
+    @VariableMgr.VarAttr(name = EXTERNAL_SORT_BYTES_THRESHOLD, checker = "checkExternalSortBytesThreshold",
+            fuzzy = FuzzyExternalSortBytesThreshold.class)
     public long externalSortBytesThreshold = 0;
 
     // Whether enable two phase read optimization
@@ -679,7 +689,8 @@ public class SessionVariable implements Serializable, Writable {
     // 2. spawn fetch RPC to other nodes to get related data by sorted rowids
     @VariableMgr.VarAttr(name = ENABLE_TWO_PHASE_READ_OPT)
     public boolean enableTwoPhaseReadOpt = true;
-    @VariableMgr.VarAttr(name = TWO_PHASE_READ_OPT_LIMIT_THRESHOLD)
+
+    @VariableMgr.VarAttr(name = TWO_PHASE_READ_OPT_LIMIT_THRESHOLD, fuzzy = FuzzyPullRequestIdFalse.class)
     public long twoPhaseReadLimitThreshold = 512;
 
     // Default value is false, which means the group by and having clause
@@ -695,44 +706,39 @@ public class SessionVariable implements Serializable, Writable {
     // not the default value set in the code.
     public void initFuzzyModeVariables() {
         Random random = new Random(System.currentTimeMillis());
-        this.parallelExecInstanceNum = random.nextInt(8) + 1;
-        this.enableLocalExchange = random.nextBoolean();
-        // This will cause be dead loop, disable it first
-        // this.disableJoinReorder = random.nextBoolean();
-        this.disableStreamPreaggregations = random.nextBoolean();
-        this.partitionedHashJoinRowsThreshold = random.nextBoolean() ? 8 : 1048576;
-        this.partitionedHashAggRowsThreshold = random.nextBoolean() ? 8 : 1048576;
-        this.enableShareHashTableForBroadcastJoin = random.nextBoolean();
-        int randomInt = random.nextInt(4);
-        if (randomInt % 2 == 0) {
-            this.rewriteOrToInPredicateThreshold = 100000;
-        } else {
-            this.rewriteOrToInPredicateThreshold = 2;
+        for (Field field : SessionVariable.class.getDeclaredFields()) {
+            VarAttr attr = field.getAnnotation(VarAttr.class);
+            if (attr == null) {
+                continue;
+            }
+            field.setAccessible(true);
+            try {
+                attr.fuzzy().newInstance().handle(field, this, random);
+            } catch (Exception e) {
+                LOG.warn("failed to fuzzy session variable {}", attr.name(), e);
+            }
         }
-        switch (randomInt) {
-            case 0:
-                this.externalSortBytesThreshold = 0;
-                break;
-            case 1:
-                this.externalSortBytesThreshold = 1;
-                break;
-            case 2:
-                this.externalSortBytesThreshold = 1024 * 1024;
-                break;
-            default:
-                this.externalSortBytesThreshold = 100 * 1024 * 1024 * 1024;
-                break;
+    }
+
+    public String printFuzzyVariables() {
+        if (!Config.use_fuzzy_session_variable) {
+            return "";
         }
-        // pull_request_id default value is 0
-        if (Config.pull_request_id % 2 == 1) {
-            // this.enablePipelineEngine = true;
-            this.enableFoldConstantByBe = true;
-            // this.enableTwoPhaseReadOpt = false;
-        } else {
-            this.enablePipelineEngine = false;
-            this.enableFoldConstantByBe = false;
-            this.enableTwoPhaseReadOpt = true;
+        List<String> res = Lists.newArrayList();
+        for (Field field : SessionVariable.class.getDeclaredFields()) {
+            VarAttr attr = field.getAnnotation(VarAttr.class);
+            if (attr == null || attr.fuzzy().getSimpleName() == DefaultVarHandler.class.getSimpleName()) {
+                continue;
+            }
+            field.setAccessible(true);
+            try {
+                Object val = field.get(this);
+                res.add(attr.name() + "=" + val.toString());
+            } catch (IllegalAccessException e) {
+                LOG.warn("failed to get fuzzy session variable {}", attr.name(), e);
+            }
         }
+        return Joiner.on(",").join(res);
     }
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/VariableMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/VariableMgr.java
@@ -29,6 +29,8 @@ import org.apache.doris.common.ErrorReport;
 import org.apache.doris.common.PatternMatcher;
 import org.apache.doris.nereids.trees.expressions.literal.Literal;
 import org.apache.doris.persist.GlobalVarPersistInfo;
+import org.apache.doris.qe.FuzzyVarHandlers.DefaultVarHandler;
+import org.apache.doris.qe.FuzzyVarHandlers.VarHandler;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
@@ -567,7 +569,7 @@ public class VariableMgr {
     }
 
     @Retention(RetentionPolicy.RUNTIME)
-    public static @interface VarAttr {
+    public @interface VarAttr {
         // Name in show variables and set statement;
         String name();
 
@@ -585,6 +587,8 @@ public class VariableMgr {
 
         // Set to true if the variables need to be forwarded along with forward statement.
         boolean needForward() default false;
+
+        Class<? extends VarHandler> fuzzy() default DefaultVarHandler.class;
     }
 
     private static class VarContext {


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

When enable `use_fuzzy_session_variable` in fe.conf, some of session variables will be set randomly
to test corner cases.
This PR changes:

1. Use Annotation callback to define the fuzzy method of the variable.
2. print fuzzy variables' value in fe.audit.log only if `use_fuzzy_session_variable` is true

eg:

```
FuzzyVariables=disable_streaming_preaggregations=false,parallel_fragment_exec_instance_num=7,enable_pipeline_engine=false,enable_fold_constant_by_be=false,enable_local_exchange=true,partitioned_hash_join_rows_threshold=8,partitioned_hash_agg_rows_threshold=1048576,enable_share_hash_table_for_broadcast_join=true,external_sort_bytes_threshold=1048576,two_phase_read_opt_limit_threshold=512
```

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
4. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
5. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
6. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
7. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

