### PR TITLE
[fix](multi-catalog) fix not find dbname from internal catalog

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/MysqlProto.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/MysqlProto.java
@@ -298,7 +298,7 @@ public class MysqlProto {
                     context.getState().setError(ErrorCode.ERR_BAD_DB_ERROR, "No match catalog in doris: " + db);
                     return false;
                 }
-                if (catalogIf.getDbNullable(dbName) == null) {
+                if (catalogIf.getDbNullable(dbFullName) == null) {
                     context.getState().setError(ErrorCode.ERR_BAD_DB_ERROR, "No match database in doris: " + db);
                     return false;
                 }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

when: mysql -h127.0.0.1 -P9030 -uroot -Dinternal.information_schema
will get error:
ERROR 2013 (HY000): Lost connection to MySQL server at 'reading authorization packet', system error: 0

because not use fulldbname

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

