### PR TITLE
[fix](cooldown) Use `pending_remote_rowsets` to avoid deleting rowset files being uploaded

### DIFF
--- a/be/src/olap/cold_data_compaction.cpp
+++ b/be/src/olap/cold_data_compaction.cpp
@@ -80,7 +80,7 @@ Status ColdDataCompaction::modify_rowsets() {
         // TODO(plat1ko): process primary key
         _tablet->tablet_meta()->set_cooldown_meta_id(cooldown_meta_id);
     }
-
+    Tablet::erase_pending_remote_rowset(_output_rowset->rowset_id().to_string());
     {
         std::shared_lock rlock(_tablet->get_header_lock());
         _tablet->save_meta();

--- a/be/src/olap/tablet.h
+++ b/be/src/olap/tablet.h
@@ -328,7 +328,11 @@ public:
 
     static void remove_unused_remote_files();
 
-    std::shared_mutex& get_remote_files_lock() { return _remote_files_lock; }
+    // If a rowset is to be written to remote filesystem, MUST add it to `pending_remote_rowsets` before uploading,
+    // and then erase it from `pending_remote_rowsets` after it has been insert to the Tablet.
+    // `remove_unused_remote_files` MUST NOT delete files of these pending rowsets.
+    static void add_pending_remote_rowset(std::string rowset_id);
+    static void erase_pending_remote_rowset(const std::string& rowset_id);
 
     uint32_t calc_cold_data_compaction_score() const;
 
@@ -524,7 +528,6 @@ private:
     // cooldown related
     int64_t _cooldown_replica_id = -1;
     int64_t _cooldown_term = -1;
-    std::shared_mutex _remote_files_lock;
     std::mutex _cold_compaction_lock;
 
     DISALLOW_COPY_AND_ASSIGN(Tablet);


### PR DESCRIPTION

# Proposed changes

Issue Number: close #xxx

## Problem summary

Previous `remote_files_lock` is not work in such situation:
```
Thread A upload new rowset.
Thread B list rowsets, then calculate unused remote files by list result and rowsets in tablet.
Thread A add new rowset to tablet.
```
Use `pending_remote_rowsets` to avoid deleting rowset files being uploaded.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [x] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

