### PR TITLE
[Thirdparty](clucene) update clucene to v2.4.6 to fix bthread/pthread  context bug

### DIFF
--- a/dist/LICENSE-dist.txt
+++ b/dist/LICENSE-dist.txt
@@ -1533,7 +1533,7 @@ The Apache Software License, Version 2.0
     * libhdfs3: 2.3.8
     * opentelemetry-proto: 0.18.0
     * opentelemetry-cpp: 1.4.0
-    * clucenc: 2.4.4
+    * clucene: 2.4.6
 
 The MIT License -- licenses/LICENSE-MIT.txt
     * datatables: 1.12.1

--- a/thirdparty/CHANGELOG.md
+++ b/thirdparty/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 This file contains version of the third-party dependency libraries in the build-env image. The docker build-env image is apache/doris, and the tag is `build-env-${version}`
 
+## v20230221
+- Modified: clucene 2.4.4 -> 2.4.6
+
 ## v20230218
 - Modified: libhdfs3 2.3.7 -> 2.3.8
 - Modified: jemalloc 5.2.1 -> 5.3.0

--- a/thirdparty/build-thirdparty.sh
+++ b/thirdparty/build-thirdparty.sh
@@ -1564,6 +1564,14 @@ build_clucene() {
     else
         USE_AVX2="${USE_AVX2:-0}"
     fi
+    if [[ -z "${USE_BTHREAD_SCANNER}" ]]; then
+        USE_BTHREAD_SCANNER='OFF'
+    fi
+    if [[ ${USE_BTHREAD_SCANNER} == "ON" ]]; then
+        USE_BTHREAD=1
+    else
+        USE_BTHREAD=0
+    fi
 
     check_if_source_exist "${CLUCENE_SOURCE}"
     cd "${TP_SOURCE_DIR}/${CLUCENE_SOURCE}"
@@ -1581,6 +1589,7 @@ build_clucene() {
         -DCMAKE_CXX_FLAGS="-fno-omit-frame-pointer ${warning_narrowing}" \
         -DUSE_STAT64=0 \
         -DUSE_AVX2="${USE_AVX2}" \
+        -DUSE_BTHREAD="${USE_BTHREAD}" \
         -DCMAKE_BUILD_TYPE=RelWithDebInfo \
         -DBUILD_CONTRIBS_LIB=ON ..
     ${BUILD_SYSTEM} -j "${PARALLEL}"

--- a/thirdparty/vars.sh
+++ b/thirdparty/vars.sh
@@ -55,10 +55,10 @@ export TP_JAR_DIR="${TP_INSTALL_DIR}/lib/jar"
 #####################################################
 
 #clucene
-CLUCENE_DOWNLOAD="https://github.com/apache/doris-thirdparty/archive/refs/tags/libclucene-v2.4.4.zip"
-CLUCENE_NAME="doris-thirdparty-libclucene-v2.4.4.zip"
-CLUCENE_SOURCE="doris-thirdparty-libclucene-v2.4.4"
-CLUCENE_MD5SUM="431b4c2dc5c75df5e114da72a2e9b74a"
+CLUCENE_DOWNLOAD="https://github.com/apache/doris-thirdparty/archive/refs/tags/libclucene-v2.4.6.zip"
+CLUCENE_NAME="doris-thirdparty-libclucene-v2.4.6.zip"
+CLUCENE_SOURCE="doris-thirdparty-libclucene-v2.4.6"
+CLUCENE_MD5SUM="3d2432c9dc4b23e4f4fb73605f0e577d"
 
 # libevent
 LIBEVENT_DOWNLOAD="https://github.com/libevent/libevent/archive/release-2.1.12-stable.tar.gz"


### PR DESCRIPTION
# Proposed changes

1. change clucene version from 2.4.4->2.4.6
2. update build-thirdparty.sh clucene's build block, adding USE_BTHREAD CMAKE flag, this flag is inherited from doris's USE_BTHREAD_SCANNER.

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [x] Does it need to update dependencies
* [x] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

