### PR TITLE
[RegressionTest](Bug) fix regression test fail to find vec function microseconds_add/sub

### DIFF
--- a/gensrc/script/doris_builtins_functions.py
+++ b/gensrc/script/doris_builtins_functions.py
@@ -790,11 +790,11 @@ visible_functions = [
     [['microseconds_add'], 'DATETIME', ['DATETIME', 'INT'],
         '_ZN5doris18TimestampFunctions10micros_addEPN9doris_udf'
         '15FunctionContextERKNS1_11DateTimeValERKNS1_6IntValE',
-        '', '', '', ''],
+        '', '', 'vec', 'ALWAYS_NULLABLE'],
     [['microseconds_sub'], 'DATETIME', ['DATETIME', 'INT'],
         '_ZN5doris18TimestampFunctions10micros_subEPN9doris_udf'
         '15FunctionContextERKNS1_11DateTimeValERKNS1_6IntValE',
-        '', '', '', ''],
+        '', '', 'vec', 'ALWAYS_NULLABLE'],
 
     [['datediff'], 'INT', ['DATETIME', 'DATETIME'],
         '_ZN5doris18TimestampFunctions9date_diffEPN9doris_udf'
@@ -1190,11 +1190,11 @@ visible_functions = [
     [['microseconds_add'], 'DATETIMEV2', ['DATETIMEV2', 'INT'],
      '_ZN5doris18TimestampFunctions10micros_addEPN9doris_udf'
      '15FunctionContextERKNS1_11DateTimeV2ValERKNS1_6IntValE',
-     '', '', '', ''],
+     '', '', 'vec', ''],
     [['microseconds_sub'], 'DATETIMEV2', ['DATETIMEV2', 'INT'],
      '_ZN5doris18TimestampFunctions10micros_subEPN9doris_udf'
      '15FunctionContextERKNS1_11DateTimeV2ValERKNS1_6IntValE',
-     '', '', '', ''],
+     '', '', 'vec', ''],
 
     [['years_add'], 'DATEV2', ['DATEV2', 'INT'],
      '_ZN5doris18TimestampFunctions9years_addEPN9doris_udf'
@@ -1255,11 +1255,11 @@ visible_functions = [
     [['microseconds_add'], 'DATETIMEV2', ['DATEV2', 'INT'],
      '_ZN5doris18TimestampFunctions10micros_addEPN9doris_udf'
      '15FunctionContextERKNS1_11DateTimeV2ValERKNS1_6IntValE',
-     '', '', '', ''],
+     '', '', 'vec', ''],
     [['microseconds_sub'], 'DATETIMEV2', ['DATEV2', 'INT'],
      '_ZN5doris18TimestampFunctions10micros_subEPN9doris_udf'
      '15FunctionContextERKNS1_11DateTimeV2ValERKNS1_6IntValE',
-     '', '', '', ''],
+     '', '', 'vec', ''],
 
     [['datediff'], 'INT', ['DATETIMEV2', 'DATETIMEV2'],
      '_ZN5doris18TimestampFunctions9date_diffEPN9doris_udf'


### PR DESCRIPTION
# Proposed changes

Before：
```
mysql> select microseconds_add(col, 100000) col1 from test_datetimev2_exprs_test order by col1;
ERROR 1105 (HY000): errCode = 2, detailMessage = Function microseconds_add is not implemented
```

After:
```
mysql> select microseconds_add(col, 100000) col1 from test_datetimev2_exprs order by col1;
+-------------------------+
| col1                    |
+-------------------------+
| 2022-01-01 11:11:11.211 |
| 2022-01-01 11:11:11.322 |
+-------------------------+
2 rows in set (0.09 sec)
```

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

