### PR TITLE
[fix](cooldown) Add cold_compaction_lock to serialize any operations which may delete the input rowsets of cold data compaction

### DIFF
--- a/be/src/olap/olap_server.cpp
+++ b/be/src/olap/olap_server.cpp
@@ -833,6 +833,11 @@ void StorageEngine::_cold_data_compaction_producer_callback() {
                     std::lock_guard lock(tablet_submitted_mtx);
                     tablet_submitted.insert(t->tablet_id());
                 }
+                std::unique_lock cold_compaction_lock(t->get_cold_compaction_lock(),
+                                                      std::try_to_lock);
+                if (!cold_compaction_lock.owns_lock()) {
+                    LOG(WARNING) << "try cold_compaction_lock failed, tablet_id=" << t->tablet_id();
+                }
                 auto st = compaction->compact();
                 {
                     std::lock_guard lock(tablet_submitted_mtx);

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -1773,9 +1773,6 @@ Status Tablet::_cooldown_data(const std::shared_ptr<io::RemoteFileSystem>& dest_
     RowsetSharedPtr new_rowset;
     RowsetFactory::create_rowset(_schema, _tablet_path, new_rowset_meta, &new_rowset);
 
-    std::vector to_add {std::move(new_rowset)};
-    std::vector to_delete {std::move(old_rowset)};
-
     {
         std::unique_lock meta_wlock(_meta_lock);
         if (tablet_state() == TABLET_RUNNING) {

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -1849,6 +1849,12 @@ Status Tablet::_follow_cooldowned_data(io::RemoteFileSystem* fs, int64_t cooldow
     LOG(INFO) << "try to follow cooldowned data. tablet_id=" << tablet_id()
               << " cooldown_replica_id=" << cooldown_replica_id
               << " local replica=" << replica_id();
+    // MUST executing serially with cold data compaction, because compaction input rowsets may be deleted by this function
+    std::unique_lock cold_compaction_lock(_cold_compaction_lock, std::try_to_lock);
+    if (!cold_compaction_lock.owns_lock()) {
+        return Status::Error<TRY_LOCK_FAILED>("try cold_compaction_lock failed");
+    }
+
     TabletMetaPB cooldown_meta_pb;
     RETURN_IF_ERROR(_read_cooldown_meta(fs, cooldown_replica_id, &cooldown_meta_pb));
     DCHECK(cooldown_meta_pb.rs_metas_size() > 0);

--- a/be/src/olap/tablet.h
+++ b/be/src/olap/tablet.h
@@ -331,6 +331,8 @@ public:
     std::shared_mutex& get_remote_files_lock() { return _remote_files_lock; }
 
     uint32_t calc_cold_data_compaction_score() const;
+
+    std::mutex& get_cold_compaction_lock() { return _cold_compaction_lock; }
     ////////////////////////////////////////////////////////////////////////////
     // end cooldown functions
     ////////////////////////////////////////////////////////////////////////////
@@ -505,10 +507,11 @@ private:
     bool _skip_base_compaction = false;
     int64_t _skip_base_compaction_ts;
 
-    // cooldown conf
+    // cooldown related
     int64_t _cooldown_replica_id = -1;
     int64_t _cooldown_term = -1;
     std::shared_mutex _remote_files_lock;
+    std::mutex _cold_compaction_lock;
 
     DISALLOW_COPY_AND_ASSIGN(Tablet);
 


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

Add cold_compaction_lock to serialize any operations which may delete the input rowsets of cold data compaction.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [x] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

