### PR TITLE
[chore](macOS) Support LLVM Clang 15

### DIFF
--- a/tools/single-node-cluster/multi-fe
+++ b/tools/single-node-cluster/multi-fe
@@ -72,7 +72,7 @@ ${BASH_SOURCE[0]} start|stop|clean [OPTIONS ...]
 
     stop     Stop the FE cluster.
 
-    clean    Stop the data (rm -rf "\$(pwd)"/fe*).
+    clean    Clean the data (rm -rf "\$(pwd)"/fe*).
 EOF
 	exit 1
 }


### PR DESCRIPTION
# Proposed changes

1. Remove the deprecated classes [std::codecvt_utf8_utf16<char16_t>](https://en.cppreference.com/w/cpp/locale/codecvt_utf8_utf16) and [std::wstring_convert](https://en.cppreference.com/w/cpp/locale/wstring_convert).
2. Use `libiconv` to convert `UTF-8` strings to `UTF-16LE` ones.

## Problem summary

If we use LLVM Clang 15 to build the codebase on macOS, the compiler will complain the 
deprecated declarations errors. See the following.

```shell
/Programs/doris/be/src/exec/table_connector.cpp:49:31: error: 'codecvt_utf8_utf16<char16_t, 1114111, 0>' is deprecated [-Werror,-Wdeprecated-declarations]
    std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t> utf8_utf16_cvt;
                              ^
/opt/homebrew/opt/llvm/bin/../include/c++/v1/codecvt:588:28: note: 'codecvt_utf8_utf16<char16_t, 1114111, 0>' has been explicitly marked deprecated here
class _LIBCPP_TEMPLATE_VIS _LIBCPP_DEPRECATED_IN_CXX17 codecvt_utf8_utf16
                           ^
/opt/homebrew/opt/llvm/bin/../include/c++/v1/__config:800:41: note: expanded from macro '_LIBCPP_DEPRECATED_IN_CXX17'
#    define _LIBCPP_DEPRECATED_IN_CXX17 _LIBCPP_DEPRECATED
                                        ^
/opt/homebrew/opt/llvm/bin/../include/c++/v1/__config:773:49: note: expanded from macro '_LIBCPP_DEPRECATED'
#      define _LIBCPP_DEPRECATED __attribute__((deprecated))
                                                ^
/Programs/doris/be/src/exec/table_connector.cpp:49:10: error: 'wstring_convert<std::codecvt_utf8_utf16<char16_t, 1114111, 0>, char16_t>' is deprecated [-Werror,-Wdeprecated-declarations]
    std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t> utf8_utf16_cvt;
         ^
/opt/homebrew/opt/llvm/bin/../include/c++/v1/locale:3621:28: note: 'wstring_convert<std::codecvt_utf8_utf16<char16_t, 1114111, 0>, char16_t>' has been explicitly marked deprecated here
class _LIBCPP_TEMPLATE_VIS _LIBCPP_DEPRECATED_IN_CXX17 wstring_convert
                           ^
/opt/homebrew/opt/llvm/bin/../include/c++/v1/__config:800:41: note: expanded from macro '_LIBCPP_DEPRECATED_IN_CXX17'
#    define _LIBCPP_DEPRECATED_IN_CXX17 _LIBCPP_DEPRECATED
                                        ^
/opt/homebrew/opt/llvm/bin/../include/c++/v1/__config:773:49: note: expanded from macro '_LIBCPP_DEPRECATED'
#      define _LIBCPP_DEPRECATED __attribute__((deprecated))
                                                ^
2 errors generated.
```

`std::codecvt_utf8_utf16<char16_t>` and `std::wstring_convert` are marked deprecated in C++ 17, we should use an alternative to handle it.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

