### PR TITLE
[enhancement](profile) add profile for json& csv file converting to doris column

### DIFF
--- a/be/src/vec/exec/format/csv/csv_reader.h
+++ b/be/src/vec/exec/format/csv/csv_reader.h
@@ -119,6 +119,8 @@ private:
 
     // save source text which have been splitted.
     std::vector<Slice> _split_values;
+
+    RuntimeProfile::Counter* _convert_to_doris_col_timer = nullptr;
 };
 } // namespace vectorized
 } // namespace doris

--- a/be/src/vec/exec/format/json/new_json_reader.cpp
+++ b/be/src/vec/exec/format/json/new_json_reader.cpp
@@ -113,7 +113,8 @@ Status NewJsonReader::init_reader() {
     if (_is_dynamic_schema) {
         _json_parser = std::make_unique<vectorized::JSONDataParser<vectorized::SimdJSONParser>>();
     }
-    LOG_INFO("parsed_jsonpaths empty {}, strip outer array {}", _parsed_jsonpaths.empty(), _strip_outer_array);
+    LOG_INFO("parsed_jsonpaths empty {}, strip outer array {}", _parsed_jsonpaths.empty(),
+             _strip_outer_array);
     return Status::OK();
 }
 

--- a/be/src/vec/exec/format/json/new_json_reader.h
+++ b/be/src/vec/exec/format/json/new_json_reader.h
@@ -161,6 +161,7 @@ private:
     RuntimeProfile::Counter* _bytes_read_counter;
     RuntimeProfile::Counter* _read_timer;
     RuntimeProfile::Counter* _file_read_timer;
+    RuntimeProfile::Counter* _convert_to_doris_col_timer;
 
     bool _is_dynamic_schema = false;
     std::unique_ptr<JSONDataParser<SimdJSONParser>> _json_parser;

--- a/be/src/vec/exec/scan/vfile_scanner.cpp
+++ b/be/src/vec/exec/scan/vfile_scanner.cpp
@@ -72,6 +72,7 @@ Status VFileScanner::prepare(
     _pre_filter_timer = ADD_TIMER(_parent->_scanner_profile, "FileScannerPreFilterTimer");
     _convert_to_output_block_timer =
             ADD_TIMER(_parent->_scanner_profile, "FileScannerConvertOuputBlockTime");
+    _next_reader_timer = ADD_TIMER(_parent->_scanner_profile, "GetNextReaderTime");
 
     _file_cache_statistics.reset(new FileCacheStatistics());
     _io_ctx.reset(new IOContext());
@@ -159,6 +160,7 @@ Status VFileScanner::_handle_dynamic_block(Block* block) {
 Status VFileScanner::_get_block_impl(RuntimeState* state, Block* block, bool* eof) {
     do {
         if (_cur_reader == nullptr || _cur_reader_eof) {
+            SCOPED_TIMER(_next_reader_timer);
             RETURN_IF_ERROR(_get_next_reader());
         }
 

--- a/be/src/vec/exec/scan/vfile_scanner.h
+++ b/be/src/vec/exec/scan/vfile_scanner.h
@@ -132,6 +132,8 @@ private:
     RuntimeProfile::Counter* _fill_missing_columns_timer = nullptr;
     RuntimeProfile::Counter* _pre_filter_timer = nullptr;
     RuntimeProfile::Counter* _convert_to_output_block_timer = nullptr;
+    // to monitor reader create time(S3 reader may take too long)
+    RuntimeProfile::Counter* _next_reader_timer = nullptr;
 
 private:
     Status _init_expr_ctxes();


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx
Previously there are no profile to monitor the time consumption of data converting to doris column, this pr mainly adds profile for json file and csv file to do so.
Plus, there was no good way for us to detect which json callback used in JsonReader, i add one log to print the information.
And formerly the FileReadTime profile is repetitive, which would result in one larger time than actually used.
## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

