### PR TITLE
[bug](jdbc) fix jdbc can't get object of PGobject 

### DIFF
--- a/be/src/vec/exec/vjdbc_connector.cpp
+++ b/be/src/vec/exec/vjdbc_connector.cpp
@@ -606,7 +606,7 @@ Status JdbcConnector::_register_func_id(JNIEnv* env) {
                                 "(Ljava/lang/Object;ZIJJJ)V", _executor_get_string_result));
     RETURN_IF_ERROR(register_id(_executor_clazz, "copyBatchCharResult",
                                 "(Ljava/lang/Object;ZIJJJZ)V", _executor_get_char_result));
-    
+
     RETURN_IF_ERROR(register_id(_executor_clazz, "copyBatchDateResult",
                                 JDBC_EXECUTOR_COPY_BATCH_SIGNATURE, _executor_get_date_result));
     RETURN_IF_ERROR(register_id(_executor_clazz, "copyBatchDateV2Result",

--- a/be/src/vec/exec/vjdbc_connector.cpp
+++ b/be/src/vec/exec/vjdbc_connector.cpp
@@ -460,7 +460,20 @@ Status JdbcConnector::_convert_batch_result_set(JNIEnv* env, jobject jcolumn_dat
                                       address[1]);
         break;
     }
-    case TYPE_CHAR:
+    case TYPE_CHAR: {
+        bool need_trim_spaces = false;
+        if ((_conn_param.table_type == TOdbcTableType::POSTGRESQL) ||
+            (_conn_param.table_type == TOdbcTableType::ORACLE)) {
+            need_trim_spaces = true;
+        }
+        auto column_string = reinterpret_cast<vectorized::ColumnString*>(col_ptr);
+        address[1] = reinterpret_cast<int64_t>(column_string->get_offsets().data());
+        auto chars_addres = reinterpret_cast<int64_t>(&column_string->get_chars());
+        env->CallNonvirtualVoidMethod(_executor_obj, _executor_clazz, _executor_get_char_result,
+                                      jcolumn_data, column_is_nullable, num_rows, address[0],
+                                      address[1], chars_addres, need_trim_spaces);
+        break;
+    }
     case TYPE_STRING:
     case TYPE_VARCHAR: {
         auto column_string = reinterpret_cast<vectorized::ColumnString*>(col_ptr);
@@ -591,7 +604,9 @@ Status JdbcConnector::_register_func_id(JNIEnv* env) {
                                 JDBC_EXECUTOR_COPY_BATCH_SIGNATURE, _executor_get_double_result));
     RETURN_IF_ERROR(register_id(_executor_clazz, "copyBatchStringResult",
                                 "(Ljava/lang/Object;ZIJJJ)V", _executor_get_string_result));
-
+    RETURN_IF_ERROR(register_id(_executor_clazz, "copyBatchCharResult",
+                                "(Ljava/lang/Object;ZIJJJZ)V", _executor_get_char_result));
+    
     RETURN_IF_ERROR(register_id(_executor_clazz, "copyBatchDateResult",
                                 JDBC_EXECUTOR_COPY_BATCH_SIGNATURE, _executor_get_date_result));
     RETURN_IF_ERROR(register_id(_executor_clazz, "copyBatchDateV2Result",

--- a/be/src/vec/exec/vjdbc_connector.h
+++ b/be/src/vec/exec/vjdbc_connector.h
@@ -127,6 +127,7 @@ private:
     jmethodID _executor_get_largeint_result;
     jmethodID _executor_get_float_result;
     jmethodID _executor_get_double_result;
+    jmethodID _executor_get_char_result;
     jmethodID _executor_get_string_result;
     jmethodID _executor_get_date_result;
     jmethodID _executor_get_datev2_result;

--- a/fe/java-udf/src/main/java/org/apache/doris/udf/JdbcExecutor.java
+++ b/fe/java-udf/src/main/java/org/apache/doris/udf/JdbcExecutor.java
@@ -353,7 +353,6 @@ public class JdbcExecutor {
             }
         } else {
             for (int i = 0; i < numRows; i++) {
-                short res = 32767;
                 UdfUtils.UNSAFE.putShort(columnAddr + (i * 2L), ((Integer) column[i]).shortValue());
             }
         }

--- a/regression-test/suites/jdbc_p0/test_jdbc_query_mysql.groovy
+++ b/regression-test/suites/jdbc_p0/test_jdbc_query_mysql.groovy
@@ -795,8 +795,9 @@ suite("test_jdbc_query_mysql", "p0") {
                                 FROM ( SELECT id AS a, id % 3 AS b FROM ${exMysqlTable}) t1
                             JOIN ${exMysqlTable} t2 ON t1.a = t2.id GROUP BY t1.a) o
                             ON l.b = o.d AND l.a = o.a order by l.a desc limit 3"""
-        order_qt_sql48 """ SELECT x, y, COUNT(*) as c FROM (SELECT k8, 0 AS x FROM $jdbcMysql57Table1) a
-                            JOIN (SELECT k8, 1 AS y FROM $jdbcMysql57Table1) b ON a.k8 = b.k8 group by x, y order by c desc limit 3 """
+        // need check plan : ERROR 1105 (HY000): errCode = 2, detailMessage = select list expression not produced by aggregation output (missing from GROUP BY clause?): `x`                    
+        // order_qt_sql48 """ SELECT x, y, COUNT(*) as c FROM (SELECT k8, 0 AS x FROM $jdbcMysql57Table1) a
+                            // JOIN (SELECT k8, 1 AS y FROM $jdbcMysql57Table1) b ON a.k8 = b.k8 group by x, y order by c desc limit 3 """
         order_qt_sql49 """ SELECT * FROM (SELECT * FROM $jdbcMysql57Table1 WHERE k8 % 120 > 110) l
                             JOIN (SELECT *, COUNT(1) OVER (PARTITION BY id ORDER BY id) FROM ${exMysqlTable}) o ON l.k8 = o.id """
         order_qt_sql50 """ SELECT COUNT(*) FROM $jdbcMysql57Table1 as a LEFT OUTER JOIN ${exMysqlTable} as b ON a.k8 = b.id AND a.k8 > 111 WHERE a.k8 < 114 """
@@ -936,12 +937,12 @@ suite("test_jdbc_query_mysql", "p0") {
 
 
         // test alter resource
-        sql """alter resource $jdbcResourceMysql57 properties("password" = "1234567")"""
-        test {
-            sql """select count(*) from $jdbcMysql57Table1"""
-            exception "Access denied for user"
-        }
-        sql """alter resource $jdbcResourceMysql57 properties("password" = "123456")"""
+        // sql """alter resource $jdbcResourceMysql57 properties("password" = "1234567")"""
+        // test {
+        //     sql """select count(*) from $jdbcMysql57Table1"""
+        //     exception "Access denied for user"
+        // }
+        // sql """alter resource $jdbcResourceMysql57 properties("password" = "123456")"""
 
         // test for type check
         sql  """ drop table if exists ${exMysqlTypeTable} """

--- a/regression-test/suites/jdbc_p0/test_jdbc_query_mysql.groovy
+++ b/regression-test/suites/jdbc_p0/test_jdbc_query_mysql.groovy
@@ -935,7 +935,7 @@ suite("test_jdbc_query_mysql", "p0") {
         order_qt_sql111 """ SELECT rank() OVER () FROM (SELECT k8 FROM $jdbcMysql57Table1 LIMIT 10) as t LIMIT 3 """
         order_qt_sql112 """ SELECT k7, count(DISTINCT k8) FROM $jdbcMysql57Table1 WHERE k8 > 110 GROUP BY GROUPING SETS ((), (k7)) """
 
-
+        // test this action result need restart?
         // test alter resource
         // sql """alter resource $jdbcResourceMysql57 properties("password" = "1234567")"""
         // test {

--- a/regression-test/suites/jdbc_p0/test_jdbc_query_mysql.groovy
+++ b/regression-test/suites/jdbc_p0/test_jdbc_query_mysql.groovy
@@ -795,9 +795,9 @@ suite("test_jdbc_query_mysql", "p0") {
                                 FROM ( SELECT id AS a, id % 3 AS b FROM ${exMysqlTable}) t1
                             JOIN ${exMysqlTable} t2 ON t1.a = t2.id GROUP BY t1.a) o
                             ON l.b = o.d AND l.a = o.a order by l.a desc limit 3"""
-        // need check plan : ERROR 1105 (HY000): errCode = 2, detailMessage = select list expression not produced by aggregation output (missing from GROUP BY clause?): `x`                    
-        // order_qt_sql48 """ SELECT x, y, COUNT(*) as c FROM (SELECT k8, 0 AS x FROM $jdbcMysql57Table1) a
-                            // JOIN (SELECT k8, 1 AS y FROM $jdbcMysql57Table1) b ON a.k8 = b.k8 group by x, y order by c desc limit 3 """
+        // this pr fixed, wait for merge: https://github.com/apache/doris/pull/16442                    
+        order_qt_sql48 """ SELECT x, y, COUNT(*) as c FROM (SELECT k8, 0 AS x FROM $jdbcMysql57Table1) a
+                            JOIN (SELECT k8, 1 AS y FROM $jdbcMysql57Table1) b ON a.k8 = b.k8 group by x, y order by c desc limit 3 """
         order_qt_sql49 """ SELECT * FROM (SELECT * FROM $jdbcMysql57Table1 WHERE k8 % 120 > 110) l
                             JOIN (SELECT *, COUNT(1) OVER (PARTITION BY id ORDER BY id) FROM ${exMysqlTable}) o ON l.k8 = o.id """
         order_qt_sql50 """ SELECT COUNT(*) FROM $jdbcMysql57Table1 as a LEFT OUTER JOIN ${exMysqlTable} as b ON a.k8 = b.id AND a.k8 > 111 WHERE a.k8 < 114 """
@@ -935,14 +935,14 @@ suite("test_jdbc_query_mysql", "p0") {
         order_qt_sql111 """ SELECT rank() OVER () FROM (SELECT k8 FROM $jdbcMysql57Table1 LIMIT 10) as t LIMIT 3 """
         order_qt_sql112 """ SELECT k7, count(DISTINCT k8) FROM $jdbcMysql57Table1 WHERE k8 > 110 GROUP BY GROUPING SETS ((), (k7)) """
 
-        // test this action result need restart?
+        // TODO: check this, maybe caused by datasource in JDBC
         // test alter resource
-        // sql """alter resource $jdbcResourceMysql57 properties("password" = "1234567")"""
-        // test {
-        //     sql """select count(*) from $jdbcMysql57Table1"""
-        //     exception "Access denied for user"
-        // }
-        // sql """alter resource $jdbcResourceMysql57 properties("password" = "123456")"""
+        sql """alter resource $jdbcResourceMysql57 properties("password" = "1234567")"""
+        test {
+            sql """select count(*) from $jdbcMysql57Table1"""
+            exception "Access denied for user"
+        }
+        sql """alter resource $jdbcResourceMysql57 properties("password" = "123456")"""
 
         // test for type check
         sql  """ drop table if exists ${exMysqlTypeTable} """

--- a/regression-test/suites/jdbc_p0/test_jdbc_query_pg.groovy
+++ b/regression-test/suites/jdbc_p0/test_jdbc_query_pg.groovy
@@ -70,7 +70,7 @@ suite("test_jdbc_query_pg", "p0") {
             );
             """
         order_qt_sql1 """select count(*) from $jdbcPg14Table1"""
-        order_qt_sql2 """select * from $jdbcPg14Table1"""
+        order_qt_sql2 """select * from $jdbcPg14Table1 order by k1,k2,k3,k4,k5,k6,k7,k8,k9,k10;"""
 
 
         // test for : doris query external table which is pg table's view
@@ -498,9 +498,9 @@ suite("test_jdbc_query_pg", "p0") {
                                 FROM ( SELECT id AS a, id % 3 AS b FROM ${dorisExTable1}) t1
                             JOIN ${dorisExTable1} t2 ON t1.a = t2.id GROUP BY t1.a) o
                             ON l.b = o.d AND l.a = o.a order by l.a desc limit 3"""
-        // need check plan: ERROR 1105 (HY000): errCode = 2, detailMessage = select list expression not produced by aggregation output (missing from GROUP BY clause?): `x`                    
-        // order_qt_sql48 """ SELECT x, y, COUNT(*) as c FROM (SELECT k8, 0 AS x FROM $jdbcPg14Table1) a
-                            // JOIN (SELECT k8, 1 AS y FROM $jdbcPg14Table1) b ON a.k8 = b.k8 group by x, y order by c desc limit 3 """
+        // this pr fixed, wait for merge: https://github.com/apache/doris/pull/16442   
+        order_qt_sql48 """ SELECT x, y, COUNT(*) as c FROM (SELECT k8, 0 AS x FROM $jdbcPg14Table1) a
+                            JOIN (SELECT k8, 1 AS y FROM $jdbcPg14Table1) b ON a.k8 = b.k8 group by x, y order by c desc limit 3 """
         order_qt_sql49 """ SELECT * FROM (SELECT * FROM $jdbcPg14Table1 WHERE k8 % 120 > 110) l
                             JOIN (SELECT *, COUNT(1) OVER (PARTITION BY id ORDER BY id) FROM ${dorisExTable1}) o ON l.k8 = o.id """
         order_qt_sql50 """ SELECT COUNT(*) FROM $jdbcPg14Table1 as a LEFT OUTER JOIN ${dorisExTable1} as b ON a.k8 = b.id AND a.k8 > 111 WHERE a.k8 < 114 """

--- a/regression-test/suites/jdbc_p0/test_jdbc_query_pg.groovy
+++ b/regression-test/suites/jdbc_p0/test_jdbc_query_pg.groovy
@@ -498,8 +498,9 @@ suite("test_jdbc_query_pg", "p0") {
                                 FROM ( SELECT id AS a, id % 3 AS b FROM ${dorisExTable1}) t1
                             JOIN ${dorisExTable1} t2 ON t1.a = t2.id GROUP BY t1.a) o
                             ON l.b = o.d AND l.a = o.a order by l.a desc limit 3"""
-        order_qt_sql48 """ SELECT x, y, COUNT(*) as c FROM (SELECT k8, 0 AS x FROM $jdbcPg14Table1) a
-                            JOIN (SELECT k8, 1 AS y FROM $jdbcPg14Table1) b ON a.k8 = b.k8 group by x, y order by c desc limit 3 """
+        // need check plan: ERROR 1105 (HY000): errCode = 2, detailMessage = select list expression not produced by aggregation output (missing from GROUP BY clause?): `x`                    
+        // order_qt_sql48 """ SELECT x, y, COUNT(*) as c FROM (SELECT k8, 0 AS x FROM $jdbcPg14Table1) a
+                            // JOIN (SELECT k8, 1 AS y FROM $jdbcPg14Table1) b ON a.k8 = b.k8 group by x, y order by c desc limit 3 """
         order_qt_sql49 """ SELECT * FROM (SELECT * FROM $jdbcPg14Table1 WHERE k8 % 120 > 110) l
                             JOIN (SELECT *, COUNT(1) OVER (PARTITION BY id ORDER BY id) FROM ${dorisExTable1}) o ON l.k8 = o.id """
         order_qt_sql50 """ SELECT COUNT(*) FROM $jdbcPg14Table1 as a LEFT OUTER JOIN ${dorisExTable1} as b ON a.k8 = b.id AND a.k8 > 111 WHERE a.k8 < 114 """


### PR DESCRIPTION
# Proposed changes
`when pg table have some  unsupported column type like: point, polygon, jsonb......
  jdbc catalog will convert it to string type in doris. but get result set in java is org.postgresql.util.PGobject
 `

Some test need this pr: #16442

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

