### PR TITLE
[cherry-pick](session-variable)add a use_fix_replica session variable to fix query replica

### DIFF
--- a/docs/en/docs/advanced/variables.md
+++ b/docs/en/docs/advanced/variables.md
@@ -565,3 +565,7 @@ Translated with www.DeepL.com/Translator (free version)
 *   `group_by_and_having_use_alias_first`
 
     Specifies whether group by and having clauses use column aliases rather than searching for column name in From clause. The default value is false.
+
+* `use_fix_replica`
+
+    Use a fixed replica to query. If use_fix_replica is 1, the smallest one is used, if use_fix_replica is 2, the second smallest one is used, and so on. The default value is -1, which means it is not enabled.

--- a/docs/zh-CN/docs/advanced/variables.md
+++ b/docs/zh-CN/docs/advanced/variables.md
@@ -553,3 +553,7 @@ SELECT /*+ SET_VAR(query_timeout = 1, enable_partition_cache=true) */ sleep(3);
 *   `group_by_and_having_use_alias_first`
 
        指定group by和having语句是否优先使用列的别名，而非从From语句里寻找列的名字。默认为false。
+
+* `use_fix_replica`
+
+    使用固定的replica进行查询，该值表示固定使用第几小的replica，默认为-1表示不启用。

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Replica.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Replica.java
@@ -35,6 +35,7 @@ import java.util.Comparator;
 public class Replica implements Writable {
     private static final Logger LOG = LogManager.getLogger(Replica.class);
     public static final VersionComparator<Replica> VERSION_DESC_COMPARATOR = new VersionComparator<Replica>();
+    public static final IdComparator<Replica> ID_COMPARATOR = new IdComparator<Replica>();
 
     public enum ReplicaState {
         NORMAL,
@@ -523,6 +524,22 @@ public class Replica implements Writable {
                 return 0;
             } else {
                 return -1;
+            }
+        }
+    }
+
+    private static class IdComparator<T extends Replica> implements Comparator<T> {
+        public IdComparator() {
+        }
+
+        @Override
+        public int compare(T replica1, T replica2) {
+            if (replica1.getId() < replica2.getId()) {
+                return -1;
+            } else if (replica1.getId() == replica2.getId()) {
+                return 0;
+            } else {
+                return 1;
             }
         }
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/OlapScanNode.java
@@ -664,29 +664,14 @@ public class OlapScanNode extends ScanNode {
                 LOG.debug("use fix replica, value: {}, replica num: {}", useFixReplica, replicas.size());
                 // sort by replica id
                 replicas.sort(Replica.ID_COMPARATOR);
-                if (useFixReplica <= 0) {
-                    useFixReplica = 1;
-                }
-                if (useFixReplica > replicas.size()) {
-                    useFixReplica = replicas.size();
-                }
+                Replica replica = replicas.get(useFixReplica >= replicas.size() : replicas.size() - 1 ? useFixReplica);
+                replicas.clear();
+                replicas.add(replica);
             }
-
-            int replicaIndex = 0;
             boolean tabletIsNull = true;
             boolean collectedStat = false;
             List<String> errs = Lists.newArrayList();
             for (Replica replica : replicas) {
-                // use fix replica, choose the {useFixReplica} smallest replica
-                if (useFixReplica != -1) {
-                    ++replicaIndex;
-                    if (replicaIndex < useFixReplica) {
-                        continue;
-                    }
-                    if (replicaIndex > useFixReplica) {
-                        break;
-                    }
-                }
                 Backend backend = Env.getCurrentSystemInfo().getBackend(replica.getBackendId());
                 if (backend == null || !backend.isAlive()) {
                     LOG.debug("backend {} not exists or is not alive for replica {}", replica.getBackendId(),

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/OlapScanNode.java
@@ -664,7 +664,7 @@ public class OlapScanNode extends ScanNode {
                 LOG.debug("use fix replica, value: {}, replica num: {}", useFixReplica, replicas.size());
                 // sort by replica id
                 replicas.sort(Replica.ID_COMPARATOR);
-                Replica replica = replicas.get(useFixReplica >= replicas.size() : replicas.size() - 1 ? useFixReplica);
+                Replica replica = replicas.get(useFixReplica >= replicas.size() ? replicas.size() - 1 : useFixReplica);
                 replicas.clear();
                 replicas.add(replica);
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/OlapScanNode.java
@@ -654,11 +654,39 @@ public class OlapScanNode extends ScanNode {
                 throw new UserException("Failed to get scan range, no queryable replica found in tablet: " + tabletId);
             }
 
-            Collections.shuffle(replicas);
+            int useFixReplica = -1;
+            if (ConnectContext.get() != null) {
+                useFixReplica = ConnectContext.get().getSessionVariable().useFixReplica;
+            }
+            if (useFixReplica == -1) {
+                Collections.shuffle(replicas);
+            } else {
+                LOG.debug("use fix replica, value: {}, replica num: {}", useFixReplica, replicas.size());
+                // sort by replica id
+                replicas.sort(Replica.ID_COMPARATOR);
+                if (useFixReplica <= 0) {
+                    useFixReplica = 1;
+                }
+                if (useFixReplica > replicas.size()) {
+                    useFixReplica = replicas.size();
+                }
+            }
+
+            int replicaIndex = 0;
             boolean tabletIsNull = true;
             boolean collectedStat = false;
             List<String> errs = Lists.newArrayList();
             for (Replica replica : replicas) {
+                // use fix replica, choose the {useFixReplica} smallest replica
+                if (useFixReplica != -1) {
+                    ++replicaIndex;
+                    if (replicaIndex < useFixReplica) {
+                        continue;
+                    }
+                    if (replicaIndex > useFixReplica) {
+                        break;
+                    }
+                }
                 Backend backend = Env.getCurrentSystemInfo().getBackend(replica.getBackendId());
                 if (backend == null || !backend.isAlive()) {
                     LOG.debug("backend {} not exists or is not alive for replica {}", replica.getBackendId(),

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -255,7 +255,7 @@ public class SessionVariable implements Serializable, Writable {
 
     public static final String GROUP_BY_AND_HAVING_USE_ALIAS_FIRST = "group_by_and_having_use_alias_first";
 
-    // fix replic to query. If num = 1, query the smallest replic, if 2 is the second smallest replic.
+    // fix replica to query. If num = 1, query the smallest replica, if 2 is the second smallest replica.
     public static final String USE_FIX_REPLICA = "use_fix_replica";
 
     // session origin value

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -255,6 +255,9 @@ public class SessionVariable implements Serializable, Writable {
 
     public static final String GROUP_BY_AND_HAVING_USE_ALIAS_FIRST = "group_by_and_having_use_alias_first";
 
+    // fix replic to query. If num = 1, query the smallest replic, if 2 is the second smallest replic.
+    public static final String USE_FIX_REPLICA = "use_fix_replica";
+
     // session origin value
     public Map<Field, String> sessionOriginValue = new HashMap<Field, String>();
     // check stmt is or not [select /*+ SET_VAR(...)*/ ...]
@@ -668,6 +671,10 @@ public class SessionVariable implements Serializable, Writable {
     // should first use column name not alias. According to mysql.
     @VariableMgr.VarAttr(name = GROUP_BY_AND_HAVING_USE_ALIAS_FIRST)
     public boolean groupByAndHavingUseAliasFirst = false;
+
+    // Default value is -1, which means not fix replica
+    @VariableMgr.VarAttr(name = USE_FIX_REPLICA)
+    public int useFixReplica = -1;
 
     // If this fe is in fuzzy mode, then will use initFuzzyModeVariables to generate some variables,
     // not the default value set in the code.


### PR DESCRIPTION
# Proposed changes

cherry-pick https://github.com/apache/doris/pull/17101

## Problem summary

Add `use_fix_replica` session variable, so that we can be better debug replica inconsistencies problem.
If `use_fix_replica` default is -1, which means not fix,
else we will choose the {`use_fix_replica`} smallest replica.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

