### PR TITLE
[fix](insert) fix memory leak for insert transaction

### DIFF
--- a/be/src/exec/plain_binary_line_reader.cpp
+++ b/be/src/exec/plain_binary_line_reader.cpp
@@ -31,13 +31,14 @@ PlainBinaryLineReader::~PlainBinaryLineReader() {
 void PlainBinaryLineReader::close() {}
 
 Status PlainBinaryLineReader::read_line(const uint8_t** ptr, size_t* size, bool* eof) {
-    std::unique_ptr<uint8_t[]> file_buf;
     int64_t read_size = 0;
-    RETURN_IF_ERROR(_file_reader->read_one_message(&file_buf, &read_size));
-    *ptr = file_buf.release();
+    RETURN_IF_ERROR(_file_reader->read_one_message(&_file_buf, &read_size));
+    *ptr = _file_buf.get();
     *size = read_size;
     if (read_size == 0) {
         *eof = true;
+    } else {
+        _cur_row.reset(*reinterpret_cast<PDataRow**>(_file_buf.get()));
     }
     return Status::OK();
 }

--- a/be/src/exec/plain_binary_line_reader.h
+++ b/be/src/exec/plain_binary_line_reader.h
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#include <gen_cpp/internal_service.pb.h>
+
 #include "exec/line_reader.h"
 
 namespace doris {
@@ -35,6 +37,8 @@ public:
 
 private:
     FileReader* _file_reader;
+    std::unique_ptr<uint8_t[]> _file_buf;
+    std::unique_ptr<PDataRow> _cur_row;
 };
 
 } // namespace doris

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -619,10 +619,14 @@ void PInternalServiceImpl::send_data(google::protobuf::RpcController* controller
         response->mutable_status()->add_error_msgs("pipe is null");
     } else {
         for (int i = 0; i < request->data_size(); ++i) {
-            PDataRow* row = new PDataRow();
+            std::unique_ptr<PDataRow> row(new PDataRow());
             row->CopyFrom(request->data(i));
-            pipe->append_and_flush(reinterpret_cast<char*>(&row), sizeof(row),
-                                   sizeof(row) + row->ByteSizeLong());
+            Status s = pipe->append(std::move(row));
+            if (!s.ok()) {
+                response->mutable_status()->set_status_code(1);
+                response->mutable_status()->add_error_msgs(s.to_string());
+                return;
+            }
         }
         response->mutable_status()->set_status_code(0);
     }

--- a/be/src/vec/exec/format/csv/csv_reader.cpp
+++ b/be/src/vec/exec/format/csv/csv_reader.cpp
@@ -402,16 +402,11 @@ Status CsvReader::_line_split_to_values(const Slice& line, bool* success) {
 void CsvReader::_split_line(const Slice& line) {
     _split_values.clear();
     if (_file_format_type == TFileFormatType::FORMAT_PROTO) {
-        PDataRow** ptr = reinterpret_cast<PDataRow**>(line.data);
-        PDataRow* row = *ptr;
-        for (const PDataColumn& col : (row)->col()) {
-            int len = col.value().size();
-            uint8_t* buf = new uint8_t[len];
-            memcpy(buf, col.value().c_str(), len);
-            _split_values.emplace_back(buf, len);
+        PDataRow** row_ptr = reinterpret_cast<PDataRow**>(line.data);
+        PDataRow* row = *row_ptr;
+        for (const PDataColumn& col : row->col()) {
+            _split_values.emplace_back(col.value());
         }
-        delete row;
-        delete[] ptr;
     } else {
         const char* value = line.data;
         size_t start = 0;     // point to the start pos of next col value.


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

```
void CsvReader::_split_line(const Slice& line) {
    _split_values.clear();
    if (_file_format_type == TFileFormatType::FORMAT_PROTO) {
        PDataRow** ptr = reinterpret_cast<PDataRow**>(line.data);
        PDataRow* row = *ptr;
        for (const PDataColumn& col : (row)->col()) {
            int len = col.value().size();
            uint8_t* buf = new uint8_t[len];
            memcpy(buf, col.value().c_str(), len);
            _split_values.emplace_back(buf, len);
        }
        delete row;
        delete[] ptr;
    } 
 ...
}
```

```
PInternalServiceImpl::send_data(google::protobuf::RpcController* controller,
                                     const PSendDataRequest* request, PSendDataResult* response,
                                     google::protobuf::Closure* done) {
    brpc::ClosureGuard closure_guard(done);
    TUniqueId fragment_instance_id;
    fragment_instance_id.hi = request->fragment_instance_id().hi();
    fragment_instance_id.lo = request->fragment_instance_id().lo();
    auto pipe = _exec_env->fragment_mgr()->get_pipe(fragment_instance_id);
    if (pipe == nullptr) {
        response->mutable_status()->set_status_code(1);
        response->mutable_status()->add_error_msgs("pipe is null");
    } else {
        for (int i = 0; i < request->data_size(); ++i) {
            PDataRow* row = new PDataRow();
            row->CopyFrom(request->data(i));
            pipe->append_and_flush(reinterpret_cast<char*>(&row), sizeof(row),
                                   sizeof(row) + row->ByteSizeLong());
        }
        response->mutable_status()->set_status_code(0);
    }
}
```
There are two problems when using begin, insert into, and commit operations.
1. The memory of buf(uint8_t* buf = new uint8_t[len]) in _split_line function didn't be released when clear _split_values.
2. The memory of PDataRow may leak when the load fails.   The memory of row(PDataRow* row = new PDataRow()) in the send_data function can't be released when some error occurs.


## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

