### PR TITLE
[fix](schema scanner) fix query some schema table report invalid parameter

### DIFF
--- a/be/src/exec/schema_scanner.cpp
+++ b/be/src/exec/schema_scanner.cpp
@@ -84,10 +84,6 @@ Status SchemaScanner::init(SchemaScannerParam* param, ObjectPool* pool) {
         return Status::InternalError("invalid parameter");
     }
 
-    if (_columns.empty()) {
-        return Status::InternalError("invalid parameter");
-    }
-
     RETURN_IF_ERROR(create_tuple_desc(pool));
 
     _param = param;

--- a/regression-test/data/query_p0/system/test_query_sys_tables.out
+++ b/regression-test/data/query_p0/system/test_query_sys_tables.out
@@ -77,3 +77,17 @@ test_view
 -- !sql --
 DUP
 
+-- !sql --
+
+-- !sql --
+
+-- !sql --
+
+-- !sql --
+
+-- !sql --
+
+-- !sql --
+
+-- !sql --
+

--- a/regression-test/suites/query_p0/system/test_query_sys_tables.groovy
+++ b/regression-test/suites/query_p0/system/test_query_sys_tables.groovy
@@ -269,4 +269,14 @@ suite("test_query_sys_tables", "query,p0") {
         def dbName = dbPrefix + i.toString()
         sql "DROP DATABASE `${dbName}`"
     }
+
+    // test no impl schema table
+    sql "USE information_schema"
+    qt_sql "select * from column_privileges"
+    qt_sql "select * from engines"
+    qt_sql "select * from events"
+    qt_sql "select * from routines"
+    qt_sql "select * from referential_constraints"
+    qt_sql "select * from key_column_usage"
+    qt_sql "select * from triggers"
 }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

Example:
```
SELECT ROUTINE_SCHEMA AS PROCEDURE_CAT, NULL AS PROCEDURE_SCHEM,ROUTINE_NAME AS PROCEDURE_NAME,NULL AS NUM_INPUT_PARAMS,NULL AS NUM_OUTPUT_PARAMS,NULL AS NUM_RESULT_SETS,ROUTINE_COMMENT AS REMARKS,IF(ROUTINE_TYPE = 'FUNCTION', 2,IF(ROUTINE_TYPE= 'PROCEDURE', 1, 0)) AS PROCEDURE_TYPE FROM INFORMATION_SCHEMA.ROUTINES WHERE ROUTINE_SCHEMA = DATABASE();
```
```
ERROR 1105 (HY000): errCode = 2, detailMessage = invalid parameter
```

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

