### PR TITLE
[fix](priv) fix duplicated priv check when check column priv

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/AccessControllerManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/AccessControllerManager.java
@@ -153,7 +153,7 @@ public class AccessControllerManager {
             PrivPredicate wanted) throws UserException {
         boolean hasGlobal = sysAccessController.checkGlobalPriv(currentUser, wanted);
         CatalogAccessController accessController = getAccessControllerOrDefault(ctl);
-        for (TableName tableName : tableToColsMap.keys()) {
+        for (TableName tableName : tableToColsMap.keySet()) {
             accessController.checkColsPriv(hasGlobal, currentUser, ctl, tableName.getDb(),
                     tableName.getTbl(), tableToColsMap.get(tableName), wanted);
         }


### PR DESCRIPTION
# Proposed changes

when executing select stmt, columns privilege check will be invoked multiple times(column number in select stmt)

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [x] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

