### PR TITLE
[fix](struct-type) fix be core when load array orc file

### DIFF
--- a/be/src/runtime/types.cpp
+++ b/be/src/runtime/types.cpp
@@ -270,12 +270,15 @@ TypeDescriptor::TypeDescriptor(const google::protobuf::RepeatedPtrField<PTypeNod
     }
 }
 
+void TypeDescriptor::add_sub_type(TypeDescriptor&& sub_type, bool&& is_nullable) {
+    children.emplace_back(sub_type);
+    contains_nulls.emplace_back(is_nullable);
+}
+
 void TypeDescriptor::add_sub_type(TypeDescriptor&& sub_type, std::string&& field_name,
                                   bool&& is_nullable) {
     children.emplace_back(sub_type);
-    if (!field_name.empty()) {
-        field_names.emplace_back(field_name);
-    }
+    field_names.emplace_back(field_name);
     contains_nulls.emplace_back(is_nullable);
 }
 

--- a/be/src/runtime/types.cpp
+++ b/be/src/runtime/types.cpp
@@ -270,6 +270,15 @@ TypeDescriptor::TypeDescriptor(const google::protobuf::RepeatedPtrField<PTypeNod
     }
 }
 
+void TypeDescriptor::add_sub_type(TypeDescriptor&& sub_type, std::string&& field_name,
+                                  bool&& is_nullable) {
+    children.emplace_back(sub_type);
+    if (!field_name.empty()) {
+        field_names.emplace_back(field_name);
+    }
+    contains_nulls.emplace_back(is_nullable);
+}
+
 std::string TypeDescriptor::debug_string() const {
     std::stringstream ss;
     switch (type) {

--- a/be/src/runtime/types.h
+++ b/be/src/runtime/types.h
@@ -219,7 +219,11 @@ struct TypeDescriptor {
 
     std::string debug_string() const;
 
-    void add_sub_type(TypeDescriptor&& sub_type, std::string&& field_name = "",
+    // use to array type and map type add sub type
+    void add_sub_type(TypeDescriptor&& sub_type, bool&& is_nullable = true);
+
+    // use to struct type add sub type
+    void add_sub_type(TypeDescriptor&& sub_type, std::string&& field_name,
                       bool&& is_nullable = true);
 
 private:

--- a/be/src/runtime/types.h
+++ b/be/src/runtime/types.h
@@ -219,6 +219,9 @@ struct TypeDescriptor {
 
     std::string debug_string() const;
 
+    void add_sub_type(TypeDescriptor&& sub_type, std::string&& field_name = "",
+                      bool&& is_nullable = true);
+
 private:
     /// Used to create a possibly nested type from the flattened Thrift representation.
     ///

--- a/be/src/vec/exec/format/orc/vorc_reader.cpp
+++ b/be/src/vec/exec/format/orc/vorc_reader.cpp
@@ -607,21 +607,28 @@ TypeDescriptor OrcReader::_convert_to_doris_type(const orc::Type* orc_type) {
     case orc::TypeKind::TIMESTAMP_INSTANT:
         return TypeDescriptor(PrimitiveType::TYPE_DATETIMEV2);
     case orc::TypeKind::LIST: {
+        // Use Object PrimitiveType to construct TypeDescriptor also need init containers_nulls with the default value of bool
         TypeDescriptor list_type(PrimitiveType::TYPE_ARRAY);
         list_type.children.emplace_back(_convert_to_doris_type(orc_type->getSubtype(0)));
+        list_type.contains_nulls.push_back(false);
         return list_type;
     }
     case orc::TypeKind::MAP: {
+        // Use Object PrimitiveType to construct TypeDescriptor also need init containers_nulls with the default value of bool
         TypeDescriptor map_type(PrimitiveType::TYPE_MAP);
         map_type.children.emplace_back(_convert_to_doris_type(orc_type->getSubtype(0)));
         map_type.children.emplace_back(_convert_to_doris_type(orc_type->getSubtype(1)));
+        map_type.contains_nulls.push_back(false);
+        map_type.contains_nulls.push_back(false);
         return map_type;
     }
     case orc::TypeKind::STRUCT: {
+        // Use Object PrimitiveType to construct TypeDescriptor also need init containers_nulls with the default value of bool
         TypeDescriptor struct_type(PrimitiveType::TYPE_STRUCT);
         for (int i = 0; i < orc_type->getSubtypeCount(); ++i) {
             struct_type.children.emplace_back(_convert_to_doris_type(orc_type->getSubtype(i)));
             struct_type.field_names.emplace_back(_get_field_name_lower_case(orc_type, i));
+            struct_type.contains_nulls.push_back(false);
         }
         return struct_type;
     }

--- a/be/src/vec/exec/format/orc/vorc_reader.cpp
+++ b/be/src/vec/exec/format/orc/vorc_reader.cpp
@@ -609,26 +609,22 @@ TypeDescriptor OrcReader::_convert_to_doris_type(const orc::Type* orc_type) {
     case orc::TypeKind::LIST: {
         // Use Object PrimitiveType to construct TypeDescriptor also need init containers_nulls with the default value of bool
         TypeDescriptor list_type(PrimitiveType::TYPE_ARRAY);
-        list_type.children.emplace_back(_convert_to_doris_type(orc_type->getSubtype(0)));
-        list_type.contains_nulls.push_back(false);
+        list_type.add_sub_type(_convert_to_doris_type(orc_type->getSubtype(0)));
         return list_type;
     }
     case orc::TypeKind::MAP: {
         // Use Object PrimitiveType to construct TypeDescriptor also need init containers_nulls with the default value of bool
         TypeDescriptor map_type(PrimitiveType::TYPE_MAP);
-        map_type.children.emplace_back(_convert_to_doris_type(orc_type->getSubtype(0)));
-        map_type.children.emplace_back(_convert_to_doris_type(orc_type->getSubtype(1)));
-        map_type.contains_nulls.push_back(false);
-        map_type.contains_nulls.push_back(false);
+        map_type.add_sub_type(_convert_to_doris_type(orc_type->getSubtype(0)));
+        map_type.add_sub_type(_convert_to_doris_type(orc_type->getSubtype(1)));
         return map_type;
     }
     case orc::TypeKind::STRUCT: {
         // Use Object PrimitiveType to construct TypeDescriptor also need init containers_nulls with the default value of bool
         TypeDescriptor struct_type(PrimitiveType::TYPE_STRUCT);
         for (int i = 0; i < orc_type->getSubtypeCount(); ++i) {
-            struct_type.children.emplace_back(_convert_to_doris_type(orc_type->getSubtype(i)));
-            struct_type.field_names.emplace_back(_get_field_name_lower_case(orc_type, i));
-            struct_type.contains_nulls.push_back(false);
+            struct_type.add_sub_type(_convert_to_doris_type(orc_type->getSubtype(i)),
+                                     _get_field_name_lower_case(orc_type, i));
         }
         return struct_type;
     }

--- a/be/src/vec/exec/format/orc/vorc_reader.cpp
+++ b/be/src/vec/exec/format/orc/vorc_reader.cpp
@@ -607,20 +607,17 @@ TypeDescriptor OrcReader::_convert_to_doris_type(const orc::Type* orc_type) {
     case orc::TypeKind::TIMESTAMP_INSTANT:
         return TypeDescriptor(PrimitiveType::TYPE_DATETIMEV2);
     case orc::TypeKind::LIST: {
-        // Use Object PrimitiveType to construct TypeDescriptor also need init containers_nulls with the default value of bool
         TypeDescriptor list_type(PrimitiveType::TYPE_ARRAY);
         list_type.add_sub_type(_convert_to_doris_type(orc_type->getSubtype(0)));
         return list_type;
     }
     case orc::TypeKind::MAP: {
-        // Use Object PrimitiveType to construct TypeDescriptor also need init containers_nulls with the default value of bool
         TypeDescriptor map_type(PrimitiveType::TYPE_MAP);
         map_type.add_sub_type(_convert_to_doris_type(orc_type->getSubtype(0)));
         map_type.add_sub_type(_convert_to_doris_type(orc_type->getSubtype(1)));
         return map_type;
     }
     case orc::TypeKind::STRUCT: {
-        // Use Object PrimitiveType to construct TypeDescriptor also need init containers_nulls with the default value of bool
         TypeDescriptor struct_type(PrimitiveType::TYPE_STRUCT);
         for (int i = 0; i < orc_type->getSubtypeCount(); ++i) {
             struct_type.add_sub_type(_convert_to_doris_type(orc_type->getSubtype(i)),


### PR DESCRIPTION
# Proposed changes

Issue Number: close #16925

## Problem summary
in be/src/vec/data_types/data_type_factory.cpp:168, col_desc.contains_nulls[0] memory access out of bounds

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

