### PR TITLE
[chore](thirdparty) Fix the linkage errors for librdkafka

### DIFF
--- a/thirdparty/build-thirdparty.sh
+++ b/thirdparty/build-thirdparty.sh
@@ -858,7 +858,8 @@ build_librdkafka() {
     # PKG_CONFIG="pkg-config --static"
 
     CPPFLAGS="-I${TP_INCLUDE_DIR}" \
-        LDFLAGS="-L${TP_LIB_DIR} -lssl -lcrypto -lzstd -lz -lsasl2" \
+        LDFLAGS="-L${TP_LIB_DIR} -lssl -lcrypto -lzstd -lz -lsasl2 \
+        -lgssapi_krb5 -lkrb5 -lkrb5support -lk5crypto -lcom_err -lresolv" \
         ./configure --prefix="${TP_INSTALL_DIR}" --enable-static --enable-sasl --disable-c11threads
 
     make -j "${PARALLEL}"


### PR DESCRIPTION
# Proposed changes

~~Issue Number: close #xxx~~

## Problem summary

Fix the linkage errors. See the following.

```shell
$ clang --version
Apple clang version 14.0.0 (clang-1400.0.29.202)
Target: arm64-apple-darwin22.3.0
Thread model: posix
InstalledDir: /Library/Developer/CommandLineTools/usr/bin

$ /usr/bin/../bin/clang++ -L/Programs/doris/thirdparty/installed/lib -lssl -lcrypto -lzstd -lz -lsasl2 -shared -dynamiclib -Wl,-install_name,/Programs/doris/thirdparty/installed/lib/librdkafka++.1.dylib RdKafka.o ConfImpl.o HandleImpl.o ConsumerImpl.o ProducerImpl.o KafkaConsumerImpl.o TopicImpl.o TopicPartitionImpl.o MessageImpl.o HeadersImpl.o QueueImpl.o MetadataImpl.o -o librdkafka++.1.dylib -L../src -lrdkafka
ar rcs librdkafka++.a RdKafka.o ConfImpl.o HandleImpl.o ConsumerImpl.o ProducerImpl.o KafkaConsumerImpl.o TopicImpl.o TopicPartitionImpl.o MessageImpl.o HeadersImpl.o QueueImpl.o MetadataImpl.o
Undefined symbols for architecture arm64:
  "_GSS_C_NT_HOSTBASED_SERVICE", referenced from:
      _gssapi_server_mech_authneg in libsasl2.a(gssapi.o)
      _gssapi_client_mech_step in libsasl2.a(gssapi.o)
  "_GSS_C_NT_USER_NAME", referenced from:
      _gssapi_server_mech_authneg in libsasl2.a(gssapi.o)
  "_GSS_C_SEC_CONTEXT_SASL_SSF", referenced from:
      _gssapi_get_ssf in libsasl2.a(gssapi.o)
  "_gss_accept_sec_context", referenced from:
      _gssapi_server_mech_authneg in libsasl2.a(gssapi.o)
  "_gss_acquire_cred", referenced from:
      _gssapi_server_mech_authneg in libsasl2.a(gssapi.o)
  "_gss_canonicalize_name", referenced from:
      _gssapi_server_mech_authneg in libsasl2.a(gssapi.o)
  "_gss_compare_name", referenced from:
      _gssapi_server_mech_authneg in libsasl2.a(gssapi.o)
  "_gss_delete_sec_context", referenced from:
      _sasl_gss_free_context_contents in libsasl2.a(gssapi.o)
      _gssapi_client_mech_step in libsasl2.a(gssapi.o)
  "_gss_display_name", referenced from:
      _gssapi_server_mech_authneg in libsasl2.a(gssapi.o)
      _gssapi_client_mech_step in libsasl2.a(gssapi.o)
  "_gss_display_status", referenced from:
      _sasl_gss_seterror_ in libsasl2.a(gssapi.o)
  "_gss_import_name", referenced from:
      _gssapi_server_mech_authneg in libsasl2.a(gssapi.o)
      _gssapi_client_mech_step in libsasl2.a(gssapi.o)
  "_gss_init_sec_context", referenced from:
      _gssapi_client_mech_step in libsasl2.a(gssapi.o)
  "_gss_inquire_context", referenced from:
      _gssapi_client_mech_step in libsasl2.a(gssapi.o)
  "_gss_inquire_sec_context_by_oid", referenced from:
      _gssapi_get_ssf in libsasl2.a(gssapi.o)
  "_gss_release_buffer", referenced from:
      _gssapi_server_mech_authneg in libsasl2.a(gssapi.o)
      _gssapi_server_mech_ssfcap in libsasl2.a(gssapi.o)
      _gssapi_server_mech_ssfreq in libsasl2.a(gssapi.o)
      _sasl_gss_seterror_ in libsasl2.a(gssapi.o)
      _sasl_gss_encode in libsasl2.a(gssapi.o)
      _gssapi_decode_packet in libsasl2.a(gssapi.o)
      _gssapi_client_mech_step in libsasl2.a(gssapi.o)
      ...
  "_gss_release_buffer_set", referenced from:
      _gssapi_get_ssf in libsasl2.a(gssapi.o)
  "_gss_release_cred", referenced from:
      _gssapi_server_mech_authneg in libsasl2.a(gssapi.o)
      _sasl_gss_free_context_contents in libsasl2.a(gssapi.o)
  "_gss_release_name", referenced from:
      _gssapi_server_mech_authneg in libsasl2.a(gssapi.o)
      _sasl_gss_free_context_contents in libsasl2.a(gssapi.o)
  "_gss_unwrap", referenced from:
      _gssapi_server_mech_ssfreq in libsasl2.a(gssapi.o)
      _gssapi_decode_packet in libsasl2.a(gssapi.o)
      _gssapi_client_mech_step in libsasl2.a(gssapi.o)
  "_gss_wrap", referenced from:
      _gssapi_server_mech_ssfcap in libsasl2.a(gssapi.o)
      _sasl_gss_encode in libsasl2.a(gssapi.o)
      _gssapi_client_mech_step in libsasl2.a(gssapi.o)
  "_gss_wrap_size_limit", referenced from:
      _gssapi_wrap_sizes in libsasl2.a(gssapi.o)
  "_krb5_gss_register_acceptor_identity", referenced from:
      _gssapiv2_server_plug_init in libsasl2.a(gssapi.o)
ld: symbol(s) not found for architecture arm64
```

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

