### PR TITLE
[bugfix](exchange node) should not depend on eos to judge the ending of stream receiver

### DIFF
--- a/be/src/vec/exec/vexchange_node.cpp
+++ b/be/src/vec/exec/vexchange_node.cpp
@@ -125,7 +125,9 @@ Status VExchangeNode::get_next(RuntimeState* state, Block* block, bool* eos) {
         block->clear();
     }
     auto status = _stream_recvr->get_next(block, eos);
-    if (!*eos) {
+    // In vsortrunmerger, it will set eos=true, and block not empty
+    // so that eos==true, could not make sure that block not have valid data
+    if (!*eos || block->rows() > 0) {
         if (!_is_merging) {
             if (_num_rows_skipped + block->rows() < _offset) {
                 _num_rows_skipped += block->rows();


### PR DESCRIPTION


# Proposed changes

This bug is introduced by https://github.com/apache/doris/pull/16412.

It will not cause data error. but profile is wrong.
![image](https://user-images.githubusercontent.com/9208457/218023955-e1de7e3b-aaab-49eb-9496-315e082c29d7.png)

If the block is the last block meet limit, eos == true, but the block is not empty. And the block is not added to profile.

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

