### PR TITLE
[fix](log) fix error code for tablet writer write failure (#14078)

### DIFF
--- a/be/src/olap/memtable_flush_executor.cpp
+++ b/be/src/olap/memtable_flush_executor.cpp
@@ -92,7 +92,7 @@ void FlushToken::_flush_memtable(MemTable* memtable, int64_t submit_task_time) {
     if (!s) {
         LOG(WARNING) << "Flush memtable failed with res = " << s;
         // If s is not ok, ignore the code, just use other code is ok
-        _flush_status.store(OLAP_ERR_OTHER_ERROR);
+        _flush_status.store(s.ok() ? OLAP_SUCCESS : (ErrorCode)s.precise_code());
     }
 
     if (_flush_status.load() != OLAP_SUCCESS) {


### PR DESCRIPTION
Fix vague error code (-1) in err log if tablet writer write failed. The original error print:

    tablet writer write failed ... err=6, errorcode=-1 ...

After this commit:

    tablet writer write failed ... err=6, errorcode=-238 ...

# Proposed changes

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

