### PR TITLE
[vectorized](bug) fix open fold constant cause be core dump

### DIFF
--- a/be/src/runtime/fold_constant_executor.h
+++ b/be/src/runtime/fold_constant_executor.h
@@ -25,6 +25,7 @@
 #include "runtime/exec_env.h"
 #include "runtime/runtime_state.h"
 #include "util/runtime_profile.h"
+#include "vec/data_types/data_type.h"
 
 namespace doris {
 
@@ -46,7 +47,9 @@ private:
     Status _prepare_and_open(Context* ctx);
 
     template <bool is_vec = false>
-    std::string _get_result(void* src, size_t size, PrimitiveType slot_type);
+    std::string _get_result(void* src, size_t size, const TypeDescriptor& type,
+                            const vectorized::ColumnPtr column_ptr,
+                            const vectorized::DataTypePtr column_type);
 
     std::unique_ptr<RuntimeState> _runtime_state;
     std::unique_ptr<MemTracker> _mem_tracker;

--- a/be/src/vec/functions/function_java_udf.cpp
+++ b/be/src/vec/functions/function_java_udf.cpp
@@ -312,8 +312,8 @@ Status JavaFunctionCall::close(FunctionContext* context,
     // JNIContext own some resource and its release method depend on JavaFunctionCall
     // has to release the resource before JavaFunctionCall is deconstructed.
     if (jni_ctx) {
-         jni_ctx->close();
-     }
+        jni_ctx->close();
+    }
     return Status::OK();
 }
 } // namespace doris::vectorized

--- a/be/src/vec/functions/function_java_udf.cpp
+++ b/be/src/vec/functions/function_java_udf.cpp
@@ -311,7 +311,9 @@ Status JavaFunctionCall::close(FunctionContext* context,
             context->get_function_state(FunctionContext::THREAD_LOCAL));
     // JNIContext own some resource and its release method depend on JavaFunctionCall
     // has to release the resource before JavaFunctionCall is deconstructed.
-    jni_ctx->close();
+    if (jni_ctx) {
+         jni_ctx->close();
+     }
     return Status::OK();
 }
 } // namespace doris::vectorized

--- a/be/src/vec/functions/in.h
+++ b/be/src/vec/functions/in.h
@@ -156,7 +156,6 @@ public:
                 }
 
             } else { // non-nullable
-                DCHECK(!in_state->null_in_set);
 
                 auto search_hash_set = [&](auto* col_ptr) {
                     for (size_t i = 0; i < input_rows_count; ++i) {
@@ -176,6 +175,12 @@ public:
                     search_hash_set(column_string_ptr);
                 } else {
                     search_hash_set(materialized_column.get());
+                }
+
+                if (in_state->null_in_set) {
+                    for (size_t i = 0; i < input_rows_count; ++i) {
+                        vec_null_map_to[i] = negative == vec_res[i];
+                    }
                 }
             }
         } else {


### PR DESCRIPTION
# Proposed changes

1.  add a defer in fold constant to close.
2. add more type when call _get_result function in fold constant.3. 
3. fix in can't handle null. eg:select 1 in (2, NULL, 1);
4. in java udf jni_ctx will be nullptr, so call close will be core dump. 

Describe your changes.

- ## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

