### PR TITLE
[fix](expr) avoid crashing caused by big depth of expression tree

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -930,6 +930,9 @@ CONF_Int32(num_broadcast_buffer, "32");
 // semi-structure configs
 CONF_Bool(enable_parse_multi_dimession_array, "true");
 
+// max depth of expression tree allowed.
+CONF_Int32(max_depth_of_expr_tree, "200");
+
 // Report a tablet as bad when io errors occurs more than this value.
 CONF_mInt64(max_tablet_io_errors, "-1");
 

--- a/be/src/vec/exprs/vexpr.cpp
+++ b/be/src/vec/exprs/vexpr.cpp
@@ -85,9 +85,17 @@ VExpr::VExpr(const TypeDescriptor& type, bool is_slotref, bool is_nullable)
 }
 
 Status VExpr::prepare(RuntimeState* state, const RowDescriptor& row_desc, VExprContext* context) {
+    ++context->_depth_num;
+    if (context->_depth_num > config::max_depth_of_expr_tree) {
+        return Status::InternalError(
+                "The depth of the expression tree is too big, make it less than {}",
+                config::max_depth_of_expr_tree);
+    }
+
     for (int i = 0; i < _children.size(); ++i) {
         RETURN_IF_ERROR(_children[i]->prepare(state, row_desc, context));
     }
+    --context->_depth_num;
     return Status::OK();
 }
 

--- a/be/src/vec/exprs/vexpr_context.h
+++ b/be/src/vec/exprs/vexpr_context.h
@@ -100,6 +100,9 @@ private:
 
     int _last_result_column_id;
 
+    /// The depth of expression-tree.
+    int _depth_num = 0;
+
     bool _stale;
 };
 } // namespace doris::vectorized


### PR DESCRIPTION
# Proposed changes

When the tree is too deep, too many recursive calls will cause stack overflow.

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

