### PR TITLE
[fix](planner) only table name should convert to lowercase when create table

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/TableName.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/TableName.java
@@ -31,6 +31,7 @@ import org.apache.doris.common.io.Writable;
 import org.apache.doris.datasource.InternalCatalog;
 import org.apache.doris.persist.gson.GsonUtils;
 
+import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.gson.annotations.SerializedName;
 
@@ -51,6 +52,21 @@ public class TableName implements Writable {
 
     public TableName() {
 
+    }
+
+    public TableName(String alias) {
+        String[] parts = alias.split("\\.");
+        Preconditions.checkArgument(parts.length > 0, "table name can't be empty");
+        tbl = parts[parts.length - 1];
+        if (Env.isStoredTableNamesLowerCase() && !Strings.isNullOrEmpty(tbl)) {
+            tbl = tbl.toLowerCase();
+        }
+        if (parts.length >= 2) {
+            db = parts[parts.length - 2];
+        }
+        if (parts.length >= 3) {
+            ctl = parts[parts.length - 3];
+        }
     }
 
     public TableName(String ctl, String db, String tbl) {

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/TupleDescriptor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/TupleDescriptor.java
@@ -199,7 +199,7 @@ public class TupleDescriptor {
     }
 
     public TableName getAliasAsName() {
-        return (aliases != null) ? new TableName(null, null, aliases[0]) : null;
+        return (aliases != null) ? new TableName(aliases[0]) : null;
     }
 
     public TTupleDescriptor toThrift() {

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/SelectStmtTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/SelectStmtTest.java
@@ -511,20 +511,20 @@ public class SelectStmtTest {
         String sql1 = "SELECT * FROM db1.table1  LEFT ANTI JOIN db1.table2 ON db1.table1.siteid = db1.table2.siteid;";
         String explain = dorisAssert.query(sql1).explainQuery();
         Assert.assertTrue(explain
-                .contains("PREDICATES: `default_cluster:db1.table1`.`__DORIS_DELETE_SIGN__` = 0"));
+                .contains("PREDICATES: `default_cluster:db1`.`table1`.`__DORIS_DELETE_SIGN__` = 0"));
         Assert.assertTrue(explain
-                .contains("PREDICATES: `default_cluster:db1.table2`.`__DORIS_DELETE_SIGN__` = 0"));
+                .contains("PREDICATES: `default_cluster:db1`.`table2`.`__DORIS_DELETE_SIGN__` = 0"));
         Assert.assertFalse(explain.contains("other predicates:"));
         String sql2 = "SELECT * FROM db1.table1 JOIN db1.table2 ON db1.table1.siteid = db1.table2.siteid;";
         explain = dorisAssert.query(sql2).explainQuery();
         Assert.assertTrue(explain
-                .contains("PREDICATES: `default_cluster:db1.table1`.`__DORIS_DELETE_SIGN__` = 0"));
+                .contains("PREDICATES: `default_cluster:db1`.`table1`.`__DORIS_DELETE_SIGN__` = 0"));
         Assert.assertTrue(explain
-                .contains("PREDICATES: `default_cluster:db1.table2`.`__DORIS_DELETE_SIGN__` = 0"));
+                .contains("PREDICATES: `default_cluster:db1`.`table2`.`__DORIS_DELETE_SIGN__` = 0"));
         Assert.assertFalse(explain.contains("other predicates:"));
         String sql3 = "SELECT * FROM db1.table1";
         Assert.assertTrue(dorisAssert.query(sql3).explainQuery()
-                .contains("PREDICATES: `default_cluster:db1.table1`.`__DORIS_DELETE_SIGN__` = 0"));
+                .contains("PREDICATES: `default_cluster:db1`.`table1`.`__DORIS_DELETE_SIGN__` = 0"));
         String sql4 = " SELECT * FROM db1.table1 table2";
         Assert.assertTrue(dorisAssert.query(sql4).explainQuery()
                 .contains("PREDICATES: `table2`.`__DORIS_DELETE_SIGN__` = 0"));

--- a/fe/fe-core/src/test/java/org/apache/doris/planner/OlapScanNodeTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/planner/OlapScanNodeTest.java
@@ -27,6 +27,7 @@ import org.apache.doris.catalog.PartitionKey;
 import org.apache.doris.catalog.PrimitiveType;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.datasource.InternalCatalog;
+import org.apache.doris.qe.GlobalVariable;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -161,5 +162,12 @@ public class OlapScanNodeTest {
             long mod = (int) ((hashValue & 0xffffffff) % 3);
             Assert.assertEquals(mod, 2);
         } // CHECKSTYLE IGNORE THIS LINE
+    }
+
+    @Test
+    public void testTableNameWithAlias() {
+        GlobalVariable.lowerCaseTableNames = 1;
+        SlotRef slot = new SlotRef(new TableName("DB.TBL"), Column.DELETE_SIGN);
+        Assert.assertTrue(slot.getTableName().toString().equals("DB.tbl"));
     }
 }


### PR DESCRIPTION
# Proposed changes

When we use `alias` as the tableName to construct a Table, all parts of the name will be lowercase if `lowerCaseTableNames = 1`. 

To avoid it, we should extract tableName from alias and only lower tableName

error:Unknown column '{}DORIS_DELETE_SIGN{}' in 'default_cluster:db.table

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [x] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

