### PR TITLE
[fix](env)Correctly parses arg `--helper` to Env

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
@@ -1167,9 +1167,9 @@ public class Env {
     private void getHelperNodes(String[] args) throws Exception {
         String helpers = null;
         for (int i = 0; i < args.length; i++) {
-            if (args[i].equalsIgnoreCase("-helper")) {
+            if (args[i].equalsIgnoreCase("--helper")) {
                 if (i + 1 >= args.length) {
-                    throw new AnalysisException("-helper need parameter host:port,host:port");
+                    throw new AnalysisException("--helper need parameter host:port,host:port");
                 }
                 helpers = args[i + 1];
                 break;


### PR DESCRIPTION
# Proposed changes

Issue Number: close #17158

## Problem summary

As seen in related issue.

Modify if (args[i].equalsIgnoreCase("-helper")) to if (args[i].equalsIgnoreCase("--helper") simply and effectively.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [x] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

