### PR TITLE
[Improvement](inverted index) inverted index query match bitmap cache

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -887,6 +887,9 @@ CONF_String(inverted_index_searcher_cache_limit, "10%");
 CONF_Bool(enable_write_index_searcher_cache, "true");
 CONF_Bool(enable_inverted_index_cache_check_timestamp, "true");
 
+// inverted index match bitmap cache size
+CONF_String(inverted_index_query_cache_limit, "10%");
+
 // inverted index
 CONF_mDouble(inverted_index_ram_buffer_size, "512");
 CONF_Int32(query_bkd_inverted_index_limit_percent, "5"); // 5%

--- a/be/src/olap/olap_common.h
+++ b/be/src/olap/olap_common.h
@@ -343,6 +343,14 @@ struct OlapReaderStatistics {
 
     int64_t rows_inverted_index_filtered = 0;
     int64_t inverted_index_filter_timer = 0;
+    int64_t inverted_index_query_timer = 0;
+    int64_t inverted_index_query_cache_hit = 0;
+    int64_t inverted_index_query_cache_miss = 0;
+    int64_t inverted_index_query_bitmap_copy_timer = 0;
+    int64_t inverted_index_query_bitmap_op_timer = 0;
+    int64_t inverted_index_searcher_open_timer = 0;
+    int64_t inverted_index_searcher_search_timer = 0;
+    int64_t inverted_index_searcher_bitmap_timer = 0;
 
     int64_t output_index_result_column_timer = 0;
     // number of segment filtered by column stat when creating seg iterator

--- a/be/src/olap/rowset/segment_v2/column_reader.cpp
+++ b/be/src/olap/rowset/segment_v2/column_reader.cpp
@@ -142,10 +142,11 @@ Status ColumnReader::new_bitmap_index_iterator(BitmapIndexIterator** iterator) {
 }
 
 Status ColumnReader::new_inverted_index_iterator(const TabletIndex* index_meta,
+                                                 OlapReaderStatistics* stats,
                                                  InvertedIndexIterator** iterator) {
     RETURN_IF_ERROR(_ensure_inverted_index_loaded(index_meta));
     if (_inverted_index) {
-        RETURN_IF_ERROR(_inverted_index->new_iterator(index_meta, iterator));
+        RETURN_IF_ERROR(_inverted_index->new_iterator(index_meta, stats, iterator));
     }
     return Status::OK();
 }

--- a/be/src/olap/rowset/segment_v2/column_reader.h
+++ b/be/src/olap/rowset/segment_v2/column_reader.h
@@ -106,6 +106,7 @@ public:
     Status new_bitmap_index_iterator(BitmapIndexIterator** iterator);
 
     Status new_inverted_index_iterator(const TabletIndex* index_meta,
+                                       OlapReaderStatistics* stats,
                                        InvertedIndexIterator** iterator);
 
     // Seek to the first entry in the column.

--- a/be/src/olap/rowset/segment_v2/column_reader.h
+++ b/be/src/olap/rowset/segment_v2/column_reader.h
@@ -105,8 +105,7 @@ public:
     // Client should delete returned iterator
     Status new_bitmap_index_iterator(BitmapIndexIterator** iterator);
 
-    Status new_inverted_index_iterator(const TabletIndex* index_meta,
-                                       OlapReaderStatistics* stats,
+    Status new_inverted_index_iterator(const TabletIndex* index_meta, OlapReaderStatistics* stats,
                                        InvertedIndexIterator** iterator);
 
     // Seek to the first entry in the column.

--- a/be/src/olap/rowset/segment_v2/inverted_index_cache.cpp
+++ b/be/src/olap/rowset/segment_v2/inverted_index_cache.cpp
@@ -70,8 +70,7 @@ Status InvertedIndexSearcherCache::get_index_searcher(const io::FileSystemSPtr& 
                                                       const std::string& index_dir,
                                                       const std::string& file_name,
                                                       InvertedIndexCacheHandle* cache_handle,
-                                                      OlapReaderStatistics* stats,
-                                                      bool use_cache) {
+                                                      OlapReaderStatistics* stats, bool use_cache) {
     auto file_path = index_dir + "/" + file_name;
 
     using namespace std::chrono;
@@ -184,13 +183,11 @@ bool InvertedIndexQueryCache::lookup(const CacheKey& key, InvertedIndexQueryCach
 }
 
 void InvertedIndexQueryCache::insert(const CacheKey& key, roaring::Roaring* bitmap,
-            InvertedIndexQueryCacheHandle* handle) {
-    auto deleter = [](const doris::CacheKey& key, void* value) {
-        delete (roaring::Roaring*)value;
-    };
+                                     InvertedIndexQueryCacheHandle* handle) {
+    auto deleter = [](const doris::CacheKey& key, void* value) { delete (roaring::Roaring*)value; };
 
-    auto lru_handle = _cache->insert(key.encode(), (void *)bitmap, bitmap->getSizeInBytes(),
-                                        deleter, CachePriority::NORMAL);
+    auto lru_handle = _cache->insert(key.encode(), (void*)bitmap, bitmap->getSizeInBytes(), deleter,
+                                     CachePriority::NORMAL);
     *handle = InvertedIndexQueryCacheHandle(_cache.get(), lru_handle);
 }
 

--- a/be/src/olap/rowset/segment_v2/inverted_index_cache.cpp
+++ b/be/src/olap/rowset/segment_v2/inverted_index_cache.cpp
@@ -186,7 +186,7 @@ bool InvertedIndexQueryCache::lookup(const CacheKey& key, InvertedIndexQueryCach
 void InvertedIndexQueryCache::insert(const CacheKey& key, roaring::Roaring* bitmap,
             InvertedIndexQueryCacheHandle* handle) {
     auto deleter = [](const doris::CacheKey& key, void* value) {
-        delete (roaring::Roaring**)value;
+        delete (roaring::Roaring*)value;
     };
 
     auto lru_handle = _cache->insert(key.encode(), (void *)bitmap, bitmap->getSizeInBytes(),

--- a/be/src/olap/rowset/segment_v2/inverted_index_cache.cpp
+++ b/be/src/olap/rowset/segment_v2/inverted_index_cache.cpp
@@ -70,6 +70,7 @@ Status InvertedIndexSearcherCache::get_index_searcher(const io::FileSystemSPtr& 
                                                       const std::string& index_dir,
                                                       const std::string& file_name,
                                                       InvertedIndexCacheHandle* cache_handle,
+                                                      OlapReaderStatistics* stats,
                                                       bool use_cache) {
     auto file_path = index_dir + "/" + file_name;
 
@@ -85,12 +86,14 @@ Status InvertedIndexSearcherCache::get_index_searcher(const io::FileSystemSPtr& 
         cache_handle->owned = false;
         return Status::OK();
     }
+
     cache_handle->owned = !use_cache;
     IndexSearcherPtr index_searcher = nullptr;
     auto mem_tracker =
             std::unique_ptr<MemTracker>(new MemTracker("InvertedIndexSearcherCacheWithRead"));
 #ifndef BE_TEST
     {
+        SCOPED_RAW_TIMER(&stats->inverted_index_searcher_open_timer);
         SCOPED_CONSUME_MEM_TRACKER(mem_tracker.get());
         index_searcher = build_index_searcher(fs, index_dir, file_name);
     }
@@ -167,6 +170,28 @@ Cache::Handle* InvertedIndexSearcherCache::_insert(const InvertedIndexSearcherCa
     Cache::Handle* lru_handle =
             _cache->insert(key.index_file_path, value, value->size, deleter, CachePriority::NORMAL);
     return lru_handle;
+}
+
+InvertedIndexQueryCache* InvertedIndexQueryCache::_s_instance = nullptr;
+
+bool InvertedIndexQueryCache::lookup(const CacheKey& key, InvertedIndexQueryCacheHandle* handle) {
+    auto lru_handle = _cache->lookup(key.encode());
+    if (lru_handle == nullptr) {
+        return false;
+    }
+    *handle = InvertedIndexQueryCacheHandle(_cache.get(), lru_handle);
+    return true;
+}
+
+void InvertedIndexQueryCache::insert(const CacheKey& key, roaring::Roaring* bitmap,
+            InvertedIndexQueryCacheHandle* handle) {
+    auto deleter = [](const doris::CacheKey& key, void* value) {
+        delete (roaring::Roaring**)value;
+    };
+
+    auto lru_handle = _cache->insert(key.encode(), (void *)bitmap, bitmap->getSizeInBytes(),
+                                        deleter, CachePriority::NORMAL);
+    *handle = InvertedIndexQueryCacheHandle(_cache.get(), lru_handle);
 }
 
 } // namespace segment_v2

--- a/be/src/olap/rowset/segment_v2/inverted_index_cache.h
+++ b/be/src/olap/rowset/segment_v2/inverted_index_cache.h
@@ -26,6 +26,8 @@
 #include <vector>
 
 #include "io/fs/file_system.h"
+#include <roaring/roaring.hh>
+
 #include "olap/lru_cache.h"
 #include "runtime/memory/mem_tracker.h"
 #include "util/time.h"
@@ -71,7 +73,7 @@ public:
 
     Status get_index_searcher(const io::FileSystemSPtr& fs, const std::string& index_dir,
                               const std::string& file_name, InvertedIndexCacheHandle* cache_handle,
-                              bool use_cache = true);
+                              OlapReaderStatistics* stats, bool use_cache = true);
 
     // function `insert` called after inverted index writer close
     Status insert(const io::FileSystemSPtr& fs, const std::string& index_dir,
@@ -161,6 +163,106 @@ private:
 
     // Don't allow copy and assign
     DISALLOW_COPY_AND_ASSIGN(InvertedIndexCacheHandle);
+};
+
+
+
+enum class InvertedIndexQueryType;
+
+class InvertedIndexQueryCacheHandle;
+
+class InvertedIndexQueryCache {
+public:
+    // cache key
+    struct CacheKey {
+        io::Path index_path; // index file path
+        std::string column_name; // column name
+        InvertedIndexQueryType query_type; // query type
+        std::wstring value; // query value
+
+        // Encode to a flat binary which can be used as LRUCache's key
+        std::string encode() const {
+            std::string key_buf(index_path.string());
+            key_buf.append("/");
+            key_buf.append(column_name);
+            key_buf.append("/");
+            key_buf.append(1, static_cast<char>(query_type));
+            key_buf.append("/");
+            key_buf.append(lucene::util::Misc::toString(value.c_str()));
+            return key_buf;
+        }
+    };
+
+    using CacheValue = roaring::Roaring;
+
+    // Create global instance of this class
+    static void create_global_cache(size_t capacity, int32_t index_cache_percentage,
+                                    uint32_t num_shards = 16) {
+        DCHECK(_s_instance == nullptr);
+        static InvertedIndexQueryCache instance(capacity, index_cache_percentage, num_shards);
+        _s_instance = &instance;
+    }
+
+    // Return global instance.
+    // Client should call create_global_cache before.
+    static InvertedIndexQueryCache* instance() { return _s_instance; }
+
+    InvertedIndexQueryCache() = delete;
+
+    InvertedIndexQueryCache(size_t capacity, int32_t index_cache_percentage, uint32_t num_shards) {
+        _cache = std::unique_ptr<Cache>(
+                new_lru_cache("InvertedIndexQueryCache", capacity, LRUCacheType::SIZE, num_shards));
+    }
+
+    bool lookup(const CacheKey& key, InvertedIndexQueryCacheHandle* handle);
+
+    void insert(const CacheKey& key, roaring::Roaring* bitmap,
+                InvertedIndexQueryCacheHandle* handle);
+
+private:
+    static InvertedIndexQueryCache* _s_instance;
+    std::unique_ptr<Cache> _cache {nullptr};
+};
+
+class InvertedIndexQueryCacheHandle {
+public:
+    InvertedIndexQueryCacheHandle() {}
+
+    InvertedIndexQueryCacheHandle(Cache* cache, Cache::Handle* handle)
+        : _cache(cache), _handle(handle) {}
+
+    ~InvertedIndexQueryCacheHandle() {
+        if (_handle != nullptr) {
+            _cache->release(_handle);
+        }
+    }
+
+    InvertedIndexQueryCacheHandle(InvertedIndexQueryCacheHandle&& other) noexcept {
+        // we can use std::exchange if we switch c++14 on
+        std::swap(_cache, other._cache);
+        std::swap(_handle, other._handle);
+    }
+
+    InvertedIndexQueryCacheHandle& operator=(InvertedIndexQueryCacheHandle&& other) noexcept {
+        std::swap(_cache, other._cache);
+        std::swap(_handle, other._handle);
+        return *this;
+    }
+
+    Cache* cache() const { return _cache; }
+    Slice data() const { return _cache->value_slice(_handle); }
+
+    InvertedIndexQueryCache::CacheValue* match_bitmap() const {
+        return ((InvertedIndexQueryCache::CacheValue*)_cache->value(_handle));
+    }
+
+private:
+    Cache* _cache = nullptr;
+    Cache::Handle* _handle = nullptr;
+
+    // Don't allow copy and assign
+    DISALLOW_COPY_AND_ASSIGN(InvertedIndexQueryCacheHandle);
+
 };
 
 } // namespace segment_v2

--- a/be/src/olap/rowset/segment_v2/inverted_index_cache.h
+++ b/be/src/olap/rowset/segment_v2/inverted_index_cache.h
@@ -23,11 +23,10 @@
 #include <map>
 #include <memory>
 #include <mutex>
+#include <roaring/roaring.hh>
 #include <vector>
 
 #include "io/fs/file_system.h"
-#include <roaring/roaring.hh>
-
 #include "olap/lru_cache.h"
 #include "runtime/memory/mem_tracker.h"
 #include "util/time.h"
@@ -165,8 +164,6 @@ private:
     DISALLOW_COPY_AND_ASSIGN(InvertedIndexCacheHandle);
 };
 
-
-
 enum class InvertedIndexQueryType;
 
 class InvertedIndexQueryCacheHandle;
@@ -175,10 +172,10 @@ class InvertedIndexQueryCache {
 public:
     // cache key
     struct CacheKey {
-        io::Path index_path; // index file path
-        std::string column_name; // column name
+        io::Path index_path;               // index file path
+        std::string column_name;           // column name
         InvertedIndexQueryType query_type; // query type
-        std::wstring value; // query value
+        std::wstring value;                // query value
 
         // Encode to a flat binary which can be used as LRUCache's key
         std::string encode() const {
@@ -229,7 +226,7 @@ public:
     InvertedIndexQueryCacheHandle() {}
 
     InvertedIndexQueryCacheHandle(Cache* cache, Cache::Handle* handle)
-        : _cache(cache), _handle(handle) {}
+            : _cache(cache), _handle(handle) {}
 
     ~InvertedIndexQueryCacheHandle() {
         if (_handle != nullptr) {
@@ -262,7 +259,6 @@ private:
 
     // Don't allow copy and assign
     DISALLOW_COPY_AND_ASSIGN(InvertedIndexQueryCacheHandle);
-
 };
 
 } // namespace segment_v2

--- a/be/src/olap/rowset/segment_v2/inverted_index_reader.cpp
+++ b/be/src/olap/rowset/segment_v2/inverted_index_reader.cpp
@@ -440,21 +440,21 @@ Status BkdIndexReader::query(OlapReaderStatistics* stats,
     auto index_dir = path.parent_path();
     auto index_file_name = InvertedIndexDescriptor::get_index_file_name(path.filename(), _index_id);
     auto index_file_path = index_dir / index_file_name;
-    std::string query_str {(const char *)query_value};
+    // std::string query_str {(const char *)query_value};
 
-    // try to get query bitmap result from cache and return immediately on cache hit
-    InvertedIndexQueryCache::CacheKey cache_key
-        {index_file_path, column_name, query_type, std::wstring(query_str.begin(), query_str.end())};
-    auto cache = InvertedIndexQueryCache::instance();
-    InvertedIndexQueryCacheHandle cache_handle;
-    if (cache->lookup(cache_key, &cache_handle)) {
-        stats->inverted_index_query_cache_hit++;
-        SCOPED_RAW_TIMER(&stats->inverted_index_query_bitmap_copy_timer);
-        *bit_map = *cache_handle.match_bitmap();
-        return Status::OK();
-    } else {
-        stats->inverted_index_query_cache_miss++;
-    }
+    // // try to get query bitmap result from cache and return immediately on cache hit
+    // InvertedIndexQueryCache::CacheKey cache_key
+    //     {index_file_path, column_name, query_type, std::wstring(query_str.begin(), query_str.end())};
+    // auto cache = InvertedIndexQueryCache::instance();
+    // InvertedIndexQueryCacheHandle cache_handle;
+    // if (cache->lookup(cache_key, &cache_handle)) {
+    //     stats->inverted_index_query_cache_hit++;
+    //     SCOPED_RAW_TIMER(&stats->inverted_index_query_bitmap_copy_timer);
+    //     *bit_map = *cache_handle.match_bitmap();
+    //     return Status::OK();
+    // } else {
+    //     stats->inverted_index_query_cache_miss++;
+    // }
 
     uint64_t start = UnixMillis();
     auto visitor = std::make_unique<InvertedIndexVisitor>(bit_map, query_type);
@@ -469,10 +469,10 @@ Status BkdIndexReader::query(OlapReaderStatistics* stats,
         return Status::Error<ErrorCode::INVERTED_INDEX_CLUCENE_ERROR>();
     }
 
-    // add to cache
-    roaring::Roaring* term_match_bitmap = new roaring::Roaring(*bit_map);
-    term_match_bitmap->runOptimize();
-    cache->insert(cache_key, term_match_bitmap, &cache_handle);
+    // // add to cache
+    // roaring::Roaring* term_match_bitmap = new roaring::Roaring(*bit_map);
+    // term_match_bitmap->runOptimize();
+    // cache->insert(cache_key, term_match_bitmap, &cache_handle);
 
     LOG(INFO) << "BKD index search time taken: " << UnixMillis() - start << "ms "
               << " column: " << column_name << " result: " << bit_map->cardinality()

--- a/be/src/olap/rowset/segment_v2/inverted_index_reader.h
+++ b/be/src/olap/rowset/segment_v2/inverted_index_reader.h
@@ -69,16 +69,13 @@ public:
     virtual ~InvertedIndexReader() = default;
 
     // create a new column iterator. Client should delete returned iterator
-    virtual Status new_iterator(const TabletIndex* index_meta,
-                                OlapReaderStatistics* stats,
+    virtual Status new_iterator(const TabletIndex* index_meta, OlapReaderStatistics* stats,
                                 InvertedIndexIterator** iterator) = 0;
-    virtual Status query(OlapReaderStatistics* stats,
-                         const std::string& column_name, const void* query_value,
-                         InvertedIndexQueryType query_type, InvertedIndexParserType analyser_type,
-                         roaring::Roaring* bit_map) = 0;
-    virtual Status try_query(OlapReaderStatistics* stats,
-                             const std::string& column_name, const void* query_value,
-                             InvertedIndexQueryType query_type,
+    virtual Status query(OlapReaderStatistics* stats, const std::string& column_name,
+                         const void* query_value, InvertedIndexQueryType query_type,
+                         InvertedIndexParserType analyser_type, roaring::Roaring* bit_map) = 0;
+    virtual Status try_query(OlapReaderStatistics* stats, const std::string& column_name,
+                             const void* query_value, InvertedIndexQueryType query_type,
                              InvertedIndexParserType analyser_type, uint32_t* count) = 0;
 
     virtual InvertedIndexReaderType type() = 0;
@@ -103,14 +100,12 @@ public:
 
     Status new_iterator(const TabletIndex* index_meta, OlapReaderStatistics* stats,
                         InvertedIndexIterator** iterator) override;
-    Status query(OlapReaderStatistics* stats,
-                 const std::string& column_name, const void* query_value,
-                 InvertedIndexQueryType query_type, InvertedIndexParserType analyser_type,
-                 roaring::Roaring* bit_map) override;
-    Status try_query(OlapReaderStatistics* stats,
-                     const std::string& column_name, const void* query_value,
-                     InvertedIndexQueryType query_type, InvertedIndexParserType analyser_type,
-                     uint32_t* count) override {
+    Status query(OlapReaderStatistics* stats, const std::string& column_name,
+                 const void* query_value, InvertedIndexQueryType query_type,
+                 InvertedIndexParserType analyser_type, roaring::Roaring* bit_map) override;
+    Status try_query(OlapReaderStatistics* stats, const std::string& column_name,
+                     const void* query_value, InvertedIndexQueryType query_type,
+                     InvertedIndexParserType analyser_type, uint32_t* count) override {
         return Status::Error<ErrorCode::NOT_IMPLEMENTED_ERROR>();
     }
 
@@ -130,14 +125,12 @@ public:
 
     Status new_iterator(const TabletIndex* index_meta, OlapReaderStatistics* stats,
                         InvertedIndexIterator** iterator) override;
-    Status query(OlapReaderStatistics* stats,
-                 const std::string& column_name, const void* query_value,
-                 InvertedIndexQueryType query_type, InvertedIndexParserType analyser_type,
-                 roaring::Roaring* bit_map) override;
-    Status try_query(OlapReaderStatistics* stats,
-                     const std::string& column_name, const void* query_value,
-                     InvertedIndexQueryType query_type, InvertedIndexParserType analyser_type,
-                     uint32_t* count) override {
+    Status query(OlapReaderStatistics* stats, const std::string& column_name,
+                 const void* query_value, InvertedIndexQueryType query_type,
+                 InvertedIndexParserType analyser_type, roaring::Roaring* bit_map) override;
+    Status try_query(OlapReaderStatistics* stats, const std::string& column_name,
+                     const void* query_value, InvertedIndexQueryType query_type,
+                     InvertedIndexParserType analyser_type, uint32_t* count) override {
         return Status::Error<ErrorCode::NOT_IMPLEMENTED_ERROR>();
     }
     InvertedIndexReaderType type() override;
@@ -191,17 +184,14 @@ public:
     Status new_iterator(const TabletIndex* index_meta, OlapReaderStatistics* stats,
                         InvertedIndexIterator** iterator) override;
 
-    Status query(OlapReaderStatistics* stats,
-                 const std::string& column_name, const void* query_value,
-                 InvertedIndexQueryType query_type, InvertedIndexParserType analyser_type,
-                 roaring::Roaring* bit_map) override;
-    Status try_query(OlapReaderStatistics* stats,
-                     const std::string& column_name, const void* query_value,
-                     InvertedIndexQueryType query_type, InvertedIndexParserType analyser_type,
-                     uint32_t* count) override;
-    Status bkd_query(OlapReaderStatistics* stats,
-                     const std::string& column_name, const void* query_value,
-                     InvertedIndexQueryType query_type,
+    Status query(OlapReaderStatistics* stats, const std::string& column_name,
+                 const void* query_value, InvertedIndexQueryType query_type,
+                 InvertedIndexParserType analyser_type, roaring::Roaring* bit_map) override;
+    Status try_query(OlapReaderStatistics* stats, const std::string& column_name,
+                     const void* query_value, InvertedIndexQueryType query_type,
+                     InvertedIndexParserType analyser_type, uint32_t* count) override;
+    Status bkd_query(OlapReaderStatistics* stats, const std::string& column_name,
+                     const void* query_value, InvertedIndexQueryType query_type,
                      std::shared_ptr<lucene::util::bkd::bkd_reader>&& r,
                      InvertedIndexVisitor* visitor);
 

--- a/be/src/olap/rowset/segment_v2/inverted_index_reader.h
+++ b/be/src/olap/rowset/segment_v2/inverted_index_reader.h
@@ -72,10 +72,12 @@ public:
     virtual Status new_iterator(const TabletIndex* index_meta,
                                 OlapReaderStatistics* stats,
                                 InvertedIndexIterator** iterator) = 0;
-    virtual Status query(const std::string& column_name, const void* query_value,
+    virtual Status query(OlapReaderStatistics* stats,
+                         const std::string& column_name, const void* query_value,
                          InvertedIndexQueryType query_type, InvertedIndexParserType analyser_type,
                          roaring::Roaring* bit_map) = 0;
-    virtual Status try_query(const std::string& column_name, const void* query_value,
+    virtual Status try_query(OlapReaderStatistics* stats,
+                             const std::string& column_name, const void* query_value,
                              InvertedIndexQueryType query_type,
                              InvertedIndexParserType analyser_type, uint32_t* count) = 0;
 
@@ -90,7 +92,6 @@ protected:
     io::FileSystemSPtr _fs;
     std::string _path;
     uint32_t _index_id;
-    OlapReaderStatistics* _stats {nullptr};
 };
 
 class FullTextIndexReader : public InvertedIndexReader {
@@ -102,10 +103,12 @@ public:
 
     Status new_iterator(const TabletIndex* index_meta, OlapReaderStatistics* stats,
                         InvertedIndexIterator** iterator) override;
-    Status query(const std::string& column_name, const void* query_value,
+    Status query(OlapReaderStatistics* stats,
+                 const std::string& column_name, const void* query_value,
                  InvertedIndexQueryType query_type, InvertedIndexParserType analyser_type,
                  roaring::Roaring* bit_map) override;
-    Status try_query(const std::string& column_name, const void* query_value,
+    Status try_query(OlapReaderStatistics* stats,
+                     const std::string& column_name, const void* query_value,
                      InvertedIndexQueryType query_type, InvertedIndexParserType analyser_type,
                      uint32_t* count) override {
         return Status::Error<ErrorCode::NOT_IMPLEMENTED_ERROR>();
@@ -127,10 +130,12 @@ public:
 
     Status new_iterator(const TabletIndex* index_meta, OlapReaderStatistics* stats,
                         InvertedIndexIterator** iterator) override;
-    Status query(const std::string& column_name, const void* query_value,
+    Status query(OlapReaderStatistics* stats,
+                 const std::string& column_name, const void* query_value,
                  InvertedIndexQueryType query_type, InvertedIndexParserType analyser_type,
                  roaring::Roaring* bit_map) override;
-    Status try_query(const std::string& column_name, const void* query_value,
+    Status try_query(OlapReaderStatistics* stats,
+                     const std::string& column_name, const void* query_value,
                      InvertedIndexQueryType query_type, InvertedIndexParserType analyser_type,
                      uint32_t* count) override {
         return Status::Error<ErrorCode::NOT_IMPLEMENTED_ERROR>();
@@ -186,13 +191,16 @@ public:
     Status new_iterator(const TabletIndex* index_meta, OlapReaderStatistics* stats,
                         InvertedIndexIterator** iterator) override;
 
-    Status query(const std::string& column_name, const void* query_value,
+    Status query(OlapReaderStatistics* stats,
+                 const std::string& column_name, const void* query_value,
                  InvertedIndexQueryType query_type, InvertedIndexParserType analyser_type,
                  roaring::Roaring* bit_map) override;
-    Status try_query(const std::string& column_name, const void* query_value,
+    Status try_query(OlapReaderStatistics* stats,
+                     const std::string& column_name, const void* query_value,
                      InvertedIndexQueryType query_type, InvertedIndexParserType analyser_type,
                      uint32_t* count) override;
-    Status bkd_query(const std::string& column_name, const void* query_value,
+    Status bkd_query(OlapReaderStatistics* stats,
+                     const std::string& column_name, const void* query_value,
                      InvertedIndexQueryType query_type,
                      std::shared_ptr<lucene::util::bkd::bkd_reader>&& r,
                      InvertedIndexVisitor* visitor);

--- a/be/src/olap/rowset/segment_v2/segment.cpp
+++ b/be/src/olap/rowset/segment_v2/segment.cpp
@@ -302,10 +302,12 @@ Status Segment::new_bitmap_index_iterator(const TabletColumn& tablet_column,
 
 Status Segment::new_inverted_index_iterator(const TabletColumn& tablet_column,
                                             const TabletIndex* index_meta,
+                                            OlapReaderStatistics* stats,
                                             InvertedIndexIterator** iter) {
     auto col_unique_id = tablet_column.unique_id();
     if (_column_readers.count(col_unique_id) > 0 && index_meta) {
-        return _column_readers.at(col_unique_id)->new_inverted_index_iterator(index_meta, iter);
+        return _column_readers.at(col_unique_id)->new_inverted_index_iterator(
+            index_meta, stats, iter);
     }
     return Status::OK();
 }

--- a/be/src/olap/rowset/segment_v2/segment.cpp
+++ b/be/src/olap/rowset/segment_v2/segment.cpp
@@ -306,8 +306,8 @@ Status Segment::new_inverted_index_iterator(const TabletColumn& tablet_column,
                                             InvertedIndexIterator** iter) {
     auto col_unique_id = tablet_column.unique_id();
     if (_column_readers.count(col_unique_id) > 0 && index_meta) {
-        return _column_readers.at(col_unique_id)->new_inverted_index_iterator(
-            index_meta, stats, iter);
+        return _column_readers.at(col_unique_id)
+                ->new_inverted_index_iterator(index_meta, stats, iter);
     }
     return Status::OK();
 }

--- a/be/src/olap/rowset/segment_v2/segment.h
+++ b/be/src/olap/rowset/segment_v2/segment.h
@@ -81,7 +81,9 @@ public:
     Status new_bitmap_index_iterator(const TabletColumn& tablet_column, BitmapIndexIterator** iter);
 
     Status new_inverted_index_iterator(const TabletColumn& tablet_column,
-                                       const TabletIndex* index_meta, InvertedIndexIterator** iter);
+                                       const TabletIndex* index_meta,
+                                       OlapReaderStatistics* stats,
+                                       InvertedIndexIterator** iter);
 
     const ShortKeyIndexDecoder* get_short_key_index() const {
         DCHECK(_load_index_once.has_called() && _load_index_once.stored_result().ok());

--- a/be/src/olap/rowset/segment_v2/segment.h
+++ b/be/src/olap/rowset/segment_v2/segment.h
@@ -81,8 +81,7 @@ public:
     Status new_bitmap_index_iterator(const TabletColumn& tablet_column, BitmapIndexIterator** iter);
 
     Status new_inverted_index_iterator(const TabletColumn& tablet_column,
-                                       const TabletIndex* index_meta,
-                                       OlapReaderStatistics* stats,
+                                       const TabletIndex* index_meta, OlapReaderStatistics* stats,
                                        InvertedIndexIterator** iter);
 
     const ShortKeyIndexDecoder* get_short_key_index() const {

--- a/be/src/olap/rowset/segment_v2/segment_iterator.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.cpp
@@ -745,7 +745,7 @@ Status SegmentIterator::_init_inverted_index_iterators() {
         if (_inverted_index_iterators.count(unique_id) < 1) {
             RETURN_IF_ERROR(_segment->new_inverted_index_iterator(
                     _opts.tablet_schema->column(cid), _opts.tablet_schema->get_inverted_index(cid),
-                    &_inverted_index_iterators[unique_id]));
+                    _opts.stats, &_inverted_index_iterators[unique_id]));
         }
     }
     return Status::OK();

--- a/be/src/runtime/exec_env_init.cpp
+++ b/be/src/runtime/exec_env_init.cpp
@@ -235,6 +235,19 @@ Status ExecEnv::_init_mem_env() {
               << PrettyPrinter::print(inverted_index_cache_limit, TUnit::BYTES)
               << ", origin config value: " << config::inverted_index_searcher_cache_limit;
 
+    // use memory limit
+    int64_t inverted_index_query_cache_limit =
+            ParseUtil::parse_mem_spec(config::inverted_index_query_cache_limit, MemInfo::mem_limit(),
+                                      MemInfo::physical_mem(), &is_percent);
+    while (!is_percent && inverted_index_query_cache_limit > MemInfo::mem_limit() / 2) {
+        // Reason same as buffer_pool_limit
+        inverted_index_query_cache_limit = inverted_index_query_cache_limit / 2;
+    }
+    InvertedIndexQueryCache::create_global_cache(inverted_index_query_cache_limit, 10);
+    LOG(INFO) << "Inverted index query match cache memory limit: "
+              << PrettyPrinter::print(inverted_index_cache_limit, TUnit::BYTES)
+              << ", origin config value: " << config::inverted_index_query_cache_limit;
+
     // 4. init other managers
     RETURN_IF_ERROR(_tmp_file_mgr->init());
     RETURN_IF_ERROR(_block_spill_mgr->init());

--- a/be/src/runtime/exec_env_init.cpp
+++ b/be/src/runtime/exec_env_init.cpp
@@ -237,8 +237,8 @@ Status ExecEnv::_init_mem_env() {
 
     // use memory limit
     int64_t inverted_index_query_cache_limit =
-            ParseUtil::parse_mem_spec(config::inverted_index_query_cache_limit, MemInfo::mem_limit(),
-                                      MemInfo::physical_mem(), &is_percent);
+            ParseUtil::parse_mem_spec(config::inverted_index_query_cache_limit,
+                                      MemInfo::mem_limit(), MemInfo::physical_mem(), &is_percent);
     while (!is_percent && inverted_index_query_cache_limit > MemInfo::mem_limit() / 2) {
         // Reason same as buffer_pool_limit
         inverted_index_query_cache_limit = inverted_index_query_cache_limit / 2;

--- a/be/src/vec/exec/scan/new_olap_scan_node.cpp
+++ b/be/src/vec/exec/scan/new_olap_scan_node.cpp
@@ -110,7 +110,17 @@ Status NewOlapScanNode::_init_profile() {
 
     _inverted_index_filter_counter =
             ADD_COUNTER(_segment_profile, "RowsInvertedIndexFiltered", TUnit::UNIT);
-    _inverted_index_filter_timer = ADD_TIMER(_segment_profile, "InvertedIndexFilterTimer");
+    _inverted_index_filter_timer = ADD_TIMER(_segment_profile, "InvertedIndexFilterTime");
+    _inverted_index_query_cache_hit_counter =
+            ADD_COUNTER(_segment_profile, "InvertedIndexQueryCacheHit", TUnit::UNIT);
+    _inverted_index_query_cache_miss_counter =
+            ADD_COUNTER(_segment_profile, "InvertedIndexQueryCacheMiss", TUnit::UNIT);
+    _inverted_index_query_timer = ADD_TIMER(_segment_profile, "InvertedIndexQueryTime");
+    _inverted_index_query_bitmap_copy_timer = ADD_TIMER(_segment_profile, "InvertedIndexQueryBitmapCopyTime");
+    _inverted_index_query_bitmap_op_timer = ADD_TIMER(_segment_profile, "InvertedIndexQueryBitmapOpTime");
+    _inverted_index_searcher_open_timer = ADD_TIMER(_segment_profile, "InvertedIndexSearcherOpenTime");
+    _inverted_index_searcher_search_timer = ADD_TIMER(_segment_profile, "InvertedIndexSearcherSearchTime");
+    _inverted_index_searcher_bitmap_timer = ADD_TIMER(_segment_profile, "InvertedIndexSearcherGenBitmapTime");
 
     _output_index_result_column_timer = ADD_TIMER(_segment_profile, "OutputIndexResultColumnTimer");
 

--- a/be/src/vec/exec/scan/new_olap_scan_node.cpp
+++ b/be/src/vec/exec/scan/new_olap_scan_node.cpp
@@ -116,11 +116,16 @@ Status NewOlapScanNode::_init_profile() {
     _inverted_index_query_cache_miss_counter =
             ADD_COUNTER(_segment_profile, "InvertedIndexQueryCacheMiss", TUnit::UNIT);
     _inverted_index_query_timer = ADD_TIMER(_segment_profile, "InvertedIndexQueryTime");
-    _inverted_index_query_bitmap_copy_timer = ADD_TIMER(_segment_profile, "InvertedIndexQueryBitmapCopyTime");
-    _inverted_index_query_bitmap_op_timer = ADD_TIMER(_segment_profile, "InvertedIndexQueryBitmapOpTime");
-    _inverted_index_searcher_open_timer = ADD_TIMER(_segment_profile, "InvertedIndexSearcherOpenTime");
-    _inverted_index_searcher_search_timer = ADD_TIMER(_segment_profile, "InvertedIndexSearcherSearchTime");
-    _inverted_index_searcher_bitmap_timer = ADD_TIMER(_segment_profile, "InvertedIndexSearcherGenBitmapTime");
+    _inverted_index_query_bitmap_copy_timer =
+            ADD_TIMER(_segment_profile, "InvertedIndexQueryBitmapCopyTime");
+    _inverted_index_query_bitmap_op_timer =
+            ADD_TIMER(_segment_profile, "InvertedIndexQueryBitmapOpTime");
+    _inverted_index_searcher_open_timer =
+            ADD_TIMER(_segment_profile, "InvertedIndexSearcherOpenTime");
+    _inverted_index_searcher_search_timer =
+            ADD_TIMER(_segment_profile, "InvertedIndexSearcherSearchTime");
+    _inverted_index_searcher_bitmap_timer =
+            ADD_TIMER(_segment_profile, "InvertedIndexSearcherGenBitmapTime");
 
     _output_index_result_column_timer = ADD_TIMER(_segment_profile, "OutputIndexResultColumnTimer");
 

--- a/be/src/vec/exec/scan/new_olap_scan_node.h
+++ b/be/src/vec/exec/scan/new_olap_scan_node.h
@@ -129,6 +129,14 @@ private:
 
     RuntimeProfile::Counter* _inverted_index_filter_counter = nullptr;
     RuntimeProfile::Counter* _inverted_index_filter_timer = nullptr;
+    RuntimeProfile::Counter* _inverted_index_query_cache_hit_counter = nullptr;
+    RuntimeProfile::Counter* _inverted_index_query_cache_miss_counter = nullptr;
+    RuntimeProfile::Counter* _inverted_index_query_timer = nullptr;
+    RuntimeProfile::Counter* _inverted_index_query_bitmap_copy_timer = nullptr;
+    RuntimeProfile::Counter* _inverted_index_query_bitmap_op_timer = nullptr;
+    RuntimeProfile::Counter* _inverted_index_searcher_open_timer = nullptr;
+    RuntimeProfile::Counter* _inverted_index_searcher_search_timer = nullptr;
+    RuntimeProfile::Counter* _inverted_index_searcher_bitmap_timer = nullptr;
 
     RuntimeProfile::Counter* _output_index_result_column_timer = nullptr;
 

--- a/be/src/vec/exec/scan/new_olap_scanner.cpp
+++ b/be/src/vec/exec/scan/new_olap_scanner.cpp
@@ -491,14 +491,21 @@ void NewOlapScanner::_update_counters_before_close() {
 
     COUNTER_UPDATE(olap_parent->_inverted_index_filter_counter, stats.rows_inverted_index_filtered);
     COUNTER_UPDATE(olap_parent->_inverted_index_filter_timer, stats.inverted_index_filter_timer);
-    COUNTER_UPDATE(olap_parent->_inverted_index_query_cache_hit_counter, stats.inverted_index_query_cache_hit);
-    COUNTER_UPDATE(olap_parent->_inverted_index_query_cache_miss_counter, stats.inverted_index_query_cache_miss);
+    COUNTER_UPDATE(olap_parent->_inverted_index_query_cache_hit_counter,
+                   stats.inverted_index_query_cache_hit);
+    COUNTER_UPDATE(olap_parent->_inverted_index_query_cache_miss_counter,
+                   stats.inverted_index_query_cache_miss);
     COUNTER_UPDATE(olap_parent->_inverted_index_query_timer, stats.inverted_index_query_timer);
-    COUNTER_UPDATE(olap_parent->_inverted_index_query_bitmap_copy_timer, stats.inverted_index_query_bitmap_copy_timer);
-    COUNTER_UPDATE(olap_parent->_inverted_index_query_bitmap_op_timer, stats.inverted_index_query_bitmap_op_timer);
-    COUNTER_UPDATE(olap_parent->_inverted_index_searcher_open_timer, stats.inverted_index_searcher_open_timer);
-    COUNTER_UPDATE(olap_parent->_inverted_index_searcher_search_timer, stats.inverted_index_searcher_search_timer);
-    COUNTER_UPDATE(olap_parent->_inverted_index_searcher_bitmap_timer, stats.inverted_index_searcher_bitmap_timer);
+    COUNTER_UPDATE(olap_parent->_inverted_index_query_bitmap_copy_timer,
+                   stats.inverted_index_query_bitmap_copy_timer);
+    COUNTER_UPDATE(olap_parent->_inverted_index_query_bitmap_op_timer,
+                   stats.inverted_index_query_bitmap_op_timer);
+    COUNTER_UPDATE(olap_parent->_inverted_index_searcher_open_timer,
+                   stats.inverted_index_searcher_open_timer);
+    COUNTER_UPDATE(olap_parent->_inverted_index_searcher_search_timer,
+                   stats.inverted_index_searcher_search_timer);
+    COUNTER_UPDATE(olap_parent->_inverted_index_searcher_bitmap_timer,
+                   stats.inverted_index_searcher_bitmap_timer);
 
     COUNTER_UPDATE(olap_parent->_output_index_result_column_timer,
                    stats.output_index_result_column_timer);

--- a/be/src/vec/exec/scan/new_olap_scanner.cpp
+++ b/be/src/vec/exec/scan/new_olap_scanner.cpp
@@ -491,6 +491,14 @@ void NewOlapScanner::_update_counters_before_close() {
 
     COUNTER_UPDATE(olap_parent->_inverted_index_filter_counter, stats.rows_inverted_index_filtered);
     COUNTER_UPDATE(olap_parent->_inverted_index_filter_timer, stats.inverted_index_filter_timer);
+    COUNTER_UPDATE(olap_parent->_inverted_index_query_cache_hit_counter, stats.inverted_index_query_cache_hit);
+    COUNTER_UPDATE(olap_parent->_inverted_index_query_cache_miss_counter, stats.inverted_index_query_cache_miss);
+    COUNTER_UPDATE(olap_parent->_inverted_index_query_timer, stats.inverted_index_query_timer);
+    COUNTER_UPDATE(olap_parent->_inverted_index_query_bitmap_copy_timer, stats.inverted_index_query_bitmap_copy_timer);
+    COUNTER_UPDATE(olap_parent->_inverted_index_query_bitmap_op_timer, stats.inverted_index_query_bitmap_op_timer);
+    COUNTER_UPDATE(olap_parent->_inverted_index_searcher_open_timer, stats.inverted_index_searcher_open_timer);
+    COUNTER_UPDATE(olap_parent->_inverted_index_searcher_search_timer, stats.inverted_index_searcher_search_timer);
+    COUNTER_UPDATE(olap_parent->_inverted_index_searcher_bitmap_timer, stats.inverted_index_searcher_bitmap_timer);
 
     COUNTER_UPDATE(olap_parent->_output_index_result_column_timer,
                    stats.output_index_result_column_timer);

--- a/be/test/olap/rowset/segment_v2/inverted_index_searcher_cache_test.cpp
+++ b/be/test/olap/rowset/segment_v2/inverted_index_searcher_cache_test.cpp
@@ -62,12 +62,14 @@ TEST_F(InvertedIndexSearcherCacheTest, insert_lookup) {
     status = index_searcher_cache->insert(fs, kTestDir, file_name_2);
     EXPECT_EQ(Status::OK(), status);
 
+    OlapReaderStatistics stats;
+
     // lookup after insert
     {
         // case 1: lookup exist entry
         InvertedIndexCacheHandle inverted_index_cache_handle;
         status = index_searcher_cache->get_index_searcher(fs, kTestDir, file_name_1,
-                                                          &inverted_index_cache_handle);
+                                                          &inverted_index_cache_handle, &stats);
         EXPECT_EQ(Status::OK(), status);
 
         auto cache_value_1 =
@@ -76,7 +78,7 @@ TEST_F(InvertedIndexSearcherCacheTest, insert_lookup) {
         EXPECT_GE(UnixMillis(), cache_value_1->last_visit_time);
 
         status = index_searcher_cache->get_index_searcher(fs, kTestDir, file_name_2,
-                                                          &inverted_index_cache_handle);
+                                                          &inverted_index_cache_handle, &stats);
         EXPECT_EQ(Status::OK(), status);
 
         auto cache_value_2 =
@@ -93,7 +95,7 @@ TEST_F(InvertedIndexSearcherCacheTest, insert_lookup) {
         {
             InvertedIndexCacheHandle inverted_index_cache_handle_1;
             status = index_searcher_cache->get_index_searcher(fs, kTestDir, file_name_not_exist_1,
-                                                              &inverted_index_cache_handle_1);
+                                                              &inverted_index_cache_handle_1, &stats);
             EXPECT_EQ(Status::OK(), status);
             EXPECT_FALSE(inverted_index_cache_handle_1.owned);
         }
@@ -102,7 +104,7 @@ TEST_F(InvertedIndexSearcherCacheTest, insert_lookup) {
         {
             InvertedIndexCacheHandle inverted_index_cache_handle_1;
             status = index_searcher_cache->get_index_searcher(fs, kTestDir, file_name_not_exist_1,
-                                                              &inverted_index_cache_handle_1);
+                                                              &inverted_index_cache_handle_1, &stats);
             EXPECT_EQ(Status::OK(), status);
             EXPECT_FALSE(inverted_index_cache_handle_1.owned);
 
@@ -115,14 +117,14 @@ TEST_F(InvertedIndexSearcherCacheTest, insert_lookup) {
         // not use cache
         InvertedIndexCacheHandle inverted_index_cache_handle_2;
         status = index_searcher_cache->get_index_searcher(fs, kTestDir, file_name_not_exist_2,
-                                                          &inverted_index_cache_handle_2, false);
+                                                          &inverted_index_cache_handle_2, &stats, false);
         EXPECT_EQ(Status::OK(), status);
         EXPECT_TRUE(inverted_index_cache_handle_2.owned);
         EXPECT_EQ(nullptr, inverted_index_cache_handle_2._cache);
         EXPECT_EQ(nullptr, inverted_index_cache_handle_2._handle);
 
         status = index_searcher_cache->get_index_searcher(fs, kTestDir, file_name_not_exist_2,
-                                                          &inverted_index_cache_handle_2);
+                                                          &inverted_index_cache_handle_2, &stats);
         EXPECT_EQ(Status::OK(), status);
         EXPECT_FALSE(inverted_index_cache_handle_2.owned);
         auto cache_value_use_cache_2 =

--- a/be/test/olap/rowset/segment_v2/inverted_index_searcher_cache_test.cpp
+++ b/be/test/olap/rowset/segment_v2/inverted_index_searcher_cache_test.cpp
@@ -94,8 +94,8 @@ TEST_F(InvertedIndexSearcherCacheTest, insert_lookup) {
         // use cache
         {
             InvertedIndexCacheHandle inverted_index_cache_handle_1;
-            status = index_searcher_cache->get_index_searcher(fs, kTestDir, file_name_not_exist_1,
-                                                              &inverted_index_cache_handle_1, &stats);
+            status = index_searcher_cache->get_index_searcher(
+                    fs, kTestDir, file_name_not_exist_1, &inverted_index_cache_handle_1, &stats);
             EXPECT_EQ(Status::OK(), status);
             EXPECT_FALSE(inverted_index_cache_handle_1.owned);
         }
@@ -103,8 +103,8 @@ TEST_F(InvertedIndexSearcherCacheTest, insert_lookup) {
         // lookup again
         {
             InvertedIndexCacheHandle inverted_index_cache_handle_1;
-            status = index_searcher_cache->get_index_searcher(fs, kTestDir, file_name_not_exist_1,
-                                                              &inverted_index_cache_handle_1, &stats);
+            status = index_searcher_cache->get_index_searcher(
+                    fs, kTestDir, file_name_not_exist_1, &inverted_index_cache_handle_1, &stats);
             EXPECT_EQ(Status::OK(), status);
             EXPECT_FALSE(inverted_index_cache_handle_1.owned);
 
@@ -116,8 +116,8 @@ TEST_F(InvertedIndexSearcherCacheTest, insert_lookup) {
 
         // not use cache
         InvertedIndexCacheHandle inverted_index_cache_handle_2;
-        status = index_searcher_cache->get_index_searcher(fs, kTestDir, file_name_not_exist_2,
-                                                          &inverted_index_cache_handle_2, &stats, false);
+        status = index_searcher_cache->get_index_searcher(
+                fs, kTestDir, file_name_not_exist_2, &inverted_index_cache_handle_2, &stats, false);
         EXPECT_EQ(Status::OK(), status);
         EXPECT_TRUE(inverted_index_cache_handle_2.owned);
         EXPECT_EQ(nullptr, inverted_index_cache_handle_2._cache);


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

Add cache for inverted index query match bitmap to accelerate common query keyword, especially for keyword matching many rows. 

Tests result:
- large result: matching 99% out of 247 million rows shows 8x speed up.
- small result: matching 0.1% out of 247 million rows shows 2x speed up.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

