### PR TITLE
[branch-1.1-lts](fix) SegmentIterator return columns missing ColumnNullable

### DIFF
--- a/be/src/olap/rowset/segment_v2/column_reader.cpp
+++ b/be/src/olap/rowset/segment_v2/column_reader.cpp
@@ -679,6 +679,7 @@ Status FileColumnIterator::read_by_rowids(const rowid_t* rowids, const size_t co
                         auto* null_col =
                                 vectorized::check_and_get_column<vectorized::ColumnNullable>(dst);
                         if (UNLIKELY(null_col == nullptr)) {
+                            LOG(WARNING) << "Column " << dst->get_name() << " should be Nullable";
                             return Status::InternalError("unexpected column type in column reader");
                         }
 

--- a/be/src/olap/rowset/segment_v2/segment_iterator.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.cpp
@@ -939,8 +939,12 @@ Status SegmentIterator::next_batch(vectorized::Block* block) {
                 // the segment of c do not effective delete condition, but it still need read the column
                 // to match the schema.
                 // TODO: skip read the not effective delete column to speed up segment read.
-                _current_return_columns[cid] =
-                        Schema::get_data_type_ptr(column_desc->type())->create_column();
+                auto data_type = Schema::get_data_type_ptr(column_desc->type());
+                if (column_desc->is_nullable()) {
+                    data_type =
+                            std::make_shared<vectorized::DataTypeNullable>(std::move(data_type));
+                }
+                _current_return_columns[cid] = data_type->create_column();
                 _current_return_columns[cid]->reserve(_opts.block_row_max);
             }
         }


### PR DESCRIPTION
After cherry-pick #9547 from master to 1.1-lts, the return columns in SegmentIterator lost ColumnNullable.

# Proposed changes

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

