### PR TITLE
[enhancement](memtracker) Add special counter for memtracker and fix thread create and destroy track

### DIFF
--- a/be/src/common/daemon.cpp
+++ b/be/src/common/daemon.cpp
@@ -245,6 +245,13 @@ void Daemon::load_channel_tracker_refresh_thread() {
     }
 }
 
+void Daemon::memory_tracker_profile_refresh_thread() {
+    while (!_stop_background_threads_latch.wait_for(std::chrono::milliseconds(50))) {
+        MemTracker::refresh_all_tracker_profile();
+        MemTrackerLimiter::refresh_all_tracker_profile();
+    }
+}
+
 /*
  * this thread will calculate some metrics at a fix interval(15 sec)
  * 1. push bytes per second
@@ -413,6 +420,11 @@ void Daemon::start() {
             [this]() { this->load_channel_tracker_refresh_thread(); },
             &_load_channel_tracker_refresh_thread);
     CHECK(st.ok()) << st;
+    st = Thread::create(
+            "Daemon", "memory_tracker_profile_refresh_thread",
+            [this]() { this->memory_tracker_profile_refresh_thread(); },
+            &_memory_tracker_profile_refresh_thread);
+    CHECK(st.ok()) << st;
 
     if (config::enable_metric_calculator) {
         st = Thread::create(
@@ -437,6 +449,9 @@ void Daemon::stop() {
     }
     if (_load_channel_tracker_refresh_thread) {
         _load_channel_tracker_refresh_thread->join();
+    }
+    if (_memory_tracker_profile_refresh_thread) {
+        _memory_tracker_profile_refresh_thread->join();
     }
     if (_calculate_metrics_thread) {
         _calculate_metrics_thread->join();

--- a/be/src/common/daemon.h
+++ b/be/src/common/daemon.h
@@ -48,6 +48,7 @@ private:
     void tcmalloc_gc_thread();
     void memory_maintenance_thread();
     void load_channel_tracker_refresh_thread();
+    void memory_tracker_profile_refresh_thread();
     void calculate_metrics_thread();
     void block_spill_gc_thread();
 
@@ -55,6 +56,7 @@ private:
     scoped_refptr<Thread> _tcmalloc_gc_thread;
     scoped_refptr<Thread> _memory_maintenance_thread;
     scoped_refptr<Thread> _load_channel_tracker_refresh_thread;
+    scoped_refptr<Thread> _memory_tracker_profile_refresh_thread;
     scoped_refptr<Thread> _calculate_metrics_thread;
     scoped_refptr<Thread> _block_spill_gc_thread;
 };

--- a/be/src/runtime/memory/mem_tracker.h
+++ b/be/src/runtime/memory/mem_tracker.h
@@ -43,6 +43,50 @@ public:
         int64_t peak_consumption = 0;
     };
 
+    // A counter that keeps track of the current and peak value seen.
+    // Relaxed ordering, not accurate in real time.
+    class MemCounter {
+    public:
+        MemCounter() : _current_value(0), _peak_value(0) {}
+
+        void add(int64_t delta) {
+            _current_value.fetch_add(delta, std::memory_order_relaxed);
+            update_peak();
+        }
+
+        void add_no_update_peak(int64_t delta) {
+            _current_value.fetch_add(delta, std::memory_order_relaxed);
+        }
+
+        bool try_add(int64_t delta, int64_t max) {
+            if (UNLIKELY(_current_value.load(std::memory_order_relaxed) + delta > max))
+                return false;
+            _current_value.fetch_add(delta, std::memory_order_relaxed);
+            update_peak();
+            return true;
+        }
+
+        void set(int64_t v) {
+            _current_value.store(v, std::memory_order_relaxed);
+            update_peak();
+        }
+
+        void update_peak() {
+            if (_current_value.load(std::memory_order_relaxed) >
+                _peak_value.load(std::memory_order_relaxed)) {
+                _peak_value.store(_current_value.load(std::memory_order_relaxed),
+                                  std::memory_order_relaxed);
+            }
+        }
+
+        int64_t current_value() const { return _current_value.load(std::memory_order_relaxed); }
+        int64_t peak_value() const { return _peak_value.load(std::memory_order_relaxed); }
+
+    private:
+        std::atomic<int64_t> _current_value;
+        std::atomic<int64_t> _peak_value;
+    };
+
     // Creates and adds the tracker to the mem_tracker_pool.
     MemTracker(const std::string& label, RuntimeProfile* profile, MemTrackerLimiter* parent,
                const std::string& profile_counter_name);
@@ -63,14 +107,24 @@ public:
     const std::string& set_parent_label() const { return _parent_label; }
     // Returns the memory consumed in bytes.
     int64_t consumption() const { return _consumption->current_value(); }
-    int64_t peak_consumption() const { return _consumption->value(); }
+    int64_t peak_consumption() const { return _consumption->peak_value(); }
 
     void consume(int64_t bytes) {
         if (bytes == 0) return;
         _consumption->add(bytes);
     }
+    void consume_no_update_peak(int64_t bytes) { // need extreme fast
+        _consumption->add_no_update_peak(bytes);
+    }
     void release(int64_t bytes) { consume(-bytes); }
     void set_consumption(int64_t bytes) { _consumption->set(bytes); }
+
+    void refresh_profile_counter() {
+        if (_profile_counter) {
+            _profile_counter->set(_consumption->current_value());
+        }
+    }
+    static void refresh_all_tracker_profile();
 
 public:
     Snapshot make_snapshot() const;
@@ -93,7 +147,8 @@ protected:
     // label used in the make snapshot, not guaranteed unique.
     std::string _label;
 
-    std::shared_ptr<RuntimeProfile::HighWaterMarkCounter> _consumption; // in bytes
+    std::shared_ptr<MemCounter> _consumption;
+    std::shared_ptr<RuntimeProfile::HighWaterMarkCounter> _profile_counter;
 
     // Tracker is located in group num in mem_tracker_pool
     int64_t _parent_group_num = 0;

--- a/be/src/runtime/memory/mem_tracker_limiter.cpp
+++ b/be/src/runtime/memory/mem_tracker_limiter.cpp
@@ -48,10 +48,10 @@ MemTrackerLimiter::MemTrackerLimiter(Type type, const std::string& label, int64_
                                      RuntimeProfile* profile,
                                      const std::string& profile_counter_name) {
     DCHECK_GE(byte_limit, -1);
-    if (profile == nullptr) {
-        _consumption = std::make_shared<RuntimeProfile::HighWaterMarkCounter>(TUnit::BYTES);
-    } else {
-        _consumption = profile->AddSharedHighWaterMarkCounter(profile_counter_name, TUnit::BYTES);
+    _consumption = std::make_shared<MemCounter>();
+    if (profile != nullptr) {
+        _profile_counter =
+                profile->AddSharedHighWaterMarkCounter(profile_counter_name, TUnit::BYTES);
     }
     _type = type;
     _label = label;
@@ -92,7 +92,7 @@ MemTracker::Snapshot MemTrackerLimiter::make_snapshot() const {
     snapshot.label = _label;
     snapshot.limit = _limit;
     snapshot.cur_consumption = _consumption->current_value();
-    snapshot.peak_consumption = _consumption->value();
+    snapshot.peak_consumption = _consumption->peak_value();
     return snapshot;
 }
 
@@ -108,6 +108,15 @@ void MemTrackerLimiter::refresh_global_counter() {
     }
     for (auto it : type_mem_sum) {
         MemTrackerLimiter::TypeMemSum[it.first]->set(it.second);
+    }
+}
+
+void MemTrackerLimiter::refresh_all_tracker_profile() {
+    for (unsigned i = 0; i < mem_tracker_limiter_pool.size(); ++i) {
+        std::lock_guard<std::mutex> l(mem_tracker_limiter_pool[i].group_lock);
+        for (auto tracker : mem_tracker_limiter_pool[i].trackers) {
+            tracker->refresh_profile_counter();
+        }
     }
 }
 

--- a/be/src/runtime/memory/mem_tracker_limiter.h
+++ b/be/src/runtime/memory/mem_tracker_limiter.h
@@ -125,6 +125,8 @@ public:
     }
 
     static void refresh_global_counter();
+    static void refresh_all_tracker_profile();
+
     Snapshot make_snapshot() const;
     // Returns a list of all the valid tracker snapshots.
     static void make_process_snapshots(std::vector<MemTracker::Snapshot>* snapshots);
@@ -215,7 +217,7 @@ private:
                 "failed alloc size {}, exceeded tracker:<{}>, limit {}, peak "
                 "used {}, current used {}",
                 print_bytes(bytes), exceed_tracker->label(), print_bytes(exceed_tracker->limit()),
-                print_bytes(exceed_tracker->_consumption->value()),
+                print_bytes(exceed_tracker->_consumption->peak_value()),
                 print_bytes(exceed_tracker->_consumption->current_value()));
     }
 

--- a/be/src/runtime/memory/thread_mem_tracker_mgr.h
+++ b/be/src/runtime/memory/thread_mem_tracker_mgr.h
@@ -39,13 +39,6 @@ public:
         if (_init) flush_untracked_mem<false, true>();
     }
 
-    // only for memory hook
-    static void consume_no_attach(int64_t size) {
-        if (ExecEnv::GetInstance()->initialized()) {
-            ExecEnv::GetInstance()->orphan_mem_tracker()->consume(size);
-        }
-    }
-
     void init();
 
     // After attach, the current thread Memory Hook starts to consume/release task mem_tracker


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

1. Add a special counter for memtracker, faster, but relaxed ordering and not accurate in real time
2. Track thread create and destroy memory, which was previously removed due to performance loss and added back

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

