### PR TITLE
[Chore](build) fix some warning on code generate and webui

### DIFF
--- a/fe/fe-core/src/main/jflex/sql_scanner.flex
+++ b/fe/fe-core/src/main/jflex/sql_scanner.flex
@@ -598,7 +598,6 @@ import org.apache.doris.qe.SqlModeHelper;
 %init}
 
 LineTerminator = \r|\n|\r\n
-NonTerminator = [^\r\n]
 Whitespace = {LineTerminator} | [ \t\f]
 
 IdentifierOrKwContents = [:digit:]*[:jletter:][:jletterdigit:]* | "&&" | "||"

--- a/gensrc/thrift/parquet.thrift
+++ b/gensrc/thrift/parquet.thrift
@@ -1,25 +1,22 @@
-/**
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
 
-/**
- * File format description for the parquet file format
- */
+// File format description for the parquet file format
+
 namespace cpp tparquet
 namespace java org.apache.parquet.format
 
@@ -423,10 +420,9 @@ enum Encoding {
    */
   PLAIN = 0;
 
-  /** Group VarInt encoding for INT32/INT64.
-   * This encoding is deprecated. It was never used
-   */
-  //  GROUP_VAR_INT = 1;
+  // Group VarInt encoding for INT32/INT64.
+  // This encoding is deprecated. It was never used
+  // GROUP_VAR_INT = 1;
 
   /**
    * Deprecated: Dictionary encoding. The values in the dictionary are encoded in the

--- a/ui/config/webpack.common.js
+++ b/ui/config/webpack.common.js
@@ -237,5 +237,9 @@ module.exports = {
             ignoreOrder: true
         }),
         new CleanWebpackPlugin()
-    ]
+    ],
+    performance: {
+        maxAssetSize: 2097152,
+        maxEntrypointSize: 2097152
+    }
 };


### PR DESCRIPTION
# Proposed changes
```
[WARNING:gensrc/thrift/parquet.thrift:22] Uncaptured doctext at on line 18.

[WARNING:gensrc/thrift/parquet.thrift:23] Uncaptured doctext at on line 22.

[WARNING:gensrc/thrift/parquet.thrift:436] Uncaptured doctext at on line 428.

WARNING in asset size limit: The following asset(s) exceed the recommended size limit (244 KiB).WARNING in asset size limit: The following asset(s) exceed the
  recommended size limit (244 KiB). This can impact web performance


WARNING in entrypoint size limit: The following entrypoint(s) combined asset size exceeds the recommended limit


Warning : Macro "NonTerminator" has been declared but never used.
```

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

