### PR TITLE
[chore](workflow) Fix the BE UT (Clang) workflow

### DIFF
--- a/.github/workflows/be-ut-clang.yml
+++ b/.github/workflows/be-ut-clang.yml
@@ -67,7 +67,6 @@ jobs:
           bash /tmp/ldb_toolchain_gen.sh "${DEFAULT_DIR}/ldb-toolchain"
 
           sudo apt update
-          sudo apt upgrade --yes
           sudo DEBIAN_FRONTEND=noninteractive apt install --yes tzdata byacc
 
           # set timezone


### PR DESCRIPTION
# Proposed changes

Remove the command `apt upgrade` in the `BE UT (Clang)` workflow.

## Problem summary

Recently, the [runner-image](https://github.com/actions/runner-images) was updated frequently and some bugs were introduced which made our workflow `BE UT (Clang)` fail. See [https://github.com/apache/doris/actions/runs/4195816421](https://github.com/apache/doris/actions/runs/4195816421).

Actually, in `BE UT (Clang)` workflow, we don't need to execute the command `apt upgrade`. We can remove it and fix the issues.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

