### PR TITLE
[fix](schema_hash) remove useless schema_hash param in tablet and replica url

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/proc/ReplicasProcNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/proc/ReplicasProcNode.java
@@ -78,14 +78,8 @@ public class ReplicasProcNode implements ProcNodeInterface {
             String host = (be == null ? Backend.DUMMY_IP : be.getIp());
             int port = (be == null ? 0 : be.getHttpPort());
             String hostPort = NetUtils.getHostPortInAccessibleFormat(host, port);
-            String metaUrl = String.format("http://" + hostPort + "/api/meta/header/%d",
-                    tabletId,
-                    replica.getSchemaHash());
-
-            String compactionUrl = String.format(
-                    "http://" + hostPort + "/api/compaction/show?tablet_id=%d",
-                    tabletId,
-                    replica.getSchemaHash());
+            String metaUrl = String.format("http://" + hostPort + "/api/meta/header/%d", tabletId);
+            String compactionUrl = String.format("http://" + hostPort + "/api/compaction/show?tablet_id=%d", tabletId);
 
             String cooldownMetaId = "";
             if (replica.getCooldownMetaId() != null) {

--- a/fe/fe-core/src/main/java/org/apache/doris/common/proc/TabletsProcDir.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/proc/TabletsProcDir.java
@@ -129,14 +129,10 @@ public class TabletsProcDir implements ProcDirInterface {
                         String host = (be == null ? Backend.DUMMY_IP : be.getIp());
                         int port = (be == null ? 0 : be.getHttpPort());
                         String hostPort = NetUtils.getHostPortInAccessibleFormat(host, port);
-                        String metaUrl = String.format("http://" + hostPort + "/api/meta/header/%d",
-                                tabletId,
-                                replica.getSchemaHash());
+                        String metaUrl = String.format("http://" + hostPort + "/api/meta/header/%d", tabletId);
                         tabletInfo.add(metaUrl);
                         String compactionUrl = String.format(
-                                "http://" + hostPort + "/api/compaction/show?tablet_id=%d",
-                                tabletId,
-                                replica.getSchemaHash());
+                                "http://" + hostPort + "/api/compaction/show?tablet_id=%d", tabletId);
                         tabletInfo.add(compactionUrl);
                         tabletInfo.add(tablet.getCooldownConf().first);
                         if (replica.getCooldownMetaId() == null) {


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

schema_hash is not used in replica or tablet url anymore, remove it.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

