### PR TITLE
[Feature-WIP](inverted index) step 1 for supporting range predicate pushing down to inverted index

### DIFF
--- a/be/src/olap/block_column_predicate.cpp
+++ b/be/src/olap/block_column_predicate.cpp
@@ -187,4 +187,11 @@ void AndBlockColumnPredicate::evaluate_vec(vectorized::MutableColumns& block, ui
     }
 }
 
+Status AndBlockColumnPredicate::evaluate(const std::string& column_name,
+                                         InvertedIndexIterator* iterator, uint32_t num_rows,
+                                         roaring::Roaring* bitmap) const {
+    return Status::NotSupported(
+            "Not Implemented evaluate with inverted index, please check the predicate");
+}
+
 } // namespace doris

--- a/be/src/olap/block_column_predicate.h
+++ b/be/src/olap/block_column_predicate.h
@@ -64,6 +64,13 @@ public:
         return true;
     }
     virtual bool can_do_bloom_filter() const { return false; }
+
+    //evaluate predicate on inverted
+    virtual Status evaluate(const std::string& column_name, InvertedIndexIterator* iterator,
+                            uint32_t num_rows, roaring::Roaring* bitmap) const {
+        return Status::NotSupported(
+                "Not Implemented evaluate with inverted index, please check the predicate");
+    }
 };
 
 class SingleColumnBlockPredicate : public BlockColumnPredicate {
@@ -162,6 +169,9 @@ public:
         }
         return true;
     }
+
+    Status evaluate(const std::string& column_name, InvertedIndexIterator* iterator,
+                    uint32_t num_rows, roaring::Roaring* bitmap) const override;
 };
 
 } //namespace doris

--- a/be/src/olap/rowset/segment_v2/segment_iterator.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.cpp
@@ -536,8 +536,9 @@ bool SegmentIterator::_check_apply_by_bitmap_index(ColumnPredicate* pred) {
 }
 
 bool SegmentIterator::_check_apply_by_inverted_index(ColumnPredicate* pred) {
-    bool handle_by_fulltext = _is_handle_predicate_by_fulltext(pred);
     int32_t unique_id = _schema.unique_id(pred->column_id());
+    bool handle_by_fulltext = _is_handle_predicate_by_fulltext(unique_id);
+
     if (_inverted_index_iterators.count(unique_id) < 1 ||
         _inverted_index_iterators[unique_id] == nullptr ||
         (pred->type() != PredicateType::MATCH && handle_by_fulltext) ||
@@ -631,9 +632,7 @@ std::string SegmentIterator::_gen_predicate_result_sign(ColumnPredicateInfo* pre
     return pred_result_sign;
 }
 
-bool SegmentIterator::_is_handle_predicate_by_fulltext(ColumnPredicate* predicate) {
-    auto column_id = predicate->column_id();
-    int32_t unique_id = _schema.unique_id(column_id);
+bool SegmentIterator::_is_handle_predicate_by_fulltext(int32_t unique_id) {
     bool handle_by_fulltext =
             _inverted_index_iterators[unique_id] != nullptr &&
             _inverted_index_iterators[unique_id]->get_inverted_index_reader_type() ==
@@ -642,52 +641,133 @@ bool SegmentIterator::_is_handle_predicate_by_fulltext(ColumnPredicate* predicat
     return handle_by_fulltext;
 }
 
+#define all_predicates_are_range_predicate(predicate_set)   \
+    std::all_of(predicate_set.begin(), predicate_set.end(), \
+                [](const ColumnPredicate* p) { return PredicateTypeTraits::is_range(p->type()); })
+
+Status SegmentIterator::_apply_inverted_index_on_column_predicate(
+        ColumnPredicate* pred, std::vector<ColumnPredicate*>& remaining_predicates,
+        bool* continue_apply) {
+    int32_t unique_id = _schema.unique_id(pred->column_id());
+    bool handle_by_fulltext = _is_handle_predicate_by_fulltext(unique_id);
+
+    if (_inverted_index_iterators.count(unique_id) < 1 ||
+        _inverted_index_iterators[unique_id] == nullptr ||
+        (pred->type() != PredicateType::MATCH && handle_by_fulltext) ||
+        pred->type() == PredicateType::IS_NULL || pred->type() == PredicateType::IS_NOT_NULL ||
+        pred->type() == PredicateType::BF) {
+        // 1. this column no inverted index
+        // 2. equal or range for fulltext index
+        // 3. is_null or is_not_null predicate
+        // 4. bloom filter predicate
+        remaining_predicates.emplace_back(pred);
+    } else {
+        roaring::Roaring bitmap = _row_bitmap;
+        Status res =
+                pred->evaluate(_schema, _inverted_index_iterators[unique_id], num_rows(), &bitmap);
+        if (!res.ok()) {
+            if ((res.code() == ErrorCode::INVERTED_INDEX_FILE_NOT_FOUND &&
+                 pred->type() != PredicateType::MATCH) ||
+                res.code() == ErrorCode::INVERTED_INDEX_FILE_HIT_LIMIT) {
+                //downgrade without index query
+                remaining_predicates.emplace_back(pred);
+                return Status::OK();
+            }
+            LOG(WARNING) << "failed to evaluate index"
+                         << ", column predicate type: " << pred->pred_type_string(pred->type())
+                         << ", error msg: " << res.code_as_string();
+            return res;
+        }
+
+        auto pred_type = pred->type();
+        if (pred_type == PredicateType::MATCH) {
+            std::string pred_result_sign = _gen_predicate_result_sign(pred);
+            _rowid_result_for_index.emplace(
+                    std::make_pair(pred_result_sign, std::make_pair(false, bitmap)));
+        }
+
+        _row_bitmap &= bitmap;
+        if (_row_bitmap.isEmpty()) {
+            // all rows have been pruned, no need to process further predicates
+            *continue_apply = false;
+        }
+    }
+    return Status::OK();
+}
+
+Status SegmentIterator::_apply_inverted_index_on_block_column_predicate(
+        ColumnId column_id, MutilColumnBlockPredicate* pred,
+        std::set<const ColumnPredicate*>& no_need_to_pass_column_predicate_set,
+        bool* continue_apply) {
+    auto unique_id = _schema.unique_id(column_id);
+    bool handle_by_fulltext = _is_handle_predicate_by_fulltext(unique_id);
+    std::set<const ColumnPredicate*> predicate_set {};
+
+    pred->get_all_column_predicate(predicate_set);
+
+    //four requirements here.
+    //1. Column has inverted index
+    //2. There are multiple predicates for this column.
+    //3. All the predicates are range predicate.
+    //4. if it's under fulltext parser type, we need to skip inverted index evaluate.
+    if (_inverted_index_iterators.count(unique_id) > 0 &&
+        _inverted_index_iterators[unique_id] != nullptr && predicate_set.size() > 1 &&
+        all_predicates_are_range_predicate(predicate_set) && !handle_by_fulltext) {
+        roaring::Roaring output_result = _row_bitmap;
+
+        std::string column_name = _schema.column(column_id)->name();
+
+        auto res = pred->evaluate(column_name, _inverted_index_iterators[unique_id], num_rows(),
+                                  &output_result);
+
+        if (res.ok()) {
+            no_need_to_pass_column_predicate_set.insert(predicate_set.begin(), predicate_set.end());
+            _row_bitmap &= output_result;
+            if (_row_bitmap.isEmpty()) {
+                // all rows have been pruned, no need to process further predicates
+                *continue_apply = false;
+            }
+            return res;
+        } else {
+            //TODO:mock until AndBlockColumnPredicate evaluate is ok.
+            if (res.code() == ErrorCode::NOT_IMPLEMENTED_ERROR) {
+                return Status::OK();
+            }
+            LOG(WARNING) << "failed to evaluate index"
+                         << ", column predicate type: range predicate"
+                         << ", error msg: " << res.code_as_string();
+            return res;
+        }
+    }
+    return Status::OK();
+}
+
 Status SegmentIterator::_apply_inverted_index() {
     SCOPED_RAW_TIMER(&_opts.stats->inverted_index_filter_timer);
     size_t input_rows = _row_bitmap.cardinality();
     std::vector<ColumnPredicate*> remaining_predicates;
+    std::set<const ColumnPredicate*> no_need_to_pass_column_predicate_set;
+
+    for (const auto& entry : _opts.col_id_to_predicates) {
+        ColumnId column_id = entry.first;
+        auto pred = entry.second;
+        bool continue_apply = true;
+        RETURN_IF_ERROR(_apply_inverted_index_on_block_column_predicate(
+                column_id, pred.get(), no_need_to_pass_column_predicate_set, &continue_apply));
+        if (!continue_apply) {
+            break;
+        }
+    }
 
     for (auto pred : _col_predicates) {
-        bool handle_by_fulltext = _is_handle_predicate_by_fulltext(pred);
-        int32_t unique_id = _schema.unique_id(pred->column_id());
-        if (_inverted_index_iterators.count(unique_id) < 1 ||
-            _inverted_index_iterators[unique_id] == nullptr ||
-            (pred->type() != PredicateType::MATCH && handle_by_fulltext) ||
-            pred->type() == PredicateType::IS_NULL || pred->type() == PredicateType::IS_NOT_NULL ||
-            pred->type() == PredicateType::BF) {
-            // 1. this column no inverted index
-            // 2. equal or range for fulltext index
-            // 3. is_null or is_not_null predicate
-            // 4. bloom filter predicate
-            remaining_predicates.push_back(pred);
+        if (no_need_to_pass_column_predicate_set.count(pred) > 0) {
+            continue;
         } else {
-            roaring::Roaring bitmap = _row_bitmap;
-            Status res = pred->evaluate(_schema, _inverted_index_iterators[unique_id], num_rows(),
-                                        &bitmap);
-            if (!res.ok()) {
-                if ((res.code() == ErrorCode::INVERTED_INDEX_FILE_NOT_FOUND &&
-                     pred->type() != PredicateType::MATCH) ||
-                    res.code() == ErrorCode::INVERTED_INDEX_FILE_HIT_LIMIT) {
-                    //downgrade without index query
-                    remaining_predicates.push_back(pred);
-                    continue;
-                }
-                LOG(WARNING) << "failed to evaluate index"
-                             << ", column predicate type: " << pred->pred_type_string(pred->type())
-                             << ", error msg: " << res.code_as_string();
-                return res;
-            }
-
-            auto pred_type = pred->type();
-            if (pred_type == PredicateType::MATCH) {
-                std::string pred_result_sign = _gen_predicate_result_sign(pred);
-                _rowid_result_for_index.emplace(
-                        std::make_pair(pred_result_sign, std::make_pair(false, bitmap)));
-            }
-
-            _row_bitmap &= bitmap;
-            if (_row_bitmap.isEmpty()) {
-                break; // all rows have been pruned, no need to process further predicates
+            bool continue_apply = true;
+            RETURN_IF_ERROR(_apply_inverted_index_on_column_predicate(pred, remaining_predicates,
+                                                                      &continue_apply));
+            if (!continue_apply) {
+                break;
             }
         }
     }

--- a/be/src/olap/rowset/segment_v2/segment_iterator.h
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.h
@@ -125,13 +125,19 @@ private:
     Status _get_row_ranges_from_conditions(RowRanges* condition_row_ranges);
     Status _apply_bitmap_index();
     Status _apply_inverted_index();
-
+    Status _apply_inverted_index_on_column_predicate(
+            ColumnPredicate* pred, std::vector<ColumnPredicate*>& remaining_predicates,
+            bool* continue_apply);
+    Status _apply_inverted_index_on_block_column_predicate(
+            ColumnId column_id, MutilColumnBlockPredicate* pred,
+            std::set<const ColumnPredicate*>& no_need_to_pass_column_predicate_set,
+            bool* continue_apply);
     Status _apply_index_except_leafnode_of_andnode();
     Status _apply_bitmap_index_except_leafnode_of_andnode(ColumnPredicate* pred,
                                                           roaring::Roaring* output_result);
     Status _apply_inverted_index_except_leafnode_of_andnode(ColumnPredicate* pred,
                                                             roaring::Roaring* output_result);
-    bool _is_handle_predicate_by_fulltext(ColumnPredicate* predicate);
+    bool _is_handle_predicate_by_fulltext(int32_t unique_id);
     bool _can_filter_by_preds_except_leafnode_of_andnode();
     Status _execute_predicates_except_leafnode_of_andnode(vectorized::VExpr* expr);
     Status _execute_compound_fn(const std::string& function_name);


### PR DESCRIPTION
# Proposed changes

Try to push down range predicate(like a>1 and a<5) to inverted index for better index filter performance.

## Problem summary

Describe your changes.

This is step 1 for "push down range predicate", in this pr, we introduced inverted index iterator evaluate for AndBlockColumnPredicate.

And we use col_id_to_predicates to construct per column predicates, 

We also refact apply_inverted_index in this pr.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

