### PR TITLE
[fix](regression) fix add drop inverted index case

### DIFF
--- a/be/src/olap/schema_change.cpp
+++ b/be/src/olap/schema_change.cpp
@@ -609,7 +609,6 @@ Status SchemaChangeForInvertedIndex::process(RowsetReaderSharedPtr rowset_reader
     auto rowset_meta = rowset_reader->rowset()->rowset_meta();
     std::string segment_dir = base_tablet->tablet_path();
     auto fs = rowset_meta->fs();
-    _olap_data_convertor->reserve(_alter_inverted_indexs.size());
 
     // load segments
     SegmentCacheHandle segment_cache_handle;
@@ -622,6 +621,7 @@ Status SchemaChangeForInvertedIndex::process(RowsetReaderSharedPtr rowset_reader
                 fmt::format("{}_{}.dat", rowset_meta->rowset_id().to_string(), seg_ptr->id());
         std::vector<ColumnId> return_columns;
         std::vector<std::pair<int64_t, int64_t>> inverted_index_writer_signs;
+        _olap_data_convertor->reserve(_alter_inverted_indexs.size());
         // create inverted index writer
         for (auto& inverted_index : _alter_inverted_indexs) {
             DCHECK_EQ(inverted_index.columns.size(), 1);
@@ -700,6 +700,8 @@ Status SchemaChangeForInvertedIndex::process(RowsetReaderSharedPtr rowset_reader
                 return Status::Error<IO_ERROR>();
             }
         }
+
+        _olap_data_convertor->reset();
     }
 
     _inverted_index_builders.clear();

--- a/be/src/vec/olap/olap_data_convertor.h
+++ b/be/src/vec/olap/olap_data_convertor.h
@@ -58,6 +58,7 @@ public:
 
     bool empty() const { return _convertors.empty(); }
     void reserve(size_t size) { _convertors.reserve(size); }
+    void reset() { _convertors.clear(); }
 
 private:
     class OlapColumnDataConvertorBase;

--- a/regression-test/suites/inverted_index_p0/test_add_drop_index_with_delete_data.groovy
+++ b/regression-test/suites/inverted_index_p0/test_add_drop_index_with_delete_data.groovy
@@ -35,7 +35,7 @@ suite("test_add_drop_index_with_delete_data", "inverted_index"){
         assertTrue(useTime <= OpTimeout)
     }
 
-    def indexTbName1 = "test_add_drop_inverted_index2"
+    def indexTbName1 = "test_add_drop_inverted_index3"
 
     sql "DROP TABLE IF EXISTS ${indexTbName1}"
     // create 1 replica table


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

1. fix test_add_drop_index.groovy
2. fix assert failed when process alter inverted index call `OlapBlockDataConvertor::set_source_content`

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

