### PR TITLE
[vectorized](jdbc) fix jdbc connect sql server error

### DIFF
--- a/fe/java-udf/pom.xml
+++ b/fe/java-udf/pom.xml
@@ -94,7 +94,7 @@ under the License.
         <dependency>
             <groupId>com.alibaba</groupId>
             <artifactId>druid</artifactId>
-            <version>1.2.8</version>
+            <version>1.2.5</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.junit.jupiter/junit-jupiter-engine -->
         <dependency>

--- a/fe/java-udf/src/main/java/org/apache/doris/udf/JdbcExecutor.java
+++ b/fe/java-udf/src/main/java/org/apache/doris/udf/JdbcExecutor.java
@@ -225,8 +225,7 @@ public class JdbcExecutor {
             if (op == TJdbcOperation.READ) {
                 conn.setAutoCommit(false);
                 Preconditions.checkArgument(sql != null);
-                stmt = conn.prepareStatement(sql, ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY,
-                        ResultSet.FETCH_FORWARD);
+                stmt = conn.prepareStatement(sql, ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY);
                 stmt.setFetchSize(batchSize);
                 batchSizeNum = batchSize;
             } else {


### PR DESCRIPTION
# Proposed changes
`Caused by: java.sql.SOLException: errCode = 2, detailMessace = UdfRuntimeException: Initialize datasource failedCAUSED BY: SOLServerException: The holdability value 1000 is not valid.`

`ResultSet.FETCH_FORWARD is not support by sqlserver, so remove it.`
`druid 1.2.8 connect for SQL Server have bug, so change it to 1.2.5. `


Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

