### PR TITLE
[fix](planner) should not turn on push agg op when olapscan has conjuncts on it

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/planner/SingleNodePlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/SingleNodePlanner.java
@@ -398,6 +398,10 @@ public class SingleNodePlanner {
                 break;
             }
 
+            if (CollectionUtils.isNotEmpty(root.getConjuncts())) {
+                break;
+            }
+
             // TODO: Support muti table in the future
             if (selectStmt.getTableRefs().size() != 1) {
                 break;

--- a/regression-test/data/query_p0/aggregate/aggregate.out
+++ b/regression-test/data/query_p0/aggregate/aggregate.out
@@ -689,3 +689,9 @@ TESTING	AGAIN
 -- !aggregate --
 9	9	10	8	7	7	7	2
 
+-- !subquery_with_inner_predicate --
+16
+
+-- !subquery_without_inner_predicate --
+7
+

--- a/regression-test/suites/query_p0/aggregate/aggregate.groovy
+++ b/regression-test/suites/query_p0/aggregate/aggregate.groovy
@@ -301,4 +301,12 @@ suite("aggregate") {
         sql("select /*+ SET_VAR(DISABLE_NEREIDS_RULES=\"ONE_PHASE_AGGREGATE_WITHOUT_DISTINCT\") */ count(*) from (select t2.c_bigint, t2.c_double, t2.c_string from (select c_bigint, c_double, c_string, c_date,c_timestamp, c_short_decimal from regression_test_query_p0_aggregate.${tableName}) t2)t1")
         contains "pushAggOp=COUNT"
     }
+
+    qt_subquery_with_inner_predicate """
+        select count(*) from (select t2.c_bigint, t2.c_double, t2.c_string from (select c_bigint, c_double, c_string, c_date,c_timestamp, c_short_decimal from regression_test_query_p0_aggregate.${tableName}) t2)t1
+    """
+
+    qt_subquery_without_inner_predicate """
+        select count(*) from (select t2.c_bigint, t2.c_double, t2.c_string from (select c_bigint, c_double, c_string, c_date,c_timestamp, c_short_decimal from regression_test_query_p0_aggregate.${tableName} where c_bigint > 5000) t2)t1
+    """
 }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

we should not set PushAggOp to any type, if olap scan already has conjunct on it.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [x] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

