### PR TITLE
[Optimize](Random distribution) Improve the performance of tablet sin…

### DIFF
--- a/be/src/olap/delta_writer.h
+++ b/be/src/olap/delta_writer.h
@@ -60,8 +60,8 @@ public:
 
     Status init();
 
-    template <bool is_append>
-    Status write(const vectorized::Block* block, const std::vector<int>& row_idxs);
+    Status write(const vectorized::Block* block, const std::vector<int>& row_idxs,
+                 bool is_append = false);
 
     Status append(const vectorized::Block* block);
 

--- a/be/src/olap/delta_writer.h
+++ b/be/src/olap/delta_writer.h
@@ -60,7 +60,10 @@ public:
 
     Status init();
 
+    template <bool is_append>
     Status write(const vectorized::Block* block, const std::vector<int>& row_idxs);
+
+    Status append(const vectorized::Block* block);
 
     // flush the last memtable to flush queue, must call it before close_wait()
     Status close();

--- a/be/src/olap/memtable.cpp
+++ b/be/src/olap/memtable.cpp
@@ -147,13 +147,8 @@ int MemTable::RowInBlockComparator::operator()(const RowInBlock* left,
                                *_pblock, -1);
 }
 
-template void MemTable::insert<true>(const vectorized::Block* block,
-                                     const std::vector<int>& row_idxs);
-template void MemTable::insert<false>(const vectorized::Block* block,
-                                      const std::vector<int>& row_idxs);
-
-template <bool is_append>
-void MemTable::insert(const vectorized::Block* input_block, const std::vector<int>& row_idxs) {
+void MemTable::insert(const vectorized::Block* input_block, const std::vector<int>& row_idxs,
+                      bool is_append) {
     SCOPED_CONSUME_MEM_TRACKER(_insert_mem_tracker_use_hook.get());
     vectorized::Block target_block = *input_block;
     if (!_tablet_schema->is_dynamic_schema()) {
@@ -182,7 +177,7 @@ void MemTable::insert(const vectorized::Block* input_block, const std::vector<in
 
     auto num_rows = row_idxs.size();
     size_t cursor_in_mutableblock = _input_mutable_block.rows();
-    if constexpr (is_append) {
+    if (is_append) {
         // Append the block, call insert range from
         _input_mutable_block.add_rows(&target_block, 0, target_block.rows());
         num_rows = target_block.rows();

--- a/be/src/olap/memtable.cpp
+++ b/be/src/olap/memtable.cpp
@@ -147,6 +147,12 @@ int MemTable::RowInBlockComparator::operator()(const RowInBlock* left,
                                *_pblock, -1);
 }
 
+template void MemTable::insert<true>(const vectorized::Block* block,
+                                     const std::vector<int>& row_idxs);
+template void MemTable::insert<false>(const vectorized::Block* block,
+                                      const std::vector<int>& row_idxs);
+
+template <bool is_append>
 void MemTable::insert(const vectorized::Block* input_block, const std::vector<int>& row_idxs) {
     SCOPED_CONSUME_MEM_TRACKER(_insert_mem_tracker_use_hook.get());
     vectorized::Block target_block = *input_block;
@@ -176,7 +182,13 @@ void MemTable::insert(const vectorized::Block* input_block, const std::vector<in
 
     auto num_rows = row_idxs.size();
     size_t cursor_in_mutableblock = _input_mutable_block.rows();
-    _input_mutable_block.add_rows(&target_block, row_idxs.data(), row_idxs.data() + num_rows);
+    if constexpr (is_append) {
+        // Append the block, call insert range from
+        _input_mutable_block.add_rows(&target_block, 0, target_block.rows());
+        num_rows = target_block.rows();
+    } else {
+        _input_mutable_block.add_rows(&target_block, row_idxs.data(), row_idxs.data() + num_rows);
+    }
     size_t input_size = target_block.allocated_bytes() * num_rows / target_block.rows();
     _mem_usage += input_size;
     _insert_mem_tracker->consume(input_size);

--- a/be/src/olap/memtable.h
+++ b/be/src/olap/memtable.h
@@ -51,6 +51,7 @@ public:
         return _insert_mem_tracker->consumption() + _flush_mem_tracker->consumption();
     }
     // insert tuple from (row_pos) to (row_pos+num_rows)
+    template <bool is_append>
     void insert(const vectorized::Block* block, const std::vector<int>& row_idxs);
 
     void shrink_memtable_by_agg();

--- a/be/src/olap/memtable.h
+++ b/be/src/olap/memtable.h
@@ -51,8 +51,8 @@ public:
         return _insert_mem_tracker->consumption() + _flush_mem_tracker->consumption();
     }
     // insert tuple from (row_pos) to (row_pos+num_rows)
-    template <bool is_append>
-    void insert(const vectorized::Block* block, const std::vector<int>& row_idxs);
+    void insert(const vectorized::Block* block, const std::vector<int>& row_idxs,
+                bool is_append = false);
 
     void shrink_memtable_by_agg();
 

--- a/be/src/runtime/tablets_channel.cpp
+++ b/be/src/runtime/tablets_channel.cpp
@@ -311,6 +311,9 @@ Status TabletsChannel::add_batch(const TabletWriterAddRequest& request,
 
     std::unordered_map<int64_t /* tablet_id */, std::vector<int> /* row index */> tablet_to_rowidxs;
     for (int i = 0; i < request.tablet_ids_size(); ++i) {
+        if (request.is_single_tablet_block()) {
+            break;
+        }
         int64_t tablet_id = request.tablet_ids(i);
         if (_is_broken_tablet(tablet_id)) {
             // skip broken tablets
@@ -328,28 +331,41 @@ Status TabletsChannel::add_batch(const TabletWriterAddRequest& request,
     auto get_send_data = [&]() { return vectorized::Block(request.block()); };
 
     auto send_data = get_send_data();
-    google::protobuf::RepeatedPtrField<PTabletError>* tablet_errors =
-            response->mutable_tablet_errors();
-    for (const auto& tablet_to_rowidxs_it : tablet_to_rowidxs) {
-        auto tablet_writer_it = _tablet_writers.find(tablet_to_rowidxs_it.first);
-        if (tablet_writer_it == _tablet_writers.end()) {
-            return Status::InternalError("unknown tablet to append data, tablet={}",
-                                         tablet_to_rowidxs_it.first);
-        }
 
-        Status st = tablet_writer_it->second->write(&send_data, tablet_to_rowidxs_it.second);
+    auto write_tablet_data = [&](uint32_t tablet_id,
+                                 std::function<Status(DeltaWriter * writer)> write_func) {
+        google::protobuf::RepeatedPtrField<PTabletError>* tablet_errors =
+                response->mutable_tablet_errors();
+        auto tablet_writer_it = _tablet_writers.find(tablet_id);
+        if (tablet_writer_it == _tablet_writers.end()) {
+            return Status::InternalError("unknown tablet to append data, tablet={}", tablet_id);
+        }
+        Status st = write_func(tablet_writer_it->second);
         if (!st.ok()) {
             auto err_msg =
                     fmt::format("tablet writer write failed, tablet_id={}, txn_id={}, err={}",
-                                tablet_to_rowidxs_it.first, _txn_id, st.to_string());
+                                tablet_id, _txn_id, st.to_string());
             LOG(WARNING) << err_msg;
             PTabletError* error = tablet_errors->Add();
-            error->set_tablet_id(tablet_to_rowidxs_it.first);
+            error->set_tablet_id(tablet_id);
             error->set_msg(err_msg);
             tablet_writer_it->second->cancel_with_status(st);
-            _add_broken_tablet(tablet_to_rowidxs_it.first);
+            _add_broken_tablet(tablet_id);
             // continue write to other tablet.
             // the error will return back to sender.
+        }
+        return Status::OK();
+    };
+
+    if (request.is_single_tablet_block()) {
+        RETURN_IF_ERROR(write_tablet_data(request.tablet_ids(0), [&](DeltaWriter* writer) {
+            return writer->append(&send_data);
+        }));
+    } else {
+        for (const auto& tablet_to_rowidxs_it : tablet_to_rowidxs) {
+            RETURN_IF_ERROR(write_tablet_data(tablet_to_rowidxs_it.first, [&](DeltaWriter* writer) {
+                return writer->write<false>(&send_data, tablet_to_rowidxs_it.second);
+            }));
         }
     }
 

--- a/be/src/runtime/tablets_channel.cpp
+++ b/be/src/runtime/tablets_channel.cpp
@@ -364,7 +364,7 @@ Status TabletsChannel::add_batch(const TabletWriterAddRequest& request,
     } else {
         for (const auto& tablet_to_rowidxs_it : tablet_to_rowidxs) {
             RETURN_IF_ERROR(write_tablet_data(tablet_to_rowidxs_it.first, [&](DeltaWriter* writer) {
-                return writer->write<false>(&send_data, tablet_to_rowidxs_it.second);
+                return writer->write(&send_data, tablet_to_rowidxs_it.second);
             }));
         }
     }

--- a/be/src/vec/exec/format/json/new_json_reader.cpp
+++ b/be/src/vec/exec/format/json/new_json_reader.cpp
@@ -24,7 +24,6 @@
 #include "olap/iterators.h"
 #include "runtime/descriptors.h"
 #include "runtime/runtime_state.h"
-#include "util/defer_op.h"
 #include "vec/core/block.h"
 #include "vec/exec/format/file_reader/new_plain_text_line_reader.h"
 #include "vec/exec/scan/vscanner.h"

--- a/be/src/vec/exec/format/json/new_json_reader.cpp
+++ b/be/src/vec/exec/format/json/new_json_reader.cpp
@@ -24,6 +24,7 @@
 #include "olap/iterators.h"
 #include "runtime/descriptors.h"
 #include "runtime/runtime_state.h"
+#include "util/defer_op.h"
 #include "vec/core/block.h"
 #include "vec/exec/format/file_reader/new_plain_text_line_reader.h"
 #include "vec/exec/scan/vscanner.h"

--- a/be/src/vec/sink/vtablet_sink.h
+++ b/be/src/vec/sink/vtablet_sink.h
@@ -39,6 +39,7 @@
 #include "util/spinlock.h"
 #include "util/thread.h"
 #include "vec/columns/column.h"
+#include "vec/columns/columns_number.h"
 #include "vec/core/block.h"
 
 namespace doris {
@@ -176,6 +177,7 @@ public:
 
     Status open_wait();
 
+    template <bool is_append>
     Status add_block(vectorized::Block* block,
                      const std::pair<std::unique_ptr<vectorized::IColumn::Selector>,
                                      std::vector<int64_t>>& payload);
@@ -436,6 +438,7 @@ private:
                             bool* stop_processing, fmt::memory_buffer& error_prefix,
                             vectorized::IColumn::Permutation* rows = nullptr);
 
+    Status _append_block_to_single_tablet(RuntimeState* state, vectorized::Block& block);
     // some output column of output expr may have different nullable property with dest slot desc
     // so here need to do the convert operation
     void _convert_to_dest_desc_block(vectorized::Block* block);

--- a/gensrc/proto/internal_service.proto
+++ b/gensrc/proto/internal_service.proto
@@ -136,6 +136,7 @@ message PTabletWriterAddBlockRequest {
     optional bool is_high_priority = 11 [default = false];
     optional bool write_single_replica = 12 [default = false];
     map<int64, PSlaveTabletNodes> slave_tablet_nodes = 13;
+    optional bool is_single_tablet_block = 14 [default = false];
 };
 
 message PSlaveTabletNodes {

--- a/regression-test/suites/load_p0/stream_load/test_json_load.groovy
+++ b/regression-test/suites/load_p0/stream_load/test_json_load.groovy
@@ -26,7 +26,7 @@ suite("test_json_load", "p0") {
                         id INT DEFAULT '10',
                         city VARCHAR(32) DEFAULT '',
                         code BIGINT SUM DEFAULT '0')
-                        DISTRIBUTED BY HASH(id) BUCKETS 10
+                        DISTRIBUTED BY RANDOM BUCKETS 10
                         PROPERTIES("replication_num" = "1");
                         """
         
@@ -48,7 +48,7 @@ suite("test_json_load", "p0") {
                         CREATE TABLE IF NOT EXISTS ${testTable} (
                         id INT DEFAULT '10',
                         code BIGINT SUM DEFAULT '0')
-                        DISTRIBUTED BY HASH(id) BUCKETS 10
+                        DISTRIBUTED BY RANDOM BUCKETS 10
                         PROPERTIES("replication_num" = "1");
                         """
         
@@ -72,7 +72,7 @@ suite("test_json_load", "p0") {
                         id INT DEFAULT '10',
                         city VARCHAR(32) NOT NULL,
                         code BIGINT SUM DEFAULT '0')
-                        DISTRIBUTED BY HASH(id) BUCKETS 10
+                        DISTRIBUTED BY RANDOM BUCKETS 10
                         PROPERTIES("replication_num" = "1");
                         """
         
@@ -116,7 +116,7 @@ suite("test_json_load", "p0") {
     
     def load_json_data = {label, strip_flag, read_flag, format_flag, exprs, json_paths, 
                         json_root, where_expr, fuzzy_flag, file_name, ignore_failure=false,
-                        expected_succ_rows = -1 ->
+                        expected_succ_rows = -1, load_to_single_tablet = 'true' ->
         
         // load the json data
         streamLoad {
@@ -132,6 +132,7 @@ suite("test_json_load", "p0") {
             set 'json_root', json_root
             set 'where', where_expr
             set 'fuzzy_parse', fuzzy_flag
+            set 'load_to_single_tablet', load_to_single_tablet
             file file_name // import json file
             time 10000 // limit inflight 10s
             if (expected_succ_rows >= 0) {
@@ -496,13 +497,13 @@ suite("test_json_load", "p0") {
 
         test_invalid_json_array_table.call(testTable)
         load_json_data.call('test_json_load_case17', 'true', '', 'json', '', '',
-                '', '', '', 'invalid_json_array.json', false, 0)
+                '', '', '', 'invalid_json_array.json', false, 0, 'false')
         load_json_data.call('test_json_load_case17_1', 'true', '', 'json', '', '',
-                '$.item', '', '', 'invalid_json_array1.json', false, 0)
+                '$.item', '', '', 'invalid_json_array1.json', false, 0, 'false')
         load_json_data.call('test_json_load_case17_2', 'true', '', 'json', '', '',
-                '$.item', '', '', 'invalid_json_array2.json', false, 0)
+                '$.item', '', '', 'invalid_json_array2.json', false, 0, 'false')
         load_json_data.call('test_json_load_case17_3', 'true', '', 'json', '', '',
-                '$.item', '', '', 'invalid_json_array3.json', false, 0)
+                '$.item', '', '', 'invalid_json_array3.json', false, 0, 'false')
         sql "sync"
         qt_select17 "select * from ${testTable}"
 


### PR DESCRIPTION
…k and delta writer of writing blocks

The current distribution model for Doris is as follows:

OlapTableSink seperate the original Block into serveral subblocks of each node(BE) by tablets distribution and distributes subblocks to storage engine of backends, then the storage engine will seperate the subblock into multiple tablets channel and each delta writer will handle partial of the block.

This model causes blocks to be split according to tablets, and the splitting process can be a relatively heavy operation. After splitting, the blocks are distributed to different DeltaWriters (Memtables) through RPCs to TabletChannels. The distribution operation on TabletChannels is also a relatively heavy operation. If the distribution property of the table is RANDOM distribution, then we have the opportunity to distribute the blocks according to the complete block during distribution. The advantage of doing so is to reduce memory copying and improve write locality, similar to appending the entire block to the memtable.

**This optimze could save 10% ~ 20% CPU cost of RANDOM distribution table load when write to single tablet
Whats more, is that we could even write to the local delta writer from OlapTableSink in the single_replica_load mode**
# Proposed changes

Issue Number: close #17388

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

