### PR TITLE
[enhancement](nereids)add a session variable to control join reorder algorithm

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/NereidsPlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/NereidsPlanner.java
@@ -170,8 +170,10 @@ public class NereidsPlanner extends Planner {
             }
             deriveStats();
 
-            if (statementContext.getConnectContext().getSessionVariable().isEnableDPHypOptimizer()) {
-                // TODO: use DPHyp according the number of join table
+            if (!statementContext.getConnectContext().getSessionVariable().isDisableJoinReorder()
+                    && statementContext.getConnectContext().getSessionVariable().isEnableDPHypOptimizer()
+                    && statementContext.getMaxNAryInnerJoin() > statementContext.getConnectContext()
+                    .getSessionVariable().getMaxTableCountUseCascadesJoinReorder()) {
                 dpHypOptimize();
             } else {
                 optimize();

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/NereidsPlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/NereidsPlanner.java
@@ -220,7 +220,6 @@ public class NereidsPlanner extends Planner {
         }
         cascadesContext.pushJob(new JoinOrderJob(root, cascadesContext.getCurrentJobContext()));
         cascadesContext.getJobScheduler().executeJobPool(cascadesContext);
-        optimize();
     }
 
     /**
@@ -234,9 +233,8 @@ public class NereidsPlanner extends Planner {
                 && statementContext.getMaxNAryInnerJoin() > statementContext.getConnectContext()
                 .getSessionVariable().getMaxTableCountUseCascadesJoinReorder()) {
             dpHypOptimize();
-        } else {
-            new OptimizeRulesJob(cascadesContext).execute();
         }
+        new OptimizeRulesJob(cascadesContext).execute();
     }
 
     private PhysicalPlan postProcess(PhysicalPlan physicalPlan) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/NereidsPlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/NereidsPlanner.java
@@ -170,14 +170,7 @@ public class NereidsPlanner extends Planner {
             }
             deriveStats();
 
-            if (!statementContext.getConnectContext().getSessionVariable().isDisableJoinReorder()
-                    && statementContext.getConnectContext().getSessionVariable().isEnableDPHypOptimizer()
-                    && statementContext.getMaxNAryInnerJoin() > statementContext.getConnectContext()
-                    .getSessionVariable().getMaxTableCountUseCascadesJoinReorder()) {
-                dpHypOptimize();
-            } else {
-                optimize();
-            }
+            optimize();
 
             PhysicalPlan physicalPlan = chooseBestPlan(getRoot(), requireProperties);
 
@@ -236,7 +229,14 @@ public class NereidsPlanner extends Planner {
      * try to find best plan under the guidance of statistic information and cost model.
      */
     private void optimize() {
-        new OptimizeRulesJob(cascadesContext).execute();
+        if (!statementContext.getConnectContext().getSessionVariable().isDisableJoinReorder()
+                && statementContext.getConnectContext().getSessionVariable().isEnableDPHypOptimizer()
+                && statementContext.getMaxNAryInnerJoin() > statementContext.getConnectContext()
+                .getSessionVariable().getMaxTableCountUseCascadesJoinReorder()) {
+            dpHypOptimize();
+        } else {
+            new OptimizeRulesJob(cascadesContext).execute();
+        }
     }
 
     private PhysicalPlan postProcess(PhysicalPlan physicalPlan) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/StatementContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/StatementContext.java
@@ -40,6 +40,8 @@ public class StatementContext {
 
     private OriginStatement originStatement;
 
+    private int maxNAryInnerJoin = 0;
+
     private final IdGenerator<ExprId> exprIdGenerator = ExprId.createGenerator();
 
     private final IdGenerator<RelationId> relationIdGenerator = RelationId.createGenerator();
@@ -72,6 +74,16 @@ public class StatementContext {
 
     public OriginStatement getOriginStatement() {
         return originStatement;
+    }
+
+    public void setMaxNArayInnerJoin(int maxNAryInnerJoin) {
+        if (maxNAryInnerJoin > this.maxNAryInnerJoin) {
+            this.maxNAryInnerJoin = maxNAryInnerJoin;
+        }
+    }
+
+    public int getMaxNAryInnerJoin() {
+        return maxNAryInnerJoin;
     }
 
     public StatementBase getParsedStatement() {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/batch/NereidsRewriteJobExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/batch/NereidsRewriteJobExecutor.java
@@ -74,7 +74,7 @@ public class NereidsRewriteJobExecutor extends BatchRulesJob {
      */
     public NereidsRewriteJobExecutor(CascadesContext cascadesContext) {
         super(cascadesContext);
-        ImmutableList<Job> jobs = new ImmutableList.Builder<Job>()
+        ImmutableList.Builder<Job> jobBuilder = new ImmutableList.Builder<Job>()
                 .addAll(new EliminateSpecificPlanUnderApplyJob(cascadesContext).rulesJob)
                 // MergeProjects depends on this rule
                 .add(bottomUpBatch(ImmutableList.of(new LogicalSubQueryAliasToLogicalProject())))
@@ -106,9 +106,13 @@ public class NereidsRewriteJobExecutor extends BatchRulesJob {
                 .add(topDownBatch(RuleSet.PUSH_DOWN_FILTERS, false))
                 .add(visitorJob(RuleType.INFER_PREDICATES, new InferPredicates()))
                 .add(topDownBatch(ImmutableList.of(new ExtractFilterFromCrossJoin())))
-                .add(topDownBatch(ImmutableList.of(new MergeFilters())))
-                .add(topDownBatch(ImmutableList.of(new ReorderJoin())))
-                .add(topDownBatch(ImmutableList.of(new ColumnPruning())))
+                .add(topDownBatch(ImmutableList.of(new MergeFilters())));
+
+        if (!cascadesContext.getConnectContext().getSessionVariable().isDisableJoinReorder()) {
+            jobBuilder.add(topDownBatch(ImmutableList.of(new ReorderJoin())));
+        }
+
+        jobBuilder.add(topDownBatch(ImmutableList.of(new ColumnPruning())))
                 .add(topDownBatch(RuleSet.PUSH_DOWN_FILTERS, false))
                 .add(visitorJob(RuleType.INFER_PREDICATES, new InferPredicates()))
                 .add(topDownBatch(RuleSet.PUSH_DOWN_FILTERS, false))
@@ -139,10 +143,8 @@ public class NereidsRewriteJobExecutor extends BatchRulesJob {
                 .add(bottomUpBatch(ImmutableList.of(
                         new AdjustNullable(),
                         new ExpressionRewrite(CheckLegalityAfterRewrite.INSTANCE),
-                        new CheckAfterRewrite()))
-                )
-                .build();
+                        new CheckAfterRewrite())));
 
-        rulesJob.addAll(jobs);
+        rulesJob.addAll(jobBuilder.build());
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/cascades/OptimizeGroupExpressionJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/cascades/OptimizeGroupExpressionJob.java
@@ -43,7 +43,10 @@ public class OptimizeGroupExpressionJob extends Job {
         countJobExecutionTimesOfGroupExpressions(groupExpression);
         List<Rule> validRules = new ArrayList<>();
         List<Rule> implementationRules = getRuleSet().getImplementationRules();
-        List<Rule> explorationRules = getRuleSet().getExplorationRules();
+        boolean isDisableJoinReorder = context.getCascadesContext().getConnectContext().getSessionVariable()
+                .isDisableJoinReorder();
+        List<Rule> explorationRules = isDisableJoinReorder ? getRuleSet().getExplorationRulesWithoutReorder()
+                : getRuleSet().getExplorationRules();
 
         validRules.addAll(getValidRules(groupExpression, implementationRules));
         validRules.addAll(getValidRules(groupExpression, explorationRules));

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/RuleSet.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/RuleSet.java
@@ -72,15 +72,17 @@ import java.util.List;
  */
 public class RuleSet {
     public static final List<Rule> EXPLORATION_RULES = planRuleFactories()
+            .add(new PushdownFilterThroughProject())
+            .add(new MergeProjects())
+            .build();
+
+    public static final List<Rule> OTHER_REORDER_RULES = planRuleFactories()
             .add(OuterJoinLAsscom.INSTANCE)
             .add(OuterJoinLAsscomProject.INSTANCE)
             .add(SemiJoinLogicalJoinTranspose.LEFT_DEEP)
             .add(SemiJoinLogicalJoinTransposeProject.LEFT_DEEP)
             .add(SemiJoinSemiJoinTranspose.INSTANCE)
             .add(SemiJoinSemiJoinTransposeProject.INSTANCE)
-            // .add(new DisassembleDistinctAggregate())
-            .add(new PushdownFilterThroughProject())
-            .add(new MergeProjects())
             .build();
 
     /**
@@ -168,6 +170,13 @@ public class RuleSet {
     public List<Rule> getExplorationRules() {
         List<Rule> rules = new ArrayList<>();
         rules.addAll(JOINORDER_RULE);
+        rules.addAll(OTHER_REORDER_RULES);
+        rules.addAll(EXPLORATION_RULES);
+        return rules;
+    }
+
+    public List<Rule> getExplorationRulesWithoutReorder() {
+        List<Rule> rules = new ArrayList<>();
         rules.addAll(EXPLORATION_RULES);
         return rules;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/logical/ReorderJoin.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/logical/ReorderJoin.java
@@ -78,6 +78,7 @@ public class ReorderJoin extends OneRewriteRuleFactory {
             Plan plan = joinToMultiJoin(filter, planToHintType);
             Preconditions.checkState(plan instanceof MultiJoin);
             MultiJoin multiJoin = (MultiJoin) plan;
+            ctx.statementContext.setMaxNArayInnerJoin(multiJoin.children().size());
             Plan after = multiJoinToJoin(multiJoin, planToHintType);
             return after;
         }).toRule(RuleType.REORDER_JOIN);

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/logical/ReorderJoin.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/logical/ReorderJoin.java
@@ -72,6 +72,9 @@ public class ReorderJoin extends OneRewriteRuleFactory {
     @Override
     public Rule build() {
         return logicalFilter(subTree(LogicalJoin.class, LogicalFilter.class)).thenApply(ctx -> {
+            if (ctx.statementContext.getConnectContext().getSessionVariable().isDisableJoinReorder()) {
+                return null;
+            }
             LogicalFilter<Plan> filter = ctx.root;
 
             Map<Plan, JoinHintType> planToHintType = Maps.newHashMap();

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -268,6 +268,8 @@ public class SessionVariable implements Serializable, Writable {
     public static final String GROUP_BY_AND_HAVING_USE_ALIAS_FIRST = "group_by_and_having_use_alias_first";
     public static final String DROP_TABLE_IF_CTAS_FAILED = "drop_table_if_ctas_failed";
 
+    public static final String MAX_TABLE_COUNT_USE_CASCADES_JOIN_REORDER = "max_table_count_use_cascades_join_reorder";
+
     // session origin value
     public Map<Field, String> sessionOriginValue = new HashMap<Field, String>();
     // check stmt is or not [select /*+ SET_VAR(...)*/ ...]
@@ -706,6 +708,12 @@ public class SessionVariable implements Serializable, Writable {
     // Whether drop table when create table as select insert data appear error.
     @VariableMgr.VarAttr(name = DROP_TABLE_IF_CTAS_FAILED, needForward = true)
     public boolean dropTableIfCtasFailed = true;
+
+
+    @VariableMgr.VarAttr(name = MAX_TABLE_COUNT_USE_CASCADES_JOIN_REORDER)
+    public int maxTableCountUseCascadesJoinReorder = 10;
+
+    public static final int MIN_JOIN_REORDER_TABLE_COUNT = 2;
 
     // If this fe is in fuzzy mode, then will use initFuzzyModeVariables to generate some variables,
     // not the default value set in the code.
@@ -1469,6 +1477,17 @@ public class SessionVariable implements Serializable, Writable {
 
     public void setEnableFileCache(boolean enableFileCache) {
         this.enableFileCache = enableFileCache;
+    }
+
+    public int getMaxTableCountUseCascadesJoinReorder() {
+        return this.maxTableCountUseCascadesJoinReorder;
+    }
+
+    public void setMaxTableCountUseCascadesJoinReorder(int maxTableCountUseCascadesJoinReorder) {
+        this.maxTableCountUseCascadesJoinReorder =
+                maxTableCountUseCascadesJoinReorder < MIN_JOIN_REORDER_TABLE_COUNT
+                        ? MIN_JOIN_REORDER_TABLE_COUNT
+                        : maxTableCountUseCascadesJoinReorder;
     }
 
     /**

--- a/regression-test/suites/nereids_syntax_p0/join_order.groovy
+++ b/regression-test/suites/nereids_syntax_p0/join_order.groovy
@@ -93,4 +93,16 @@ suite("join_order") {
                 ON dcii.b = dcssm.e1
                     AND dcbc.d3 = dcssm.e2;
         """
+
+    sql 'set disable_join_reorder=true;'
+    explain {
+        sql("select * from outerjoin_A_order, outerjoin_B_order, outerjoin_C_order where outerjoin_A_order.a1 = outerjoin_C_order.c and outerjoin_B_order.b = outerjoin_C_order.c;")
+        contains "CROSS JOIN"
+    }
+
+    sql 'set disable_join_reorder=false;'
+    explain {
+        sql("select * from outerjoin_A_order, outerjoin_B_order, outerjoin_C_order where outerjoin_A_order.a1 = outerjoin_C_order.c and outerjoin_B_order.b = outerjoin_C_order.c;")
+        notContains "CROSS JOIN"
+    }
 }


### PR DESCRIPTION
# Proposed changes
1. disable join reorder in nereids if **disable_join_reorder** is true.
2. add a session variable **max_table_count_use_cascades_join_reorder** to control join reorder algorithm in nereids. if dp hyper is used only when **enable_dphyp_optimizer** is true and the joined table count more than **max_table_count_use_cascades_join_reorder**, which default value is 10.

close #16699 close #16708 

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

