### PR TITLE
[improvement](config)add task pool config

### DIFF
--- a/docs/en/docs/admin-manual/config/fe-config.md
+++ b/docs/en/docs/admin-manual/config/fe-config.md
@@ -469,11 +469,23 @@ Default：1G
 
 Used to set the initial flow window size of the GRPC client channel, and also used to max message size.  When the result set is large, you may need to increase this value.
 
+#### `core_mysql_service_task_threads_num`
+
+Default：8
+
+the number of threads to keep in the pool, even if they are idle, unless allowCoreThreadTimeOut is set.
+
 #### `max_mysql_service_task_threads_num`
 
 Default：4096
 
 When FeEstarts the MySQL server based on NIO model, the number of threads responsible for Task events. Only `mysql_service_nio_enabled` is true takes effect.
+
+#### `mysql_service_task_threads_keep_alive_time`
+
+Default：60 second
+
+when the number of threads is greater than the core, this is the maximum time that excess idle threads will wait for new tasks before terminating.
 
 #### `mysql_service_io_threads_num`
 

--- a/docs/en/docs/admin-manual/config/fe-config.md
+++ b/docs/en/docs/admin-manual/config/fe-config.md
@@ -471,7 +471,7 @@ Used to set the initial flow window size of the GRPC client channel, and also us
 
 #### `core_mysql_service_task_threads_num`
 
-Default：8
+Default：0
 
 the number of threads to keep in the pool, even if they are idle, unless allowCoreThreadTimeOut is set.
 

--- a/docs/zh-CN/docs/admin-manual/config/fe-config.md
+++ b/docs/zh-CN/docs/admin-manual/config/fe-config.md
@@ -469,11 +469,23 @@ thrift_client_timeout_ms 的默认值设置为零以防止读取超时
 
 用于设置 GRPC 客户端通道的初始流窗口大小，也用于设置最大消息大小。当结果集较大时，可能需要增大该值。
 
+#### `core_mysql_service_task_threads_num`
+
+默认值：8
+
+mysql 中处理任务的线程池核心线程数大小。
+
 #### `max_mysql_service_task_threads_num`
 
 默认值：4096
 
 mysql 中处理任务的最大线程数。
+
+#### `mysql_service_task_threads_keep_alive_time`
+
+默认值：60 秒
+
+mysql 中处理任务线程空闲多久会被回收。
 
 #### `mysql_service_io_threads_num`
 

--- a/docs/zh-CN/docs/admin-manual/config/fe-config.md
+++ b/docs/zh-CN/docs/admin-manual/config/fe-config.md
@@ -471,7 +471,7 @@ thrift_client_timeout_ms 的默认值设置为零以防止读取超时
 
 #### `core_mysql_service_task_threads_num`
 
-默认值：8
+默认值：0
 
 mysql 中处理任务的线程池核心线程数大小。
 

--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -426,11 +426,19 @@ public class Config extends ConfigBase {
      * num of thread to handle io events in mysql.
      */
     @ConfField public static int mysql_service_io_threads_num = 4;
-
+    /**
+     * core num of thread to handle task in mysql.The corePoolSize param of ThreadPoolExecutor.
+     */
+    @ConfField public static int core_mysql_service_task_threads_num = 8;
     /**
      * max num of thread to handle task in mysql.
      */
     @ConfField public static int max_mysql_service_task_threads_num = 4096;
+
+    /**
+     * this is the maximum time that excess idle threads will wait for new tasks before terminating.
+     */
+    @ConfField public static long mysql_service_task_threads_keep_alive_time = 60L;
 
     /**
      * node(FE or BE) will be considered belonging to the same Palo cluster if they have same cluster id.

--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -429,7 +429,7 @@ public class Config extends ConfigBase {
     /**
      * core num of thread to handle task in mysql.The corePoolSize param of ThreadPoolExecutor.
      */
-    @ConfField public static int core_mysql_service_task_threads_num = 8;
+    @ConfField public static int core_mysql_service_task_threads_num = 0;
     /**
      * max num of thread to handle task in mysql.
      */

--- a/fe/fe-core/src/main/java/org/apache/doris/common/ThreadPoolManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/ThreadPoolManager.java
@@ -108,9 +108,13 @@ public class ThreadPoolManager {
 
     public static ThreadPoolExecutor newDaemonCacheThreadPool(int maxNumThread,
             String poolName, boolean needRegisterMetric) {
-        return newDaemonThreadPool(0, maxNumThread, KEEP_ALIVE_TIME,
-                TimeUnit.SECONDS, new SynchronousQueue(),
-                new LogDiscardPolicy(poolName), poolName, needRegisterMetric);
+        return newDaemonCacheThreadPool(0, maxNumThread, KEEP_ALIVE_TIME, poolName, needRegisterMetric);
+    }
+
+    public static ThreadPoolExecutor newDaemonCacheThreadPool(int corePoolSize, int maxNumThread, long keepAliveTime,
+                                                              String poolName, boolean needRegisterMetric) {
+        return newDaemonThreadPool(corePoolSize, maxNumThread, keepAliveTime, TimeUnit.SECONDS, new SynchronousQueue(),
+            new LogDiscardPolicy(poolName), poolName, needRegisterMetric);
     }
 
     public static ThreadPoolExecutor newDaemonFixedThreadPool(int numThread,

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/MysqlServer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/MysqlServer.java
@@ -52,7 +52,8 @@ public class MysqlServer {
 
     // default task service.
     private ExecutorService taskService = ThreadPoolManager.newDaemonCacheThreadPool(
-            Config.max_mysql_service_task_threads_num, "mysql-nio-pool", true);
+            Config.core_mysql_service_task_threads_num, Config.max_mysql_service_task_threads_num,
+            Config.mysql_service_task_threads_keep_alive_time, "mysql-nio-pool", true);
 
     public MysqlServer(int port, ConnectScheduler connectScheduler) {
         this.port = port;


### PR DESCRIPTION
# Proposed changes
Add corePoolSize and keepAliveTime config for task threadPool

## Problem summary

The task thread pool core size is 0. this may cause query slow and can't be monitor.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [x] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

