### PR TITLE
[fix](information_schema) catch and skip exception when getting schema from FE catalog

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/external/jdbc/JdbcClient.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/external/jdbc/JdbcClient.java
@@ -77,6 +77,12 @@ public class JdbcClient {
             config.setUsername(jdbcUser);
             config.setPassword(password);
             config.setMaximumPoolSize(1);
+            // set connection timeout to 5s.
+            // The default is 30s, which is too long.
+            // Because when querying information_schema db, BE will call thrift rpc(default timeout is 30s)
+            // to FE to get schema info, and may create connection here, if we set it too long and the url is invalid,
+            // it may cause the thrift rpc timeout.
+            config.setConnectionTimeout(5000);
             dataSource = new HikariDataSource(config);
         } catch (MalformedURLException e) {
             throw new JdbcClientException("MalformedURLException to load class about " + driverUrl, e);


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

When querying `information_schema` database, BE will call FE RPC
to get schema info such as db name list, table name list, etc.
But some external catalog when failed to get these info because of wrong connection info.
We should catch these kind of exception and skip it, so that it can continue to
get schema info of other catalogs.
Otherwise, the whole query on `information_schema` will fail, even if user just want to get
info of internal catalog.

And set jdbc connection timeout to 5s, to avoid thrift rpc timeout from BE to FE(default is 30s)

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

