### PR TITLE
[fix](merge-on-write) when if publish and be down, need recalc delete bitmap for MoW

### DIFF
--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -2624,18 +2624,20 @@ Status Tablet::update_delete_bitmap(const RowsetSharedPtr& rowset, const TabletT
                                        delete_bitmap, cur_version - 1, true));
 
     // Check the delete_bitmap correctness.
-    DeleteBitmap rs_bm(tablet_id());
-    delete_bitmap->subset({rowset->rowset_id(), 0, 0}, {rowset->rowset_id(), UINT32_MAX, INT64_MAX},
-                          &rs_bm);
-    auto num_rows = rowset->num_rows();
-    auto bitmap_cardinality = rs_bm.cardinality();
-    std::string err_msg = fmt::format(
-            "The delete bitmap of unique key table may not correct, expect num unique keys: {}, "
-            "now the num_rows: {}, delete bitmap cardinality: {}, num sgements: {}",
-            load_info->num_keys, num_rows, bitmap_cardinality, rowset->num_segments());
-    DCHECK_EQ(load_info->num_keys, num_rows - bitmap_cardinality) << err_msg;
-    if (load_info->num_keys != num_rows - bitmap_cardinality) {
-        return Status::InternalError(err_msg);
+    if (load_info->num_keys != 0) {
+        DeleteBitmap rs_bm(tablet_id());
+        delete_bitmap->subset({rowset->rowset_id(), 0, 0}, {rowset->rowset_id(), UINT32_MAX, INT64_MAX},
+                            &rs_bm);
+        auto num_rows = rowset->num_rows();
+        auto bitmap_cardinality = rs_bm.cardinality();
+        std::string err_msg = fmt::format(
+                "The delete bitmap of unique key table may not correct, expect num unique keys: {}, "
+                "now the num_rows: {}, delete bitmap cardinality: {}, num sgements: {}",
+                load_info->num_keys, num_rows, bitmap_cardinality, rowset->num_segments());
+        DCHECK_EQ(load_info->num_keys, num_rows - bitmap_cardinality) << err_msg;
+        if (load_info->num_keys != num_rows - bitmap_cardinality) {
+            return Status::InternalError(err_msg);
+        }
     }
 
     // update version without write lock, compaction and publish_txn

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -2626,12 +2626,13 @@ Status Tablet::update_delete_bitmap(const RowsetSharedPtr& rowset, const TabletT
     // Check the delete_bitmap correctness.
     if (load_info->num_keys != 0) {
         DeleteBitmap rs_bm(tablet_id());
-        delete_bitmap->subset({rowset->rowset_id(), 0, 0}, {rowset->rowset_id(), UINT32_MAX, INT64_MAX},
-                            &rs_bm);
+        delete_bitmap->subset({rowset->rowset_id(), 0, 0},
+                              {rowset->rowset_id(), UINT32_MAX, INT64_MAX}, &rs_bm);
         auto num_rows = rowset->num_rows();
         auto bitmap_cardinality = rs_bm.cardinality();
         std::string err_msg = fmt::format(
-                "The delete bitmap of unique key table may not correct, expect num unique keys: {}, "
+                "The delete bitmap of unique key table may not correct, expect num unique keys:"
+                "{}, "
                 "now the num_rows: {}, delete bitmap cardinality: {}, num sgements: {}",
                 load_info->num_keys, num_rows, bitmap_cardinality, rowset->num_segments());
         DCHECK_EQ(load_info->num_keys, num_rows - bitmap_cardinality) << err_msg;


### PR DESCRIPTION


# Proposed changes

Issue Number: close #xxx

## Problem summary

if publish and be down, load_info will set unique_key_merge_on_write=false, need recalc delete bitmap

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

