### PR TITLE
[fix](hive) fix unable to specify user to access hdfs

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HiveMetaStoreCache.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HiveMetaStoreCache.java
@@ -18,6 +18,7 @@
 package org.apache.doris.datasource.hive;
 
 import org.apache.doris.analysis.PartitionValue;
+import org.apache.doris.catalog.HdfsResource;
 import org.apache.doris.catalog.ListPartitionItem;
 import org.apache.doris.catalog.PartitionItem;
 import org.apache.doris.catalog.PartitionKey;
@@ -55,9 +56,12 @@ import org.apache.hadoop.mapred.FileInputFormat;
 import org.apache.hadoop.mapred.InputFormat;
 import org.apache.hadoop.mapred.InputSplit;
 import org.apache.hadoop.mapred.JobConf;
+import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.parquet.Strings;
 
+import java.security.PrivilegedExceptionAction;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -230,8 +234,7 @@ public class HiveMetaStoreCache {
         try {
             Thread.currentThread().setContextClassLoader(ClassLoader.getSystemClassLoader());
             String finalLocation = convertToS3IfNecessary(key.location);
-            Configuration conf = getConfiguration();
-            JobConf jobConf = new JobConf(conf);
+            JobConf jobConf = getJobConf();
             // For Tez engine, it may generate subdirectories for "union" query.
             // So there may be files and directories in the table directory at the same time. eg:
             //      /us£er/hive/warehouse/region_tmp_union_all2/000000_0
@@ -243,8 +246,16 @@ public class HiveMetaStoreCache {
             jobConf.set("mapreduce.input.fileinputformat.input.dir.recursive", "true");
             FileInputFormat.setInputPaths(jobConf, finalLocation);
             try {
-                InputFormat<?, ?> inputFormat = HiveUtil.getInputFormat(conf, key.inputFormat, false);
-                InputSplit[] splits = inputFormat.getSplits(jobConf, 0);
+                InputFormat<?, ?> inputFormat = HiveUtil.getInputFormat(jobConf, key.inputFormat, false);
+                InputSplit[] splits;
+                String remoteUser = jobConf.get(HdfsResource.HADOOP_USER_NAME);
+                if (!Strings.isNullOrEmpty(remoteUser)) {
+                    UserGroupInformation ugi = UserGroupInformation.createRemoteUser(remoteUser);
+                    splits = ugi.doAs(
+                            (PrivilegedExceptionAction<InputSplit[]>) () -> inputFormat.getSplits(jobConf, 0));
+                } else {
+                    splits = inputFormat.getSplits(jobConf, 0 /* use hdfs block size as default */);
+                }
                 if (LOG.isDebugEnabled()) {
                     LOG.debug("load #{} files for {} in catalog {}", splits.length, key, catalog.getName());
                 }
@@ -275,12 +286,12 @@ public class HiveMetaStoreCache {
         return location;
     }
 
-    private Configuration getConfiguration() {
+    private JobConf getJobConf() {
         Configuration configuration = new HdfsConfiguration();
         for (Map.Entry<String, String> entry : catalog.getCatalogProperty().getHadoopProperties().entrySet()) {
             configuration.set(entry.getKey(), entry.getValue());
         }
-        return configuration;
+        return new JobConf(configuration);
     }
 
     public HivePartitionValues getPartitionValues(String dbName, String tblName, List<Type> types) {

--- a/fe/fe-core/src/main/java/org/apache/doris/external/hive/util/HiveUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/external/hive/util/HiveUtil.java
@@ -25,7 +25,6 @@ import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.UserException;
 
 import com.google.common.collect.Lists;
-import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.ql.io.SymlinkTextInputFormat;
 import org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat;
@@ -55,17 +54,15 @@ public final class HiveUtil {
     /**
      * get input format class from inputFormatName.
      *
-     * @param configuration jobConf used when getInputFormatClass
+     * @param jobConf jobConf used when getInputFormatClass
      * @param inputFormatName inputFormat class name
      * @param symlinkTarget use target inputFormat class when inputFormat is SymlinkTextInputFormat
      * @return a class of inputFormat.
-     * @throws UserException  when class not found.
+     * @throws UserException when class not found.
      */
-    public static InputFormat<?, ?> getInputFormat(Configuration configuration,
-                                                   String inputFormatName, boolean symlinkTarget) throws UserException {
+    public static InputFormat<?, ?> getInputFormat(JobConf jobConf,
+            String inputFormatName, boolean symlinkTarget) throws UserException {
         try {
-            JobConf jobConf = new JobConf(configuration);
-
             Class<? extends InputFormat<?, ?>> inputFormatClass = getInputFormatClass(jobConf, inputFormatName);
             if (symlinkTarget && (inputFormatClass == SymlinkTextInputFormat.class)) {
                 // symlink targets are always TextInputFormat


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

In version 1.2.1, user can set `"hadoop.username" = "xxx"` to specify a remote user to access hdfs
when creating hive catalog.
But in version 1.2.2, we upgrade the hadoop version from 2.8 to 3.3, some behavior changed and the
user specified remote user is useless.

This PR try to fix this by using `UserGroupInformation` to delegate.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

