### PR TITLE
[chore](fe) enhance mysql data type

### DIFF
--- a/be/src/exec/schema_scanner/schema_columns_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_columns_scanner.cpp
@@ -141,6 +141,15 @@ std::string SchemaColumnsScanner::_to_mysql_data_type_string(TColumnDesc& desc) 
     case TPrimitiveType::JSONB: {
         return "json";
     }
+    case TPrimitiveType::MAP: {
+        return "map";
+    }
+    case TPrimitiveType::ARRAY: {
+        return "array";
+    }
+    case TPrimitiveType::STRUCT: {
+        return "struct";
+    }
     default:
         return "unknown";
     }

--- a/regression-test/data/nereids_p0/system/test_query_sys_data_type.out
+++ b/regression-test/data/nereids_p0/system/test_query_sys_data_type.out
@@ -8,3 +8,7 @@ os	char
 set1	hll
 set2	bitmap
 
+-- !sql --
+id	int
+c_array	array
+

--- a/regression-test/data/query_p0/system/test_query_sys_data_type.out
+++ b/regression-test/data/query_p0/system/test_query_sys_data_type.out
@@ -8,3 +8,7 @@ os	char
 set1	hll
 set2	bitmap
 
+-- !sql --
+id	int
+c_array	array
+

--- a/regression-test/suites/nereids_p0/system/test_query_sys_data_type.groovy
+++ b/regression-test/suites/nereids_p0/system/test_query_sys_data_type.groovy
@@ -31,4 +31,21 @@ suite("test_query_sys_data_type", 'query,p0') {
     """
 
     qt_sql "select column_name, data_type from information_schema.columns where table_schema = '${dbName}' and table_name = '${tbName}'"
+
+    sql """ DROP TABLE IF EXISTS array_test """
+    sql """
+        CREATE TABLE `array_test` (
+        `id` int(11) NULL COMMENT "",
+        `c_array` ARRAY<int(11)> NULL COMMENT ""
+        ) ENGINE=OLAP
+        DUPLICATE KEY(`id`)
+        COMMENT "OLAP"
+        DISTRIBUTED BY HASH(`id`) BUCKETS 1
+        PROPERTIES (
+        "replication_allocation" = "tag.location.default: 1",
+        "in_memory" = "false",
+        "storage_format" = "V2"
+        )
+    """
+    qt_sql "select column_name, data_type from information_schema.columns where table_schema = '${dbName}' and table_name = 'array_test'"
 }

--- a/regression-test/suites/query_p0/system/test_query_sys_data_type.groovy
+++ b/regression-test/suites/query_p0/system/test_query_sys_data_type.groovy
@@ -28,4 +28,21 @@ suite("test_query_sys_data_type", 'query,p0') {
     """
 
     qt_sql "select column_name, data_type from information_schema.columns where table_schema = '${dbName}' and table_name = '${tbName}'"
+
+    sql """ DROP TABLE IF EXISTS array_test """
+    sql """
+        CREATE TABLE `array_test` (
+        `id` int(11) NULL COMMENT "",
+        `c_array` ARRAY<int(11)> NULL COMMENT ""
+        ) ENGINE=OLAP
+        DUPLICATE KEY(`id`)
+        COMMENT "OLAP"
+        DISTRIBUTED BY HASH(`id`) BUCKETS 1
+        PROPERTIES (
+        "replication_allocation" = "tag.location.default: 1",
+        "in_memory" = "false",
+        "storage_format" = "V2"
+        )
+    """
+    qt_sql "select column_name, data_type from information_schema.columns where table_schema = '${dbName}' and table_name = 'array_test'"
 }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary
Previously if we try to query the data type of one array/map/struct in mysql client, we would get one return type `unknown`. This pr makes be return the corresponding data type.
Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

