### PR TITLE
[fix](merge-on-write) fix that delete bitmap is not calculated correctly when clone tablet

### DIFF
--- a/be/src/olap/snapshot_manager.cpp
+++ b/be/src/olap/snapshot_manager.cpp
@@ -422,13 +422,6 @@ Status SnapshotManager::_create_snapshot_files(const TabletSharedPtr& ref_tablet
                         break;
                     }
                 }
-
-                // Take a full snapshot, will revise according to missed rowset later.
-                if (ref_tablet->keys_type() == UNIQUE_KEYS &&
-                    ref_tablet->enable_unique_key_merge_on_write()) {
-                    delete_bitmap_snapshot = ref_tablet->tablet_meta()->delete_bitmap().snapshot(
-                            ref_tablet->max_version().second);
-                }
             }
 
             int64_t version = -1;

--- a/be/src/olap/tablet.h
+++ b/be/src/olap/tablet.h
@@ -83,7 +83,8 @@ public:
     void save_meta();
     // Used in clone task, to update local meta when finishing a clone job
     Status revise_tablet_meta(const std::vector<RowsetSharedPtr>& to_add,
-                              const std::vector<RowsetSharedPtr>& to_delete);
+                              const std::vector<RowsetSharedPtr>& to_delete,
+                              bool is_incremental_clone);
 
     int64_t cumulative_layer_point() const;
     void set_cumulative_layer_point(int64_t new_point);

--- a/be/src/olap/tablet_meta.h
+++ b/be/src/olap/tablet_meta.h
@@ -362,6 +362,14 @@ public:
                 DeleteBitmap* subset_delete_map) const;
 
     /**
+     * Merges the given segment delete bitmap into *this
+     *
+     * @param bmk
+     * @param segment_delete_bitmap
+     */
+    void merge(const BitmapKey& bmk, const roaring::Roaring& segment_delete_bitmap);
+
+    /**
      * Merges the given delete bitmap into *this
      *
      * @param other

--- a/be/src/olap/task/engine_clone_task.cpp
+++ b/be/src/olap/task/engine_clone_task.cpp
@@ -579,7 +579,7 @@ Status EngineCloneTask::_finish_incremental_clone(Tablet* tablet,
     /// clone_data to tablet
     /// For incremental clone, nothing will be deleted.
     /// So versions_to_delete is empty.
-    return tablet->revise_tablet_meta(rowsets_to_clone, {});
+    return tablet->revise_tablet_meta(rowsets_to_clone, {}, true);
 }
 
 /// This method will do:
@@ -632,7 +632,10 @@ Status EngineCloneTask::_finish_full_clone(Tablet* tablet,
         to_add.push_back(std::move(rs));
     }
     tablet->tablet_meta()->set_cooldown_meta_id(cloned_tablet_meta->cooldown_meta_id());
-    return tablet->revise_tablet_meta(to_add, to_delete);
+    if (tablet->enable_unique_key_merge_on_write()) {
+        tablet->tablet_meta()->delete_bitmap() = cloned_tablet_meta->delete_bitmap();
+    }
+    return tablet->revise_tablet_meta(to_add, to_delete, false);
     // TODO(plat1ko): write cooldown meta to remote if this replica is cooldown replica
 }
 


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

1. Because of specified_rowset_ids is nullptr, the delete bitmap is not be recalculated when clone, introduced by #14995.  
2. Optimize delete bitmap calculation of full clone, by clone the delete bitmap of remote tablet.
3. Change the set operation of delete bitmap into a merge operation.
4. Delete some useless code.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

