### PR TITLE
[feature](io) enable s3 file writer with multi part uploading concurrently

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -941,6 +941,12 @@ CONF_mInt64(max_tablet_io_errors, "-1");
 
 // Page size of row column, default 4KB
 CONF_mInt64(row_column_page_size, "4096");
+// it must be larger than or equal to 5MB
+CONF_mInt32(s3_write_buffer_size, "5242880");
+// the size of the whole s3 buffer pool, which indicates the s3 file writer
+// can at most buffer 50MB data. And the num of multi part upload task is
+// s3_write_buffer_whole_size / s3_write_buffer_size
+CONF_mInt32(s3_write_buffer_whole_size, "524288000");
 
 #ifdef BE_TEST
 // test s3

--- a/be/src/io/CMakeLists.txt
+++ b/be/src/io/CMakeLists.txt
@@ -34,6 +34,7 @@ set(IO_FILES
     fs/s3_file_system.cpp
     fs/s3_file_reader.cpp
     fs/s3_file_writer.cpp
+    fs/s3_file_write_bufferpool.cpp
     fs/hdfs_file_system.cpp
     fs/hdfs_file_reader.cpp
     fs/hdfs_file_writer.cpp

--- a/be/src/io/fs/s3_file_write_bufferpool.cpp
+++ b/be/src/io/fs/s3_file_write_bufferpool.cpp
@@ -1,0 +1,108 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "s3_file_write_bufferpool.h"
+
+#include <cstring>
+
+#include "common/config.h"
+#include "common/logging.h"
+#include "io/fs/s3_common.h"
+#include "runtime/exec_env.h"
+#include "util/defer_op.h"
+
+namespace doris {
+namespace io {
+void S3FileBuffer::on_finished() {
+    if (_buf == nullptr) {
+        return;
+    }
+    reset();
+    S3FileBufferPool::GetInstance()->reclaim(shared_from_this());
+}
+
+// when there is memory preserved, directly write data to buf
+// TODO:(AlexYue): write to file cache otherwise, then we'll wait for free buffer
+// and to rob it
+void S3FileBuffer::append_data(const Slice& data) {
+    Defer defer {[&] { _size += data.get_size(); }};
+    while (true) {
+        // if buf is not empty, it means there is memory preserved for this buf
+        if (_buf != nullptr) {
+            memcpy(_buf->data() + _size, data.get_data(), data.get_size());
+            break;
+        } else {
+            // wait allocate buffer pool
+            auto tmp = S3FileBufferPool::GetInstance()->allocate(true);
+            rob_buffer(tmp);
+        }
+    }
+}
+
+void S3FileBuffer::submit() {
+    if (LIKELY(_buf != nullptr)) {
+        _stream_ptr = std::make_shared<StringViewStream>(_buf->data(), _size);
+    }
+
+    ExecEnv::GetInstance()->buffered_reader_prefetch_thread_pool()->submit_func(
+            [buf = this->shared_from_this()]() { buf->_on_upload(); });
+}
+
+S3FileBufferPool::S3FileBufferPool() {
+    // the nums could be one configuration
+    size_t buf_num = config::s3_write_buffer_whole_size / config::s3_write_buffer_size;
+    DCHECK((config::s3_write_buffer_size >= 5 * 1024 * 1024) &&
+           (config::s3_write_buffer_whole_size > config::s3_write_buffer_size));
+    LOG_INFO("S3 file buffer pool with {} buffers", buf_num);
+    for (size_t i = 0; i < buf_num; i++) {
+        auto buf = std::make_shared<S3FileBuffer>();
+        buf->reserve_buffer();
+        _free_buffers.emplace_back(std::move(buf));
+    }
+}
+
+std::shared_ptr<S3FileBuffer> S3FileBufferPool::allocate(bool reserve) {
+    std::shared_ptr<S3FileBuffer> buf;
+    // if need reserve then we must ensure return buf with memory preserved
+    if (reserve) {
+        {
+            std::unique_lock<std::mutex> lck {_lock};
+            _cv.wait(lck, [this]() { return !_free_buffers.empty(); });
+            buf = std::move(_free_buffers.front());
+            _free_buffers.pop_front();
+        }
+        return buf;
+    }
+    // try to get one memory reserved buffer
+    {
+        std::unique_lock<std::mutex> lck {_lock};
+        if (!_free_buffers.empty()) {
+            buf = std::move(_free_buffers.front());
+            _free_buffers.pop_front();
+        }
+    }
+    if (buf != nullptr) {
+        return buf;
+    }
+    // if there is no free buffer and no need to reserve memory, we could return one empty buffer
+    buf = std::make_shared<S3FileBuffer>();
+    // if the buf has no memory reserved, it would try to write the data to file cache first
+    // or it would try to rob buffer from other S3FileBuffer
+    return buf;
+}
+} // namespace io
+} // namespace doris

--- a/be/src/io/fs/s3_file_write_bufferpool.h
+++ b/be/src/io/fs/s3_file_write_bufferpool.h
@@ -1,0 +1,140 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <condition_variable>
+#include <cstdint>
+#include <fstream>
+#include <functional>
+#include <list>
+#include <memory>
+#include <mutex>
+
+#include "common/config.h"
+#include "common/status.h"
+#include "io/fs/s3_common.h"
+#include "util/slice.h"
+
+namespace doris {
+namespace io {
+
+// TODO(AlexYue): 1. support write into cache 2. unify write buffer and read buffer
+struct S3FileBuffer : public std::enable_shared_from_this<S3FileBuffer> {
+    using Callback = std::function<void()>;
+
+    S3FileBuffer() = default;
+    ~S3FileBuffer() = default;
+
+    void rob_buffer(std::shared_ptr<S3FileBuffer>& other) {
+        _buf = std::move(other->_buf);
+        other->_buf = nullptr;
+    }
+
+    void reserve_buffer() {
+        _buf = std::make_unique<std::string>();
+        _buf->resize(config::s3_write_buffer_size);
+    }
+
+    // apend data into the memory buffer inside or into the file cache
+    // if the buffer has no memory buffer
+    void append_data(const Slice& data);
+    // upload to S3 and file cache in async threadpool
+    void submit();
+    // set the callback to upload to S3 file
+    void set_upload_remote_callback(Callback cb) { _upload_to_remote_callback = std::move(cb); }
+    // set callback to do task sync for the caller
+    void set_finish_upload(Callback cb) { _on_finish_upload = std::move(cb); }
+    // set cancel callback to indicate if the whole task is cancelled or not
+    void set_is_cancel(std::function<bool()> cb) { _is_cancelled = std::move(cb); }
+    // set callback to notify all the tasks that the whole procedure could be cancelled
+    // if this buffer's task failed
+    void set_on_failed(std::function<void(Status)> cb) { _on_failed = std::move(cb); }
+    // reclaim this buffer when task is done
+    void on_finished();
+    // set the status of the caller if task failed
+    void set_status(Status s) { _status = std::move(s); }
+    // get the size of the content already appendded
+    size_t get_size() const { return _size; }
+    // get the underlying stream containing
+    std::shared_ptr<std::iostream> get_stream() const { return _stream_ptr; }
+    // get file offset corresponding to the buffer
+    size_t get_file_offset() const { return _offset; }
+    // set the offset of the buffer
+    void set_file_offset(size_t offset) { _offset = offset; }
+    // reset this buffer to be reused
+    void reset() {
+        _upload_to_remote_callback = nullptr;
+        _is_cancelled = nullptr;
+        _on_failed = nullptr;
+        _on_finish_upload = nullptr;
+        _offset = 0;
+        _size = 0;
+    }
+
+    Callback _upload_to_remote_callback = nullptr;
+    // to control the callback control flow
+    // 1. read from cache if the data is written to cache first
+    // 2. upload content of buffer to S3
+    // 3. upload content to file cache if necessary
+    // 4. call the finish callback caller specified
+    // 5. reclaim self
+    void _on_upload() {
+        _upload_to_remote_callback();
+        _on_finish_upload();
+        on_finished();
+    };
+    // the caller might be cancelled
+    std::function<bool()> _is_cancelled = []() { return false; };
+    // set the caller to be failed
+    std::function<void(Status)> _on_failed = nullptr;
+    // caller of this buf could use this callback to do syncronization
+    Callback _on_finish_upload = nullptr;
+    Status _status;
+    size_t _offset;
+    size_t _size;
+    std::shared_ptr<std::iostream> _stream_ptr;
+    // only served as one reserved buffer
+    std::unique_ptr<std::string> _buf;
+    size_t _append_offset {0};
+};
+
+class S3FileBufferPool {
+public:
+    S3FileBufferPool();
+    ~S3FileBufferPool() = default;
+
+    static S3FileBufferPool* GetInstance() {
+        static S3FileBufferPool _pool;
+        return &_pool;
+    }
+
+    void reclaim(std::shared_ptr<S3FileBuffer> buf) {
+        std::unique_lock<std::mutex> lck {_lock};
+        _free_buffers.emplace_front(std::move(buf));
+        _cv.notify_all();
+    }
+
+    std::shared_ptr<S3FileBuffer> allocate(bool reserve = false);
+
+private:
+    std::mutex _lock;
+    std::condition_variable _cv;
+    std::list<std::shared_ptr<S3FileBuffer>> _free_buffers;
+};
+} // namespace io
+} // namespace doris

--- a/be/src/io/fs/s3_file_writer.cpp
+++ b/be/src/io/fs/s3_file_writer.cpp
@@ -44,8 +44,8 @@
 #include "io/fs/file_writer.h"
 #include "io/fs/path.h"
 #include "io/fs/s3_file_write_bufferpool.h"
-#include "util/runtime_profile.h"
 #include "util/doris_metrics.h"
+#include "util/runtime_profile.h"
 
 namespace Aws {
 namespace S3 {

--- a/be/src/io/fs/s3_file_writer.cpp
+++ b/be/src/io/fs/s3_file_writer.cpp
@@ -39,9 +39,12 @@
 #include <sstream>
 #include <utility>
 
+#include "common/config.h"
 #include "common/status.h"
 #include "io/fs/file_writer.h"
 #include "io/fs/path.h"
+#include "io/fs/s3_file_write_bufferpool.h"
+#include "util/runtime_profile.h"
 #include "util/doris_metrics.h"
 
 namespace Aws {
@@ -57,23 +60,21 @@ using Aws::S3::Model::CompletedPart;
 using Aws::S3::Model::CompletedMultipartUpload;
 using Aws::S3::Model::CompleteMultipartUploadRequest;
 using Aws::S3::Model::CreateMultipartUploadRequest;
-using Aws::S3::Model::DeleteObjectRequest;
 using Aws::S3::Model::UploadPartRequest;
 using Aws::S3::Model::UploadPartOutcome;
 
 namespace doris {
 namespace io {
+using namespace Aws::S3::Model;
+using Aws::S3::S3Client;
 
-// max size of each part when uploading: 5MB
-static const int MAX_SIZE_EACH_PART = 5 * 1024 * 1024;
-static const char* STREAM_TAG = "S3FileWriter";
-
-S3FileWriter::S3FileWriter(Path path, std::shared_ptr<Aws::S3::S3Client> client,
-                           const S3Conf& s3_conf, FileSystemSPtr fs)
-        : FileWriter(std::move(path), fs), _client(client), _s3_conf(s3_conf) {
-    DorisMetrics::instance()->s3_file_open_writing->increment(1);
-    DorisMetrics::instance()->s3_file_writer_total->increment(1);
-}
+S3FileWriter::S3FileWriter(Path path, std::shared_ptr<S3Client> client, const S3Conf& s3_conf,
+                           FileSystemSPtr fs)
+        : FileWriter(Path(s3_conf.endpoint) / s3_conf.bucket / path, std::move(fs)),
+          _bucket(s3_conf.bucket),
+          _key(std::move(path)),
+          _upload_cost_ms(std::make_shared<int64_t>()),
+          _client(std::move(client)) {}
 
 S3FileWriter::~S3FileWriter() {
     if (_opened) {
@@ -82,168 +83,208 @@ S3FileWriter::~S3FileWriter() {
     CHECK(!_opened || _closed) << "open: " << _opened << ", closed: " << _closed;
 }
 
-Status S3FileWriter::close() {
-    return _close();
+Status S3FileWriter::open() {
+    VLOG_DEBUG << "S3FileWriter::open, path: " << _path.native();
+    CreateMultipartUploadRequest create_request;
+    create_request.WithBucket(_bucket).WithKey(_key);
+    create_request.SetContentType("text/plain");
+
+    auto outcome = _client->CreateMultipartUpload(create_request);
+
+    if (outcome.IsSuccess()) {
+        _upload_id = outcome.GetResult().GetUploadId();
+        _closed = false;
+        _opened = true;
+        return Status::OK();
+    }
+    return Status::IOError("failed to create multipart upload(bucket={}, key={}, upload_id={}): {}",
+                           _bucket, _path.native(), _upload_id, outcome.GetError().GetMessage());
 }
 
 Status S3FileWriter::abort() {
+    _failed = true;
+    if (_closed || !_opened) {
+        return Status::OK();
+    }
+    VLOG_DEBUG << "S3FileWriter::abort, path: " << _path.native();
+    _closed = true;
+    while (!_wait.wait()) {
+        LOG(WARNING) << "Abort multipart upload already takes 5 min"
+                     << "bucket=" << _bucket << ", key=" << _path.native()
+                     << ", upload_id=" << _upload_id;
+    }
     AbortMultipartUploadRequest request;
-    request.WithBucket(_s3_conf.bucket).WithKey(_path.native()).WithUploadId(_upload_id);
+    request.WithBucket(_bucket).WithKey(_key).WithUploadId(_upload_id);
     auto outcome = _client->AbortMultipartUpload(request);
     if (outcome.IsSuccess() ||
         outcome.GetError().GetErrorType() == Aws::S3::S3Errors::NO_SUCH_UPLOAD ||
         outcome.GetError().GetResponseCode() == Aws::Http::HttpResponseCode::NOT_FOUND) {
-        LOG(INFO) << "Abort multipart upload successfully. endpoint=" << _s3_conf.endpoint
-                  << ", bucket=" << _s3_conf.bucket << ", key=" << _path.native()
+        LOG(INFO) << "Abort multipart upload successfully"
+                  << "bucket=" << _bucket << ", key=" << _path.native()
                   << ", upload_id=" << _upload_id;
         return Status::OK();
     }
-    return Status::IOError(
-            "failed to abort multipart upload(endpoint={}, bucket={}, key={}, upload_id={}): {}",
-            _s3_conf.endpoint, _s3_conf.bucket, _path.native(), _upload_id,
-            outcome.GetError().GetMessage());
+    return Status::IOError("failed to abort multipart upload(bucket={}, key={}, upload_id={}): {}",
+                           _bucket, _path.native(), _upload_id, outcome.GetError().GetMessage());
+}
+
+Status S3FileWriter::close() {
+    if (_closed) {
+        return Status::OK();
+    }
+    VLOG_DEBUG << "S3FileWriter::close, path: " << _path.native();
+    _closed = true;
+    if (_pending_buf != nullptr) {
+        _wait.add();
+        _pending_buf->submit();
+        _pending_buf = nullptr;
+    }
+    RETURN_IF_ERROR(_complete());
+
+    return Status::OK();
 }
 
 Status S3FileWriter::appendv(const Slice* data, size_t data_cnt) {
+    // lazy open
+    if (!_opened) {
+        RETURN_IF_ERROR(open());
+    }
     DCHECK(!_closed);
-    if (!_is_open) {
-        RETURN_IF_ERROR(_open());
-        _is_open = true;
+    size_t buffer_size = config::s3_write_buffer_size;
+    SCOPED_RAW_TIMER(_upload_cost_ms.get());
+    for (size_t i = 0; i < data_cnt; i++) {
+        size_t data_size = data[i].get_size();
+        for (size_t pos = 0, data_size_to_append = 0; pos < data_size; pos += data_size_to_append) {
+            if (!_pending_buf) {
+                _pending_buf = S3FileBufferPool::GetInstance()->allocate();
+                // capture part num by value along with the value of the shared ptr
+                _pending_buf->set_upload_remote_callback(
+                        [part_num = _cur_part_num, this, cur_buf = _pending_buf]() {
+                            _upload_one_part(part_num, *cur_buf);
+                        });
+                _pending_buf->set_file_offset(_bytes_appended);
+                // later we might need to wait all prior tasks to be finished
+                _pending_buf->set_finish_upload([this]() { _wait.done(); });
+                _pending_buf->set_is_cancel([this]() { return _failed.load(); });
+                _pending_buf->set_on_failed([this, part_num = _cur_part_num](Status st) {
+                    VLOG_NOTICE << "failed at key: " << _key << ", load part " << part_num
+                                << ", st " << st.to_string();
+                    std::unique_lock<std::mutex> _lck {_completed_lock};
+                    _failed = true;
+                    this->_st = std::move(st);
+                });
+            }
+            // we need to make sure all parts except the last one to be 5MB or more
+            // and shouldn't be larger than buf
+            data_size_to_append = std::min(data_size - pos, _pending_buf->get_file_offset() +
+                                                                    buffer_size - _bytes_appended);
+
+            // if the buffer has memory buf inside, the data would be written into memory first then S3 then file cache
+            // it would be written to cache then S3 if the buffer doesn't have memory preserved
+            _pending_buf->append_data(Slice {data[i].get_data() + pos, data_size_to_append});
+
+            // if it's the last part, it could be less than 5MB, or it must
+            // satisfy that the size is larger than or euqal to 5MB
+            // _complete() would handle the first situation
+            if (_pending_buf->get_size() == buffer_size) {
+                _cur_part_num++;
+                _wait.add();
+                _pending_buf->submit();
+                _pending_buf = nullptr;
+            }
+            _bytes_appended += data_size_to_append;
+        }
+    }
+    return Status::OK();
+}
+
+void S3FileWriter::_upload_one_part(int64_t part_num, S3FileBuffer& buf) {
+    if (buf._is_cancelled()) {
+        return;
+    }
+    UploadPartRequest upload_request;
+    upload_request.WithBucket(_bucket).WithKey(_key).WithPartNumber(part_num).WithUploadId(
+            _upload_id);
+
+    auto _stream_ptr = buf.get_stream();
+
+    upload_request.SetBody(buf.get_stream());
+
+    Aws::Utils::ByteBuffer part_md5(Aws::Utils::HashingUtils::CalculateMD5(*_stream_ptr));
+    upload_request.SetContentMD5(Aws::Utils::HashingUtils::Base64Encode(part_md5));
+
+    upload_request.SetContentLength(buf.get_size());
+
+    auto upload_part_callable = _client->UploadPartCallable(upload_request);
+
+    UploadPartOutcome upload_part_outcome = upload_part_callable.get();
+    if (!upload_part_outcome.IsSuccess()) {
+        auto s = Status::IOError(
+                "failed to upload part (bucket={}, key={}, part_num={}, up_load_id={}): {}",
+                _bucket, _path.native(), part_num, _upload_id,
+                upload_part_outcome.GetError().GetMessage());
+        LOG_WARNING(s.to_string());
+        buf._on_failed(s);
+        return;
     }
 
-    for (size_t i = 0; i < data_cnt; i++) {
-        const Slice& result = data[i];
-        _stream_ptr->write(result.data, result.size);
-        _bytes_appended += result.size;
-        auto start_pos = _stream_ptr->tellg();
-        _stream_ptr->seekg(0LL, _stream_ptr->end);
-        _stream_ptr->seekg(start_pos);
+    std::shared_ptr<CompletedPart> completed_part = std::make_shared<CompletedPart>();
+    completed_part->SetPartNumber(part_num);
+    auto etag = upload_part_outcome.GetResult().GetETag();
+    // DCHECK(etag.empty());
+    completed_part->SetETag(etag);
+
+    std::unique_lock<std::mutex> lck {_completed_lock};
+    _completed_parts.emplace_back(completed_part);
+    _bytes_written += buf.get_size();
+}
+
+// TODO(AlexYue): if the whole size is less than 5MB, we can use just call put object method
+// to reduce the network IO num to just one time
+Status S3FileWriter::_complete() {
+    SCOPED_RAW_TIMER(_upload_cost_ms.get());
+    if (_failed) {
+        return _st;
     }
-    if (_stream_ptr->str().size() >= MAX_SIZE_EACH_PART) {
-        RETURN_IF_ERROR(_upload_part());
+    CompleteMultipartUploadRequest complete_request;
+    complete_request.WithBucket(_bucket).WithKey(_key).WithUploadId(_upload_id);
+
+    while (!_wait.wait()) {
+        LOG(WARNING) << "Complete multipart upload already takes 5 min"
+                     << "bucket=" << _bucket << ", key=" << _path.native()
+                     << ", upload_id=" << _upload_id;
+    }
+    // make sure _completed_parts are ascending order
+    std::sort(_completed_parts.begin(), _completed_parts.end(),
+              [](auto& p1, auto& p2) { return p1->GetPartNumber() < p2->GetPartNumber(); });
+    CompletedMultipartUpload completed_upload;
+    for (std::shared_ptr<CompletedPart> part : _completed_parts) {
+        completed_upload.AddParts(*part);
+    }
+
+    complete_request.WithMultipartUpload(completed_upload);
+
+    auto compute_outcome = _client->CompleteMultipartUpload(complete_request);
+
+    if (!compute_outcome.IsSuccess()) {
+        auto s = Status::IOError(
+                "failed to create complete multi part upload (bucket={}, key={}): {}", _bucket,
+                _path.native(), compute_outcome.GetError().GetMessage());
+        LOG_WARNING(s.to_string());
+        return s;
     }
     return Status::OK();
 }
 
 Status S3FileWriter::finalize() {
     DCHECK(!_closed);
-    if (_opened) {
-        _close();
+    // submit pending buf if it's not nullptr
+    // it's the last buf, we can submit it right now
+    if (_pending_buf != nullptr) {
+        _wait.add();
+        _pending_buf->submit();
+        _pending_buf = nullptr;
     }
-    return Status::OK();
-}
-
-Status S3FileWriter::_open() {
-    CreateMultipartUploadRequest create_request;
-    create_request.WithBucket(_s3_conf.bucket).WithKey(_path.native());
-    create_request.SetContentType("text/plain");
-
-    _reset_stream();
-    auto outcome = _client->CreateMultipartUpload(create_request);
-
-    if (outcome.IsSuccess()) {
-        _upload_id = outcome.GetResult().GetUploadId();
-        LOG(INFO) << "create multi part upload successfully (endpoint=" << _s3_conf.endpoint
-                  << ", bucket=" << _s3_conf.bucket << ", key=" << _path.native()
-                  << ") upload_id: " << _upload_id;
-        return Status::OK();
-    }
-    return Status::IOError(
-            "failed to create multi part upload when open (endpoint={}, bucket={}, key={}): {}",
-            _s3_conf.endpoint, _s3_conf.bucket, _path.native(), outcome.GetError().GetMessage());
-}
-
-Status S3FileWriter::_upload_part() {
-    if (_stream_ptr->str().size() == 0) {
-        return Status::OK();
-    }
-    ++_cur_part_num;
-
-    UploadPartRequest upload_request;
-    upload_request.WithBucket(_s3_conf.bucket)
-            .WithKey(_path.native())
-            .WithPartNumber(_cur_part_num)
-            .WithUploadId(_upload_id);
-
-    upload_request.SetBody(_stream_ptr);
-
-    Aws::Utils::ByteBuffer part_md5(Aws::Utils::HashingUtils::CalculateMD5(*_stream_ptr));
-    upload_request.SetContentMD5(Aws::Utils::HashingUtils::Base64Encode(part_md5));
-
-    auto start_pos = _stream_ptr->tellg();
-    _stream_ptr->seekg(0LL, _stream_ptr->end);
-    upload_request.SetContentLength(static_cast<long>(_stream_ptr->tellg()));
-    _stream_ptr->seekg(start_pos);
-
-    auto upload_part_callable = _client->UploadPartCallable(upload_request);
-
-    UploadPartOutcome upload_part_outcome = upload_part_callable.get();
-    _reset_stream();
-    if (!upload_part_outcome.IsSuccess()) {
-        LOG(ERROR) << "failed to upload part (endpoint=" << _s3_conf.endpoint
-                   << ", bucket=" << _s3_conf.bucket << ", key=" << _path.native()
-                   << ", part_num=" << _cur_part_num
-                   << ") Error msg: " << upload_part_outcome.GetError().GetMessage();
-        return Status::IOError("failed to upload part.");
-    }
-
-    std::shared_ptr<CompletedPart> completed_part = std::make_shared<CompletedPart>();
-    completed_part->SetPartNumber(_cur_part_num);
-    auto etag = upload_part_outcome.GetResult().GetETag();
-    if (etag.empty()) {
-        LOG(ERROR) << "upload part success but etag is empty (endpoint=" << _s3_conf.endpoint
-                   << ", bucket=" << _s3_conf.bucket << ", key=" << _path.native()
-                   << ", part_num=" << _cur_part_num << ")";
-        return Status::IOError("upload part success but etag is empty.");
-    }
-    completed_part->SetETag(etag);
-    _completed_parts.emplace_back(completed_part);
-    return Status::OK();
-}
-
-void S3FileWriter::_reset_stream() {
-    _stream_ptr = Aws::MakeShared<Aws::StringStream>(STREAM_TAG, "");
-}
-
-Status S3FileWriter::_close() {
-    if (_closed) {
-        return Status::OK();
-    }
-    if (_is_open) {
-        RETURN_IF_ERROR(_upload_part());
-
-        CompleteMultipartUploadRequest complete_request;
-        complete_request.WithBucket(_s3_conf.bucket)
-                .WithKey(_path.native())
-                .WithUploadId(_upload_id);
-
-        CompletedMultipartUpload completed_upload;
-        for (std::shared_ptr<CompletedPart> part : _completed_parts) {
-            completed_upload.AddParts(*part);
-        }
-
-        complete_request.WithMultipartUpload(completed_upload);
-
-        auto compute_outcome = _client->CompleteMultipartUpload(complete_request);
-
-        if (!compute_outcome.IsSuccess()) {
-            return Status::IOError(
-                    "failed to create multi part upload when close (endpoint={}, bucket={}, "
-                    "key={}): {}",
-                    _s3_conf.endpoint, _s3_conf.bucket, _path.native(),
-                    compute_outcome.GetError().GetMessage());
-        }
-        _is_open = false;
-    }
-    _closed = true;
-
-    DorisMetrics::instance()->s3_file_open_writing->increment(-1);
-    DorisMetrics::instance()->s3_file_created_total->increment(1);
-    DorisMetrics::instance()->s3_bytes_written_total->increment(_bytes_appended);
-
-    LOG(INFO) << "complete multi part upload successfully (endpoint=" << _s3_conf.endpoint
-              << ", bucket=" << _s3_conf.bucket << ", key=" << _path.native()
-              << ") upload_id: " << _upload_id;
     return Status::OK();
 }
 

--- a/be/src/io/fs/s3_file_writer.h
+++ b/be/src/io/fs/s3_file_writer.h
@@ -40,6 +40,7 @@ class S3Client;
 
 namespace doris {
 namespace io {
+struct S3FileBuffer;
 
 class S3FileWriter final : public FileWriter {
 public:
@@ -47,7 +48,10 @@ public:
                  FileSystemSPtr fs);
     ~S3FileWriter() override;
 
+    Status open();
+
     Status close() override;
+
     Status abort() override;
     Status appendv(const Slice* data, size_t data_cnt) override;
     Status finalize() override;
@@ -55,23 +59,75 @@ public:
         return Status::NotSupported("not support");
     }
 
-private:
-    Status _close();
-    Status _open();
-    Status _upload_part();
-    void _reset_stream();
+    size_t bytes_appended() const { return _bytes_appended; }
+
+    int64_t upload_cost_ms() const { return *_upload_cost_ms; }
 
 private:
+    class WaitGroup {
+    public:
+        WaitGroup() = default;
+
+        ~WaitGroup() = default;
+
+        WaitGroup(const WaitGroup&) = delete;
+        WaitGroup(WaitGroup&&) = delete;
+        void operator=(const WaitGroup&) = delete;
+        void operator=(WaitGroup&&) = delete;
+        // add one counter indicating one more concurrent worker
+        void add(int count = 1) { _count += count; }
+
+        // decrease count if one concurrent worker finished it's work
+        void done() {
+            _count--;
+            if (_count.load() <= 0) {
+                _cv.notify_all();
+            }
+        }
+
+        // wait for all concurrent workers finish their work and return true
+        // would return false if timeout, default timeout would be 5min
+        bool wait(int64_t timeout_seconds = 300) {
+            if (_count.load() <= 0) {
+                return true;
+            }
+            std::unique_lock<std::mutex> lck {_lock};
+            _cv.wait_for(lck, std::chrono::seconds(timeout_seconds),
+                         [this]() { return _count.load() <= 0; });
+            return false;
+        }
+
+    private:
+        std::mutex _lock;
+        std::condition_variable _cv;
+        std::atomic_int64_t _count {0};
+    };
+    Status _complete();
+    void _upload_one_part(int64_t part_num, S3FileBuffer& buf);
+
+    std::string _bucket;
+    std::string _key;
+    bool _closed = true;
+    bool _opened = false;
+
+    std::shared_ptr<int64_t> _upload_cost_ms;
+
     std::shared_ptr<Aws::S3::S3Client> _client;
-    S3Conf _s3_conf;
     std::string _upload_id;
-    bool _is_open = false;
-    bool _closed = false;
+    size_t _bytes_appended {0};
 
-    std::shared_ptr<Aws::StringStream> _stream_ptr;
     // Current Part Num for CompletedPart
-    int _cur_part_num = 0;
-    std::list<std::shared_ptr<Aws::S3::Model::CompletedPart>> _completed_parts;
+    int _cur_part_num = 1;
+    std::mutex _completed_lock;
+    std::vector<std::shared_ptr<Aws::S3::Model::CompletedPart>> _completed_parts;
+
+    WaitGroup _wait;
+
+    std::atomic_bool _failed = false;
+    Status _st = Status::OK();
+    size_t _bytes_written = 0;
+
+    std::shared_ptr<S3FileBuffer> _pending_buf = nullptr;
 };
 
 } // namespace io

--- a/be/src/io/fs/s3_file_writer.h
+++ b/be/src/io/fs/s3_file_writer.h
@@ -94,7 +94,7 @@ private:
             std::unique_lock<std::mutex> lck {_lock};
             _cv.wait_for(lck, std::chrono::seconds(timeout_seconds),
                          [this]() { return _count.load() <= 0; });
-            return false;
+            return _count.load() <= 0;
         }
 
     private:

--- a/be/test/io/fs/remote_file_system_test.cpp
+++ b/be/test/io/fs/remote_file_system_test.cpp
@@ -24,7 +24,9 @@
 #include "io/fs/local_file_system.h"
 #include "io/fs/s3_file_system.h"
 #include "io/hdfs_builder.h"
+#include "runtime/exec_env.h"
 #include "util/s3_uri.h"
+#include "util/threadpool.h"
 
 namespace doris {
 
@@ -392,6 +394,12 @@ TEST_F(RemoteFileSystemTest, TestHdfsFileSystem) {
 }
 
 TEST_F(RemoteFileSystemTest, TestS3FileSystem) {
+    std::unique_ptr<ThreadPool> _pool;
+    ThreadPoolBuilder("BufferedReaderPrefetchThreadPool")
+            .set_min_threads(5)
+            .set_max_threads(10)
+            .build(&_pool);
+    ExecEnv::GetInstance()->_buffered_reader_prefetch_thread_pool = std::move(_pool);
     S3Conf s3_conf;
     S3URI s3_uri(s3_location);
     CHECK_STATUS_OK(s3_uri.parse());


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx
Formerly S3FileWriter has to write each buffer with 5MB or more then upload one part, after all these works are done it could then process the incoming data, it's blocking and inefficient. This pr brings one bufferpool where the data could write into memory buffer immediately if has free buffer and then it would be uploaded into the S3.
This pr doesn't provide the ability to elegantly support cases where there is no free buffer, i'll leave it as one future work.
## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

