### PR TITLE
[fix](scanner) remove useless _src_block_mem_reuse to avoid core dump while loading

### DIFF
--- a/be/src/vec/exec/scan/vfile_scanner.cpp
+++ b/be/src/vec/exec/scan/vfile_scanner.cpp
@@ -402,10 +402,9 @@ Status VFileScanner::_convert_to_output_block(Block* block) {
     size_t rows = _src_block.rows();
     auto filter_column = vectorized::ColumnUInt8::create(rows, 1);
     auto& filter_map = filter_column->get_data();
-    auto origin_column_num = _src_block.columns();
 
     // Set block dynamic, block maybe merge or add_rows
-    // in in later process.
+    // in later process.
     if (_is_dynamic_schema) {
         block->set_block_type(BlockType::DYNAMIC);
     }

--- a/be/src/vec/exec/scan/vfile_scanner.cpp
+++ b/be/src/vec/exec/scan/vfile_scanner.cpp
@@ -81,7 +81,6 @@ Status VFileScanner::prepare(
     _io_ctx->enable_file_cache = _state->query_options().enable_file_cache;
 
     if (_is_load) {
-        _src_block_mem_reuse = true;
         _src_row_desc.reset(new RowDescriptor(_state->desc_tbl(),
                                               std::vector<TupleId>({_input_tuple_desc->id()}),
                                               std::vector<bool>({false})));
@@ -437,11 +436,7 @@ Status VFileScanner::_convert_to_output_block(Block* block) {
             int result_column_id = -1;
             // PT1 => dest primitive type
             RETURN_IF_ERROR(ctx->execute(&_src_block, &result_column_id));
-            bool is_origin_column = result_column_id < origin_column_num;
-            column_ptr = is_origin_column && _src_block_mem_reuse
-                                 ? _src_block.get_by_position(result_column_id)
-                                           .column->clone_resized(rows)
-                                 : _src_block.get_by_position(result_column_id).column;
+            column_ptr = _src_block.get_by_position(result_column_id).column;
         }
         // column_ptr maybe a ColumnConst, convert it to a normal column
         column_ptr = column_ptr->convert_to_full_column_if_const();
@@ -533,11 +528,7 @@ Status VFileScanner::_convert_to_output_block(Block* block) {
     }
 
     // after do the dest block insert operation, clear _src_block to remove the reference of origin column
-    if (_src_block_mem_reuse) {
-        _src_block.clear_column_data(origin_column_num);
-    } else {
-        _src_block.clear();
-    }
+    _src_block.clear();
 
     size_t dest_size = block->columns();
     // do filter
@@ -809,8 +800,6 @@ Status VFileScanner::_init_expr_ctxes() {
     _is_dynamic_schema =
             _output_tuple_desc && _output_tuple_desc->slots().back()->type().is_variant_type();
     if (_is_dynamic_schema) {
-        // should not resuse Block since Block is variable
-        _src_block_mem_reuse = false;
         _full_base_schema_view.reset(new vectorized::schema_util::FullBaseSchemaView);
         _full_base_schema_view->db_name = _output_tuple_desc->table_desc()->database();
         _full_base_schema_view->table_name = _output_tuple_desc->table_desc()->name();

--- a/be/src/vec/exec/scan/vfile_scanner.h
+++ b/be/src/vec/exec/scan/vfile_scanner.h
@@ -106,7 +106,6 @@ protected:
     int _rows = 0;
     int _num_of_columns_from_file;
 
-    bool _src_block_mem_reuse = false;
     bool _strict_mode;
 
     bool _src_block_init = false;


### PR DESCRIPTION
# Proposed changes

Issue Number: close #17587 

## Problem summary

The `_src_block_mem_reuse` variable actually not work, since the `_src_block` is cleared each time when we call get_block.
But current code may cause core dump, see issue #17587. Because we insert some result column generated by expr into dest block, and such a column holds a pointer to some column in original schema. When clearing the data of _src_block, some column's data in dest block is also cleared.

e.g. coalesce will return a result column which holds a pointer to some original column, see issue #17588

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

