### PR TITLE
[enhance](cooldown) turn write cooldown meta async

### DIFF
--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -1849,7 +1849,7 @@ void TaskWorkerPool::_push_cooldown_conf_worker_thread_callback() {
             }
             if (tablet->update_cooldown_conf(cooldown_conf.cooldown_term,
                                              cooldown_conf.cooldown_replica_id)) {
-                tablet->async_write_cooldown_meta();
+                Tablet::async_write_cooldown_meta(tablet);
             }
         }
     }

--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -1847,9 +1847,10 @@ void TaskWorkerPool::_push_cooldown_conf_worker_thread_callback() {
                 LOG(WARNING) << "failed to get tablet. tablet_id=" << tablet_id;
                 continue;
             }
-            tablet->update_cooldown_conf(cooldown_conf.cooldown_term,
-                                         cooldown_conf.cooldown_replica_id);
-            // TODO(AlexYue): if `update_cooldown_conf` success, async call `write_cooldown_meta`
+            if (tablet->update_cooldown_conf(cooldown_conf.cooldown_term,
+                                             cooldown_conf.cooldown_replica_id)) {
+                tablet->async_write_cooldown_meta();
+            }
         }
     }
 }

--- a/be/src/olap/cold_data_compaction.cpp
+++ b/be/src/olap/cold_data_compaction.cpp
@@ -80,8 +80,7 @@ Status ColdDataCompaction::modify_rowsets(const Merger::Statistics* stats) {
         _tablet->save_meta();
     }
     // write remote tablet meta
-    // TODO(AlexYue): async call `write_cooldown_meta`
-    RETURN_IF_ERROR(_tablet->write_cooldown_meta());
+    _tablet->async_write_cooldown_meta();
     return Status::OK();
 }
 

--- a/be/src/olap/cold_data_compaction.cpp
+++ b/be/src/olap/cold_data_compaction.cpp
@@ -80,7 +80,7 @@ Status ColdDataCompaction::modify_rowsets(const Merger::Statistics* stats) {
         _tablet->save_meta();
     }
     // write remote tablet meta
-    _tablet->async_write_cooldown_meta();
+    Tablet::async_write_cooldown_meta(_tablet);
     return Status::OK();
 }
 

--- a/be/src/olap/tablet.h
+++ b/be/src/olap/tablet.h
@@ -64,6 +64,35 @@ using TabletSharedPtr = std::shared_ptr<Tablet>;
 
 enum TabletStorageType { STORAGE_TYPE_LOCAL, STORAGE_TYPE_REMOTE, STORAGE_TYPE_REMOTE_AND_LOCAL };
 
+class WriteCooldownMetaExecutors {
+public:
+    WriteCooldownMetaExecutors(size_t executor_nums = 5) : _executor_nums(executor_nums) {
+        for (size_t i = 0; i < _executor_nums; i++) {
+            std::unique_ptr<ThreadPool> pool;
+            ThreadPoolBuilder("AsyncWriteCooldownMetaExecutor")
+                    .set_min_threads(1)
+                    .set_max_threads(1)
+                    .set_max_queue_size(1024)
+                    .build(&pool);
+            _executors.emplace_back(std::move(pool));
+        }
+    }
+
+    static WriteCooldownMetaExecutors* GetInstance() {
+        static WriteCooldownMetaExecutors instance;
+        return &instance;
+    }
+
+    void submit(int64_t tablet_id, std::function<Status()> task);
+
+private:
+    void _do_task(int64_t tablet_id, std::function<Status()> task);
+    size_t _get_executor_pos(int64_t tablet_id) const { return tablet_id % _executor_nums; };
+    std::vector<std::unique_ptr<ThreadPool>> _executors;
+    std::unordered_set<int64_t> _pengding_tablets;
+    std::mutex _latch;
+    size_t _executor_nums;
+};
 class Tablet : public BaseTablet {
 public:
     static TabletSharedPtr create_tablet_from_meta(TabletMetaSharedPtr tablet_meta,
@@ -365,6 +394,7 @@ public:
     std::shared_mutex& get_cooldown_conf_lock() { return _cooldown_conf_lock; }
 
     Status write_cooldown_meta();
+    void async_write_cooldown_meta();
     ////////////////////////////////////////////////////////////////////////////
     // end cooldown functions
     ////////////////////////////////////////////////////////////////////////////
@@ -476,6 +506,7 @@ private:
     Status _follow_cooldowned_data();
     Status _read_cooldown_meta(const std::shared_ptr<io::RemoteFileSystem>& fs,
                                TabletMetaPB* tablet_meta_pb);
+    Status _write_cooldown_meta();
     ////////////////////////////////////////////////////////////////////////////
     // end cooldown functions
     ////////////////////////////////////////////////////////////////////////////

--- a/be/test/olap/tablet_cooldown_test.cpp
+++ b/be/test/olap/tablet_cooldown_test.cpp
@@ -366,6 +366,7 @@ TEST_F(TabletCooldownTest, normal) {
     ASSERT_EQ(Status::OK(), st);
     st = tablet1->cooldown(); // rowset [2-2]
     ASSERT_EQ(Status::OK(), st);
+    sleep(30);
     auto rs = tablet1->get_rowset_by_version({2, 2});
     ASSERT_FALSE(rs->is_local());
 
@@ -391,6 +392,7 @@ TEST_F(TabletCooldownTest, normal) {
     tablet2->update_cooldown_conf(2, kReplicaId);
     st = tablet2->cooldown(); // rowset [0-1]
     ASSERT_EQ(Status::OK(), st);
+    sleep(30);
     auto rs2 = tablet2->get_rowset_by_version({2, 2});
     ASSERT_FALSE(rs2->is_local());
 


### PR DESCRIPTION

# Proposed changes

Issue Number: close #xxx
Upload meta file first once this replica is chosen to be new cooldown replica.
Consider such case:
replica A: term 15, replica B: term 14, replica C: term 15
and the former cooldown replica is A
if FE chooses C to be the new cooldown replica, and B tries to
follow C now, B wouldn't be able to find .meta file on remote storage
## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

