### PR TITLE
[chore](config) Increase the default maximum depth limit for expressions

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -931,7 +931,7 @@ CONF_Int32(num_broadcast_buffer, "32");
 CONF_Bool(enable_parse_multi_dimession_array, "true");
 
 // max depth of expression tree allowed.
-CONF_Int32(max_depth_of_expr_tree, "200");
+CONF_Int32(max_depth_of_expr_tree, "600");
 
 // Report a tablet as bad when io errors occurs more than this value.
 CONF_mInt64(max_tablet_io_errors, "-1");


### PR DESCRIPTION
# Proposed changes

In the master branch, it seems that larger expression depth is acceptable.

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

