### PR TITLE
[fix](Nereids) use a threshold to check the equal double values in n-th rank

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Memo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Memo.java
@@ -51,7 +51,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.PriorityQueue;
-import java.util.Queue;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 
@@ -721,20 +720,24 @@ public class Memo {
      * In unrank() function, we will extract the actual physical function according the unique ID
      */
     public long rank(long n) {
+        double threshold = 0.000000001;
         Preconditions.checkArgument(n > 0, "the n %d must be greater than 0 in nthPlan", n);
         List<Pair<Long, Double>> plans = rankGroup(root, PhysicalProperties.GATHER);
-        Queue<Pair<Long, Double>> rankingQueue = new PriorityQueue<>(
-                (l, r) -> -Double.compare(l.second, r.second));
-
-        for (Pair<Long, Double> plan : plans) {
-            if (rankingQueue.size() == 0 || rankingQueue.size() < n) {
-                rankingQueue.add(plan);
-            } else if (rankingQueue.peek().second > plan.second) {
-                rankingQueue.poll();
-                rankingQueue.add(plan);
+        plans = plans.stream().filter(
+                p -> !p.second.equals(Double.NaN)
+                        && !p.second.equals(Double.POSITIVE_INFINITY)
+                        && !p.second.equals(Double.NEGATIVE_INFINITY))
+                .collect(Collectors.toList());
+        // This is big heap, it always pops the element with larger cost or larger id.
+        PriorityQueue<Pair<Long, Double>> pq = new PriorityQueue<>((l, r) -> Math.abs(l.second - r.second) < threshold
+                ? -Long.compare(l.first, r.first) : -Double.compare(l.second, r.second));
+        for (Pair<Long, Double> p : plans) {
+            pq.add(p);
+            if (pq.size() > n) {
+                pq.poll();
             }
         }
-        return rankingQueue.peek().first;
+        return pq.peek().first;
     }
 
     private List<Pair<Long, Double>> rankGroup(Group group, PhysicalProperties prop) {


### PR DESCRIPTION
# Proposed changes

The cost is inaccurate, so we use a threshold to check the equal double values

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

