### PR TITLE
[fix](sort) fix bug of sort

### DIFF
--- a/be/src/vec/common/sort/sorter.cpp
+++ b/be/src/vec/common/sort/sorter.cpp
@@ -183,7 +183,7 @@ Status FullSorter::_do_sort() {
         // to order the block in _block_priority_queue.
         // if one block totally greater the heap top of _block_priority_queue
         // we can throw the block data directly.
-        if (_state->num_rows < _limit) {
+        if (_state->num_rows < _offset + _limit) {
             _state->num_rows += desc_block.rows();
             _state->sorted_blocks.emplace_back(std::move(desc_block));
             _block_priority_queue.emplace(_pool->add(

--- a/be/src/vec/common/sort/topn_sorter.cpp
+++ b/be/src/vec/common/sort/topn_sorter.cpp
@@ -62,7 +62,7 @@ Status TopNSorter::_do_sort(Block* block) {
         // to order the block in _block_priority_queue.
         // if one block totally greater the heap top of _block_priority_queue
         // we can throw the block data directly.
-        if (_state->num_rows < _limit) {
+        if (_state->num_rows < _offset + _limit) {
             _state->num_rows += sorted_block.rows();
             _state->sorted_blocks.emplace_back(std::move(sorted_block));
             _block_priority_queue.emplace(_pool->add(


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

The logic of topn and full sort is wrong when there are both offsets and limits, the offset is not considered when doing the max heap optimization, which will lead to wrong result. 

cherry-pick #17151

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

