### PR TITLE
[fix](publish) fix when TabletPublishTxnTask::handle() error, transaction publish success, and query table error

### DIFF
--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -882,6 +882,7 @@ void TaskWorkerPool::_publish_version_worker_thread_callback() {
         finish_task_request.__set_task_type(agent_task_req.task_type);
         finish_task_request.__set_signature(agent_task_req.signature);
         finish_task_request.__set_report_version(_s_report_version);
+        finish_task_request.__set_error_tablet_ids(error_tablet_ids);
 
         _finish_task(finish_task_request);
         _remove_task_info(agent_task_req.task_type, agent_task_req.signature);


### PR DESCRIPTION

BE use EnginePublishVersionTask to publish all replica of all tablets of table of one transaction, and EnginePublishVersionTask use TabletPublishTxnTask to truly publish tablet and make rowset visible. but if TabletPublishTxnTask error, tablet id will add _error_tablet_ids but no return some errors, and EnginePublishVersionTask will not report any error to FE, and FE make this transaction visible, and partition's version add 1.

but if you query this table, will return error like "MySQL [test]> select * from test12;ERROR 1105 (HY000): errCode = 2, detailMessage = [INTERNAL_ERROR]failed to initialize storage reader. tablet=14023.730105214.xxxx, res=[INTERNAL_ERROR][xxx]fail to find path in version_graph. spec_version: 0-3, backend=xxx".

after this pr, _error_tablet_ids will report to FE, this transaction will not be visible and add ErrMsg like "publish on tablet 14038 failed.".

# Proposed changes

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

