### PR TITLE
[fix](routine load) fix be core dump while use routine load

### DIFF
--- a/be/src/runtime/routine_load/routine_load_task_executor.cpp
+++ b/be/src/runtime/routine_load/routine_load_task_executor.cpp
@@ -277,6 +277,7 @@ void RoutineLoadTaskExecutor::exec_task(std::shared_ptr<StreamLoadContext> ctx,
     }
     }
     ctx->body_sink = pipe;
+    ctx->pipe = pipe;
 
     // must put pipe before executing plan fragment
     HANDLE_ERROR(_exec_env->new_load_stream_mgr()->put(ctx->id, ctx), "failed to add pipe");


### PR DESCRIPTION
# Proposed changes

Issue Number: close #17221
be core dump while use routine load, _file_reader in be/src/vec/exec/format/csv/csv_reader.cpp::145 is nullptr, because of stream_load_ctx->pipe is not be initialized.
This problem was introduced by pr https://github.com/apache/doris/pull/16996

routine load will try to start a fragment to read data, fragment will read data from pipe, but pipe is not set.

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

