### PR TITLE
[Chore](third-party) upgrade thrift from 0.13 to 0.16

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,3 +98,4 @@ tools/single-node-cluster/fe*
 data_test
 
 /conf/log4j2-spring.xml
+/fe/fe-core/src/test/resources/real-help-resource.zip

--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -1647,7 +1647,7 @@ Status TaskWorkerPool::_move_dir(const TTabletId tablet_id, const std::string& s
     return loader.move(src, tablet, overwrite);
 }
 
-void TaskWorkerPool::_handle_report(TReportRequest& request, ReportType type) {
+void TaskWorkerPool::_handle_report(const TReportRequest& request, ReportType type) {
     TMasterResult result;
     Status status = MasterServerClient::instance()->report(request, &result);
     bool is_report_success = false;

--- a/be/src/agent/task_worker_pool.h
+++ b/be/src/agent/task_worker_pool.h
@@ -203,7 +203,7 @@ private:
 
     void _alter_tablet(const TAgentTaskRequest& alter_tablet_request, int64_t signature,
                        const TTaskType::type task_type, TFinishTaskRequest* finish_task_request);
-    void _handle_report(TReportRequest& request, ReportType type);
+    void _handle_report(const TReportRequest& request, ReportType type);
 
     Status _get_tablet_info(const TTabletId tablet_id, const TSchemaHash schema_hash,
                             int64_t signature, TTabletInfo* tablet_info);

--- a/be/src/gen_cpp/CMakeLists.txt
+++ b/be/src/gen_cpp/CMakeLists.txt
@@ -19,77 +19,12 @@
 set(LIBRARY_OUTPUT_PATH "${BUILD_DIR}/src/gen_cpp")
 
 set (GEN_CPP_DIR ${GENSRC_DIR}/gen_cpp)
-set(SRC_FILES
-    ${GEN_CPP_DIR}/AgentService_constants.cpp
-    ${GEN_CPP_DIR}/AgentService_types.cpp
-    ${GEN_CPP_DIR}/BackendService_constants.cpp
-    ${GEN_CPP_DIR}/BackendService.cpp
-    ${GEN_CPP_DIR}/BackendService_types.cpp
-    ${GEN_CPP_DIR}/PaloBrokerService_types.cpp
-    ${GEN_CPP_DIR}/TDorisExternalService.cpp
-    ${GEN_CPP_DIR}/DorisExternalService_types.cpp
-    ${GEN_CPP_DIR}/DorisExternalService_constants.cpp
-    ${GEN_CPP_DIR}/QueryPlanExtra_types.cpp
-    ${GEN_CPP_DIR}/QueryPlanExtra_constants.cpp
-    ${GEN_CPP_DIR}/TPaloBrokerService.cpp
-    ${GEN_CPP_DIR}/HeartbeatService_constants.cpp
-    ${GEN_CPP_DIR}/HeartbeatService.cpp
-    ${GEN_CPP_DIR}/HeartbeatService_types.cpp
-    ${GEN_CPP_DIR}/PaloInternalService_constants.cpp
-    ${GEN_CPP_DIR}/PaloInternalService_types.cpp
-    ${GEN_CPP_DIR}/FrontendService.cpp
-    ${GEN_CPP_DIR}/FrontendService_constants.cpp
-    ${GEN_CPP_DIR}/FrontendService_types.cpp
-    ${GEN_CPP_DIR}/PaloService_constants.cpp
-    ${GEN_CPP_DIR}/PaloService_types.cpp
-    ${GEN_CPP_DIR}/Data_constants.cpp
-    ${GEN_CPP_DIR}/Data_types.cpp
-    ${GEN_CPP_DIR}/DataSinks_constants.cpp
-    ${GEN_CPP_DIR}/DataSinks_types.cpp
-    ${GEN_CPP_DIR}/Ddl_constants.cpp
-    ${GEN_CPP_DIR}/Ddl_types.cpp
-    ${GEN_CPP_DIR}/Descriptors_constants.cpp
-    ${GEN_CPP_DIR}/Descriptors_types.cpp
-    ${GEN_CPP_DIR}/Exprs_constants.cpp
-    ${GEN_CPP_DIR}/Exprs_types.cpp
-    ${GEN_CPP_DIR}/MasterService_constants.cpp
-    ${GEN_CPP_DIR}/MasterService_types.cpp
-    ${GEN_CPP_DIR}/MetricDefs_constants.cpp
-    ${GEN_CPP_DIR}/MetricDefs_types.cpp
-    ${GEN_CPP_DIR}/Metrics_constants.cpp
-    ${GEN_CPP_DIR}/Metrics_types.cpp
-    ${GEN_CPP_DIR}/NetworkTest_constants.cpp
-    ${GEN_CPP_DIR}/NetworkTest_types.cpp
-    ${GEN_CPP_DIR}/NetworkTestService.cpp
-    ${GEN_CPP_DIR}/Opcodes_constants.cpp
-    ${GEN_CPP_DIR}/Opcodes_types.cpp
-    ${GEN_CPP_DIR}/PlanNodes_constants.cpp
-    ${GEN_CPP_DIR}/PlanNodes_types.cpp
-    ${GEN_CPP_DIR}/Partitions_constants.cpp
-    ${GEN_CPP_DIR}/Partitions_types.cpp
-    ${GEN_CPP_DIR}/Planner_constants.cpp
-    ${GEN_CPP_DIR}/Planner_types.cpp
-    ${GEN_CPP_DIR}/RuntimeProfile_constants.cpp
-    ${GEN_CPP_DIR}/RuntimeProfile_types.cpp
-    ${GEN_CPP_DIR}/Status_constants.cpp
-    ${GEN_CPP_DIR}/Status_types.cpp
-    ${GEN_CPP_DIR}/Types_constants.cpp
-    ${GEN_CPP_DIR}/Types_types.cpp
-    ${GEN_CPP_DIR}/olap_common.pb.cc
-    ${GEN_CPP_DIR}/olap_file.pb.cc
-    ${GEN_CPP_DIR}/column_data_file.pb.cc
-    ${GEN_CPP_DIR}/data.pb.cc
-    ${GEN_CPP_DIR}/descriptors.pb.cc
-    ${GEN_CPP_DIR}/internal_service.pb.cc
-    ${GEN_CPP_DIR}/function_service.pb.cc
-    ${GEN_CPP_DIR}/types.pb.cc
-    ${GEN_CPP_DIR}/segment_v2.pb.cc
-    ${GEN_CPP_DIR}/parquet_constants.cpp
-    ${GEN_CPP_DIR}/parquet_types.cpp
-    #$${GEN_CPP_DIR}/opcode/functions.cc
-    #$${GEN_CPP_DIR}/opcode/vector-functions.cc
-    #$${GEN_CPP_DIR}/opcode/opcode-registry-init.cc
+file(GLOB SRC_FILES CONFIGURE_DEPENDS
+    ${GEN_CPP_DIR}/*.cpp
+    ${GEN_CPP_DIR}/*.cc
 )
+
+add_compile_options(-Wno-return-type)
 
 # keep everything in one library, the object files reference 
 # each other

--- a/fe/fe-core/src/main/java/org/apache/doris/common/GenericPool.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/GenericPool.java
@@ -28,10 +28,10 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.thrift.protocol.TBinaryProtocol;
 import org.apache.thrift.protocol.TProtocol;
-import org.apache.thrift.transport.TFramedTransport;
 import org.apache.thrift.transport.TSocket;
 import org.apache.thrift.transport.TTransport;
 import org.apache.thrift.transport.TTransportException;
+import org.apache.thrift.transport.layered.TFramedTransport;
 
 import java.lang.reflect.Constructor;
 

--- a/fe/fe-core/src/main/java/org/apache/doris/common/ThriftServerContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/ThriftServerContext.java
@@ -34,4 +34,13 @@ public class ThriftServerContext implements ServerContext {
     public TNetworkAddress getClient() {
         return client;
     }
+
+    public boolean isWrapperFor(Class<?> iface) {
+        return false;
+    }
+
+    @Override
+    public <T> T unwrap(Class<T> iface) {
+        throw new UnsupportedOperationException("Unimplemented method 'unwrap'");
+    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/common/ThriftServerEventProcessor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/ThriftServerEventProcessor.java
@@ -25,9 +25,9 @@ import org.apache.logging.log4j.Logger;
 import org.apache.thrift.protocol.TProtocol;
 import org.apache.thrift.server.ServerContext;
 import org.apache.thrift.server.TServerEventHandler;
-import org.apache.thrift.transport.TFramedTransport;
 import org.apache.thrift.transport.TSocket;
 import org.apache.thrift.transport.TTransport;
+import org.apache.thrift.transport.layered.TFramedTransport;
 
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/TableQueryPlanAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/TableQueryPlanAction.java
@@ -236,9 +236,10 @@ public class TableQueryPlanAction extends RestBaseController {
         tQueryPlanInfo.tablet_info = tabletInfo;
 
         // serialize TQueryPlanInfo and encode plan with Base64 to string in order to translate by json format
-        TSerializer serializer = new TSerializer();
+        TSerializer serializer;
         String opaquedQueryPlan;
         try {
+            serializer = new TSerializer();
             byte[] queryPlanStream = serializer.serialize(tQueryPlanInfo);
             opaquedQueryPlan = Base64.getEncoder().encodeToString(queryPlanStream);
         } catch (TException e) {

--- a/fe/fe-core/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.java
+++ b/fe/fe-core/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.java
@@ -222,10 +222,10 @@ import org.apache.thrift.TException;
 import org.apache.thrift.protocol.TBinaryProtocol;
 import org.apache.thrift.protocol.TCompactProtocol;
 import org.apache.thrift.protocol.TProtocol;
-import org.apache.thrift.transport.TFramedTransport;
 import org.apache.thrift.transport.TSocket;
 import org.apache.thrift.transport.TTransport;
 import org.apache.thrift.transport.TTransportException;
+import org.apache.thrift.transport.layered.TFramedTransport;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -653,7 +653,12 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
               throw new MetaException(e.toString());
             }
           } else {
-            transport = new TSocket(store.getHost(), store.getPort(), clientSocketTimeout);
+            try {
+              transport = new TSocket(store.getHost(), store.getPort(), clientSocketTimeout);
+            } catch (TTransportException e) {
+              tte = e;
+              throw new MetaException(e.toString());
+            }
           }
 
           if (useSasl) {
@@ -691,7 +696,12 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
             }
           } else {
             if (useFramedTransport) {
-              transport = new TFramedTransport(transport);
+              try {
+                transport = new TFramedTransport(transport);
+              } catch (TTransportException e) {
+                tte = e;
+                throw new MetaException(e.toString());
+              }
             }
           }
 

--- a/fe/java-udf/src/main/java/org/apache/doris/udf/JniUtil.java
+++ b/fe/java-udf/src/main/java/org/apache/doris/udf/JniUtil.java
@@ -90,8 +90,8 @@ public class JniUtil {
      * Serializes input into a byte[] using the default protocol factory.
      */
     public static <T extends TBase<?, ?>> byte[] serializeToThrift(T input) throws InternalException {
-        TSerializer serializer = new TSerializer(protocolFactory_);
         try {
+            TSerializer serializer = new TSerializer(protocolFactory_);
             return serializer.serialize(input);
         } catch (TException e) {
             throw new InternalException(e.getMessage());
@@ -103,8 +103,8 @@ public class JniUtil {
      */
     public static <T extends TBase<?, ?>, F extends TProtocolFactory> byte[] serializeToThrift(
             T input, F protocolFactory) throws InternalException {
-        TSerializer serializer = new TSerializer(protocolFactory);
         try {
+            TSerializer serializer = new TSerializer(protocolFactory);
             return serializer.serialize(input);
         } catch (TException e) {
             throw new InternalException(e.getMessage());
@@ -122,8 +122,8 @@ public class JniUtil {
     public static <T extends TBase<?, ?>, F extends TProtocolFactory> void deserializeThrift(
             F protocolFactory, T result, byte[] thriftData) throws InternalException {
         // TODO: avoid creating deserializer for each query?
-        TDeserializer deserializer = new TDeserializer(protocolFactory);
         try {
+            TDeserializer deserializer = new TDeserializer(protocolFactory);
             deserializer.deserialize(result, thriftData);
         } catch (TException e) {
             throw new InternalException(e.getMessage());

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -189,7 +189,7 @@ under the License.
         <json-simple.version>1.1.1</json-simple.version>
         <junit.version>5.8.2</junit.version>
         <druid.version>1.2.5</druid.version>
-        <thrift.version>0.13.0</thrift.version>
+        <thrift.version>0.16.0</thrift.version>
         <tomcat-embed-core.version>8.5.86</tomcat-embed-core.version>
         <log4j2.version>2.18.0</log4j2.version>
         <log4j-1.2.version>2.18.0</log4j-1.2.version>

--- a/fs_brokers/apache_hdfs_broker/pom.xml
+++ b/fs_brokers/apache_hdfs_broker/pom.xml
@@ -252,7 +252,7 @@ under the License.
         <dependency>
             <groupId>org.apache.thrift</groupId>
             <artifactId>libthrift</artifactId>
-            <version>0.13.0</version>
+            <version>0.16.0</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-api -->
         <dependency>

--- a/thirdparty/CHANGELOG.md
+++ b/thirdparty/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 This file contains version of the third-party dependency libraries in the build-env image. The docker build-env image is apache/doris, and the tag is `build-env-${version}`
 
+## v20230228
+- Modified: thrift 0.13 -> 0.16
+
 ## v20230221
 - Modified: clucene 2.4.4 -> 2.4.6
 

--- a/thirdparty/build-thirdparty.sh
+++ b/thirdparty/build-thirdparty.sh
@@ -367,11 +367,11 @@ build_thrift() {
 
     if [[ "${KERNEL}" != 'Darwin' ]]; then
         cflags="-I${TP_INCLUDE_DIR}"
-        cxxflags="-I${TP_INCLUDE_DIR} ${warning_unused_but_set_variable}"
+        cxxflags="-I${TP_INCLUDE_DIR} ${warning_unused_but_set_variable} -Wno-inconsistent-missing-override"
         ldflags="-L${TP_LIB_DIR} --static"
     else
-        cflags="-I${TP_INCLUDE_DIR} -Wno-implicit-function-declaration"
-        cxxflags="-I${TP_INCLUDE_DIR} ${warning_unused_but_set_variable}"
+        cflags="-I${TP_INCLUDE_DIR} -Wno-implicit-function-declaration -Wno-inconsistent-missing-override"
+        cxxflags="-I${TP_INCLUDE_DIR} ${warning_unused_but_set_variable} -Wno-inconsistent-missing-override"
         ldflags="-L${TP_LIB_DIR}"
     fi
 

--- a/thirdparty/vars.sh
+++ b/thirdparty/vars.sh
@@ -73,10 +73,10 @@ OPENSSL_SOURCE=openssl-OpenSSL_1_1_1s
 OPENSSL_MD5SUM="7e79a7560dee77c0758baa33c61af4b4"
 
 # thrift
-THRIFT_DOWNLOAD="http://archive.apache.org/dist/thrift/0.13.0/thrift-0.13.0.tar.gz"
-THRIFT_NAME=thrift-0.13.0.tar.gz
-THRIFT_SOURCE=thrift-0.13.0
-THRIFT_MD5SUM="38a27d391a2b03214b444cb13d5664f1"
+THRIFT_DOWNLOAD="http://archive.apache.org/dist/thrift/0.16.0/thrift-0.16.0.tar.gz"
+THRIFT_NAME=thrift-0.16.0.tar.gz
+THRIFT_SOURCE=thrift-0.16.0
+THRIFT_MD5SUM="44cf1b54b4ec1890576c85804acfa637"
 
 # protobuf
 PROTOBUF_DOWNLOAD="https://github.com/google/protobuf/archive/v3.15.0.tar.gz"


### PR DESCRIPTION
# Proposed changes

I found that `thrift` often has some crash under `asan`, I want to try to upgrade it to the latest version and see if the problem still occurs.
There is thrift's release notes https://github.com/apache/thrift/blob/master/CHANGES.md

```cpp
=================================================================
==3313527==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x7f620d10adb0 at pc 0x560af1186b17 bp 0x7f620d10ad80 sp 0x7f620d10a528
WRITE of size 24 at 0x7f620d10adb0 thread T861 (EvHttpServer [w)
    #0 0x560af1186b16 in __interceptor_sigaltstack.part.0 (/mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster7/be/lib/doris_be+0x7049b16)
    #1 0x560af11ec8bf in __asan::PlatformUnpoisonStacks() (/mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster7/be/lib/doris_be+0x70af8bf)
    #2 0x560af11f2224 in __asan_handle_no_return (/mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster7/be/lib/doris_be+0x70b5224)
    #3 0x560af38641bf in __gnu_cxx::new_allocator<char>::~new_allocator() /var/local/ldb-toolchain/include/c++/11/ext/new_allocator.h:89
    #4 0x560af38641bf in std::allocator<char>::~allocator() /var/local/ldb-toolchain/include/c++/11/bits/allocator.h:162
    #5 0x560af38641bf in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_Alloc_hider::~_Alloc_hider() /var/local/ldb-toolchain/include/c++/11/bits/basic_string.h:150
    #6 0x560af38641bf in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::~basic_string() /var/local/ldb-toolchain/include/c++/11/bits/basic_string.h:658
    #7 0x560af38641bf in doris::FrontendServiceClient::recv_streamLoadPut(doris::TStreamLoadPutResult&) /root/doris/gensrc/build/gen_cpp/FrontendService.cpp:6420
    #8 0x560af3864369 in doris::FrontendServiceClient::streamLoadPut(doris::TStreamLoadPutResult&, doris::TStreamLoadPutRequest const&) /root/doris/gensrc/build/gen_cpp/FrontendService.cpp:6367
    #9 0x560af4220b56 in operator() /root/doris/be/src/http/action/stream_load.cpp:584
    #10 0x560af4220b56 in __invoke_impl<void, doris::StreamLoadAction::_process_put(doris::HttpRequest*, doris::StreamLoadContext*)::<lambda(doris::FrontendServiceConnection&)>&, doris::ClientConnection<doris::FrontendServiceClient>&> /var/local/ldb-toolchain/include/c++/11/bits/invoke.h:61
    #11 0x560af4220b56 in __invoke_r<void, doris::StreamLoadAction::_process_put(doris::HttpRequest*, doris::StreamLoadContext*)::<lambda(doris::FrontendServiceConnection&)>&, doris::ClientConnection<doris::FrontendServiceClient>&> /var/local/ldb-toolchain/include/c++/11/bits/invoke.h:111
    #12 0x560af4220b56 in _M_invoke /var/local/ldb-toolchain/include/c++/11/bits/std_function.h:291
    #13 0x560af325f612 in std::function<void (doris::ClientConnection<doris::FrontendServiceClient>&)>::operator()(doris::ClientConnection<doris::FrontendServiceClient>&) const /var/local/ldb-toolchain/include/c++/11/bits/std_function.h:560
    #14 0x560af325f612 in doris::Status doris::ThriftRpcHelper::rpc<doris::FrontendServiceClient>(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, int, std::function<void (doris::ClientConnection<doris::FrontendServiceClient>&)>, int) /root/doris/be/src/util/thrift_rpc_helper.cpp:59
    #15 0x560af4231bef in doris::Status doris::ThriftRpcHelper::rpc<doris::FrontendServiceClient>(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, int, std::function<void (doris::ClientConnection<doris::FrontendServiceClient>&)>) /root/doris/be/src/util/thrift_rpc_helper.h:40
    #16 0x560af4231bef in doris::StreamLoadAction::_process_put(doris::HttpRequest*, doris::StreamLoadContext*) /root/doris/be/src/http/action/stream_load.cpp:584
    #17 0x560af4235da4 in doris::StreamLoadAction::_on_header(doris::HttpRequest*, doris::StreamLoadContext*) /root/doris/be/src/http/action/stream_load.cpp:341
    #18 0x560af4241834 in doris::StreamLoadAction::on_header(doris::HttpRequest*) /root/doris/be/src/http/action/stream_load.cpp:242
    #19 0x560af416de47 in doris::EvHttpServer::on_header(evhttp_request*) /root/doris/be/src/http/ev_http_server.cpp:242
    #20 0x560af416e259 in on_header /root/doris/be/src/http/ev_http_server.cpp:64
    #21 0x560b07a898b9  (/mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster7/be/lib/doris_be+0x1d94c8b9)
    #22 0x560b07a6bf50 in bufferevent_run_readcb_ (/mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster7/be/lib/doris_be+0x1d92ef50)
    #23 0x560b07a8ddf2  (/mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster7/be/lib/doris_be+0x1d950df2)
    #24 0x560b07a74d58  (/mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster7/be/lib/doris_be+0x1d937d58)
    #25 0x560b07a753d6  (/mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster7/be/lib/doris_be+0x1d9383d6)
    #26 0x560b07a77a07  (/mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster7/be/lib/doris_be+0x1d93aa07)
    #27 0x560af416737a in operator() /root/doris/be/src/http/ev_http_server.cpp:105
    #28 0x560af416737a in __invoke_impl<void, doris::EvHttpServer::start()::<lambda()>&> /var/local/ldb-toolchain/include/c++/11/bits/invoke.h:61
    #29 0x560af416737a in __invoke_r<void, doris::EvHttpServer::start()::<lambda()>&> /var/local/ldb-toolchain/include/c++/11/bits/invoke.h:111
    #30 0x560af416737a in _M_invoke /var/local/ldb-toolchain/include/c++/11/bits/std_function.h:291
    #31 0x560af32fc1c2 in std::function<void ()>::operator()() const /var/local/ldb-toolchain/include/c++/11/bits/std_function.h:560
    #32 0x560af32fc1c2 in doris::FunctionRunnable::run() /root/doris/be/src/util/threadpool.cpp:46
    #33 0x560af32fa0a0 in doris::ThreadPool::dispatch_thread() /root/doris/be/src/util/threadpool.cpp:529
    #34 0x560af32fbd77 in void std::__invoke_impl<void, void (doris::ThreadPool::*&)(), doris::ThreadPool*&>(std::__invoke_memfun_deref, void (doris::ThreadPool::*&)(), doris::ThreadPool*&) /var/local/ldb-toolchain/include/c++/11/bits/invoke.h:74
    #35 0x560af32fbd77 in std::__invoke_result<void (doris::ThreadPool::*&)(), doris::ThreadPool*&>::type std::__invoke<void (doris::ThreadPool::*&)(), doris::ThreadPool*&>(void (doris::ThreadPool::*&)(), doris::ThreadPool*&) /var/local/ldb-toolchain/include/c++/11/bits/invoke.h:96
    #36 0x560af32fbd77 in void std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>::__call<void, , 0ul>(std::tuple<>&&, std::_Index_tuple<0ul>) /var/local/ldb-toolchain/include/c++/11/functional:420
    #37 0x560af32fbd77 in void std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>::operator()<, void>() /var/local/ldb-toolchain/include/c++/11/functional:503
    #38 0x560af32fbd77 in void std::__invoke_impl<void, std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>&>(std::__invoke_other, std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>&) /var/local/ldb-toolchain/include/c++/11/bits/invoke.h:61
    #39 0x560af32fbd77 in std::enable_if<is_invocable_r_v<void, std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>&>, void>::type std::__invoke_r<void, std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>&>(std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>&) /var/local/ldb-toolchain/include/c++/11/bits/invoke.h:111
    #40 0x560af32fbd77 in std::_Function_handler<void (), std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()> >::_M_invoke(std::_Any_data const&) /var/local/ldb-toolchain/include/c++/11/bits/std_function.h:291
    #41 0x560af32ce334 in std::function<void ()>::operator()() const /var/local/ldb-toolchain/include/c++/11/bits/std_function.h:560
    #42 0x560af32ce334 in doris::Thread::supervise_thread(void*) /root/doris/be/src/util/thread.cpp:453
    #43 0x7f64402a0608 in start_thread /build/glibc-SzIz7B/glibc-2.31/nptl/pthread_create.c:477
    #44 0x7f6440076132 in __clone (/lib/x86_64-linux-gnu/libc.so.6+0x11f132)

Address 0x7f620d10adb0 is located in stack of thread T861 (EvHttpServer [w) at offset 208 in frame
    #0 0x560af1e8ad3f in apache::thrift::protocol::TBinaryProtocolT<apache::thrift::transport::TTransport, apache::thrift::protocol::TNetworkBigEndian>::readMessageBegin(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, apache::thrift::protocol::TMessageType&, int&) /var/local/thirdparty/installed/include/thrift/protocol/TBinaryProtocol.tcc:200

  This frame has 7 object(s):
    [48, 49) '<unknown>'
    [64, 68) 'theBytes' (line 372)
    [80, 84) 'theBytes' (line 372)
    [96, 100) 'theBytes' (line 372)
    [112, 116) 'theBytes' (line 372)
    [128, 160) '<unknown>'
    [192, 193) 'b' (line 350) <== Memory access at offset 208 overflows this variable
HINT: this may be a false positive if your program uses some custom stack unwind mechanism, swapcontext or vfork
      (longjmp and C++ exceptions *are* supported)
Thread T861 (EvHttpServer [w) created by T0 here:
    #0 0x560af118b061 in pthread_create (/mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster7/be/lib/doris_be+0x704e061)
    #1 0x560af32ca1d1 in doris::Thread::start_thread(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::function<void ()> const&, unsigned long, scoped_refptr<doris::Thread>*) /root/doris/be/src/util/thread.cpp:407
    #2 0x560af32e7aaa in doris::Status doris::Thread::create<void (doris::ThreadPool::*)(), doris::ThreadPool*>(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, void (doris::ThreadPool::* const&)(), doris::ThreadPool* const&, scoped_refptr<doris::Thread>*) /root/doris/be/src/util/thread.h:57
    #3 0x560af32e7aaa in doris::ThreadPool::create_thread() /root/doris/be/src/util/threadpool.cpp:598
    #4 0x560af32f1633 in doris::ThreadPool::init() /root/doris/be/src/util/threadpool.cpp:257
    #5 0x560af4168efc in doris::Status doris::ThreadPoolBuilder::build<doris::ThreadPool>(std::unique_ptr<doris::ThreadPool, std::default_delete<doris::ThreadPool> >*) const /root/doris/be/src/util/threadpool.h:114
    #6 0x560af4168efc in doris::EvHttpServer::start() /root/doris/be/src/http/ev_http_server.cpp:100
    #7 0x560af2ecb33f in doris::HttpService::start() /root/doris/be/src/service/http_service.cpp:191
    #8 0x560af1238d53 in main /root/doris/be/src/service/doris_main.cpp:496
    #9 0x7f643ff7b082 in __libc_start_main ../csu/libc-start.c:308

SUMMARY: AddressSanitizer: stack-buffer-overflow (/mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster7/be/lib/doris_be+0x7049b16) in __interceptor_sigaltstack.part.0
Shadow bytes around the buggy address:
  0x0fecc1a19560: 00 00 00 00 00 00 f1 f1 f1 f1 f1 f1 01 f2 00 00
  0x0fecc1a19570: 00 00 f3 f3 f3 f3 00 00 00 00 00 00 00 00 00 00
  0x0fecc1a19580: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0fecc1a19590: 00 00 00 00 00 00 00 00 00 00 00 00 f1 f1 f1 f1
  0x0fecc1a195a0: f1 f1 01 f2 04 f2 04 f2 04 f2 04 f2 00 00 00 00
=>0x0fecc1a195b0: f2 f2 f2 f2 01 f3[f3]f3 00 00 00 00 00 00 00 00
  0x0fecc1a195c0: 00 00 00 00 00 00 00 00 00 00 f1 f1 f1 f1 01 f2
  0x0fecc1a195d0: f8 f2 01 f2 04 f2 04 f2 00 00 f2 f2 00 00 f2 f2
  0x0fecc1a195e0: 00 00 f2 f2 00 00 f2 f2 00 00 00 f2 f2 f2 f2 f2
  0x0fecc1a195f0: 00 00 00 00 f2 f2 f2 f2 00 00 00 00 f2 f2 f2 f2
  0x0fecc1a19600: 00 00 00 00 00 00 f3 f3 f3 f3 00 00 00 00 00 00
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
  Shadow gap:              cc
==3313527==ABORTING
start time: Fri 24 Feb 2023 01:47:08 PM CST
WARNING: Logging before InitGoogleLogging() is written to STDERR
I0224 13:47:08.619928 3332520 doris_main.cpp:324] enable_fuzzy_mode is true, set fuzzy configs
=================================================================
==3332520==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x7f261aa5d8c8 at pc 0x555d91c56b17 bp 0x7f261aa5d890 sp 0x7f261aa5d038
WRITE of size 24 at 0x7f261aa5d8c8 thread T611 (TaskWorkerPool.)
    #0 0x555d91c56b16 in __interceptor_sigaltstack.part.0 (/mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster7/be/lib/doris_be+0x7049b16)
    #1 0x555d91cbc8bf in __asan::PlatformUnpoisonStacks() (/mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster7/be/lib/doris_be+0x70af8bf)
    #2 0x555d91cc2224 in __asan_handle_no_return (/mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster7/be/lib/doris_be+0x70b5224)
    #3 0x555d946706d1 in apache::thrift::protocol::TProtocol::decrementOutputRecursionDepth() /var/local/thirdparty/installed/include/thrift/protocol/TProtocol.h:576
    #4 0x555d946706d1 in apache::thrift::protocol::TOutputRecursionTracker::~TOutputRecursionTracker() /var/local/thirdparty/installed/include/thrift/protocol/TProtocol.h:648
    #5 0x555d946706d1 in doris::TTabletInfo::write(apache::thrift::protocol::TProtocol*) const /root/doris/gensrc/build/gen_cpp/MasterService_types.cpp:483
    #6 0x555d94666b0c in doris::TTablet::write(apache::thrift::protocol::TProtocol*) const /root/doris/gensrc/build/gen_cpp/MasterService_types.cpp:1215
    #7 0x555d9466d15a in doris::TReportRequest::write(apache::thrift::protocol::TProtocol*) const /root/doris/gensrc/build/gen_cpp/MasterService_types.cpp:1930
    #8 0x555d942bf17b in doris::FrontendService_report_pargs::write(apache::thrift::protocol::TProtocol*) const /root/doris/gensrc/build/gen_cpp/FrontendService.cpp:1204
    #9 0x555d942f866c in doris::FrontendServiceClient::send_report(doris::TReportRequest const&) /root/doris/gensrc/build/gen_cpp/FrontendService.cpp:5566
    #10 0x555d9431f360 in doris::FrontendServiceClient::report(doris::TMasterResult&, doris::TReportRequest const&) /root/doris/gensrc/build/gen_cpp/FrontendService.cpp:5555
    #11 0x555d9294362c in doris::MasterServerClient::report(doris::TReportRequest const&, doris::TMasterResult*) /root/doris/be/src/agent/utils.cpp:109
    #12 0x555d928d4e74 in doris::TaskWorkerPool::_handle_report(doris::TReportRequest&, doris::TaskWorkerPool::ReportType) /root/doris/be/src/agent/task_worker_pool.cpp:1651
    #13 0x555d928dbbf5 in doris::TaskWorkerPool::_report_tablet_worker_thread_callback() /root/doris/be/src/agent/task_worker_pool.cpp:1376
    #14 0x555d92923c21 in void std::__invoke_impl<void, void (doris::TaskWorkerPool::*&)(), doris::TaskWorkerPool*&>(std::__invoke_memfun_deref, void (doris::TaskWorkerPool::*&)(), doris::TaskWorkerPool*&) /var/local/ldb-toolchain/include/c++/11/bits/invoke.h:74
    #15 0x555d92923c21 in std::enable_if<is_invocable_r_v<void, void (doris::TaskWorkerPool::*&)(), doris::TaskWorkerPool*&>, void>::type std::__invoke_r<void, void (doris::TaskWorkerPool::*&)(), doris::TaskWorkerPool*&>(void (doris::TaskWorkerPool::*&)(), doris::TaskWorkerPool*&) /var/local/ldb-toolchain/include/c++/11/bits/invoke.h:111
    #16 0x555d92923c21 in void std::_Bind_result<void, void (doris::TaskWorkerPool::*(doris::TaskWorkerPool*))()>::__call<void, , 0ul>(std::tuple<>&&, std::_Index_tuple<0ul>) /var/local/ldb-toolchain/include/c++/11/functional:570
    #17 0x555d92923c21 in void std::_Bind_result<void, void (doris::TaskWorkerPool::*(doris::TaskWorkerPool*))()>::operator()<>() /var/local/ldb-toolchain/include/c++/11/functional:629
    #18 0x555d92923c21 in void std::__invoke_impl<void, std::_Bind_result<void, void (doris::TaskWorkerPool::*(doris::TaskWorkerPool*))()>&>(std::__invoke_other, std::_Bind_result<void, void (doris::TaskWorkerPool::*(doris::TaskWorkerPool*))()>&) /var/local/ldb-toolchain/include/c++/11/bits/invoke.h:61
    #19 0x555d92923c21 in std::enable_if<is_invocable_r_v<void, std::_Bind_result<void, void (doris::TaskWorkerPool::*(doris::TaskWorkerPool*))()>&>, void>::type std::__invoke_r<void, std::_Bind_result<void, void (doris::TaskWorkerPool::*(doris::TaskWorkerPool*))()>&>(std::_Bind_result<void, void (doris::TaskWorkerPool::*(doris::TaskWorkerPool*))()>&) /var/local/ldb-toolchain/include/c++/11/bits/invoke.h:111
    #20 0x555d92923c21 in std::_Function_handler<void (), std::_Bind_result<void, void (doris::TaskWorkerPool::*(doris::TaskWorkerPool*))()> >::_M_invoke(std::_Any_data const&) /var/local/ldb-toolchain/include/c++/11/bits/std_function.h:291
    #21 0x555d93dcc1c2 in std::function<void ()>::operator()() const /var/local/ldb-toolchain/include/c++/11/bits/std_function.h:560
    #22 0x555d93dcc1c2 in doris::FunctionRunnable::run() /root/doris/be/src/util/threadpool.cpp:46
    #23 0x555d93dca0a0 in doris::ThreadPool::dispatch_thread() /root/doris/be/src/util/threadpool.cpp:529
    #24 0x555d93dcbd77 in void std::__invoke_impl<void, void (doris::ThreadPool::*&)(), doris::ThreadPool*&>(std::__invoke_memfun_deref, void (doris::ThreadPool::*&)(), doris::ThreadPool*&) /var/local/ldb-toolchain/include/c++/11/bits/invoke.h:74
    #25 0x555d93dcbd77 in std::__invoke_result<void (doris::ThreadPool::*&)(), doris::ThreadPool*&>::type std::__invoke<void (doris::ThreadPool::*&)(), doris::ThreadPool*&>(void (doris::ThreadPool::*&)(), doris::ThreadPool*&) /var/local/ldb-toolchain/include/c++/11/bits/invoke.h:96
    #26 0x555d93dcbd77 in void std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>::__call<void, , 0ul>(std::tuple<>&&, std::_Index_tuple<0ul>) /var/local/ldb-toolchain/include/c++/11/functional:420
    #27 0x555d93dcbd77 in void std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>::operator()<, void>() /var/local/ldb-toolchain/include/c++/11/functional:503
    #28 0x555d93dcbd77 in void std::__invoke_impl<void, std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>&>(std::__invoke_other, std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>&) /var/local/ldb-toolchain/include/c++/11/bits/invoke.h:61
    #29 0x555d93dcbd77 in std::enable_if<is_invocable_r_v<void, std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>&>, void>::type std::__invoke_r<void, std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>&>(std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>&) /var/local/ldb-toolchain/include/c++/11/bits/invoke.h:111
    #30 0x555d93dcbd77 in std::_Function_handler<void (), std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()> >::_M_invoke(std::_Any_data const&) /var/local/ldb-toolchain/include/c++/11/bits/std_function.h:291
    #31 0x555d93d9e334 in std::function<void ()>::operator()() const /var/local/ldb-toolchain/include/c++/11/bits/std_function.h:560
    #32 0x555d93d9e334 in doris::Thread::supervise_thread(void*) /root/doris/be/src/util/thread.cpp:453
    #33 0x7f27bf731608 in start_thread /build/glibc-SzIz7B/glibc-2.31/nptl/pthread_create.c:477
    #34 0x7f27bf507132 in __clone (/lib/x86_64-linux-gnu/libc.so.6+0x11f132)

Address 0x7f261aa5d8c8 is located in stack of thread T611 (TaskWorkerPool.) at offset 40 in frame
    #0 0x555d929457ef in apache::thrift::protocol::TVirtualProtocol<apache::thrift::protocol::TBinaryProtocolT<apache::thrift::transport::TTransport, apache::thrift::protocol::TNetworkBigEndian>, apache::thrift::protocol::TProtocolDefaults>::writeI64_virt(long) /var/local/thirdparty/installed/include/thrift/protocol/TVirtualProtocol.h:380

  This frame has 1 object(s):
    [32, 40) 'net' <== Memory access at offset 40 overflows this variable
HINT: this may be a false positive if your program uses some custom stack unwind mechanism, swapcontext or vfork
      (longjmp and C++ exceptions *are* supported)
Thread T611 (TaskWorkerPool.) created by T0 here:
    #0 0x555d91c5b061 in pthread_create (/mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster7/be/lib/doris_be+0x704e061)
    #1 0x555d93d9a1d1 in doris::Thread::start_thread(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::function<void ()> const&, unsigned long, scoped_refptr<doris::Thread>*) /root/doris/be/src/util/thread.cpp:407
    #2 0x555d93db7aaa in doris::Status doris::Thread::create<void (doris::ThreadPool::*)(), doris::ThreadPool*>(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, void (doris::ThreadPool::* const&)(), doris::ThreadPool* const&, scoped_refptr<doris::Thread>*) /root/doris/be/src/util/thread.h:57
    #3 0x555d93db7aaa in doris::ThreadPool::create_thread() /root/doris/be/src/util/threadpool.cpp:598
    #4 0x555d93dc1633 in doris::ThreadPool::init() /root/doris/be/src/util/threadpool.cpp:257
    #5 0x555d928cf7b0 in doris::Status doris::ThreadPoolBuilder::build<doris::ThreadPool>(std::unique_ptr<doris::ThreadPool, std::default_delete<doris::ThreadPool> >*) const /root/doris/be/src/util/threadpool.h:114
    #6 0x555d928cf7b0 in doris::TaskWorkerPool::start() /root/doris/be/src/agent/task_worker_pool.cpp:223
    #7 0x555d9396e75a in doris::AgentServer::AgentServer(doris::ExecEnv*, doris::TMasterInfo const&) /root/doris/be/src/agent/agent_server.cpp:96
    #8 0x555d93948f1b in doris::BackendService::BackendService(doris::ExecEnv*) /root/doris/be/src/service/backend_service.cpp:68
    #9 0x555d93952eec in doris::BackendService::create_service(doris::ExecEnv*, int, doris::ThriftServer**) /root/doris/be/src/service/backend_service.cpp:71
    #10 0x555d91d085cb in main /root/doris/be/src/service/doris_main.cpp:463
    #11 0x7f27bf40c082 in __libc_start_main ../csu/libc-start.c:308

SUMMARY: AddressSanitizer: stack-buffer-overflow (/mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster7/be/lib/doris_be+0x7049b16) in __interceptor_sigaltstack.part.0
Shadow bytes around the buggy address:
  0x0fe543543ac0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0fe543543ad0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0fe543543ae0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0fe543543af0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0fe543543b00: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
=>0x0fe543543b10: 00 00 00 00 f1 f1 f1 f1 00[f3]f3 f3 00 00 00 00
  0x0fe543543b20: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0fe543543b30: f1 f1 f1 f1 f1 f1 01 f2 00 f2 f2 f2 00 f2 f2 f2
  0x0fe543543b40: 00 f2 f2 f2 00 f2 f2 f2 00 f3 f3 f3 00 00 00 00
  0x0fe543543b50: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0fe543543b60: f1 f1 f1 f1 f1 f1 01 f2 00 f2 f2 f2 00 f2 f2 f2
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
  Shadow gap:              cc
==3332520==ABORTING


=================================================================
==3537813==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x7f784aa162b0 at pc 0x55bde672eb17 bp 0x7f784aa16280 sp 0x7f784aa15a28
WRITE of size 24 at 0x7f784aa162b0 thread T858 (EvHttpServer [w)
    #0 0x55bde672eb16 in __interceptor_sigaltstack.part.0 (/mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster7/be/lib/doris_be+0x7eb9b16)
    #1 0x55bde67948bf in __asan::PlatformUnpoisonStacks() (/mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster7/be/lib/doris_be+0x7f1f8bf)
    #2 0x55bde679a224 in __asan_handle_no_return (/mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster7/be/lib/doris_be+0x7f25224)
    #3 0x55bde8e13477 in __gnu_cxx::new_allocator<char>::~new_allocator() /var/local/ldb-toolchain/include/c++/11/ext/new_allocator.h:89
    #4 0x55bde8e13477 in std::allocator<char>::~allocator() /var/local/ldb-toolchain/include/c++/11/bits/allocator.h:162
    #5 0x55bde8e13477 in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_Alloc_hider::~_Alloc_hider() /var/local/ldb-toolchain/include/c++/11/bits/basic_string.h:150
    #6 0x55bde8e13477 in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::~basic_string() /var/local/ldb-toolchain/include/c++/11/bits/basic_string.h:658
    #7 0x55bde8e13477 in doris::FrontendServiceClient::recv_loadTxnPreCommit(doris::TLoadTxnCommitResult&) /root/doris/gensrc/build/gen_cpp/FrontendService.cpp:6130
    #8 0x55bde8e13621 in doris::FrontendServiceClient::loadTxnPreCommit(doris::TLoadTxnCommitResult&, doris::TLoadTxnCommitRequest const&) /root/doris/gensrc/build/gen_cpp/FrontendService.cpp:6077
    #9 0x55bde82f62cf in operator() /root/doris/be/src/runtime/stream_load/stream_load_executor.cpp:183
    #10 0x55bde82f62cf in __invoke_impl<void, doris::StreamLoadExecutor::pre_commit_txn(doris::StreamLoadContext*)::<lambda(doris::FrontendServiceConnection&)>&, doris::ClientConnection<doris::FrontendServiceClient>&> /var/local/ldb-toolchain/include/c++/11/bits/invoke.h:61
    #11 0x55bde82f62cf in __invoke_r<void, doris::StreamLoadExecutor::pre_commit_txn(doris::StreamLoadContext*)::<lambda(doris::FrontendServiceConnection&)>&, doris::ClientConnection<doris::FrontendServiceClient>&> /var/local/ldb-toolchain/include/c++/11/bits/invoke.h:111
    #12 0x55bde82f62cf in _M_invoke /var/local/ldb-toolchain/include/c++/11/bits/std_function.h:291
    #13 0x55bde8816062 in std::function<void (doris::ClientConnection<doris::FrontendServiceClient>&)>::operator()(doris::ClientConnection<doris::FrontendServiceClient>&) const /var/local/ldb-toolchain/include/c++/11/bits/std_function.h:560
    #14 0x55bde8816062 in doris::Status doris::ThriftRpcHelper::rpc<doris::FrontendServiceClient>(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, int, std::function<void (doris::ClientConnection<doris::FrontendServiceClient>&)>, int) /root/doris/be/src/util/thrift_rpc_helper.cpp:59
    #15 0x55bde82ff907 in doris::StreamLoadExecutor::pre_commit_txn(doris::StreamLoadContext*) /root/doris/be/src/runtime/stream_load/stream_load_executor.cpp:183
    #16 0x55bde97dd273 in doris::StreamLoadAction::_handle(std::shared_ptr<doris::StreamLoadContext>) /root/doris/be/src/http/action/stream_load.cpp:210
    #17 0x55bde97e1da6 in doris::StreamLoadAction::handle(doris::HttpRequest*) /root/doris/be/src/http/action/stream_load.cpp:155
    #18 0x55bde971b32e in on_request /root/doris/be/src/http/ev_http_server.cpp:59
    #19 0x55bdfe119ad6  (/mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster7/be/lib/doris_be+0x1f8a4ad6)
    #20 0x55bdfe0f9e50 in bufferevent_run_readcb_ (/mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster7/be/lib/doris_be+0x1f884e50)
    #21 0x55bdfe11bcf2  (/mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster7/be/lib/doris_be+0x1f8a6cf2)
    #22 0x55bdfe102c58  (/mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster7/be/lib/doris_be+0x1f88dc58)
    #23 0x55bdfe1032d6  (/mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster7/be/lib/doris_be+0x1f88e2d6)
    #24 0x55bdfe105907  (/mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster7/be/lib/doris_be+0x1f890907)
    #25 0x55bde97218ba in operator() /root/doris/be/src/http/ev_http_server.cpp:105
    #26 0x55bde97218ba in __invoke_impl<void, doris::EvHttpServer::start()::<lambda()>&> /var/local/ldb-toolchain/include/c++/11/bits/invoke.h:61
    #27 0x55bde97218ba in __invoke_r<void, doris::EvHttpServer::start()::<lambda()>&> /var/local/ldb-toolchain/include/c++/11/bits/invoke.h:111
    #28 0x55bde97218ba in _M_invoke /var/local/ldb-toolchain/include/c++/11/bits/std_function.h:291
    #29 0x55bde88b2c62 in std::function<void ()>::operator()() const /var/local/ldb-toolchain/include/c++/11/bits/std_function.h:560
    #30 0x55bde88b2c62 in doris::FunctionRunnable::run() /root/doris/be/src/util/threadpool.cpp:46
    #31 0x55bde88b0b40 in doris::ThreadPool::dispatch_thread() /root/doris/be/src/util/threadpool.cpp:529
    #32 0x55bde88b2817 in void std::__invoke_impl<void, void (doris::ThreadPool::*&)(), doris::ThreadPool*&>(std::__invoke_memfun_deref, void (doris::ThreadPool::*&)(), doris::ThreadPool*&) /var/local/ldb-toolchain/include/c++/11/bits/invoke.h:74
    #33 0x55bde88b2817 in std::__invoke_result<void (doris::ThreadPool::*&)(), doris::ThreadPool*&>::type std::__invoke<void (doris::ThreadPool::*&)(), doris::ThreadPool*&>(void (doris::ThreadPool::*&)(), doris::ThreadPool*&) /var/local/ldb-toolchain/include/c++/11/bits/invoke.h:96
    #34 0x55bde88b2817 in void std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>::__call<void, , 0ul>(std::tuple<>&&, std::_Index_tuple<0ul>) /var/local/ldb-toolchain/include/c++/11/functional:420
    #35 0x55bde88b2817 in void std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>::operator()<, void>() /var/local/ldb-toolchain/include/c++/11/functional:503
    #36 0x55bde88b2817 in void std::__invoke_impl<void, std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>&>(std::__invoke_other, std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>&) /var/local/ldb-toolchain/include/c++/11/bits/invoke.h:61
    #37 0x55bde88b2817 in std::enable_if<is_invocable_r_v<void, std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>&>, void>::type std::__invoke_r<void, std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>&>(std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>&) /var/local/ldb-toolchain/include/c++/11/bits/invoke.h:111
    #38 0x55bde88b2817 in std::_Function_handler<void (), std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()> >::_M_invoke(std::_Any_data const&) /var/local/ldb-toolchain/include/c++/11/bits/std_function.h:291
    #39 0x55bde8884dd4 in std::function<void ()>::operator()() const /var/local/ldb-toolchain/include/c++/11/bits/std_function.h:560
    #40 0x55bde8884dd4 in doris::Thread::supervise_thread(void*) /root/doris/be/src/util/thread.cpp:453
    #41 0x7f7a7d277608 in start_thread /build/glibc-SzIz7B/glibc-2.31/nptl/pthread_create.c:477
    #42 0x7f7a7d04d132 in __clone (/lib/x86_64-linux-gnu/libc.so.6+0x11f132)

Address 0x7f784aa162b0 is located in stack of thread T858 (EvHttpServer [w) at offset 208 in frame
    #0 0x55bde743bb3f in apache::thrift::protocol::TBinaryProtocolT<apache::thrift::transport::TTransport, apache::thrift::protocol::TNetworkBigEndian>::readMessageBegin(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, apache::thrift::protocol::TMessageType&, int&) /var/local/thirdparty/installed/include/thrift/protocol/TBinaryProtocol.tcc:200

  This frame has 7 object(s):
    [48, 49) '<unknown>'
    [64, 68) 'theBytes' (line 372)
    [80, 84) 'theBytes' (line 372)
    [96, 100) 'theBytes' (line 372)
    [112, 116) 'theBytes' (line 372)
    [128, 160) '<unknown>'
    [192, 193) 'b' (line 350) <== Memory access at offset 208 overflows this variable
HINT: this may be a false positive if your program uses some custom stack unwind mechanism, swapcontext or vfork
      (longjmp and C++ exceptions *are* supported)
Thread T858 (EvHttpServer [w) created by T0 here:
    #0 0x55bde6733061 in pthread_create (/mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster7/be/lib/doris_be+0x7ebe061)
    #1 0x55bde8880c71 in doris::Thread::start_thread(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::function<void ()> const&, unsigned long, scoped_refptr<doris::Thread>*) /root/doris/be/src/util/thread.cpp:407
    #2 0x55bde889e54a in doris::Status doris::Thread::create<void (doris::ThreadPool::*)(), doris::ThreadPool*>(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, void (doris::ThreadPool::* const&)(), doris::ThreadPool* const&, scoped_refptr<doris::Thread>*) /root/doris/be/src/util/thread.h:57
    #3 0x55bde889e54a in doris::ThreadPool::create_thread() /root/doris/be/src/util/threadpool.cpp:598
    #4 0x55bde88a80d3 in doris::ThreadPool::init() /root/doris/be/src/util/threadpool.cpp:257
    #5 0x55bde972343c in doris::Status doris::ThreadPoolBuilder::build<doris::ThreadPool>(std::unique_ptr<doris::ThreadPool, std::default_delete<doris::ThreadPool> >*) const /root/doris/be/src/util/threadpool.h:114
    #6 0x55bde972343c in doris::EvHttpServer::start() /root/doris/be/src/http/ev_http_server.cpp:100
    #7 0x55bde84810ef in doris::HttpService::start() /root/doris/be/src/service/http_service.cpp:191
    #8 0x55bde67e0da3 in main /root/doris/be/src/service/doris_main.cpp:496
    #9 0x7f7a7cf52082 in __libc_start_main ../csu/libc-start.c:308

SUMMARY: AddressSanitizer: stack-buffer-overflow (/mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster7/be/lib/doris_be+0x7eb9b16) in __interceptor_sigaltstack.part.0
Shadow bytes around the buggy address:
  0x0fef8953ac00: 00 00 00 00 00 00 f1 f1 f1 f1 f1 f1 01 f2 00 00
  0x0fef8953ac10: 00 00 f3 f3 f3 f3 00 00 00 00 00 00 00 00 00 00
  0x0fef8953ac20: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0fef8953ac30: 00 00 00 00 00 00 00 00 00 00 00 00 f1 f1 f1 f1
  0x0fef8953ac40: f1 f1 01 f2 04 f2 04 f2 04 f2 04 f2 00 00 00 00
=>0x0fef8953ac50: f2 f2 f2 f2 01 f3[f3]f3 00 00 00 00 00 00 00 00
  0x0fef8953ac60: 00 00 00 00 00 00 00 00 00 00 f1 f1 f1 f1 01 f2
  0x0fef8953ac70: f8 f2 01 f2 04 f2 04 f2 00 00 f2 f2 00 00 f2 f2
  0x0fef8953ac80: 00 00 f2 f2 00 00 f2 f2 00 00 00 f2 f2 f2 f2 f2
  0x0fef8953ac90: 00 00 00 00 f2 f2 f2 f2 00 00 00 00 f2 f2 f2 f2
  0x0fef8953aca0: 00 00 00 00 00 00 f3 f3 f3 f3 00 00 00 00 00 00
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
  Shadow gap:              cc
==3537813==ABORTING
start time: Mon 27 Feb 2023 09:31:44 PM CST
WARNING: Logging before InitGoogleLogging() is written to STDERR
I0227 21:31:45.326819 3568200 doris_main.cpp:324] enable_fuzzy_mode is true, set fuzzy configs
=================================================================
==3568200==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x7faade82b8c8 at pc 0x55b93dc78b17 bp 0x7faade82b890 sp 0x7faade82b038
WRITE of size 24 at 0x7faade82b8c8 thread T611 (TaskWorkerPool.)
    #0 0x55b93dc78b16 in __interceptor_sigaltstack.part.0 (/mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster7/be/lib/doris_be+0x7eb9b16)
    #1 0x55b93dcde8bf in __asan::PlatformUnpoisonStacks() (/mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster7/be/lib/doris_be+0x7f1f8bf)
    #2 0x55b93dce4224 in __asan_handle_no_return (/mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster7/be/lib/doris_be+0x7f25224)
    #3 0x55b9406a17d3 in apache::thrift::protocol::TProtocol::decrementOutputRecursionDepth() /var/local/thirdparty/installed/include/thrift/protocol/TProtocol.h:576
    #4 0x55b9406a17d3 in apache::thrift::protocol::TOutputRecursionTracker::~TOutputRecursionTracker() /var/local/thirdparty/installed/include/thrift/protocol/TProtocol.h:648
    #5 0x55b9406a17d3 in doris::TTabletInfo::write(apache::thrift::protocol::TProtocol*) const /root/doris/gensrc/build/gen_cpp/MasterService_types.cpp:483
    #6 0x55b940697c0e in doris::TTablet::write(apache::thrift::protocol::TProtocol*) const /root/doris/gensrc/build/gen_cpp/MasterService_types.cpp:1215
    #7 0x55b94069e25c in doris::TReportRequest::write(apache::thrift::protocol::TProtocol*) const /root/doris/gensrc/build/gen_cpp/MasterService_types.cpp:1930
    #8 0x55b9402efc3d in doris::FrontendService_report_pargs::write(apache::thrift::protocol::TProtocol*) const /root/doris/gensrc/build/gen_cpp/FrontendService.cpp:1204
    #9 0x55b94032912e in doris::FrontendServiceClient::send_report(doris::TReportRequest const&) /root/doris/gensrc/build/gen_cpp/FrontendService.cpp:5566
    #10 0x55b94034fe22 in doris::FrontendServiceClient::report(doris::TMasterResult&, doris::TReportRequest const&) /root/doris/gensrc/build/gen_cpp/FrontendService.cpp:5555
    #11 0x55b93e96e42c in doris::MasterServerClient::report(doris::TReportRequest const&, doris::TMasterResult*) /root/doris/be/src/agent/utils.cpp:109
    #12 0x55b93e8ffbb4 in doris::TaskWorkerPool::_handle_report(doris::TReportRequest&, doris::TaskWorkerPool::ReportType) /root/doris/be/src/agent/task_worker_pool.cpp:1651
    #13 0x55b93e906935 in doris::TaskWorkerPool::_report_tablet_worker_thread_callback() /root/doris/be/src/agent/task_worker_pool.cpp:1376
    #14 0x55b93e94e9c1 in void std::__invoke_impl<void, void (doris::TaskWorkerPool::*&)(), doris::TaskWorkerPool*&>(std::__invoke_memfun_deref, void (doris::TaskWorkerPool::*&)(), doris::TaskWorkerPool*&) /var/local/ldb-toolchain/include/c++/11/bits/invoke.h:74
    #15 0x55b93e94e9c1 in std::enable_if<is_invocable_r_v<void, void (doris::TaskWorkerPool::*&)(), doris::TaskWorkerPool*&>, void>::type std::__invoke_r<void, void (doris::TaskWorkerPool::*&)(), doris::TaskWorkerPool*&>(void (doris::TaskWorkerPool::*&)(), doris::TaskWorkerPool*&) /var/local/ldb-toolchain/include/c++/11/bits/invoke.h:111
    #16 0x55b93e94e9c1 in void std::_Bind_result<void, void (doris::TaskWorkerPool::*(doris::TaskWorkerPool*))()>::__call<void, , 0ul>(std::tuple<>&&, std::_Index_tuple<0ul>) /var/local/ldb-toolchain/include/c++/11/functional:570
    #17 0x55b93e94e9c1 in void std::_Bind_result<void, void (doris::TaskWorkerPool::*(doris::TaskWorkerPool*))()>::operator()<>() /var/local/ldb-toolchain/include/c++/11/functional:629
    #18 0x55b93e94e9c1 in void std::__invoke_impl<void, std::_Bind_result<void, void (doris::TaskWorkerPool::*(doris::TaskWorkerPool*))()>&>(std::__invoke_other, std::_Bind_result<void, void (doris::TaskWorkerPool::*(doris::TaskWorkerPool*))()>&) /var/local/ldb-toolchain/include/c++/11/bits/invoke.h:61
    #19 0x55b93e94e9c1 in std::enable_if<is_invocable_r_v<void, std::_Bind_result<void, void (doris::TaskWorkerPool::*(doris::TaskWorkerPool*))()>&>, void>::type std::__invoke_r<void, std::_Bind_result<void, void (doris::TaskWorkerPool::*(doris::TaskWorkerPool*))()>&>(std::_Bind_result<void, void (doris::TaskWorkerPool::*(doris::TaskWorkerPool*))()>&) /var/local/ldb-toolchain/include/c++/11/bits/invoke.h:111
    #20 0x55b93e94e9c1 in std::_Function_handler<void (), std::_Bind_result<void, void (doris::TaskWorkerPool::*(doris::TaskWorkerPool*))()> >::_M_invoke(std::_Any_data const&) /var/local/ldb-toolchain/include/c++/11/bits/std_function.h:291
    #21 0x55b93fdfcc62 in std::function<void ()>::operator()() const /var/local/ldb-toolchain/include/c++/11/bits/std_function.h:560
    #22 0x55b93fdfcc62 in doris::FunctionRunnable::run() /root/doris/be/src/util/threadpool.cpp:46
    #23 0x55b93fdfab40 in doris::ThreadPool::dispatch_thread() /root/doris/be/src/util/threadpool.cpp:529
    #24 0x55b93fdfc817 in void std::__invoke_impl<void, void (doris::ThreadPool::*&)(), doris::ThreadPool*&>(std::__invoke_memfun_deref, void (doris::ThreadPool::*&)(), doris::ThreadPool*&) /var/local/ldb-toolchain/include/c++/11/bits/invoke.h:74
    #25 0x55b93fdfc817 in std::__invoke_result<void (doris::ThreadPool::*&)(), doris::ThreadPool*&>::type std::__invoke<void (doris::ThreadPool::*&)(), doris::ThreadPool*&>(void (doris::ThreadPool::*&)(), doris::ThreadPool*&) /var/local/ldb-toolchain/include/c++/11/bits/invoke.h:96
    #26 0x55b93fdfc817 in void std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>::__call<void, , 0ul>(std::tuple<>&&, std::_Index_tuple<0ul>) /var/local/ldb-toolchain/include/c++/11/functional:420
    #27 0x55b93fdfc817 in void std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>::operator()<, void>() /var/local/ldb-toolchain/include/c++/11/functional:503
    #28 0x55b93fdfc817 in void std::__invoke_impl<void, std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>&>(std::__invoke_other, std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>&) /var/local/ldb-toolchain/include/c++/11/bits/invoke.h:61
    #29 0x55b93fdfc817 in std::enable_if<is_invocable_r_v<void, std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>&>, void>::type std::__invoke_r<void, std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>&>(std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>&) /var/local/ldb-toolchain/include/c++/11/bits/invoke.h:111
    #30 0x55b93fdfc817 in std::_Function_handler<void (), std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()> >::_M_invoke(std::_Any_data const&) /var/local/ldb-toolchain/include/c++/11/bits/std_function.h:291
    #31 0x55b93fdcedd4 in std::function<void ()>::operator()() const /var/local/ldb-toolchain/include/c++/11/bits/std_function.h:560
    #32 0x55b93fdcedd4 in doris::Thread::supervise_thread(void*) /root/doris/be/src/util/thread.cpp:453
    #33 0x7fac84550608 in start_thread /build/glibc-SzIz7B/glibc-2.31/nptl/pthread_create.c:477
    #34 0x7fac84326132 in __clone (/lib/x86_64-linux-gnu/libc.so.6+0x11f132)

Address 0x7faade82b8c8 is located in stack of thread T611 (TaskWorkerPool.) at offset 40 in frame
    #0 0x55b93e9705ef in apache::thrift::protocol::TVirtualProtocol<apache::thrift::protocol::TBinaryProtocolT<apache::thrift::transport::TTransport, apache::thrift::protocol::TNetworkBigEndian>, apache::thrift::protocol::TProtocolDefaults>::writeI64_virt(long) /var/local/thirdparty/installed/include/thrift/protocol/TVirtualProtocol.h:380

  This frame has 1 object(s):
    [32, 40) 'net' <== Memory access at offset 40 overflows this variable
HINT: this may be a false positive if your program uses some custom stack unwind mechanism, swapcontext or vfork
      (longjmp and C++ exceptions *are* supported)
Thread T611 (TaskWorkerPool.) created by T0 here:
    #0 0x55b93dc7d061 in pthread_create (/mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster7/be/lib/doris_be+0x7ebe061)
    #1 0x55b93fdcac71 in doris::Thread::start_thread(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::function<void ()> const&, unsigned long, scoped_refptr<doris::Thread>*) /root/doris/be/src/util/thread.cpp:407
    #2 0x55b93fde854a in doris::Status doris::Thread::create<void (doris::ThreadPool::*)(), doris::ThreadPool*>(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, void (doris::ThreadPool::* const&)(), doris::ThreadPool* const&, scoped_refptr<doris::Thread>*) /root/doris/be/src/util/thread.h:57
    #3 0x55b93fde854a in doris::ThreadPool::create_thread() /root/doris/be/src/util/threadpool.cpp:598
    #4 0x55b93fdf20d3 in doris::ThreadPool::init() /root/doris/be/src/util/threadpool.cpp:257
    #5 0x55b93e8fa4f0 in doris::Status doris::ThreadPoolBuilder::build<doris::ThreadPool>(std::unique_ptr<doris::ThreadPool, std::default_delete<doris::ThreadPool> >*) const /root/doris/be/src/util/threadpool.h:114
    #6 0x55b93e8fa4f0 in doris::TaskWorkerPool::start() /root/doris/be/src/agent/task_worker_pool.cpp:223
    #7 0x55b93f99e4da in doris::AgentServer::AgentServer(doris::ExecEnv*, doris::TMasterInfo const&) /root/doris/be/src/agent/agent_server.cpp:96
    #8 0x55b93f978c3b in doris::BackendService::BackendService(doris::ExecEnv*) /root/doris/be/src/service/backend_service.cpp:68
    #9 0x55b93f982c0c in doris::BackendService::create_service(doris::ExecEnv*, int, doris::ThriftServer**) /root/doris/be/src/service/backend_service.cpp:71
    #10 0x55b93dd2a61b in main /root/doris/be/src/service/doris_main.cpp:463
    #11 0x7fac8422b082 in __libc_start_main ../csu/libc-start.c:308

SUMMARY: AddressSanitizer: stack-buffer-overflow (/mnt/ssd01/pipline/OpenSourceDoris/clusterEnv/P0/Cluster7/be/lib/doris_be+0x7eb9b16) in __interceptor_sigaltstack.part.0
Shadow bytes around the buggy address:
  0x0ff5dbcfd6c0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0ff5dbcfd6d0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0ff5dbcfd6e0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0ff5dbcfd6f0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0ff5dbcfd700: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
=>0x0ff5dbcfd710: 00 00 00 00 f1 f1 f1 f1 00[f3]f3 f3 00 00 00 00
  0x0ff5dbcfd720: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0ff5dbcfd730: f1 f1 f1 f1 f1 f1 01 f2 00 f2 f2 f2 00 f2 f2 f2
  0x0ff5dbcfd740: 00 f2 f2 f2 00 f2 f2 f2 00 f3 f3 f3 00 00 00 00
  0x0ff5dbcfd750: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0ff5dbcfd760: f1 f1 f1 f1 f1 f1 01 f2 00 f2 f2 f2 00 f2 f2 f2
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
  Shadow gap:              cc
==3568200==ABORTING

```

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

