### PR TITLE
[enhancement](merge-on-write) change cu compaction correctness check to warning

### DIFF
--- a/be/src/olap/compaction.cpp
+++ b/be/src/olap/compaction.cpp
@@ -438,8 +438,10 @@ Status Compaction::modify_rowsets(const Merger::Statistics* stats) {
                         "cumulative compaction: the merged rows({}) is not equal to missed "
                         "rows({}) in rowid conversion, tablet_id: {}, table_id:{}",
                         stats->merged_rows, missed_rows, _tablet->tablet_id(), _tablet->table_id());
-                DCHECK(stats != nullptr || stats->merged_rows == missed_rows) << err_msg;
-                LOG(WARNING) << err_msg;
+                DCHECK(stats == nullptr || stats->merged_rows == missed_rows) << err_msg;
+                if (stats != nullptr && stats->merged_rows != missed_rows) {
+                    LOG(WARNING) << err_msg;
+                }
             }
 
             _tablet->merge_delete_bitmap(output_rowset_delete_bitmap);

--- a/be/src/olap/compaction.cpp
+++ b/be/src/olap/compaction.cpp
@@ -434,12 +434,12 @@ Status Compaction::modify_rowsets(const Merger::Statistics* stats) {
             RETURN_IF_ERROR(_tablet->check_rowid_conversion(_output_rowset, location_map));
 
             if (compaction_type() == READER_CUMULATIVE_COMPACTION) {
-                std::string err_msg =
-                        "The merged rows is not equal to missed rows in rowid conversion";
+                std::string err_msg = fmt::format(
+                        "cumulative compaction: the merged rows({}) is not equal to missed "
+                        "rows({}) in rowid conversion, tablet_id: {}, table_id:{}",
+                        stats->merged_rows, missed_rows, _tablet->tablet_id(), _tablet->table_id());
                 DCHECK(stats != nullptr || stats->merged_rows == missed_rows) << err_msg;
-                if (stats != nullptr && stats->merged_rows != missed_rows) {
-                    return Status::InternalError(err_msg);
-                }
+                LOG(WARNING) << err_msg;
             }
 
             _tablet->merge_delete_bitmap(output_rowset_delete_bitmap);


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

for some online service, compaction keep failing may cause large mem consumption, and it's not easy to recover
change the error to warning log, which is more friendly to online users.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

