### PR TITLE
[fix](point query) Fix NegativeArraySizeException when prepared state…

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/LiteralExpr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/LiteralExpr.java
@@ -24,6 +24,7 @@ import org.apache.doris.catalog.PrimitiveType;
 import org.apache.doris.catalog.Type;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.NotImplementedException;
+import org.apache.doris.mysql.MysqlProto;
 
 import com.google.common.base.Preconditions;
 import org.apache.logging.log4j.LogManager;
@@ -334,41 +335,36 @@ public abstract class LiteralExpr extends Expr implements Comparable<LiteralExpr
             return 0;
         }
         // get and advance 1 byte
-        int len = data.get();
-        if (len < 251) {
+        int len = MysqlProto.readInt1(data);
+        if (len == 252) {
+            if (maxLen < 3) {
+                return 0;
+            }
+            // get and advance 2 bytes
+            return MysqlProto.readInt2(data);
+        } else if (len == 253) {
+            if (maxLen < 4) {
+                return 0;
+            }
+            // get and advance 3 bytes
+            return MysqlProto.readInt3(data);
+        } else if (len == 254) {
+            /*
+            In our client-server protocol all numbers bigger than 2^24
+            stored as 8 bytes with uint8korr. Here we always know that
+            parameter length is less than 2^4 so we don't look at the second
+            4 bytes. But still we need to obey the protocol hence 9 in the
+            assignment below.
+            */
+            if (maxLen < 5) {
+                return 0;
+            }
+            return MysqlProto.readInt4(data);
+        } else if (len == 255) {
+            return 0;
+        } else {
             return len;
         }
-        if (maxLen < 3) {
-            return 0;
-        }
-        if (len == 252) {
-            // get and advance 2 bytes
-            return data.getChar();
-        }
-        if (maxLen < 4) {
-            return 0;
-        }
-        if (len == 253) {
-            // get and advance 3 bytes
-            byte[] bytes = new byte[3];
-            data.get(bytes);
-            return ByteBuffer.wrap(bytes).getInt();
-        }
-        if (maxLen < 5) {
-            return 0;
-        }
-        // Must be 254 when here
-        /*
-          In our client-server protocol all numbers bigger than 2^24
-          stored as 8 bytes with uint8korr. Here we always know that
-          parameter length is less than 2^4 so don't look at the second
-          4 bytes. But still we need to obey the protocol hence 9 in the
-          assignment above.
-        */
-        int ret = data.getInt();
-        // advance more useless 4 bytes
-        data.getInt();
-        return ret;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/LiteralExpr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/LiteralExpr.java
@@ -356,10 +356,12 @@ public abstract class LiteralExpr extends Expr implements Comparable<LiteralExpr
             4 bytes. But still we need to obey the protocol hence 9 in the
             assignment below.
             */
-            if (maxLen < 5) {
+            if (maxLen < 9) {
                 return 0;
             }
-            return MysqlProto.readInt4(data);
+            len = MysqlProto.readInt4(data);
+            MysqlProto.readFixedString(data, 4);
+            return len;
         } else if (len == 255) {
             return 0;
         } else {

--- a/regression-test/data/point_query_p0/test_point_query.out
+++ b/regression-test/data/point_query_p0/test_point_query.out
@@ -9,6 +9,15 @@
 1237	120939.111300000	a    ddd	laooq	2030-01-02	2020-01-01T12:36:38	22.822	7022-01-01
 
 -- !point_select --
+251	120939.111300000	aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa	laooq	2030-01-02	2020-01-01T12:36:38	251.0	7022-01-01
+
+-- !point_select --
+252	120939.111300000	aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa	laooq	2030-01-02	2020-01-01T12:36:38	252.0	7022-01-01
+
+-- !point_select --
+298	120939.111300000	aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa	laooq	2030-01-02	2020-01-01T12:36:38	298.0	7022-01-01
+
+-- !point_select --
 1235	991129292901.111380000	dd	\N	2120-01-02	2020-01-01T12:36:38	652.692	5022-01-01
 
 -- !point_select --

--- a/regression-test/suites/point_query_p0/test_point_query.groovy
+++ b/regression-test/suites/point_query_p0/test_point_query.groovy
@@ -22,6 +22,15 @@ suite("test_point_query") {
     def user = context.config.jdbcUser
     def password = context.config.jdbcPassword
     def url = context.config.jdbcUrl + "&useServerPrepStmts=true"
+
+    def generateString = {len ->
+        def str = ""
+        for (int i = 0; i < len; i++) {
+            str += "a"
+        }
+        return str
+    }
+
     // def url = context.config.jdbcUrl
     def result1 = connect(user=user, password=password, url=url) {
     sql """DROP TABLE IF EXISTS ${tableName}"""
@@ -45,7 +54,7 @@ suite("test_point_query") {
               CREATE TABLE IF NOT EXISTS ${tableName} (
                 `k1` int(11) NULL COMMENT "",
                 `k2` decimalv3(27, 9) NULL COMMENT "",
-                `k3` varchar(30) NULL COMMENT "",
+                `k3` varchar(300) NULL COMMENT "",
                 `k4` varchar(30) NULL COMMENT "",
                 `k5` date NULL COMMENT "",
                 `k6` datetime NULL COMMENT "",
@@ -69,6 +78,9 @@ suite("test_point_query") {
       sql """ INSERT INTO ${tableName} VALUES(1235, 991129292901.11138, "dd", null, "2120-01-02", "2020-01-01 12:36:38", 652.692, "5022-01-01 11:30:38") """
       sql """ INSERT INTO ${tableName} VALUES(1236, 100320.11139, "laa    ddd", "laooq", "2220-01-02", "2020-01-01 12:36:38", 2.7692, "6022-01-01 11:30:38") """
       sql """ INSERT INTO ${tableName} VALUES(1237, 120939.11130, "a    ddd", "laooq", "2030-01-02", "2020-01-01 12:36:38", 22.822, "7022-01-01 11:30:38") """
+      sql """ INSERT INTO ${tableName} VALUES(251, 120939.11130, "${generateString(251)}", "laooq", "2030-01-02", "2020-01-01 12:36:38", 251, "7022-01-01 11:30:38") """
+      sql """ INSERT INTO ${tableName} VALUES(252, 120939.11130, "${generateString(252)}", "laooq", "2030-01-02", "2020-01-01 12:36:38", 252, "7022-01-01 11:30:38") """
+      sql """ INSERT INTO ${tableName} VALUES(298, 120939.11130, "${generateString(298)}", "laooq", "2030-01-02", "2020-01-01 12:36:38", 298, "7022-01-01 11:30:38") """
 
       def stmt = prepareStatement "select * from ${tableName} where k1 = ? and k2 = ? and k3 = ?"
       assertEquals(stmt.class, com.mysql.cj.jdbc.ServerPreparedStatement);
@@ -83,6 +95,19 @@ suite("test_point_query") {
       stmt.setInt(1, 1237)
       stmt.setBigDecimal(2, new BigDecimal("120939.11130"))
       stmt.setString(3, "a    ddd")
+      qe_point_select stmt
+
+      stmt.setInt(1, 251)
+      stmt.setBigDecimal(2, new BigDecimal("120939.11130"))
+      stmt.setString(3, generateString(251))
+      qe_point_select stmt
+      stmt.setInt(1, 252)
+      stmt.setBigDecimal(2, new BigDecimal("120939.11130"))
+      stmt.setString(3, generateString(252))
+      qe_point_select stmt
+      stmt.setInt(1, 298)
+      stmt.setBigDecimal(2, new BigDecimal("120939.11130"))
+      stmt.setString(3, generateString(298))
       qe_point_select stmt
 
       stmt = prepareStatement "select * from ${tableName} where k1 = 1235 and k2 = ? and k3 = ?"


### PR DESCRIPTION
…ment contains a long string

# Proposed changes

Issue Number: close #xxx

## Problem summary

When use prepared statement with a long string, get a NegativeArraySizeException in client side, the exception in fe is:

```
2023-03-10 14:03:39,527 WARN (mysql-nio-pool-1|645) [ConnectProcessor.handleExecute():249] Process one query failed because unknown reason: 
java.lang.NegativeArraySizeException: null
        at org.apache.doris.analysis.StringLiteral.setupParamFromBinary(StringLiteral.java:308) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.ConnectProcessor.handleExecute(ConnectProcessor.java:235) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.ConnectProcessor.dispatch(ConnectProcessor.java:566) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.qe.ConnectProcessor.processOnce(ConnectProcessor.java:794) ~[doris-fe.jar:1.2-SNAPSHOT]
        at org.apache.doris.mysql.ReadListener.lambda$handleEvent$0(ReadListener.java:52) ~[doris-fe.jar:1.2-SNAPSHOT]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142) ~[?:1.8.0_131]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617) ~[?:1.8.0_131]
        at java.lang.Thread.run(Thread.java:748) ~[?:1.8.0_131]
```

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

