### PR TITLE
[fix](inverted index) fix still execute match query after drop inverted index

### DIFF
--- a/be/src/vec/exec/scan/new_olap_scanner.cpp
+++ b/be/src/vec/exec/scan/new_olap_scanner.cpp
@@ -91,8 +91,7 @@ Status NewOlapScanner::prepare(const TPaloScanRange& scan_range,
             }
         }
 
-        if (olap_scan_node.__isset.indexes_desc && !olap_scan_node.indexes_desc.empty() &&
-            olap_scan_node.indexes_desc[0].index_id >= 0) {
+        if (olap_scan_node.__isset.indexes_desc) {
             _tablet_schema->update_indexes_from_thrift(olap_scan_node.indexes_desc);
         }
 

--- a/regression-test/suites/inverted_index_p0/test_add_drop_index_with_data.groovy
+++ b/regression-test/suites/inverted_index_p0/test_add_drop_index_with_data.groovy
@@ -164,6 +164,49 @@ suite("test_add_drop_index_with_data", "inverted_index"){
     assertEquals(select_result[0][1], "name2")
     assertEquals(select_result[0][2], "desc 2")
 
+    // drop idx_id index
+    sql "drop index idx_id on ${indexTbName1}"
+    wait_for_latest_op_on_table_finish(indexTbName1, timeout)
+
+    // show index of create table
+    show_result = sql "show index from ${indexTbName1}"
+    logger.info("show index from " + indexTbName1 + " result: " + show_result)
+    assertEquals(show_result.size(), 1)
+    assertEquals(show_result[0][2], "idx_name")
+
+    // query rows where name match 'name1'
+    select_result = sql "select * from ${indexTbName1} where name match 'name1'"
+    assertEquals(select_result.size(), 1)
+    assertEquals(select_result[0][0], 1)
+    assertEquals(select_result[0][1], "name1")
+    assertEquals(select_result[0][2], "desc 1")
+
+    // query rows where name match 'name2'
+    select_result = sql "select * from ${indexTbName1} where name match 'name2'"
+    assertEquals(select_result.size(), 1)
+    assertEquals(select_result[0][0], 2)
+    assertEquals(select_result[0][1], "name2")
+    assertEquals(select_result[0][2], "desc 2")
+
+    // drop idx_id index
+    sql "drop index idx_name on ${indexTbName1}"
+    wait_for_latest_op_on_table_finish(indexTbName1, timeout)
+
+    // query rows where name match 'name1', should fail without index
+    success = false
+    try {
+        sql "select * from ${indexTbName1} where name match 'name1'"
+        success = true
+    } catch(Exception ex) {
+        logger.info("sql exception: " + ex)
+    }
+    assertEquals(success, false)
+
+    // show index of create table
+    show_result = sql "show index from ${indexTbName1}"
+    logger.info("show index from " + indexTbName1 + " result: " + show_result)
+    assertEquals(show_result.size(), 0)
+
     // add index on column description
     sql "create index idx_desc on ${indexTbName1}(description) USING INVERTED PROPERTIES(\"parser\"=\"standard\");"
     wait_for_latest_op_on_table_finish(indexTbName1, timeout)


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary
- background：
At the moment, match query must with inverted index, 

- problem description:
After drop inverted index which is the only index in table, there still can use match query for this index column.

- fix it:
The index should be updated on BE regardless of whether the indexes_desc from FE is empty.



## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

