### PR TITLE
[enhancement](cache) make segment cache prune more effectively

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -219,7 +219,7 @@ CONF_mInt64(memory_limitation_per_thread_for_schema_change_bytes, "2147483648");
 CONF_mInt64(memory_limitation_per_thread_for_storage_migration_bytes, "100000000");
 
 // the clean interval of file descriptor cache and segment cache
-CONF_mInt32(cache_clean_interval, "1800");
+CONF_mInt32(cache_clean_interval, "60");
 // the clean interval of tablet lookup cache
 CONF_mInt32(tablet_lookup_cache_clean_interval, "30");
 CONF_mInt32(disk_stat_monitor_interval, "5");

--- a/be/src/olap/lru_cache.cpp
+++ b/be/src/olap/lru_cache.cpp
@@ -461,7 +461,7 @@ int64_t LRUCache::prune() {
     return pruned_count;
 }
 
-int64_t LRUCache::prune_if(CacheValuePredicate pred) {
+int64_t LRUCache::prune_if(CacheValuePredicate pred, bool lazy_mode) {
     LRUHandle* to_remove_head = nullptr;
     {
         std::lock_guard l(_mutex);
@@ -472,6 +472,8 @@ int64_t LRUCache::prune_if(CacheValuePredicate pred) {
                 _evict_one_entry(p);
                 p->next = to_remove_head;
                 to_remove_head = p;
+            } else if (lazy_mode) {
+                break;
             }
             p = next;
         }
@@ -483,6 +485,8 @@ int64_t LRUCache::prune_if(CacheValuePredicate pred) {
                 _evict_one_entry(p);
                 p->next = to_remove_head;
                 to_remove_head = p;
+            } else if (lazy_mode) {
+                break;
             }
             p = next;
         }
@@ -610,10 +614,10 @@ int64_t ShardedLRUCache::prune() {
     return num_prune;
 }
 
-int64_t ShardedLRUCache::prune_if(CacheValuePredicate pred) {
+int64_t ShardedLRUCache::prune_if(CacheValuePredicate pred, bool lazy_mode) {
     int64_t num_prune = 0;
     for (int s = 0; s < _num_shards; s++) {
-        num_prune += _shards[s]->prune_if(pred);
+        num_prune += _shards[s]->prune_if(pred, lazy_mode);
     }
     return num_prune;
 }

--- a/be/src/olap/lru_cache.h
+++ b/be/src/olap/lru_cache.h
@@ -221,7 +221,7 @@ public:
     // Same as prune(), but the entry will only be pruned if the predicate matched.
     // NOTICE: the predicate should be simple enough, or the prune_if() function
     // may hold lock for a long time to execute predicate.
-    virtual int64_t prune_if(CacheValuePredicate pred) { return 0; }
+    virtual int64_t prune_if(CacheValuePredicate pred, bool lazy_mode = false) { return 0; }
 
     virtual int64_t mem_consumption() = 0;
 
@@ -337,7 +337,7 @@ public:
     void release(Cache::Handle* handle);
     void erase(const CacheKey& key, uint32_t hash);
     int64_t prune();
-    int64_t prune_if(CacheValuePredicate pred);
+    int64_t prune_if(CacheValuePredicate pred, bool lazy_mode = false);
 
     void set_cache_value_time_extractor(CacheValueTimeExtractor cache_value_time_extractor);
     void set_cache_value_check_timestamp(bool cache_value_check_timestamp);
@@ -406,7 +406,7 @@ public:
     Slice value_slice(Handle* handle) override;
     virtual uint64_t new_id() override;
     virtual int64_t prune() override;
-    virtual int64_t prune_if(CacheValuePredicate pred) override;
+    virtual int64_t prune_if(CacheValuePredicate pred, bool lazy_mode = false) override;
     int64_t mem_consumption() override;
 
 private:

--- a/be/src/olap/lru_cache.h
+++ b/be/src/olap/lru_cache.h
@@ -406,7 +406,7 @@ public:
     Slice value_slice(Handle* handle) override;
     virtual uint64_t new_id() override;
     virtual int64_t prune() override;
-    virtual int64_t prune_if(CacheValuePredicate pred, bool lazy_mode = false) override;
+    int64_t prune_if(CacheValuePredicate pred, bool lazy_mode = false) override;
     int64_t mem_consumption() override;
 
 private:

--- a/be/src/olap/segment_loader.cpp
+++ b/be/src/olap/segment_loader.cpp
@@ -91,7 +91,8 @@ Status SegmentLoader::prune() {
 
     MonotonicStopWatch watch;
     watch.start();
-    int64_t prune_num = _cache->prune_if(pred);
+    // Prune cache in lazy mode to save cpu and minimize the time holding write lock
+    int64_t prune_num = _cache->prune_if(pred, true);
     LOG(INFO) << "prune " << prune_num
               << " entries in segment cache. cost(ms): " << watch.elapsed_time() / 1000 / 1000;
     return Status::OK();

--- a/be/test/olap/lru_cache_test.cpp
+++ b/be/test/olap/lru_cache_test.cpp
@@ -316,7 +316,7 @@ TEST_F(CacheTest, Prune) {
 
 TEST_F(CacheTest, PruneIfLazyMode) {
     LRUCache cache(LRUCacheType::NUMBER);
-    cache.set_capacity(5);
+    cache.set_capacity(10);
 
     // The lru usage is 1, add one entry
     CacheKey key1("100");
@@ -341,25 +341,27 @@ TEST_F(CacheTest, PruneIfLazyMode) {
 
     CacheKey key6("600");
     insert_LRUCache(cache, key6, 600, CachePriority::NORMAL);
-    EXPECT_EQ(5, cache.get_usage());
+    EXPECT_EQ(6, cache.get_usage());
 
     CacheKey key7("700");
     insert_LRUCache(cache, key7, 700, CachePriority::DURABLE);
-    EXPECT_EQ(5, cache.get_usage());
+    EXPECT_EQ(7, cache.get_usage());
 
     auto pred = [](const void* value) -> bool { return false; };
     cache.prune_if(pred, true);
-    EXPECT_EQ(5, cache.get_usage());
+    EXPECT_EQ(7, cache.get_usage());
 
     // in lazy mode, the first item not satisfied the pred2, `prune_if` then stopped
     // and no item's removed.
     auto pred2 = [](const void* value) -> bool { return DecodeValue((void*)value) > 400; };
     cache.prune_if(pred2, true);
-    EXPECT_EQ(5, cache.get_usage());
+    EXPECT_EQ(7, cache.get_usage());
 
+    // in normal priority, 100, 300 are removed
+    // in durable priority, 200 is removed
     auto pred3 = [](const void* value) -> bool { return DecodeValue((void*)value) <= 600; };
     EXPECT_EQ(3, cache.prune_if(pred3, true));
-    EXPECT_EQ(3, cache.get_usage()); // keys before 666 are removed
+    EXPECT_EQ(4, cache.get_usage());
 }
 
 TEST_F(CacheTest, HeavyEntries) {

--- a/be/test/olap/lru_cache_test.cpp
+++ b/be/test/olap/lru_cache_test.cpp
@@ -332,7 +332,7 @@ TEST_F(CacheTest, PruneIfLazyMode) {
     EXPECT_EQ(3, cache.get_usage());
 
     CacheKey key4("666");
-    insert_LRUCache(cache, key4, 400, CachePriority::NORMAL);
+    insert_LRUCache(cache, key4, 666, CachePriority::NORMAL);
     EXPECT_EQ(4, cache.get_usage());
 
     CacheKey key5("500");
@@ -357,7 +357,7 @@ TEST_F(CacheTest, PruneIfLazyMode) {
     cache.prune_if(pred2, true);
     EXPECT_EQ(5, cache.get_usage());
 
-    auto pred3 = [](const void* value) -> bool { return DecodeValue((void*)value) < 600; };
+    auto pred3 = [](const void* value) -> bool { return DecodeValue((void*)value) <= 600; };
     EXPECT_EQ(3, cache.prune_if(pred3, true));
     EXPECT_EQ(3, cache.get_usage()); // keys before 666 are removed
 }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

For Unqiue Key MoW table, Segment object holds a PrimaryKeyIndexReader, which will load a primary key bloom filter to it's member `_bf`, the memory will be released until the segment object is cleared from SegmentCache. Primary key boom filter can consume quite large memory, we've seen a user with 40000 handles (which is not a quite large number), their SegmentCache consumes 20GB memory.

The `_bf` variable is designed to be loaded on demand (currently it's only load when we need to lookup row key), but for MoW table, almost all segment need to load it(all segments need to check if they have keys that should be marked as deleted).  In most MoW scenario, user need realtime load, the segments will be retired very quickly (due to frequently compaction), So we need to release the segment object timely.

In this PR, I propose to prune stale segments every 1 minute (now it's 30min).
The prune operation is quite costive, since it needs to hold the write lock to traverse all items in cache and check if they need to be pruned. The traverse is start from the oldest item to newest ones, If we try to prune stale segments only, we don't need to traverse all items every time, we can stop once we found an item is not stale.
In this way, every item only need to be checked once, even we try to prune the cache frequently, it's still very effective.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

