### PR TITLE
[fix](nereids)need add all output column to outputColumnUniqueIds in OlapScanNode

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/OlapScanNode.java
@@ -1115,6 +1115,7 @@ public class OlapScanNode extends ScanNode {
 
     @Override
     protected void toThrift(TPlanNode msg) {
+        computeOutputColumnUniqueIds();
         List<String> keyColumnNames = new ArrayList<String>();
         List<TPrimitiveType> keyColumnTypes = new ArrayList<TPrimitiveType>();
         List<TColumn> columnsDesc = new ArrayList<TColumn>();
@@ -1351,6 +1352,22 @@ public class OlapScanNode extends ScanNode {
     public void finalizeForNerieds() {
         computeNumNodes();
         computeStatsForNerieds();
+    }
+
+    private void computeOutputColumnUniqueIds() {
+        // compute outputColumnUniqueIds for nereids
+        if (outputColumnUniqueIds.isEmpty()) {
+            if (projectList != null) {
+                projectList.stream().forEach(expr -> {
+                    if (expr instanceof SlotRef) {
+                        outputColumnUniqueIds.add(((SlotRef) expr).getDesc().getColumn().getUniqueId());
+                    }
+                });
+            } else {
+                desc.getSlots().stream()
+                        .forEach(slot -> outputColumnUniqueIds.add(slot.getColumn().getUniqueId()));
+            }
+        }
     }
 
     private void computeStatsForNerieds() {


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary
outputColumnUniqueIds is introduced in by https://github.com/apache/doris/pull/16569, nereids should add all output columns in outputColumnUniqueIds to adapt that pr.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

