### PR TITLE
[improvement](rowset reader) fix possible memleak

### DIFF
--- a/be/src/olap/iterators.h
+++ b/be/src/olap/iterators.h
@@ -126,6 +126,8 @@ public:
     int32_t tablet_id = 0;
 };
 
+class RowwiseIterator;
+using RowwiseIteratorUPtr = std::unique_ptr<RowwiseIterator>;
 class RowwiseIterator {
 public:
     RowwiseIterator() = default;

--- a/be/src/olap/reader.cpp
+++ b/be/src/olap/reader.cpp
@@ -133,10 +133,8 @@ bool TabletReader::_optimize_for_single_rowset(
     return !has_overlapping && nonoverlapping_count == 1 && !has_delete_rowset;
 }
 
-Status TabletReader::_capture_rs_readers(const ReaderParams& read_params,
-                                         std::vector<RowsetReaderSharedPtr>* valid_rs_readers) {
-    const std::vector<RowsetReaderSharedPtr>* rs_readers = &read_params.rs_readers;
-    if (rs_readers->empty()) {
+Status TabletReader::_capture_rs_readers(const ReaderParams& read_params) {
+    if (read_params.rs_readers.empty()) {
         return Status::InternalError("fail to acquire data sources. tablet={}",
                                      _tablet->full_name());
     }
@@ -228,8 +226,6 @@ Status TabletReader::_capture_rs_readers(const ReaderParams& read_params,
     _reader_context.is_key_column_group = read_params.is_key_column_group;
     _reader_context.remaining_vconjunct_root = read_params.remaining_vconjunct_root;
     _reader_context.output_columns = &read_params.output_columns;
-
-    *valid_rs_readers = *rs_readers;
 
     return Status::OK();
 }

--- a/be/src/olap/reader.h
+++ b/be/src/olap/reader.h
@@ -183,8 +183,7 @@ protected:
 
     Status _init_params(const ReaderParams& read_params);
 
-    Status _capture_rs_readers(const ReaderParams& read_params,
-                               std::vector<RowsetReaderSharedPtr>* valid_rs_readers);
+    Status _capture_rs_readers(const ReaderParams& read_params);
 
     bool _optimize_for_single_rowset(const std::vector<RowsetReaderSharedPtr>& rs_readers);
 

--- a/be/src/olap/rowset/beta_rowset_reader.h
+++ b/be/src/olap/rowset/beta_rowset_reader.h
@@ -34,7 +34,7 @@ public:
     Status init(RowsetReaderContext* read_context) override;
 
     Status get_segment_iterators(RowsetReaderContext* read_context,
-                                 std::vector<RowwiseIterator*>* out_iters,
+                                 std::vector<RowwiseIteratorUPtr>* out_iters,
                                  bool use_cache = false) override;
     void reset_read_options() override;
     Status next_block(vectorized::Block* block) override;

--- a/be/src/olap/rowset/beta_rowset_writer.h
+++ b/be/src/olap/rowset/beta_rowset_writer.h
@@ -107,10 +107,10 @@ private:
     void _build_rowset_meta(std::shared_ptr<RowsetMeta> rowset_meta);
     Status _segcompaction_if_necessary();
     Status _segcompaction_ramaining_if_necessary();
-    vectorized::VMergeIterator* _get_segcompaction_reader(SegCompactionCandidatesSharedPtr segments,
-                                                          std::shared_ptr<Schema> schema,
-                                                          OlapReaderStatistics* stat,
-                                                          uint64_t* merged_row_stat);
+    RowwiseIteratorUPtr _get_segcompaction_reader(SegCompactionCandidatesSharedPtr segments,
+                                                  std::shared_ptr<Schema> schema,
+                                                  OlapReaderStatistics* stat,
+                                                  uint64_t* merged_row_stat);
     std::unique_ptr<segment_v2::SegmentWriter> _create_segcompaction_writer(uint64_t begin,
                                                                             uint64_t end);
     Status _delete_original_segments(uint32_t begin, uint32_t end);

--- a/be/src/olap/rowset/rowset_reader.h
+++ b/be/src/olap/rowset/rowset_reader.h
@@ -44,7 +44,7 @@ public:
     virtual Status init(RowsetReaderContext* read_context) = 0;
 
     virtual Status get_segment_iterators(RowsetReaderContext* read_context,
-                                         std::vector<RowwiseIterator*>* out_iters,
+                                         std::vector<RowwiseIteratorUPtr>* out_iters,
                                          bool use_cache = false) = 0;
     virtual void reset_read_options() = 0;
 

--- a/be/src/olap/rowset/segment_v2/segment.cpp
+++ b/be/src/olap/rowset/segment_v2/segment.cpp
@@ -135,8 +135,7 @@ Status Segment::new_iterator(const Schema& schema, const StorageReadOptions& rea
     } else {
         iter->reset(new SegmentIterator(this->shared_from_this(), schema));
     }
-    iter->get()->init(read_options);
-    return Status::OK();
+    return iter->get()->init(read_options);
 }
 
 Status Segment::_parse_footer() {

--- a/be/src/vec/olap/block_reader.h
+++ b/be/src/vec/olap/block_reader.h
@@ -62,8 +62,7 @@ private:
     // to minimize the comparison time in merge heap.
     Status _unique_key_next_block(Block* block, bool* eof);
 
-    Status _init_collect_iter(const ReaderParams& read_params,
-                              std::vector<RowsetReaderSharedPtr>* valid_rs_readers);
+    Status _init_collect_iter(const ReaderParams& read_params);
 
     void _init_agg_state(const ReaderParams& read_params);
 

--- a/be/src/vec/olap/vertical_block_reader.h
+++ b/be/src/vec/olap/vertical_block_reader.h
@@ -65,7 +65,7 @@ private:
     Status _init_collect_iter(const ReaderParams& read_params);
 
     Status _get_segment_iterators(const ReaderParams& read_params,
-                                  std::vector<RowwiseIterator*>* segment_iters,
+                                  std::vector<RowwiseIteratorUPtr>* segment_iters,
                                   std::vector<bool>* iterator_init_flag,
                                   std::vector<RowsetId>* rowset_ids);
 

--- a/be/src/vec/olap/vertical_merge_iterator.cpp
+++ b/be/src/vec/olap/vertical_merge_iterator.cpp
@@ -463,9 +463,9 @@ Status VerticalHeapMergeIterator::init(const StorageReadOptions& opts) {
     // will not be pushed into heap, we should init next one util we find a valid iter
     // so this rowset can work in heap
     bool pre_iter_invalid = false;
-    for (auto iter : _origin_iters) {
+    for (auto& iter : _origin_iters) {
         VerticalMergeIteratorContext* ctx = new VerticalMergeIteratorContext(
-                iter, _rowset_ids[seg_order], _ori_return_cols, seg_order, _seq_col_idx);
+                std::move(iter), _rowset_ids[seg_order], _ori_return_cols, seg_order, _seq_col_idx);
         _ori_iter_ctx.push_back(ctx);
         if (_iterator_init_flags[seg_order] || pre_iter_invalid) {
             RETURN_IF_ERROR(ctx->init(opts));
@@ -600,9 +600,9 @@ Status VerticalMaskMergeIterator::init(const StorageReadOptions& opts) {
     _opts = opts;
 
     RowsetId rs_id;
-    for (auto iter : _origin_iters) {
-        auto ctx = std::make_unique<VerticalMergeIteratorContext>(iter, rs_id, _ori_return_cols, -1,
-                                                                  -1);
+    for (auto& iter : _origin_iters) {
+        auto ctx = std::make_unique<VerticalMergeIteratorContext>(std::move(iter), rs_id,
+                                                                  _ori_return_cols, -1, -1);
         _origin_iter_ctx.emplace_back(ctx.release());
     }
     _origin_iters.clear();
@@ -613,7 +613,7 @@ Status VerticalMaskMergeIterator::init(const StorageReadOptions& opts) {
 
 // interfaces to create vertical merge iterator
 std::shared_ptr<RowwiseIterator> new_vertical_heap_merge_iterator(
-        std::vector<RowwiseIterator*> inputs, const std::vector<bool>& iterator_init_flag,
+        std::vector<RowwiseIteratorUPtr>&& inputs, const std::vector<bool>& iterator_init_flag,
         const std::vector<RowsetId>& rowset_ids, size_t ori_return_cols, KeysType keys_type,
         uint32_t seq_col_idx, RowSourcesBuffer* row_sources) {
     return std::make_shared<VerticalHeapMergeIterator>(std::move(inputs), iterator_init_flag,
@@ -622,9 +622,10 @@ std::shared_ptr<RowwiseIterator> new_vertical_heap_merge_iterator(
 }
 
 std::shared_ptr<RowwiseIterator> new_vertical_mask_merge_iterator(
-        const std::vector<RowwiseIterator*>& inputs, size_t ori_return_cols,
+        std::vector<RowwiseIteratorUPtr>&& inputs, size_t ori_return_cols,
         RowSourcesBuffer* row_sources) {
-    return std::make_shared<VerticalMaskMergeIterator>(inputs, ori_return_cols, row_sources);
+    return std::make_shared<VerticalMaskMergeIterator>(std::move(inputs), ori_return_cols,
+                                                       row_sources);
 }
 
 } // namespace vectorized

--- a/be/src/vec/olap/vertical_merge_iterator.h
+++ b/be/src/vec/olap/vertical_merge_iterator.h
@@ -129,9 +129,9 @@ private:
 // takes ownership of rowwise iterator
 class VerticalMergeIteratorContext {
 public:
-    VerticalMergeIteratorContext(RowwiseIterator* iter, RowsetId rowset_id, size_t ori_return_cols,
-                                 uint32_t order, uint32_t seq_col_idx)
-            : _iter(iter),
+    VerticalMergeIteratorContext(RowwiseIteratorUPtr&& iter, RowsetId rowset_id,
+                                 size_t ori_return_cols, uint32_t order, uint32_t seq_col_idx)
+            : _iter(std::move(iter)),
               _rowset_id(rowset_id),
               _ori_return_cols(ori_return_cols),
               _order(order),
@@ -143,10 +143,7 @@ public:
     VerticalMergeIteratorContext& operator=(const VerticalMergeIteratorContext&) = delete;
     VerticalMergeIteratorContext& operator=(VerticalMergeIteratorContext&&) = delete;
 
-    ~VerticalMergeIteratorContext() {
-        delete _iter;
-        _iter = nullptr;
-    }
+    ~VerticalMergeIteratorContext() {}
     Status block_reset(const std::shared_ptr<Block>& block);
     Status init(const StorageReadOptions& opts);
     bool compare(const VerticalMergeIteratorContext& rhs) const;
@@ -188,7 +185,7 @@ private:
     // Load next block into _block
     Status _load_next_block();
 
-    RowwiseIterator* _iter;
+    RowwiseIteratorUPtr _iter;
     RowsetId _rowset_id;
     size_t _ori_return_cols = 0;
 
@@ -219,7 +216,7 @@ private:
 class VerticalHeapMergeIterator : public RowwiseIterator {
 public:
     // VerticalMergeIterator takes the ownership of input iterators
-    VerticalHeapMergeIterator(std::vector<RowwiseIterator*> iters,
+    VerticalHeapMergeIterator(std::vector<RowwiseIteratorUPtr>&& iters,
                               std::vector<bool> iterator_init_flags,
                               std::vector<RowsetId> rowset_ids, size_t ori_return_cols,
                               KeysType keys_type, int32_t seq_col_idx,
@@ -255,7 +252,7 @@ private:
 
 private:
     // It will be released after '_merge_heap' has been built.
-    std::vector<RowwiseIterator*> _origin_iters;
+    std::vector<RowwiseIteratorUPtr> _origin_iters;
     std::vector<bool> _iterator_init_flags;
     std::vector<RowsetId> _rowset_ids;
     size_t _ori_return_cols;
@@ -289,7 +286,7 @@ private:
 class VerticalMaskMergeIterator : public RowwiseIterator {
 public:
     // VerticalMaskMergeIterator takes the ownership of input iterators
-    VerticalMaskMergeIterator(std::vector<RowwiseIterator*> iters, size_t ori_return_cols,
+    VerticalMaskMergeIterator(std::vector<RowwiseIteratorUPtr>&& iters, size_t ori_return_cols,
                               RowSourcesBuffer* row_sources_buf)
             : _origin_iters(std::move(iters)),
               _ori_return_cols(ori_return_cols),
@@ -318,7 +315,7 @@ private:
 
 private:
     // released after build ctx
-    std::vector<RowwiseIterator*> _origin_iters;
+    std::vector<RowwiseIteratorUPtr> _origin_iters;
     size_t _ori_return_cols = 0;
 
     std::vector<VerticalMergeIteratorContext*> _origin_iter_ctx;
@@ -332,12 +329,12 @@ private:
 
 // segment merge iterator
 std::shared_ptr<RowwiseIterator> new_vertical_heap_merge_iterator(
-        std::vector<RowwiseIterator*> inputs, const std::vector<bool>& iterator_init_flag,
+        std::vector<RowwiseIteratorUPtr>&& inputs, const std::vector<bool>& iterator_init_flag,
         const std::vector<RowsetId>& rowset_ids, size_t _ori_return_cols, KeysType key_type,
         uint32_t seq_col_idx, RowSourcesBuffer* row_sources_buf);
 
 std::shared_ptr<RowwiseIterator> new_vertical_mask_merge_iterator(
-        const std::vector<RowwiseIterator*>& inputs, size_t ori_return_cols,
+        std::vector<RowwiseIteratorUPtr>&& inputs, size_t ori_return_cols,
         RowSourcesBuffer* row_sources_buf);
 
 } // namespace vectorized

--- a/be/src/vec/olap/vertical_merge_iterator.h
+++ b/be/src/vec/olap/vertical_merge_iterator.h
@@ -136,7 +136,7 @@ public:
               _ori_return_cols(ori_return_cols),
               _order(order),
               _seq_col_idx(seq_col_idx),
-              _num_key_columns(iter->schema().num_key_columns()) {}
+              _num_key_columns(_iter->schema().num_key_columns()) {}
 
     VerticalMergeIteratorContext(const VerticalMergeIteratorContext&) = delete;
     VerticalMergeIteratorContext(VerticalMergeIteratorContext&&) = delete;

--- a/be/src/vec/olap/vgeneric_iterators.cpp
+++ b/be/src/vec/olap/vgeneric_iterators.cpp
@@ -317,12 +317,13 @@ Status VMergeIterator::init(const StorageReadOptions& opts) {
     if (_origin_iters.empty()) {
         return Status::OK();
     }
-    _schema = &(*_origin_iters.begin())->schema();
+    _schema = &(_origin_iters[0]->schema());
     _record_rowids = opts.record_rowids;
 
-    for (auto iter : _origin_iters) {
-        auto ctx = std::make_unique<VMergeIteratorContext>(
-                iter, _sequence_id_idx, _is_unique, _is_reverse, opts.read_orderby_key_columns);
+    for (auto& iter : _origin_iters) {
+        auto ctx = std::make_unique<VMergeIteratorContext>(std::move(iter), _sequence_id_idx,
+                                                           _is_unique, _is_reverse,
+                                                           opts.read_orderby_key_columns);
         RETURN_IF_ERROR(ctx->init(opts));
         if (!ctx->valid()) {
             continue;
@@ -343,12 +344,9 @@ public:
     // Iterators' ownership it transferred to this class.
     // This class will delete all iterators when destructs
     // Client should not use iterators anymore.
-    VUnionIterator(std::vector<RowwiseIterator*>& v) : _origin_iters(v.begin(), v.end()) {}
+    VUnionIterator(std::vector<RowwiseIteratorUPtr>&& v) : _origin_iters(std::move(v)) {}
 
-    ~VUnionIterator() override {
-        std::for_each(_origin_iters.begin(), _origin_iters.end(),
-                      std::default_delete<RowwiseIterator>());
-    }
+    ~VUnionIterator() override {}
 
     Status init(const StorageReadOptions& opts) override;
 
@@ -368,7 +366,7 @@ public:
 private:
     const Schema* _schema = nullptr;
     RowwiseIterator* _cur_iter = nullptr;
-    std::deque<RowwiseIterator*> _origin_iters;
+    std::vector<RowwiseIteratorUPtr> _origin_iters;
 };
 
 Status VUnionIterator::init(const StorageReadOptions& opts) {
@@ -376,10 +374,10 @@ Status VUnionIterator::init(const StorageReadOptions& opts) {
         return Status::OK();
     }
 
-    for (auto iter : _origin_iters) {
+    for (auto& iter : _origin_iters) {
         RETURN_IF_ERROR(iter->init(opts));
     }
-    _cur_iter = *(_origin_iters.begin());
+    _cur_iter = _origin_iters.back().get();
     _schema = &_cur_iter->schema();
     return Status::OK();
 }
@@ -388,10 +386,9 @@ Status VUnionIterator::next_batch(Block* block) {
     while (_cur_iter != nullptr) {
         auto st = _cur_iter->next_batch(block);
         if (st.is<END_OF_FILE>()) {
-            delete _cur_iter;
-            _origin_iters.pop_front();
+            _origin_iters.pop_back();
             if (!_origin_iters.empty()) {
-                _cur_iter = *(_origin_iters.begin());
+                _cur_iter = _origin_iters.back().get();
             } else {
                 _cur_iter = nullptr;
             }
@@ -410,19 +407,21 @@ Status VUnionIterator::current_block_row_locations(std::vector<RowLocation>* loc
     return _cur_iter->current_block_row_locations(locations);
 }
 
-RowwiseIterator* new_merge_iterator(std::vector<RowwiseIterator*>& inputs, int sequence_id_idx,
-                                    bool is_unique, bool is_reverse, uint64_t* merged_rows) {
+RowwiseIteratorUPtr new_merge_iterator(std::vector<RowwiseIteratorUPtr>&& inputs,
+                                       int sequence_id_idx, bool is_unique, bool is_reverse,
+                                       uint64_t* merged_rows) {
     if (inputs.size() == 1) {
-        return *(inputs.begin());
+        return std::move(inputs[0]);
     }
-    return new VMergeIterator(inputs, sequence_id_idx, is_unique, is_reverse, merged_rows);
+    return std::make_unique<VMergeIterator>(std::move(inputs), sequence_id_idx, is_unique,
+                                            is_reverse, merged_rows);
 }
 
-RowwiseIterator* new_union_iterator(std::vector<RowwiseIterator*>& inputs) {
+RowwiseIteratorUPtr new_union_iterator(std::vector<RowwiseIteratorUPtr>&& inputs) {
     if (inputs.size() == 1) {
-        return *(inputs.begin());
+        return std::move(inputs[0]);
     }
-    return new VUnionIterator(inputs);
+    return std::make_unique<VUnionIterator>(std::move(inputs));
 }
 
 RowwiseIterator* new_vstatistics_iterator(std::shared_ptr<Segment> segment, const Schema& schema) {

--- a/be/src/vec/olap/vgeneric_iterators.cpp
+++ b/be/src/vec/olap/vgeneric_iterators.cpp
@@ -428,8 +428,8 @@ RowwiseIterator* new_vstatistics_iterator(std::shared_ptr<Segment> segment, cons
     return new VStatisticsIterator(segment, schema);
 }
 
-RowwiseIterator* new_auto_increment_iterator(const Schema& schema, size_t num_rows) {
-    return new VAutoIncrementIterator(schema, num_rows);
+RowwiseIteratorUPtr new_auto_increment_iterator(const Schema& schema, size_t num_rows) {
+    return std::make_unique<VAutoIncrementIterator>(schema, num_rows);
 }
 
 } // namespace vectorized

--- a/be/src/vec/olap/vgeneric_iterators.h
+++ b/be/src/vec/olap/vgeneric_iterators.h
@@ -71,8 +71,8 @@ public:
               _sequence_id_idx(sequence_id_idx),
               _is_unique(is_unique),
               _is_reverse(is_reverse),
-              _num_columns(iter->schema().num_column_ids()),
-              _num_key_columns(iter->schema().num_key_columns()),
+              _num_columns(_iter->schema().num_column_ids()),
+              _num_key_columns(_iter->schema().num_key_columns()),
               _compare_columns(read_orderby_key_columns) {}
 
     VMergeIteratorContext(const VMergeIteratorContext&) = delete;
@@ -319,7 +319,7 @@ RowwiseIteratorUPtr new_union_iterator(std::vector<RowwiseIteratorUPtr>&& inputs
 // This class aims to be used in unit test.
 //
 // Client should delete returned iterator.
-RowwiseIterator* new_auto_increment_iterator(const Schema& schema, size_t num_rows);
+RowwiseIteratorUPtr new_auto_increment_iterator(const Schema& schema, size_t num_rows);
 
 RowwiseIterator* new_vstatistics_iterator(std::shared_ptr<Segment> segment, const Schema& schema);
 

--- a/be/src/vec/olap/vgeneric_iterators.h
+++ b/be/src/vec/olap/vgeneric_iterators.h
@@ -65,9 +65,9 @@ private:
 //      }
 class VMergeIteratorContext {
 public:
-    VMergeIteratorContext(RowwiseIterator* iter, int sequence_id_idx, bool is_unique,
+    VMergeIteratorContext(RowwiseIteratorUPtr&& iter, int sequence_id_idx, bool is_unique,
                           bool is_reverse, std::vector<uint32_t>* read_orderby_key_columns)
-            : _iter(iter),
+            : _iter(std::move(iter)),
               _sequence_id_idx(sequence_id_idx),
               _is_unique(is_unique),
               _is_reverse(is_reverse),
@@ -80,10 +80,7 @@ public:
     VMergeIteratorContext& operator=(const VMergeIteratorContext&) = delete;
     VMergeIteratorContext& operator=(VMergeIteratorContext&&) = delete;
 
-    ~VMergeIteratorContext() {
-        delete _iter;
-        _iter = nullptr;
-    }
+    ~VMergeIteratorContext() {}
 
     Status block_reset(const std::shared_ptr<Block>& block);
 
@@ -143,7 +140,7 @@ private:
     // Load next block into _block
     Status _load_next_block();
 
-    RowwiseIterator* _iter;
+    RowwiseIteratorUPtr _iter;
 
     int _sequence_id_idx = -1;
     bool _is_unique = false;
@@ -171,9 +168,9 @@ private:
 class VMergeIterator : public RowwiseIterator {
 public:
     // VMergeIterator takes the ownership of input iterators
-    VMergeIterator(std::vector<RowwiseIterator*>& iters, int sequence_id_idx, bool is_unique,
+    VMergeIterator(std::vector<RowwiseIteratorUPtr>&& iters, int sequence_id_idx, bool is_unique,
                    bool is_reverse, uint64_t* merged_rows)
-            : _origin_iters(iters),
+            : _origin_iters(std::move(iters)),
               _sequence_id_idx(sequence_id_idx),
               _is_unique(is_unique),
               _is_reverse(is_reverse),
@@ -204,7 +201,7 @@ public:
 
     bool update_profile(RuntimeProfile* profile) override {
         if (!_origin_iters.empty()) {
-            return (*_origin_iters.begin())->update_profile(profile);
+            return _origin_iters[0]->update_profile(profile);
         }
         return false;
     }
@@ -277,7 +274,7 @@ private:
     }
 
     // It will be released after '_merge_heap' has been built.
-    std::vector<RowwiseIterator*> _origin_iters;
+    std::vector<RowwiseIteratorUPtr> _origin_iters;
 
     const Schema* _schema = nullptr;
 
@@ -308,15 +305,15 @@ private:
 //
 // Inputs iterators' ownership is taken by created merge iterator. And client
 // should delete returned iterator after usage.
-RowwiseIterator* new_merge_iterator(std::vector<RowwiseIterator*>& inputs, int sequence_id_idx,
-                                    bool is_unique, bool is_reverse, uint64_t* merged_rows);
+RowwiseIteratorUPtr new_merge_iterator(std::vector<RowwiseIteratorUPtr>&& inputs,
+                                       int sequence_id_idx, bool is_unique, bool is_reverse,
+                                       uint64_t* merged_rows);
 
 // Create a union iterator for input iterators. Union iterator will read
 // input iterators one by one.
 //
-// Inputs iterators' ownership is taken by created union iterator. And client
-// should delete returned iterator after usage.
-RowwiseIterator* new_union_iterator(std::vector<RowwiseIterator*>& inputs);
+// Inputs iterators' ownership is taken by created union iterator.
+RowwiseIteratorUPtr new_union_iterator(std::vector<RowwiseIteratorUPtr>&& inputs);
 
 // Create an auto increment iterator which returns num_rows data in format of schema.
 // This class aims to be used in unit test.


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

Fix possible memory leaks when constructing betarowset reader, by using unique_ptrs.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

