### PR TITLE
[improvement](memory) fix possible double free in vcollect iterator

### DIFF
--- a/be/src/vec/olap/vcollect_iterator.h
+++ b/be/src/vec/olap/vcollect_iterator.h
@@ -244,7 +244,7 @@ private:
     // Iterate from LevelIterators (maybe Level0Iterators or Level1Iterator or mixed)
     class Level1Iterator : public LevelIterator {
     public:
-        Level1Iterator(std::list<LevelIterator*>&& children, TabletReader* reader, bool merge,
+        Level1Iterator(const std::list<LevelIterator*>& children, TabletReader* reader, bool merge,
                        bool is_reverse, bool skip_same);
 
         Status init(bool get_data_by_ref = false) override;


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

```
           std::list<LevelIterator*> cumu_children;
            int i = 0;
            for (const auto& child : _children) {
                if (i != base_reader_idx) {
                    cumu_children.push_back(child);
                }
                ++i;
            }
            bool is_merge = cumu_children.size() > 1;
            auto cumu_iter = std::make_unique<Level1Iterator>(std::move(cumu_children), _reader,
                                                              is_merge, _is_reverse, _skip_same);
            RETURN_IF_NOT_EOF_AND_OK(cumu_iter->init());
```
This code in `VCollectIterator::build_heap` is possible to cause double free if cumu_iter->init() fails and returns early, becuase some `LevelIterator*` exists both in `VCollectIterator::_children` and `cumu_iter::_children`.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

