### PR TITLE
[fix](merge-on-write) fix that delete bitmap is not calculated correctly when clone tablet (#17334)

### DIFF
--- a/be/src/olap/snapshot_manager.cpp
+++ b/be/src/olap/snapshot_manager.cpp
@@ -421,13 +421,6 @@ Status SnapshotManager::_create_snapshot_files(const TabletSharedPtr& ref_tablet
                         break;
                     }
                 }
-
-                // Take a full snapshot, will revise according to missed rowset later.
-                if (ref_tablet->keys_type() == UNIQUE_KEYS &&
-                    ref_tablet->enable_unique_key_merge_on_write()) {
-                    delete_bitmap_snapshot = ref_tablet->tablet_meta()->delete_bitmap().snapshot(
-                            ref_tablet->max_version().second);
-                }
             }
 
             int64_t version = -1;

--- a/be/src/olap/tablet_meta.cpp
+++ b/be/src/olap/tablet_meta.cpp
@@ -660,6 +660,11 @@ void TabletMeta::delete_rs_meta_by_version(const Version& version,
             if (deleted_rs_metas != nullptr) {
                 deleted_rs_metas->push_back(*it);
             }
+            // delete delete_bitmap of to_delete's rowsets
+            if (_enable_unique_key_merge_on_write) {
+                delete_bitmap().remove({(*it)->rowset_id(), 0, 0},
+                                       {(*it)->rowset_id(), UINT32_MAX, 0});
+            }
             _rs_metas.erase(it);
             return;
         } else {
@@ -682,6 +687,11 @@ void TabletMeta::modify_rs_metas(const std::vector<RowsetMetaSharedPtr>& to_add,
             } else {
                 ++it;
             }
+        }
+        // delete delete_bitmap of to_delete's rowsets if not added to _stale_rs_metas.
+        if (same_version && _enable_unique_key_merge_on_write) {
+            delete_bitmap().remove({rs_to_del->rowset_id(), 0, 0},
+                                   {rs_to_del->rowset_id(), UINT32_MAX, 0});
         }
     }
     if (!same_version) {
@@ -934,6 +944,14 @@ void DeleteBitmap::subset(const BitmapKey& start, const BitmapKey& end,
             break;
         }
         subset_rowset_map->set(k, bm);
+    }
+}
+
+void DeleteBitmap::merge(const BitmapKey& bmk, const roaring::Roaring& segment_delete_bitmap) {
+    std::lock_guard l(lock);
+    auto [iter, succ] = delete_bitmap.emplace(bmk, segment_delete_bitmap);
+    if (!succ) {
+        iter->second |= segment_delete_bitmap;
     }
 }
 

--- a/be/src/olap/tablet_meta.h
+++ b/be/src/olap/tablet_meta.h
@@ -363,6 +363,14 @@ public:
                 DeleteBitmap* subset_delete_map) const;
 
     /**
+     * Merges the given segment delete bitmap into *this
+     *
+     * @param bmk
+     * @param segment_delete_bitmap
+     */
+    void merge(const BitmapKey& bmk, const roaring::Roaring& segment_delete_bitmap);
+
+    /**
      * Merges the given delete bitmap into *this
      *
      * @param other


### PR DESCRIPTION

# Proposed changes

Issue Number: close #xxx

## Problem summary

cherry-pick from: #17334 

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

