### PR TITLE
[fix](nereids) PushdownExpressionsInHashCondition contains duplicate column and WindowExpression miss column stats

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/logical/PushdownExpressionsInHashCondition.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/logical/PushdownExpressionsInHashCondition.java
@@ -34,7 +34,6 @@ import org.apache.doris.nereids.util.JoinUtils;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableList.Builder;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
@@ -44,7 +43,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
-import javax.naming.Name;
 
 /**
  * push down expression which is not slot reference

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/logical/PushdownExpressionsInHashCondition.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/logical/PushdownExpressionsInHashCondition.java
@@ -25,6 +25,7 @@ import org.apache.doris.nereids.trees.expressions.EqualTo;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.NamedExpression;
 import org.apache.doris.nereids.trees.expressions.Slot;
+import org.apache.doris.nereids.trees.expressions.SlotReference;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalJoin;
 import org.apache.doris.nereids.trees.plans.logical.LogicalProject;
@@ -42,6 +43,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
+import javax.naming.Name;
 
 /**
  * push down expression which is not slot reference
@@ -70,7 +73,7 @@ public class PushdownExpressionsInHashCondition extends OneRewriteRuleFactory {
                 .then(join -> {
                     List<List<Expression>> exprsOfHashConjuncts =
                             Lists.newArrayList(Lists.newArrayList(), Lists.newArrayList());
-                    Map<Expression, Alias> exprMap = Maps.newHashMap();
+                    Map<Expression, NamedExpression> exprMap = Maps.newHashMap();
                     join.getHashJoinConjuncts().forEach(conjunct -> {
                         Preconditions.checkArgument(conjunct instanceof EqualTo);
                         // sometimes: t1 join t2 on t2.a + 1 = t1.a + 2, so check the situation, but actually it
@@ -79,8 +82,13 @@ public class PushdownExpressionsInHashCondition extends OneRewriteRuleFactory {
                                 (EqualTo) conjunct, join.left().getOutputSet());
                         exprsOfHashConjuncts.get(0).add(conjunct.child(0));
                         exprsOfHashConjuncts.get(1).add(conjunct.child(1));
-                        conjunct.children().forEach(expr ->
-                                exprMap.put(expr, new Alias(expr, "expr_" + expr.toSql())));
+                        conjunct.children().forEach(expr -> {
+                            if ((expr instanceof SlotReference)) {
+                                exprMap.put(expr, (SlotReference) expr);
+                            } else {
+                                exprMap.put(expr, new Alias(expr, "expr_" + expr.toSql()));
+                            }
+                        });
                     });
                     Iterator<List<Expression>> iter = exprsOfHashConjuncts.iterator();
                     return join.withHashJoinConjunctsAndChildren(
@@ -90,10 +98,16 @@ public class PushdownExpressionsInHashCondition extends OneRewriteRuleFactory {
                                             .collect(ImmutableList.toImmutableList())))
                                     .collect(ImmutableList.toImmutableList()),
                             join.children().stream().map(
-                                    plan -> new LogicalProject<>(new Builder<NamedExpression>()
-                                            .addAll(iter.next().stream().map(exprMap::get)
-                                                    .collect(ImmutableList.toImmutableList()))
-                                            .addAll(getOutput(plan, join)).build(), plan))
+                                        plan -> {
+                                            Set<NamedExpression> projectSet = Sets.newHashSet();
+                                            projectSet.addAll(iter.next().stream().map(exprMap::get)
+                                                    .collect(Collectors.toList()));
+                                            projectSet.addAll(getOutput(plan, join));
+                                            List<NamedExpression> projectList = projectSet.stream()
+                                                    .collect(ImmutableList.toImmutableList());
+                                            return new LogicalProject<>(projectList, plan);
+                                        }
+                                    )
                                     .collect(ImmutableList.toImmutableList()));
                 }).toRule(RuleType.PUSHDOWN_EXPRESSIONS_IN_HASH_CONDITIONS);
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/StatsCalculator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/StatsCalculator.java
@@ -666,6 +666,7 @@ public class StatsCalculator extends DefaultPlanVisitor<StatsDeriveResult, Void>
                     }
                     return Pair.of(expr.toSlot().getExprId(), value);
                 }).collect(Collectors.toMap(Pair::key, Pair::value));
+        columnStatisticMap.putAll(childColumnStats);
         return new StatsDeriveResult(stats.getRowCount(), columnStatisticMap);
     }
 }


### PR DESCRIPTION
# Proposed changes
tpcds: q47 and q57
1. PushdownExpressionsInHashCondition:project contains duplicate column
2. WindowExpression stats caclucate: miss column stats

Issue Number: close #xxx

## Problem summary


Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

