### PR TITLE
[fix](alter inverted index) fix write edit log in replaymodifyTableAddOrDropInvertedIndices function

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
@@ -2497,7 +2497,6 @@ public class SchemaChangeHandler extends AlterHandler {
         // set Job state then add job
         schemaChangeJob.setJobState(AlterJobV2.JobState.WAITING_TXN);
         this.addAlterJobV2(schemaChangeJob);
-        LOG.debug("logAlterJob schemaChangeJob:{}", schemaChangeJob);
         LOG.info("finished modify table's meta for add or drop inverted index. table: {}, is replay: {}",
                  olapTable.getName(), isReplay);
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
@@ -2498,7 +2498,6 @@ public class SchemaChangeHandler extends AlterHandler {
         schemaChangeJob.setJobState(AlterJobV2.JobState.WAITING_TXN);
         this.addAlterJobV2(schemaChangeJob);
         LOG.debug("logAlterJob schemaChangeJob:{}", schemaChangeJob);
-        Env.getCurrentEnv().getEditLog().logAlterJob(schemaChangeJob);
         LOG.info("finished modify table's meta for add or drop inverted index. table: {}, is replay: {}",
                  olapTable.getName(), isReplay);
     }

--- a/fe/fe-core/src/test/java/org/apache/doris/alter/SchemaChangeHandlerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/alter/SchemaChangeHandlerTest.java
@@ -374,4 +374,181 @@ public class SchemaChangeHandlerTest extends TestWithFeService {
         }
 
     }
+
+    @Test
+    public void testAggAddOrDropInvertedIndex() throws Exception {
+        LOG.info("dbName: {}", Env.getCurrentInternalCatalog().getDbNames());
+
+        Database db = Env.getCurrentInternalCatalog().getDbOrMetaException("default_cluster:test");
+        OlapTable tbl = (OlapTable) db.getTableOrMetaException("sc_agg", Table.TableType.OLAP);
+        tbl.readLock();
+        try {
+            Assertions.assertNotNull(tbl);
+            Assertions.assertEquals("Doris", tbl.getEngine());
+            Assertions.assertEquals(0, tbl.getIndexes().size());
+        } finally {
+            tbl.readUnlock();
+        }
+
+        //process agg add inverted index schema change
+        String addInvertedIndexStmtStr = "alter table test.sc_agg add index idx_city(city) using inverted properties(\"parser\"=\"english\")";
+        AlterTableStmt addInvertedIndexStmt = (AlterTableStmt) parseAndAnalyzeStmt(addInvertedIndexStmtStr);
+        Env.getCurrentEnv().getAlterInstance().processAlterTable(addInvertedIndexStmt);
+        jobSize++;
+        //check alter job
+        Map<Long, AlterJobV2> alterJobs = Env.getCurrentEnv().getSchemaChangeHandler().getAlterJobsV2();
+        LOG.info("alterJobs:{}", alterJobs);
+        Assertions.assertEquals(jobSize, alterJobs.size());
+        waitAlterJobDone(alterJobs);
+
+        tbl.readLock();
+        try {
+            Assertions.assertEquals(1, tbl.getIndexes().size());
+            String baseIndexName = tbl.getIndexNameById(tbl.getBaseIndexId());
+            Assertions.assertEquals(baseIndexName, tbl.getName());
+            MaterializedIndexMeta indexMeta = tbl.getIndexMetaByIndexId(tbl.getBaseIndexId());
+            Assertions.assertNotNull(indexMeta);
+        } finally {
+            tbl.readUnlock();
+        }
+
+        //process agg drop inverted index schema change
+        String dropInvertedIndexStmtStr = "alter table test.sc_agg drop index idx_city";
+        AlterTableStmt dropInvertedIndexStmt = (AlterTableStmt) parseAndAnalyzeStmt(dropInvertedIndexStmtStr);
+        Env.getCurrentEnv().getAlterInstance().processAlterTable(dropInvertedIndexStmt);
+        jobSize++;
+        //check alter job
+        LOG.info("alterJobs:{}", alterJobs);
+        Assertions.assertEquals(jobSize, alterJobs.size());
+        waitAlterJobDone(alterJobs);
+
+        tbl.readLock();
+        try {
+            Assertions.assertEquals(0, tbl.getIndexes().size());
+            String baseIndexName = tbl.getIndexNameById(tbl.getBaseIndexId());
+            Assertions.assertEquals(baseIndexName, tbl.getName());
+            MaterializedIndexMeta indexMeta = tbl.getIndexMetaByIndexId(tbl.getBaseIndexId());
+            Assertions.assertNotNull(indexMeta);
+        } finally {
+            tbl.readUnlock();
+        }
+    }
+
+    @Test
+    public void testUniqAddOrDropInvertedIndex() throws Exception {
+
+        LOG.info("dbName: {}", Env.getCurrentInternalCatalog().getDbNames());
+
+        Database db = Env.getCurrentInternalCatalog().getDbOrMetaException("default_cluster:test");
+        OlapTable tbl = (OlapTable) db.getTableOrMetaException("sc_uniq", Table.TableType.OLAP);
+        tbl.readLock();
+        try {
+            Assertions.assertNotNull(tbl);
+            Assertions.assertEquals("Doris", tbl.getEngine());
+            Assertions.assertEquals(0, tbl.getIndexes().size());
+        } finally {
+            tbl.readUnlock();
+        }
+
+        //process uniq add inverted index schema change
+        String addInvertedIndexStmtStr = "alter table test.sc_uniq add index idx_city(city) using inverted properties(\"parser\"=\"english\")";
+        AlterTableStmt addInvertedIndexStmt = (AlterTableStmt) parseAndAnalyzeStmt(addInvertedIndexStmtStr);
+        Env.getCurrentEnv().getAlterInstance().processAlterTable(addInvertedIndexStmt);
+        jobSize++;
+        //check alter job
+        Map<Long, AlterJobV2> alterJobs = Env.getCurrentEnv().getSchemaChangeHandler().getAlterJobsV2();
+        LOG.info("alterJobs:{}", alterJobs);
+        Assertions.assertEquals(jobSize, alterJobs.size());
+        waitAlterJobDone(alterJobs);
+
+        tbl.readLock();
+        try {
+            Assertions.assertEquals(1, tbl.getIndexes().size());
+            String baseIndexName = tbl.getIndexNameById(tbl.getBaseIndexId());
+            Assertions.assertEquals(baseIndexName, tbl.getName());
+            MaterializedIndexMeta indexMeta = tbl.getIndexMetaByIndexId(tbl.getBaseIndexId());
+            Assertions.assertNotNull(indexMeta);
+        } finally {
+            tbl.readUnlock();
+        }
+
+        //process uniq drop inverted indexn schema change
+        String dropInvertedIndexStmtStr = "alter table test.sc_uniq drop index idx_city";
+        AlterTableStmt dropInvertedIndexStmt = (AlterTableStmt) parseAndAnalyzeStmt(dropInvertedIndexStmtStr);
+        Env.getCurrentEnv().getAlterInstance().processAlterTable(dropInvertedIndexStmt);
+        jobSize++;
+        //check alter job
+        Assertions.assertEquals(jobSize, alterJobs.size());
+        waitAlterJobDone(alterJobs);
+
+        tbl.readLock();
+        try {
+            Assertions.assertEquals(0, tbl.getIndexes().size());
+            String baseIndexName = tbl.getIndexNameById(tbl.getBaseIndexId());
+            Assertions.assertEquals(baseIndexName, tbl.getName());
+            MaterializedIndexMeta indexMeta = tbl.getIndexMetaByIndexId(tbl.getBaseIndexId());
+            Assertions.assertNotNull(indexMeta);
+        } finally {
+            tbl.readUnlock();
+        }
+    }
+
+    @Test
+    public void testDupAddOrDropInvertedIndex() throws Exception {
+
+        LOG.info("dbName: {}", Env.getCurrentInternalCatalog().getDbNames());
+
+        Database db = Env.getCurrentInternalCatalog().getDbOrMetaException("default_cluster:test");
+        OlapTable tbl = (OlapTable) db.getTableOrMetaException("sc_dup", Table.TableType.OLAP);
+        tbl.readLock();
+        try {
+            Assertions.assertNotNull(tbl);
+            Assertions.assertEquals("Doris", tbl.getEngine());
+            Assertions.assertEquals(0, tbl.getIndexes().size());
+        } finally {
+            tbl.readUnlock();
+        }
+
+        //process dup add inverted index schema change
+        String addInvertedIndexStmtStr = "alter table test.sc_dup add index idx_error_msg(error_msg) using inverted properties(\"parser\"=\"standard\")";
+        AlterTableStmt addInvertedIndexStmt = (AlterTableStmt) parseAndAnalyzeStmt(addInvertedIndexStmtStr);
+        Env.getCurrentEnv().getAlterInstance().processAlterTable(addInvertedIndexStmt);
+        jobSize++;
+        //check dup job
+        Map<Long, AlterJobV2> alterJobs = Env.getCurrentEnv().getSchemaChangeHandler().getAlterJobsV2();
+        LOG.info("alterJobs:{}", alterJobs);
+        Assertions.assertEquals(jobSize, alterJobs.size());
+        waitAlterJobDone(alterJobs);
+
+        tbl.readLock();
+        try {
+            Assertions.assertEquals(1, tbl.getIndexes().size());
+            String baseIndexName = tbl.getIndexNameById(tbl.getBaseIndexId());
+            Assertions.assertEquals(baseIndexName, tbl.getName());
+            MaterializedIndexMeta indexMeta = tbl.getIndexMetaByIndexId(tbl.getBaseIndexId());
+            Assertions.assertNotNull(indexMeta);
+        } finally {
+            tbl.readUnlock();
+        }
+
+        //process dup drop inverted index schema change
+        String dropInvertedIndexStmtStr = "alter table test.sc_dup drop index idx_error_msg";
+        AlterTableStmt dropInvertedIndexStmt = (AlterTableStmt) parseAndAnalyzeStmt(dropInvertedIndexStmtStr);
+        Env.getCurrentEnv().getAlterInstance().processAlterTable(dropInvertedIndexStmt);
+        jobSize++;
+        //check alter job
+        Assertions.assertEquals(jobSize, alterJobs.size());
+        waitAlterJobDone(alterJobs);
+
+        tbl.readLock();
+        try {
+            Assertions.assertEquals(0, tbl.getIndexes().size());
+            String baseIndexName = tbl.getIndexNameById(tbl.getBaseIndexId());
+            Assertions.assertEquals(baseIndexName, tbl.getName());
+            MaterializedIndexMeta indexMeta = tbl.getIndexMetaByIndexId(tbl.getBaseIndexId());
+            Assertions.assertNotNull(indexMeta);
+        } finally {
+            tbl.readUnlock();
+        }
+    }
 }


### PR DESCRIPTION
# Proposed changes

Issue Number: close (https://github.com/apache/doris/issues/16976)

## Problem summary

Actually, when `modifyTableAddOrDropInvertedIndices`, no need write `logAlterJob` edit log, because write `logModifyTableAddOrDropInvertedIndices` is enough

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

