### PR TITLE
[feature](cooldown) Forbid storage policy for MoW tables

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
@@ -1936,7 +1936,7 @@ public class SchemaChangeHandler extends AlterHandler {
             }
         }
         String storagePolicy = properties.get(PropertyAnalyzer.PROPERTIES_STORAGE_POLICY);
-        if (enableUniqueKeyMergeOnWrite && !storagePolicy.equals("")) {
+        if (enableUniqueKeyMergeOnWrite && Strings.isNullOrEmpty(storagePolicy)) {
             throw new UserException(
                 "Can not set UNIQUE KEY table that enables Merge-On-write"
                 + " with storage policy(" + storagePolicy + ")");
@@ -1977,7 +1977,7 @@ public class SchemaChangeHandler extends AlterHandler {
         }
         String storagePolicy = properties.get(PropertyAnalyzer.PROPERTIES_STORAGE_POLICY);
         boolean enableUniqueKeyMergeOnWrite = olapTable.getEnableUniqueKeyMergeOnWrite();
-        if (enableUniqueKeyMergeOnWrite && !storagePolicy.equals("")) {
+        if (enableUniqueKeyMergeOnWrite && !Strings.isNullOrEmpty(storagePolicy)) {
             throw new DdlException(
                 "Can not set UNIQUE KEY table that enables Merge-On-write"
                 + " with storage policy(" + storagePolicy + ")");

--- a/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
@@ -1936,7 +1936,7 @@ public class SchemaChangeHandler extends AlterHandler {
             }
         }
         String storagePolicy = properties.get(PropertyAnalyzer.PROPERTIES_STORAGE_POLICY);
-        if (enableUniqueKeyMergeOnWrite && Strings.isNullOrEmpty(storagePolicy)) {
+        if (enableUniqueKeyMergeOnWrite && !Strings.isNullOrEmpty(storagePolicy)) {
             throw new UserException(
                 "Can not set UNIQUE KEY table that enables Merge-On-write"
                 + " with storage policy(" + storagePolicy + ")");

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ModifyTablePropertiesClause.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ModifyTablePropertiesClause.java
@@ -25,6 +25,8 @@ import org.apache.doris.common.util.DynamicPartitionUtil;
 import org.apache.doris.common.util.PrintableMap;
 import org.apache.doris.common.util.PropertyAnalyzer;
 
+import com.google.common.base.Strings;
+
 import java.util.Map;
 
 // clause which is used to modify table properties
@@ -102,7 +104,7 @@ public class ModifyTablePropertiesClause extends AlterTableClause {
         } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_STORAGE_POLICY)) {
             this.needTableStable = false;
             String storagePolicy = properties.getOrDefault(PropertyAnalyzer.PROPERTIES_STORAGE_POLICY, "");
-            if (!storagePolicy.equals("")
+            if (!Strings.isNullOrEmpty(storagePolicy)
                     && properties.containsKey(PropertyAnalyzer.ENABLE_UNIQUE_KEY_MERGE_ON_WRITE)) {
                 throw new AnalysisException(
                         "Can not set UNIQUE KEY table that enables Merge-On-write"

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ModifyTablePropertiesClause.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ModifyTablePropertiesClause.java
@@ -101,7 +101,14 @@ public class ModifyTablePropertiesClause extends AlterTableClause {
             throw new AnalysisException("Alter tablet type not supported");
         } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_STORAGE_POLICY)) {
             this.needTableStable = false;
-            setStoragePolicy(properties.getOrDefault(PropertyAnalyzer.PROPERTIES_STORAGE_POLICY, ""));
+            String storagePolicy = properties.getOrDefault(PropertyAnalyzer.PROPERTIES_STORAGE_POLICY, "");
+            if (!storagePolicy.equals("")
+                    && properties.containsKey(PropertyAnalyzer.ENABLE_UNIQUE_KEY_MERGE_ON_WRITE)) {
+                throw new AnalysisException(
+                        "Can not set UNIQUE KEY table that enables Merge-On-write"
+                                + " with storage policy(" + storagePolicy + ")");
+            }
+            setStoragePolicy(storagePolicy);
         } else if (properties.containsKey(PropertyAnalyzer.ENABLE_UNIQUE_KEY_MERGE_ON_WRITE)) {
             throw new AnalysisException("Can not change UNIQUE KEY to Merge-On-Write mode");
         } else {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
@@ -2013,7 +2013,8 @@ public class InternalCatalog implements CatalogIf<Database> {
         // set storage policy
         String storagePolicy = PropertyAnalyzer.analyzeStoragePolicy(properties);
         Env.getCurrentEnv().getPolicyMgr().checkStoragePolicyExist(storagePolicy);
-        if (olapTable.getEnableUniqueKeyMergeOnWrite() && !storagePolicy.equals("")) {
+        if (olapTable.getEnableUniqueKeyMergeOnWrite()
+                && !Strings.isNullOrEmpty(storagePolicy)) {
             throw new AnalysisException(
                     "Can not create UNIQUE KEY table that enables Merge-On-write"
                     + " with storage policy(" + storagePolicy + ")");
@@ -2236,7 +2237,8 @@ public class InternalCatalog implements CatalogIf<Database> {
                     DistributionInfo partitionDistributionInfo = distributionDesc.toDistributionInfo(baseSchema);
                     // use partition storage policy if it exist.
                     String partionStoragePolicy = partitionInfo.getStoragePolicy(entry.getValue());
-                    if (olapTable.getEnableUniqueKeyMergeOnWrite() && !partionStoragePolicy.equals("")) {
+                    if (olapTable.getEnableUniqueKeyMergeOnWrite()
+                            && !Strings.isNullOrEmpty(partionStoragePolicy)) {
                         throw new AnalysisException(
                                 "Can not create UNIQUE KEY table that enables Merge-On-write"
                                 + " with storage policy(" + partionStoragePolicy + ")");

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
@@ -2013,6 +2013,11 @@ public class InternalCatalog implements CatalogIf<Database> {
         // set storage policy
         String storagePolicy = PropertyAnalyzer.analyzeStoragePolicy(properties);
         Env.getCurrentEnv().getPolicyMgr().checkStoragePolicyExist(storagePolicy);
+        if (olapTable.getEnableUniqueKeyMergeOnWrite() && !storagePolicy.equals("")) {
+            throw new AnalysisException(
+                    "Can not create UNIQUE KEY table that enables Merge-On-write"
+                    + " with storage policy(" + storagePolicy + ")");
+        }
         olapTable.setStoragePolicy(storagePolicy);
 
         TTabletType tabletType;
@@ -2231,6 +2236,11 @@ public class InternalCatalog implements CatalogIf<Database> {
                     DistributionInfo partitionDistributionInfo = distributionDesc.toDistributionInfo(baseSchema);
                     // use partition storage policy if it exist.
                     String partionStoragePolicy = partitionInfo.getStoragePolicy(entry.getValue());
+                    if (olapTable.getEnableUniqueKeyMergeOnWrite() && !partionStoragePolicy.equals("")) {
+                        throw new AnalysisException(
+                                "Can not create UNIQUE KEY table that enables Merge-On-write"
+                                + " with storage policy(" + partionStoragePolicy + ")");
+                    }
                     if (!partionStoragePolicy.equals("")) {
                         storagePolicy = partionStoragePolicy;
                     }

--- a/regression-test/suites/cold_heat_separation/use_policy/disable_storage_policy_MoW.groovy
+++ b/regression-test/suites/cold_heat_separation/use_policy/disable_storage_policy_MoW.groovy
@@ -16,8 +16,8 @@
 // under the License.
 
 suite("disable_storage_policy_MoW"){
-    def s3_source_name = "default_s3_source"
-    def storage_policy_name = "default_storage_policy"
+    def s3_source_name = "default_s3_source_test"
+    def storage_policy_name = "default_storage_policy_test"
 
     def storage_exist = { name ->
         def show_storage_policy = sql """

--- a/regression-test/suites/cold_heat_separation/use_policy/disable_storage_policy_MoW.groovy
+++ b/regression-test/suites/cold_heat_separation/use_policy/disable_storage_policy_MoW.groovy
@@ -81,7 +81,7 @@ suite("disable_storage_policy_MoW"){
         exception "with storage policy(${storage_policy_name})"
     }
 
-    //Test case II. Should panic when sets storage policy to MoW table
+    //Test case II. Should panic when sets storage policy to MoW table or its partitions
     sql """
         CREATE TABLE IF NOT EXISTS ${table_name_test_2} (
             id INT,
@@ -95,17 +95,21 @@ suite("disable_storage_policy_MoW"){
         );
     """
 
-    // test {
+    test {
         sql """
             ALTER TABLE ${table_name_test_2} MODIFY PARTITION(*) SET("storage_policy" = "${storage_policy_name}");
         """
+        exception "with storage policy(${storage_policy_name})"
+    }
 
-        // exception "with storage policy(${storage_policy_name})"
-    // }
-
+    test {
         sql """
             ALTER TABLE ${table_name_test_2} SET ("storage_policy" = "${storage_policy_name}");
         """
+        exception "with storage policy(${storage_policy_name})"
+    }
+
+    //Test case III. Should panic when creates MoW table(without partitions) with storage policy
     test {
         sql """
             CREATE TABLE IF NOT EXISTS ${table_name_test_3} (

--- a/regression-test/suites/cold_heat_separation/use_policy/disable_storage_policy_MoW.groovy
+++ b/regression-test/suites/cold_heat_separation/use_policy/disable_storage_policy_MoW.groovy
@@ -1,0 +1,130 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("disable_storage_policy_MoW"){
+    def s3_source_name = "default_s3_source"
+    def storage_policy_name = "default_storage_policy"
+
+    def storage_exist = { name ->
+        def show_storage_policy = sql """
+        SHOW STORAGE POLICY;
+        """
+        for(iter in show_storage_policy){
+            if(name == iter[0]){
+                return true;
+            }
+        }
+        return false;
+    }
+
+    if(!storage_exist.call("${storage_policy_name}")){
+        def create_s3_resource = sql """
+            CREATE RESOURCE "${s3_source_name}"
+            PROPERTIES(
+                "type"="s3",
+                "AWS_REGION" = "bj",
+                "AWS_ENDPOINT" = "bj.s3.comaaaa",
+                "AWS_ROOT_PATH" = "path/to/rootaaaa",
+                "AWS_SECRET_KEY" = "aaaa",
+                "AWS_ACCESS_KEY" = "bbba",
+                "AWS_BUCKET" = "test-bucket",
+                "s3_validity_check" = "false"
+            );
+        """
+        def create_storage_policy = sql """
+            CREATE STORAGE POLICY ${storage_policy_name} PROPERTIES(
+                "storage_resource" = "${s3_source_name}",
+                "cooldown_ttl" = "1008611"
+            );
+        """
+
+        create_s3_resource
+        create_storage_policy
+    }
+
+    def table_name_test_1 = "disable_storage_policy_on_mow1"
+    def table_name_test_2 = "disable_storage_policy_on_mow2"
+    def table_name_test_3 = "disable_storage_policy_on_mow3"
+    //Test case I. Should panic when creates MoW table with storage policy
+    test{
+        sql """
+            CREATE TABLE IF NOT EXISTS ${table_name_test_1} (
+                k1 DATE,
+                k2 INT,
+                V1 VARCHAR(2048) 
+            ) ENGINE = OLAP
+            UNIQUE KEY(k1,k2)
+            PARTITION BY RANGE (k1) 
+            ( 
+                PARTITION p1 VALUES LESS THAN ("2022-01-01") ("storage_policy" = "${storage_policy_name}", "replication_num"="1"), 
+                PARTITION p2 VALUES LESS THAN ("2022-02-01") ("storage_policy" = "${storage_policy_name}", "replication_num"="1") 
+            ) DISTRIBUTED BY HASH(k2) BUCKETS 1
+            PROPERTIES(
+                "replication_num" = "1",
+                "enable_unique_key_merge_on_write" = "true"
+            )  
+        """
+        exception "with storage policy(${storage_policy_name})"
+    }
+
+    //Test case II. Should panic when sets storage policy to MoW table
+    sql """
+        CREATE TABLE IF NOT EXISTS ${table_name_test_2} (
+            id INT,
+            v1 INT
+        ) ENGINE = OLAP
+        UNIQUE KEY(id)
+        DISTRIBUTED BY HASH(id) BUCKETS 1
+        PROPERTIES(
+            "replication_num" = "1",
+            "enable_unique_key_merge_on_write" = "true"
+        );
+    """
+
+    // test {
+        sql """
+            ALTER TABLE ${table_name_test_2} MODIFY PARTITION(*) SET("storage_policy" = "${storage_policy_name}");
+        """
+
+        // exception "with storage policy(${storage_policy_name})"
+    // }
+
+        sql """
+            ALTER TABLE ${table_name_test_2} SET ("storage_policy" = "${storage_policy_name}");
+        """
+    test {
+        sql """
+            CREATE TABLE IF NOT EXISTS ${table_name_test_3} (
+                k1 INT,
+                V1 INT
+            ) ENGINE = OLAP
+            UNIQUE KEY(k1)
+            DISTRIBUTED BY HASH (k1) BUCKETS 1
+            PROPERTIES(
+                "replication_num" = "1",
+                "enable_unique_key_merge_on_write" = "true",
+                "storage_policy" = "${storage_policy_name}"
+            );
+        """
+        exception "with storage policy(${storage_policy_name})"
+    }
+
+    //clean resource
+    sql""" DROP TABLE IF EXISTS ${table_name_test_1} """
+    sql""" DROP TABLE IF EXISTS ${table_name_test_2} """
+    sql""" DROP TABLE IF EXISTS ${table_name_test_3} """
+}


### PR DESCRIPTION
# Proposed changes

Issue Number: close #17065

## Problem summary

Cooldown may cause serious performance degradation on MoW tables, temporarily disable storage policy for MoW tables.

## Describe your changes.

1. modify 3 java source files. check table properties before setting storage policy, if it has unique key MoW property, then throw an error and stop setting storage policy.
2. add a regression-test to test if it does disable storage policy on MoW table, it includes following tests:
    i. create table with storage policy on MoW table(both table and partitions)
    ii. alter table to set storage policy on existing MoW table(both table and partitions)

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [x] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

