### PR TITLE
[BugFix](Load) Add a secure path for MySql Load to load local file from fe node

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -1992,6 +1992,15 @@ public class Config extends ConfigBase {
     /**
      * TokenManager will generate token every token_generate_period_hour.
      */
+    @ConfField(mutable = false, masterOnly = true)
     public static int token_generate_period_hour = 12;
+
+    /**
+     * The secure local path of the FE node the place the data which will be loaded in doris.
+     * The default value is empty for this config which means this feature is not allowed.
+     * User who want to load fe server local file should config the value to a right local path.
+     */
+    @ConfField(mutable = false, masterOnly = false)
+    public static String mysql_load_server_secure_path = "";
 }
 


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary
MySql load can load fe server node, but it will cause secure issue that user use it to detect the fe node local file.

For this reason, add a configuration named `mysql_load_server_secure_path` to set a secure path to load data.

By default, load fe local file feature is disabled by this configuration.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [x] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [x] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

