### PR TITLE
[fix](subquery) fix bug of using constexpr and some agg func(like count,max) as subquery's output

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/SelectStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/SelectStmt.java
@@ -898,10 +898,13 @@ public class SelectStmt extends QueryStmt {
             }
             boolean hasConstant = resultExprs.stream().anyMatch(e -> e.isConstant() || e.refToCountStar());
             // In such case, agg output must be materialized whether outer query block required or not.
-            if (tableRef instanceof InlineViewRef && hasConstant) {
+            if (tableRef instanceof InlineViewRef) {
                 InlineViewRef inlineViewRef = (InlineViewRef) tableRef;
                 QueryStmt queryStmt = inlineViewRef.getQueryStmt();
-                queryStmt.resultExprs.forEach(Expr::materializeSrcExpr);
+                boolean inlineViewHasConstant = queryStmt.resultExprs.stream().anyMatch(Expr::isConstant);
+                if (hasConstant || inlineViewHasConstant) {
+                    queryStmt.resultExprs.forEach(Expr::materializeSrcExpr);
+                }
             }
         }
     }

--- a/regression-test/data/correctness_p0/test_outer_join_with_subquery.out
+++ b/regression-test/data/correctness_p0/test_outer_join_with_subquery.out
@@ -5,3 +5,59 @@
 -- !select --
 1
 
+-- !select --
+1
+
+-- !select --
+
+-- !select --
+aaa
+
+-- !select --
+1
+
+-- !select --
+1	aaa
+
+-- !select --
+0
+
+-- !select --
+1	aaa
+
+-- !select --
+0	aaa
+
+-- !select --
+1	aaa
+
+-- !select --
+0	aaa
+
+-- !select --
+1
+
+-- !select --
+0
+
+-- !select --
+1
+
+-- !select --
+0	\N
+
+-- !select --
+0	\N
+
+-- !select --
+1	100
+
+-- !select --
+1	100
+
+-- !select --
+1	0
+
+-- !select --
+1	100
+

--- a/regression-test/data/correctness_p0/test_outer_join_with_subquery.out
+++ b/regression-test/data/correctness_p0/test_outer_join_with_subquery.out
@@ -61,3 +61,21 @@ aaa
 -- !select --
 1	100
 
+-- !select --
+\N
+
+-- !select --
+\N
+
+-- !select --
+100
+
+-- !select --
+100
+
+-- !select --
+0
+
+-- !select --
+100
+

--- a/regression-test/suites/correctness_p0/test_outer_join_with_subquery.groovy
+++ b/regression-test/suites/correctness_p0/test_outer_join_with_subquery.groovy
@@ -299,6 +299,30 @@ suite("test_outer_join_with_subquery") {
         select count(1), max(user_id) from(  select max(user_id), 100 as user_id FROM test_outer_join_with_subquery_outerjoin_A_1  )t;
     """
 
+qt_select """
+        select max(user_id) from(  select user_id FROM test_outer_join_with_subquery_outerjoin_A_1  )t;
+    """
+
+    qt_select """
+        select max(user_id) from(  select user_id FROM (  select user_id FROM test_outer_join_with_subquery_outerjoin_A_1  )s  )t;
+    """
+
+    qt_select """
+        select max(user_id) from(  select count(1), 100 as user_id FROM test_outer_join_with_subquery_outerjoin_A_1  )t;
+    """
+
+    qt_select """
+        select max(user_id) from(  select 100 as user_id FROM (  select max(user_id) FROM test_outer_join_with_subquery_outerjoin_A_1  )s  )t;
+    """
+
+    qt_select """
+        select max(user_id) from(  select user_id FROM (  select count(1) as user_id, 'abc' FROM test_outer_join_with_subquery_outerjoin_A_1 )s  )t;
+    """
+
+    qt_select """
+        select max(user_id) from(  select max(user_id), 100 as user_id FROM test_outer_join_with_subquery_outerjoin_A_1  )t;
+    """
+
     sql """
         drop table if exists test_outer_join_with_subquery_outerjoin_A_1;
     """

--- a/regression-test/suites/correctness_p0/test_outer_join_with_subquery.groovy
+++ b/regression-test/suites/correctness_p0/test_outer_join_with_subquery.groovy
@@ -110,4 +110,209 @@ suite("test_outer_join_with_subquery") {
     sql """
         drop table if exists test_outer_join_with_subquery_outerjoin_B;
     """
+
+    ////////////////////////////////////
+
+    sql """
+        drop table if exists test_outer_join_with_subquery_outerjoin_A_1;
+    """
+
+    sql """
+        drop table if exists test_outer_join_with_subquery_outerjoin_B_1;
+    """
+
+    sql """
+        drop table if exists test_outer_join_with_subquery_outerjoin_C_1;
+    """
+
+    sql """
+        drop table if exists test_outer_join_with_subquery_outerjoin_D_1;
+    """
+
+    sql """
+        CREATE TABLE test_outer_join_with_subquery_outerjoin_A_1(user_id int NULL) 
+        ENGINE = OLAP DUPLICATE KEY(user_id) DISTRIBUTED BY HASH(user_id) BUCKETS 1 PROPERTIES (
+            "replication_allocation" = "tag.location.default: 1",
+            "in_memory" = "false",
+            "storage_format" = "V2"
+        );
+    """    
+
+    sql """
+        CREATE TABLE test_outer_join_with_subquery_outerjoin_B_1(user_id int NULL) 
+        ENGINE = OLAP DUPLICATE KEY(user_id) DISTRIBUTED BY HASH(user_id) BUCKETS 1 PROPERTIES (
+            "replication_allocation" = "tag.location.default: 1",
+            "in_memory" = "false",
+            "storage_format" = "V2"
+        );
+    """
+
+    sql """
+        CREATE TABLE test_outer_join_with_subquery_outerjoin_C_1(user_id int NULL) 
+        ENGINE = OLAP DUPLICATE KEY(user_id) DISTRIBUTED BY HASH(user_id) BUCKETS 1 PROPERTIES (
+            "replication_allocation" = "tag.location.default: 1",
+            "in_memory" = "false",
+            "storage_format" = "V2"
+        );
+    """
+
+    sql """
+        CREATE TABLE test_outer_join_with_subquery_outerjoin_D_1(user_id int NULL) 
+        ENGINE = OLAP DUPLICATE KEY(user_id) DISTRIBUTED BY HASH(user_id) BUCKETS 1 PROPERTIES (
+            "replication_allocation" = "tag.location.default: 1",
+            "in_memory" = "false",
+            "storage_format" = "V2"
+        );
+    """
+
+    qt_select """
+        WITH W1 AS (
+            SELECT
+                t.user_id
+            FROM
+                test_outer_join_with_subquery_outerjoin_A_1 t
+                JOIN test_outer_join_with_subquery_outerjoin_B_1 u ON u.user_id = t.user_id
+        ),
+        W2 AS (
+            SELECT
+                t.user_id
+            FROM
+                test_outer_join_with_subquery_outerjoin_C_1 t
+                JOIN test_outer_join_with_subquery_outerjoin_B_1 u ON u.user_id = t.user_id
+            GROUP BY
+                t.user_id
+        ),
+        W3 AS (
+            SELECT
+                t.user_id
+            FROM
+                test_outer_join_with_subquery_outerjoin_D_1 t
+                JOIN test_outer_join_with_subquery_outerjoin_B_1 u ON u.user_id = t.user_id
+            GROUP BY
+                t.user_id
+        )
+        SELECT
+            COUNT(dataset_30.reg_user_cnt) AS u_18efaea722a8747c_2
+        FROM
+            (
+                SELECT
+                    t1.reg_user_cnt,
+                    t2.commit_case_user_cnt,
+                    t3.watch_live_course_and_commit_case_user_cnt
+                FROM
+                    (
+                        SELECT
+                            COUNT(user_id) AS reg_user_cnt,
+                            '1' AS flag
+                        FROM
+                            W1
+                    ) t1
+                    JOIN (
+                        SELECT
+                            COUNT(user_id) AS commit_case_user_cnt,
+                            '1' AS flag
+                        FROM
+                            W2
+                    ) t2 ON t2.flag = t1.flag
+                    JOIN (
+                        SELECT
+                            COUNT(t1.user_id) AS watch_live_course_and_commit_case_user_cnt,
+                            '1' AS flag
+                        FROM
+                            W2 t1
+                            JOIN W3 t2 ON t2.user_id = t1.user_id
+                    ) t3 ON t3.flag = t1.flag
+            ) dataset_30
+        LIMIT
+            1000;
+    """        
+
+    qt_select """
+        select 'aaa' from(  select 'bbb' FROM test_outer_join_with_subquery_outerjoin_A_1  )t;
+    """    
+
+    qt_select """
+        select 'aaa' from(  select 'bbb' ,count(1) FROM test_outer_join_with_subquery_outerjoin_A_1  )t;
+    """    
+
+    qt_select """
+        select count(1) from(  select 'bbb' ,count(1) FROM test_outer_join_with_subquery_outerjoin_A_1  )t;
+    """
+
+    qt_select """
+        select count(1), 'aaa' from(  select 'bbb' ,count(1) FROM test_outer_join_with_subquery_outerjoin_A_1  )t;
+    """
+
+    qt_select """
+        select count(1) from(  select 'bbb' FROM test_outer_join_with_subquery_outerjoin_A_1  )t;
+    """
+
+    qt_select """
+        select count(1), 'aaa' from(  select count(1) FROM test_outer_join_with_subquery_outerjoin_A_1  )t;
+    """
+
+    qt_select """
+        select count(1), 'aaa' from(  select 'bbb' FROM test_outer_join_with_subquery_outerjoin_A_1  )t;
+    """
+
+    qt_select """
+        select count(1), 'aaa' from(  select count(1) FROM (  select count(1) FROM test_outer_join_with_subquery_outerjoin_A_1  )s  )t;
+    """
+
+    qt_select """
+        select count(1), 'aaa' from(  select 'bbb' FROM (  select 'bbb' FROM test_outer_join_with_subquery_outerjoin_A_1  )s  )t;
+    """
+
+    qt_select """
+        select count(1) from(  select count(1) FROM (  select count(1) FROM test_outer_join_with_subquery_outerjoin_A_1  )s  )t;
+    """
+
+    qt_select """
+        select count(1) from(  select 'bbb' FROM (  select 'bbb' FROM test_outer_join_with_subquery_outerjoin_A_1  )s  )t;
+    """
+
+    qt_select """
+        select count(1) from(  select 'bbb',count(1) FROM (  select 'bbb',count(1) FROM test_outer_join_with_subquery_outerjoin_A_1  )s  )t;
+    """
+
+    qt_select """
+        select count(1), max(user_id) from(  select user_id FROM test_outer_join_with_subquery_outerjoin_A_1  )t;
+    """
+
+    qt_select """
+        select count(1), max(user_id) from(  select user_id FROM (  select user_id FROM test_outer_join_with_subquery_outerjoin_A_1  )s  )t;
+    """
+
+    qt_select """
+        select count(1), max(user_id) from(  select count(1), 100 as user_id FROM test_outer_join_with_subquery_outerjoin_A_1  )t;
+    """
+
+    qt_select """
+        select count(1), max(user_id) from(  select 100 as user_id FROM (  select max(user_id) FROM test_outer_join_with_subquery_outerjoin_A_1  )s  )t;
+    """
+
+    qt_select """
+        select count(1), max(user_id) from(  select user_id FROM (  select count(1) as user_id, 'abc' FROM test_outer_join_with_subquery_outerjoin_A_1 )s  )t;
+    """
+
+    qt_select """
+        select count(1), max(user_id) from(  select max(user_id), 100 as user_id FROM test_outer_join_with_subquery_outerjoin_A_1  )t;
+    """
+
+    sql """
+        drop table if exists test_outer_join_with_subquery_outerjoin_A_1;
+    """
+
+    sql """
+        drop table if exists test_outer_join_with_subquery_outerjoin_B_1;
+    """
+
+    sql """
+        drop table if exists test_outer_join_with_subquery_outerjoin_C_1;
+    """
+
+    sql """
+        drop table if exists test_outer_join_with_subquery_outerjoin_D_1;
+    """
 }
+


### PR DESCRIPTION
…tput

Signed-off-by: nextdreamblue <zxw520blue1@163.com>

# Proposed changes

Issue Number: close #16481 #16534

## Problem summary

pr:#16556，just fix some bug about count()，if select like this:
```
select  max(user_id) from(  select max(user_id), 100 as user_id FROM A  )t;
```
will get wrong resout.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [x] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

