### PR TITLE
[Fix](load) Fix memory leak for stream load 2pc #16430

### DIFF
--- a/be/src/http/action/stream_load_2pc.cpp
+++ b/be/src/http/action/stream_load_2pc.cpp
@@ -99,4 +99,18 @@ std::string StreamLoad2PCAction::get_success_info(const std::string txn_id, cons
     return s.GetString();
 }
 
+void StreamLoad2PCAction::free_handler_ctx(void* param) {
+    StreamLoadContext* ctx = (StreamLoadContext*)param;
+    if (ctx == nullptr) {
+        return;
+    }
+    // sender is gone, make receiver know it
+    if (ctx->body_sink != nullptr) {
+        ctx->body_sink->cancel("sender is gone");
+    }
+    if (ctx->unref()) {
+        delete ctx;
+    }
+}
+
 } // namespace doris

--- a/be/src/http/action/stream_load_2pc.h
+++ b/be/src/http/action/stream_load_2pc.h
@@ -32,6 +32,7 @@ public:
 
     void handle(HttpRequest* req) override;
     std::string get_success_info(const std::string txn_id, const std::string txn_operation);
+    void free_handler_ctx(void* param) override;
 
 private:
     ExecEnv* _exec_env;


### PR DESCRIPTION

# Proposed changes

Issue Number: close #xxx

## Problem summary

StreamLoadContext is not deleted correctly. Fix memory leak for stream load `2PC`.
## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

