### PR TITLE
[bugfix](topn) fix topn read_orderby_key_columns nullptr

### DIFF
--- a/be/src/olap/reader.cpp
+++ b/be/src/olap/reader.cpp
@@ -412,10 +412,6 @@ Status TabletReader::_init_keys_param(const ReaderParams& read_params) {
 }
 
 Status TabletReader::_init_orderby_keys_param(const ReaderParams& read_params) {
-    if (read_params.start_key.empty()) {
-        return Status::OK();
-    }
-
     // UNIQUE_KEYS will compare all keys as before
     if (_tablet_schema->keys_type() == DUP_KEYS || (_tablet_schema->keys_type() == UNIQUE_KEYS &&
                                                     _tablet->enable_unique_key_merge_on_write())) {

--- a/be/src/vec/olap/vcollect_iterator.cpp
+++ b/be/src/vec/olap/vcollect_iterator.cpp
@@ -246,7 +246,7 @@ Status VCollectIterator::_topn_next(Block* block) {
     MutableBlock mutable_block = vectorized::MutableBlock::build_mutable_block(&cloneBlock);
 
     if (!_reader->_reader_context.read_orderby_key_columns) {
-        return Status::Error<INTERNAL_ERROR>("read_orderby_key_columns should not be nullptr");
+        return Status::Error<ErrorCode::INTERNAL_ERROR>("read_orderby_key_columns should not be nullptr");
     }
 
     size_t first_sort_column_idx = (*_reader->_reader_context.read_orderby_key_columns)[0];

--- a/be/src/vec/olap/vcollect_iterator.cpp
+++ b/be/src/vec/olap/vcollect_iterator.cpp
@@ -245,6 +245,10 @@ Status VCollectIterator::_topn_next(Block* block) {
     auto cloneBlock = block->clone_empty();
     MutableBlock mutable_block = vectorized::MutableBlock::build_mutable_block(&cloneBlock);
 
+    if (!_reader->_reader_context.read_orderby_key_columns) {
+        return Status::Error<INTERNAL_ERROR>("read_orderby_key_columns should not be nullptr");
+    }
+
     size_t first_sort_column_idx = (*_reader->_reader_context.read_orderby_key_columns)[0];
     const std::vector<uint32_t>* sort_columns = _reader->_reader_context.read_orderby_key_columns;
 

--- a/be/src/vec/olap/vcollect_iterator.cpp
+++ b/be/src/vec/olap/vcollect_iterator.cpp
@@ -246,7 +246,8 @@ Status VCollectIterator::_topn_next(Block* block) {
     MutableBlock mutable_block = vectorized::MutableBlock::build_mutable_block(&cloneBlock);
 
     if (!_reader->_reader_context.read_orderby_key_columns) {
-        return Status::Error<ErrorCode::INTERNAL_ERROR>("read_orderby_key_columns should not be nullptr");
+        return Status::Error<ErrorCode::INTERNAL_ERROR>(
+                "read_orderby_key_columns should not be nullptr");
     }
 
     size_t first_sort_column_idx = (*_reader->_reader_context.read_orderby_key_columns)[0];


### PR DESCRIPTION
# Proposed changes

Issue Number: related to #16818

## Problem summary

The SQL `SELECT nationkey FROM regression_test_query_p0_limit.tpch_tiny_nation ORDER BY nationkey DESC LIMIT 5` make be core dump since dereference a nullptr `read_orderby_key_columns in VCollectIterator::_topn_next`, triggered by skipping _colname_to_value_range init in #16818 .

This PR makes two changes:
1. avoid read_orderby_key_columns nullptr in TabletReader::_init_orderby_keys_param
2. return error if read_orderby_key_columns is nullptr unexpected in VCollectIterator::_topn_next to avoid core dump


## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

