### PR TITLE
[chore](macOS) Disable detect_container_overflow at BE startup

### DIFF
--- a/bin/start_be.sh
+++ b/bin/start_be.sh
@@ -187,7 +187,7 @@ if [[ "${RUN_IN_AWS}" -eq 0 ]]; then
 fi
 
 ## set asan and ubsan env to generate core file
-export ASAN_OPTIONS=symbolize=1:abort_on_error=1:disable_coredump=0:unmap_shadow_on_exit=1
+export ASAN_OPTIONS=symbolize=1:abort_on_error=1:disable_coredump=0:unmap_shadow_on_exit=1:detect_container_overflow=0
 export UBSAN_OPTIONS=print_stacktrace=1
 
 ## set TCMALLOC_HEAP_LIMIT_MB to limit memory used by tcmalloc


### PR DESCRIPTION
# Proposed changes

Issue Number: close #17513

## Problem summary

BE failed to start up due to `container-overflow` errors reported by address sanitizer.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

