### PR TITLE
[regression](mtmv) sleep a while to avoid table state not normal issue

### DIFF
--- a/regression-test/suites/materialized_view_p0/test_mv_useless/test_dup_mv_useless.groovy
+++ b/regression-test/suites/materialized_view_p0/test_mv_useless/test_dup_mv_useless.groovy
@@ -54,6 +54,7 @@ suite ("test_dup_mv_useless") {
     while (max_try_secs--) {
         String res = getJobState(testTable)
         if (res == "FINISHED") {
+            Thread.sleep(5000)
             break
         } else {
             Thread.sleep(2000)
@@ -68,6 +69,7 @@ suite ("test_dup_mv_useless") {
     while (max_try_secs--) {
         String res = getJobState(testTable)
         if (res == "FINISHED") {
+            Thread.sleep(5000)
             break
         } else {
             Thread.sleep(2000)
@@ -82,6 +84,7 @@ suite ("test_dup_mv_useless") {
     while (max_try_secs--) {
         String res = getJobState(testTable)
         if (res == "FINISHED") {
+            Thread.sleep(5000)
             break
         } else {
             Thread.sleep(2000)
@@ -96,6 +99,7 @@ suite ("test_dup_mv_useless") {
     while (max_try_secs--) {
         String res = getJobState(testTable)
         if (res == "FINISHED") {
+            Thread.sleep(5000)
             break
         } else {
             Thread.sleep(2000)


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

The table's state will change to NORMAL after Alter table operation finished.
But there is a gap between  Alter table finish and table state change to normal.
So we should sleep for a while before doing next alter operation, to avoid:
`Table' state is not NORMAL` error.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

