### PR TITLE
[Bug](build) fix compile fail on unused value

### DIFF
--- a/be/src/vec/exec/format/json/new_json_reader.cpp
+++ b/be/src/vec/exec/format/json/new_json_reader.cpp
@@ -1388,9 +1388,9 @@ Status NewJsonReader::_simdjson_set_column_value(simdjson::ondemand::object* val
     for (size_t i = 0; i < columns.size(); ++i) {
         DCHECK_EQ(columns[i]->size(), cur_row_count + 1);
     }
+#endif
     // There is at least one valid value here
     DCHECK(nullcount < columns.size());
-#endif
     *valid = true;
     return Status::OK();
 }


### PR DESCRIPTION
# Proposed changes

error: variable 'nullcount' set but not used [-Werror,-Wunused-but-set-variable]
    int nullcount = 0;

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

