### PR TITLE
[feature](nereids) adjust stats calculator for tpch sf 500

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/cost/CostModelV1.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/cost/CostModelV1.java
@@ -171,8 +171,8 @@ class CostModelV1 extends PlanVisitor<Cost, PlanContext> {
                 return CostV1.of(Double.MAX_VALUE, Double.MAX_VALUE, Double.MAX_VALUE);
             }
             return CostV1.of(
-                    childStatistics.getRowCount() * beNumber,
-                    childStatistics.getRowCount() * beNumber * instanceNumber,
+                    childStatistics.getRowCount(),
+                    childStatistics.getRowCount() / beNumber,
                     childStatistics.getRowCount() * beNumber * instanceNumber);
         }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Group.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Group.java
@@ -397,10 +397,6 @@ public class Group {
     @Override
     public String toString() {
         StringBuilder str = new StringBuilder("Group[" + groupId + "]\n");
-        str.append("logical expressions:\n");
-        for (GroupExpression logicalExpression : logicalExpressions) {
-            str.append("  ").append(logicalExpression).append("\n");
-        }
         str.append("physical expressions:\n");
         for (GroupExpression physicalExpression : physicalExpressions) {
             str.append("  ").append(physicalExpression).append("\n");

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/GroupExpression.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/GroupExpression.java
@@ -34,6 +34,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 
+import java.text.DecimalFormat;
 import java.util.BitSet;
 import java.util.List;
 import java.util.Map;
@@ -305,8 +306,10 @@ public class GroupExpression {
         } else {
             builder.append("#").append(ownerGroup.getGroupId().asInt());
         }
+        DecimalFormat decimalFormat = new DecimalFormat();
+        decimalFormat.setGroupingSize(3);
 
-        builder.append(" cost=").append((long) cost);
+        builder.append(" cost=").append(decimalFormat.format((long) cost));
 
         builder.append(" estRows=").append(estOutputRowCount);
         builder.append(" (plan=").append(plan.toString()).append(") children=[");

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Memo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Memo.java
@@ -707,9 +707,9 @@ public class Memo {
             builder.append(" lowest Plan(cost, properties, plan)");
             group.getAllProperties().forEach(
                     prop -> {
-                        Optional<Pair<Double, GroupExpression>> costAndGroupExpression = group.getLowestCostPlan(prop);
+                        Optional<Pair<Cost, GroupExpression>> costAndGroupExpression = group.getLowestCostPlan(prop);
                         if (costAndGroupExpression.isPresent()) {
-                            builder.append("\n    " + costAndGroupExpression.get().first + " " + prop)
+                            builder.append("\n    " + costAndGroupExpression.get().first.getValue() + " " + prop)
                                     .append("\n     ").append(costAndGroupExpression.get().second);
                         }
                     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/PhysicalProperties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/PhysicalProperties.java
@@ -135,5 +135,4 @@ public class PhysicalProperties {
         }
         return distributionSpec.toString() + " " + orderSpec.toString();
     }
-
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalProject.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalProject.java
@@ -116,7 +116,10 @@ public class LogicalProject<CHILD_TYPE extends Plan> extends LogicalUnary<CHILD_
 
     @Override
     public String toString() {
-        return Utils.toSqlString("LogicalProject",
+        String groupId = getGroupExpression().isPresent()
+                ? "#" + getGroupExpression().get().getOwnerGroup().getGroupId().asInt()
+                : "";
+        return Utils.toSqlString("LogicalProject" + groupId,
                 "distinct", isDistinct,
                 "projects", projects,
                 "excepts", excepts,

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalDistribute.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalDistribute.java
@@ -61,7 +61,10 @@ public class PhysicalDistribute<CHILD_TYPE extends Plan> extends PhysicalUnary<C
 
     @Override
     public String toString() {
-        return Utils.toSqlString("PhysicalDistribute",
+        String groupId = getGroupExpression().isPresent()
+                ? "#" + getGroupExpression().get().getOwnerGroup().getGroupId().asInt()
+                : "";
+        return Utils.toSqlString("PhysicalDistribute" + groupId,
                 "distributionSpec", distributionSpec,
                 "stats", statsDeriveResult
         );
@@ -102,7 +105,7 @@ public class PhysicalDistribute<CHILD_TYPE extends Plan> extends PhysicalUnary<C
     @Override
     public PhysicalDistribute<CHILD_TYPE> withPhysicalPropertiesAndStats(PhysicalProperties physicalProperties,
             StatsDeriveResult statsDeriveResult) {
-        return new PhysicalDistribute<>(distributionSpec, Optional.empty(),
+        return new PhysicalDistribute<>(distributionSpec, groupExpression,
                 getLogicalProperties(), physicalProperties, statsDeriveResult, child());
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalFilter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalFilter.java
@@ -120,7 +120,7 @@ public class PhysicalFilter<CHILD_TYPE extends Plan> extends PhysicalUnary<CHILD
     @Override
     public PhysicalFilter<CHILD_TYPE> withPhysicalPropertiesAndStats(PhysicalProperties physicalProperties,
             StatsDeriveResult statsDeriveResult) {
-        return new PhysicalFilter<>(conjuncts, Optional.empty(), getLogicalProperties(), physicalProperties,
+        return new PhysicalFilter<>(conjuncts, groupExpression, getLogicalProperties(), physicalProperties,
                 statsDeriveResult, child());
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalHashAggregate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalHashAggregate.java
@@ -183,6 +183,9 @@ public class PhysicalHashAggregate<CHILD_TYPE extends Plan> extends PhysicalUnar
     @Override
     public String toString() {
         return Utils.toSqlString("PhysicalHashAggregate",
+                "group", getGroupExpression().isPresent()
+                        ? getGroupExpression().get().getOwnerGroup().getGroupId()
+                        : "",
                 "aggPhase", aggregateParam.aggPhase,
                 "aggMode", aggregateParam.aggMode,
                 "maybeUseStreaming", maybeUsingStream,
@@ -249,7 +252,7 @@ public class PhysicalHashAggregate<CHILD_TYPE extends Plan> extends PhysicalUnar
     public PhysicalHashAggregate<CHILD_TYPE> withPhysicalPropertiesAndStats(PhysicalProperties physicalProperties,
             StatsDeriveResult statsDeriveResult) {
         return new PhysicalHashAggregate<>(groupByExpressions, outputExpressions, partitionExpressions,
-                aggregateParam, maybeUsingStream, Optional.empty(), getLogicalProperties(),
+                aggregateParam, maybeUsingStream, groupExpression, getLogicalProperties(),
                 requireProperties, physicalProperties, statsDeriveResult,
                 child());
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalHashJoin.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalHashJoin.java
@@ -105,7 +105,11 @@ public class PhysicalHashJoin<
 
     @Override
     public String toString() {
-        List<Object> args = Lists.newArrayList("type", joinType,
+        String groupId = getGroupExpression().isPresent()
+                ? "#" + getGroupExpression().get().getOwnerGroup().getGroupId().asInt()
+                : "";
+        List<Object> args = Lists.newArrayList(
+                "type", joinType,
                 "hashJoinCondition", hashJoinConjuncts,
                 "otherJoinCondition", otherJoinConjuncts,
                 "isMarkJoin", markJoinSlotReference.isPresent(),
@@ -115,7 +119,7 @@ public class PhysicalHashJoin<
             args.add("hint");
             args.add(hint);
         }
-        return Utils.toSqlString("PhysicalHashJoin", args.toArray());
+        return Utils.toSqlString("PhysicalHashJoin" + groupId, args.toArray());
     }
 
     @Override
@@ -143,6 +147,6 @@ public class PhysicalHashJoin<
     public PhysicalHashJoin<LEFT_CHILD_TYPE, RIGHT_CHILD_TYPE> withPhysicalPropertiesAndStats(
             PhysicalProperties physicalProperties, StatsDeriveResult statsDeriveResult) {
         return new PhysicalHashJoin<>(joinType, hashJoinConjuncts, otherJoinConjuncts, hint, markJoinSlotReference,
-                Optional.empty(), getLogicalProperties(), physicalProperties, statsDeriveResult, left(), right());
+                groupExpression, getLogicalProperties(), physicalProperties, statsDeriveResult, left(), right());
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalNestedLoopJoin.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalNestedLoopJoin.java
@@ -151,7 +151,7 @@ public class PhysicalNestedLoopJoin<
     public PhysicalNestedLoopJoin<LEFT_CHILD_TYPE, RIGHT_CHILD_TYPE> withPhysicalPropertiesAndStats(
             PhysicalProperties physicalProperties, StatsDeriveResult statsDeriveResult) {
         return new PhysicalNestedLoopJoin<>(joinType,
-                hashJoinConjuncts, otherJoinConjuncts, markJoinSlotReference, Optional.empty(),
+                hashJoinConjuncts, otherJoinConjuncts, markJoinSlotReference, groupExpression,
                 getLogicalProperties(), physicalProperties, statsDeriveResult, left(), right());
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalOlapScan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalOlapScan.java
@@ -109,8 +109,14 @@ public class PhysicalOlapScan extends PhysicalRelation implements OlapScan {
 
     @Override
     public String toString() {
-        return Utils.toSqlString("PhysicalOlapScan",
+        String groupId = getGroupExpression().isPresent()
+                ? "#" + getGroupExpression().get().getOwnerGroup().getGroupId().asInt()
+                : "";
+        return Utils.toSqlString("PhysicalOlapScan" + groupId,
                 "qualified", Utils.qualifiedName(qualifier, olapTable.getName()),
+                "group", getGroupExpression().isPresent()
+                        ? getGroupExpression().get().getOwnerGroup().getGroupId()
+                        : "",
                 "stats", statsDeriveResult
         );
     }
@@ -157,7 +163,7 @@ public class PhysicalOlapScan extends PhysicalRelation implements OlapScan {
     public PhysicalOlapScan withPhysicalPropertiesAndStats(
             PhysicalProperties physicalProperties, StatsDeriveResult statsDeriveResult) {
         return new PhysicalOlapScan(id, olapTable, qualifier, selectedIndexId, selectedTabletIds,
-                selectedPartitionIds, distributionSpec, preAggStatus, Optional.empty(),
+                selectedPartitionIds, distributionSpec, preAggStatus, groupExpression,
                 getLogicalProperties(), physicalProperties, statsDeriveResult);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalOneRowRelation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalOneRowRelation.java
@@ -116,7 +116,7 @@ public class PhysicalOneRowRelation extends PhysicalLeaf implements OneRowRelati
     @Override
     public PhysicalOneRowRelation withPhysicalPropertiesAndStats(PhysicalProperties physicalProperties,
             StatsDeriveResult statsDeriveResult) {
-        return new PhysicalOneRowRelation(projects, buildUnionNode, Optional.empty(),
+        return new PhysicalOneRowRelation(projects, buildUnionNode, groupExpression,
                 logicalPropertiesSupplier.get(), physicalProperties, statsDeriveResult);
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalProject.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalProject.java
@@ -68,6 +68,9 @@ public class PhysicalProject<CHILD_TYPE extends Plan> extends PhysicalUnary<CHIL
     @Override
     public String toString() {
         return Utils.toSqlString("PhysicalProject",
+                "group", getGroupExpression().isPresent()
+                        ? getGroupExpression().get().getOwnerGroup().getGroupId()
+                        : "",
                 "projects", projects,
                 "stats", statsDeriveResult
         );
@@ -119,7 +122,7 @@ public class PhysicalProject<CHILD_TYPE extends Plan> extends PhysicalUnary<CHIL
     @Override
     public PhysicalProject<CHILD_TYPE> withPhysicalPropertiesAndStats(PhysicalProperties physicalProperties,
             StatsDeriveResult statsDeriveResult) {
-        return new PhysicalProject<>(projects, Optional.empty(), getLogicalProperties(), physicalProperties,
+        return new PhysicalProject<>(projects, groupExpression, getLogicalProperties(), physicalProperties,
                 statsDeriveResult, child());
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalQuickSort.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalQuickSort.java
@@ -91,7 +91,7 @@ public class PhysicalQuickSort<CHILD_TYPE extends Plan> extends AbstractPhysical
     @Override
     public PhysicalQuickSort<CHILD_TYPE> withPhysicalPropertiesAndStats(PhysicalProperties physicalProperties,
             StatsDeriveResult statsDeriveResult) {
-        return new PhysicalQuickSort<>(orderKeys, phase, Optional.empty(), getLogicalProperties(), physicalProperties,
+        return new PhysicalQuickSort<>(orderKeys, phase, groupExpression, getLogicalProperties(), physicalProperties,
                 statsDeriveResult, child());
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalRepeat.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalRepeat.java
@@ -160,7 +160,7 @@ public class PhysicalRepeat<CHILD_TYPE extends Plan> extends PhysicalUnary<CHILD
     @Override
     public PhysicalRepeat<CHILD_TYPE> withPhysicalPropertiesAndStats(PhysicalProperties physicalProperties,
             StatsDeriveResult statsDeriveResult) {
-        return new PhysicalRepeat<>(groupingSets, outputExpressions, Optional.empty(),
+        return new PhysicalRepeat<>(groupingSets, outputExpressions, groupExpression,
                 getLogicalProperties(), physicalProperties, statsDeriveResult, child());
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalTopN.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalTopN.java
@@ -125,7 +125,7 @@ public class PhysicalTopN<CHILD_TYPE extends Plan> extends AbstractPhysicalSort<
     @Override
     public PhysicalTopN<CHILD_TYPE> withPhysicalPropertiesAndStats(PhysicalProperties physicalProperties,
             StatsDeriveResult statsDeriveResult) {
-        return new PhysicalTopN<>(orderKeys, limit, offset, phase, Optional.empty(),
+        return new PhysicalTopN<>(orderKeys, limit, offset, phase, groupExpression,
                 getLogicalProperties(), physicalProperties, statsDeriveResult, child());
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalUnion.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalUnion.java
@@ -86,7 +86,7 @@ public class PhysicalUnion extends PhysicalSetOperation {
     @Override
     public PhysicalUnion withPhysicalPropertiesAndStats(
             PhysicalProperties physicalProperties, StatsDeriveResult statsDeriveResult) {
-        return new PhysicalUnion(qualifier, Optional.empty(),
+        return new PhysicalUnion(qualifier, groupExpression,
                 getLogicalProperties(), physicalProperties, statsDeriveResult, children);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalWindow.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalWindow.java
@@ -146,7 +146,7 @@ public class PhysicalWindow<CHILD_TYPE extends Plan> extends PhysicalUnary<CHILD
     @Override
     public PhysicalPlan withPhysicalPropertiesAndStats(PhysicalProperties physicalProperties,
                                                        StatsDeriveResult statsDeriveResult) {
-        return new PhysicalWindow<>(windowFrameGroup, requireProperties, Optional.empty(),
+        return new PhysicalWindow<>(windowFrameGroup, requireProperties, groupExpression,
                 getLogicalProperties(), physicalProperties, statsDeriveResult, child());
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -281,6 +281,8 @@ public class SessionVariable implements Serializable, Writable {
 
     public static final String SHOW_USER_DEFAULT_ROLE = "show_user_default_role";
 
+    public static final String DUMP_NEREIDS_MEMO = "dump_nereids_memo";
+
     // fix replica to query. If num = 1, query the smallest replica, if 2 is the second smallest replica.
     public static final String USE_FIX_REPLICA = "use_fix_replica";
 
@@ -754,6 +756,9 @@ public class SessionVariable implements Serializable, Writable {
     // Default value is -1, which means not fix replica
     @VariableMgr.VarAttr(name = USE_FIX_REPLICA)
     public int useFixReplica = -1;
+
+    @VariableMgr.VarAttr(name = DUMP_NEREIDS_MEMO)
+    public boolean dumpNereidsMemo = false;
 
     // If set to true, all query will be executed without returning result
     @VariableMgr.VarAttr(name = DRY_RUN_QUERY, needForward = true)
@@ -1839,5 +1844,13 @@ public class SessionVariable implements Serializable, Writable {
             }
         }
         return "";
+    }
+
+    public boolean isDumpNereidsMemo() {
+        return dumpNereidsMemo;
+    }
+
+    public void setDumpNereidsMemo(boolean dumpNereidsMemo) {
+        this.dumpNereidsMemo = dumpNereidsMemo;
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/ColumnStatistic.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/ColumnStatistic.java
@@ -186,18 +186,13 @@ public class ColumnStatistic {
             return DEFAULT;
         }
         ColumnStatisticBuilder builder = new ColumnStatisticBuilder(this);
-        Double rowsAfterFilter = rowCount * selectivity;
         if (isAlmostUnique(ndv, rowCount)) {
             builder.setSelectivity(this.selectivity * selectivity);
             builder.setNdv(ndv * selectivity);
         } else {
-            if (ndv > rowsAfterFilter) {
-                builder.setSelectivity(this.selectivity * rowsAfterFilter / ndv);
-                builder.setNdv(rowsAfterFilter);
-            } else {
-                builder.setSelectivity(this.selectivity);
-                builder.setNdv(this.ndv);
-            }
+            double newNdv = ndv * (1 - Math.pow(1 - selectivity, rowCount / ndv));
+            builder.setSelectivity(this.selectivity * newNdv / ndv);
+            builder.setNdv(newNdv);
         }
         builder.setNumNulls((long) Math.ceil(numNulls * selectivity));
         return builder.build();

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/StatsDeriveResult.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/StatsDeriveResult.java
@@ -79,7 +79,7 @@ public class StatsDeriveResult {
     public double computeSize() {
         if (computeSize < 0) {
             computeSize = Math.max(1, slotIdToColumnStats.values().stream()
-                    .map(s -> s.dataSize).reduce(0D, Double::sum)
+                    .map(s -> s.avgSizeByte).reduce(0D, Double::sum)
             ) * rowCount;
         }
         return computeSize;

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/stats/FilterEstimationTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/stats/FilterEstimationTest.java
@@ -467,7 +467,7 @@ class FilterEstimationTest {
 
     //c>100
     // a is primary-key, a.ndv is reduced
-    // b is normal, b.ndv is not changed
+    // b is normal, b.ndv is smaller: newNdv = ndv * (1 - Math.pow(1 - selectivity, rowCount / ndv));
     // c.selectivity is still 1, but its range becomes half
     @Test
     public void test12() {
@@ -508,8 +508,8 @@ class FilterEstimationTest {
         Assertions.assertEquals(500, statsA.ndv);
         Assertions.assertEquals(0.5, statsA.selectivity);
         ColumnStatistic statsB = estimated.getColumnStatsBySlotId(b.getExprId());
-        Assertions.assertEquals(100, statsB.ndv);
-        Assertions.assertEquals(1.0, statsB.selectivity);
+        Assertions.assertTrue(100 > statsB.ndv);
+        Assertions.assertTrue(1.0 > statsB.selectivity);
         ColumnStatistic statsC = estimated.getColumnStatsBySlotId(c.getExprId());
         Assertions.assertEquals(50, statsC.ndv);
         Assertions.assertEquals(100, statsC.minValue);
@@ -521,7 +521,7 @@ class FilterEstimationTest {
      * test filter estimation, like 20>c>10, c in (0,40)
      * filter range has intersection with (c.min, c.max)
      *     a primary key, a.ndv reduced by 1/4, a.selectivity=0.25
-     *     b normal field, b.ndv not changed, b.selectivity=1.0
+     *     b normal field, b.ndv becomes less, b.selectivity < 1.0
      *     c.ndv = 10/40 * c.ndv, c.selectivity=1
      */
     @Test
@@ -571,10 +571,10 @@ class FilterEstimationTest {
         Assertions.assertEquals(100, statsA.maxValue);
 
         ColumnStatistic statsB = estimated.getColumnStatsBySlot(b);
-        Assertions.assertEquals(20, statsB.ndv);
+        Assertions.assertTrue(20 > statsB.ndv);
         Assertions.assertEquals(0, statsB.minValue);
         Assertions.assertEquals(500, statsB.maxValue);
-        Assertions.assertEquals(1.0, statsB.selectivity);
+        Assertions.assertTrue(1.0 > statsB.selectivity);
 
         ColumnStatistic statsC = estimated.getColumnStatsBySlot(c);
         Assertions.assertEquals(10, statsC.ndv);
@@ -651,7 +651,7 @@ class FilterEstimationTest {
      *
      * after
      * A: ndv 5, (0, 100),  selectivity=2/40,  primary-key
-     * B: ndv 5,  (0, 500),  selectivity=0.25,
+     * B: ndv < 5,  (0, 500),  selectivity<0.25,
      * C: ndv 2,  (10, 20),   selectivity=0.2,
      *
      * C.selectivity=0.2:
@@ -711,10 +711,10 @@ class FilterEstimationTest {
         Assertions.assertEquals(0, statsA.minValue);
         Assertions.assertEquals(100, statsA.maxValue);
         Assertions.assertEquals(0.05, statsA.selectivity);
-        Assertions.assertEquals(5, statsB.ndv);
+        Assertions.assertTrue(5 > statsB.ndv);
         Assertions.assertEquals(0, statsB.minValue);
         Assertions.assertEquals(500, statsB.maxValue);
-        Assertions.assertEquals(0.25, statsB.selectivity);
+        Assertions.assertTrue(0.25 > statsB.selectivity);
         Assertions.assertEquals(2, statsC.ndv);
         Assertions.assertEquals(10, statsC.minValue);
         Assertions.assertEquals(20, statsC.maxValue);
@@ -732,7 +732,7 @@ class FilterEstimationTest {
      *
      * after
      * A: ndv 5, (0, 100),  selectivity=2/40,  primary-key
-     * B: ndv 5,  (0, 500),  selectivity=0.25,
+     * B: ndv 5,  (0, 500),  selectivity<0.25,
      * C: ndv 2,  (10, 15),  selectivity=0.4,
      *
      * c.selectivity=0.4:
@@ -791,10 +791,10 @@ class FilterEstimationTest {
         Assertions.assertEquals(0, statsA.minValue);
         Assertions.assertEquals(100, statsA.maxValue);
         Assertions.assertEquals(0.05, statsA.selectivity);
-        Assertions.assertEquals(5, statsB.ndv);
+        Assertions.assertTrue(5 > statsB.ndv);
         Assertions.assertEquals(0, statsB.minValue);
         Assertions.assertEquals(500, statsB.maxValue);
-        Assertions.assertEquals(0.25, statsB.selectivity);
+        Assertions.assertTrue(0.25 > statsB.selectivity);
         Assertions.assertEquals(2, statsC.ndv);
         Assertions.assertEquals(10, statsC.minValue);
         Assertions.assertEquals(15, statsC.maxValue);
@@ -813,7 +813,7 @@ class FilterEstimationTest {
      * after
      * rows = 30
      * A: ndv 75, (0, 100),  selectivity= 30/40,  primary-key
-     * B: ndv 20,  (0, 500),  selectivity=1.0,
+     * B: ndv < 20,  (0, 500),  selectivity < 1.0,
      * C: ndv 30,  (10, 40),  selectivity=1.0,
      */
     @Test
@@ -866,10 +866,10 @@ class FilterEstimationTest {
         Assertions.assertEquals(0, statsA.minValue);
         Assertions.assertEquals(100, statsA.maxValue);
         Assertions.assertEquals(0.75, statsA.selectivity);
-        Assertions.assertEquals(20, statsB.ndv);
+        Assertions.assertTrue(20 > statsB.ndv);
         Assertions.assertEquals(0, statsB.minValue);
         Assertions.assertEquals(500, statsB.maxValue);
-        Assertions.assertEquals(1.0, statsB.selectivity);
+        Assertions.assertTrue(1.0 > statsB.selectivity);
         Assertions.assertEquals(30, statsC.ndv);
         Assertions.assertEquals(10, statsC.minValue);
         Assertions.assertEquals(40, statsC.maxValue);

--- a/regression-test/suites/nereids_syntax_p0/join.groovy
+++ b/regression-test/suites/nereids_syntax_p0/join.groovy
@@ -224,7 +224,7 @@ suite("join") {
     assertTrue(
         //if analyze finished
             explainStr.contains("4:VAGGREGATE (update serialize)") && explainStr.contains("6:VAGGREGATE (merge finalize)")
-                    && explainStr.contains("wtid[#8] = CAST(wtid[#3] AS CHARACTER)") && explainStr.contains("projections: wtid[#5], wfid[#6]")
+                    && explainStr.contains("wtid[#8] = wtid[#3]") && explainStr.contains("projections: wtid[#5], wfid[#6]")
                     ||
         //analyze not finished
                     explainStr.contains("7:VAGGREGATE (update finalize)") && explainStr.contains("5:VAGGREGATE (update finalize)")


### PR DESCRIPTION
# Proposed changes

1. AGG stats derive: `group by A, B` => result rowCount is Min(ndv_A, ndv_B)
2. set default selectivity ratio of LIKE to 0.5 (former is 0.2)
3. skip filter like "__DORIS_DELETE_SIGN__ =0" in stats derive,
4. update cost model for DistributedReplicated
5. use session variable dump_nereids_memo to turn on/off memo dump

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

