### PR TITLE
[Fix](inverted index) fix memory leak when DorisCompoundReader strdup  file name

### DIFF
--- a/be/src/olap/rowset/segment_v2/inverted_index_compound_reader.cpp
+++ b/be/src/olap/rowset/segment_v2/inverted_index_compound_reader.cpp
@@ -108,9 +108,9 @@ DorisCompoundReader::DorisCompoundReader(lucene::store::Directory* d, const char
         : readBufferSize(read_buffer_size),
           dir(d),
           ram_dir(new lucene::store::RAMDirectory()),
+          file_name(name),
           stream(nullptr),
           entries(_CLNEW EntriesType(true, true)) {
-    file_name = strdup(name);
     bool success = false;
     try {
         stream = dir->openInput(name, readBufferSize);


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

1. strdup(const char*) will copy a temporary char array.
2. std::string's copy construct will copy the temporary char array to std::string buffer.
3. finally the temporary char array will leak.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

