### PR TITLE
[improvement](filecache) use dynamic segment size to cache remote file block

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -875,6 +875,8 @@ CONF_Bool(enable_file_cache, "false");
 CONF_String(file_cache_path, "");
 CONF_String(disposable_file_cache_path, "");
 CONF_Int64(file_cache_max_file_segment_size, "4194304"); // 4MB
+CONF_Validator(file_cache_max_file_segment_size,
+               [](const int64_t config) -> bool { return config >= 4096; }); // 4KB
 CONF_Bool(clear_file_cache, "false");
 CONF_Bool(enable_file_cache_query_limit, "false");
 

--- a/be/src/io/cache/block/cached_remote_file_reader.cpp
+++ b/be/src/io/cache/block/cached_remote_file_reader.cpp
@@ -44,12 +44,13 @@ Status CachedRemoteFileReader::close() {
 
 std::pair<size_t, size_t> CachedRemoteFileReader::_align_size(size_t offset,
                                                               size_t read_size) const {
+    size_t segment_size = std::min(std::max(read_size, (size_t)4096), // 4k
+                                   (size_t)config::file_cache_max_file_segment_size);
+    segment_size = BitUtil::next_power_of_two(segment_size);
     size_t left = offset;
     size_t right = offset + read_size - 1;
-    size_t align_left = (left / config::file_cache_max_file_segment_size) *
-                        config::file_cache_max_file_segment_size;
-    size_t align_right = (right / config::file_cache_max_file_segment_size + 1) *
-                         config::file_cache_max_file_segment_size;
+    size_t align_left = (left / segment_size) * segment_size;
+    size_t align_right = (right / segment_size + 1) * segment_size;
     align_right = align_right < size() ? align_right : size();
     size_t align_size = align_right - align_left;
     return std::make_pair(align_left, align_size);
@@ -92,7 +93,6 @@ Status CachedRemoteFileReader::read_at_impl(size_t offset, Slice result,
         auto pair = _align_size(offset, bytes_req);
         align_left = pair.first;
         align_size = pair.second;
-        DCHECK((align_left % config::file_cache_max_file_segment_size) == 0);
     }
     bool is_persistent = _io_ctx->is_persistent;
     TUniqueId query_id = _io_ctx->query_id ? *(_io_ctx->query_id) : TUniqueId();

--- a/be/src/io/file_factory.cpp
+++ b/be/src/io/file_factory.cpp
@@ -159,7 +159,8 @@ Status FileFactory::create_file_reader(RuntimeProfile* /*profile*/,
     if (config::enable_file_cache && io_ctx->enable_file_cache) {
         cache_policy = io::FileCachePolicy::FILE_BLOCK_CACHE;
     }
-    io::FileReaderOptions reader_options(cache_policy, io::FileBlockCachePathPolicy());
+    io::FileBlockCachePathPolicy file_block_cache;
+    io::FileReaderOptions reader_options(cache_policy, file_block_cache);
     switch (type) {
     case TFileType::FILE_LOCAL: {
         RETURN_IF_ERROR(io::global_local_filesystem()->open_file(


### PR DESCRIPTION
# Proposed changes

`CachedRemoteFileReader` has used fixed segment size(file_cache_max_file_segment_size=4M) to cache remote file blocks. However, the column size in a rowgroup/strip maybe smaller than 10K if a parquet/orc file has many columns, resulting in particularly serious read amplification. For example:
Q1 in clickbench: select count(*) from hits
```
-  FileCache:  0ns
  -  IOHitCacheNum:  552
  -  IOTotalNum:  835
  -  ReadFromFileCacheBytes:  19.98  MB
  -  ReadFromWriteCacheBytes:  0.00  
  -  ReadTotalBytes:  29.52  MB
  -  SkipCacheBytes:  0.00  
  -  WriteInFileCacheBytes:  915.77  MB
  -  WriteInFileCacheNum:  283 
```
Only 30MB of data is needed, but 900MB+ of data is read from hdfs. The query time of Q1(single scan thread) increased from **5.17s** to **24.45s** when enable file cache.

Therefore, this PR introduce dynamic segment size which is based on the `read_size` of the data. In order to prevent too small or too large IO, the segment size is limited in [4096, file_cache_max_file_segment_size].

Q1 in clickbench is **5.66s** when enable file cache. The performance is almost the same as if the cache is disabled, and the data size read from hdfs is reduced to 45MB.
```
-  FileCache:  0ns
    -  IOHitCacheNum:  297
    -  IOTotalNum:  835
    -  ReadFromFileCacheBytes:  8.73  MB
    -  ReadFromWriteCacheBytes:  0.00  
    -  ReadTotalBytes:  29.52  MB
    -  SkipCacheBytes:  0.00  
    -  WriteInFileCacheBytes:  45.66  MB
    -  WriteInFileCacheNum:  544
```
## Remaining Problems
Small queries may result in a large number of small files(4KB at least), and the `BE` saves too much meta information of cached segments.

## Fix bug
`FileCachePolicy` in `FileReaderOptions` is a constant reference, but the parameter passed in `FileFactory::create_file_reader` is a temporary variable, resulting in segmentation fault.

## Experiment on S3
Query the `orders` table of tpch 100g:
```sql
select count(o_shippriority) from orders
```
The actual bytes to read is `ReadTotalBytes:  3.04  MB`
| segment_size | profile |
| --- | --- |
| 4MB | WriteInFileCacheBytes:  360.94  MB <br> FileReadTime:  18s639ms |
| 2MB | WriteInFileCacheBytes:   128.73  MB <br> FileReadTime:  13s721ms |
| 1MB | WriteInFileCacheBytes:  91.94  MB <br> FileReadTime:  8s81ms |
| 50KB | WriteInFileCacheBytes:  6.69  MB <br> FileReadTime:  6s333ms |
| 10KB | WriteInFileCacheBytes:  4.72  MB <br> FileReadTime:  5s877ms |
| dynamic | WriteInFileCacheBytes:  4.54  MB <br> FileReadTime:  5s726ms |

When IO size < 1MB, the performance improvement is not obvious.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

