### PR TITLE
[fix](metric) Fix be core when set enable_system_metrics to false in be

### DIFF
--- a/be/src/common/configbase.cpp
+++ b/be/src/common/configbase.cpp
@@ -439,9 +439,8 @@ Status set_fuzzy_config(const std::string& field, const std::string& value) {
 
 void set_fuzzy_configs() {
     // random value true or false
-    Status s =
-            set_fuzzy_config("disable_storage_page_cache", ((rand() % 2) == 0) ? "true" : "false");
-    LOG(INFO) << s.to_string();
+    set_fuzzy_config("disable_storage_page_cache", ((rand() % 2) == 0) ? "true" : "false");
+    set_fuzzy_config("enable_system_metrics", ((rand() % 2) == 0) ? "true" : "false");
     // random value from 8 to 48
     // s = set_fuzzy_config("doris_scanner_thread_pool_thread_num", std::to_string((rand() % 41) + 8));
     // LOG(INFO) << s.to_string();

--- a/be/src/common/daemon.cpp
+++ b/be/src/common/daemon.cpp
@@ -181,7 +181,9 @@ void Daemon::memory_maintenance_thread() {
         // Refresh allocator memory metrics.
 #if !defined(ADDRESS_SANITIZER) && !defined(LEAK_SANITIZER) && !defined(THREAD_SANITIZER)
         doris::MemInfo::refresh_allocator_mem();
-        DorisMetrics::instance()->system_metrics()->update_allocator_metrics();
+        if (config::enable_system_metrics) {
+            DorisMetrics::instance()->system_metrics()->update_allocator_metrics();
+        }
 #endif
         doris::MemInfo::refresh_proc_mem_no_allocator_cache();
 


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary
when enable_system_metrics is false, we should not use system_metrics any more

## Checklist(Required)

* [x] Does it affect the original behavior
* [x] Has unit tests been added
* [x] Has document been added or modified
* [x] Does it need to update dependencies
* [x] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

