### PR TITLE
[fix](ParquetReader) definition level of repeated parent is wrong

### DIFF
--- a/be/src/vec/exec/format/parquet/schema_desc.cpp
+++ b/be/src/vec/exec/format/parquet/schema_desc.cpp
@@ -58,7 +58,11 @@ static void set_child_node_level(FieldSchema* parent, size_t rep_inc = 0, size_t
     for (auto& child : parent->children) {
         child.repetition_level = parent->repetition_level + rep_inc;
         child.definition_level = parent->definition_level + def_inc;
-        child.repeated_parent_def_level = parent->definition_level;
+        if (is_repeated_node(parent->parquet_schema)) {
+            child.repeated_parent_def_level = parent->definition_level;
+        } else {
+            child.repeated_parent_def_level = parent->repeated_parent_def_level;
+        }
     }
 }
 

--- a/be/src/vec/exec/format/parquet/vparquet_column_reader.cpp
+++ b/be/src/vec/exec/format/parquet/vparquet_column_reader.cpp
@@ -40,7 +40,7 @@ static void fill_struct_null_map(FieldSchema* field, NullMap& null_map,
     DCHECK_EQ(num_levels, rep_levels.size());
     size_t origin_size = null_map.size();
     null_map.resize(origin_size + num_levels);
-    size_t pos = 0;
+    size_t pos = origin_size;
     for (size_t i = 0; i < num_levels; ++i) {
         // skip the levels affect its ancestor or its descendants
         if (def_levels[i] < field->repeated_parent_def_level ||
@@ -53,7 +53,7 @@ static void fill_struct_null_map(FieldSchema* field, NullMap& null_map,
             null_map[pos++] = 1;
         }
     }
-    null_map.resize(origin_size + pos);
+    null_map.resize(pos + 1);
 }
 
 static void fill_array_offset(FieldSchema* field, ColumnArray::Offsets64& offsets_data,
@@ -88,9 +88,9 @@ static void fill_array_offset(FieldSchema* field, ColumnArray::Offsets64& offset
             (*null_map_ptr)[offset_pos] = 1;
         }
     }
-    offsets_data.resize(origin_size + offset_pos + 1);
+    offsets_data.resize(offset_pos + 1);
     if (null_map_ptr != nullptr) {
-        null_map_ptr->resize(origin_size + offset_pos + 1);
+        null_map_ptr->resize(offset_pos + 1);
     }
 }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/HiveMetaStoreClientHelper.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/HiveMetaStoreClientHelper.java
@@ -676,13 +676,18 @@ public class HiveMetaStoreClientHelper {
      */
     private static int findNextNestedField(String commaSplitFields) {
         int numLess = 0;
+        int numBracket = 0;
         for (int i = 0; i < commaSplitFields.length(); i++) {
             char c = commaSplitFields.charAt(i);
             if (c == '<') {
                 numLess++;
             } else if (c == '>') {
                 numLess--;
-            } else if (c == ',' && numLess == 0) {
+            } else if (c == '(') {
+                numBracket++;
+            } else if (c == ')') {
+                numBracket--;
+            } else if (c == ',' && numLess == 0 && numBracket == 0) {
                 return i;
             }
         }


### PR DESCRIPTION
# Proposed changes

Fix three bugs:
1.  `repeated_parent_def_level ` should be the definition of its repeated parent.
2. Failed to parse schema like `decimal(p, s)`
3. Fill wrong offsets for array type

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

