### PR TITLE
[Chore](regression-test) modify expectRelativeError from 1e-10 to 1e-8

### DIFF
--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/util/OutputUtils.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/util/OutputUtils.groovy
@@ -77,7 +77,7 @@ class OutputUtils {
                 double realDouble = Double.parseDouble(realCell)
 
                 double realRelativeError = Math.abs(expectDouble - realDouble) / realDouble
-                double expectRelativeError = 1e-10
+                double expectRelativeError = 1e-8
 
                 if (expectRelativeError < realRelativeError) {
                     // Keep the scale of low precision data to solve TPCH cases like:


### PR DESCRIPTION
# Proposed changes

It turns out that the limit on precision error is too strict, this pr is changed to expectRelativeError to relax the limit

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

