### PR TITLE
[enhancement](execute model) using thread pool to execute report or join task instead of staring too many thread

### DIFF
--- a/be/src/pipeline/pipeline_fragment_context.cpp
+++ b/be/src/pipeline/pipeline_fragment_context.cpp
@@ -103,6 +103,7 @@ PipelineFragmentContext::PipelineFragmentContext(
           _report_thread_active(false),
           _report_status_cb(report_status_cb),
           _is_report_on_cancel(true) {
+    _report_thread_future = _report_thread_promise.get_future();
     _fragment_watcher.start();
 }
 

--- a/be/src/pipeline/pipeline_fragment_context.h
+++ b/be/src/pipeline/pipeline_fragment_context.h
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#include <future>
+
 #include "io/fs/stream_load_pipe.h"
 #include "pipeline/pipeline.h"
 #include "pipeline/pipeline_task.h"
@@ -179,7 +181,8 @@ private:
     bool _report_thread_active;
     // profile reporting-related
     report_status_callback _report_status_cb;
-    std::thread _report_thread;
+    std::promise<bool> _report_thread_promise;
+    std::future<bool> _report_thread_future;
     std::mutex _report_thread_lock;
 
     // Indicates that profile reporting thread should stop.

--- a/be/src/runtime/exec_env.h
+++ b/be/src/runtime/exec_env.h
@@ -124,6 +124,9 @@ public:
     MemTrackerLimiter* experimental_mem_tracker() { return _experimental_mem_tracker.get(); }
     ThreadPool* send_batch_thread_pool() { return _send_batch_thread_pool.get(); }
     ThreadPool* download_cache_thread_pool() { return _download_cache_thread_pool.get(); }
+    ThreadPool* send_report_thread_pool() { return _send_report_thread_pool.get(); }
+    ThreadPool* join_node_thread_pool() { return _join_node_thread_pool.get(); }
+
     void set_serial_download_cache_thread_token() {
         _serial_download_cache_thread_token =
                 download_cache_thread_pool()->new_token(ThreadPool::ExecutionMode::SERIAL, 1);
@@ -215,6 +218,10 @@ private:
     std::unique_ptr<ThreadPool> _download_cache_thread_pool;
     // A token used to submit download cache task serially
     std::unique_ptr<ThreadPoolToken> _serial_download_cache_thread_token;
+    // Pool used by fragment manager to send profile or status to FE coordinator
+    std::unique_ptr<ThreadPool> _send_report_thread_pool;
+    // Pool used by join node to build hash table
+    std::unique_ptr<ThreadPool> _join_node_thread_pool;
     // ThreadPoolToken -> buffer
     std::unordered_map<ThreadPoolToken*, std::unique_ptr<char[]>> _download_cache_buf_map;
     CgroupsMgr* _cgroups_mgr = nullptr;

--- a/be/src/runtime/exec_env_init.cpp
+++ b/be/src/runtime/exec_env_init.cpp
@@ -102,6 +102,21 @@ Status ExecEnv::_init(const std::vector<StorePath>& store_paths) {
 
     init_download_cache_required_components();
 
+    // min num equal to fragment pool's min num
+    // max num is useless because it will start as many as requested in the past
+    // queue size is useless because the max thread num is very large
+    ThreadPoolBuilder("SendReportThreadPool")
+            .set_min_threads(config::fragment_pool_thread_num_min)
+            .set_max_threads(std::numeric_limits<int>::max())
+            .set_max_queue_size(config::fragment_pool_queue_size)
+            .build(&_send_report_thread_pool);
+
+    ThreadPoolBuilder("JoinNodeThreadPool")
+            .set_min_threads(config::fragment_pool_thread_num_min)
+            .set_max_threads(std::numeric_limits<int>::max())
+            .set_max_queue_size(config::fragment_pool_queue_size)
+            .build(&_join_node_thread_pool);
+
     RETURN_IF_ERROR(init_pipeline_task_scheduler());
     _scanner_scheduler = new doris::vectorized::ScannerScheduler();
 

--- a/be/src/runtime/plan_fragment_executor.h
+++ b/be/src/runtime/plan_fragment_executor.h
@@ -22,6 +22,7 @@
 
 #include <condition_variable>
 #include <functional>
+#include <future>
 #include <vector>
 
 #include "common/object_pool.h"
@@ -135,7 +136,8 @@ private:
 
     // profile reporting-related
     report_status_callback _report_status_cb;
-    std::thread _report_thread;
+    std::promise<bool> _report_thread_promise;
+    std::future<bool> _report_thread_future;
     std::mutex _report_thread_lock;
 
     // Indicates that profile reporting thread should stop.

--- a/be/src/vec/exec/join/vjoin_node_base.cpp
+++ b/be/src/vec/exec/join/vjoin_node_base.cpp
@@ -180,7 +180,7 @@ Status VJoinNodeBase::open(RuntimeState* state) {
 
     std::promise<Status> thread_status;
     try {
-        state->exec_env()->join_node_thread_pool()->submit(
+        state->exec_env()->join_node_thread_pool()->submit_func(
                 [this, state, thread_status_p = &thread_status,
                  parent_span = opentelemetry::trace::Tracer::GetCurrentSpan()] {
                     OpentelemetryScope scope {parent_span};

--- a/be/src/vec/exec/join/vjoin_node_base.cpp
+++ b/be/src/vec/exec/join/vjoin_node_base.cpp
@@ -180,7 +180,7 @@ Status VJoinNodeBase::open(RuntimeState* state) {
 
     std::promise<Status> thread_status;
     try {
-        state->exec_env()->join_node_thread_pool->submit(
+        state->exec_env()->join_node_thread_pool()->submit(
                 [this, state, thread_status_p = &thread_status,
                  parent_span = opentelemetry::trace::Tracer::GetCurrentSpan()] {
                     OpentelemetryScope scope {parent_span};

--- a/be/src/vec/exec/join/vjoin_node_base.cpp
+++ b/be/src/vec/exec/join/vjoin_node_base.cpp
@@ -180,11 +180,12 @@ Status VJoinNodeBase::open(RuntimeState* state) {
 
     std::promise<Status> thread_status;
     try {
-        std::thread([this, state, thread_status_p = &thread_status,
-                     parent_span = opentelemetry::trace::Tracer::GetCurrentSpan()] {
-            OpentelemetryScope scope {parent_span};
-            this->_probe_side_open_thread(state, thread_status_p);
-        }).detach();
+        state->exec_env()->join_node_thread_pool->submit(
+                [this, state, thread_status_p = &thread_status,
+                 parent_span = opentelemetry::trace::Tracer::GetCurrentSpan()] {
+                    OpentelemetryScope scope {parent_span};
+                    this->_probe_side_open_thread(state, thread_status_p);
+                });
     } catch (const std::system_error& e) {
         LOG(WARNING) << "In VJoinNodeBase::open create thread fail, " << e.what();
         return Status::InternalError(e.what());


### PR DESCRIPTION
# Proposed changes

 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /root/doris/be/src/common/signal_handler.h:420
 1# os::Linux::chained_handler(int, siginfo*, void*) in /usr/local/jdk1.8.0_301/jre/lib/amd64/server/libjvm.so
 2# JVM_handle_linux_signal in /usr/local/jdk1.8.0_301/jre/lib/amd64/server/libjvm.so
 3# signalHandler(int, siginfo*, void*) in /usr/local/jdk1.8.0_301/jre/lib/amd64/server/libjvm.so
 4# 0x00007F6498457400 in /lib64/libc.so.6
 5# je_large_prof_tctx_get at ../src/large.c:374
 6# je_free_default at ../src/jemalloc.c:2790
 7# __GI__dl_deallocate_tls in /lib64/ld-linux-x86-64.so.2
 8# __free_stacks in /lib64/libpthread.so.0
 9# __deallocate_stack in /lib64/libpthread.so.0
10# pthread_join in /lib64/libpthread.so.0
11# std::thread::join() in /opt/doris/doris/be/lib/doris_be
12# doris::PlanFragmentExecutor::open_vectorized_internal() at /root/doris/be/src/runtime/plan_fragment_executor.cpp:338
13# doris::PlanFragmentExecutor::open() at /root/doris/be/src/runtime/plan_fragment_executor.cpp:253
14# doris::FragmentExecState::execute() at /root/doris/be/src/runtime/fragment_mgr.cpp:251
15# doris::FragmentMgr::_exec_actual(std::shared_ptr<doris::FragmentExecState>, std::function<void (doris::PlanFragmentExecutor*)>) at /root/doris/be/src/runtime/fragment_mgr.cpp:498
16# std::_Function_handler<void (), doris::FragmentMgr::exec_plan_fragment(doris::TExecPlanFragmentParams const&, std::function<void (doris::PlanFragmentExecutor*)>)::{lambda()#1}>::_M_invoke(std::_Any_data const&) at /var/local/ldb-toolchain/include/c++/11/bits/std_function.h:291
17# doris::ThreadPool::dispatch_thread() at /root/doris/be/src/util/threadpool.cpp:542
18# doris::Thread::supervise_thread(void*) at /root/doris/be/src/util/thread.cpp:455
19# start_thread in /lib64/libpthread.so.0

## Problem summary

Doris will start report thread and join thread during fragment execution. There are many problems if create and destroy thread very frequently.  Jemalloc may not behave very well, it may crashed.

https://github.com/jemalloc/jemalloc/pull/1405

It is better to using thread pool to do these tasks.



## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

