### PR TITLE
[Improvement](parquet-reader) Improve performance of parquet reader filter calculation.

### DIFF
--- a/be/src/vec/exec/format/parquet/vparquet_group_reader.cpp
+++ b/be/src/vec/exec/format/parquet/vparquet_group_reader.cpp
@@ -115,7 +115,7 @@ Status RowGroupReader::next_batch(Block* block, size_t batch_size, size_t* read_
         if (_lazy_read_ctx.vconjunct_ctx != nullptr) {
             int result_column_id = -1;
             RETURN_IF_ERROR(_lazy_read_ctx.vconjunct_ctx->execute(block, &result_column_id));
-            ColumnPtr filter_column = block->get_by_position(result_column_id).column;
+            ColumnPtr& filter_column = block->get_by_position(result_column_id).column;
             RETURN_IF_ERROR(_filter_block(block, filter_column, column_to_keep, columns_to_filter));
         } else {
             RETURN_IF_ERROR(_filter_block(block, column_to_keep, columns_to_filter));
@@ -256,7 +256,7 @@ Status RowGroupReader::_do_lazy_read(Block* block, size_t batch_size, size_t* re
             // generated from next batch, so the filter column is removed ahead.
             DCHECK_EQ(block->rows(), 0);
         } else {
-            ColumnPtr filter_column = block->get_by_position(filter_column_id).column;
+            ColumnPtr& filter_column = block->get_by_position(filter_column_id).column;
             RETURN_IF_ERROR(_filter_block(block, filter_column, origin_column_num,
                                           _lazy_read_ctx.all_predicate_col_ids));
         }
@@ -493,10 +493,10 @@ Status RowGroupReader::_build_pos_delete_filter(size_t read_rows) {
     return Status::OK();
 }
 
-Status RowGroupReader::_filter_block(Block* block, const ColumnPtr filter_column,
+Status RowGroupReader::_filter_block(Block* block, const ColumnPtr& filter_column,
                                      int column_to_keep, std::vector<uint32_t> columns_to_filter) {
     if (auto* nullable_column = check_and_get_column<ColumnNullable>(*filter_column)) {
-        ColumnPtr nested_column = nullable_column->get_nested_column_ptr();
+        const ColumnPtr& nested_column = nullable_column->get_nested_column_ptr();
 
         MutableColumnPtr mutable_holder =
                 nested_column->use_count() == 1

--- a/be/src/vec/exec/format/parquet/vparquet_group_reader.h
+++ b/be/src/vec/exec/format/parquet/vparquet_group_reader.h
@@ -100,6 +100,14 @@ public:
         PositionDeleteContext(const PositionDeleteContext& filter) = default;
     };
 
+    struct FilterContext {
+        const IColumn::Filter* filter;
+        bool reverse;
+
+        FilterContext(const IColumn::Filter* filter, bool reverse)
+                : filter(filter), reverse(reverse) {}
+    };
+
     RowGroupReader(io::FileReaderSPtr file_reader,
                    const std::vector<ParquetReadColumn>& read_columns, const int32_t row_group_id,
                    const tparquet::RowGroup& row_group, cctz::time_zone* ctz,
@@ -134,9 +142,11 @@ private:
     Status _build_pos_delete_filter(size_t read_rows);
     Status _filter_block(Block* block, const ColumnPtr filter_column, int column_to_keep,
                          std::vector<uint32_t> columns_to_filter);
+    bool _merge_filter(IColumn::Filter& to_filter, std::vector<FilterContext>& from_filters);
     Status _filter_block(Block* block, int column_to_keep,
                          const vector<uint32_t>& columns_to_filter);
-    Status _filter_block_internal(Block* block, const vector<uint32_t>& columns_to_filter);
+    Status _filter_block_internal(Block* block, const vector<uint32_t>& columns_to_filter,
+                                  const IColumn::Filter& filter);
 
     io::FileReaderSPtr _file_reader;
     std::unordered_map<std::string, std::unique_ptr<ParquetColumnReader>> _column_readers;
@@ -154,7 +164,7 @@ private:
     // If continuous batches are skipped, we can cache them to skip a whole page
     size_t _cached_filtered_rows = 0;
     std::unique_ptr<TextConverter> _text_converter = nullptr;
-    std::unique_ptr<IColumn::Filter> _filter_ptr = nullptr;
+    std::unique_ptr<IColumn::Filter> _pos_delete_filter_ptr = nullptr;
     int64_t _total_read_rows = 0;
 };
 } // namespace doris::vectorized

--- a/be/src/vec/exec/format/parquet/vparquet_group_reader.h
+++ b/be/src/vec/exec/format/parquet/vparquet_group_reader.h
@@ -132,7 +132,7 @@ private:
             Block* block, size_t rows,
             const std::unordered_map<std::string, VExprContext*>& missing_columns);
     Status _build_pos_delete_filter(size_t read_rows);
-    Status _filter_block(Block* block, const ColumnPtr filter_column, int column_to_keep,
+    Status _filter_block(Block* block, const ColumnPtr& filter_column, int column_to_keep,
                          std::vector<uint32_t> columns_to_filter);
     Status _filter_block(Block* block, int column_to_keep,
                          const vector<uint32_t>& columns_to_filter);

--- a/be/src/vec/exec/format/parquet/vparquet_group_reader.h
+++ b/be/src/vec/exec/format/parquet/vparquet_group_reader.h
@@ -100,14 +100,6 @@ public:
         PositionDeleteContext(const PositionDeleteContext& filter) = default;
     };
 
-    struct FilterContext {
-        const IColumn::Filter* filter;
-        bool reverse;
-
-        FilterContext(const IColumn::Filter* filter, bool reverse)
-                : filter(filter), reverse(reverse) {}
-    };
-
     RowGroupReader(io::FileReaderSPtr file_reader,
                    const std::vector<ParquetReadColumn>& read_columns, const int32_t row_group_id,
                    const tparquet::RowGroup& row_group, cctz::time_zone* ctz,
@@ -142,7 +134,6 @@ private:
     Status _build_pos_delete_filter(size_t read_rows);
     Status _filter_block(Block* block, const ColumnPtr filter_column, int column_to_keep,
                          std::vector<uint32_t> columns_to_filter);
-    bool _merge_filter(IColumn::Filter& to_filter, std::vector<FilterContext>& from_filters);
     Status _filter_block(Block* block, int column_to_keep,
                          const vector<uint32_t>& columns_to_filter);
     Status _filter_block_internal(Block* block, const vector<uint32_t>& columns_to_filter,


### PR DESCRIPTION
# Proposed changes

Improve performance of parquet reader filter calculation.

- Use `filter_data` instead of `(*filter_ptr)` to merge filter to improve performance. 
- Use mutable column filter func instead of original new column filter func which introduced by #16850.
- Avoid column ref-count increasing which caused unnecessary copying by passing column pointer ref.

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

