### PR TITLE
[improve](inverted index) Add element count limit for inverted index searcher cache

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -897,6 +897,7 @@ CONF_String(inverted_index_searcher_cache_limit, "10%");
 // set `true` to enable insert searcher into cache when write inverted index data
 CONF_Bool(enable_write_index_searcher_cache, "true");
 CONF_Bool(enable_inverted_index_cache_check_timestamp, "true");
+CONF_Int32(inverted_index_fd_number_limit_percent, "50"); // 50%
 
 // inverted index match bitmap cache size
 CONF_String(inverted_index_query_cache_limit, "10%");

--- a/be/src/olap/lru_cache.cpp
+++ b/be/src/olap/lru_cache.cpp
@@ -163,6 +163,10 @@ void HandleTable::_resize() {
     _length = new_length;
 }
 
+uint32_t HandleTable::element_count() const {
+    return _elems;
+}
+
 LRUCache::LRUCache(LRUCacheType type) : _type(type) {
     // Make empty circular linked list
     _lru_normal.next = &_lru_normal;
@@ -269,7 +273,8 @@ void LRUCache::release(Cache::Handle* handle) {
 
 void LRUCache::_evict_from_lru_with_time(size_t total_size, LRUHandle** to_remove_head) {
     // 1. evict normal cache entries
-    while (_usage + total_size > _capacity && !_sorted_normal_entries_with_timestamp.empty()) {
+    while ((_usage + total_size > _capacity || _check_element_count_limit()) &&
+           !_sorted_normal_entries_with_timestamp.empty()) {
         auto entry_pair = _sorted_normal_entries_with_timestamp.top();
         LRUHandle* remove_handle = entry_pair.second;
         if (_cache_value_time_extractor(remove_handle->value) != entry_pair.first) {
@@ -288,7 +293,8 @@ void LRUCache::_evict_from_lru_with_time(size_t total_size, LRUHandle** to_remov
     }
 
     // 2. evict durable cache entries if need
-    while (_usage + total_size > _capacity && !_sorted_durable_entries_with_timestamp.empty()) {
+    while ((_usage + total_size > _capacity || _check_element_count_limit()) &&
+           !_sorted_durable_entries_with_timestamp.empty()) {
         auto entry_pair = _sorted_durable_entries_with_timestamp.top();
         LRUHandle* remove_handle = entry_pair.second;
         if (_cache_value_time_extractor(remove_handle->value) != entry_pair.first) {
@@ -309,7 +315,8 @@ void LRUCache::_evict_from_lru_with_time(size_t total_size, LRUHandle** to_remov
 
 void LRUCache::_evict_from_lru(size_t total_size, LRUHandle** to_remove_head) {
     // 1. evict normal cache entries
-    while (_usage + total_size > _capacity && _lru_normal.next != &_lru_normal) {
+    while ((_usage + total_size > _capacity || _check_element_count_limit()) &&
+           _lru_normal.next != &_lru_normal) {
         LRUHandle* old = _lru_normal.next;
         DCHECK(old->priority == CachePriority::NORMAL);
         _evict_one_entry(old);
@@ -317,7 +324,8 @@ void LRUCache::_evict_from_lru(size_t total_size, LRUHandle** to_remove_head) {
         *to_remove_head = old;
     }
     // 2. evict durable cache entries if need
-    while (_usage + total_size > _capacity && _lru_durable.next != &_lru_durable) {
+    while ((_usage + total_size > _capacity || _check_element_count_limit()) &&
+           _lru_durable.next != &_lru_durable) {
         LRUHandle* old = _lru_durable.next;
         DCHECK(old->priority == CachePriority::DURABLE);
         _evict_one_entry(old);
@@ -335,6 +343,10 @@ void LRUCache::_evict_one_entry(LRUHandle* e) {
     e->in_cache = false;
     _unref(e);
     _usage -= e->total_size;
+}
+
+bool LRUCache::_check_element_count_limit() {
+    return _element_count_limit != 0 && _table.element_count() > _element_count_limit;
 }
 
 Cache::Handle* LRUCache::insert(const CacheKey& key, uint32_t hash, void* value, size_t charge,
@@ -498,7 +510,7 @@ inline uint32_t ShardedLRUCache::_hash_slice(const CacheKey& s) {
 }
 
 ShardedLRUCache::ShardedLRUCache(const std::string& name, size_t total_capacity, LRUCacheType type,
-                                 uint32_t num_shards)
+                                 uint32_t num_shards, uint32_t element_count_limit)
         : _name(name),
           _num_shard_bits(Bits::FindLSBSetNonZero(num_shards)),
           _num_shards(num_shards),
@@ -510,10 +522,13 @@ ShardedLRUCache::ShardedLRUCache(const std::string& name, size_t total_capacity,
             << "num_shards should be power of two, but got " << num_shards;
 
     const size_t per_shard = (total_capacity + (_num_shards - 1)) / _num_shards;
+    const size_t per_shard_element_count_limit =
+            (element_count_limit + (_num_shards - 1)) / _num_shards;
     LRUCache** shards = new (std::nothrow) LRUCache*[_num_shards];
     for (int s = 0; s < _num_shards; s++) {
         shards[s] = new LRUCache(type);
         shards[s]->set_capacity(per_shard);
+        shards[s]->set_element_count_limit(per_shard_element_count_limit);
     }
     _shards = shards;
 
@@ -531,8 +546,8 @@ ShardedLRUCache::ShardedLRUCache(const std::string& name, size_t total_capacity,
 ShardedLRUCache::ShardedLRUCache(const std::string& name, size_t total_capacity, LRUCacheType type,
                                  uint32_t num_shards,
                                  CacheValueTimeExtractor cache_value_time_extractor,
-                                 bool cache_value_check_timestamp)
-        : ShardedLRUCache(name, total_capacity, type, num_shards) {
+                                 bool cache_value_check_timestamp, uint32_t element_count_limit)
+        : ShardedLRUCache(name, total_capacity, type, num_shards, element_count_limit) {
     for (int s = 0; s < _num_shards; s++) {
         _shards[s]->set_cache_value_time_extractor(cache_value_time_extractor);
         _shards[s]->set_cache_value_check_timestamp(cache_value_check_timestamp);

--- a/be/src/olap/lru_cache.h
+++ b/be/src/olap/lru_cache.h
@@ -289,6 +289,8 @@ public:
     // Return whether h is found and removed.
     bool remove(const LRUHandle* h);
 
+    uint32_t element_count() const;
+
 private:
     FRIEND_TEST(CacheTest, HandleTableTest);
 
@@ -322,6 +324,9 @@ public:
 
     // Separate from constructor so caller can easily make an array of LRUCache
     void set_capacity(size_t capacity) { _capacity = capacity; }
+    void set_element_count_limit(uint32_t element_count_limit) {
+        _element_count_limit = element_count_limit;
+    }
 
     // Like Cache methods, but with an extra "hash" parameter.
     Cache::Handle* insert(const CacheKey& key, uint32_t hash, void* value, size_t charge,
@@ -349,6 +354,7 @@ private:
     void _evict_from_lru(size_t total_size, LRUHandle** to_remove_head);
     void _evict_from_lru_with_time(size_t total_size, LRUHandle** to_remove_head);
     void _evict_one_entry(LRUHandle* e);
+    bool _check_element_count_limit();
 
 private:
     LRUCacheType _type;
@@ -376,16 +382,18 @@ private:
     bool _cache_value_check_timestamp = false;
     LRUHandleHeap _sorted_normal_entries_with_timestamp;
     LRUHandleHeap _sorted_durable_entries_with_timestamp;
+
+    uint32_t _element_count_limit = 0;
 };
 
 class ShardedLRUCache : public Cache {
 public:
     explicit ShardedLRUCache(const std::string& name, size_t total_capacity, LRUCacheType type,
-                             uint32_t num_shards);
+                             uint32_t num_shards, uint32_t element_count_limit = 0);
     explicit ShardedLRUCache(const std::string& name, size_t total_capacity, LRUCacheType type,
                              uint32_t num_shards,
                              CacheValueTimeExtractor cache_value_time_extractor,
-                             bool cache_value_check_timestamp);
+                             bool cache_value_check_timestamp, uint32_t element_count_limit = 0);
     // TODO(fdy): 析构时清除所有cache元素
     virtual ~ShardedLRUCache();
     virtual Handle* insert(const CacheKey& key, void* value, size_t charge,

--- a/be/src/olap/lru_cache.h
+++ b/be/src/olap/lru_cache.h
@@ -324,8 +324,8 @@ public:
 
     // Separate from constructor so caller can easily make an array of LRUCache
     void set_capacity(size_t capacity) { _capacity = capacity; }
-    void set_element_count_limit(uint32_t element_count_limit) {
-        _element_count_limit = element_count_limit;
+    void set_element_count_capacity(uint32_t element_count_capacity) {
+        _element_count_capacity = element_count_capacity;
     }
 
     // Like Cache methods, but with an extra "hash" parameter.
@@ -383,17 +383,17 @@ private:
     LRUHandleHeap _sorted_normal_entries_with_timestamp;
     LRUHandleHeap _sorted_durable_entries_with_timestamp;
 
-    uint32_t _element_count_limit = 0;
+    uint32_t _element_count_capacity = 0;
 };
 
 class ShardedLRUCache : public Cache {
 public:
     explicit ShardedLRUCache(const std::string& name, size_t total_capacity, LRUCacheType type,
-                             uint32_t num_shards, uint32_t element_count_limit = 0);
+                             uint32_t num_shards, uint32_t element_count_capacity = 0);
     explicit ShardedLRUCache(const std::string& name, size_t total_capacity, LRUCacheType type,
                              uint32_t num_shards,
                              CacheValueTimeExtractor cache_value_time_extractor,
-                             bool cache_value_check_timestamp, uint32_t element_count_limit = 0);
+                             bool cache_value_check_timestamp, uint32_t element_count_capacity = 0);
     // TODO(fdy): 析构时清除所有cache元素
     virtual ~ShardedLRUCache();
     virtual Handle* insert(const CacheKey& key, void* value, size_t charge,

--- a/be/src/olap/rowset/segment_v2/inverted_index_cache.cpp
+++ b/be/src/olap/rowset/segment_v2/inverted_index_cache.cpp
@@ -59,9 +59,12 @@ InvertedIndexSearcherCache::InvertedIndexSearcherCache(size_t capacity, uint32_t
         fd_number = static_cast<uint64_t>(l.rlim_cur);
     }
 
-    uint64_t open_searcher_limit = fd_number / 3 * 2;
-    LOG(INFO) << "open_searcher_limit = fd_number / 3 * 2, fd_number: " << fd_number
-              << " open_searcher_limit: " << open_searcher_limit;
+    uint64_t open_searcher_limit = fd_number * config::inverted_index_fd_number_limit_percent / 100;
+    LOG(INFO) << "fd_number: " << fd_number
+              << ", inverted index open searcher limit: " << open_searcher_limit;
+#ifdef BE_TEST
+    open_searcher_limit = 2;
+#endif
 
     if (config::enable_inverted_index_cache_check_timestamp) {
         auto get_last_visit_time = [](const void* value) -> int64_t {

--- a/be/src/olap/rowset/segment_v2/inverted_index_cache.cpp
+++ b/be/src/olap/rowset/segment_v2/inverted_index_cache.cpp
@@ -49,6 +49,19 @@ void InvertedIndexSearcherCache::create_global_instance(size_t capacity, uint32_
 InvertedIndexSearcherCache::InvertedIndexSearcherCache(size_t capacity, uint32_t num_shards)
         : _mem_tracker(std::make_unique<MemTracker>("InvertedIndexSearcherCache")) {
     SCOPED_CONSUME_MEM_TRACKER(_mem_tracker.get());
+    uint64_t fd_number = config::min_file_descriptor_number;
+    struct rlimit l;
+    int ret = getrlimit(RLIMIT_NOFILE, &l);
+    if (ret != 0) {
+        LOG(WARNING) << "call getrlimit() failed. errno=" << strerror(errno)
+                     << ", use default configuration instead.";
+    } else {
+        fd_number = static_cast<uint64_t>(l.rlim_cur);
+    }
+
+    uint64_t open_searcher_limit = fd_number / 3 * 2;
+    LOG(INFO) << "open_searcher_limit = fd_number / 3 * 2, fd_number: " << fd_number
+              << " open_searcher_limit: " << open_searcher_limit;
 
     if (config::enable_inverted_index_cache_check_timestamp) {
         auto get_last_visit_time = [](const void* value) -> int64_t {
@@ -57,12 +70,12 @@ InvertedIndexSearcherCache::InvertedIndexSearcherCache(size_t capacity, uint32_t
             return cache_value->last_visit_time;
         };
         _cache = std::unique_ptr<Cache>(
-                new ShardedLRUCache("InvertedIndexSearcher:InvertedIndexSearcherCache", capacity,
-                                    LRUCacheType::SIZE, num_shards, get_last_visit_time, true));
+                new ShardedLRUCache("InvertedIndexSearcherCache", capacity, LRUCacheType::SIZE,
+                                    num_shards, get_last_visit_time, true, open_searcher_limit));
     } else {
-        _cache = std::unique_ptr<Cache>(
-                new_lru_cache("InvertedIndexSearcher:InvertedIndexSearcherCache", capacity,
-                              LRUCacheType::SIZE, num_shards));
+        _cache = std::unique_ptr<Cache>(new ShardedLRUCache("InvertedIndexSearcherCache", capacity,
+                                                            LRUCacheType::SIZE, num_shards,
+                                                            open_searcher_limit));
     }
 }
 

--- a/be/test/olap/rowset/segment_v2/inverted_index_searcher_cache_test.cpp
+++ b/be/test/olap/rowset/segment_v2/inverted_index_searcher_cache_test.cpp
@@ -136,7 +136,7 @@ TEST_F(InvertedIndexSearcherCacheTest, insert_lookup) {
     delete index_searcher_cache;
 }
 
-TEST_F(InvertedIndexSearcherCacheTest, evict) {
+TEST_F(InvertedIndexSearcherCacheTest, evict_by_usage) {
     InvertedIndexSearcherCache* index_searcher_cache =
             new InvertedIndexSearcherCache(kCacheSize, 1);
     // no need evict
@@ -194,6 +194,79 @@ TEST_F(InvertedIndexSearcherCacheTest, evict) {
             index_searcher_cache->_insert(key_4, cache_value_4.release()));
     {
         InvertedIndexCacheHandle cache_handle;
+        // lookup key_3
+        EXPECT_TRUE(index_searcher_cache->_lookup(key_3, &cache_handle));
+        // lookup key_4
+        EXPECT_TRUE(index_searcher_cache->_lookup(key_4, &cache_handle));
+    }
+
+    delete index_searcher_cache;
+}
+
+TEST_F(InvertedIndexSearcherCacheTest, evict_by_element_count_limit) {
+    InvertedIndexSearcherCache* index_searcher_cache =
+            new InvertedIndexSearcherCache(kCacheSize, 1);
+    // no need evict
+    std::string file_name_1 = "test_1.idx";
+    InvertedIndexSearcherCache::CacheKey key_1(file_name_1);
+    IndexCacheValuePtr cache_value_1 = std::make_unique<InvertedIndexSearcherCache::CacheValue>();
+    cache_value_1->size = 20;
+    cache_value_1->index_searcher = nullptr;
+    cache_value_1->last_visit_time = 10;
+    index_searcher_cache->_cache->release(
+            index_searcher_cache->_insert(key_1, cache_value_1.release()));
+
+    // no need evict
+    std::string file_name_2 = "test_2.idx";
+    InvertedIndexSearcherCache::CacheKey key_2(file_name_2);
+    IndexCacheValuePtr cache_value_2 = std::make_unique<InvertedIndexSearcherCache::CacheValue>();
+    cache_value_2->size = 50;
+    cache_value_2->index_searcher = nullptr;
+    cache_value_2->last_visit_time = 20;
+    index_searcher_cache->_cache->release(
+            index_searcher_cache->_insert(key_2, cache_value_2.release()));
+    {
+        InvertedIndexCacheHandle cache_handle;
+        // lookup key_1
+        EXPECT_TRUE(index_searcher_cache->_lookup(key_1, &cache_handle));
+        // lookup key_2
+        EXPECT_TRUE(index_searcher_cache->_lookup(key_2, &cache_handle));
+    }
+
+    // should evict {key_1, cache_value_1}
+    std::string file_name_3 = "test_3.idx";
+    InvertedIndexSearcherCache::CacheKey key_3(file_name_3);
+    IndexCacheValuePtr cache_value_3 = std::make_unique<InvertedIndexSearcherCache::CacheValue>();
+    cache_value_3->size = 80;
+    cache_value_3->index_searcher = nullptr;
+    cache_value_3->last_visit_time = 30;
+    index_searcher_cache->_cache->release(
+            index_searcher_cache->_insert(key_3, cache_value_3.release()));
+    {
+        InvertedIndexCacheHandle cache_handle;
+        // lookup key_1
+        EXPECT_FALSE(index_searcher_cache->_lookup(key_1, &cache_handle));
+        // lookup key_2
+        EXPECT_TRUE(index_searcher_cache->_lookup(key_2, &cache_handle));
+        // lookup key_3
+        EXPECT_TRUE(index_searcher_cache->_lookup(key_3, &cache_handle));
+    }
+
+    // should evict {key_2, cache_value_2}
+    std::string file_name_4 = "test_4.idx";
+    InvertedIndexSearcherCache::CacheKey key_4(file_name_4);
+    IndexCacheValuePtr cache_value_4 = std::make_unique<InvertedIndexSearcherCache::CacheValue>();
+    cache_value_4->size = 100;
+    cache_value_4->index_searcher = nullptr;
+    cache_value_4->last_visit_time = 40;
+    index_searcher_cache->_cache->release(
+            index_searcher_cache->_insert(key_4, cache_value_4.release()));
+    {
+        InvertedIndexCacheHandle cache_handle;
+        // lookup key_1
+        EXPECT_FALSE(index_searcher_cache->_lookup(key_1, &cache_handle));
+        // lookup key_2
+        EXPECT_FALSE(index_searcher_cache->_lookup(key_2, &cache_handle));
         // lookup key_3
         EXPECT_TRUE(index_searcher_cache->_lookup(key_3, &cache_handle));
         // lookup key_4

--- a/be/test/olap/rowset/segment_v2/inverted_index_searcher_cache_test.cpp
+++ b/be/test/olap/rowset/segment_v2/inverted_index_searcher_cache_test.cpp
@@ -229,6 +229,10 @@ TEST_F(InvertedIndexSearcherCacheTest, evict_by_element_count_limit) {
         InvertedIndexCacheHandle cache_handle;
         // lookup key_1
         EXPECT_TRUE(index_searcher_cache->_lookup(key_1, &cache_handle));
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(2));
+    {
+        InvertedIndexCacheHandle cache_handle;
         // lookup key_2
         EXPECT_TRUE(index_searcher_cache->_lookup(key_2, &cache_handle));
     }
@@ -246,8 +250,16 @@ TEST_F(InvertedIndexSearcherCacheTest, evict_by_element_count_limit) {
         InvertedIndexCacheHandle cache_handle;
         // lookup key_1
         EXPECT_FALSE(index_searcher_cache->_lookup(key_1, &cache_handle));
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(2));
+    {
+        InvertedIndexCacheHandle cache_handle;
         // lookup key_2
         EXPECT_TRUE(index_searcher_cache->_lookup(key_2, &cache_handle));
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(2));
+    {
+        InvertedIndexCacheHandle cache_handle;
         // lookup key_3
         EXPECT_TRUE(index_searcher_cache->_lookup(key_3, &cache_handle));
     }
@@ -267,8 +279,16 @@ TEST_F(InvertedIndexSearcherCacheTest, evict_by_element_count_limit) {
         EXPECT_FALSE(index_searcher_cache->_lookup(key_1, &cache_handle));
         // lookup key_2
         EXPECT_FALSE(index_searcher_cache->_lookup(key_2, &cache_handle));
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(2));
+    {
+        InvertedIndexCacheHandle cache_handle;
         // lookup key_3
         EXPECT_TRUE(index_searcher_cache->_lookup(key_3, &cache_handle));
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(2));
+    {
+        InvertedIndexCacheHandle cache_handle;
         // lookup key_4
         EXPECT_TRUE(index_searcher_cache->_lookup(key_4, &cache_handle));
     }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary
The element in InvertedIndexSearcherCache is inverted index searcher, which is a file descriptor of inverted index file, so `InvertedIndexSearcherCache` is actually cache file descriptor of inverted index file.

If open file descriptor limit of the Linux system is set too small and config `inverted_index_searcher_cache_limit`  is too big, during high pressure load maybe cause "Too many open files".

So, when insert inverted index searcher into `InvertedIndexSearcherCache`, need also check whether reach file_descriptor_number limit for inverted index file.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

