### PR TITLE
[fix](engine_clone_task) disable compact when tablet version discontinuous to avoid engine clone task failure

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -276,6 +276,8 @@ CONF_Bool(enable_low_cardinality_optimize, "true");
 CONF_mBool(enable_compaction_checksum, "false");
 // whether disable automatic compaction task
 CONF_mBool(disable_auto_compaction, "false");
+// when tablet versions are discontinuous, keep the latest `(this ratio) * max_tablet_version_num` rowsets
+CONF_mDouble(compact_keep_latest_rowset_num_ratio_when_version_incomplete, "0.4");
 // whether enable vertical compaction
 CONF_mBool(enable_vertical_compaction, "true");
 // whether enable ordered data compaction

--- a/be/src/olap/tablet.h
+++ b/be/src/olap/tablet.h
@@ -190,6 +190,7 @@ public:
     void calc_missed_versions(int64_t spec_version, std::vector<Version>* missed_versions);
     void calc_missed_versions_unlocked(int64_t spec_version,
                                        std::vector<Version>* missed_versions) const;
+    bool check_version_continuous_unlocked() const;
 
     // This function to find max continuous version from the beginning.
     // For example: If there are 1, 2, 3, 5, 6, 7 versions belongs tablet, then 3 is target.


### PR DESCRIPTION
[fix](engine_clone_task) disable compact when tablet version discontinuous to avoid engine clone task failure

Fix the Error case：
1. if a version incomplete tablet's local version: 0-10, 12-12 (missed version 11-11)
2. engine_clone task starts to snapshot and download from src be, the cloned version is 0-12, 13-13
3. During download, local be accept data write and triggered compaction, now the local version is 0-10, 12-15
4. after clone download finished, local version 12-15 report error: version cross src latest(max cloned version 13) the engine clone task failed

To solve this, we diable compact when tablet version exist holes
1. after clone download finished：
   local version  :        0-10, 12-12, 13-13, 14-14, 15-15
   cloned version :        0-12, 13-13
2. local repaired result:  0-12, 13-13, 14-14, 15-15

For more details and logs：https://github.com/apache/doris/issues/16424

# Proposed changes

Issue Number: close #16424

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [x] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

