### PR TITLE
[enhance](report) add local and remote size in tablet meta header action

### DIFF
--- a/be/src/http/action/meta_action.cpp
+++ b/be/src/http/action/meta_action.cpp
@@ -60,8 +60,6 @@ Status MetaAction::_handle_header(HttpRequest* req, std::string* json_meta) {
         LOG(WARNING) << "no tablet for tablet_id:" << tablet_id;
         return Status::InternalError("no tablet exist");
     }
-    tablet->tablet_local_size();
-    tablet->tablet_remote_size();
     TabletMetaSharedPtr tablet_meta(new TabletMeta());
     tablet->generate_tablet_meta_copy(tablet_meta);
     json2pb::Pb2JsonOptions json_options;

--- a/be/src/http/action/meta_action.cpp
+++ b/be/src/http/action/meta_action.cpp
@@ -60,6 +60,8 @@ Status MetaAction::_handle_header(HttpRequest* req, std::string* json_meta) {
         LOG(WARNING) << "no tablet for tablet_id:" << tablet_id;
         return Status::InternalError("no tablet exist");
     }
+    tablet->tablet_local_size();
+    tablet->tablet_remote_size();
     TabletMetaSharedPtr tablet_meta(new TabletMeta());
     tablet->generate_tablet_meta_copy(tablet_meta);
     json2pb::Pb2JsonOptions json_options;

--- a/be/src/olap/tablet_meta.cpp
+++ b/be/src/olap/tablet_meta.cpp
@@ -577,8 +577,8 @@ void TabletMeta::to_meta_pb(TabletMetaPB* tablet_meta_pb) {
     tablet_meta_pb->set_shard_id(shard_id());
     tablet_meta_pb->set_creation_time(creation_time());
     tablet_meta_pb->set_cumulative_layer_point(cumulative_layer_point());
-    tablet_meta_pb->set_local_size(tablet_local_size());
-    tablet_meta_pb->set_remote_size(tablet_remote_size());
+    tablet_meta_pb->set_local_data_size(tablet_local_size());
+    tablet_meta_pb->set_remote_data_size(tablet_remote_size());
     *(tablet_meta_pb->mutable_tablet_uid()) = tablet_uid().to_proto();
     tablet_meta_pb->set_tablet_type(_tablet_type);
     switch (tablet_state()) {

--- a/be/src/olap/tablet_meta.cpp
+++ b/be/src/olap/tablet_meta.cpp
@@ -577,6 +577,8 @@ void TabletMeta::to_meta_pb(TabletMetaPB* tablet_meta_pb) {
     tablet_meta_pb->set_shard_id(shard_id());
     tablet_meta_pb->set_creation_time(creation_time());
     tablet_meta_pb->set_cumulative_layer_point(cumulative_layer_point());
+    tablet_meta_pb->set_local_size(tablet_local_size());
+    tablet_meta_pb->set_remote_size(tablet_remote_size());
     *(tablet_meta_pb->mutable_tablet_uid()) = tablet_uid().to_proto();
     tablet_meta_pb->set_tablet_type(_tablet_type);
     switch (tablet_state()) {

--- a/be/test/olap/test_data/header_without_inc_rs.txt
+++ b/be/test/olap/test_data/header_without_inc_rs.txt
@@ -108,5 +108,7 @@
     "preferred_rowset_type": "BETA_ROWSET",
     "tablet_type": "TABLET_TYPE_DISK",
     "replica_id": 0,
-    "enable_unique_key_merge_on_write": false
+    "enable_unique_key_merge_on_write": false,
+    "local_data_size": 84464,
+    "remote_data_size": 0
 }

--- a/gensrc/proto/olap_file.proto
+++ b/gensrc/proto/olap_file.proto
@@ -298,6 +298,8 @@ message TabletMetaPB {
     optional bool enable_unique_key_merge_on_write = 24 [default = false];
     optional int64 storage_policy_id = 25;
     optional PUniqueId cooldown_meta_id = 26;
+    optional int64 local_size = 27;
+    optional int64 remote_size = 28;
 }
 
 message OLAPRawDeltaHeaderMessage {

--- a/gensrc/proto/olap_file.proto
+++ b/gensrc/proto/olap_file.proto
@@ -298,8 +298,8 @@ message TabletMetaPB {
     optional bool enable_unique_key_merge_on_write = 24 [default = false];
     optional int64 storage_policy_id = 25;
     optional PUniqueId cooldown_meta_id = 26;
-    optional int64 local_size = 27;
-    optional int64 remote_size = 28;
+    optional int64 local_data_size = 27;
+    optional int64 remote_data_size = 28;
 }
 
 message OLAPRawDeltaHeaderMessage {


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx
Return local data size and remote data size when doing meta header action.
![image](https://user-images.githubusercontent.com/43750022/222723284-7bacc2cb-35ba-4c57-89da-0a3b8f50b3fd.png)

This is mainly to provide one way to get the accurate table data size for cooldown regression cases
## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

