### PR TITLE
[fix](FileCache) load file cache before start up daemon threads

### DIFF
--- a/be/src/service/doris_main.cpp
+++ b/be/src/service/doris_main.cpp
@@ -423,6 +423,7 @@ int main(int argc, char** argv) {
         }
     }
 
+    // Load file cache before starting up daemon threads to make sure StorageEngine is read.
     doris::Daemon daemon;
     daemon.init(argc, argv, paths);
     daemon.start();

--- a/be/src/service/doris_main.cpp
+++ b/be/src/service/doris_main.cpp
@@ -385,10 +385,6 @@ int main(int argc, char** argv) {
         }
     }
 
-    doris::Daemon daemon;
-    daemon.init(argc, argv, paths);
-    daemon.start();
-
     if (doris::config::enable_file_cache) {
         std::vector<doris::CachePath> cache_paths;
         olap_res = doris::parse_conf_cache_paths(doris::config::file_cache_path, cache_paths);
@@ -426,6 +422,10 @@ int main(int argc, char** argv) {
             }
         }
     }
+
+    doris::Daemon daemon;
+    daemon.init(argc, argv, paths);
+    daemon.start();
 
     doris::ResourceTls::init();
     if (!doris::BackendOptions::init()) {


### PR DESCRIPTION
# Proposed changes

Load file cache before starting up daemon threads in `doris_main.cpp`

## Problem summary

Daemon threads in `doris_main.cpp` will upload tablet metrics periodically, which will use `StorageEngine::instance()`. However loading file cache is a process in main thread, when it takes a lot of time to load file cache, `StorageEngine::instance()` will be a null pointer in daemon threads.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

