### PR TITLE
[fix](regression) fix test_array_export and test_map_export dir conflict

### DIFF
--- a/regression-test/suites/export/test_array_export.groovy
+++ b/regression-test/suites/export/test_array_export.groovy
@@ -52,7 +52,7 @@ suite("test_array_export", "export") {
     
     // define the table and out file path
     def tableName = "array_outfile_test"
-    def outFilePath = """${context.file.parent}/tmp"""
+    def outFilePath = """${context.file.parent}/test_array_export"""
     logger.warn("test_array_export the outFilePath=" + outFilePath)
     
     def create_test_table = {testTablex ->

--- a/regression-test/suites/export/test_map_export.groovy
+++ b/regression-test/suites/export/test_map_export.groovy
@@ -76,7 +76,7 @@ suite("test_map_export", "export") {
     // check result
     qt_select """ SELECT * FROM ${testTable} ORDER BY id; """
 
-    def outFilePath = """${context.file.parent}/tmp"""
+    def outFilePath = """${context.file.parent}/test_map_export"""
     logger.info("test_map_export the outFilePath=" + outFilePath)
     // map select into outfile
     try {


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

regression test test_array_export and test_map_export use same output dir, if they run at the same time, the cases will failed.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

