### PR TITLE
[chore](tools) Fix NoSuchMethodError while loading data by http requests

### DIFF
--- a/tools/single-node-cluster/multi-fe
+++ b/tools/single-node-cluster/multi-fe
@@ -198,8 +198,10 @@ function start_fe() {
 
 	prepare "${port}" "${doris_home}" "${log_dir}"
 
-	local classpath
-	read -r -a classpath <<<"$(find "${libs_path}" -exec echo {} \+)"
+	declare -a classpath=("${libs_path}")
+	for lib in "${libs_path}"/*.jar; do
+		classpath+=("${lib}")
+	done
 
 	if [[ "${id}" -gt 1 ]]; then
 		helper="-helper 127.0.0.1:$((PORT + 1))"


### PR DESCRIPTION
# Proposed changes

Place netty-all library before other libraries in `classpath`.

## Problem summary

When we used the tool `multi-fe` to start multiple FEs cluster and loaded data by stream load way, the request failed. See the following log.

The issue was caused by the netty libraries. There are multiple netty libraries in classpath and the FE used the newer version netty library which made these errors. 

```shell
2023-02-23 17:36:26,790 DEBUG (qtp1394338834-241|241) [RestApiExceptionHandler.unexpectedExceptionHandler():61] unexpected exception
org.springframework.web.util.NestedServletException: Handler dispatch failed; nested exception is java.lang.NoSuchMethodError: io.netty.util.internal.ReferenceCountUpdater.setInitialValue(Lio/netty/util/ReferenceCounted;)V
        at org.springframework.web.servlet.DispatcherServlet.doDispatch(DispatcherServlet.java:1086) ~[spring-webmvc-5.3.25.jar:5.3.25]
        at org.springframework.web.servlet.DispatcherServlet.doService(DispatcherServlet.java:964) ~[spring-webmvc-5.3.25.jar:5.3.25]
        at org.springframework.web.servlet.FrameworkServlet.processRequest(FrameworkServlet.java:1006) ~[spring-webmvc-5.3.25.jar:5.3.25]
        at org.springframework.web.servlet.FrameworkServlet.doPut(FrameworkServlet.java:920) ~[spring-webmvc-5.3.25.jar:5.3.25]
        at javax.servlet.http.HttpServlet.service(HttpServlet.java:710) ~[javax.servlet-api-3.1.0.jar:3.1.0]
        at org.springframework.web.servlet.FrameworkServlet.service(FrameworkServlet.java:883) ~[spring-webmvc-5.3.25.jar:5.3.25]
        at javax.servlet.http.HttpServlet.service(HttpServlet.java:790) ~[javax.servlet-api-3.1.0.jar:3.1.0]
        at org.eclipse.jetty.servlet.ServletHolder.handle(ServletHolder.java:799) ~[jetty-servlet-9.4.50.v20221201.jar:9.4.50.v20221201]
        at org.eclipse.jetty.servlet.ServletHandler$ChainEnd.doFilter(ServletHandler.java:1656) ~[jetty-servlet-9.4.50.v20221201.jar:9.4.50.v20221201]
        at org.eclipse.jetty.websocket.server.WebSocketUpgradeFilter.doFilter(WebSocketUpgradeFilter.java:292) ~[websocket-server-9.4.50.v20221201.jar:9.4.50.v20221201]
        at org.eclipse.jetty.servlet.FilterHolder.doFilter(FilterHolder.java:193) ~[jetty-servlet-9.4.50.v20221201.jar:9.4.50.v20221201]
        at org.eclipse.jetty.servlet.ServletHandler$Chain.doFilter(ServletHandler.java:1626) ~[jetty-servlet-9.4.50.v20221201.jar:9.4.50.v20221201]
        at org.apache.doris.httpv2.interceptor.ServletTraceIterceptor.doFilter(ServletTraceIterceptor.java:55) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.eclipse.jetty.servlet.FilterHolder.doFilter(FilterHolder.java:201) ~[jetty-servlet-9.4.50.v20221201.jar:9.4.50.v20221201]
        at org.eclipse.jetty.servlet.ServletHandler$Chain.doFilter(ServletHandler.java:1626) ~[jetty-servlet-9.4.50.v20221201.jar:9.4.50.v20221201]
        at org.springframework.web.filter.RequestContextFilter.doFilterInternal(RequestContextFilter.java:100) ~[spring-web-5.3.25.jar:5.3.25]
        at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:117) ~[spring-web-5.3.25.jar:5.3.25]
        at org.eclipse.jetty.servlet.FilterHolder.doFilter(FilterHolder.java:193) ~[jetty-servlet-9.4.50.v20221201.jar:9.4.50.v20221201]
        at org.eclipse.jetty.servlet.ServletHandler$Chain.doFilter(ServletHandler.java:1626) ~[jetty-servlet-9.4.50.v20221201.jar:9.4.50.v20221201]
        at org.springframework.web.filter.FormContentFilter.doFilterInternal(FormContentFilter.java:93) ~[spring-web-5.3.25.jar:5.3.25]
        at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:117) ~[spring-web-5.3.25.jar:5.3.25]
        at org.eclipse.jetty.servlet.FilterHolder.doFilter(FilterHolder.java:193) ~[jetty-servlet-9.4.50.v20221201.jar:9.4.50.v20221201]
        at org.eclipse.jetty.servlet.ServletHandler$Chain.doFilter(ServletHandler.java:1626) ~[jetty-servlet-9.4.50.v20221201.jar:9.4.50.v20221201]
        at org.springframework.web.filter.CharacterEncodingFilter.doFilterInternal(CharacterEncodingFilter.java:201) ~[spring-web-5.3.25.jar:5.3.25]
        at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:117) ~[spring-web-5.3.25.jar:5.3.25]
        at org.eclipse.jetty.servlet.FilterHolder.doFilter(FilterHolder.java:193) ~[jetty-servlet-9.4.50.v20221201.jar:9.4.50.v20221201]
        at org.eclipse.jetty.servlet.ServletHandler$Chain.doFilter(ServletHandler.java:1626) ~[jetty-servlet-9.4.50.v20221201.jar:9.4.50.v20221201]
        at org.eclipse.jetty.servlet.ServletHandler.doHandle(ServletHandler.java:552) ~[jetty-servlet-9.4.50.v20221201.jar:9.4.50.v20221201]
        at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:143) ~[jetty-server-9.4.50.v20221201.jar:9.4.50.v20221201]
        at org.eclipse.jetty.security.SecurityHandler.handle(SecurityHandler.java:600) ~[jetty-security-9.4.50.v20221201.jar:9.4.50.v20221201]
        at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:127) ~[jetty-server-9.4.50.v20221201.jar:9.4.50.v20221201]
        at org.eclipse.jetty.server.handler.ScopedHandler.nextHandle(ScopedHandler.java:235) ~[jetty-server-9.4.50.v20221201.jar:9.4.50.v20221201]
        at org.eclipse.jetty.server.session.SessionHandler.doHandle(SessionHandler.java:1624) ~[jetty-server-9.4.50.v20221201.jar:9.4.50.v20221201]
        at org.eclipse.jetty.server.handler.ScopedHandler.nextHandle(ScopedHandler.java:233) ~[jetty-server-9.4.50.v20221201.jar:9.4.50.v20221201]
        at org.eclipse.jetty.server.handler.ContextHandler.doHandle(ContextHandler.java:1440) ~[jetty-server-9.4.50.v20221201.jar:9.4.50.v20221201]
        at org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:188) ~[jetty-server-9.4.50.v20221201.jar:9.4.50.v20221201]
        at org.eclipse.jetty.servlet.ServletHandler.doScope(ServletHandler.java:505) ~[jetty-servlet-9.4.50.v20221201.jar:9.4.50.v20221201]
        at org.eclipse.jetty.server.session.SessionHandler.doScope(SessionHandler.java:1594) ~[jetty-server-9.4.50.v20221201.jar:9.4.50.v20221201]
        at org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:186) ~[jetty-server-9.4.50.v20221201.jar:9.4.50.v20221201]
        at org.eclipse.jetty.server.handler.ContextHandler.doScope(ContextHandler.java:1355) ~[jetty-server-9.4.50.v20221201.jar:9.4.50.v20221201]
        at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:141) ~[jetty-server-9.4.50.v20221201.jar:9.4.50.v20221201]
        at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:127) ~[jetty-server-9.4.50.v20221201.jar:9.4.50.v20221201]
        at org.eclipse.jetty.server.Server.handle(Server.java:516) ~[jetty-server-9.4.50.v20221201.jar:9.4.50.v20221201]
        at org.eclipse.jetty.server.HttpChannel.lambda$handle$1(HttpChannel.java:487) ~[jetty-server-9.4.50.v20221201.jar:9.4.50.v20221201]
        at org.eclipse.jetty.server.HttpChannel.dispatch(HttpChannel.java:732) ~[jetty-server-9.4.50.v20221201.jar:9.4.50.v20221201]
        at org.eclipse.jetty.server.HttpChannel.handle(HttpChannel.java:479) ~[jetty-server-9.4.50.v20221201.jar:9.4.50.v20221201]
        at org.eclipse.jetty.server.HttpConnection.onFillable(HttpConnection.java:277) ~[jetty-server-9.4.50.v20221201.jar:9.4.50.v20221201]
        at org.eclipse.jetty.io.AbstractConnection$ReadCallback.succeeded(AbstractConnection.java:311) ~[jetty-io-9.4.50.v20221201.jar:9.4.50.v20221201]
        at org.eclipse.jetty.io.FillInterest.fillable(FillInterest.java:105) ~[jetty-io-9.4.50.v20221201.jar:9.4.50.v20221201]
        at org.eclipse.jetty.io.ChannelEndPoint$1.run(ChannelEndPoint.java:104) ~[jetty-io-9.4.50.v20221201.jar:9.4.50.v20221201]
        at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.runTask(EatWhatYouKill.java:338) ~[jetty-util-9.4.50.v20221201.jar:9.4.50.v20221201]
        at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.doProduce(EatWhatYouKill.java:315) ~[jetty-util-9.4.50.v20221201.jar:9.4.50.v20221201]
        at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.tryProduce(EatWhatYouKill.java:173) ~[jetty-util-9.4.50.v20221201.jar:9.4.50.v20221201]
        at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.run(EatWhatYouKill.java:131) ~[jetty-util-9.4.50.v20221201.jar:9.4.50.v20221201]
        at org.eclipse.jetty.util.thread.ReservedThreadExecutor$ReservedThread.run(ReservedThreadExecutor.java:409) ~[jetty-util-9.4.50.v20221201.jar:9.4.50.v20221201]
        at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:883) ~[jetty-util-9.4.50.v20221201.jar:9.4.50.v20221201]
        at org.eclipse.jetty.util.thread.QueuedThreadPool$Runner.run(QueuedThreadPool.java:1034) ~[jetty-util-9.4.50.v20221201.jar:9.4.50.v20221201]
        at java.lang.Thread.run(Thread.java:834) ~[?:?]
Caused by: java.lang.NoSuchMethodError: io.netty.util.internal.ReferenceCountUpdater.setInitialValue(Lio/netty/util/ReferenceCounted;)V
        at io.netty.buffer.AbstractReferenceCountedByteBuf.<init>(AbstractReferenceCountedByteBuf.java:50) ~[netty-buffer-4.1.87.Final.jar:4.1.87.Final]
        at io.netty.buffer.UnpooledHeapByteBuf.<init>(UnpooledHeapByteBuf.java:70) ~[netty-buffer-4.1.87.Final.jar:4.1.87.Final]
        at io.netty.buffer.Unpooled.wrappedBuffer(Unpooled.java:160) ~[netty-buffer-4.1.87.Final.jar:4.1.87.Final]
        at io.netty.buffer.Unpooled.copiedBuffer(Unpooled.java:400) ~[netty-buffer-4.1.87.Final.jar:4.1.87.Final]
        at org.apache.doris.httpv2.controller.BaseController.parseAuthInfo(BaseController.java:255) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.httpv2.controller.BaseController.getAuthorizationInfo(BaseController.java:233) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.httpv2.rest.RestBaseController.executeCheckPassword(RestBaseController.java:56) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.httpv2.rest.LoadAction.streamLoad(LoadAction.java:76) ~[doris-fe.jar:1.2-SNAPSHOT]
        at jdk.internal.reflect.GeneratedMethodAccessor7.invoke(Unknown Source) ~[?:?]
        at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:?]
        at java.lang.reflect.Method.invoke(Method.java:566) ~[?:?]
        at org.springframework.web.method.support.InvocableHandlerMethod.doInvoke(InvocableHandlerMethod.java:205) ~[spring-web-5.3.25.jar:5.3.25]
        at org.springframework.web.method.support.InvocableHandlerMethod.invokeForRequest(InvocableHandlerMethod.java:150) ~[spring-web-5.3.25.jar:5.3.25]
        at org.springframework.web.servlet.mvc.method.annotation.ServletInvocableHandlerMethod.invokeAndHandle(ServletInvocableHandlerMethod.java:117) ~[spring-webmvc-5.3.25.jar:5.3.25]
        at org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter.invokeHandlerMethod(RequestMappingHandlerAdapter.java:895) ~[spring-webmvc-5.3.25.jar:5.3.25]
        at org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter.handleInternal(RequestMappingHandlerAdapter.java:808) ~[spring-webmvc-5.3.25.jar:5.3.25]
        at org.springframework.web.servlet.mvc.method.AbstractHandlerMethodAdapter.handle(AbstractHandlerMethodAdapter.java:87) ~[spring-webmvc-5.3.25.jar:5.3.25]
        at org.springframework.web.servlet.DispatcherServlet.doDispatch(DispatcherServlet.java:1071) ~[spring-webmvc-5.3.25.jar:5.3.25]
        ... 57 more

```

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

