### PR TITLE
[fix](Nereids) fix signatures of some window functions

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/window/FirstOrLastValue.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/window/FirstOrLastValue.java
@@ -19,14 +19,28 @@ package org.apache.doris.nereids.trees.expressions.functions.window;
 
 import org.apache.doris.catalog.FunctionSignature;
 import org.apache.doris.nereids.trees.expressions.Expression;
-import org.apache.doris.nereids.trees.expressions.functions.CustomSignature;
+import org.apache.doris.nereids.trees.expressions.functions.IdenticalSignature;
 import org.apache.doris.nereids.trees.expressions.functions.PropagateNullable;
 import org.apache.doris.nereids.trees.expressions.shape.UnaryExpression;
-import org.apache.doris.nereids.types.DataType;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+
+import java.util.List;
 
 /** parent class for first_value() and last_value() */
 public abstract class FirstOrLastValue extends WindowFunction
-        implements UnaryExpression, PropagateNullable, CustomSignature {
+        implements UnaryExpression, PropagateNullable, IdenticalSignature, RequireTrivialTypes {
+
+    static {
+        List<FunctionSignature> signatures = Lists.newArrayList();
+        trivialTypes.forEach(t ->
+                signatures.add(FunctionSignature.ret(t).args(t))
+        );
+        SIGNATURES = ImmutableList.copyOf(signatures);
+    }
+
+    private static final List<FunctionSignature> SIGNATURES;
 
     public FirstOrLastValue(String name, Expression child) {
         super(name, child);
@@ -41,8 +55,7 @@ public abstract class FirstOrLastValue extends WindowFunction
     }
 
     @Override
-    public FunctionSignature customSignature() {
-        DataType dataType = getArgument(0).getDataType();
-        return FunctionSignature.ret(dataType).args(dataType);
+    public List<FunctionSignature> getSignatures() {
+        return SIGNATURES;
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/window/Lag.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/window/Lag.java
@@ -65,10 +65,16 @@ public class Lag extends WindowFunction implements TernaryExpression, PropagateN
     }
 
     public Expression getOffset() {
+        if (children().size() <= 1) {
+            throw new AnalysisException("Not set offset of Lead(): " + this.toSql());
+        }
         return child(1);
     }
 
     public Expression getDefaultValue() {
+        if (children.size() <= 2) {
+            throw new AnalysisException("Not set default value of Lead(): " + this.toSql());
+        }
         return child(2);
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/window/Lag.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/window/Lag.java
@@ -18,22 +18,35 @@
 package org.apache.doris.nereids.trees.expressions.functions.window;
 
 import org.apache.doris.catalog.FunctionSignature;
+import org.apache.doris.nereids.exceptions.AnalysisException;
 import org.apache.doris.nereids.trees.expressions.Expression;
-import org.apache.doris.nereids.trees.expressions.functions.ImplicitlyCastableSignature;
+import org.apache.doris.nereids.trees.expressions.functions.ExplicitlyCastableSignature;
 import org.apache.doris.nereids.trees.expressions.functions.PropagateNullable;
 import org.apache.doris.nereids.trees.expressions.literal.Literal;
 import org.apache.doris.nereids.trees.expressions.shape.TernaryExpression;
 import org.apache.doris.nereids.trees.expressions.visitor.ExpressionVisitor;
+import org.apache.doris.nereids.types.BigIntType;
 import org.apache.doris.nereids.types.DataType;
-import org.apache.doris.nereids.types.IntegerType;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
 
 import java.util.List;
 
 /** Window function: lag */
-public class Lag extends WindowFunction implements TernaryExpression, PropagateNullable, ImplicitlyCastableSignature {
+public class Lag extends WindowFunction implements TernaryExpression, PropagateNullable,
+        ExplicitlyCastableSignature, RequireTrivialTypes {
+
+    static {
+        List<FunctionSignature> signatures = Lists.newArrayList();
+        trivialTypes.forEach(t ->
+                signatures.add(FunctionSignature.ret(t).args(t, BigIntType.INSTANCE, t))
+        );
+        SIGNATURES = ImmutableList.copyOf(signatures);
+    }
+
+    private static final List<FunctionSignature> SIGNATURES;
 
     public Lag(Expression child) {
         this(child, Literal.of(1), Literal.of(null));
@@ -66,9 +79,21 @@ public class Lag extends WindowFunction implements TernaryExpression, PropagateN
     }
 
     @Override
+    public void checkLegalityBeforeTypeCoercion() {
+        if (children().size() == 1) {
+            return;
+        }
+        if (children().size() >= 2) {
+            DataType offsetType = getOffset().getDataType();
+            if (!offsetType.isNumericType()) {
+                throw new AnalysisException("The offset of LEAD must be a number:" + this.toSql());
+            }
+        }
+    }
+
+    @Override
     public List<FunctionSignature> getSignatures() {
-        return ImmutableList.of(FunctionSignature.ret(getArgument(0).getDataType())
-                .args(getArgument(0).getDataType(), IntegerType.INSTANCE, getArgument(0).getDataType()));
+        return SIGNATURES;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/window/Lead.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/window/Lead.java
@@ -18,24 +18,37 @@
 package org.apache.doris.nereids.trees.expressions.functions.window;
 
 import org.apache.doris.catalog.FunctionSignature;
+import org.apache.doris.nereids.exceptions.AnalysisException;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.functions.ExplicitlyCastableSignature;
 import org.apache.doris.nereids.trees.expressions.functions.PropagateNullable;
 import org.apache.doris.nereids.trees.expressions.literal.Literal;
 import org.apache.doris.nereids.trees.expressions.shape.TernaryExpression;
 import org.apache.doris.nereids.trees.expressions.visitor.ExpressionVisitor;
+import org.apache.doris.nereids.types.BigIntType;
 import org.apache.doris.nereids.types.DataType;
-import org.apache.doris.nereids.types.IntegerType;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
 
 import java.util.List;
 
 /**
  * Window function: Lead()
  */
-public class Lead extends WindowFunction implements TernaryExpression, PropagateNullable, ExplicitlyCastableSignature {
+public class Lead extends WindowFunction implements TernaryExpression, PropagateNullable,
+        ExplicitlyCastableSignature, RequireTrivialTypes {
+
+    static {
+        List<FunctionSignature> signatures = Lists.newArrayList();
+        trivialTypes.forEach(t ->
+                signatures.add(FunctionSignature.ret(t).args(t, BigIntType.INSTANCE, t))
+        );
+        SIGNATURES = ImmutableList.copyOf(signatures);
+    }
+
+    private static final List<FunctionSignature> SIGNATURES;
 
     public Lead(Expression child) {
         this(child, Literal.of(1), Literal.of(null));
@@ -54,10 +67,16 @@ public class Lead extends WindowFunction implements TernaryExpression, Propagate
     }
 
     public Expression getOffset() {
+        if (children().size() <= 1) {
+            throw new AnalysisException("Not set offset of Lead(): " + this.toSql());
+        }
         return child(1);
     }
 
     public Expression getDefaultValue() {
+        if (children.size() <= 2) {
+            throw new AnalysisException("Not set default value of Lead(): " + this.toSql());
+        }
         return child(2);
     }
 
@@ -67,9 +86,21 @@ public class Lead extends WindowFunction implements TernaryExpression, Propagate
     }
 
     @Override
+    public void checkLegalityBeforeTypeCoercion() {
+        if (children().size() == 1) {
+            return;
+        }
+        if (children().size() >= 2) {
+            DataType offsetType = getOffset().getDataType();
+            if (!offsetType.isNumericType()) {
+                throw new AnalysisException("The offset of LEAD must be a number:" + this.toSql());
+            }
+        }
+    }
+
+    @Override
     public List<FunctionSignature> getSignatures() {
-        return ImmutableList.of(FunctionSignature.ret(getArgument(0).getDataType())
-            .args(getArgument(0).getDataType(), IntegerType.INSTANCE, getArgument(0).getDataType()));
+        return SIGNATURES;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/window/RequireTrivialTypes.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/window/RequireTrivialTypes.java
@@ -1,0 +1,73 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.trees.expressions.functions.window;
+
+import org.apache.doris.nereids.types.BigIntType;
+import org.apache.doris.nereids.types.BooleanType;
+import org.apache.doris.nereids.types.CharType;
+import org.apache.doris.nereids.types.DataType;
+import org.apache.doris.nereids.types.DateTimeType;
+import org.apache.doris.nereids.types.DateTimeV2Type;
+import org.apache.doris.nereids.types.DateType;
+import org.apache.doris.nereids.types.DateV2Type;
+import org.apache.doris.nereids.types.DecimalV2Type;
+import org.apache.doris.nereids.types.DecimalV3Type;
+import org.apache.doris.nereids.types.DoubleType;
+import org.apache.doris.nereids.types.FloatType;
+import org.apache.doris.nereids.types.IntegerType;
+import org.apache.doris.nereids.types.LargeIntType;
+import org.apache.doris.nereids.types.SmallIntType;
+import org.apache.doris.nereids.types.StringType;
+import org.apache.doris.nereids.types.TimeType;
+import org.apache.doris.nereids.types.TimeV2Type;
+import org.apache.doris.nereids.types.TinyIntType;
+import org.apache.doris.nereids.types.VarcharType;
+
+import com.google.common.collect.ImmutableList;
+
+/**
+ * types used for specific window functions.
+ * This list is equal with Type.trivialTypes used in legacy planner
+ */
+public interface RequireTrivialTypes {
+
+    // todo: add JsonBType
+    ImmutableList<DataType> trivialTypes = ImmutableList.of(
+            TinyIntType.INSTANCE,
+            SmallIntType.INSTANCE,
+            IntegerType.INSTANCE,
+            BigIntType.INSTANCE,
+            LargeIntType.INSTANCE,
+            FloatType.INSTANCE,
+            DoubleType.INSTANCE,
+            DecimalV2Type.SYSTEM_DEFAULT,
+            DecimalV3Type.DEFAULT_DECIMAL32,
+            DecimalV3Type.DEFAULT_DECIMAL64,
+            DecimalV3Type.DEFAULT_DECIMAL128,
+            BooleanType.INSTANCE,
+            VarcharType.INSTANCE,
+            StringType.INSTANCE,
+            CharType.INSTANCE,
+            DateType.INSTANCE,
+            DateTimeType.INSTANCE,
+            DateV2Type.INSTANCE,
+            DateTimeV2Type.SYSTEM_DEFAULT,
+            TimeType.INSTANCE,
+            TimeV2Type.INSTANCE
+    );
+}


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

change signatures of lead(), lag(), first_value(), last_value() to be equal with legacy optimizer;
these four functions only support Type.trivialTypes as returnType and input column type.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

