### PR TITLE
[Fix](inverted index) fix inverted index bkd reader memory leak problem

### DIFF
--- a/be/src/olap/rowset/segment_v2/inverted_index_reader.h
+++ b/be/src/olap/rowset/segment_v2/inverted_index_reader.h
@@ -192,11 +192,11 @@ public:
                      InvertedIndexParserType analyser_type, uint32_t* count) override;
     Status bkd_query(OlapReaderStatistics* stats, const std::string& column_name,
                      const void* query_value, InvertedIndexQueryType query_type,
-                     std::shared_ptr<lucene::util::bkd::bkd_reader>&& r,
+                     std::shared_ptr<lucene::util::bkd::bkd_reader>& r,
                      InvertedIndexVisitor* visitor);
 
     InvertedIndexReaderType type() override;
-    Status get_bkd_reader(lucene::util::bkd::bkd_reader*& reader);
+    Status get_bkd_reader(std::shared_ptr<lucene::util::bkd::bkd_reader>& reader);
 
 private:
     const TypeInfo* _type_info {};


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

Original implementation of get_bkd_reader's raw pointer usage may cause memory leak problem, use shared_ptr to avoid that.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

