### PR TITLE
[Fix](inverted index) fix compound directory unlock problem

### DIFF
--- a/be/src/olap/rowset/segment_v2/inverted_index_compound_directory.h
+++ b/be/src/olap/rowset/segment_v2/inverted_index_compound_directory.h
@@ -26,6 +26,7 @@
 #include <vector>
 
 #include "io/fs/file_system.h"
+#include "util/lock.h"
 
 namespace doris {
 
@@ -49,7 +50,7 @@ class CLUCENE_EXPORT DorisCompoundDirectory : public lucene::store::Directory {
 private:
     int filemode;
 
-    std::mutex _this_lock;
+    doris::Mutex _this_lock;
 
 protected:
     DorisCompoundDirectory();
@@ -115,7 +116,7 @@ class DorisCompoundDirectory::FSIndexInput : public lucene::store::BufferedIndex
         io::FileReaderSPtr _reader;
         uint64_t _length;
         int64_t _fpos;
-        std::mutex _shared_lock;
+        doris::Mutex* _shared_lock;
         char path[4096];
         SharedHandle(const char* path);
         ~SharedHandle() override;
@@ -145,7 +146,7 @@ public:
     const char* getObjectName() const override { return getClassName(); }
     static const char* getClassName() { return "FSIndexInput"; }
 
-    std::mutex _this_lock;
+    doris::Mutex _this_lock;
 
 protected:
     // Random-access methods


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

In DorisCompoundDirectory::FSIndexInput::close, use lock_guard to automatic unlock, or it may cause lock leak.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

