### PR TITLE
[fix](Nereids) fold constant on BE could not process alias

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rewrite/rules/FoldConstantRule.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rewrite/rules/FoldConstantRule.java
@@ -31,7 +31,7 @@ public class FoldConstantRule extends AbstractExpressionRewriteRule {
     @Override
     public Expression rewrite(Expression expr, ExpressionRewriteContext ctx) {
         if (ctx.connectContext != null && ctx.connectContext.getSessionVariable().isEnableFoldConstantByBe()) {
-            return FoldConstantRuleOnBE.INSTANCE.rewrite(expr, ctx);
+            return new FoldConstantRuleOnBE().rewrite(expr, ctx);
         }
         return FoldConstantRuleOnFE.INSTANCE.rewrite(expr, ctx);
     }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

1. could not use static INSTANCE for FoldConstantOnBE rule, because it is stateful
2. if expression root is Alias, should use its child to do const collection

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

