### PR TITLE
[fix](insert) fix memory leak for insert transaction

### DIFF
--- a/be/src/io/fs/stream_load_pipe.h
+++ b/be/src/io/fs/stream_load_pipe.h
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#include <gen_cpp/internal_service.pb.h>
+
 #include <condition_variable>
 #include <deque>
 
@@ -38,6 +40,8 @@ public:
     ~StreamLoadPipe() override;
 
     Status append_and_flush(const char* data, size_t size, size_t proto_byte_size = 0);
+
+    Status append(std::unique_ptr<PDataRow>&& row);
 
     Status append(const char* data, size_t size) override;
 
@@ -90,6 +94,7 @@ private:
     int64_t _total_length = -1;
     bool _use_proto = false;
     std::deque<ByteBufferPtr> _buf_queue;
+    std::deque<std::unique_ptr<PDataRow>> _data_row_ptrs;
     std::condition_variable _put_cond;
     std::condition_variable _get_cond;
 

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -728,10 +728,14 @@ void PInternalServiceImpl::send_data(google::protobuf::RpcController* controller
         } else {
             auto pipe = stream_load_ctx->pipe;
             for (int i = 0; i < request->data_size(); ++i) {
-                PDataRow* row = new PDataRow();
+                std::unique_ptr<PDataRow> row(new PDataRow());
                 row->CopyFrom(request->data(i));
-                pipe->append_and_flush(reinterpret_cast<char*>(&row), sizeof(row),
-                                       sizeof(row) + row->ByteSizeLong());
+                Status s = pipe->append(std::move(row));
+                if (!s.ok()) {
+                    response->mutable_status()->set_status_code(1);
+                    response->mutable_status()->add_error_msgs(s.to_string());
+                    return;
+                }
             }
             response->mutable_status()->set_status_code(0);
         }

--- a/be/src/vec/exec/format/csv/csv_reader.cpp
+++ b/be/src/vec/exec/format/csv/csv_reader.cpp
@@ -179,7 +179,7 @@ Status CsvReader::init_reader(bool is_load) {
 
         break;
     case TFileFormatType::FORMAT_PROTO:
-        _line_reader.reset(new NewPlainBinaryLineReader(_file_reader, _params.file_type));
+        _line_reader.reset(new NewPlainBinaryLineReader(_file_reader));
         break;
     default:
         return Status::InternalError(
@@ -441,16 +441,11 @@ Status CsvReader::_line_split_to_values(const Slice& line, bool* success) {
 }
 
 void CsvReader::_split_line_for_proto_format(const Slice& line) {
-    PDataRow** ptr = reinterpret_cast<PDataRow**>(line.data);
-    PDataRow* row = *ptr;
-    for (const PDataColumn& col : (row)->col()) {
-        int len = col.value().size();
-        uint8_t* buf = new uint8_t[len];
-        memcpy(buf, col.value().c_str(), len);
-        _split_values.emplace_back(buf, len);
+    PDataRow** row_ptr = reinterpret_cast<PDataRow**>(line.data);
+    PDataRow* row = *row_ptr;
+    for (const PDataColumn& col : row->col()) {
+        _split_values.emplace_back(col.value());
     }
-    delete row;
-    delete[] ptr;
 }
 
 void CsvReader::_split_line_for_single_char_delimiter(const Slice& line) {

--- a/be/src/vec/exec/format/file_reader/new_plain_binary_line_reader.h
+++ b/be/src/vec/exec/format/file_reader/new_plain_binary_line_reader.h
@@ -18,15 +18,18 @@
 #pragma once
 
 #include <gen_cpp/Types_types.h>
+#include <gen_cpp/internal_service.pb.h>
 
 #include "exec/line_reader.h"
 #include "io/fs/file_reader.h"
 
 namespace doris {
 
+// only used for FORMAT_PROTO type, which used for insert
+// transaction(begin/insert into/commit)
 class NewPlainBinaryLineReader : public LineReader {
 public:
-    NewPlainBinaryLineReader(io::FileReaderSPtr file_reader, TFileType::type file_type);
+    NewPlainBinaryLineReader(io::FileReaderSPtr file_reader);
 
     ~NewPlainBinaryLineReader() override;
 
@@ -37,7 +40,8 @@ public:
 private:
     io::FileReaderSPtr _file_reader;
 
-    TFileType::type _file_type;
+    std::unique_ptr<uint8_t[]> _file_buf;
+    std::unique_ptr<PDataRow> _cur_row;
 };
 
 } // namespace doris


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

cherry-pick from: #17512
```
void CsvReader::_split_line_for_proto_format(const Slice& line) {
    PDataRow** ptr = reinterpret_cast<PDataRow**>(line.data);
    PDataRow* row = *ptr;
    for (const PDataColumn& col : (row)->col()) {
        int len = col.value().size();
        uint8_t* buf = new uint8_t[len];
        memcpy(buf, col.value().c_str(), len);
        _split_values.emplace_back(buf, len);
    }
    delete row;
    delete[] ptr;
}
```

```
  void PInternalServiceImpl::send_data(google::protobuf::RpcController* controller,
                                       const PSendDataRequest* request, PSendDataResult* response,
                                       google::protobuf::Closure* done) {
      bool ret = _heavy_work_pool.try_offer([this, request, response, done]() {
          brpc::ClosureGuard closure_guard(done);
          TUniqueId load_id;
           load_id.hi = request->load_id().hi();
           load_id.lo = request->load_id().lo();
          // On 1.2.3 we add load id to send data request and using load id to get pipe
          auto stream_load_ctx = _exec_env->new_load_stream_mgr()->get(load_id);
          if (stream_load_ctx == nullptr) {
              response->mutable_status()->set_status_code(1);
              response->mutable_status()->add_error_msgs("could not find stream load context");
          } else {
              auto pipe = stream_load_ctx->pipe;
              for (int i = 0; i < request->data_size(); ++i) {
                  PDataRow* row = new PDataRow();
                  row->CopyFrom(request->data(i));
                  pipe->append_and_flush(reinterpret_cast<char*>(&row), sizeof(row),
                                         sizeof(row) + row->ByteSizeLong());
              }
              response->mutable_status()->set_status_code(0);
          }
      });
      if (!ret) {
          LOG(WARNING) << "fail to offer request to the work pool";
          brpc::ClosureGuard closure_guard(done);
          response->mutable_status()->set_status_code(TStatusCode::CANCELLED);
          response->mutable_status()->add_error_msgs("fail to offer request to the work pool");
      }
  }
```
There are two problems when using begin, insert into, and commit operations.
1. The memory of buf(uint8_t* buf = new uint8_t[len]) in `_split_line_for_proto_format` function didn't be released when clear _split_values.
2. The memory of PDataRow may leak when the load fails.   The memory of row(PDataRow* row = new PDataRow()) in the send_data function can't be released when some error occurs.


## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

