### PR TITLE
[improvement](MOW) move update_delete_bitmap out of txn lock

### DIFF
--- a/be/src/olap/task/engine_publish_version_task.cpp
+++ b/be/src/olap/task/engine_publish_version_task.cpp
@@ -183,11 +183,9 @@ Status EnginePublishVersionTask::finish() {
         }
     }
 
-    VLOG_CRITICAL << "finish to publish version on transaction."
-                  << "transaction_id=" << transaction_id
-                  << ", cost(us): " << watch.get_elapse_time_us()
-                  << ", error_tablet_size=" << _error_tablet_ids->size()
-                  << ", res=" << res.to_string();
+    LOG(INFO) << "finish to publish version on transaction."
+              << "transaction_id=" << transaction_id << ", cost(us): " << watch.get_elapse_time_us()
+              << ", error_tablet_size=" << _error_tablet_ids->size() << ", res=" << res.to_string();
     return res;
 }
 

--- a/be/src/olap/txn_manager.cpp
+++ b/be/src/olap/txn_manager.cpp
@@ -292,9 +292,9 @@ Status TxnManager::publish_txn(OlapMeta* meta, TPartitionId partition_id,
     RowsetSharedPtr rowset_ptr = nullptr;
     TabletTxnInfo* load_info = nullptr;
     {
-        std::unique_lock<std::mutex> txn_lock(_get_txn_lock(transaction_id));
         {
-            std::shared_lock rlock(_get_txn_map_lock(transaction_id));
+            std::unique_lock<std::mutex> txn_rlock(_get_txn_lock(transaction_id));
+            std::shared_lock txn_map_rlock(_get_txn_map_lock(transaction_id));
             txn_tablet_map_t& txn_tablet_map = _get_txn_tablet_map(transaction_id);
             auto it = txn_tablet_map.find(key);
             if (it != txn_tablet_map.end()) {


### PR DESCRIPTION
# Proposed changes

update_delete_bitmap will cost a lot of time and lock here is unnecessary, txn_lock is used to lock load info

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

