### PR TITLE
[Enhancement](inverted-index) use read buffer when read index bytes in compound reader

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -923,6 +923,7 @@ CONF_mDouble(inverted_index_ram_buffer_size, "512");
 CONF_Int32(query_bkd_inverted_index_limit_percent, "5"); // 5%
 // dict path for chinese analyzer
 CONF_String(inverted_index_dict_path, "${DORIS_HOME}/dict");
+CONF_Int32(inverted_index_read_buffer_size, "4096");
 // tree depth for bkd index
 CONF_Int32(max_depth_in_bkd_tree, "32");
 // use num_broadcast_buffer blocks as buffer to do broadcast

--- a/be/src/olap/rowset/segment_v2/inverted_index_cache.cpp
+++ b/be/src/olap/rowset/segment_v2/inverted_index_cache.cpp
@@ -29,8 +29,9 @@ InvertedIndexSearcherCache* InvertedIndexSearcherCache::_s_instance = nullptr;
 IndexSearcherPtr InvertedIndexSearcherCache::build_index_searcher(const io::FileSystemSPtr& fs,
                                                                   const std::string& index_dir,
                                                                   const std::string& file_name) {
-    DorisCompoundReader* directory = new DorisCompoundReader(
-            DorisCompoundDirectory::getDirectory(fs, index_dir.c_str()), file_name.c_str());
+    DorisCompoundReader* directory =
+            new DorisCompoundReader(DorisCompoundDirectory::getDirectory(fs, index_dir.c_str()),
+                                    file_name.c_str(), config::inverted_index_read_buffer_size);
     auto closeDirectory = true;
     auto index_searcher =
             std::make_shared<lucene::search::IndexSearcher>(directory, closeDirectory);

--- a/be/src/olap/rowset/segment_v2/inverted_index_compound_reader.cpp
+++ b/be/src/olap/rowset/segment_v2/inverted_index_compound_reader.cpp
@@ -86,7 +86,8 @@ void CSIndexInput::readInternal(uint8_t* b, const int32_t len) {
         _CLTHROWA(CL_ERR_IO, "read past EOF");
     }
     base->seek(fileOffset + start);
-    base->readBytes(b, len, false);
+    bool read_from_buffer = true;
+    base->readBytes(b, len, read_from_buffer);
 }
 
 CSIndexInput::~CSIndexInput() = default;

--- a/be/src/olap/rowset/segment_v2/inverted_index_reader.cpp
+++ b/be/src/olap/rowset/segment_v2/inverted_index_reader.cpp
@@ -354,7 +354,8 @@ BkdIndexReader::BkdIndexReader(io::FileSystemSPtr fs, const std::string& path,
         return;
     }
     compoundReader = new DorisCompoundReader(
-            DorisCompoundDirectory::getDirectory(fs, index_dir.c_str()), index_file_name.c_str());
+            DorisCompoundDirectory::getDirectory(fs, index_dir.c_str()), index_file_name.c_str(),
+            config::inverted_index_read_buffer_size);
 }
 
 Status BkdIndexReader::new_iterator(const TabletIndex* index_meta, OlapReaderStatistics* stats,


### PR DESCRIPTION
# Proposed changes

Read IO would be a problem when reading inverted index from disk.
Using read buffer to reduce IO.

## Problem summary

Set use buffer flag to be true when reading internal bytes in compound reader for inverted index.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

