### PR TITLE
[typo](docs) collect doc md language annotation

### DIFF
--- a/docs/en/community/feedback.md
+++ b/docs/en/community/feedback.md
@@ -1,5 +1,8 @@
 ---
-{ "title": "Feedback", "language": "zh-CN" }
+{
+    "title": "Feedback",
+    "language": "en"
+}
 ---
 
 <!--

--- a/docs/en/community/how-to-contribute/how-to-be-a-committer.md
+++ b/docs/en/community/how-to-contribute/how-to-be-a-committer.md
@@ -1,7 +1,7 @@
 ---
 {
     "title": "How to Become Doris Committer",
-    "language": "zh-CN"
+    "language": "en"
 }
 ---
 

--- a/docs/en/docs/admin-manual/data-admin/delete-recover.md
+++ b/docs/en/docs/admin-manual/data-admin/delete-recover.md
@@ -1,7 +1,7 @@
 ---
 {
     "title": "Data Recover",
-    "language": "zh-CN"
+    "language": "en"
 }
 ---
 

--- a/docs/en/docs/admin-manual/http-actions/check-reset-rpc-cache.md
+++ b/docs/en/docs/admin-manual/http-actions/check-reset-rpc-cache.md
@@ -1,7 +1,7 @@
 ---
 {
     "title": "CHECK/RESET Stub Cache",
-    "language": "zh-CN"
+    "language": "en"
 }
 ---
 

--- a/docs/en/docs/admin-manual/http-actions/fe/backends-action.md
+++ b/docs/en/docs/admin-manual/http-actions/fe/backends-action.md
@@ -1,7 +1,7 @@
 ---
 {
     "title": "Backends Action",
-    "language": "zh-CN"
+    "language": "en"
 }
 ---
 

--- a/docs/en/docs/admin-manual/maint-monitor/tablet-local-debug.md
+++ b/docs/en/docs/admin-manual/maint-monitor/tablet-local-debug.md
@@ -1,7 +1,7 @@
 ---
 {
     "title": "Tablet Local Debug",
-    "language": "zh-CN"
+    "language": "en"
 }
 ---
 

--- a/docs/en/docs/data-operate/import/import-scenes/load-data-convert.md
+++ b/docs/en/docs/data-operate/import/import-scenes/load-data-convert.md
@@ -1,7 +1,7 @@
 ---
 {
     "title": "Data transformation, column mapping and filtering",
-    "language": "zh-CN"
+    "language": "en"
 }
 ---
 

--- a/docs/en/docs/install/construct-docker/run-docker-cluster.md
+++ b/docs/en/docs/install/construct-docker/run-docker-cluster.md
@@ -1,7 +1,7 @@
 ---
 {
-"title": "Deploy Docker cluster",
-"language": "zh-CN"
+    "title": "Deploy Docker cluster",
+    "language": "en"
 }
 ---
 

--- a/docs/en/docs/sql-manual/sql-functions/aggregate-functions/histogram.md
+++ b/docs/en/docs/sql-manual/sql-functions/aggregate-functions/histogram.md
@@ -1,7 +1,7 @@
 ---
 {
-"title": "TOPN",
-"language": "zh-CN"
+    "title": "TOPN",
+    "language": "en"
 }
 ---
 

--- a/docs/en/docs/sql-manual/sql-functions/json-functions/jsonb_parse.md
+++ b/docs/en/docs/sql-manual/sql-functions/json-functions/jsonb_parse.md
@@ -1,7 +1,7 @@
 ---
 {
     "title": "jsonb_parse",
-    "language": "zh-CN"
+    "language": "en"
 }
 ---
 

--- a/docs/en/docs/sql-manual/sql-functions/string-functions/replace.md
+++ b/docs/en/docs/sql-manual/sql-functions/string-functions/replace.md
@@ -1,7 +1,7 @@
 ---
 {
     "title": "replace",
-    "language": "zh-CN"
+    "language": "en"
 }
 ---
 

--- a/docs/en/docs/sql-manual/sql-functions/string-functions/split_by_string.md
+++ b/docs/en/docs/sql-manual/sql-functions/string-functions/split_by_string.md
@@ -1,7 +1,7 @@
 ---
 {
     "title": "split_by_string",
-    "language": "zh-CN"
+    "language": "en"
 }
 ---
 

--- a/docs/en/docs/sql-manual/sql-reference/Data-Types/QUANTILE_STATE.md
+++ b/docs/en/docs/sql-manual/sql-reference/Data-Types/QUANTILE_STATE.md
@@ -1,7 +1,7 @@
 ---
 {
     "title": "QUANTILE_STATE",
-    "language": "zh-CN"
+    "language": "en"
 }
 ---
 

--- a/docs/en/docs/sql-manual/sql-reference/Show-Statements/SHOW-CREATE-CATALOG.md
+++ b/docs/en/docs/sql-manual/sql-reference/Show-Statements/SHOW-CREATE-CATALOG.md
@@ -1,7 +1,7 @@
 ---
 {
     "title": "SHOW-CREATE-CATALOG",
-    "language": "zh-CN"
+    "language": "en"
 }
 ---
 

--- a/docs/en/docs/sql-manual/sql-reference/Show-Statements/SHOW-PROPERTY.md
+++ b/docs/en/docs/sql-manual/sql-reference/Show-Statements/SHOW-PROPERTY.md
@@ -1,7 +1,7 @@
 ---
 {
     "title": "SHOW-PROPERTY",
-    "language": "zh-CN"
+    "language": "en"
 }
 ---
 

--- a/docs/zh-CN/community/how-to-contribute/commit-format-specification.md
+++ b/docs/zh-CN/community/how-to-contribute/commit-format-specification.md
@@ -1,7 +1,7 @@
 ---
 {
     "title": "Commit 格式规范",
-    "language": "en"
+    "language": "zh-CN"
 }
 
 ---

--- a/docs/zh-CN/docs/sql-manual/sql-functions/date-time-functions/to_monday.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/date-time-functions/to_monday.md
@@ -1,7 +1,7 @@
 ---
 {
     "title": "to_monday",
-    "language": "en"
+    "language": "zh-CN"
 }
 ---
 


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

Some doc md language annotation is not correct, for example:
language annotation in `docs/en/community/how-to-contribute/how-to-be-a-committer.md` is
```
{
    "title": "How to Become Doris Committer",
    "language": "zh-CN"
}
```
where `"language": "zh-CN"` should be `"language": "en"`

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

