### PR TITLE
[Enhancement](array) vectorized string equal comparasion in array_contains function

### DIFF
--- a/be/src/vec/functions/array/function_array_index.h
+++ b/be/src/vec/functions/array/function_array_index.h
@@ -19,11 +19,10 @@
 // and modified by Doris
 #pragma once
 
-#include <string_view>
-
 #include "vec/columns/column.h"
 #include "vec/columns/column_array.h"
 #include "vec/columns/column_string.h"
+#include "vec/common/string_ref.h"
 #include "vec/data_types/data_type_array.h"
 #include "vec/data_types/data_type_number.h"
 #include "vec/functions/function.h"
@@ -125,8 +124,8 @@ private:
                 size_t str_len = str_offs[pos + off] - str_pos;
                 const char* left_raw_v = reinterpret_cast<const char*>(&str_chars[str_pos]);
                 const char* right_raw_v = reinterpret_cast<const char*>(&right_chars[right_off]);
-                if (std::string_view(left_raw_v, str_len) ==
-                    std::string_view(right_raw_v, right_len)) {
+                // StringRef operator == using vec impl
+                if (StringRef(left_raw_v, str_len) == StringRef(right_raw_v, right_len)) {
                     ConcreteAction::apply(res, pos);
                     break;
                 }


### PR DESCRIPTION


# Proposed changes

Issue Number: close #xxx

## Problem summary

Describe your changes.

use StringRef instead of string_view operator == for vectorized impl for array_contains function.

- test data: 10,000,000 rows with a ARRAY<STRING> column. There are 10 elements, average length 11 chars, in the array column in each row.
- test SQL: `select count() from test_like_array where array_contains(s_arr, 'xxxxxxxx');`
- test result: 0.76 sec vs. 0.52 sec, 30% time reduced

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

