### PR TITLE
[fix](planner)fix bug for missing slot

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/planner/AnalyticPlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/AnalyticPlanner.java
@@ -682,10 +682,43 @@ public class AnalyticPlanner {
         List<WindowGroup> groups = Lists.newArrayList();
         for (int i = 0; i < analyticExprs.size(); ++i) {
             AnalyticExpr analyticExpr = (AnalyticExpr) analyticExprs.get(i);
-            // Do not generate the plan for non-materialized analytic exprs.
-            if (!analyticInfo.getOutputTupleDesc().getSlots().get(i).isMaterialized()) {
-                continue;
-            }
+            /*
+            TODO: re-design rule for count(*)
+            In previous version, if the output slot of analyticExpr is not materialized, the analyticExpr is pruned.
+            But there are some cases that it cannot be pruned.
+            For example:
+                    SELECT
+                        count(*)
+                    FROM T1,
+                        (SELECT dd
+                        FROM (
+                            SELECT
+                                1.1 as cc,
+                                ROW_NUMBER() OVER() as dd
+                            FROM T2
+                            ) V1
+                        ORDER BY cc DESC
+                        limit 1
+                        ) V2;
+             analyticExpr(ROW_NUMBER() OVER() as dd) is not materialized, but we have to generate
+             WindowGroup for it.
+             tmp.dd is used by upper count(*), we have to generate data for tmp.dd
+
+             In order to prune 'ROW_NUMBER() OVER() as dd', we need to rethink the rule of choosing a column
+             for count(*). (refer to SingleNodePlanner.materializeTableResultForCrossJoinOrCountStar)
+             V2 can be transformed to
+                        SELECT cc
+                        FROM (
+                            SELECT
+                                1.1 as cc,
+                                ROW_NUMBER() OVER() as dd
+                            FROM T2
+                            ) V1
+                        ORDER BY cc DESC
+                        limit 1
+                        ) V2;
+             Except the byte size of cc and dd, we need to consider the cost to generate cc and dd.
+             */
             boolean match = false;
             for (WindowGroup group : groups) {
                 if (group.isCompatible(analyticExpr)) {

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/SingleNodePlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/SingleNodePlanner.java
@@ -1190,25 +1190,26 @@ public class SingleNodePlanner {
             root = createCheapestJoinPlan(analyzer, refPlans);
             Preconditions.checkState(root != null);
         } else {
+            // create left-deep sequence of binary hash joins; assign node ids as we go along
+            TableRef tblRef = selectStmt.getTableRefs().get(0);
+            materializeTableResultForCrossJoinOrCountStar(tblRef, analyzer);
             if (selectStmt.getSelectList().getItems().size() == 1) {
                 final List<SlotId> slotIds = Lists.newArrayList();
                 final List<TupleId> tupleIds = Lists.newArrayList();
                 Expr resultExprSelected = selectStmt.getSelectList().getItems().get(0).getExpr();
-
-                resultExprSelected.getIds(tupleIds, slotIds);
-                for (SlotId id : slotIds) {
-                    final SlotDescriptor slot = analyzer.getDescTbl().getSlotDesc(id);
-                    slot.setIsMaterialized(true);
-                    slot.materializeSrcExpr();
-                }
-                for (TupleId id : tupleIds) {
-                    final TupleDescriptor tuple = analyzer.getDescTbl().getTupleDesc(id);
-                    tuple.setIsMaterialized(true);
+                if (resultExprSelected != null && resultExprSelected instanceof SlotRef) {
+                    resultExprSelected.getIds(tupleIds, slotIds);
+                    for (SlotId id : slotIds) {
+                        final SlotDescriptor slot = analyzer.getDescTbl().getSlotDesc(id);
+                        slot.setIsMaterialized(true);
+                        slot.materializeSrcExpr();
+                    }
+                    for (TupleId id : tupleIds) {
+                        final TupleDescriptor tuple = analyzer.getDescTbl().getTupleDesc(id);
+                        tuple.setIsMaterialized(true);
+                    }
                 }
             }
-            // create left-deep sequence of binary hash joins; assign node ids as we go along
-            TableRef tblRef = selectStmt.getTableRefs().get(0);
-            materializeTableResultForCrossJoinOrCountStar(tblRef, analyzer);
             root = createTableRefNode(analyzer, tblRef, selectStmt);
             // to change the inner contains analytic function
             // selectStmt.seondSubstituteInlineViewExprs(analyzer.getChangeResSmap());


### PR DESCRIPTION
# Proposed changes
In previous version, if the output slot of analyticExpr is not materialized, the analyticExpr is pruned.
But there are some cases that it cannot be pruned.
For example:

                   SELECT
                        count(*)
                    FROM T1,
                        (SELECT dd
                        FROM (
                            SELECT
                                1.1 as cc,
                                ROW_NUMBER() OVER() as dd
                            FROM T2
                            ) V1
                        ORDER BY cc DESC
                        limit 1
                        ) V2;


 analyticExpr(ROW_NUMBER() OVER() as dd) is not materialized, but we have to generate
 WindowGroup for it.
 tmp.dd is used by upper count(*), we have to generate data for tmp.dd

In this fix, if an inline view only output one column(in this example, the 'dd'), we materialize this column.

TODO:
 In order to prune 'ROW_NUMBER() OVER() as dd', we need to rethink the rule of choosing a column
 for count(*). (refer to SingleNodePlanner.materializeTableResultForCrossJoinOrCountStar)
 V2 can be transformed to
                        

       SELECT cc
        FROM (
            SELECT
                1.1 as cc,
                ROW_NUMBER() OVER() as dd
            FROM T2
            ) V1
        ORDER BY cc DESC
        limit 1
        ) V2;
Except the byte size of cc and dd, we need to consider the cost to generate cc and dd.



Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

