### PR TITLE
[Feature-wip](MySQL Load)Support cancel query for mysql load

### DIFF
--- a/docs/en/docs/data-operate/import/import-way/mysql-load-manual.md
+++ b/docs/en/docs/data-operate/import/import-way/mysql-load-manual.md
@@ -102,7 +102,7 @@ PROPERTIES ("strict_mode" = "true")
 ```
 1. The only difference between the syntax of importing server level local files and importing client side syntax is whether the'LOCAL 'keyword is added after the'LOAD DATA' keyword.
 2. FE will have multi-nodes, and importing server level files can only import FE nodes connected by the client side, and cannot import files local to other FE nodes.
-3. Server side load was disabled by default. Enable it by setting `mysql_load_server_secure_path` with a secure path. All the load file should be under this path. Recommend create a `local_import_data` directory under `DORIS_HOME` to load data.
+3. Server side load was disabled by default. Enable it by setting `mysql_load_server_secure_path` with a secure path. All the load file should be under this path.
 
 ### Return result
 Since MySQL load is a synchronous import method, the imported results are returned to the user through SQL syntax.
@@ -112,6 +112,10 @@ If the import fails, a specific error message will be displayed. If the import i
 Query OK, 1 row affected (0.17 sec)
 Records: 1 Deleted: 0 Skipped: 0 Warnings: 0
 ```
+
+### Configuration
+1. `mysql_load_thread_pool`: the thread pool size for singe FE node, set 4 thread by default. The block queue size is 5 times of `mysql_load_thread_pool`. So FE can accept 4 + 4*5 = 24 requests in one time. Increase this configuration if the parallelism are larger than 24.
+2. `mysql_load_server_secure_path`: the secure path for load data from server. Empty path by default means that it's not allowed for server load. Recommend to create a `local_import_data` directory under `DORIS_HOME` to load data if you want enable it.
 
 ## Notice 
 

--- a/docs/en/docs/sql-manual/sql-reference/Data-Manipulation-Statements/Load/MYSQL-LOAD.md
+++ b/docs/en/docs/sql-manual/sql-reference/Data-Manipulation-Statements/Load/MYSQL-LOAD.md
@@ -121,8 +121,8 @@ This import method can still guarantee the atomicity of a batch of import tasks,
     ```sql
     LOAD DATA LOCAL
     INFILE 'testData'
-    PARTITION (p1, p2)
     INTO TABLE testDb.testTbl
+    PARTITION (p1, p2)
     PROPERTIES ("max_filter_ratio"="0.2")
     ```
 
@@ -141,8 +141,8 @@ This import method can still guarantee the atomicity of a batch of import tasks,
     ```sql
     LOAD DATA LOCAL
     INFILE 'testData'
-    PARTITION (p1, p2)
     INTO TABLE testDb.testTbl
+    PARTITION (p1, p2)
     IGNORE 1 LINES
     ```
 

--- a/docs/zh-CN/docs/data-operate/import/import-way/mysql-load-manual.md
+++ b/docs/zh-CN/docs/data-operate/import/import-way/mysql-load-manual.md
@@ -103,7 +103,7 @@ PROPERTIES ("strict_mode"="true")
 ```
 1. 导入服务端本地文件的语法和导入客户端语法的唯一区别是`LOAD DATA`关键词后面是否加入`LOCAL`关键字.
 2. FE为多节点部署, 导入服务端文件功能只能够导入客户端连接的FE节点, 无法导入其他FE节点本地的文件.
-3. 服务端导入默认是关闭, 通过设置FE的配置`mysql_load_server_secure_path`开启, 导入文件的必须在该目录下.建议在`DORIS_HOME`目录下创建一个`local_import_data`目录用于导入数据.
+3. 服务端导入默认是关闭, 通过设置FE的配置`mysql_load_server_secure_path`开启, 导入文件的必须在该目录下.
 
 ### 返回结果
 
@@ -114,6 +114,10 @@ PROPERTIES ("strict_mode"="true")
 Query OK, 1 row affected (0.17 sec)
 Records: 1  Deleted: 0  Skipped: 0  Warnings: 0
 ```
+
+### 配置项
+1. `mysql_load_thread_pool`控制单个FE中MySQL Load并发执行线程个数, 默认为4. 线程池的排队对接大小为`mysql_load_thread_pool`的5倍, 因此默认情况下, 可以并发提交的任务为 4 + 4*5 = 24个. 如果并发个数超过24时, 可以调大该配置项.
+2. `mysql_load_server_secure_path`服务端导入的安全路径, 默认为空, 即不允许服务端导入. 如需开启这个功能, 建议在`DORIS_HOME`目录下创建一个`local_import_data`目录, 用于导入数据.
 
 ## 注意事项
 

--- a/docs/zh-CN/docs/sql-manual/sql-reference/Data-Manipulation-Statements/Load/MYSQL-LOAD.md
+++ b/docs/zh-CN/docs/sql-manual/sql-reference/Data-Manipulation-Statements/Load/MYSQL-LOAD.md
@@ -120,8 +120,8 @@ INTO TABLE tbl_name
     ```sql
     LOAD DATA LOCAL
     INFILE 'testData'
-    PARTITION (p1, p2)
     INTO TABLE testDb.testTbl
+    PARTITION (p1, p2)
     PROPERTIES ("max_filter_ratio"="0.2")
     ```
 
@@ -140,8 +140,8 @@ INTO TABLE tbl_name
     ```sql
     LOAD DATA LOCAL
     INFILE 'testData'
-    PARTITION (p1, p2)
     INTO TABLE testDb.testTbl
+    PARTITION (p1, p2)
     IGNORE 1 LINES
     ```
 

--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -2037,5 +2037,8 @@ public class Config extends ConfigBase {
      */
     @ConfField(mutable = false, masterOnly = false)
     public static String mysql_load_server_secure_path = "";
+
+    @ConfField(mutable = false, masterOnly = false)
+    public static int mysql_load_thread_pool = 4;
 }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/LoadStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/LoadStmt.java
@@ -39,6 +39,7 @@ import com.google.common.collect.Lists;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -429,10 +430,15 @@ public class LoadStmt extends DdlStmt {
                     throw new AnalysisException("Load local data from fe local is not enabled. If you want to use it,"
                             + " plz set the `mysql_load_server_secure_path` for FE to be a right path.");
                 } else {
-                    if (!(path.startsWith(Config.mysql_load_server_secure_path))) {
-                        throw new AnalysisException("Local file should be under the secure path of FE.");
+                    File file = new File(path);
+                    try {
+                        if (!(file.getCanonicalPath().startsWith(Config.mysql_load_server_secure_path))) {
+                            throw new AnalysisException("Local file should be under the secure path of FE.");
+                        }
+                    } catch (IOException e) {
+                        throw new RuntimeException(e);
                     }
-                    if (!new File(path).exists()) {
+                    if (!file.exists()) {
                         throw new AnalysisException("File: " + path + " is not exists.");
                     }
                 }

--- a/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/MysqlLoadManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/MysqlLoadManager.java
@@ -144,16 +144,16 @@ public class MysqlLoadManager {
                 }
             }
         } catch (Throwable t) {
-            LOG.error("Execute mysql load failed", t);
+            LOG.warn("Execute mysql load {} failed", loadId, t);
             // drain the data from client conn util empty packet received, otherwise the connection will be reset
             if (loadContextMap.containsKey(loadId) && !loadContextMap.get(loadId).isFinished()) {
-                LOG.warn("not drained yet, try reading left data from client connection.");
+                LOG.warn("not drained yet, try reading left data from client connection for load {}.", loadId);
                 ByteBuffer buffer = context.getMysqlChannel().fetchOnePacket();
                 // MySql client will send an empty packet when eof
                 while (buffer != null && buffer.limit() != 0) {
                     buffer = context.getMysqlChannel().fetchOnePacket();
                 }
-                LOG.warn("Finished reading the left bytes.");
+                LOG.debug("Finished reading the left bytes.");
             }
             // make cancel message to user
             if (loadContextMap.containsKey(loadId) && loadContextMap.get(loadId).isCancelled()) {
@@ -248,7 +248,7 @@ public class MysqlLoadManager {
                     loadContextMap.get(loadId).setFinished(true);
                 }
             } catch (IOException | InterruptedException e) {
-                LOG.warn("Failed fetch packet from mysql client", e);
+                LOG.warn("Failed fetch packet from mysql client for load: " + loadId, e);
                 throw new RuntimeException(e);
             } finally {
                 inputStream.markFinished();

--- a/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/MysqlLoadManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/MysqlLoadManager.java
@@ -103,8 +103,9 @@ public class MysqlLoadManager {
 
 
     public MysqlLoadManager(TokenManager tokenManager) {
-        this.mysqlLoadPool = ThreadPoolManager.newDaemonFixedThreadPool(
-                Config.mysql_load_thread_pool, 20, "Mysql Load", true);
+        int poolSize = Config.mysql_load_thread_pool;
+        // MySqlLoad pool can accept 4 + 4 * 5 = 24  requests by default.
+        this.mysqlLoadPool = ThreadPoolManager.newDaemonFixedThreadPool(poolSize, poolSize * 5, "Mysql Load", true);
         this.tokenManager = tokenManager;
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -1009,9 +1009,7 @@ public class StmtExecutor implements ProfileWriter {
         if (coordRef != null) {
             coordRef.cancel();
         }
-        LOG.info("cancel1()");
         if (mysqlLoadId != null) {
-            LOG.info("cancel2()");
             Env.getCurrentEnv().getLoadManager().getMysqlLoadManager().cancelMySqlLoad(mysqlLoadId);
         }
     }

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/LoadStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/LoadStmtTest.java
@@ -240,4 +240,47 @@ public class LoadStmtTest {
         Assert.assertNull(stmt.getLabel().getDbName());
         Assert.assertEquals(EtlJobType.LOCAL_FILE, stmt.getEtlJobType());
     }
+
+    @Test
+    public void testMySqlLoadPath(@Injectable DataDescription desc) throws UserException, IOException {
+        File temp = File.createTempFile("testMySqlLoadData_path", ".txt");
+        String parentPath = temp.getParent();
+        String fakePath = parentPath + "/../fake_path";
+        new Expectations() {
+            {
+                desc.isClientLocal();
+                minTimes = 0;
+                result = false;
+
+                desc.getFilePaths();
+                minTimes = 0;
+                result = Lists.newArrayList(fakePath);
+
+                desc.toSql();
+                minTimes = 0;
+                result = "XXX";
+
+                desc.getTableName();
+                minTimes = 0;
+                result = "testTbl";
+
+                desc.analyzeFullDbName(null, (Analyzer) any);
+                minTimes = 0;
+                result = "testCluster:testDb";
+
+                desc.getMergeType();
+                minTimes = 0;
+                result = LoadTask.MergeType.APPEND;
+            }
+        };
+
+        LoadStmt stmt = new LoadStmt(desc, Maps.newHashMap(), "");
+        Config.mysql_load_server_secure_path = parentPath;
+        try {
+            stmt.analyze(analyzer);
+        } catch (AnalysisException ae) {
+            Assert.assertEquals("errCode = 2, detailMessage = Local file should be under the secure path of FE.",
+                    ae.getMessage());
+        }
+    }
 }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary
Notice some changes:
1. Support cancel query for mysql load 
2. Change the thread pool for mysql load manager.
3. Fix sucret path check logic
4. Fix some doc error

## Checklist(Required)

* [ ] Does it affect the original behavior
* [x] Has unit tests been added
* [x] Has document been added or modified
* [ ] Is this PR support rollback (If NO, please explain WHY)
* [ ] Does it need to update dependencies

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

