### PR TITLE
[refactor](mempool) remove mempool parameter from key decoder methods

### DIFF
--- a/be/src/olap/field.h
+++ b/be/src/olap/field.h
@@ -192,10 +192,6 @@ public:
     void full_encode_ascending(const void* value, std::string* buf) const {
         _key_coder->full_encode_ascending(value, buf);
     }
-
-    Status decode_ascending(Slice* encoded_key, uint8_t* cell_ptr, MemPool* pool) const {
-        return _key_coder->decode_ascending(encoded_key, _index_size, cell_ptr, pool);
-    }
     void add_sub_field(std::unique_ptr<Field> sub_field) {
         _sub_fields.emplace_back(std::move(sub_field));
     }

--- a/be/src/olap/key_coder.cpp
+++ b/be/src/olap/key_coder.cpp
@@ -69,6 +69,9 @@ private:
 
         add_mapping<OLAP_FIELD_TYPE_DATE>();
         add_mapping<OLAP_FIELD_TYPE_DECIMAL>();
+        add_mapping<OLAP_FIELD_TYPE_CHAR>();
+        add_mapping<OLAP_FIELD_TYPE_VARCHAR>();
+        add_mapping<OLAP_FIELD_TYPE_STRING>();
         add_mapping<OLAP_FIELD_TYPE_BOOL>();
         add_mapping<OLAP_FIELD_TYPE_DATEV2>();
         add_mapping<OLAP_FIELD_TYPE_DATETIMEV2>();

--- a/be/src/olap/key_coder.cpp
+++ b/be/src/olap/key_coder.cpp
@@ -24,8 +24,7 @@ namespace doris {
 template <typename TraitsType>
 KeyCoder::KeyCoder(TraitsType traits)
         : _full_encode_ascending(traits.full_encode_ascending),
-          _encode_ascending(traits.encode_ascending),
-          _decode_ascending(traits.decode_ascending) {}
+          _encode_ascending(traits.encode_ascending) {}
 
 struct EnumClassHash {
     template <typename T>

--- a/be/src/olap/key_coder.cpp
+++ b/be/src/olap/key_coder.cpp
@@ -69,9 +69,6 @@ private:
 
         add_mapping<OLAP_FIELD_TYPE_DATE>();
         add_mapping<OLAP_FIELD_TYPE_DECIMAL>();
-        add_mapping<OLAP_FIELD_TYPE_CHAR>();
-        add_mapping<OLAP_FIELD_TYPE_VARCHAR>();
-        add_mapping<OLAP_FIELD_TYPE_STRING>();
         add_mapping<OLAP_FIELD_TYPE_BOOL>();
         add_mapping<OLAP_FIELD_TYPE_DATEV2>();
         add_mapping<OLAP_FIELD_TYPE_DATETIMEV2>();

--- a/be/src/olap/key_coder.cpp
+++ b/be/src/olap/key_coder.cpp
@@ -24,7 +24,8 @@ namespace doris {
 template <typename TraitsType>
 KeyCoder::KeyCoder(TraitsType traits)
         : _full_encode_ascending(traits.full_encode_ascending),
-          _encode_ascending(traits.encode_ascending) {}
+          _encode_ascending(traits.encode_ascending),
+          _decode_ascending(traits.decode_ascending) {}
 
 struct EnumClassHash {
     template <typename T>

--- a/be/src/olap/key_coder.h
+++ b/be/src/olap/key_coder.h
@@ -32,6 +32,7 @@ using strings::Substitute;
 
 using FullEncodeAscendingFunc = void (*)(const void* value, std::string* buf);
 using EncodeAscendingFunc = void (*)(const void* value, size_t index_size, std::string* buf);
+using DecodeAscendingFunc = Status (*)(Slice* encoded_key, size_t index_size, uint8_t* cell_ptr);
 
 // Order-preserving binary encoding for values of a particular type so that
 // those values can be compared by memcpy their encoded bytes.
@@ -53,9 +54,15 @@ public:
         _encode_ascending(value, index_size, buf);
     }
 
+    // Only used for test, should delete it in the future
+    Status decode_ascending(Slice* encoded_key, size_t index_size, uint8_t* cell_ptr) const {
+        return _decode_ascending(encoded_key, index_size, cell_ptr);
+    }
+
 private:
     FullEncodeAscendingFunc _full_encode_ascending;
     EncodeAscendingFunc _encode_ascending;
+    DecodeAscendingFunc _decode_ascending;
 };
 
 extern const KeyCoder* get_key_coder(FieldType type);
@@ -203,7 +210,7 @@ public:
         memcpy(&decimal_val, value, sizeof(decimal12_t));
         KeyCoderTraits<OLAP_FIELD_TYPE_BIGINT>::full_encode_ascending(&decimal_val.integer, buf);
         KeyCoderTraits<OLAP_FIELD_TYPE_INT>::full_encode_ascending(&decimal_val.fraction, buf);
-    }
+    } // namespace doris
 
     static void encode_ascending(const void* value, size_t index_size, std::string* buf) {
         full_encode_ascending(value, buf);

--- a/be/src/olap/key_coder.h
+++ b/be/src/olap/key_coder.h
@@ -32,8 +32,6 @@ using strings::Substitute;
 
 using FullEncodeAscendingFunc = void (*)(const void* value, std::string* buf);
 using EncodeAscendingFunc = void (*)(const void* value, size_t index_size, std::string* buf);
-using DecodeAscendingFunc = Status (*)(Slice* encoded_key, size_t index_size, uint8_t* cell_ptr,
-                                       MemPool* pool);
 
 // Order-preserving binary encoding for values of a particular type so that
 // those values can be compared by memcpy their encoded bytes.
@@ -112,6 +110,12 @@ public:
     }
 
     static Status decode_ascending(Slice* encoded_key, size_t index_size, uint8_t* cell_ptr) {
+        // decode_ascending only used in orinal index page, maybe should remove it in the future.
+        // currently, we reduce the usage of this method.
+        if constexpr (std::is_same<field_type, OLAP_FIELD_TYPE_UNSIGNED_BIGINT>::value) {
+            LOG(FATAL) << "decode_ascending should only be used for "
+                          "OLAP_FIELD_TYPE_UNSIGNED_BIGINT in ordinal index page";
+        }
         if (encoded_key->size < sizeof(UnsignedCppType)) {
             return Status::InvalidArgument("Key too short, need={} vs real={}",
                                            sizeof(UnsignedCppType), encoded_key->size);

--- a/be/src/olap/key_coder.h
+++ b/be/src/olap/key_coder.h
@@ -252,9 +252,9 @@ public:
     static Status decode_ascending(Slice* encoded_key, size_t index_size, uint8_t* cell_ptr) {
         decimal12_t decimal_val = {0, 0};
         RETURN_IF_ERROR(KeyCoderTraits<OLAP_FIELD_TYPE_BIGINT>::decode_ascending(
-                encoded_key, sizeof(decimal_val.integer), (uint8_t*)&decimal_val.integer, pool));
+                encoded_key, sizeof(decimal_val.integer), (uint8_t*)&decimal_val.integer));
         RETURN_IF_ERROR(KeyCoderTraits<OLAP_FIELD_TYPE_INT>::decode_ascending(
-                encoded_key, sizeof(decimal_val.fraction), (uint8_t*)&decimal_val.fraction, pool));
+                encoded_key, sizeof(decimal_val.fraction), (uint8_t*)&decimal_val.fraction));
         memcpy(cell_ptr, &decimal_val, sizeof(decimal12_t));
         return Status::OK();
     }

--- a/be/src/olap/key_coder.h
+++ b/be/src/olap/key_coder.h
@@ -275,6 +275,11 @@ public:
                 << ", char=" << slice->size;
         buf->append(slice->data, index_size);
     }
+
+    static Status decode_ascending(Slice* encoded_key, size_t index_size, uint8_t* cell_ptr) {
+        LOG(FATAL) << "decode_ascending is not implemented";
+        return Status::OK();
+    }
 };
 
 template <>
@@ -290,6 +295,11 @@ public:
         size_t copy_size = std::min(index_size, slice->size);
         buf->append(slice->data, copy_size);
     }
+
+    static Status decode_ascending(Slice* encoded_key, size_t index_size, uint8_t* cell_ptr) {
+        LOG(FATAL) << "decode_ascending is not implemented";
+        return Status::OK();
+    }
 };
 
 template <>
@@ -304,6 +314,11 @@ public:
         const Slice* slice = (const Slice*)value;
         size_t copy_size = std::min(index_size, slice->size);
         buf->append(slice->data, copy_size);
+    }
+
+    static Status decode_ascending(Slice* encoded_key, size_t index_size, uint8_t* cell_ptr) {
+        LOG(FATAL) << "decode_ascending is not implemented";
+        return Status::OK();
     }
 };
 

--- a/be/src/olap/key_coder.h
+++ b/be/src/olap/key_coder.h
@@ -112,7 +112,9 @@ public:
     static Status decode_ascending(Slice* encoded_key, size_t index_size, uint8_t* cell_ptr) {
         // decode_ascending only used in orinal index page, maybe should remove it in the future.
         // currently, we reduce the usage of this method.
-        if constexpr (std::is_same<field_type, OLAP_FIELD_TYPE_UNSIGNED_BIGINT>::value) {
+        if constexpr (std::is_same<CppType,
+                                   typename CppTypeTraits<
+                                           OLAP_FIELD_TYPE_UNSIGNED_BIGINT>::CppType>::value) {
             LOG(FATAL) << "decode_ascending should only be used for "
                           "OLAP_FIELD_TYPE_UNSIGNED_BIGINT in ordinal index page";
         }

--- a/be/src/olap/rowset/segment_v2/ordinal_page_index.cpp
+++ b/be/src/olap/rowset/segment_v2/ordinal_page_index.cpp
@@ -97,7 +97,7 @@ Status OrdinalIndexReader::load(bool use_page_cache, bool kept_in_memory) {
         Slice key = reader.get_key(i);
         ordinal_t ordinal = 0;
         RETURN_IF_ERROR(KeyCoderTraits<OLAP_FIELD_TYPE_UNSIGNED_BIGINT>::decode_ascending(
-                &key, sizeof(ordinal_t), (uint8_t*)&ordinal, nullptr));
+                &key, sizeof(ordinal_t), (uint8_t*)&ordinal));
 
         _ordinals[i] = ordinal;
         _pages[i] = reader.get_value(i);

--- a/be/test/olap/key_coder_test.cpp
+++ b/be/test/olap/key_coder_test.cpp
@@ -227,26 +227,28 @@ TEST_F(KeyCoderTest, test_char) {
         std::string key;
         key_coder->encode_ascending(&slice, 10, &key);
         Slice encoded_key(key);
-
+        /*
         Slice check_slice;
         auto st = key_coder->decode_ascending(&encoded_key, 10, (uint8_t*)&check_slice, &_pool);
         EXPECT_TRUE(st.ok());
 
         EXPECT_EQ(10, check_slice.size);
         EXPECT_EQ(strncmp("1234567890", check_slice.data, 10), 0);
+        */
     }
 
     {
         std::string key;
         key_coder->encode_ascending(&slice, 5, &key);
         Slice encoded_key(key);
-
+        /*
         Slice check_slice;
         auto st = key_coder->decode_ascending(&encoded_key, 5, (uint8_t*)&check_slice, &_pool);
         EXPECT_TRUE(st.ok());
 
         EXPECT_EQ(5, check_slice.size);
         EXPECT_EQ(strncmp("12345", check_slice.data, 5), 0);
+        */
     }
 }
 
@@ -260,26 +262,28 @@ TEST_F(KeyCoderTest, test_varchar) {
         std::string key;
         key_coder->encode_ascending(&slice, 15, &key);
         Slice encoded_key(key);
-
+        /*
         Slice check_slice;
         auto st = key_coder->decode_ascending(&encoded_key, 15, (uint8_t*)&check_slice, &_pool);
         EXPECT_TRUE(st.ok());
 
         EXPECT_EQ(10, check_slice.size);
         EXPECT_EQ(strncmp("1234567890", check_slice.data, 10), 0);
+        */
     }
 
     {
         std::string key;
         key_coder->encode_ascending(&slice, 5, &key);
         Slice encoded_key(key);
-
+        /*
         Slice check_slice;
         auto st = key_coder->decode_ascending(&encoded_key, 5, (uint8_t*)&check_slice, &_pool);
         EXPECT_TRUE(st.ok());
 
         EXPECT_EQ(5, check_slice.size);
         EXPECT_EQ(strncmp("12345", check_slice.data, 5), 0);
+        */
     }
 }
 

--- a/be/test/olap/key_coder_test.cpp
+++ b/be/test/olap/key_coder_test.cpp
@@ -57,7 +57,7 @@ void test_integer_encode() {
         {
             Slice slice(buf);
             CppType check_val;
-            key_coder->decode_ascending(&slice, sizeof(CppType), (uint8_t*)&check_val, nullptr);
+            key_coder->decode_ascending(&slice, sizeof(CppType), (uint8_t*)&check_val);
             EXPECT_EQ(val, check_val);
         }
     }
@@ -76,7 +76,7 @@ void test_integer_encode() {
         {
             Slice slice(buf);
             CppType check_val;
-            key_coder->decode_ascending(&slice, sizeof(CppType), (uint8_t*)&check_val, nullptr);
+            key_coder->decode_ascending(&slice, sizeof(CppType), (uint8_t*)&check_val);
             EXPECT_EQ(val, check_val);
         }
     }
@@ -132,7 +132,7 @@ TEST_F(KeyCoderTest, test_date) {
         {
             Slice slice(buf);
             CppType check_val;
-            key_coder->decode_ascending(&slice, sizeof(CppType), (uint8_t*)&check_val, nullptr);
+            key_coder->decode_ascending(&slice, sizeof(CppType), (uint8_t*)&check_val);
             EXPECT_EQ(val, check_val);
         }
     }
@@ -148,7 +148,7 @@ TEST_F(KeyCoderTest, test_date) {
         {
             Slice slice(buf);
             CppType check_val;
-            key_coder->decode_ascending(&slice, sizeof(CppType), (uint8_t*)&check_val, nullptr);
+            key_coder->decode_ascending(&slice, sizeof(CppType), (uint8_t*)&check_val);
             EXPECT_EQ(val, check_val);
         }
     }
@@ -183,7 +183,7 @@ TEST_F(KeyCoderTest, test_decimal) {
 
     decimal12_t check_val;
     Slice slice1(buf1);
-    key_coder->decode_ascending(&slice1, sizeof(decimal12_t), (uint8_t*)&check_val, nullptr);
+    key_coder->decode_ascending(&slice1, sizeof(decimal12_t), (uint8_t*)&check_val);
     EXPECT_EQ(check_val, val1);
 
     {


### PR DESCRIPTION

decode method is only used for big int and other decode method is only used in unit test.

I remove the useless method and we can remove mempool parameter from decode method.

# Proposed changes

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

