### PR TITLE
[enhancement](Nereids) Refactor EliminateLimitTest and EliminateFilterTest by match-pattern

### DIFF
--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/logical/EliminateFilterTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/logical/EliminateFilterTest.java
@@ -17,39 +17,29 @@
 
 package org.apache.doris.nereids.rules.rewrite.logical;
 
-import org.apache.doris.nereids.CascadesContext;
-import org.apache.doris.nereids.rules.Rule;
 import org.apache.doris.nereids.trees.expressions.literal.BooleanLiteral;
-import org.apache.doris.nereids.trees.plans.Plan;
-import org.apache.doris.nereids.trees.plans.logical.LogicalEmptyRelation;
-import org.apache.doris.nereids.trees.plans.logical.LogicalOlapScan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalPlan;
 import org.apache.doris.nereids.util.LogicalPlanBuilder;
+import org.apache.doris.nereids.util.MemoPatternMatchSupported;
 import org.apache.doris.nereids.util.MemoTestUtils;
+import org.apache.doris.nereids.util.PlanChecker;
 import org.apache.doris.nereids.util.PlanConstructor;
 
-import com.google.common.collect.Lists;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-
-import java.util.List;
 
 /**
  * Tests for {@link EliminateFilter}.
  */
-class EliminateFilterTest {
+class EliminateFilterTest implements MemoPatternMatchSupported {
     @Test
     void testEliminateFilterFalse() {
         LogicalPlan filterFalse = new LogicalPlanBuilder(PlanConstructor.newLogicalOlapScan(0, "t1", 0))
                 .filter(BooleanLiteral.FALSE)
                 .build();
 
-        CascadesContext cascadesContext = MemoTestUtils.createCascadesContext(filterFalse);
-        List<Rule> rules = Lists.newArrayList(new EliminateFilter().build());
-        cascadesContext.topDownRewrite(rules);
-
-        Plan actual = cascadesContext.getMemo().copyOut();
-        Assertions.assertTrue(actual instanceof LogicalEmptyRelation);
+        PlanChecker.from(MemoTestUtils.createConnectContext(), filterFalse)
+                .applyTopDown(new EliminateFilter())
+                .matches(logicalEmptyRelation());
     }
 
     @Test
@@ -58,11 +48,8 @@ class EliminateFilterTest {
                 .filter(BooleanLiteral.TRUE)
                 .build();
 
-        CascadesContext cascadesContext = MemoTestUtils.createCascadesContext(filterTrue);
-        List<Rule> rules = Lists.newArrayList(new EliminateFilter().build());
-        cascadesContext.topDownRewrite(rules);
-
-        Plan actual = cascadesContext.getMemo().copyOut();
-        Assertions.assertTrue(actual instanceof LogicalOlapScan);
+        PlanChecker.from(MemoTestUtils.createConnectContext(), filterTrue)
+                .applyTopDown(new EliminateFilter())
+                .matches(logicalOlapScan());
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/logical/EliminateFilterTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/logical/EliminateFilterTest.java
@@ -34,9 +34,12 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-public class EliminateFilterTest {
+/**
+ * Tests for {@link EliminateFilter}.
+ */
+class EliminateFilterTest {
     @Test
-    public void testEliminateFilterFalse() {
+    void testEliminateFilterFalse() {
         LogicalPlan filterFalse = new LogicalPlanBuilder(PlanConstructor.newLogicalOlapScan(0, "t1", 0))
                 .filter(BooleanLiteral.FALSE)
                 .build();
@@ -50,12 +53,12 @@ public class EliminateFilterTest {
     }
 
     @Test
-    public void testEliminateFilterTrue() {
-        LogicalPlan filterFalse = new LogicalPlanBuilder(PlanConstructor.newLogicalOlapScan(0, "t1", 0))
+    void testEliminateFilterTrue() {
+        LogicalPlan filterTrue = new LogicalPlanBuilder(PlanConstructor.newLogicalOlapScan(0, "t1", 0))
                 .filter(BooleanLiteral.TRUE)
                 .build();
 
-        CascadesContext cascadesContext = MemoTestUtils.createCascadesContext(filterFalse);
+        CascadesContext cascadesContext = MemoTestUtils.createCascadesContext(filterTrue);
         List<Rule> rules = Lists.newArrayList(new EliminateFilter().build());
         cascadesContext.topDownRewrite(rules);
 

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/logical/EliminateLimitTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/logical/EliminateLimitTest.java
@@ -17,55 +17,43 @@
 
 package org.apache.doris.nereids.rules.rewrite.logical;
 
-import org.apache.doris.nereids.CascadesContext;
 import org.apache.doris.nereids.properties.OrderKey;
-import org.apache.doris.nereids.rules.Rule;
-import org.apache.doris.nereids.trees.plans.LimitPhase;
-import org.apache.doris.nereids.trees.plans.Plan;
-import org.apache.doris.nereids.trees.plans.logical.LogicalEmptyRelation;
 import org.apache.doris.nereids.trees.plans.logical.LogicalLimit;
 import org.apache.doris.nereids.trees.plans.logical.LogicalOlapScan;
-import org.apache.doris.nereids.trees.plans.logical.LogicalSort;
-import org.apache.doris.nereids.trees.plans.logical.LogicalTopN;
+import org.apache.doris.nereids.trees.plans.logical.LogicalPlan;
+import org.apache.doris.nereids.util.LogicalPlanBuilder;
+import org.apache.doris.nereids.util.MemoPatternMatchSupported;
 import org.apache.doris.nereids.util.MemoTestUtils;
 import org.apache.doris.nereids.util.PlanChecker;
 import org.apache.doris.nereids.util.PlanConstructor;
 
-import com.google.common.collect.Lists;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import java.util.List;
 import java.util.stream.Collectors;
 
 /**
  * Tests for the elimination of {@link LogicalLimit}.
  */
-class EliminateLimitTest {
+class EliminateLimitTest implements MemoPatternMatchSupported {
     @Test
     void testEliminateLimit() {
-        LogicalOlapScan scan = PlanConstructor.newLogicalOlapScan(0, "t1", 0);
-        LogicalLimit<LogicalOlapScan> limit = new LogicalLimit<>(0, 0, LimitPhase.ORIGIN, scan);
+        LogicalPlan limit = new LogicalPlanBuilder(PlanConstructor.newLogicalOlapScan(0, "t1", 0))
+                .limit(0, 0).build();
 
-        CascadesContext cascadesContext = MemoTestUtils.createCascadesContext(limit);
-        List<Rule> rules = Lists.newArrayList(new EliminateLimit().build());
-        cascadesContext.topDownRewrite(rules);
-
-        Plan actual = cascadesContext.getMemo().copyOut();
-        Assertions.assertTrue(actual instanceof LogicalEmptyRelation);
+        PlanChecker.from(MemoTestUtils.createConnectContext(), limit)
+                .applyTopDown(new EliminateLimit())
+                .matches(logicalEmptyRelation());
     }
 
     @Test
     void testLimitSort() {
         LogicalOlapScan scan = PlanConstructor.newLogicalOlapScan(0, "t1", 0);
-        LogicalLimit limit = new LogicalLimit<>(1, 1, LimitPhase.ORIGIN,
-                new LogicalSort<>(
-                        scan.getOutput().stream().map(c -> new OrderKey(c, true, true)).collect(Collectors.toList()),
-                        scan));
+        LogicalPlan limit = new LogicalPlanBuilder(scan).sort(
+                        scan.getOutput().stream().map(c -> new OrderKey(c, true, true)).collect(Collectors.toList()))
+                .limit(1, 1).build();
 
-        Plan actual = PlanChecker.from(MemoTestUtils.createConnectContext(), limit)
+        PlanChecker.from(MemoTestUtils.createConnectContext(), limit)
                 .rewrite()
-                .getPlan();
-        Assertions.assertTrue(actual instanceof LogicalTopN);
+                .matches(logicalTopN());
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/logical/EliminateLimitTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/logical/EliminateLimitTest.java
@@ -39,11 +39,11 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 /**
- * MergeConsecutiveFilter ut
+ * Tests for the elimination of {@link LogicalLimit}.
  */
-public class EliminateLimitTest {
+class EliminateLimitTest {
     @Test
-    public void testEliminateLimit() {
+    void testEliminateLimit() {
         LogicalOlapScan scan = PlanConstructor.newLogicalOlapScan(0, "t1", 0);
         LogicalLimit<LogicalOlapScan> limit = new LogicalLimit<>(0, 0, LimitPhase.ORIGIN, scan);
 
@@ -56,10 +56,11 @@ public class EliminateLimitTest {
     }
 
     @Test
-    public void testLimitSort() {
+    void testLimitSort() {
         LogicalOlapScan scan = PlanConstructor.newLogicalOlapScan(0, "t1", 0);
         LogicalLimit limit = new LogicalLimit<>(1, 1, LimitPhase.ORIGIN,
-                new LogicalSort<>(scan.getOutput().stream().map(c -> new OrderKey(c, true, true)).collect(Collectors.toList()),
+                new LogicalSort<>(
+                        scan.getOutput().stream().map(c -> new OrderKey(c, true, true)).collect(Collectors.toList()),
                         scan));
 
         Plan actual = PlanChecker.from(MemoTestUtils.createConnectContext(), limit)

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/util/LogicalPlanBuilder.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/util/LogicalPlanBuilder.java
@@ -18,6 +18,7 @@
 package org.apache.doris.nereids.util;
 
 import org.apache.doris.common.Pair;
+import org.apache.doris.nereids.properties.OrderKey;
 import org.apache.doris.nereids.trees.expressions.Alias;
 import org.apache.doris.nereids.trees.expressions.EqualTo;
 import org.apache.doris.nereids.trees.expressions.Expression;
@@ -33,6 +34,7 @@ import org.apache.doris.nereids.trees.plans.logical.LogicalLimit;
 import org.apache.doris.nereids.trees.plans.logical.LogicalOlapScan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalPlan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalProject;
+import org.apache.doris.nereids.trees.plans.logical.LogicalSort;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
@@ -121,6 +123,11 @@ public class LogicalPlanBuilder {
     public LogicalPlanBuilder joinEmptyOn(LogicalPlan right, JoinType joinType) {
         LogicalJoin<LogicalPlan, LogicalPlan> join = new LogicalJoin<>(joinType, new ArrayList<>(), this.plan, right);
         return from(join);
+    }
+
+    public LogicalPlanBuilder sort(List<OrderKey> orderKeys) {
+        LogicalSort<LogicalPlan> sortPlan = new LogicalSort<>(orderKeys, this.plan);
+        return from(sortPlan);
     }
 
     public LogicalPlanBuilder limit(long limit, long offset) {


### PR DESCRIPTION
# Proposed changes

Issue Number: #17625

## Problem summary

- Remove useless public modifier and fix typo in EliminateFilterTest and EliminateLimistTest.
- Refactor EliminateLimitTest and EliminateFilterTest by match-pattern.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

