### PR TITLE
[Fix](multi-catalog) fix oss access issue with aws s3 sdk

### DIFF
--- a/be/src/io/s3_reader.cpp
+++ b/be/src/io/s3_reader.cpp
@@ -17,6 +17,7 @@
 
 #include "io/s3_reader.h"
 
+#include <aws/core/http/URI.h>
 #include <aws/s3/S3Client.h>
 #include <aws/s3/model/GetObjectRequest.h>
 #include <aws/s3/model/HeadObjectRequest.h>
@@ -45,6 +46,7 @@ S3Reader::S3Reader(const std::map<std::string, std::string>& properties, const s
           _closed(false),
           _client(ClientFactory::instance().create(_properties)) {
     DCHECK(_client) << "init aws s3 client error.";
+    Aws::Http::SetCompliantRfc3986Encoding(true);
 }
 
 S3Reader::~S3Reader() {}

--- a/be/src/io/s3_writer.cpp
+++ b/be/src/io/s3_writer.cpp
@@ -17,6 +17,7 @@
 
 #include "io/s3_writer.h"
 
+#include <aws/core/http/URI.h>
 #include <aws/core/utils/FileSystemUtils.h>
 #include <aws/s3/S3Client.h>
 #include <aws/s3/model/HeadObjectRequest.h>
@@ -52,6 +53,8 @@ S3Writer::S3Writer(const std::map<std::string, std::string>& properties, const s
             tmp_path.c_str(), ".doris_tmp",
             std::ios_base::binary | std::ios_base::trunc | std::ios_base::in | std::ios_base::out);
     DCHECK(_client) << "init aws s3 client error.";
+
+    Aws::Http::SetCompliantRfc3986Encoding(true);
 }
 
 S3Writer::~S3Writer() {

--- a/thirdparty/download-thirdparty.sh
+++ b/thirdparty/download-thirdparty.sh
@@ -377,7 +377,7 @@ echo "Finished patching ${HYPERSCAN_SOURCE}"
 cd "${TP_SOURCE_DIR}/${AWS_SDK_SOURCE}"
 if [[ ! -f "${PATCHED_MARK}" ]]; then
     if [[ "${AWS_SDK_SOURCE}" == "aws-sdk-cpp-1.9.211" ]]; then
-	    patch -p1 <"${TP_PATCH_DIR}/aws-sdk-cpp-1.9.211.patch"
+        patch -p1 <"${TP_PATCH_DIR}/aws-sdk-cpp-1.9.211.patch"
         if wget --no-check-certificate -q https://doris-thirdparty-repo.bj.bcebos.com/thirdparty/aws-crt-cpp-1.9.211.tar.gz -O aws-crt-cpp-1.9.211.tar.gz; then
             tar xzf aws-crt-cpp-1.9.211.tar.gz
         else

--- a/thirdparty/download-thirdparty.sh
+++ b/thirdparty/download-thirdparty.sh
@@ -377,6 +377,7 @@ echo "Finished patching ${HYPERSCAN_SOURCE}"
 cd "${TP_SOURCE_DIR}/${AWS_SDK_SOURCE}"
 if [[ ! -f "${PATCHED_MARK}" ]]; then
     if [[ "${AWS_SDK_SOURCE}" == "aws-sdk-cpp-1.9.211" ]]; then
+	    patch -p1 <"${TP_PATCH_DIR}/aws-sdk-cpp-1.9.211.patch"
         if wget --no-check-certificate -q https://doris-thirdparty-repo.bj.bcebos.com/thirdparty/aws-crt-cpp-1.9.211.tar.gz -O aws-crt-cpp-1.9.211.tar.gz; then
             tar xzf aws-crt-cpp-1.9.211.tar.gz
         else

--- a/thirdparty/patches/aws-sdk-cpp-1.9.211.patch
+++ b/thirdparty/patches/aws-sdk-cpp-1.9.211.patch
@@ -1,0 +1,169 @@
+diff --git a/aws-cpp-sdk-core/include/aws/core/Aws.h b/aws-cpp-sdk-core/include/aws/core/Aws.h
+index 419f5e14f6..dfbbb986a6 100644
+--- a/aws-cpp-sdk-core/include/aws/core/Aws.h
++++ b/aws-cpp-sdk-core/include/aws/core/Aws.h
+@@ -80,7 +80,7 @@ namespace Aws
+      */
+     struct HttpOptions
+     {
+-        HttpOptions() : initAndCleanupCurl(true), installSigPipeHandler(false)
++        HttpOptions() : initAndCleanupCurl(true), installSigPipeHandler(false), compliantRfc3986Encoding(false)
+         { }
+ 
+         /**
+@@ -100,6 +100,10 @@ namespace Aws
+          * NOTE: CURLOPT_NOSIGNAL is already being set.
+          */
+         bool installSigPipeHandler;
++        /**
++         * Disable legacy URL encoding that leaves `$&,:@=` unescaped for legacy purposes.
++         */
++        bool compliantRfc3986Encoding;
+     };
+ 
+     /**
+diff --git a/aws-cpp-sdk-core/include/aws/core/http/URI.h b/aws-cpp-sdk-core/include/aws/core/http/URI.h
+index 4cff72d4a8..b536926cb0 100644
+--- a/aws-cpp-sdk-core/include/aws/core/http/URI.h
++++ b/aws-cpp-sdk-core/include/aws/core/http/URI.h
+@@ -21,6 +21,9 @@ namespace Aws
+         static const uint16_t HTTP_DEFAULT_PORT = 80;
+         static const uint16_t HTTPS_DEFAULT_PORT = 443;
+ 
++        extern bool s_compliantRfc3986Encoding;
++        AWS_CORE_API void SetCompliantRfc3986Encoding(bool compliant);
++
+         //per https://tools.ietf.org/html/rfc3986#section-3.4 there is nothing preventing servers from allowing
+         //multiple values for the same key. So use a multimap instead of a map.
+         typedef Aws::MultiMap<Aws::String, Aws::String> QueryStringParameterCollection;
+diff --git a/aws-cpp-sdk-core/source/Aws.cpp b/aws-cpp-sdk-core/source/Aws.cpp
+index 6049b12264..e9aca9c580 100644
+--- a/aws-cpp-sdk-core/source/Aws.cpp
++++ b/aws-cpp-sdk-core/source/Aws.cpp
+@@ -136,6 +136,7 @@ namespace Aws
+ 
+         Aws::Http::SetInitCleanupCurlFlag(options.httpOptions.initAndCleanupCurl);
+         Aws::Http::SetInstallSigPipeHandlerFlag(options.httpOptions.installSigPipeHandler);
++        Aws::Http::SetCompliantRfc3986Encoding(options.httpOptions.compliantRfc3986Encoding);
+         Aws::Http::InitHttp();
+         Aws::InitializeEnumOverflowContainer();
+         cJSON_AS4CPP_Hooks hooks;
+diff --git a/aws-cpp-sdk-core/source/http/URI.cpp b/aws-cpp-sdk-core/source/http/URI.cpp
+index ce9ec064cb..9dfc10a875 100644
+--- a/aws-cpp-sdk-core/source/http/URI.cpp
++++ b/aws-cpp-sdk-core/source/http/URI.cpp
+@@ -24,6 +24,48 @@ namespace Http
+ 
+ const char* SEPARATOR = "://";
+ 
++bool s_compliantRfc3986Encoding = false;
++void SetCompliantRfc3986Encoding(bool compliant) { s_compliantRfc3986Encoding = compliant; }
++
++Aws::String urlEncodeSegment(const Aws::String& segment)
++{
++    // consolidates legacy escaping logic into one local method
++    if (s_compliantRfc3986Encoding)
++    {
++        return StringUtils::URLEncode(segment.c_str());
++    }
++    else
++    {
++        Aws::StringStream ss;
++        ss << std::hex << std::uppercase;
++        for(unsigned char c : segment) // alnum results in UB if the value of c is not unsigned char & is not EOF
++        {
++            // RFC 3986 §2.3 unreserved characters
++            if (StringUtils::IsAlnum(c))
++            {
++                ss << c;
++                continue;
++            }
++            switch(c)
++            {
++                // §2.3 unreserved characters
++                // The path section of the URL allows unreserved characters to appear unescaped
++                case '-': case '_': case '.': case '~':
++                // RFC 3986 §2.2 Reserved characters
++                // NOTE: this implementation does not accurately implement the RFC on purpose to accommodate for
++                // discrepancies in the implementations of URL encoding between AWS services for legacy reasons.
++                case '$': case '&': case ',':
++                case ':': case '=': case '@':
++                    ss << c;
++                    break;
++                default:
++                    ss << '%' << std::setfill('0') << std::setw(2) << (int)c << std::setw(0);
++            }
++        }
++        return ss.str();
++    }
++}
++
+ } // namespace Http
+ } // namespace Aws
+ 
+@@ -113,31 +155,7 @@ Aws::String URI::URLEncodePathRFC3986(const Aws::String& path)
+     // escape characters appearing in a URL path according to RFC 3986
+     for (const auto& segment : pathParts)
+     {
+-        ss << '/';
+-        for(unsigned char c : segment) // alnum results in UB if the value of c is not unsigned char & is not EOF
+-        {
+-            // §2.3 unreserved characters
+-            if (StringUtils::IsAlnum(c))
+-            {
+-                ss << c;
+-                continue;
+-            }
+-            switch(c)
+-            {
+-                // §2.3 unreserved characters
+-                case '-': case '_': case '.': case '~':
+-                // The path section of the URL allow reserved characters to appear unescaped
+-                // RFC 3986 §2.2 Reserved characters
+-                // NOTE: this implementation does not accurately implement the RFC on purpose to accommodate for
+-                // discrepancies in the implementations of URL encoding between AWS services for legacy reasons.
+-                case '$': case '&': case ',':
+-                case ':': case '=': case '@':
+-                    ss << c;
+-                    break;
+-                default:
+-                    ss << '%' << std::setfill('0') << std::setw(2) << (int)((unsigned char)c) << std::setw(0);
+-            }
+-        }
++        ss << '/' << urlEncodeSegment(segment);
+     }
+ 
+     //if the last character was also a slash, then add that back here.
+@@ -218,31 +236,7 @@ Aws::String URI::GetURLEncodedPathRFC3986() const
+     // escape characters appearing in a URL path according to RFC 3986
+     for (const auto& segment : m_pathSegments)
+     {
+-        ss << '/';
+-        for(unsigned char c : segment) // alnum results in UB if the value of c is not unsigned char & is not EOF
+-        {
+-            // §2.3 unreserved characters
+-            if (StringUtils::IsAlnum(c))
+-            {
+-                ss << c;
+-                continue;
+-            }
+-            switch(c)
+-            {
+-                // §2.3 unreserved characters
+-                case '-': case '_': case '.': case '~':
+-                // The path section of the URL allow reserved characters to appear unescaped
+-                // RFC 3986 §2.2 Reserved characters
+-                // NOTE: this implementation does not accurately implement the RFC on purpose to accommodate for
+-                // discrepancies in the implementations of URL encoding between AWS services for legacy reasons.
+-                case '$': case '&': case ',':
+-                case ':': case '=': case '@':
+-                    ss << c;
+-                    break;
+-                default:
+-                    ss << '%' << std::setfill('0') << std::setw(2) << (int)((unsigned char)c) << std::setw(0);
+-            }
+-        }
++        ss << '/' << urlEncodeSegment(segment);
+     }
+ 
+     if (m_pathSegments.empty() || m_pathHasTrailingSlash)


### PR DESCRIPTION
# Proposed changes

when access oss with key contains char ($&,:@=`), the aws-sdk-cpp(version:1.9.211) will get "$&,:@=`" unescaped, 
so cause get none when the key contains special char like ($&,:@=`)。 this pr try to fix this with compliantRfc3986Encoding=true,  which is fix in master version of aws-sdk-cpp( https://github.com/aws/aws-sdk-cpp )。
## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [ No] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [ ] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [ ] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

