### PR TITLE
[improvement][fix](catalog) check required properties when creating catalog and fix jdbc catalog issue

### DIFF
--- a/docs/en/docs/lakehouse/multi-catalog/faq.md
+++ b/docs/en/docs/lakehouse/multi-catalog/faq.md
@@ -67,3 +67,17 @@ under the License.
     `"hive.exec.orc.split.strategy" = "BI"`
 
     Other options: HYBRID (default), ETL.
+
+6. An error is reported when connecting to SQLServer through JDBC Catalog: `unable to find valid certification path to requested target`
+
+    Please add `trustServerCertificate=true` option in `jdbc_url`.
+
+7. When connecting to the MySQL database through the JDBC Catalog, the Chinese characters are garbled, or the Chinese character condition query is incorrect
+
+    Please add `useUnicode=true&characterEncoding=utf-8` in `jdbc_url`
+
+    > Note: After version 1.2.3, these parameters will be automatically added when using JDBC Catalog to connect to the MySQL database.
+
+8. An error is reported when connecting to the MySQL database through the JDBC Catalog: `Establishing SSL connection without server's identity verification is not recommended`
+
+    Please add `useSSL=true` in `jdbc_url`

--- a/docs/zh-CN/docs/lakehouse/multi-catalog/faq.md
+++ b/docs/zh-CN/docs/lakehouse/multi-catalog/faq.md
@@ -67,3 +67,17 @@ under the License.
    `"hive.exec.orc.split.strategy" = "BI"`
 
    其他选项：HYBRID（默认），ETL。
+
+6. 通过 JDBC Catalog 连接 SQLServer 报错：`unable to find valid certification path to requested target`
+
+   请在 `jdbc_url` 中添加 `trustServerCertificate=true` 选项。
+
+7. 通过 JDBC Catalog 连接 MySQL 数据库，中文字符乱码，或中文字符条件查询不正确
+
+   请在 `jdbc_url` 中添加 `useUnicode=true&characterEncoding=utf-8`
+
+   > 注：1.2.3 版本后，使用 JDBC Catalog 连接 MySQL 数据库，会自动添加这些参数。
+
+8. 通过 JDBC Catalog 连接 MySQL 数据库报错：`Establishing SSL connection without server's identity verification is not recommended`
+
+   请在 `jdbc_url` 中添加 `useSSL=true`

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/HdfsResource.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/HdfsResource.java
@@ -51,6 +51,7 @@ public class HdfsResource extends Resource {
     public static String HADOOP_KERBEROS_KEYTAB = "hadoop.kerberos.keytab";
     public static String HADOOP_SHORT_CIRCUIT = "dfs.client.read.shortcircuit";
     public static String HADOOP_SOCKET_PATH = "dfs.domain.socket.path";
+    public static String DSF_NAMESERVICES = "dfs.nameservices";
 
     @SerializedName(value = "properties")
     private Map<String, String> properties;

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/CatalogMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/CatalogMgr.java
@@ -250,7 +250,10 @@ public class CatalogMgr implements Writable, GsonPostProcessable {
             }
             long id = Env.getCurrentEnv().getNextId();
             CatalogLog log = CatalogFactory.constructorCatalogLog(id, stmt);
-            replayCreateCatalog(log);
+            CatalogIf catalog = replayCreateCatalog(log);
+            if (catalog instanceof ExternalCatalog) {
+                ((ExternalCatalog) catalog).checkProperties();
+            }
             Env.getCurrentEnv().getEditLog().logCatalogLog(OperationType.OP_CREATE_CATALOG, log);
         } finally {
             writeUnlock();
@@ -458,11 +461,12 @@ public class CatalogMgr implements Writable, GsonPostProcessable {
     /**
      * Reply for create catalog event.
      */
-    public void replayCreateCatalog(CatalogLog log) throws DdlException {
+    public CatalogIf replayCreateCatalog(CatalogLog log) throws DdlException {
         writeLock();
         try {
             CatalogIf catalog = CatalogFactory.constructorFromLog(log);
             addCatalog(catalog);
+            return catalog;
         } finally {
             writeUnlock();
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalCatalog.java
@@ -26,6 +26,7 @@ import org.apache.doris.catalog.external.HMSExternalDatabase;
 import org.apache.doris.catalog.external.IcebergExternalDatabase;
 import org.apache.doris.catalog.external.JdbcExternalDatabase;
 import org.apache.doris.cluster.ClusterNamespace;
+import org.apache.doris.common.DdlException;
 import org.apache.doris.common.io.Text;
 import org.apache.doris.common.io.Writable;
 import org.apache.doris.common.util.Util;
@@ -150,6 +151,9 @@ public abstract class ExternalCatalog implements CatalogIf<ExternalDatabase>, Wr
     // hms client, read properties from hive-site.xml, es client
     protected abstract void initLocalObjectsImpl();
 
+    // check if all required properties are set when creating catalog
+    public void checkProperties() throws DdlException {
+    }
 
     /**
      * eg:

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/JdbcExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/JdbcExternalCatalog.java
@@ -39,6 +39,12 @@ import java.util.Map;
 public class JdbcExternalCatalog extends ExternalCatalog {
     private static final Logger LOG = LogManager.getLogger(JdbcExternalCatalog.class);
 
+    private static final List<String> REQUIRED_PROPERTIES = Lists.newArrayList(
+            JdbcResource.JDBC_URL,
+            JdbcResource.DRIVER_URL,
+            JdbcResource.DRIVER_CLASS
+    );
+
     // Must add "transient" for Gson to ignore this field,
     // or Gson will throw exception with HikariCP
     private transient JdbcClient jdbcClient;
@@ -48,6 +54,16 @@ public class JdbcExternalCatalog extends ExternalCatalog {
         super(catalogId, name);
         this.type = "jdbc";
         this.catalogProperty = new CatalogProperty(resource, processCompatibleProperties(props));
+    }
+
+    @Override
+    public void checkProperties() throws DdlException {
+        super.checkProperties();
+        for (String requiredProperty : REQUIRED_PROPERTIES) {
+            if (!catalogProperty.getProperties().containsKey(requiredProperty)) {
+                throw new DdlException("Required property '" + requiredProperty + "' is missing");
+            }
+        }
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/MasterCatalogExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/MasterCatalogExecutor.java
@@ -40,7 +40,12 @@ public class MasterCatalogExecutor {
 
     public MasterCatalogExecutor() {
         ctx = ConnectContext.get();
-        waitTimeoutMs = ctx.getSessionVariable().getQueryTimeoutS() * 1000;
+        if (ctx == null) {
+            // The method may be called by FrontendServiceImpl from BE, which does not have ConnectContext.
+            waitTimeoutMs = 300 * 1000;
+        } else {
+            waitTimeoutMs = ctx.getSessionVariable().getQueryTimeoutS() * 1000;
+        }
     }
 
     public void forward(long catalogId, long dbId) throws Exception {


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

1. Check required properties when creating catalog.

To avoid some strange error when missing required properties

This PR add checks for:
1. hms catalog: check the validation of dfs.ha properties
2. jdbc catalog: check jdbc_url, driver_url, driver_class is set.

2. Fix NPE when init MasterCatalogExecutor
   The MasterCatalogExecutor may be called by FrontendServiceImpl from BE, which does not have ConnectionContext.

3. Add more jdbc url param to resolve Chinese issue

    add `useUnicode=true&characterEncoding=utf-8` by default in jdbc catalog when connecting to MySQL

5. Update FAQ doc of catalog

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

