### PR TITLE
[Docs](docs) Fix typo in property name of pipeline-execution-engine.md to `enable_pipeline_engine` 

### DIFF
--- a/docs/en/docs/advanced/pipeline-execution-engine.md
+++ b/docs/en/docs/advanced/pipeline-execution-engine.md
@@ -65,7 +65,7 @@ This improves the efficiency of CPU execution on mixed-load SQL and enhances the
 This improves the efficiency of CPU execution on mixed-load SQL and enhances the performance of SQL queries
 
 ```
-set enable_vectorized_engine = true;
+set enable_pipeline_engine = true;
 ```
 
 #### parallel_fragment_exec_instance_num

--- a/docs/zh-CN/docs/advanced/pipeline-execution-engine.md
+++ b/docs/zh-CN/docs/advanced/pipeline-execution-engine.md
@@ -65,7 +65,7 @@ Pipeline执行引擎 是 Doris 在2.0版本加入的实验性功能。目标是�
 将session变量`enable_pipeline_engine `设置为`true`，则BE在进行查询执行时就会默认将SQL的执行模型转变Pipeline的执行方式。
 
 ```
-set enable_vectorized_engine = true;
+set enable_pipeline_engine = true;
 ```
 
 #### parallel_fragment_exec_instance_num


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

- Seems the existed example with `set enable_vectorized_engine` command is irrelevant to pipeline execution,  Fix the property name to `enable_pipeline_engine`.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [x] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

