### PR TITLE
Revert "[Performance] Optimize performance of like expr using strstr()"

### DIFF
--- a/be/src/runtime/string_search.hpp
+++ b/be/src/runtime/string_search.hpp
@@ -41,11 +41,13 @@ public:
             return -1;
         }
 
-        char* occurence = std::strstr(str->ptr, _pattern->ptr);
-        if (occurence == nullptr) {
+        auto it = std::search(str->ptr, str->ptr + str->len,
+                              std::default_searcher(_pattern->ptr, _pattern->ptr + _pattern->len));
+        if (it == str->ptr + str->len) {
             return -1;
+        } else {
+            return it - str->ptr;
         }
-        return occurence - str->ptr;
     }
 
 private:

--- a/be/src/vec/functions/like.cpp
+++ b/be/src/vec/functions/like.cpp
@@ -76,7 +76,7 @@ Status FunctionLikeBase::constant_substring_fn(LikeSearchState* state, const Str
         *result = true;
         return Status::OK();
     }
-    StringValue pattern_value(val.ptr, val.len);
+    StringValue pattern_value = StringValue::from_string_val(val.ptr);
     *result = state->substring_pattern.search(&pattern_value) != -1;
     return Status::OK();
 }


### PR DESCRIPTION
Reverts apache/doris#15168

in our case,  there are one table named `table_A`, having a column `col_1`. It has value "三星" and "红包". 

a sql like 
```
select `col_1` from table_A where ... and `col_1` like '%红包%' ... group by xxx  LEFT JOIN (select `col_1` from table_A where ...  and `col_1` like '%红包%' ... group by xxx）on xxxx = xxxx
```
returns a row that `col_1` == "三星"。


 