### PR TITLE
[fix](Nereids): fold 'version()' function in Nereids

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rewrite/rules/FoldConstantRuleOnFE.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rewrite/rules/FoldConstantRuleOnFE.java
@@ -50,14 +50,17 @@ import org.apache.doris.nereids.trees.expressions.functions.scalar.ConnectionId;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.CurrentUser;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.Database;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.User;
+import org.apache.doris.nereids.trees.expressions.functions.scalar.Version;
 import org.apache.doris.nereids.trees.expressions.literal.ArrayLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.BigIntLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.BooleanLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.Literal;
 import org.apache.doris.nereids.trees.expressions.literal.NullLiteral;
+import org.apache.doris.nereids.trees.expressions.literal.StringLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.VarcharLiteral;
 import org.apache.doris.nereids.types.BooleanType;
 import org.apache.doris.nereids.util.ExpressionUtils;
+import org.apache.doris.qe.GlobalVariable;
 
 import com.google.common.collect.ImmutableList;
 
@@ -366,6 +369,11 @@ public class FoldConstantRuleOnFE extends AbstractExpressionRewriteRule {
         }
         List<Literal> arguments = (List) array.getArguments();
         return new ArrayLiteral(arguments);
+    }
+
+    @Override
+    public Expression visitVersion(Version version, ExpressionRewriteContext context) {
+        return new StringLiteral(GlobalVariable.version);
     }
 
     private Expression rewriteChildren(Expression expr, ExpressionRewriteContext ctx) {

--- a/regression-test/suites/nereids_p0/system/test_query_sys.groovy
+++ b/regression-test/suites/nereids_p0/system/test_query_sys.groovy
@@ -25,7 +25,6 @@ suite("test_query_sys", "query,p0") {
     sql "SELECT DATABASE();"
     sql "SELECT \"welecome to my blog!\";"
     sql "describe ${tableName};"
-    sql "select version();"
     sql "select rand();"
     sql "select rand(20);"
     sql "select random();"
@@ -42,4 +41,11 @@ suite("test_query_sys", "query,p0") {
     // INFORMATION_SCHEMA
     sql "SELECT table_name FROM INFORMATION_SCHEMA.TABLES where table_schema=\"test_query_db\" and TABLE_TYPE = \"BASE TABLE\" order by table_name"
     sql "SELECT COLUMN_NAME, DATA_TYPE, IS_NULLABLE, COLUMN_DEFAULT FROM INFORMATION_SCHEMA.COLUMNS WHERE table_name = \"${tableName}\" AND table_schema =\"test_query_db\" AND column_name LIKE \"k%\""
+    
+    // test version()
+    sql "set enable_nereids_planner=false"
+    def v1 = sql "select version()"
+    sql "set enable_nereids_planner=true"
+    def v2 = sql "select version()"
+    assertEquals(v1, v2)
 }


### PR DESCRIPTION
# Proposed changes

For compatibility with older optimizer, we fold `version()` with `GlobalVariable.version` in Nereids

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [x] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

