### PR TITLE
[enhancement](log)enhance log msg of finding be policy failure

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/system/BeSelectionPolicy.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/system/BeSelectionPolicy.java
@@ -172,7 +172,7 @@ public class BeSelectionPolicy {
 
     @Override
     public String toString() {
-        return String.format("cluster:%s | query:%s | load:%s | schedule:%s | tags:%s | medium:%s ",
+        return String.format("cluster=%s | query=%s | load=%s | schedule=%s | tags=%s | medium=%s",
                 cluster, needLoadAvailable, needLoadAvailable, needScheduleAvailable, resourceTags, storageMedium);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/system/BeSelectionPolicy.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/system/BeSelectionPolicy.java
@@ -172,14 +172,7 @@ public class BeSelectionPolicy {
 
     @Override
     public String toString() {
-        StringBuilder sb = new StringBuilder();
-        sb.append("cluster|query|load|schedule|tags|medium: ");
-        sb.append(cluster).append("|");
-        sb.append(needQueryAvailable).append("|");
-        sb.append(needLoadAvailable).append("|");
-        sb.append(needScheduleAvailable).append("|");
-        sb.append(resourceTags).append("|");
-        sb.append(storageMedium);
-        return sb.toString();
+        return String.format("cluster:%s | query:%s | load:%s | schedule:%s | tags:%s | medium:%s ",
+                cluster, needLoadAvailable, needLoadAvailable, needScheduleAvailable, resourceTags, storageMedium);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/system/SystemInfoService.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/system/SystemInfoService.java
@@ -865,7 +865,7 @@ public class SystemInfoService {
             BeSelectionPolicy policy = builder.build();
             List<Long> beIds = selectBackendIdsByPolicy(policy, entry.getValue());
             if (beIds.isEmpty()) {
-                throw new DdlException("Failed to find " + entry.getValue() + " backends for policy: " + policy);
+                throw new DdlException("Failed to find " + entry.getValue() + " backend(s) for policy: " + policy);
             }
             chosenBackendIds.put(entry.getKey(), beIds);
             totalReplicaNum += beIds.size();

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/CreateTableTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/CreateTableTest.java
@@ -266,7 +266,7 @@ public class CreateTableTest {
                         + "properties('replication_num' = '1', 'short_key' = '4');"));
 
         ExceptionChecker
-                .expectThrowsWithMsg(DdlException.class, "Failed to find 3 backends for policy",
+                .expectThrowsWithMsg(DdlException.class, "Failed to find 3 backend(s) for policy",
                         () -> createTable("create table test.atbl5\n" + "(k1 int, k2 int, k3 int)\n"
                                 + "duplicate key(k1, k2, k3)\n" + "distributed by hash(k1) buckets 1\n"
                                 + "properties('replication_num' = '3');"));
@@ -283,7 +283,7 @@ public class CreateTableTest {
 
         ConfigBase.setMutableConfig("disable_storage_medium_check", "false");
         ExceptionChecker
-                .expectThrowsWithMsg(DdlException.class, " Failed to find 1 backends for policy:",
+                .expectThrowsWithMsg(DdlException.class, " Failed to find 1 backend(s) for policy:",
                         () -> createTable("create table test.tb7(key1 int, key2 varchar(10)) distributed by hash(key1) \n"
                                 + "buckets 1 properties('replication_num' = '1', 'storage_medium' = 'ssd');"));
 

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/ModifyBackendTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/ModifyBackendTest.java
@@ -80,7 +80,7 @@ public class ModifyBackendTest {
         String createStr = "create table test.tbl1(\n" + "k1 int\n" + ") distributed by hash(k1)\n"
                 + "buckets 3 properties(\n" + "\"replication_num\" = \"1\"\n" + ");";
         CreateTableStmt createStmt = (CreateTableStmt) UtFrameUtils.parseAndAnalyzeStmt(createStr, connectContext);
-        ExceptionChecker.expectThrowsWithMsg(DdlException.class, "Failed to find 1 backends for policy:",
+        ExceptionChecker.expectThrowsWithMsg(DdlException.class, "Failed to find 1 backend(s) for policy:",
                 () -> DdlExecutor.execute(Env.getCurrentEnv(), createStmt));
 
         createStr = "create table test.tbl1(\n" + "k1 int\n" + ") distributed by hash(k1)\n" + "buckets 3 properties(\n"
@@ -100,7 +100,7 @@ public class ModifyBackendTest {
                 + ");";
         CreateTableStmt createStmt3 = (CreateTableStmt) UtFrameUtils.parseAndAnalyzeStmt(createStr, connectContext);
         //partition create failed, because there is no BE with "default" tag
-        ExceptionChecker.expectThrowsWithMsg(DdlException.class, "Failed to find 3 backends for policy",
+        ExceptionChecker.expectThrowsWithMsg(DdlException.class, "Failed to find 3 backend(s) for policy",
                 () -> DdlExecutor.execute(Env.getCurrentEnv(), createStmt3));
         Database db = Env.getCurrentInternalCatalog().getDbNullable("default_cluster:test");
 


### PR DESCRIPTION
# Proposed changes

Issue Number: close #16960

## Problem summary

Enhance the errmsg of finding be policy failure like below.

```
mysql> CREATE TABLE test_backend_miss_policy (c1 INT) DISTRIBUTED BY HASH(c1) PROPERTIES('replication_num'='1');
ERROR 1105 (HY000): errCode = 2, detailMessage = Failed to find 1 backend(s) for policy: cluster=default_cluster | query=false | load=false | schedule=true | tags=[{"location" : "default"}] | medium=HDD
```

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [x] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

