### PR TITLE
[Feature] Support CREATE DB COMMENT (#16678)

### DIFF
--- a/docs/en/docs/sql-manual/sql-reference/Data-Definition-Statements/Create/CREATE-DATABASE.md
+++ b/docs/en/docs/sql-manual/sql-reference/Data-Definition-Statements/Create/CREATE-DATABASE.md
@@ -38,6 +38,7 @@ grammar:
 
 ```sql
 CREATE DATABASE [IF NOT EXISTS] db_name
+    [COMMENT "db comment"]
     [PROPERTIES ("key"="value", ...)];
 ````
 
@@ -76,6 +77,11 @@ CREATE DATABASE [IF NOT EXISTS] db_name
    "iceberg.hive.metastore.uris" = "thrift://127.0.0.1:9083",
    "iceberg.catalog.type" = "HIVE_CATALOG"
    );
+   ````
+
+3. Create a new database db_test with comment
+   ```sql
+   CREATE DATABASE db_test COMMENT "this is test comment";
    ````
 
 ### Keywords

--- a/docs/en/docs/sql-manual/sql-reference/Show-Statements/SHOW-CREATE-DATABASE.md
+++ b/docs/en/docs/sql-manual/sql-reference/Show-Statements/SHOW-CREATE-DATABASE.md
@@ -58,8 +58,21 @@ illustrate:
     1 row in set (0.00 sec)
     ````
 
+2. View the creation of the test database in doris(with comment)
+
+    ```sql
+    mysql> SHOW CREATE DATABASE test;
+    +----------+--------------------------------------------------+
+    | Database | Create Database                                  |
+    +----------+--------------------------------------------------+
+    | test     | CREATE DATABASE `test`                           |
+    |          | COMMENT "this is comment"                        |
+    +----------+--------------------------------------------------+
+    1 row in set (0.00 sec)
+    ````
+
 ### Keywords
 
-     SHOW, CREATE, DATABASE
+     SHOW, CREATE, DATABASE, COMMENT
 
 ### Best Practice

--- a/docs/zh-CN/docs/sql-manual/sql-reference/Data-Definition-Statements/Create/CREATE-DATABASE.md
+++ b/docs/zh-CN/docs/sql-manual/sql-reference/Data-Definition-Statements/Create/CREATE-DATABASE.md
@@ -38,6 +38,7 @@ CREATE DATABASE
 
 ```sql
 CREATE DATABASE [IF NOT EXISTS] db_name
+    [COMMENT "db comment"]
     [PROPERTIES ("key"="value", ...)];
 ```
 
@@ -77,6 +78,11 @@ CREATE DATABASE [IF NOT EXISTS] db_name
    	"iceberg.catalog.type" = "HIVE_CATALOG"
    );
    ```
+
+3. 新建带注释的数据库 db_test
+   ```sql
+   CREATE DATABASE db_test COMMENT "this is test comment";
+   ````
 
 ### Keywords
 

--- a/docs/zh-CN/docs/sql-manual/sql-reference/Show-Statements/SHOW-CREATE-DATABASE.md
+++ b/docs/zh-CN/docs/sql-manual/sql-reference/Show-Statements/SHOW-CREATE-DATABASE.md
@@ -58,9 +58,22 @@ SHOW CREATE DATABASE db_name;
    1 row in set (0.00 sec)
    ```
 
+2. 查看doris中test数据库的创建情况（带有库注释）
+
+    ```sql
+    mysql> SHOW CREATE DATABASE test;
+    +----------+--------------------------------------------------+
+    | Database | Create Database                                  |
+    +----------+--------------------------------------------------+
+    | test     | CREATE DATABASE `test`                           |
+    |          | COMMENT "this is comment"                        |
+    +----------+--------------------------------------------------+
+    1 row in set (0.00 sec)
+    ````
+
 ### Keywords
 
-    SHOW, CREATE, DATABASE
+    SHOW, CREATE, DATABASE, COMMENT
 
 ### Best Practice
 

--- a/fe/fe-common/src/main/java/org/apache/doris/common/FeMetaVersion.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/FeMetaVersion.java
@@ -52,6 +52,8 @@ public final class FeMetaVersion {
     public static final int VERSION_115 = 115;
     // change Auto to rbac
     public static final int VERSION_116 = 116;
+    // support db comment
+    public static final int VERSION_117 = 117;
     // note: when increment meta version, should assign the latest version to VERSION_CURRENT
     public static final int VERSION_CURRENT = VERSION_116;
 

--- a/fe/fe-core/src/main/cup/sql_parser.cup
+++ b/fe/fe-core/src/main/cup/sql_parser.cup
@@ -1752,13 +1752,13 @@ opt_mv_partition ::=
 // Create Statement
 create_stmt ::=
     /* Database */
-    KW_CREATE KW_DATABASE opt_if_not_exists:ifNotExists ident:db opt_properties:properties
+    KW_CREATE KW_DATABASE opt_if_not_exists:ifNotExists ident:db opt_comment:dbComment opt_properties:properties
     {:
-        RESULT = new CreateDbStmt(ifNotExists, db, properties);
+        RESULT = new CreateDbStmt(ifNotExists, db, properties, dbComment);
     :}
-    | KW_CREATE KW_SCHEMA opt_if_not_exists:ifNotExists ident:db
+    | KW_CREATE KW_SCHEMA opt_if_not_exists:ifNotExists ident:db opt_comment:schemaComment
     {:
-        RESULT = new CreateDbStmt(ifNotExists, db, null);
+        RESULT = new CreateDbStmt(ifNotExists, db, null, schemaComment);
     :}
     /* Catalog */
     | KW_CREATE KW_CATALOG opt_if_not_exists:ifNotExists ident:catalogName opt_properties:properties

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateDbStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateDbStmt.java
@@ -36,11 +36,17 @@ public class CreateDbStmt extends DdlStmt {
     private boolean ifNotExists;
     private String dbName;
     private Map<String, String> properties;
+    private String comment;
 
-    public CreateDbStmt(boolean ifNotExists, String dbName, Map<String, String> properties) {
+    public CreateDbStmt(boolean ifNotExists, String dbName, Map<String, String> properties, String comment) {
         this.ifNotExists = ifNotExists;
         this.dbName = dbName;
         this.properties = properties == null ? new HashMap<>() : properties;
+        this.comment = Strings.nullToEmpty(comment);
+    }
+
+    public CreateDbStmt(boolean ifNotExists, String dbName, Map<String, String> properties) {
+        this(ifNotExists, dbName, properties, null);
     }
 
     public String getFullDbName() {
@@ -53,6 +59,10 @@ public class CreateDbStmt extends DdlStmt {
 
     public Map<String, String> getProperties() {
         return properties;
+    }
+
+    public String getComment() {
+        return comment;
     }
 
     @Override
@@ -79,6 +89,11 @@ public class CreateDbStmt extends DdlStmt {
     public String toSql() {
         StringBuilder stringBuilder = new StringBuilder();
         stringBuilder.append("CREATE DATABASE ").append("`").append(dbName).append("`");
+
+        if (!Strings.isNullOrEmpty(comment)) {
+            stringBuilder.append("\nCOMMENT \"").append(comment).append("\"");
+        }
+
         if (properties.size() > 0) {
             stringBuilder.append("\nPROPERTIES (\n");
             stringBuilder.append(new PrintableMap<>(properties, "=", true, true, false));

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/DatabaseIf.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/DatabaseIf.java
@@ -66,6 +66,10 @@ public interface DatabaseIf<T extends TableIf> {
 
     DatabaseProperty getDbProperties();
 
+    String getDbComment();
+
+    String getDbComment(boolean escapeQuota);
+
     boolean isTableExist(String tableName);
 
     List<T> getTables();

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/external/ExternalDatabase.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/external/ExternalDatabase.java
@@ -202,6 +202,16 @@ public class ExternalDatabase<T extends ExternalTable> implements DatabaseIf<T>,
     }
 
     @Override
+    public String getDbComment() {
+        throw new NotImplementedException();
+    }
+
+    @Override
+    public String getDbComment(boolean escapeQuota) {
+        throw new NotImplementedException();
+    }
+
+    @Override
     public boolean isTableExist(String tableName) {
         return extCatalog.tableExist(ConnectContext.get().getSessionContext(), name, tableName);
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
@@ -405,6 +405,7 @@ public class InternalCatalog implements CatalogIf<Database> {
         db.setClusterName(clusterName);
         // check and analyze database properties before create database
         db.setDbProperties(new DatabaseProperty(properties).checkAndBuildProperties());
+        db.setDbComment(stmt.getComment());
 
         if (!tryLock(false)) {
             throw new DdlException("Failed to acquire catalog lock. Try again");

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ShowExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ShowExecutor.java
@@ -862,6 +862,9 @@ public class ShowExecutor {
         DatabaseIf db = ctx.getCurrentCatalog().getDbOrAnalysisException(showStmt.getDb());
         StringBuilder sb = new StringBuilder();
         sb.append("CREATE DATABASE `").append(ClusterNamespace.getNameFromFullName(showStmt.getDb())).append("`");
+        if (!Strings.isNullOrEmpty(db.getDbComment())) {
+            sb.append("\nCOMMENT \"").append(db.getDbComment()).append("\"");
+        }
         if (db.getDbProperties().getProperties().size() > 0) {
             sb.append("\nPROPERTIES (\n");
             sb.append(new PrintableMap<>(db.getDbProperties().getProperties(), "=", true, true, false));

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/CreateDbStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/CreateDbStmtTest.java
@@ -54,6 +54,14 @@ public class CreateDbStmtTest {
         Assert.assertEquals("CREATE DATABASE `testCluster:test`", dbStmt.toString());
     }
 
+    @Test
+    public void testAnalyzeWithComment() throws UserException {
+        CreateDbStmt dbStmt = new CreateDbStmt(false, "test", null, "this is comment");
+        dbStmt.analyze(analyzer);
+        Assert.assertEquals("testCluster:test", dbStmt.getFullDbName());
+        Assert.assertEquals("CREATE DATABASE `testCluster:test` COMMENT \"this is comment\"", dbStmt.toString());
+    }
+
     @Test(expected = AnalysisException.class)
     public void testAnalyzeWithException() throws UserException {
         CreateDbStmt stmt = new CreateDbStmt(false, "", null);


### PR DESCRIPTION
When create a database, add support for comment, which explains something about the database so that people who see it know what it is and what it does. CREATE DATABASE [IF NOT EXISTS] db_name COMMENT database_comment [PROPERTIES ("key"="value", ...)]; Add database's comment to the result of the SHOW CREATE DATABASE statement.

# Proposed changes

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [x] Has unit tests been added
* [x] Has document been added or modified
* [ ] Does it need to update dependencies
* [x] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

