### PR TITLE
[Fix](multi catalog)Fix iceberg parquet file doesn't have iceberg.schema meta problem.

### DIFF
--- a/be/src/vec/exec/format/parquet/vparquet_reader.cpp
+++ b/be/src/vec/exec/format/parquet/vparquet_reader.cpp
@@ -207,8 +207,9 @@ Status ParquetReader::init_reader(
         auto name = schema_desc.get_column(i)->name;
         // If the column in parquet file is included in all_column_names and not in missing_column_names,
         // add it to _map_column, which means the reader should read the data of this column.
-        // Here to check against missing_column_names is to for the 'Add a column with back to the table
-        // with the same column name' case. Shouldn't read this column data in this case.
+        // Here to check against missing_column_names is for the 'Add a column back to the table
+        // with the same column name' case. (drop column a then add column a).
+        // Shouldn't read this column data in this case.
         if (find(all_column_names.begin(), all_column_names.end(), name) !=
                     all_column_names.end() &&
             find(missing_column_names.begin(), missing_column_names.end(), name) ==

--- a/be/src/vec/exec/format/table/iceberg_reader.cpp
+++ b/be/src/vec/exec/format/table/iceberg_reader.cpp
@@ -425,6 +425,7 @@ Status IcebergTableReader::_gen_col_name_maps(std::vector<tparquet::KeyValue> pa
     for (int i = 0; i < parquet_meta_kv.size(); ++i) {
         tparquet::KeyValue kv = parquet_meta_kv[i];
         if (kv.key == "iceberg.schema") {
+            _has_iceberg_schema = true;
             std::string schema = kv.value;
             rapidjson::Document json;
             json.Parse(schema.c_str());
@@ -478,7 +479,9 @@ void IcebergTableReader::_gen_file_col_names() {
         auto iter = _table_col_to_file_col.find(name);
         if (iter == _table_col_to_file_col.end()) {
             _all_required_col_names.emplace_back(name);
-            _not_in_file_col_names.emplace_back(name);
+            if (_has_iceberg_schema) {
+                _not_in_file_col_names.emplace_back(name);
+            }
         } else {
             _all_required_col_names.emplace_back(iter->second);
         }

--- a/be/src/vec/exec/format/table/iceberg_reader.h
+++ b/be/src/vec/exec/format/table/iceberg_reader.h
@@ -118,6 +118,7 @@ private:
 
     IOContext* _io_ctx;
     bool _has_schema_change = false;
+    bool _has_iceberg_schema = false;
 };
 } // namespace vectorized
 } // namespace doris


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

To support schema evolution, Iceberg add schema information to Parquet file metadata. But for early iceberg version, it doesn't write any schema information to Parquet file. This PR is to support read parquet without schema information.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

