### PR TITLE
[enhancement](regression-test) add sleep 3s for schema change and rollup

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
@@ -311,7 +311,9 @@ public class InternalCatalog implements CatalogIf<Database> {
                         // to see which thread held this lock for long time.
                         Thread owner = lock.getOwner();
                         if (owner != null) {
-                            LOG.debug("catalog lock is held by: {}", Util.dumpThread(owner, 10));
+                            // There are many catalog timeout during regression test
+                            // And this timeout should not happen very often, so it could be info log
+                            LOG.info("catalog lock is held by: {}", Util.dumpThread(owner, 10));
                         }
                     }
 

--- a/regression-test/suites/datatype_p0/date/test_default_current_timestamp.groovy
+++ b/regression-test/suites/datatype_p0/date/test_default_current_timestamp.groovy
@@ -40,6 +40,7 @@ suite("test_default_current_timestamp") {
     while(max_try_time--){
         String result = getJobState(tbName)
         if (result == "FINISHED") {
+            sleep(3000)
             break
         } else {
             sleep(100)

--- a/regression-test/suites/index_p0/test_bitmap_index.groovy
+++ b/regression-test/suites/index_p0/test_bitmap_index.groovy
@@ -65,6 +65,7 @@ suite("test_bitmap_index") {
     while (max_try_secs--) {
         String res = getJobState(tbName1)
         if (res == "FINISHED") {
+            sleep(3000)
             break
         } else {
             Thread.sleep(1000)
@@ -85,6 +86,7 @@ suite("test_bitmap_index") {
     while (max_try_secs--) {
         String res = getJobState(tbName1)
         if (res == "FINISHED") {
+            sleep(3000)
             break
         } else {
             Thread.sleep(1000)
@@ -144,6 +146,7 @@ suite("test_bitmap_index") {
     while (max_try_secs--) {
         String res = getJobState(tbName2)
         if (res == "FINISHED") {
+            sleep(3000)
             break
         } else {
             Thread.sleep(1000)
@@ -168,6 +171,7 @@ suite("test_bitmap_index") {
     while (max_try_secs--) {
         String res = getJobState(tbName2)
         if (res == "FINISHED") {
+            sleep(3000)
             break
         } else {
             Thread.sleep(1000)
@@ -227,6 +231,7 @@ suite("test_bitmap_index") {
     while (max_try_secs--) {
         String res = getJobState(tbName3)
         if (res == "FINISHED") {
+            sleep(3000)
             break
         } else {
             Thread.sleep(1000)
@@ -247,6 +252,7 @@ suite("test_bitmap_index") {
     while (max_try_secs--) {
         String res = getJobState(tbName3)
         if (res == "FINISHED") {
+            sleep(3000)
             break
         } else {
             Thread.sleep(1000)

--- a/regression-test/suites/inverted_index_p0/test_bitmap_index.groovy
+++ b/regression-test/suites/inverted_index_p0/test_bitmap_index.groovy
@@ -57,6 +57,7 @@ suite("test_bitmap_index", "inverted_index") {
     while (max_try_secs--) {
         String res = getJobState(tbName1)
         if (res == "FINISHED") {
+            sleep(3000)
             break
         } else {
             Thread.sleep(1000)
@@ -77,6 +78,7 @@ suite("test_bitmap_index", "inverted_index") {
     while (max_try_secs--) {
         String res = getJobState(tbName1)
         if (res == "FINISHED") {
+            sleep(3000)
             break
         } else {
             Thread.sleep(1000)
@@ -128,6 +130,7 @@ suite("test_bitmap_index", "inverted_index") {
     while (max_try_secs--) {
         String res = getJobState(tbName2)
         if (res == "FINISHED") {
+            sleep(3000)
             break
         } else {
             Thread.sleep(1000)
@@ -152,6 +155,7 @@ suite("test_bitmap_index", "inverted_index") {
     while (max_try_secs--) {
         String res = getJobState(tbName2)
         if (res == "FINISHED") {
+            sleep(3000)
             break
         } else {
             Thread.sleep(1000)
@@ -203,6 +207,7 @@ suite("test_bitmap_index", "inverted_index") {
     while (max_try_secs--) {
         String res = getJobState(tbName3)
         if (res == "FINISHED") {
+            sleep(3000)
             break
         } else {
             Thread.sleep(1000)
@@ -223,6 +228,7 @@ suite("test_bitmap_index", "inverted_index") {
     while (max_try_secs--) {
         String res = getJobState(tbName3)
         if (res == "FINISHED") {
+            sleep(3000)
             break
         } else {
             Thread.sleep(1000)

--- a/regression-test/suites/nereids_syntax_p0/rollup.groovy
+++ b/regression-test/suites/nereids_syntax_p0/rollup.groovy
@@ -50,6 +50,7 @@ suite("rollup") {
     while (max_try_secs--) {
         String res = getJobRollupState("rollup_t1")
         if (res == "FINISHED") {
+            sleep(3000)
             break
         } else {
             Thread.sleep(2000)

--- a/regression-test/suites/nereids_syntax_p0/test_materialized_view_nereids.groovy
+++ b/regression-test/suites/nereids_syntax_p0/test_materialized_view_nereids.groovy
@@ -50,6 +50,7 @@ suite("test_materialized_view_nereids") {
     while (max_try_secs--) {
         String res = getJobState(tbName1)
         if (res == "FINISHED") {
+            sleep(3000)
             break
         } else {
             Thread.sleep(2000)
@@ -64,6 +65,7 @@ suite("test_materialized_view_nereids") {
     while (max_try_secs--) {
         String res = getJobState(tbName2)
         if (res == "FINISHED") {
+            sleep(3000)
             break
         } else {
             Thread.sleep(2000)
@@ -101,6 +103,7 @@ suite("test_materialized_view_nereids") {
     while (max_try_secs--) {
         String res = getJobState(tbName1)
         if (res == "FINISHED") {
+            sleep(3000)
             break
         } else {
             Thread.sleep(2000)

--- a/regression-test/suites/rollup/test_materialized_view_bitmap.groovy
+++ b/regression-test/suites/rollup/test_materialized_view_bitmap.groovy
@@ -36,6 +36,7 @@ suite("test_materialized_view_bitmap", "rollup") {
     while (max_try_secs--) {
         String res = getJobState(tbName1)
         if (res == "FINISHED") {
+            sleep(3000)
             break
         } else {
             Thread.sleep(2000)

--- a/regression-test/suites/rollup/test_materialized_view_date.groovy
+++ b/regression-test/suites/rollup/test_materialized_view_date.groovy
@@ -42,6 +42,7 @@ suite("test_materialized_view_date", "rollup") {
     while (max_try_secs--) {
         String res = getJobState(tbName1)
         if (res == "FINISHED") {
+            sleep(3000)
             break
         } else {
             Thread.sleep(2000)
@@ -57,6 +58,7 @@ suite("test_materialized_view_date", "rollup") {
     while (max_try_secs--) {
         String res = getJobState(tbName1)
         if (res == "FINISHED") {
+            sleep(3000)
             break
         } else {
             Thread.sleep(2000)
@@ -72,6 +74,7 @@ suite("test_materialized_view_date", "rollup") {
     while (max_try_secs--) {
         String res = getJobState(tbName1)
         if (res == "FINISHED") {
+            sleep(3000)
             break
         } else {
             Thread.sleep(2000)
@@ -87,6 +90,7 @@ suite("test_materialized_view_date", "rollup") {
     while (max_try_secs--) {
         String res = getJobState(tbName1)
         if (res == "FINISHED") {
+            sleep(3000)
             break
         } else {
             Thread.sleep(2000)

--- a/regression-test/suites/rollup/test_materialized_view_hll.groovy
+++ b/regression-test/suites/rollup/test_materialized_view_hll.groovy
@@ -38,6 +38,7 @@ suite("test_materialized_view_hll", "rollup") {
     while (max_try_secs--) {
         String res = getJobState(tbName1)
         if (res == "FINISHED") {
+            sleep(3000)
             break
         } else {
             Thread.sleep(2000)

--- a/regression-test/suites/rollup/test_materialized_view_hll_with_light_sc.groovy
+++ b/regression-test/suites/rollup/test_materialized_view_hll_with_light_sc.groovy
@@ -38,6 +38,7 @@ suite("test_materialized_view_hll_with_light_sc", "rollup") {
     while (max_try_secs--) {
         String res = getJobState(tbName1)
         if (res == "FINISHED") {
+            sleep(3000)
             break
         } else {
             Thread.sleep(2000)

--- a/regression-test/suites/rollup_p0/test_materialized_view.groovy
+++ b/regression-test/suites/rollup_p0/test_materialized_view.groovy
@@ -49,6 +49,7 @@ suite("test_materialized_view") {
     while (max_try_secs--) {
         String res = getJobState(tbName1)
         if (res == "FINISHED") {
+            sleep(3000)
             break
         } else {
             Thread.sleep(2000)
@@ -63,6 +64,7 @@ suite("test_materialized_view") {
     while (max_try_secs--) {
         String res = getJobState(tbName2)
         if (res == "FINISHED") {
+            sleep(3000)
             break
         } else {
             Thread.sleep(2000)
@@ -95,6 +97,7 @@ suite("test_materialized_view") {
     while (max_try_secs--) {
         String res = getJobState(tbName1)
         if (res == "FINISHED") {
+            sleep(3000)
             break
         } else {
             Thread.sleep(2000)

--- a/regression-test/suites/rollup_p0/test_rollup_add_column.groovy
+++ b/regression-test/suites/rollup_p0/test_rollup_add_column.groovy
@@ -45,6 +45,7 @@ suite("test_rollup_add_column") {
     while (max_try_secs--) {
         String res = getJobRollupState(tbName)
         if (res == "FINISHED") {
+            sleep(3000)
             break
         } else {
             Thread.sleep(2000)
@@ -61,6 +62,7 @@ suite("test_rollup_add_column") {
     while (max_try_secs--) {
         String res = getJobColumnState(tbName)
         if (res == "FINISHED") {
+            sleep(3000)
             break
         } else {
             Thread.sleep(2000)

--- a/regression-test/suites/rollup_p0/test_rollup_agg.groovy
+++ b/regression-test/suites/rollup_p0/test_rollup_agg.groovy
@@ -42,6 +42,7 @@ suite("test_rollup_agg") {
     while (max_try_secs--) {
         String res = getJobRollupState(tbName)
         if (res == "FINISHED") {
+            sleep(3000)
             break
         } else {
             Thread.sleep(2000)
@@ -57,6 +58,7 @@ suite("test_rollup_agg") {
     while (max_try_secs--) {
         String res = getJobColumnState(tbName)
         if (res == "FINISHED") {
+            sleep(3000)
             break
         } else {
             Thread.sleep(2000)

--- a/regression-test/suites/rollup_p0/test_rollup_agg_date.groovy
+++ b/regression-test/suites/rollup_p0/test_rollup_agg_date.groovy
@@ -45,6 +45,7 @@ suite("test_rollup_agg_date", "rollup") {
     while (max_try_secs--) {
         String res = getJobRollupState(tbName)
         if (res == "FINISHED") {
+            sleep(3000)
             break
         } else {
             Thread.sleep(2000)
@@ -60,6 +61,7 @@ suite("test_rollup_agg_date", "rollup") {
     while (max_try_secs--) {
         String res = getJobColumnState(tbName)
         if (res == "FINISHED") {
+            sleep(3000)
             break
         } else {
             Thread.sleep(2000)

--- a/regression-test/suites/schema_change/test_alter_table_column_with_delete_drop_column_dup_key.groovy
+++ b/regression-test/suites/schema_change/test_alter_table_column_with_delete_drop_column_dup_key.groovy
@@ -51,6 +51,7 @@ suite("test_alter_table_column_with_delete_drop_column_dup_key", "schema_change"
     while (max_try_secs--) {
         String res = getJobState(tbName1)
         if (res == "FINISHED") {
+            sleep(3000)
             break
         } else {
             Thread.sleep(100)
@@ -71,6 +72,7 @@ suite("test_alter_table_column_with_delete_drop_column_dup_key", "schema_change"
     while (max_try_secs--) {
         String res = getJobState(tbName1)
         if (res == "FINISHED") {
+            sleep(3000)
             break
         } else {
             Thread.sleep(100)
@@ -115,6 +117,7 @@ suite("test_alter_table_column_with_delete_drop_column_dup_key", "schema_change"
     while (max_try_secs--) {
         String res = getJobState(tbName1)
         if (res == "FINISHED") {
+            sleep(3000)
             break
         } else {
             Thread.sleep(100)
@@ -135,6 +138,7 @@ suite("test_alter_table_column_with_delete_drop_column_dup_key", "schema_change"
     while (max_try_secs--) {
         String res = getJobState(tbName1)
         if (res == "FINISHED") {
+            sleep(3000)
             break
         } else {
             Thread.sleep(100)
@@ -158,6 +162,7 @@ suite("test_alter_table_column_with_delete_drop_column_dup_key", "schema_change"
     while (max_try_secs--) {
         String res = getJobState(tbName1)
         if (res == "FINISHED") {
+            sleep(3000)
             break
         } else {
             Thread.sleep(100)
@@ -199,6 +204,7 @@ suite("test_alter_table_column_with_delete_drop_column_dup_key", "schema_change"
     while (max_try_secs--) {
         String res = getJobState(tbName1)
         if (res == "FINISHED") {
+            sleep(3000)
             break
         } else {
             Thread.sleep(100)
@@ -219,6 +225,7 @@ suite("test_alter_table_column_with_delete_drop_column_dup_key", "schema_change"
     while (max_try_secs--) {
         String res = getJobState(tbName1)
         if (res == "FINISHED") {
+            sleep(3000)
             break
         } else {
             Thread.sleep(100)

--- a/regression-test/suites/schema_change/test_alter_table_column_with_delete_drop_column_unique_key.groovy
+++ b/regression-test/suites/schema_change/test_alter_table_column_with_delete_drop_column_unique_key.groovy
@@ -52,6 +52,7 @@ suite("test_alter_table_column_with_delete_drop_column_unique_key", "schema_chan
     while (max_try_secs--) {
         String res = getJobState(tbName1)
         if (res == "FINISHED") {
+            sleep(3000)
             break
         } else {
             Thread.sleep(100)
@@ -72,6 +73,7 @@ suite("test_alter_table_column_with_delete_drop_column_unique_key", "schema_chan
     while (max_try_secs--) {
         String res = getJobState(tbName1)
         if (res == "FINISHED") {
+            sleep(3000)
             break
         } else {
             Thread.sleep(100)
@@ -116,6 +118,7 @@ suite("test_alter_table_column_with_delete_drop_column_unique_key", "schema_chan
     while (max_try_secs--) {
         String res = getJobState(tbName1)
         if (res == "FINISHED") {
+            sleep(3000)
             break
         } else {
             Thread.sleep(100)
@@ -136,6 +139,7 @@ suite("test_alter_table_column_with_delete_drop_column_unique_key", "schema_chan
     while (max_try_secs--) {
         String res = getJobState(tbName1)
         if (res == "FINISHED") {
+            sleep(3000)
             break
         } else {
             Thread.sleep(100)
@@ -159,6 +163,7 @@ suite("test_alter_table_column_with_delete_drop_column_unique_key", "schema_chan
     while (max_try_secs--) {
         String res = getJobState(tbName1)
         if (res == "FINISHED") {
+            sleep(3000)
             break
         } else {
             Thread.sleep(100)

--- a/regression-test/suites/schema_change/test_schema_change_datev2_with_delete.groovy
+++ b/regression-test/suites/schema_change/test_schema_change_datev2_with_delete.groovy
@@ -48,6 +48,7 @@ suite("test_schema_change_datev2_with_delete") {
     while(max_try_time--){
         String result = getJobState(tbName)
         if (result == "FINISHED") {
+            sleep(3000)
             break
         } else {
             sleep(100)
@@ -63,6 +64,7 @@ suite("test_schema_change_datev2_with_delete") {
     while(max_try_time--){
         String result = getJobState(tbName)
         if (result == "FINISHED") {
+            sleep(3000)
             break
         } else {
             sleep(100)
@@ -78,6 +80,7 @@ suite("test_schema_change_datev2_with_delete") {
     while(max_try_time--){
         String result = getJobState(tbName)
         if (result == "FINISHED") {
+            sleep(3000)
             break
         } else {
             sleep(100)

--- a/regression-test/suites/schema_change/test_schema_change_with_delete.groovy
+++ b/regression-test/suites/schema_change/test_schema_change_with_delete.groovy
@@ -52,6 +52,7 @@ suite("test_schema_change_with_delete") {
     while(max_try_time--){
           String result = getJobState(tbName)
           if (result == "FINISHED") {
+               sleep(3000)
                break
           } else {
                sleep(100)

--- a/regression-test/suites/schema_change_p0/datev2/test_agg_keys_schema_change_datev2.groovy
+++ b/regression-test/suites/schema_change_p0/datev2/test_agg_keys_schema_change_datev2.groovy
@@ -136,6 +136,7 @@ suite("test_agg_keys_schema_change_datev2") {
     while (max_try_time--){
         String result = getJobState(tbName)
         if (result == "FINISHED") {
+            sleep(3000)
             break
         } else {
             sleep(100)
@@ -157,6 +158,7 @@ suite("test_agg_keys_schema_change_datev2") {
     while (max_try_time--){
         String result = getJobState(tbName)
         if (result == "FINISHED") {
+            sleep(3000)
             break
         } else {
             sleep(100)
@@ -185,6 +187,7 @@ suite("test_agg_keys_schema_change_datev2") {
     while (max_try_time--){
         String result = getJobState(tbName)
         if (result == "FINISHED") {
+            sleep(3000)
             break
         } else {
             sleep(100)
@@ -206,6 +209,7 @@ suite("test_agg_keys_schema_change_datev2") {
     while (max_try_time--){
         String result = getJobState(tbName)
         if (result == "FINISHED") {
+            sleep(3000)
             break
         } else {
             sleep(100)
@@ -234,6 +238,7 @@ suite("test_agg_keys_schema_change_datev2") {
     while (max_try_time--){
         String result = getJobState(tbName)
         if (result == "FINISHED") {
+            sleep(3000)
             break
         } else {
             sleep(100)
@@ -263,6 +268,7 @@ suite("test_agg_keys_schema_change_datev2") {
     while (max_try_time--){
         String result = getJobState(tbName)
         if (result == "FINISHED") {
+            sleep(3000)
             break
         } else {
             sleep(100)

--- a/regression-test/suites/schema_change_p0/datev2/test_dup_keys_schema_change_datev2.groovy
+++ b/regression-test/suites/schema_change_p0/datev2/test_dup_keys_schema_change_datev2.groovy
@@ -131,6 +131,7 @@ suite("test_dup_keys_schema_change_datev2") {
     while (max_try_time--){
         String result = getJobState(tbName)
         if (result == "FINISHED") {
+            sleep(3000)
             break
         } else {
             sleep(100)
@@ -158,6 +159,7 @@ suite("test_dup_keys_schema_change_datev2") {
     while (max_try_time--){
         String result = getJobState(tbName)
         if (result == "FINISHED") {
+            sleep(3000)
             break
         } else {
             sleep(100)
@@ -185,6 +187,7 @@ suite("test_dup_keys_schema_change_datev2") {
     while (max_try_time--){
         String result = getJobState(tbName)
         if (result == "FINISHED") {
+            sleep(3000)
             break
         } else {
             sleep(100)

--- a/regression-test/suites/schema_change_p0/decimalv3/test_agg_keys_schema_change_decimalv3.groovy
+++ b/regression-test/suites/schema_change_p0/decimalv3/test_agg_keys_schema_change_decimalv3.groovy
@@ -125,6 +125,7 @@ suite("test_agg_keys_schema_change_decimalv3") {
     while (max_try_time--){
         String result = getJobState(tbName)
         if (result == "FINISHED") {
+            sleep(3000)
             break
         } else {
             sleep(100)
@@ -143,6 +144,7 @@ suite("test_agg_keys_schema_change_decimalv3") {
     while (max_try_time--){
         String result = getJobState(tbName)
         if (result == "FINISHED") {
+            sleep(3000)
             break
         } else {
             sleep(100)
@@ -159,6 +161,7 @@ suite("test_agg_keys_schema_change_decimalv3") {
     while (max_try_time--){
         String result = getJobState(tbName)
         if (result == "FINISHED") {
+            sleep(3000)
             break
         } else {
             sleep(100)
@@ -176,6 +179,7 @@ suite("test_agg_keys_schema_change_decimalv3") {
     while (max_try_time--){
         String result = getJobState(tbName)
         if (result == "FINISHED") {
+            sleep(3000)
             break
         } else {
             sleep(100)
@@ -193,6 +197,7 @@ suite("test_agg_keys_schema_change_decimalv3") {
     while (max_try_time--){
         String result = getJobState(tbName)
         if (result == "FINISHED") {
+            sleep(3000)
             break
         } else {
             sleep(100)

--- a/regression-test/suites/schema_change_p0/test_agg_keys_schema_change.groovy
+++ b/regression-test/suites/schema_change_p0/test_agg_keys_schema_change.groovy
@@ -105,6 +105,7 @@ suite ("test_agg_keys_schema_change") {
         while (max_try_time--){
             String result = getJobState(tableName)
             if (result == "FINISHED") {
+                sleep(3000)
                 break
             } else {
                 sleep(100)
@@ -159,6 +160,7 @@ suite ("test_agg_keys_schema_change") {
         while (max_try_time--){
             String result = getJobState(tableName)
             if (result == "FINISHED") {
+                sleep(3000)
                 break
             } else {
                 sleep(100)

--- a/regression-test/suites/schema_change_p0/test_agg_mv_schema_change.groovy
+++ b/regression-test/suites/schema_change_p0/test_agg_mv_schema_change.groovy
@@ -91,6 +91,7 @@ suite ("test_agg_mv_schema_change") {
         while (max_try_time--){
             String result = getMVJobState(tableName)
             if (result == "FINISHED") {
+                sleep(3000)
                 break
             } else {
                 sleep(100)
@@ -124,6 +125,7 @@ suite ("test_agg_mv_schema_change") {
         while (max_try_time--){
             String result = getJobState(tableName)
             if (result == "FINISHED") {
+                sleep(3000)
                 break
             } else {
                 sleep(100)

--- a/regression-test/suites/schema_change_p0/test_agg_rollup_schema_change.groovy
+++ b/regression-test/suites/schema_change_p0/test_agg_rollup_schema_change.groovy
@@ -92,6 +92,7 @@ suite ("test_agg_rollup_schema_change") {
         while (max_try_time--){
             String result = getMVJobState(tableName)
             if (result == "FINISHED") {
+                sleep(3000)
                 break
             } else {
                 sleep(100)
@@ -125,6 +126,7 @@ suite ("test_agg_rollup_schema_change") {
         while (max_try_time--){
             String result = getJobState(tableName)
             if (result == "FINISHED") {
+                sleep(3000)
                 break
             } else {
                 sleep(100)

--- a/regression-test/suites/schema_change_p0/test_alter_table_column.groovy
+++ b/regression-test/suites/schema_change_p0/test_alter_table_column.groovy
@@ -42,6 +42,7 @@ suite("test_alter_table_column") {
     while (max_try_secs--) {
         String res = getJobState(tbName1)
         if (res == "FINISHED") {
+            sleep(3000)
             break
         } else {
             Thread.sleep(2000)
@@ -61,6 +62,7 @@ suite("test_alter_table_column") {
     while (max_try_secs--) {
         String res = getJobState(tbName1)
         if (res == "FINISHED") {
+            sleep(3000)
             break
         } else {
             Thread.sleep(2000)
@@ -97,6 +99,7 @@ suite("test_alter_table_column") {
     while (max_try_secs--) {
         String res = getJobState(tbName2)
         if (res == "FINISHED") {
+            sleep(3000)
             break
         } else {
             Thread.sleep(2000)
@@ -162,6 +165,7 @@ suite("test_alter_table_column") {
     while (max_try_secs--) {
         String res = getJobState(tbName3)
         if (res == "FINISHED") {
+            sleep(3000)
             break
         } else {
             Thread.sleep(2000)

--- a/regression-test/suites/schema_change_p0/test_alter_table_column_nullable.groovy
+++ b/regression-test/suites/schema_change_p0/test_alter_table_column_nullable.groovy
@@ -50,6 +50,7 @@ suite("test_alter_table_column_nullable") {
     while (max_try_secs--) {
         String res = getJobState(tbName)
         if (res == "FINISHED") {
+            sleep(3000)
             break
         } else {
             Thread.sleep(2000)
@@ -86,6 +87,7 @@ suite("test_alter_table_column_nullable") {
     while (max_try_secs--) {
         String res = getJobState(tbName)
         if (res == "FINISHED") {
+            sleep(3000)
             break
         } else {
             Thread.sleep(2000)
@@ -153,6 +155,7 @@ suite("test_alter_table_column_nullable") {
     while (max_try_secs--) {
         String res = getJobState(tbName)
         if (res == "FINISHED") {
+            sleep(3000)
             break
         } else {
             Thread.sleep(2000)

--- a/regression-test/suites/schema_change_p0/test_alter_table_column_with_delete.groovy
+++ b/regression-test/suites/schema_change_p0/test_alter_table_column_with_delete.groovy
@@ -47,6 +47,7 @@ suite("test_alter_table_column_with_delete") {
     while (max_try_secs--) {
         String res = getJobState(tbName1)
         if (res == "FINISHED") {
+            sleep(3000)
             break
         } else {
             Thread.sleep(500)

--- a/regression-test/suites/schema_change_p0/test_dup_keys_schema_change.groovy
+++ b/regression-test/suites/schema_change_p0/test_dup_keys_schema_change.groovy
@@ -130,6 +130,7 @@ suite ("test_dup_keys_schema_change") {
         while (max_try_time--){
             String result = getJobState(tableName)
             if (result == "FINISHED") {
+                sleep(3000)
                 break
             } else {
                 sleep(100)

--- a/regression-test/suites/schema_change_p0/test_dup_mv_schema_change.groovy
+++ b/regression-test/suites/schema_change_p0/test_dup_mv_schema_change.groovy
@@ -91,6 +91,7 @@ suite ("test_dup_mv_schema_change") {
         while (max_try_time--){
             String result = getMVJobState(tableName)
             if (result == "FINISHED") {
+                sleep(3000)
                 break
             } else {
                 sleep(100)
@@ -150,6 +151,7 @@ suite ("test_dup_mv_schema_change") {
         while (max_try_time--){
             String result = getJobState(tableName)
             if (result == "FINISHED") {
+                sleep(3000)
                 break
             } else {
                 sleep(100)

--- a/regression-test/suites/schema_change_p0/test_dup_rollup_schema_change.groovy
+++ b/regression-test/suites/schema_change_p0/test_dup_rollup_schema_change.groovy
@@ -90,6 +90,7 @@ suite ("test_dup_rollup_schema_change") {
         while (max_try_time--){
             String result = getMVJobState(tableName)
             if (result == "FINISHED") {
+                sleep(3000)
                 break
             } else {
                 sleep(100)
@@ -147,6 +148,7 @@ suite ("test_dup_rollup_schema_change") {
         while (max_try_time--){
             String result = getJobState(tableName)
             if (result == "FINISHED") {
+                sleep(3000)
                 break
             } else {
                 sleep(100)

--- a/regression-test/suites/schema_change_p0/test_rename_column.groovy
+++ b/regression-test/suites/schema_change_p0/test_rename_column.groovy
@@ -152,6 +152,7 @@ suite ("test_rename_column") {
     while (max_try_time--){
         String result = getRollupJobState(tableName)
         if (result == "FINISHED") {
+            sleep(3000)
             break
         } else {
             sleep(100)
@@ -217,6 +218,7 @@ suite ("test_rename_column") {
     while (max_try_time--){
         String result = getMVJobState(tableName)
         if (result == "FINISHED") {
+            sleep(3000)
             break
         } else {
             sleep(100)

--- a/regression-test/suites/schema_change_p0/test_schema_change.groovy
+++ b/regression-test/suites/schema_change_p0/test_schema_change.groovy
@@ -50,6 +50,7 @@ suite("test_schema_change") {
      while (max_try_time--){
           String result = getJobState(tbName)
           if (result == "FINISHED") {
+               sleep(3000)
                qt_desc_uniq_table """ desc ${tbName} """
                qt_sql """ SELECT * FROM ${tbName} order by event_day,citycode  """
                sql """ DROP TABLE  ${tbName} """

--- a/regression-test/suites/schema_change_p0/test_uniq_mv_schema_change.groovy
+++ b/regression-test/suites/schema_change_p0/test_uniq_mv_schema_change.groovy
@@ -86,6 +86,7 @@ suite ("test_uniq_mv_schema_change") {
     while (max_try_time--){
         String result = getMVJobState(tableName)
         if (result == "FINISHED") {
+            sleep(3000)
             break
         } else {
             sleep(100)

--- a/regression-test/suites/schema_change_p0/test_uniq_rollup_schema_change.groovy
+++ b/regression-test/suites/schema_change_p0/test_uniq_rollup_schema_change.groovy
@@ -90,6 +90,7 @@ suite ("test_uniq_rollup_schema_change") {
     while (max_try_time--){
         String result = getMVJobState(tableName)
         if (result == "FINISHED") {
+            sleep(3000)
             break
         } else {
             sleep(100)
@@ -151,6 +152,7 @@ suite ("test_uniq_rollup_schema_change") {
     while (max_try_time--){
         String result = getJobState(tableName)
         if (result == "FINISHED") {
+            sleep(3000)
             break
         } else {
             sleep(100)

--- a/regression-test/suites/schema_change_p0/test_update_schema_change.groovy
+++ b/regression-test/suites/schema_change_p0/test_update_schema_change.groovy
@@ -61,6 +61,7 @@ suite ("test_update_schema_change") {
     while (max_try_secs--) {
         String result = getAlterColumnJobState(tableName)
         if (result == "FINISHED") {
+            sleep(3000)
             break
         } else {
             Thread.sleep(2000)
@@ -107,6 +108,7 @@ suite ("test_update_schema_change") {
     while (max_try_secs--) {
         String result = getAlterColumnJobState(tableName)
         if (result == "FINISHED") {
+            sleep(3000)
             break
         } else {
             Thread.sleep(2000)


### PR DESCRIPTION
# Proposed changes

Sometime in regression test, the schema change or rollup finished but it may not be ready, so the regression test is not very stable.

I add sleep 3s after rollup or schema change finished to avoid failure.

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

