### PR TITLE
[fix](struct-type) forbid struct-type to be distributed key/aggregation key and add more tests

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/catalog/Type.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/catalog/Type.java
@@ -382,12 +382,13 @@ public abstract class Type {
     // 3. don't support group by
     // 4. don't support index
     public boolean isOnlyMetricType() {
-        return isObjectStored() || isArrayType();
+        return isObjectStored() || isComplexType();
     }
 
     public static final String OnlyMetricTypeErrorMsg =
-            "Doris hll, bitmap and array column must use with specific function, and don't support filter or group by."
-                    + "please run 'help hll' or 'help bitmap' or 'help array' in your mysql client.";
+            "Doris hll, bitmap, array, map, struct column must use with specific function, and don't"
+                    + " support filter or group by. please run 'help hll' or 'help bitmap' or 'help array'"
+                    + " or 'help map' or 'help struct' in your mysql client.";
 
     public boolean isHllType() {
         return isScalarType(PrimitiveType.HLL);
@@ -480,7 +481,7 @@ public abstract class Type {
     }
 
     public boolean isCollectionType() {
-        return isMapType() || isArrayType() || isMultiRowType() || isStructType();
+        return isMapType() || isArrayType() || isMultiRowType();
     }
 
     public boolean isMapType() {

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateTableStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateTableStmt.java
@@ -372,7 +372,7 @@ public class CreateTableStmt extends DdlStmt {
                         if (columnDef.getType().getPrimitiveType() == PrimitiveType.JSONB) {
                             break;
                         }
-                        if (columnDef.getType().isCollectionType()) {
+                        if (columnDef.getType().isComplexType()) {
                             break;
                         }
                         if (columnDef.getType().getPrimitiveType() == PrimitiveType.VARCHAR) {

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/HashDistributionDesc.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/HashDistributionDesc.java
@@ -120,6 +120,12 @@ public class HashDistributionDesc extends DistributionDesc {
                     } else if (column.getType().isArrayType()) {
                         throw new DdlException("Array Type should not be used in distribution column["
                                 + column.getName() + "].");
+                    } else if (column.getType().isMapType()) {
+                        throw new DdlException("Map Type should not be used in distribution column["
+                                + column.getName() + "].");
+                    } else if (column.getType().isStructType()) {
+                        throw new DdlException("Struct Type should not be used in distribution column["
+                                + column.getName() + "].");
                     } else if (column.getType().isFloatingPointType()) {
                         throw new DdlException("Floating point type should not be used in distribution column["
                                 + column.getName() + "].");

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/analysis/CheckExpressionLegalityTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/analysis/CheckExpressionLegalityTest.java
@@ -65,7 +65,7 @@ public class CheckExpressionLegalityTest implements PatternMatchSupported {
                 ));
 
         ExceptionChecker.expectThrowsWithMsg(AnalysisException.class,
-                "Doris hll, bitmap and array, map, struct column must use with specific function", () ->
+                "Doris hll, bitmap, array, map, struct column must use with specific function", () ->
                         PlanChecker.from(connectContext)
                                 .analyze("select count(distinct id) from (select to_bitmap(1) id) tbl")
                                 .applyBottomUp(new ExpressionRewrite(CheckLegalityAfterRewrite.INSTANCE))

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/analysis/CheckExpressionLegalityTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/analysis/CheckExpressionLegalityTest.java
@@ -65,7 +65,7 @@ public class CheckExpressionLegalityTest implements PatternMatchSupported {
                 ));
 
         ExceptionChecker.expectThrowsWithMsg(AnalysisException.class,
-                "Doris hll, bitmap and array column must use with specific function", () ->
+                "Doris hll, bitmap and array, map, struct column must use with specific function", () ->
                         PlanChecker.from(connectContext)
                                 .analyze("select count(distinct id) from (select to_bitmap(1) id) tbl")
                                 .applyBottomUp(new ExpressionRewrite(CheckLegalityAfterRewrite.INSTANCE))


### PR DESCRIPTION
# Proposed changes

Issue Number: close #16547 
This commits forbid struct and map type to be distributed key/aggregation key.

The sql such as 

```
select distinct stuct_col from struct_table
```

will report an error.

## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [x] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [x] Yes
    - [ ] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [ ] No
    - [x] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

