### PR TITLE
[feature](table-valued-function) add Backends table-valued-function

### DIFF
--- a/be/src/vec/exec/scan/vmeta_scanner.h
+++ b/be/src/vec/exec/scan/vmeta_scanner.h
@@ -34,12 +34,15 @@ public:
 
 protected:
     Status _get_block_impl(RuntimeState* state, Block* block, bool* eos) override;
+
+private:
     Status _fill_block_with_remote_data(const std::vector<MutableColumnPtr>& columns);
     Status _fetch_metadata(const TMetaScanRange& meta_scan_range);
     Status _build_iceberg_metadata_request(const TMetaScanRange& meta_scan_range,
                                            TFetchSchemaTableDataRequest* request);
+    Status _build_backends_metadata_request(const TMetaScanRange& meta_scan_range,
+                                            TFetchSchemaTableDataRequest* request);
 
-private:
     bool _meta_eos;
     TupleId _tuple_id;
     const TupleDescriptor* _tuple_desc;

--- a/fe/fe-core/src/main/cup/sql_parser.cup
+++ b/fe/fe-core/src/main/cup/sql_parser.cup
@@ -5349,7 +5349,7 @@ table_ref ::=
   ;
 
 table_valued_function_ref ::=
-  ident:func_name LPAREN key_value_map:properties RPAREN opt_table_alias:alias
+  ident:func_name LPAREN opt_properties:properties RPAREN opt_table_alias:alias
   {:
     RESULT = new TableValuedFunctionRef(func_name, alias, properties);
   :}

--- a/fe/fe-core/src/main/cup/sql_parser.cup
+++ b/fe/fe-core/src/main/cup/sql_parser.cup
@@ -794,7 +794,7 @@ nonterminal SetVar option_value, option_value_follow_option_type, option_value_n
 nonterminal List<SetVar> option_value_list, option_value_list_continued, start_option_value_list,
         start_option_value_list_following_option_type, user_property_list;
 
-nonterminal Map<String, String> key_value_map, opt_key_value_map, opt_properties,
+nonterminal Map<String, String> key_value_map, opt_key_value_map, opt_key_value_map_in_paren, opt_properties,
             opt_ext_properties, opt_enable_feature_properties, properties;
 nonterminal ColumnDef column_definition;
 nonterminal IndexDef index_definition;
@@ -3315,6 +3315,23 @@ opt_key_value_map ::=
     :}
     ;
 
+opt_key_value_map_in_paren ::=
+    /* empty */
+    {:
+    RESULT = Maps.newHashMap();
+    :}
+    | STRING_LITERAL:name EQUAL STRING_LITERAL:value
+    {:
+    RESULT = Maps.newHashMap();
+    RESULT.put(name, value);
+    :}
+    | opt_key_value_map_in_paren:map COMMA STRING_LITERAL:name EQUAL STRING_LITERAL:value
+    {:
+    map.put(name, value);
+    RESULT = map;
+    :}
+    ;
+
 key_value_map ::=
     STRING_LITERAL:name EQUAL STRING_LITERAL:value
     {:
@@ -5349,7 +5366,7 @@ table_ref ::=
   ;
 
 table_valued_function_ref ::=
-  ident:func_name LPAREN opt_properties:properties RPAREN opt_table_alias:alias
+  ident:func_name LPAREN opt_key_value_map_in_paren:properties RPAREN opt_table_alias:alias
   {:
     RESULT = new TableValuedFunctionRef(func_name, alias, properties);
   :}

--- a/fe/fe-core/src/main/java/org/apache/doris/tablefunction/BackendsTableValuedFunction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/tablefunction/BackendsTableValuedFunction.java
@@ -1,0 +1,96 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.tablefunction;
+
+import org.apache.doris.catalog.Column;
+import org.apache.doris.catalog.PrimitiveType;
+import org.apache.doris.catalog.ScalarType;
+import org.apache.doris.nereids.exceptions.AnalysisException;
+import org.apache.doris.thrift.TBackendsMetadataParams;
+import org.apache.doris.thrift.TMetaScanRange;
+import org.apache.doris.thrift.TMetadataType;
+
+import com.google.common.collect.Lists;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * The Implement of table valued function
+ * backends().
+ */
+public class BackendsTableValuedFunction extends MetadataTableValuedFunction {
+    public static final String NAME = "backends";
+
+    public BackendsTableValuedFunction(Map<String, String> params) throws AnalysisException {
+        if (params.size() !=  0) {
+            throw new AnalysisException("backends table-valued-function does not support any params");
+        }
+    }
+
+    @Override
+    public TMetadataType getMetadataType() {
+        return TMetadataType.BACKENDS;
+    }
+
+    @Override
+    public TMetaScanRange getMetaScanRange() {
+        TMetaScanRange metaScanRange = new TMetaScanRange();
+        metaScanRange.setMetadataType(TMetadataType.BACKENDS);
+        TBackendsMetadataParams backendsMetadataParams = new TBackendsMetadataParams();
+        backendsMetadataParams.setClusterName("");
+        metaScanRange.setBackendsParams(backendsMetadataParams);
+        return metaScanRange;
+    }
+
+    @Override
+    public String getTableName() {
+        return "BackendsTableValuedFunction";
+    }
+
+    @Override
+    public List<Column> getTableColumns() throws AnalysisException {
+        List<Column> resColumns = Lists.newArrayList();
+        resColumns.add(new Column("BackendId", ScalarType.createType(PrimitiveType.BIGINT)));
+        resColumns.add(new Column("Cluster", ScalarType.createVarchar(64)));
+        resColumns.add(new Column("IP", ScalarType.createVarchar(16)));
+        resColumns.add(new Column("HeartbeatPort", ScalarType.createType(PrimitiveType.INT)));
+        resColumns.add(new Column("BePort", ScalarType.createType(PrimitiveType.INT)));
+        resColumns.add(new Column("HttpPort", ScalarType.createType(PrimitiveType.INT)));
+        resColumns.add(new Column("BrpcPort", ScalarType.createType(PrimitiveType.INT)));
+        resColumns.add(new Column("LastStartTime", ScalarType.createVarchar(32)));
+        resColumns.add(new Column("LastHeartbeat", ScalarType.createVarchar(32)));
+        resColumns.add(new Column("Alive", ScalarType.createVarchar(8)));
+        resColumns.add(new Column("SystemDecommissioned", ScalarType.createVarchar(8)));
+        resColumns.add(new Column("ClusterDecommissioned", ScalarType.createVarchar(8)));
+        resColumns.add(new Column("TabletNum", ScalarType.createType(PrimitiveType.BIGINT)));
+        resColumns.add(new Column("DataUsedCapacity", ScalarType.createType(PrimitiveType.BIGINT)));
+        resColumns.add(new Column("AvailCapacity", ScalarType.createType(PrimitiveType.BIGINT)));
+        resColumns.add(new Column("TotalCapacity", ScalarType.createType(PrimitiveType.BIGINT)));
+        resColumns.add(new Column("UsedPct", ScalarType.createType(PrimitiveType.DOUBLE)));
+        resColumns.add(new Column("MaxDiskUsedPct", ScalarType.createType(PrimitiveType.DOUBLE)));
+        resColumns.add(new Column("RemoteUsedCapacity", ScalarType.createType(PrimitiveType.BIGINT)));
+        resColumns.add(new Column("Tag", ScalarType.createVarchar(128)));
+        resColumns.add(new Column("ErrMsg", ScalarType.createVarchar(2048)));
+        resColumns.add(new Column("Version", ScalarType.createVarchar(64)));
+        resColumns.add(new Column("Status", ScalarType.createVarchar(1024)));
+        resColumns.add(new Column("HeartbeatFailureCounter", ScalarType.createType(PrimitiveType.INT)));
+        resColumns.add(new Column("NodeRole", ScalarType.createVarchar(64)));
+        return resColumns;
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/tablefunction/TableValuedFunctionIf.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/tablefunction/TableValuedFunctionIf.java
@@ -51,6 +51,8 @@ public abstract class TableValuedFunctionIf {
                 return new HdfsTableValuedFunction(params);
             case IcebergTableValuedFunction.NAME:
                 return new IcebergTableValuedFunction(params);
+            case BackendsTableValuedFunction.NAME:
+                return new BackendsTableValuedFunction(params);
             default:
                 throw new AnalysisException("Could not find table function " + funcName);
         }

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -723,6 +723,7 @@ enum TSchemaTableName {
 struct TMetadataTableRequestParams {
   1: optional Types.TMetadataType metadata_type
   2: optional PlanNodes.TIcebergMetadataParams iceberg_metadata_params
+  3: optional PlanNodes.TBackendsMetadataParams backends_metadata_params
 }
 
 struct TFetchSchemaTableDataRequest {

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -385,9 +385,14 @@ struct TIcebergMetadataParams {
   4: optional string table
 }
 
+struct TBackendsMetadataParams {
+  1: optional string cluster_name
+}
+
 struct TMetaScanRange {
   1: optional Types.TMetadataType metadata_type
   2: optional TIcebergMetadataParams iceberg_params
+  3: optional TBackendsMetadataParams backends_params
 }
 
 // Specification of an individual data range which is held in its entirety

--- a/gensrc/thrift/Types.thrift
+++ b/gensrc/thrift/Types.thrift
@@ -658,7 +658,8 @@ enum TSortType {
 }
 
 enum TMetadataType {
-  ICEBERG
+  ICEBERG,
+  BACKENDS
 }
 
 enum TIcebergQueryType {


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

This pr implement a new Metadata TVF called `backends`. And the implement process tutorial is in #17974.
The use of `backends` TVF like:
```sql
mysql> select * from backends()\G;
*************************** 1. row ***************************
              BackendId: 10008
                Cluster: default_cluster
                     IP: 10.16.10.14
          HeartbeatPort: 9159
                 BePort: 9169
               HttpPort: 8149
               BrpcPort: 8169
          LastStartTime: 2023-03-23 16:45:37
          LastHeartbeat: 2023-03-23 16:46:12
                  Alive: true
   SystemDecommissioned: false
  ClusterDecommissioned: false
              TabletNum: 770
       DataUsedCapacity: 5187840661
          AvailCapacity: 768259072001
          TotalCapacity: 3169589592064
                UsedPct: 75.7615599847828
         MaxDiskUsedPct: 75.761559984814355
     RemoteUsedCapacity: 0
                    Tag: {"location" : "default"}
                 ErrMsg:
                Version: doris-0.0.0-trunk-ecc02ef274
                 Status: {"lastSuccessReportTabletsTime":"2023-03-23 16:45:44","lastStreamLoadTime":1679386518626,"isQueryDisabled":false,"isLoadDisabled":false}
HeartbeatFailureCounter: 0
               NodeRole: mix
1 row in set (0.03 sec)
```

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

