### PR TITLE
[enhance](cooldown) no snapshot or migration action for cooldown tablet

### DIFF
--- a/be/src/olap/task/engine_clone_task.cpp
+++ b/be/src/olap/task/engine_clone_task.cpp
@@ -311,7 +311,10 @@ Status EngineCloneTask::_make_snapshot(const std::string& ip, int port, TTableId
     request.__set_version(_clone_req.committed_version);
     // TODO: missing version composed of singleton delta.
     // if not, this place should be rewrote.
-    request.__isset.missing_version = (!missed_versions.empty());
+    // we make every TSnapshotRequest sent from be with __isset.missing_version = true
+    // then if one be received one req with __isset.missing_version = false it means
+    // this req is sent from FE(FE would never set this field)
+    request.__isset.missing_version = true;
     for (auto& version : missed_versions) {
         request.missing_version.push_back(version.first);
     }

--- a/be/src/olap/task/engine_storage_migration_task.cpp
+++ b/be/src/olap/task/engine_storage_migration_task.cpp
@@ -41,6 +41,12 @@ Status EngineStorageMigrationTask::execute() {
 Status EngineStorageMigrationTask::_get_versions(int32_t start_version, int32_t* end_version,
                                                  std::vector<RowsetSharedPtr>* consistent_rowsets) {
     std::shared_lock rdlock(_tablet->get_header_lock());
+    // check if tablet is in cooldown, we don't support migration in this case
+    if (_tablet->tablet_meta()->cooldown_meta_id().initialized()) {
+        LOG(WARNING) << "tablet is in cooldown, not support snapshot. tablet="
+                     << _tablet->tablet_id();
+        return Status::NotSupported("tablet is in cooldown, not support snapshot");
+    }
     const RowsetSharedPtr last_version = _tablet->rowset_with_max_version();
     if (last_version == nullptr) {
         return Status::InternalError("failed to get rowset with max version, tablet={}",

--- a/be/src/olap/task/engine_storage_migration_task.cpp
+++ b/be/src/olap/task/engine_storage_migration_task.cpp
@@ -43,9 +43,10 @@ Status EngineStorageMigrationTask::_get_versions(int32_t start_version, int32_t*
     std::shared_lock rdlock(_tablet->get_header_lock());
     // check if tablet is in cooldown, we don't support migration in this case
     if (_tablet->tablet_meta()->cooldown_meta_id().initialized()) {
-        LOG(WARNING) << "tablet is in cooldown, not support snapshot. tablet="
+        LOG(WARNING) << "currently not support migrate tablet with cooldowned remote data. tablet="
                      << _tablet->tablet_id();
-        return Status::NotSupported("tablet is in cooldown, not support snapshot");
+        return Status::NotSupported(
+                "currently not support migrate tablet with cooldowned remote data");
     }
     const RowsetSharedPtr last_version = _tablet->rowset_with_max_version();
     if (last_version == nullptr) {


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx
Once one tablet is cooldown, some data of it would be uploaded into the object storage. So we shouldn't do migration task and snapshot task on suck kind tablet.
## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

