### PR TITLE
[fix](olap) The 'scan key' generated by the 'is null' expression causes incorrect query results

### DIFF
--- a/be/src/exec/olap_common.h
+++ b/be/src/exec/olap_common.h
@@ -1203,7 +1203,21 @@ Status OlapScanKeys::extend_scan_key(ColumnValueRange<primitive_type>& range,
     else {
         _has_range_value = true;
 
-        if (_begin_scan_keys.empty()) {
+        /// if max < min, this range should only contains a null value.
+        if (range.get_range_max_value() < range.get_range_min_value()) {
+            CHECK(range.contain_null());
+            if (_begin_scan_keys.empty()) {
+                _begin_scan_keys.emplace_back();
+                _begin_scan_keys.back().add_null();
+                _end_scan_keys.emplace_back();
+                _end_scan_keys.back().add_null();
+            } else {
+                for (int i = 0; i < _begin_scan_keys.size(); ++i) {
+                    _begin_scan_keys[i].add_null();
+                    _end_scan_keys[i].add_null();
+                }
+            }
+        } else if (_begin_scan_keys.empty()) {
             _begin_scan_keys.emplace_back();
             _begin_scan_keys.back().add_value(cast_to_string<primitive_type, CppType>(
                                                       range.get_range_min_value(), range.scale()),

--- a/regression-test/data/correctness_p0/test_null_predicate.out
+++ b/regression-test/data/correctness_p0/test_null_predicate.out
@@ -179,3 +179,7 @@
 3	\N	ccc
 5	\N	eeee
 
+-- !select16 --
+\N	99
+\N	101
+

--- a/regression-test/suites/correctness_p0/test_null_predicate.groovy
+++ b/regression-test/suites/correctness_p0/test_null_predicate.groovy
@@ -115,4 +115,36 @@ suite("test_null_predicate") {
     """
 
     qt_select15 """ select * from test_null_predicate2 where `value` is null order by id; """
+
+    sql """ DROP TABLE IF EXISTS test_null_predicate"""
+    sql """
+        create table test_null_predicate (
+            id boolean null,
+            value int null
+        ) duplicate key(id)
+        DISTRIBUTED BY HASH(id) buckets 1
+        PROPERTIES (
+            "replication_allocation" = "tag.location.default: 1",
+            "disable_auto_compaction" = "true"
+        );
+    """
+    sql """
+        insert into test_null_predicate values(1, null), (1,1), (null, 2), (1,2), (0, 3), (0, 4);
+    """
+
+    sql """
+        insert into test_null_predicate values(1, null), (1,1), (null, 2), (1,2), (0, 3), (0, 4);
+    """
+
+    sql """
+        delete from test_null_predicate where id is null;
+    """
+
+    sql """
+        insert into test_null_predicate values (null, 99), (null, 101);
+    """
+
+    qt_select16 """
+        select * from test_null_predicate where id is null order by id, value;
+    """
 }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #17568

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

