### PR TITLE
[fix](tvf) fix bug that failed to get schema of tvf when file is empty

### DIFF
--- a/be/src/vec/exec/format/csv/csv_reader.cpp
+++ b/be/src/vec/exec/format/csv/csv_reader.cpp
@@ -136,7 +136,7 @@ Status CsvReader::init_reader(bool is_load) {
     }
     if (_file_reader->size() == 0 && _params.file_type != TFileType::FILE_STREAM &&
         _params.file_type != TFileType::FILE_BROKER) {
-        return Status::EndOfFile("Empty File");
+        return Status::EndOfFile("init reader failed, empty csv file: " + _range.path);
     }
 
     // get column_separator and line_delimiter
@@ -582,7 +582,7 @@ Status CsvReader::_prepare_parse(size_t* read_line, bool* is_parse_name) {
                                                     &_file_system, &_file_reader, _io_ctx));
     if (_file_reader->size() == 0 && _params.file_type != TFileType::FILE_STREAM &&
         _params.file_type != TFileType::FILE_BROKER) {
-        return Status::EndOfFile("Empty File");
+        return Status::EndOfFile("get parsed schema failed, empty csv file: " + _range.path);
     }
 
     // get column_separator and line_delimiter

--- a/be/src/vec/exec/format/orc/vorc_reader.cpp
+++ b/be/src/vec/exec/format/orc/vorc_reader.cpp
@@ -165,7 +165,7 @@ Status OrcReader::init_reader(
         _file_reader = new ORCFileInputStream(_scan_range.path, inner_reader);
     }
     if (_file_reader->getLength() == 0) {
-        return Status::EndOfFile("Empty orc file");
+        return Status::EndOfFile("init reader failed, empty orc file: " + _scan_range.path);
     }
 
     // create orc reader
@@ -176,7 +176,7 @@ Status OrcReader::init_reader(
         return Status::InternalError("Init OrcReader failed. reason = {}", e.what());
     }
     if (_reader->getNumberOfRows() == 0) {
-        return Status::EndOfFile("Empty orc file");
+        return Status::EndOfFile("init reader failed, empty orc file with row num 0: " + _scan_range.path);
     }
     // _init_bloom_filter(colname_to_value_range);
 
@@ -231,7 +231,7 @@ Status OrcReader::get_parsed_schema(std::vector<std::string>* col_names,
         _file_reader = new ORCFileInputStream(_scan_range.path, inner_reader);
     }
     if (_file_reader->getLength() == 0) {
-        return Status::EndOfFile("Empty orc file");
+        return Status::EndOfFile("get parsed schema fail, empty orc file: " + _scan_range.path);
     }
 
     // create orc reader
@@ -240,10 +240,6 @@ Status OrcReader::get_parsed_schema(std::vector<std::string>* col_names,
         _reader = orc::createReader(std::unique_ptr<ORCFileInputStream>(_file_reader), options);
     } catch (std::exception& e) {
         return Status::InternalError("Init OrcReader failed. reason = {}", e.what());
-    }
-
-    if (_reader->getNumberOfRows() == 0) {
-        return Status::EndOfFile("Empty orc file");
     }
 
     auto& root_type = _reader->getType();

--- a/be/src/vec/exec/format/orc/vorc_reader.cpp
+++ b/be/src/vec/exec/format/orc/vorc_reader.cpp
@@ -176,7 +176,8 @@ Status OrcReader::init_reader(
         return Status::InternalError("Init OrcReader failed. reason = {}", e.what());
     }
     if (_reader->getNumberOfRows() == 0) {
-        return Status::EndOfFile("init reader failed, empty orc file with row num 0: " + _scan_range.path);
+        return Status::EndOfFile("init reader failed, empty orc file with row num 0: " +
+                                 _scan_range.path);
     }
     // _init_bloom_filter(colname_to_value_range);
 

--- a/be/src/vec/exec/format/parquet/vparquet_reader.cpp
+++ b/be/src/vec/exec/format/parquet/vparquet_reader.cpp
@@ -164,7 +164,7 @@ Status ParquetReader::_open_file() {
     }
     if (_file_metadata == nullptr) {
         if (_file_reader->size() == 0) {
-            return Status::EndOfFile("Empty Parquet File");
+            return Status::EndOfFile("open file failed, empty parquet file: " + _scan_range.path);
         }
         RETURN_IF_ERROR(parse_thrift_footer(_file_reader, _file_metadata));
     }
@@ -196,7 +196,7 @@ Status ParquetReader::init_reader(
     SCOPED_RAW_TIMER(&_statistics.parse_meta_time);
     _total_groups = _t_metadata->row_groups.size();
     if (_total_groups == 0) {
-        return Status::EndOfFile("Empty Parquet File");
+        return Status::EndOfFile("init reader failed, empty parquet file: " + _scan_range.path);
     }
     // all_column_names are all the columns required by user sql.
     // missing_column_names are the columns required by user sql but not in the parquet file,
@@ -367,10 +367,6 @@ Status ParquetReader::get_parsed_schema(std::vector<std::string>* col_names,
     _t_metadata = &_file_metadata->to_thrift();
 
     _total_groups = _t_metadata->row_groups.size();
-    if (_total_groups == 0) {
-        return Status::EndOfFile("Empty Parquet File");
-    }
-
     auto schema_desc = _file_metadata->schema();
     for (int i = 0; i < schema_desc.size(); ++i) {
         // Get the Column Reader for the boolean column

--- a/be/src/vec/exec/scan/vfile_scanner.cpp
+++ b/be/src/vec/exec/scan/vfile_scanner.cpp
@@ -584,7 +584,7 @@ Status VFileScanner::_get_next_reader() {
                         new IcebergTableReader((GenericReader*)parquet_reader, _profile, _state,
                                                _params, range, _kv_cache, _io_ctx.get());
                 init_status = iceberg_reader->init_reader(_file_col_names, _col_id_name_map,
-                                            _colname_to_value_range, _push_down_expr);
+                                                          _colname_to_value_range, _push_down_expr);
                 RETURN_IF_ERROR(iceberg_reader->init_row_filters(range));
                 _cur_reader.reset((GenericReader*)iceberg_reader);
             } else {

--- a/be/src/vec/exec/scan/vfile_scanner.cpp
+++ b/be/src/vec/exec/scan/vfile_scanner.cpp
@@ -583,7 +583,7 @@ Status VFileScanner::_get_next_reader() {
                 IcebergTableReader* iceberg_reader =
                         new IcebergTableReader((GenericReader*)parquet_reader, _profile, _state,
                                                _params, range, _kv_cache, _io_ctx.get());
-                iceberg_reader->init_reader(_file_col_names, _col_id_name_map,
+                init_status = iceberg_reader->init_reader(_file_col_names, _col_id_name_map,
                                             _colname_to_value_range, _push_down_expr);
                 RETURN_IF_ERROR(iceberg_reader->init_row_filters(range));
                 _cur_reader.reset((GenericReader*)iceberg_reader);

--- a/docs/en/docs/lakehouse/multi-catalog/faq.md
+++ b/docs/en/docs/lakehouse/multi-catalog/faq.md
@@ -41,8 +41,29 @@ under the License.
 
 2. What to do with the `GSS initiate failed` error when connecting to Hive Metastore with Kerberos authentication?
 
-   In Doris 1.2.1 and the older versions, gsasl is disabled for libhdfs3, so please update to Doris 1.2.2 or newer.
+   Usually it is caused by incorrect Kerberos authentication information, you can troubleshoot by the following steps:
+
+   1. In versions before  1.2.1, the libhdfs3 library that Doris depends on does not enable gsasl. Please update to a version later than 1.2.2.
+   2. Confirm that the correct keytab and principal are set for each component, and confirm that the keytab file exists on all FE and BE nodes.
+
+       1. `hadoop.kerberos.keytab`/`hadoop.kerberos.principal`: for Hadoop HDFS
+       2. `hive.metastore.kerberos.principal`: for hive metastore.
+
+   3. Try to replace the IP in the principal with a domain name (do not use the default `_HOST` placeholder)
+   4. Confirm that the `/etc/krb5.conf` file exists on all FE and BE nodes.
 
 3. What to do with the`java.lang.VerifyError: xxx` error when accessing HDFS 3.x?
 
    Doris 1.2.1 and the older versions rely on Hadoop 2.8. Please update Hadoop to 2.10.2 or update Doris to 1.2.2 or newer.
+
+4. An error is reported when using KMS to access HDFS: `java.security.InvalidKeyException: Illegal key size`
+
+    Upgrade the JDK version to a version >= Java 8 u162. Or download and install the JCE Unlimited Strength Jurisdiction Policy Files corresponding to the JDK.
+
+5. When querying a table in ORC format, FE reports an error `Could not obtain block`
+
+    For ORC files, by default, FE will access HDFS to obtain file information and split files. In some cases, FE may not be able to access HDFS. It can be solved by adding the following parameters:
+
+    `"hive.exec.orc.split.strategy" = "BI"`
+
+    Other options: HYBRID (default), ETL.

--- a/docs/en/docs/lakehouse/multi-catalog/hive.md
+++ b/docs/en/docs/lakehouse/multi-catalog/hive.md
@@ -85,9 +85,7 @@ CREATE CATALOG hive PROPERTIES (
     'hadoop.security.authentication' = 'kerberos',
     'hadoop.kerberos.keytab' = '/your-keytab-filepath/your.keytab',   
     'hadoop.kerberos.principal' = 'your-principal@YOUR.COM',
-    'hive.metastore.kerberos.principal' = 'your-hms-principal',
-    'yarn.resourcemanager.address' = 'your-rm-address:your-rm-port',    
-    'yarn.resourcemanager.principal' = 'your-rm-principal/your-rm-address@YOUR.COM'
+    'hive.metastore.kerberos.principal' = 'your-hms-principal'
 );
 ```
 

--- a/docs/zh-CN/docs/lakehouse/multi-catalog/faq.md
+++ b/docs/zh-CN/docs/lakehouse/multi-catalog/faq.md
@@ -41,11 +41,29 @@ under the License.
 
 2. 连接 Kerberos 认证的 Hive Metastore 报错：`GSS initiate failed`
 
-	1.2.1 之前的版本中，Doris 依赖的 libhdfs3 库没有开启 gsasl。请更新至 1.2.2 之后的版本。
+    通常是因为 Kerberos 认证信息填写不正确导致的，可以通过以下步骤排查：
+
+    1. 1.2.1 之前的版本中，Doris 依赖的 libhdfs3 库没有开启 gsasl。请更新至 1.2.2 之后的版本。
+    2. 确认对各个组件，设置了正确的 keytab 和 principal，并确认 keytab 文件存在于所有 FE、BE 节点上。
+
+        1. `hadoop.kerberos.keytab`/`hadoop.kerberos.principal`：用于 Hadoop hdfs 访问，填写 hdfs 对应的值。
+        2. `hive.metastore.kerberos.principal`：用于 hive metastore。
+
+    3. 尝试将 principal 中的 ip 换成域名（不要使用默认的 `_HOST` 占位符）
+    4. 确认 `/etc/krb5.conf` 文件存在于所有 FE、BE 节点上。
 	
 3. 访问 HDFS 3.x 时报错：`java.lang.VerifyError: xxx`
 
-	1.2.1 之前的版本中，Doris 依赖的 Hadoop 版本为 2.8。需更新至 2.10.2。或更新 Doris 至 1.2.2 之后的版本。
+   1.2.1 之前的版本中，Doris 依赖的 Hadoop 版本为 2.8。需更新至 2.10.2。或更新 Doris 至 1.2.2 之后的版本。
+
 4. 使用 KMS 访问 HDFS 时报错：`java.security.InvalidKeyException: Illegal key size`
 
-        升级 JDK 版本到 >= Java 8 u162 的版本。或者下载安装 JDK 相应的 JCE Unlimited Strength Jurisdiction Policy Files。
+   升级 JDK 版本到 >= Java 8 u162 的版本。或者下载安装 JDK 相应的 JCE Unlimited Strength Jurisdiction Policy Files。
+
+5. 查询 ORC 格式的表，FE 报错 `Could not obtain block`
+
+   对于 ORC 文件，在默认情况下，FE 会访问 HDFS 获取文件信息，进行文件切分。部分情况下，FE 可能无法访问到 HDFS。可以通过添加以下参数解决：
+
+   `"hive.exec.orc.split.strategy" = "BI"`
+
+   其他选项：HYBRID（默认），ETL。

--- a/docs/zh-CN/docs/lakehouse/multi-catalog/hive.md
+++ b/docs/zh-CN/docs/lakehouse/multi-catalog/hive.md
@@ -83,9 +83,7 @@ CREATE CATALOG hive PROPERTIES (
     'hadoop.security.authentication' = 'kerberos',
     'hadoop.kerberos.keytab' = '/your-keytab-filepath/your.keytab',   
     'hadoop.kerberos.principal' = 'your-principal@YOUR.COM',
-    'hive.metastore.kerberos.principal' = 'your-hms-principal',
-    'yarn.resourcemanager.address' = 'your-rm-address:your-rm-port',    
-    'yarn.resourcemanager.principal' = 'your-rm-principal/your-rm-address@YOUR.COM'
+    'hive.metastore.kerberos.principal' = 'your-hms-principal'
 );
 ```
 


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

In previous implementation, when querying tvf, FE will get schema from BE.
And BE will try to open the first file to get its schema info, but for orc or parquet format,
if the file is empty, it will return error.
But even for an empty file, we can still get schema info from file's footer.
So we should handle the empty file to get schema info correctly.

Also modify the catalog doc to add some FAQ.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

