### PR TITLE
[fix](nereids)make slot binding compatible to original planner

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/BindExpression.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/BindExpression.java
@@ -583,6 +583,7 @@ public class BindExpression implements AnalysisRuleFactory {
     private <E extends Expression> E bindSlot(E expr, List<Plan> inputs, CascadesContext cascadesContext) {
         return bindSlot(expr, inputs, cascadesContext, true);
     }
+
     @SuppressWarnings("unchecked")
     private <E extends Expression> E bindFunction(E expr, CascadesContext cascadesContext) {
         return (E) FunctionBinder.INSTANCE.bind(expr, cascadesContext);

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/BindExpression.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/BindExpression.java
@@ -414,8 +414,8 @@ public class BindExpression implements AnalysisRuleFactory {
                     Plan childPlan = having.child();
                     Set<Expression> boundConjuncts = having.getConjuncts().stream()
                             .map(expr -> {
-                                expr = bindSlot(expr, childPlan.children(), ctx.cascadesContext);
-                                return bindSlot(expr, childPlan, ctx.cascadesContext);
+                                expr = bindSlot(expr, childPlan.children(), ctx.cascadesContext, false);
+                                return bindSlot(expr, childPlan, ctx.cascadesContext, false);
                             })
                             .map(expr -> bindFunction(expr, ctx.cascadesContext))
                             .collect(Collectors.toSet());
@@ -428,8 +428,8 @@ public class BindExpression implements AnalysisRuleFactory {
                     Plan childPlan = having.child();
                     Set<Expression> boundConjuncts = having.getConjuncts().stream()
                             .map(expr -> {
-                                expr = bindSlot(expr, childPlan, ctx.cascadesContext);
-                                return bindSlot(expr, childPlan.children(), ctx.cascadesContext);
+                                expr = bindSlot(expr, childPlan, ctx.cascadesContext, false);
+                                return bindSlot(expr, childPlan.children(), ctx.cascadesContext, false);
                             })
                             .map(expr -> bindFunction(expr, ctx.cascadesContext))
                             .collect(Collectors.toSet());
@@ -560,26 +560,29 @@ public class BindExpression implements AnalysisRuleFactory {
             .collect(Collectors.toList());
     }
 
-    private <E extends Expression> Set<E> bindSlot(
-            Set<E> exprList, List<Plan> inputs, CascadesContext cascadesContext) {
-        return exprList.stream()
-                .map(expr -> bindSlot(expr, inputs, cascadesContext))
-                .collect(Collectors.toSet());
+    @SuppressWarnings("unchecked")
+    private <E extends Expression> E bindSlot(E expr, Plan input, CascadesContext cascadesContext) {
+        return bindSlot(expr, input, cascadesContext, true);
+    }
+
+    private <E extends Expression> E bindSlot(E expr, Plan input, CascadesContext cascadesContext,
+            boolean enableExactMatch) {
+        return (E) new SlotBinder(toScope(input.getOutput()), cascadesContext, enableExactMatch).bind(expr);
     }
 
     @SuppressWarnings("unchecked")
-    private <E extends Expression> E bindSlot(E expr, Plan input, CascadesContext cascadesContext) {
-        return (E) new SlotBinder(toScope(input.getOutput()), cascadesContext).bind(expr);
+    private <E extends Expression> E bindSlot(E expr, List<Plan> inputs, CascadesContext cascadesContext,
+            boolean enableExactMatch) {
+        List<Slot> boundedSlots = inputs.stream()
+                .flatMap(input -> input.getOutput().stream())
+                .collect(Collectors.toList());
+        return (E) new SlotBinder(toScope(boundedSlots), cascadesContext, enableExactMatch).bind(expr);
     }
 
     @SuppressWarnings("unchecked")
     private <E extends Expression> E bindSlot(E expr, List<Plan> inputs, CascadesContext cascadesContext) {
-        List<Slot> boundedSlots = inputs.stream()
-                .flatMap(input -> input.getOutput().stream())
-                .collect(Collectors.toList());
-        return (E) new SlotBinder(toScope(boundedSlots), cascadesContext).bind(expr);
+        return bindSlot(expr, inputs, cascadesContext, true);
     }
-
     @SuppressWarnings("unchecked")
     private <E extends Expression> E bindFunction(E expr, CascadesContext cascadesContext) {
         return (E) FunctionBinder.INSTANCE.bind(expr, cascadesContext);

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/SlotBinder.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/SlotBinder.java
@@ -37,9 +37,24 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 class SlotBinder extends SubExprAnalyzer {
-
+    /*
+    bounded={table.a, a}
+    unbound=a
+    if enableExactMatch, 'a' is bound to bounded 'a',
+    if not enableExactMatch, 'a' is ambiguous
+    in order to be compatible to original planner,
+    exact match mode is not enabled for having clause
+    but enabled for order by clause
+    TODO after remove original planner, always enable exact match mode.
+     */
+    private boolean enableExactMatch = true;
     public SlotBinder(Scope scope, CascadesContext cascadesContext) {
+        this(scope, cascadesContext, true);
+    }
+
+    public SlotBinder(Scope scope, CascadesContext cascadesContext, boolean enableExactMatch) {
         super(scope, cascadesContext);
+        this.enableExactMatch = enableExactMatch;
     }
 
     public Expression bind(Expression expression) {
@@ -84,21 +99,23 @@ class SlotBinder extends SubExprAnalyzer {
                 }
                 return bounded.get(0);
             default:
-                // select t1.k k, t2.k
-                // from t1 join t2 order by k
-                //
-                // 't1.k k' is denoted by alias_k, its full name is 'k'
-                // 'order by k' is denoted as order_k, it full name is 'k'
-                // 't2.k' in select list, its full name is 't2.k'
-                //
-                // order_k can be bound on alias_k and t2.k
-                // alias_k is exactly matched, since its full name is exactly match full name of order_k
-                // t2.k is not exactly matched, since t2.k's full name is larger than order_k
-                List<Slot> exactMatch = bounded.stream()
-                        .filter(bound -> unboundSlot.getNameParts().size() == bound.getQualifier().size() + 1)
-                        .collect(Collectors.toList());
-                if (exactMatch.size() == 1) {
-                    return exactMatch.get(0);
+                if (enableExactMatch) {
+                    // select t1.k k, t2.k
+                    // from t1 join t2 order by k
+                    //
+                    // 't1.k k' is denoted by alias_k, its full name is 'k'
+                    // 'order by k' is denoted as order_k, it full name is 'k'
+                    // 't2.k' in select list, its full name is 't2.k'
+                    //
+                    // order_k can be bound on alias_k and t2.k
+                    // alias_k is exactly matched, since its full name is exactly match full name of order_k
+                    // t2.k is not exactly matched, since t2.k's full name is larger than order_k
+                    List<Slot> exactMatch = bounded.stream()
+                            .filter(bound -> unboundSlot.getNameParts().size() == bound.getQualifier().size() + 1)
+                            .collect(Collectors.toList());
+                    if (exactMatch.size() == 1) {
+                        return exactMatch.get(0);
+                    }
                 }
                 throw new AnalysisException(String.format("%s is ambiguous: %s.",
                         unboundSlot.toSql(),

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/SlotBinder.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/SlotBinder.java
@@ -48,6 +48,7 @@ class SlotBinder extends SubExprAnalyzer {
     TODO after remove original planner, always enable exact match mode.
      */
     private boolean enableExactMatch = true;
+
     public SlotBinder(Scope scope, CascadesContext cascadesContext) {
         this(scope, cascadesContext, true);
     }

--- a/regression-test/suites/nereids_syntax_p0/bind_priority.groovy
+++ b/regression-test/suites/nereids_syntax_p0/bind_priority.groovy
@@ -113,4 +113,9 @@ suite("bind_priority") {
         from bind_priority_tbl join bind_priority_tbl2 on bind_priority_tbl.a=bind_priority_tbl2.a 
         order by b;
         """
+
+    test{
+        sql "SELECT a,2 as a FROM (SELECT '1' as a) b HAVING a=1"
+        exception "Unexpected exception: a is ambiguous: a#0, a#1."
+    }
 }


### PR DESCRIPTION
# Proposed changes
`SELECT a,2 as a FROM (SELECT '1' as a) b HAVING a=1`

in original planner, having clause binding is failed. Make nereids failed too.

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

