### PR TITLE
[fix](sort) fix bug of sort

### DIFF
--- a/be/src/vec/common/sort/sorter.cpp
+++ b/be/src/vec/common/sort/sorter.cpp
@@ -338,7 +338,7 @@ Status FullSorter::_do_sort() {
         // to order the block in _block_priority_queue.
         // if one block totally greater the heap top of _block_priority_queue
         // we can throw the block data directly.
-        if (_state->num_rows() < _limit) {
+        if (_state->num_rows() < _offset + _limit) {
             _state->add_sorted_block(desc_block);
             // if it's spilled, sorted_block is not added into sorted block vector,
             // so it's should not be added to _block_priority_queue, since

--- a/be/src/vec/common/sort/topn_sorter.cpp
+++ b/be/src/vec/common/sort/topn_sorter.cpp
@@ -52,7 +52,7 @@ Status TopNSorter::_do_sort(Block* block) {
         // to order the block in _block_priority_queue.
         // if one block totally greater the heap top of _block_priority_queue
         // we can throw the block data directly.
-        if (_state->num_rows() < _limit) {
+        if (_state->num_rows() < _offset + _limit) {
             _state->add_sorted_block(sorted_block);
             // if it's spilled, sorted_block is not added into sorted block vector,
             // so it's should not be added to _block_priority_queue, since


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

The logic of topn and full sort is wrong when there are both offsets and limits, the offset is not considered when doing the max heap optimization, which will lead to wrong result.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

