### PR TITLE
[Bug](cooldown) set new replica id when early exit in doing clone when no missed versions

### DIFF
--- a/be/src/olap/tablet_meta.h
+++ b/be/src/olap/tablet_meta.h
@@ -120,6 +120,7 @@ public:
     int64_t partition_id() const;
     int64_t tablet_id() const;
     int64_t replica_id() const;
+    void set_replica_id(int64_t replica_id);
     int32_t schema_hash() const;
     int16_t shard_id() const;
     void set_shard_id(int32_t shard_id);
@@ -433,6 +434,10 @@ inline int64_t TabletMeta::tablet_id() const {
 
 inline int64_t TabletMeta::replica_id() const {
     return _replica_id;
+}
+
+inline void TabletMeta::set_replica_id(int64_t replica_id) {
+    _replica_id = replica_id;
 }
 
 inline int32_t TabletMeta::schema_hash() const {

--- a/be/src/olap/task/engine_clone_task.cpp
+++ b/be/src/olap/task/engine_clone_task.cpp
@@ -98,6 +98,12 @@ Status EngineCloneTask::_do_clone() {
         if (missed_versions.empty()) {
             LOG(INFO) << "missed version size = 0, skip clone and return success. tablet_id="
                       << _clone_req.tablet_id << " req replica=" << _clone_req.replica_id;
+            // update replica id to meet cooldown replica
+            {
+                std::lock_guard<std::shared_mutex> wrlock(tablet->get_header_lock());
+                tablet->tablet_meta()->set_replica_id(_clone_req.replica_id);
+                tablet->save_meta();
+            }
             _set_tablet_info(is_new_tablet);
             return Status::OK();
         }
@@ -204,7 +210,7 @@ Status EngineCloneTask::_set_tablet_info(bool is_new_tablet) {
 /// This method will do following things:
 /// 1. Make snapshots on source BE.
 /// 2. Download all snapshots to CLONE dir.
-/// 3. Convert rowset ids of downloaded snapshots.
+/// 3. Convert rowset ids of downloaded snapshots(would also change the replica id).
 /// 4. Release the snapshots on source BE.
 Status EngineCloneTask::_make_and_download_snapshots(DataDir& data_dir,
                                                      const std::string& local_data_path,
@@ -540,7 +546,7 @@ Status EngineCloneTask::_finish_incremental_clone(Tablet* tablet,
                                                   int64_t committed_version) {
     LOG(INFO) << "begin to finish incremental clone. tablet=" << tablet->full_name()
               << ", committed_version=" << committed_version
-              << ", cloned_tablet_replica_id=" << cloned_tablet_meta.tablet_id();
+              << ", cloned_tablet_replica_id=" << cloned_tablet_meta.replica_id();
 
     /// Get missing versions again from local tablet.
     /// We got it before outside the lock, so it has to be got again.

--- a/be/src/olap/task/engine_clone_task.cpp
+++ b/be/src/olap/task/engine_clone_task.cpp
@@ -99,9 +99,9 @@ Status EngineCloneTask::_do_clone() {
             LOG(INFO) << "missed version size = 0, skip clone and return success. tablet_id="
                       << _clone_req.tablet_id << " req replica=" << _clone_req.replica_id;
             // update replica id to meet cooldown replica
+            tablet->tablet_meta()->set_replica_id(_clone_req.replica_id);
             {
-                std::lock_guard<std::shared_mutex> wrlock(tablet->get_header_lock());
-                tablet->tablet_meta()->set_replica_id(_clone_req.replica_id);
+                std::shared_lock rlock(tablet->get_header_lock());
                 tablet->save_meta();
             }
             _set_tablet_info(is_new_tablet);

--- a/be/src/olap/task/engine_clone_task.cpp
+++ b/be/src/olap/task/engine_clone_task.cpp
@@ -98,11 +98,13 @@ Status EngineCloneTask::_do_clone() {
         if (missed_versions.empty()) {
             LOG(INFO) << "missed version size = 0, skip clone and return success. tablet_id="
                       << _clone_req.tablet_id << " req replica=" << _clone_req.replica_id;
-            // update replica id to meet cooldown replica
-            tablet->tablet_meta()->set_replica_id(_clone_req.replica_id);
-            {
-                std::shared_lock rlock(tablet->get_header_lock());
-                tablet->save_meta();
+            if (_clone_req.replica_id != tablet->replica_id()) {
+                // update replica id to meet cooldown replica
+                tablet->tablet_meta()->set_replica_id(_clone_req.replica_id);
+                {
+                    std::shared_lock rlock(tablet->get_header_lock());
+                    tablet->save_meta();
+                }
             }
             _set_tablet_info(is_new_tablet);
             return Status::OK();


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx
When doing clone task, the logic would early exit if the missed version is empty. But the tablet meta is not set with the newly replica id inside the clone request. It would result inconsistent cooldown replica id when doing cooldown.

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

