### PR TITLE
[feature](nereids) add unique id for groupExpression and plan node

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/StatementContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/StatementContext.java
@@ -21,7 +21,7 @@ import org.apache.doris.analysis.StatementBase;
 import org.apache.doris.common.IdGenerator;
 import org.apache.doris.nereids.rules.analysis.ColumnAliasGenerator;
 import org.apache.doris.nereids.trees.expressions.ExprId;
-import org.apache.doris.nereids.trees.plans.RelationId;
+import org.apache.doris.nereids.trees.plans.ObjectId;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.OriginStatement;
 
@@ -47,7 +47,7 @@ public class StatementContext {
 
     private final IdGenerator<ExprId> exprIdGenerator = ExprId.createGenerator();
 
-    private final IdGenerator<RelationId> relationIdGenerator = RelationId.createGenerator();
+    private final IdGenerator<ObjectId> objectIdGenerator = ObjectId.createGenerator();
 
     @GuardedBy("this")
     private final Map<String, Supplier<Object>> contextCacheMap = Maps.newLinkedHashMap();
@@ -101,8 +101,8 @@ public class StatementContext {
         return exprIdGenerator.getNextId();
     }
 
-    public RelationId getNextRelationId() {
-        return relationIdGenerator.getNextId();
+    public ObjectId getNextObjectId() {
+        return objectIdGenerator.getNextId();
     }
 
     public void setParsedStatement(StatementBase parsedStatement) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/analyzer/UnboundOneRowRelation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/analyzer/UnboundOneRowRelation.java
@@ -24,9 +24,9 @@ import org.apache.doris.nereids.properties.UnboundLogicalProperties;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.NamedExpression;
 import org.apache.doris.nereids.trees.expressions.Slot;
+import org.apache.doris.nereids.trees.plans.ObjectId;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PlanType;
-import org.apache.doris.nereids.trees.plans.RelationId;
 import org.apache.doris.nereids.trees.plans.algebra.OneRowRelation;
 import org.apache.doris.nereids.trees.plans.logical.LogicalLeaf;
 import org.apache.doris.nereids.trees.plans.visitor.PlanVisitor;
@@ -45,14 +45,14 @@ import java.util.Optional;
  */
 public class UnboundOneRowRelation extends LogicalLeaf implements Unbound, OneRowRelation {
 
-    private final RelationId id;
+    private final ObjectId id;
     private final List<NamedExpression> projects;
 
-    public UnboundOneRowRelation(RelationId id, List<NamedExpression> projects) {
+    public UnboundOneRowRelation(ObjectId id, List<NamedExpression> projects) {
         this(id, projects, Optional.empty(), Optional.empty());
     }
 
-    private UnboundOneRowRelation(RelationId id,
+    private UnboundOneRowRelation(ObjectId id,
                                   List<NamedExpression> projects,
                                   Optional<GroupExpression> groupExpression,
             Optional<LogicalProperties> logicalProperties) {
@@ -63,7 +63,7 @@ public class UnboundOneRowRelation extends LogicalLeaf implements Unbound, OneRo
         this.projects = ImmutableList.copyOf(projects);
     }
 
-    public RelationId getId() {
+    public ObjectId getId() {
         return id;
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/analyzer/UnboundRelation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/analyzer/UnboundRelation.java
@@ -24,9 +24,9 @@ import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.properties.UnboundLogicalProperties;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.Slot;
+import org.apache.doris.nereids.trees.plans.ObjectId;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PlanType;
-import org.apache.doris.nereids.trees.plans.RelationId;
 import org.apache.doris.nereids.trees.plans.logical.LogicalRelation;
 import org.apache.doris.nereids.trees.plans.visitor.PlanVisitor;
 import org.apache.doris.nereids.util.Utils;
@@ -50,20 +50,20 @@ public class UnboundRelation extends LogicalRelation implements Unbound {
     private final boolean isTempPart;
     private final List<String> hints;
 
-    public UnboundRelation(RelationId id, List<String> nameParts) {
+    public UnboundRelation(ObjectId id, List<String> nameParts) {
         this(id, nameParts, Optional.empty(), Optional.empty(), ImmutableList.of(), false, ImmutableList.of());
     }
 
-    public UnboundRelation(RelationId id, List<String> nameParts, List<String> partNames, boolean isTempPart) {
+    public UnboundRelation(ObjectId id, List<String> nameParts, List<String> partNames, boolean isTempPart) {
         this(id, nameParts, Optional.empty(), Optional.empty(), partNames, isTempPart, ImmutableList.of());
     }
 
-    public UnboundRelation(RelationId id, List<String> nameParts, List<String> partNames, boolean isTempPart,
+    public UnboundRelation(ObjectId id, List<String> nameParts, List<String> partNames, boolean isTempPart,
             List<String> hints) {
         this(id, nameParts, Optional.empty(), Optional.empty(), partNames, isTempPart, hints);
     }
 
-    public UnboundRelation(RelationId id, List<String> nameParts, Optional<GroupExpression> groupExpression,
+    public UnboundRelation(ObjectId id, List<String> nameParts, Optional<GroupExpression> groupExpression,
             Optional<LogicalProperties> logicalProperties, List<String> partNames, boolean isTempPart,
             List<String> hints) {
         super(id, PlanType.LOGICAL_UNBOUND_RELATION, groupExpression, logicalProperties);
@@ -132,7 +132,7 @@ public class UnboundRelation extends LogicalRelation implements Unbound {
         throw new UnsupportedOperationException(this.getClass().getSimpleName() + " don't support getExpression()");
     }
 
-    public RelationId getId() {
+    public ObjectId getId() {
         return id;
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/analyzer/UnboundTVFRelation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/analyzer/UnboundTVFRelation.java
@@ -25,9 +25,9 @@ import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.Slot;
 import org.apache.doris.nereids.trees.expressions.TVFProperties;
 import org.apache.doris.nereids.trees.expressions.functions.table.TableValuedFunction;
+import org.apache.doris.nereids.trees.plans.ObjectId;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PlanType;
-import org.apache.doris.nereids.trees.plans.RelationId;
 import org.apache.doris.nereids.trees.plans.algebra.TVFRelation;
 import org.apache.doris.nereids.trees.plans.logical.LogicalLeaf;
 import org.apache.doris.nereids.trees.plans.visitor.PlanVisitor;
@@ -40,15 +40,15 @@ import java.util.Optional;
 /** UnboundTVFRelation */
 public class UnboundTVFRelation extends LogicalLeaf implements TVFRelation, Unbound {
 
-    private final RelationId id;
+    private final ObjectId id;
     private final String functionName;
     private final TVFProperties properties;
 
-    public UnboundTVFRelation(RelationId id, String functionName, TVFProperties properties) {
+    public UnboundTVFRelation(ObjectId id, String functionName, TVFProperties properties) {
         this(id, functionName, properties, Optional.empty(), Optional.empty());
     }
 
-    public UnboundTVFRelation(RelationId id, String functionName, TVFProperties properties,
+    public UnboundTVFRelation(ObjectId id, String functionName, TVFProperties properties,
             Optional<GroupExpression> groupExpression, Optional<LogicalProperties> logicalProperties) {
         super(PlanType.LOGICAL_UNBOUND_TVF_RELATION, groupExpression, logicalProperties);
         this.id = id;
@@ -64,7 +64,7 @@ public class UnboundTVFRelation extends LogicalLeaf implements TVFRelation, Unbo
         return properties;
     }
 
-    public RelationId getId() {
+    public ObjectId getId() {
         return id;
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/RuntimeFilterTranslator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/RuntimeFilterTranslator.java
@@ -27,7 +27,7 @@ import org.apache.doris.nereids.processor.post.RuntimeFilterContext;
 import org.apache.doris.nereids.trees.expressions.ExprId;
 import org.apache.doris.nereids.trees.expressions.Slot;
 import org.apache.doris.nereids.trees.expressions.SlotReference;
-import org.apache.doris.nereids.trees.plans.RelationId;
+import org.apache.doris.nereids.trees.plans.ObjectId;
 import org.apache.doris.nereids.trees.plans.physical.AbstractPhysicalJoin;
 import org.apache.doris.nereids.trees.plans.physical.RuntimeFilter;
 import org.apache.doris.planner.HashJoinNode;
@@ -60,7 +60,7 @@ public class RuntimeFilterTranslator {
         return context.getRuntimeFilterOnHashJoinNode(join);
     }
 
-    public List<Slot> getTargetOnScanNode(RelationId id) {
+    public List<Slot> getTargetOnScanNode(ObjectId id) {
         return context.getTargetOnOlapScanNodeMap().getOrDefault(id, Collections.emptyList());
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/GroupExpression.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/GroupExpression.java
@@ -26,6 +26,8 @@ import org.apache.doris.nereids.metrics.event.CostStateUpdateEvent;
 import org.apache.doris.nereids.properties.PhysicalProperties;
 import org.apache.doris.nereids.rules.Rule;
 import org.apache.doris.nereids.rules.RuleType;
+import org.apache.doris.nereids.trees.expressions.StatementScopeIdGenerator;
+import org.apache.doris.nereids.trees.plans.ObjectId;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.util.Utils;
 import org.apache.doris.statistics.StatsDeriveResult;
@@ -70,6 +72,8 @@ public class GroupExpression {
 
     // After mergeGroup(), source Group was cleaned up, but it may be in the Job Stack. So use this to mark and skip it.
     private boolean isUnused = false;
+
+    private ObjectId id = StatementScopeIdGenerator.newObjectId();
 
     public GroupExpression(Plan plan) {
         this(plan, Lists.newArrayList());
@@ -306,7 +310,8 @@ public class GroupExpression {
 
     @Override
     public String toString() {
-        StringBuilder builder = new StringBuilder();
+        StringBuilder builder = new StringBuilder("id:");
+        builder.append(id.asInt());
         if (ownerGroup == null) {
             builder.append("OWNER GROUP IS NULL[]");
         } else {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/RuntimeFilterContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/RuntimeFilterContext.java
@@ -23,8 +23,8 @@ import org.apache.doris.common.Pair;
 import org.apache.doris.nereids.trees.expressions.ExprId;
 import org.apache.doris.nereids.trees.expressions.NamedExpression;
 import org.apache.doris.nereids.trees.expressions.Slot;
+import org.apache.doris.nereids.trees.plans.ObjectId;
 import org.apache.doris.nereids.trees.plans.Plan;
-import org.apache.doris.nereids.trees.plans.RelationId;
 import org.apache.doris.nereids.trees.plans.physical.AbstractPhysicalJoin;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalHashJoin;
 import org.apache.doris.nereids.trees.plans.physical.RuntimeFilter;
@@ -58,7 +58,7 @@ public class RuntimeFilterContext {
     private final Map<Plan, List<ExprId>> joinToTargetExprId = Maps.newHashMap();
 
     // olap scan node that contains target of a runtime filter.
-    private final Map<RelationId, List<Slot>> targetOnOlapScanNodeMap = Maps.newHashMap();
+    private final Map<ObjectId, List<Slot>> targetOnOlapScanNodeMap = Maps.newHashMap();
 
     private final List<org.apache.doris.planner.RuntimeFilter> legacyFilters = Lists.newArrayList();
 
@@ -70,7 +70,7 @@ public class RuntimeFilterContext {
     // alias -> alias's child, if there's a key that is alias's child, the key-value will change by this way
     // Alias(A) = B, now B -> A in map, and encounter Alias(B) -> C, the kv will be C -> A.
     // you can see disjoint set data structure to learn the processing detailed.
-    private final Map<NamedExpression, Pair<RelationId, Slot>> aliasTransferMap = Maps.newHashMap();
+    private final Map<NamedExpression, Pair<ObjectId, Slot>> aliasTransferMap = Maps.newHashMap();
 
     private final Map<Slot, ScanNode> scanNodeOfLegacyRuntimeFilterTarget = Maps.newHashMap();
 
@@ -117,7 +117,7 @@ public class RuntimeFilterContext {
         }
     }
 
-    public void setTargetsOnScanNode(RelationId id, Slot slot) {
+    public void setTargetsOnScanNode(ObjectId id, Slot slot) {
         this.targetOnOlapScanNodeMap.computeIfAbsent(id, k -> Lists.newArrayList()).add(slot);
     }
 
@@ -125,7 +125,7 @@ public class RuntimeFilterContext {
         return exprIdToOlapScanNodeSlotRef;
     }
 
-    public Map<NamedExpression, Pair<RelationId, Slot>> getAliasTransferMap() {
+    public Map<NamedExpression, Pair<ObjectId, Slot>> getAliasTransferMap() {
         return aliasTransferMap;
     }
 
@@ -146,7 +146,7 @@ public class RuntimeFilterContext {
         return targetExprIdToFilter;
     }
 
-    public Map<RelationId, List<Slot>> getTargetOnOlapScanNodeMap() {
+    public Map<ObjectId, List<Slot>> getTargetOnOlapScanNodeMap() {
         return targetOnOlapScanNodeMap;
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/RuntimeFilterGenerator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/RuntimeFilterGenerator.java
@@ -28,8 +28,8 @@ import org.apache.doris.nereids.trees.expressions.Not;
 import org.apache.doris.nereids.trees.expressions.Slot;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.BitmapContains;
 import org.apache.doris.nereids.trees.plans.JoinType;
+import org.apache.doris.nereids.trees.plans.ObjectId;
 import org.apache.doris.nereids.trees.plans.Plan;
-import org.apache.doris.nereids.trees.plans.RelationId;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalHashJoin;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalNestedLoopJoin;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalPlan;
@@ -80,7 +80,7 @@ public class RuntimeFilterGenerator extends PlanPostProcessor {
     public PhysicalPlan visitPhysicalHashJoin(PhysicalHashJoin<? extends Plan, ? extends Plan> join,
             CascadesContext context) {
         RuntimeFilterContext ctx = context.getRuntimeFilterContext();
-        Map<NamedExpression, Pair<RelationId, Slot>> aliasTransferMap = ctx.getAliasTransferMap();
+        Map<NamedExpression, Pair<ObjectId, Slot>> aliasTransferMap = ctx.getAliasTransferMap();
         join.right().accept(this, context);
         join.left().accept(this, context);
         if (deniedJoinType.contains(join.getJoinType()) || join.isMarkJoin()) {
@@ -128,7 +128,7 @@ public class RuntimeFilterGenerator extends PlanPostProcessor {
             return join;
         }
         RuntimeFilterContext ctx = context.getRuntimeFilterContext();
-        Map<NamedExpression, Pair<RelationId, Slot>> aliasTransferMap = ctx.getAliasTransferMap();
+        Map<NamedExpression, Pair<ObjectId, Slot>> aliasTransferMap = ctx.getAliasTransferMap();
         join.right().accept(this, context);
         join.left().accept(this, context);
 
@@ -175,7 +175,7 @@ public class RuntimeFilterGenerator extends PlanPostProcessor {
     @Override
     public PhysicalPlan visitPhysicalProject(PhysicalProject<? extends Plan> project, CascadesContext context) {
         project.child().accept(this, context);
-        Map<NamedExpression, Pair<RelationId, Slot>> aliasTransferMap
+        Map<NamedExpression, Pair<ObjectId, Slot>> aliasTransferMap
                 = context.getRuntimeFilterContext().getAliasTransferMap();
         // change key when encounter alias.
         for (Expression expression : project.getProjects()) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/AbstractTreeNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/AbstractTreeNode.java
@@ -18,6 +18,8 @@
 package org.apache.doris.nereids.trees;
 
 import org.apache.doris.nereids.memo.GroupExpression;
+import org.apache.doris.nereids.trees.expressions.StatementScopeIdGenerator;
+import org.apache.doris.nereids.trees.plans.ObjectId;
 
 import com.google.common.collect.ImmutableList;
 
@@ -32,7 +34,7 @@ import java.util.Optional;
  */
 public abstract class AbstractTreeNode<NODE_TYPE extends TreeNode<NODE_TYPE>>
         implements TreeNode<NODE_TYPE> {
-
+    protected final ObjectId id = StatementScopeIdGenerator.newObjectId();
     protected final List<NODE_TYPE> children;
     // TODO: Maybe we should use a GroupPlan to avoid TreeNode hold the GroupExpression.
     // https://github.com/apache/doris/pull/9807#discussion_r884829067

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/Alias.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/Alias.java
@@ -44,7 +44,7 @@ public class Alias extends NamedExpression implements UnaryExpression {
      * @param name alias name
      */
     public Alias(Expression child, String name) {
-        this(NamedExpressionUtil.newExprId(), child, name);
+        this(StatementScopeIdGenerator.newExprId(), child, name);
     }
 
     public Alias(ExprId exprId, Expression child, String name) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/ExprId.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/ExprId.java
@@ -44,7 +44,7 @@ public class ExprId extends Id<ExprId> {
     }
 
     /**
-     * Should be only called by {@link org.apache.doris.nereids.trees.expressions.NamedExpressionUtil}.
+     * Should be only called by {@link StatementScopeIdGenerator}.
      */
     public static IdGenerator<ExprId> createGenerator() {
         return new IdGenerator<ExprId>() {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/SlotReference.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/SlotReference.java
@@ -43,15 +43,15 @@ public class SlotReference extends Slot {
     private final Column column;
 
     public SlotReference(String name, DataType dataType) {
-        this(NamedExpressionUtil.newExprId(), name, dataType, true, ImmutableList.of(), null);
+        this(StatementScopeIdGenerator.newExprId(), name, dataType, true, ImmutableList.of(), null);
     }
 
     public SlotReference(String name, DataType dataType, boolean nullable) {
-        this(NamedExpressionUtil.newExprId(), name, dataType, nullable, ImmutableList.of(), null);
+        this(StatementScopeIdGenerator.newExprId(), name, dataType, nullable, ImmutableList.of(), null);
     }
 
     public SlotReference(String name, DataType dataType, boolean nullable, List<String> qualifier) {
-        this(NamedExpressionUtil.newExprId(), name, dataType, nullable, qualifier, null);
+        this(StatementScopeIdGenerator.newExprId(), name, dataType, nullable, qualifier, null);
     }
 
     public SlotReference(ExprId exprId, String name, DataType dataType, boolean nullable, List<String> qualifier) {
@@ -84,7 +84,7 @@ public class SlotReference extends Slot {
 
     public static SlotReference fromColumn(Column column, List<String> qualifier) {
         DataType dataType = DataType.fromCatalogType(column.getType());
-        return new SlotReference(NamedExpressionUtil.newExprId(), column.getName(), dataType,
+        return new SlotReference(StatementScopeIdGenerator.newExprId(), column.getName(), dataType,
                 column.isAllowNull(), qualifier, column);
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/StatementScopeIdGenerator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/StatementScopeIdGenerator.java
@@ -18,6 +18,7 @@
 package org.apache.doris.nereids.trees.expressions;
 
 import org.apache.doris.nereids.StatementContext;
+import org.apache.doris.nereids.trees.plans.ObjectId;
 import org.apache.doris.qe.ConnectContext;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -25,7 +26,7 @@ import com.google.common.annotations.VisibleForTesting;
 /**
  * The util of named expression.
  */
-public class NamedExpressionUtil {
+public class StatementScopeIdGenerator {
 
     // for test only
     private static StatementContext statementContext = new StatementContext();
@@ -36,6 +37,14 @@ public class NamedExpressionUtil {
             return statementContext.getNextExprId();
         }
         return ConnectContext.get().getStatementContext().getNextExprId();
+    }
+
+    public static ObjectId newObjectId() {
+        // this branch is for test only
+        if (ConnectContext.get() == null || ConnectContext.get().getStatementContext() == null) {
+            return statementContext.getNextObjectId();
+        }
+        return ConnectContext.get().getStatementContext().getNextObjectId();
     }
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/VirtualSlotReference.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/VirtualSlotReference.java
@@ -46,7 +46,7 @@ public class VirtualSlotReference extends SlotReference implements SlotNotFromCh
 
     public VirtualSlotReference(String name, DataType dataType, Optional<GroupingScalarFunction> originExpression,
             Function<GroupingSetShapes, List<Long>> computeLongValueMethod) {
-        this(NamedExpressionUtil.newExprId(), name, dataType, false, ImmutableList.of(),
+        this(StatementScopeIdGenerator.newExprId(), name, dataType, false, ImmutableList.of(),
                 originExpression, computeLongValueMethod);
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/ObjectId.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/ObjectId.java
@@ -19,15 +19,16 @@ package org.apache.doris.nereids.trees.plans;
 
 import org.apache.doris.common.Id;
 import org.apache.doris.common.IdGenerator;
+import org.apache.doris.nereids.trees.expressions.StatementScopeIdGenerator;
 
 import java.util.Objects;
 
 /**
  * relation id
  */
-public class RelationId extends Id<RelationId> {
+public class ObjectId extends Id<ObjectId> {
 
-    public RelationId(int id) {
+    public ObjectId(int id) {
         super(id);
     }
 
@@ -39,18 +40,18 @@ public class RelationId extends Id<RelationId> {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        RelationId relationId = (RelationId) o;
+        ObjectId relationId = (ObjectId) o;
         return id == relationId.id;
     }
 
     /**
-     * Should be only called by {@link org.apache.doris.nereids.trees.expressions.NamedExpressionUtil}.
+     * Should be only called by {@link StatementScopeIdGenerator}.
      */
-    public static IdGenerator<RelationId> createGenerator() {
-        return new IdGenerator<RelationId>() {
+    public static IdGenerator<ObjectId> createGenerator() {
+        return new IdGenerator<ObjectId>() {
             @Override
-            public RelationId getNextId() {
-                return new RelationId(nextId++);
+            public ObjectId getNextId() {
+                return new ObjectId(nextId++);
             }
         };
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalAggregate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalAggregate.java
@@ -140,7 +140,7 @@ public class LogicalAggregate<CHILD_TYPE extends Plan>
 
     @Override
     public String toString() {
-        return Utils.toSqlString("LogicalAggregate",
+        return Utils.toSqlString("LogicalAggregate[" + id.asInt() + "]",
                 "groupByExpr", groupByExpressions,
                 "outputExpr", outputExpressions,
                 "hasRepeat", sourceRepeat.isPresent()

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalEsScan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalEsScan.java
@@ -20,8 +20,8 @@ package org.apache.doris.nereids.trees.plans.logical;
 import org.apache.doris.catalog.external.ExternalTable;
 import org.apache.doris.nereids.memo.GroupExpression;
 import org.apache.doris.nereids.properties.LogicalProperties;
+import org.apache.doris.nereids.trees.plans.ObjectId;
 import org.apache.doris.nereids.trees.plans.PlanType;
-import org.apache.doris.nereids.trees.plans.RelationId;
 import org.apache.doris.nereids.trees.plans.visitor.PlanVisitor;
 import org.apache.doris.nereids.util.Utils;
 
@@ -38,14 +38,14 @@ public class LogicalEsScan extends LogicalRelation {
     /**
      * Constructor for LogicalEsScan.
      */
-    public LogicalEsScan(RelationId id, ExternalTable table, List<String> qualifier,
+    public LogicalEsScan(ObjectId id, ExternalTable table, List<String> qualifier,
                            Optional<GroupExpression> groupExpression,
                            Optional<LogicalProperties> logicalProperties) {
         super(id, PlanType.LOGICAL_ES_SCAN, table, qualifier,
                 groupExpression, logicalProperties);
     }
 
-    public LogicalEsScan(RelationId id, ExternalTable table, List<String> qualifier) {
+    public LogicalEsScan(ObjectId id, ExternalTable table, List<String> qualifier) {
         this(id, table, qualifier, Optional.empty(), Optional.empty());
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalFileScan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalFileScan.java
@@ -20,8 +20,8 @@ package org.apache.doris.nereids.trees.plans.logical;
 import org.apache.doris.catalog.external.ExternalTable;
 import org.apache.doris.nereids.memo.GroupExpression;
 import org.apache.doris.nereids.properties.LogicalProperties;
+import org.apache.doris.nereids.trees.plans.ObjectId;
 import org.apache.doris.nereids.trees.plans.PlanType;
-import org.apache.doris.nereids.trees.plans.RelationId;
 import org.apache.doris.nereids.trees.plans.visitor.PlanVisitor;
 import org.apache.doris.nereids.util.Utils;
 
@@ -38,14 +38,14 @@ public class LogicalFileScan extends LogicalRelation {
     /**
      * Constructor for LogicalFileScan.
      */
-    public LogicalFileScan(RelationId id, ExternalTable table, List<String> qualifier,
+    public LogicalFileScan(ObjectId id, ExternalTable table, List<String> qualifier,
                            Optional<GroupExpression> groupExpression,
                            Optional<LogicalProperties> logicalProperties) {
         super(id, PlanType.LOGICAL_FILE_SCAN, table, qualifier,
                 groupExpression, logicalProperties);
     }
 
-    public LogicalFileScan(RelationId id, ExternalTable table, List<String> qualifier) {
+    public LogicalFileScan(ObjectId id, ExternalTable table, List<String> qualifier) {
         this(id, table, qualifier, Optional.empty(), Optional.empty());
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalFilter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalFilter.java
@@ -84,7 +84,9 @@ public class LogicalFilter<CHILD_TYPE extends Plan> extends LogicalUnary<CHILD_T
 
     @Override
     public String toString() {
-        return Utils.toSqlString("LogicalFilter", "predicates", getPredicate());
+        return Utils.toSqlString("LogicalFilter[" + id.asInt() + "]",
+                "predicates", getPredicate()
+        );
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalJdbcScan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalJdbcScan.java
@@ -20,8 +20,8 @@ package org.apache.doris.nereids.trees.plans.logical;
 import org.apache.doris.catalog.external.ExternalTable;
 import org.apache.doris.nereids.memo.GroupExpression;
 import org.apache.doris.nereids.properties.LogicalProperties;
+import org.apache.doris.nereids.trees.plans.ObjectId;
 import org.apache.doris.nereids.trees.plans.PlanType;
-import org.apache.doris.nereids.trees.plans.RelationId;
 import org.apache.doris.nereids.trees.plans.visitor.PlanVisitor;
 import org.apache.doris.nereids.util.Utils;
 
@@ -38,14 +38,14 @@ public class LogicalJdbcScan extends LogicalRelation {
     /**
      * Constructor for LogicalJdbcScan.
      */
-    public LogicalJdbcScan(RelationId id, ExternalTable table, List<String> qualifier,
+    public LogicalJdbcScan(ObjectId id, ExternalTable table, List<String> qualifier,
                            Optional<GroupExpression> groupExpression,
                            Optional<LogicalProperties> logicalProperties) {
         super(id, PlanType.LOGICAL_JDBC_SCAN, table, qualifier,
                 groupExpression, logicalProperties);
     }
 
-    public LogicalJdbcScan(RelationId id, ExternalTable table, List<String> qualifier) {
+    public LogicalJdbcScan(ObjectId id, ExternalTable table, List<String> qualifier) {
         this(id, table, qualifier, Optional.empty(), Optional.empty());
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalJoin.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalJoin.java
@@ -180,7 +180,7 @@ public class LogicalJoin<LEFT_CHILD_TYPE extends Plan, RIGHT_CHILD_TYPE extends 
             args.add("hint");
             args.add(hint);
         }
-        return Utils.toSqlString("LogicalJoin", args.toArray());
+        return Utils.toSqlString("LogicalJoin[" + id.asInt() + "]", args.toArray());
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalOlapScan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalOlapScan.java
@@ -28,9 +28,9 @@ import org.apache.doris.nereids.memo.GroupExpression;
 import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.trees.expressions.Slot;
 import org.apache.doris.nereids.trees.expressions.SlotReference;
+import org.apache.doris.nereids.trees.plans.ObjectId;
 import org.apache.doris.nereids.trees.plans.PlanType;
 import org.apache.doris.nereids.trees.plans.PreAggStatus;
-import org.apache.doris.nereids.trees.plans.RelationId;
 import org.apache.doris.nereids.trees.plans.algebra.CatalogRelation;
 import org.apache.doris.nereids.trees.plans.algebra.OlapScan;
 import org.apache.doris.nereids.trees.plans.visitor.PlanVisitor;
@@ -104,32 +104,32 @@ public class LogicalOlapScan extends LogicalRelation implements CatalogRelation,
     ///////////////////////////////////////////////////////////////////////////
     private final List<String> hints;
 
-    public LogicalOlapScan(RelationId id, OlapTable table) {
+    public LogicalOlapScan(ObjectId id, OlapTable table) {
         this(id, table, ImmutableList.of());
     }
 
-    public LogicalOlapScan(RelationId id, OlapTable table, List<String> qualifier) {
+    public LogicalOlapScan(ObjectId id, OlapTable table, List<String> qualifier) {
         this(id, table, qualifier, Optional.empty(), Optional.empty(),
                 table.getPartitionIds(), false,
                 ImmutableList.of(), false,
                 -1, false, PreAggStatus.on(), ImmutableList.of(), ImmutableList.of());
     }
 
-    public LogicalOlapScan(RelationId id, OlapTable table, List<String> qualifier, List<String> hints) {
+    public LogicalOlapScan(ObjectId id, OlapTable table, List<String> qualifier, List<String> hints) {
         this(id, table, qualifier, Optional.empty(), Optional.empty(),
                 table.getPartitionIds(), false,
                 ImmutableList.of(), false,
                 -1, false, PreAggStatus.on(), ImmutableList.of(), hints);
     }
 
-    public LogicalOlapScan(RelationId id, OlapTable table, List<String> qualifier, List<Long> specifiedPartitions,
+    public LogicalOlapScan(ObjectId id, OlapTable table, List<String> qualifier, List<Long> specifiedPartitions,
             List<String> hints) {
         this(id, table, qualifier, Optional.empty(), Optional.empty(),
                 specifiedPartitions, false, ImmutableList.of(), false,
                 -1, false, PreAggStatus.on(), specifiedPartitions, hints);
     }
 
-    public LogicalOlapScan(RelationId id, Table table, List<String> qualifier) {
+    public LogicalOlapScan(ObjectId id, Table table, List<String> qualifier) {
         this(id, table, qualifier, Optional.empty(), Optional.empty(),
                 ((OlapTable) table).getPartitionIds(), false, ImmutableList.of(), false,
                 -1, false, PreAggStatus.on(), ImmutableList.of(), ImmutableList.of());
@@ -138,7 +138,7 @@ public class LogicalOlapScan extends LogicalRelation implements CatalogRelation,
     /**
      * Constructor for LogicalOlapScan.
      */
-    public LogicalOlapScan(RelationId id, Table table, List<String> qualifier,
+    public LogicalOlapScan(ObjectId id, Table table, List<String> qualifier,
             Optional<GroupExpression> groupExpression, Optional<LogicalProperties> logicalProperties,
             List<Long> selectedPartitionIds, boolean partitionPruned,
             List<Long> selectedTabletIds, boolean tabletPruned,

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalProject.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalProject.java
@@ -116,7 +116,7 @@ public class LogicalProject<CHILD_TYPE extends Plan> extends LogicalUnary<CHILD_
 
     @Override
     public String toString() {
-        return Utils.toSqlString("LogicalProject",
+        return Utils.toSqlString("LogicalProject[" + id.asInt() + "]",
                 "distinct", isDistinct,
                 "projects", projects,
                 "excepts", excepts,

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalRelation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalRelation.java
@@ -24,8 +24,8 @@ import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.Slot;
 import org.apache.doris.nereids.trees.expressions.SlotReference;
+import org.apache.doris.nereids.trees.plans.ObjectId;
 import org.apache.doris.nereids.trees.plans.PlanType;
-import org.apache.doris.nereids.trees.plans.RelationId;
 import org.apache.doris.nereids.trees.plans.algebra.Scan;
 import org.apache.doris.nereids.trees.plans.visitor.PlanVisitor;
 import org.apache.doris.nereids.util.Utils;
@@ -41,15 +41,15 @@ import java.util.Optional;
  */
 public abstract class LogicalRelation extends LogicalLeaf implements Scan {
 
-    protected final RelationId id;
+    protected final ObjectId id;
     protected final TableIf table;
     protected final ImmutableList<String> qualifier;
 
-    public LogicalRelation(RelationId id, PlanType type, TableIf table, List<String> qualifier) {
+    public LogicalRelation(ObjectId id, PlanType type, TableIf table, List<String> qualifier) {
         this(id, type, table, qualifier, Optional.empty(), Optional.empty());
     }
 
-    public LogicalRelation(RelationId id, PlanType type, Optional<GroupExpression> groupExpression,
+    public LogicalRelation(ObjectId id, PlanType type, Optional<GroupExpression> groupExpression,
             Optional<LogicalProperties> logicalProperties) {
         this(id, type, new OlapTable(), ImmutableList.of(), groupExpression, logicalProperties);
     }
@@ -60,7 +60,7 @@ public abstract class LogicalRelation extends LogicalLeaf implements Scan {
      * @param table Doris table
      * @param qualifier qualified relation name
      */
-    public LogicalRelation(RelationId id, PlanType type, TableIf table, List<String> qualifier,
+    public LogicalRelation(ObjectId id, PlanType type, TableIf table, List<String> qualifier,
             Optional<GroupExpression> groupExpression, Optional<LogicalProperties> logicalProperties) {
         super(type, groupExpression, logicalProperties);
         this.id = id;
@@ -128,7 +128,7 @@ public abstract class LogicalRelation extends LogicalLeaf implements Scan {
         return Utils.qualifiedName(qualifier, table.getName());
     }
 
-    public RelationId getId() {
+    public ObjectId getId() {
         return id;
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalSchemaScan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalSchemaScan.java
@@ -21,9 +21,9 @@ import org.apache.doris.catalog.SchemaTable;
 import org.apache.doris.catalog.TableIf;
 import org.apache.doris.nereids.memo.GroupExpression;
 import org.apache.doris.nereids.properties.LogicalProperties;
+import org.apache.doris.nereids.trees.plans.ObjectId;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PlanType;
-import org.apache.doris.nereids.trees.plans.RelationId;
 import org.apache.doris.nereids.trees.plans.algebra.Scan;
 import org.apache.doris.nereids.trees.plans.visitor.PlanVisitor;
 import org.apache.doris.nereids.util.Utils;
@@ -36,11 +36,11 @@ import java.util.Optional;
  */
 public class LogicalSchemaScan extends LogicalRelation implements Scan {
 
-    public LogicalSchemaScan(RelationId id, TableIf table, List<String> qualifier) {
+    public LogicalSchemaScan(ObjectId id, TableIf table, List<String> qualifier) {
         super(id, PlanType.LOGICAL_SCHEMA_SCAN, table, qualifier);
     }
 
-    public LogicalSchemaScan(RelationId id, TableIf table, List<String> qualifier,
+    public LogicalSchemaScan(ObjectId id, TableIf table, List<String> qualifier,
             Optional<GroupExpression> groupExpression, Optional<LogicalProperties> logicalProperties) {
         super(id, PlanType.LOGICAL_SCHEMA_SCAN, table, qualifier, groupExpression, logicalProperties);
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalSort.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalSort.java
@@ -70,7 +70,7 @@ public class LogicalSort<CHILD_TYPE extends Plan> extends LogicalUnary<CHILD_TYP
 
     @Override
     public String toString() {
-        return Utils.toSqlString("LogicalSort",
+        return Utils.toSqlString("LogicalSort[" + id.asInt() + "]",
                 "orderKeys", orderKeys);
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalTVFRelation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalTVFRelation.java
@@ -20,8 +20,8 @@ package org.apache.doris.nereids.trees.plans.logical;
 import org.apache.doris.nereids.memo.GroupExpression;
 import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.trees.expressions.functions.table.TableValuedFunction;
+import org.apache.doris.nereids.trees.plans.ObjectId;
 import org.apache.doris.nereids.trees.plans.PlanType;
-import org.apache.doris.nereids.trees.plans.RelationId;
 import org.apache.doris.nereids.trees.plans.algebra.TVFRelation;
 import org.apache.doris.nereids.trees.plans.visitor.PlanVisitor;
 import org.apache.doris.nereids.util.Utils;
@@ -36,14 +36,14 @@ public class LogicalTVFRelation extends LogicalRelation implements TVFRelation {
 
     private final TableValuedFunction function;
 
-    public LogicalTVFRelation(RelationId id, TableValuedFunction function) {
+    public LogicalTVFRelation(ObjectId id, TableValuedFunction function) {
         super(id, PlanType.LOGICAL_TVF_RELATION,
                 Objects.requireNonNull(function, "table valued function can not be null").getTable(),
                 ImmutableList.of());
         this.function = function;
     }
 
-    public LogicalTVFRelation(RelationId id, TableValuedFunction function, Optional<GroupExpression> groupExpression,
+    public LogicalTVFRelation(ObjectId id, TableValuedFunction function, Optional<GroupExpression> groupExpression,
             Optional<LogicalProperties> logicalProperties) {
         super(id, PlanType.LOGICAL_TVF_RELATION,
                 Objects.requireNonNull(function, "table valued function can not be null").getTable(),

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/RelationUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/RelationUtil.java
@@ -18,7 +18,7 @@
 package org.apache.doris.nereids.trees.plans.logical;
 
 import org.apache.doris.nereids.StatementContext;
-import org.apache.doris.nereids.trees.plans.RelationId;
+import org.apache.doris.nereids.trees.plans.ObjectId;
 import org.apache.doris.qe.ConnectContext;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -31,12 +31,12 @@ public class RelationUtil {
     // for test only
     private static StatementContext statementContext = new StatementContext();
 
-    public static RelationId newRelationId() {
+    public static ObjectId newRelationId() {
         // this branch is for test only
         if (ConnectContext.get() == null || ConnectContext.get().getStatementContext() == null) {
-            return statementContext.getNextRelationId();
+            return statementContext.getNextObjectId();
         }
-        return ConnectContext.get().getStatementContext().getNextRelationId();
+        return ConnectContext.get().getStatementContext().getNextObjectId();
     }
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalDistribute.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalDistribute.java
@@ -61,7 +61,7 @@ public class PhysicalDistribute<CHILD_TYPE extends Plan> extends PhysicalUnary<C
 
     @Override
     public String toString() {
-        return Utils.toSqlString("PhysicalDistribute",
+        return Utils.toSqlString("PhysicalDistribute[" + id.asInt() + "]",
                 "distributionSpec", distributionSpec,
                 "stats", statsDeriveResult
         );

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalEsScan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalEsScan.java
@@ -22,8 +22,8 @@ import org.apache.doris.nereids.memo.GroupExpression;
 import org.apache.doris.nereids.properties.DistributionSpec;
 import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.properties.PhysicalProperties;
+import org.apache.doris.nereids.trees.plans.ObjectId;
 import org.apache.doris.nereids.trees.plans.PlanType;
-import org.apache.doris.nereids.trees.plans.RelationId;
 import org.apache.doris.nereids.trees.plans.visitor.PlanVisitor;
 import org.apache.doris.nereids.util.Utils;
 import org.apache.doris.statistics.StatsDeriveResult;
@@ -43,7 +43,7 @@ public class PhysicalEsScan extends PhysicalRelation {
     /**
      * Constructor for PhysicalEsScan.
      */
-    public PhysicalEsScan(RelationId id, ExternalTable table, List<String> qualifier,
+    public PhysicalEsScan(ObjectId id, ExternalTable table, List<String> qualifier,
                             DistributionSpec distributionSpec, Optional<GroupExpression> groupExpression,
                             LogicalProperties logicalProperties) {
         super(id, PlanType.PHYSICAL_ES_SCAN, qualifier, groupExpression, logicalProperties);
@@ -54,7 +54,7 @@ public class PhysicalEsScan extends PhysicalRelation {
     /**
      * Constructor for PhysicalEsScan.
      */
-    public PhysicalEsScan(RelationId id, ExternalTable table, List<String> qualifier,
+    public PhysicalEsScan(ObjectId id, ExternalTable table, List<String> qualifier,
                             DistributionSpec distributionSpec, Optional<GroupExpression> groupExpression,
                             LogicalProperties logicalProperties, PhysicalProperties physicalProperties,
                             StatsDeriveResult statsDeriveResult) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalFileScan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalFileScan.java
@@ -22,8 +22,8 @@ import org.apache.doris.nereids.memo.GroupExpression;
 import org.apache.doris.nereids.properties.DistributionSpec;
 import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.properties.PhysicalProperties;
+import org.apache.doris.nereids.trees.plans.ObjectId;
 import org.apache.doris.nereids.trees.plans.PlanType;
-import org.apache.doris.nereids.trees.plans.RelationId;
 import org.apache.doris.nereids.trees.plans.visitor.PlanVisitor;
 import org.apache.doris.nereids.util.Utils;
 import org.apache.doris.statistics.StatsDeriveResult;
@@ -43,7 +43,7 @@ public class PhysicalFileScan extends PhysicalRelation {
     /**
      * Constructor for PhysicalFileScan.
      */
-    public PhysicalFileScan(RelationId id, ExternalTable table, List<String> qualifier,
+    public PhysicalFileScan(ObjectId id, ExternalTable table, List<String> qualifier,
                             DistributionSpec distributionSpec, Optional<GroupExpression> groupExpression,
                             LogicalProperties logicalProperties) {
         super(id, PlanType.PHYSICAL_FILE_SCAN, qualifier, groupExpression, logicalProperties);
@@ -54,7 +54,7 @@ public class PhysicalFileScan extends PhysicalRelation {
     /**
      * Constructor for PhysicalFileScan.
      */
-    public PhysicalFileScan(RelationId id, ExternalTable table, List<String> qualifier,
+    public PhysicalFileScan(ObjectId id, ExternalTable table, List<String> qualifier,
                             DistributionSpec distributionSpec, Optional<GroupExpression> groupExpression,
                             LogicalProperties logicalProperties, PhysicalProperties physicalProperties,
                             StatsDeriveResult statsDeriveResult) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalFilter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalFilter.java
@@ -73,7 +73,7 @@ public class PhysicalFilter<CHILD_TYPE extends Plan> extends PhysicalUnary<CHILD
 
     @Override
     public String toString() {
-        return Utils.toSqlString("PhysicalFilter",
+        return Utils.toSqlString("PhysicalFilter[" + id.asInt() + "]",
                 "predicates", getPredicate(),
                 "stats", statsDeriveResult
         );

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalHashAggregate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalHashAggregate.java
@@ -182,7 +182,7 @@ public class PhysicalHashAggregate<CHILD_TYPE extends Plan> extends PhysicalUnar
 
     @Override
     public String toString() {
-        return Utils.toSqlString("PhysicalHashAggregate",
+        return Utils.toSqlString("PhysicalHashAggregate[" + id.asInt() + "]",
                 "aggPhase", aggregateParam.aggPhase,
                 "aggMode", aggregateParam.aggMode,
                 "maybeUseStreaming", maybeUsingStream,

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalHashJoin.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalHashJoin.java
@@ -115,7 +115,7 @@ public class PhysicalHashJoin<
             args.add("hint");
             args.add(hint);
         }
-        return Utils.toSqlString("PhysicalHashJoin", args.toArray());
+        return Utils.toSqlString("PhysicalHashJoin[" + id.asInt() + "]", args.toArray());
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalJdbcScan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalJdbcScan.java
@@ -22,8 +22,8 @@ import org.apache.doris.nereids.memo.GroupExpression;
 import org.apache.doris.nereids.properties.DistributionSpec;
 import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.properties.PhysicalProperties;
+import org.apache.doris.nereids.trees.plans.ObjectId;
 import org.apache.doris.nereids.trees.plans.PlanType;
-import org.apache.doris.nereids.trees.plans.RelationId;
 import org.apache.doris.nereids.trees.plans.visitor.PlanVisitor;
 import org.apache.doris.nereids.util.Utils;
 import org.apache.doris.statistics.StatsDeriveResult;
@@ -43,7 +43,7 @@ public class PhysicalJdbcScan extends PhysicalRelation {
     /**
      * Constructor for PhysicalJdbcScan.
      */
-    public PhysicalJdbcScan(RelationId id, ExternalTable table, List<String> qualifier,
+    public PhysicalJdbcScan(ObjectId id, ExternalTable table, List<String> qualifier,
                             DistributionSpec distributionSpec, Optional<GroupExpression> groupExpression,
                             LogicalProperties logicalProperties) {
         super(id, PlanType.PHYSICAL_JDBC_SCAN, qualifier, groupExpression, logicalProperties);
@@ -54,7 +54,7 @@ public class PhysicalJdbcScan extends PhysicalRelation {
     /**
      * Constructor for PhysicalJdbcScan.
      */
-    public PhysicalJdbcScan(RelationId id, ExternalTable table, List<String> qualifier,
+    public PhysicalJdbcScan(ObjectId id, ExternalTable table, List<String> qualifier,
                             DistributionSpec distributionSpec, Optional<GroupExpression> groupExpression,
                             LogicalProperties logicalProperties, PhysicalProperties physicalProperties,
                             StatsDeriveResult statsDeriveResult) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalOlapScan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalOlapScan.java
@@ -22,9 +22,9 @@ import org.apache.doris.nereids.memo.GroupExpression;
 import org.apache.doris.nereids.properties.DistributionSpec;
 import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.properties.PhysicalProperties;
+import org.apache.doris.nereids.trees.plans.ObjectId;
 import org.apache.doris.nereids.trees.plans.PlanType;
 import org.apache.doris.nereids.trees.plans.PreAggStatus;
-import org.apache.doris.nereids.trees.plans.RelationId;
 import org.apache.doris.nereids.trees.plans.algebra.OlapScan;
 import org.apache.doris.nereids.trees.plans.visitor.PlanVisitor;
 import org.apache.doris.nereids.util.Utils;
@@ -51,7 +51,7 @@ public class PhysicalOlapScan extends PhysicalRelation implements OlapScan {
     /**
      * Constructor for PhysicalOlapScan.
      */
-    public PhysicalOlapScan(RelationId id, OlapTable olapTable, List<String> qualifier, long selectedIndexId,
+    public PhysicalOlapScan(ObjectId id, OlapTable olapTable, List<String> qualifier, long selectedIndexId,
             List<Long> selectedTabletIds, List<Long> selectedPartitionIds, DistributionSpec distributionSpec,
             PreAggStatus preAggStatus, Optional<GroupExpression> groupExpression, LogicalProperties logicalProperties) {
         super(id, PlanType.PHYSICAL_OLAP_SCAN, qualifier, groupExpression, logicalProperties);
@@ -66,7 +66,7 @@ public class PhysicalOlapScan extends PhysicalRelation implements OlapScan {
     /**
      * Constructor for PhysicalOlapScan.
      */
-    public PhysicalOlapScan(RelationId id, OlapTable olapTable, List<String> qualifier, long selectedIndexId,
+    public PhysicalOlapScan(ObjectId id, OlapTable olapTable, List<String> qualifier, long selectedIndexId,
             List<Long> selectedTabletIds, List<Long> selectedPartitionIds, DistributionSpec distributionSpec,
             PreAggStatus preAggStatus, Optional<GroupExpression> groupExpression, LogicalProperties logicalProperties,
             PhysicalProperties physicalProperties, StatsDeriveResult statsDeriveResult) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalProject.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalProject.java
@@ -67,7 +67,7 @@ public class PhysicalProject<CHILD_TYPE extends Plan> extends PhysicalUnary<CHIL
 
     @Override
     public String toString() {
-        return Utils.toSqlString("PhysicalProject",
+        return Utils.toSqlString("PhysicalProject[" + id.asInt() + "]",
                 "projects", projects,
                 "stats", statsDeriveResult
         );

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalRelation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalRelation.java
@@ -21,8 +21,8 @@ import org.apache.doris.nereids.memo.GroupExpression;
 import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.properties.PhysicalProperties;
 import org.apache.doris.nereids.trees.expressions.Expression;
+import org.apache.doris.nereids.trees.plans.ObjectId;
 import org.apache.doris.nereids.trees.plans.PlanType;
-import org.apache.doris.nereids.trees.plans.RelationId;
 import org.apache.doris.nereids.trees.plans.algebra.Scan;
 import org.apache.doris.nereids.trees.plans.visitor.PlanVisitor;
 import org.apache.doris.statistics.StatsDeriveResult;
@@ -38,13 +38,13 @@ import java.util.Optional;
  */
 public abstract class PhysicalRelation extends PhysicalLeaf implements Scan {
 
-    protected final RelationId id;
+    protected final ObjectId id;
     protected final ImmutableList<String> qualifier;
 
     /**
      * Constructor for PhysicalRelation.
      */
-    public PhysicalRelation(RelationId id, PlanType type, List<String> qualifier,
+    public PhysicalRelation(ObjectId id, PlanType type, List<String> qualifier,
             Optional<GroupExpression> groupExpression, LogicalProperties logicalProperties) {
         super(type, groupExpression, logicalProperties);
         this.id = id;
@@ -54,7 +54,7 @@ public abstract class PhysicalRelation extends PhysicalLeaf implements Scan {
     /**
      * Constructor for PhysicalRelation.
      */
-    public PhysicalRelation(RelationId id, PlanType type, List<String> qualifier,
+    public PhysicalRelation(ObjectId id, PlanType type, List<String> qualifier,
             Optional<GroupExpression> groupExpression, LogicalProperties logicalProperties,
             PhysicalProperties physicalProperties, StatsDeriveResult statsDeriveResult) {
         super(type, groupExpression, logicalProperties, physicalProperties, statsDeriveResult);
@@ -93,7 +93,7 @@ public abstract class PhysicalRelation extends PhysicalLeaf implements Scan {
         return ImmutableList.of();
     }
 
-    public RelationId getId() {
+    public ObjectId getId() {
         return id;
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalSchemaScan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalSchemaScan.java
@@ -21,9 +21,9 @@ import org.apache.doris.catalog.Table;
 import org.apache.doris.nereids.memo.GroupExpression;
 import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.properties.PhysicalProperties;
+import org.apache.doris.nereids.trees.plans.ObjectId;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PlanType;
-import org.apache.doris.nereids.trees.plans.RelationId;
 import org.apache.doris.nereids.trees.plans.algebra.Scan;
 import org.apache.doris.nereids.trees.plans.visitor.PlanVisitor;
 import org.apache.doris.nereids.util.Utils;
@@ -39,13 +39,13 @@ public class PhysicalSchemaScan extends PhysicalRelation implements Scan {
 
     private final Table table;
 
-    public PhysicalSchemaScan(RelationId id, Table table, List<String> qualifier,
+    public PhysicalSchemaScan(ObjectId id, Table table, List<String> qualifier,
             Optional<GroupExpression> groupExpression, LogicalProperties logicalProperties) {
         super(id, PlanType.PHYSICAL_SCHEMA_SCAN, qualifier, groupExpression, logicalProperties);
         this.table = table;
     }
 
-    public PhysicalSchemaScan(RelationId id, Table table, List<String> qualifier,
+    public PhysicalSchemaScan(ObjectId id, Table table, List<String> qualifier,
             Optional<GroupExpression> groupExpression, LogicalProperties logicalProperties,
             PhysicalProperties physicalProperties, StatsDeriveResult statsDeriveResult) {
         super(id, PlanType.PHYSICAL_SCHEMA_SCAN, qualifier, groupExpression, logicalProperties, physicalProperties,

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalTVFRelation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalTVFRelation.java
@@ -22,8 +22,8 @@ import org.apache.doris.nereids.memo.GroupExpression;
 import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.properties.PhysicalProperties;
 import org.apache.doris.nereids.trees.expressions.functions.table.TableValuedFunction;
+import org.apache.doris.nereids.trees.plans.ObjectId;
 import org.apache.doris.nereids.trees.plans.PlanType;
-import org.apache.doris.nereids.trees.plans.RelationId;
 import org.apache.doris.nereids.trees.plans.algebra.TVFRelation;
 import org.apache.doris.nereids.trees.plans.visitor.PlanVisitor;
 import org.apache.doris.nereids.util.Utils;
@@ -39,13 +39,13 @@ public class PhysicalTVFRelation extends PhysicalRelation implements TVFRelation
 
     private final TableValuedFunction function;
 
-    public PhysicalTVFRelation(RelationId id, TableValuedFunction function, LogicalProperties logicalProperties) {
+    public PhysicalTVFRelation(ObjectId id, TableValuedFunction function, LogicalProperties logicalProperties) {
         super(id, PlanType.PHYSICAL_TVF_RELATION,
                 ImmutableList.of(), Optional.empty(), logicalProperties);
         this.function = Objects.requireNonNull(function, "function can not be null");
     }
 
-    public PhysicalTVFRelation(RelationId id, TableValuedFunction function, Optional<GroupExpression> groupExpression,
+    public PhysicalTVFRelation(ObjectId id, TableValuedFunction function, Optional<GroupExpression> groupExpression,
             LogicalProperties logicalProperties, PhysicalProperties physicalProperties,
             StatsDeriveResult statsDeriveResult) {
         super(id, PlanType.PHYSICAL_TVF_RELATION, ImmutableList.of(), groupExpression, logicalProperties,

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalWindow.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalWindow.java
@@ -95,7 +95,7 @@ public class PhysicalWindow<CHILD_TYPE extends Plan> extends PhysicalUnary<CHILD
 
     @Override
     public String toString() {
-        return Utils.toSqlString("PhysicalWindow",
+        return Utils.toSqlString("PhysicalWindow[" + id.asInt() + "]",
             "windowFrameGroup", windowFrameGroup,
             "requiredProperties", requireProperties
         );

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/datasets/tpch/AnalyzeCheckTestBase.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/datasets/tpch/AnalyzeCheckTestBase.java
@@ -19,7 +19,7 @@ package org.apache.doris.nereids.datasets.tpch;
 
 import org.apache.doris.nereids.analyzer.Unbound;
 import org.apache.doris.nereids.trees.expressions.Expression;
-import org.apache.doris.nereids.trees.expressions.NamedExpressionUtil;
+import org.apache.doris.nereids.trees.expressions.StatementScopeIdGenerator;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalPlan;
 import org.apache.doris.utframe.TestWithFeService;
@@ -32,7 +32,7 @@ public abstract class AnalyzeCheckTestBase extends TestWithFeService {
 
     @Override
     public void runBeforeEach() throws Exception {
-        NamedExpressionUtil.clear();
+        StatementScopeIdGenerator.clear();
     }
 
     protected void checkAnalyze(String sql) {

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/postprocess/MergeProjectPostProcessTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/postprocess/MergeProjectPostProcessTest.java
@@ -26,8 +26,8 @@ import org.apache.doris.nereids.trees.expressions.Alias;
 import org.apache.doris.nereids.trees.expressions.NamedExpression;
 import org.apache.doris.nereids.trees.expressions.Slot;
 import org.apache.doris.nereids.trees.expressions.SlotReference;
+import org.apache.doris.nereids.trees.plans.ObjectId;
 import org.apache.doris.nereids.trees.plans.PreAggStatus;
-import org.apache.doris.nereids.trees.plans.RelationId;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalOlapScan;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalPlan;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalProject;
@@ -74,7 +74,7 @@ public class MergeProjectPostProcessTest {
         t1Output.add(b);
         t1Output.add(c);
         LogicalProperties t1Properties = new LogicalProperties(() -> t1Output);
-        PhysicalOlapScan scan = new PhysicalOlapScan(RelationId.createGenerator().getNextId(), t1, qualifier, 0L,
+        PhysicalOlapScan scan = new PhysicalOlapScan(ObjectId.createGenerator().getNextId(), t1, qualifier, 0L,
                 Collections.emptyList(), Collections.emptyList(), null, PreAggStatus.on(),
                 Optional.empty(), t1Properties);
         Alias x = new Alias(a, "x");

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/analysis/AnalyzeSubQueryTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/analysis/AnalyzeSubQueryTest.java
@@ -25,8 +25,8 @@ import org.apache.doris.nereids.parser.NereidsParser;
 import org.apache.doris.nereids.properties.PhysicalProperties;
 import org.apache.doris.nereids.trees.expressions.EqualTo;
 import org.apache.doris.nereids.trees.expressions.ExprId;
-import org.apache.doris.nereids.trees.expressions.NamedExpressionUtil;
 import org.apache.doris.nereids.trees.expressions.SlotReference;
+import org.apache.doris.nereids.trees.expressions.StatementScopeIdGenerator;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalPlan;
 import org.apache.doris.nereids.types.BigIntType;
 import org.apache.doris.nereids.util.FieldChecker;
@@ -82,13 +82,13 @@ public class AnalyzeSubQueryTest extends TestWithFeService implements MemoPatter
 
     @Override
     protected void runBeforeEach() throws Exception {
-        NamedExpressionUtil.clear();
+        StatementScopeIdGenerator.clear();
     }
 
     @Test
     public void testTranslateCase() throws Exception {
         for (String sql : testSql) {
-            NamedExpressionUtil.clear();
+            StatementScopeIdGenerator.clear();
             StatementContext statementContext = MemoTestUtils.createStatementContext(connectContext, sql);
             NereidsPlanner planner = new NereidsPlanner(statementContext);
             PhysicalPlan plan = planner.plan(

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/analysis/AnalyzeWhereSubqueryTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/analysis/AnalyzeWhereSubqueryTest.java
@@ -39,8 +39,8 @@ import org.apache.doris.nereids.trees.expressions.Alias;
 import org.apache.doris.nereids.trees.expressions.EqualTo;
 import org.apache.doris.nereids.trees.expressions.ExprId;
 import org.apache.doris.nereids.trees.expressions.LessThan;
-import org.apache.doris.nereids.trees.expressions.NamedExpressionUtil;
 import org.apache.doris.nereids.trees.expressions.SlotReference;
+import org.apache.doris.nereids.trees.expressions.StatementScopeIdGenerator;
 import org.apache.doris.nereids.trees.expressions.functions.agg.Max;
 import org.apache.doris.nereids.trees.expressions.functions.agg.Sum;
 import org.apache.doris.nereids.trees.plans.JoinType;
@@ -120,7 +120,7 @@ public class AnalyzeWhereSubqueryTest extends TestWithFeService implements MemoP
 
     @Override
     protected void runBeforeEach() throws Exception {
-        NamedExpressionUtil.clear();
+        StatementScopeIdGenerator.clear();
     }
 
     @Test
@@ -134,7 +134,7 @@ public class AnalyzeWhereSubqueryTest extends TestWithFeService implements MemoP
 
         for (String sql : testSql) {
             try {
-                NamedExpressionUtil.clear();
+                StatementScopeIdGenerator.clear();
                 StatementContext statementContext = MemoTestUtils.createStatementContext(connectContext, sql);
                 PhysicalPlan plan = new NereidsPlanner(statementContext).plan(
                         parser.parseSingle(sql),

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/analysis/BindSlotReferenceTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/analysis/BindSlotReferenceTest.java
@@ -20,8 +20,8 @@ package org.apache.doris.nereids.rules.analysis;
 import org.apache.doris.nereids.analyzer.UnboundSlot;
 import org.apache.doris.nereids.exceptions.AnalysisException;
 import org.apache.doris.nereids.trees.expressions.Alias;
-import org.apache.doris.nereids.trees.expressions.NamedExpressionUtil;
 import org.apache.doris.nereids.trees.expressions.SlotReference;
+import org.apache.doris.nereids.trees.expressions.StatementScopeIdGenerator;
 import org.apache.doris.nereids.trees.expressions.functions.agg.Count;
 import org.apache.doris.nereids.trees.expressions.literal.IntegerLiteral;
 import org.apache.doris.nereids.trees.plans.JoinType;
@@ -45,7 +45,7 @@ class BindSlotReferenceTest {
 
     @BeforeEach
     public void beforeEach() throws Exception {
-        NamedExpressionUtil.clear();
+        StatementScopeIdGenerator.clear();
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/analysis/RegisterCTETest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/analysis/RegisterCTETest.java
@@ -36,8 +36,8 @@ import org.apache.doris.nereids.rules.rewrite.logical.UnCorrelatedApplyFilter;
 import org.apache.doris.nereids.trees.expressions.Alias;
 import org.apache.doris.nereids.trees.expressions.EqualTo;
 import org.apache.doris.nereids.trees.expressions.ExprId;
-import org.apache.doris.nereids.trees.expressions.NamedExpressionUtil;
 import org.apache.doris.nereids.trees.expressions.SlotReference;
+import org.apache.doris.nereids.trees.expressions.StatementScopeIdGenerator;
 import org.apache.doris.nereids.trees.expressions.functions.agg.Count;
 import org.apache.doris.nereids.trees.plans.JoinType;
 import org.apache.doris.nereids.trees.plans.logical.LogicalPlan;
@@ -102,7 +102,7 @@ public class RegisterCTETest extends TestWithFeService implements MemoPatternMat
 
     @Override
     protected void runBeforeEach() throws Exception {
-        NamedExpressionUtil.clear();
+        StatementScopeIdGenerator.clear();
     }
 
     private CTEContext getCTEContextAfterRegisterCTE(String sql) {
@@ -126,7 +126,7 @@ public class RegisterCTETest extends TestWithFeService implements MemoPatternMat
         };
 
         for (String sql : testSql) {
-            NamedExpressionUtil.clear();
+            StatementScopeIdGenerator.clear();
             StatementContext statementContext = MemoTestUtils.createStatementContext(connectContext, sql);
             PhysicalPlan plan = new NereidsPlanner(statementContext).plan(
                     parser.parseSingle(sql),

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/exploration/join/OuterJoinAssocTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/exploration/join/OuterJoinAssocTest.java
@@ -18,7 +18,7 @@
 package org.apache.doris.nereids.rules.exploration.join;
 
 import org.apache.doris.common.Pair;
-import org.apache.doris.nereids.trees.expressions.NamedExpressionUtil;
+import org.apache.doris.nereids.trees.expressions.StatementScopeIdGenerator;
 import org.apache.doris.nereids.trees.plans.JoinType;
 import org.apache.doris.nereids.trees.plans.logical.LogicalOlapScan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalPlan;
@@ -39,7 +39,7 @@ class OuterJoinAssocTest implements MemoPatternMatchSupported {
 
     public OuterJoinAssocTest() throws Exception {
         // clear id so that slot id keep consistent every running
-        NamedExpressionUtil.clear();
+        StatementScopeIdGenerator.clear();
         scan1 = PlanConstructor.newLogicalOlapScan(0, "t1", 0);
         scan2 = PlanConstructor.newLogicalOlapScan(1, "t2", 0);
         scan3 = PlanConstructor.newLogicalOlapScan(2, "t3", 0);

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/rewrite/ExpressionRewriteTestHelper.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/rewrite/ExpressionRewriteTestHelper.java
@@ -25,7 +25,7 @@ import org.apache.doris.nereids.rules.analysis.FunctionBinder;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.Slot;
 import org.apache.doris.nereids.trees.expressions.SlotReference;
-import org.apache.doris.nereids.trees.plans.RelationId;
+import org.apache.doris.nereids.trees.plans.ObjectId;
 import org.apache.doris.nereids.types.BigIntType;
 import org.apache.doris.nereids.types.BooleanType;
 import org.apache.doris.nereids.types.DataType;
@@ -52,7 +52,7 @@ public abstract class ExpressionRewriteTestHelper {
 
     public ExpressionRewriteTestHelper() {
         CascadesContext cascadesContext = MemoTestUtils.createCascadesContext(
-                new UnboundRelation(new RelationId(1), ImmutableList.of("tbl")));
+                new UnboundRelation(new ObjectId(1), ImmutableList.of("tbl")));
         context = new ExpressionRewriteContext(cascadesContext);
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/rewrite/SimplifyRangeTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/rewrite/SimplifyRangeTest.java
@@ -25,7 +25,7 @@ import org.apache.doris.nereids.rules.expression.rewrite.rules.SimplifyRange;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.Slot;
 import org.apache.doris.nereids.trees.expressions.SlotReference;
-import org.apache.doris.nereids.trees.plans.RelationId;
+import org.apache.doris.nereids.trees.plans.ObjectId;
 import org.apache.doris.nereids.types.BigIntType;
 import org.apache.doris.nereids.types.BooleanType;
 import org.apache.doris.nereids.types.DataType;
@@ -52,7 +52,7 @@ public class SimplifyRangeTest {
 
     public SimplifyRangeTest() {
         CascadesContext cascadesContext = MemoTestUtils.createCascadesContext(
-                new UnboundRelation(new RelationId(1), ImmutableList.of("tbl")));
+                new UnboundRelation(new ObjectId(1), ImmutableList.of("tbl")));
         context = new ExpressionRewriteContext(cascadesContext);
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/logical/EliminateGroupByConstantTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/logical/EliminateGroupByConstantTest.java
@@ -33,7 +33,7 @@ import org.apache.doris.nereids.trees.expressions.functions.agg.Max;
 import org.apache.doris.nereids.trees.expressions.functions.agg.Min;
 import org.apache.doris.nereids.trees.expressions.literal.IntegerLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.StringLiteral;
-import org.apache.doris.nereids.trees.plans.RelationId;
+import org.apache.doris.nereids.trees.plans.ObjectId;
 import org.apache.doris.nereids.trees.plans.logical.LogicalAggregate;
 import org.apache.doris.nereids.trees.plans.logical.LogicalOlapScan;
 import org.apache.doris.nereids.types.IntegerType;
@@ -69,7 +69,7 @@ public class EliminateGroupByConstantTest {
         LogicalAggregate<LogicalOlapScan> aggregate = new LogicalAggregate<>(
                 ImmutableList.of(new IntegerLiteral(1), k2),
                 ImmutableList.of(k1, k2),
-                new LogicalOlapScan(RelationId.createGenerator().getNextId(), table)
+                new LogicalOlapScan(ObjectId.createGenerator().getNextId(), table)
         );
 
         CascadesContext context = MemoTestUtils.createCascadesContext(aggregate);
@@ -88,7 +88,7 @@ public class EliminateGroupByConstantTest {
                         new StringLiteral("str"), k2),
                 ImmutableList.of(
                         new Alias(new StringLiteral("str"), "str"), k1, k2),
-                new LogicalOlapScan(RelationId.createGenerator().getNextId(), table)
+                new LogicalOlapScan(ObjectId.createGenerator().getNextId(), table)
         );
 
         CascadesContext context = MemoTestUtils.createCascadesContext(aggregate);
@@ -112,7 +112,7 @@ public class EliminateGroupByConstantTest {
                 ImmutableList.of(
                         new Alias(new StringLiteral("str"), "str"),
                         k2, k1, new Alias(new IntegerLiteral(1), "integer")),
-                new LogicalOlapScan(RelationId.createGenerator().getNextId(), table)
+                new LogicalOlapScan(ObjectId.createGenerator().getNextId(), table)
         );
 
         CascadesContext context = MemoTestUtils.createCascadesContext(aggregate);
@@ -137,7 +137,7 @@ public class EliminateGroupByConstantTest {
                         new Alias(new Max(k1), "max"),
                         new Alias(new Min(k2), "min"),
                         new Alias(new Add(k1, k2), "add")),
-                new LogicalOlapScan(RelationId.createGenerator().getNextId(), table)
+                new LogicalOlapScan(ObjectId.createGenerator().getNextId(), table)
         );
 
         CascadesContext context = MemoTestUtils.createCascadesContext(aggregate);
@@ -161,7 +161,7 @@ public class EliminateGroupByConstantTest {
                 ImmutableList.of(
                         new Alias(new StringLiteral("str"), "str"),
                         k2, k1, new Alias(new IntegerLiteral(1), "integer")),
-                new LogicalOlapScan(RelationId.createGenerator().getNextId(), table)
+                new LogicalOlapScan(ObjectId.createGenerator().getNextId(), table)
         );
 
         CascadesContext context = MemoTestUtils.createCascadesContext(aggregate);

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/logical/EliminateOuterJoinTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/logical/EliminateOuterJoinTest.java
@@ -20,7 +20,7 @@ package org.apache.doris.nereids.rules.rewrite.logical;
 import org.apache.doris.common.Pair;
 import org.apache.doris.nereids.trees.expressions.And;
 import org.apache.doris.nereids.trees.expressions.GreaterThan;
-import org.apache.doris.nereids.trees.expressions.NamedExpressionUtil;
+import org.apache.doris.nereids.trees.expressions.StatementScopeIdGenerator;
 import org.apache.doris.nereids.trees.expressions.literal.Literal;
 import org.apache.doris.nereids.trees.plans.JoinType;
 import org.apache.doris.nereids.trees.plans.logical.LogicalOlapScan;
@@ -41,7 +41,7 @@ class EliminateOuterJoinTest implements MemoPatternMatchSupported {
 
     public EliminateOuterJoinTest() throws Exception {
         // clear id so that slot id keep consistent every running
-        NamedExpressionUtil.clear();
+        StatementScopeIdGenerator.clear();
         scan1 = PlanConstructor.newLogicalOlapScan(0, "t1", 0);
         scan2 = PlanConstructor.newLogicalOlapScan(1, "t2", 0);
     }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/logical/PruneOlapScanTabletTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/logical/PruneOlapScanTabletTest.java
@@ -37,7 +37,7 @@ import org.apache.doris.nereids.trees.expressions.LessThanEqual;
 import org.apache.doris.nereids.trees.expressions.SlotReference;
 import org.apache.doris.nereids.trees.expressions.literal.DateLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.IntegerLiteral;
-import org.apache.doris.nereids.trees.plans.RelationId;
+import org.apache.doris.nereids.trees.plans.ObjectId;
 import org.apache.doris.nereids.trees.plans.logical.LogicalFilter;
 import org.apache.doris.nereids.trees.plans.logical.LogicalOlapScan;
 import org.apache.doris.nereids.types.DataType;
@@ -149,7 +149,7 @@ public class PruneOlapScanTabletTest {
 
         LogicalFilter<LogicalOlapScan> filter = new LogicalFilter<>(
                 ImmutableSet.of(greaterThanEqual, lessThanEqual, inPredicate1, inPredicate2, inPredicate3, equalTo),
-                new LogicalOlapScan(RelationId.createGenerator().getNextId(), olapTable));
+                new LogicalOlapScan(ObjectId.createGenerator().getNextId(), olapTable));
 
         Assertions.assertEquals(0, filter.child().getSelectedTabletIds().size());
 

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/logical/PushdownExpressionsInHashConditionTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/logical/PushdownExpressionsInHashConditionTest.java
@@ -21,7 +21,7 @@ import org.apache.doris.nereids.NereidsPlanner;
 import org.apache.doris.nereids.parser.NereidsParser;
 import org.apache.doris.nereids.properties.PhysicalProperties;
 import org.apache.doris.nereids.trees.expressions.Cast;
-import org.apache.doris.nereids.trees.expressions.NamedExpressionUtil;
+import org.apache.doris.nereids.trees.expressions.StatementScopeIdGenerator;
 import org.apache.doris.nereids.util.MemoPatternMatchSupported;
 import org.apache.doris.nereids.util.PlanChecker;
 import org.apache.doris.utframe.TestWithFeService;
@@ -63,7 +63,7 @@ public class PushdownExpressionsInHashConditionTest extends TestWithFeService im
 
     @Override
     protected void runBeforeEach() throws Exception {
-        NamedExpressionUtil.clear();
+        StatementScopeIdGenerator.clear();
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/logical/PushdownLimitTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/logical/PushdownLimitTest.java
@@ -23,8 +23,8 @@ import org.apache.doris.nereids.trees.expressions.EqualTo;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.plans.JoinType;
 import org.apache.doris.nereids.trees.plans.LimitPhase;
+import org.apache.doris.nereids.trees.plans.ObjectId;
 import org.apache.doris.nereids.trees.plans.Plan;
-import org.apache.doris.nereids.trees.plans.RelationId;
 import org.apache.doris.nereids.trees.plans.logical.LogicalJoin;
 import org.apache.doris.nereids.trees.plans.logical.LogicalLimit;
 import org.apache.doris.nereids.trees.plans.logical.LogicalOlapScan;
@@ -265,8 +265,8 @@ class PushdownLimitTest extends TestWithFeService implements MemoPatternMatchSup
         LogicalJoin<? extends Plan, ? extends Plan> join = new LogicalJoin<>(
                 joinType,
                 joinConditions,
-                new LogicalOlapScan(new RelationId(0), PlanConstructor.score),
-                new LogicalOlapScan(new RelationId(1), PlanConstructor.student)
+                new LogicalOlapScan(new ObjectId(0), PlanConstructor.score),
+                new LogicalOlapScan(new ObjectId(1), PlanConstructor.student)
         );
 
         if (hasProject) {

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/sqltest/SqlTestBase.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/sqltest/SqlTestBase.java
@@ -17,7 +17,7 @@
 
 package org.apache.doris.nereids.sqltest;
 
-import org.apache.doris.nereids.trees.expressions.NamedExpressionUtil;
+import org.apache.doris.nereids.trees.expressions.StatementScopeIdGenerator;
 import org.apache.doris.nereids.util.MemoPatternMatchSupported;
 import org.apache.doris.utframe.TestWithFeService;
 
@@ -80,6 +80,6 @@ public abstract class SqlTestBase extends TestWithFeService implements MemoPatte
 
     @Override
     protected void runBeforeEach() throws Exception {
-        NamedExpressionUtil.clear();
+        StatementScopeIdGenerator.clear();
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/ViewTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/ViewTest.java
@@ -78,7 +78,7 @@ public class ViewTest extends TestWithFeService implements MemoPatternMatchSuppo
 
     @Override
     protected void runBeforeEach() throws Exception {
-        NamedExpressionUtil.clear();
+        StatementScopeIdGenerator.clear();
     }
 
     @Test
@@ -96,7 +96,7 @@ public class ViewTest extends TestWithFeService implements MemoPatternMatchSuppo
 
         // check whether they can be translated.
         for (String sql : testSql) {
-            NamedExpressionUtil.clear();
+            StatementScopeIdGenerator.clear();
             System.out.println("\n\n***** " + sql + " *****\n\n");
             StatementContext statementContext = MemoTestUtils.createStatementContext(connectContext, sql);
             NereidsPlanner planner = new NereidsPlanner(statementContext);

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/PlanEqualsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/PlanEqualsTest.java
@@ -255,7 +255,7 @@ public class PlanEqualsTest {
             selectedTabletId.addAll(partition.getBaseIndex().getTabletIdsInOrder());
         }
 
-        RelationId id = RelationUtil.newRelationId();
+        ObjectId id = RelationUtil.newRelationId();
 
         PhysicalOlapScan actual = new PhysicalOlapScan(id, olapTable, Lists.newArrayList("a"),
                 olapTable.getBaseIndexId(), selectedTabletId, olapTable.getPartitionIds(), distributionSpecHash,

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/PlanToStringTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/PlanToStringTest.java
@@ -57,14 +57,14 @@ public class PlanToStringTest {
                 new SlotReference(new ExprId(0), "a", BigIntType.INSTANCE, true, Lists.newArrayList())), child);
 
         Assertions.assertTrue(plan.toString()
-                .matches("LogicalAggregate \\( groupByExpr=\\[], outputExpr=\\[a#\\d+], hasRepeat=false \\)"));
+                .matches("LogicalAggregate\\[\\d+\\] \\( groupByExpr=\\[], outputExpr=\\[a#\\d+], hasRepeat=false \\)"));
     }
 
     @Test
     public void testLogicalFilter(@Mocked Plan child) {
         LogicalFilter<Plan> plan = new LogicalFilter<>(ImmutableSet.of(new EqualTo(Literal.of(1), Literal.of(1))), child);
-
-        Assertions.assertEquals("LogicalFilter ( predicates=(1 = 1) )", plan.toString());
+        Assertions.assertTrue(plan.toString().matches(
+                "LogicalFilter\\[\\d+\\] \\( predicates=\\(1 = 1\\) \\)"));
     }
 
     @Test
@@ -74,7 +74,7 @@ public class PlanToStringTest {
                         new SlotReference(new ExprId(1), "b", BigIntType.INSTANCE, true, Lists.newArrayList()))),
                 left, right);
         Assertions.assertTrue(plan.toString().matches(
-                "LogicalJoin \\( type=INNER_JOIN, markJoinSlotReference=Optional.empty, hashJoinConjuncts=\\[\\(a#\\d+ = b#\\d+\\)], otherJoinConjuncts=\\[] \\)"));
+                "LogicalJoin\\[\\d+\\] \\( type=INNER_JOIN, markJoinSlotReference=Optional.empty, hashJoinConjuncts=\\[\\(a#\\d+ = b#\\d+\\)], otherJoinConjuncts=\\[] \\)"));
     }
 
     @Test
@@ -91,7 +91,7 @@ public class PlanToStringTest {
         LogicalProject<Plan> plan = new LogicalProject<>(ImmutableList.of(
                 new SlotReference(new ExprId(0), "a", BigIntType.INSTANCE, true, Lists.newArrayList())), child);
 
-        Assertions.assertTrue(plan.toString().matches("LogicalProject \\( distinct=false, projects=\\[a#\\d+], excepts=\\[], canEliminate=true \\)"));
+        Assertions.assertTrue(plan.toString().matches("LogicalProject\\[\\d+\\] \\( distinct=false, projects=\\[a#\\d+], excepts=\\[], canEliminate=true \\)"));
     }
 
     @Test
@@ -101,6 +101,6 @@ public class PlanToStringTest {
                 new OrderKey(new SlotReference("col2", IntegerType.INSTANCE), true, true));
 
         LogicalSort<Plan> plan = new LogicalSort<>(orderKeyList, child);
-        Assertions.assertTrue(plan.toString().matches("LogicalSort \\( orderKeys=\\[col1#\\d+ asc null first, col2#\\d+ asc null first] \\)"));
+        Assertions.assertTrue(plan.toString().matches("LogicalSort\\[\\d+\\] \\( orderKeys=\\[col1#\\d+ asc null first, col2#\\d+ asc null first] \\)"));
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/util/PlanConstructor.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/util/PlanConstructor.java
@@ -25,7 +25,7 @@ import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.catalog.PartitionInfo;
 import org.apache.doris.catalog.Type;
 import org.apache.doris.common.IdGenerator;
-import org.apache.doris.nereids.trees.plans.RelationId;
+import org.apache.doris.nereids.trees.plans.ObjectId;
 import org.apache.doris.nereids.trees.plans.logical.LogicalOlapScan;
 import org.apache.doris.thrift.TStorageType;
 
@@ -44,7 +44,7 @@ public class PlanConstructor {
     public static final LogicalOlapScan scan3;
     public static final LogicalOlapScan scan4;
 
-    private static final IdGenerator<RelationId> RELATION_ID_GENERATOR = RelationId.createGenerator();
+    private static final IdGenerator<ObjectId> RELATION_ID_GENERATOR = ObjectId.createGenerator();
 
     static {
         student = new OlapTable(0L, "student",
@@ -119,11 +119,11 @@ public class PlanConstructor {
     }
 
     public static LogicalOlapScan newLogicalOlapScanWithSameId(long tableId, String tableName, int hashColumn) {
-        return new LogicalOlapScan(RelationId.createGenerator().getNextId(),
+        return new LogicalOlapScan(ObjectId.createGenerator().getNextId(),
                 newOlapTable(tableId, tableName, hashColumn), ImmutableList.of("db"));
     }
 
-    public static RelationId getNextRelationId() {
+    public static ObjectId getNextRelationId() {
         return RELATION_ID_GENERATOR.getNextId();
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/util/ReadLockTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/util/ReadLockTest.java
@@ -30,6 +30,8 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 public class ReadLockTest extends SSBTestBase {
 
@@ -100,7 +102,9 @@ public class ReadLockTest extends SSBTestBase {
         CascadesContext cascadesContext = planner.getCascadesContext();
         List<Table> f = (List<Table>) Deencapsulation.getField(cascadesContext, "tables");
         Assertions.assertEquals(2, f.size());
-        Assertions.assertEquals("supplier", f.stream().map(Table::getName).findFirst().get());
+        Set<String> tableNames = f.stream().map(Table::getName).collect(Collectors.toSet());
+        Assertions.assertTrue(tableNames.contains("supplier"));
+        Assertions.assertTrue(tableNames.contains("lineorder"));
 
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/utframe/TestWithFeService.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/utframe/TestWithFeService.java
@@ -54,7 +54,7 @@ import org.apache.doris.common.MetaNotFoundException;
 import org.apache.doris.common.util.SqlParserUtils;
 import org.apache.doris.nereids.CascadesContext;
 import org.apache.doris.nereids.StatementContext;
-import org.apache.doris.nereids.trees.expressions.NamedExpressionUtil;
+import org.apache.doris.nereids.trees.expressions.StatementScopeIdGenerator;
 import org.apache.doris.nereids.trees.plans.logical.LogicalPlan;
 import org.apache.doris.nereids.util.MemoTestUtils;
 import org.apache.doris.planner.Planner;
@@ -135,7 +135,7 @@ public abstract class TestWithFeService {
     public final void afterAll() throws Exception {
         runAfterAll();
         Env.getCurrentEnv().clear();
-        NamedExpressionUtil.clear();
+        StatementScopeIdGenerator.clear();
         cleanDorisFeDir();
     }
 


### PR DESCRIPTION
# Proposed changes
The main purpose is to facilitate debug, tracing every groupExpression and plan node.

rename RelationId to ObjectId, and assign id to every groupExpression and PlanNode
for example, in plan.treeString(), 5253 is the id for this project. It helps us to set break point condition.
`
 +--PhysicalProject[5253] ( projects=[i_product_name#21], stats=(rows=5760, width=2, penalty=0.0) 
`
Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

