### PR TITLE
[fix](Nereids): order of project's logical properties is different with that of project expression

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslator.java
@@ -1361,7 +1361,10 @@ public class PhysicalPlanTranslator extends DefaultPlanVisitor<PlanFragment, Pla
         // TODO: fix the project alias of an aliased relation.
 
         PlanNode inputPlanNode = inputFragment.getPlanRoot();
-        List<Slot> slotList = project.getOutput();
+        List<Slot> slotList = project.getProjects()
+                .stream()
+                .map(e -> e.toSlot())
+                .collect(Collectors.toList());
         // For hash join node, use vSrcToOutputSMap to describe the expression calculation, use
         // vIntermediateTupleDescList as input, and set vOutputTupleDesc as the final output.
         // TODO: HashJoinNode's be implementation is not support projection yet, remove this after when supported.

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/cascades/ApplyRuleJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/cascades/ApplyRuleJob.java
@@ -76,6 +76,7 @@ public class ApplyRuleJob extends Job {
                     continue;
                 }
                 GroupExpression newGroupExpression = result.correspondingExpression;
+                newGroupExpression.setFromRule(rule);
                 if (newPlan instanceof LogicalPlan) {
                     pushJob(new OptimizeGroupExpressionJob(newGroupExpression, context));
                 } else {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/GroupExpression.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/GroupExpression.java
@@ -57,6 +57,9 @@ public class GroupExpression {
 
     private long estOutputRowCount = -1;
 
+    //Record the rule that generate this plan. It's used for debugging
+    private Rule fromRule;
+
     // Mapping from output properties to the corresponding best cost, statistics, and child properties.
     // key is the physical properties the group expression support for its parent
     // and value is cost and request physical properties to its children.
@@ -98,6 +101,10 @@ public class GroupExpression {
 
     public int arity() {
         return children.size();
+    }
+
+    public void setFromRule(Rule rule) {
+        this.fromRule = rule;
     }
 
     public Group getOwnerGroup() {


### PR DESCRIPTION
# Proposed changes

1. Add `fromRule` to mark the rule that create this group expression for debuging
2. fix a bug that the order of project's logical properties is different with that of project expression

For example, in some rules like `LOGICAL_SEMI_JOIN_LOGICAL_JOIN_TRANSPOSE_PROJECT`, we create project with a different order, e.g.,
```
project(a, b) -> project(b, a) 
```
However, the logical properties of the group are not changed. Therefore, we get
```
project(b, a) with logical properties (a, b)
```
It causes a binding error when translating physical project, where we use `logicalproperties` to generate `tupleDesc` but calculate the actual output by projects expression


## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

