### PR TITLE
[enhancement](exception) add exception structure and using unique ptr in VExplodeBitmapTableFunction

### DIFF
--- a/be/src/common/CMakeLists.txt
+++ b/be/src/common/CMakeLists.txt
@@ -24,6 +24,7 @@ add_library(Common STATIC
   resource_tls.cpp
   logconfig.cpp
   configbase.cpp
+  exception.cpp
 )
 
 # Generate env_config.h according to env_config.h.in

--- a/be/src/common/exception.cpp
+++ b/be/src/common/exception.cpp
@@ -15,8 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#pragma once
-
 #include "common/exception.h"
 
 namespace doris {

--- a/be/src/common/exception.cpp
+++ b/be/src/common/exception.cpp
@@ -33,6 +33,7 @@ Exception::Exception(const Exception& nested, int code, const std::string_view m
     _err_msg->_stack = get_stack_trace();
     _nested_excption = std::make_unique<Exception>();
     _nested_excption->_code = nested._code;
+    _nested_excption->_err_msg = std::make_unique<ErrMsg>();
     _nested_excption->_err_msg->_msg = nested._err_msg->_msg;
     _nested_excption->_err_msg->_stack = nested._err_msg->_stack;
 }

--- a/be/src/common/exception.cpp
+++ b/be/src/common/exception.cpp
@@ -17,6 +17,7 @@
 
 #include "common/exception.h"
 
+#include "util/stack_util.h"
 namespace doris {
 
 Exception::Exception(int code, const std::string_view msg) {

--- a/be/src/common/exception.cpp
+++ b/be/src/common/exception.cpp
@@ -24,9 +24,7 @@ Exception::Exception(int code, const std::string_view msg) {
     _err_msg = std::make_unique<ErrMsg>();
     _err_msg->_msg = msg;
 #ifdef ENABLE_STACKTRACE
-    if constexpr (capture_stacktrace<code>()) {
-        _err_msg->_stack = get_stack_trace();
-    }
+    _err_msg->_stack = get_stack_trace();
 #endif
 }
 Exception::Exception(int code, const std::string_view msg, const Exception& nested) {
@@ -34,13 +32,14 @@ Exception::Exception(int code, const std::string_view msg, const Exception& nest
     _err_msg = std::make_unique<ErrMsg>();
     _err_msg->_msg = msg;
 #ifdef ENABLE_STACKTRACE
-    if constexpr (capture_stacktrace<code>()) {
-        _err_msg->_stack = get_stack_trace();
-    }
+    _err_msg->_stack = get_stack_trace();
 #endif
     _nested_excption = std::make_unique<Exception>();
     _nested_excption->_code = nested._code;
-    _nested_excption->_err_msg = nested._err_msg;
+    _nested_excption->_err_msg->_msg = nested._err_msg->_msg;
+#ifdef ENABLE_STACKTRACE
+    _nested_excption->_err_msg->_stack = nested._err_msg->_stack;
+#endif
 }
 
 } // namespace doris

--- a/be/src/common/exception.cpp
+++ b/be/src/common/exception.cpp
@@ -1,0 +1,48 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include "common/exception.h"
+
+namespace doris {
+
+Exception::Exception(int code, const std::string_view msg) {
+    _code = code;
+    _err_msg = std::make_unique<ErrMsg>();
+    _err_msg->_msg = msg;
+#ifdef ENABLE_STACKTRACE
+    if constexpr (capture_stacktrace<code>()) {
+        _err_msg->_stack = get_stack_trace();
+    }
+#endif
+}
+Exception::Exception(int code, const std::string_view msg, const Exception& nested) {
+    _code = code;
+    _err_msg = std::make_unique<ErrMsg>();
+    _err_msg->_msg = msg;
+#ifdef ENABLE_STACKTRACE
+    if constexpr (capture_stacktrace<code>()) {
+        _err_msg->_stack = get_stack_trace();
+    }
+#endif
+    _nested_excption = std::make_unique<Exception>();
+    _nested_excption->_code = nested._code;
+    _nested_excption->_err_msg = nested._err_msg;
+}
+
+} // namespace doris

--- a/be/src/common/exception.cpp
+++ b/be/src/common/exception.cpp
@@ -26,7 +26,7 @@ Exception::Exception(int code, const std::string_view msg) {
     _err_msg->_msg = msg;
     _err_msg->_stack = get_stack_trace();
 }
-Exception::Exception(int code, const std::string_view msg, const Exception& nested) {
+Exception::Exception(const Exception& nested, int code, const std::string_view msg) {
     _code = code;
     _err_msg = std::make_unique<ErrMsg>();
     _err_msg->_msg = msg;

--- a/be/src/common/exception.cpp
+++ b/be/src/common/exception.cpp
@@ -23,23 +23,17 @@ Exception::Exception(int code, const std::string_view msg) {
     _code = code;
     _err_msg = std::make_unique<ErrMsg>();
     _err_msg->_msg = msg;
-#ifdef ENABLE_STACKTRACE
     _err_msg->_stack = get_stack_trace();
-#endif
 }
 Exception::Exception(int code, const std::string_view msg, const Exception& nested) {
     _code = code;
     _err_msg = std::make_unique<ErrMsg>();
     _err_msg->_msg = msg;
-#ifdef ENABLE_STACKTRACE
     _err_msg->_stack = get_stack_trace();
-#endif
     _nested_excption = std::make_unique<Exception>();
     _nested_excption->_code = nested._code;
     _nested_excption->_err_msg->_msg = nested._err_msg->_msg;
-#ifdef ENABLE_STACKTRACE
     _nested_excption->_err_msg->_stack = nested._err_msg->_stack;
-#endif
 }
 
 } // namespace doris

--- a/be/src/common/exception.h
+++ b/be/src/common/exception.h
@@ -25,7 +25,9 @@ class Exception : public std::exception {
 public:
     Exception() : _code(ErrorCode::OK) {}
     Exception(int code, const std::string_view msg);
-    Exception(int code, const std::string_view msg, const Exception& nested);
+    // add nested exception as first param, or the template may could not find
+    // the correct method for ...args
+    Exception(const Exception& nested, int code, const std::string_view msg);
 
     // Format message with fmt::format, like the logging functions.
     template <typename... Args>

--- a/be/src/common/exception.h
+++ b/be/src/common/exception.h
@@ -37,6 +37,8 @@ public:
                                : fmt::format("E{}", (int16_t)_code);
     }
 
+    int code() { return _code; }
+
     std::string to_string() const;
 
     friend std::ostream& operator<<(std::ostream& ostr, const Exception& exp);

--- a/be/src/common/exception.h
+++ b/be/src/common/exception.h
@@ -32,8 +32,6 @@ public:
     Exception(int code, const std::string_view fmt, Args&&... args)
             : Exception(code, fmt::format(fmt, std::forward<Args>(args)...)) {}
 
-    void rethrow() const override { throw *this; }
-
     std::string code_as_string() const {
         return (int)_code >= 0 ? doris::to_string(static_cast<TStatusCode::type>(_code))
                                : fmt::format("E{}", (int16_t)_code);

--- a/be/src/common/exception.h
+++ b/be/src/common/exception.h
@@ -61,8 +61,8 @@ inline std::ostream& operator<<(std::ostream& ostr, const Exception& exp) {
         ostr << '\n' << exp._err_msg->_stack;
     }
 #endif
-    if (_nested_excption != nullptr) {
-        ostr << '\n' << "Caused by:" << *_nested_excption;
+    if (exp._nested_excption != nullptr) {
+        ostr << '\n' << "Caused by:" << *exp._nested_excption;
     }
     return ostr;
 }

--- a/be/src/common/exception.h
+++ b/be/src/common/exception.h
@@ -39,7 +39,7 @@ public:
                                : fmt::format("E{}", (int16_t)_code);
     }
 
-    int code() { return _code; }
+    int code() const { return _code; }
 
     std::string to_string() const;
 

--- a/be/src/common/exception.h
+++ b/be/src/common/exception.h
@@ -54,7 +54,7 @@ private:
 };
 
 inline std::ostream& operator<<(std::ostream& ostr, const Exception& exp) {
-    ostr << '[' << exp.code_as_string() << '] ';
+    ostr << '[' << exp.code_as_string() << "] ";
     ostr << (exp._err_msg ? exp._err_msg->_msg : "");
     if (exp._err_msg && !exp._err_msg->_stack.empty()) {
         ostr << '\n' << exp._err_msg->_stack;

--- a/be/src/common/exception.h
+++ b/be/src/common/exception.h
@@ -47,9 +47,7 @@ private:
     int _code;
     struct ErrMsg {
         std::string _msg;
-#ifdef ENABLE_STACKTRACE
         std::string _stack;
-#endif
     };
     std::unique_ptr<ErrMsg> _err_msg;
     std::unique_ptr<Exception> _nested_excption;
@@ -58,11 +56,9 @@ private:
 inline std::ostream& operator<<(std::ostream& ostr, const Exception& exp) {
     ostr << '[' << exp.code_as_string() << ']';
     ostr << (exp._err_msg ? exp._err_msg->_msg : "");
-#ifdef ENABLE_STACKTRACE
     if (exp._err_msg && !exp._err_msg->_stack.empty()) {
         ostr << '\n' << exp._err_msg->_stack;
     }
-#endif
     if (exp._nested_excption != nullptr) {
         ostr << '\n' << "Caused by:" << *exp._nested_excption;
     }

--- a/be/src/common/exception.h
+++ b/be/src/common/exception.h
@@ -54,7 +54,7 @@ private:
 };
 
 inline std::ostream& operator<<(std::ostream& ostr, const Exception& exp) {
-    ostr << '[' << exp.code_as_string() << ']';
+    ostr << '[' << exp.code_as_string() << '] ';
     ostr << (exp._err_msg ? exp._err_msg->_msg : "");
     if (exp._err_msg && !exp._err_msg->_stack.empty()) {
         ostr << '\n' << exp._err_msg->_stack;

--- a/be/src/common/exception.h
+++ b/be/src/common/exception.h
@@ -41,6 +41,8 @@ public:
 
     std::string to_string() const;
 
+    friend std::ostream& operator<<(std::ostream& ostr, const Exception& exp);
+
 private:
     int _code;
     struct ErrMsg {

--- a/be/src/common/exception.h
+++ b/be/src/common/exception.h
@@ -1,0 +1,76 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include "common/status.h"
+
+namespace doris {
+
+class Exception : public std::exception {
+public:
+    Exception() : _code(ErrorCode::OK) {}
+    Exception(int code, const std::string_view msg);
+    Exception(int code, const std::string_view msg, const Exception& nested);
+
+    // Format message with fmt::format, like the logging functions.
+    template <typename... Args>
+    Exception(int code, const std::string_view fmt, Args&&... args)
+            : Exception(code, fmt::format(fmt, std::forward<Args>(args)...)) {}
+
+    void rethrow() const override { throw *this; }
+
+    std::string code_as_string() const {
+        return (int)_code >= 0 ? doris::to_string(static_cast<TStatusCode::type>(_code))
+                               : fmt::format("E{}", (int16_t)_code);
+    }
+
+    std::string to_string() const;
+
+private:
+    int _code;
+    struct ErrMsg {
+        std::string _msg;
+#ifdef ENABLE_STACKTRACE
+        std::string _stack;
+#endif
+    };
+    std::unique_ptr<ErrMsg> _err_msg;
+    std::unique_ptr<Exception> _nested_excption;
+};
+
+inline std::ostream& operator<<(std::ostream& ostr, const Exception& exp) {
+    ostr << '[' << exp.code_as_string() << ']';
+    ostr << (exp._err_msg ? exp._err_msg->_msg : "");
+#ifdef ENABLE_STACKTRACE
+    if (exp._err_msg && !exp._err_msg->_stack.empty()) {
+        ostr << '\n' << exp._err_msg->_stack;
+    }
+#endif
+    if (_nested_excption != nullptr) {
+        ostr << '\n' << "Caused by:" << *_nested_excption;
+    }
+    return ostr;
+}
+
+inline std::string Exception::to_string() const {
+    std::stringstream ss;
+    ss << *this;
+    return ss.str();
+}
+
+} // namespace doris

--- a/be/src/vec/exprs/table_function/vexplode_bitmap.cpp
+++ b/be/src/vec/exprs/table_function/vexplode_bitmap.cpp
@@ -27,13 +27,6 @@ VExplodeBitmapTableFunction::VExplodeBitmapTableFunction() {
     _fn_name = "vexplode_bitmap";
 }
 
-VExplodeBitmapTableFunction::~VExplodeBitmapTableFunction() {
-    if (_cur_iter != nullptr) {
-        delete _cur_iter;
-        _cur_iter = nullptr;
-    }
-}
-
 Status VExplodeBitmapTableFunction::process_init(vectorized::Block* block) {
     CHECK(_vexpr_context->root()->children().size() == 1)
             << "VExplodeNumbersTableFunction must be have 1 children but have "
@@ -84,11 +77,7 @@ Status VExplodeBitmapTableFunction::get_value(void** output) {
 
 void VExplodeBitmapTableFunction::_reset_iterator() {
     DCHECK(_cur_bitmap->cardinality() > 0) << _cur_bitmap->cardinality();
-    if (_cur_iter != nullptr) {
-        delete _cur_iter;
-        _cur_iter = nullptr;
-    }
-    _cur_iter = new BitmapValueIterator(*_cur_bitmap);
+    _cur_iter.reset(new BitmapValueIterator(*_cur_bitmap));
     _cur_value = **_cur_iter;
     _cur_offset = 0;
 }

--- a/be/src/vec/exprs/table_function/vexplode_bitmap.h
+++ b/be/src/vec/exprs/table_function/vexplode_bitmap.h
@@ -26,7 +26,7 @@ namespace doris::vectorized {
 class VExplodeBitmapTableFunction final : public TableFunction {
 public:
     VExplodeBitmapTableFunction();
-    ~VExplodeBitmapTableFunction() = default;
+    ~VExplodeBitmapTableFunction() override = default;
 
     Status reset() override;
     Status get_value(void** output) override;

--- a/be/src/vec/exprs/table_function/vexplode_bitmap.h
+++ b/be/src/vec/exprs/table_function/vexplode_bitmap.h
@@ -26,7 +26,7 @@ namespace doris::vectorized {
 class VExplodeBitmapTableFunction final : public TableFunction {
 public:
     VExplodeBitmapTableFunction();
-    ~VExplodeBitmapTableFunction() override;
+    ~VExplodeBitmapTableFunction() = default;
 
     Status reset() override;
     Status get_value(void** output) override;
@@ -39,10 +39,10 @@ public:
 
 private:
     void _reset_iterator();
-
+    // Not own object, just a reference
     const BitmapValue* _cur_bitmap = nullptr;
     // iterator of _cur_bitmap
-    BitmapValueIterator* _cur_iter = nullptr;
+    std::unique_ptr<BitmapValueIterator> _cur_iter = nullptr;
     // current value read from bitmap, it will be referenced by
     // table function scan node.
     uint64_t _cur_value = 0;

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -31,6 +31,7 @@ set(COMMON_TEST_FILES
     common/resource_tls_test.cpp
     common/status_test.cpp
     common/config_test.cpp
+    common/exception_test.cpp
 )
 set(ENV_TEST_FILES
     env/env_posix_test.cpp

--- a/be/test/common/exception_test.cpp
+++ b/be/test/common/exception_test.cpp
@@ -20,6 +20,7 @@
 #include <gtest/gtest.h>
 
 #include <iostream>
+#include <string>
 
 namespace doris {
 
@@ -38,7 +39,7 @@ TEST_F(ExceptionTest, SingleError) {
     try {
         throw doris::Exception(ErrorCode::OS_ERROR, "test OS_ERROR {}", "bug");
     } catch (doris::Exception& e) {
-        std::cout << e << std::endl;
+        EXPECT_TRUE(e.to_string().find("OS_ERROR") != std::string::npos);
     }
 }
 
@@ -46,11 +47,12 @@ TEST_F(ExceptionTest, NestedError) {
     try {
         throw doris::Exception(ErrorCode::OS_ERROR, "test OS_ERROR {}", "bug");
     } catch (doris::Exception& e1) {
-        std::cout << e1 << std::endl;
+        EXPECT_TRUE(e1.to_string().find("OS_ERROR") != std::string::npos);
         try {
             throw doris::Exception(e1, ErrorCode::INVALID_ARGUMENT, "test INVALID_ARGUMENT");
         } catch (doris::Exception& e2) {
-            std::cout << e2 << std::endl;
+            EXPECT_TRUE(e2.to_string().find("OS_ERROR") != std::string::npos);
+            EXPECT_TRUE(e2.to_string().find("INVALID_ARGUMENT") != std::string::npos);
         }
     }
 }

--- a/be/test/common/exception_test.cpp
+++ b/be/test/common/exception_test.cpp
@@ -36,9 +36,22 @@ TEST_F(ExceptionTest, OK) {
 
 TEST_F(ExceptionTest, SingleError) {
     try {
-        throw doris::Exception(ErrorCode::OS_ERROR, "test os error {}", "bug");
+        throw doris::Exception(ErrorCode::OS_ERROR, "test OS_ERROR {}", "bug");
     } catch (doris::Exception& e) {
         std::cout << e << std::endl;
+    }
+}
+
+TEST_F(ExceptionTest, NestedError) {
+    try {
+        throw doris::Exception(ErrorCode::OS_ERROR, "test OS_ERROR {}", "bug");
+    } catch (doris::Exception& e1) {
+        std::cout << e << std::endl;
+        try {
+            throw doris::Exception(ErrorCode::INVALID_ARGUMENT, "test INVALID_ARGUMENT", e);
+        } catch (doris::Exception& e2) {
+            std::cout << e << std::endl;
+        }
     }
 }
 

--- a/be/test/common/exception_test.cpp
+++ b/be/test/common/exception_test.cpp
@@ -48,7 +48,7 @@ TEST_F(ExceptionTest, NestedError) {
     } catch (doris::Exception& e1) {
         std::cout << e1 << std::endl;
         try {
-            throw doris::Exception(ErrorCode::INVALID_ARGUMENT, "test INVALID_ARGUMENT", e1);
+            throw doris::Exception(e1, ErrorCode::INVALID_ARGUMENT, "test INVALID_ARGUMENT");
         } catch (doris::Exception& e2) {
             std::cout << e2 << std::endl;
         }

--- a/be/test/common/exception_test.cpp
+++ b/be/test/common/exception_test.cpp
@@ -1,0 +1,45 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "common/exception.h"
+
+#include <gtest/gtest.h>
+
+#include <iostream>
+
+namespace doris {
+
+class ExceptionTest : public testing::Test {};
+
+TEST_F(ExceptionTest, OK) {
+    // default
+    try {
+        throw doris::Exception();
+    } catch (doris::Exception& e) {
+        EXPECT_TRUE(e.code() == ErrorCode::OK);
+    }
+}
+
+TEST_F(ExceptionTest, SingleError) {
+    try {
+        throw doris::Exception(ErrorCode::OS_ERROR, "test os error {}", "bug");
+    } catch (doris::Exception& e) {
+        std::cout << e << std::endl;
+    }
+}
+
+} // namespace doris

--- a/be/test/common/exception_test.cpp
+++ b/be/test/common/exception_test.cpp
@@ -46,11 +46,11 @@ TEST_F(ExceptionTest, NestedError) {
     try {
         throw doris::Exception(ErrorCode::OS_ERROR, "test OS_ERROR {}", "bug");
     } catch (doris::Exception& e1) {
-        std::cout << e << std::endl;
+        std::cout << e1 << std::endl;
         try {
-            throw doris::Exception(ErrorCode::INVALID_ARGUMENT, "test INVALID_ARGUMENT", e);
+            throw doris::Exception(ErrorCode::INVALID_ARGUMENT, "test INVALID_ARGUMENT", e1);
         } catch (doris::Exception& e2) {
-            std::cout << e << std::endl;
+            std::cout << e2 << std::endl;
         }
     }
 }


### PR DESCRIPTION
# Proposed changes

1. add exception class in common.
2. using unique ptr in VExplodeBitmapTableFunction

support single exception or nested exception, like this:

---SingleException
[E-100] test OS_ERROR bug
    @     0x55e80b93c0d9  doris::Exception::Exception<>()
    @     0x55e80b938df1  doris::ExceptionTest_NestedError_Test::TestBody()
    @     0x55e82e16bafb  testing::internal::HandleSehExceptionsInMethodIfSupported<>()
    @     0x55e82e15ab3a  testing::internal::HandleExceptionsInMethodIfSupported<>()
    @     0x55e82e1361e3  testing::Test::Run()
    @     0x55e82e136f29  testing::TestInfo::Run()
    @     0x55e82e1376e4  testing::TestSuite::Run()
    @     0x55e82e148042  testing::internal::UnitTestImpl::RunAllTests()
    @     0x55e82e16dcab  testing::internal::HandleSehExceptionsInMethodIfSupported<>()
    @     0x55e82e15ce4a  testing::internal::HandleExceptionsInMethodIfSupported<>()
    @     0x55e82e147bab  testing::UnitTest::Run()
    @     0x55e80c4b39e3  RUN_ALL_TESTS()
    @     0x55e80c4a99b5  main
    @     0x7f0a619d0493  __libc_start_main
    @     0x55e80b84602a  _start
    @              (nil)  (unknown)


----NestedException
[INVALID_ARGUMENT] test INVALID_ARGUMENT
    @     0x55e80b938f6b  doris::ExceptionTest_NestedError_Test::TestBody()
    @     0x55e82e16bafb  testing::internal::HandleSehExceptionsInMethodIfSupported<>()
    @     0x55e82e15ab3a  testing::internal::HandleExceptionsInMethodIfSupported<>()
    @     0x55e82e1361e3  testing::Test::Run()
    @     0x55e82e136f29  testing::TestInfo::Run()
    @     0x55e82e1376e4  testing::TestSuite::Run()
    @     0x55e82e148042  testing::internal::UnitTestImpl::RunAllTests()
    @     0x55e82e16dcab  testing::internal::HandleSehExceptionsInMethodIfSupported<>()
    @     0x55e82e15ce4a  testing::internal::HandleExceptionsInMethodIfSupported<>()
    @     0x55e82e147bab  testing::UnitTest::Run()
    @     0x55e80c4b39e3  RUN_ALL_TESTS()
    @     0x55e80c4a99b5  main
    @     0x7f0a619d0493  __libc_start_main
    @     0x55e80b84602a  _start
    @              (nil)  (unknown)

Caused by:[E-100] test OS_ERROR bug
    @     0x55e80b93c0d9  doris::Exception::Exception<>()
    @     0x55e80b938df1  doris::ExceptionTest_NestedError_Test::TestBody()
    @     0x55e82e16bafb  testing::internal::HandleSehExceptionsInMethodIfSupported<>()
    @     0x55e82e15ab3a  testing::internal::HandleExceptionsInMethodIfSupported<>()
    @     0x55e82e1361e3  testing::Test::Run()
    @     0x55e82e136f29  testing::TestInfo::Run()
    @     0x55e82e1376e4  testing::TestSuite::Run()
    @     0x55e82e148042  testing::internal::UnitTestImpl::RunAllTests()
    @     0x55e82e16dcab  testing::internal::HandleSehExceptionsInMethodIfSupported<>()
    @     0x55e82e15ce4a  testing::internal::HandleExceptionsInMethodIfSupported<>()
    @     0x55e82e147bab  testing::UnitTest::Run()
    @     0x55e80c4b39e3  RUN_ALL_TESTS()
    @     0x55e80c4a99b5  main
    @     0x7f0a619d0493  __libc_start_main
    @     0x55e80b84602a  _start
    @              (nil)  (unknown)

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

