### PR TITLE
[Improvement](brpc) replace brpc bthread with pthread

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -35,8 +35,10 @@ CONF_Int32(be_port, "9060");
 // port for brpc
 CONF_Int32(brpc_port, "8060");
 
-// the number of bthreads for brpc, the default value is set to 16
-CONF_Int32(brpc_num_threads, "16");
+// the number of bthreads for brpc, the default value is set to 32
+// brpc only for network service send or accept request
+// no more  process any logic 
+CONF_Int32(brpc_num_threads, "32");
 
 // port to brpc server for single replica load
 CONF_Int32(single_replica_load_brpc_port, "8070");
@@ -389,9 +391,10 @@ CONF_mInt64(load_error_log_reserve_hours, "48");
 // be brpc interface is classified into two categories: light and heavy
 // each category has diffrent thread number 
 // threads to handle heavy api interface, such as transmit_data/transmit_block etc
-CONF_Int32(brpc_heavy_work_pool_threads, "240");
+// 
+CONF_Int32(brpc_heavy_work_pool_threads, "192");
 // threads to handle light api interface, such as exec_plan_fragment_prepare/exec_plan_fragment_start
-CONF_Int32(brpc_light_work_pool_threads, "16");
+CONF_Int32(brpc_light_work_pool_threads, "32");
 
 // The maximum amount of data that can be processed by a stream load
 CONF_mInt64(streaming_load_max_mb, "10240");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -37,7 +37,7 @@ CONF_Int32(brpc_port, "8060");
 
 // the number of bthreads for brpc, the default value is set to 32
 // brpc only for network service send or accept request
-// no more  process any logic 
+// no more  process any logic
 CONF_Int32(brpc_num_threads, "32");
 
 // port to brpc server for single replica load
@@ -389,7 +389,7 @@ CONF_Int64(load_data_reserve_hours, "4");
 CONF_mInt64(load_error_log_reserve_hours, "48");
 
 // be brpc interface is classified into two categories: light and heavy
-// each category has diffrent thread number 
+// each category has diffrent thread number
 // threads to handle heavy api interface, such as transmit_data/transmit_block etc
 CONF_Int32(brpc_heavy_work_pool_threads, "192");
 // threads to handle light api interface, such as exec_plan_fragment_prepare/exec_plan_fragment_start

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -35,8 +35,8 @@ CONF_Int32(be_port, "9060");
 // port for brpc
 CONF_Int32(brpc_port, "8060");
 
-// the number of bthreads for brpc, the default value is set to -1, which means the number of bthreads is #cpu-cores
-CONF_Int32(brpc_num_threads, "-1");
+// the number of bthreads for brpc, the default value is set to 16
+CONF_Int32(brpc_num_threads, "16");
 
 // port to brpc server for single replica load
 CONF_Int32(single_replica_load_brpc_port, "8070");
@@ -385,8 +385,13 @@ CONF_Int32(single_replica_load_download_num_workers, "64");
 CONF_Int64(load_data_reserve_hours, "4");
 // log error log will be removed after this time
 CONF_mInt64(load_error_log_reserve_hours, "48");
-CONF_Int32(number_tablet_writer_threads, "16");
-CONF_Int32(number_slave_replica_download_threads, "64");
+
+// be brpc interface is classified into two categories: light and heavy
+// each category has diffrent thread number 
+// threads to handle heavy api interface, such as transmit_data/transmit_block etc
+CONF_Int32(brpc_heavy_work_pool_threads, "240");
+// threads to handle light api interface, such as exec_plan_fragment_prepare/exec_plan_fragment_start
+CONF_Int32(brpc_light_work_pool_threads, "16");
 
 // The maximum amount of data that can be processed by a stream load
 CONF_mInt64(streaming_load_max_mb, "10240");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -391,10 +391,11 @@ CONF_mInt64(load_error_log_reserve_hours, "48");
 // be brpc interface is classified into two categories: light and heavy
 // each category has diffrent thread number 
 // threads to handle heavy api interface, such as transmit_data/transmit_block etc
-// 
 CONF_Int32(brpc_heavy_work_pool_threads, "192");
 // threads to handle light api interface, such as exec_plan_fragment_prepare/exec_plan_fragment_start
 CONF_Int32(brpc_light_work_pool_threads, "32");
+CONF_Int32(brpc_heavy_work_pool_max_queue_size, "10240");
+CONF_Int32(brpc_light_work_pool_max_queue_size, "10240");
 
 // The maximum amount of data that can be processed by a stream load
 CONF_mInt64(streaming_load_max_mb, "10240");

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -418,7 +418,8 @@ void PInternalServiceImpl::fetch_table_schema(google::protobuf::RpcController* c
         case TFileFormatType::FORMAT_CSV_DEFLATE: {
             // file_slots is no use
             std::vector<SlotDescriptor*> file_slots;
-            reader.reset(new vectorized::CsvReader(profile.get(), params, range, file_slots, &io_ctx));
+            reader.reset(
+                    new vectorized::CsvReader(profile.get(), params, range, file_slots, &io_ctx));
             break;
         }
         case TFileFormatType::FORMAT_PARQUET: {
@@ -432,13 +433,13 @@ void PInternalServiceImpl::fetch_table_schema(google::protobuf::RpcController* c
         }
         case TFileFormatType::FORMAT_JSON: {
             std::vector<SlotDescriptor*> file_slots;
-            reader.reset(
-                    new vectorized::NewJsonReader(profile.get(), params, range, file_slots, &io_ctx));
+            reader.reset(new vectorized::NewJsonReader(profile.get(), params, range, file_slots,
+                                                       &io_ctx));
             break;
         }
         default:
             st = Status::InternalError("Not supported file format in fetch table schema: {}",
-                                    params.format_type);
+                                       params.format_type);
             st.to_protobuf(result->mutable_status());
             return;
         }

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -173,7 +173,7 @@ void PInternalServiceImpl::tablet_writer_open(google::protobuf::RpcController* c
                                               PTabletWriterOpenResult* response,
                                               google::protobuf::Closure* done) {
     DorisMetrics::instance()->tablet_writer_open->increment(1);
-    _light_work_pool.offer([this, controller, request, response, done]() {
+    _light_work_pool.offer([this, request, response, done]() {
         VLOG_RPC << "tablet writer open, id=" << request->id()
                  << ", index_id=" << request->index_id() << ", txn_id=" << request->txn_id();
         brpc::ClosureGuard closure_guard(done);
@@ -595,7 +595,7 @@ void PInternalServiceImpl::send_data(google::protobuf::RpcController* controller
                                      const PSendDataRequest* request, PSendDataResult* response,
                                      google::protobuf::Closure* done) {
     DorisMetrics::instance()->send_data->increment(1);
-    _heavy_work_pool.offer([this, controller, request, response, done]() {
+    _heavy_work_pool.offer([this, request, response, done]() {
         brpc::ClosureGuard closure_guard(done);
         TUniqueId fragment_instance_id;
         fragment_instance_id.hi = request->fragment_instance_id().hi();
@@ -621,7 +621,7 @@ void PInternalServiceImpl::commit(google::protobuf::RpcController* controller,
                                   const PCommitRequest* request, PCommitResult* response,
                                   google::protobuf::Closure* done) {
     DorisMetrics::instance()->commit->increment(1);
-    _light_work_pool.offer([this, controller, request, response, done]() {
+    _light_work_pool.offer([this, request, response, done]() {
         brpc::ClosureGuard closure_guard(done);
         TUniqueId fragment_instance_id;
         fragment_instance_id.hi = request->fragment_instance_id().hi();
@@ -642,7 +642,7 @@ void PInternalServiceImpl::rollback(google::protobuf::RpcController* controller,
                                     const PRollbackRequest* request, PRollbackResult* response,
                                     google::protobuf::Closure* done) {
     DorisMetrics::instance()->rollback->increment(1);
-    _light_work_pool.offer([this, controller, request, response, done]() {
+    _light_work_pool.offer([this, request, response, done]() {
         brpc::ClosureGuard closure_guard(done);
         TUniqueId fragment_instance_id;
         fragment_instance_id.hi = request->fragment_instance_id().hi();
@@ -714,7 +714,7 @@ void PInternalServiceImpl::transmit_block_by_http(google::protobuf::RpcControlle
                                                   PTransmitDataResult* response,
                                                   google::protobuf::Closure* done) {
     DorisMetrics::instance()->transmit_block_by_http->increment(1);
-    _heavy_work_pool.offer([this, controller, request, response, done]() {
+    _heavy_work_pool.offer([this, controller, response, done]() {
         PTransmitDataParams* new_request = new PTransmitDataParams();
         google::protobuf::Closure* new_done =
                 new NewHttpClosure<PTransmitDataParams>(new_request, done);
@@ -764,7 +764,7 @@ void PInternalServiceImpl::check_rpc_channel(google::protobuf::RpcController* co
                                              PCheckRPCChannelResponse* response,
                                              google::protobuf::Closure* done) {
     DorisMetrics::instance()->check_rpc_channel->increment(1);
-    _light_work_pool.offer([this, controller, request, response, done]() {
+    _light_work_pool.offer([controller, request, response, done]() {
         brpc::ClosureGuard closure_guard(done);
         response->mutable_status()->set_status_code(0);
         if (request->data().size() != request->size()) {

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -124,13 +124,13 @@ PInternalServiceImpl::PInternalServiceImpl(ExecEnv* exec_env)
                          [this]() { return _light_work_pool.get_active_threads(); });
     
     REGISTER_HOOK_METRIC(heavy_work_pool_max_queue_size,
-                         [this]() { return config::brpc_heavy_work_pool_max_queue_size; });
+                         []() { return config::brpc_heavy_work_pool_max_queue_size; });
     REGISTER_HOOK_METRIC(light_work_pool_max_queue_size,
-                         [this]() { return config::brpc_light_work_pool_max_queue_size; });
+                         []() { return config::brpc_light_work_pool_max_queue_size; });
     REGISTER_HOOK_METRIC(heavy_work_max_threads,
-                         [this]() { return config::brpc_heavy_work_pool_threads; });
+                         []() { return config::brpc_heavy_work_pool_threads; });
     REGISTER_HOOK_METRIC(light_work_max_threads,
-                         [this]() { return config::brpc_light_work_pool_threads; });
+                         []() { return config::brpc_light_work_pool_threads; });
     CHECK_EQ(0, bthread_key_create(&btls_key, thread_context_deleter));
     CHECK_EQ(0, bthread_key_create(&AsyncIO::btls_io_ctx_key, AsyncIO::io_ctx_key_deleter));
 }

--- a/be/src/service/internal_service.h
+++ b/be/src/service/internal_service.h
@@ -191,7 +191,7 @@ private:
 private:
     ExecEnv* _exec_env;
     // every brpc service request should put into thread pool
-    // the reason see issue
+    // the reason see issue #16634
     // define the interface for reading and writing data as heavy interface
     // otherwise as light interface
     PriorityThreadPool _heavy_work_pool;

--- a/be/src/service/internal_service.h
+++ b/be/src/service/internal_service.h
@@ -191,7 +191,7 @@ private:
 private:
     ExecEnv* _exec_env;
     // every brpc service request should put into thread pool
-    // the reason see issue 
+    // the reason see issue
     // define the interface for reading and writing data as heavy interface
     // otherwise as light interface
     PriorityThreadPool _heavy_work_pool;

--- a/be/src/service/internal_service.h
+++ b/be/src/service/internal_service.h
@@ -190,8 +190,12 @@ private:
 
 private:
     ExecEnv* _exec_env;
-    PriorityThreadPool _tablet_worker_pool;
-    PriorityThreadPool _slave_replica_worker_pool;
+    // every brpc service request should put into thread pool
+    // the reason see issue 
+    // define the interface for reading and writing data as heavy interface
+    // otherwise as light interface
+    PriorityThreadPool _heavy_work_pool;
+    PriorityThreadPool _light_work_pool;
 };
 
 } // namespace doris

--- a/be/src/util/doris_metrics.cpp
+++ b/be/src/util/doris_metrics.cpp
@@ -260,7 +260,7 @@ DorisMetrics::DorisMetrics() : _metric_registry(_s_registry_name) {
     INT_COUNTER_METRIC_REGISTER(_server_metric_entity, request_slave_tablet_pull_rowset);
     INT_COUNTER_METRIC_REGISTER(_server_metric_entity, response_slave_tablet_pull_rowset);
     INT_COUNTER_METRIC_REGISTER(_server_metric_entity, multiget_data);
-   
+
     INT_COUNTER_METRIC_REGISTER(_server_metric_entity, fragment_request_duration_us);
     INT_COUNTER_METRIC_REGISTER(_server_metric_entity, query_scan_bytes);
     INT_COUNTER_METRIC_REGISTER(_server_metric_entity, query_scan_rows);

--- a/be/src/util/doris_metrics.cpp
+++ b/be/src/util/doris_metrics.cpp
@@ -37,9 +37,10 @@ DEFINE_COUNTER_METRIC_PROTOTYPE_3ARG(exec_plan_fragment_prepare, MetricUnit::REQ
 DEFINE_COUNTER_METRIC_PROTOTYPE_3ARG(exec_plan_fragment_start, MetricUnit::REQUESTS, "");
 DEFINE_COUNTER_METRIC_PROTOTYPE_3ARG(cancel_plan_fragment, MetricUnit::REQUESTS, "");
 DEFINE_COUNTER_METRIC_PROTOTYPE_3ARG(fetch_data, MetricUnit::REQUESTS, "");
+DEFINE_COUNTER_METRIC_PROTOTYPE_3ARG(fetch_table_schema, MetricUnit::REQUESTS, "");
 DEFINE_COUNTER_METRIC_PROTOTYPE_3ARG(tablet_writer_open, MetricUnit::REQUESTS, "");
-DEFINE_COUNTER_METRIC_PROTOTYPE_3ARG(tablet_writer_add_batch, MetricUnit::REQUESTS, "");
-DEFINE_COUNTER_METRIC_PROTOTYPE_3ARG(tablet_writer_add_batch_by_http, MetricUnit::REQUESTS, "");
+DEFINE_COUNTER_METRIC_PROTOTYPE_3ARG(tablet_writer_add_block, MetricUnit::REQUESTS, "");
+DEFINE_COUNTER_METRIC_PROTOTYPE_3ARG(tablet_writer_add_block_by_http, MetricUnit::REQUESTS, "");
 DEFINE_COUNTER_METRIC_PROTOTYPE_3ARG(tablet_writer_cancel, MetricUnit::REQUESTS, "");
 DEFINE_COUNTER_METRIC_PROTOTYPE_3ARG(get_info, MetricUnit::REQUESTS, "");
 DEFINE_COUNTER_METRIC_PROTOTYPE_3ARG(update_cache, MetricUnit::REQUESTS, "");
@@ -56,11 +57,9 @@ DEFINE_COUNTER_METRIC_PROTOTYPE_3ARG(fold_constant_expr, MetricUnit::REQUESTS, "
 DEFINE_COUNTER_METRIC_PROTOTYPE_3ARG(check_rpc_channel, MetricUnit::REQUESTS, "");
 DEFINE_COUNTER_METRIC_PROTOTYPE_3ARG(reset_rpc_channel, MetricUnit::REQUESTS, "");
 DEFINE_COUNTER_METRIC_PROTOTYPE_3ARG(hand_shake, MetricUnit::REQUESTS, "");
-DEFINE_COUNTER_METRIC_PROTOTYPE_3ARG(response_slave_tablet_pull_rowset, MetricUnit::REQUESTS, "");
 DEFINE_COUNTER_METRIC_PROTOTYPE_3ARG(request_slave_tablet_pull_rowset, MetricUnit::REQUESTS, "");
-DEFINE_COUNTER_METRIC_PROTOTYPE_3ARG(tablet_writer_add_block, MetricUnit::REQUESTS, "");
-DEFINE_COUNTER_METRIC_PROTOTYPE_3ARG(tablet_writer_add_block_by_http, MetricUnit::REQUESTS, "");
-DEFINE_COUNTER_METRIC_PROTOTYPE_3ARG(fetch_table_schema, MetricUnit::REQUESTS, "");
+DEFINE_COUNTER_METRIC_PROTOTYPE_3ARG(response_slave_tablet_pull_rowset, MetricUnit::REQUESTS, "");
+DEFINE_COUNTER_METRIC_PROTOTYPE_3ARG(multiget_data, MetricUnit::REQUESTS, "");
 
 DEFINE_COUNTER_METRIC_PROTOTYPE_2ARG(fragment_request_duration_us, MetricUnit::MICROSECONDS);
 DEFINE_COUNTER_METRIC_PROTOTYPE_2ARG(query_scan_bytes, MetricUnit::BYTES);
@@ -230,6 +229,38 @@ DorisMetrics::DorisMetrics() : _metric_registry(_s_registry_name) {
     _server_metric_entity = _metric_registry.register_entity("server");
 
     INT_COUNTER_METRIC_REGISTER(_server_metric_entity, fragment_requests_total);
+
+    INT_COUNTER_METRIC_REGISTER(_server_metric_entity, transmit_data);
+    INT_COUNTER_METRIC_REGISTER(_server_metric_entity, transmit_data_by_http);
+    INT_COUNTER_METRIC_REGISTER(_server_metric_entity, exec_plan_fragment);
+    INT_COUNTER_METRIC_REGISTER(_server_metric_entity, exec_plan_fragment_prepare);
+    INT_COUNTER_METRIC_REGISTER(_server_metric_entity, exec_plan_fragment_start);
+    INT_COUNTER_METRIC_REGISTER(_server_metric_entity, cancel_plan_fragment);
+    INT_COUNTER_METRIC_REGISTER(_server_metric_entity, fetch_data);
+    INT_COUNTER_METRIC_REGISTER(_server_metric_entity, fetch_table_schema);
+    INT_COUNTER_METRIC_REGISTER(_server_metric_entity, tablet_writer_open);
+    INT_COUNTER_METRIC_REGISTER(_server_metric_entity, tablet_writer_add_block);
+    INT_COUNTER_METRIC_REGISTER(_server_metric_entity, tablet_writer_add_block_by_http);
+    INT_COUNTER_METRIC_REGISTER(_server_metric_entity, tablet_writer_cancel);
+    INT_COUNTER_METRIC_REGISTER(_server_metric_entity, get_info);
+    INT_COUNTER_METRIC_REGISTER(_server_metric_entity, update_cache);
+    INT_COUNTER_METRIC_REGISTER(_server_metric_entity, fetch_cache);
+    INT_COUNTER_METRIC_REGISTER(_server_metric_entity, clear_cache);
+    INT_COUNTER_METRIC_REGISTER(_server_metric_entity, merge_filter);
+    INT_COUNTER_METRIC_REGISTER(_server_metric_entity, apply_filter);
+    INT_COUNTER_METRIC_REGISTER(_server_metric_entity, transmit_block);
+    INT_COUNTER_METRIC_REGISTER(_server_metric_entity, transmit_block_by_http);
+    INT_COUNTER_METRIC_REGISTER(_server_metric_entity, send_data);
+    INT_COUNTER_METRIC_REGISTER(_server_metric_entity, commit);
+    INT_COUNTER_METRIC_REGISTER(_server_metric_entity, rollback);
+    INT_COUNTER_METRIC_REGISTER(_server_metric_entity, fold_constant_expr);
+    INT_COUNTER_METRIC_REGISTER(_server_metric_entity, check_rpc_channel);
+    INT_COUNTER_METRIC_REGISTER(_server_metric_entity, reset_rpc_channel);
+    INT_COUNTER_METRIC_REGISTER(_server_metric_entity, hand_shake);
+    INT_COUNTER_METRIC_REGISTER(_server_metric_entity, request_slave_tablet_pull_rowset);
+    INT_COUNTER_METRIC_REGISTER(_server_metric_entity, response_slave_tablet_pull_rowset);
+    INT_COUNTER_METRIC_REGISTER(_server_metric_entity, multiget_data);
+   
     INT_COUNTER_METRIC_REGISTER(_server_metric_entity, fragment_request_duration_us);
     INT_COUNTER_METRIC_REGISTER(_server_metric_entity, query_scan_bytes);
     INT_COUNTER_METRIC_REGISTER(_server_metric_entity, query_scan_rows);

--- a/be/src/util/doris_metrics.cpp
+++ b/be/src/util/doris_metrics.cpp
@@ -29,6 +29,39 @@ namespace doris {
 
 DEFINE_COUNTER_METRIC_PROTOTYPE_3ARG(fragment_requests_total, MetricUnit::REQUESTS,
                                      "Total fragment requests received.");
+
+DEFINE_COUNTER_METRIC_PROTOTYPE_3ARG(transmit_data, MetricUnit::REQUESTS, "");
+DEFINE_COUNTER_METRIC_PROTOTYPE_3ARG(transmit_data_by_http, MetricUnit::REQUESTS, "");
+DEFINE_COUNTER_METRIC_PROTOTYPE_3ARG(exec_plan_fragment, MetricUnit::REQUESTS, "");
+DEFINE_COUNTER_METRIC_PROTOTYPE_3ARG(exec_plan_fragment_prepare, MetricUnit::REQUESTS, "");
+DEFINE_COUNTER_METRIC_PROTOTYPE_3ARG(exec_plan_fragment_start, MetricUnit::REQUESTS, "");
+DEFINE_COUNTER_METRIC_PROTOTYPE_3ARG(cancel_plan_fragment, MetricUnit::REQUESTS, "");
+DEFINE_COUNTER_METRIC_PROTOTYPE_3ARG(fetch_data, MetricUnit::REQUESTS, "");
+DEFINE_COUNTER_METRIC_PROTOTYPE_3ARG(tablet_writer_open, MetricUnit::REQUESTS, "");
+DEFINE_COUNTER_METRIC_PROTOTYPE_3ARG(tablet_writer_add_batch, MetricUnit::REQUESTS, "");
+DEFINE_COUNTER_METRIC_PROTOTYPE_3ARG(tablet_writer_add_batch_by_http, MetricUnit::REQUESTS, "");
+DEFINE_COUNTER_METRIC_PROTOTYPE_3ARG(tablet_writer_cancel, MetricUnit::REQUESTS, "");
+DEFINE_COUNTER_METRIC_PROTOTYPE_3ARG(get_info, MetricUnit::REQUESTS, "");
+DEFINE_COUNTER_METRIC_PROTOTYPE_3ARG(update_cache, MetricUnit::REQUESTS, "");
+DEFINE_COUNTER_METRIC_PROTOTYPE_3ARG(fetch_cache, MetricUnit::REQUESTS, "");
+DEFINE_COUNTER_METRIC_PROTOTYPE_3ARG(clear_cache, MetricUnit::REQUESTS, "");
+DEFINE_COUNTER_METRIC_PROTOTYPE_3ARG(merge_filter, MetricUnit::REQUESTS, "");
+DEFINE_COUNTER_METRIC_PROTOTYPE_3ARG(apply_filter, MetricUnit::REQUESTS, "");
+DEFINE_COUNTER_METRIC_PROTOTYPE_3ARG(transmit_block, MetricUnit::REQUESTS, "");
+DEFINE_COUNTER_METRIC_PROTOTYPE_3ARG(transmit_block_by_http, MetricUnit::REQUESTS, "");
+DEFINE_COUNTER_METRIC_PROTOTYPE_3ARG(send_data, MetricUnit::REQUESTS, "");
+DEFINE_COUNTER_METRIC_PROTOTYPE_3ARG(commit, MetricUnit::REQUESTS, "");
+DEFINE_COUNTER_METRIC_PROTOTYPE_3ARG(rollback, MetricUnit::REQUESTS, "");
+DEFINE_COUNTER_METRIC_PROTOTYPE_3ARG(fold_constant_expr, MetricUnit::REQUESTS, "");
+DEFINE_COUNTER_METRIC_PROTOTYPE_3ARG(check_rpc_channel, MetricUnit::REQUESTS, "");
+DEFINE_COUNTER_METRIC_PROTOTYPE_3ARG(reset_rpc_channel, MetricUnit::REQUESTS, "");
+DEFINE_COUNTER_METRIC_PROTOTYPE_3ARG(hand_shake, MetricUnit::REQUESTS, "");
+DEFINE_COUNTER_METRIC_PROTOTYPE_3ARG(response_slave_tablet_pull_rowset, MetricUnit::REQUESTS, "");
+DEFINE_COUNTER_METRIC_PROTOTYPE_3ARG(request_slave_tablet_pull_rowset, MetricUnit::REQUESTS, "");
+DEFINE_COUNTER_METRIC_PROTOTYPE_3ARG(tablet_writer_add_block, MetricUnit::REQUESTS, "");
+DEFINE_COUNTER_METRIC_PROTOTYPE_3ARG(tablet_writer_add_block_by_http, MetricUnit::REQUESTS, "");
+DEFINE_COUNTER_METRIC_PROTOTYPE_3ARG(fetch_table_schema, MetricUnit::REQUESTS, "");
+
 DEFINE_COUNTER_METRIC_PROTOTYPE_2ARG(fragment_request_duration_us, MetricUnit::MICROSECONDS);
 DEFINE_COUNTER_METRIC_PROTOTYPE_2ARG(query_scan_bytes, MetricUnit::BYTES);
 DEFINE_COUNTER_METRIC_PROTOTYPE_2ARG(query_scan_rows, MetricUnit::ROWS);

--- a/be/src/util/doris_metrics.h
+++ b/be/src/util/doris_metrics.h
@@ -45,6 +45,39 @@ namespace doris {
 class DorisMetrics {
 public:
     IntCounter* fragment_requests_total;
+    // counter every service qps
+    IntCounter* transmit_data;
+    IntCounter* transmit_data_by_http;
+    IntCounter* exec_plan_fragment;
+    IntCounter* exec_plan_fragment_prepare;
+    IntCounter* exec_plan_fragment_start;
+    IntCounter* cancel_plan_fragment;
+    IntCounter* fetch_data;
+    IntCounter* tablet_writer_open;
+    IntCounter* tablet_writer_add_batch;
+    IntCounter* tablet_writer_add_batch_by_http;
+    IntCounter* tablet_writer_cancel;
+    IntCounter* get_info;
+    IntCounter* update_cache;
+    IntCounter* fetch_cache;
+    IntCounter* clear_cache;
+    IntCounter* merge_filter;
+    IntCounter* apply_filter;
+    IntCounter* transmit_block;
+    IntCounter* transmit_block_by_http;
+    IntCounter* send_data;
+    IntCounter* commit;
+    IntCounter* rollback;
+    IntCounter* fold_constant_expr;
+    IntCounter* check_rpc_channel;
+    IntCounter* reset_rpc_channel;
+    IntCounter* hand_shake;
+    IntCounter* response_slave_tablet_pull_rowset;
+    IntCounter* request_slave_tablet_pull_rowset;
+    IntCounter* fetch_table_schema;
+    IntCounter* tablet_writer_add_block;
+    IntCounter* tablet_writer_add_block_by_http;
+
     IntCounter* fragment_request_duration_us;
     IntCounter* query_scan_bytes;
     IntCounter* query_scan_rows;
@@ -221,6 +254,11 @@ public:
     UIntGauge* upload_total_byte;
     IntCounter* upload_rowset_count;
     IntCounter* upload_fail_count;
+
+    UIntGauge* light_work_pool_queue_size;
+    UIntGauge* heavy_work_pool_queue_size;
+    UIntGauge* heavy_work_active_threads;
+    UIntGauge* light_work_active_threads;
 
     static DorisMetrics* instance() {
         static DorisMetrics instance;

--- a/be/src/util/doris_metrics.h
+++ b/be/src/util/doris_metrics.h
@@ -259,6 +259,11 @@ public:
     UIntGauge* heavy_work_active_threads;
     UIntGauge* light_work_active_threads;
 
+    UIntGauge* heavy_work_pool_max_queue_size;
+    UIntGauge* light_work_pool_max_queue_size;
+    UIntGauge* heavy_work_max_threads;
+    UIntGauge* light_work_max_threads;
+
     static DorisMetrics* instance() {
         static DorisMetrics instance;
         return &instance;

--- a/be/src/util/doris_metrics.h
+++ b/be/src/util/doris_metrics.h
@@ -53,9 +53,10 @@ public:
     IntCounter* exec_plan_fragment_start;
     IntCounter* cancel_plan_fragment;
     IntCounter* fetch_data;
+    IntCounter* fetch_table_schema;
     IntCounter* tablet_writer_open;
-    IntCounter* tablet_writer_add_batch;
-    IntCounter* tablet_writer_add_batch_by_http;
+    IntCounter* tablet_writer_add_block;
+    IntCounter* tablet_writer_add_block_by_http;
     IntCounter* tablet_writer_cancel;
     IntCounter* get_info;
     IntCounter* update_cache;
@@ -72,11 +73,9 @@ public:
     IntCounter* check_rpc_channel;
     IntCounter* reset_rpc_channel;
     IntCounter* hand_shake;
-    IntCounter* response_slave_tablet_pull_rowset;
     IntCounter* request_slave_tablet_pull_rowset;
-    IntCounter* fetch_table_schema;
-    IntCounter* tablet_writer_add_block;
-    IntCounter* tablet_writer_add_block_by_http;
+    IntCounter* response_slave_tablet_pull_rowset;
+    IntCounter* multiget_data;
 
     IntCounter* fragment_request_duration_us;
     IntCounter* query_scan_bytes;

--- a/be/src/util/priority_thread_pool.hpp
+++ b/be/src/util/priority_thread_pool.hpp
@@ -101,6 +101,7 @@ public:
     virtual void join() { _threads.join_all(); }
 
     virtual uint32_t get_queue_size() const { return _work_queue.get_size(); }
+    virtual uint32_t get_active_threads() const { return active_threads; }
 
     // Blocks until the work queue is empty, and then calls shutdown to stop the worker
     // threads and Join to wait until they are finished.
@@ -136,7 +137,9 @@ private:
         while (!is_shutdown()) {
             Task task;
             if (_work_queue.blocking_get(&task)) {
+                active_threads++;
                 task.work_function();
+                active_threads--;
             }
             if (_work_queue.get_size() == 0) {
                 _empty_cv.notify_all();
@@ -151,6 +154,9 @@ private:
     // Set to true when threads should stop doing work and terminate.
     std::atomic<bool> _shutdown;
     std::string _name;
+
+    //static active thread
+    std::atomic<int> active_threads;
 };
 
 } // namespace doris

--- a/be/src/util/priority_thread_pool.hpp
+++ b/be/src/util/priority_thread_pool.hpp
@@ -55,7 +55,7 @@ public:
     //     queue exceeds this size, subsequent calls to Offer will block until there is
     //     capacity available.
     PriorityThreadPool(uint32_t num_threads, uint32_t queue_size, const std::string& name)
-            : _work_queue(queue_size), _shutdown(false), _name(name),_active_threads(0) {
+            : _work_queue(queue_size), _shutdown(false), _name(name), _active_threads(0) {
         for (int i = 0; i < num_threads; ++i) {
             _threads.create_thread(
                     std::bind<void>(std::mem_fn(&PriorityThreadPool::work_thread), this, i));


### PR DESCRIPTION
# Proposed changes

Issue Number: close #16634 

## Problem summary

mainly include:
1. brpc service adds two types of thread pools. The number of "light" and "heavy" thread pools is different
2. Classify the interfaces of be. Those related to data transmission are classified as heavy interfaces and others as light interfaces
3. Add some monitoring to the thread pool, including the queue size and the number of active threads. Use these indicators to guide the configuration of the number of threads

主要包括
- 1.brpc服务增加2类线程池，"轻","重"  不同线程池的数量配置不一样
- 2.对be的接口进行分类，跟数据传输有关的归类为重接口，其他为轻接口
- 3.增加一些监控，包括be每个接口qps和线程池队列大小、活跃线程个数，根据这些指标来指导线程数的配置
<img width="1359" alt="image" src="https://user-images.githubusercontent.com/11487604/218252833-b0648a66-c5e3-4cbf-9930-3de5a86cfd08.png">


## Checklist(Required)

1. Does it affect the original behavior: 
    - [x] Yes
    - [ ] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [ ] No
    - [x] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

