### PR TITLE
[fix](segcompaction) core when doing segcompaction for cancelling load(#16731)

### DIFF
--- a/be/src/olap/rowset/beta_rowset_writer.cpp
+++ b/be/src/olap/rowset/beta_rowset_writer.cpp
@@ -62,7 +62,11 @@ BetaRowsetWriter::BetaRowsetWriter()
 }
 
 BetaRowsetWriter::~BetaRowsetWriter() {
-    // OLAP_UNUSED_ARG(_wait_flying_segcompaction());
+    /* Note that segcompaction is async and in parallel with load job. So we should handle carefully
+     * when the job is cancelled. Although it is meaningless to continue segcompaction when the job
+     * is cancelled, the objects involved in the job should be preserved during segcompaction to
+     * avoid crashs for memory issues. */
+    OLAP_UNUSED_ARG(_wait_flying_segcompaction());
 
     // TODO(lingbin): Should wrapper exception logic, no need to know file ops directly.
     if (!_already_built) {       // abnormal exit, remove all files generated


### PR DESCRIPTION
segcompaction is async and in parallel with load job. If the load job is canncelling, memory structures will be destroyed and cause segcompaction crash. This commit will wait segcompaction finished before destruction.

# Proposed changes

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

