### PR TITLE
[Fix](multi catalog) Fix partition case bug.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/BrokerUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/BrokerUtil.java
@@ -119,6 +119,12 @@ public class BrokerUtil {
         if (columnsFromPath == null || columnsFromPath.isEmpty()) {
             return Collections.emptyList();
         }
+        if (!caseSensitive) {
+            for (int i = 0; i < columnsFromPath.size(); i++) {
+                String path = columnsFromPath.remove(i);
+                columnsFromPath.add(i, path.toLowerCase());
+            }
+        }
         String[] strings = filePath.split("/");
         if (strings.length < 2) {
             throw new UserException("Fail to parse columnsFromPath, expected: "


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

Set column names from path to lower case in case-insensitive case. 
This is for Iceberg columns from path. Iceberg columns are case sensitive, which may cause error for table with partitions.

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

