### PR TITLE
[Bug](Cooldown) fix load balance causing no cooldown replica

### DIFF
--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -1768,7 +1768,8 @@ Status Tablet::_write_cooldown_meta(io::RemoteFileSystem* fs, RowsetMeta* new_rs
 
 Status Tablet::_follow_cooldowned_data(io::RemoteFileSystem* fs, int64_t cooldown_replica_id) {
     LOG(INFO) << "try to follow cooldowned data. tablet_id=" << tablet_id()
-              << " cooldown_replica_id=" << cooldown_replica_id;
+              << " cooldown_replica_id=" << cooldown_replica_id
+              << "local replica=" << replica_id();
     TabletMetaPB cooldown_meta_pb;
     RETURN_IF_ERROR(_read_cooldown_meta(fs, cooldown_replica_id, &cooldown_meta_pb));
     DCHECK(cooldown_meta_pb.rs_metas_size() > 0);

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -1769,7 +1769,7 @@ Status Tablet::_write_cooldown_meta(io::RemoteFileSystem* fs, RowsetMeta* new_rs
 Status Tablet::_follow_cooldowned_data(io::RemoteFileSystem* fs, int64_t cooldown_replica_id) {
     LOG(INFO) << "try to follow cooldowned data. tablet_id=" << tablet_id()
               << " cooldown_replica_id=" << cooldown_replica_id
-              << "local replica=" << replica_id();
+              << " local replica=" << replica_id();
     TabletMetaPB cooldown_meta_pb;
     RETURN_IF_ERROR(_read_cooldown_meta(fs, cooldown_replica_id, &cooldown_meta_pb));
     DCHECK(cooldown_meta_pb.rs_metas_size() > 0);

--- a/be/src/olap/tablet_manager.cpp
+++ b/be/src/olap/tablet_manager.cpp
@@ -771,6 +771,7 @@ Status TabletManager::load_tablet_from_meta(DataDir* data_dir, TTabletId tablet_
         return Status::Error<HEADER_PB_PARSE_FAILED>();
     }
 
+    LOG_INFO("load tablet {} from meta, replica id {}", tablet_id, tablet_meta->replica_id());
     if (restore) {
         // we're restoring tablet from trash, tablet state should be changed from shutdown back to running
         tablet_meta->set_tablet_state(TABLET_RUNNING);

--- a/be/src/olap/tablet_manager.cpp
+++ b/be/src/olap/tablet_manager.cpp
@@ -771,7 +771,6 @@ Status TabletManager::load_tablet_from_meta(DataDir* data_dir, TTabletId tablet_
         return Status::Error<HEADER_PB_PARSE_FAILED>();
     }
 
-    LOG_INFO("load tablet {} from meta, replica id {}", tablet_id, tablet_meta->replica_id());
     if (restore) {
         // we're restoring tablet from trash, tablet state should be changed from shutdown back to running
         tablet_meta->set_tablet_state(TABLET_RUNNING);

--- a/be/src/olap/tablet_meta.cpp
+++ b/be/src/olap/tablet_meta.cpp
@@ -242,6 +242,7 @@ TabletMeta::TabletMeta(const TabletMeta& b)
         : _table_id(b._table_id),
           _partition_id(b._partition_id),
           _tablet_id(b._tablet_id),
+          _replica_id(b._replica_id),
           _schema_hash(b._schema_hash),
           _shard_id(b._shard_id),
           _creation_time(b._creation_time),

--- a/be/src/olap/tablet_meta.cpp
+++ b/be/src/olap/tablet_meta.cpp
@@ -338,8 +338,6 @@ Status TabletMeta::create_from_file(const string& file_path) {
     }
 
     init_from_pb(tablet_meta_pb);
-    LOG_INFO("create from file, file's tablet id: {}, replica id{}", tablet_meta_pb.tablet_id(),
-             tablet_meta_pb.replica_id());
     return Status::OK();
 }
 

--- a/be/src/olap/tablet_meta.cpp
+++ b/be/src/olap/tablet_meta.cpp
@@ -337,6 +337,8 @@ Status TabletMeta::create_from_file(const string& file_path) {
     }
 
     init_from_pb(tablet_meta_pb);
+    LOG_INFO("create from file, file's tablet id: {}, replica id{}", tablet_meta_pb.tablet_id(),
+             tablet_meta_pb.replica_id());
     return Status::OK();
 }
 

--- a/be/src/olap/task/engine_clone_task.cpp
+++ b/be/src/olap/task/engine_clone_task.cpp
@@ -119,7 +119,8 @@ Status EngineCloneTask::_do_clone() {
     } else {
         LOG(INFO) << "clone tablet not exist, begin clone a new tablet from remote be. "
                   << "signature=" << _signature << ", tablet_id=" << _clone_req.tablet_id
-                  << ", committed_version=" << _clone_req.committed_version;
+                  << ", committed_version=" << _clone_req.committed_version
+                  << ", req replica=" << _clone_req.replica_id;
         // create a new tablet in this be
         // Get local disk from olap
         string local_shard_root_path;
@@ -194,6 +195,7 @@ Status EngineCloneTask::_set_tablet_info(bool is_new_tablet) {
     }
     LOG(INFO) << "clone get tablet info success. tablet_id:" << _clone_req.tablet_id
               << ", schema_hash:" << _clone_req.schema_hash << ", signature:" << _signature
+              << ", replica id:" << _clone_req.replica_id
               << ", version:" << tablet_info.version;
     _tablet_infos->push_back(tablet_info);
     return Status::OK();

--- a/be/src/olap/task/engine_clone_task.cpp
+++ b/be/src/olap/task/engine_clone_task.cpp
@@ -97,8 +97,7 @@ Status EngineCloneTask::_do_clone() {
         // completed. Or remote be will just return header not the rowset files. clone will failed.
         if (missed_versions.empty()) {
             LOG(INFO) << "missed version size = 0, skip clone and return success. tablet_id="
-                      << _clone_req.tablet_id
-                      << " req replica=" << _clone_req.replica_id;
+                      << _clone_req.tablet_id << " req replica=" << _clone_req.replica_id;
             _set_tablet_info(is_new_tablet);
             return Status::OK();
         }
@@ -197,8 +196,7 @@ Status EngineCloneTask::_set_tablet_info(bool is_new_tablet) {
     }
     LOG(INFO) << "clone get tablet info success. tablet_id:" << _clone_req.tablet_id
               << ", schema_hash:" << _clone_req.schema_hash << ", signature:" << _signature
-              << ", replica id:" << _clone_req.replica_id
-              << ", version:" << tablet_info.version;
+              << ", replica id:" << _clone_req.replica_id << ", version:" << tablet_info.version;
     _tablet_infos->push_back(tablet_info);
     return Status::OK();
 }

--- a/be/src/olap/task/engine_clone_task.cpp
+++ b/be/src/olap/task/engine_clone_task.cpp
@@ -97,7 +97,8 @@ Status EngineCloneTask::_do_clone() {
         // completed. Or remote be will just return header not the rowset files. clone will failed.
         if (missed_versions.empty()) {
             LOG(INFO) << "missed version size = 0, skip clone and return success. tablet_id="
-                      << _clone_req.tablet_id;
+                      << _clone_req.tablet_id
+                      << " req replica=" << _clone_req.replica_id;
             _set_tablet_info(is_new_tablet);
             return Status::OK();
         }

--- a/be/src/olap/task/engine_clone_task.cpp
+++ b/be/src/olap/task/engine_clone_task.cpp
@@ -105,7 +105,8 @@ Status EngineCloneTask::_do_clone() {
         LOG(INFO) << "clone to existed tablet. missed_versions_size=" << missed_versions.size()
                   << ", allow_incremental_clone=" << allow_incremental_clone
                   << ", signature=" << _signature << ", tablet_id=" << _clone_req.tablet_id
-                  << ", committed_version=" << _clone_req.committed_version;
+                  << ", committed_version=" << _clone_req.committed_version
+                  << ", req replica=" << _clone_req.replica_id;
 
         // try to download missing version from src backend.
         // if tablet on src backend does not contains missing version, it will download all versions,
@@ -539,7 +540,8 @@ Status EngineCloneTask::_finish_incremental_clone(Tablet* tablet,
                                                   const TabletMeta& cloned_tablet_meta,
                                                   int64_t committed_version) {
     LOG(INFO) << "begin to finish incremental clone. tablet=" << tablet->full_name()
-              << ", committed_version=" << committed_version;
+              << ", committed_version=" << committed_version
+              << ", cloned_tablet_replica_id=" << cloned_tablet_meta.tablet_id();
 
     /// Get missing versions again from local tablet.
     /// We got it before outside the lock, so it has to be got again.

--- a/gensrc/proto/olap_file.proto
+++ b/gensrc/proto/olap_file.proto
@@ -289,7 +289,8 @@ message TabletMetaPB {
     // optional StorageMediumPB storage_medium = 19 [default = HDD];
     // optional string remote_storage_name = 20;
     optional int64 replica_id = 21 [default = 0];
-    // optional string storage_policy = 22;
+    // 22 used to be string storage_policy = 22;
+    reserved 22;
     optional DeleteBitmapPB delete_bitmap = 23;
     // Use primary key index to speed up tabel unique key model
     optional bool enable_unique_key_merge_on_write = 24 [default = false];


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx
Currently cooldown's implementation would compare the replica id of the local replica and cooldown_replica_id inside the cooldown conf, unfortunately the `Tablet::revise_tablet_meta` didn't set the right replica id due to the lack of copy of replica id when using copy constructor of tablet meta. Which would end up tablet meta with replica id equals to 0. And the subsequent comparison would fail, neither would the cooldown operation.
Plus, this pr add some log for better replica tracing when doing cloning.
## Problem summary

Describe your changes.

## Checklist(Required)

1. Does it affect the original behavior: 
    - [ ] Yes
    - [x] No
    - [ ] I don't know
2. Has unit tests been added:
    - [ ] Yes
    - [x] No
    - [ ] No Need
3. Has document been added or modified:
    - [ ] Yes
    - [x] No
    - [ ] No Need
4. Does it need to update dependencies:
    - [ ] Yes
    - [x] No
5. Are there any changes that cannot be rolled back:
    - [ ] Yes (If Yes, please explain WHY)
    - [x] No

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

