### PR TITLE
[Fix](cpp17) fix gutil unary_function/binary_function for cpp17

### DIFF
--- a/be/src/gutil/stl_util.h
+++ b/be/src/gutil/stl_util.h
@@ -41,7 +41,6 @@ using std::swap;
 #include <deque>
 using std::deque;
 #include <functional>
-using std::binary_function;
 using std::less;
 #include <iterator>
 using std::back_insert_iterator;
@@ -641,7 +640,7 @@ bool STLIncludes(const SortedSTLContainerA& a, const SortedSTLContainerB& b) {
 // the contents of an STL map. For other sample usage, see the unittest.
 
 template <typename Pair, typename UnaryOp>
-class UnaryOperateOnFirst : public std::unary_function<Pair, typename UnaryOp::result_type> {
+class UnaryOperateOnFirst {
 public:
     UnaryOperateOnFirst() {}
 
@@ -660,7 +659,7 @@ UnaryOperateOnFirst<Pair, UnaryOp> UnaryOperate1st(const UnaryOp& f) {
 }
 
 template <typename Pair, typename UnaryOp>
-class UnaryOperateOnSecond : public std::unary_function<Pair, typename UnaryOp::result_type> {
+class UnaryOperateOnSecond {
 public:
     UnaryOperateOnSecond() {}
 
@@ -679,8 +678,7 @@ UnaryOperateOnSecond<Pair, UnaryOp> UnaryOperate2nd(const UnaryOp& f) {
 }
 
 template <typename Pair, typename BinaryOp>
-class BinaryOperateOnFirst
-        : public std::binary_function<Pair, Pair, typename BinaryOp::result_type> {
+class BinaryOperateOnFirst {
 public:
     BinaryOperateOnFirst() {}
 
@@ -702,8 +700,7 @@ BinaryOperateOnFirst<Pair, BinaryOp> BinaryOperate1st(const BinaryOp& f) {
 }
 
 template <typename Pair, typename BinaryOp>
-class BinaryOperateOnSecond
-        : public std::binary_function<Pair, Pair, typename BinaryOp::result_type> {
+class BinaryOperateOnSecond {
 public:
     BinaryOperateOnSecond() {}
 
@@ -736,9 +733,7 @@ BinaryOperateOnSecond<Pair, BinaryOp> BinaryOperate2nd(const BinaryOp& f) {
 // F has to be a model of AdaptableBinaryFunction.
 // G1 and G2 have to be models of AdabtableUnaryFunction.
 template <typename F, typename G1, typename G2>
-class BinaryComposeBinary
-        : public binary_function<typename G1::argument_type, typename G2::argument_type,
-                                 typename F::result_type> {
+class BinaryComposeBinary {
 public:
     BinaryComposeBinary(F f, G1 g1, G2 g2) : f_(f), g1_(g1), g2_(g2) {}
 

--- a/be/src/gutil/strings/numbers.h
+++ b/be/src/gutil/strings/numbers.h
@@ -11,7 +11,6 @@
 #include <time.h>
 
 #include <functional>
-using std::binary_function;
 using std::less;
 #include <limits>
 using std::numeric_limits;
@@ -329,25 +328,25 @@ bool AutoDigitLessThan(const char* a, int alen, const char* b, int blen);
 
 bool StrictAutoDigitLessThan(const char* a, int alen, const char* b, int blen);
 
-struct autodigit_less : public binary_function<const string&, const string&, bool> {
+struct autodigit_less {
     bool operator()(const string& a, const string& b) const {
         return AutoDigitLessThan(a.data(), a.size(), b.data(), b.size());
     }
 };
 
-struct autodigit_greater : public binary_function<const string&, const string&, bool> {
+struct autodigit_greater {
     bool operator()(const string& a, const string& b) const {
         return AutoDigitLessThan(b.data(), b.size(), a.data(), a.size());
     }
 };
 
-struct strict_autodigit_less : public binary_function<const string&, const string&, bool> {
+struct strict_autodigit_less {
     bool operator()(const string& a, const string& b) const {
         return StrictAutoDigitLessThan(a.data(), a.size(), b.data(), b.size());
     }
 };
 
-struct strict_autodigit_greater : public binary_function<const string&, const string&, bool> {
+struct strict_autodigit_greater {
     bool operator()(const string& a, const string& b) const {
         return StrictAutoDigitLessThan(b.data(), b.size(), a.data(), a.size());
     }

--- a/be/src/gutil/strings/util.h
+++ b/be/src/gutil/strings/util.h
@@ -34,7 +34,6 @@
 #endif
 
 #include <functional>
-using std::binary_function;
 using std::less;
 #include <string>
 using std::string;
@@ -253,7 +252,7 @@ char* AdjustedLastPos(const char* str, char separator, int n);
 // Compares two char* strings for equality. (Works with NULL, which compares
 // equal only to another NULL). Useful in hash tables:
 //    hash_map<const char*, Value, hash<const char*>, streq> ht;
-struct streq : public binary_function<const char*, const char*, bool> {
+struct streq {
     bool operator()(const char* s1, const char* s2) const {
         return ((s1 == 0 && s2 == 0) || (s1 && s2 && *s1 == *s2 && strcmp(s1, s2) == 0));
     }
@@ -262,7 +261,7 @@ struct streq : public binary_function<const char*, const char*, bool> {
 // Compares two char* strings. (Works with NULL, which compares greater than any
 // non-NULL). Useful in maps:
 //    map<const char*, Value, strlt> m;
-struct strlt : public binary_function<const char*, const char*, bool> {
+struct strlt {
     bool operator()(const char* s1, const char* s2) const {
         return (s1 != s2) && (s2 == 0 || (s1 != 0 && strcmp(s1, s2) < 0));
     }

--- a/be/src/util/container_util.hpp
+++ b/be/src/util/container_util.hpp
@@ -35,11 +35,11 @@ inline std::size_t hash_value(const TNetworkAddress& host_port) {
     return HashUtil::hash(&host_port.port, sizeof(host_port.port), hash);
 }
 
-struct HashTNetworkAddressPtr : public std::unary_function<TNetworkAddress*, size_t> {
+struct HashTNetworkAddressPtr {
     size_t operator()(const TNetworkAddress* const& p) const { return hash_value(*p); }
 };
 
-struct TNetworkAddressPtrEquals : public std::unary_function<TNetworkAddress*, bool> {
+struct TNetworkAddressPtrEquals {
     bool operator()(const TNetworkAddress* const& p1, const TNetworkAddress* const& p2) const {
         return p1->hostname == p2->hostname && p1->port == p2->port;
     }


### PR DESCRIPTION
# Proposed changes

be gutil contains unary_function/binary_function, but they are removed in C++17. Fix these for gcc12 to compile be.


![image](https://user-images.githubusercontent.com/3295714/218426123-14bf0a4c-b592-4fcc-91e9-c24310cdd2b0.png)
