### PR TITLE
[Improvement](writer) make DeltaWriter close idempotent to be more robust

### DIFF
--- a/be/src/olap/delta_writer.cpp
+++ b/be/src/olap/delta_writer.cpp
@@ -293,7 +293,7 @@ Status DeltaWriter::close() {
     if (_is_closed) {
         LOG(WARNING) << "close after closed tablet_id=" << _req.tablet_id
                      << " load_id=" << _req.load_id << " txn_id=" << _req.txn_id;
-        return Status::Error<ALREADY_CLOSED>();
+        return Status::OK();
     }
 
     auto s = _flush_memtable_async();


### PR DESCRIPTION
# Proposed changes

Issue Number: releated to #16453


## Problem summary

return `Status::OK()` instead of `Status::Error<ALREADY_CLOSED>()` for close() in `DeltaWriter` if it's already closed.


## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

