### PR TITLE
[fix](union iterator) fix bug that result data order of VUnionIterator is different

### DIFF
--- a/be/src/vec/olap/vgeneric_iterators.cpp
+++ b/be/src/vec/olap/vgeneric_iterators.cpp
@@ -374,6 +374,11 @@ Status VUnionIterator::init(const StorageReadOptions& opts) {
         return Status::OK();
     }
 
+    // we use back() and pop_back() of std::vector to handle each iterator,
+    // so reverse the vector here to keep result block of next_batch to be
+    // in the same order as the original segments.
+    std::reverse(_origin_iters.begin(), _origin_iters.end());
+
     for (auto& iter : _origin_iters) {
         RETURN_IF_ERROR(iter->init(opts));
     }

--- a/be/test/vec/exec/vgeneric_iterators_test.cpp
+++ b/be/test/vec/exec/vgeneric_iterators_test.cpp
@@ -115,17 +115,19 @@ TEST(VGenericIteratorsTest, Union) {
     auto c1 = block.get_by_position(1).column;
     auto c2 = block.get_by_position(2).column;
 
+    size_t row_count = 0;
     for (int i = 0; i < block.rows(); ++i) {
-        size_t base_value = i;
-        if (i >= 500) {
-            base_value -= 500;
-        } else if (i >= 300) {
+        size_t base_value = row_count;
+        if (row_count >= 300) {
             base_value -= 300;
+        } else if (i >= 100) {
+            base_value -= 100;
         }
 
         EXPECT_EQ(base_value, (*c0)[i].get<int>());
         EXPECT_EQ(base_value + 1, (*c1)[i].get<int>());
         EXPECT_EQ(base_value + 2, (*c2)[i].get<int>());
+        row_count++;
     }
 }
 


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

Fix bug of #16680, data order of VUnionIterator outout block is changed, which will impact compaction.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

