### PR TITLE
[enhancement](inverted index) Support fulltext index evaluate equal query and list query

### DIFF
--- a/be/src/common/status.h
+++ b/be/src/common/status.h
@@ -253,6 +253,7 @@ E(INVERTED_INDEX_NOT_SUPPORTED, -6001);
 E(INVERTED_INDEX_CLUCENE_ERROR, -6002);
 E(INVERTED_INDEX_FILE_NOT_FOUND, -6003);
 E(INVERTED_INDEX_FILE_HIT_LIMIT, -6004);
+E(INVERTED_INDEX_NO_TERMS, -6005);
 #undef E
 } // namespace ErrorCode
 
@@ -280,7 +281,8 @@ static constexpr bool capture_stacktrace() {
         && code != ErrorCode::INVERTED_INDEX_NOT_SUPPORTED
         && code != ErrorCode::INVERTED_INDEX_CLUCENE_ERROR
         && code != ErrorCode::INVERTED_INDEX_FILE_NOT_FOUND
-        && code != ErrorCode::INVERTED_INDEX_FILE_HIT_LIMIT;
+        && code != ErrorCode::INVERTED_INDEX_FILE_HIT_LIMIT
+        && code != ErrorCode::INVERTED_INDEX_NO_TERMS;
 }
 // clang-format on
 

--- a/be/src/olap/column_predicate.h
+++ b/be/src/olap/column_predicate.h
@@ -110,6 +110,10 @@ struct PredicateTypeTraits {
         return (type == PredicateType::IN_LIST || type == PredicateType::NOT_IN_LIST);
     }
 
+    static constexpr bool is_eqaul_and_list(PredicateType type) {
+        return (type == PredicateType::EQ || type == PredicateType::IN_LIST);
+    }
+
     static constexpr bool is_comparison(PredicateType type) {
         return (type == PredicateType::EQ || type == PredicateType::NE ||
                 type == PredicateType::LT || type == PredicateType::LE ||

--- a/be/src/olap/column_predicate.h
+++ b/be/src/olap/column_predicate.h
@@ -110,7 +110,7 @@ struct PredicateTypeTraits {
         return (type == PredicateType::IN_LIST || type == PredicateType::NOT_IN_LIST);
     }
 
-    static constexpr bool is_eqaul_and_list(PredicateType type) {
+    static constexpr bool is_equal_or_list(PredicateType type) {
         return (type == PredicateType::EQ || type == PredicateType::IN_LIST);
     }
 

--- a/be/src/olap/rowset/segment_v2/inverted_index_reader.cpp
+++ b/be/src/olap/rowset/segment_v2/inverted_index_reader.cpp
@@ -130,19 +130,19 @@ Status FullTextIndexReader::query(OlapReaderStatistics* stats, const std::string
         if (analyse_result.empty()) {
             LOG(WARNING) << "invalid input query_str: " << search_str
                          << ", please check your query sql";
-            return Status::Error<ErrorCode::INVERTED_INDEX_INVALID_PARAMETERS>();
+            return Status::Error<ErrorCode::INVERTED_INDEX_NO_TERMS>();
         }
 
         roaring::Roaring query_match_bitmap;
         bool first = true;
-        for (auto token : analyse_result) {
+        for (auto token_ws : analyse_result) {
             roaring::Roaring* term_match_bitmap = nullptr;
 
             // try to get term bitmap match result from cache to avoid query index on cache hit
             auto cache = InvertedIndexQueryCache::instance();
             // use EQUAL_QUERY type here since cache is for each term/token
             InvertedIndexQueryCache::CacheKey cache_key {
-                    index_file_path, column_name, InvertedIndexQueryType::EQUAL_QUERY, token};
+                    index_file_path, column_name, InvertedIndexQueryType::EQUAL_QUERY, token_ws};
             InvertedIndexQueryCacheHandle cache_handle;
             if (cache->lookup(cache_key, &cache_handle)) {
                 stats->inverted_index_query_cache_hit++;
@@ -150,7 +150,6 @@ Status FullTextIndexReader::query(OlapReaderStatistics* stats, const std::string
             } else {
                 stats->inverted_index_query_cache_miss++;
                 term_match_bitmap = new roaring::Roaring();
-                std::wstring token_ws = std::wstring(token.begin(), token.end());
                 // unique_ptr with custom deleter
                 std::unique_ptr<lucene::index::Term, void (*)(lucene::index::Term*)> term {
                         _CLNEW lucene::index::Term(field_ws.c_str(), token_ws.c_str()),
@@ -198,6 +197,7 @@ Status FullTextIndexReader::query(OlapReaderStatistics* stats, const std::string
                 query_match_bitmap |= *term_match_bitmap;
                 break;
             }
+            case InvertedIndexQueryType::EQUAL_QUERY:
             case InvertedIndexQueryType::MATCH_ALL_QUERY: {
                 SCOPED_RAW_TIMER(&stats->inverted_index_query_bitmap_op_timer);
                 query_match_bitmap &= *term_match_bitmap;

--- a/be/src/olap/rowset/segment_v2/segment_iterator.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.cpp
@@ -533,7 +533,7 @@ Status SegmentIterator::_execute_compound_fn(const std::string& function_name) {
 bool SegmentIterator::_can_filter_by_preds_except_leafnode_of_andnode() {
     for (auto pred : _col_preds_except_leafnode_of_andnode) {
         if (_not_apply_index_pred.count(pred->column_id()) ||
-            (!_check_apply_by_bitmap_index(pred) && !_check_apply_by_inverted_index(pred))) {
+            (!_check_apply_by_bitmap_index(pred) && !_check_apply_by_inverted_index(pred, true))) {
             return false;
         }
     }
@@ -550,21 +550,35 @@ bool SegmentIterator::_check_apply_by_bitmap_index(ColumnPredicate* pred) {
     return true;
 }
 
-bool SegmentIterator::_check_apply_by_inverted_index(ColumnPredicate* pred) {
+bool SegmentIterator::_check_apply_by_inverted_index(ColumnPredicate* pred, bool pred_in_compound) {
     int32_t unique_id = _schema.unique_id(pred->column_id());
-    bool handle_by_fulltext = _is_handle_predicate_by_fulltext(unique_id);
-
     if (_inverted_index_iterators.count(unique_id) < 1 ||
-        _inverted_index_iterators[unique_id] == nullptr ||
-        (pred->type() != PredicateType::MATCH && handle_by_fulltext) ||
-        pred->type() == PredicateType::IS_NULL || pred->type() == PredicateType::IS_NOT_NULL ||
-        pred->type() == PredicateType::BF) {
-        // 1. this column without inverted index
-        // 2. equal or range qeury for fulltext index
-        // 3. is_null or is_not_null predicate
-        // 4. bloom filter predicate
+        _inverted_index_iterators[unique_id] == nullptr) {
+        //this column without inverted index
         return false;
     }
+
+    if (_inverted_index_not_support_pred_type(pred->type())) {
+        return false;
+    }
+
+    if ((pred->type() == PredicateType::IN_LIST || pred->type() == PredicateType::NOT_IN_LIST) &&
+        pred->predicate_params()->marked_by_runtime_filter) {
+        // in_list or not_in_list predicate produced by runtime filter
+        return false;
+    }
+
+    bool handle_by_fulltext = _column_has_fulltext_index(unique_id);
+    if (handle_by_fulltext) {
+        // when predicate in compound condition which except leafNode of andNode,
+        // only can apply match query for fulltext index,
+        // when predicate is leafNode of andNode,
+        // can apply 'match qeury' and 'equal query' and 'list query' for fulltext index.
+        return (pred_in_compound ? pred->type() == PredicateType::MATCH
+                                 : (pred->type() == PredicateType::MATCH ||
+                                    PredicateTypeTraits::is_eqaul_and_list(pred->type())));
+    }
+
     return true;
 }
 
@@ -596,7 +610,7 @@ Status SegmentIterator::_apply_index_except_leafnode_of_andnode() {
         }
 
         bool can_apply_by_bitmap_index = _check_apply_by_bitmap_index(pred);
-        bool can_apply_by_inverted_index = _check_apply_by_inverted_index(pred);
+        bool can_apply_by_inverted_index = _check_apply_by_inverted_index(pred, true);
         roaring::Roaring bitmap = _row_bitmap;
         Status res = Status::OK();
         if (can_apply_by_bitmap_index) {
@@ -658,13 +672,18 @@ std::string SegmentIterator::_gen_predicate_result_sign(ColumnPredicateInfo* pre
     return pred_result_sign;
 }
 
-bool SegmentIterator::_is_handle_predicate_by_fulltext(int32_t unique_id) {
-    bool handle_by_fulltext =
+bool SegmentIterator::_column_has_fulltext_index(int32_t unique_id) {
+    bool has_fulltext_index =
             _inverted_index_iterators[unique_id] != nullptr &&
             _inverted_index_iterators[unique_id]->get_inverted_index_reader_type() ==
                     InvertedIndexReaderType::FULLTEXT;
 
-    return handle_by_fulltext;
+    return has_fulltext_index;
+}
+
+inline bool SegmentIterator::_inverted_index_not_support_pred_type(const PredicateType& type) {
+    return type == PredicateType::IS_NULL || type == PredicateType::IS_NOT_NULL ||
+           type == PredicateType::BF || type == PredicateType::BITMAP_FILTER;
 }
 
 #define all_predicates_are_range_predicate(predicate_set)   \
@@ -679,30 +698,21 @@ bool SegmentIterator::_is_handle_predicate_by_fulltext(int32_t unique_id) {
 Status SegmentIterator::_apply_inverted_index_on_column_predicate(
         ColumnPredicate* pred, std::vector<ColumnPredicate*>& remaining_predicates,
         bool* continue_apply) {
-    int32_t unique_id = _schema.unique_id(pred->column_id());
-    bool handle_by_fulltext = _is_handle_predicate_by_fulltext(unique_id);
-
-    if (_inverted_index_iterators.count(unique_id) < 1 ||
-        _inverted_index_iterators[unique_id] == nullptr ||
-        (pred->type() != PredicateType::MATCH && handle_by_fulltext) ||
-        pred->type() == PredicateType::IS_NULL || pred->type() == PredicateType::IS_NOT_NULL ||
-        pred->type() == PredicateType::BF ||
-        ((pred->type() == PredicateType::IN_LIST || pred->type() == PredicateType::NOT_IN_LIST) &&
-         pred->predicate_params()->marked_by_runtime_filter)) {
-        // 1. this column no inverted index
-        // 2. equal or range for fulltext index
-        // 3. is_null or is_not_null predicate
-        // 4. bloom filter predicate
-        // 5. in_list or not_in_list predicate produced by runtime filter
+    if (!_check_apply_by_inverted_index(pred)) {
         remaining_predicates.emplace_back(pred);
     } else {
+        int32_t unique_id = _schema.unique_id(pred->column_id());
+        bool need_remaining_after_evaluate = _column_has_fulltext_index(unique_id) &&
+                                             PredicateTypeTraits::is_eqaul_and_list(pred->type());
         roaring::Roaring bitmap = _row_bitmap;
         Status res =
                 pred->evaluate(_schema, _inverted_index_iterators[unique_id], num_rows(), &bitmap);
         if (!res.ok()) {
             if ((res.code() == ErrorCode::INVERTED_INDEX_FILE_NOT_FOUND &&
                  pred->type() != PredicateType::MATCH) ||
-                res.code() == ErrorCode::INVERTED_INDEX_FILE_HIT_LIMIT) {
+                res.code() == ErrorCode::INVERTED_INDEX_FILE_HIT_LIMIT ||
+                (res.code() == ErrorCode::INVERTED_INDEX_NO_TERMS &&
+                 need_remaining_after_evaluate)) {
                 //downgrade without index query
                 remaining_predicates.emplace_back(pred);
                 return Status::OK();
@@ -711,12 +721,6 @@ Status SegmentIterator::_apply_inverted_index_on_column_predicate(
                          << ", column predicate type: " << pred->pred_type_string(pred->type())
                          << ", error msg: " << res.code_as_string();
             return res;
-        }
-
-        auto column_name = _schema.column(pred->column_id())->name();
-        if (_check_column_pred_all_push_down(column_name) &&
-            !pred->predicate_params()->marked_by_runtime_filter) {
-            _need_read_data_indices[unique_id] = false;
         }
 
         auto pred_type = pred->type();
@@ -731,6 +735,17 @@ Status SegmentIterator::_apply_inverted_index_on_column_predicate(
             // all rows have been pruned, no need to process further predicates
             *continue_apply = false;
         }
+
+        if (need_remaining_after_evaluate) {
+            remaining_predicates.emplace_back(pred);
+            return Status::OK();
+        }
+
+        auto column_name = _schema.column(pred->column_id())->name();
+        if (_check_column_pred_all_push_down(column_name) &&
+            !pred->predicate_params()->marked_by_runtime_filter) {
+            _need_read_data_indices[unique_id] = false;
+        }
     }
     return Status::OK();
 }
@@ -740,7 +755,7 @@ Status SegmentIterator::_apply_inverted_index_on_block_column_predicate(
         std::set<const ColumnPredicate*>& no_need_to_pass_column_predicate_set,
         bool* continue_apply) {
     auto unique_id = _schema.unique_id(column_id);
-    bool handle_by_fulltext = _is_handle_predicate_by_fulltext(unique_id);
+    bool handle_by_fulltext = _column_has_fulltext_index(unique_id);
     std::set<const ColumnPredicate*> predicate_set {};
 
     pred->get_all_column_predicate(predicate_set);

--- a/be/src/olap/rowset/segment_v2/segment_iterator.h
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.h
@@ -163,7 +163,8 @@ private:
                                                           roaring::Roaring* output_result);
     Status _apply_inverted_index_except_leafnode_of_andnode(ColumnPredicate* pred,
                                                             roaring::Roaring* output_result);
-    bool _is_handle_predicate_by_fulltext(int32_t unique_id);
+    bool _column_has_fulltext_index(int32_t unique_id);
+    inline bool _inverted_index_not_support_pred_type(const PredicateType& type);
     bool _can_filter_by_preds_except_leafnode_of_andnode();
     Status _execute_predicates_except_leafnode_of_andnode(vectorized::VExpr* expr);
     Status _execute_compound_fn(const std::string& function_name);
@@ -218,7 +219,7 @@ private:
     void _update_max_row(const vectorized::Block* block);
 
     bool _check_apply_by_bitmap_index(ColumnPredicate* pred);
-    bool _check_apply_by_inverted_index(ColumnPredicate* pred);
+    bool _check_apply_by_inverted_index(ColumnPredicate* pred, bool pred_in_compound = false);
 
     std::string _gen_predicate_result_sign(ColumnPredicate* predicate);
     std::string _gen_predicate_result_sign(ColumnPredicateInfo* predicate_info);


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

fulltext index is  the inverted index of the specified tokenizer, before this pr, fulltext index only can evaluate match predicate, this pr to support evaluate equal predicate and list predicate.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

