### PR TITLE
[fix](cooldown) Forbid re-add replica with cooldowned rowsets

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/master/ReportHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/master/ReportHandler.java
@@ -851,7 +851,9 @@ public class ReportHandler extends Daemon {
                     // if add failed. delete this tablet from backend.
                     try {
                         tabletMeta = invertedIndex.getTabletMeta(tabletId);
-                        if (tabletMeta != null) {
+                        // Directly forbid re-add replica with cooldowned rowsets, because these cooldowned rowsets may
+                        // already been confirmed as unused data and deleted.
+                        if (tabletMeta != null && !backendTabletInfo.isSetCooldownMetaId()) {
                             addReplica(tabletId, tabletMeta, backendTabletInfo, backendId);
                             // update counter
                             ++addToMetaCounter;


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

Forbid re-add replica with cooldowned rowsets, because these cooldowned rowsets may already been confirmed as unused data and deleted.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [x] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

