### PR TITLE
[fix](inverted index) fix array type inverted index query error

### DIFF
--- a/be/src/exec/olap_common.h
+++ b/be/src/exec/olap_common.h
@@ -296,7 +296,7 @@ public:
                 condition.__set_condition_op("match_element_ge");
             }
             condition.condition_values.push_back(
-                    cast_to_string<primitive_type, CppType>(value.second, 0));
+                    cast_to_string<primitive_type, CppType>(value.second, _scale));
             if (condition.condition_values.size() != 0) {
                 filters.push_back(condition);
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/MatchPredicate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/MatchPredicate.java
@@ -228,7 +228,7 @@ public class MatchPredicate extends Predicate {
         Expr e2 = getChild(1);
         // Here we cast match_element_xxx value type from string to array item type.
         // Because be need to know the actual TExprNodeType when doing Expr Literal transform
-        if (isMatchElement(op) && e1.type.isArrayType() && (e2 instanceof StringLiteral)) {
+        if (isMatchElement(op) && e1.type.isArrayType()) {
             Type itemType = ((ArrayType) e1.type).getItemType();
             try {
                 setChild(1, e2.castTo(itemType));


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

fix test_array_index query accidental failure.

due to not processed type cast for numeric item type value in array index condition, don't know the actual TExprNodeType when doing Expr Literal transform, if there are dirty values in the memory address, the value obtained by the predicate maybe incorrect, which will lead to query errors.


## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

