### PR TITLE
[fix](Nereids) type coercion for subquery

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/BindExpression.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/BindExpression.java
@@ -77,6 +77,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -142,7 +143,7 @@ public class BindExpression implements AnalysisRuleFactory {
                     Set<Expression> boundConjuncts = filter.getConjuncts().stream()
                             .map(expr -> bindSlot(expr, filter.children(), ctx.cascadesContext))
                             .map(expr -> bindFunction(expr, ctx.cascadesContext))
-                            .collect(Collectors.toSet());
+                            .collect(Collectors.toCollection(LinkedHashSet::new));
                     return new LogicalFilter<>(boundConjuncts, filter.child());
                 })
             ),

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/Exists.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/Exists.java
@@ -28,6 +28,7 @@ import com.google.common.base.Preconditions;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 /**
  * Exists subquery expression.
@@ -41,8 +42,16 @@ public class Exists extends SubqueryExpr implements LeafExpression {
     }
 
     public Exists(LogicalPlan subquery, List<Slot> correlateSlots, boolean isNot) {
+        this(Objects.requireNonNull(subquery, "subquery can not be null"),
+                Objects.requireNonNull(correlateSlots, "subquery can not be null"),
+                Optional.empty(), isNot);
+    }
+
+    public Exists(LogicalPlan subquery, List<Slot> correlateSlots,
+                  Optional<Expression> typeCoercionExpr, boolean isNot) {
         super(Objects.requireNonNull(subquery, "subquery can not be null"),
-                Objects.requireNonNull(correlateSlots, "subquery can not be null"));
+                Objects.requireNonNull(correlateSlots, "subquery can not be null"),
+                typeCoercionExpr);
         this.isNot = Objects.requireNonNull(isNot, "isNot can not be null");
     }
 
@@ -87,5 +96,10 @@ public class Exists extends SubqueryExpr implements LeafExpression {
     @Override
     public int hashCode() {
         return Objects.hash(this.queryPlan, this.isNot);
+    }
+
+    @Override
+    public Expression withTypeCoercion(DataType dataType) {
+        return this;
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/InSubquery.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/InSubquery.java
@@ -25,6 +25,7 @@ import com.google.common.base.Preconditions;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 /**
  * In predicate expression.
@@ -43,8 +44,20 @@ public class InSubquery extends SubqueryExpr {
     }
 
     public InSubquery(Expression compareExpr, ListQuery listQuery, List<Slot> correlateSlots, boolean isNot) {
+        this(compareExpr, listQuery, correlateSlots, Optional.empty(), isNot);
+    }
+
+    /**
+     * InSubquery Constructor.
+     */
+    public InSubquery(Expression compareExpr,
+                      ListQuery listQuery,
+                      List<Slot> correlateSlots,
+                      Optional<Expression> typeCoercionExpr,
+                      boolean isNot) {
         super(Objects.requireNonNull(listQuery.getQueryPlan(), "subquery can not be null"),
-                Objects.requireNonNull(correlateSlots, "correlateSlots can not be null"));
+                Objects.requireNonNull(correlateSlots, "correlateSlots can not be null"),
+                typeCoercionExpr);
         this.compareExpr = Objects.requireNonNull(compareExpr, "compareExpr can not be null");
         this.listQuery = Objects.requireNonNull(listQuery, "listQuery can not be null");
         this.isNot = Objects.requireNonNull(isNot, "isNot can not be null");
@@ -99,12 +112,23 @@ public class InSubquery extends SubqueryExpr {
             return false;
         }
         InSubquery inSubquery = (InSubquery) o;
-        return Objects.equals(this.compareExpr, inSubquery.getCompareExpr())
+        return super.equals(inSubquery)
+                && Objects.equals(this.compareExpr, inSubquery.getCompareExpr())
+                && Objects.equals(this.listQuery, inSubquery.listQuery)
                 && this.isNot == inSubquery.isNot;
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(this.compareExpr, this.listQuery, this.isNot);
+    }
+
+    @Override
+    public Expression withTypeCoercion(DataType dataType) {
+        return new InSubquery(compareExpr, listQuery, correlateSlots,
+            dataType == listQuery.queryPlan.getOutput().get(0).getDataType()
+                ? Optional.of(listQuery.queryPlan.getOutput().get(0))
+                : Optional.of(new Cast(listQuery.queryPlan.getOutput().get(0), dataType)),
+            isNot);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/util/TypeCoercionUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/util/TypeCoercionUtils.java
@@ -227,12 +227,16 @@ public class TypeCoercionUtils {
      * cast input type if input's datatype is not same with dateType.
      */
     public static Expression castIfNotSameType(Expression input, DataType targetType) {
-        if (input.getDataType().equals(targetType)) {
+        if (input.getDataType().equals(targetType) || isSubqueryAndDataTypeIsBitmap(input)) {
             return input;
         } else {
             checkCanCastTo(input.getDataType(), targetType);
             return unSafeCast(input, targetType);
         }
+    }
+
+    private static boolean isSubqueryAndDataTypeIsBitmap(Expression input) {
+        return input instanceof SubqueryExpr && input.getDataType().isBitmapType();
     }
 
     private static boolean canCastTo(DataType input, DataType target) {
@@ -262,6 +266,13 @@ public class TypeCoercionUtils {
                     return promoted;
                 }
             }
+        }
+        return recordTypeCoercionForSubQuery(input, dataType);
+    }
+
+    private static Expression recordTypeCoercionForSubQuery(Expression input, DataType dataType) {
+        if (input instanceof SubqueryExpr) {
+            return ((SubqueryExpr) input).withTypeCoercion(dataType);
         }
         return new Cast(input, dataType);
     }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/MarkJoinTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/MarkJoinTest.java
@@ -29,13 +29,13 @@ public class MarkJoinTest extends TestWithFeService {
         useDatabase("test");
 
         createTable("CREATE TABLE `test_sq_dj1` (\n"
-                + " `c1` bigint(20) NULL,\n"
+                + " `c1` varchar(20) NULL,\n"
                 + " `c2` bigint(20) NULL,\n"
-                + " `c3` bigint(20) not NULL,\n"
-                + " `k4` bigint(20) not NULL,\n"
-                + " `k5` bigint(20) NULL\n"
+                + " `c3` int(20) not NULL,\n"
+                + " `k4` bitmap BITMAP_UNION NULL,\n"
+                + " `k5` bitmap BITMAP_UNION NULL\n"
                 + ") ENGINE=OLAP\n"
-                + "DUPLICATE KEY(`c1`)\n"
+                + "AGGREGATE KEY(`c1`, `c2`, `c3`)\n"
                 + "COMMENT 'OLAP'\n"
                 + "DISTRIBUTED BY HASH(`c2`) BUCKETS 1\n"
                 + "PROPERTIES (\n"
@@ -49,10 +49,10 @@ public class MarkJoinTest extends TestWithFeService {
                 + " `c1` bigint(20) NULL,\n"
                 + " `c2` bigint(20) NULL,\n"
                 + " `c3` bigint(20) not NULL,\n"
-                + " `k4` bigint(20) not NULL,\n"
-                + " `k5` bigint(20) NULL\n"
+                + " `k4` bitmap BITMAP_UNION NULL,\n"
+                + " `k5` bitmap BITMAP_UNION NULL\n"
                 + ") ENGINE=OLAP\n"
-                + "DUPLICATE KEY(`c1`)\n"
+                + "AGGREGATE KEY(`c1`, `c2`, `c3`)\n"
                 + "COMMENT 'OLAP'\n"
                 + "DISTRIBUTED BY HASH(`c2`) BUCKETS 1\n"
                 + "PROPERTIES (\n"
@@ -178,17 +178,17 @@ public class MarkJoinTest extends TestWithFeService {
                 .checkPlannerResult("SELECT CASE\n"
                     + "            WHEN (\n"
                     + "                SELECT COUNT(*) / 2\n"
-                    + "                FROM test_sq_dj1\n"
+                    + "                FROM test_sq_dj2\n"
                     + "            ) > c1 THEN (\n"
                     + "                SELECT AVG(c1)\n"
-                    + "                FROM test_sq_dj1\n"
+                    + "                FROM test_sq_dj2\n"
                     + "            )\n"
                     + "            ELSE (\n"
                     + "                SELECT SUM(c2)\n"
-                    + "                FROM test_sq_dj1\n"
+                    + "                FROM test_sq_dj2\n"
                     + "            )\n"
                     + "            END AS kk4\n"
-                    + "        FROM test_sq_dj1 ;");
+                    + "        FROM test_sq_dj2 ;");
     }
 
     @Test
@@ -197,17 +197,17 @@ public class MarkJoinTest extends TestWithFeService {
                 .checkPlannerResult("SELECT CASE\n"
                     + "            WHEN  exists (\n"
                     + "                SELECT COUNT(*) / 2\n"
-                    + "                FROM test_sq_dj1\n"
+                    + "                FROM test_sq_dj2\n"
                     + "            ) THEN (\n"
                     + "                SELECT AVG(c1)\n"
-                    + "                FROM test_sq_dj1\n"
+                    + "                FROM test_sq_dj2\n"
                     + "            )\n"
                     + "            ELSE (\n"
                     + "                SELECT SUM(c2)\n"
-                    + "                FROM test_sq_dj1\n"
+                    + "                FROM test_sq_dj2\n"
                     + "            )\n"
                     + "            END AS kk4\n"
-                    + "        FROM test_sq_dj1 ;");
+                    + "        FROM test_sq_dj2 ;");
     }
 
     @Test
@@ -245,5 +245,41 @@ public class MarkJoinTest extends TestWithFeService {
                 .checkPlannerResult("SELECT * FROM test_sq_dj1 WHERE c1 IN (SELECT c1 FROM test_sq_dj2 WHERE test_sq_dj1.c1 = test_sq_dj2.c1)"
                     + " OR c1 < (SELECT sum(c1) FROM test_sq_dj2 WHERE test_sq_dj1.c1 = test_sq_dj2.c1)"
                     + " AND exists (SELECT c1 FROM test_sq_dj2 WHERE test_sq_dj1.c1 = test_sq_dj2.c1)");
+    }
+
+    @Test
+    public void test20() {
+        PlanChecker.from(connectContext)
+                .checkPlannerResult("SELECT * FROM test_sq_dj1 WHERE c1 < (cast('1.2' as decimal(2,1)) * (SELECT sum(c1) FROM test_sq_dj2 WHERE test_sq_dj1.c1 = test_sq_dj2.c1))");
+    }
+
+    @Test
+    public void test21() {
+        PlanChecker.from(connectContext)
+                .checkPlannerResult("SELECT * FROM test_sq_dj1 WHERE c1 < (cast('1.2' as decimal(2,1)) * (SELECT sum(c1) FROM test_sq_dj2 WHERE test_sq_dj1.c1 = test_sq_dj2.c1)) or c1 > 10");
+    }
+
+    @Test
+    public void test22() {
+        PlanChecker.from(connectContext)
+                .checkPlannerResult("SELECT * FROM test_sq_dj1 WHERE c1 != (cast('1.2' as decimal(2,1)) * (SELECT sum(c1) FROM test_sq_dj2 WHERE test_sq_dj1.c1 = test_sq_dj2.c1)) or c1 > 10");
+    }
+
+    @Test
+    public void test23() {
+        PlanChecker.from(connectContext)
+                .checkPlannerResult("SELECT * FROM test_sq_dj1 WHERE c2 in (select k4 from test_sq_dj2)");
+    }
+
+    @Test
+    public void test24() {
+        PlanChecker.from(connectContext)
+                .checkPlannerResult("SELECT * FROM test_sq_dj1 WHERE c3 in (select k4 from test_sq_dj2)");
+    }
+
+    @Test
+    public void test25() {
+        PlanChecker.from(connectContext)
+                .checkPlannerResult("select * from test_sq_dj1 where c1 in (select c1 from test_sq_dj1 where c2 in (select c2 from test_sq_dj2) and c2 > (select sum(c1) from test_sq_dj2))");
     }
 }

--- a/regression-test/data/nereids_syntax_p0/sub_query_correlated.out
+++ b/regression-test/data/nereids_syntax_p0/sub_query_correlated.out
@@ -355,3 +355,22 @@
 
 -- !multi_subquery_scalar_and_in_or_scalar_and_exists --
 
+-- !cast_subquery_in --
+1	2
+1	3
+2	4
+2	5
+3	3
+3	4
+
+-- !cast_subquery_in_with_disconjunct --
+1	2
+1	3
+2	4
+2	5
+3	3
+3	4
+20	2
+22	3
+24	4
+

--- a/regression-test/suites/nereids_syntax_p0/sub_query_correlated.groovy
+++ b/regression-test/suites/nereids_syntax_p0/sub_query_correlated.groovy
@@ -383,4 +383,13 @@ suite ("sub_query_correlated") {
                                              OR k1 < (SELECT sum(k1) FROM sub_query_correlated_subquery3 WHERE sub_query_correlated_subquery1.k1 = sub_query_correlated_subquery3.k1))
                                         and exists (SELECT k1 FROM sub_query_correlated_subquery3 WHERE sub_query_correlated_subquery1.k1 = sub_query_correlated_subquery3.k1);
     """
+    
+    //----------type coercion subquery-----------
+    qt_cast_subquery_in """
+        SELECT * FROM sub_query_correlated_subquery1 WHERE k1 < (cast('1.2' as decimal(2,1)) * (SELECT sum(k1) FROM sub_query_correlated_subquery3 WHERE sub_query_correlated_subquery1.k1 = sub_query_correlated_subquery3.k1)) order by k1, k2;
+    """
+
+    qt_cast_subquery_in_with_disconjunct """
+        SELECT * FROM sub_query_correlated_subquery1 WHERE k1 < (cast('1.2' as decimal(2,1)) * (SELECT sum(k1) FROM sub_query_correlated_subquery3 WHERE sub_query_correlated_subquery1.k1 = sub_query_correlated_subquery3.k1)) or k1 > 10 order by k1, k2;
+    """
 }


### PR DESCRIPTION
# Proposed changes

## Problem summary

Complete the type coercion of the subquery in the function Binder process.

Expressions generated when subqueries are nested are uniformly converted to implicit types in the analyze stage.
Method: Add a typeCoercionExpr field to the subquery expression to store the generated cast information.

Fix scenario where scalarSubQuery handles arithmetic expressions when implicitly converting types

## Checklist(Required)

* [ ] Does it affect the original behavior
* [x] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

