### PR TITLE
[fix](fe)bucket shuffle join is not recognized if the first table is a subquery

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/planner/PlanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/PlanNode.java
@@ -965,8 +965,9 @@ public abstract class PlanNode extends TreeNode<PlanNode> implements PlanStats {
     }
 
     public SlotRef findSrcSlotRef(SlotRef slotRef) {
-        slotRef = slotRef.getSrcSlotRef();
-        Preconditions.checkState(slotRef != null);
+        if (slotRef.getSrcSlotRef() != null) {
+            slotRef = slotRef.getSrcSlotRef();
+        }
         if (slotRef.getTable() instanceof OlapTable) {
             return slotRef;
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/PlanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/PlanNode.java
@@ -965,6 +965,8 @@ public abstract class PlanNode extends TreeNode<PlanNode> implements PlanStats {
     }
 
     public SlotRef findSrcSlotRef(SlotRef slotRef) {
+        slotRef = slotRef.getSrcSlotRef();
+        Preconditions.checkState(slotRef != null);
         if (slotRef.getTable() instanceof OlapTable) {
             return slotRef;
         }

--- a/regression-test/suites/correctness_p0/test_bucket_shuffle_join.groovy
+++ b/regression-test/suites/correctness_p0/test_bucket_shuffle_join.groovy
@@ -78,4 +78,17 @@ suite("test_bucket_shuffle_join") {
         contains "4:VHASH JOIN\n  |  join op: INNER JOIN(BUCKET_SHUFFLE)"
         contains "2:VHASH JOIN\n  |  join op: INNER JOIN(BUCKET_SHUFFLE)"
     }
+
+    explain {
+        sql("""select a.id,a.name,b.id,b.name 
+                from (select * from test_colo1) a 
+                inner join 
+                (select * from test_colo2) b 
+                on a.id = b.id  and a.name = b.name and a.name = b.name
+                inner join 
+                (select * from test_colo3) c 
+                on a.id = c.id  and a.name = c.name and a.name = c.name""")
+        contains "4:VHASH JOIN\n  |  join op: INNER JOIN(BUCKET_SHUFFLE)"
+        contains "2:VHASH JOIN\n  |  join op: INNER JOIN(BUCKET_SHUFFLE)"
+    }
 }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary
consider sql select *
from 
(select * from test_1) a 
inner join 
(select * from test_2) b 
on **a.id** = b.id 
inner join 
(select * from test_3) c 
on **a.id** = c.id 

Because a.id is from a subquery, to find its source table, need use function getSrcSlotRef().

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

