### PR TITLE
[fix](meta) fix concurrent modification exception and potential NPE

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/DescriptorTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/DescriptorTable.java
@@ -27,14 +27,12 @@ import org.apache.doris.thrift.TDescriptorTable;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 
@@ -185,7 +183,7 @@ public class DescriptorTable {
 
     public TDescriptorTable toThrift() {
         TDescriptorTable result = new TDescriptorTable();
-        HashSet<TableIf> referencedTbls = Sets.newHashSet();
+        Map<Long, TableIf> referencedTbls = Maps.newHashMap();
         for (TupleDescriptor tupleD : tupleDescs.values()) {
             // inline view of a non-constant select has a non-materialized tuple descriptor
             // in the descriptor table just for type checking, which we need to skip
@@ -195,7 +193,7 @@ public class DescriptorTable {
                 // but its table has no id
                 if (tupleD.getTable() != null
                         && tupleD.getTable().getId() >= 0) {
-                    referencedTbls.add(tupleD.getTable());
+                    referencedTbls.put(tupleD.getTable().getId(), tupleD.getTable());
                 }
                 for (SlotDescriptor slotD : tupleD.getMaterializedSlots()) {
                     result.addToSlotDescriptors(slotD.toThrift());
@@ -203,9 +201,11 @@ public class DescriptorTable {
             }
         }
 
-        referencedTbls.addAll(referencedTables);
+        for (TableIf tbl : referencedTables) {
+            referencedTbls.put(tbl.getId(), tbl);
+        }
 
-        for (TableIf tbl : referencedTbls) {
+        for (TableIf tbl : referencedTbls.values()) {
             result.addToTableDescriptors(tbl.toThrift());
         }
         return result;


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

Fix 2 bugs:
1.
```
java.util.ConcurrentModificationException: null
        at java.util.HashMap$HashIterator.nextNode(HashMap.java:1442) ~[?:1.8.0_191]
        at java.util.HashMap$EntryIterator.next(HashMap.java:1476) ~[?:1.8.0_191]
        at java.util.HashMap$EntryIterator.next(HashMap.java:1474) ~[?:1.8.0_191]
        at java.util.AbstractMap.hashCode(AbstractMap.java:530) ~[?:1.8.0_191]
        at java.util.Arrays.hashCode(Arrays.java:4146) ~[?:1.8.0_191]
        at java.util.Objects.hash(Objects.java:128) ~[?:1.8.0_191]
        at org.apache.doris.catalog.PartitionInfo.hashCode(PartitionInfo.java:400) ~[doris-fe.jar:1.2-SNAPSHOT]
        at java.util.Arrays.hashCode(Arrays.java:4146) ~[?:1.8.0_191]
        at java.util.Objects.hash(Objects.java:128) ~[?:1.8.0_191]
        at org.apache.doris.catalog.OlapTable.hashCode(OlapTable.java:1557) ~[doris-fe.jar:1.2-SNAPSHOT]
        at java.util.HashMap.hash(HashMap.java:339) ~[?:1.8.0_191]
        at java.util.HashMap.put(HashMap.java:612) ~[?:1.8.0_191]
        at java.util.HashSet.add(HashSet.java:220) ~[?:1.8.0_191]
        at org.apache.doris.analysis.DescriptorTable.toThrift(DescriptorTable.java:194) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.Coordinator.<init>(Coordinator.java:251) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.StmtExecutor.sendResult(StmtExecutor.java:1135) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.StmtExecutor.handleQueryStmt(StmtExecutor.java:1122) ~[doris-fe.jar:1.2-SNAPSHOT]

java.util.ConcurrentModificationException: null
        at java.util.HashMap$HashIterator.nextNode(HashMap.java:1442) ~[?:1.8.0_191]
        at java.util.HashMap$EntryIterator.next(HashMap.java:1476) ~[?:1.8.0_191]
        at java.util.HashMap$EntryIterator.next(HashMap.java:1474) ~[?:1.8.0_191]
        at java.util.AbstractMap.hashCode(AbstractMap.java:530) ~[?:1.8.0_191]
        at java.util.Arrays.hashCode(Arrays.java:4146) ~[?:1.8.0_191]
        at java.util.Objects.hash(Objects.java:128) ~[?:1.8.0_191]
        at org.apache.doris.catalog.PartitionInfo.hashCode(PartitionInfo.java:400) ~[doris-fe.jar:1.2-SNAPSHOT]
        at java.util.Arrays.hashCode(Arrays.java:4146) ~[?:1.8.0_191]
        at java.util.Objects.hash(Objects.java:128) ~[?:1.8.0_191]
        at org.apache.doris.catalog.OlapTable.hashCode(OlapTable.java:1557) ~[doris-fe.jar:1.2-SNAPSHOT]
        at java.util.HashMap.hash(HashMap.java:339) ~[?:1.8.0_191]
        at java.util.HashMap.put(HashMap.java:612) ~[?:1.8.0_191]
        at java.util.HashSet.add(HashSet.java:220) ~[?:1.8.0_191]
        at org.apache.doris.analysis.DescriptorTable.toThrift(DescriptorTable.java:194) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.Coordinator.<init>(Coordinator.java:251) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.StmtExecutor.handleInsertStmt(StmtExecutor.java:1464) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.StmtExecutor.execute(StmtExecutor.java:555) ~[doris-fe.jar:1.2-SNAPSHOT]
```

2.
```
java.lang.NullPointerException: null
        at org.apache.doris.transaction.GlobalTransactionMgr.existCommittedTxns
```

The second bug's root cause is unclear, I just add a log to observe, and avoid throwing NPE.


## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

