### PR TITLE
[fix](alter inverted index) fix incorrect CreateTime of 'show alter' query result after fe restart

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
@@ -2456,34 +2456,6 @@ public class SchemaChangeHandler extends AlterHandler {
             throw new DdlException("Nothing is changed. please check your alter stmt.");
         }
 
-        long timeoutSecond = PropertyAnalyzer.analyzeTimeout(propertyMap, Config.alter_table_timeout_second);
-
-        // after modify tablet meta, we will create a WAITING_TXN state schema change job v2
-        // to handle alter inverted index task
-        SchemaChangeJobV2 schemaChangeJob = new SchemaChangeJobV2(
-                jobId, db.getId(), olapTable.getId(),
-                olapTable.getName(), timeoutSecond * 1000);
-        schemaChangeJob.setAlterInvertedIndexInfo(hasInvertedIndexChange, isDropInvertedIndex, alterInvertedIndexes);
-        schemaChangeJob.setOriIndexInfo(oriIndexes);
-        // only V2 support index, so if there is index changed, storage format must be V2
-        schemaChangeJob.setStorageFormat(TStorageFormat.V2);
-
-        for (Map.Entry<Long, List<Column>> entry : changedIndexIdToSchema.entrySet()) {
-            long originIndexId = entry.getKey();
-            for (Partition partition : olapTable.getPartitions()) {
-                long partitionId = partition.getId();
-                schemaChangeJob.addPartitionOriginIndexIdMap(partitionId, originIndexId);
-            } // end for partition
-            String newIndexName = SHADOW_NAME_PREFIX + olapTable.getIndexNameById(originIndexId);
-            MaterializedIndexMeta currentIndexMeta = olapTable.getIndexMetaByIndexId(originIndexId);
-            // 1. get new schema version/schema version hash, short key column count
-            int currentSchemaVersion = currentIndexMeta.getSchemaVersion();
-            int newSchemaVersion = currentSchemaVersion + 1;
-            schemaChangeJob.addIndexSchema(originIndexId, originIndexId, newIndexName, newSchemaVersion,
-                    currentIndexMeta.getSchemaHash(),
-                    currentIndexMeta.getShortKeyColumnCount(), entry.getValue());
-        } // end for index
-
         //update base index schema
         updateBaseIndexSchema(olapTable, indexSchemaMap, indexes);
 
@@ -2493,12 +2465,43 @@ public class SchemaChangeHandler extends AlterHandler {
                     alterInvertedIndexes, isDropInvertedIndex, oriIndexes, jobId);
             LOG.debug("logModifyTableAddOrDropInvertedIndices info:{}", info);
             Env.getCurrentEnv().getEditLog().logModifyTableAddOrDropInvertedIndices(info);
+
+            // after modify tablet meta, we will create a WAITING_TXN state schema change job v2
+            // to handle alter inverted index task
+            long timeoutSecond = PropertyAnalyzer.analyzeTimeout(propertyMap, Config.alter_table_timeout_second);
+            SchemaChangeJobV2 schemaChangeJob = new SchemaChangeJobV2(
+                    jobId, db.getId(), olapTable.getId(),
+                    olapTable.getName(), timeoutSecond * 1000);
+            schemaChangeJob.setAlterInvertedIndexInfo(hasInvertedIndexChange,
+                            isDropInvertedIndex, alterInvertedIndexes);
+            schemaChangeJob.setOriIndexInfo(oriIndexes);
+            // only V2 support index, so if there is index changed, storage format must be V2
+            schemaChangeJob.setStorageFormat(TStorageFormat.V2);
+
+            for (Map.Entry<Long, List<Column>> entry : changedIndexIdToSchema.entrySet()) {
+                long originIndexId = entry.getKey();
+                for (Partition partition : olapTable.getPartitions()) {
+                    long partitionId = partition.getId();
+                    schemaChangeJob.addPartitionOriginIndexIdMap(partitionId, originIndexId);
+                } // end for partition
+                String newIndexName = SHADOW_NAME_PREFIX + olapTable.getIndexNameById(originIndexId);
+                MaterializedIndexMeta currentIndexMeta = olapTable.getIndexMetaByIndexId(originIndexId);
+                // 1. get new schema version/schema version hash, short key column count
+                int currentSchemaVersion = currentIndexMeta.getSchemaVersion();
+                int newSchemaVersion = currentSchemaVersion + 1;
+                schemaChangeJob.addIndexSchema(originIndexId, originIndexId, newIndexName, newSchemaVersion,
+                        currentIndexMeta.getSchemaHash(),
+                        currentIndexMeta.getShortKeyColumnCount(), entry.getValue());
+            } // end for index
+
+            // set Job state then add job
+            schemaChangeJob.setJobState(AlterJobV2.JobState.WAITING_TXN);
+            this.addAlterJobV2(schemaChangeJob);
+            LOG.debug("logAlterJob schemaChangeJob:{}", schemaChangeJob);
+            Env.getCurrentEnv().getEditLog().logAlterJob(schemaChangeJob);
         }
-        // set Job state then add job
-        schemaChangeJob.setJobState(AlterJobV2.JobState.WAITING_TXN);
-        this.addAlterJobV2(schemaChangeJob);
-        LOG.info("finished modify table's meta for add or drop inverted index. table: {}, is replay: {}",
-                 olapTable.getName(), isReplay);
+        LOG.info("finished modify table's meta for add or drop inverted index. table: {}, job: {}, is replay: {}",
+                 olapTable.getName(), jobId, isReplay);
     }
 
     public void replaymodifyTableAddOrDropInvertedIndices(

--- a/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeJobV2.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeJobV2.java
@@ -927,7 +927,7 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
         }
         jobState = JobState.FINISHED;
         this.finishedTimeMs = replayedJob.finishedTimeMs;
-        LOG.info("replay finished schema change job: {}", jobId);
+        LOG.info("replay finished schema change job: {} table id: {}", jobId, tableId);
     }
 
     /**


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

For add or drop inverted index, when replay the logModifyTableAddOrDropInvertedIndices will new a schema change job, that has a new CreateTime, here should new a schema change job when not replay log.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

