### PR TITLE
[Bug](pipeline) fix not close when pipeline context prepare failed

### DIFF
--- a/be/src/pipeline/pipeline_fragment_context.cpp
+++ b/be/src/pipeline/pipeline_fragment_context.cpp
@@ -780,6 +780,9 @@ Status PipelineFragmentContext::submit() {
 }
 
 void PipelineFragmentContext::close_if_prepare_failed() {
+    if (_tasks.empty()) {
+        _root_plan->close(_runtime_state.get());
+    }
     for (auto& task : _tasks) {
         DCHECK(!task->is_pending_finish());
         WARN_IF_ERROR(task->close(), "close_if_prepare_failed failed: ");


### PR DESCRIPTION
# Proposed changes

fix not close when pipeline context prepare failed.
<img width="875" alt="图片" src="https://user-images.githubusercontent.com/7939630/220817043-8d586bac-c30a-420c-a9ca-5e5ff9d5de29.png">


## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

