### PR TITLE
[fix](MTMV) Reset insert timeout in handleInsert

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/InsertStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/InsertStmt.java
@@ -304,7 +304,9 @@ public class InsertStmt extends DdlStmt {
 
         db = analyzer.getEnv().getCatalogMgr().getCatalog(tblName.getCtl()).getDbOrAnalysisException(tblName.getDb());
         // create label and begin transaction
-        long timeoutSecond = ConnectContext.get().getExecTimeout();
+        ConnectContext ctx = ConnectContext.get();
+        int timeoutSecond = Math.max(ctx.getExecTimeout(), ctx.getSessionVariable().getInsertTimeoutS());
+        ctx.setExecTimeout(timeoutSecond);
         if (Strings.isNullOrEmpty(label)) {
             label = "insert_" + DebugUtil.printId(analyzer.getContext().queryId()).replace("-", "_");
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/InsertStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/InsertStmt.java
@@ -304,9 +304,7 @@ public class InsertStmt extends DdlStmt {
 
         db = analyzer.getEnv().getCatalogMgr().getCatalog(tblName.getCtl()).getDbOrAnalysisException(tblName.getDb());
         // create label and begin transaction
-        ConnectContext ctx = ConnectContext.get();
-        int timeoutSecond = Math.max(ctx.getExecTimeout(), ctx.getSessionVariable().getInsertTimeoutS());
-        ctx.setExecTimeout(timeoutSecond);
+        long timeoutSecond = ConnectContext.get().resetExecTimeoutByInsert();
         if (Strings.isNullOrEmpty(label)) {
             label = "insert_" + DebugUtil.printId(analyzer.getContext().queryId()).replace("-", "_");
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectContext.java
@@ -155,7 +155,7 @@ public class ConnectContext {
      * the global execution timeout in seconds, currently set according to query_timeout and insert_timeout.
      * <p>
      * when a connection is established, exec_timeout is set by query_timeout, when the statement is an insert stmt,
-     * then it is set to max(query_timeout, insert_timeout) with {@link #resetExecTimeout()} in
+     * then it is set to max(query_timeout, insert_timeout) with {@link #setExecTimeout(int timeout)} in
      * after the StmtExecutor is specified.
      */
     private int executionTimeoutS;
@@ -640,12 +640,8 @@ public class ConnectContext {
         return currentConnectedFEIp;
     }
 
-    public void resetExecTimeout() {
-        if (executor != null && executor.isInsertStmt()) {
-            // particular timeout for insert stmt, we can make other particular timeout in the same way.
-            // set the execution timeout as max(insert_timeout,query_timeout) to be compatible with older versions
-            executionTimeoutS = Math.max(sessionVariable.getInsertTimeoutS(), executionTimeoutS);
-        }
+    public void setExecTimeout(int timeout) {
+        executionTimeoutS = Math.max(timeout, executionTimeoutS);
     }
 
     public int getExecTimeout() {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectContext.java
@@ -155,8 +155,8 @@ public class ConnectContext {
      * the global execution timeout in seconds, currently set according to query_timeout and insert_timeout.
      * <p>
      * when a connection is established, exec_timeout is set by query_timeout, when the statement is an insert stmt,
-     * then it is set to max(query_timeout, insert_timeout) with {@link #setExecTimeout(int timeout)} in
-     * after the StmtExecutor is specified.
+     * then it is set to max(executionTimeoutS, insert_timeout) using {@link #setExecTimeout(int timeout)} at
+     * {@link StmtExecutor}.
      */
     private int executionTimeoutS;
 
@@ -641,7 +641,7 @@ public class ConnectContext {
     }
 
     public void setExecTimeout(int timeout) {
-        executionTimeoutS = Math.max(timeout, executionTimeoutS);
+        executionTimeoutS = timeout;
     }
 
     public int getExecTimeout() {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectContext.java
@@ -644,6 +644,11 @@ public class ConnectContext {
         executionTimeoutS = timeout;
     }
 
+    public long resetExecTimeoutByInsert() {
+        executionTimeoutS = Math.max(executionTimeoutS, sessionVariable.getInsertTimeoutS());
+        return executionTimeoutS;
+    }
+
     public int getExecTimeout() {
         return executionTimeoutS;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectProcessor.java
@@ -408,8 +408,6 @@ public class ConnectProcessor {
             parsedStmt.setUserInfo(ctx.getCurrentUserIdentity());
             executor = new StmtExecutor(ctx, parsedStmt);
             ctx.setExecutor(executor);
-            // reset the executionTimeout corresponding with the StmtExecutor
-            ctx.resetExecTimeout();
 
             try {
                 executor.execute();

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -1535,7 +1535,7 @@ public class StmtExecutor implements ProfileWriter {
 
         analyzeVariablesInStmt(insertStmt.getQueryStmt());
         // reset the executionTimeout corresponding with the StmtExecutor
-        context.setExecTimeout(context.getSessionVariable().getInsertTimeoutS());
+        context.setExecTimeout(Math.max(context.getSessionVariable().getInsertTimeoutS(), context.getExecTimeout()));
 
         long createTime = System.currentTimeMillis();
         Throwable throwable = null;

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -1534,6 +1534,8 @@ public class StmtExecutor implements ProfileWriter {
         }
 
         analyzeVariablesInStmt(insertStmt.getQueryStmt());
+        // reset the executionTimeout corresponding with the StmtExecutor
+        context.resetExecTimeout();
 
         long createTime = System.currentTimeMillis();
         Throwable throwable = null;

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -1473,7 +1473,9 @@ public class StmtExecutor implements ProfileWriter {
             InterruptedException, ExecutionException, TimeoutException {
         TransactionEntry txnEntry = context.getTxnEntry();
         TTxnParams txnConf = txnEntry.getTxnConf();
-        long timeoutSecond = ConnectContext.get().getSessionVariable().getQueryTimeoutS();
+        ConnectContext ctx = ConnectContext.get();
+        int timeoutSecond = Math.max(ctx.getSessionVariable().getInsertTimeoutS(), ctx.getExecTimeout());
+        ctx.setExecTimeout(timeoutSecond);
         TransactionState.LoadJobSourceType sourceType = TransactionState.LoadJobSourceType.INSERT_STREAMING;
         Database dbObj = Env.getCurrentInternalCatalog()
                 .getDbOrException(dbName, s -> new TException("database is invalid for dbName: " + s));

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -1535,7 +1535,7 @@ public class StmtExecutor implements ProfileWriter {
 
         analyzeVariablesInStmt(insertStmt.getQueryStmt());
         // reset the executionTimeout corresponding with the StmtExecutor
-        context.resetExecTimeout();
+        context.setExecTimeout(context.getSessionVariable().getInsertTimeoutS());
 
         long createTime = System.currentTimeMillis();
         Throwable throwable = null;

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -1473,9 +1473,7 @@ public class StmtExecutor implements ProfileWriter {
             InterruptedException, ExecutionException, TimeoutException {
         TransactionEntry txnEntry = context.getTxnEntry();
         TTxnParams txnConf = txnEntry.getTxnConf();
-        ConnectContext ctx = ConnectContext.get();
-        int timeoutSecond = Math.max(ctx.getSessionVariable().getInsertTimeoutS(), ctx.getExecTimeout());
-        ctx.setExecTimeout(timeoutSecond);
+        long timeoutSecond = ConnectContext.get().getExecTimeout();
         TransactionState.LoadJobSourceType sourceType = TransactionState.LoadJobSourceType.INSERT_STREAMING;
         Database dbObj = Env.getCurrentInternalCatalog()
                 .getDbOrException(dbName, s -> new TException("database is invalid for dbName: " + s));
@@ -1536,8 +1534,8 @@ public class StmtExecutor implements ProfileWriter {
         }
 
         analyzeVariablesInStmt(insertStmt.getQueryStmt());
-        // reset the executionTimeout corresponding with the StmtExecutor
-        context.setExecTimeout(Math.max(context.getSessionVariable().getInsertTimeoutS(), context.getExecTimeout()));
+        // reset the executionTimeout since query hint maybe change the insert_timeout again
+        context.resetExecTimeoutByInsert();
 
         long createTime = System.currentTimeMillis();
         Throwable throwable = null;

--- a/fe/fe-core/src/test/java/org/apache/doris/qe/ConnectContextTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/qe/ConnectContextTest.java
@@ -176,14 +176,14 @@ public class ConnectContextTest {
         // sleep no time out
         Assert.assertFalse(ctx.isKilled());
         ctx.setExecutor(executor);
-        ctx.resetExecTimeout();
+        ctx.setExecTimeout(ctx.getSessionVariable().getInsertTimeoutS());
         long now = ctx.getExecTimeout() * 1000L - 1;
         ctx.checkTimeout(now);
         Assert.assertFalse(ctx.isKilled());
 
         // Timeout
         ctx.setExecutor(executor);
-        ctx.resetExecTimeout();
+        ctx.setExecTimeout(ctx.getSessionVariable().getInsertTimeoutS());
         now = ctx.getExecTimeout() * 1000L + 1;
         ctx.checkTimeout(now);
         Assert.assertFalse(ctx.isKilled());


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary
PR #16343 seprate the `query_timeout` and `insert_timeout`.
But it only change the timeout in `ConnectProcessor::handleQuery` function which only handle mysql client sql.
The CTAS and MTMV insert job will miss these sesssion variable.
So I move it into `StmtExecutor::handleInsert` funtion since all these three feature will go through these code.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

