### PR TITLE
[fix](compile) fix compile error while use gcc12

### DIFF
--- a/be/src/vec/core/field.h
+++ b/be/src/vec/core/field.h
@@ -641,8 +641,8 @@ public:
 
 private:
     std::aligned_union_t<DBMS_MIN_FIELD_SIZE - sizeof(Types::Which), Null, UInt64, UInt128, Int64,
-                         Int128, Float64, String, JsonbField, Array, Tuple, DecimalField<Decimal32>,
-                         DecimalField<Decimal64>, DecimalField<Decimal128>,
+                         Int128, Float64, String, JsonbField, Array, Tuple, VariantMap,
+                         DecimalField<Decimal32>, DecimalField<Decimal64>, DecimalField<Decimal128>,
                          DecimalField<Decimal128I>, AggregateFunctionStateData>
             storage;
 


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary
Error message:
```
/home/disk1/zhuxiaoli01/doris/baidu/bdg/doris/core/be/src/vec/core/field.h:647:13: note: 'doris::vectorized::Field::storage' declared here
  647 |             storage;
      |             ^~~~~~~
/home/disk1/zhuxiaoli01/doris/baidu/bdg/doris/core/be/src/vec/core/field.h: In instantiation of 'void doris::vectorized::Field::create_concrete(T&&) [with T = doris::vectorized::VariantMap]':
/home/disk1/zhuxiaoli01/doris/baidu/bdg/doris/core/be/src/vec/core/field.h:741:55:   required from 'doris::vectorized::Field::create(doris::vectorized::Field&&)::<lambda(auto:29&)> [with auto:29 = doris::vectorized::VariantMap]'
/home/disk1/zhuxiaoli01/doris/baidu/bdg/doris/core/be/src/vec/core/field.h:731:14:   required from 'static void doris::vectorized::Field::dispatch(F&&, Field&) [with F = doris::vectorized::Field::create(doris::vectorized::Field&&)::<lambda(auto:29&)>; Field = doris::vectorized::Field]'
/home/disk1/zhuxiaoli01/doris/baidu/bdg/doris/core/be/src/vec/core/field.h:741:17:   required from here
/home/disk1/zhuxiaoli01/doris/baidu/bdg/doris/core/be/src/vec/core/field.h:662:14: error: placement new constructing an object of type 'StorageType' {aka 'doris::vectorized::VariantMap'} and size '48' in a region of type 'std::aligned_union_t<28, doris::vectorized::Null, long unsigned int, doris::vectorized::UInt128, long int, __int128, double, std::basic_string<char, std::char_traits<char>, std::allocator<char> >, doris::vectorized::JsonbField, doris::vectorized::Array, doris::vectorized::Tuple, doris::vectorized::Map, doris::vectorized::DecimalField<doris::vectorized::Decimal<int> >, doris::vectorized::DecimalField<doris::vectorized::Decimal<long int> >, doris::vectorized::DecimalField<doris::vectorized::Decimal<__int128> >, doris::vectorized::DecimalField<doris::vectorized::Decimal<doris::vectorized::Int128I> >, doris::vectorized::AggregateFunctionStateData>' {aka 'std::aligned_storage<32, 16>::type'} and size '32' [-Werror=placement-new=]
  662 |         new (&storage) StorageType(std::forward<T>(x));
      |              ^~~~~~~~
/home/disk1/zhuxiaoli01/doris/baidu/bdg/doris/core/be/src/vec/core/field.h:647:13: note: 'doris::vectorized::Field::storage' declared here
  647 |             storage;
      |             ^~~~~~~
cc1plus: all warnings being treated as errors

```

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

