### PR TITLE
[regression-test](storage) add fuzzy variables for storage

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -847,7 +847,7 @@ CONF_String(be_node_role, "mix");
 // Hide the be config page for webserver.
 CONF_Bool(hide_webserver_config_page, "false");
 
-CONF_Bool(enable_segcompaction, "false"); // currently only support vectorized storage
+CONF_Bool(enable_segcompaction, "true"); // currently only support vectorized storage
 
 // Trigger segcompaction if the num of segments in a rowset exceeds this threshold.
 CONF_Int32(segcompaction_threshold_segment_num, "10");

--- a/be/src/common/configbase.cpp
+++ b/be/src/common/configbase.cpp
@@ -439,12 +439,8 @@ Status set_fuzzy_config(const std::string& field, const std::string& value) {
 
 void set_fuzzy_configs() {
     // random value true or false
-    Status s =
-            set_fuzzy_config("disable_storage_page_cache", ((rand() % 2) == 0) ? "true" : "false");
-    LOG(INFO) << s.to_string();
-    // random value from 8 to 48
-    // s = set_fuzzy_config("doris_scanner_thread_pool_thread_num", std::to_string((rand() % 41) + 8));
-    // LOG(INFO) << s.to_string();
+    set_fuzzy_config("disable_storage_page_cache", ((rand() % 2) == 0) ? "true" : "false");
+    set_fuzzy_config("enable_segcompaction", ((rand() % 2) == 0) ? "true" : "false");
 }
 
 std::mutex* get_mutable_string_config_lock() {

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/TableProperty.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/TableProperty.java
@@ -19,6 +19,7 @@ package org.apache.doris.catalog;
 
 import org.apache.doris.analysis.DataSortInfo;
 import org.apache.doris.common.AnalysisException;
+import org.apache.doris.common.Config;
 import org.apache.doris.common.FeMetaVersion;
 import org.apache.doris.common.io.Text;
 import org.apache.doris.common.io.Writable;
@@ -39,6 +40,7 @@ import java.io.DataOutput;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Random;
 
 /**
  * TableProperty contains additional information about OlapTable
@@ -80,6 +82,8 @@ public class TableProperty implements Writable {
     private boolean storeRowColumn = false;
 
     private DataSortInfo dataSortInfo = new DataSortInfo();
+
+    private Random random = new Random(System.currentTimeMillis());
 
     public TableProperty(Map<String, String> properties) {
         this.properties = properties;
@@ -154,14 +158,22 @@ public class TableProperty implements Writable {
     }
 
     public TableProperty buildEnableLightSchemaChange() {
+        String defaultValue = "false";
+        if (Config.use_fuzzy_session_variable) {
+            defaultValue = random.nextBoolean() ? "false" : "true";
+        }
         enableLightSchemaChange = Boolean.parseBoolean(
-                properties.getOrDefault(PropertyAnalyzer.PROPERTIES_ENABLE_LIGHT_SCHEMA_CHANGE, "false"));
+                properties.getOrDefault(PropertyAnalyzer.PROPERTIES_ENABLE_LIGHT_SCHEMA_CHANGE, defaultValue));
         return this;
     }
 
     public TableProperty buildDisableAutoCompaction() {
+        String defaultValue = "false";
+        if (Config.use_fuzzy_session_variable) {
+            defaultValue = random.nextBoolean() ? "false" : "true";
+        }
         disableAutoCompaction = Boolean.parseBoolean(
-                properties.getOrDefault(PropertyAnalyzer.PROPERTIES_DISABLE_AUTO_COMPACTION, "false"));
+                properties.getOrDefault(PropertyAnalyzer.PROPERTIES_DISABLE_AUTO_COMPACTION, defaultValue));
         return this;
     }
 
@@ -259,7 +271,11 @@ public class TableProperty implements Writable {
     }
 
     public boolean isAutoBucket() {
-        return Boolean.parseBoolean(properties.getOrDefault(PropertyAnalyzer.PROPERTIES_AUTO_BUCKET, "false"));
+        String defaultValue = "false";
+        if (Config.use_fuzzy_session_variable) {
+            defaultValue = random.nextBoolean() ? "false" : "true";
+        }
+        return Boolean.parseBoolean(properties.getOrDefault(PropertyAnalyzer.PROPERTIES_AUTO_BUCKET, defaultValue));
     }
 
     public String getEstimatePartitionSize() {
@@ -291,8 +307,12 @@ public class TableProperty implements Writable {
     }
 
     public boolean getEnableUniqueKeyMergeOnWrite() {
+        String defaultValue = "true";
+        if (Config.use_fuzzy_session_variable) {
+            defaultValue = random.nextBoolean() ? "false" : "true";
+        }
         return Boolean.parseBoolean(properties.getOrDefault(
-                PropertyAnalyzer.ENABLE_UNIQUE_KEY_MERGE_ON_WRITE, "true"));
+                PropertyAnalyzer.ENABLE_UNIQUE_KEY_MERGE_ON_WRITE, defaultValue));
     }
 
     public void setSequenceMapCol(String colName) {


### PR DESCRIPTION
# Proposed changes

1. fuzzy table properties like enable_light_weight_schema_change, auto_compaction, auto_bucket, merge_on_read or merge on write.
2. change segment_compaction default to true;
3. fuzzy segment_compaction in BE.conf.

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
4. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
5. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
6. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
7. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

