### PR TITLE
[fix](agg) coredump caused by grouping by null

### DIFF
--- a/be/src/vec/exec/vaggregation_node.h
+++ b/be/src/vec/exec/vaggregation_node.h
@@ -949,6 +949,7 @@ private:
         for (size_t i = 0; i < key_size; ++i) {
             int result_column_id = -1;
             RETURN_IF_ERROR(_probe_expr_ctxs[i]->execute(block, &result_column_id));
+            block->replace_by_position_if_const(result_column_id);
             key_columns[i] = block->get_by_position(result_column_id).column.get();
         }
 


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

`VLiteral::execute` will get a `ColumnConst` with `ColumnNullable` in it, this `ColumnConst` should be converted to `ColumnNullable`.

```bash
#0  0x00007f4f5693f37f in raise () from /lib64/libc.so.6
#1  0x00007f4f56929db5 in abort () from /lib64/libc.so.6
#2  0x000055a3a877cb19 in ?? ()
#3  0x000055a3a877312d in google::LogMessage::SendToLog() ()
#4  0x000055a3a877362c in google::LogMessage::Flush() ()
#5  0x000055a3a8776b49 in google::LogMessageFatal::~LogMessageFatal() ()
#6  0x000055a3a391bebf in doris::vectorized::IColumn::get_raw_data (this=0x7f4d8db659a0) at /mnt/disk1/root/doris/be/src/vec/columns/column.h:569
#7  0x000055a3a40d51f7 in doris::vectorized::ColumnsHashing::HashMethodOneNumber<PairNoInit<unsigned char, char*>, char*, unsigned char, false>::HashMethodOneNumber (this=<optimized out>, key_columns=...) at /mnt/disk1/root/doris/be/src/vec/common/columns_hashing.h:52
#8  doris::vectorized::ColumnsHashing::HashMethodSingleLowNullableColumn<doris::vectorized::ColumnsHashing::HashMethodOneNumber<PairNoInit<unsigned char, char*>, char*, unsigned char, false>, char*, true>::HashMethodSingleLowNullableColumn (this=this@entry=0x7f4ec03f1e20, key_columns_nullable=..., key_sizes=..., context=...) at /mnt/disk1/root/doris/be/src/vec/common/columns_hashing.h:228
#9  0x000055a3a4067582 in doris::vectorized::AggregationNode::_emplace_into_hash_table(char**, std::vector<doris::vectorized::IColumn const*, std::allocator<doris::vectorized::IColumn const*> >&, unsigned long)::$_4::operator()<doris::vectorized::AggregationMethodSingleNullableColumn<doris::vectorized::AggregationMethodOneNumber<unsigned char, doris::vectorized::AggregationDataWithNullKey<FixedHashMap<unsigned char, char*, FixedHashMapImplicitZeroCell<unsigned char, char*, HashTableNoState>, FixedHashTableCalculatedSize<FixedHashMapImplicitZeroCell<unsigned char, char*, HashTableNoState> >, Allocator<true, true> > >, false> >&>(doris::vectorized::AggregationMethodSingleNullableColumn<doris::vectorized::AggregationMethodOneNumber<unsigned char, doris::vectorized::AggregationDataWithNullKey<FixedHashMap<unsigned char, char*, FixedHashMapImplicitZeroCell<unsigned char, char*, HashTableNoState>, FixedHashTableCalculatedSize<FixedHashMapImplicitZeroCell<unsigned char, char*, HashTableNoState> >, Allocator<true, true> > >, false> >&) const (this=0x7f4ec03f1f68, agg_method=...) at /mnt/disk1/root/doris/be/src/vec/exec/vaggregation_node.cpp:804
#10 std::__invoke_impl<void, doris::vectorized::AggregationNode::_emplace_into_hash_table(char**, std::vector<doris::vectorized::IColumn const*, std::allocator<doris::vectorized::IColumn const*> >&, unsigned long)::$_4, doris::vectorized::AggregationMethodSingleNullableColumn<doris::vectorized::AggregationMethodOneNumber<unsigned char, doris::vectorized::AggregationDataWithNullKey<FixedHashMap<unsigned char, char*, FixedHashMapImplicitZeroCell<unsigned char, char*, HashTableNoState>, FixedHashTableCalculatedSize<FixedHashMapImplicitZeroCell<unsigned char, char*, HashTableNoState> >, Allocator<true, true> > >, false> >&>(std::__invoke_other, doris::vectorized::AggregationNode::_emplace_into_hash_table(char**, std::vector<doris::vectorized::IColumn const*, std::allocator<doris::vectorized::IColumn const*> >&, unsigned long)::$_4&&, doris::vectorized::AggregationMethodSingleNullableColumn<doris::vectorized::AggregationMethodOneNumber<unsigned char, doris::vectorized::AggregationDataWithNullKey<FixedHashMap<unsigned char, char*, FixedHashMapImplicitZeroCell<unsigned char, char*, HashTableNoState>, FixedHashTableCalculatedSize<FixedHashMapImplicitZeroCell<unsigned char, char*, HashTableNoState> >, Allocator<true, true> > >, false> >&) (__f=..., __args=...) at /mnt/disk1/root/.local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61
#11 std::__invoke<doris::vectorized::AggregationNode::_emplace_into_hash_table(char**, std::vector<doris::vectorized::IColumn const*, std::allocator<doris::vectorized::IColumn const*> >&, unsigned long)::$_4, doris::vectorized::AggregationMethodSingleNullableColumn<doris::vectorized::AggregationMethodOneNumber<unsigned char, doris::vectorized::AggregationDataWithNullKey<FixedHashMap<unsigned char, char*, FixedHashMapImplicitZeroCell<unsigned char, char*, HashTableNoState>, FixedHashTableCalculatedSize<FixedHashMapImplicitZeroCell<unsigned char, char*, HashTableNoState> >, Allocator<true, true> > >, false> >&>(doris::vectorized::AggregationNode::_emplace_into_hash_table(char**, std::vector<doris::vectorized::IColumn const*, std::allocator<doris::vectorized::IColumn const*> >&, unsigned long)::$_4&&, doris::vectorized::AggregationMethodSingleNullableColumn<doris::vectorized::AggregationMethodOneNumber<unsigned char, doris::vectorized::AggregationDataWithNullKey<FixedHashMap<unsigned char, char*, FixedHashMapImplicitZeroCell<unsigned char, char*, HashTableNoState>, FixedHashTableCalculatedSize<FixedHashMapImplicitZeroCell<unsigned char, char*, HashTableNoState> >, Allocator<true, true> > >, false> >&) (__fn=..., __args=...) at /mnt/disk1/root/.local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:96
#12 _ZNSt8__detail9__variant17__gen_vtable_implINS0_12_Multi_arrayIPFNS0_21__deduce_visit_resultIvEEOZN5doris10vectorized15AggregationNode24_emplace_into_hash_tableEPPcRSt6vectorIPKNS6_7IColumnESaISD_EEmE3$_4RSt7variantIJNS6_27AggregationMethodSerializedI9PHHashMapI9StringRefS8_11DefaultHashISM_vELb0EEEENS6_26AggregationMethodOneNumberIh12FixedHashMapIhS8_28FixedHashMapImplicitZeroCellIhS8_16HashTableNoStateE28FixedHashTableCalculatedSizeISV_E9AllocatorILb1ELb1EEELb0EEENSR_ItSS_ItS8_ST_ItS8_SU_E24FixedHashTableStoredSizeIS12_ESZ_ELb0EEENSR_IjSL_IjS8_9HashCRC32IjELb0EELb0EEENSR_ImSL_ImS8_S17_ImELb0EELb0EEENS6_30AggregationMethodStringNoCacheI13StringHashMapIS8_SZ_EEENSR_INS6_7UInt128ESL_IS1I_S8_S17_IS1I_ELb0EELb0EEENSR_IjSL_IjS8_14HashMixWrapperIjS18_ELb0EELb0EEENSR_ImSL_ImS8_S1M_ImS1B_ELb0EELb0EEENSR_IS1I_SL_IS1I_S8_S1M_IS1I_S1J_ELb0EELb0EEENS6_37AggregationMethodSingleNullableColumnINSR_IhNS6_26AggregationDataWithNullKeyIS10_EELb0EEEEENS1W_INSR_ItNS1X_IS15_EELb0EEEEENS1W_INSR_IjNS1X_IS19_EELb0EEEEENS1W_INSR_ImNS1X_IS1C_EELb0EEEEENS1W_INSR_IjNS1X_IS1O_EELb0EEEEENS1W_INSR_ImNS1X_IS1R_EELb0EEEEENS1W_INSR_IS1I_NS1X_IS1K_EELb0EEEEENS1W_INSR_IS1I_NS1X_IS1U_EELb0EEEEENS1W_INS1E_INS1X_IS1G_EEEEEENS6_26AggregationMethodKeysFixedIS1C_Lb0EEENS2P_IS1C_Lb1EEENS2P_IS1K_Lb0EEENS2P_IS1K_Lb1EEENS2P_ISL_INS6_7UInt256ES8_S17_IS2U_ELb0EELb0EEENS2P_IS2W_Lb1EEENS2P_IS1R_Lb0EEENS2P_IS1R_Lb1EEENS2P_IS1U_Lb0EEENS2P_IS1U_Lb1EEENS2P_ISL_IS2U_S8_S1M_IS2U_S2V_ELb0EELb0EEENS2P_IS34_Lb1EEEEEEJEEESt16integer_sequenceImJLm10EEEE14__visit_invokeESI_S38_ (__visitor=..., __vars=...) at /mnt/disk1/root/.local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/variant:1013
#13 0x000055a3a40cec21 in _ZSt10__do_visitINSt8__detail9__variant21__deduce_visit_resultIvEEZN5doris10vectorized15AggregationNode24_emplace_into_hash_tableEPPcRSt6vectorIPKNS5_7IColumnESaISC_EEmE3$_4JRSt7variantIJNS5_27AggregationMethodSerializedI9PHHashMapI9StringRefS7_11DefaultHashISK_vELb0EEEENS5_26AggregationMethodOneNumberIh12FixedHashMapIhS7_28FixedHashMapImplicitZeroCellIhS7_16HashTableNoStateE28FixedHashTableCalculatedSizeIST_E9AllocatorILb1ELb1EEELb0EEENSP_ItSQ_ItS7_SR_ItS7_SS_E24FixedHashTableStoredSizeIS10_ESX_ELb0EEENSP_IjSJ_IjS7_9HashCRC32IjELb0EELb0EEENSP_ImSJ_ImS7_S15_ImELb0EELb0EEENS5_30AggregationMethodStringNoCacheI13StringHashMapIS7_SX_EEENSP_INS5_7UInt128ESJ_IS1G_S7_S15_IS1G_ELb0EELb0EEENSP_IjSJ_IjS7_14HashMixWrapperIjS16_ELb0EELb0EEENSP_ImSJ_ImS7_S1K_ImS19_ELb0EELb0EEENSP_IS1G_SJ_IS1G_S7_S1K_IS1G_S1H_ELb0EELb0EEENS5_37AggregationMethodSingleNullableColumnINSP_IhNS5_26AggregationDataWithNullKeyISY_EELb0EEEEENS1U_INSP_ItNS1V_IS13_EELb0EEEEENS1U_INSP_IjNS1V_IS17_EELb0EEEEENS1U_INSP_ImNS1V_IS1A_EELb0EEEEENS1U_INSP_IjNS1V_IS1M_EELb0EEEEENS1U_INSP_ImNS1V_IS1P_EELb0EEEEENS1U_INSP_IS1G_NS1V_IS1I_EELb0EEEEENS1U_INSP_IS1G_NS1V_IS1S_EELb0EEEEENS1U_INS1C_INS1V_IS1E_EEEEEENS5_26AggregationMethodKeysFixedIS1A_Lb0EEENS2N_IS1A_Lb1EEENS2N_IS1I_Lb0EEENS2N_IS1I_Lb1EEENS2N_ISJ_INS5_7UInt256ES7_S15_IS2S_ELb0EELb0EEENS2N_IS2U_Lb1EEENS2N_IS1P_Lb0EEENS2N_IS1P_Lb1EEENS2N_IS1S_Lb0EEENS2N_IS1S_Lb1EEENS2N_ISJ_IS2S_S7_S1K_IS2S_S2T_ELb0EELb0EEENS2N_IS32_Lb1EEEEEEEDcOT0_DpOT1_ (__visitor=..., __variants=...) at /mnt/disk1/root/.local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/variant:1714
#14 _ZSt5visitIZN5doris10vectorized15AggregationNode24_emplace_into_hash_tableEPPcRSt6vectorIPKNS1_7IColumnESaIS8_EEmE3$_4JRSt7variantIJNS1_27AggregationMethodSerializedI9PHHashMapI9StringRefS3_11DefaultHashISG_vELb0EEEENS1_26AggregationMethodOneNumberIh12FixedHashMapIhS3_28FixedHashMapImplicitZeroCellIhS3_16HashTableNoStateE28FixedHashTableCalculatedSizeISP_E9AllocatorILb1ELb1EEELb0EEENSL_ItSM_ItS3_SN_ItS3_SO_E24FixedHashTableStoredSizeISW_EST_ELb0EEENSL_IjSF_IjS3_9HashCRC32IjELb0EELb0EEENSL_ImSF_ImS3_S11_ImELb0EELb0EEENS1_30AggregationMethodStringNoCacheI13StringHashMapIS3_ST_EEENSL_INS1_7UInt128ESF_IS1C_S3_S11_IS1C_ELb0EELb0EEENSL_IjSF_IjS3_14HashMixWrapperIjS12_ELb0EELb0EEENSL_ImSF_ImS3_S1G_ImS15_ELb0EELb0EEENSL_IS1C_SF_IS1C_S3_S1G_IS1C_S1D_ELb0EELb0EEENS1_37AggregationMethodSingleNullableColumnINSL_IhNS1_26AggregationDataWithNullKeyISU_EELb0EEEEENS1Q_INSL_ItNS1R_ISZ_EELb0EEEEENS1Q_INSL_IjNS1R_IS13_EELb0EEEEENS1Q_INSL_ImNS1R_IS16_EELb0EEEEENS1Q_INSL_IjNS1R_IS1I_EELb0EEEEENS1Q_INSL_ImNS1R_IS1L_EELb0EEEEENS1Q_INSL_IS1C_NS1R_IS1E_EELb0EEEEENS1Q_INSL_IS1C_NS1R_IS1O_EELb0EEEEENS1Q_INS18_INS1R_IS1A_EEEEEENS1_26AggregationMethodKeysFixedIS16_Lb0EEENS2J_IS16_Lb1EEENS2J_IS1E_Lb0EEENS2J_IS1E_Lb1EEENS2J_ISF_INS1_7UInt256ES3_S11_IS2O_ELb0EELb0EEENS2J_IS2Q_Lb1EEENS2J_IS1L_Lb0EEENS2J_IS1L_Lb1EEENS2J_IS1O_Lb0EEENS2J_IS1O_Lb1EEENS2J_ISF_IS2O_S3_S1G_IS2O_S2P_ELb0EELb0EEENS2J_IS2Y_Lb1EEEEEEEDcOT_DpOT0_ (__visitor=..., __variants=...) at /mnt/disk1/root/.local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/variant:1764
#15 doris::vectorized::AggregationNode::_emplace_into_hash_table (this=0x7f4daf105c00, places=<optimized out>, key_columns=..., num_rows=15) at /mnt/disk1/root/doris/be/src/vec/exec/vaggregation_node.cpp:798
#16 doris::vectorized::AggregationNode::_merge_with_serialized_key_helper<false> (this=0x7f4daf105c00, block=0x7f4ec03f20d0) at /mnt/disk1/root/doris/be/src/vec/exec/vaggregation_node.h:1001
#17 0x000055a3a405b144 in doris::vectorized::AggregationNode::_merge_with_serialized_key (this=0x7f4ec03f10c0, block=0x0) at /mnt/disk1/root/doris/be/src/vec/exec/vaggregation_node.cpp:1314
#18 0x000055a3a40d948b in std::__invoke_impl<doris::Status, doris::Status (doris::vectorized::AggregationNode::*&)(doris::vectorized::Block*), doris::vectorized::AggregationNode*&, doris::vectorized::Block*> (__f=<optimized out>, __t=<optimized out>, __args=<optimized out>) at /mnt/disk1/root/.local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:74
#19 std::__invoke_r<doris::Status, doris::Status (doris::vectorized::AggregationNode::*&)(doris::vectorized::Block*), doris::vectorized::AggregationNode*&, doris::vectorized::Block*> (__fn=<optimized out>, __args=<optimized out>, __args=<optimized out>) at /mnt/disk1/root/.local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:114
#20 std::_Bind_result<doris::Status, doris::Status (doris::vectorized::AggregationNode::*(doris::vectorized::AggregationNode*, std::_Placeholder<1>))(doris::vectorized::Block*)>::__call<doris::Status, doris::vectorized::Block*&&, 0ul, 1ul>(std::tuple<doris::vectorized::Block*&&>&&, std::_Index_tuple<0ul, 1ul>) (this=<optimized out>, __args=...) at /mnt/disk1/root/.local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/functional:570
#21 std::_Bind_result<doris::Status, doris::Status (doris::vectorized::AggregationNode::*(doris::vectorized::AggregationNode*, std::_Placeholder<1>))(doris::vectorized::Block*)>::operator()<doris::vectorized::Block*>(doris::vectorized::Block*&&) (this=<optimized out>,  __args=<optimized out>) at /mnt/disk1/root/.local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/functional:629
#22 std::__invoke_impl<doris::Status, std::_Bind_result<doris::Status, doris::Status (doris::vectorized::AggregationNode::*(doris::vectorized::AggregationNode*, std::_Placeholder<1>))(doris::vectorized::Block*)>&, doris::vectorized::Block*>(std::__invoke_other, std::_Bind_result<doris::Status, doris::Status (doris::vectorized::AggregationNode::*(doris::vectorized::AggregationNode*, std::_Placeholder<1>))(doris::vectorized::Block*)>&, doris::vectorized::Block*&&) (__f=..., __args=<optimized out>) at /mnt/disk1/root/.local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61
#23 std::__invoke_r<doris::Status, std::_Bind_result<doris::Status, doris::Status (doris::vectorized::AggregationNode::*(doris::vectorized::AggregationNode*, std::_Placeholder<1>))(doris::vectorized::Block*)>&, doris::vectorized::Block*>(std::_Bind_result<doris::Status, doris::Status (doris::vectorized::AggregationNode::*(doris::vectorized::AggregationNode*, std::_Placeholder<1>))(doris::vectorized::Block*)>&, doris::vectorized::Block*&&) (__fn=..., __args=<optimized out>) at /mnt/disk1/root/.local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:114
#24 std::_Function_handler<doris::Status (doris::vectorized::Block*), std::_Bind_result<doris::Status, doris::Status (doris::vectorized::AggregationNode::*(doris::vectorized::AggregationNode*, std::_Placeholder<1>))(doris::vectorized::Block*)> >::_M_invoke(std::_Any_data const&, doris::vectorized::Block*&&) (__functor=..., __args=<optimized out>) at /mnt/disk1/root/.local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291
#25 0x000055a3a405d4dd in std::function<doris::Status (doris::vectorized::Block*)>::operator()(doris::vectorized::Block*) const (this=0x7f4daf1060d0, __args=0x7f4ec03f20d0) at /mnt/disk1/root/.local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:560
#26 doris::vectorized::AggregationNode::open (this=0x7f4daf105c00, state=0x7f4d8db57700) at /mnt/disk1/root/doris/be/src/vec/exec/vaggregation_node.cpp:479
#27 0x000055a3a3313540 in doris::PlanFragmentExecutor::open_vectorized_internal (this=this@entry=0x7f4daf07e370) at /mnt/disk1/root/doris/be/src/runtime/plan_fragment_executor.cpp:281
#28 0x000055a3a33129e3 in doris::PlanFragmentExecutor::open (this=0x7f4daf07e370) at /mnt/disk1/root/doris/be/src/runtime/plan_fragment_executor.cpp:253
#29 0x000055a3a32f2658 in doris::FragmentExecState::execute (this=0x7f4daf07e300) at /mnt/disk1/root/doris/be/src/runtime/fragment_mgr.cpp:250
#30 0x000055a3a32f4cf1 in doris::FragmentMgr::_exec_actual(std::shared_ptr<doris::FragmentExecState>, std::function<void (doris::PlanFragmentExecutor*)>) (this=this@entry=0x7f4f524a7000, exec_state=..., cb=...) at /mnt/disk1/root/doris/be/src/runtime/fragment_mgr.cpp:497
#31 0x000055a3a32fd801 in doris::FragmentMgr::exec_plan_fragment(doris::TExecPlanFragmentParams const&, std::function<void (doris::PlanFragmentExecutor*)>)::$_3::operator()() const (this=0x7f4daf1329a0) at /mnt/disk1/root/doris/be/src/runtime/fragment_mgr.cpp:721
#32 std::__invoke_impl<void, doris::FragmentMgr::exec_plan_fragment(doris::TExecPlanFragmentParams const&, std::function<void (doris::PlanFragmentExecutor*)>)::$_3&>(std::__invoke_other, doris::FragmentMgr::exec_plan_fragment(doris::TExecPlanFragmentParams const&, std::function<void (doris::PlanFragmentExecutor*)>)::$_3&) (__f=...) at /mnt/disk1/root/.local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61
#33 std::__invoke_r<void, doris::FragmentMgr::exec_plan_fragment(doris::TExecPlanFragmentParams const&, std::function<void (doris::PlanFragmentExecutor*)>)::$_3&>(doris::FragmentMgr::exec_plan_fragment(doris::TExecPlanFragmentParams const&, std::function<void (doris::PlanFragmentExecutor*)>)::$_3&) (__fn=...) at /mnt/disk1/root/.local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:111
#34 std::_Function_handler<void (), doris::FragmentMgr::exec_plan_fragment(doris::TExecPlanFragmentParams const&, std::function<void (doris::PlanFragmentExecutor*)>)::$_3>::_M_invoke(std::_Any_data const&) (__functor=...) at /mnt/disk1/root/.local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291
#35 0x000055a3a3516e5f in doris::ThreadPool::dispatch_thread (this=0x7f4f524a6000) at /mnt/disk1/root/doris/be/src/util/threadpool.cpp:534
#36 0x000055a3a351007c in std::function<void ()>::operator()() const (this=0x2) at /mnt/disk1/root/.local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:560
#37 doris::Thread::supervise_thread (arg=0x7f4f524a19c0) at /mnt/disk1/root/doris/be/src/util/thread.cpp:454
```

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

