### PR TITLE
[feature](Nereids): infer isNotNull from Inner/Semi/Anti Join

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/batch/NereidsRewriteJobExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/batch/NereidsRewriteJobExecutor.java
@@ -47,6 +47,7 @@ import org.apache.doris.nereids.rules.rewrite.logical.ExtractFilterFromCrossJoin
 import org.apache.doris.nereids.rules.rewrite.logical.ExtractSingleTableExpressionFromDisjunction;
 import org.apache.doris.nereids.rules.rewrite.logical.FindHashConditionForJoin;
 import org.apache.doris.nereids.rules.rewrite.logical.InferFilterNotNull;
+import org.apache.doris.nereids.rules.rewrite.logical.InferJoinNotNull;
 import org.apache.doris.nereids.rules.rewrite.logical.InferPredicates;
 import org.apache.doris.nereids.rules.rewrite.logical.InnerToCrossJoin;
 import org.apache.doris.nereids.rules.rewrite.logical.LimitPushDown;
@@ -96,11 +97,12 @@ public class NereidsRewriteJobExecutor extends BatchRulesJob {
                 .add(topDownBatch(ImmutableList.of(new EliminateGroupByConstant())))
                 .add(topDownBatch(ImmutableList.of(new NormalizeAggregate())))
                 .add(topDownBatch(ImmutableList.of(new ExtractAndNormalizeWindowExpression())))
-                //execute NormalizeAggregate() again to resolve nested AggregateFunctions in WindowExpression,
-                //e.g. sum(sum(c1)) over(partition by avg(c1))
+                // execute NormalizeAggregate() again to resolve nested AggregateFunctions in WindowExpression,
+                // e.g. sum(sum(c1)) over(partition by avg(c1))
                 .add(topDownBatch(ImmutableList.of(new NormalizeAggregate())))
                 .add(topDownBatch(ImmutableList.of(new CheckAndStandardizeWindowFunctionAndFrame())))
                 .add(topDownBatch(ImmutableList.of(new InferFilterNotNull())))
+                .add(topDownBatch(ImmutableList.of(new InferJoinNotNull())))
                 .add(topDownBatch(RuleSet.PUSH_DOWN_FILTERS, false))
                 .add(visitorJob(RuleType.INFER_PREDICATES, new InferPredicates()))
                 .add(topDownBatch(ImmutableList.of(new ExtractFilterFromCrossJoin())))

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/logical/InferJoinNotNull.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/logical/InferJoinNotNull.java
@@ -1,0 +1,71 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.rules.rewrite.logical;
+
+import org.apache.doris.nereids.rules.Rule;
+import org.apache.doris.nereids.rules.RuleType;
+import org.apache.doris.nereids.rules.rewrite.OneRewriteRuleFactory;
+import org.apache.doris.nereids.trees.expressions.Expression;
+import org.apache.doris.nereids.trees.plans.Plan;
+import org.apache.doris.nereids.trees.plans.logical.LogicalJoin;
+import org.apache.doris.nereids.util.ExpressionUtils;
+import org.apache.doris.nereids.util.PlanUtils;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * InferNotNull From Join. Like:
+ * Join: a inner join b on a.id = b.id
+ * ->
+ * Join: a inner join b on a.id = b.id.
+ * - Filter: a.id is not null
+ * - Filter: b.id is not null
+ */
+public class InferJoinNotNull extends OneRewriteRuleFactory {
+    @Override
+    public Rule build() {
+        return logicalJoin().when(join -> join.getJoinType().isInnerJoin() || join.getJoinType().isSemiOrAntiJoin())
+            .whenNot(LogicalJoin::isGenerateIsNotNull)
+            .then(join -> {
+                Set<Expression> conjuncts = new HashSet<>();
+                conjuncts.addAll(join.getHashJoinConjuncts());
+                conjuncts.addAll(join.getOtherJoinConjuncts());
+
+                Plan left = join.left();
+                Plan right = join.right();
+                if (join.getJoinType().isInnerJoin()) {
+                    Set<Expression> leftNotNull = ExpressionUtils.inferNotNull(conjuncts, join.left().getOutputSet());
+                    Set<Expression> rightNotNull = ExpressionUtils.inferNotNull(conjuncts, join.right().getOutputSet());
+                    left = PlanUtils.filterOrSelf(leftNotNull, join.left());
+                    right = PlanUtils.filterOrSelf(rightNotNull, join.right());
+                } else if (join.getJoinType().isLeftSemiOrAntiJoin()) {
+                    Set<Expression> leftNotNull = ExpressionUtils.inferNotNull(conjuncts, join.left().getOutputSet());
+                    left = PlanUtils.filterOrSelf(leftNotNull, join.left());
+                } else {
+                    Set<Expression> rightNotNull = ExpressionUtils.inferNotNull(conjuncts, join.right().getOutputSet());
+                    right = PlanUtils.filterOrSelf(rightNotNull, join.right());
+                }
+
+                if (left == join.left() && right == join.right()) {
+                    return null;
+                }
+                return join.withIsGenerateIsNotNullAndChildren(true, left, right);
+            }).toRule(RuleType.INFER_JOIN_NOT_NULL);
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/Expression.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/Expression.java
@@ -117,9 +117,7 @@ public abstract class Expression extends AbstractTreeNode<Expression> implements
     }
 
     public final Expression withChildren(Expression... children) {
-        Expression expr = withChildren(ImmutableList.copyOf(children));
-        expr.isGeneratedIsNotNull = this.isGeneratedIsNotNull;
-        return expr;
+        return withChildren(ImmutableList.copyOf(children));
     }
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/Not.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/Not.java
@@ -88,7 +88,9 @@ public class Not extends Expression implements UnaryExpression, ExpectsInputType
     @Override
     public Not withChildren(List<Expression> children) {
         Preconditions.checkArgument(children.size() == 1);
-        return new Not(children.get(0));
+        Not not = new Not(children.get(0));
+        not.isGeneratedIsNotNull = this.isGeneratedIsNotNull;
+        return not;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/JoinType.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/JoinType.java
@@ -133,6 +133,10 @@ public enum JoinType {
                 || this == NULL_AWARE_LEFT_ANTI_JOIN || this == RIGHT_ANTI_JOIN;
     }
 
+    public final boolean isSemiJoin() {
+        return this == LEFT_SEMI_JOIN || this == RIGHT_SEMI_JOIN;
+    }
+
     public final boolean isOuterJoin() {
         return this == LEFT_OUTER_JOIN || this == RIGHT_OUTER_JOIN || this == FULL_OUTER_JOIN;
     }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/logical/InferJoinNotNullTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/logical/InferJoinNotNullTest.java
@@ -1,0 +1,93 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.rules.rewrite.logical;
+
+import org.apache.doris.common.Pair;
+import org.apache.doris.nereids.trees.plans.JoinType;
+import org.apache.doris.nereids.trees.plans.logical.LogicalOlapScan;
+import org.apache.doris.nereids.trees.plans.logical.LogicalPlan;
+import org.apache.doris.nereids.util.LogicalPlanBuilder;
+import org.apache.doris.nereids.util.MemoTestUtils;
+import org.apache.doris.nereids.util.PatternMatchSupported;
+import org.apache.doris.nereids.util.PlanChecker;
+import org.apache.doris.nereids.util.PlanConstructor;
+
+import org.junit.jupiter.api.Test;
+
+class InferJoinNotNullTest implements PatternMatchSupported {
+    private final LogicalOlapScan scan1 = PlanConstructor.newLogicalOlapScan(0, "t1", 0);
+    private final LogicalOlapScan scan2 = PlanConstructor.newLogicalOlapScan(1, "t2", 0);
+    private final LogicalOlapScan scan3 = PlanConstructor.newLogicalOlapScan(2, "t3", 0);
+
+    @Test
+    void testInferIsNotNull() {
+        LogicalPlan innerJoin = new LogicalPlanBuilder(scan1)
+                .join(scan2, JoinType.INNER_JOIN, Pair.of(0, 0))
+                .build();
+        PlanChecker.from(MemoTestUtils.createConnectContext(), innerJoin)
+                .applyTopDown(new InferJoinNotNull())
+                .matches(
+                        innerLogicalJoin(
+                                logicalFilter().when(f -> f.getPredicate().toString().equals("( not id IS NULL)")),
+                                logicalFilter().when(f -> f.getPredicate().toString().equals("( not id IS NULL)"))
+                        )
+                );
+
+        LogicalPlan leftSemiJoin = new LogicalPlanBuilder(scan1)
+                .join(scan2, JoinType.LEFT_SEMI_JOIN, Pair.of(0, 0))
+                .build();
+        PlanChecker.from(MemoTestUtils.createConnectContext(), leftSemiJoin)
+                .applyTopDown(new InferJoinNotNull())
+                .matches(
+                        leftSemiLogicalJoin(
+                                logicalFilter().when(f -> f.getPredicate().toString().equals("( not id IS NULL)")),
+                                logicalOlapScan()
+                        )
+                );
+
+        LogicalPlan rightSemiJoin = new LogicalPlanBuilder(scan1)
+                .join(scan2, JoinType.RIGHT_SEMI_JOIN, Pair.of(0, 0))
+                .build();
+        PlanChecker.from(MemoTestUtils.createConnectContext(), rightSemiJoin)
+                .applyTopDown(new InferJoinNotNull())
+                .matches(
+                        rightSemiLogicalJoin(
+                                logicalOlapScan(),
+                                logicalFilter().when(f -> f.getPredicate().toString().equals("( not id IS NULL)"))
+                        )
+                );
+    }
+
+    @Test
+    void testInferAndEliminate() {
+        LogicalPlan plan = new LogicalPlanBuilder(scan1)
+                .join(scan2, JoinType.INNER_JOIN, Pair.of(0, 0))
+                .build();
+
+        PlanChecker.from(MemoTestUtils.createConnectContext(), plan)
+                .applyTopDown(new InferJoinNotNull())
+                .applyTopDown(new EliminateNotNull())
+                .matches(
+                        innerLogicalJoin(
+                                logicalOlapScan(),
+                                logicalOlapScan()
+                        )
+                );
+    }
+
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/logical/InferPredicatesTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/logical/InferPredicatesTest.java
@@ -498,14 +498,18 @@ public class InferPredicatesTest extends TestWithFeService implements PatternMat
                 .analyze(sql)
                 .rewrite()
                 .matchesFromRoot(
-                    logicalJoin(
-                        logicalJoin(
-                                logicalOlapScan(),
-                                logicalFilter(
-                                        logicalOlapScan()
-                                ).when(filter -> filter.getPredicate().toSql().contains("sid > 1"))
+                    innerLogicalJoin(
+                        innerLogicalJoin(
+                            logicalFilter(
+                                logicalOlapScan()
+                            ).when(filter -> filter.getPredicate().toSql().contains("id > 1")),
+                            logicalFilter(
+                                logicalOlapScan()
+                            ).when(filter -> filter.getPredicate().toSql().contains("sid > 1"))
                         ),
-                        logicalOlapScan()
+                        logicalFilter(
+                            logicalOlapScan()
+                        ).when(filter -> filter.getPredicate().toSql().contains("id > 1"))
                     )
                 );
     }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

Infer `is not null` from Inner/Semi/Anti Join

## Checklist(Required)

* [x] Does it affect the original behavior
* [x] Has unit tests been added
* [ ] Has document been added or modified
* [x] Does it need to update dependencies
* [x] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

