### PR TITLE
[fix](fe)should check slot from both lhs and rhs of outputSmap of join node for colocate join

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/planner/HashJoinNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/HashJoinNode.java
@@ -849,7 +849,11 @@ public class HashJoinNode extends JoinNodeBase {
             if (mappedExpr != null && mappedExpr instanceof SlotRef) {
                 return (SlotRef) mappedExpr;
             } else {
-                return null;
+                if (outputSmap.containsMappingFor(slotRef)) {
+                    return slotRef;
+                } else {
+                    return null;
+                }
             }
         } else {
             return slotRef;


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

colocated join is depended on if the both side of the join conjuncts are simple column with same distribution policy etc. So the key is to figure out the original source column in scan node if there is one. To do that, we should check the slot from both lhs and rhs of outputSmap in join node.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

