### PR TITLE
[Bug](regression-test) remove some exception title on regression case

### DIFF
--- a/regression-test/suites/nereids_p0/sql_functions/string_functions/test_split_part.groovy
+++ b/regression-test/suites/nereids_p0/sql_functions/string_functions/test_split_part.groovy
@@ -28,7 +28,7 @@ suite("test_split_part") {
       where
           split_part("bCKHDX07at", "5.7.37", cast(name as int)) is not null;
     """
-    exception "[RUNTIME_ERROR]Argument at index 3 for function split_part must be constant"
+    exception "Argument at index 3 for function split_part must be constant"
   }
 
   qt_1 "select split_part(k8, '1', 1), k8, split_part(concat(k8, '12'), '1', 1) from test_query_db.test order by k8 limit 2;"

--- a/regression-test/suites/query_p0/sql_functions/cast_function/test_cast_function.groovy
+++ b/regression-test/suites/query_p0/sql_functions/cast_function/test_cast_function.groovy
@@ -37,7 +37,7 @@ suite("test_cast_function") {
                 end as bitmap
             ) is NULL
         """
-        exception "[INVALID_ARGUMENT]Conversion from UInt8 to BitMap is not supported"
+        exception "Conversion from UInt8 to BitMap is not supported"
     }
 }
 

--- a/regression-test/suites/query_p0/sql_functions/string_functions/test_split_part.groovy
+++ b/regression-test/suites/query_p0/sql_functions/string_functions/test_split_part.groovy
@@ -25,7 +25,7 @@ suite("test_split_part") {
       where
           split_part("bCKHDX07at", "5.7.37", cast(name as int)) is not null;
     """
-    exception "[RUNTIME_ERROR]Argument at index 3 for function split_part must be constant"
+    exception "Argument at index 3 for function split_part must be constant"
   }
 
   qt_1 "select split_part(k8, '1', 1), k8, split_part(concat(k8, '12'), '1', 1) from test_query_db.test order by k8 limit 2;"


### PR DESCRIPTION
# Proposed changes

Caused by: java.lang.AssertionError: Expect exception msg contains '[INVALID_ARGUMENT]Conversion from UInt8 to BitMap is not supported', but meet 'java.sql.SQLException: errCode = 2, detailMessage = [CANCELLED][INVALID_ARGUMENT][172.16.0.22]Conversion from UInt8 to BitMap is not supported'

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

