### PR TITLE
[enhance](cooldown)skip follow cooldown once failed to do follow cooldown

### DIFF
--- a/be/src/olap/olap_server.cpp
+++ b/be/src/olap/olap_server.cpp
@@ -712,15 +712,22 @@ Status StorageEngine::submit_seg_compaction_task(BetaRowsetWriter* writer,
 
 void StorageEngine::_cooldown_tasks_producer_callback() {
     int64_t interval = config::generate_cooldown_task_interval_sec;
+    // the cooldown replica may be slow to upload it's meta file, so we should wait
+    // until it has done uploaded
+    int64_t skip_failed_interval = interval * 10;
     do {
         // these tables are ordered by priority desc
         std::vector<TabletSharedPtr> tablets;
         // TODO(luwei) : a more efficient way to get cooldown tablets
+        auto cur_time = time(nullptr);
         // we should skip all the tablets which are not running and those pending to do cooldown
-        auto skip_tablet = [this](const TabletSharedPtr& tablet) -> bool {
+        // also tablets once failed to do follow cooldown
+        auto skip_tablet = [this, skip_failed_interval,
+                            cur_time](const TabletSharedPtr& tablet) -> bool {
             std::lock_guard<std::mutex> lock(_running_cooldown_mutex);
-            return TABLET_RUNNING != tablet->tablet_state() ||
-                   _running_cooldown_tablets.find(tablet->tablet_id()) ==
+            return cur_time - tablet->last_failed_follow_cooldown_time() < skip_failed_interval ||
+                   TABLET_RUNNING != tablet->tablet_state() ||
+                   _running_cooldown_tablets.find(tablet->tablet_id()) !=
                            _running_cooldown_tablets.end();
         };
         _tablet_manager->get_cooldown_tablets(&tablets, std::move(skip_tablet));

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -1669,8 +1669,12 @@ Status Tablet::cooldown() {
         // this replica is cooldown replica
         RETURN_IF_ERROR(_cooldown_data());
     } else {
-        // try to follow cooldowned data from cooldown replica
-        RETURN_IF_ERROR(_follow_cooldowned_data());
+        Status st = _follow_cooldowned_data();
+        if (UNLIKELY(!st.ok())) {
+            _last_failed_follow_cooldown_time = time(nullptr);
+            return st;
+        }
+        _last_failed_follow_cooldown_time = 0;
     }
     return Status::OK();
 }

--- a/be/src/olap/tablet.h
+++ b/be/src/olap/tablet.h
@@ -309,6 +309,8 @@ public:
     ////////////////////////////////////////////////////////////////////////////
     // begin cooldown functions
     ////////////////////////////////////////////////////////////////////////////
+    int64_t last_failed_follow_cooldown_time() const { return _last_failed_follow_cooldown_time; }
+
     // Cooldown to remote fs.
     Status cooldown();
 
@@ -562,6 +564,7 @@ private:
     // `_cold_compaction_lock` is used to serialize cold data compaction and all operations that
     // may delete compaction input rowsets.
     std::mutex _cold_compaction_lock;
+    int64_t _last_failed_follow_cooldown_time = 0;
 
     DISALLOW_COPY_AND_ASSIGN(Tablet);
 


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx
Once the tablet failed to do follow cooldown, it means the cooldown replica may be slow to upload it's rowset meta file. It would be wasteful if we keeping trying to do follow cooldown, we'd better skip follow cooldown for an interval.
## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

