### PR TITLE
[fix](maxminby) fix coredump of maxminby of decimal type

### DIFF
--- a/be/src/exprs/aggregate_functions.cpp
+++ b/be/src/exprs/aggregate_functions.cpp
@@ -520,10 +520,14 @@ void AggregateFunctions::maxminby_update(FunctionContext* ctx, const T& slot1, c
         auto max_by = reinterpret_cast<MaxMinByState<T, KT>*>(dst->ptr);
 
         bool condition = !max_by->flag || maxminby_compare<KT, max_by_fn>(slot2, max_by->val2);
-        ;
         if (condition) {
-            max_by->val1 = slot1;
-            max_by->val2 = slot2;
+            if constexpr (sizeof(T) > 8 || sizeof(KT) > 8) {
+                memcpy(&max_by->val1, &slot1, sizeof(max_by->val1));
+                memcpy(&max_by->val2, &slot2, sizeof(max_by->val2));
+            } else {
+                max_by->val1 = slot1;
+                max_by->val2 = slot2;
+            }
             if (!max_by->flag) {
                 max_by->flag = true;
             }
@@ -597,10 +601,14 @@ void AggregateFunctions::maxminby_merge(FunctionContext* ctx, const StringVal& s
         }
         bool condition =
                 max_by2->flag == 0 || maxminby_compare<KT, max_by_fn>(max_by1->val2, max_by2->val2);
-        ;
         if (condition) {
-            max_by2->val2 = max_by1->val2;
-            max_by2->val1 = max_by1->val1;
+            if constexpr (sizeof(T) > 8 || sizeof(KT) > 8) {
+                memcpy(&max_by2->val2, &max_by1->val2, sizeof(max_by2->val2));
+                memcpy(&max_by2->val1, &max_by1->val1, sizeof(max_by2->val1));
+            } else {
+                max_by2->val2 = max_by1->val2;
+                max_by2->val1 = max_by1->val1;
+            }
             if (!max_by2->flag) {
                 max_by2->flag = true;
             }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

min_by decimal type cause BE to coredump in release build:
```
select
        id,
        min_by (amount, time) pay_amount
FROM
        t
GROUP BY
        id
```

coredump callstack:
```
start time: Wed Mar 1 15:15:33 CST 2023                                                                             
WARNING: Logging before InitGoogleLogging() is written to STDERR
I0301 15:15:33.988014 1130487 env.cpp:46] Env init successfully.
I0000 00:00:00.000000 1130487 vlog_is_on.cc:197] RAW: Set VLOG level for "*" to 10
*** Query id: 0-0 ***
*** Aborted at 1677654998 (unix time) try "date -d @1677654998" if you are using GNU date ***
*** SIGSEGV unkown detail explain (@0x0) received by PID 1130487 (TID 0x7efb363b1700) from PID 0; stack trace: ***
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /mnt/disk1/tengjianping/doris-1.1/be/src/common/signal_handler.h:428
 1# 0x00007F485CEE7400 in /lib64/libc.so.6
 2# void doris::AggregateFunctions::maxminby_merge<doris_udf::DecimalV2Val, doris_udf::BigIntVal, false>(doris_udf::FunctionContext*, doris_udf::StringVal const&, doris_udf::StringVal*) at /mnt/disk1/tengjianping/doris-1.1/be/src/exprs/aggregate_functions.cpp:603
 3# doris::NewAggFnEvaluator::Update(doris::TupleRow const*, doris::Tuple*, void*) at /mnt/disk1/tengjianping/doris-1.1/be/src/exprs/new_agg_fn_evaluator.cc:403
 4# doris::Status doris::PartitionedAggregationNode::ProcessBatch<false>(doris::RowBatch*, doris::PartitionedHashTableCtx*) at /mnt/disk1/tengjianping/doris-1.1/be/src/exec/partitioned_aggregation_node.cc:1457
 5# doris::PartitionedAggregationNode::open(doris::RuntimeState*) at /mnt/disk1/tengjianping/doris-1.1/be/src/exec/partitioned_aggregation_node.cc:316
 6# doris::HashJoinNode::open(doris::RuntimeState*) at /mnt/disk1/tengjianping/doris-1.1/be/src/exec/hash_join_node.cpp:273
 7# doris::PartitionedAggregationNode::open(doris::RuntimeState*) at /mnt/disk1/tengjianping/doris-1.1/be/src/exec/partitioned_aggregation_node.cc:249
 8# doris::PlanFragmentExecutor::open_internal() at /mnt/disk1/tengjianping/doris-1.1/be/src/runtime/plan_fragment_executor.cpp:370
 9# doris::PlanFragmentExecutor::open() at /mnt/disk1/tengjianping/doris-1.1/be/src/runtime/plan_fragment_executor.cpp:261
```
The reason is that `DecimalV2Val` uses __int128, and assignment of __int128 in -O3 release build has aliagnment problem.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

