### PR TITLE
[feature](merge-on-write) add DCHECK in compaction to detect data inconsistency

### DIFF
--- a/be/src/olap/cold_data_compaction.cpp
+++ b/be/src/olap/cold_data_compaction.cpp
@@ -60,7 +60,7 @@ Status ColdDataCompaction::pick_rowsets_to_compact() {
     return check_version_continuity(_input_rowsets);
 }
 
-Status ColdDataCompaction::modify_rowsets() {
+Status ColdDataCompaction::modify_rowsets(const Merger::Statistics* stats) {
     UniqueId cooldown_meta_id = UniqueId::gen_uid();
 
     // write remote tablet meta

--- a/be/src/olap/cold_data_compaction.h
+++ b/be/src/olap/cold_data_compaction.h
@@ -34,7 +34,7 @@ private:
     ReaderType compaction_type() const override { return ReaderType::READER_COLD_DATA_COMPACTION; }
 
     Status pick_rowsets_to_compact() override;
-    Status modify_rowsets() override;
+    Status modify_rowsets(const Merger::Statistics* stats = nullptr) override;
 };
 
 } // namespace doris

--- a/be/src/olap/compaction.cpp
+++ b/be/src/olap/compaction.cpp
@@ -439,13 +439,11 @@ Status Compaction::modify_rowsets(const Merger::Statistics* stats) {
                     _input_rowsets, _rowid_conversion, version.second, UINT64_MAX, &location_map,
                     &output_rowset_delete_bitmap);
             RETURN_IF_ERROR(_tablet->check_rowid_conversion(_output_rowset, location_map));
-
             _tablet->merge_delete_bitmap(output_rowset_delete_bitmap);
             RETURN_NOT_OK(_tablet->modify_rowsets(output_rowsets, _input_rowsets, true));
         }
         if (compaction_type() == READER_CUMULATIVE_COMPACTION) {
-            std::string err_msg =
-                    "The merged rows is not equal to missed rows in rowid conversion";
+            std::string err_msg = "The merged rows is not equal to missed rows in rowid conversion";
             DCHECK(stats != nullptr || stats->merged_rows == missed_rows) << err_msg;
             if (stats != nullptr && stats->merged_rows != missed_rows) {
                 return Status::InternalError(err_msg);

--- a/be/src/olap/compaction.cpp
+++ b/be/src/olap/compaction.cpp
@@ -424,9 +424,9 @@ Status Compaction::modify_rowsets(const Merger::Statistics* stats) {
         // New loads are not blocked, so some keys of input rowsets might
         // be deleted during the time. We need to deal with delete bitmap
         // of incremental data later.
-        missed_rows += _tablet->calc_compaction_output_rowset_delete_bitmap(_input_rowsets, _rowid_conversion, 0,
-                                                             version.second + 1, &location_map,
-                                                             &output_rowset_delete_bitmap);
+        missed_rows += _tablet->calc_compaction_output_rowset_delete_bitmap(
+                _input_rowsets, _rowid_conversion, 0, version.second + 1, &location_map,
+                &output_rowset_delete_bitmap);
         RETURN_IF_ERROR(_tablet->check_rowid_conversion(_output_rowset, location_map));
         location_map.clear();
         {

--- a/be/src/olap/compaction.cpp
+++ b/be/src/olap/compaction.cpp
@@ -333,7 +333,7 @@ Status Compaction::do_compaction_impl(int64_t permits) {
     TRACE("check correctness finished");
 
     // 4. modify rowsets in memory
-    RETURN_NOT_OK(modify_rowsets());
+    RETURN_NOT_OK(modify_rowsets(&stats));
     TRACE("modify rowsets finished");
 
     // 5. update last success compaction time
@@ -410,9 +410,10 @@ Status Compaction::construct_input_rowset_readers() {
     return Status::OK();
 }
 
-Status Compaction::modify_rowsets() {
+Status Compaction::modify_rowsets(const Merger::Statistics* stats) {
     std::vector<RowsetSharedPtr> output_rowsets;
     output_rowsets.push_back(_output_rowset);
+    uint64_t missed_rows = 0;
 
     if (_tablet->keys_type() == KeysType::UNIQUE_KEYS &&
         _tablet->enable_unique_key_merge_on_write()) {
@@ -423,7 +424,7 @@ Status Compaction::modify_rowsets() {
         // New loads are not blocked, so some keys of input rowsets might
         // be deleted during the time. We need to deal with delete bitmap
         // of incremental data later.
-        _tablet->calc_compaction_output_rowset_delete_bitmap(_input_rowsets, _rowid_conversion, 0,
+        missed_rows += _tablet->calc_compaction_output_rowset_delete_bitmap(_input_rowsets, _rowid_conversion, 0,
                                                              version.second + 1, &location_map,
                                                              &output_rowset_delete_bitmap);
         RETURN_IF_ERROR(_tablet->check_rowid_conversion(_output_rowset, location_map));
@@ -434,13 +435,21 @@ Status Compaction::modify_rowsets() {
 
             // Convert the delete bitmap of the input rowsets to output rowset for
             // incremental data.
-            _tablet->calc_compaction_output_rowset_delete_bitmap(
+            missed_rows += _tablet->calc_compaction_output_rowset_delete_bitmap(
                     _input_rowsets, _rowid_conversion, version.second, UINT64_MAX, &location_map,
                     &output_rowset_delete_bitmap);
             RETURN_IF_ERROR(_tablet->check_rowid_conversion(_output_rowset, location_map));
 
             _tablet->merge_delete_bitmap(output_rowset_delete_bitmap);
             RETURN_NOT_OK(_tablet->modify_rowsets(output_rowsets, _input_rowsets, true));
+        }
+        if (compaction_type() == READER_CUMULATIVE_COMPACTION) {
+            std::string err_msg =
+                    "The merged rows is not equal to missed rows in rowid conversion";
+            DCHECK(stats != nullptr || stats->merged_rows == missed_rows) << err_msg;
+            if (stats != nullptr && stats->merged_rows != missed_rows) {
+                return Status::InternalError(err_msg);
+            }
         }
     } else {
         std::lock_guard<std::shared_mutex> wrlock(_tablet->get_header_lock());

--- a/be/src/olap/compaction.cpp
+++ b/be/src/olap/compaction.cpp
@@ -439,15 +439,18 @@ Status Compaction::modify_rowsets(const Merger::Statistics* stats) {
                     _input_rowsets, _rowid_conversion, version.second, UINT64_MAX, &location_map,
                     &output_rowset_delete_bitmap);
             RETURN_IF_ERROR(_tablet->check_rowid_conversion(_output_rowset, location_map));
+
+            if (compaction_type() == READER_CUMULATIVE_COMPACTION) {
+                std::string err_msg =
+                        "The merged rows is not equal to missed rows in rowid conversion";
+                DCHECK(stats != nullptr || stats->merged_rows == missed_rows) << err_msg;
+                if (stats != nullptr && stats->merged_rows != missed_rows) {
+                    return Status::InternalError(err_msg);
+                }
+            }
+
             _tablet->merge_delete_bitmap(output_rowset_delete_bitmap);
             RETURN_NOT_OK(_tablet->modify_rowsets(output_rowsets, _input_rowsets, true));
-        }
-        if (compaction_type() == READER_CUMULATIVE_COMPACTION) {
-            std::string err_msg = "The merged rows is not equal to missed rows in rowid conversion";
-            DCHECK(stats != nullptr || stats->merged_rows == missed_rows) << err_msg;
-            if (stats != nullptr && stats->merged_rows != missed_rows) {
-                return Status::InternalError(err_msg);
-            }
         }
     } else {
         std::lock_guard<std::shared_mutex> wrlock(_tablet->get_header_lock());

--- a/be/src/olap/compaction.h
+++ b/be/src/olap/compaction.h
@@ -64,7 +64,7 @@ protected:
     Status do_compaction(int64_t permits);
     Status do_compaction_impl(int64_t permits);
 
-    virtual Status modify_rowsets();
+    virtual Status modify_rowsets(const Merger::Statistics* stats = nullptr);
     void gc_output_rowset();
 
     Status construct_output_rowset_writer(bool is_vertical = false);

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -2563,11 +2563,12 @@ Status Tablet::update_delete_bitmap(const RowsetSharedPtr& rowset, DeleteBitmapP
     return Status::OK();
 }
 
-void Tablet::calc_compaction_output_rowset_delete_bitmap(
+uint64_t Tablet::calc_compaction_output_rowset_delete_bitmap(
         const std::vector<RowsetSharedPtr>& input_rowsets, const RowIdConversion& rowid_conversion,
         uint64_t start_version, uint64_t end_version,
         std::map<RowsetSharedPtr, std::list<std::pair<RowLocation, RowLocation>>>* location_map,
         DeleteBitmap* output_rowset_delete_bitmap) {
+    uint64_t  missed_rows = 0;
     RowLocation src;
     RowLocation dst;
     for (auto& rowset : input_rowsets) {
@@ -2589,6 +2590,7 @@ void Tablet::calc_compaction_output_rowset_delete_bitmap(
                                       << " src loaction: |" << src.rowset_id << "|"
                                       << src.segment_id << "|" << src.row_id
                                       << " version: " << cur_version;
+                        missed_rows++;
                         continue;
                     }
                     VLOG_DEBUG << "calc_compaction_output_rowset_delete_bitmap dst location: |"
@@ -2603,6 +2605,7 @@ void Tablet::calc_compaction_output_rowset_delete_bitmap(
             }
         }
     }
+    return missed_rows;
 }
 
 void Tablet::merge_delete_bitmap(const DeleteBitmap& delete_bitmap) {

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -2568,7 +2568,7 @@ uint64_t Tablet::calc_compaction_output_rowset_delete_bitmap(
         uint64_t start_version, uint64_t end_version,
         std::map<RowsetSharedPtr, std::list<std::pair<RowLocation, RowLocation>>>* location_map,
         DeleteBitmap* output_rowset_delete_bitmap) {
-    uint64_t  missed_rows = 0;
+    uint64_t missed_rows = 0;
     RowLocation src;
     RowLocation dst;
     for (auto& rowset : input_rowsets) {

--- a/be/src/olap/tablet.h
+++ b/be/src/olap/tablet.h
@@ -364,7 +364,7 @@ public:
     Status update_delete_bitmap_without_lock(const RowsetSharedPtr& rowset);
     Status update_delete_bitmap(const RowsetSharedPtr& rowset, DeleteBitmapPtr delete_bitmap,
                                 const RowsetIdUnorderedSet& pre_rowset_ids);
-    void calc_compaction_output_rowset_delete_bitmap(
+    uint64_t calc_compaction_output_rowset_delete_bitmap(
             const std::vector<RowsetSharedPtr>& input_rowsets,
             const RowIdConversion& rowid_conversion, uint64_t start_version, uint64_t end_version,
             std::map<RowsetSharedPtr, std::list<std::pair<RowLocation, RowLocation>>>* location_map,


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

MoW will mark all duplicate primary key as deleted, so we can add a DCHECK while compaction, if MoW's delete bitmap works incorrectly, we're able to detect this kind of issue ASAP.
In Debug version, DCHECK will make BE crush, in release version, compaction will fail and finally load will fail due to -235

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

