### PR TITLE
[feature](cooldown) Auto delete unused remote files

### DIFF
--- a/be/src/agent/agent_server.cpp
+++ b/be/src/agent/agent_server.cpp
@@ -25,6 +25,7 @@
 #include "agent/task_worker_pool.h"
 #include "agent/topic_subscriber.h"
 #include "agent/user_resource_listener.h"
+#include "agent/utils.h"
 #include "common/logging.h"
 #include "common/status.h"
 #include "gutil/strings/substitute.h"
@@ -48,6 +49,8 @@ AgentServer::AgentServer(ExecEnv* exec_env, const TMasterInfo& master_info)
             LOG(WARNING) << "boost exception when remove dpp download path. path=" << path.path;
         }
     }
+
+    MasterServerClient::create(master_info);
 
     // It is the same code to create workers of each type, so we use a macro
     // to make code to be more readable.

--- a/be/src/agent/task_worker_pool.h
+++ b/be/src/agent/task_worker_pool.h
@@ -34,6 +34,7 @@ namespace doris {
 
 class ExecEnv;
 class ThreadPool;
+class AgentUtils;
 
 class TaskWorkerPool {
 public:

--- a/be/src/agent/task_worker_pool.h
+++ b/be/src/agent/task_worker_pool.h
@@ -23,7 +23,6 @@
 #include <utility>
 #include <vector>
 
-#include "agent/utils.h"
 #include "common/status.h"
 #include "gen_cpp/AgentService_types.h"
 #include "gen_cpp/HeartbeatService_types.h"
@@ -224,7 +223,6 @@ private:
     const TMasterInfo& _master_info;
     TBackend _backend;
     std::unique_ptr<AgentUtils> _agent_utils;
-    std::unique_ptr<MasterServerClient> _master_client;
     ExecEnv* _env;
 
     // Protect task queue
@@ -246,7 +244,6 @@ private:
     uint32_t _worker_count;
     TaskWorkerType _task_worker_type;
 
-    static FrontendServiceClientCache _master_service_client_cache;
     static std::atomic_ulong _s_report_version;
 
     static std::mutex _s_task_signatures_lock;

--- a/be/src/agent/utils.cpp
+++ b/be/src/agent/utils.cpp
@@ -27,23 +27,34 @@
 #include <sstream>
 
 #include "common/status.h"
+#include "runtime/client_cache.h"
 
 using std::map;
 using std::string;
 using std::stringstream;
-using std::vector;
 using apache::thrift::TException;
 using apache::thrift::transport::TTransportException;
 
 namespace doris {
 
-MasterServerClient::MasterServerClient(const TMasterInfo& master_info,
-                                       FrontendServiceClientCache* client_cache)
-        : _master_info(master_info), _client_cache(client_cache) {}
+static FrontendServiceClientCache s_client_cache;
+static std::unique_ptr<MasterServerClient> s_client;
+
+MasterServerClient* MasterServerClient::create(const TMasterInfo& master_info) {
+    s_client.reset(new MasterServerClient(master_info));
+    return s_client.get();
+}
+
+MasterServerClient* MasterServerClient::instance() {
+    return s_client.get();
+}
+
+MasterServerClient::MasterServerClient(const TMasterInfo& master_info)
+        : _master_info(master_info) {}
 
 Status MasterServerClient::finish_task(const TFinishTaskRequest& request, TMasterResult* result) {
     Status client_status;
-    FrontendServiceConnection client(_client_cache, _master_info.network_address,
+    FrontendServiceConnection client(&s_client_cache, _master_info.network_address,
                                      config::thrift_rpc_timeout_ms, &client_status);
 
     if (!client_status.ok()) {
@@ -82,7 +93,7 @@ Status MasterServerClient::finish_task(const TFinishTaskRequest& request, TMaste
 
 Status MasterServerClient::report(const TReportRequest& request, TMasterResult* result) {
     Status client_status;
-    FrontendServiceConnection client(_client_cache, _master_info.network_address,
+    FrontendServiceConnection client(&s_client_cache, _master_info.network_address,
                                      config::thrift_rpc_timeout_ms, &client_status);
 
     if (!client_status.ok()) {
@@ -129,6 +140,57 @@ Status MasterServerClient::report(const TReportRequest& request, TMasterResult* 
     }
 
     return Status::OK();
+}
+
+Status MasterServerClient::confirm_unused_remote_files(
+        const TConfirmUnusedRemoteFilesRequest& request) {
+    Status client_status;
+    FrontendServiceConnection client(&s_client_cache, _master_info.network_address,
+                                     config::thrift_rpc_timeout_ms, &client_status);
+
+    if (!client_status.ok()) {
+        return Status::InternalError(
+                "fail to get master client from cache. host={}, port={}, code={}",
+                _master_info.network_address.hostname, _master_info.network_address.port,
+                client_status.code());
+    }
+    TStatus t_status;
+    try {
+        try {
+            client->confirmUnusedRemoteFiles(t_status, request);
+        } catch (TTransportException& e) {
+            TTransportException::TTransportExceptionType type = e.getType();
+            if (type != TTransportException::TTransportExceptionType::TIMED_OUT) {
+                // if not TIMED_OUT, retry
+                LOG(WARNING) << "master client, retry finishTask: " << e.what();
+
+                client_status = client.reopen(config::thrift_rpc_timeout_ms);
+                if (!client_status.ok()) {
+                    return Status::InternalError(
+                            "fail to get master client from cache. host={}, port={}, code={}",
+                            _master_info.network_address.hostname,
+                            _master_info.network_address.port, client_status.code());
+                }
+
+                client->confirmUnusedRemoteFiles(t_status, request);
+            } else {
+                // TIMED_OUT exception. do not retry
+                // actually we don't care what FE returns.
+                return Status::InternalError(
+                        "fail to confirm unused remote files. host={}, port={}, code={}, reason={}",
+                        _master_info.network_address.hostname, _master_info.network_address.port,
+                        client_status.code(), e.what());
+            }
+        }
+    } catch (TException& e) {
+        client.reopen(config::thrift_rpc_timeout_ms);
+        return Status::InternalError(
+                "fail to confirm unused remote files. host={}, port={}, code={}, reason={}",
+                _master_info.network_address.hostname, _master_info.network_address.port,
+                client_status.code(), e.what());
+    }
+
+    return t_status;
 }
 
 bool AgentUtils::exec_cmd(const string& command, string* errmsg, bool redirect_stderr) {

--- a/be/src/agent/utils.cpp
+++ b/be/src/agent/utils.cpp
@@ -143,7 +143,7 @@ Status MasterServerClient::report(const TReportRequest& request, TMasterResult* 
 }
 
 Status MasterServerClient::confirm_unused_remote_files(
-        const TConfirmUnusedRemoteFilesRequest& request) {
+        const TConfirmUnusedRemoteFilesRequest& request, TConfirmUnusedRemoteFilesResult* result) {
     Status client_status;
     FrontendServiceConnection client(&s_client_cache, _master_info.network_address,
                                      config::thrift_rpc_timeout_ms, &client_status);
@@ -154,10 +154,9 @@ Status MasterServerClient::confirm_unused_remote_files(
                 _master_info.network_address.hostname, _master_info.network_address.port,
                 client_status.code());
     }
-    TStatus t_status;
     try {
         try {
-            client->confirmUnusedRemoteFiles(t_status, request);
+            client->confirmUnusedRemoteFiles(*result, request);
         } catch (TTransportException& e) {
             TTransportException::TTransportExceptionType type = e.getType();
             if (type != TTransportException::TTransportExceptionType::TIMED_OUT) {
@@ -172,7 +171,7 @@ Status MasterServerClient::confirm_unused_remote_files(
                             _master_info.network_address.port, client_status.code());
                 }
 
-                client->confirmUnusedRemoteFiles(t_status, request);
+                client->confirmUnusedRemoteFiles(*result, request);
             } else {
                 // TIMED_OUT exception. do not retry
                 // actually we don't care what FE returns.
@@ -190,7 +189,7 @@ Status MasterServerClient::confirm_unused_remote_files(
                 client_status.code(), e.what());
     }
 
-    return t_status;
+    return Status::OK();
 }
 
 bool AgentUtils::exec_cmd(const string& command, string* errmsg, bool redirect_stderr) {

--- a/be/src/agent/utils.h
+++ b/be/src/agent/utils.h
@@ -28,7 +28,7 @@ namespace doris {
 
 class MasterServerClient {
 public:
-    static MasterServerClient* create(const TMasterInfo& master_info); 
+    static MasterServerClient* create(const TMasterInfo& master_info);
     static MasterServerClient* instance();
 
     ~MasterServerClient() = default;

--- a/be/src/agent/utils.h
+++ b/be/src/agent/utils.h
@@ -22,14 +22,16 @@
 #include <gen_cpp/MasterService_types.h>
 
 #include "common/status.h"
-#include "runtime/client_cache.h"
+#include "gutil/macros.h"
 
 namespace doris {
 
 class MasterServerClient {
 public:
-    MasterServerClient(const TMasterInfo& master_info, FrontendServiceClientCache* client_cache);
-    virtual ~MasterServerClient() = default;
+    static MasterServerClient* create(const TMasterInfo& master_info); 
+    static MasterServerClient* instance();
+
+    ~MasterServerClient() = default;
 
     // Report finished task to the master server
     //
@@ -38,7 +40,7 @@ public:
     //
     // Output parameters:
     // * result: The result of report task
-    virtual Status finish_task(const TFinishTaskRequest& request, TMasterResult* result);
+    Status finish_task(const TFinishTaskRequest& request, TMasterResult* result);
 
     // Report tasks/olap tablet/disk state to the master server
     //
@@ -47,14 +49,17 @@ public:
     //
     // Output parameters:
     // * result: The result of report task
-    virtual Status report(const TReportRequest& request, TMasterResult* result);
+    Status report(const TReportRequest& request, TMasterResult* result);
+
+    Status confirm_unused_remote_files(const TConfirmUnusedRemoteFilesRequest& request);
 
 private:
+    MasterServerClient(const TMasterInfo& master_info);
+
     DISALLOW_COPY_AND_ASSIGN(MasterServerClient);
 
     // Not owner. Reference to the ExecEnv::_master_info
     const TMasterInfo& _master_info;
-    FrontendServiceClientCache* _client_cache;
 };
 
 class AgentUtils {

--- a/be/src/agent/utils.h
+++ b/be/src/agent/utils.h
@@ -51,7 +51,8 @@ public:
     // * result: The result of report task
     Status report(const TReportRequest& request, TMasterResult* result);
 
-    Status confirm_unused_remote_files(const TConfirmUnusedRemoteFilesRequest& request);
+    Status confirm_unused_remote_files(const TConfirmUnusedRemoteFilesRequest& request,
+                                       TConfirmUnusedRemoteFilesResult* result);
 
 private:
     MasterServerClient(const TMasterInfo& master_info);

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -810,6 +810,7 @@ CONF_mInt32(bloom_filter_predicate_check_row_num, "204800");
 CONF_Int32(cooldown_thread_num, "5");
 CONF_mInt64(generate_cooldown_task_interval_sec, "20");
 CONF_mInt32(remove_unused_remote_files_interval_sec, "21600");  // 6h
+CONF_mInt32(confirm_unused_remote_files_interval_sec, "60");
 CONF_mInt64(generate_cache_cleaner_task_interval_sec, "43200"); // 12 h
 CONF_Int32(concurrency_per_dir, "2");
 CONF_mInt64(cooldown_lag_time_sec, "10800");       // 3h

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -809,7 +809,7 @@ CONF_mInt32(bloom_filter_predicate_check_row_num, "204800");
 // cooldown task configs
 CONF_Int32(cooldown_thread_num, "5");
 CONF_mInt64(generate_cooldown_task_interval_sec, "20");
-CONF_mInt32(remove_unused_files_interbal_sec, "21600");         // 6h
+CONF_mInt32(remove_unused_remote_files_interval_sec, "21600");  // 6h
 CONF_mInt64(generate_cache_cleaner_task_interval_sec, "43200"); // 12 h
 CONF_Int32(concurrency_per_dir, "2");
 CONF_mInt64(cooldown_lag_time_sec, "10800");       // 3h

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -809,6 +809,7 @@ CONF_mInt32(bloom_filter_predicate_check_row_num, "204800");
 // cooldown task configs
 CONF_Int32(cooldown_thread_num, "5");
 CONF_mInt64(generate_cooldown_task_interval_sec, "20");
+CONF_mInt32(remove_unused_files_interbal_sec, "21600");         // 6h
 CONF_mInt64(generate_cache_cleaner_task_interval_sec, "43200"); // 12 h
 CONF_Int32(concurrency_per_dir, "2");
 CONF_mInt64(cooldown_lag_time_sec, "10800");       // 3h

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -809,7 +809,7 @@ CONF_mInt32(bloom_filter_predicate_check_row_num, "204800");
 // cooldown task configs
 CONF_Int32(cooldown_thread_num, "5");
 CONF_mInt64(generate_cooldown_task_interval_sec, "20");
-CONF_mInt32(remove_unused_remote_files_interval_sec, "21600");  // 6h
+CONF_mInt32(remove_unused_remote_files_interval_sec, "21600"); // 6h
 CONF_mInt32(confirm_unused_remote_files_interval_sec, "60");
 CONF_mInt64(generate_cache_cleaner_task_interval_sec, "43200"); // 12 h
 CONF_Int32(concurrency_per_dir, "2");

--- a/be/src/io/fs/remote_file_system.h
+++ b/be/src/io/fs/remote_file_system.h
@@ -34,6 +34,10 @@ public:
     virtual Status batch_upload(const std::vector<Path>& local_paths,
                                 const std::vector<Path>& dest_paths) = 0;
 
+    virtual Status batch_delete(const std::vector<Path>& paths) {
+        return Status::NotSupported("batch_delete");
+    }
+
     virtual Status connect() = 0;
 
     Status open_file(const Path& path, const FileReaderOptions& reader_options,

--- a/be/src/io/fs/s3_file_system.cpp
+++ b/be/src/io/fs/s3_file_system.cpp
@@ -26,6 +26,7 @@
 #include <aws/s3/model/ListObjectsV2Request.h>
 #include <aws/s3/model/PutObjectRequest.h>
 #include <aws/transfer/TransferManager.h>
+#include <opentelemetry/common/threadlocal.h>
 
 #include <filesystem>
 #include <fstream>
@@ -61,6 +62,9 @@ S3FileSystem::S3FileSystem(S3Conf&& s3_conf, std::string&& id)
           _s3_conf(std::move(s3_conf)) {
     if (_s3_conf.prefix.size() > 0 && _s3_conf.prefix[0] == '/') {
         _s3_conf.prefix = _s3_conf.prefix.substr(1);
+    }
+    if (!_s3_conf.prefix.empty() && _s3_conf.prefix.back() == '/') {
+        _s3_conf.prefix.pop_back();
     }
     _executor = Aws::MakeShared<Aws::Utils::Threading::PooledThreadExecutor>(
             id.c_str(), config::s3_transfer_executor_pool_size);
@@ -372,7 +376,70 @@ Status S3FileSystem::file_size_impl(const Path& path, size_t* file_size) const {
 }
 
 Status S3FileSystem::list(const Path& path, std::vector<Path>* files) {
-    return Status::NotSupported("not support");
+    auto client = get_client();
+    CHECK_S3_CLIENT(client);
+
+    Aws::S3::Model::ListObjectsV2Request request;
+    auto prefix = get_key(path);
+    if (!prefix.empty() && prefix.back() != '/') {
+        prefix.push_back('/');
+    }
+    request.WithBucket(_s3_conf.bucket).WithPrefix(prefix);
+    bool is_trucated = false;
+    do {
+        auto outcome = client->ListObjectsV2(request);
+        if (!outcome.IsSuccess()) {
+            return Status::IOError("failed to list objects(endpoint={}, bucket={}, prefix={}): {}",
+                                   _s3_conf.endpoint, _s3_conf.bucket, prefix,
+                                   outcome.GetError().GetMessage());
+        }
+        for (const auto& obj : outcome.GetResult().GetContents()) {
+            files->push_back(obj.GetKey().substr(_s3_conf.prefix.size()));
+        }
+        is_trucated = outcome.GetResult().GetIsTruncated();
+    } while (is_trucated);
+    return Status::OK();
+}
+
+Status S3FileSystem::batch_delete(const std::vector<Path>& paths) {
+    auto client = get_client();
+    CHECK_S3_CLIENT(client);
+
+    // `DeleteObjectsRequest` can only contain 1000 keys at most.
+    constexpr size_t max_delete_batch = 1000;
+    auto path_iter = paths.begin();
+
+    Aws::S3::Model::DeleteObjectsRequest delete_request;
+    delete_request.SetBucket(_s3_conf.bucket);
+    do {
+        Aws::S3::Model::Delete del;
+        Aws::Vector<Aws::S3::Model::ObjectIdentifier> objects;
+        auto path_begin = path_iter;
+        for (; path_iter != paths.end() && (path_iter - path_begin < max_delete_batch);
+             ++path_iter) {
+            objects.emplace_back().SetKey(get_key(*path_iter));
+        }
+        if (objects.empty()) {
+            return Status::OK();
+        }
+        del.WithObjects(std::move(objects)).SetQuiet(true);
+        delete_request.SetDelete(std::move(del));
+        auto delete_outcome = client->DeleteObjects(delete_request);
+        if (UNLIKELY(!delete_outcome.IsSuccess())) {
+            return Status::IOError(
+                    "failed to delete objects(endpoint={}, bucket={}, key[0]={}): {}",
+                    _s3_conf.endpoint, _s3_conf.bucket, objects.front().GetKey(),
+                    delete_outcome.GetError().GetMessage());
+        }
+        if (UNLIKELY(!delete_outcome.GetResult().GetErrors().empty())) {
+            const auto& e = delete_outcome.GetResult().GetErrors().front();
+            return Status::IOError("failed to delete objects(endpoint={}, bucket={}, key={}): {}",
+                                   _s3_conf.endpoint, _s3_conf.bucket, e.GetKey(),
+                                   delete_outcome.GetError().GetMessage());
+        }
+    } while (path_iter != paths.end());
+
+    return Status::OK();
 }
 
 std::string S3FileSystem::get_key(const Path& path) const {

--- a/be/src/io/fs/s3_file_system.cpp
+++ b/be/src/io/fs/s3_file_system.cpp
@@ -394,7 +394,7 @@ Status S3FileSystem::list(const Path& path, std::vector<Path>* files) {
                                    outcome.GetError().GetMessage());
         }
         for (const auto& obj : outcome.GetResult().GetContents()) {
-            files->push_back(obj.GetKey().substr(_s3_conf.prefix.size()));
+            files->push_back(obj.GetKey().substr(prefix.size()));
         }
         is_trucated = outcome.GetResult().GetIsTruncated();
     } while (is_trucated);

--- a/be/src/io/fs/s3_file_system.h
+++ b/be/src/io/fs/s3_file_system.h
@@ -80,6 +80,8 @@ public:
     Status batch_upload_impl(const std::vector<Path>& local_paths,
                              const std::vector<Path>& dest_paths);
 
+    Status batch_delete(const std::vector<Path>& paths) override;
+
     Status connect() override;
 
     Status connect_impl();

--- a/be/src/olap/data_dir.cpp
+++ b/be/src/olap/data_dir.cpp
@@ -853,6 +853,8 @@ void DataDir::perform_remote_rowset_gc() {
         for (int i = 0; i < gc_pb.num_segments(); ++i) {
             seg_paths.push_back(BetaRowset::remote_segment_path(gc_pb.tablet_id(), rowset_id, i));
         }
+        LOG(INFO) << "delete remote rowset. root_path=" << fs->root_path()
+                  << ", rowset_id=" << rowset_id;
         auto st = std::static_pointer_cast<io::RemoteFileSystem>(fs)->batch_delete(seg_paths);
         if (st.ok()) {
             deleted_keys.push_back(std::move(key));
@@ -890,6 +892,8 @@ void DataDir::perform_remote_tablet_gc() {
                 success = false;
                 continue;
             }
+            LOG(INFO) << "delete remote rowsets of tablet. root_path=" << fs->root_path()
+                      << ", tablet_id=" << tablet_id;
             auto st = fs->delete_directory(DATA_PREFIX + '/' + tablet_id);
             if (!st.ok()) {
                 LOG(WARNING) << "failed to delete all remote rowset in tablet. err=" << st;

--- a/be/src/olap/data_dir.cpp
+++ b/be/src/olap/data_dir.cpp
@@ -848,18 +848,16 @@ void DataDir::perform_remote_rowset_gc() {
             continue;
         }
         DCHECK(fs->type() != io::FileSystemType::LOCAL);
-        bool success = true;
+        std::vector<io::Path> seg_paths;
+        seg_paths.reserve(gc_pb.num_segments());
         for (int i = 0; i < gc_pb.num_segments(); ++i) {
-            auto seg_path = BetaRowset::remote_segment_path(gc_pb.tablet_id(), rowset_id, i);
-            // TODO(plat1ko): batch delete
-            auto st = fs->delete_file(seg_path);
-            if (!st.ok()) {
-                LOG(WARNING) << "failed to delete remote rowset. err=" << st;
-                success = false;
-            }
+            seg_paths.push_back(BetaRowset::remote_segment_path(gc_pb.tablet_id(), rowset_id, i));
         }
-        if (success) {
+        auto st = std::static_pointer_cast<io::RemoteFileSystem>(fs)->batch_delete(seg_paths);
+        if (st.ok()) {
             deleted_keys.push_back(std::move(key));
+        } else {
+            LOG(WARNING) << "failed to delete remote rowset. err=" << st;
         }
     }
     for (const auto& key : deleted_keys) {

--- a/be/src/olap/olap_server.cpp
+++ b/be/src/olap/olap_server.cpp
@@ -750,14 +750,7 @@ void StorageEngine::_cooldown_tasks_producer_callback() {
 void StorageEngine::_remove_unused_remote_files_callback() {
     while (!_stop_background_threads_latch.wait_for(
             std::chrono::seconds(config::remove_unused_remote_files_interval_sec))) {
-        auto tablets = _tablet_manager->get_all_tablet([](Tablet* t) {
-            return t->tablet_meta()->cooldown_meta_id().initialized() && t->is_used();
-        });
-        for (auto& t : tablets) {
-            if (t.use_count() > 1) {
-                t->remove_unused_remote_files();
-            }
-        }
+        Tablet::remove_unused_remote_files();
     }
 }
 

--- a/be/src/olap/olap_server.cpp
+++ b/be/src/olap/olap_server.cpp
@@ -749,7 +749,7 @@ void StorageEngine::_cooldown_tasks_producer_callback() {
 
 void StorageEngine::_remove_unused_remote_files_callback() {
     while (!_stop_background_threads_latch.wait_for(
-            std::chrono::seconds(config::remove_unused_files_interbal_sec))) {
+            std::chrono::seconds(config::remove_unused_remote_files_interval_sec))) {
         auto tablets = _tablet_manager->get_all_tablet([](Tablet* t) {
             return t->tablet_meta()->cooldown_meta_id().initialized() && t->is_used();
         });

--- a/be/src/olap/olap_server.cpp
+++ b/be/src/olap/olap_server.cpp
@@ -740,7 +740,7 @@ void StorageEngine::_cooldown_tasks_producer_callback() {
             task.priority = max_priority--;
             bool submited = _cooldown_thread_pool->offer(std::move(task));
 
-            if (submited) {
+            if (!submited) {
                 LOG(INFO) << "failed to submit cooldown task";
             }
         }
@@ -750,6 +750,7 @@ void StorageEngine::_cooldown_tasks_producer_callback() {
 void StorageEngine::_remove_unused_remote_files_callback() {
     while (!_stop_background_threads_latch.wait_for(
             std::chrono::seconds(config::remove_unused_remote_files_interval_sec))) {
+        LOG(INFO) << "begin to remove unused remote files";
         Tablet::remove_unused_remote_files();
     }
 }

--- a/be/src/olap/storage_engine.h
+++ b/be/src/olap/storage_engine.h
@@ -273,6 +273,7 @@ private:
     void _adjust_compaction_thread_num();
 
     void _cooldown_tasks_producer_callback();
+    void _remove_unused_remote_files_callback();
 
     void _cache_file_cleaner_tasks_producer_callback();
 
@@ -394,6 +395,7 @@ private:
     std::shared_ptr<CumulativeCompactionPolicy> _cumulative_compaction_policy;
 
     scoped_refptr<Thread> _cooldown_tasks_producer_thread;
+    scoped_refptr<Thread> _remove_unused_remote_files_thread;
 
     scoped_refptr<Thread> _cache_file_cleaner_tasks_producer_thread;
 

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -1975,107 +1975,156 @@ Status Tablet::remove_all_remote_rowsets() {
 }
 
 void Tablet::remove_unused_remote_files() {
-    if (_cooldown_replica_id != replica_id()) {
-        return;
-    }
+    auto tablets = StorageEngine::instance()->tablet_manager()->get_all_tablet([](Tablet* t) {
+        return t->tablet_meta()->cooldown_meta_id().initialized() && t->is_used();
+    });
+    TConfirmUnusedRemoteFilesRequest req;
+    req.__isset.confirm_list = true;
+    // tablet_id -> [fs, unused_remote_files]
+    using unused_remote_files_buffer_t = std::unordered_map<
+            int64_t, std::pair<std::shared_ptr<io::RemoteFileSystem>, std::vector<io::Path>>>;
+    unused_remote_files_buffer_t buffer;
+    int64_t num_files_in_buffer = 0;
+    // assume a filename is 0.1KB, buffer size should not larger than 100MB
+    constexpr int64_t max_files_in_buffer = 1000000;
 
-    auto storage_policy = get_storage_policy(storage_policy_id());
-    if (storage_policy == nullptr) {
-        LOG(WARNING) << "could not find storage_policy, storage_policy_id=" << storage_policy_id();
-        return;
-    }
-    auto resource = get_storage_resource(storage_policy->resource_id);
-    auto dest_fs = std::static_pointer_cast<io::RemoteFileSystem>(resource.fs);
-    if (dest_fs == nullptr) {
-        LOG(WARNING) << "could not find resource, resouce_id=" << storage_policy->resource_id;
-        return;
-    }
-    DCHECK(atol(dest_fs->id().c_str()) == storage_policy->resource_id);
-    DCHECK(dest_fs->type() != io::FileSystemType::LOCAL);
-
-    Status st;
-    std::vector<io::Path> files;
-    {
-        std::unique_lock xlock(_remote_files_lock, std::try_to_lock);
-        if (!xlock.owns_lock()) {
-            LOG(WARNING) << "try remote_files_lock failed. tablet_id=" << tablet_id();
+    auto calc_unused_remote_files = [&req, &buffer, &num_files_in_buffer](Tablet* t) {
+        auto storage_policy = get_storage_policy(t->storage_policy_id());
+        if (storage_policy == nullptr) {
+            LOG(WARNING) << "could not find storage_policy, storage_policy_id="
+                         << t->storage_policy_id();
             return;
         }
-        // FIXME(plat1ko): What if user reset resource in storage policy to another resource?
-        //  Maybe we should also list files in previously uploaded resources.
-        st = dest_fs->list(BetaRowset::remote_tablet_path(tablet_id()), &files);
-    }
-    if (!st.ok()) {
-        LOG(WARNING) << "encounter error when remove unused remote files, tablet_id=" << tablet_id()
-                     << " : " << st;
-    }
-    if (files.empty()) {
-        return;
-    }
-    // get all cooldowned rowsets
-    std::unordered_set<std::string> cooldowned_rowsets;
-    UniqueId cooldown_meta_id;
-    {
-        std::shared_lock rlock(_meta_lock);
-        for (auto& rs_meta : _tablet_meta->all_rs_metas()) {
-            if (!rs_meta->is_local()) {
-                cooldowned_rowsets.insert(rs_meta->rowset_id().to_string());
+        auto resource = get_storage_resource(storage_policy->resource_id);
+        auto dest_fs = std::static_pointer_cast<io::RemoteFileSystem>(resource.fs);
+        if (dest_fs == nullptr) {
+            LOG(WARNING) << "could not find resource, resouce_id=" << storage_policy->resource_id;
+            return;
+        }
+        DCHECK(atol(dest_fs->id().c_str()) == storage_policy->resource_id);
+        DCHECK(dest_fs->type() != io::FileSystemType::LOCAL);
+
+        Status st;
+        std::vector<io::Path> files;
+        {
+            std::unique_lock xlock(t->_remote_files_lock, std::try_to_lock);
+            if (!xlock.owns_lock()) {
+                LOG(WARNING) << "try remote_files_lock failed. tablet_id=" << t->tablet_id();
+                return;
             }
+            // FIXME(plat1ko): What if user reset resource in storage policy to another resource?
+            //  Maybe we should also list files in previously uploaded resources.
+            st = dest_fs->list(BetaRowset::remote_tablet_path(t->tablet_id()), &files);
         }
-        cooldown_meta_id = _tablet_meta->cooldown_meta_id();
-    }
-    // {replica_id}.meta
-    std::string remote_meta_path = std::to_string(replica_id()) + ".meta";
-    // filter out the paths that should be reserved
-    // clang-format off
-    files.erase(std::remove_if(files.begin(), files.end(), [&](io::Path& path) {
-        const std::string& path_str = path.native();
-        if (StringPiece(path_str).ends_with(".meta")) {
-            return path_str == remote_meta_path;
+        if (!st.ok()) {
+            LOG(WARNING) << "encounter error when remove unused remote files, tablet_id="
+                         << t->tablet_id() << " : " << st;
         }
-        if (StringPiece(path_str).ends_with(".dat")) {
-            // extract rowset id. filename format: {rowset_id}_{segment_num}.dat
-            auto end = path_str.rfind('_');
-            if (UNLIKELY(end == std::string::npos)) {
-                return false;
+        if (files.empty()) {
+            return;
+        }
+        // get all cooldowned rowsets
+        std::unordered_set<std::string> cooldowned_rowsets;
+        UniqueId cooldown_meta_id;
+        {
+            std::shared_lock rlock(t->_meta_lock);
+            for (auto& rs_meta : t->_tablet_meta->all_rs_metas()) {
+                if (!rs_meta->is_local()) {
+                    cooldowned_rowsets.insert(rs_meta->rowset_id().to_string());
+                }
             }
-            return !!cooldowned_rowsets.count(path_str.substr(0, end)); 
+            cooldown_meta_id = t->_tablet_meta->cooldown_meta_id();
         }
-        if (StringPiece(path_str).ends_with(".idx")) {
-            // extract rowset id. filename format: {rowset_id}_{segment_num}_{index_id}.idx
-            auto end = path_str.find('_');
-            if (UNLIKELY(end == std::string::npos)) {
-                return false;
+        // {replica_id}.meta
+        std::string remote_meta_path = std::to_string(t->replica_id()) + ".meta";
+        // filter out the paths that should be reserved
+        // clang-format off
+        files.erase(std::remove_if(files.begin(), files.end(), [&](io::Path& path) {
+            const std::string& path_str = path.native();
+            if (StringPiece(path_str).ends_with(".meta")) {
+                return path_str == remote_meta_path;
             }
-            return !!cooldowned_rowsets.count(path_str.substr(0, end));
+            if (StringPiece(path_str).ends_with(".dat")) {
+                // extract rowset id. filename format: {rowset_id}_{segment_num}.dat
+                auto end = path_str.rfind('_');
+                if (UNLIKELY(end == std::string::npos)) {
+                    return false;
+                }
+                return !!cooldowned_rowsets.count(path_str.substr(0, end)); 
+            }
+            if (StringPiece(path_str).ends_with(".idx")) {
+                // extract rowset id. filename format: {rowset_id}_{segment_num}_{index_id}.idx
+                auto end = path_str.find('_');
+                if (UNLIKELY(end == std::string::npos)) {
+                    return false;
+                }
+                return !!cooldowned_rowsets.count(path_str.substr(0, end));
+            }
+            return false;
+        }), files.end());
+        // clang-format on
+        if (files.empty()) {
+            return;
         }
-        return false;
-    }), files.end());
-    // clang-format on
-    if (files.empty()) {
-        return;
+        files.shrink_to_fit();
+        buffer.insert({t->tablet_id(), {std::move(dest_fs), std::move(files)}});
+        auto& info = req.confirm_list.emplace_back();
+        info.__set_tablet_id(t->tablet_id());
+        info.__set_cooldown_replica_id(t->replica_id());
+        info.__set_cooldown_meta_id(cooldown_meta_id.to_thrift());
+        num_files_in_buffer += files.size();
+    };
+
+    auto confirm_and_remove_files = [&buffer, &req]() {
+        TConfirmUnusedRemoteFilesResult result;
+        auto st = MasterServerClient::instance()->confirm_unused_remote_files(req, &result);
+        if (st.ok()) {
+            for (auto& id : result.confirmed_tablets) {
+                if (auto it = buffer.find(id); LIKELY(it != buffer.end())) {
+                    auto& fs = it->second.first;
+                    auto& files = it->second.second;
+                    // delete unused files
+                    LOG(INFO) << "delete unused files. root_path=" << fs->root_path()
+                              << " tablet_id=" << id;
+                    io::Path dir("data/" + std::to_string(id));
+                    for (auto& file : files) {
+                        file = dir / file;
+                        LOG(INFO) << "delete unused file: " << file.native();
+                    }
+                    st = fs->batch_delete(files);
+                    if (!st.ok()) {
+                        LOG(WARNING)
+                                << "failed to delete unused files, tablet_id=" << id << " : " << st;
+                    }
+                }
+            }
+        } else {
+            LOG(WARNING) << st;
+        }
+    };
+
+    // batch confirm to reduce FE's overhead
+    auto next_confirm_time = std::chrono::steady_clock::now() +
+                             std::chrono::seconds(config::confirm_unused_remote_files_interval_sec);
+    for (auto& t : tablets) {
+        if (t.use_count() <= 1 // this means tablet has been dropped
+            || t->_cooldown_replica_id != t->replica_id()) {
+            continue;
+        }
+        calc_unused_remote_files(t.get());
+        if (num_files_in_buffer > 0 && (num_files_in_buffer > max_files_in_buffer ||
+                                        std::chrono::steady_clock::now() > next_confirm_time)) {
+            confirm_and_remove_files();
+            buffer.clear();
+            req.confirm_list.clear();
+            num_files_in_buffer = 0;
+            next_confirm_time =
+                    std::chrono::steady_clock::now() +
+                    std::chrono::seconds(config::confirm_unused_remote_files_interval_sec);
+        }
     }
-    // ask FE to confirm
-    TConfirmUnusedRemoteFilesRequest req;
-    req.__set_tablet_id(tablet_id());
-    req.__set_cooldown_replica_id(_cooldown_replica_id);
-    req.__set_cooldown_meta_id(cooldown_meta_id.to_thrift());
-    st = MasterServerClient::instance()->confirm_unused_remote_files(req);
-    if (!st.ok()) {
-        LOG(WARNING) << "failed to delete unused files, tablet_id=" << tablet_id() << " : " << st;
-        return;
-    }
-    // delete unused files
-    LOG(INFO) << "delete unused files. root_path=" << dest_fs->root_path()
-              << " tablet_id=" << tablet_id();
-    io::Path dir("data/" + std::to_string(tablet_id()));
-    for (auto& file : files) {
-        file = dir / file;
-        LOG(INFO) << "delete unused file: " << file.native();
-    }
-    st = dest_fs->batch_delete(files);
-    if (!st.ok()) {
-        LOG(WARNING) << "failed to delete unused files, tablet_id=" << tablet_id() << " : " << st;
+    if (num_files_in_buffer > 0) {
+        confirm_and_remove_files();
     }
 }
 

--- a/be/src/olap/tablet.h
+++ b/be/src/olap/tablet.h
@@ -318,6 +318,8 @@ public:
 
     void record_unused_remote_rowset(const RowsetId& rowset_id, const std::string& resource,
                                      int64_t num_segments);
+
+    void remove_unused_remote_files();
     ////////////////////////////////////////////////////////////////////////////
     // end cooldown functions
     ////////////////////////////////////////////////////////////////////////////
@@ -360,6 +362,16 @@ public:
     bool should_skip_compaction(CompactionType compaction_type, int64_t now);
 
     RowsetSharedPtr get_rowset(const RowsetId& rowset_id);
+
+    void traverse_rowsets(std::function<void(const RowsetSharedPtr&)> visitor) {
+        std::shared_lock rlock(_meta_lock);
+        for (auto& [v, rs] : _rs_version_map) {
+            visitor(rs);
+        }
+        for (auto& [v, rs] : _stale_rs_version_map) {
+            visitor(rs);
+        }
+    }
 
 private:
     Status _init_once_action();
@@ -404,7 +416,8 @@ private:
     Status _follow_cooldowned_data(io::RemoteFileSystem* fs, int64_t cooldown_replica_id);
     Status _read_cooldown_meta(io::RemoteFileSystem* fs, int64_t cooldown_replica_id,
                                TabletMetaPB* tablet_meta_pb);
-    Status _write_cooldown_meta(io::RemoteFileSystem* fs, RowsetMeta* new_rs_meta);
+    Status _write_cooldown_meta(io::RemoteFileSystem* fs, UniqueId cooldown_meta_id,
+                                RowsetMeta* new_rs_meta);
     ////////////////////////////////////////////////////////////////////////////
     // end cooldown functions
     ////////////////////////////////////////////////////////////////////////////
@@ -484,6 +497,7 @@ private:
     // cooldown conf
     int64_t _cooldown_replica_id = -1;
     int64_t _cooldown_term = -1;
+    std::shared_mutex _remote_files_lock;
 
     DISALLOW_COPY_AND_ASSIGN(Tablet);
 

--- a/be/src/olap/tablet.h
+++ b/be/src/olap/tablet.h
@@ -319,7 +319,7 @@ public:
     void record_unused_remote_rowset(const RowsetId& rowset_id, const std::string& resource,
                                      int64_t num_segments);
 
-    void remove_unused_remote_files();
+    static void remove_unused_remote_files();
     ////////////////////////////////////////////////////////////////////////////
     // end cooldown functions
     ////////////////////////////////////////////////////////////////////////////

--- a/be/src/olap/tablet_manager.cpp
+++ b/be/src/olap/tablet_manager.cpp
@@ -31,6 +31,7 @@
 #include <cstdlib>
 #include <filesystem>
 
+#include "common/compiler_util.h"
 #include "env/env.h"
 #include "env/env_util.h"
 #include "gutil/strings/strcat.h"
@@ -88,6 +89,12 @@ TabletManager::TabletManager(int32_t tablet_map_lock_shard_size)
 
 TabletManager::~TabletManager() {
     DEREGISTER_HOOK_METRIC(tablet_meta_mem_consumption);
+}
+
+void TabletManager::add_tablet(const TabletSharedPtr& tablet) {
+    auto& tablet_map = _get_tablet_map(tablet->tablet_id());
+    std::lock_guard wlock(_get_tablets_shard_lock(tablet->tablet_id()));
+    tablet_map[tablet->tablet_id()] = tablet;
 }
 
 Status TabletManager::_add_tablet_unlocked(TTabletId tablet_id, const TabletSharedPtr& tablet,
@@ -580,23 +587,6 @@ TabletSharedPtr TabletManager::get_tablet(TTabletId tablet_id, TabletUid tablet_
     return nullptr;
 }
 
-std::vector<TabletSharedPtr> TabletManager::get_all_tablet() {
-    std::vector<TabletSharedPtr> res;
-    for (const auto& tablets_shard : _tablets_shards) {
-        std::shared_lock rdlock(tablets_shard.lock);
-        for (const auto& tablet_map : tablets_shard.tablet_map) {
-            // these are tablets which is not deleted
-            TabletSharedPtr tablet = tablet_map.second;
-            if (!tablet->is_used()) {
-                LOG(WARNING) << "tablet cannot be used. tablet=" << tablet->tablet_id();
-                continue;
-            }
-            res.emplace_back(tablet);
-        }
-    }
-    return res;
-}
-
 uint64_t TabletManager::get_rowset_nums() {
     uint64_t rowset_nums = 0;
     for (const auto& tablets_shard : _tablets_shards) {
@@ -898,37 +888,31 @@ Status TabletManager::build_all_report_tablets_info(std::map<TTabletId, TTablet>
 
     DorisMetrics::instance()->report_all_tablets_requests_total->increment(1);
     HistogramStat tablet_version_num_hist;
+    auto tablets = get_all_tablet([](Tablet*) { return true; });
     auto local_cache = std::make_shared<std::vector<TTabletStat>>();
-    for (const auto& tablets_shard : _tablets_shards) {
-        std::shared_lock rdlock(tablets_shard.lock);
-        for (const auto& item : tablets_shard.tablet_map) {
-            uint64_t tablet_id = item.first;
-            TabletSharedPtr tablet_ptr = item.second;
-            TTablet t_tablet;
-            TTabletInfo tablet_info;
-            tablet_ptr->build_tablet_report_info(&tablet_info, true);
-            // find expired transaction corresponding to this tablet
-            TabletInfo tinfo(tablet_id, tablet_ptr->schema_hash(), tablet_ptr->tablet_uid());
-            auto find = expire_txn_map.find(tinfo);
-            if (find != expire_txn_map.end()) {
-                tablet_info.__set_transaction_ids(find->second);
-                expire_txn_map.erase(find);
-            }
-            t_tablet.tablet_infos.push_back(tablet_info);
-            tablet_version_num_hist.add(tablet_ptr->version_count());
-            tablets_info->emplace(tablet_id, t_tablet);
-            TTabletStat t_tablet_stat;
-            t_tablet_stat.__set_tablet_id(tablet_info.tablet_id);
-            t_tablet_stat.__set_data_size(tablet_info.data_size);
-            t_tablet_stat.__set_remote_data_size(tablet_info.remote_data_size);
-            t_tablet_stat.__set_row_num(tablet_info.row_count);
-            t_tablet_stat.__set_version_count(tablet_info.version_count);
-            local_cache->emplace_back(std::move(t_tablet_stat));
+    local_cache->reserve(tablets.size());
+    for (auto& tablet : tablets) {
+        auto& t_tablet = (*tablets_info)[tablet->tablet_id()];
+        TTabletInfo& tablet_info = t_tablet.tablet_infos.emplace_back();
+        tablet->build_tablet_report_info(&tablet_info, true);
+        // find expired transaction corresponding to this tablet
+        TabletInfo tinfo(tablet->tablet_id(), tablet->schema_hash(), tablet->tablet_uid());
+        auto find = expire_txn_map.find(tinfo);
+        if (find != expire_txn_map.end()) {
+            tablet_info.__set_transaction_ids(find->second);
+            expire_txn_map.erase(find);
         }
+        tablet_version_num_hist.add(tablet->version_count());
+        auto& t_tablet_stat = local_cache->emplace_back();
+        t_tablet_stat.__set_tablet_id(tablet_info.tablet_id);
+        t_tablet_stat.__set_data_size(tablet_info.data_size);
+        t_tablet_stat.__set_remote_data_size(tablet_info.remote_data_size);
+        t_tablet_stat.__set_row_num(tablet_info.row_count);
+        t_tablet_stat.__set_version_count(tablet_info.version_count);
     }
     {
         std::lock_guard<std::mutex> guard(_tablet_stat_cache_mutex);
-        _tablet_stat_list_cache = local_cache;
+        _tablet_stat_list_cache.swap(local_cache);
     }
     DorisMetrics::instance()->tablet_version_num_distribution->set_histogram(
             tablet_version_num_hist);

--- a/be/src/olap/tablet_manager.h
+++ b/be/src/olap/tablet_manager.h
@@ -61,6 +61,8 @@ public:
     // task to be fail, even if there is enough space on other disks
     Status create_tablet(const TCreateTabletReq& request, std::vector<DataDir*> stores);
 
+    void add_tablet(const TabletSharedPtr& tablet);
+
     // Drop a tablet by description.
     // If `is_drop_table_or_partition` is true, we need to remove all remote rowsets in this tablet.
     Status drop_tablet(TTabletId tablet_id, TReplicaId replica_id, bool is_drop_table_or_partition);
@@ -78,7 +80,19 @@ public:
     TabletSharedPtr get_tablet(TTabletId tablet_id, TabletUid tablet_uid,
                                bool include_deleted = false, std::string* err = nullptr);
 
-    std::vector<TabletSharedPtr> get_all_tablet();
+    std::vector<TabletSharedPtr> get_all_tablet(std::function<bool(Tablet*)>&& filter =
+                                                        [](Tablet* t) { return t->is_used(); }) {
+        std::vector<TabletSharedPtr> res;
+        for (const auto& tablets_shard : _tablets_shards) {
+            std::shared_lock rdlock(tablets_shard.lock);
+            for (auto& [id, tablet] : tablets_shard.tablet_map) {
+                if (filter(tablet.get())) {
+                    res.emplace_back(tablet);
+                }
+            }
+        }
+        return res;
+    }
 
     uint64_t get_rowset_nums();
     uint64_t get_segment_nums();

--- a/be/src/olap/tablet_meta.cpp
+++ b/be/src/olap/tablet_meta.cpp
@@ -538,6 +538,10 @@ void TabletMeta::init_from_pb(const TabletMetaPB& tablet_meta_pb) {
     }
 
     _storage_policy_id = tablet_meta_pb.storage_policy_id();
+    if (tablet_meta_pb.has_cooldown_meta_id()) {
+        _cooldown_meta_id = tablet_meta_pb.cooldown_meta_id();
+    }
+
     if (tablet_meta_pb.has_enable_unique_key_merge_on_write()) {
         _enable_unique_key_merge_on_write = tablet_meta_pb.enable_unique_key_merge_on_write();
     }
@@ -606,6 +610,10 @@ void TabletMeta::to_meta_pb(TabletMetaPB* tablet_meta_pb) {
     if (_storage_policy_id > 0) {
         tablet_meta_pb->set_storage_policy_id(_storage_policy_id);
     }
+    if (_cooldown_meta_id.initialized()) {
+        tablet_meta_pb->mutable_cooldown_meta_id()->CopyFrom(_cooldown_meta_id.to_proto());
+    }
+
     tablet_meta_pb->set_enable_unique_key_merge_on_write(_enable_unique_key_merge_on_write);
 
     if (_enable_unique_key_merge_on_write) {

--- a/be/src/olap/tablet_meta.h
+++ b/be/src/olap/tablet_meta.h
@@ -116,6 +116,7 @@ public:
 
     TabletTypePB tablet_type() const { return _tablet_type; }
     TabletUid tablet_uid() const;
+    void set_tablet_uid(TabletUid uid) { _tablet_uid = uid; }
     int64_t table_id() const;
     int64_t partition_id() const;
     int64_t tablet_id() const;
@@ -194,6 +195,9 @@ public:
         _storage_policy_id = id;
     }
 
+    UniqueId cooldown_meta_id() const { return _cooldown_meta_id; }
+    void set_cooldown_meta_id(UniqueId uid) { _cooldown_meta_id = uid; }
+
     static void init_column_from_tcolumn(uint32_t unique_id, const TColumn& tcolumn,
                                          ColumnPB* column);
 
@@ -238,6 +242,7 @@ private:
 
     // meta for cooldown
     int64_t _storage_policy_id = 0; // <= 0 means no storage policy
+    UniqueId _cooldown_meta_id;
 
     // For unique key data model, the feature Merge-on-Write will leverage a primary
     // key index and a delete-bitmap to mark duplicate keys as deleted in load stage,

--- a/be/src/olap/task/engine_clone_task.cpp
+++ b/be/src/olap/task/engine_clone_task.cpp
@@ -17,6 +17,7 @@
 
 #include "olap/task/engine_clone_task.h"
 
+#include <memory>
 #include <set>
 #include <system_error>
 
@@ -30,6 +31,8 @@
 #include "olap/rowset/rowset.h"
 #include "olap/rowset/rowset_factory.h"
 #include "olap/snapshot_manager.h"
+#include "olap/storage_engine.h"
+#include "olap/tablet_meta.h"
 #include "runtime/client_cache.h"
 #include "runtime/thread_context.h"
 #include "util/defer_op.h"
@@ -485,8 +488,8 @@ Status EngineCloneTask::_finish_clone(Tablet* tablet, const std::string& clone_d
     // The tablet meta info is downloaded from source BE as .hdr file.
     // So we load it and generate cloned_tablet_meta.
     auto cloned_tablet_meta_file = fmt::format("{}/{}.hdr", clone_dir, tablet->tablet_id());
-    TabletMeta cloned_tablet_meta;
-    RETURN_IF_ERROR(cloned_tablet_meta.create_from_file(cloned_tablet_meta_file));
+    auto cloned_tablet_meta = std::make_shared<TabletMeta>();
+    RETURN_IF_ERROR(cloned_tablet_meta->create_from_file(cloned_tablet_meta_file));
 
     // remove the cloned meta file
     FileUtils::remove(cloned_tablet_meta_file);
@@ -528,7 +531,7 @@ Status EngineCloneTask::_finish_clone(Tablet* tablet, const std::string& clone_d
     if (is_incremental_clone) {
         status = _finish_incremental_clone(tablet, cloned_tablet_meta, committed_version);
     } else {
-        status = _finish_full_clone(tablet, const_cast<TabletMeta*>(&cloned_tablet_meta));
+        status = _finish_full_clone(tablet, cloned_tablet_meta);
     }
 
     // if full clone success, need to update cumulative layer point
@@ -544,7 +547,7 @@ Status EngineCloneTask::_finish_clone(Tablet* tablet, const std::string& clone_d
 /// 1. Get missing version from local tablet again and check if they exist in cloned tablet.
 /// 2. Revise the local tablet meta to add all incremental cloned rowset's meta.
 Status EngineCloneTask::_finish_incremental_clone(Tablet* tablet,
-                                                  const TabletMeta& cloned_tablet_meta,
+                                                  const TabletMetaSharedPtr& cloned_tablet_meta,
                                                   int64_t committed_version) {
     LOG(INFO) << "begin to finish incremental clone. tablet=" << tablet->full_name()
               << ", committed_version=" << committed_version
@@ -576,10 +579,29 @@ Status EngineCloneTask::_finish_incremental_clone(Tablet* tablet,
     return tablet->revise_tablet_meta(rowsets_to_clone, versions_to_delete);
 }
 
+// replace `origin_tablet` with Tablet created by `cloned_tablet_meta`.
+static Status full_clone(Tablet* origin_tablet, const TabletMetaSharedPtr& cloned_tablet_meta) {
+    // keep origin `replica_id` and `tablet_uid`
+    cloned_tablet_meta->set_replica_id(origin_tablet->replica_id());
+    cloned_tablet_meta->set_tablet_uid(origin_tablet->tablet_uid());
+    auto tablet = Tablet::create_tablet_from_meta(cloned_tablet_meta, origin_tablet->data_dir());
+    RETURN_IF_ERROR(tablet->init());
+    tablet->save_meta();
+    StorageEngine::instance()->tablet_manager()->add_tablet(tablet);
+    // reclaim local rowsets in origin tablet
+    tablet->traverse_rowsets([](auto& rs) {
+        if (rs->is_local()) {
+            StorageEngine::instance()->add_unused_rowset(rs);
+        }
+    });
+    return Status::OK();
+}
+
 /// This method will do:
 /// 1. Compare the version of local tablet and cloned tablet to decide which version to keep
 /// 2. Revise the local tablet meta
-Status EngineCloneTask::_finish_full_clone(Tablet* tablet, TabletMeta* cloned_tablet_meta) {
+Status EngineCloneTask::_finish_full_clone(Tablet* tablet,
+                                           const TabletMetaSharedPtr& cloned_tablet_meta) {
     Version cloned_max_version = cloned_tablet_meta->max_version();
     LOG(INFO) << "begin to finish full clone. tablet=" << tablet->full_name()
               << ", cloned_max_version=" << cloned_max_version;
@@ -648,6 +670,12 @@ Status EngineCloneTask::_finish_full_clone(Tablet* tablet, TabletMeta* cloned_ta
     }
     std::vector<RowsetMetaSharedPtr> rowsets_to_clone;
     for (auto& rs_meta : cloned_tablet_meta->all_rs_metas()) {
+        if (!rs_meta->is_local()) {
+            // MUST clone all cooldowned rowset if there is any cooldowned rowset to clone to ensure
+            // `cooldown_meta_id` is consistent with the cooldowned rowsets after clone.
+            LOG(INFO) << "clone cooldowned rowsets, tablet_id=" << tablet->tablet_id();
+            RETURN_IF_ERROR(full_clone(tablet, cloned_tablet_meta));
+        }
         rowsets_to_clone.push_back(rs_meta);
         LOG(INFO) << "version to be cloned from clone tablet to local tablet: "
                   << tablet->full_name() << ", version=" << rs_meta->version();

--- a/be/src/olap/task/engine_clone_task.cpp
+++ b/be/src/olap/task/engine_clone_task.cpp
@@ -551,7 +551,7 @@ Status EngineCloneTask::_finish_incremental_clone(Tablet* tablet,
                                                   int64_t committed_version) {
     LOG(INFO) << "begin to finish incremental clone. tablet=" << tablet->full_name()
               << ", committed_version=" << committed_version
-              << ", cloned_tablet_replica_id=" << cloned_tablet_meta.replica_id();
+              << ", cloned_tablet_replica_id=" << cloned_tablet_meta->replica_id();
 
     /// Get missing versions again from local tablet.
     /// We got it before outside the lock, so it has to be got again.
@@ -564,7 +564,7 @@ Status EngineCloneTask::_finish_incremental_clone(Tablet* tablet,
     // check missing versions exist in clone src
     std::vector<RowsetMetaSharedPtr> rowsets_to_clone;
     for (Version version : missed_versions) {
-        RowsetMetaSharedPtr rs_meta = cloned_tablet_meta.acquire_rs_meta_by_version(version);
+        RowsetMetaSharedPtr rs_meta = cloned_tablet_meta->acquire_rs_meta_by_version(version);
         if (rs_meta == nullptr) {
             return Status::InternalError("missed version {} is not found in cloned tablet meta",
                                          version.to_string());

--- a/be/src/olap/task/engine_clone_task.h
+++ b/be/src/olap/task/engine_clone_task.h
@@ -45,10 +45,10 @@ private:
     virtual Status _finish_clone(Tablet* tablet, const std::string& clone_dir,
                                  int64_t committed_version, bool is_incremental_clone);
 
-    Status _finish_incremental_clone(Tablet* tablet, const TabletMeta& cloned_tablet_meta,
+    Status _finish_incremental_clone(Tablet* tablet, const TabletMetaSharedPtr& cloned_tablet_meta,
                                      int64_t committed_version);
 
-    Status _finish_full_clone(Tablet* tablet, TabletMeta* cloned_tablet_meta);
+    Status _finish_full_clone(Tablet* tablet, const TabletMetaSharedPtr& cloned_tablet_meta);
 
     Status _make_and_download_snapshots(DataDir& data_dir, const std::string& local_data_path,
                                         TBackend* src_host, string* src_file_path,

--- a/be/src/util/pprof_utils.cpp
+++ b/be/src/util/pprof_utils.cpp
@@ -24,6 +24,9 @@
 #include "util/file_utils.h"
 
 namespace doris {
+namespace config {
+extern std::string pprof_profile_dir;
+}
 
 Status PprofUtils::get_pprof_cmd(std::string* cmd) {
     AgentUtils util;

--- a/be/src/util/uid_util.h
+++ b/be/src/util/uid_util.h
@@ -65,6 +65,8 @@ struct UniqueId {
         from_hex(&lo, lo_str);
     }
 
+    bool initialized() const { return hi != 0 || lo != 0; }
+
     // currently, the implementation is uuid, but it may change in the future
     static UniqueId gen_uid() {
         UniqueId uid(0, 0);

--- a/be/src/util/uid_util.h
+++ b/be/src/util/uid_util.h
@@ -56,6 +56,7 @@ struct UniqueId {
     int64_t hi = 0;
     int64_t lo = 0;
 
+    UniqueId() = default;
     UniqueId(int64_t hi_, int64_t lo_) : hi(hi_), lo(lo_) {}
     UniqueId(const UniqueId& uid) : hi(uid.hi), lo(uid.lo) {}
     UniqueId(const TUniqueId& tuid) : hi(tuid.hi), lo(tuid.lo) {}

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Replica.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Replica.java
@@ -19,6 +19,7 @@ package org.apache.doris.catalog;
 
 import org.apache.doris.common.io.Text;
 import org.apache.doris.common.io.Writable;
+import org.apache.doris.thrift.TUniqueId;
 
 import com.google.gson.annotations.SerializedName;
 import org.apache.logging.log4j.LogManager;
@@ -107,6 +108,8 @@ public class Replica implements Writable {
 
     // bad means this Replica is unrecoverable, and we will delete it
     private boolean bad = false;
+
+    private TUniqueId cooldownMetaId;
 
     /*
      * If set to true, with means this replica need to be repaired. explicitly.
@@ -232,6 +235,14 @@ public class Replica implements Writable {
         }
         this.bad = bad;
         return true;
+    }
+
+    public TUniqueId getCooldownMetaId() {
+        return cooldownMetaId;
+    }
+
+    public void setCooldownMetaId(TUniqueId cooldownMetaId) {
+        this.cooldownMetaId = cooldownMetaId;
     }
 
     public boolean needFurtherRepair() {

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/TabletInvertedIndex.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/TabletInvertedIndex.java
@@ -193,6 +193,7 @@ public class TabletInvertedIndex {
                             if (Config.enable_storage_policy) {
                                 handleCooldownConf(tabletMeta, backendTabletInfo, cooldownConfToPush,
                                         cooldownConfToUpdate);
+                                replica.setCooldownMetaId(backendTabletInfo.getCooldownMetaId());
                             }
 
                             long partitionId = tabletMeta.getPartitionId();

--- a/fe/fe-core/src/main/java/org/apache/doris/cooldown/CooldownDelete.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cooldown/CooldownDelete.java
@@ -21,51 +21,15 @@ import org.apache.doris.common.io.Text;
 import org.apache.doris.common.io.Writable;
 import org.apache.doris.persist.gson.GsonUtils;
 
-import com.google.gson.annotations.SerializedName;
-import lombok.Data;
-
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 
 /**
- * This class is used to log update cooldown conf operation.
+ * This class is used to log delete unused remote files operation.
  */
-@Data
-public class CooldownConf implements Writable {
-    @SerializedName(value = "dbId")
-    protected long dbId;
-    @SerializedName(value = "tableId")
-    protected long tableId;
-    @SerializedName(value = "partitionId")
-    protected long partitionId;
-    @SerializedName(value = "indexId")
-    protected long indexId;
-    @SerializedName(value = "tabletId")
-    protected long tabletId;
-    @SerializedName(value = "cooldownReplicaId")
-    protected long cooldownReplicaId = -1;
-    @SerializedName(value = "cooldownTerm")
-    protected long cooldownTerm = -1;
-
-    public CooldownConf() {
-    }
-
-    // for update
-    public CooldownConf(long dbId, long tableId, long partitionId, long indexId, long tabletId, long cooldownTerm) {
-        this.dbId = dbId;
-        this.tableId = tableId;
-        this.partitionId = partitionId;
-        this.indexId = indexId;
-        this.tabletId = tabletId;
-        this.cooldownTerm = cooldownTerm;
-    }
-
-    // for push
-    public CooldownConf(long tabletId, long cooldownReplicaId, long cooldownTerm) {
-        this.tabletId = tabletId;
-        this.cooldownReplicaId = cooldownReplicaId;
-        this.cooldownTerm = cooldownTerm;
+public class CooldownDelete implements Writable {
+    public CooldownDelete() {
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/journal/JournalEntity.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/journal/JournalEntity.java
@@ -37,6 +37,7 @@ import org.apache.doris.common.io.Text;
 import org.apache.doris.common.io.Writable;
 import org.apache.doris.common.util.SmallFileMgr.SmallFile;
 import org.apache.doris.cooldown.CooldownConfList;
+import org.apache.doris.cooldown.CooldownDelete;
 import org.apache.doris.datasource.CatalogLog;
 import org.apache.doris.datasource.ExternalObjectLog;
 import org.apache.doris.datasource.InitCatalogLog;
@@ -583,6 +584,11 @@ public class JournalEntity implements Writable {
             }
             case OperationType.OP_UPDATE_COOLDOWN_CONF: {
                 data = CooldownConfList.read(in);
+                isRead = true;
+                break;
+            }
+            case OperationType.OP_COOLDOWN_DELETE: {
+                data = CooldownDelete.read(in);
                 isRead = true;
                 break;
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/EditLog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/EditLog.java
@@ -43,6 +43,7 @@ import org.apache.doris.common.io.Writable;
 import org.apache.doris.common.util.SmallFileMgr.SmallFile;
 import org.apache.doris.cooldown.CooldownConfHandler;
 import org.apache.doris.cooldown.CooldownConfList;
+import org.apache.doris.cooldown.CooldownDelete;
 import org.apache.doris.datasource.CatalogLog;
 import org.apache.doris.datasource.ExternalObjectLog;
 import org.apache.doris.datasource.InitCatalogLog;
@@ -724,6 +725,9 @@ public class EditLog {
                 case OperationType.OP_UPDATE_COOLDOWN_CONF:
                     CooldownConfList cooldownConfList = (CooldownConfList) journal.getData();
                     CooldownConfHandler.replayUpdateCooldownConf(cooldownConfList);
+                    break;
+                case OperationType.OP_COOLDOWN_DELETE:
+                    // noop
                     break;
                 case OperationType.OP_BATCH_ADD_ROLLUP: {
                     BatchAlterJobPersistInfo batchAlterJobV2 = (BatchAlterJobPersistInfo) journal.getData();
@@ -1524,6 +1528,10 @@ public class EditLog {
 
     public void logUpdateCooldownConf(CooldownConfList cooldownConf) {
         logEdit(OperationType.OP_UPDATE_COOLDOWN_CONF, cooldownConf);
+    }
+
+    public void logCooldownDelete(CooldownDelete cooldownDelete) {
+        logEdit(OperationType.OP_COOLDOWN_DELETE, cooldownDelete);
     }
 
     public void logBatchAlterJob(BatchAlterJobPersistInfo batchAlterJobV2) {

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/OperationType.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/OperationType.java
@@ -267,8 +267,9 @@ public class OperationType {
     public static final short OP_REFRESH_EXTERNAL_PARTITIONS = 356;
 
     public static final short OP_ALTER_USER = 400;
-    // cooldown conf
+    // cooldown related
     public static final short OP_UPDATE_COOLDOWN_CONF = 401;
+    public static final short OP_COOLDOWN_DELETE = 402;
 
     /**
      * Get opcode name by op code.

--- a/gensrc/proto/olap_file.proto
+++ b/gensrc/proto/olap_file.proto
@@ -296,6 +296,7 @@ message TabletMetaPB {
     // Use primary key index to speed up tabel unique key model
     optional bool enable_unique_key_merge_on_write = 24 [default = false];
     optional int64 storage_policy_id = 25;
+    optional PUniqueId cooldown_meta_id = 26;
 }
 
 message OLAPRawDeltaHeaderMessage {

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -739,10 +739,18 @@ struct TMySqlLoadAcquireTokenResult {
     2: optional string token
 }
 
+struct TTabletCooldownInfo {
+    1: optional Types.TTabletId tablet_id
+    2: optional Types.TReplicaId cooldown_replica_id
+    3: optional Types.TUniqueId cooldown_meta_id
+}
+
 struct TConfirmUnusedRemoteFilesRequest {
-  1: optional Types.TTabletId tablet_id
-  2: optional Types.TReplicaId cooldown_replica_id
-  3: optional Types.TUniqueId cooldown_meta_id
+    1: optional list<TTabletCooldownInfo> confirm_list
+}
+
+struct TConfirmUnusedRemoteFilesResult {
+    1: optional list<Types.TTabletId> confirmed_tablets
 }
 
 service FrontendService {
@@ -787,5 +795,5 @@ service FrontendService {
 
     TMySqlLoadAcquireTokenResult acquireToken()
 
-    Status.TStatus confirmUnusedRemoteFiles(1: TConfirmUnusedRemoteFilesRequest request)
+    TConfirmUnusedRemoteFilesResult confirmUnusedRemoteFiles(1: TConfirmUnusedRemoteFilesRequest request)
 }

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -739,6 +739,12 @@ struct TMySqlLoadAcquireTokenResult {
     2: optional string token
 }
 
+struct TConfirmUnusedRemoteFilesRequest {
+  1: optional Types.TTabletId tablet_id
+  2: optional Types.TReplicaId cooldown_replica_id
+  3: optional Types.TUniqueId cooldown_meta_id
+}
+
 service FrontendService {
     TGetDbsResult getDbNames(1: TGetDbsParams params)
     TGetTablesResult getTableNames(1: TGetTablesParams params)
@@ -780,4 +786,6 @@ service FrontendService {
     TFetchSchemaTableDataResult fetchSchemaTableData(1: TFetchSchemaTableDataRequest request)
 
     TMySqlLoadAcquireTokenResult acquireToken()
+
+    Status.TStatus confirmUnusedRemoteFiles(1: TConfirmUnusedRemoteFilesRequest request)
 }

--- a/gensrc/thrift/MasterService.thrift
+++ b/gensrc/thrift/MasterService.thrift
@@ -45,6 +45,7 @@ struct TTabletInfo {
     17: optional Types.TReplicaId cooldown_replica_id
     // 18: optional bool is_cooldown
     19: optional i64 cooldown_term
+    20: optional Types.TUniqueId cooldown_meta_id
 }
 
 struct TFinishTaskRequest {


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary
Designed with @pengxiangyu together.

In this PR, BE will launch a thread to calculate unused remote files periodically and then ask FE to confirm. After confirm success, BE will delete these unused remote files. The conditions for confirmation are: 
1. Replica which send confirm request is cooldown replica.
2. All replicas of a tablet have the same cooldown meta id which means all replicas share the same cooldowned rowsets.
3. FE is master.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [x] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
4. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
5. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
6. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

