### PR TITLE
[enhance](util) Split PriorityWorkStealingThreadPool into impl cpp && modernize-pass-by-value blocking_put

### DIFF
--- a/be/src/runtime/record_batch_queue.h
+++ b/be/src/runtime/record_batch_queue.h
@@ -48,8 +48,8 @@ public:
         return _queue.blocking_get(result);
     }
 
-    bool blocking_put(const std::shared_ptr<arrow::RecordBatch>& val) {
-        return _queue.blocking_put(val);
+    bool blocking_put(std::shared_ptr<arrow::RecordBatch> val) {
+        return _queue.blocking_put(std::move(val));
     }
 
     // Shut down the queue. Wakes up all threads waiting on blocking_get or blocking_put.

--- a/be/src/util/CMakeLists.txt
+++ b/be/src/util/CMakeLists.txt
@@ -83,6 +83,7 @@ set(UTIL_FILES
   file_cache.cpp
   thread.cpp
   threadpool.cpp
+  priority_work_stealing_thread_pool.cpp
   trace.cpp
   trace_metrics.cpp
   timezone_utils.cpp

--- a/be/src/util/blocking_priority_queue.hpp
+++ b/be/src/util/blocking_priority_queue.hpp
@@ -86,7 +86,7 @@ public:
                     T v = _queue.top();
                     _queue.pop();
                     ++v;
-                    tmp_queue.push(v);
+                    tmp_queue.push(std::move(v));
                 }
                 swap(_queue, tmp_queue);
                 _upgrade_counter = 0;
@@ -122,7 +122,7 @@ public:
                     T v = _queue.top();
                     _queue.pop();
                     ++v;
-                    tmp_queue.push(v);
+                    tmp_queue.push(std::move(v));
                 }
                 swap(_queue, tmp_queue);
                 _upgrade_counter = 0;
@@ -140,7 +140,7 @@ public:
 
     // Puts an element into the queue, waiting indefinitely until there is space.
     // If the queue is shut down, returns false.
-    bool blocking_put(const T& val) {
+    bool blocking_put(T val) {
         MonotonicStopWatch timer;
         timer.start();
         std::unique_lock unique_lock(_lock);
@@ -153,7 +153,7 @@ public:
             return false;
         }
 
-        _queue.push(val);
+        _queue.push(std::move(val));
         _get_cv.notify_one();
         return true;
     }

--- a/be/src/util/blocking_queue.hpp
+++ b/be/src/util/blocking_queue.hpp
@@ -26,6 +26,7 @@
 #include <condition_variable>
 #include <list>
 #include <mutex>
+#include <utility>
 
 #include "common/logging.h"
 #include "util/stopwatch.hpp"
@@ -66,7 +67,7 @@ public:
 
     // Puts an element into the queue, waiting indefinitely until there is space.
     // If the queue is shut down, returns false.
-    bool blocking_put(const T& val) {
+    bool blocking_put(T val) {
         MonotonicStopWatch timer;
         timer.start();
         std::unique_lock<std::mutex> unique_lock(_lock);
@@ -77,7 +78,7 @@ public:
             return false;
         }
 
-        _list.push_back(val);
+        _list.push_back(std::move(val));
         _get_cv.notify_one();
         return true;
     }

--- a/be/src/util/priority_thread_pool.hpp
+++ b/be/src/util/priority_thread_pool.hpp
@@ -80,12 +80,9 @@ public:
     //
     // Returns true if the work item was successfully added to the queue, false otherwise
     // (which typically means that the thread pool has already been shut down).
-    virtual bool offer(Task task) { return _work_queue.blocking_put(task); }
+    virtual bool offer(Task task) { return _work_queue.blocking_put(std::move(task)); }
 
-    virtual bool offer(WorkFunction func) {
-        PriorityThreadPool::Task task = {0, func, 0};
-        return _work_queue.blocking_put(task);
-    }
+    virtual bool offer(WorkFunction func) { return _work_queue.blocking_put({0, func, 0}); }
 
     virtual bool try_offer(WorkFunction func) {
         PriorityThreadPool::Task task = {0, func, 0};

--- a/be/src/util/priority_thread_pool.hpp
+++ b/be/src/util/priority_thread_pool.hpp
@@ -19,6 +19,7 @@
 
 #include <mutex>
 #include <thread>
+#include <utility>
 
 #include "util/blocking_priority_queue.hpp"
 #include "util/lock.h"
@@ -54,8 +55,8 @@ public:
     //  -- queue_size: the maximum size of the queue on which work items are offered. If the
     //     queue exceeds this size, subsequent calls to Offer will block until there is
     //     capacity available.
-    PriorityThreadPool(uint32_t num_threads, uint32_t queue_size, const std::string& name)
-            : _work_queue(queue_size), _shutdown(false), _name(name), _active_threads(0) {
+    PriorityThreadPool(uint32_t num_threads, uint32_t queue_size, std::string name)
+            : _work_queue(queue_size), _name(std::move(name)) {
         for (int i = 0; i < num_threads; ++i) {
             _threads.create_thread(
                     std::bind<void>(std::mem_fn(&PriorityThreadPool::work_thread), this, i));
@@ -154,9 +155,9 @@ private:
     BlockingPriorityQueue<Task> _work_queue;
 
     // Set to true when threads should stop doing work and terminate.
-    std::atomic<bool> _shutdown;
+    std::atomic<bool> _shutdown {false};
     std::string _name;
-    std::atomic<int> _active_threads;
+    std::atomic<int> _active_threads {0};
 };
 
 } // namespace doris

--- a/be/src/util/priority_work_stealing_thread_pool.cpp
+++ b/be/src/util/priority_work_stealing_thread_pool.cpp
@@ -1,0 +1,113 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "util/priority_work_stealing_thread_pool.hpp"
+
+#include <cstdio>
+#include <mutex>
+#include <utility>
+
+#include "util/blocking_priority_queue.hpp"
+#include "util/thread.h"
+
+namespace doris {
+PriorityWorkStealingThreadPool::PriorityWorkStealingThreadPool(uint32_t num_threads,
+                                                               uint32_t num_queues,
+                                                               uint32_t queue_size,
+                                                               std::string name)
+        : PriorityThreadPool(0, 0, std::move(name)) {
+    DCHECK_GT(num_queues, 0);
+    DCHECK_GE(num_threads, num_queues);
+    // init _work_queues first because the work thread needs it
+    for (int i = 0; i < num_queues; ++i) {
+        _work_queues.emplace_back(std::make_shared<BlockingPriorityQueue<Task>>(queue_size));
+    }
+    for (int i = 0; i < num_threads; ++i) {
+        _threads.create_thread(std::bind<void>(
+                std::mem_fn(&PriorityWorkStealingThreadPool::work_thread), this, i));
+    }
+}
+
+PriorityWorkStealingThreadPool::~PriorityWorkStealingThreadPool() {
+    shutdown();
+    join();
+}
+
+bool PriorityWorkStealingThreadPool::offer(Task task) {
+    return _work_queues[task.queue_id]->blocking_put(std::move(task));
+}
+
+bool PriorityWorkStealingThreadPool::offer(WorkFunction func) {
+    return offer({0, func, 0});
+}
+
+void PriorityWorkStealingThreadPool::shutdown() {
+    PriorityThreadPool::shutdown();
+    for (auto work_queue : _work_queues) {
+        work_queue->shutdown();
+    }
+}
+
+uint32_t PriorityWorkStealingThreadPool::get_queue_size() const {
+    uint32_t size = 0;
+    for (auto work_queue : _work_queues) {
+        size += work_queue->get_size();
+    }
+    return size;
+}
+
+void PriorityWorkStealingThreadPool::drain_and_shutdown() {
+    {
+        std::unique_lock l(_lock);
+        while (get_queue_size() != 0) {
+            _empty_cv.wait(l);
+        }
+    }
+    shutdown();
+    join();
+}
+
+void PriorityWorkStealingThreadPool::work_thread(int thread_id) {
+    auto queue_id = thread_id % _work_queues.size();
+    auto steal_queue_id = (queue_id + 1) % _work_queues.size();
+    while (!is_shutdown()) {
+        Task task;
+        // avoid blocking get
+        bool is_other_queues_empty = true;
+        // steal work in round-robin if nothing to do
+        while (_work_queues[queue_id]->get_size() == 0 && queue_id != steal_queue_id &&
+               !is_shutdown()) {
+            if (_work_queues[steal_queue_id]->non_blocking_get(&task)) {
+                is_other_queues_empty = false;
+                task.work_function();
+            }
+            steal_queue_id = (steal_queue_id + 1) % _work_queues.size();
+        }
+        if (queue_id == steal_queue_id) {
+            steal_queue_id = (steal_queue_id + 1) % _work_queues.size();
+        }
+        if (is_other_queues_empty &&
+            _work_queues[queue_id]->blocking_get(
+                    &task, config::doris_blocking_priority_queue_wait_timeout_ms)) {
+            task.work_function();
+        }
+        if (_work_queues[queue_id]->get_size() == 0) {
+            _empty_cv.notify_all();
+        }
+    }
+}
+} // namespace doris

--- a/be/src/util/priority_work_stealing_thread_pool.hpp
+++ b/be/src/util/priority_work_stealing_thread_pool.hpp
@@ -30,7 +30,7 @@ class BlockingPriorityQueue;
 
 // Work-Stealing threadpool which processes items (of type T) in parallel which were placed on multi
 // blocking queues by Offer(). Each item is processed by a single user-supplied method.
-class PriorityWorkStealingThreadPool : public PriorityThreadPool {
+class PriorityWorkStealingThreadPool final : public PriorityThreadPool {
 public:
     // Creates a new thread pool and start num_threads threads.
     //  -- num_threads: how many threads are part of this pool
@@ -40,7 +40,7 @@ public:
     //     capacity available.
     PriorityWorkStealingThreadPool(uint32_t num_threads, uint32_t num_queues, uint32_t queue_size,
                                    std::string name);
-    virtual ~PriorityWorkStealingThreadPool();
+    ~PriorityWorkStealingThreadPool() override;
 
     bool offer(Task task) override;
     bool offer(WorkFunction func) override;

--- a/be/src/util/priority_work_stealing_thread_pool.hpp
+++ b/be/src/util/priority_work_stealing_thread_pool.hpp
@@ -17,14 +17,16 @@
 
 #pragma once
 
-#include <mutex>
-#include <thread>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
 
-#include "util/blocking_priority_queue.hpp"
-#include "util/lock.h"
-#include "util/thread_group.h"
+#include "util/priority_thread_pool.hpp"
 
 namespace doris {
+template <typename T>
+class BlockingPriorityQueue;
 
 // Work-Stealing threadpool which processes items (of type T) in parallel which were placed on multi
 // blocking queues by Offer(). Each item is processed by a single user-supplied method.
@@ -37,109 +39,31 @@ public:
     //     queue exceeds this size, subsequent calls to Offer will block until there is
     //     capacity available.
     PriorityWorkStealingThreadPool(uint32_t num_threads, uint32_t num_queues, uint32_t queue_size,
-                                   const std::string& name)
-            : PriorityThreadPool(0, 0, name) {
-        DCHECK_GT(num_queues, 0);
-        DCHECK_GE(num_threads, num_queues);
-        // init _work_queues first because the work thread needs it
-        for (int i = 0; i < num_queues; ++i) {
-            _work_queues.emplace_back(std::make_shared<BlockingPriorityQueue<Task>>(queue_size));
-        }
-        for (int i = 0; i < num_threads; ++i) {
-            _threads.create_thread(std::bind<void>(
-                    std::mem_fn(&PriorityWorkStealingThreadPool::work_thread), this, i));
-        }
-    }
+                                   std::string name);
+    virtual ~PriorityWorkStealingThreadPool();
 
-    virtual ~PriorityWorkStealingThreadPool() {
-        shutdown();
-        join();
-    }
-
-    // Blocking operation that puts a work item on the queue. If the queue is full, blocks
-    // until there is capacity available.
-    //
-    // 'work' is copied into the work queue, but may be referenced at any time in the
-    // future. Therefore the caller needs to ensure that any data referenced by work (if T
-    // is, e.g., a pointer type) remains valid until work has been processed, and it's up to
-    // the caller to provide their own signalling mechanism to detect this (or to wait until
-    // after DrainAndshutdown returns).
-    //
-    // Returns true if the work item was successfully added to the queue, false otherwise
-    // (which typically means that the thread pool has already been shut down).
-    bool offer(Task task) override { return _work_queues[task.queue_id]->blocking_put(task); }
-
-    bool offer(WorkFunction func) override {
-        PriorityThreadPool::Task task = {0, func, 0};
-        return _work_queues[task.queue_id]->blocking_put(task);
-    }
+    bool offer(Task task) override;
+    bool offer(WorkFunction func) override;
 
     // Shuts the thread pool down, causing the work queue to cease accepting offered work
     // and the worker threads to terminate once they have processed their current work item.
     // Returns once the shutdown flag has been set, does not wait for the threads to
     // terminate.
-    void shutdown() override {
-        PriorityThreadPool::shutdown();
-        for (auto work_queue : _work_queues) {
-            work_queue->shutdown();
-        }
-    }
-
-    uint32_t get_queue_size() const override {
-        uint32_t size = 0;
-        for (auto work_queue : _work_queues) {
-            size += work_queue->get_size();
-        }
-        return size;
-    }
+    void shutdown() override;
 
     // Blocks until the work queue is empty, and then calls shutdown to stop the worker
     // threads and Join to wait until they are finished.
     // Any work Offer()'ed during DrainAndshutdown may or may not be processed.
-    void drain_and_shutdown() override {
-        {
-            std::unique_lock l(_lock);
-            while (get_queue_size() != 0) {
-                _empty_cv.wait(l);
-            }
-        }
-        shutdown();
-        join();
-    }
+    void drain_and_shutdown() override;
+
+    uint32_t get_queue_size() const override;
 
 private:
     // Driver method for each thread in the pool. Continues to read work from the queue
     // until the pool is shutdown.
-    void work_thread(int thread_id) {
-        auto queue_id = thread_id % _work_queues.size();
-        auto steal_queue_id = (queue_id + 1) % _work_queues.size();
-        while (!is_shutdown()) {
-            Task task;
-            // avoid blocking get
-            bool is_other_queues_empty = true;
-            // steal work in round-robin if nothing to do
-            while (_work_queues[queue_id]->get_size() == 0 && queue_id != steal_queue_id &&
-                   !is_shutdown()) {
-                if (_work_queues[steal_queue_id]->non_blocking_get(&task)) {
-                    is_other_queues_empty = false;
-                    task.work_function();
-                }
-                steal_queue_id = (steal_queue_id + 1) % _work_queues.size();
-            }
-            if (queue_id == steal_queue_id) {
-                steal_queue_id = (steal_queue_id + 1) % _work_queues.size();
-            }
-            if (is_other_queues_empty &&
-                _work_queues[queue_id]->blocking_get(
-                        &task, config::doris_blocking_priority_queue_wait_timeout_ms)) {
-                task.work_function();
-            }
-            if (_work_queues[queue_id]->get_size() == 0) {
-                _empty_cv.notify_all();
-            }
-        }
-    }
+    void work_thread(int thread_id);
 
+private:
     // Queue on which work items are held until a thread is available to process them in
     // FIFO order.
     std::vector<std::shared_ptr<BlockingPriorityQueue<Task>>> _work_queues;

--- a/be/src/vec/exec/scan/scanner_scheduler.cpp
+++ b/be/src/vec/exec/scan/scanner_scheduler.cpp
@@ -17,6 +17,8 @@
 
 #include "scanner_scheduler.h"
 
+#include <memory>
+
 #include "common/config.h"
 #include "util/async_io.h"
 #include "util/priority_thread_pool.hpp"
@@ -73,9 +75,9 @@ Status ScannerScheduler::init(ExecEnv* env) {
     }
 
     // 2. local scan thread pool
-    _local_scan_thread_pool.reset(new PriorityWorkStealingThreadPool(
+    _local_scan_thread_pool = std::make_unique<PriorityWorkStealingThreadPool>(
             config::doris_scanner_thread_pool_thread_num, env->store_paths().size(),
-            config::doris_scanner_thread_pool_queue_size, "local_scan"));
+            config::doris_scanner_thread_pool_queue_size, "local_scan");
 
     // 3. remote scan thread pool
     ThreadPoolBuilder("RemoteScanThreadPool")

--- a/be/src/vec/sink/vmemory_scratch_sink.cpp
+++ b/be/src/vec/sink/vmemory_scratch_sink.cpp
@@ -71,7 +71,7 @@ Status MemoryScratchSink::send(RuntimeState* state, Block* block, bool eos) {
     std::shared_ptr<arrow::RecordBatch> result;
     RETURN_IF_ERROR(
             convert_to_arrow_batch(*block, _arrow_schema, arrow::default_memory_pool(), &result));
-    _queue->blocking_put(result);
+    _queue->blocking_put(std::move(result));
     return Status::OK();
 }
 


### PR DESCRIPTION
## Problem summary

- Split PriorityWorkStealingThreadPool into impl cpp to reduce compile time
- Refactor record_batch_queue blocking_queue blocking_put to pass-by-value

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [x] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

