### PR TITLE
[feature](multi-catalog) parquet reader support nested array column

### DIFF
--- a/be/src/vec/exec/format/parquet/parquet_common.cpp
+++ b/be/src/vec/exec/format/parquet/parquet_common.cpp
@@ -18,7 +18,6 @@
 #include "parquet_common.h"
 
 #include "util/coding.h"
-#include "vec/columns/column_dictionary.h"
 #include "vec/data_types/data_type_nullable.h"
 
 namespace doris::vectorized {
@@ -115,11 +114,11 @@ void ColumnSelectVector::set_run_length_null_map(const std::vector<uint16_t>& ru
                 if (is_null) {
                     _num_nulls += run_length;
                     for (int i = 0; i < run_length; ++i) {
-                        map_data_column[null_map_index++] = (UInt8) true;
+                        map_data_column[null_map_index++] = 1;
                     }
                 } else {
                     for (int i = 0; i < run_length; ++i) {
-                        map_data_column[null_map_index++] = (UInt8) false;
+                        map_data_column[null_map_index++] = 0;
                     }
                 }
                 is_null = !is_null;

--- a/be/src/vec/exec/format/parquet/schema_desc.h
+++ b/be/src/vec/exec/format/parquet/schema_desc.h
@@ -42,6 +42,7 @@ struct FieldSchema {
     int physical_column_index = -1;
     int16_t definition_level = 0;
     int16_t repetition_level = 0;
+    int16_t repeated_parent_def_level = 0;
     std::vector<FieldSchema> children;
 
     FieldSchema() = default;

--- a/be/src/vec/exec/format/parquet/vparquet_column_reader.cpp
+++ b/be/src/vec/exec/format/parquet/vparquet_column_reader.cpp
@@ -29,6 +29,44 @@
 
 namespace doris::vectorized {
 
+static void fill_array_offset(FieldSchema* field, ColumnArray::Offsets64& offsets_data,
+                              NullMap* null_map_ptr, const std::vector<level_t>& rep_levels,
+                              const std::vector<level_t>& def_levels) {
+    size_t num_levels = rep_levels.size();
+    DCHECK_EQ(num_levels, def_levels.size());
+    size_t origin_size = offsets_data.size();
+    offsets_data.resize(origin_size + num_levels);
+    if (null_map_ptr != nullptr) {
+        null_map_ptr->resize(origin_size + num_levels);
+    }
+    size_t offset_pos = origin_size - 1;
+    for (size_t i = 0; i < num_levels; ++i) {
+        // skip the levels affect its ancestor or its descendants
+        if (def_levels[i] < field->repeated_parent_def_level ||
+            rep_levels[i] > field->repetition_level) {
+            continue;
+        }
+        if (rep_levels[i] == field->repetition_level) {
+            offsets_data[offset_pos]++;
+            continue;
+        }
+        offset_pos++;
+        offsets_data[offset_pos] = offsets_data[offset_pos - 1];
+        if (def_levels[i] >= field->definition_level) {
+            offsets_data[offset_pos]++;
+        }
+        if (def_levels[i] >= field->definition_level - 1) {
+            (*null_map_ptr)[offset_pos] = 0;
+        } else {
+            (*null_map_ptr)[offset_pos] = 1;
+        }
+    }
+    offsets_data.resize(origin_size + offset_pos + 1);
+    if (null_map_ptr != nullptr) {
+        null_map_ptr->resize(origin_size + offset_pos + 1);
+    }
+}
+
 Status ParquetColumnReader::create(io::FileReaderSPtr file, FieldSchema* field,
                                    const tparquet::RowGroup& row_group,
                                    const std::vector<RowRange>& row_ranges, cctz::time_zone* ctz,
@@ -38,32 +76,28 @@ Status ParquetColumnReader::create(io::FileReaderSPtr file, FieldSchema* field,
         return Status::Corruption("not supported type");
     }
     if (field->type.type == TYPE_ARRAY) {
-        tparquet::ColumnChunk chunk = row_group.columns[field->children[0].physical_column_index];
+        std::unique_ptr<ParquetColumnReader> element_reader;
+        RETURN_IF_ERROR(create(file, &field->children[0], row_group, row_ranges, ctz,
+                               element_reader, max_buf_size));
+        element_reader->set_nested_column();
         ArrayColumnReader* array_reader = new ArrayColumnReader(row_ranges, ctz);
-        array_reader->init_column_metadata(chunk);
-        RETURN_IF_ERROR(array_reader->init(file, field, &chunk, max_buf_size));
+        RETURN_IF_ERROR(array_reader->init(std::move(element_reader), field));
         reader.reset(array_reader);
     } else {
-        tparquet::ColumnChunk chunk = row_group.columns[field->physical_column_index];
-        ScalarColumnReader* scalar_reader = new ScalarColumnReader(row_ranges, ctz);
-        scalar_reader->init_column_metadata(chunk);
-        RETURN_IF_ERROR(scalar_reader->init(file, field, &chunk, max_buf_size));
+        const tparquet::ColumnChunk& chunk = row_group.columns[field->physical_column_index];
+        ScalarColumnReader* scalar_reader = new ScalarColumnReader(row_ranges, chunk, ctz);
+        RETURN_IF_ERROR(scalar_reader->init(file, field, max_buf_size));
         reader.reset(scalar_reader);
     }
     return Status::OK();
 }
 
-void ParquetColumnReader::init_column_metadata(const tparquet::ColumnChunk& chunk) {
-    auto chunk_meta = chunk.meta_data;
-    int64_t chunk_start = chunk_meta.__isset.dictionary_page_offset
-                                  ? chunk_meta.dictionary_page_offset
-                                  : chunk_meta.data_page_offset;
-    size_t chunk_len = chunk_meta.total_compressed_size;
-    _metadata.reset(new ParquetColumnMetadata(chunk_start, chunk_len, chunk_meta));
-}
-
 void ParquetColumnReader::_generate_read_ranges(int64_t start_index, int64_t end_index,
                                                 std::list<RowRange>& read_ranges) {
+    if (_nested_column) {
+        read_ranges.emplace_back(start_index, end_index);
+        return;
+    }
     int index = _row_range_index;
     while (index < _row_ranges.size()) {
         const RowRange& read_range = _row_ranges[index];
@@ -82,19 +116,18 @@ void ParquetColumnReader::_generate_read_ranges(int64_t start_index, int64_t end
     }
 }
 
-Status ScalarColumnReader::init(io::FileReaderSPtr file, FieldSchema* field,
-                                tparquet::ColumnChunk* chunk, size_t max_buf_size) {
-    _stream_reader =
-            new BufferedFileStreamReader(file, _metadata->start_offset(), _metadata->size(),
-                                         std::min((size_t)_metadata->size(), max_buf_size));
-    _chunk_reader.reset(new ColumnChunkReader(_stream_reader, chunk, field, _ctz));
+Status ScalarColumnReader::init(io::FileReaderSPtr file, FieldSchema* field, size_t max_buf_size) {
+    _field_schema = field;
+    auto& chunk_meta = _chunk_meta.meta_data;
+    int64_t chunk_start = chunk_meta.__isset.dictionary_page_offset
+                                  ? chunk_meta.dictionary_page_offset
+                                  : chunk_meta.data_page_offset;
+    size_t chunk_len = chunk_meta.total_compressed_size;
+    _stream_reader = std::make_unique<BufferedFileStreamReader>(file, chunk_start, chunk_len,
+                                                                std::min(chunk_len, max_buf_size));
+    _chunk_reader =
+            std::make_unique<ColumnChunkReader>(_stream_reader.get(), &_chunk_meta, field, _ctz);
     RETURN_IF_ERROR(_chunk_reader->init());
-    if (_chunk_reader->max_def_level() > 1) {
-        return Status::Corruption("Max definition level in scalar column can't exceed 1");
-    }
-    if (_chunk_reader->max_rep_level() != 0) {
-        return Status::Corruption("Max repetition level in scalar column should be 0");
-    }
     return Status::OK();
 }
 
@@ -193,6 +226,101 @@ Status ScalarColumnReader::_read_values(size_t num_values, ColumnPtr& doris_colu
     return _chunk_reader->decode_values(data_column, type, select_vector);
 }
 
+Status ScalarColumnReader::_read_nested_column(ColumnPtr& doris_column, DataTypePtr& type,
+                                               ColumnSelectVector& select_vector, size_t batch_size,
+                                               size_t* read_rows, bool* eof) {
+    // prepare repetition and definition levels
+    _rep_levels.resize(0);
+    _def_levels.resize(0);
+    size_t parsed_rows = 0;
+    if (_nested_first_read) {
+        _nested_first_read = false;
+    } else {
+        // we have read one more repetition leve in last loop
+        parsed_rows = 1;
+        _rep_levels.emplace_back(0);
+    }
+    size_t remaining_values = _chunk_reader->remaining_num_values() - parsed_rows;
+    LevelDecoder& rep_decoder = _chunk_reader->rep_level_decoder();
+    while (parsed_rows <= batch_size && remaining_values > 0) {
+        level_t rep_level;
+        // TODO(gaoxin): It's better to read repetition levels in a batch.
+        size_t loop_parsed = rep_decoder.get_next_run(&rep_level, remaining_values);
+        for (size_t i = 0; i < loop_parsed; ++i) {
+            _rep_levels.emplace_back(rep_level);
+        }
+        remaining_values -= loop_parsed;
+        // when repetition level == 1, it's a new row in doris_column.
+        if (rep_level == 0) {
+            parsed_rows += loop_parsed;
+        }
+    }
+    size_t parsed_values = _chunk_reader->remaining_num_values() - remaining_values;
+    _def_levels.resize(parsed_values);
+    _chunk_reader->def_level_decoder().get_levels(&_def_levels[0], parsed_values);
+
+    MutableColumnPtr data_column;
+    std::vector<uint16_t> null_map;
+    NullMap* map_data_column = nullptr;
+    if (doris_column->is_nullable()) {
+        SCOPED_RAW_TIMER(&_decode_null_map_time);
+        auto* nullable_column = reinterpret_cast<vectorized::ColumnNullable*>(
+                (*std::move(doris_column)).mutate().get());
+        data_column = nullable_column->get_nested_column_ptr();
+        map_data_column = &(nullable_column->get_null_map_data());
+    } else {
+        if (_field_schema->is_nullable) {
+            return Status::Corruption("Not nullable column has null values in parquet file");
+        }
+        data_column = doris_column->assume_mutable();
+    }
+    size_t has_read = 0;
+    size_t ancestor_nulls = 0;
+    bool prev_is_null = true;
+    while (has_read < parsed_values) {
+        level_t def_level = _def_levels[has_read++];
+        size_t loop_read = 1;
+        while (has_read < parsed_values && _def_levels[has_read] == def_level) {
+            has_read++;
+            loop_read++;
+        }
+        if (def_level < _field_schema->repeated_parent_def_level) {
+            // when def_level is less than repeated_parent_def_level, it means that level
+            // will affect its ancestor.
+            ancestor_nulls++;
+            continue;
+        }
+        bool is_null = def_level < _field_schema->definition_level;
+        if (!(prev_is_null ^ is_null)) {
+            null_map.emplace_back(0);
+        }
+        size_t remaining = loop_read;
+        while (remaining > USHRT_MAX) {
+            null_map.emplace_back(USHRT_MAX);
+            null_map.emplace_back(0);
+            remaining -= USHRT_MAX;
+        }
+        null_map.emplace_back((u_short)remaining);
+        prev_is_null = is_null;
+    }
+
+    size_t num_values = parsed_values - ancestor_nulls;
+    if (num_values > 0) {
+        SCOPED_RAW_TIMER(&_decode_null_map_time);
+        select_vector.set_run_length_null_map(null_map, num_values, map_data_column);
+    }
+    RETURN_IF_ERROR(_chunk_reader->decode_values(data_column, type, select_vector));
+    if (ancestor_nulls != 0) {
+        _chunk_reader->skip_values(ancestor_nulls, false);
+    }
+
+    *read_rows = parsed_rows;
+    if (_chunk_reader->remaining_num_values() == 0 && !_chunk_reader->has_next_page()) {
+        *eof = true;
+    }
+    return Status::OK();
+}
+
 Status ScalarColumnReader::read_column_data(ColumnPtr& doris_column, DataTypePtr& type,
                                             ColumnSelectVector& select_vector, size_t batch_size,
                                             size_t* read_rows, bool* eof) {
@@ -203,6 +331,10 @@ Status ScalarColumnReader::read_column_data(ColumnPtr& doris_column, DataTypePtr
             return Status::OK();
         }
         RETURN_IF_ERROR(_chunk_reader->next_page());
+    }
+    if (_nested_column) {
+        RETURN_IF_ERROR(_chunk_reader->load_page_data_idempotent());
+        return _read_nested_column(doris_column, type, select_vector, batch_size, read_rows, eof);
     }
 
     // generate the row ranges that should be read
@@ -273,374 +405,47 @@ Status ScalarColumnReader::read_column_data(ColumnPtr& doris_column, DataTypePtr
     return Status::OK();
 }
 
-void ScalarColumnReader::close() {}
-
-void ArrayColumnReader::_reserve_def_levels_buf(size_t size) {
-    if (size > _def_levels_buf_size || _def_levels_buf == nullptr) {
-        _def_levels_buf_size = BitUtil::next_power_of_two(size);
-        _def_levels_buf.reset(new level_t[_def_levels_buf_size]);
-    }
-}
-
-Status ArrayColumnReader::init(io::FileReaderSPtr file, FieldSchema* field,
-                               tparquet::ColumnChunk* chunk, size_t max_buf_size) {
-    _stream_reader =
-            new BufferedFileStreamReader(file, _metadata->start_offset(), _metadata->size(),
-                                         std::min((size_t)_metadata->size(), max_buf_size));
-    _chunk_reader.reset(new ColumnChunkReader(_stream_reader, chunk, &field->children[0], _ctz));
-    RETURN_IF_ERROR(_chunk_reader->init());
-    if (_chunk_reader->max_def_level() > 4) {
-        return Status::Corruption(
-                "Max definition level in array column can't exceed 4(not support nested array)");
-    } else {
-        FieldSchema& child = field->children[0];
-        _CONCRETE_ELEMENT = child.definition_level;
-        if (child.is_nullable) {
-            _NULL_ELEMENT = _CONCRETE_ELEMENT - 1;
-        }
-        _EMPTY_ARRAY = field->definition_level;
-        if (field->is_nullable) {
-            _NULL_ARRAY = _EMPTY_ARRAY - 1;
-        }
-    }
-    if (_chunk_reader->max_rep_level() != 1) {
-        return Status::Corruption(
-                "Max repetition level in array column should be 1(not support nested array)");
-    }
+Status ArrayColumnReader::init(std::unique_ptr<ParquetColumnReader> element_reader,
+                               FieldSchema* field) {
+    _field_schema = field;
+    _element_reader = std::move(element_reader);
     return Status::OK();
 }
 
 Status ArrayColumnReader::read_column_data(ColumnPtr& doris_column, DataTypePtr& type,
                                            ColumnSelectVector& select_vector, size_t batch_size,
                                            size_t* read_rows, bool* eof) {
-    if (_chunk_reader->remaining_num_values() == 0) {
-        if (!_chunk_reader->has_next_page()) {
-            *eof = true;
-            *read_rows = 0;
-            return Status::OK();
-        }
-        RETURN_IF_ERROR(_chunk_reader->next_page());
-        // array should load data to analyze row range
-        RETURN_IF_ERROR(_chunk_reader->load_page_data());
-        _init_rep_levels_buf();
-    }
-
     MutableColumnPtr data_column;
-    NullMap* map_data_ptr = nullptr;
+    NullMap* null_map_ptr = nullptr;
     if (doris_column->is_nullable()) {
         auto* nullable_column = reinterpret_cast<vectorized::ColumnNullable*>(
                 (*std::move(doris_column)).mutate().get());
-        map_data_ptr = &nullable_column->get_null_map_data();
+        null_map_ptr = &nullable_column->get_null_map_data();
         data_column = nullable_column->get_nested_column_ptr();
     } else {
+        if (_field_schema->is_nullable) {
+            return Status::Corruption("Not nullable column has null values in parquet file");
+        }
         data_column = doris_column->assume_mutable();
     }
 
-    // generate array offset
-    size_t real_batch_size = 0;
-    size_t num_values = 0;
-    std::vector<size_t> element_offsets;
-    RETURN_IF_ERROR(
-            _generate_array_offset(element_offsets, batch_size, &real_batch_size, &num_values));
-    _reserve_def_levels_buf(num_values);
-    level_t* definitions = _def_levels_buf.get();
-    _chunk_reader->get_def_levels(definitions, num_values);
-    _def_offset = 0;
-
-    // generate the row ranges that should be read
-    std::list<RowRange> read_ranges;
-    _generate_read_ranges(_current_row_index, _current_row_index + real_batch_size, read_ranges);
-    if (read_ranges.size() == 0) {
-        // skip the current batch
-        _current_row_index += real_batch_size;
-        _skip_values(num_values);
-        *read_rows = 0;
-    } else {
-        size_t has_read = 0;
-        int offset_index = 0;
-        for (auto& range : read_ranges) {
-            // generate the skipped values
-            size_t skip_rows = range.first_row - _current_row_index;
-            size_t skip_values =
-                    element_offsets[offset_index + skip_rows] - element_offsets[offset_index];
-            RETURN_IF_ERROR(_skip_values(skip_values));
-            offset_index += skip_rows;
-            _current_row_index += skip_rows;
-            real_batch_size -= skip_rows;
-
-            // generate the read values
-            size_t scan_rows = range.last_row - range.first_row;
-            size_t scan_values =
-                    element_offsets[offset_index + scan_rows] - element_offsets[offset_index];
-            // null array, should ignore the last offset in element_offsets
-            if (doris_column->is_nullable()) {
-                SCOPED_RAW_TIMER(&_decode_null_map_time);
-                NullMap& map_data_column = *map_data_ptr;
-                auto origin_size = map_data_column.size();
-                map_data_column.resize(origin_size + scan_rows);
-                for (int i = 0; i < scan_rows; ++i) {
-                    map_data_column[origin_size + i] =
-                            (UInt8)(definitions[element_offsets[offset_index + i]] == _NULL_ARRAY);
-                }
-            } else {
-                for (int i = offset_index; i < offset_index + scan_rows; ++i) {
-                    if (definitions[element_offsets[i]] == _NULL_ARRAY) {
-                        return Status::Corruption(
-                                "Not nullable column has null values in parquet file");
-                    }
-                }
-            }
-            // fill array offset, should skip a value when parsing null array
-            _fill_array_offset(data_column, element_offsets, offset_index, scan_rows);
-            // fill nested array elements
-            if (LIKELY(scan_values > 0)) {
-                RETURN_IF_ERROR(_load_nested_column(
-                        static_cast<ColumnArray&>(*data_column).get_data_ptr(),
-                        const_cast<DataTypePtr&>((reinterpret_cast<const DataTypeArray*>(
-                                                          remove_nullable(type).get()))
-                                                         ->get_nested_type()),
-                        scan_values, select_vector));
-            }
-            offset_index += scan_rows;
-            has_read += scan_rows;
-            _current_row_index += scan_rows;
-        }
-        if (offset_index != element_offsets.size() - 1) {
-            size_t skip_rows = element_offsets.size() - 1 - offset_index;
-            size_t skip_values = element_offsets.back() - element_offsets[offset_index];
-            RETURN_IF_ERROR(_skip_values(skip_values));
-            offset_index += skip_rows;
-            _current_row_index += skip_rows;
-            real_batch_size -= skip_rows;
-        }
-        DCHECK_EQ(real_batch_size, has_read);
-        *read_rows = has_read;
-    }
-
-    if (_chunk_reader->remaining_num_values() == 0 && !_chunk_reader->has_next_page()) {
-        *eof = true;
-    }
-    return Status::OK();
-}
-
-Status ArrayColumnReader::_load_nested_column(ColumnPtr& doris_column, DataTypePtr& type,
-                                              size_t read_values,
-                                              ColumnSelectVector& select_vector) {
-    level_t* definitions = _def_levels_buf.get();
-    MutableColumnPtr data_column;
-    if (doris_column->is_nullable()) {
-        SCOPED_RAW_TIMER(&_decode_null_map_time);
-        auto* nullable_column = reinterpret_cast<vectorized::ColumnNullable*>(
-                (*std::move(doris_column)).mutate().get());
-        data_column = nullable_column->get_nested_column_ptr();
-        NullMap& map_data_column = nullable_column->get_null_map_data();
-        size_t null_map_size = 0;
-        for (int i = _def_offset; i < _def_offset + read_values; ++i) {
-            // should skip _EMPTY_ARRAY and _NULL_ARRAY
-            if (definitions[i] == _CONCRETE_ELEMENT || definitions[i] == _NULL_ELEMENT) {
-                null_map_size++;
-            }
-        }
-        auto origin_size = map_data_column.size();
-        map_data_column.resize(origin_size + null_map_size);
-        size_t null_map_idx = origin_size;
-        for (int i = _def_offset; i < _def_offset + read_values; ++i) {
-            if (definitions[i] == _CONCRETE_ELEMENT) {
-                map_data_column[null_map_idx++] = (UInt8) false;
-            } else if (definitions[i] == _NULL_ELEMENT) {
-                map_data_column[null_map_idx++] = (UInt8) true;
-            }
-        }
-    } else {
-        doris_column->assume_mutable();
-        for (int i = _def_offset; i < _def_offset + read_values; ++i) {
-            if (definitions[i] == _NULL_ELEMENT) {
-                return Status::Corruption("Not nullable column has null values in parquet file");
-            }
-        }
-    }
-
-    std::vector<uint16_t> null_map;
-    bool map_prev_is_null = true;
-    // column with null values
-    int start_idx = _def_offset;
-    while (start_idx < read_values) {
-        if (definitions[start_idx] == _CONCRETE_ELEMENT ||
-            definitions[start_idx] == _NULL_ELEMENT) {
-            break;
-        } else {
-            // only decrease _remaining_num_values
-            _chunk_reader->skip_values(1, false);
-            start_idx++;
-        }
-    }
-    if (start_idx == _def_offset + read_values) {
-        // all values are empty array or null array
-        return Status::OK();
-    }
-    bool prev_is_null = definitions[start_idx] == _NULL_ELEMENT;
-    size_t num_values = 1;
-    size_t total_values = 0;
-    for (int i = start_idx + 1; i < _def_offset + read_values; ++i) {
-        if (definitions[i] == _EMPTY_ARRAY || definitions[i] == _NULL_ARRAY) {
-            // only decrease _remaining_num_values
-            _chunk_reader->skip_values(1, false);
-            continue;
-        }
-        bool curr_is_null = definitions[i] == _NULL_ELEMENT;
-        if (prev_is_null ^ curr_is_null) {
-            if (!(map_prev_is_null ^ prev_is_null)) {
-                null_map.emplace_back(0);
-            }
-            size_t remaining = num_values;
-            while (remaining > USHRT_MAX) {
-                null_map.emplace_back(USHRT_MAX);
-                null_map.emplace_back(0);
-                remaining -= USHRT_MAX;
-            }
-            null_map.emplace_back((u_short)remaining);
-            map_prev_is_null = prev_is_null;
-            prev_is_null = curr_is_null;
-            total_values += num_values;
-            num_values = 1;
-        } else {
-            num_values++;
-        }
-    }
-    if (!(map_prev_is_null ^ prev_is_null)) {
-        null_map.emplace_back(0);
-    }
-    size_t remaining = num_values;
-    while (remaining > USHRT_MAX) {
-        null_map.emplace_back(USHRT_MAX);
-        null_map.emplace_back(0);
-        remaining -= USHRT_MAX;
-    }
-    null_map.emplace_back((u_short)remaining);
-    total_values += num_values;
-    _def_offset += read_values;
-    select_vector.set_run_length_null_map(null_map, total_values);
-    return _chunk_reader->decode_values(data_column, type, select_vector);
-}
-
-void ArrayColumnReader::close() {}
-
-void ArrayColumnReader::_init_rep_levels_buf() {
-    size_t max_buf_size = _chunk_reader->remaining_num_values() < 4096
-                                  ? _chunk_reader->remaining_num_values()
-                                  : 4096;
-    if (_rep_levels_buf_size < max_buf_size || _rep_levels_buf == nullptr) {
-        _rep_levels_buf.reset(new level_t[max_buf_size]);
-        _rep_levels_buf_size = max_buf_size;
-    }
-    _remaining_rep_levels = _chunk_reader->remaining_num_values();
-    _start_offset = 0;
-}
-
-void ArrayColumnReader::_load_rep_levels() {
-    _start_offset += _rep_size;
-    _rep_size = _remaining_rep_levels < _rep_levels_buf_size ? _remaining_rep_levels
-                                                             : _rep_levels_buf_size;
-    _chunk_reader->get_rep_levels(_rep_levels_buf.get(), _rep_size);
-    _rep_offset = 0;
-}
-
-Status ArrayColumnReader::_generate_array_offset(std::vector<size_t>& element_offsets,
-                                                 size_t pre_batch_size, size_t* real_batch_size,
-                                                 size_t* num_values) {
-    if (_remaining_rep_levels == 0) {
-        *real_batch_size = 0;
-        *num_values = 0;
+    // read nested column
+    RETURN_IF_ERROR(_element_reader->read_column_data(
+            static_cast<ColumnArray&>(*data_column).get_data_ptr(),
+            const_cast<DataTypePtr&>(
+                    (reinterpret_cast<const DataTypeArray*>(remove_nullable(type).get()))
+                            ->get_nested_type()),
+            select_vector, batch_size, read_rows, eof));
+    if (*read_rows == 0) {
         return Status::OK();
     }
 
-    size_t num_array = 0;
-    size_t remaining_values = _remaining_rep_levels;
-    level_t* repetitions = _rep_levels_buf.get();
-    if (_rep_offset == _rep_size) {
-        _load_rep_levels();
-    }
-    size_t prev_rep_offset = _start_offset + _rep_offset;
-    _remaining_rep_levels--;
-    element_offsets.emplace_back(0);
-    if (repetitions[_rep_offset++] != 0) {
-        return Status::Corruption("Wrong repetition level in array column");
-    }
-    while (_remaining_rep_levels > 0) {
-        if (_rep_offset == _rep_size) {
-            _load_rep_levels();
-        }
-        if (repetitions[_rep_offset] != 1) { // new array
-            element_offsets.emplace_back(_start_offset + _rep_offset - prev_rep_offset);
-            if (++num_array >= pre_batch_size) {
-                break;
-            }
-        }
-        _rep_offset++;
-        _remaining_rep_levels--;
-    }
-    if (_remaining_rep_levels == 0) { // resolve the last array
-        element_offsets.emplace_back(_start_offset + _rep_offset - prev_rep_offset);
-        num_array++;
-    }
+    // fill offset and null map
+    fill_array_offset(_field_schema, static_cast<ColumnArray&>(*data_column).get_offsets(),
+                      null_map_ptr, _element_reader->get_rep_level(),
+                      _element_reader->get_def_level());
 
-    *real_batch_size = num_array;
-    *num_values = remaining_values - _remaining_rep_levels;
     return Status::OK();
 }
 
-void ArrayColumnReader::_fill_array_offset(MutableColumnPtr& doris_column,
-                                           std::vector<size_t>& element_offsets, int offset_index,
-                                           size_t num_rows) {
-    if (LIKELY(num_rows > 0)) {
-        auto& offsets_data = static_cast<ColumnArray&>(*doris_column).get_offsets();
-        level_t* definitions = _def_levels_buf.get();
-        auto prev_offset = offsets_data.back();
-        auto base_offset = element_offsets[offset_index];
-        size_t null_empty_array = 0;
-        for (int i = offset_index; i < offset_index + num_rows + 1; ++i) {
-            auto& offset = element_offsets[i];
-            if (i != offset_index) {
-                offsets_data.emplace_back(prev_offset + offset - base_offset - null_empty_array);
-            }
-            if ((i != offset_index + num_rows) &&
-                (definitions[offset] == _EMPTY_ARRAY || definitions[offset] == _NULL_ARRAY)) {
-                null_empty_array++;
-            }
-        }
-    }
-}
-
-Status ArrayColumnReader::_skip_values(size_t num_values) {
-    if (LIKELY(num_values > 0)) {
-        size_t null_size = 0;
-        size_t nonnull_size = 0;
-        level_t* definitions = _def_levels_buf.get();
-        bool prev_is_null = definitions[_def_offset] != _CONCRETE_ELEMENT;
-        int cnt = 1;
-        for (int i = _def_offset + 1; i < _def_offset + num_values; ++i) {
-            bool curr_is_null = definitions[i] != _CONCRETE_ELEMENT;
-            if (prev_is_null ^ curr_is_null) {
-                if (prev_is_null) {
-                    null_size += cnt;
-                } else {
-                    nonnull_size += cnt;
-                }
-                prev_is_null = curr_is_null;
-                cnt = 1;
-            } else {
-                cnt++;
-            }
-        }
-        if (prev_is_null) {
-            null_size += cnt;
-        } else {
-            nonnull_size += cnt;
-        }
-        RETURN_IF_ERROR(_chunk_reader->skip_values(null_size, false));
-        RETURN_IF_ERROR(_chunk_reader->skip_values(nonnull_size, true));
-        _def_offset += num_values;
-    }
-    return Status::OK();
-}
 }; // namespace doris::vectorized

--- a/be/src/vec/exec/format/parquet/vparquet_column_reader.h
+++ b/be/src/vec/exec/format/parquet/vparquet_column_reader.h
@@ -24,25 +24,6 @@
 
 namespace doris::vectorized {
 
-class ParquetColumnMetadata {
-public:
-    ParquetColumnMetadata(int64_t chunk_start_offset, int64_t chunk_length,
-                          tparquet::ColumnMetaData metadata)
-            : _chunk_start_offset(chunk_start_offset),
-              _chunk_length(chunk_length),
-              _metadata(metadata) {}
-
-    ~ParquetColumnMetadata() = default;
-    int64_t start_offset() const { return _chunk_start_offset; }
-    int64_t size() const { return _chunk_length; }
-    tparquet::ColumnMetaData t_metadata() { return _metadata; }
-
-private:
-    int64_t _chunk_start_offset;
-    int64_t _chunk_length;
-    tparquet::ColumnMetaData _metadata;
-};
-
 class ParquetColumnReader {
 public:
     struct Statistics {
@@ -98,12 +79,7 @@ public:
 
     ParquetColumnReader(const std::vector<RowRange>& row_ranges, cctz::time_zone* ctz)
             : _row_ranges(row_ranges), _ctz(ctz) {}
-    virtual ~ParquetColumnReader() {
-        if (_stream_reader != nullptr) {
-            delete _stream_reader;
-            _stream_reader = nullptr;
-        }
-    }
+    virtual ~ParquetColumnReader() = default;
     virtual Status read_column_data(ColumnPtr& doris_column, DataTypePtr& type,
                                     ColumnSelectVector& select_vector, size_t batch_size,
                                     size_t* read_rows, bool* eof) = 0;
@@ -111,23 +87,23 @@ public:
                          const tparquet::RowGroup& row_group,
                          const std::vector<RowRange>& row_ranges, cctz::time_zone* ctz,
                          std::unique_ptr<ParquetColumnReader>& reader, size_t max_buf_size);
-    void init_column_metadata(const tparquet::ColumnChunk& chunk);
     void add_offset_index(tparquet::OffsetIndex* offset_index) { _offset_index = offset_index; }
-    Statistics statistics() {
-        return Statistics(_stream_reader->statistics(), _chunk_reader->statistics(),
-                          _decode_null_map_time);
-    }
+    void set_nested_column() { _nested_column = true; }
+    virtual const std::vector<level_t>& get_rep_level() const = 0;
+    virtual const std::vector<level_t>& get_def_level() const = 0;
+    virtual Statistics statistics() = 0;
     virtual void close() = 0;
 
 protected:
     void _generate_read_ranges(int64_t start_index, int64_t end_index,
                                std::list<RowRange>& read_ranges);
 
-    BufferedFileStreamReader* _stream_reader;
-    std::unique_ptr<ParquetColumnMetadata> _metadata;
+    FieldSchema* _field_schema;
+    // When scalar column is the child of nested column, we should turn off the filtering by page index and lazy read.
+    bool _nested_column = false;
+    bool _nested_first_read = true;
     const std::vector<RowRange>& _row_ranges;
     cctz::time_zone* _ctz;
-    std::unique_ptr<ColumnChunkReader> _chunk_reader;
     tparquet::OffsetIndex* _offset_index;
     int64_t _current_row_index = 0;
     int _row_range_index = 0;
@@ -136,18 +112,35 @@ protected:
 
 class ScalarColumnReader : public ParquetColumnReader {
 public:
-    ScalarColumnReader(const std::vector<RowRange>& row_ranges, cctz::time_zone* ctz)
-            : ParquetColumnReader(row_ranges, ctz) {}
+    ScalarColumnReader(const std::vector<RowRange>& row_ranges,
+                       const tparquet::ColumnChunk& chunk_meta, cctz::time_zone* ctz)
+            : ParquetColumnReader(row_ranges, ctz), _chunk_meta(chunk_meta) {}
     ~ScalarColumnReader() override { close(); }
-    Status init(io::FileReaderSPtr file, FieldSchema* field, tparquet::ColumnChunk* chunk,
-                size_t max_buf_size);
+    Status init(io::FileReaderSPtr file, FieldSchema* field, size_t max_buf_size);
     Status read_column_data(ColumnPtr& doris_column, DataTypePtr& type,
                             ColumnSelectVector& select_vector, size_t batch_size, size_t* read_rows,
                             bool* eof) override;
+    const std::vector<level_t>& get_rep_level() const override { return _rep_levels; }
+    const std::vector<level_t>& get_def_level() const override { return _def_levels; }
+    Statistics statistics() override {
+        return Statistics(_stream_reader->statistics(), _chunk_reader->statistics(),
+                          _decode_null_map_time);
+    }
+    void close() override {}
+
+private:
+    tparquet::ColumnChunk _chunk_meta;
+    std::unique_ptr<BufferedFileStreamReader> _stream_reader;
+    std::unique_ptr<ColumnChunkReader> _chunk_reader;
+    std::vector<level_t> _rep_levels;
+    std::vector<level_t> _def_levels;
+
     Status _skip_values(size_t num_values);
     Status _read_values(size_t num_values, ColumnPtr& doris_column, DataTypePtr& type,
                         ColumnSelectVector& select_vector);
-    void close() override;
+    Status _read_nested_column(ColumnPtr& doris_column, DataTypePtr& type,
+                               ColumnSelectVector& select_vector, size_t batch_size,
+                               size_t* read_rows, bool* eof);
 };
 
 class ArrayColumnReader : public ParquetColumnReader {
@@ -155,39 +148,20 @@ public:
     ArrayColumnReader(const std::vector<RowRange>& row_ranges, cctz::time_zone* ctz)
             : ParquetColumnReader(row_ranges, ctz) {}
     ~ArrayColumnReader() override { close(); }
-    Status init(io::FileReaderSPtr file, FieldSchema* field, tparquet::ColumnChunk* chunk,
-                size_t max_buf_size);
+    Status init(std::unique_ptr<ParquetColumnReader> element_reader, FieldSchema* field);
     Status read_column_data(ColumnPtr& doris_column, DataTypePtr& type,
                             ColumnSelectVector& select_vector, size_t batch_size, size_t* read_rows,
                             bool* eof) override;
-    void close() override;
+    const std::vector<level_t>& get_rep_level() const override {
+        return _element_reader->get_rep_level();
+    }
+    const std::vector<level_t>& get_def_level() const override {
+        return _element_reader->get_def_level();
+    }
+    Statistics statistics() override { return _element_reader->statistics(); }
+    void close() override {}
 
 private:
-    void _reserve_def_levels_buf(size_t size);
-    void _init_rep_levels_buf();
-    void _load_rep_levels();
-    Status _load_nested_column(ColumnPtr& doris_column, DataTypePtr& type, size_t read_values,
-                               ColumnSelectVector& select_vector);
-    Status _generate_array_offset(std::vector<size_t>& element_offsets, size_t pre_batch_size,
-                                  size_t* real_batch_size, size_t* num_values);
-    void _fill_array_offset(MutableColumnPtr& doris_column, std::vector<size_t>& element_offsets,
-                            int offset_index, size_t num_rows);
-    Status _skip_values(size_t num_values);
-
-    std::unique_ptr<level_t[]> _def_levels_buf = nullptr;
-    size_t _def_levels_buf_size = 0;
-    size_t _def_offset = 0;
-
-    std::unique_ptr<level_t[]> _rep_levels_buf = nullptr;
-    size_t _rep_levels_buf_size = 0;
-    size_t _rep_size = 0;
-    size_t _rep_offset = 0;
-    size_t _start_offset = 0;
-    size_t _remaining_rep_levels = 0;
-
-    level_t _CONCRETE_ELEMENT = -1;
-    level_t _NULL_ELEMENT = -1;
-    level_t _EMPTY_ARRAY = -1;
-    level_t _NULL_ARRAY = -1;
+    std::unique_ptr<ParquetColumnReader> _element_reader = nullptr;
 };
 }; // namespace doris::vectorized

--- a/be/src/vec/exec/format/parquet/vparquet_reader.cpp
+++ b/be/src/vec/exec/format/parquet/vparquet_reader.cpp
@@ -269,13 +269,12 @@ Status ParquetReader::set_fill_columns(
         visit_slot(_lazy_read_ctx.vconjunct_ctx->root());
     }
 
-    bool has_complex_type = false;
     const FieldDescriptor& schema = _file_metadata->schema();
     for (auto& read_col : _read_columns) {
         _lazy_read_ctx.all_read_columns.emplace_back(read_col._file_slot_name);
         PrimitiveType column_type = schema.get_column(read_col._file_slot_name)->type.type;
         if (column_type == TYPE_ARRAY || column_type == TYPE_MAP || column_type == TYPE_STRUCT) {
-            has_complex_type = true;
+            _has_complex_type = true;
         }
         if (predicate_columns.size() > 0) {
             auto iter = predicate_columns.find(read_col._file_slot_name);
@@ -308,7 +307,7 @@ Status ParquetReader::set_fill_columns(
         }
     }
 
-    if (!has_complex_type && _lazy_read_ctx.predicate_columns.size() > 0 &&
+    if (!_has_complex_type && _lazy_read_ctx.predicate_columns.size() > 0 &&
         _lazy_read_ctx.lazy_read_columns.size() > 0) {
         _lazy_read_ctx.can_lazy_read = true;
     }
@@ -544,12 +543,8 @@ Status ParquetReader::_process_page_index(const tparquet::RowGroup& row_group,
         _statistics.read_rows += row_group.num_rows;
     };
 
-    if (_lazy_read_ctx.vconjunct_ctx == nullptr) {
-        read_whole_row_group();
-        return Status::OK();
-    }
-
-    if (_colname_to_value_range == nullptr || _colname_to_value_range->empty()) {
+    if (_has_complex_type || _lazy_read_ctx.vconjunct_ctx == nullptr ||
+        _colname_to_value_range == nullptr || _colname_to_value_range->empty()) {
         read_whole_row_group();
         return Status::OK();
     }

--- a/be/src/vec/exec/format/parquet/vparquet_reader.h
+++ b/be/src/vec/exec/format/parquet/vparquet_reader.h
@@ -177,6 +177,9 @@ private:
     const std::vector<int64_t>* _delete_rows = nullptr;
     int64_t _delete_rows_index = 0;
 
+    // should turn off filtering by page index and lazy read if having complex type
+    bool _has_complex_type = false;
+
     // Used for column lazy read.
     RowGroupReader::LazyReadContext _lazy_read_ctx;
 

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/external/ExternalFileScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/external/ExternalFileScanNode.java
@@ -482,7 +482,12 @@ public class ExternalFileScanNode extends ExternalScanNode {
                 }
             } else {
                 if (column.isAllowNull()) {
-                    expr = NullLiteral.create(column.getType());
+                    if (type == Type.LOAD) {
+                        // In load process, the source type is string.
+                        expr = NullLiteral.create(org.apache.doris.catalog.Type.VARCHAR);
+                    } else {
+                        expr = NullLiteral.create(column.getType());
+                    }
                 } else {
                     expr = null;
                 }

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/external/ExternalFileScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/external/ExternalFileScanNode.java
@@ -482,7 +482,7 @@ public class ExternalFileScanNode extends ExternalScanNode {
                 }
             } else {
                 if (column.isAllowNull()) {
-                    expr = NullLiteral.create(org.apache.doris.catalog.Type.VARCHAR);
+                    expr = NullLiteral.create(column.getType());
                 } else {
                     expr = null;
                 }


### PR DESCRIPTION
# Proposed changes

Support to decode nested array column in parquet reader:
1. FE should generate the right nested column type. FE doesn't check the nesting depth and legality, like map\<array\<int\>, int\>.
2. `ParquetColumnReader` has removed the filtering of page index to support nested array type. It's too difficult to skip values in nested complex  types. Maybe we should support the filtering of page index and lazy read in later PR.
3. `ExternalFileScanNode` has a bug in creating default value expression.
4. Maybe it's slow to read repetition levels in a while loop. I'll optimize this in next PR.
5. Array column has temporary `SchemaElement` in its thrift definition, we have removed them and keep its parent in former implementation. The remaining parent should inherit the repetition and definition level of its child.

## Inherit repetition and definition level of child
The full schema for type `ARRAY<ARRAY<INT32>>` is:
```
 five levels for ARRAY<ARRAY<INT32>>
 income --- bag --- array_element --- bag --- array_element
  opt       rep          opt          rep         opt
 R=0,D=1  R=1,D=2       R=1,D=3     R=2,D=4      R=2,D=5
```
`bag` is the temporary `SchemaElement`. We should keep `income` and assign the R,D as its removed child `R=1,D=2`, so the final schema for type `ARRAY<ARRAY<INT32>>` is:
```
 three levels for ARRAY<ARRAY<INT32>>
 income --- array_element --- array_element
   rep           rep              opt
 R=1,D=2       R=2,D=4          R=2,D=5
```
## Record the definition level of parent
`repeated_parent_def_level` is the definition level of its parent `SchemaElement`, so the `R, D, P` in the final schema for type `ARRAY<ARRAY<INT32>>` is:
```
 three levels for ARRAY<ARRAY<INT32>>
   income ------ array_element ----- array_element
    rep              rep                 opt
 R=1,D=2,P=0      R=2,D=4,P=2         R=2,D=5,P=4
```
When definition level is less than `repeated_parent_def_level`, it means that level will affect its parent. When repetition level is greater than max_rep_level, it means that level affects its descendants.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

