### PR TITLE
[fix](file reader) fix be core in broker file reader

### DIFF
--- a/be/src/vec/exec/format/csv/csv_reader.cpp
+++ b/be/src/vec/exec/format/csv/csv_reader.cpp
@@ -63,6 +63,8 @@ CsvReader::CsvReader(RuntimeState* state, RuntimeProfile* profile, ScannerCounte
 
     _text_converter.reset(new (std::nothrow) TextConverter('\\'));
     _split_values.reserve(sizeof(Slice) * _file_slot_descs.size());
+    _init_system_properties();
+    _init_file_description();
 }
 
 CsvReader::CsvReader(RuntimeProfile* profile, const TFileScanRangeParams& params,
@@ -81,9 +83,27 @@ CsvReader::CsvReader(RuntimeProfile* profile, const TFileScanRangeParams& params
     _file_format_type = _params.format_type;
     _file_compress_type = _params.compress_type;
     _size = _range.size;
+    _init_system_properties();
+    _init_file_description();
 }
 
 CsvReader::~CsvReader() = default;
+
+void CsvReader::_init_system_properties() {
+    _system_properties.system_type = _params.file_type;
+    _system_properties.properties = _params.properties;
+    _system_properties.hdfs_params = _params.hdfs_params;
+    if (_params.__isset.broker_addresses) {
+        _system_properties.broker_addresses.assign(_params.broker_addresses.begin(),
+                                                   _params.broker_addresses.end());
+    }
+}
+
+void CsvReader::_init_file_description() {
+    _file_description.path = _range.path;
+    _file_description.start_offset = _range.start_offset;
+    _file_description.file_size = _range.__isset.file_size ? _range.file_size : 0;
+}
 
 Status CsvReader::init_reader(bool is_load) {
     // set the skip lines and start offset
@@ -113,25 +133,13 @@ Status CsvReader::init_reader(bool is_load) {
         _skip_lines = 1;
     }
 
-    FileSystemProperties system_properties;
-    system_properties.system_type = _params.file_type;
-    system_properties.properties = _params.properties;
-    system_properties.hdfs_params = _params.hdfs_params;
-    if (_params.__isset.broker_addresses) {
-        system_properties.broker_addresses.assign(_params.broker_addresses.begin(),
-                                                  _params.broker_addresses.end());
-    }
-
-    FileDescription file_description;
-    file_description.path = _range.path;
-    file_description.start_offset = start_offset;
-    file_description.file_size = _range.__isset.file_size ? _range.file_size : 0;
+    _file_description.start_offset = start_offset;
 
     if (_params.file_type == TFileType::FILE_STREAM) {
         RETURN_IF_ERROR(FileFactory::create_pipe_reader(_range.load_id, &_file_reader));
     } else {
-        RETURN_IF_ERROR(FileFactory::create_file_reader(_profile, system_properties,
-                                                        file_description, &_file_system,
+        RETURN_IF_ERROR(FileFactory::create_file_reader(_profile, _system_properties,
+                                                        _file_description, &_file_system,
                                                         &_file_reader, _io_ctx));
     }
     if (_file_reader->size() == 0 && _params.file_type != TFileType::FILE_STREAM &&
@@ -568,17 +576,9 @@ Status CsvReader::_prepare_parse(size_t* read_line, bool* is_parse_name) {
         }
     }
 
-    FileSystemProperties system_properties;
-    system_properties.system_type = _params.file_type;
-    system_properties.properties = _params.properties;
-    system_properties.hdfs_params = _params.hdfs_params;
+    _file_description.start_offset = start_offset;
 
-    FileDescription file_description;
-    file_description.path = _range.path;
-    file_description.start_offset = start_offset;
-    file_description.file_size = _range.__isset.file_size ? _range.file_size : 0;
-
-    RETURN_IF_ERROR(FileFactory::create_file_reader(_profile, system_properties, file_description,
+    RETURN_IF_ERROR(FileFactory::create_file_reader(_profile, _system_properties, _file_description,
                                                     &_file_system, &_file_reader, _io_ctx));
     if (_file_reader->size() == 0 && _params.file_type != TFileType::FILE_STREAM &&
         _params.file_type != TFileType::FILE_BROKER) {

--- a/be/src/vec/exec/format/csv/csv_reader.h
+++ b/be/src/vec/exec/format/csv/csv_reader.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include "io/file_factory.h"
 #include "io/fs/file_reader.h"
 #include "olap/iterators.h"
 #include "vec/exec/format/generic_reader.h"
@@ -65,6 +66,8 @@ private:
     Status _check_array_format(std::vector<Slice>& split_values, bool* is_success);
     bool _is_null(const Slice& slice);
     bool _is_array(const Slice& slice);
+    void _init_system_properties();
+    void _init_file_description();
 
     // used for parse table schema of csv file.
     // Currently, this feature is for table valued function.
@@ -79,6 +82,8 @@ private:
     ScannerCounter* _counter;
     const TFileScanRangeParams& _params;
     const TFileRangeDesc& _range;
+    FileSystemProperties _system_properties;
+    FileDescription _file_description;
     const std::vector<SlotDescriptor*>& _file_slot_descs;
     // Only for query task, save the file slot to columns in block map.
     // eg, there are 3 cols in "_file_slot_descs" named: k1, k2, k3

--- a/be/src/vec/exec/format/json/new_json_reader.h
+++ b/be/src/vec/exec/format/json/new_json_reader.h
@@ -22,6 +22,7 @@
 #include <rapidjson/stringbuffer.h>
 #include <rapidjson/writer.h>
 
+#include "io/file_factory.h"
 #include "io/fs/file_reader.h"
 #include "olap/iterators.h"
 #include "vec/exec/format/generic_reader.h"
@@ -61,6 +62,8 @@ public:
 
 private:
     Status _get_range_params();
+    void _init_system_properties();
+    void _init_file_description();
     Status _open_file_reader();
     Status _open_line_reader();
     Status _parse_jsonpath_and_json_root();
@@ -146,6 +149,8 @@ private:
     ScannerCounter* _counter;
     const TFileScanRangeParams& _params;
     const TFileRangeDesc& _range;
+    FileSystemProperties _system_properties;
+    FileDescription _file_description;
     const std::vector<SlotDescriptor*>& _file_slot_descs;
 
     std::shared_ptr<io::FileSystem> _file_system;

--- a/be/src/vec/exec/format/orc/vorc_reader.cpp
+++ b/be/src/vec/exec/format/orc/vorc_reader.cpp
@@ -85,6 +85,7 @@ OrcReader::OrcReader(RuntimeProfile* profile, const TFileScanRangeParams& params
     TimezoneUtils::find_cctz_time_zone(ctz, _time_zone);
     _init_profile();
     _init_system_properties();
+    _init_file_description();
 }
 
 OrcReader::OrcReader(const TFileScanRangeParams& params, const TFileRangeDesc& range,
@@ -99,6 +100,7 @@ OrcReader::OrcReader(const TFileScanRangeParams& params, const TFileRangeDesc& r
           _file_system(nullptr),
           _io_ctx(io_ctx) {
     _init_system_properties();
+    _init_file_description();
 }
 
 OrcReader::~OrcReader() {
@@ -146,13 +148,8 @@ Status OrcReader::init_reader(
     if (_file_reader == nullptr) {
         io::FileReaderSPtr inner_reader;
 
-        FileDescription file_description;
-        file_description.path = _scan_range.path;
-        file_description.start_offset = _scan_range.start_offset;
-        file_description.file_size = _scan_range.__isset.file_size ? _scan_range.file_size : 0;
-
         RETURN_IF_ERROR(FileFactory::create_file_reader(_profile, _system_properties,
-                                                        file_description, &_file_system,
+                                                        _file_description, &_file_system,
                                                         &inner_reader, _io_ctx));
 
         _file_reader = new ORCFileInputStream(_scan_range.path, inner_reader);
@@ -208,13 +205,8 @@ Status OrcReader::get_parsed_schema(std::vector<std::string>* col_names,
     if (_file_reader == nullptr) {
         io::FileReaderSPtr inner_reader;
 
-        FileDescription file_description;
-        file_description.path = _scan_range.path;
-        file_description.start_offset = _scan_range.start_offset;
-        file_description.file_size = _scan_range.__isset.file_size ? _scan_range.file_size : 0;
-
         RETURN_IF_ERROR(FileFactory::create_file_reader(_profile, _system_properties,
-                                                        file_description, &_file_system,
+                                                        _file_description, &_file_system,
                                                         &inner_reader, _io_ctx));
 
         _file_reader = new ORCFileInputStream(_scan_range.path, inner_reader);
@@ -566,6 +558,12 @@ void OrcReader::_init_system_properties() {
         _system_properties.broker_addresses.assign(_scan_params.broker_addresses.begin(),
                                                    _scan_params.broker_addresses.end());
     }
+}
+
+void OrcReader::_init_file_description() {
+    _file_description.path = _scan_range.path;
+    _file_description.start_offset = _scan_range.start_offset;
+    _file_description.file_size = _scan_range.__isset.file_size ? _scan_range.file_size : 0;
 }
 
 TypeDescriptor OrcReader::_convert_to_doris_type(const orc::Type* orc_type) {

--- a/be/src/vec/exec/format/orc/vorc_reader.cpp
+++ b/be/src/vec/exec/format/orc/vorc_reader.cpp
@@ -22,7 +22,6 @@
 #include "cctz/civil_time.h"
 #include "cctz/time_zone.h"
 #include "gutil/strings/substitute.h"
-#include "io/file_factory.h"
 #include "io/fs/file_reader.h"
 #include "olap/iterators.h"
 #include "util/slice.h"
@@ -85,6 +84,7 @@ OrcReader::OrcReader(RuntimeProfile* profile, const TFileScanRangeParams& params
           _io_ctx(io_ctx) {
     TimezoneUtils::find_cctz_time_zone(ctz, _time_zone);
     _init_profile();
+    _init_system_properties();
 }
 
 OrcReader::OrcReader(const TFileScanRangeParams& params, const TFileRangeDesc& range,
@@ -97,7 +97,9 @@ OrcReader::OrcReader(const TFileScanRangeParams& params, const TFileRangeDesc& r
           _column_names(column_names),
           _is_hive(params.__isset.slot_name_to_schema_pos),
           _file_system(nullptr),
-          _io_ctx(io_ctx) {}
+          _io_ctx(io_ctx) {
+    _init_system_properties();
+}
 
 OrcReader::~OrcReader() {
     close();
@@ -144,21 +146,12 @@ Status OrcReader::init_reader(
     if (_file_reader == nullptr) {
         io::FileReaderSPtr inner_reader;
 
-        FileSystemProperties system_properties;
-        system_properties.system_type = _scan_params.file_type;
-        system_properties.properties = _scan_params.properties;
-        system_properties.hdfs_params = _scan_params.hdfs_params;
-        if (_scan_params.__isset.broker_addresses) {
-            system_properties.broker_addresses.assign(_scan_params.broker_addresses.begin(),
-                                                      _scan_params.broker_addresses.end());
-        }
-
         FileDescription file_description;
         file_description.path = _scan_range.path;
         file_description.start_offset = _scan_range.start_offset;
         file_description.file_size = _scan_range.__isset.file_size ? _scan_range.file_size : 0;
 
-        RETURN_IF_ERROR(FileFactory::create_file_reader(_profile, system_properties,
+        RETURN_IF_ERROR(FileFactory::create_file_reader(_profile, _system_properties,
                                                         file_description, &_file_system,
                                                         &inner_reader, _io_ctx));
 
@@ -215,17 +208,12 @@ Status OrcReader::get_parsed_schema(std::vector<std::string>* col_names,
     if (_file_reader == nullptr) {
         io::FileReaderSPtr inner_reader;
 
-        FileSystemProperties system_properties;
-        system_properties.system_type = _scan_params.file_type;
-        system_properties.properties = _scan_params.properties;
-        system_properties.hdfs_params = _scan_params.hdfs_params;
-
         FileDescription file_description;
         file_description.path = _scan_range.path;
         file_description.start_offset = _scan_range.start_offset;
         file_description.file_size = _scan_range.__isset.file_size ? _scan_range.file_size : 0;
 
-        RETURN_IF_ERROR(FileFactory::create_file_reader(_profile, system_properties,
+        RETURN_IF_ERROR(FileFactory::create_file_reader(_profile, _system_properties,
                                                         file_description, &_file_system,
                                                         &inner_reader, _io_ctx));
 
@@ -568,6 +556,16 @@ void OrcReader::_init_bloom_filter(
         std::unordered_map<std::string, ColumnValueRangeType>* colname_to_value_range) {
     // generate bloom filter
     // _reader->getBloomFilters()
+}
+
+void OrcReader::_init_system_properties() {
+    _system_properties.system_type = _scan_params.file_type;
+    _system_properties.properties = _scan_params.properties;
+    _system_properties.hdfs_params = _scan_params.hdfs_params;
+    if (_scan_params.__isset.broker_addresses) {
+        _system_properties.broker_addresses.assign(_scan_params.broker_addresses.begin(),
+                                                   _scan_params.broker_addresses.end());
+    }
 }
 
 TypeDescriptor OrcReader::_convert_to_doris_type(const orc::Type* orc_type) {

--- a/be/src/vec/exec/format/orc/vorc_reader.h
+++ b/be/src/vec/exec/format/orc/vorc_reader.h
@@ -21,6 +21,7 @@
 
 #include "common/config.h"
 #include "exec/olap_common.h"
+#include "io/file_factory.h"
 #include "io/fs/file_reader.h"
 #include "vec/core/block.h"
 #include "vec/data_types/data_type_decimal.h"
@@ -116,6 +117,7 @@ private:
             std::unordered_map<std::string, ColumnValueRangeType>* colname_to_value_range);
     void _init_bloom_filter(
             std::unordered_map<std::string, ColumnValueRangeType>* colname_to_value_range);
+    void _init_system_properties();
     Status _orc_column_to_doris_column(const std::string& col_name, const ColumnPtr& doris_column,
                                        const DataTypePtr& data_type,
                                        const orc::Type* orc_column_type,
@@ -259,6 +261,7 @@ private:
     RuntimeProfile* _profile;
     const TFileScanRangeParams& _scan_params;
     const TFileRangeDesc& _scan_range;
+    FileSystemProperties _system_properties;
     size_t _batch_size;
     int64_t _range_start_offset;
     int64_t _range_size;

--- a/be/src/vec/exec/format/orc/vorc_reader.h
+++ b/be/src/vec/exec/format/orc/vorc_reader.h
@@ -118,6 +118,7 @@ private:
     void _init_bloom_filter(
             std::unordered_map<std::string, ColumnValueRangeType>* colname_to_value_range);
     void _init_system_properties();
+    void _init_file_description();
     Status _orc_column_to_doris_column(const std::string& col_name, const ColumnPtr& doris_column,
                                        const DataTypePtr& data_type,
                                        const orc::Type* orc_column_type,
@@ -262,6 +263,7 @@ private:
     const TFileScanRangeParams& _scan_params;
     const TFileRangeDesc& _scan_range;
     FileSystemProperties _system_properties;
+    FileDescription _file_description;
     size_t _batch_size;
     int64_t _range_start_offset;
     int64_t _range_size;

--- a/be/src/vec/exec/format/parquet/vparquet_reader.h
+++ b/be/src/vec/exec/format/parquet/vparquet_reader.h
@@ -26,6 +26,7 @@
 #include "common/status.h"
 #include "exec/olap_common.h"
 #include "gen_cpp/parquet_types.h"
+#include "io/file_factory.h"
 #include "io/fs/file_reader.h"
 #include "io/fs/file_system.h"
 #include "vec/core/block.h"
@@ -141,6 +142,8 @@ private:
             const RowGroupReader::RowGroupIndex& row_group_index);
     Status _init_read_columns();
     Status _init_row_groups(const bool& is_filter_groups);
+    void _init_system_properties();
+    void _init_file_description();
     // Page Index Filter
     bool _has_page_index(const std::vector<tparquet::ColumnChunk>& columns, PageIndex& page_index);
     Status _process_page_index(const tparquet::RowGroup& row_group,
@@ -160,6 +163,8 @@ private:
     RuntimeProfile* _profile;
     const TFileScanRangeParams& _scan_params;
     const TFileRangeDesc& _scan_range;
+    FileSystemProperties _system_properties;
+    FileDescription _file_description;
     std::shared_ptr<io::FileSystem> _file_system = nullptr;
     io::FileReaderSPtr _file_reader = nullptr;
     std::shared_ptr<FileMetaData> _file_metadata;


### PR DESCRIPTION
# Proposed changes

Issue Number: close #17033

## Problem summary

A const reference member variables as class member stores a temporary object, which cannot be got after the temporary object being destroyed, cause be core dump while enable debug level log

_broker_addr has been destroyed in BrokerFileReader

```
(gdb) bt
#0  0x00007f121b2123e8 in uw_frame_state_for ()
#1  0x00007f121b21351c in _Unwind_Backtrace ()
#2  0x00007f120fec4100 in boost::stacktrace::detail::this_thread_frames::collect (out_frames=0x7f108f7c7f60, max_frames_count=128, skip=2)
    at /home/disk2/doris/thirdparty/installed/include/boost/stacktrace/detail/collect_unwind.ipp:90
#3  0x00007f120fecdc76 in boost::stacktrace::basic_stacktrace<std::allocator<boost::stacktrace::frame> >::init (this=0x7f108f7c83c0, frames_to_skip=0, max_depth=18446744073709551615)
    at /home/disk2/doris/thirdparty/installed/include/boost/stacktrace/stacktrace.hpp:75
#4  0x00007f120febac4c in boost::stacktrace::basic_stacktrace<std::allocator<boost::stacktrace::frame> >::basic_stacktrace (this=<optimized out>)
    at /home/disk2/doris/thirdparty/installed/include/boost/stacktrace/stacktrace.hpp:126
#5  doris::signal::(anonymous namespace)::FailureSignalHandler (signal_number=11, signal_info=0x7f108f7c87b0, ucontext=0x7f108f7c8680)
    at /home/disk2/doris/be/src/common/signal_handler.h:428
#6  0x00007f11fe6a8ca7 in ?? () from /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.275.b01-0.el6_10.x86_64/jre/lib/amd64/server/libjvm.so
#7  0x00007f11fe6b01f5 in JVM_handle_linux_signal () from /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.275.b01-0.el6_10.x86_64/jre/lib/amd64/server/libjvm.so
#8  0x00007f11fe6a5363 in ?? () from /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.275.b01-0.el6_10.x86_64/jre/lib/amd64/server/libjvm.so
#9  <signal handler called>
#10 0x0000000900003161 in ?? ()
#11 0x00007f121113a292 in doris::operator<< (out=..., obj=...) at /home/disk2/doris/gensrc/build/gen_cpp/Types_types.cpp:1890
#12 0x00007f1211fff7ee in doris::io::BrokerFileReader::read_at (this=0x7f104360eb20, offset=3845195, result=..., bytes_read=0x7f108f7c96b8)
    at /home/disk2/doris/be/src/io/fs/broker_file_reader.cpp:98

(gdb) f 12
#12 0x00007f9e7bf2f48a in doris::io::BrokerFileReader::read_at (this=0x7f9e4e015fd0, offset=3845195, result=..., bytes_read=0x7f9cdc9f5608)
    at /home/disk2/doris/be/src/io/fs/broker_file_reader.cpp:98
98	        VLOG_RPC << "send pread request to broker:" << _broker_addr << " position:" << offset
(gdb) l 98
93	    request.__set_offset(offset);
94	    request.__set_length(bytes_req);
95
96	    TBrokerReadResponse response;
97	    try {
98	        VLOG_RPC << "send pread request to broker:" << _broker_addr << " position:" << offset
99	                 << ", read bytes length:" << bytes_req;
100	        try {
101	            (*_client)->pread(response, request);
102	        } catch (apache::thrift::transport::TTransportException& e) {
(gdb) p _broker_addr
$6 = (const doris::TNetworkAddress &) @0x7f9e4e0120c0: {<apache::thrift::TBase> = <invalid address>, hostname = {static npos = 18446744073709551615,
    _M_dataplus = {<std::allocator<char>> = {<__gnu_cxx::new_allocator<char>> = {<No data fields>}, <No data fields>}, _M_p = 0x7f9e4e01f5e0 "\300 \001N\236\177"},
    _M_string_length = 140317890257120, {_M_local_buf = "\002\000\000\000\000\000\000\000k1\000\000\000\000\000", _M_allocated_capacity = 2}}, port = 8086}
(gdb) p offset
$7 = 3845195
(gdb) p bytes_req
$8 = 342
```
## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

