### PR TITLE
[fix](Nereids): provide BUCKETED property only when child's property is enforced for agg

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/ChildOutputPropertyDeriver.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/ChildOutputPropertyDeriver.java
@@ -90,7 +90,9 @@ public class ChildOutputPropertyDeriver extends PlanVisitor<PhysicalProperties, 
             case DISTINCT_LOCAL:
             case DISTINCT_GLOBAL:
                 DistributionSpec childSpec = childOutputProperty.getDistributionSpec();
-                if (childSpec instanceof DistributionSpecHash) {
+                // If child's property is enforced, change it to bucketed
+                if (childSpec instanceof DistributionSpecHash
+                        && ((DistributionSpecHash) childSpec).getShuffleType().equals(ShuffleType.ENFORCED)) {
                     DistributionSpecHash distributionSpecHash = (DistributionSpecHash) childSpec;
                     return new PhysicalProperties(distributionSpecHash.withShuffleType(ShuffleType.BUCKETED));
                 }


### PR DESCRIPTION
# Proposed changes

When agg's child property is Nature, agg should keep the child's property

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [x] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

