### PR TITLE
[fix](cooldown) Fix deadlock in tablet clone

### DIFF
--- a/be/src/io/fs/s3_file_system.cpp
+++ b/be/src/io/fs/s3_file_system.cpp
@@ -397,6 +397,7 @@ Status S3FileSystem::list(const Path& path, std::vector<Path>* files) {
             files->push_back(obj.GetKey().substr(prefix.size()));
         }
         is_trucated = outcome.GetResult().GetIsTruncated();
+        request.SetContinuationToken(outcome.GetResult().GetNextContinuationToken());
     } while (is_trucated);
     return Status::OK();
 }

--- a/be/src/olap/rowset/rowset.cpp
+++ b/be/src/olap/rowset/rowset.cpp
@@ -23,9 +23,9 @@
 
 namespace doris {
 
-Rowset::Rowset(TabletSchemaSPtr schema, const std::string& tablet_path,
-               RowsetMetaSharedPtr rowset_meta)
-        : _tablet_path(tablet_path), _rowset_meta(std::move(rowset_meta)), _refs_by_reader(0) {
+Rowset::Rowset(const TabletSchemaSPtr& schema, const std::string& tablet_path,
+               const RowsetMetaSharedPtr& rowset_meta)
+        : _tablet_path(tablet_path), _rowset_meta(rowset_meta), _refs_by_reader(0) {
     _is_pending = !_rowset_meta->has_version();
     if (_is_pending) {
         _is_cumulative = false;

--- a/be/src/olap/rowset/rowset.h
+++ b/be/src/olap/rowset/rowset.h
@@ -282,8 +282,8 @@ protected:
 
     DISALLOW_COPY_AND_ASSIGN(Rowset);
     // this is non-public because all clients should use RowsetFactory to obtain pointer to initialized Rowset
-    Rowset(TabletSchemaSPtr schema, const std::string& tablet_path,
-           RowsetMetaSharedPtr rowset_meta);
+    Rowset(const TabletSchemaSPtr& schema, const std::string& tablet_path,
+           const RowsetMetaSharedPtr& rowset_meta);
 
     // this is non-public because all clients should use RowsetFactory to obtain pointer to initialized Rowset
     virtual Status init() = 0;

--- a/be/src/olap/rowset/rowset_factory.h
+++ b/be/src/olap/rowset/rowset_factory.h
@@ -31,6 +31,8 @@ class RowsetFactory {
 public:
     // return OK and set inited rowset in `*rowset`.
     // return others if failed to create or init rowset.
+    // NOTE: `rowset_meta` loaded from `RowsetMetaPB` before version 1.2 doesn't have tablet schema,
+    //  use tablet's schema as rowset's schema for compatibility.
     static Status create_rowset(const TabletSchemaSPtr& schema, const std::string& tablet_path,
                                 const RowsetMetaSharedPtr& rowset_meta, RowsetSharedPtr* rowset);
 

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -1642,7 +1642,7 @@ void Tablet::_init_context_common_fields(RowsetWriterContext& context) {
 }
 
 Status Tablet::create_rowset(const RowsetMetaSharedPtr& rowset_meta, RowsetSharedPtr* rowset) {
-    return RowsetFactory::create_rowset(tablet_schema(), tablet_path(), rowset_meta, rowset);
+    return RowsetFactory::create_rowset(_schema, tablet_path(), rowset_meta, rowset);
 }
 
 Status Tablet::cooldown() {


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

`Tablet::create_rowset` acquires shared `_meta_lock`, while caller already holds the exclusive `_meta_lock`.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [x] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

