### PR TITLE
[Enhancement](Planner)fix unclear exception msg when tag.location invaild.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/PropertyAnalyzer.java
@@ -698,7 +698,7 @@ public class PropertyAnalyzer {
             if (!parts[0].startsWith(TAG_LOCATION)) {
                 throw new AnalysisException("Invalid replication allocation tag property: " + location);
             }
-            String locationVal = parts[0].substring(TAG_LOCATION.length() + 1); // +1 to skip dot.
+            String locationVal = parts[0].replace(TAG_LOCATION, "").replace(".", "");
             if (Strings.isNullOrEmpty(locationVal)) {
                 throw new AnalysisException("Invalid replication allocation location tag property: " + location);
             }


### PR DESCRIPTION
# Proposed changes

cherry-pick #17473

## Problem summary

CREATE TABLE `test` (
  `id` BIGINT COMMENT '',
) ENGINE = OLAP 
DUPLICATE KEY(`dmp_share_cd_time_idatat`) 
COMMENT 'OLAP' 
DISTRIBUTED BY HASH(`dmp_share_cd_time_idatat`) BUCKETS AUTO 
PROPERTIES (
  "replication_allocation" = "tag.location: 1",
  "in_memory" = "false",
  "storage_format" = "V2",
  "compression" = "ZSTD",
  "estimate_partition_size" = "115G",
  "disable_auto_compaction" = "false"
);

exception msg: String index out of range: -1 is weird, now it will be 'Invalid replication allocation location tag property: tag: location: 1'

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [x] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

