### PR TITLE
[fix](OrcReader) typo in analyzing null values

### DIFF
--- a/be/src/vec/exec/format/orc/vorc_reader.cpp
+++ b/be/src/vec/exec/format/orc/vorc_reader.cpp
@@ -674,7 +674,7 @@ Status OrcReader::_decode_string_column(const std::string& col_name,
     if (type_kind == orc::TypeKind::CHAR) {
         // Possibly there are some zero padding characters in CHAR type, we have to strip them off.
         for (int i = 0; i < num_values; ++i) {
-            if (cvb->notNull[0]) {
+            if (cvb->notNull[i]) {
                 string_values.emplace_back(data->data[i],
                                            trim_right(data->data[i], data->length[i]));
             } else {
@@ -686,7 +686,7 @@ Status OrcReader::_decode_string_column(const std::string& col_name,
         }
     } else {
         for (int i = 0; i < num_values; ++i) {
-            if (cvb->notNull[0]) {
+            if (cvb->notNull[i]) {
                 string_values.emplace_back(data->data[i], data->length[i]);
             } else {
                 string_values.emplace_back(empty_string.data(), 0);


### PR DESCRIPTION
# Proposed changes

typographical error in  analyzing null values for OrcReader.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

