### PR TITLE
[fix](vec) crash caused by not-implemented function in ColumnFixedLengthObject

### DIFF
--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -236,6 +236,7 @@ set(VEC_TEST_FILES
     vec/aggregate_functions/vec_sequence_match_test.cpp
     vec/aggregate_functions/agg_min_max_by_test.cpp
     vec/columns/column_decimal_test.cpp
+    vec/columns/column_fixed_length_object_test.cpp
     vec/core/block_test.cpp
     vec/core/block_spill_test.cpp
     vec/core/column_array_test.cpp

--- a/be/test/vec/columns/column_fixed_length_object_test.cpp
+++ b/be/test/vec/columns/column_fixed_length_object_test.cpp
@@ -1,0 +1,54 @@
+
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "vec/columns/column_fixed_length_object.h"
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <string>
+
+namespace doris::vectorized {
+
+TEST(ColumnFixedLenghtObjectTest, InsertRangeFrom) {
+    auto column1 = ColumnFixedLengthObject::create(sizeof(size_t));
+    EXPECT_EQ(sizeof(size_t), column1->item_size());
+    const size_t count = 1000;
+
+    column1->resize(count);
+    auto& data = column1->get_data();
+    for (size_t i = 0; i < count; ++i) {
+        *((size_t*)&data[i * sizeof(size_t)]) = i;
+    }
+
+    auto column2 = ColumnFixedLengthObject::create(sizeof(size_t));
+    EXPECT_EQ(sizeof(size_t), column2->item_size());
+
+    column2->insert_range_from(*column1, 100, 0);
+    EXPECT_EQ(column2->size(), 0);
+
+    column2->insert_range_from(*column1, 97, 100);
+    EXPECT_EQ(column2->size(), 100);
+
+    auto& data2 = column2->get_data();
+    for (size_t i = 0; i < 100; ++i) {
+        EXPECT_EQ(*((size_t*)&data2[i * sizeof(size_t)]), i + 97);
+    }
+}
+
+} // namespace doris::vectorized


### PR DESCRIPTION

# Proposed changes

Issue Number: close #17211

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

