### PR TITLE
[Bug](point query) Reusable in PointQueryExecutor should  call init b…

### DIFF
--- a/be/src/service/point_query_executor.cpp
+++ b/be/src/service/point_query_executor.cpp
@@ -63,6 +63,7 @@ std::unique_ptr<vectorized::Block> Reusable::get_block() {
         return std::make_unique<vectorized::Block>(tuple_desc()->slots(), 4);
     }
     auto block = std::move(_block_pool.back());
+    CHECK(block != nullptr);
     _block_pool.pop_back();
     return block;
 }
@@ -149,9 +150,9 @@ Status PointQueryExecutor::init(const PTabletKeyLookupRequest* request,
                 &t_output_exprs));
         _reusable = reusable_ptr;
         if (uuid != 0) {
-            LookupCache::instance().add(uuid, reusable_ptr);
             // could be reused by requests after, pre allocte more blocks
             RETURN_IF_ERROR(reusable_ptr->init(t_desc_tbl, t_output_exprs.exprs, 128));
+            LookupCache::instance().add(uuid, reusable_ptr);
         } else {
             RETURN_IF_ERROR(reusable_ptr->init(t_desc_tbl, t_output_exprs.exprs, 1));
         }
@@ -164,7 +165,7 @@ Status PointQueryExecutor::init(const PTabletKeyLookupRequest* request,
     }
     RETURN_IF_ERROR(_init_keys(request));
     _result_block = _reusable->get_block();
-    DCHECK(_result_block != nullptr);
+    CHECK(_result_block != nullptr);
     return Status::OK();
 }
 


### PR DESCRIPTION
…efore add to LookupCache

Otherwise in high concurrent query, _block_pool maybe used before Reusable::init done in other threads

# Proposed changes

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

