### PR TITLE
[Enchancement](function) nullable inline refactor of min_max_by/bitmap && add register_functio…

### DIFF
--- a/be/src/vec/aggregate_functions/aggregate_function_avg.cpp
+++ b/be/src/vec/aggregate_functions/aggregate_function_avg.cpp
@@ -52,7 +52,6 @@ AggregateFunctionPtr create_aggregate_function_avg(const std::string& name,
 }
 
 void register_aggregate_function_avg(AggregateFunctionSimpleFactory& factory) {
-    factory.register_function("avg", create_aggregate_function_avg);
-    factory.register_function("avg", create_aggregate_function_avg, true);
+    factory.register_function_both("avg", create_aggregate_function_avg);
 }
 } // namespace doris::vectorized

--- a/be/src/vec/aggregate_functions/aggregate_function_bit.cpp
+++ b/be/src/vec/aggregate_functions/aggregate_function_bit.cpp
@@ -47,21 +47,12 @@ AggregateFunctionPtr createAggregateFunctionBitwise(const std::string& name,
 }
 
 void register_aggregate_function_bit(AggregateFunctionSimpleFactory& factory) {
-    factory.register_function("group_bit_or",
-                              createAggregateFunctionBitwise<AggregateFunctionGroupBitOrData>);
-    factory.register_function("group_bit_and",
-                              createAggregateFunctionBitwise<AggregateFunctionGroupBitAndData>);
-    factory.register_function("group_bit_xor",
-                              createAggregateFunctionBitwise<AggregateFunctionGroupBitXorData>);
-
-    factory.register_function(
-            "group_bit_or", createAggregateFunctionBitwise<AggregateFunctionGroupBitOrData>, true);
-    factory.register_function("group_bit_and",
-                              createAggregateFunctionBitwise<AggregateFunctionGroupBitAndData>,
-                              true);
-    factory.register_function("group_bit_xor",
-                              createAggregateFunctionBitwise<AggregateFunctionGroupBitXorData>,
-                              true);
+    factory.register_function_both("group_bit_or",
+                                   createAggregateFunctionBitwise<AggregateFunctionGroupBitOrData>);
+    factory.register_function_both(
+            "group_bit_and", createAggregateFunctionBitwise<AggregateFunctionGroupBitAndData>);
+    factory.register_function_both(
+            "group_bit_xor", createAggregateFunctionBitwise<AggregateFunctionGroupBitXorData>);
 }
 
 } // namespace doris::vectorized

--- a/be/src/vec/aggregate_functions/aggregate_function_bitmap.cpp
+++ b/be/src/vec/aggregate_functions/aggregate_function_bitmap.cpp
@@ -23,7 +23,7 @@
 namespace doris::vectorized {
 
 template <bool nullable, template <bool, typename> class AggregateFunctionTemplate>
-static IAggregateFunction* createWithIntDataType(const DataTypes& argument_type) {
+static IAggregateFunction* create_with_int_data_type(const DataTypes& argument_type) {
     auto type = remove_nullable(argument_type[0]);
     WhichDataType which(type);
 #define DISPATCH(TYPE)                                                                     \
@@ -76,10 +76,10 @@ AggregateFunctionPtr create_aggregate_function_bitmap_union_int(const std::strin
     const bool arg_is_nullable = argument_types[0]->is_nullable();
     if (arg_is_nullable) {
         return std::shared_ptr<IAggregateFunction>(
-                createWithIntDataType<true, AggregateFunctionBitmapCount>(argument_types));
+                create_with_int_data_type<true, AggregateFunctionBitmapCount>(argument_types));
     } else {
         return std::shared_ptr<IAggregateFunction>(
-                createWithIntDataType<false, AggregateFunctionBitmapCount>(argument_types));
+                create_with_int_data_type<false, AggregateFunctionBitmapCount>(argument_types));
     }
 }
 

--- a/be/src/vec/aggregate_functions/aggregate_function_bitmap.cpp
+++ b/be/src/vec/aggregate_functions/aggregate_function_bitmap.cpp
@@ -29,7 +29,7 @@ static IAggregateFunction* createWithIntDataType(const DataTypes& argument_type)
 #define DISPATCH(TYPE)                                                                     \
     if (which.idx == TypeIndex::TYPE) {                                                    \
         return new AggregateFunctionTemplate<nullable, ColumnVector<TYPE>>(argument_type); \
-    }                                                                                      \
+    }                                                                                      
     FOR_INTEGER_TYPES(DISPATCH)
 #undef DISPATCH
     return nullptr;

--- a/be/src/vec/aggregate_functions/aggregate_function_bitmap.cpp
+++ b/be/src/vec/aggregate_functions/aggregate_function_bitmap.cpp
@@ -24,10 +24,7 @@ namespace doris::vectorized {
 
 template <bool nullable, template <bool, typename> class AggregateFunctionTemplate>
 static IAggregateFunction* createWithIntDataType(const DataTypes& argument_type) {
-    auto type = argument_type[0].get();
-    if (type->is_nullable()) {
-        type = assert_cast<const DataTypeNullable*>(type)->get_nested_type().get();
-    }
+    auto type = remove_nullable(argument_type[0]);
     WhichDataType which(type);
 #define DISPATCH(TYPE)                                                                     \
     if (which.idx == TypeIndex::TYPE) {                                                    \

--- a/be/src/vec/aggregate_functions/aggregate_function_bitmap.cpp
+++ b/be/src/vec/aggregate_functions/aggregate_function_bitmap.cpp
@@ -29,7 +29,7 @@ static IAggregateFunction* createWithIntDataType(const DataTypes& argument_type)
 #define DISPATCH(TYPE)                                                                     \
     if (which.idx == TypeIndex::TYPE) {                                                    \
         return new AggregateFunctionTemplate<nullable, ColumnVector<TYPE>>(argument_type); \
-    }                                                                                      
+    }
     FOR_INTEGER_TYPES(DISPATCH)
 #undef DISPATCH
     return nullptr;

--- a/be/src/vec/aggregate_functions/aggregate_function_group_concat.cpp
+++ b/be/src/vec/aggregate_functions/aggregate_function_group_concat.cpp
@@ -17,6 +17,8 @@
 
 #include "vec/aggregate_functions/aggregate_function_group_concat.h"
 
+#include "vec/aggregate_functions/helpers.h"
+
 namespace doris::vectorized {
 
 const std::string AggregateFunctionGroupConcatImplStr::separator = ", ";
@@ -26,12 +28,14 @@ AggregateFunctionPtr create_aggregate_function_group_concat(const std::string& n
                                                             const bool result_is_nullable) {
     if (argument_types.size() == 1) {
         return AggregateFunctionPtr(
-                new AggregateFunctionGroupConcat<AggregateFunctionGroupConcatImplStr>(
-                        argument_types));
+                creator_without_type::create<
+                        AggregateFunctionGroupConcat<AggregateFunctionGroupConcatImplStr>>(
+                        result_is_nullable, argument_types));
     } else if (argument_types.size() == 2) {
         return AggregateFunctionPtr(
-                new AggregateFunctionGroupConcat<AggregateFunctionGroupConcatImplStrStr>(
-                        argument_types));
+                creator_without_type::create<
+                        AggregateFunctionGroupConcat<AggregateFunctionGroupConcatImplStrStr>>(
+                        result_is_nullable, argument_types));
     }
 
     LOG(WARNING) << fmt::format("Illegal number {} of argument for aggregate function {}",
@@ -40,6 +44,6 @@ AggregateFunctionPtr create_aggregate_function_group_concat(const std::string& n
 }
 
 void register_aggregate_function_group_concat(AggregateFunctionSimpleFactory& factory) {
-    factory.register_function("group_concat", create_aggregate_function_group_concat);
+    factory.register_function_both("group_concat", create_aggregate_function_group_concat);
 }
 } // namespace doris::vectorized

--- a/be/src/vec/aggregate_functions/aggregate_function_histogram.cpp
+++ b/be/src/vec/aggregate_functions/aggregate_function_histogram.cpp
@@ -23,56 +23,46 @@
 namespace doris::vectorized {
 
 template <typename T>
-AggregateFunctionPtr create_agg_function_histogram(const DataTypes& argument_types) {
+AggregateFunctionPtr create_agg_function_histogram(const DataTypes& argument_types,
+                                                   const bool result_is_nullable) {
     bool has_input_param = (argument_types.size() == 3);
 
     if (has_input_param) {
         return AggregateFunctionPtr(
-                new AggregateFunctionHistogram<AggregateFunctionHistogramData<T>, T, true>(
-                        argument_types));
+                creator_without_type::create<
+                        AggregateFunctionHistogram<AggregateFunctionHistogramData<T>, T, true>>(
+                        result_is_nullable, argument_types));
     } else {
         return AggregateFunctionPtr(
-                new AggregateFunctionHistogram<AggregateFunctionHistogramData<T>, T, false>(
-                        argument_types));
+                creator_without_type::create<
+                        AggregateFunctionHistogram<AggregateFunctionHistogramData<T>, T, false>>(
+                        result_is_nullable, argument_types));
     }
 }
 
 AggregateFunctionPtr create_aggregate_function_histogram(const std::string& name,
                                                          const DataTypes& argument_types,
                                                          const bool result_is_nullable) {
-    WhichDataType type(argument_types[0]);
+    WhichDataType type(remove_nullable(argument_types[0]));
 
-    LOG(INFO) << fmt::format("supported input type {} for aggregate function {}",
-                             argument_types[0]->get_name(), name);
-
-#define DISPATCH(TYPE) \
-    if (type.idx == TypeIndex::TYPE) return create_agg_function_histogram<TYPE>(argument_types);
+#define DISPATCH(TYPE)               \
+    if (type.idx == TypeIndex::TYPE) \
+        return create_agg_function_histogram<TYPE>(argument_types, result_is_nullable);
     FOR_NUMERIC_TYPES(DISPATCH)
+    FOR_DECIMAL_TYPES(DISPATCH)
 #undef DISPATCH
 
     if (type.idx == TypeIndex::String) {
-        return create_agg_function_histogram<String>(argument_types);
+        return create_agg_function_histogram<String>(argument_types, result_is_nullable);
     }
     if (type.idx == TypeIndex::DateTime || type.idx == TypeIndex::Date) {
-        return create_agg_function_histogram<Int64>(argument_types);
+        return create_agg_function_histogram<Int64>(argument_types, result_is_nullable);
     }
     if (type.idx == TypeIndex::DateV2) {
-        return create_agg_function_histogram<UInt32>(argument_types);
+        return create_agg_function_histogram<UInt32>(argument_types, result_is_nullable);
     }
     if (type.idx == TypeIndex::DateTimeV2) {
-        return create_agg_function_histogram<UInt64>(argument_types);
-    }
-    if (type.idx == TypeIndex::Decimal32) {
-        return create_agg_function_histogram<Decimal32>(argument_types);
-    }
-    if (type.idx == TypeIndex::Decimal64) {
-        return create_agg_function_histogram<Decimal64>(argument_types);
-    }
-    if (type.idx == TypeIndex::Decimal128) {
-        return create_agg_function_histogram<Decimal128>(argument_types);
-    }
-    if (type.idx == TypeIndex::Decimal128I) {
-        return create_agg_function_histogram<Decimal128I>(argument_types);
+        return create_agg_function_histogram<UInt64>(argument_types, result_is_nullable);
     }
 
     LOG(WARNING) << fmt::format("unsupported input type {} for aggregate function {}",
@@ -81,7 +71,7 @@ AggregateFunctionPtr create_aggregate_function_histogram(const std::string& name
 }
 
 void register_aggregate_function_histogram(AggregateFunctionSimpleFactory& factory) {
-    factory.register_function("histogram", create_aggregate_function_histogram);
+    factory.register_function_both("histogram", create_aggregate_function_histogram);
     factory.register_alias("histogram", "hist");
 }
 

--- a/be/src/vec/aggregate_functions/aggregate_function_min_max.cpp
+++ b/be/src/vec/aggregate_functions/aggregate_function_min_max.cpp
@@ -97,14 +97,9 @@ AggregateFunctionPtr create_aggregate_function_any(const std::string& name,
 }
 
 void register_aggregate_function_minmax(AggregateFunctionSimpleFactory& factory) {
-    factory.register_function("max", create_aggregate_function_max);
-    factory.register_function("min", create_aggregate_function_min);
-    factory.register_function("any", create_aggregate_function_any);
-
-    factory.register_function("max", create_aggregate_function_max, true);
-    factory.register_function("min", create_aggregate_function_min, true);
-    factory.register_function("any", create_aggregate_function_any, true);
-
+    factory.register_function_both("max", create_aggregate_function_max);
+    factory.register_function_both("min", create_aggregate_function_min);
+    factory.register_function_both("any", create_aggregate_function_any);
     factory.register_alias("any", "any_value");
 }
 

--- a/be/src/vec/aggregate_functions/aggregate_function_min_max_by.cpp
+++ b/be/src/vec/aggregate_functions/aggregate_function_min_max_by.cpp
@@ -26,101 +26,95 @@
 namespace doris::vectorized {
 
 /// min_by, max_by
-template <template <typename, bool> class AggregateFunctionTemplate,
+template <template <typename> class AggregateFunctionTemplate,
           template <typename, typename> class Data, typename VT>
 static IAggregateFunction* create_aggregate_function_min_max_by_impl(
-        const DataTypes& argument_types) {
-    const DataTypePtr& value_arg_type = argument_types[0];
-    const DataTypePtr& key_arg_type = argument_types[1];
+        const DataTypes& argument_types, const bool result_is_nullable) {
+    WhichDataType which(argument_types[1]);
 
-    WhichDataType which(key_arg_type);
-#define DISPATCH(TYPE)                                                                     \
-    if (which.idx == TypeIndex::TYPE)                                                      \
-        return new AggregateFunctionTemplate<Data<VT, SingleValueDataFixed<TYPE>>, false>( \
-                value_arg_type, key_arg_type);
+#define DISPATCH(TYPE)                                                            \
+    if (which.idx == TypeIndex::TYPE)                                             \
+        return creator_without_type::create<                                      \
+                AggregateFunctionTemplate<Data<VT, SingleValueDataFixed<TYPE>>>>( \
+                result_is_nullable, argument_types);
     FOR_NUMERIC_TYPES(DISPATCH)
 #undef DISPATCH
+
+#define DISPATCH(TYPE)                                                              \
+    if (which.idx == TypeIndex::TYPE)                                               \
+        return creator_without_type::create<                                        \
+                AggregateFunctionTemplate<Data<VT, SingleValueDataDecimal<TYPE>>>>( \
+                result_is_nullable, argument_types);
+    FOR_DECIMAL_TYPES(DISPATCH)
+#undef DISPATCH
+
     if (which.idx == TypeIndex::String) {
-        return new AggregateFunctionTemplate<Data<VT, SingleValueDataString>, false>(value_arg_type,
-                                                                                     key_arg_type);
+        return creator_without_type::create<
+                AggregateFunctionTemplate<Data<VT, SingleValueDataString>>>(result_is_nullable,
+                                                                            argument_types);
     }
     if (which.idx == TypeIndex::DateTime || which.idx == TypeIndex::Date) {
-        return new AggregateFunctionTemplate<Data<VT, SingleValueDataFixed<Int64>>, false>(
-                value_arg_type, key_arg_type);
+        return creator_without_type::create<
+                AggregateFunctionTemplate<Data<VT, SingleValueDataFixed<Int64>>>>(
+                result_is_nullable, argument_types);
     }
     if (which.idx == TypeIndex::DateV2) {
-        return new AggregateFunctionTemplate<Data<VT, SingleValueDataFixed<UInt32>>, false>(
-                value_arg_type, key_arg_type);
+        return creator_without_type::create<
+                AggregateFunctionTemplate<Data<VT, SingleValueDataFixed<UInt32>>>>(
+                result_is_nullable, argument_types);
     }
-    if (which.idx == TypeIndex::Decimal32) {
-        return new AggregateFunctionTemplate<Data<VT, SingleValueDataDecimal<Decimal32>>, false>(
-                value_arg_type, key_arg_type);
-    }
-    if (which.idx == TypeIndex::Decimal64) {
-        return new AggregateFunctionTemplate<Data<VT, SingleValueDataDecimal<Decimal64>>, false>(
-                value_arg_type, key_arg_type);
-    }
-    if (which.idx == TypeIndex::Decimal128) {
-        return new AggregateFunctionTemplate<Data<VT, SingleValueDataDecimal<Decimal128>>, false>(
-                value_arg_type, key_arg_type);
-    }
-    if (which.idx == TypeIndex::Decimal128I) {
-        return new AggregateFunctionTemplate<Data<VT, SingleValueDataDecimal<Decimal128I>>, false>(
-                value_arg_type, key_arg_type);
+    if (which.idx == TypeIndex::DateTimeV2) {
+        return creator_without_type::create<
+                AggregateFunctionTemplate<Data<VT, SingleValueDataFixed<UInt64>>>>(
+                result_is_nullable, argument_types);
     }
     return nullptr;
 }
 
 /// min_by, max_by
-template <template <typename, bool> class AggregateFunctionTemplate,
+template <template <typename> class AggregateFunctionTemplate,
           template <typename, typename> class Data>
 static IAggregateFunction* create_aggregate_function_min_max_by(const String& name,
-                                                                const DataTypes& argument_types) {
+                                                                const DataTypes& argument_types,
+                                                                const bool result_is_nullable) {
     assert_binary(name, argument_types);
 
-    const DataTypePtr& value_arg_type = argument_types[0];
-
-    WhichDataType which(value_arg_type);
+    WhichDataType which(argument_types[0]);
 #define DISPATCH(TYPE)                                                                    \
     if (which.idx == TypeIndex::TYPE)                                                     \
         return create_aggregate_function_min_max_by_impl<AggregateFunctionTemplate, Data, \
                                                          SingleValueDataFixed<TYPE>>(     \
-                argument_types);
+                argument_types, result_is_nullable);
     FOR_NUMERIC_TYPES(DISPATCH)
 #undef DISPATCH
+
+#define DISPATCH(TYPE)                                                                    \
+    if (which.idx == TypeIndex::TYPE)                                                     \
+        return create_aggregate_function_min_max_by_impl<AggregateFunctionTemplate, Data, \
+                                                         SingleValueDataDecimal<TYPE>>(   \
+                argument_types, result_is_nullable);
+    FOR_DECIMAL_TYPES(DISPATCH)
+#undef DISPATCH
+
     if (which.idx == TypeIndex::String) {
         return create_aggregate_function_min_max_by_impl<AggregateFunctionTemplate, Data,
-                                                         SingleValueDataString>(argument_types);
+                                                         SingleValueDataString>(argument_types,
+                                                                                result_is_nullable);
     }
     if (which.idx == TypeIndex::DateTime || which.idx == TypeIndex::Date) {
         return create_aggregate_function_min_max_by_impl<AggregateFunctionTemplate, Data,
                                                          SingleValueDataFixed<Int64>>(
-                argument_types);
+                argument_types, result_is_nullable);
     }
     if (which.idx == TypeIndex::DateV2) {
         return create_aggregate_function_min_max_by_impl<AggregateFunctionTemplate, Data,
                                                          SingleValueDataFixed<UInt32>>(
-                argument_types);
+                argument_types, result_is_nullable);
     }
-    if (which.idx == TypeIndex::Decimal128) {
+    if (which.idx == TypeIndex::DateTimeV2) {
         return create_aggregate_function_min_max_by_impl<AggregateFunctionTemplate, Data,
-                                                         SingleValueDataDecimal<Decimal128>>(
-                argument_types);
-    }
-    if (which.idx == TypeIndex::Decimal32) {
-        return create_aggregate_function_min_max_by_impl<AggregateFunctionTemplate, Data,
-                                                         SingleValueDataDecimal<Decimal32>>(
-                argument_types);
-    }
-    if (which.idx == TypeIndex::Decimal64) {
-        return create_aggregate_function_min_max_by_impl<AggregateFunctionTemplate, Data,
-                                                         SingleValueDataDecimal<Decimal64>>(
-                argument_types);
-    }
-    if (which.idx == TypeIndex::Decimal128I) {
-        return create_aggregate_function_min_max_by_impl<AggregateFunctionTemplate, Data,
-                                                         SingleValueDataDecimal<Decimal128I>>(
-                argument_types);
+                                                         SingleValueDataFixed<UInt64>>(
+                argument_types, result_is_nullable);
     }
     return nullptr;
 }
@@ -128,22 +122,22 @@ static IAggregateFunction* create_aggregate_function_min_max_by(const String& na
 AggregateFunctionPtr create_aggregate_function_max_by(const std::string& name,
                                                       const DataTypes& argument_types,
                                                       const bool result_is_nullable) {
-    return AggregateFunctionPtr(
-            create_aggregate_function_min_max_by<AggregateFunctionsMinMaxBy,
-                                                 AggregateFunctionMaxByData>(name, argument_types));
+    return AggregateFunctionPtr(create_aggregate_function_min_max_by<AggregateFunctionsMinMaxBy,
+                                                                     AggregateFunctionMaxByData>(
+            name, argument_types, result_is_nullable));
 }
 
 AggregateFunctionPtr create_aggregate_function_min_by(const std::string& name,
                                                       const DataTypes& argument_types,
                                                       const bool result_is_nullable) {
-    return AggregateFunctionPtr(
-            create_aggregate_function_min_max_by<AggregateFunctionsMinMaxBy,
-                                                 AggregateFunctionMinByData>(name, argument_types));
+    return AggregateFunctionPtr(create_aggregate_function_min_max_by<AggregateFunctionsMinMaxBy,
+                                                                     AggregateFunctionMinByData>(
+            name, argument_types, result_is_nullable));
 }
 
 void register_aggregate_function_min_max_by(AggregateFunctionSimpleFactory& factory) {
-    factory.register_function("max_by", create_aggregate_function_max_by);
-    factory.register_function("min_by", create_aggregate_function_min_by);
+    factory.register_function_both("max_by", create_aggregate_function_max_by);
+    factory.register_function_both("min_by", create_aggregate_function_min_by);
 }
 
 } // namespace doris::vectorized

--- a/be/src/vec/aggregate_functions/aggregate_function_min_max_by.cpp
+++ b/be/src/vec/aggregate_functions/aggregate_function_min_max_by.cpp
@@ -30,7 +30,7 @@ template <template <typename> class AggregateFunctionTemplate,
           template <typename, typename> class Data, typename VT>
 static IAggregateFunction* create_aggregate_function_min_max_by_impl(
         const DataTypes& argument_types, const bool result_is_nullable) {
-    WhichDataType which(argument_types[1]);
+    WhichDataType which(remove_nullable(argument_types[1]));
 
 #define DISPATCH(TYPE)                                                            \
     if (which.idx == TypeIndex::TYPE)                                             \
@@ -79,7 +79,7 @@ static IAggregateFunction* create_aggregate_function_min_max_by(const String& na
                                                                 const bool result_is_nullable) {
     assert_binary(name, argument_types);
 
-    WhichDataType which(argument_types[0]);
+    WhichDataType which(remove_nullable(argument_types[0]));
 #define DISPATCH(TYPE)                                                                    \
     if (which.idx == TypeIndex::TYPE)                                                     \
         return create_aggregate_function_min_max_by_impl<AggregateFunctionTemplate, Data, \

--- a/be/src/vec/aggregate_functions/aggregate_function_min_max_by.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_min_max_by.h
@@ -95,24 +95,22 @@ struct AggregateFunctionMinByData : public AggregateFunctionMinMaxByBaseData<VT,
     static const char* name() { return "min_by"; }
 };
 
-template <typename Data, bool AllocatesMemoryInArena>
+template <typename Data>
 class AggregateFunctionsMinMaxBy final
-        : public IAggregateFunctionDataHelper<
-                  Data, AggregateFunctionsMinMaxBy<Data, AllocatesMemoryInArena>> {
+        : public IAggregateFunctionDataHelper<Data, AggregateFunctionsMinMaxBy<Data>> {
 private:
     DataTypePtr& value_type;
     DataTypePtr& key_type;
 
 public:
-    AggregateFunctionsMinMaxBy(const DataTypePtr& value_type_, const DataTypePtr& key_type_)
-            : IAggregateFunctionDataHelper<
-                      Data, AggregateFunctionsMinMaxBy<Data, AllocatesMemoryInArena>>(
-                      {value_type_, key_type_}),
+    AggregateFunctionsMinMaxBy(const DataTypes& arguments)
+            : IAggregateFunctionDataHelper<Data, AggregateFunctionsMinMaxBy<Data>>(
+                      {arguments[0], arguments[1]}),
               value_type(this->argument_types[0]),
               key_type(this->argument_types[1]) {
         if (StringRef(Data::name()) == StringRef("min_by") ||
             StringRef(Data::name()) == StringRef("max_by")) {
-            CHECK(key_type_->is_comparable());
+            CHECK(key_type->is_comparable());
         }
     }
 
@@ -140,8 +138,6 @@ public:
                      Arena*) const override {
         this->data(place).read(buf);
     }
-
-    bool allocates_memory_in_arena() const override { return AllocatesMemoryInArena; }
 
     void insert_result_into(ConstAggregateDataPtr __restrict place, IColumn& to) const override {
         this->data(place).insert_result_into(to);

--- a/be/src/vec/aggregate_functions/aggregate_function_orthogonal_bitmap.cpp
+++ b/be/src/vec/aggregate_functions/aggregate_function_orthogonal_bitmap.cpp
@@ -85,26 +85,12 @@ AggregateFunctionPtr create_aggregate_function_orthogonal_bitmap_union_count(
 }
 
 void register_aggregate_function_orthogonal_bitmap(AggregateFunctionSimpleFactory& factory) {
-    factory.register_function("orthogonal_bitmap_intersect",
-                              create_aggregate_function_orthogonal_bitmap_intersect);
-
-    factory.register_function("orthogonal_bitmap_intersect_count",
-                              create_aggregate_function_orthogonal_bitmap_intersect_count);
-
-    factory.register_function("orthogonal_bitmap_union_count",
-                              create_aggregate_function_orthogonal_bitmap_union_count);
-
-    factory.register_function("intersect_count", create_aggregate_function_intersect_count);
-
-    factory.register_function("orthogonal_bitmap_intersect",
-                              create_aggregate_function_orthogonal_bitmap_intersect, true);
-
-    factory.register_function("orthogonal_bitmap_intersect_count",
-                              create_aggregate_function_orthogonal_bitmap_intersect_count, true);
-
-    factory.register_function("orthogonal_bitmap_union_count",
-                              create_aggregate_function_orthogonal_bitmap_union_count, true);
-
-    factory.register_function("intersect_count", create_aggregate_function_intersect_count, true);
+    factory.register_function_both("orthogonal_bitmap_intersect",
+                                   create_aggregate_function_orthogonal_bitmap_intersect);
+    factory.register_function_both("orthogonal_bitmap_intersect_count",
+                                   create_aggregate_function_orthogonal_bitmap_intersect_count);
+    factory.register_function_both("orthogonal_bitmap_union_count",
+                                   create_aggregate_function_orthogonal_bitmap_union_count);
+    factory.register_function_both("intersect_count", create_aggregate_function_intersect_count);
 }
 } // namespace doris::vectorized

--- a/be/src/vec/aggregate_functions/aggregate_function_simple_factory.h
+++ b/be/src/vec/aggregate_functions/aggregate_function_simple_factory.h
@@ -107,6 +107,11 @@ public:
         }
     }
 
+    void register_function_both(const std::string& name, const Creator& creator) {
+        register_function(name, creator, false);
+        register_function(name, creator, true);
+    }
+
     void register_alias(const std::string& name, const std::string& alias) {
         function_alias[alias] = name;
     }

--- a/be/src/vec/aggregate_functions/aggregate_function_sum.cpp
+++ b/be/src/vec/aggregate_functions/aggregate_function_sum.cpp
@@ -73,9 +73,8 @@ AggregateFunctionPtr create_aggregate_function_sum_reader(const std::string& nam
 }
 
 void register_aggregate_function_sum(AggregateFunctionSimpleFactory& factory) {
-    factory.register_function("sum", create_aggregate_function_sum<AggregateFunctionSumSimple>);
-    factory.register_function("sum", create_aggregate_function_sum<AggregateFunctionSumSimple>,
-                              true);
+    factory.register_function_both("sum",
+                                   create_aggregate_function_sum<AggregateFunctionSumSimple>);
 }
 
 } // namespace doris::vectorized

--- a/be/src/vec/aggregate_functions/aggregate_function_topn.cpp
+++ b/be/src/vec/aggregate_functions/aggregate_function_topn.cpp
@@ -26,10 +26,12 @@ AggregateFunctionPtr create_aggregate_function_topn(const std::string& name,
                                                     const bool result_is_nullable) {
     if (argument_types.size() == 2) {
         return AggregateFunctionPtr(
-                new AggregateFunctionTopN<AggregateFunctionTopNImplInt>(argument_types));
+                creator_without_type::create<AggregateFunctionTopN<AggregateFunctionTopNImplInt>>(
+                        result_is_nullable, argument_types));
     } else if (argument_types.size() == 3) {
-        return AggregateFunctionPtr(
-                new AggregateFunctionTopN<AggregateFunctionTopNImplIntInt>(argument_types));
+        return AggregateFunctionPtr(creator_without_type::create<
+                                    AggregateFunctionTopN<AggregateFunctionTopNImplIntInt>>(
+                result_is_nullable, argument_types));
     }
 
     LOG(WARNING) << fmt::format("Illegal number {} of argument for aggregate function {}",
@@ -39,44 +41,55 @@ AggregateFunctionPtr create_aggregate_function_topn(const std::string& name,
 
 template <template <typename, bool> class AggregateFunctionTemplate, bool has_default_param,
           bool is_weighted>
-AggregateFunctionPtr create_topn_array(const DataTypes& argument_types) {
-    auto type = argument_types[0].get();
-    if (type->is_nullable()) {
-        type = assert_cast<const DataTypeNullable*>(type)->get_nested_type().get();
-    }
+AggregateFunctionPtr create_topn_array(const DataTypes& argument_types,
+                                       const bool result_is_nullable) {
+    WhichDataType which(remove_nullable(argument_types[0]));
 
-    WhichDataType which(*type);
-
-#define DISPATCH(TYPE)                                                                             \
-    if (which.idx == TypeIndex::TYPE)                                                              \
-        return AggregateFunctionPtr(                                                               \
-                new AggregateFunctionTopNArray<AggregateFunctionTemplate<TYPE, has_default_param>, \
-                                               TYPE, is_weighted>(argument_types));
+#define DISPATCH(TYPE)                                                                           \
+    if (which.idx == TypeIndex::TYPE)                                                            \
+        return AggregateFunctionPtr(                                                             \
+                creator_without_type::create<AggregateFunctionTopNArray<                         \
+                        AggregateFunctionTemplate<TYPE, has_default_param>, TYPE, is_weighted>>( \
+                        result_is_nullable, argument_types));
     FOR_NUMERIC_TYPES(DISPATCH)
 #undef DISPATCH
+
+#define DISPATCH(TYPE)                                                                           \
+    if (which.idx == TypeIndex::TYPE)                                                            \
+        return AggregateFunctionPtr(                                                             \
+                creator_without_type::create<AggregateFunctionTopNArray<                         \
+                        AggregateFunctionTemplate<TYPE, has_default_param>, TYPE, is_weighted>>( \
+                        result_is_nullable, argument_types));                                    \
+    FOR_DECIMAL_TYPES(DISPATCH)
+#undef DISPATCH
+
     if (which.is_string_or_fixed_string()) {
-        return AggregateFunctionPtr(new AggregateFunctionTopNArray<
-                                    AggregateFunctionTemplate<std::string, has_default_param>,
-                                    std::string, is_weighted>(argument_types));
-    }
-    if (which.is_decimal()) {
-        return AggregateFunctionPtr(new AggregateFunctionTopNArray<
-                                    AggregateFunctionTemplate<Decimal128, has_default_param>,
-                                    Decimal128, is_weighted>(argument_types));
-    }
-    if (which.is_date_or_datetime() || which.is_date_time_v2()) {
         return AggregateFunctionPtr(
-                new AggregateFunctionTopNArray<AggregateFunctionTemplate<Int64, has_default_param>,
-                                               Int64, is_weighted>(argument_types));
+                creator_without_type::create<AggregateFunctionTopNArray<
+                        AggregateFunctionTemplate<std::string, has_default_param>, std::string,
+                        is_weighted>>(result_is_nullable, argument_types));
+    }
+    if (which.is_date_or_datetime()) {
+        return AggregateFunctionPtr(
+                creator_without_type::create<AggregateFunctionTopNArray<
+                        AggregateFunctionTemplate<Int64, has_default_param>, Int64, is_weighted>>(
+                        result_is_nullable, argument_types));
     }
     if (which.is_date_v2()) {
         return AggregateFunctionPtr(
-                new AggregateFunctionTopNArray<AggregateFunctionTemplate<UInt32, has_default_param>,
-                                               UInt32, is_weighted>(argument_types));
+                creator_without_type::create<AggregateFunctionTopNArray<
+                        AggregateFunctionTemplate<UInt32, has_default_param>, UInt32, is_weighted>>(
+                        result_is_nullable, argument_types));
+    }
+    if (which.is_date_time_v2()) {
+        return AggregateFunctionPtr(
+                creator_without_type::create<AggregateFunctionTopNArray<
+                        AggregateFunctionTemplate<UInt64, has_default_param>, UInt64, is_weighted>>(
+                        result_is_nullable, argument_types));
     }
 
     LOG(WARNING) << fmt::format("Illegal argument  type for aggregate function topn_array is: {}",
-                                type->get_name());
+                                remove_nullable(argument_types[0])->get_name());
     return nullptr;
 }
 
@@ -85,9 +98,11 @@ AggregateFunctionPtr create_aggregate_function_topn_array(const std::string& nam
                                                           const bool result_is_nullable) {
     bool has_default_param = (argument_types.size() == 3);
     if (has_default_param) {
-        return create_topn_array<AggregateFunctionTopNImplArray, true, false>(argument_types);
+        return create_topn_array<AggregateFunctionTopNImplArray, true, false>(argument_types,
+                                                                              result_is_nullable);
     } else {
-        return create_topn_array<AggregateFunctionTopNImplArray, false, false>(argument_types);
+        return create_topn_array<AggregateFunctionTopNImplArray, false, false>(argument_types,
+                                                                               result_is_nullable);
     }
 }
 
@@ -96,16 +111,18 @@ AggregateFunctionPtr create_aggregate_function_topn_weighted(const std::string& 
                                                              const bool result_is_nullable) {
     bool has_default_param = (argument_types.size() == 4);
     if (has_default_param) {
-        return create_topn_array<AggregateFunctionTopNImplWeight, true, true>(argument_types);
+        return create_topn_array<AggregateFunctionTopNImplWeight, true, true>(argument_types,
+                                                                              result_is_nullable);
     } else {
-        return create_topn_array<AggregateFunctionTopNImplWeight, false, true>(argument_types);
+        return create_topn_array<AggregateFunctionTopNImplWeight, false, true>(argument_types,
+                                                                               result_is_nullable);
     }
 }
 
 void register_aggregate_function_topn(AggregateFunctionSimpleFactory& factory) {
-    factory.register_function("topn", create_aggregate_function_topn);
-    factory.register_function("topn_array", create_aggregate_function_topn_array);
-    factory.register_function("topn_weighted", create_aggregate_function_topn_weighted);
+    factory.register_function_both("topn", create_aggregate_function_topn);
+    factory.register_function_both("topn_array", create_aggregate_function_topn_array);
+    factory.register_function_both("topn_weighted", create_aggregate_function_topn_weighted);
 }
 
 } // namespace doris::vectorized

--- a/be/src/vec/aggregate_functions/aggregate_function_topn.cpp
+++ b/be/src/vec/aggregate_functions/aggregate_function_topn.cpp
@@ -52,14 +52,6 @@ AggregateFunctionPtr create_topn_array(const DataTypes& argument_types,
                         AggregateFunctionTemplate<TYPE, has_default_param>, TYPE, is_weighted>>( \
                         result_is_nullable, argument_types));
     FOR_NUMERIC_TYPES(DISPATCH)
-#undef DISPATCH
-
-#define DISPATCH(TYPE)                                                                           \
-    if (which.idx == TypeIndex::TYPE)                                                            \
-        return AggregateFunctionPtr(                                                             \
-                creator_without_type::create<AggregateFunctionTopNArray<                         \
-                        AggregateFunctionTemplate<TYPE, has_default_param>, TYPE, is_weighted>>( \
-                        result_is_nullable, argument_types));                                    \
     FOR_DECIMAL_TYPES(DISPATCH)
 #undef DISPATCH
 

--- a/be/src/vec/aggregate_functions/aggregate_function_uniq.cpp
+++ b/be/src/vec/aggregate_functions/aggregate_function_uniq.cpp
@@ -70,8 +70,7 @@ AggregateFunctionPtr create_aggregate_function_uniq(const std::string& name,
 void register_aggregate_function_uniq(AggregateFunctionSimpleFactory& factory) {
     AggregateFunctionCreator creator =
             create_aggregate_function_uniq<AggregateFunctionUniqExactData>;
-    factory.register_function("multi_distinct_count", creator);
-    factory.register_function("multi_distinct_count", creator, true);
+    factory.register_function_both("multi_distinct_count", creator);
 }
 
 } // namespace doris::vectorized

--- a/be/src/vec/aggregate_functions/aggregate_function_window.cpp
+++ b/be/src/vec/aggregate_functions/aggregate_function_window.cpp
@@ -114,14 +114,10 @@ void register_aggregate_function_window_rank(AggregateFunctionSimpleFactory& fac
 
 void register_aggregate_function_window_lead_lag_first_last(
         AggregateFunctionSimpleFactory& factory) {
-    factory.register_function("lead", create_aggregate_function_window_lead);
-    factory.register_function("lead", create_aggregate_function_window_lead, true);
-    factory.register_function("lag", create_aggregate_function_window_lag);
-    factory.register_function("lag", create_aggregate_function_window_lag, true);
-    factory.register_function("first_value", create_aggregate_function_window_first);
-    factory.register_function("first_value", create_aggregate_function_window_first, true);
-    factory.register_function("last_value", create_aggregate_function_window_last);
-    factory.register_function("last_value", create_aggregate_function_window_last, true);
+    factory.register_function_both("lead", create_aggregate_function_window_lead);
+    factory.register_function_both("lag", create_aggregate_function_window_lag);
+    factory.register_function_both("first_value", create_aggregate_function_window_first);
+    factory.register_function_both("last_value", create_aggregate_function_window_last);
 }
 
 } // namespace doris::vectorized

--- a/be/src/vec/aggregate_functions/helpers.h
+++ b/be/src/vec/aggregate_functions/helpers.h
@@ -28,9 +28,6 @@
 // TODO: Should we support decimal in numeric types?
 #define FOR_INTEGER_TYPES(M) \
     M(UInt8)                 \
-    M(UInt16)                \
-    M(UInt32)                \
-    M(UInt64)                \
     M(Int8)                  \
     M(Int16)                 \
     M(Int32)                 \

--- a/be/src/vec/common/hash_table/hash.h
+++ b/be/src/vec/common/hash_table/hash.h
@@ -27,6 +27,64 @@
 #include "vec/common/uint128.h"
 #include "vec/core/types.h"
 
+/** Hash functions that are better than the trivial function std::hash.
+  *
+  * Example: when we do aggregation by the visitor ID, the performance increase is more than 5 times.
+  * This is because of following reasons:
+  * - in Yandex, visitor identifier is an integer that has timestamp with seconds resolution in lower bits;
+  * - in typical implementation of standard library, hash function for integers is trivial and just use lower bits;
+  * - traffic is non-uniformly distributed across a day;
+  * - we are using open-addressing linear probing hash tables that are most critical to hash function quality,
+  *   and trivial hash function gives disastrous results.
+  */
+
+/** Taken from MurmurHash. This is Murmur finalizer.
+  * Faster than int_hash32 when inserting into the hash table UInt64 -> UInt64, where the key is the visitor ID.
+  */
+inline doris::vectorized::UInt64 int_hash64(doris::vectorized::UInt64 x) {
+    x ^= x >> 33;
+    x *= 0xff51afd7ed558ccdULL;
+    x ^= x >> 33;
+    x *= 0xc4ceb9fe1a85ec53ULL;
+    x ^= x >> 33;
+
+    return x;
+}
+
+/** CRC32C is not very high-quality as a hash function,
+  *  according to avalanche and bit independence tests (see SMHasher software), as well as a small number of bits,
+  *  but can behave well when used in hash tables,
+  *  due to high speed (latency 3 + 1 clock cycle, throughput 1 clock cycle).
+  * Works only with SSE 4.2 support.
+  */
+#ifdef __SSE4_2__
+#include <nmmintrin.h>
+#endif
+
+#if defined(__aarch64__)
+#include <sse2neon.h>
+#endif
+
+inline doris::vectorized::UInt64 int_hash_crc32(doris::vectorized::UInt64 x) {
+#if defined(__SSE4_2__) || (defined(__aarch64__) && defined(__ARM_FEATURE_CRC32))
+    return _mm_crc32_u64(-1ULL, x);
+#else
+    /// On other platforms we do not have CRC32. NOTE This can be confusing.
+    return int_hash64(x);
+#endif
+}
+
+template <typename T>
+inline size_t default_hash64(T key) {
+    union {
+        T in;
+        doris::vectorized::UInt64 out;
+    } u;
+    u.out = 0;
+    u.in = key;
+    return int_hash64(u.out);
+}
+
 template <typename T, typename Enable = void>
 struct DefaultHash;
 

--- a/be/src/vec/core/types.h
+++ b/be/src/vec/core/types.h
@@ -626,68 +626,12 @@ struct std::hash<doris::vectorized::Decimal128> {
     }
 };
 
-/** Hash functions that are better than the trivial function std::hash.
-  *
-  * Example: when we do aggregation by the visitor ID, the performance increase is more than 5 times.
-  * This is because of following reasons:
-  * - in Yandex, visitor identifier is an integer that has timestamp with seconds resolution in lower bits;
-  * - in typical implementation of standard library, hash function for integers is trivial and just use lower bits;
-  * - traffic is non-uniformly distributed across a day;
-  * - we are using open-addressing linear probing hash tables that are most critical to hash function quality,
-  *   and trivial hash function gives disastrous results.
-  */
-
-/** Taken from MurmurHash. This is Murmur finalizer.
-  * Faster than int_hash32 when inserting into the hash table UInt64 -> UInt64, where the key is the visitor ID.
-  */
-inline doris::vectorized::UInt64 int_hash64(doris::vectorized::UInt64 x) {
-    x ^= x >> 33;
-    x *= 0xff51afd7ed558ccdULL;
-    x ^= x >> 33;
-    x *= 0xc4ceb9fe1a85ec53ULL;
-    x ^= x >> 33;
-
-    return x;
-}
-
-/** CRC32C is not very high-quality as a hash function,
-  *  according to avalanche and bit independence tests (see SMHasher software), as well as a small number of bits,
-  *  but can behave well when used in hash tables,
-  *  due to high speed (latency 3 + 1 clock cycle, throughput 1 clock cycle).
-  * Works only with SSE 4.2 support.
-  */
-#ifdef __SSE4_2__
-#include <nmmintrin.h>
-#endif
-
-#if defined(__aarch64__)
-#include <sse2neon.h>
-#endif
-
-inline doris::vectorized::UInt64 int_hash_crc32(doris::vectorized::UInt64 x) {
-#if defined(__SSE4_2__) || (defined(__aarch64__) && defined(__ARM_FEATURE_CRC32))
-    return _mm_crc32_u64(-1ULL, x);
-#else
-    /// On other platforms we do not have CRC32. NOTE This can be confusing.
-    return int_hash64(x);
-#endif
-}
-
-template <typename T>
-inline size_t default_hash64(T key) {
-    union {
-        T in;
-        doris::vectorized::UInt64 out;
-    } u;
-    u.out = 0;
-    u.in = key;
-    return int_hash64(u.out);
-}
-
 template <>
 struct std::hash<doris::vectorized::Decimal128I> {
     size_t operator()(const doris::vectorized::Decimal<doris::vectorized::Int128I>& x) const {
-        return default_hash64<doris::vectorized::Decimal<doris::vectorized::Int128I>>(x);
+        return std::hash<doris::vectorized::Int64>()(x.value >> 64) ^
+               std::hash<doris::vectorized::Int64>()(
+                       x.value & std::numeric_limits<doris::vectorized::UInt64>::max());
     }
 };
 

--- a/be/src/vec/core/types.h
+++ b/be/src/vec/core/types.h
@@ -626,6 +626,71 @@ struct std::hash<doris::vectorized::Decimal128> {
     }
 };
 
+/** Hash functions that are better than the trivial function std::hash.
+  *
+  * Example: when we do aggregation by the visitor ID, the performance increase is more than 5 times.
+  * This is because of following reasons:
+  * - in Yandex, visitor identifier is an integer that has timestamp with seconds resolution in lower bits;
+  * - in typical implementation of standard library, hash function for integers is trivial and just use lower bits;
+  * - traffic is non-uniformly distributed across a day;
+  * - we are using open-addressing linear probing hash tables that are most critical to hash function quality,
+  *   and trivial hash function gives disastrous results.
+  */
+
+/** Taken from MurmurHash. This is Murmur finalizer.
+  * Faster than int_hash32 when inserting into the hash table UInt64 -> UInt64, where the key is the visitor ID.
+  */
+inline doris::vectorized::UInt64 int_hash64(doris::vectorized::UInt64 x) {
+    x ^= x >> 33;
+    x *= 0xff51afd7ed558ccdULL;
+    x ^= x >> 33;
+    x *= 0xc4ceb9fe1a85ec53ULL;
+    x ^= x >> 33;
+
+    return x;
+}
+
+/** CRC32C is not very high-quality as a hash function,
+  *  according to avalanche and bit independence tests (see SMHasher software), as well as a small number of bits,
+  *  but can behave well when used in hash tables,
+  *  due to high speed (latency 3 + 1 clock cycle, throughput 1 clock cycle).
+  * Works only with SSE 4.2 support.
+  */
+#ifdef __SSE4_2__
+#include <nmmintrin.h>
+#endif
+
+#if defined(__aarch64__)
+#include <sse2neon.h>
+#endif
+
+inline doris::vectorized::UInt64 int_hash_crc32(doris::vectorized::UInt64 x) {
+#if defined(__SSE4_2__) || (defined(__aarch64__) && defined(__ARM_FEATURE_CRC32))
+    return _mm_crc32_u64(-1ULL, x);
+#else
+    /// On other platforms we do not have CRC32. NOTE This can be confusing.
+    return int_hash64(x);
+#endif
+}
+
+template <typename T>
+inline size_t default_hash64(T key) {
+    union {
+        T in;
+        doris::vectorized::UInt64 out;
+    } u;
+    u.out = 0;
+    u.in = key;
+    return int_hash64(u.out);
+}
+
+template <>
+struct std::hash<doris::vectorized::Decimal128I> {
+    size_t operator()(const doris::vectorized::Decimal<doris::vectorized::Int128I>& x) const {
+        return default_hash64<doris::vectorized::Decimal<doris::vectorized::Int128I>>(x);
+    }
+};
+
 constexpr bool typeindex_is_int(doris::vectorized::TypeIndex index) {
     using TypeIndex = doris::vectorized::TypeIndex;
     switch (index) {


### PR DESCRIPTION
# Proposed changes

1. nullable inline refactor of min_max_by/bitmap/group_concat/histogram/topn
2. add register_function_both method
3. add datetimev2 type creator of min_max_by
4. remove uint16/32/64 in FOR_INTEGER_TYPES

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

