### PR TITLE
[UT-Fix](MTMV) Fix MTMV FE UT bugs

### DIFF
--- a/fe/fe-core/src/test/java/org/apache/doris/mtmv/MTMVJobManagerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/mtmv/MTMVJobManagerTest.java
@@ -59,7 +59,10 @@ public class MTMVJobManagerTest extends TestWithFeService {
         MTMVJob job = MTMVUtilsTest.createSchedulerJob();
         jobManager.createJob(job, false);
         Assertions.assertEquals(1, jobManager.showJobs(MTMVUtilsTest.dbName).size());
-        Thread.sleep(5000L);
+        while (jobManager.getTaskManager().getAllHistory().isEmpty()) {
+            Thread.sleep(1000L);
+            System.out.println("Loop    once");
+        }
         Assertions.assertTrue(jobManager.getTaskManager().getAllHistory().size() > 1);
     }
 
@@ -73,7 +76,7 @@ public class MTMVJobManagerTest extends TestWithFeService {
         Assertions.assertEquals(1, jobManager.showJobs(MTMVUtilsTest.dbName).size());
         Assertions.assertEquals(1, jobManager.showJobs(MTMVUtilsTest.dbName, MTMVUtilsTest.MV_NAME).size());
         while (!jobManager.getJob(MTMVUtilsTest.O_JOB).getState().equals(JobState.COMPLETE)) {
-            Thread.sleep(10000);
+            Thread.sleep(1000L);
             System.out.println("Loop    once");
         }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/mtmv/MTMVJobManagerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/mtmv/MTMVJobManagerTest.java
@@ -56,6 +56,7 @@ public class MTMVJobManagerTest extends TestWithFeService {
     public void testSchedulerJob() throws DdlException, InterruptedException {
         MTMVJobManager jobManager = new MTMVJobManager();
         jobManager.start();
+        Assertions.assertTrue(jobManager.getTaskManager().getAllHistory().isEmpty());
         MTMVJob job = MTMVUtilsTest.createSchedulerJob();
         jobManager.createJob(job, false);
         Assertions.assertEquals(1, jobManager.showJobs(MTMVUtilsTest.dbName).size());
@@ -63,7 +64,7 @@ public class MTMVJobManagerTest extends TestWithFeService {
             Thread.sleep(1000L);
             System.out.println("Loop    once");
         }
-        Assertions.assertTrue(jobManager.getTaskManager().getAllHistory().size() > 1);
+        Assertions.assertTrue(jobManager.getTaskManager().getAllHistory().size() > 0);
     }
 
     @Test


### PR DESCRIPTION
# Proposed changes



## Problem summary
Code in `MTMVJobManagerTest.java` sleep 5 seconds to wait the jobmanager generate task.
```sql
        Thread.sleep(5000L);
        Assertions.assertTrue(jobManager.getTaskManager().getAllHistory().size() > 1);
```
These will assert failed when running a heavy CI node.

So use a loop to wait the task to be generated.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [x] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

