### PR TITLE
[feat](Nereids): Add hint `NTH_OPTIMIZED_PLAN` to let the optimzier can select n-th optimized plan

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Memo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Memo.java
@@ -18,6 +18,7 @@
 package org.apache.doris.nereids.memo;
 
 import org.apache.doris.common.IdGenerator;
+import org.apache.doris.common.Pair;
 import org.apache.doris.nereids.CascadesContext;
 import org.apache.doris.nereids.StatementContext;
 import org.apache.doris.nereids.analyzer.CTEContext;
@@ -48,6 +49,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
+import java.util.Queue;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 
@@ -705,5 +707,13 @@ public class Memo {
             }
         }
         return builder.toString();
+    }
+
+    public void rank(Queue<Pair<Long, Double>> rankingQueue) {
+        throw new RuntimeException();
+    }
+
+    public PhysicalPlan unrank(long id) {
+        throw new RuntimeException();
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -194,6 +194,8 @@ public class SessionVariable implements Serializable, Writable {
 
     public static final String ENABLE_DPHYP_OPTIMIZER = "enable_dphyp_optimizer";
 
+    public static final String NTH_OPTIMIZED_PLAN = "nth_optimized_plan";
+
     public static final String ENABLE_NEREIDS_PLANNER = "enable_nereids_planner";
     public static final String DISABLE_NEREIDS_RULES = "disable_nereids_rules";
 
@@ -560,6 +562,15 @@ public class SessionVariable implements Serializable, Writable {
 
     @VariableMgr.VarAttr(name = ENABLE_DPHYP_OPTIMIZER)
     private boolean enableDPHypOptimizer = false;
+
+    /**
+     * This variable is used to select n-th optimized plan in memo.
+     * It can allow us select different plans for the same SQL statement
+     * and these plans can be used to evaluate the cost model.
+     */
+    @VariableMgr.VarAttr(name = NTH_OPTIMIZED_PLAN)
+    private int nthOptimizedPlan = 1;
+
     /**
      * as the new optimizer is not mature yet, use this var
      * to control whether to use new optimizer, remove it when
@@ -1383,6 +1394,10 @@ public class SessionVariable implements Serializable, Writable {
 
     public boolean isEnableDPHypOptimizer() {
         return isEnableNereidsPlanner() && enableDPHypOptimizer;
+    }
+
+    public int getNthOptimizedPlan() {
+        return nthOptimizedPlan;
     }
 
     public void setEnableDphypOptimizer(boolean enableDPHypOptimizer) {

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/memo/RankTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/memo/RankTest.java
@@ -1,0 +1,67 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.memo;
+
+import org.apache.doris.nereids.datasets.tpch.TPCHTestBase;
+import org.apache.doris.nereids.datasets.tpch.TPCHUtils;
+import org.apache.doris.nereids.properties.PhysicalProperties;
+import org.apache.doris.nereids.trees.plans.physical.PhysicalPlan;
+import org.apache.doris.nereids.util.PlanChecker;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+
+public class RankTest extends TPCHTestBase {
+    @Test
+    void testRank() throws NoSuchFieldException, IllegalAccessException {
+        for (int i = 1; i < 22; i++) {
+            Field field = TPCHUtils.class.getField("Q" + String.valueOf(i));
+            System.out.println("Q" + String.valueOf(i));
+            Memo memo = PlanChecker.from(connectContext)
+                    .analyze(field.get(null).toString())
+                    .rewrite()
+                    .optimize()
+                    .getCascadesContext()
+                    .getMemo();
+            memo.rank(1);
+        }
+    }
+
+    @Test
+    void testUnrank() throws NoSuchFieldException, IllegalAccessException {
+        for (int i = 1; i < 22; i++) {
+            Field field = TPCHUtils.class.getField("Q" + String.valueOf(i));
+            System.out.println("Q" + String.valueOf(i));
+            Memo memo = PlanChecker.from(connectContext)
+                    .analyze(field.get(null).toString())
+                    .rewrite()
+                    .optimize()
+                    .getCascadesContext()
+                    .getMemo();
+            PhysicalPlan plan1 = memo.unrank(memo.rank(1));
+            PhysicalPlan plan2 = PlanChecker.from(connectContext)
+                    .analyze(field.get(null).toString())
+                    .rewrite()
+                    .optimize()
+                    .getBestPlanTree(PhysicalProperties.GATHER);
+            Assertions.assertEquals(plan1.treeString(), plan2.treeString());
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/util/PlanChecker.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/util/PlanChecker.java
@@ -528,6 +528,10 @@ public class PlanChecker {
         return chooseBestPlan(cascadesContext.getMemo().getRoot(), PhysicalProperties.ANY);
     }
 
+    public PhysicalPlan getBestPlanTree(PhysicalProperties properties) {
+        return chooseBestPlan(cascadesContext.getMemo().getRoot(), properties);
+    }
+
     public PlanChecker printlnBestPlanTree() {
         System.out.println(chooseBestPlan(cascadesContext.getMemo().getRoot(), PhysicalProperties.ANY).treeString());
         System.out.println("-----------------------------");


### PR DESCRIPTION
# Proposed changes

Add hint NTH_OPTIMIZED_PLAN to let the optimzier can select n-th optimized plan. For example:
you could use 
```
select /*+SET_VAR("nth_optimized_plan"=2) */ * from table
```
to select the second-best plan in the optimizer.

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

