### PR TITLE
[fix](expr) avoid crashing caused by big depth of expression tree

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -745,6 +745,9 @@ CONF_mInt32(max_fragment_start_wait_time_seconds, "30");
 
 // limit the queue of pending batches which will be sent by a single nodechannel
 CONF_mInt64(nodechannel_pending_queue_max_bytes, "67108864");
+
+// max depth of expression tree allowed.
+CONF_Int32(max_depth_of_expr_tree, "200");
 } // namespace config
 
 } // namespace doris

--- a/be/src/vec/exprs/vexpr_context.h
+++ b/be/src/vec/exprs/vexpr_context.h
@@ -92,5 +92,8 @@ private:
     std::unique_ptr<MemPool> _pool;
 
     int _last_result_column_id;
+
+    /// The depth of expression-tree.
+    int _depth_num = 0;
 };
 } // namespace doris::vectorized


### PR DESCRIPTION
# Proposed changes

pick from #17314 into branch-1.1-lts

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

