### PR TITLE
[Fix](Lightweight schema Change) query error caused by array default type is unsupported

### DIFF
--- a/be/src/olap/rowset/segment_v2/column_reader.cpp
+++ b/be/src/olap/rowset/segment_v2/column_reader.cpp
@@ -32,6 +32,7 @@
 #include "vec/columns/column_array.h"
 #include "vec/columns/column_map.h"
 #include "vec/columns/column_struct.h"
+#include "vec/core/field.h"
 #include "vec/core/types.h"
 #include "vec/runtime/vdatetime_value.h" //for VecDateTime
 
@@ -1209,7 +1210,9 @@ void DefaultValueColumnIterator::insert_default_data(const TypeInfo* type_info, 
         break;
     }
     case OLAP_FIELD_TYPE_ARRAY: {
-        dst->insert_many_defaults(n);
+        for (int i = 0; i < n; i++) {
+            dst->insert(doris::vectorized::Array(0));
+        }
         break;
     }
     default: {

--- a/be/src/olap/rowset/segment_v2/column_reader.cpp
+++ b/be/src/olap/rowset/segment_v2/column_reader.cpp
@@ -1139,9 +1139,6 @@ Status DefaultValueColumnIterator::init(const ColumnIteratorOptions& opts) {
 void DefaultValueColumnIterator::insert_default_data(const TypeInfo* type_info, size_t type_size,
                                                      void* mem_value,
                                                      vectorized::MutableColumnPtr& dst, size_t n) {
-    vectorized::Int128 int128;
-    char* data_ptr = (char*)&int128;
-    size_t data_len = sizeof(int128);
     dst = dst->convert_to_predicate_column_if_dictionary();
 
     switch (type_info->type()) {
@@ -1151,18 +1148,26 @@ void DefaultValueColumnIterator::insert_default_data(const TypeInfo* type_info, 
         break;
     }
     case OLAP_FIELD_TYPE_DATE: {
+        vectorized::Int64 int64;
+        char* data_ptr = (char*)&int64;
+        size_t data_len = sizeof(int64);
+
         assert(type_size == sizeof(FieldTypeTraits<OLAP_FIELD_TYPE_DATE>::CppType)); //uint24_t
         std::string str = FieldTypeTraits<OLAP_FIELD_TYPE_DATE>::to_string(mem_value);
 
         vectorized::VecDateTimeValue value;
         value.from_date_str(str.c_str(), str.length());
         value.cast_to_date();
-        //TODO: here is int128 = int64, here rely on the logic of little endian
-        int128 = binary_cast<vectorized::VecDateTimeValue, vectorized::Int64>(value);
+        
+        int64 = binary_cast<vectorized::VecDateTimeValue, vectorized::Int64>(value);
         dst->insert_many_data(data_ptr, data_len, n);
         break;
     }
     case OLAP_FIELD_TYPE_DATETIME: {
+        vectorized::Int64 int64;
+        char* data_ptr = (char*)&int64;
+        size_t data_len = sizeof(int64);
+
         assert(type_size == sizeof(FieldTypeTraits<OLAP_FIELD_TYPE_DATETIME>::CppType)); //int64_t
         std::string str = FieldTypeTraits<OLAP_FIELD_TYPE_DATETIME>::to_string(mem_value);
 
@@ -1170,11 +1175,15 @@ void DefaultValueColumnIterator::insert_default_data(const TypeInfo* type_info, 
         value.from_date_str(str.c_str(), str.length());
         value.to_datetime();
 
-        int128 = binary_cast<vectorized::VecDateTimeValue, vectorized::Int64>(value);
+        int64 = binary_cast<vectorized::VecDateTimeValue, vectorized::Int64>(value);
         dst->insert_many_data(data_ptr, data_len, n);
         break;
     }
     case OLAP_FIELD_TYPE_DECIMAL: {
+        vectorized::Int128 int128;
+        char* data_ptr = (char*)&int128;
+        size_t data_len = sizeof(int128);
+
         assert(type_size ==
                sizeof(FieldTypeTraits<OLAP_FIELD_TYPE_DECIMAL>::CppType)); //decimal12_t
         decimal12_t* d = (decimal12_t*)mem_value;
@@ -1186,14 +1195,14 @@ void DefaultValueColumnIterator::insert_default_data(const TypeInfo* type_info, 
     case OLAP_FIELD_TYPE_VARCHAR:
     case OLAP_FIELD_TYPE_CHAR:
     case OLAP_FIELD_TYPE_JSONB: {
-        data_ptr = ((Slice*)mem_value)->data;
-        data_len = ((Slice*)mem_value)->size;
+        char* data_ptr = ((Slice*)mem_value)->data;
+        size_t data_len = ((Slice*)mem_value)->size;
         dst->insert_many_data(data_ptr, data_len, n);
         break;
     }
     default: {
-        data_ptr = (char*)mem_value;
-        data_len = type_size;
+        char* data_ptr = (char*)mem_value;
+        size_t data_len = type_size;
         dst->insert_many_data(data_ptr, data_len, n);
     }
     }

--- a/be/src/olap/rowset/segment_v2/column_reader.cpp
+++ b/be/src/olap/rowset/segment_v2/column_reader.cpp
@@ -1166,7 +1166,7 @@ void DefaultValueColumnIterator::insert_default_data(const TypeInfo* type_info, 
         vectorized::VecDateTimeValue value;
         value.from_date_str(str.c_str(), str.length());
         value.cast_to_date();
-        
+
         int64 = binary_cast<vectorized::VecDateTimeValue, vectorized::Int64>(value);
         dst->insert_many_data(data_ptr, data_len, n);
         break;

--- a/be/src/olap/rowset/segment_v2/column_reader.cpp
+++ b/be/src/olap/rowset/segment_v2/column_reader.cpp
@@ -32,7 +32,6 @@
 #include "vec/columns/column_array.h"
 #include "vec/columns/column_map.h"
 #include "vec/columns/column_struct.h"
-#include "vec/core/field.h"
 #include "vec/core/types.h"
 #include "vec/runtime/vdatetime_value.h" //for VecDateTime
 
@@ -1210,8 +1209,10 @@ void DefaultValueColumnIterator::insert_default_data(const TypeInfo* type_info, 
         break;
     }
     case OLAP_FIELD_TYPE_ARRAY: {
-        for (int i = 0; i < n; i++) {
-            dst->insert(doris::vectorized::Array(0));
+        if (dst->is_nullable()) {
+            static_cast<vectorized::ColumnNullable&>(*dst).insert_not_null_elements(n);
+        } else {
+            dst->insert_many_defaults(n);
         }
         break;
     }

--- a/be/src/vec/columns/column_nullable.h
+++ b/be/src/vec/columns/column_nullable.h
@@ -153,6 +153,12 @@ public:
         _has_null = true;
     }
 
+    void insert_not_null_elements(size_t num) {
+        get_nested_column().insert_many_defaults(num);
+        _get_null_map_column().fill(0, num);
+        _has_null = false;
+    }
+
     void insert_null_elements(int num) {
         get_nested_column().insert_many_defaults(num);
         _get_null_map_column().fill(1, num);

--- a/regression-test/data/schema_change_p0/test_alter_table_column.out
+++ b/regression-test/data/schema_change_p0/test_alter_table_column.out
@@ -23,10 +23,11 @@ k1	INT	Yes	true	\N
 value1	INT	Yes	false	\N	NONE
 value2	ARRAY<INT(11)>	Yes	false	[]	NONE
 value3	ARRAY<INT(11)>	Yes	false	\N	NONE
+value4	ARRAY<INT(11)>	No	false	[]	NONE
 
 -- !sql --
-1	2	[]	\N
-3	4	[]	\N
+1	2	[]	\N	[]
+3	4	[]	\N	[]
 
 -- !select --
 \N	\N	\N

--- a/regression-test/data/schema_change_p0/test_alter_table_column.out
+++ b/regression-test/data/schema_change_p0/test_alter_table_column.out
@@ -18,6 +18,16 @@ value2	INT	Yes	false	\N	SUM
 -- !sql --
 1	1	40	60
 
+-- !sql --
+k1	INT	Yes	true	\N	
+value1	INT	Yes	false	\N	NONE
+value2	ARRAY<INT(11)>	Yes	false	[]	NONE
+value3	ARRAY<INT(11)>	Yes	false	\N	NONE
+
+-- !sql --
+1	2	[]	\N
+3	4	[]	\N
+
 -- !select --
 \N	\N	\N
 1	1989	1001

--- a/regression-test/suites/schema_change_p0/test_alter_table_column.groovy
+++ b/regression-test/suites/schema_change_p0/test_alter_table_column.groovy
@@ -133,7 +133,8 @@ suite("test_alter_table_column") {
     sql """
             ALTER TABLE ${tbNameAddArray} 
             ADD COLUMN value2 ARRAY<INT> DEFAULT '[]' AFTER value1,
-            ADD COLUMN value3 ARRAY<INT> AFTER value2
+            ADD COLUMN value3 ARRAY<INT> AFTER value2,
+            ADD COLUMN value4 ARRAY<INT> NOT NULL DEFAULT '[]' AFTER value3;
         """
     max_try_secs = 60
     while (max_try_secs--) {

--- a/regression-test/suites/schema_change_p0/test_alter_table_column.groovy
+++ b/regression-test/suites/schema_change_p0/test_alter_table_column.groovy
@@ -114,6 +114,46 @@ suite("test_alter_table_column") {
     qt_sql "select * from ${tbName2};"
     sql "DROP TABLE ${tbName2} FORCE;"
 
+    def tbNameAddArray = "alter_table_add_array_column_dup"
+    sql "DROP TABLE IF EXISTS ${tbNameAddArray}"
+    sql """
+            CREATE TABLE IF NOT EXISTS ${tbNameAddArray} (
+                k1 INT,
+                value1 INT
+            )
+            DUPLICATE KEY (k1)
+            DISTRIBUTED BY HASH(k1) BUCKETS 5 properties(
+                "replication_num" = "1", 
+                "light_schema_change" = "true",
+                "disable_auto_compaction" = "true");
+        """
+
+    sql "insert into ${tbNameAddArray} values(1,2)"
+    sql "insert into ${tbNameAddArray} values(3,4)"
+    sql """
+            ALTER TABLE ${tbNameAddArray} 
+            ADD COLUMN value2 ARRAY<INT> DEFAULT '[]' AFTER value1,
+            ADD COLUMN value3 ARRAY<INT> AFTER value2
+        """
+    max_try_secs = 60
+    while (max_try_secs--) {
+        String res = getJobState(tbNameAddArray)
+        if (res == "FINISHED") {
+            break
+        } else {
+            Thread.sleep(2000)
+            if (max_try_secs < 1) {
+                println "test timeout," + "state:" + res
+                assertEquals("FINISHED",res)
+            }
+        }
+    }
+    
+    Thread.sleep(200)
+    qt_sql "desc ${tbNameAddArray};"
+    qt_sql "select * from ${tbNameAddArray};"
+    sql "DROP TABLE ${tbNameAddArray} FORCE;"
+
     // vector search
     def check_load_result = {checklabel, testTablex ->
         Integer max_try_milli_secs = 10000
@@ -175,4 +215,5 @@ suite("test_alter_table_column") {
     def res4 = sql "select k1, k2, k3, null from baseall order by k1"
     check2_doris(res3, res4)
     sql "DROP TABLE ${tbName3} FORCE;"
+
 }


### PR DESCRIPTION
We have supportted array type default [], but when using lightweight schema Change to add column array type, query failed as follows:

<img width="1098" alt="image" src="https://user-images.githubusercontent.com/67053339/222371750-5c828975-7e2d-47cb-b8ee-dc53965fa92e.png">


1. Fix "array default type is unsupported" error.
2. Fix the default value filling assignment digit problem.


# Proposed changes

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

