### PR TITLE
[improvement](memory) fix possible memory leak of vcollect iterator

### DIFF
--- a/be/src/vec/olap/vcollect_iterator.h
+++ b/be/src/vec/olap/vcollect_iterator.h
@@ -244,7 +244,7 @@ private:
     // Iterate from LevelIterators (maybe Level0Iterators or Level1Iterator or mixed)
     class Level1Iterator : public LevelIterator {
     public:
-        Level1Iterator(const std::list<LevelIterator*>& children, TabletReader* reader, bool merge,
+        Level1Iterator(std::list<LevelIterator*>&& children, TabletReader* reader, bool merge,
                        bool is_reverse, bool skip_same);
 
         Status init(bool get_data_by_ref = false) override;


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

Logic in function `VCollectIterator::build_heap` is not robust, which may cause memory leak:
```
            Level1Iterator* cumu_iter = new Level1Iterator(
                    cumu_children, _reader, cumu_children.size() > 1, _is_reverse, _skip_same);
            RETURN_IF_NOT_EOF_AND_OK(cumu_iter->init());
            std::list<LevelIterator*> children;
            children.push_back(*base_reader_child);
            children.push_back(cumu_iter);
            _inner_iter.reset(
                    new Level1Iterator(children, _reader, _merge, _is_reverse, _skip_same));
```
cumu_iter will be leaked if `cumu_iter->init());` is not success.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

