### PR TITLE
[fix](load) disable OLAP_ERR_PUSH_VERSION_ALREADY_EXIST print stack

### DIFF
--- a/be/src/common/status.h
+++ b/be/src/common/status.h
@@ -142,7 +142,7 @@ class PStatus;
     M(OLAP_ERR_PUSH_ACQUIRE_DATASOURCE_ERROR, -905, "", true)            \
     M(OLAP_ERR_PUSH_CREAT_CUMULATIVE_ERROR, -906, "", true)              \
     M(OLAP_ERR_PUSH_BUILD_DELTA_ERROR, -907, "", true)                   \
-    M(OLAP_ERR_PUSH_VERSION_ALREADY_EXIST, -908, "", true)               \
+    M(OLAP_ERR_PUSH_VERSION_ALREADY_EXIST, -908, "", false)               \
     M(OLAP_ERR_PUSH_TABLE_NOT_EXIST, -909, "", true)                     \
     M(OLAP_ERR_PUSH_INPUT_DATA_ERROR, -910, "", true)                    \
     M(OLAP_ERR_PUSH_TRANSACTION_ALREADY_EXIST, -911, "", true)           \

--- a/be/src/common/status.h
+++ b/be/src/common/status.h
@@ -142,7 +142,7 @@ class PStatus;
     M(OLAP_ERR_PUSH_ACQUIRE_DATASOURCE_ERROR, -905, "", true)            \
     M(OLAP_ERR_PUSH_CREAT_CUMULATIVE_ERROR, -906, "", true)              \
     M(OLAP_ERR_PUSH_BUILD_DELTA_ERROR, -907, "", true)                   \
-    M(OLAP_ERR_PUSH_VERSION_ALREADY_EXIST, -908, "", false)               \
+    M(OLAP_ERR_PUSH_VERSION_ALREADY_EXIST, -908, "", false)              \
     M(OLAP_ERR_PUSH_TABLE_NOT_EXIST, -909, "", true)                     \
     M(OLAP_ERR_PUSH_INPUT_DATA_ERROR, -910, "", true)                    \
     M(OLAP_ERR_PUSH_TRANSACTION_ALREADY_EXIST, -911, "", true)           \


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

Describe your changes.

```
#0  __libc_pread64 (offset=<optimized out>, count=64, buf=0x7fe18e83f2d0, fd=167) at ../sysdeps/unix/sysv/linux/pread64.c:29
#1  __libc_pread64 (fd=167, buf=0x7fe18e83f2d0, count=64, offset=140602038300672) at ../sysdeps/unix/sysv/linux/pread64.c:27
#2  0x000055939314d603 in ?? ()
#3  0x000055939314dea4 in ?? ()
#4  0x000055939314e3a6 in ?? ()
#5  0x000055939314d1b4 in ?? ()
#6  0x000055938d9e3a98 in doris::get_stack_trace[abi:cxx11]() () at /home/zcp/repo_center/zcp_repo/be/src/util/stack_util.cpp:35
#7  0x000055938cd85c84 in doris::Status::ConstructErrorStatus (tcode=tcode@entry=doris::TStatusCode::INTERNAL_ERROR, precise_code=precise_code@entry=-908, msg=...) at /home/zcp/repo_center/zcp_rep
o/be/src/common/status.cpp:84
#8  0x000055938cd86145 in doris::Status::OLAPInternalError (precise_code=precise_code@entry=-908, msg=...) at /home/zcp/repo_center/zcp_repo/be/src/common/status.cpp:70
#9  0x000055938d2686c0 in doris::Tablet::_contains_version (this=this@entry=0x7fe1c92c2710, version=...) at /home/zcp/repo_center/zcp_repo/be/src/olap/tablet.cpp:1150
#10 0x000055938d277802 in doris::Tablet::add_inc_rowset (this=0x7fe1c92c2710, rowset=...) at /home/zcp/repo_center/zcp_repo/be/src/olap/tablet.cpp:466
#11 0x000055938d68dfad in doris::TabletPublishTxnTask::handle (this=0x7fe1de7e7990) at /home/zcp/repo_center/zcp_repo/be/src/olap/task/engine_publish_version_task.cpp:220
#12 0x000055938da5377d in std::function<void ()>::operator()() const (this=<optimized out>) at /var/local/ldb_toolchain/include/c++/11/bits/std_function.h:560
#13 doris::FunctionRunnable::run (this=<optimized out>) at /home/zcp/repo_center/zcp_repo/be/src/util/threadpool.cpp:45
#14 doris::ThreadPool::dispatch_thread (this=0x7fe1d3f63a00) at /home/zcp/repo_center/zcp_repo/be/src/util/threadpool.cpp:534
#15 0x000055938da4903c in std::function<void ()>::operator()() const (this=0x7fe1d063c4d8) at /var/local/ldb_toolchain/include/c++/11/bits/std_function.h:560
#16 doris::Thread::supervise_thread (arg=0x7fe1d063c4c0) at /home/zcp/repo_center/zcp_repo/be/src/util/thread.cpp:454
#17 0x00007fe341afb609 in start_thread (arg=<optimized out>) at pthread_create.c:477
#18 0x00007fe341c35163 in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:95
```

The thread hangs on this stack, holding the write lock of the tablet meta, causing the load to fail

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

