### PR TITLE
[bugfix](reader) make segment_overlapping meta correct

### DIFF
--- a/be/src/olap/rowset/beta_rowset_writer.cpp
+++ b/be/src/olap/rowset/beta_rowset_writer.cpp
@@ -727,7 +727,7 @@ bool BetaRowsetWriter::_is_segment_overlapping(
     for (auto segment_encode_key : segments_encoded_key_bounds) {
         auto cur_min = segment_encode_key.min_key();
         auto cur_max = segment_encode_key.max_key();
-        if (cur_min < last) {
+        if (cur_min <= last) {
             return true;
         }
         last = cur_max;


### PR DESCRIPTION
It's a bug, If a rowset has 2 segments and rows are same, then min max key would be same and rowset meta would set meta with NONE_OVERLAPPING, and then agg key or unique key will have same keys

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

