### PR TITLE
[BugFix](Jdbc Catalog) Fix null pointer exception in JdbcExecutor

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/external/jdbc/JdbcClient.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/external/jdbc/JdbcClient.java
@@ -264,13 +264,7 @@ public class JdbcClient {
         // for utf8 encoding, if columnSize=10, then charOctetLength=30
         // because for utf8 encoding, a Chinese character takes up 3 bytes
         private int charOctetLength;
-        /**
-         *  Whether it is allowed to be NULL
-         *  0 (columnNoNulls)
-         *  1 (columnNullable)
-         *  2 (columnNullableUnknown)
-         */
-        private int nullAble;
+        private boolean isAllowNull;
     }
 
     /**
@@ -312,7 +306,13 @@ public class JdbcClient {
                 field.setColumnSize(rs.getInt("COLUMN_SIZE"));
                 field.setDecimalDigits(rs.getInt("DECIMAL_DIGITS"));
                 field.setNumPrecRadix(rs.getInt("NUM_PREC_RADIX"));
-                field.setNullAble(rs.getInt("NULLABLE"));
+                /**
+                 *  Whether it is allowed to be NULL
+                 *  0 (columnNoNulls)
+                 *  1 (columnNullable)
+                 *  2 (columnNullableUnknown)
+                 */
+                field.setAllowNull(rs.getInt("NULLABLE") == 0 ? false : true);
                 field.setRemarks(rs.getString("REMARKS"));
                 field.setCharOctetLength(rs.getInt("CHAR_OCTET_LENGTH"));
                 tableSchema.add(field);
@@ -684,7 +684,7 @@ public class JdbcClient {
         for (JdbcFieldSchema field : jdbcTableSchema) {
             dorisTableSchema.add(new Column(field.getColumnName(),
                     jdbcTypeToDoris(field), true, null,
-                    true, field.getRemarks(),
+                    field.isAllowNull(), field.getRemarks(),
                     true, -1));
         }
         return dorisTableSchema;

--- a/fe/java-udf/src/main/java/org/apache/doris/udf/JdbcExecutor.java
+++ b/fe/java-udf/src/main/java/org/apache/doris/udf/JdbcExecutor.java
@@ -262,6 +262,7 @@ public class JdbcExecutor {
     private void bigDecimalPutToByte(Object[] column, boolean isNullable, int numRows, long nullMapAddr,
             long columnAddr) {
         if (isNullable) {
+            // TODO(ftw): start at i, other than start at 0.
             for (int i = 0; i < numRows; i++) {
                 if (column[i] == null) {
                     UdfUtils.UNSAFE.putByte(nullMapAddr + i, (byte) 1);
@@ -315,11 +316,19 @@ public class JdbcExecutor {
     public void copyBatchTinyIntResult(Object columnObj, boolean isNullable, int numRows, long nullMapAddr,
             long columnAddr) {
         Object[] column = (Object[]) columnObj;
-        if (column[0] instanceof BigDecimal) {
+        int firstNotNullIndex = 0;
+        if (isNullable) {
+            firstNotNullIndex = getFirstNotNullObject(column, numRows, nullMapAddr);
+        }
+        // TODO(ftw): There is an enhancement:
+        // because column[i] == null may have been judged outside the function
+        // so we can start at index 'i' other than start at 0 in bigDecimalPutToByte.
+        // only used for isNullable Field.
+        if (column[firstNotNullIndex] instanceof BigDecimal) {
             bigDecimalPutToByte(column, isNullable, numRows, nullMapAddr, columnAddr);
-        } else if (column[0] instanceof Integer) {
+        } else if (column[firstNotNullIndex] instanceof Integer) {
             integerPutToByte(column, isNullable, numRows, nullMapAddr, columnAddr);
-        } else if (column[0] instanceof Short) {
+        } else if (column[firstNotNullIndex] instanceof Short) {
             shortPutToByte(column, isNullable, numRows, nullMapAddr, columnAddr);
         }
     }
@@ -378,11 +387,15 @@ public class JdbcExecutor {
     public void copyBatchSmallIntResult(Object columnObj, boolean isNullable, int numRows, long nullMapAddr,
             long columnAddr) {
         Object[] column = (Object[]) columnObj;
-        if (column[0] instanceof BigDecimal) {
+        int firstNotNullIndex = 0;
+        if (isNullable) {
+            firstNotNullIndex = getFirstNotNullObject(column, numRows, nullMapAddr);
+        }
+        if (column[firstNotNullIndex] instanceof BigDecimal) {
             bigDecimalPutToShort(column, isNullable, numRows, nullMapAddr, columnAddr);
-        } else if (column[0] instanceof Integer) {
+        } else if (column[firstNotNullIndex] instanceof Integer) {
             integerPutToShort(column, isNullable, numRows, nullMapAddr, columnAddr);
-        } else if (column[0] instanceof Short) {
+        } else if (column[firstNotNullIndex] instanceof Short) {
             shortPutToShort(column, isNullable, numRows, nullMapAddr, columnAddr);
         }
     }
@@ -425,9 +438,13 @@ public class JdbcExecutor {
     public void copyBatchIntResult(Object columnObj, boolean isNullable, int numRows, long nullMapAddr,
             long columnAddr) {
         Object[] column = (Object[]) columnObj;
-        if (column[0] instanceof BigDecimal) {
+        int firstNotNullIndex = 0;
+        if (isNullable) {
+            firstNotNullIndex = getFirstNotNullObject(column, numRows, nullMapAddr);
+        }
+        if (column[firstNotNullIndex] instanceof BigDecimal) {
             bigDecimalPutToInt(column, isNullable, numRows, nullMapAddr, columnAddr);
-        } else if (column[0] instanceof Integer) {
+        } else if (column[firstNotNullIndex] instanceof Integer) {
             integerPutToInt(column, isNullable, numRows, nullMapAddr, columnAddr);
         }
     }
@@ -469,9 +486,13 @@ public class JdbcExecutor {
     public void copyBatchBigIntResult(Object columnObj, boolean isNullable, int numRows, long nullMapAddr,
             long columnAddr) {
         Object[] column = (Object[]) columnObj;
-        if (column[0] instanceof BigDecimal) {
+        int firstNotNullIndex = 0;
+        if (isNullable) {
+            firstNotNullIndex = getFirstNotNullObject(column, numRows, nullMapAddr);
+        }
+        if (column[firstNotNullIndex] instanceof BigDecimal) {
             bigDecimalPutToLong(column, isNullable, numRows, nullMapAddr, columnAddr);
-        } else if (column[0] instanceof Long) {
+        } else if (column[firstNotNullIndex] instanceof Long) {
             longPutToLong(column, isNullable, numRows, nullMapAddr, columnAddr);
         }
     }
@@ -528,9 +549,13 @@ public class JdbcExecutor {
     public void copyBatchLargeIntResult(Object columnObj, boolean isNullable, int numRows, long nullMapAddr,
             long columnAddr) {
         Object[] column = (Object[]) columnObj;
-        if (column[0] instanceof BigDecimal) {
+        int firstNotNullIndex = 0;
+        if (isNullable) {
+            firstNotNullIndex = getFirstNotNullObject(column, numRows, nullMapAddr);
+        }
+        if (column[firstNotNullIndex] instanceof BigDecimal) {
             bigDecimalPutToBigInteger(column, isNullable, numRows, nullMapAddr, columnAddr);
-        } else if (column[0] instanceof BigInteger) {
+        } else if (column[firstNotNullIndex] instanceof BigInteger) {
             bigIntegerPutToByte(column, isNullable, numRows, nullMapAddr, columnAddr);
         }
     }
@@ -591,9 +616,13 @@ public class JdbcExecutor {
     public void copyBatchDoubleResult(Object columnObj, boolean isNullable, int numRows, long nullMapAddr,
             long columnAddr) {
         Object[] column = (Object[]) columnObj;
-        if (column[0] instanceof BigDecimal) {
+        int firstNotNullIndex = 0;
+        if (isNullable) {
+            firstNotNullIndex = getFirstNotNullObject(column, numRows, nullMapAddr);
+        }
+        if (column[firstNotNullIndex] instanceof BigDecimal) {
             bigDecimalPutToDouble(column, isNullable, numRows, nullMapAddr, columnAddr);
-        } else if (column[0] instanceof Double) {
+        } else if (column[firstNotNullIndex] instanceof Double) {
             doublePutToDouble(column, isNullable, numRows, nullMapAddr, columnAddr);
         }
     }
@@ -662,9 +691,13 @@ public class JdbcExecutor {
     public void copyBatchDateResult(Object columnObj, boolean isNullable, int numRows, long nullMapAddr,
             long columnAddr) {
         Object[] column = (Object[]) columnObj;
-        if (column[0] instanceof LocalDate) {
+        int firstNotNullIndex = 0;
+        if (isNullable) {
+            firstNotNullIndex = getFirstNotNullObject(column, numRows, nullMapAddr);
+        }
+        if (column[firstNotNullIndex] instanceof LocalDate) {
             localDatePutToLong(column, isNullable, numRows, nullMapAddr, columnAddr);
-        } else if (column[0] instanceof Date) {
+        } else if (column[firstNotNullIndex] instanceof Date) {
             datePutToLong(column, isNullable, numRows, nullMapAddr, columnAddr);
         }
     }
@@ -716,9 +749,13 @@ public class JdbcExecutor {
     public void copyBatchDateV2Result(Object columnObj, boolean isNullable, int numRows, long nullMapAddr,
             long columnAddr) {
         Object[] column = (Object[]) columnObj;
-        if (column[0] instanceof LocalDate) {
+        int firstNotNullIndex = 0;
+        if (isNullable) {
+            firstNotNullIndex = getFirstNotNullObject(column, numRows, nullMapAddr);
+        }
+        if (column[firstNotNullIndex] instanceof LocalDate) {
             localDatePutToInt(column, isNullable, numRows, nullMapAddr, columnAddr);
-        } else if (column[0] instanceof Date) {
+        } else if (column[firstNotNullIndex] instanceof Date) {
             datePutToInt(column, isNullable, numRows, nullMapAddr, columnAddr);
         }
     }
@@ -822,11 +859,15 @@ public class JdbcExecutor {
     public void copyBatchDateTimeResult(Object columnObj, boolean isNullable, int numRows, long nullMapAddr,
             long columnAddr) throws SQLException {
         Object[] column = (Object[]) columnObj;
-        if (column[0] instanceof LocalDateTime) {
+        int firstNotNullIndex = 0;
+        if (isNullable) {
+            firstNotNullIndex = getFirstNotNullObject(column, numRows, nullMapAddr);
+        }
+        if (column[firstNotNullIndex] instanceof LocalDateTime) {
             localDateTimePutToLong(column, isNullable, numRows, nullMapAddr, columnAddr);
-        } else if (column[0] instanceof java.sql.Timestamp) {
+        } else if (column[firstNotNullIndex] instanceof java.sql.Timestamp) {
             timestampPutToLong(column, isNullable, numRows, nullMapAddr, columnAddr);
-        } else if (column[0] instanceof oracle.sql.TIMESTAMP) {
+        } else if (column[firstNotNullIndex] instanceof oracle.sql.TIMESTAMP) {
             oracleTimetampPutToLong(column, isNullable, numRows, nullMapAddr, columnAddr);
         }
     }
@@ -905,11 +946,15 @@ public class JdbcExecutor {
     public void copyBatchDateTimeV2Result(Object columnObj, boolean isNullable, int numRows, long nullMapAddr,
             long columnAddr) throws SQLException {
         Object[] column = (Object[]) columnObj;
-        if (column[0] instanceof LocalDateTime) {
+        int firstNotNullIndex = 0;
+        if (isNullable) {
+            firstNotNullIndex = getFirstNotNullObject(column, numRows, nullMapAddr);
+        }
+        if (column[firstNotNullIndex] instanceof LocalDateTime) {
             localDateTimePutToLongV2(column, isNullable, numRows, nullMapAddr, columnAddr);
-        } else if (column[0] instanceof java.sql.Timestamp) {
+        } else if (column[firstNotNullIndex] instanceof java.sql.Timestamp) {
             timestampPutToLongV2(column, isNullable, numRows, nullMapAddr, columnAddr);
-        } else if (column[0] instanceof oracle.sql.TIMESTAMP) {
+        } else if (column[firstNotNullIndex] instanceof oracle.sql.TIMESTAMP) {
             oracleTimetampPutToLongV2(column, isNullable, numRows, nullMapAddr, columnAddr);
         }
     }
@@ -1010,7 +1055,11 @@ public class JdbcExecutor {
     public void copyBatchStringResult(Object columnObj, boolean isNullable, int numRows, long nullMapAddr,
             long offsetsAddr, long charsAddr) {
         Object[] column = (Object[]) columnObj;
-        if (column[0] instanceof String) {
+        int firstNotNullIndex = 0;
+        if (isNullable) {
+            firstNotNullIndex = getFirstNotNullObject(column, numRows, nullMapAddr);
+        }
+        if (column[firstNotNullIndex] instanceof String) {
             stringPutToString(column, isNullable, numRows, nullMapAddr, offsetsAddr, charsAddr);
         } else {
             //object like in pg type point, polygon, jsonb..... get object is org.postgresql.util.PGobject.....
@@ -1110,5 +1159,17 @@ public class JdbcExecutor {
                         typeLen);
             }
         }
+    }
+
+    private int getFirstNotNullObject(Object[] column, int numRows, long nullMapAddr) {
+        int i = 0;
+        for (; i < numRows; ++i) {
+            if (null == column[i]) {
+                UdfUtils.UNSAFE.putByte(nullMapAddr + i, (byte) 1);
+            } else {
+                break;
+            }
+        }
+        return i;
     }
 }

--- a/fe/java-udf/src/main/java/org/apache/doris/udf/JdbcExecutor.java
+++ b/fe/java-udf/src/main/java/org/apache/doris/udf/JdbcExecutor.java
@@ -320,6 +320,9 @@ public class JdbcExecutor {
         if (isNullable) {
             firstNotNullIndex = getFirstNotNullObject(column, numRows, nullMapAddr);
         }
+        if (firstNotNullIndex == numRows) {
+            return;
+        }
         // TODO(ftw): There is an enhancement:
         // because column[i] == null may have been judged outside the function
         // so we can start at index 'i' other than start at 0 in bigDecimalPutToByte.
@@ -391,6 +394,9 @@ public class JdbcExecutor {
         if (isNullable) {
             firstNotNullIndex = getFirstNotNullObject(column, numRows, nullMapAddr);
         }
+        if (firstNotNullIndex == numRows) {
+            return;
+        }
         if (column[firstNotNullIndex] instanceof BigDecimal) {
             bigDecimalPutToShort(column, isNullable, numRows, nullMapAddr, columnAddr);
         } else if (column[firstNotNullIndex] instanceof Integer) {
@@ -442,6 +448,9 @@ public class JdbcExecutor {
         if (isNullable) {
             firstNotNullIndex = getFirstNotNullObject(column, numRows, nullMapAddr);
         }
+        if (firstNotNullIndex == numRows) {
+            return;
+        }
         if (column[firstNotNullIndex] instanceof BigDecimal) {
             bigDecimalPutToInt(column, isNullable, numRows, nullMapAddr, columnAddr);
         } else if (column[firstNotNullIndex] instanceof Integer) {
@@ -489,6 +498,9 @@ public class JdbcExecutor {
         int firstNotNullIndex = 0;
         if (isNullable) {
             firstNotNullIndex = getFirstNotNullObject(column, numRows, nullMapAddr);
+        }
+        if (firstNotNullIndex == numRows) {
+            return;
         }
         if (column[firstNotNullIndex] instanceof BigDecimal) {
             bigDecimalPutToLong(column, isNullable, numRows, nullMapAddr, columnAddr);
@@ -552,6 +564,9 @@ public class JdbcExecutor {
         int firstNotNullIndex = 0;
         if (isNullable) {
             firstNotNullIndex = getFirstNotNullObject(column, numRows, nullMapAddr);
+        }
+        if (firstNotNullIndex == numRows) {
+            return;
         }
         if (column[firstNotNullIndex] instanceof BigDecimal) {
             bigDecimalPutToBigInteger(column, isNullable, numRows, nullMapAddr, columnAddr);
@@ -619,6 +634,9 @@ public class JdbcExecutor {
         int firstNotNullIndex = 0;
         if (isNullable) {
             firstNotNullIndex = getFirstNotNullObject(column, numRows, nullMapAddr);
+        }
+        if (firstNotNullIndex == numRows) {
+            return;
         }
         if (column[firstNotNullIndex] instanceof BigDecimal) {
             bigDecimalPutToDouble(column, isNullable, numRows, nullMapAddr, columnAddr);
@@ -695,6 +713,9 @@ public class JdbcExecutor {
         if (isNullable) {
             firstNotNullIndex = getFirstNotNullObject(column, numRows, nullMapAddr);
         }
+        if (firstNotNullIndex == numRows) {
+            return;
+        }
         if (column[firstNotNullIndex] instanceof LocalDate) {
             localDatePutToLong(column, isNullable, numRows, nullMapAddr, columnAddr);
         } else if (column[firstNotNullIndex] instanceof Date) {
@@ -752,6 +773,9 @@ public class JdbcExecutor {
         int firstNotNullIndex = 0;
         if (isNullable) {
             firstNotNullIndex = getFirstNotNullObject(column, numRows, nullMapAddr);
+        }
+        if (firstNotNullIndex == numRows) {
+            return;
         }
         if (column[firstNotNullIndex] instanceof LocalDate) {
             localDatePutToInt(column, isNullable, numRows, nullMapAddr, columnAddr);
@@ -863,6 +887,9 @@ public class JdbcExecutor {
         if (isNullable) {
             firstNotNullIndex = getFirstNotNullObject(column, numRows, nullMapAddr);
         }
+        if (firstNotNullIndex == numRows) {
+            return;
+        }
         if (column[firstNotNullIndex] instanceof LocalDateTime) {
             localDateTimePutToLong(column, isNullable, numRows, nullMapAddr, columnAddr);
         } else if (column[firstNotNullIndex] instanceof java.sql.Timestamp) {
@@ -949,6 +976,9 @@ public class JdbcExecutor {
         int firstNotNullIndex = 0;
         if (isNullable) {
             firstNotNullIndex = getFirstNotNullObject(column, numRows, nullMapAddr);
+        }
+        if (firstNotNullIndex == numRows) {
+            return;
         }
         if (column[firstNotNullIndex] instanceof LocalDateTime) {
             localDateTimePutToLongV2(column, isNullable, numRows, nullMapAddr, columnAddr);
@@ -1058,6 +1088,9 @@ public class JdbcExecutor {
         int firstNotNullIndex = 0;
         if (isNullable) {
             firstNotNullIndex = getFirstNotNullObject(column, numRows, nullMapAddr);
+        }
+        if (firstNotNullIndex == numRows) {
+            return;
         }
         if (column[firstNotNullIndex] instanceof String) {
             stringPutToString(column, isNullable, numRows, nullMapAddr, offsetsAddr, charsAddr);

--- a/fe/java-udf/src/main/java/org/apache/doris/udf/JdbcExecutor.java
+++ b/fe/java-udf/src/main/java/org/apache/doris/udf/JdbcExecutor.java
@@ -260,10 +260,9 @@ public class JdbcExecutor {
     }
 
     private void bigDecimalPutToByte(Object[] column, boolean isNullable, int numRows, long nullMapAddr,
-            long columnAddr) {
+            long columnAddr, int startRowForNullable) {
         if (isNullable) {
-            // TODO(ftw): start at i, other than start at 0.
-            for (int i = 0; i < numRows; i++) {
+            for (int i = startRowForNullable; i < numRows; i++) {
                 if (column[i] == null) {
                     UdfUtils.UNSAFE.putByte(nullMapAddr + i, (byte) 1);
                 } else {
@@ -280,9 +279,9 @@ public class JdbcExecutor {
     }
 
     private void integerPutToByte(Object[] column, boolean isNullable, int numRows, long nullMapAddr,
-            long columnAddr) {
+            long columnAddr, int startRowForNullable) {
         if (isNullable) {
-            for (int i = 0; i < numRows; i++) {
+            for (int i = startRowForNullable; i < numRows; i++) {
                 if (column[i] == null) {
                     UdfUtils.UNSAFE.putByte(nullMapAddr + i, (byte) 1);
                 } else {
@@ -297,9 +296,9 @@ public class JdbcExecutor {
     }
 
     private void shortPutToByte(Object[] column, boolean isNullable, int numRows, long nullMapAddr,
-            long columnAddr) {
+            long columnAddr, int startRowForNullable) {
         if (isNullable) {
-            for (int i = 0; i < numRows; i++) {
+            for (int i = startRowForNullable; i < numRows; i++) {
                 if (column[i] == null) {
                     UdfUtils.UNSAFE.putByte(nullMapAddr + i, (byte) 1);
                 } else {
@@ -323,23 +322,19 @@ public class JdbcExecutor {
         if (firstNotNullIndex == numRows) {
             return;
         }
-        // TODO(ftw): There is an enhancement:
-        // because column[i] == null may have been judged outside the function
-        // so we can start at index 'i' other than start at 0 in bigDecimalPutToByte.
-        // only used for isNullable Field.
         if (column[firstNotNullIndex] instanceof BigDecimal) {
-            bigDecimalPutToByte(column, isNullable, numRows, nullMapAddr, columnAddr);
+            bigDecimalPutToByte(column, isNullable, numRows, nullMapAddr, columnAddr, firstNotNullIndex);
         } else if (column[firstNotNullIndex] instanceof Integer) {
-            integerPutToByte(column, isNullable, numRows, nullMapAddr, columnAddr);
+            integerPutToByte(column, isNullable, numRows, nullMapAddr, columnAddr, firstNotNullIndex);
         } else if (column[firstNotNullIndex] instanceof Short) {
-            shortPutToByte(column, isNullable, numRows, nullMapAddr, columnAddr);
+            shortPutToByte(column, isNullable, numRows, nullMapAddr, columnAddr, firstNotNullIndex);
         }
     }
 
     private void bigDecimalPutToShort(Object[] column, boolean isNullable, int numRows, long nullMapAddr,
-            long columnAddr) {
+            long columnAddr, int startRowForNullable) {
         if (isNullable) {
-            for (int i = 0; i < numRows; i++) {
+            for (int i = startRowForNullable; i < numRows; i++) {
                 if (column[i] == null) {
                     UdfUtils.UNSAFE.putByte(nullMapAddr + i, (byte) 1);
                 } else {
@@ -354,9 +349,9 @@ public class JdbcExecutor {
     }
 
     private void integerPutToShort(Object[] column, boolean isNullable, int numRows, long nullMapAddr,
-            long columnAddr) {
+            long columnAddr, int startRowForNullable) {
         if (isNullable) {
-            for (int i = 0; i < numRows; i++) {
+            for (int i = startRowForNullable; i < numRows; i++) {
                 if (column[i] == null) {
                     UdfUtils.UNSAFE.putByte(nullMapAddr + i, (byte) 1);
                 } else {
@@ -371,9 +366,9 @@ public class JdbcExecutor {
     }
 
     private void shortPutToShort(Object[] column, boolean isNullable, int numRows, long nullMapAddr,
-            long columnAddr) {
+            long columnAddr, int startRowForNullable) {
         if (isNullable) {
-            for (int i = 0; i < numRows; i++) {
+            for (int i = startRowForNullable; i < numRows; i++) {
                 if (column[i] == null) {
                     UdfUtils.UNSAFE.putByte(nullMapAddr + i, (byte) 1);
                 } else {
@@ -398,19 +393,19 @@ public class JdbcExecutor {
             return;
         }
         if (column[firstNotNullIndex] instanceof BigDecimal) {
-            bigDecimalPutToShort(column, isNullable, numRows, nullMapAddr, columnAddr);
+            bigDecimalPutToShort(column, isNullable, numRows, nullMapAddr, columnAddr, firstNotNullIndex);
         } else if (column[firstNotNullIndex] instanceof Integer) {
-            integerPutToShort(column, isNullable, numRows, nullMapAddr, columnAddr);
+            integerPutToShort(column, isNullable, numRows, nullMapAddr, columnAddr, firstNotNullIndex);
         } else if (column[firstNotNullIndex] instanceof Short) {
-            shortPutToShort(column, isNullable, numRows, nullMapAddr, columnAddr);
+            shortPutToShort(column, isNullable, numRows, nullMapAddr, columnAddr, firstNotNullIndex);
         }
     }
 
 
     private void bigDecimalPutToInt(Object[] column, boolean isNullable, int numRows, long nullMapAddr,
-            long columnAddr) {
+            long columnAddr, int startRowForNullable) {
         if (isNullable) {
-            for (int i = 0; i < numRows; i++) {
+            for (int i = startRowForNullable; i < numRows; i++) {
                 if (column[i] == null) {
                     UdfUtils.UNSAFE.putByte(nullMapAddr + i, (byte) 1);
                 } else {
@@ -425,9 +420,9 @@ public class JdbcExecutor {
     }
 
     private void integerPutToInt(Object[] column, boolean isNullable, int numRows, long nullMapAddr,
-            long columnAddr) {
+            long columnAddr, int startRowForNullable) {
         if (isNullable) {
-            for (int i = 0; i < numRows; i++) {
+            for (int i = startRowForNullable; i < numRows; i++) {
                 if (column[i] == null) {
                     UdfUtils.UNSAFE.putByte(nullMapAddr + i, (byte) 1);
                 } else {
@@ -452,16 +447,16 @@ public class JdbcExecutor {
             return;
         }
         if (column[firstNotNullIndex] instanceof BigDecimal) {
-            bigDecimalPutToInt(column, isNullable, numRows, nullMapAddr, columnAddr);
+            bigDecimalPutToInt(column, isNullable, numRows, nullMapAddr, columnAddr, firstNotNullIndex);
         } else if (column[firstNotNullIndex] instanceof Integer) {
-            integerPutToInt(column, isNullable, numRows, nullMapAddr, columnAddr);
+            integerPutToInt(column, isNullable, numRows, nullMapAddr, columnAddr, firstNotNullIndex);
         }
     }
 
     private void bigDecimalPutToLong(Object[] column, boolean isNullable, int numRows, long nullMapAddr,
-            long columnAddr) {
+            long columnAddr, int startRowForNullable) {
         if (isNullable) {
-            for (int i = 0; i < numRows; i++) {
+            for (int i = startRowForNullable; i < numRows; i++) {
                 if (column[i] == null) {
                     UdfUtils.UNSAFE.putByte(nullMapAddr + i, (byte) 1);
                 } else {
@@ -476,9 +471,9 @@ public class JdbcExecutor {
     }
 
     private void longPutToLong(Object[] column, boolean isNullable, int numRows, long nullMapAddr,
-            long columnAddr) {
+            long columnAddr, int startRowForNullable) {
         if (isNullable) {
-            for (int i = 0; i < numRows; i++) {
+            for (int i = startRowForNullable; i < numRows; i++) {
                 if (column[i] == null) {
                     UdfUtils.UNSAFE.putByte(nullMapAddr + i, (byte) 1);
                 } else {
@@ -503,14 +498,14 @@ public class JdbcExecutor {
             return;
         }
         if (column[firstNotNullIndex] instanceof BigDecimal) {
-            bigDecimalPutToLong(column, isNullable, numRows, nullMapAddr, columnAddr);
+            bigDecimalPutToLong(column, isNullable, numRows, nullMapAddr, columnAddr, firstNotNullIndex);
         } else if (column[firstNotNullIndex] instanceof Long) {
-            longPutToLong(column, isNullable, numRows, nullMapAddr, columnAddr);
+            longPutToLong(column, isNullable, numRows, nullMapAddr, columnAddr, firstNotNullIndex);
         }
     }
 
     private void bigDecimalPutToBigInteger(Object[] column, boolean isNullable, int numRows, long nullMapAddr,
-            long columnAddr) {
+            long columnAddr, int startRowForNullable) {
         BigInteger[] data = new BigInteger[numRows];
         for (int i = 0; i < numRows; i++) {
             if (column[i] == null) {
@@ -520,13 +515,13 @@ public class JdbcExecutor {
                 data[i] = ((BigDecimal) column[i]).toBigInteger();
             }
         }
-        copyBatchDecimalResult(data, isNullable, numRows, columnAddr, 16);
+        copyBatchDecimalResult(data, isNullable, numRows, columnAddr, 16, startRowForNullable);
     }
 
     private void bigIntegerPutToByte(Object[] column, boolean isNullable, int numRows, long nullMapAddr,
-            long columnAddr) {
+            long columnAddr, int startRowForNullable) {
         if (isNullable == true) {
-            for (int i = 0; i < numRows; i++) {
+            for (int i = startRowForNullable; i < numRows; i++) {
                 if (column[i] == null) {
                     UdfUtils.UNSAFE.putByte(nullMapAddr + i, (byte) 1);
                 } else {
@@ -569,9 +564,9 @@ public class JdbcExecutor {
             return;
         }
         if (column[firstNotNullIndex] instanceof BigDecimal) {
-            bigDecimalPutToBigInteger(column, isNullable, numRows, nullMapAddr, columnAddr);
+            bigDecimalPutToBigInteger(column, isNullable, numRows, nullMapAddr, columnAddr, firstNotNullIndex);
         } else if (column[firstNotNullIndex] instanceof BigInteger) {
-            bigIntegerPutToByte(column, isNullable, numRows, nullMapAddr, columnAddr);
+            bigIntegerPutToByte(column, isNullable, numRows, nullMapAddr, columnAddr, firstNotNullIndex);
         }
     }
 
@@ -594,9 +589,9 @@ public class JdbcExecutor {
     }
 
     private void bigDecimalPutToDouble(Object[] column, boolean isNullable, int numRows, long nullMapAddr,
-            long columnAddr) {
+            long columnAddr, int startRowForNullable) {
         if (isNullable) {
-            for (int i = 0; i < numRows; i++) {
+            for (int i = startRowForNullable; i < numRows; i++) {
                 if (column[i] == null) {
                     UdfUtils.UNSAFE.putByte(nullMapAddr + i, (byte) 1);
                 } else {
@@ -612,9 +607,9 @@ public class JdbcExecutor {
 
 
     private void doublePutToDouble(Object[] column, boolean isNullable, int numRows, long nullMapAddr,
-            long columnAddr) {
+            long columnAddr, int startRowForNullable) {
         if (isNullable) {
-            for (int i = 0; i < numRows; i++) {
+            for (int i = startRowForNullable; i < numRows; i++) {
                 if (column[i] == null) {
                     UdfUtils.UNSAFE.putByte(nullMapAddr + i, (byte) 1);
                 } else {
@@ -639,9 +634,9 @@ public class JdbcExecutor {
             return;
         }
         if (column[firstNotNullIndex] instanceof BigDecimal) {
-            bigDecimalPutToDouble(column, isNullable, numRows, nullMapAddr, columnAddr);
+            bigDecimalPutToDouble(column, isNullable, numRows, nullMapAddr, columnAddr, firstNotNullIndex);
         } else if (column[firstNotNullIndex] instanceof Double) {
-            doublePutToDouble(column, isNullable, numRows, nullMapAddr, columnAddr);
+            doublePutToDouble(column, isNullable, numRows, nullMapAddr, columnAddr, firstNotNullIndex);
         }
     }
 
@@ -661,9 +656,9 @@ public class JdbcExecutor {
     }
 
     private void localDatePutToLong(Object[] column, boolean isNullable, int numRows, long nullMapAddr,
-            long columnAddr) {
+            long columnAddr, int startRowForNullable) {
         if (isNullable) {
-            for (int i = 0; i < numRows; i++) {
+            for (int i = startRowForNullable; i < numRows; i++) {
                 if (column[i] == null) {
                     UdfUtils.UNSAFE.putByte(nullMapAddr + i, (byte) 1);
                 } else {
@@ -684,9 +679,9 @@ public class JdbcExecutor {
     }
 
     private void datePutToLong(Object[] column, boolean isNullable, int numRows, long nullMapAddr,
-            long columnAddr) {
+            long columnAddr, int startRowForNullable) {
         if (isNullable) {
-            for (int i = 0; i < numRows; i++) {
+            for (int i = startRowForNullable; i < numRows; i++) {
                 if (column[i] == null) {
                     UdfUtils.UNSAFE.putByte(nullMapAddr + i, (byte) 1);
                 } else {
@@ -717,16 +712,16 @@ public class JdbcExecutor {
             return;
         }
         if (column[firstNotNullIndex] instanceof LocalDate) {
-            localDatePutToLong(column, isNullable, numRows, nullMapAddr, columnAddr);
+            localDatePutToLong(column, isNullable, numRows, nullMapAddr, columnAddr, firstNotNullIndex);
         } else if (column[firstNotNullIndex] instanceof Date) {
-            datePutToLong(column, isNullable, numRows, nullMapAddr, columnAddr);
+            datePutToLong(column, isNullable, numRows, nullMapAddr, columnAddr, firstNotNullIndex);
         }
     }
 
     private void localDatePutToInt(Object[] column, boolean isNullable, int numRows, long nullMapAddr,
-            long columnAddr) {
+            long columnAddr, int startRowForNullable) {
         if (isNullable) {
-            for (int i = 0; i < numRows; i++) {
+            for (int i = startRowForNullable; i < numRows; i++) {
                 if (column[i] == null) {
                     UdfUtils.UNSAFE.putByte(nullMapAddr + i, (byte) 1);
                 } else {
@@ -747,9 +742,9 @@ public class JdbcExecutor {
     }
 
     private void datePutToInt(Object[] column, boolean isNullable, int numRows, long nullMapAddr,
-            long columnAddr) {
+            long columnAddr, int startRowForNullable) {
         if (isNullable) {
-            for (int i = 0; i < numRows; i++) {
+            for (int i = startRowForNullable; i < numRows; i++) {
                 if (column[i] == null) {
                     UdfUtils.UNSAFE.putByte(nullMapAddr + i, (byte) 1);
                 } else {
@@ -778,9 +773,9 @@ public class JdbcExecutor {
             return;
         }
         if (column[firstNotNullIndex] instanceof LocalDate) {
-            localDatePutToInt(column, isNullable, numRows, nullMapAddr, columnAddr);
+            localDatePutToInt(column, isNullable, numRows, nullMapAddr, columnAddr, firstNotNullIndex);
         } else if (column[firstNotNullIndex] instanceof Date) {
-            datePutToInt(column, isNullable, numRows, nullMapAddr, columnAddr);
+            datePutToInt(column, isNullable, numRows, nullMapAddr, columnAddr, firstNotNullIndex);
         }
     }
 
@@ -809,9 +804,9 @@ public class JdbcExecutor {
     }
 
     private void localDateTimePutToLong(Object[] column, boolean isNullable, int numRows, long nullMapAddr,
-            long columnAddr) {
+            long columnAddr, int startRowForNullable) {
         if (isNullable) {
-            for (int i = 0; i < numRows; i++) {
+            for (int i = startRowForNullable; i < numRows; i++) {
                 if (column[i] == null) {
                     UdfUtils.UNSAFE.putByte(nullMapAddr + i, (byte) 1);
                 } else {
@@ -834,9 +829,9 @@ public class JdbcExecutor {
     }
 
     private void timestampPutToLong(Object[] column, boolean isNullable, int numRows, long nullMapAddr,
-            long columnAddr) {
+            long columnAddr, int startRowForNullable) {
         if (isNullable) {
-            for (int i = 0; i < numRows; i++) {
+            for (int i = startRowForNullable; i < numRows; i++) {
                 if (column[i] == null) {
                     UdfUtils.UNSAFE.putByte(nullMapAddr + i, (byte) 1);
                 } else {
@@ -858,9 +853,9 @@ public class JdbcExecutor {
 
     private void oracleTimetampPutToLong(Object[] column, boolean isNullable, int numRows,
             long nullMapAddr,
-            long columnAddr) throws SQLException {
+            long columnAddr, int startRowForNullable) throws SQLException {
         if (isNullable) {
-            for (int i = 0; i < numRows; i++) {
+            for (int i = startRowForNullable; i < numRows; i++) {
                 if (column[i] == null) {
                     UdfUtils.UNSAFE.putByte(nullMapAddr + i, (byte) 1);
                 } else {
@@ -891,18 +886,18 @@ public class JdbcExecutor {
             return;
         }
         if (column[firstNotNullIndex] instanceof LocalDateTime) {
-            localDateTimePutToLong(column, isNullable, numRows, nullMapAddr, columnAddr);
+            localDateTimePutToLong(column, isNullable, numRows, nullMapAddr, columnAddr, firstNotNullIndex);
         } else if (column[firstNotNullIndex] instanceof java.sql.Timestamp) {
-            timestampPutToLong(column, isNullable, numRows, nullMapAddr, columnAddr);
+            timestampPutToLong(column, isNullable, numRows, nullMapAddr, columnAddr, firstNotNullIndex);
         } else if (column[firstNotNullIndex] instanceof oracle.sql.TIMESTAMP) {
-            oracleTimetampPutToLong(column, isNullable, numRows, nullMapAddr, columnAddr);
+            oracleTimetampPutToLong(column, isNullable, numRows, nullMapAddr, columnAddr, firstNotNullIndex);
         }
     }
 
     private void localDateTimePutToLongV2(Object[] column, boolean isNullable, int numRows, long nullMapAddr,
-            long columnAddr) {
+            long columnAddr, int startRowForNullable) {
         if (isNullable) {
-            for (int i = 0; i < numRows; i++) {
+            for (int i = startRowForNullable; i < numRows; i++) {
                 if (column[i] == null) {
                     UdfUtils.UNSAFE.putByte(nullMapAddr + i, (byte) 1);
                 } else {
@@ -925,9 +920,9 @@ public class JdbcExecutor {
     }
 
     private void timestampPutToLongV2(Object[] column, boolean isNullable, int numRows, long nullMapAddr,
-            long columnAddr) {
+            long columnAddr, int startRowForNullable) {
         if (isNullable) {
-            for (int i = 0; i < numRows; i++) {
+            for (int i = startRowForNullable; i < numRows; i++) {
                 if (column[i] == null) {
                     UdfUtils.UNSAFE.putByte(nullMapAddr + i, (byte) 1);
                 } else {
@@ -948,9 +943,9 @@ public class JdbcExecutor {
     }
 
     private void oracleTimetampPutToLongV2(Object[] column, boolean isNullable, int numRows,
-            long nullMapAddr, long columnAddr) throws SQLException {
+            long nullMapAddr, long columnAddr, int startRowForNullable) throws SQLException {
         if (isNullable) {
-            for (int i = 0; i < numRows; i++) {
+            for (int i = startRowForNullable; i < numRows; i++) {
                 if (column[i] == null) {
                     UdfUtils.UNSAFE.putByte(nullMapAddr + i, (byte) 1);
                 } else {
@@ -981,11 +976,11 @@ public class JdbcExecutor {
             return;
         }
         if (column[firstNotNullIndex] instanceof LocalDateTime) {
-            localDateTimePutToLongV2(column, isNullable, numRows, nullMapAddr, columnAddr);
+            localDateTimePutToLongV2(column, isNullable, numRows, nullMapAddr, columnAddr, firstNotNullIndex);
         } else if (column[firstNotNullIndex] instanceof java.sql.Timestamp) {
-            timestampPutToLongV2(column, isNullable, numRows, nullMapAddr, columnAddr);
+            timestampPutToLongV2(column, isNullable, numRows, nullMapAddr, columnAddr, firstNotNullIndex);
         } else if (column[firstNotNullIndex] instanceof oracle.sql.TIMESTAMP) {
-            oracleTimetampPutToLongV2(column, isNullable, numRows, nullMapAddr, columnAddr);
+            oracleTimetampPutToLongV2(column, isNullable, numRows, nullMapAddr, columnAddr, firstNotNullIndex);
         }
     }
 
@@ -1018,6 +1013,8 @@ public class JdbcExecutor {
         byte[][] byteRes = new byte[numRows][];
         int offset = 0;
         if (isNullable == true) {
+            // Here can not loop from startRowForNullable,
+            // because byteRes will be used later
             for (int i = 0; i < numRows; i++) {
                 if (column[i] == null) {
                     byteRes[i] = emptyBytes;
@@ -1113,7 +1110,7 @@ public class JdbcExecutor {
                 data[i] = ((BigDecimal) column[i]).setScale(9, RoundingMode.HALF_EVEN).unscaledValue();
             }
         }
-        copyBatchDecimalResult(data, isNullable, numRows, columnAddr, 16);
+        copyBatchDecimalResult(data, isNullable, numRows, columnAddr, 16, 0);
     }
 
     public void copyBatchDecimal32Result(Object columnObj, boolean isNullable, int numRows, long nullMapAddr,
@@ -1128,7 +1125,7 @@ public class JdbcExecutor {
                 data[i] = ((BigDecimal) column[i]).setScale(scale, RoundingMode.HALF_EVEN).unscaledValue();
             }
         }
-        copyBatchDecimalResult(data, isNullable, numRows, columnAddr, 4);
+        copyBatchDecimalResult(data, isNullable, numRows, columnAddr, 4, 0);
     }
 
     public void copyBatchDecimal64Result(Object columnObj, boolean isNullable, int numRows, long nullMapAddr,
@@ -1143,7 +1140,7 @@ public class JdbcExecutor {
                 data[i] = ((BigDecimal) column[i]).setScale(scale, RoundingMode.HALF_EVEN).unscaledValue();
             }
         }
-        copyBatchDecimalResult(data, isNullable, numRows, columnAddr, 8);
+        copyBatchDecimalResult(data, isNullable, numRows, columnAddr, 8, 0);
     }
 
     public void copyBatchDecimal128Result(Object columnObj, boolean isNullable, int numRows, long nullMapAddr,
@@ -1158,13 +1155,13 @@ public class JdbcExecutor {
                 data[i] = ((BigDecimal) column[i]).setScale(scale, RoundingMode.HALF_EVEN).unscaledValue();
             }
         }
-        copyBatchDecimalResult(data, isNullable, numRows, columnAddr, 16);
+        copyBatchDecimalResult(data, isNullable, numRows, columnAddr, 16, 0);
     }
 
     private void copyBatchDecimalResult(BigInteger[] column, boolean isNullable, int numRows,
-            long columnAddr, int typeLen) {
+            long columnAddr, int typeLen, int startRowForNullable) {
         if (isNullable == true) {
-            for (int i = 0; i < numRows; i++) {
+            for (int i = startRowForNullable; i < numRows; i++) {
                 if (column[i] != null) {
                     byte[] bytes = UdfUtils.convertByteOrder(column[i].toByteArray());
                     byte[] value = new byte[typeLen];


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

This pr do two things:
1. fix: 
    It use `column[0]` to judge class type in JdbcExecutor, but column[0] may be null !

3. enhencement:
     In the original logic, all fields in jdbc catalog table will be set Nullable. Howerver, it is inefficient for nullable fields. Actually, we can know if the fields in data source table is nullable throught jdbc. So we can set the corresponding fields in doris jdbc catalog to nullable or not.

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

