### PR TITLE
[Improvement](jsonb) add suport for JSONB type for arrow

### DIFF
--- a/be/src/util/arrow/block_convertor.cpp
+++ b/be/src/util/arrow/block_convertor.cpp
@@ -38,8 +38,8 @@
 #include "gutil/strings/substitute.h"
 #include "runtime/descriptor_helper.h"
 #include "runtime/descriptors.h"
-#include "runtime/large_int_value.h"
 #include "runtime/jsonb_value.h"
+#include "runtime/large_int_value.h"
 #include "util/arrow/utils.h"
 #include "util/types.h"
 
@@ -140,7 +140,7 @@ public:
             }
             case vectorized::TypeIndex::JSONB: {
                 std::string string_temp =
-                            JsonbToJson::jsonb_to_json_string(data_ref.data, data_ref.size);
+                        JsonbToJson::jsonb_to_json_string(data_ref.data, data_ref.size);
                 ARROW_RETURN_NOT_OK(builder.Append(string_temp.data(), string_temp.size()));
                 break;
             }

--- a/be/src/util/arrow/block_convertor.cpp
+++ b/be/src/util/arrow/block_convertor.cpp
@@ -39,6 +39,7 @@
 #include "runtime/descriptor_helper.h"
 #include "runtime/descriptors.h"
 #include "runtime/large_int_value.h"
+#include "runtime/jsonb_value.h"
 #include "util/arrow/utils.h"
 #include "util/types.h"
 
@@ -137,9 +138,15 @@ public:
                 ARROW_RETURN_NOT_OK(builder.Append(string_temp.data(), string_temp.size()));
                 break;
             }
+            case vectorized::TypeIndex::JSONB: {
+                std::string string_temp =
+                            JsonbToJson::jsonb_to_json_string(data_ref.data, data_ref.size);
+                ARROW_RETURN_NOT_OK(builder.Append(string_temp.data(), string_temp.size()));
+                break;
+            }
             default: {
                 LOG(WARNING) << "can't convert this type = " << vectorized::getTypeName(type_idx)
-                             << "to arrow type";
+                             << " to arrow type";
                 return arrow::Status::TypeError("unsupported column type");
             }
             }

--- a/be/src/util/arrow/row_batch.cpp
+++ b/be/src/util/arrow/row_batch.cpp
@@ -78,6 +78,7 @@ Status convert_to_arrow_type(const TypeDescriptor& type, std::shared_ptr<arrow::
     case TYPE_DATEV2:
     case TYPE_DATETIMEV2:
     case TYPE_STRING:
+    case TYPE_JSONB:
         *result = arrow::utf8();
         break;
     case TYPE_DECIMALV2:


### PR DESCRIPTION
# Proposed changes

Issue Number: close #16872 

## Problem summary

add suport for JSONB type for arrow, which is used by doris spark/flink connector.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

