### PR TITLE
[fix](auth)(meta) fix auto info missing when upgrading from 1.1 to 1.2

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/UserPrivTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/UserPrivTable.java
@@ -47,21 +47,18 @@ public class UserPrivTable extends PrivTable {
                     && !globalPrivEntry.match(UserIdentity.ADMIN, true)
                     && !globalPrivEntry.privSet.isEmpty()) {
                 try {
-                    // USAGE_PRIV is no need to degrade.
-                    PrivBitSet removeUsagePriv = globalPrivEntry.privSet.copy();
-                    removeUsagePriv.unset(Privilege.USAGE_PRIV.getIdx());
-                    removeUsagePriv.unset(Privilege.NODE_PRIV.getIdx());
+                    // USAGE_PRIV, NODE_PRIV and ADMIN_PRIV are no need to degrade.
+                    PrivBitSet privsAfterRemoved = globalPrivEntry.privSet.copy();
+                    privsAfterRemoved.unset(Privilege.USAGE_PRIV.getIdx());
+                    privsAfterRemoved.unset(Privilege.NODE_PRIV.getIdx());
+                    privsAfterRemoved.unset(Privilege.ADMIN_PRIV.getIdx());
                     CatalogPrivEntry entry = CatalogPrivEntry.create(globalPrivEntry.origUser, globalPrivEntry.origHost,
-                            InternalCatalog.INTERNAL_CATALOG_NAME, globalPrivEntry.isDomain, removeUsagePriv);
+                            InternalCatalog.INTERNAL_CATALOG_NAME, globalPrivEntry.isDomain, privsAfterRemoved);
                     entry.setSetByDomainResolver(false);
                     catalogPrivTable.addEntry(entry, false, false);
-                    if (globalPrivEntry.privSet.containsResourcePriv()) {
-                        // Should only keep the USAGE_PRIV in userPrivTable, and remove other privs and entries.
-                        globalPrivEntry.privSet.and(PrivBitSet.of(Privilege.USAGE_PRIV));
-                    } else {
-                        // Remove all other privs
-                        globalPrivEntry.privSet.clean();
-                    }
+                    // only keep USAGE_PRIV, NODE_PRIV and ADMIN_PRIV in global entry, if they exist before.
+                    globalPrivEntry.privSet.and(
+                            PrivBitSet.of(Privilege.USAGE_PRIV, Privilege.NODE_PRIV, Privilege.ADMIN_PRIV));
                 } catch (Exception e) {
                     throw new IOException(e.getMessage());
                 }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

When upgrading from 1.1.x to 1.2.x, the ADMIN_PRIV of normal user maybe missing.
This PR fix it

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

