### PR TITLE
[fix](s3) fix SdkClientException: Multiple HTTP implementations were found on the classpath

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/PaloFe.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/PaloFe.java
@@ -134,6 +134,14 @@ public class PaloFe {
                 return;
             }
 
+            // To resolve: "SdkClientException: Multiple HTTP implementations were found on the classpath"
+            // Currently, there are 2 implements of HTTP client: ApacheHttpClient and UrlConnectionHttpClient
+            // The UrlConnectionHttpClient is introduced by #16602, and it causes the exception.
+            // So we set the default HTTP client to UrlConnectionHttpClient.
+            // TODO: remove this after we remove ApacheHttpClient
+            System.setProperty("software.amazon.awssdk.http.service.impl",
+                    "software.amazon.awssdk.http.urlconnection.UrlConnectionSdkHttpService");
+
             // init catalog and wait it be ready
             Env.getCurrentEnv().initialize(args);
             Env.getCurrentEnv().waitForReady();


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

To resolve: `SdkClientException: Multiple HTTP implementations were found on the classpath`
Currently, there are 2 implements of HTTP client: ApacheHttpClient and UrlConnectionHttpClient
The UrlConnectionHttpClient is introduced by #16602, and it causes the exception.
So we set the default HTTP client to UrlConnectionHttpClient.
TODO: remove this after we remove ApacheHttpClient

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

