### PR TITLE
[fix](planner)sub_bitmap always nullable

### DIFF
--- a/gensrc/script/doris_builtins_functions.py
+++ b/gensrc/script/doris_builtins_functions.py
@@ -1441,7 +1441,7 @@ visible_functions = [
     [['bitmap_and_count'], 'BIGINT', ['BITMAP','BITMAP'], ''],
     [['bitmap_or_count'], 'BIGINT', ['BITMAP','BITMAP','...'], ''],
     [['bitmap_or_count'], 'BIGINT', ['BITMAP','BITMAP'], ''],
-    [['sub_bitmap'], 'BITMAP', ['BITMAP', 'BIGINT', 'BIGINT'], ''],
+    [['sub_bitmap'], 'BITMAP', ['BITMAP', 'BIGINT', 'BIGINT'], 'ALWAYS_NULLABLE'],
     [['bitmap_to_array'], 'ARRAY_BIGINT', ['BITMAP'], ''],
     # quantile_function
     [['to_quantile_state'], 'QUANTILE_STATE', ['VARCHAR', 'FLOAT'], ''],


### PR DESCRIPTION
# Proposed changes
sub_bitmap return type should be ALWAYS_NULLABLE, not depend on children.
For example
sub_bitmap(bitmap_empty(), 1, 2) return NULL, but all children are not null.

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

