### PR TITLE
[bugfix](information schema) sometimes fe throw thrift_rpc_error

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
@@ -260,7 +260,7 @@ public class InternalCatalog implements CatalogIf<Database> {
             if (fullName.equalsIgnoreCase(InfoSchemaDb.DATABASE_NAME)) {
                 String clusterName = ClusterNamespace.getClusterNameFromFullName(dbName);
                 fullName = ClusterNamespace.getFullName(clusterName, fullName.toLowerCase());
-                // If the fullname is not valid, ClusterNamespace.getFullName may return null 
+                // If the fullname is not valid, ClusterNamespace.getFullName may return null
                 // and fullNameToDb.get(fullName) may throw null pointer exception
                 if (fullName == null) {
                     return null;

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
@@ -260,6 +260,11 @@ public class InternalCatalog implements CatalogIf<Database> {
             if (fullName.equalsIgnoreCase(InfoSchemaDb.DATABASE_NAME)) {
                 String clusterName = ClusterNamespace.getClusterNameFromFullName(dbName);
                 fullName = ClusterNamespace.getFullName(clusterName, fullName.toLowerCase());
+                // If the fullname is not valid, ClusterNamespace.getFullName may return null and fullNameToDb.get(fullName)
+                // may throw null pointer exception
+                if (fullName == null) {
+                    return null;
+                }
                 return fullNameToDb.get(fullName);
             }
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
@@ -260,8 +260,8 @@ public class InternalCatalog implements CatalogIf<Database> {
             if (fullName.equalsIgnoreCase(InfoSchemaDb.DATABASE_NAME)) {
                 String clusterName = ClusterNamespace.getClusterNameFromFullName(dbName);
                 fullName = ClusterNamespace.getFullName(clusterName, fullName.toLowerCase());
-                // If the fullname is not valid, ClusterNamespace.getFullName may return null and fullNameToDb.get(fullName)
-                // may throw null pointer exception
+                // If the fullname is not valid, ClusterNamespace.getFullName may return null 
+                // and fullNameToDb.get(fullName) may throw null pointer exception
                 if (fullName == null) {
                     return null;
                 }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

mysql> SELECT TABLE_NAME, CHECK_OPTION, IS_UPDATABLE, SECURITY_TYPE, DEFINER FROM INFORMATION_SCHEMA.VIEWS WHERE TABLE_SCHEMA = 'test' ORDER BY TABLE_NAME ASC;
ERROR 2006 (HY000): MySQL server has gone away
No connection. Trying to reconnect...
Connection id:    0
Current database: *** NONE ***

ERROR 1105 (HY000): RpcException, msg: org.apache.doris.rpc.RpcException: failed to call frontend service/n    @     0x563a2b11b6ea  doris::Status::ConstructErrorStatus()
    @     0x563a2bcd638f  doris::ThriftRpcHelper::rpc<>()
    @     0x563a2b78b777  doris::SchemaHelper::list_table_status()
    @     0x563a2b7a0972  doris::SchemaViewsScanner::get_new_table()
    @     0x563a2b7a0b00  doris::SchemaViewsScanner::get_next_row()
    @     0x563a2ccd0c93  doris::vectorized::VSchemaScanNode::get_next()
    @     0x563a2b7450d6

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

