### PR TITLE
[chore](macOS) Fix linkage errors for the release build

### DIFF
--- a/be/src/vec/exec/format/parquet/decoder.cpp
+++ b/be/src/vec/exec/format/parquet/decoder.cpp
@@ -132,27 +132,4 @@ void Decoder::init(FieldSchema* field_schema, cctz::time_zone* ctz) {
         }
     }
 }
-template <typename DecimalPrimitiveType>
-void Decoder::init_decimal_converter(DataTypePtr& data_type) {
-    if (_decode_params == nullptr || _field_schema == nullptr ||
-        _decode_params->decimal_scale.scale_type != DecimalScaleParams::NOT_INIT) {
-        return;
-    }
-    auto scale = _field_schema->parquet_schema.scale;
-    auto* decimal_type = reinterpret_cast<DataTypeDecimal<Decimal<DecimalPrimitiveType>>*>(
-            const_cast<IDataType*>(remove_nullable(data_type).get()));
-    auto dest_scale = decimal_type->get_scale();
-    if (dest_scale > scale) {
-        _decode_params->decimal_scale.scale_type = DecimalScaleParams::SCALE_UP;
-        _decode_params->decimal_scale.scale_factor =
-                DecimalScaleParams::get_scale_factor<DecimalPrimitiveType>(dest_scale - scale);
-    } else if (dest_scale < scale) {
-        _decode_params->decimal_scale.scale_type = DecimalScaleParams::SCALE_DOWN;
-        _decode_params->decimal_scale.scale_factor =
-                DecimalScaleParams::get_scale_factor<DecimalPrimitiveType>(scale - dest_scale);
-    } else {
-        _decode_params->decimal_scale.scale_type = DecimalScaleParams::NO_SCALE;
-        _decode_params->decimal_scale.scale_factor = 1;
-    }
-}
 } // namespace doris::vectorized

--- a/be/src/vec/exec/format/parquet/decoder.h
+++ b/be/src/vec/exec/format/parquet/decoder.h
@@ -92,6 +92,30 @@ protected:
     std::unique_ptr<DecodeParams> _decode_params = nullptr;
 };
 
+template <typename DecimalPrimitiveType>
+void Decoder::init_decimal_converter(DataTypePtr& data_type) {
+    if (_decode_params == nullptr || _field_schema == nullptr ||
+        _decode_params->decimal_scale.scale_type != DecimalScaleParams::NOT_INIT) {
+        return;
+    }
+    auto scale = _field_schema->parquet_schema.scale;
+    auto* decimal_type = reinterpret_cast<DataTypeDecimal<Decimal<DecimalPrimitiveType>>*>(
+            const_cast<IDataType*>(remove_nullable(data_type).get()));
+    auto dest_scale = decimal_type->get_scale();
+    if (dest_scale > scale) {
+        _decode_params->decimal_scale.scale_type = DecimalScaleParams::SCALE_UP;
+        _decode_params->decimal_scale.scale_factor =
+                DecimalScaleParams::get_scale_factor<DecimalPrimitiveType>(dest_scale - scale);
+    } else if (dest_scale < scale) {
+        _decode_params->decimal_scale.scale_type = DecimalScaleParams::SCALE_DOWN;
+        _decode_params->decimal_scale.scale_factor =
+                DecimalScaleParams::get_scale_factor<DecimalPrimitiveType>(scale - dest_scale);
+    } else {
+        _decode_params->decimal_scale.scale_type = DecimalScaleParams::NO_SCALE;
+        _decode_params->decimal_scale.scale_factor = 1;
+    }
+}
+
 class BaseDictDecoder : public Decoder {
 public:
     BaseDictDecoder() = default;


### PR DESCRIPTION
# Proposed changes

Issue Number: close #17003

## Problem summary

The linker couldn't find some symbols because the implementation of a template member function `doris::vectorized::Decoder::init_decimal_converter` is missing in the header file in which the corresponding declaration is placed.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

