### PR TITLE
[fix](planner) insert default value should not change return type of function object in function set

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/FunctionCallExpr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/FunctionCallExpr.java
@@ -1072,7 +1072,8 @@ public class FunctionCallExpr extends Expr {
      * @throws AnalysisException
      */
     public void analyzeImplForDefaultValue(Type type) throws AnalysisException {
-        fn = getBuiltinFunction(fnName.getFunction(), new Type[0], Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
+        fn = new Function(getBuiltinFunction(fnName.getFunction(), new Type[0],
+                Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF));
         fn.setReturnType(type);
         this.type = type;
         for (int i = 0; i < children.size(); ++i) {

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Function.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Function.java
@@ -163,6 +163,26 @@ public class Function implements Writable {
         this(id, name, argTypes, retType, hasVarArgs, TFunctionBinaryType.BUILTIN, true, vectorized, mode);
     }
 
+    public Function(Function other) {
+        if (other == null) {
+            return;
+        }
+        this.id = other.id;
+        this.name = new FunctionName(other.name.getDb(), other.name.getFunction());
+        this.hasVarArgs = other.hasVarArgs;
+        this.retType = other.retType;
+        this.userVisible = other.userVisible;
+        this.nullableMode = other.nullableMode;
+        this.vectorized = other.vectorized;
+        this.binaryType = other.binaryType;
+        this.location = other.location;
+        if (other.argTypes != null) {
+            this.argTypes = new Type[other.argTypes.length];
+            System.arraycopy(other.argTypes, 0, this.argTypes, 0, other.argTypes.length);
+        }
+        this.checksum = other.checksum;
+    }
+
     public FunctionName getFunctionName() {
         return name;
     }

--- a/regression-test/suites/correctness_p0/test_current_timestamp.groovy
+++ b/regression-test/suites/correctness_p0/test_current_timestamp.groovy
@@ -49,6 +49,8 @@ suite("test_current_timestamp") {
     qt_insert_into """ select count(*) from ${tableName} where to_date(dt_4) = to_date(dt_5); """
     qt_insert_into """ select count(*) from ${tableName} where to_date(dt_6) = to_date(dt_7); """
 
+    sql """select now()"""
+
     // test stream load.
     streamLoad {
         table "${tableName}"
@@ -64,4 +66,6 @@ suite("test_current_timestamp") {
     qt_stream_load """ select count(*) from ${tableName} where id > 4 and to_date(dt_2) = to_date(dt_3); """
     qt_stream_load """ select count(*) from ${tableName} where id > 4 and to_date(dt_4) = to_date(dt_5); """
     qt_stream_load """ select count(*) from ${tableName} where id > 4 and to_date(dt_6) = to_date(dt_7); """
+
+    sql """select now()"""
  }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

function now's return type changed to datetimev2 by mistake.
It can be reproduced in the following way

```sql
CREATE TABLE `testdt` (
  `c1` int(11) NULL,
  `c2` datetimev2 NULL DEFAULT CURRENT_TIMESTAMP
) ENGINE=OLAP
DUPLICATE KEY(`c1`, `c2`)
COMMENT 'OLAP'
DISTRIBUTED BY HASH(`c1`) BUCKETS 10
PROPERTIES (
"replication_allocation" = "tag.location.default: 1",
"in_memory" = "false",
"storage_format" = "V2",
"light_schema_change" = "true",
"disable_auto_compaction" = "false"
);

 insert into testdt2(c1) values(1);

select now();
```

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

