### PR TITLE
[improvement](inverted index)Remove searcher bitmap timer to improve query speed

### DIFF
--- a/be/src/olap/olap_common.h
+++ b/be/src/olap/olap_common.h
@@ -353,7 +353,6 @@ struct OlapReaderStatistics {
     int64_t inverted_index_query_bitmap_op_timer = 0;
     int64_t inverted_index_searcher_open_timer = 0;
     int64_t inverted_index_searcher_search_timer = 0;
-    int64_t inverted_index_searcher_bitmap_timer = 0;
 
     int64_t output_index_result_column_timer = 0;
     // number of segment filtered by column stat when creating seg iterator

--- a/be/src/olap/rowset/segment_v2/inverted_index_reader.cpp
+++ b/be/src/olap/rowset/segment_v2/inverted_index_reader.cpp
@@ -165,9 +165,8 @@ Status FullTextIndexReader::query(OlapReaderStatistics* stats, const std::string
                 try {
                     SCOPED_RAW_TIMER(&stats->inverted_index_searcher_search_timer);
                     index_searcher->_search(
-                            query.get(), [&term_match_bitmap, stats](const int32_t docid,
+                            query.get(), [&term_match_bitmap](const int32_t docid,
                                                                      const float_t /*score*/) {
-                                SCOPED_RAW_TIMER(&stats->inverted_index_searcher_bitmap_timer);
                                 // docid equal to rowid in segment
                                 term_match_bitmap->add(docid);
                             });
@@ -316,9 +315,8 @@ Status StringTypeInvertedIndexReader::query(OlapReaderStatistics* stats,
     try {
         SCOPED_RAW_TIMER(&stats->inverted_index_searcher_search_timer);
         index_searcher->_search(query.get(),
-                                [&result, stats](const int32_t docid, const float_t /*score*/) {
+                                [&result](const int32_t docid, const float_t /*score*/) {
                                     // docid equal to rowid in segment
-                                    SCOPED_RAW_TIMER(&stats->inverted_index_searcher_bitmap_timer);
                                     result.add(docid);
                                 });
     } catch (const CLuceneError& e) {

--- a/be/src/olap/rowset/segment_v2/inverted_index_reader.cpp
+++ b/be/src/olap/rowset/segment_v2/inverted_index_reader.cpp
@@ -165,8 +165,8 @@ Status FullTextIndexReader::query(OlapReaderStatistics* stats, const std::string
                 try {
                     SCOPED_RAW_TIMER(&stats->inverted_index_searcher_search_timer);
                     index_searcher->_search(
-                            query.get(), [&term_match_bitmap](const int32_t docid,
-                                                                     const float_t /*score*/) {
+                            query.get(),
+                            [&term_match_bitmap](const int32_t docid, const float_t /*score*/) {
                                 // docid equal to rowid in segment
                                 term_match_bitmap->add(docid);
                             });

--- a/be/src/vec/exec/scan/new_olap_scan_node.cpp
+++ b/be/src/vec/exec/scan/new_olap_scan_node.cpp
@@ -124,8 +124,6 @@ Status NewOlapScanNode::_init_profile() {
             ADD_TIMER(_segment_profile, "InvertedIndexSearcherOpenTime");
     _inverted_index_searcher_search_timer =
             ADD_TIMER(_segment_profile, "InvertedIndexSearcherSearchTime");
-    _inverted_index_searcher_bitmap_timer =
-            ADD_TIMER(_segment_profile, "InvertedIndexSearcherGenBitmapTime");
 
     _output_index_result_column_timer = ADD_TIMER(_segment_profile, "OutputIndexResultColumnTimer");
 

--- a/be/src/vec/exec/scan/new_olap_scan_node.h
+++ b/be/src/vec/exec/scan/new_olap_scan_node.h
@@ -138,7 +138,6 @@ private:
     RuntimeProfile::Counter* _inverted_index_query_bitmap_op_timer = nullptr;
     RuntimeProfile::Counter* _inverted_index_searcher_open_timer = nullptr;
     RuntimeProfile::Counter* _inverted_index_searcher_search_timer = nullptr;
-    RuntimeProfile::Counter* _inverted_index_searcher_bitmap_timer = nullptr;
 
     RuntimeProfile::Counter* _output_index_result_column_timer = nullptr;
 

--- a/be/src/vec/exec/scan/new_olap_scanner.cpp
+++ b/be/src/vec/exec/scan/new_olap_scanner.cpp
@@ -515,8 +515,6 @@ void NewOlapScanner::_update_counters_before_close() {
                    stats.inverted_index_searcher_open_timer);
     COUNTER_UPDATE(olap_parent->_inverted_index_searcher_search_timer,
                    stats.inverted_index_searcher_search_timer);
-    COUNTER_UPDATE(olap_parent->_inverted_index_searcher_bitmap_timer,
-                   stats.inverted_index_searcher_bitmap_timer);
 
     COUNTER_UPDATE(olap_parent->_output_index_result_column_timer,
                    stats.output_index_result_column_timer);


### PR DESCRIPTION
# Proposed changes

Timer becomes a bottleneck when the query hit volume is very high.

Test result:


 sql | TIMER Added | TIMER Removed | Hits
 -- | -- | -- | --
select count() from hits where PageCharset match_any 'windows'; | 1.23s | 0.60s | 60715906
select count() from hits_one_bucket2 where agent match_any 'windows'; | 4.27s | 1.95s | 41142388
select count() from hits_one_bucket2 where agent match_any 'Windows Chrome'; | 7.00s | 2.06s | 45256626
select count() from hits_one_bucket2 where agent match_all 'Windows Chrome'; | 7.74s | 2.79s | 41142388



## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [x] Does it need to update dependencies
* [x] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

