### PR TITLE
[improvement](be) add a name for be jvm

### DIFF
--- a/be/src/util/jni-util.cpp
+++ b/be/src/util/jni-util.cpp
@@ -73,10 +73,13 @@ void FindOrCreateJavaVM() {
         auto classpath = GetDorisJNIClasspath();
         std::string heap_size = fmt::format("-Xmx{}", config::jvm_max_heap_size);
         std::string log_path = fmt::format("-DlogPath={}/log/udf-jdbc.log", getenv("DORIS_HOME"));
+        std::string jvm_name = fmt::format("-Dsun.java.command={}", "DORIS_BE");
+
         JavaVMOption options[] = {
                 {const_cast<char*>(classpath.c_str()), nullptr},
                 {const_cast<char*>(heap_size.c_str()), nullptr},
                 {const_cast<char*>(log_path.c_str()), nullptr},
+                {const_cast<char*>(jvm_name.c_str()), nullptr},
 #ifdef __APPLE__
                 // On macOS, we should disable MaxFDLimit, otherwise the RLIMIT_NOFILE
                 // will be assigned the minimum of OPEN_MAX (10240) and rlim_cur (See src/hotspot/os/bsd/os_bsd.cpp)

--- a/be/src/util/jni-util.cpp
+++ b/be/src/util/jni-util.cpp
@@ -73,7 +73,7 @@ void FindOrCreateJavaVM() {
         auto classpath = GetDorisJNIClasspath();
         std::string heap_size = fmt::format("-Xmx{}", config::jvm_max_heap_size);
         std::string log_path = fmt::format("-DlogPath={}/log/udf-jdbc.log", getenv("DORIS_HOME"));
-        std::string jvm_name = fmt::format("-Dsun.java.command={}", "DORIS_BE");
+        std::string jvm_name = fmt::format("-Dsun.java.command={}", "DorisBE");
 
         JavaVMOption options[] = {
                 {const_cast<char*>(classpath.c_str()), nullptr},


### PR DESCRIPTION
# Proposed changes

before jps will not display the name of BE,  so don't know it's the Doris be
then maybe killed by user.

Issue Number: close #xxx
<img width="477" alt="Snipaste_2023-03-09_11-38-15" src="https://user-images.githubusercontent.com/87313068/223910565-3f2893e1-b918-46a2-bae7-67f846790715.png">

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

