### PR TITLE
[bugfix](TabletSchedule) remove unalive replica first when FORCE_REDUNDANT

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/clone/TabletScheduler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/TabletScheduler.java
@@ -886,8 +886,19 @@ public class TabletScheduler extends MasterDaemon {
                 // this case should be handled in deleteBackendDropped()
                 continue;
             }
-            if (!be.isScheduleAvailable()) {
+            if (!be.isAlive()) {
                 deleteReplicaInternal(tabletCtx, replica, "backend unavailable", force);
+                return true;
+            }
+        }
+        for (Replica replica : tabletCtx.getReplicas()) {
+            Backend be = infoService.getBackend(replica.getBackendId());
+            if (be == null) {
+                // this case should be handled in deleteBackendDropped()
+                continue;
+            }
+            if (!be.isDecommissioned()) {
+                deleteReplicaInternal(tabletCtx, replica, "backend decomissioned", force);
                 return true;
             }
         }


### PR DESCRIPTION


Case like this:
we have 4 be, decommission 1 and than drop one, then this tablet will set FORCE_REDUNDANT in as no enough backend for us to create a new replica, and we will drop replica unScheduleAble, so the decommisioned replica may be dropped and then lead to only one replica alive in tablet. We should drop unalive replica first and wait clone enough replica and then drop decommission replica.

# Proposed changes

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

