### PR TITLE
[Chore](third-party) upgrade thrift from 0.13 to 0.16

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,3 +98,4 @@ tools/single-node-cluster/fe*
 data_test
 
 /conf/log4j2-spring.xml
+/fe/fe-core/src/test/resources/real-help-resource.zip

--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -1646,7 +1646,7 @@ Status TaskWorkerPool::_move_dir(const TTabletId tablet_id, const std::string& s
     return loader.move(src, tablet, overwrite);
 }
 
-void TaskWorkerPool::_handle_report(TReportRequest& request, ReportType type) {
+void TaskWorkerPool::_handle_report(const TReportRequest& request, ReportType type) {
     TMasterResult result;
     Status status = MasterServerClient::instance()->report(request, &result);
     bool is_report_success = false;

--- a/be/src/agent/task_worker_pool.h
+++ b/be/src/agent/task_worker_pool.h
@@ -203,7 +203,7 @@ private:
 
     void _alter_tablet(const TAgentTaskRequest& alter_tablet_request, int64_t signature,
                        const TTaskType::type task_type, TFinishTaskRequest* finish_task_request);
-    void _handle_report(TReportRequest& request, ReportType type);
+    void _handle_report(const TReportRequest& request, ReportType type);
 
     Status _get_tablet_info(const TTabletId tablet_id, const TSchemaHash schema_hash,
                             int64_t signature, TTabletInfo* tablet_info);

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -188,7 +188,7 @@ under the License.
         <json-simple.version>1.1.1</json-simple.version>
         <junit.version>5.8.2</junit.version>
         <hikaricp.version>3.4.5</hikaricp.version>
-        <thrift.version>0.13.0</thrift.version>
+        <thrift.version>0.18.0</thrift.version>
         <log4j2.version>2.18.0</log4j2.version>
         <metrics-core.version>4.0.2</metrics-core.version>
         <netty-all.version>4.1.42.Final</netty-all.version>

--- a/fs_brokers/apache_hdfs_broker/pom.xml
+++ b/fs_brokers/apache_hdfs_broker/pom.xml
@@ -252,7 +252,7 @@ under the License.
         <dependency>
             <groupId>org.apache.thrift</groupId>
             <artifactId>libthrift</artifactId>
-            <version>0.13.0</version>
+            <version>0.18.0</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-api -->
         <dependency>

--- a/thirdparty/CHANGELOG.md
+++ b/thirdparty/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 This file contains version of the third-party dependency libraries in the build-env image. The docker build-env image is apache/doris, and the tag is `build-env-${version}`
 
+## v20230224
+- Modified: thrift 0.13 -> 0.18
+
 ## v20230221
 - Modified: clucene 2.4.4 -> 2.4.6
 

--- a/thirdparty/build-thirdparty.sh
+++ b/thirdparty/build-thirdparty.sh
@@ -367,10 +367,10 @@ build_thrift() {
 
     if [[ "${KERNEL}" != 'Darwin' ]]; then
         cflags="-I${TP_INCLUDE_DIR}"
-        cxxflags="-I${TP_INCLUDE_DIR} ${warning_unused_but_set_variable}"
+        cxxflags="-I${TP_INCLUDE_DIR} ${warning_unused_but_set_variable} -Wno-deprecated-declarations"
         ldflags="-L${TP_LIB_DIR} --static"
     else
-        cflags="-I${TP_INCLUDE_DIR} -Wno-implicit-function-declaration"
+        cflags="-I${TP_INCLUDE_DIR} -Wno-implicit-function-declaration -Wno-deprecated-declarations"
         cxxflags="-I${TP_INCLUDE_DIR} ${warning_unused_but_set_variable}"
         ldflags="-L${TP_LIB_DIR}"
     fi

--- a/thirdparty/vars.sh
+++ b/thirdparty/vars.sh
@@ -73,10 +73,10 @@ OPENSSL_SOURCE=openssl-OpenSSL_1_1_1s
 OPENSSL_MD5SUM="7e79a7560dee77c0758baa33c61af4b4"
 
 # thrift
-THRIFT_DOWNLOAD="http://archive.apache.org/dist/thrift/0.13.0/thrift-0.13.0.tar.gz"
-THRIFT_NAME=thrift-0.13.0.tar.gz
-THRIFT_SOURCE=thrift-0.13.0
-THRIFT_MD5SUM="38a27d391a2b03214b444cb13d5664f1"
+THRIFT_DOWNLOAD="http://archive.apache.org/dist/thrift/0.18.0/thrift-0.18.0.tar.gz"
+THRIFT_NAME=thrift-0.18.0.tar.gz
+THRIFT_SOURCE=thrift-0.18.0
+THRIFT_MD5SUM="f1b607c6d1cf8d87390dc5f1fb46c9b5"
 
 # protobuf
 PROTOBUF_DOWNLOAD="https://github.com/google/protobuf/archive/v3.15.0.tar.gz"


### PR DESCRIPTION
# Proposed changes

I found that `thrift` often has some crash under `asan`, I want to try to upgrade it to the latest version and see if the problem still occurs.
There is thrift's release notes https://github.com/apache/thrift/blob/master/CHANGES.md

```cpp
=================================================================
==3313527==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x7f620d10adb0 at pc 0x560af1186b17 bp 0x7f620d10ad80 sp 0x7f620d10a528
WRITE of size 24 at 0x7f620d10adb0 thread T861 (EvHttpServer [w)
    #0 0x560af1186b16 in __interceptor_sigaltstack.part.0 (/mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster7/be/lib/doris_be+0x7049b16)
    #1 0x560af11ec8bf in __asan::PlatformUnpoisonStacks() (/mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster7/be/lib/doris_be+0x70af8bf)
    #2 0x560af11f2224 in __asan_handle_no_return (/mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster7/be/lib/doris_be+0x70b5224)
    #3 0x560af38641bf in __gnu_cxx::new_allocator<char>::~new_allocator() /var/local/ldb-toolchain/include/c++/11/ext/new_allocator.h:89
    #4 0x560af38641bf in std::allocator<char>::~allocator() /var/local/ldb-toolchain/include/c++/11/bits/allocator.h:162
    #5 0x560af38641bf in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_Alloc_hider::~_Alloc_hider() /var/local/ldb-toolchain/include/c++/11/bits/basic_string.h:150
    #6 0x560af38641bf in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::~basic_string() /var/local/ldb-toolchain/include/c++/11/bits/basic_string.h:658
    #7 0x560af38641bf in doris::FrontendServiceClient::recv_streamLoadPut(doris::TStreamLoadPutResult&) /root/doris/gensrc/build/gen_cpp/FrontendService.cpp:6420
    #8 0x560af3864369 in doris::FrontendServiceClient::streamLoadPut(doris::TStreamLoadPutResult&, doris::TStreamLoadPutRequest const&) /root/doris/gensrc/build/gen_cpp/FrontendService.cpp:6367
    #9 0x560af4220b56 in operator() /root/doris/be/src/http/action/stream_load.cpp:584
    #10 0x560af4220b56 in __invoke_impl<void, doris::StreamLoadAction::_process_put(doris::HttpRequest*, doris::StreamLoadContext*)::<lambda(doris::FrontendServiceConnection&)>&, doris::ClientConnection<doris::FrontendServiceClient>&> /var/local/ldb-toolchain/include/c++/11/bits/invoke.h:61
    #11 0x560af4220b56 in __invoke_r<void, doris::StreamLoadAction::_process_put(doris::HttpRequest*, doris::StreamLoadContext*)::<lambda(doris::FrontendServiceConnection&)>&, doris::ClientConnection<doris::FrontendServiceClient>&> /var/local/ldb-toolchain/include/c++/11/bits/invoke.h:111
    #12 0x560af4220b56 in _M_invoke /var/local/ldb-toolchain/include/c++/11/bits/std_function.h:291
    #13 0x560af325f612 in std::function<void (doris::ClientConnection<doris::FrontendServiceClient>&)>::operator()(doris::ClientConnection<doris::FrontendServiceClient>&) const /var/local/ldb-toolchain/include/c++/11/bits/std_function.h:560
    #14 0x560af325f612 in doris::Status doris::ThriftRpcHelper::rpc<doris::FrontendServiceClient>(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, int, std::function<void (doris::ClientConnection<doris::FrontendServiceClient>&)>, int) /root/doris/be/src/util/thrift_rpc_helper.cpp:59
    #15 0x560af4231bef in doris::Status doris::ThriftRpcHelper::rpc<doris::FrontendServiceClient>(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, int, std::function<void (doris::ClientConnection<doris::FrontendServiceClient>&)>) /root/doris/be/src/util/thrift_rpc_helper.h:40
    #16 0x560af4231bef in doris::StreamLoadAction::_process_put(doris::HttpRequest*, doris::StreamLoadContext*) /root/doris/be/src/http/action/stream_load.cpp:584
    #17 0x560af4235da4 in doris::StreamLoadAction::_on_header(doris::HttpRequest*, doris::StreamLoadContext*) /root/doris/be/src/http/action/stream_load.cpp:341
    #18 0x560af4241834 in doris::StreamLoadAction::on_header(doris::HttpRequest*) /root/doris/be/src/http/action/stream_load.cpp:242
    #19 0x560af416de47 in doris::EvHttpServer::on_header(evhttp_request*) /root/doris/be/src/http/ev_http_server.cpp:242
    #20 0x560af416e259 in on_header /root/doris/be/src/http/ev_http_server.cpp:64
    #21 0x560b07a898b9  (/mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster7/be/lib/doris_be+0x1d94c8b9)
    #22 0x560b07a6bf50 in bufferevent_run_readcb_ (/mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster7/be/lib/doris_be+0x1d92ef50)
    #23 0x560b07a8ddf2  (/mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster7/be/lib/doris_be+0x1d950df2)
    #24 0x560b07a74d58  (/mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster7/be/lib/doris_be+0x1d937d58)
    #25 0x560b07a753d6  (/mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster7/be/lib/doris_be+0x1d9383d6)
    #26 0x560b07a77a07  (/mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster7/be/lib/doris_be+0x1d93aa07)
    #27 0x560af416737a in operator() /root/doris/be/src/http/ev_http_server.cpp:105
    #28 0x560af416737a in __invoke_impl<void, doris::EvHttpServer::start()::<lambda()>&> /var/local/ldb-toolchain/include/c++/11/bits/invoke.h:61
    #29 0x560af416737a in __invoke_r<void, doris::EvHttpServer::start()::<lambda()>&> /var/local/ldb-toolchain/include/c++/11/bits/invoke.h:111
    #30 0x560af416737a in _M_invoke /var/local/ldb-toolchain/include/c++/11/bits/std_function.h:291
    #31 0x560af32fc1c2 in std::function<void ()>::operator()() const /var/local/ldb-toolchain/include/c++/11/bits/std_function.h:560
    #32 0x560af32fc1c2 in doris::FunctionRunnable::run() /root/doris/be/src/util/threadpool.cpp:46
    #33 0x560af32fa0a0 in doris::ThreadPool::dispatch_thread() /root/doris/be/src/util/threadpool.cpp:529
    #34 0x560af32fbd77 in void std::__invoke_impl<void, void (doris::ThreadPool::*&)(), doris::ThreadPool*&>(std::__invoke_memfun_deref, void (doris::ThreadPool::*&)(), doris::ThreadPool*&) /var/local/ldb-toolchain/include/c++/11/bits/invoke.h:74
    #35 0x560af32fbd77 in std::__invoke_result<void (doris::ThreadPool::*&)(), doris::ThreadPool*&>::type std::__invoke<void (doris::ThreadPool::*&)(), doris::ThreadPool*&>(void (doris::ThreadPool::*&)(), doris::ThreadPool*&) /var/local/ldb-toolchain/include/c++/11/bits/invoke.h:96
    #36 0x560af32fbd77 in void std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>::__call<void, , 0ul>(std::tuple<>&&, std::_Index_tuple<0ul>) /var/local/ldb-toolchain/include/c++/11/functional:420
    #37 0x560af32fbd77 in void std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>::operator()<, void>() /var/local/ldb-toolchain/include/c++/11/functional:503
    #38 0x560af32fbd77 in void std::__invoke_impl<void, std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>&>(std::__invoke_other, std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>&) /var/local/ldb-toolchain/include/c++/11/bits/invoke.h:61
    #39 0x560af32fbd77 in std::enable_if<is_invocable_r_v<void, std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>&>, void>::type std::__invoke_r<void, std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>&>(std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>&) /var/local/ldb-toolchain/include/c++/11/bits/invoke.h:111
    #40 0x560af32fbd77 in std::_Function_handler<void (), std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()> >::_M_invoke(std::_Any_data const&) /var/local/ldb-toolchain/include/c++/11/bits/std_function.h:291
    #41 0x560af32ce334 in std::function<void ()>::operator()() const /var/local/ldb-toolchain/include/c++/11/bits/std_function.h:560
    #42 0x560af32ce334 in doris::Thread::supervise_thread(void*) /root/doris/be/src/util/thread.cpp:453
    #43 0x7f64402a0608 in start_thread /build/glibc-SzIz7B/glibc-2.31/nptl/pthread_create.c:477
    #44 0x7f6440076132 in __clone (/lib/x86_64-linux-gnu/libc.so.6+0x11f132)

Address 0x7f620d10adb0 is located in stack of thread T861 (EvHttpServer [w) at offset 208 in frame
    #0 0x560af1e8ad3f in apache::thrift::protocol::TBinaryProtocolT<apache::thrift::transport::TTransport, apache::thrift::protocol::TNetworkBigEndian>::readMessageBegin(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, apache::thrift::protocol::TMessageType&, int&) /var/local/thirdparty/installed/include/thrift/protocol/TBinaryProtocol.tcc:200

  This frame has 7 object(s):
    [48, 49) '<unknown>'
    [64, 68) 'theBytes' (line 372)
    [80, 84) 'theBytes' (line 372)
    [96, 100) 'theBytes' (line 372)
    [112, 116) 'theBytes' (line 372)
    [128, 160) '<unknown>'
    [192, 193) 'b' (line 350) <== Memory access at offset 208 overflows this variable
HINT: this may be a false positive if your program uses some custom stack unwind mechanism, swapcontext or vfork
      (longjmp and C++ exceptions *are* supported)
Thread T861 (EvHttpServer [w) created by T0 here:
    #0 0x560af118b061 in pthread_create (/mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster7/be/lib/doris_be+0x704e061)
    #1 0x560af32ca1d1 in doris::Thread::start_thread(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::function<void ()> const&, unsigned long, scoped_refptr<doris::Thread>*) /root/doris/be/src/util/thread.cpp:407
    #2 0x560af32e7aaa in doris::Status doris::Thread::create<void (doris::ThreadPool::*)(), doris::ThreadPool*>(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, void (doris::ThreadPool::* const&)(), doris::ThreadPool* const&, scoped_refptr<doris::Thread>*) /root/doris/be/src/util/thread.h:57
    #3 0x560af32e7aaa in doris::ThreadPool::create_thread() /root/doris/be/src/util/threadpool.cpp:598
    #4 0x560af32f1633 in doris::ThreadPool::init() /root/doris/be/src/util/threadpool.cpp:257
    #5 0x560af4168efc in doris::Status doris::ThreadPoolBuilder::build<doris::ThreadPool>(std::unique_ptr<doris::ThreadPool, std::default_delete<doris::ThreadPool> >*) const /root/doris/be/src/util/threadpool.h:114
    #6 0x560af4168efc in doris::EvHttpServer::start() /root/doris/be/src/http/ev_http_server.cpp:100
    #7 0x560af2ecb33f in doris::HttpService::start() /root/doris/be/src/service/http_service.cpp:191
    #8 0x560af1238d53 in main /root/doris/be/src/service/doris_main.cpp:496
    #9 0x7f643ff7b082 in __libc_start_main ../csu/libc-start.c:308

SUMMARY: AddressSanitizer: stack-buffer-overflow (/mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster7/be/lib/doris_be+0x7049b16) in __interceptor_sigaltstack.part.0
Shadow bytes around the buggy address:
  0x0fecc1a19560: 00 00 00 00 00 00 f1 f1 f1 f1 f1 f1 01 f2 00 00
  0x0fecc1a19570: 00 00 f3 f3 f3 f3 00 00 00 00 00 00 00 00 00 00
  0x0fecc1a19580: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0fecc1a19590: 00 00 00 00 00 00 00 00 00 00 00 00 f1 f1 f1 f1
  0x0fecc1a195a0: f1 f1 01 f2 04 f2 04 f2 04 f2 04 f2 00 00 00 00
=>0x0fecc1a195b0: f2 f2 f2 f2 01 f3[f3]f3 00 00 00 00 00 00 00 00
  0x0fecc1a195c0: 00 00 00 00 00 00 00 00 00 00 f1 f1 f1 f1 01 f2
  0x0fecc1a195d0: f8 f2 01 f2 04 f2 04 f2 00 00 f2 f2 00 00 f2 f2
  0x0fecc1a195e0: 00 00 f2 f2 00 00 f2 f2 00 00 00 f2 f2 f2 f2 f2
  0x0fecc1a195f0: 00 00 00 00 f2 f2 f2 f2 00 00 00 00 f2 f2 f2 f2
  0x0fecc1a19600: 00 00 00 00 00 00 f3 f3 f3 f3 00 00 00 00 00 00
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
  Shadow gap:              cc
==3313527==ABORTING
start time: Fri 24 Feb 2023 01:47:08 PM CST
WARNING: Logging before InitGoogleLogging() is written to STDERR
I0224 13:47:08.619928 3332520 doris_main.cpp:324] enable_fuzzy_mode is true, set fuzzy configs
=================================================================
==3332520==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x7f261aa5d8c8 at pc 0x555d91c56b17 bp 0x7f261aa5d890 sp 0x7f261aa5d038
WRITE of size 24 at 0x7f261aa5d8c8 thread T611 (TaskWorkerPool.)
    #0 0x555d91c56b16 in __interceptor_sigaltstack.part.0 (/mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster7/be/lib/doris_be+0x7049b16)
    #1 0x555d91cbc8bf in __asan::PlatformUnpoisonStacks() (/mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster7/be/lib/doris_be+0x70af8bf)
    #2 0x555d91cc2224 in __asan_handle_no_return (/mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster7/be/lib/doris_be+0x70b5224)
    #3 0x555d946706d1 in apache::thrift::protocol::TProtocol::decrementOutputRecursionDepth() /var/local/thirdparty/installed/include/thrift/protocol/TProtocol.h:576
    #4 0x555d946706d1 in apache::thrift::protocol::TOutputRecursionTracker::~TOutputRecursionTracker() /var/local/thirdparty/installed/include/thrift/protocol/TProtocol.h:648
    #5 0x555d946706d1 in doris::TTabletInfo::write(apache::thrift::protocol::TProtocol*) const /root/doris/gensrc/build/gen_cpp/MasterService_types.cpp:483
    #6 0x555d94666b0c in doris::TTablet::write(apache::thrift::protocol::TProtocol*) const /root/doris/gensrc/build/gen_cpp/MasterService_types.cpp:1215
    #7 0x555d9466d15a in doris::TReportRequest::write(apache::thrift::protocol::TProtocol*) const /root/doris/gensrc/build/gen_cpp/MasterService_types.cpp:1930
    #8 0x555d942bf17b in doris::FrontendService_report_pargs::write(apache::thrift::protocol::TProtocol*) const /root/doris/gensrc/build/gen_cpp/FrontendService.cpp:1204
    #9 0x555d942f866c in doris::FrontendServiceClient::send_report(doris::TReportRequest const&) /root/doris/gensrc/build/gen_cpp/FrontendService.cpp:5566
    #10 0x555d9431f360 in doris::FrontendServiceClient::report(doris::TMasterResult&, doris::TReportRequest const&) /root/doris/gensrc/build/gen_cpp/FrontendService.cpp:5555
    #11 0x555d9294362c in doris::MasterServerClient::report(doris::TReportRequest const&, doris::TMasterResult*) /root/doris/be/src/agent/utils.cpp:109
    #12 0x555d928d4e74 in doris::TaskWorkerPool::_handle_report(doris::TReportRequest&, doris::TaskWorkerPool::ReportType) /root/doris/be/src/agent/task_worker_pool.cpp:1651
    #13 0x555d928dbbf5 in doris::TaskWorkerPool::_report_tablet_worker_thread_callback() /root/doris/be/src/agent/task_worker_pool.cpp:1376
    #14 0x555d92923c21 in void std::__invoke_impl<void, void (doris::TaskWorkerPool::*&)(), doris::TaskWorkerPool*&>(std::__invoke_memfun_deref, void (doris::TaskWorkerPool::*&)(), doris::TaskWorkerPool*&) /var/local/ldb-toolchain/include/c++/11/bits/invoke.h:74
    #15 0x555d92923c21 in std::enable_if<is_invocable_r_v<void, void (doris::TaskWorkerPool::*&)(), doris::TaskWorkerPool*&>, void>::type std::__invoke_r<void, void (doris::TaskWorkerPool::*&)(), doris::TaskWorkerPool*&>(void (doris::TaskWorkerPool::*&)(), doris::TaskWorkerPool*&) /var/local/ldb-toolchain/include/c++/11/bits/invoke.h:111
    #16 0x555d92923c21 in void std::_Bind_result<void, void (doris::TaskWorkerPool::*(doris::TaskWorkerPool*))()>::__call<void, , 0ul>(std::tuple<>&&, std::_Index_tuple<0ul>) /var/local/ldb-toolchain/include/c++/11/functional:570
    #17 0x555d92923c21 in void std::_Bind_result<void, void (doris::TaskWorkerPool::*(doris::TaskWorkerPool*))()>::operator()<>() /var/local/ldb-toolchain/include/c++/11/functional:629
    #18 0x555d92923c21 in void std::__invoke_impl<void, std::_Bind_result<void, void (doris::TaskWorkerPool::*(doris::TaskWorkerPool*))()>&>(std::__invoke_other, std::_Bind_result<void, void (doris::TaskWorkerPool::*(doris::TaskWorkerPool*))()>&) /var/local/ldb-toolchain/include/c++/11/bits/invoke.h:61
    #19 0x555d92923c21 in std::enable_if<is_invocable_r_v<void, std::_Bind_result<void, void (doris::TaskWorkerPool::*(doris::TaskWorkerPool*))()>&>, void>::type std::__invoke_r<void, std::_Bind_result<void, void (doris::TaskWorkerPool::*(doris::TaskWorkerPool*))()>&>(std::_Bind_result<void, void (doris::TaskWorkerPool::*(doris::TaskWorkerPool*))()>&) /var/local/ldb-toolchain/include/c++/11/bits/invoke.h:111
    #20 0x555d92923c21 in std::_Function_handler<void (), std::_Bind_result<void, void (doris::TaskWorkerPool::*(doris::TaskWorkerPool*))()> >::_M_invoke(std::_Any_data const&) /var/local/ldb-toolchain/include/c++/11/bits/std_function.h:291
    #21 0x555d93dcc1c2 in std::function<void ()>::operator()() const /var/local/ldb-toolchain/include/c++/11/bits/std_function.h:560
    #22 0x555d93dcc1c2 in doris::FunctionRunnable::run() /root/doris/be/src/util/threadpool.cpp:46
    #23 0x555d93dca0a0 in doris::ThreadPool::dispatch_thread() /root/doris/be/src/util/threadpool.cpp:529
    #24 0x555d93dcbd77 in void std::__invoke_impl<void, void (doris::ThreadPool::*&)(), doris::ThreadPool*&>(std::__invoke_memfun_deref, void (doris::ThreadPool::*&)(), doris::ThreadPool*&) /var/local/ldb-toolchain/include/c++/11/bits/invoke.h:74
    #25 0x555d93dcbd77 in std::__invoke_result<void (doris::ThreadPool::*&)(), doris::ThreadPool*&>::type std::__invoke<void (doris::ThreadPool::*&)(), doris::ThreadPool*&>(void (doris::ThreadPool::*&)(), doris::ThreadPool*&) /var/local/ldb-toolchain/include/c++/11/bits/invoke.h:96
    #26 0x555d93dcbd77 in void std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>::__call<void, , 0ul>(std::tuple<>&&, std::_Index_tuple<0ul>) /var/local/ldb-toolchain/include/c++/11/functional:420
    #27 0x555d93dcbd77 in void std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>::operator()<, void>() /var/local/ldb-toolchain/include/c++/11/functional:503
    #28 0x555d93dcbd77 in void std::__invoke_impl<void, std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>&>(std::__invoke_other, std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>&) /var/local/ldb-toolchain/include/c++/11/bits/invoke.h:61
    #29 0x555d93dcbd77 in std::enable_if<is_invocable_r_v<void, std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>&>, void>::type std::__invoke_r<void, std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>&>(std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>&) /var/local/ldb-toolchain/include/c++/11/bits/invoke.h:111
    #30 0x555d93dcbd77 in std::_Function_handler<void (), std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()> >::_M_invoke(std::_Any_data const&) /var/local/ldb-toolchain/include/c++/11/bits/std_function.h:291
    #31 0x555d93d9e334 in std::function<void ()>::operator()() const /var/local/ldb-toolchain/include/c++/11/bits/std_function.h:560
    #32 0x555d93d9e334 in doris::Thread::supervise_thread(void*) /root/doris/be/src/util/thread.cpp:453
    #33 0x7f27bf731608 in start_thread /build/glibc-SzIz7B/glibc-2.31/nptl/pthread_create.c:477
    #34 0x7f27bf507132 in __clone (/lib/x86_64-linux-gnu/libc.so.6+0x11f132)

Address 0x7f261aa5d8c8 is located in stack of thread T611 (TaskWorkerPool.) at offset 40 in frame
    #0 0x555d929457ef in apache::thrift::protocol::TVirtualProtocol<apache::thrift::protocol::TBinaryProtocolT<apache::thrift::transport::TTransport, apache::thrift::protocol::TNetworkBigEndian>, apache::thrift::protocol::TProtocolDefaults>::writeI64_virt(long) /var/local/thirdparty/installed/include/thrift/protocol/TVirtualProtocol.h:380

  This frame has 1 object(s):
    [32, 40) 'net' <== Memory access at offset 40 overflows this variable
HINT: this may be a false positive if your program uses some custom stack unwind mechanism, swapcontext or vfork
      (longjmp and C++ exceptions *are* supported)
Thread T611 (TaskWorkerPool.) created by T0 here:
    #0 0x555d91c5b061 in pthread_create (/mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster7/be/lib/doris_be+0x704e061)
    #1 0x555d93d9a1d1 in doris::Thread::start_thread(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::function<void ()> const&, unsigned long, scoped_refptr<doris::Thread>*) /root/doris/be/src/util/thread.cpp:407
    #2 0x555d93db7aaa in doris::Status doris::Thread::create<void (doris::ThreadPool::*)(), doris::ThreadPool*>(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, void (doris::ThreadPool::* const&)(), doris::ThreadPool* const&, scoped_refptr<doris::Thread>*) /root/doris/be/src/util/thread.h:57
    #3 0x555d93db7aaa in doris::ThreadPool::create_thread() /root/doris/be/src/util/threadpool.cpp:598
    #4 0x555d93dc1633 in doris::ThreadPool::init() /root/doris/be/src/util/threadpool.cpp:257
    #5 0x555d928cf7b0 in doris::Status doris::ThreadPoolBuilder::build<doris::ThreadPool>(std::unique_ptr<doris::ThreadPool, std::default_delete<doris::ThreadPool> >*) const /root/doris/be/src/util/threadpool.h:114
    #6 0x555d928cf7b0 in doris::TaskWorkerPool::start() /root/doris/be/src/agent/task_worker_pool.cpp:223
    #7 0x555d9396e75a in doris::AgentServer::AgentServer(doris::ExecEnv*, doris::TMasterInfo const&) /root/doris/be/src/agent/agent_server.cpp:96
    #8 0x555d93948f1b in doris::BackendService::BackendService(doris::ExecEnv*) /root/doris/be/src/service/backend_service.cpp:68
    #9 0x555d93952eec in doris::BackendService::create_service(doris::ExecEnv*, int, doris::ThriftServer**) /root/doris/be/src/service/backend_service.cpp:71
    #10 0x555d91d085cb in main /root/doris/be/src/service/doris_main.cpp:463
    #11 0x7f27bf40c082 in __libc_start_main ../csu/libc-start.c:308

SUMMARY: AddressSanitizer: stack-buffer-overflow (/mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster7/be/lib/doris_be+0x7049b16) in __interceptor_sigaltstack.part.0
Shadow bytes around the buggy address:
  0x0fe543543ac0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0fe543543ad0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0fe543543ae0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0fe543543af0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0fe543543b00: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
=>0x0fe543543b10: 00 00 00 00 f1 f1 f1 f1 00[f3]f3 f3 00 00 00 00
  0x0fe543543b20: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0fe543543b30: f1 f1 f1 f1 f1 f1 01 f2 00 f2 f2 f2 00 f2 f2 f2
  0x0fe543543b40: 00 f2 f2 f2 00 f2 f2 f2 00 f3 f3 f3 00 00 00 00
  0x0fe543543b50: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0fe543543b60: f1 f1 f1 f1 f1 f1 01 f2 00 f2 f2 f2 00 f2 f2 f2
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
  Shadow gap:              cc
==3332520==ABORTING

```

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

