### PR TITLE
[refactor](Nereids): add two phase sort

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/cost/CostCalculator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/cost/CostCalculator.java
@@ -133,7 +133,10 @@ public class CostCalculator {
             // TODO: consider two-phase sort and enforcer.
             StatsDeriveResult statistics = context.getStatisticsWithCheck();
             StatsDeriveResult childStatistics = context.getChildStatistics(0);
-
+            if (physicalQuickSort.getSortPhase().isGather()) {
+                // Now we do more like two-phase sort, so penalise one-phase sort
+                statistics.updateRowCount(statistics.getRowCount() * 100);
+            }
             return CostEstimate.of(
                     childStatistics.getRowCount(),
                     statistics.getRowCount(),
@@ -145,7 +148,10 @@ public class CostCalculator {
             // TODO: consider two-phase sort and enforcer.
             StatsDeriveResult statistics = context.getStatisticsWithCheck();
             StatsDeriveResult childStatistics = context.getChildStatistics(0);
-
+            if (topN.getSortPhase().isGather()) {
+                // Now we do more like two-phase sort, so penalise one-phase sort
+                statistics.updateRowCount(statistics.getRowCount() * 100);
+            }
             return CostEstimate.of(
                     childStatistics.getRowCount(),
                     statistics.getRowCount(),

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslator.java
@@ -87,7 +87,6 @@ import org.apache.doris.nereids.trees.plans.physical.PhysicalHashAggregate;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalHashJoin;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalIntersect;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalLimit;
-import org.apache.doris.nereids.trees.plans.physical.PhysicalLocalQuickSort;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalNestedLoopJoin;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalOlapScan;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalOneRowRelation;
@@ -609,17 +608,45 @@ public class PhysicalPlanTranslator extends DefaultPlanVisitor<PlanFragment, Pla
     @Override
     public PlanFragment visitPhysicalQuickSort(PhysicalQuickSort<? extends Plan> sort,
             PlanTranslatorContext context) {
-        PlanFragment childFragment = visitAbstractPhysicalSort(sort, context);
-        SortNode sortNode = (SortNode) childFragment.getPlanRoot();
-        // isPartitioned() == false means there is only one instance, so no merge phase
-        if (!childFragment.isPartitioned()) {
-            return childFragment;
+        PlanFragment inputFragment = sort.child(0).accept(this, context);
+        PlanFragment currentFragment = inputFragment;
+
+        //1. generate new fragment for sort when the child is exchangeNode
+        if (inputFragment.getPlanRoot() instanceof ExchangeNode
+                && sort.child(0) instanceof PhysicalDistribute) {
+            DataPartition outputPartition = DataPartition.UNPARTITIONED;
+            if (sort.getSortPhase().isLocal()) {
+                // The window function like over (partition by xx order by) can generate plan
+                // shuffle -> localSort -> windowFunction
+                // In this case, the child's partition need to keep
+                outputPartition = hashSpecToDataPartition((PhysicalDistribute) sort.child(0), context);
+            }
+            ExchangeNode exchangeNode = (ExchangeNode) inputFragment.getPlanRoot();
+            inputFragment.setOutputPartition(outputPartition);
+            inputFragment.setPlanRoot(exchangeNode.getChild(0));
+            inputFragment.setDestination(exchangeNode);
+            currentFragment = new PlanFragment(context.nextFragmentId(), exchangeNode, DataPartition.UNPARTITIONED);
+            context.addPlanFragment(currentFragment);
         }
-        PlanFragment mergeFragment = createParentFragment(childFragment, DataPartition.UNPARTITIONED, context);
-        ExchangeNode exchangeNode = (ExchangeNode) mergeFragment.getPlanRoot();
-        // exchangeNode.limit/offset will be set in when translating  PhysicalLimit
-        exchangeNode.setMergeInfo(sortNode.getSortInfo());
-        return mergeFragment;
+
+        // 2. According to the type of sort, generate physical plan
+        if (!sort.getSortPhase().isMerge()) {
+            // For localSort or Gather->Sort, we just need to add sortNode
+            SortNode sortNode = translateSortNode(sort, inputFragment.getPlanRoot(), context);
+            currentFragment.addPlanRoot(sortNode);
+        } else {
+            // For mergeSort, we need to push sortInfo to exchangeNode
+            if (!(currentFragment.getPlanRoot() instanceof ExchangeNode)) {
+                // if there is no exchange node for mergeSort
+                //   e.g., localSort -> mergeSort
+                // It means the local has satisfied the Gather property. We can just ignore mergeSort
+                return currentFragment;
+            }
+            Preconditions.checkArgument(inputFragment.getPlanRoot() instanceof SortNode);
+            SortNode sortNode = (SortNode) inputFragment.getPlanRoot();
+            ((ExchangeNode) currentFragment.getPlanRoot()).setMergeInfo(sortNode.getSortInfo());
+        }
+        return currentFragment;
     }
 
     @Override
@@ -717,87 +744,43 @@ public class PhysicalPlanTranslator extends DefaultPlanVisitor<PlanFragment, Pla
 
     @Override
     public PlanFragment visitPhysicalTopN(PhysicalTopN<? extends Plan> topN, PlanTranslatorContext context) {
-        PlanFragment childFragment = visitAbstractPhysicalSort(topN, context);
-        SortNode sortNode = (SortNode) childFragment.getPlanRoot();
-        sortNode.setOffset(topN.getOffset());
-        sortNode.setLimit(topN.getLimit());
-        // isPartitioned() == false means there is only one instance, so no merge phase
-        if (!childFragment.isPartitioned()) {
-            return childFragment;
-        }
-        PlanFragment mergeFragment = createParentFragment(childFragment, DataPartition.UNPARTITIONED, context);
-        ExchangeNode exchangeNode = (ExchangeNode) mergeFragment.getPlanRoot();
-        exchangeNode.setMergeInfo(sortNode.getSortInfo());
-        exchangeNode.setOffset(topN.getOffset());
-        exchangeNode.setLimit(topN.getLimit());
-        return mergeFragment;
-    }
+        PlanFragment inputFragment = topN.child(0).accept(this, context);
+        PlanFragment currentFragment = inputFragment;
 
-    /**
-     * Currently this function is added for PhysicalWindow's requiredProperties only.
-     * The code is equal with visitAbstractPhysicalSort(), except step 2:check if it is a sort for PhysicalWindow
-     * and setBufferedTupleForWindow() in step 3.
-     */
-    @Override
-    public PlanFragment visitPhysicalLocalQuickSort(PhysicalLocalQuickSort<? extends Plan> sort,
-                                                    PlanTranslatorContext context) {
-        PlanFragment childFragment = sort.child(0).accept(this, context);
-        List<Expr> oldOrderingExprList = Lists.newArrayList();
-        List<Boolean> ascOrderList = Lists.newArrayList();
-        List<Boolean> nullsFirstParamList = Lists.newArrayList();
-        List<OrderKey> orderKeyList = sort.getOrderKeys();
-        // 1. Get previous slotRef
-        orderKeyList.forEach(k -> {
-            oldOrderingExprList.add(ExpressionTranslator.translate(k.getExpr(), context));
-            ascOrderList.add(k.isAsc());
-            nullsFirstParamList.add(k.isNullFirst());
-        });
-        List<Expr> sortTupleOutputList = new ArrayList<>();
-        List<Slot> outputList = sort.getOutput();
-        outputList.forEach(k -> {
-            sortTupleOutputList.add(ExpressionTranslator.translate(k, context));
-        });
-
-        // 2. check if it is a sort for PhysicalWindow
-        PlanFragment currentFragment;
-        boolean useTopN = true;
-        if (childFragment.getPlanRoot() instanceof ExchangeNode && sort.child() instanceof PhysicalDistribute) {
-            PhysicalDistribute physicalDistribute = (PhysicalDistribute) sort.child();
-            DataPartition dataPartition = hashSpecToDataPartition(physicalDistribute, context);
-
-            ExchangeNode exchangeNode = (ExchangeNode) childFragment.getPlanRoot();
-            currentFragment = new PlanFragment(context.nextFragmentId(), exchangeNode, dataPartition);
-            childFragment.setOutputPartition(dataPartition);
-            childFragment.setPlanRoot(exchangeNode.getChild(0));
-            childFragment.setDestination(exchangeNode);
+        //1. generate new fragment for sort when the child is exchangeNode
+        if (inputFragment.getPlanRoot() instanceof ExchangeNode) {
+            Preconditions.checkArgument(!topN.getSortPhase().isLocal());
+            DataPartition outputPartition = DataPartition.UNPARTITIONED;
+            ExchangeNode exchangeNode = (ExchangeNode) inputFragment.getPlanRoot();
+            inputFragment.setOutputPartition(outputPartition);
+            inputFragment.setPlanRoot(exchangeNode.getChild(0));
+            inputFragment.setDestination(exchangeNode);
+            currentFragment = new PlanFragment(context.nextFragmentId(), exchangeNode, DataPartition.UNPARTITIONED);
             context.addPlanFragment(currentFragment);
-            useTopN = false;
+        }
+
+        // 2. According to the type of sort, generate physical plan
+        if (!topN.getSortPhase().isMerge()) {
+            // For localSort or Gather->Sort, we just need to add sortNode
+            SortNode sortNode = translateSortNode(topN, inputFragment.getPlanRoot(), context);
+            currentFragment.addPlanRoot(sortNode);
         } else {
-            currentFragment = childFragment;
+            // For mergeSort, we need to push sortInfo to exchangeNode
+            if (!(currentFragment.getPlanRoot() instanceof ExchangeNode)) {
+                // if there is no exchange node for mergeSort
+                //   e.g., localSort -> mergeSort
+                // It means the local has satisfied the Gather property. We can just ignore mergeSort
+                return currentFragment;
+            }
+            Preconditions.checkArgument(inputFragment.getPlanRoot() instanceof SortNode);
+            SortNode sortNode = (SortNode) inputFragment.getPlanRoot();
+            ((ExchangeNode) currentFragment.getPlanRoot()).setMergeInfo(sortNode.getSortInfo());
         }
-
-        // 3. Generate new Tuple and get current slotRef for newOrderingExprList
-        List<Expr> newOrderingExprList = Lists.newArrayList();
-        TupleDescriptor tupleDesc = generateTupleDesc(outputList, orderKeyList, newOrderingExprList, context, null);
-        context.setBufferedTupleForWindow(tupleDesc);
-
-        // 4. fill in SortInfo members
-        SortInfo sortInfo = new SortInfo(newOrderingExprList, ascOrderList, nullsFirstParamList, tupleDesc);
-        PlanNode childNode = currentFragment.getPlanRoot();
-        SortNode sortNode = new SortNode(context.nextPlanNodeId(), childNode, sortInfo, useTopN);
-        sortNode.finalizeForNereids(tupleDesc, sortTupleOutputList, oldOrderingExprList);
-        if (sort.getStats() != null) {
-            sortNode.setCardinality((long) sort.getStats().getRowCount());
-        }
-        currentFragment.addPlanRoot(sortNode);
         return currentFragment;
     }
 
-    @Override
-    public PlanFragment visitAbstractPhysicalSort(
-            AbstractPhysicalSort<? extends Plan> sort,
+    private SortNode translateSortNode(AbstractPhysicalSort<? extends Plan> sort, PlanNode childNode,
             PlanTranslatorContext context) {
-        PlanFragment childFragment = sort.child(0).accept(this, context);
         List<Expr> oldOrderingExprList = Lists.newArrayList();
         List<Boolean> ascOrderList = Lists.newArrayList();
         List<Boolean> nullsFirstParamList = Lists.newArrayList();
@@ -818,12 +801,21 @@ public class PhysicalPlanTranslator extends DefaultPlanVisitor<PlanFragment, Pla
         TupleDescriptor tupleDesc = generateTupleDesc(outputList, orderKeyList, newOrderingExprList, context, null);
         // 3. fill in SortInfo members
         SortInfo sortInfo = new SortInfo(newOrderingExprList, ascOrderList, nullsFirstParamList, tupleDesc);
-        PlanNode childNode = childFragment.getPlanRoot();
         SortNode sortNode = new SortNode(context.nextPlanNodeId(), childNode, sortInfo, true);
         sortNode.finalizeForNereids(tupleDesc, sortTupleOutputList, oldOrderingExprList);
         if (sort.getStats() != null) {
             sortNode.setCardinality((long) sort.getStats().getRowCount());
         }
+        return sortNode;
+    }
+
+    @Override
+    public PlanFragment visitAbstractPhysicalSort(
+            AbstractPhysicalSort<? extends Plan> sort,
+            PlanTranslatorContext context) {
+        PlanFragment childFragment = sort.child(0).accept(this, context);
+        PlanNode childNode = childFragment.getPlanRoot();
+        SortNode sortNode = translateSortNode(sort, childNode, context);
         childFragment.addPlanRoot(sortNode);
         return childFragment;
     }
@@ -977,8 +969,8 @@ public class PhysicalPlanTranslator extends DefaultPlanVisitor<PlanFragment, Pla
 
         if (hashJoin.getOtherJoinConjuncts().isEmpty()
                 && (joinType == JoinType.LEFT_ANTI_JOIN
-                    || joinType == JoinType.LEFT_SEMI_JOIN
-                    || joinType == JoinType.NULL_AWARE_LEFT_ANTI_JOIN)) {
+                || joinType == JoinType.LEFT_SEMI_JOIN
+                || joinType == JoinType.NULL_AWARE_LEFT_ANTI_JOIN)) {
             for (SlotDescriptor leftSlotDescriptor : leftSlotDescriptors) {
                 if (!leftSlotDescriptor.isMaterialized()) {
                     continue;
@@ -1500,8 +1492,8 @@ public class PhysicalPlanTranslator extends DefaultPlanVisitor<PlanFragment, Pla
             // and fix up the fragment tree in the process.
             for (int i = 0; i < childrenFragments.size(); ++i) {
                 connectChildFragmentNotCheckExchangeNode(setOperationNode, i, setOperationFragment,
-                         childrenFragments.get(i),
-                         context);
+                        childrenFragments.get(i),
+                        context);
             }
         } else {
             setOperationFragment = new PlanFragment(context.nextFragmentId(), setOperationNode,
@@ -1675,8 +1667,8 @@ public class PhysicalPlanTranslator extends DefaultPlanVisitor<PlanFragment, Pla
     }
 
     private void connectChildFragmentNotCheckExchangeNode(PlanNode parent, int childIdx,
-                                      PlanFragment parentFragment, PlanFragment childFragment,
-                                      PlanTranslatorContext context) {
+            PlanFragment parentFragment, PlanFragment childFragment,
+            PlanTranslatorContext context) {
         PlanNode exchange = new ExchangeNode(
                 context.nextPlanNodeId(), childFragment.getPlanRoot(), false);
         exchange.setNumInstances(childFragment.getPlanRoot().getNumInstances());

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/ChildOutputPropertyDeriver.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/ChildOutputPropertyDeriver.java
@@ -119,6 +119,11 @@ public class ChildOutputPropertyDeriver extends PlanVisitor<PhysicalProperties, 
     @Override
     public PhysicalProperties visitPhysicalQuickSort(PhysicalQuickSort<? extends Plan> sort, PlanContext context) {
         Preconditions.checkState(childrenOutputProperties.size() == 1);
+        if (sort.getSortPhase().isLocal()) {
+            return new PhysicalProperties(
+                    childrenOutputProperties.get(0).getDistributionSpec(),
+                    new OrderSpec(sort.getOrderKeys()));
+        }
         return new PhysicalProperties(DistributionSpecGather.INSTANCE, new OrderSpec(sort.getOrderKeys()));
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/OrderSpec.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/OrderSpec.java
@@ -20,7 +20,7 @@ package org.apache.doris.nereids.properties;
 import org.apache.doris.nereids.memo.Group;
 import org.apache.doris.nereids.memo.GroupExpression;
 import org.apache.doris.nereids.trees.plans.GroupPlan;
-import org.apache.doris.nereids.trees.plans.physical.PhysicalLocalQuickSort;
+import org.apache.doris.nereids.trees.plans.SortPhase;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalQuickSort;
 
 import com.google.common.collect.Lists;
@@ -66,7 +66,8 @@ public class OrderSpec {
      */
     public GroupExpression addLocalQuickSortEnforcer(Group child) {
         return new GroupExpression(
-                new PhysicalLocalQuickSort<>(orderKeys, child.getLogicalProperties(), new GroupPlan(child)),
+                new PhysicalQuickSort<>(orderKeys, child.getLogicalProperties(),
+                        new GroupPlan(child), SortPhase.LOCAL_SORT),
                 Lists.newArrayList(child)
         );
     }
@@ -76,7 +77,8 @@ public class OrderSpec {
      */
     public GroupExpression addGlobalQuickSortEnforcer(Group child) {
         return new GroupExpression(
-                new PhysicalQuickSort<>(orderKeys, child.getLogicalProperties(), new GroupPlan(child)),
+                new PhysicalQuickSort<>(orderKeys, child.getLogicalProperties(),
+                        new GroupPlan(child), SortPhase.MERGE_SORT),
                 Lists.newArrayList(child)
         );
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/RequestPropertyDeriver.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/RequestPropertyDeriver.java
@@ -96,7 +96,11 @@ public class RequestPropertyDeriver extends PlanVisitor<Void, PlanContext> {
 
     @Override
     public Void visitPhysicalQuickSort(PhysicalQuickSort<? extends Plan> sort, PlanContext context) {
-        addRequestPropertyToChildren(PhysicalProperties.ANY);
+        if (!sort.getSortPhase().isLocal()) {
+            addRequestPropertyToChildren(PhysicalProperties.GATHER);
+        } else {
+            addRequestPropertyToChildren(PhysicalProperties.ANY);
+        }
         return null;
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/SortPhase.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/SortPhase.java
@@ -1,0 +1,45 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.trees.plans;
+
+/**
+ * Represents different phase of agg and map it to the
+ * enum of agg phase definition of stale optimizer.
+ */
+public enum SortPhase {
+    MERGE_SORT("MergeSort"),
+    GATHER_SORT("GatherSort"),
+    LOCAL_SORT("LocalSort");
+    private final String name;
+
+    SortPhase(String name) {
+        this.name = name;
+    }
+
+    public boolean isLocal() {
+        return this == LOCAL_SORT;
+    }
+
+    public boolean isMerge() {
+        return this == MERGE_SORT;
+    }
+
+    public boolean isGather() {
+        return this == GATHER_SORT;
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/AbstractPhysicalSort.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/AbstractPhysicalSort.java
@@ -24,6 +24,7 @@ import org.apache.doris.nereids.properties.PhysicalProperties;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PlanType;
+import org.apache.doris.nereids.trees.plans.SortPhase;
 import org.apache.doris.nereids.trees.plans.algebra.Sort;
 import org.apache.doris.statistics.StatsDeriveResult;
 
@@ -39,15 +40,17 @@ import java.util.Optional;
 public abstract class AbstractPhysicalSort<CHILD_TYPE extends Plan> extends PhysicalUnary<CHILD_TYPE> implements Sort {
 
     protected final List<OrderKey> orderKeys;
+    protected final SortPhase phase;
 
     /**
      * Constructor of AbstractPhysicalSort.
      */
     public AbstractPhysicalSort(PlanType type, List<OrderKey> orderKeys,
             Optional<GroupExpression> groupExpression, LogicalProperties logicalProperties,
-            CHILD_TYPE child) {
+            CHILD_TYPE child, SortPhase phase) {
         super(type, groupExpression, logicalProperties, child);
         this.orderKeys = ImmutableList.copyOf(Objects.requireNonNull(orderKeys, "orderKeys can not be null"));
+        this.phase = phase;
     }
 
     /**
@@ -55,13 +58,19 @@ public abstract class AbstractPhysicalSort<CHILD_TYPE extends Plan> extends Phys
      */
     public AbstractPhysicalSort(PlanType type, List<OrderKey> orderKeys,
             Optional<GroupExpression> groupExpression, LogicalProperties logicalProperties,
-            PhysicalProperties physicalProperties, StatsDeriveResult statsDeriveResult, CHILD_TYPE child) {
+            PhysicalProperties physicalProperties, StatsDeriveResult statsDeriveResult, CHILD_TYPE child,
+            SortPhase phase) {
         super(type, groupExpression, logicalProperties, physicalProperties, statsDeriveResult, child);
         this.orderKeys = ImmutableList.copyOf(Objects.requireNonNull(orderKeys, "orderKeys can not be null"));
+        this.phase = phase;
     }
 
     public List<OrderKey> getOrderKeys() {
         return orderKeys;
+    }
+
+    public SortPhase getSortPhase() {
+        return phase;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalLocalQuickSort.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalLocalQuickSort.java
@@ -23,6 +23,7 @@ import org.apache.doris.nereids.properties.OrderKey;
 import org.apache.doris.nereids.properties.PhysicalProperties;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PlanType;
+import org.apache.doris.nereids.trees.plans.SortPhase;
 import org.apache.doris.nereids.trees.plans.algebra.Sort;
 import org.apache.doris.nereids.trees.plans.visitor.PlanVisitor;
 import org.apache.doris.nereids.util.Utils;
@@ -49,7 +50,8 @@ public class PhysicalLocalQuickSort<CHILD_TYPE extends Plan> extends AbstractPhy
     public PhysicalLocalQuickSort(List<OrderKey> orderKeys,
             Optional<GroupExpression> groupExpression, LogicalProperties logicalProperties,
             CHILD_TYPE child) {
-        super(PlanType.PHYSICAL_LOCAL_QUICK_SORT, orderKeys, groupExpression, logicalProperties, child);
+        super(PlanType.PHYSICAL_LOCAL_QUICK_SORT, orderKeys, groupExpression,
+                logicalProperties, child, SortPhase.LOCAL_SORT);
     }
 
     /**
@@ -59,7 +61,7 @@ public class PhysicalLocalQuickSort<CHILD_TYPE extends Plan> extends AbstractPhy
             Optional<GroupExpression> groupExpression, LogicalProperties logicalProperties,
             PhysicalProperties physicalProperties, StatsDeriveResult statsDeriveResult, CHILD_TYPE child) {
         super(PlanType.PHYSICAL_LOCAL_QUICK_SORT, orderKeys, groupExpression,
-                logicalProperties, physicalProperties, statsDeriveResult, child);
+                logicalProperties, physicalProperties, statsDeriveResult, child, SortPhase.LOCAL_SORT);
     }
 
     public List<OrderKey> getOrderKeys() {

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/properties/ChildOutputPropertyDeriverTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/properties/ChildOutputPropertyDeriverTest.java
@@ -34,6 +34,7 @@ import org.apache.doris.nereids.trees.plans.GroupPlan;
 import org.apache.doris.nereids.trees.plans.JoinHint;
 import org.apache.doris.nereids.trees.plans.JoinType;
 import org.apache.doris.nereids.trees.plans.Plan;
+import org.apache.doris.nereids.trees.plans.SortPhase;
 import org.apache.doris.nereids.trees.plans.physical.AbstractPhysicalJoin;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalAssertNumRows;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalHashAggregate;
@@ -369,7 +370,7 @@ public class ChildOutputPropertyDeriverTest {
     public void testQuickSort() {
         SlotReference key = new SlotReference("col1", IntegerType.INSTANCE);
         List<OrderKey> orderKeys = Lists.newArrayList(new OrderKey(key, true, true));
-        PhysicalQuickSort<GroupPlan> sort = new PhysicalQuickSort<>(orderKeys, logicalProperties, groupPlan);
+        PhysicalQuickSort<GroupPlan> sort = new PhysicalQuickSort<>(orderKeys, logicalProperties, groupPlan, SortPhase.MERGE_SORT);
         GroupExpression groupExpression = new GroupExpression(sort);
         PhysicalProperties child = new PhysicalProperties(DistributionSpecReplicated.INSTANCE,
                 new OrderSpec(Lists.newArrayList(
@@ -385,7 +386,7 @@ public class ChildOutputPropertyDeriverTest {
     public void testTopN() {
         SlotReference key = new SlotReference("col1", IntegerType.INSTANCE);
         List<OrderKey> orderKeys = Lists.newArrayList(new OrderKey(key, true, true));
-        PhysicalTopN<GroupPlan> sort = new PhysicalTopN<>(orderKeys, 10, 10, logicalProperties, groupPlan);
+        PhysicalTopN<GroupPlan> sort = new PhysicalTopN<>(orderKeys, 10, 10, logicalProperties, groupPlan, SortPhase.LOCAL_SORT);
         GroupExpression groupExpression = new GroupExpression(sort);
         PhysicalProperties child = new PhysicalProperties(DistributionSpecReplicated.INSTANCE,
                 new OrderSpec(Lists.newArrayList(

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/implementation/ImplementationTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/implementation/ImplementationTest.java
@@ -68,7 +68,6 @@ public class ImplementationTest {
     public PhysicalPlan executeImplementationRule(LogicalPlan plan) {
         Rule rule = rulesMap.get(plan.getClass().getName());
         List<Plan> transform = rule.transform(plan, cascadesContext);
-        Assertions.assertEquals(1, transform.size());
         Assertions.assertTrue(transform.get(0) instanceof PhysicalPlan);
         return (PhysicalPlan) transform.get(0);
     }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/sqltest/SortTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/sqltest/SortTest.java
@@ -17,46 +17,26 @@
 
 package org.apache.doris.nereids.sqltest;
 
-import org.apache.doris.nereids.rules.rewrite.logical.ReorderJoin;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalDistribute;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalPlan;
+import org.apache.doris.nereids.trees.plans.physical.PhysicalQuickSort;
 import org.apache.doris.nereids.util.PlanChecker;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class JoinTest extends SqlTestBase {
+public class SortTest extends SqlTestBase {
     @Test
-    void testJoinUsing() {
-        String sql = "SELECT * FROM T1 JOIN T2 using (id)";
-        PlanChecker.from(connectContext)
-                .analyze(sql)
-                .applyBottomUp(new ReorderJoin())
-                .matches(
-                        innerLogicalJoin().when(j -> j.getHashJoinConjuncts().size() == 1)
-                );
-    }
-
-    @Test
-    void testColocatedJoin() {
-        String sql = "select * from T2 join T2 b on T2.id = b.id and T2.id = b.id;";
+    public void testTwoPhaseSort() {
+        String sql = "select * from\n"
+                + "(select score from T1 order by id) as t order by score\n";
         PhysicalPlan plan = PlanChecker.from(connectContext)
                 .analyze(sql)
                 .rewrite()
-                .deriveStats()
                 .optimize()
                 .getBestPlanTree();
-        // generate colocate join plan without physicalDistribute
         System.out.println(plan.treeString());
-        Assertions.assertFalse(plan.anyMatch(PhysicalDistribute.class::isInstance));
-        sql = "select * from T1 join T0 on T1.score = T0.score and T1.id = T0.id;";
-        plan = PlanChecker.from(connectContext)
-                .analyze(sql)
-                .rewrite()
-                .deriveStats()
-                .optimize()
-                .getBestPlanTree();
-        // generate colocate join plan without physicalDistribute
-        Assertions.assertFalse(plan.anyMatch(PhysicalDistribute.class::isInstance));
+        Assertions.assertTrue(plan.anyMatch(e -> e instanceof PhysicalQuickSort
+                && ((PhysicalQuickSort<?>) e).getSortPhase().isMerge() && e.child(0) instanceof PhysicalDistribute));
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/PlanEqualsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/PlanEqualsTest.java
@@ -310,14 +310,14 @@ public class PlanEqualsTest {
                         new SlotReference(new ExprId(1), "b", BigIntType.INSTANCE, true, Lists.newArrayList()), true,
                         true)),
                 logicalProperties,
-                child);
+                child, SortPhase.LOCAL_SORT);
 
         PhysicalQuickSort<Plan> expected = new PhysicalQuickSort<>(
                 ImmutableList.of(new OrderKey(
                         new SlotReference(new ExprId(1), "b", BigIntType.INSTANCE, true, Lists.newArrayList()), true,
                         true)),
                 logicalProperties,
-                child);
+                child, SortPhase.LOCAL_SORT);
         Assertions.assertEquals(expected, actual);
 
         PhysicalQuickSort<Plan> unexpected = new PhysicalQuickSort<>(
@@ -325,7 +325,7 @@ public class PlanEqualsTest {
                         new SlotReference(new ExprId(2), "a", BigIntType.INSTANCE, true, Lists.newArrayList()), true,
                         true)),
                 logicalProperties,
-                child);
+                child, SortPhase.LOCAL_SORT);
         Assertions.assertNotEquals(unexpected, actual);
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/util/PlanChecker.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/util/PlanChecker.java
@@ -23,6 +23,8 @@ import org.apache.doris.nereids.NereidsPlanner;
 import org.apache.doris.nereids.StatementContext;
 import org.apache.doris.nereids.exceptions.AnalysisException;
 import org.apache.doris.nereids.glue.LogicalPlanAdapter;
+import org.apache.doris.nereids.glue.translator.PhysicalPlanTranslator;
+import org.apache.doris.nereids.glue.translator.PlanTranslatorContext;
 import org.apache.doris.nereids.jobs.JobContext;
 import org.apache.doris.nereids.jobs.batch.NereidsRewriteJobExecutor;
 import org.apache.doris.nereids.jobs.batch.OptimizeRulesJob;
@@ -37,6 +39,7 @@ import org.apache.doris.nereids.pattern.GroupExpressionMatching;
 import org.apache.doris.nereids.pattern.MatchingContext;
 import org.apache.doris.nereids.pattern.PatternDescriptor;
 import org.apache.doris.nereids.pattern.PatternMatcher;
+import org.apache.doris.nereids.properties.DistributionSpecGather;
 import org.apache.doris.nereids.properties.PhysicalProperties;
 import org.apache.doris.nereids.rules.Rule;
 import org.apache.doris.nereids.rules.RuleFactory;
@@ -44,11 +47,15 @@ import org.apache.doris.nereids.rules.RuleSet;
 import org.apache.doris.nereids.rules.RuleType;
 import org.apache.doris.nereids.rules.rewrite.OneRewriteRuleFactory;
 import org.apache.doris.nereids.trees.expressions.Slot;
+import org.apache.doris.nereids.trees.plans.GroupPlan;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.commands.ExplainCommand.ExplainLevel;
 import org.apache.doris.nereids.trees.plans.logical.LogicalPlan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalProject;
+import org.apache.doris.nereids.trees.plans.physical.PhysicalDistribute;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalPlan;
+import org.apache.doris.nereids.trees.plans.physical.PhysicalQuickSort;
+import org.apache.doris.planner.PlanFragment;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.OriginStatement;
 
@@ -56,9 +63,9 @@ import com.google.common.base.Supplier;
 import com.google.common.collect.Lists;
 import org.junit.jupiter.api.Assertions;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
 
 /**
  * Utility to apply rules to plan and check output plan matches the expected pattern.
@@ -207,6 +214,13 @@ public class PlanChecker {
     public PlanChecker implement() {
         Plan plan = transformToPhysicalPlan(cascadesContext.getMemo().getRoot());
         Assertions.assertTrue(plan instanceof PhysicalPlan);
+        if (plan instanceof PhysicalQuickSort && !((PhysicalQuickSort) plan).getSortPhase().isLocal()) {
+            PhysicalQuickSort<? extends Plan> sort = (PhysicalQuickSort) plan;
+            plan = sort.withChildren(new PhysicalDistribute<>(
+                    DistributionSpecGather.INSTANCE,
+                    plan.child(0).getLogicalProperties(),
+                    plan.child(0)));
+        }
         physicalPlan = ((PhysicalPlan) plan);
         return this;
     }
@@ -230,8 +244,19 @@ public class PlanChecker {
             }
         }
         Assertions.assertNotNull(current);
-        return current.withChildren(group.getLogicalExpression().children()
-                .stream().map(this::transformToPhysicalPlan).collect(Collectors.toList()));
+        return flatGroupPlan(current);
+    }
+
+    private Plan flatGroupPlan(Plan plan) {
+        if (plan instanceof GroupPlan) {
+            return transformToPhysicalPlan(((GroupPlan) plan).getGroup());
+        }
+        List<Plan> newChildren = new ArrayList<>();
+        for (Plan child : plan.children()) {
+            newChildren.add(flatGroupPlan(child));
+        }
+        return (PhysicalPlan) plan.withChildren(newChildren);
+
     }
 
     public PlanChecker transform(PatternMatcher patternMatcher) {
@@ -522,6 +547,26 @@ public class PlanChecker {
             System.out.println("--------------------------------");
         }
         return this;
+    }
+
+    public String getExplainFragments() {
+        PhysicalPlan plan = getBestPlanTree();
+        PhysicalPlanTranslator t = new PhysicalPlanTranslator();
+        PlanTranslatorContext ctx = new PlanTranslatorContext();
+        plan.accept(t, ctx);
+
+        StringBuilder str = new StringBuilder();
+        List<PlanFragment> fragments = ctx.getPlanFragments();
+        for (int i = 0; i < fragments.size(); ++i) {
+            PlanFragment fragment = fragments.get(i);
+            if (i > 0) {
+                // a blank line between plan fragments
+                str.append("\n");
+            }
+            str.append("PLAN FRAGMENT " + i + "\n");
+            str.append(fragment.getExplainString(org.apache.doris.thrift.TExplainLevel.NORMAL));
+        }
+        return str.toString();
     }
 
     public int plansNumber() {


### PR DESCRIPTION
# Proposed changes

1. Add a rule that generates two-phase sort and one-phase sort
2. Add phase for PhysicalSort

TODO: I'll remove PhysicalLocalSort in next PR.

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
5. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
6. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

