### PR TITLE
[fix](cooldown) Handle replica re-choosed as cooldown replica

### DIFF
--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -1848,6 +1848,7 @@ void TaskWorkerPool::_push_cooldown_conf_worker_thread_callback() {
             }
             tablet->update_cooldown_conf(cooldown_conf.cooldown_term,
                                          cooldown_conf.cooldown_replica_id);
+            // TODO(AlexYue): if `update_cooldown_conf` success, async call `write_cooldown_meta`
         }
     }
 }

--- a/be/src/olap/olap_define.h
+++ b/be/src/olap/olap_define.h
@@ -98,6 +98,17 @@ static const std::string PENDING_DELTA_PREFIX = "pending_delta";
 static const std::string INCREMENTAL_DELTA_PREFIX = "incremental_delta";
 static const std::string CLONE_PREFIX = "clone";
 
+// define paths
+static inline std::string remote_tablet_path(int64_t tablet_id) {
+    // data/{tablet_id}
+    return fmt::format("{}/{}", DATA_PREFIX, tablet_id);
+}
+static inline std::string remote_tablet_meta_path(int64_t tablet_id, int64_t replica_id,
+                                                  int64_t cooldown_term) {
+    // data/{tablet_id}/{replica_id}.{cooldown_term}.meta
+    return fmt::format("{}/{}.{}.meta", remote_tablet_path(tablet_id), replica_id, cooldown_term);
+}
+
 static const std::string TABLET_UID = "tablet_uid";
 static const std::string STORAGE_NAME = "storage_name";
 

--- a/be/src/olap/olap_server.cpp
+++ b/be/src/olap/olap_server.cpp
@@ -797,7 +797,7 @@ void StorageEngine::_cold_data_compaction_producer_callback() {
         tablet_to_follow.reserve(n + 1);
 
         for (auto& t : tablets) {
-            if (t->replica_id() == t->cooldown_replica_id()) {
+            if (t->replica_id() == t->cooldown_conf_unlocked().first) {
                 auto score = t->calc_cold_data_compaction_score();
                 if (score < 4) {
                     continue;

--- a/be/src/olap/rowset/beta_rowset.cpp
+++ b/be/src/olap/rowset/beta_rowset.cpp
@@ -69,16 +69,6 @@ std::string BetaRowset::segment_file_path(const std::string& rowset_dir, const R
     return fmt::format("{}/{}_{}.dat", rowset_dir, rowset_id.to_string(), segment_id);
 }
 
-std::string BetaRowset::remote_tablet_path(int64_t tablet_id) {
-    // data/{tablet_id}
-    return fmt::format("{}/{}", DATA_PREFIX, tablet_id);
-}
-
-std::string BetaRowset::remote_tablet_meta_path(int64_t tablet_id, int64_t replica_id) {
-    // data/{tablet_id}/{replica_id}.meta
-    return fmt::format("{}/{}.meta", remote_tablet_path(tablet_id), replica_id);
-}
-
 std::string BetaRowset::remote_segment_path(int64_t tablet_id, const RowsetId& rowset_id,
                                             int segment_id) {
     // data/{tablet_id}/{rowset_id}_{seg_num}.dat

--- a/be/src/olap/rowset/beta_rowset.h
+++ b/be/src/olap/rowset/beta_rowset.h
@@ -61,10 +61,6 @@ public:
     static std::string remote_segment_path(int64_t tablet_id, const std::string& rowset_id,
                                            int segment_id);
 
-    static std::string remote_tablet_path(int64_t tablet_id);
-
-    static std::string remote_tablet_meta_path(int64_t tablet_id, int64_t replica_id);
-
     Status remove() override;
 
     Status link_files_to(const std::string& dir, RowsetId new_rowset_id,

--- a/be/src/olap/tablet.h
+++ b/be/src/olap/tablet.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include <atomic>
 #include <functional>
 #include <memory>
 #include <mutex>
@@ -301,8 +302,6 @@ public:
     ////////////////////////////////////////////////////////////////////////////
     // begin cooldown functions
     ////////////////////////////////////////////////////////////////////////////
-    int64_t cooldown_replica_id() const { return _cooldown_replica_id; }
-
     // Cooldown to remote fs.
     Status cooldown();
 
@@ -310,7 +309,22 @@ public:
 
     bool need_cooldown(int64_t* cooldown_timestamp, size_t* file_size);
 
-    void update_cooldown_conf(int64_t cooldown_term, int64_t cooldown_replica_id) {
+    std::pair<int64_t, int64_t> cooldown_conf() const {
+        std::shared_lock rlock(_cooldown_conf_lock);
+        return {_cooldown_replica_id, _cooldown_term};
+    }
+
+    std::pair<int64_t, int64_t> cooldown_conf_unlocked() const {
+        return {_cooldown_replica_id, _cooldown_term};
+    }
+
+    // return true if update success
+    bool update_cooldown_conf(int64_t cooldown_term, int64_t cooldown_replica_id) {
+        std::unique_lock wlock(_cooldown_conf_lock, std::try_to_lock);
+        if (!wlock.owns_lock()) {
+            LOG(INFO) << "try cooldown_conf_lock failed, tablet_id=" << tablet_id();
+            return false;
+        }
         if (cooldown_term > _cooldown_term) {
             LOG(INFO) << "update cooldown conf. tablet_id=" << tablet_id()
                       << " cooldown_replica_id: " << _cooldown_replica_id << " -> "
@@ -318,7 +332,9 @@ public:
                       << cooldown_term;
             _cooldown_replica_id = cooldown_replica_id;
             _cooldown_term = cooldown_term;
+            return true;
         }
+        return false;
     }
 
     Status remove_all_remote_rowsets();
@@ -337,6 +353,10 @@ public:
     uint32_t calc_cold_data_compaction_score() const;
 
     std::mutex& get_cold_compaction_lock() { return _cold_compaction_lock; }
+
+    std::shared_mutex& get_cooldown_conf_lock() { return _cooldown_conf_lock; }
+
+    Status write_cooldown_meta();
     ////////////////////////////////////////////////////////////////////////////
     // end cooldown functions
     ////////////////////////////////////////////////////////////////////////////
@@ -409,10 +429,6 @@ public:
         return config::max_tablet_io_errors > 0 && _io_error_times >= config::max_tablet_io_errors;
     }
 
-    Status write_cooldown_meta(const std::shared_ptr<io::RemoteFileSystem>& fs,
-                               UniqueId cooldown_meta_id, const RowsetMetaSharedPtr& new_rs_meta,
-                               const std::vector<RowsetMetaSharedPtr>& to_deletes);
-
 private:
     Status _init_once_action();
     void _print_missed_versions(const std::vector<Version>& missed_versions) const;
@@ -452,11 +468,10 @@ private:
     ////////////////////////////////////////////////////////////////////////////
     // begin cooldown functions
     ////////////////////////////////////////////////////////////////////////////
-    Status _cooldown_data(const std::shared_ptr<io::RemoteFileSystem>& dest_fs);
-    Status _follow_cooldowned_data(const std::shared_ptr<io::RemoteFileSystem>& fs,
-                                   int64_t cooldown_replica_id);
+    Status _cooldown_data();
+    Status _follow_cooldowned_data();
     Status _read_cooldown_meta(const std::shared_ptr<io::RemoteFileSystem>& fs,
-                               int64_t cooldown_replica_id, TabletMetaPB* tablet_meta_pb);
+                               TabletMetaPB* tablet_meta_pb);
     ////////////////////////////////////////////////////////////////////////////
     // end cooldown functions
     ////////////////////////////////////////////////////////////////////////////
@@ -536,6 +551,13 @@ private:
     // cooldown related
     int64_t _cooldown_replica_id = -1;
     int64_t _cooldown_term = -1;
+    // `_cooldown_conf_lock` is used to serialize update cooldown conf and all operations that:
+    // 1. read cooldown conf
+    // 2. upload rowsets to remote storage
+    // 3. update cooldown meta id
+    mutable std::shared_mutex _cooldown_conf_lock;
+    // `_cold_compaction_lock` is used to serialize cold data compaction and all operations that
+    // may delete compaction input rowsets.
     std::mutex _cold_compaction_lock;
 
     DISALLOW_COPY_AND_ASSIGN(Tablet);

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Replica.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Replica.java
@@ -110,6 +110,7 @@ public class Replica implements Writable {
     private boolean bad = false;
 
     private TUniqueId cooldownMetaId;
+    private long cooldownTerm = -1;
 
     /*
      * If set to true, with means this replica need to be repaired. explicitly.
@@ -243,6 +244,14 @@ public class Replica implements Writable {
 
     public void setCooldownMetaId(TUniqueId cooldownMetaId) {
         this.cooldownMetaId = cooldownMetaId;
+    }
+
+    public long getCooldownTerm() {
+        return cooldownTerm;
+    }
+
+    public void setCooldownTerm(long cooldownTerm) {
+        this.cooldownTerm = cooldownTerm;
     }
 
     public boolean needFurtherRepair() {

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/TabletInvertedIndex.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/TabletInvertedIndex.java
@@ -190,10 +190,11 @@ public class TabletInvertedIndex {
                                 }
                             }
 
-                            if (Config.enable_storage_policy && backendTabletInfo.isSetCooldownReplicaId()) {
+                            if (Config.enable_storage_policy && backendTabletInfo.isSetCooldownTerm()) {
                                 handleCooldownConf(tabletMeta, backendTabletInfo, cooldownConfToPush,
                                         cooldownConfToUpdate);
                                 replica.setCooldownMetaId(backendTabletInfo.getCooldownMetaId());
+                                replica.setCooldownTerm(backendTabletInfo.getCooldownTerm());
                             }
 
                             long partitionId = tabletMeta.getPartitionId();
@@ -395,7 +396,7 @@ public class TabletInvertedIndex {
             return;
         }
 
-        if (cooldownConf.first != beTabletInfo.getCooldownReplicaId()) {
+        if (beTabletInfo.getCooldownTerm() < cooldownConf.second) {
             CooldownConf conf = new CooldownConf(beTabletInfo.tablet_id, cooldownConf.first, cooldownConf.second);
             synchronized (cooldownConfToPush) {
                 cooldownConfToPush.add(conf);

--- a/gensrc/thrift/MasterService.thrift
+++ b/gensrc/thrift/MasterService.thrift
@@ -42,7 +42,7 @@ struct TTabletInfo {
     15: optional Types.TReplicaId replica_id
     // data size on remote storage
     16: optional Types.TSize remote_data_size
-    17: optional Types.TReplicaId cooldown_replica_id
+    // 17: optional Types.TReplicaId cooldown_replica_id
     // 18: optional bool is_cooldown
     19: optional i64 cooldown_term
     20: optional Types.TUniqueId cooldown_meta_id


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

This PR is to solve such situations:
```
Situation 1:
Replica A is cooldown replica，cooldown_replica=A, cooldown_meta_id=1
Replica B: cooldown_replica=A, cooldown_meta_id=1
Replica A: cooldown_data, cooldown_replica=A, cooldown_meta_id=2
Replica A not alive, FE choose Replica B as cooldown replica
Replica A alive again
Replica A: update_cooldown_conf, cooldown_replica=B, cooldown_meta_id=2
Replica A: follow_cooldown_data, cooldown_replica=B, cooldown_meta_id=1
After tablet report, FE finds all replicas' cooldown_meta_id=1
Replica B, Thread1: begin follow_cooldown_data, cooldown_replica=A, cooldown_meta_id=1
Replica B, Thread2: update_cooldown_conf, cooldown_replica=B,  cooldown_meta_id=1
Replica B, Thread3: confirm_unused_remote_files success, cooldown_replica=B, cooldown_meta_id=1, delete some cooldowned data of cooldown_meta_id=2
Replica B, Thread1: finish follow_cooldown_data, cooldown_replica=B, cooldown_meta_id=2, but some cooldowned data has been deleted
```
To solve above situation, MUST serialize `update_cooldown_conf` and `follow_cooldown_data`. However, when there is another replica C:
```
Situation 2:
Replica A is cooldown replica，cooldown_replica=A, cooldown_meta_id=1
Replica B: cooldown_replica=A, cooldown_meta_id=1
Replica C: cooldown_replica=A, cooldown_meta_id=1
Replica A: cooldown_data, cooldown_replica=A, cooldown_meta_id=2
Replica A not alive, FE choose Replica B as cooldown replica
Replica A alive again
Replica A: update_cooldown_conf, cooldown_replica=B, cooldown_meta_id=2
Replica A: follow_cooldown_data, cooldown_replica=B, cooldown_meta_id=1
After tablet report, FE finds all replicas' cooldown_meta_id=1
Replica B: update_cooldown_conf, cooldown_replica=B,  cooldown_meta_id=1
Replica B: confirm_unused_remote_files success, cooldown_replica=B, cooldown_meta_id=1, delete some cooldowned data of cooldown_meta_id=2
Replica C: follow_cooldown_data, cooldown_replica=A, cooldown_meta_id=2, but some cooldowned data has been deleted
```
Seems that if we check that all replicas `cooldownReplicaId` matches this tablet's `cooldownReplicaId` when FE confirms unused remote files, this problem can be solved.
Consider another situation:
```
Situation 3:
Replica A is cooldown replica，cooldown_replica=A, cooldown_meta_id=1
Replica B: cooldown_replica=A, cooldown_meta_id=1
Replica A not alive , FE choose Replica B as cooldown replica
Replica A alive again
Replica A, Thread 1: begin cooldown_data, cooldown_replica=A, cooldown_meta_id=1
Replica A, Thread 2: update_cooldown_conf, cooldown_replica=B, cooldown_meta_id=1
Replica B: update_cooldown_conf, cooldown_replica=B, cooldown_meta_id=1
After tablet report, FE finds all replicas' cooldown_replica=B, cooldown_meta_id=1
Replica A, Thread 1: finish cooldown_data, cooldown_replica=B, cooldown_meta_id=2
Replica B: confirm_unused_remote_files success, cooldown_replica=B, cooldown_meta_id=1, delete some cooldowned data of cooldown_meta_id=2
```
So serialize `update_cooldown_conf` and `follow_cooldown_data` is not enough, we MUST serialize `update_cooldown_conf` and all operations that update cooldowned data (i.e. cold data compaction, cooldown data, follow cooldown data).
However, if `cooldown_replica` switch back to replica A:
```
Situation 4:
...(same with Situation 2 line 1-7)
Replica A: follow_cooldown_data, cooldown_replica=B, cooldown_meta_id=1
Replica B not alive, FE choose Replica A as cooldown replica
Replica B alive again
After update_cooldown_conf, all replicas' state is: cooldown_replica=A, cooldown_meta_id=1
After tablet report, FE finds all replicas' cooldown_replica=A, cooldown_meta_id=1
Replica A: confirm_unused_remote_files success, cooldown_replica=A, cooldown_meta_id=1, delete some cooldowned data of cooldown_meta_id=2
Replica C: follow_cooldown_data, cooldown_replica=A, cooldown_meta_id=2, but some cooldowned data has been deleted
```
So we need a variable that will never fall back as the watermark, and `cooldown_term` has such property. And in order to prevent replica C from following cooldown data of replica A uploaded in old cooldown term (whose cooldown_meta_id=2), we change cooldown meta path from `data/{tablet_id}/{replica_id}.meta` to `data/tablet_id/{replica_id}.{cooldown_term}.meta`.
In addition, this PR also reverses the order of `wrIte_cooldown_meta` and `save_meta` to solve such situation:
```
Replica A is cooldown replica, cooldown_replica=A, cooldown_term=1, cooldown_meta_id=1
Replica B: cooldown_replica=A, cooldown_meta_id=1
Replica A: cooldown_data, write_cooldown_meta, cooldown_replica=A, cooldown_term=1, cooldown_meta_id=2
Replica A: restart before save_meta, cooldown_replica=null, cooldown_term=-1, cooldown_meta_id=1
Replica A: update_cooldown_conf, cooldown_replica=A, cooldown_term=1, cooldown_meta_id=1
After tablet report, FE finds all replicas' cooldown_term=1, cooldown_meta_id=1
Replica A: confirm_unused_remote_files success, cooldown_replica=A, cooldown_meta_id=1, delete some cooldowned data of cooldown_meta_id=2
Replica B: follow_cooldown_data, cooldown_replica=A, cooldown_term=1, cooldown_meta_id=2
```

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [x] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

