### PR TITLE
[fix](window function) invalid order_by_start in VAnalyticEvalNode

### DIFF
--- a/be/src/vec/exec/vanalytic_eval_node.cpp
+++ b/be/src/vec/exec/vanalytic_eval_node.cpp
@@ -468,7 +468,7 @@ BlockRowPos VAnalyticEvalNode::_compare_row_to_find_end(int idx, BlockRowPos sta
 
     //check whether need get column again, maybe same as first init
     // if the start_block_num have move to forword, so need update start block num and compare it from row_num=0
-    if (start_column.get() != start_next_block_column.get()) {
+    if (start_block_num != start.block_num) {
         start_init_row_num = 0;
         start.block_num = start_block_num;
         start_column = _input_blocks[start.block_num].get_by_position(idx).column;
@@ -477,7 +477,7 @@ BlockRowPos VAnalyticEvalNode::_compare_row_to_find_end(int idx, BlockRowPos sta
     int64_t start_pos = start_init_row_num;
     int64_t end_pos = _input_blocks[start.block_num].rows() - 1;
     //if end_block_num haven't moved, only start_block_num go to the end block
-    //so could used the end.row_num for binary search
+    //so could use the end.row_num for binary search
     if (start.block_num == end.block_num) {
         end_pos = end.row_num;
     }
@@ -489,7 +489,7 @@ BlockRowPos VAnalyticEvalNode::_compare_row_to_find_end(int idx, BlockRowPos sta
             start_pos = mid_pos + 1;
         }
     }
-    start.row_num = start_pos; //upadte row num, return the find end
+    start.row_num = start_pos; //update row num, return the find end
     return start;
 }
 
@@ -684,6 +684,12 @@ void VAnalyticEvalNode::_update_order_by_range() {
             input_block_first_row_positions[_order_by_start.block_num] + _order_by_start.row_num;
     _order_by_end.pos =
             input_block_first_row_positions[_order_by_end.block_num] + _order_by_end.row_num;
+    // `_order_by_end` will be assigned to `_order_by_start` next time,
+    // so make it a valid position.
+    if (_order_by_end.row_num == _input_blocks[_order_by_end.block_num].rows()) {
+        _order_by_end.block_num++;
+        _order_by_end.row_num = 0;
+    }
 }
 
 Status VAnalyticEvalNode::_init_result_columns() {


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

```bash
0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /mnt/disk1/root/projects/doris/be/src/common/signal_handler.h:428
1# 0x00007F1190F9B400 in /lib64/libc.so.6
2# __GI_raise in /lib64/libc.so.6
3# __GI_abort in /lib64/libc.so.6
4# 0x000055DB3C0758D9 in /mnt/disk1/root/projects/doris/output/be/lib/doris_be
5# google::LogMessage::SendToLog() in /mnt/disk1/root/projects/doris/output/be/lib/doris_be
6# google::LogMessage::Flush() in /mnt/disk1/root/projects/doris/output/be/lib/doris_be
7# google::LogMessageFatal::~LogMessageFatal() in /mnt/disk1/root/projects/doris/output/be/lib/doris_be
8# doris::vectorized::Block::safe_get_by_position(unsigned long) in /mnt/disk1/root/projects/doris/output/be/lib/doris_be
9# doris::vectorized::VAnalyticEvalNode::_compare_row_to_find_end(int, doris::vectorized::BlockRowPos, doris::vectorized::BlockRowPos, bool) at /mnt/disk1/root/projects
/doris/be/src/vec/exec/vanalytic_eval_node.cpp:427
10# doris::vectorized::VAnalyticEvalNode::_update_order_by_range() at /mnt/disk1/root/projects/doris/be/src/vec/exec/vanalytic_eval_node.cpp:680
11# doris::vectorized::VAnalyticEvalNode::_get_next_for_range(unsigned long) at /mnt/disk1/root/projects/doris/be/src/vec/exec/vanalytic_eval_node.cpp:345
12# doris::Status std::__invoke_impl<doris::Status, doris::Status (doris::vectorized::VAnalyticEvalNode::&)(unsigned long), doris::vectorized::VAnalyticEvalNode&, unsigne
d long>(std::__invoke_memfun_deref, doris::Status (doris::vectorized::VAnalyticEvalNode::&)(unsigned long), doris::vectorized::VAnalyticEvalNode&, unsigned long&&) at /mn
t/disk1/root/projects/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:74
13# std::enable_if<is_invocable_r_v<doris::Status, doris::Status (doris::vectorized::VAnalyticEvalNode::&)(unsigned long), doris::vectorized::VAnalyticEvalNode&, unsigned
long>, doris::Status>::type std::__invoke_r<doris::Status, doris::Status (doris::vectorized::VAnalyticEvalNode::&)(unsigned long), doris::vectorized::VAnalyticEvalNode&,
unsigned long>(doris::Status (doris::vectorized::VAnalyticEvalNode::&)(unsigned long), doris::vectorized::VAnalyticEvalNode&, unsigned long&&) at /mnt/disk1/root/proj
ects/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:114
14# doris::Status std::_Bind_result<doris::Status, doris::Status (doris::vectorized::VAnalyticEvalNode::(doris::vectorized::VAnalyticEvalNode, std::_Placeholder<1>))(unsi
gned long)>::__call<doris::Status, unsigned long&&, 0ul, 1ul>(std::tuple<unsigned long&&>&&, std::_Index_tuple<0ul, 1ul>) at /mnt/disk1/root/projects/ldb_toolchain/bin/.
./lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/functional:570
15# doris::Status std::_Bind_result<doris::Status, doris::Status (doris::vectorized::VAnalyticEvalNode::(doris::vectorized::VAnalyticEvalNode, std::_Placeholder<1>))(unsi
gned long)>::operator()<unsigned long>(unsigned long&&) at /mnt/disk1/root/projects/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/functiona
l:629
16# doris::Status std::__invoke_impl<doris::Status, std::_Bind_result<doris::Status, doris::Status (doris::vectorized::VAnalyticEvalNode::*(doris::vectorized::VAnalyticEval
Node*, std::Placeholder<1>))(unsigned long)>&, unsigned long>(std::_invoke_other, std::_Bind_result<doris::Status, doris::Status (doris::vectorized::VAnalyticEvalNode::*(
doris::vectorized::VAnalyticEvalNode*, std::_Placeholder<1>))(unsigned long)>&, unsigned long&&) at /mnt/disk1/root/projects/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gn
u/11/../../../../include/c++/11/bits/invoke.h:61
17# std::enable_if<is_invocable_r_v<doris::Status, std::_Bind_result<doris::Status, doris::Status (doris::vectorized::VAnalyticEvalNode::*(doris::vectorized::VAnalyticEvalN
ode*, std::Placeholder<1>))(unsigned long)>&, unsigned long>, doris::Status>::type std::_invoke_r<doris::Status, std::_Bind_result<doris::Status, doris::Status (doris::ve
ctorized::VAnalyticEvalNode::(doris::vectorized::VAnalyticEvalNode, std::_Placeholder<1>))(unsigned long)>&, unsigned long>(std::_Bind_result<doris::Status, doris::Status
(doris::vectorized::VAnalyticEvalNode::(doris::vectorized::VAnalyticEvalNode, std::_Placeholder<1>))(unsigned long)>&, unsigned long&&) at /mnt/disk1/root/projects/ld
b_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:114
18# std::_Function_handler<doris::Status (unsigned long), std::_Bind_result<doris::Status, doris::Status (doris::vectorized::VAnalyticEvalNode::*(doris::vectorized::VAnalyt
icEvalNode*, std::_Placeholder<1>))(unsigned long)> >::_M_invoke(std::_Any_data const&, unsigned long&&) at /mnt/disk1/root/projects/ldb_toolchain/bin/../lib/gcc/x86_64-
linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291
19# std::function<doris::Status (unsigned long)>::operator()(unsigned long) const at /mnt/disk1/root/projects/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../.
./include/c++/11/bits/std_function.h:560
20# doris::vectorized::VAnalyticEvalNode::get_next(doris::RuntimeState*, doris::vectorized::Block*, bool*) at /mnt/disk1/root/projects/doris/be/src/vec/exec/vanalytic_ev
al_node.cpp:321
21# doris::Status std::__invoke_impl<doris::Status, doris::Status (doris::ExecNode::&)(doris::RuntimeState, doris::vectorized::Block*, bool*), doris::ExecNode*&, doris::R
untimeState*, doris::vectorized::Block*, bool*>(std::__invoke_memfun_deref, doris::Status (doris::ExecNode::&)(doris::RuntimeState, doris::vectorized::Block*, bool*), dor
is::ExecNode*&, doris::RuntimeState*&&, doris::vectorized::Block*&&, bool*&&) at /mnt/disk1/root/projects/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../in
clude/c++/11/bits/invoke.h:74
22# std::__invoke_result<doris::Status (doris::ExecNode::&)(doris::RuntimeState, doris::vectorized::Block*, bool*), doris::ExecNode*&, doris::RuntimeState*, doris::vector
ized::Block*, bool*>::type std::__invoke<doris::Status (doris::ExecNode::&)(doris::RuntimeState, doris::vectorized::Block*, bool*), doris::ExecNode*&, doris::RuntimeState
, doris::vectorized::Block, bool*>(doris::Status (doris::ExecNode::&)(doris::RuntimeState, doris::vectorized::Block*, bool*), doris::ExecNode*&, doris::RuntimeState*&&,
doris::vectorized::Block*&&, bool*&&) at /mnt/disk1/root/projects/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:96
23# doris::Status std::_Bind<doris::Status (doris::ExecNode::(doris::ExecNode, std::_Placeholder<1>, std::_Placeholder<2>, std::_Placeholder<3>))(doris::RuntimeState*, do
ris::vectorized::Block*, bool*)>::__call<doris::Status, doris::RuntimeState*&&, doris::vectorized::Block*&&, bool*&&, 0ul, 1ul, 2ul, 3ul>(std::tuple<doris::RuntimeState*&&,
doris::vectorized::Block*&&, bool*&&>&&, std::_Index_tuple<0ul, 1ul, 2ul, 3ul>) at /mnt/disk1/root/projects/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../..
/include/c++/11/functional:420
24# doris::Status std::_Bind<doris::Status (doris::ExecNode::(doris::ExecNode, std::_Placeholder<1>, std::_Placeholder<2>, std::_Placeholder<3>))(doris::RuntimeState*, do
ris::vectorized::Block*, bool*)>::operator()<doris::RuntimeState*, doris::vectorized::Block*, bool*, doris::Status>(doris::RuntimeState*&&, doris::vectorized::Block*&&, boo
l*&&) at /mnt/disk1/root/projects/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/functional:503
25# doris::Status std::__invoke_impl<doris::Status, std::_Bind<doris::Status (doris::ExecNode::(doris::ExecNode, std::_Placeholder<1>, std::_Placeholder<2>, std::_Placeho
lder<3>))(doris::RuntimeState*, doris::vectorized::Block*, bool*)>&, doris::RuntimeState*, doris::vectorized::Block*, bool*>(std::__invoke_other, std::_Bind<doris::Status (
doris::ExecNode::(doris::ExecNode, std::_Placeholder<1>, std::_Placeholder<2>, std::_Placeholder<3>))(doris::RuntimeState*, doris::vectorized::Block*, bool*)>&, doris::Ru
ntimeState*&&, doris::vectorized::Block*&&, bool*&&) at /mnt/disk1/root/projects/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.
h:61
26# std::enable_if<is_invocable_r_v<doris::Status, std::_Bind<doris::Status (doris::ExecNode::(doris::ExecNode, std::_Placeholder<1>, std::_Placeholder<2>, std::_Placehol
der<3>))(doris::RuntimeState*, doris::vectorized::Block*, bool*)>&, doris::RuntimeState*, doris::vectorized::Block*, bool*>, doris::Status>::type std::__invoke_r<doris::Sta
tus, std::_Bind<doris::Status (doris::ExecNode::(doris::ExecNode, std::_Placeholder<1>, std::_Placeholder<2>, std::_Placeholder<3>))(doris::RuntimeState*, doris::vectoriz
ed::Block*, bool*)>&, doris::RuntimeState*, doris::vectorized::Block*, bool*>(std::_Bind<doris::Status (doris::ExecNode::(doris::ExecNode, std::_Placeholder<1>, std::_Pla
ceholder<2>, std::_Placeholder<3>))(doris::RuntimeState*, doris::vectorized::Block*, bool*)>&, doris::RuntimeState*&&, doris::vectorized::Block*&&, bool*&&) at /mnt/disk1/y
uejing/projects/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:114
27# std::_Function_handler<doris::Status (doris::RuntimeState*, doris::vectorized::Block*, bool*), std::_Bind<doris::Status (doris::ExecNode::(doris::ExecNode, std::_Plac
eholder<1>, std::_Placeholder<2>, std::_Placeholder<3>))(doris::RuntimeState*, doris::vectorized::Block*, bool*)> >::_M_invoke(std::_Any_data const&, doris::RuntimeState*&&
, doris::vectorized::Block*&&, bool*&&) at /mnt/disk1/root/projects/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291
28# std::function<doris::Status (doris::RuntimeState*, doris::vectorized::Block*, bool*)>::operator()(doris::RuntimeState*, doris::vectorized::Block*, bool*) const at /mnt/
disk1/root/projects/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:560
29# doris::ExecNode::get_next_after_projects(doris::RuntimeState*, doris::vectorized::Block*, bool*, std::function<doris::Status (doris::RuntimeState*, doris::vectorized::B
lock*, bool*)> const&) in /mnt/disk1/root/projects/doris/output/be/lib/doris_be
30# doris::PlanFragmentExecutor::get_vectorized_internal(doris::vectorized::Block*, bool*) at /mnt/disk1/root/projects/doris/be/src/runtime/plan_fragment_executor.cpp:33
2
31# doris::PlanFragmentExecutor::open_vectorized_internal() at /mnt/disk1/root/projects/doris/be/src/runtime/plan_fragment_executor.cpp:287
32# doris::PlanFragmentExecutor::open() at /mnt/disk1/root/projects/doris/be/src/runtime/plan_fragment_executor.cpp:241
33# doris::FragmentExecState::execute() at /mnt/disk1/root/projects/doris/be/src/runtime/fragment_mgr.cpp:250
34# doris::FragmentMgr::_exec_actual(std::shared_ptr<doris::FragmentExecState>, std::function<void (doris::RuntimeState*, doris::Status*)>) at /mnt/disk1/root/projects/d
oris/be/src/runtime/fragment_mgr.cpp:490
35# doris::FragmentMgr::exec_plan_fragment(doris::TExecPlanFragmentParams const&, std::function<void (doris::RuntimeState*, doris::Status*)>)::$_3::operator()() const at /m
nt/disk1/root/projects/doris/be/src/runtime/fragment_mgr.cpp:746
36# void std::__invoke_impl<void, doris::FragmentMgr::exec_plan_fragment(doris::TExecPlanFragmentParams const&, std::function<void (doris::RuntimeState*, doris::Status*)>):
:$3&>(std::_invoke_other, doris::FragmentMgr::exec_plan_fragment(doris::TExecPlanFragmentParams const&, std::function<void (doris::RuntimeState*, doris::Status*)>)::$_3&)
at /mnt/disk1/root/projects/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61
37# std::enable_if<is_invocable_r_v<void, doris::FragmentMgr::exec_plan_fragment(doris::TExecPlanFragmentParams const&, std::function<void (doris::RuntimeState*, doris::Sta
tus*)>)::$3&>, void>::type std::_invoke_r<void, doris::FragmentMgr::exec_plan_fragment(doris::TExecPlanFragmentParams const&, std::function<void (doris::RuntimeState*, do
ris::Status*)>)::$_3&>(doris::FragmentMgr::exec_plan_fragment(doris::TExecPlanFragmentParams const&, std::function<void (doris::RuntimeState*, doris::Status*)>)::$_3&) at /
mnt/disk1/root/projects/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:117
38# std::_Function_handler<void (), doris::FragmentMgr::exec_plan_fragment(doris::TExecPlanFragmentParams const&, std::function<void (doris::RuntimeState*, doris::Status*)>
)::$_3>::_M_invoke(std::_Any_data const&) at /mnt/disk1/root/projects/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291
39# std::function<void ()>::operator()() const at /mnt/disk1/root/projects/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.
h:560
40# doris::FunctionRunnable::run() at /mnt/disk1/root/projects/doris/be/src/util/threadpool.cpp:46
41# doris::ThreadPool::dispatch_thread() at /mnt/disk1/root/projects/doris/be/src/util/threadpool.cpp:535
42# void std::_invoke_impl<void, void (doris::ThreadPool::&)(), doris::ThreadPool&>(std::_invoke_memfun_deref, void (doris::ThreadPool::&)(), doris::ThreadPool&) at /
mnt/disk1/root/projects/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:74
43# std::_invoke_result<void (doris::ThreadPool::&)(), doris::ThreadPool&>::type std::_invoke<void (doris::ThreadPool::&)(), doris::ThreadPool&>(void (doris::ThreadPo
ol::&)(), doris::ThreadPool&) at /mnt/disk1/root/projects/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:96
44# void std::Bind<void (doris::ThreadPool::(doris::ThreadPool))()>::_call<void, , 0ul>(std::tuple<>&&, std::_Index_tuple<0ul>) at /mnt/disk1/root/projects/ldb_toolc
hain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/functional:420
45# void std::_Bind<void (doris::ThreadPool::(doris::ThreadPool))()>::operator()<, void>() at /mnt/disk1/root/projects/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11
/../../../../include/c++/11/functional:503
46# void std::_invoke_impl<void, std::_Bind<void (doris::ThreadPool::(doris::ThreadPool))()>&>(std::_invoke_other, std::_Bind<void (doris::ThreadPool::*(doris::ThreadPo
ol*))()>&) at /mnt/disk1/root/projects/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61
47# std::enable_if<is_invocable_r_v<void, std::Bind<void (doris::ThreadPool::(doris::ThreadPool))()>&>, void>::type std::_invoke_r<void, std::_Bind<void (doris::ThreadP
ool::(doris::ThreadPool))()>&>(std::_Bind<void (doris::ThreadPool::(doris::ThreadPool))()>&) at /mnt/disk1/root/projects/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gn
u/11/../../../../include/c++/11/bits/invoke.h:117
48# std::_Function_handler<void (), std::_Bind<void (doris::ThreadPool::(doris::ThreadPool))()> >::_M_invoke(std::_Any_data const&) at /mnt/disk1/root/projects/ldb_too
lchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291
49# std::function<void ()>::operator()() const at /mnt/disk1/root/projects/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.
h:560
50# doris::Thread::supervise_thread(void*) at /mnt/disk1/root/projects/doris/be/src/util/thread.cpp:453
51# start_thread in /lib64/libpthread.so.0
52# _GI__clone in /lib64/libc.so.6
```

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

