### PR TITLE
[fix](fragmen mgr) fix possible coredump of FragmentExecState destruction

### DIFF
--- a/be/src/runtime/query_fragments_ctx.h
+++ b/be/src/runtime/query_fragments_ctx.h
@@ -108,6 +108,7 @@ public:
     }
 
 public:
+    ObjectPool obj_pool;
     TUniqueId query_id;
     DescriptorTbl* desc_tbl;
     bool set_rsc_info = false;
@@ -125,7 +126,6 @@ public:
     /// will clean up QueryFragmentsCtx.
     std::atomic<int> fragment_num;
     int timeout_second;
-    ObjectPool obj_pool;
     // MemTracker that is shared by all fragment instances running on this host.
     std::shared_ptr<MemTrackerLimiter> query_mem_tracker;
 


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

When `FragmentExecState` is destroied, `PlanFragmentExecutor` destructor will still access some objects created by `_fragments_ctx->obj_pool`,  but `FragmentExecState::_fragments_ctx ` maybe destructed before `FragmentExecState::_executor`, so as for all objects created by `_fragments_ctx->obj_pool`, so it wil cause coredump.

## Problem summary

When open vlog in be.conf ：sys_log_verbose_modules = *
be will coredump: 
```
Query id: adf238ca0fdf4d8c-9e874de2d6d8a069 ***
Aborted at 1677729014 (unix time) try "date -d @1677729014" if you are using GNU date ***
Current BE git commitID: 8ee5f45 ***
SIGSEGV address not mapped to object (@0x16) received by PID 244527 (TID 0x7ff94c1e8700) from PID 22; stack trace: ***
0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /root/doris/be/src/common/signal_handler.h:420
1# os::Linux::chained_handler(int, siginfo*, void*) in /usr/java/jdk1.8.0_181-amd64/jre/lib/amd64/server/libjvm.so
2# JVM_handle_linux_signal in /usr/java/jdk1.8.0_181-amd64/jre/lib/amd64/server/libjvm.so
3# signalHandler(int, siginfo*, void*) in /usr/java/jdk1.8.0_181-amd64/jre/lib/amd64/server/libjvm.so
4# 0x00007FFA25CD0450 in /lib64/libc.so.6
5# memcpy at /root/doris/be/src/glibc-compatibility/memcpy/memcpy_x86_64.cpp:219
6# std::basic_streambuf<char, std::char_traits<char> >::xsputn(char const*, long) in /software/servers/doris/doris1.2/apache-doris-be-1.2.0-bin-x86_64/lib/doris_be
7# std::basic_ostream<char, std::char_traits<char> >& std::__ostream_insert<char, std::char_traits<char> >(std::basic_ostream<char, std::char_traits<char> >&, char const*, long) in /software/servers/doris/doris1.2/apache-doris-be-1.2.0-bin-x86_64/lib/doris_be
8# doris::SlotDescriptor::debug_string[abi:cxx11]() const at /root/doris/be/src/runtime/descriptors.cpp:112
9# doris::TupleDescriptor::debug_string[abi:cxx11]() const at /root/doris/be/src/runtime/descriptors.cpp:340
10# doris::RowDescriptor::debug_string[abi:cxx11]() const at /root/doris/be/src/runtime/descriptors.cpp:513
11# doris::vectorized::VDataStreamSender::Channel::send_block(doris::PBlock*, bool) at /root/doris/be/src/vec/sink/vdata_stream_sender.cpp:152
12# doris::vectorized::VDataStreamSender::Channel::close_internal() at /root/doris/be/src/vec/sink/vdata_stream_sender.cpp:258
13# doris::vectorized::VDataStreamSender::close(doris::RuntimeState*, doris::Status) at /root/doris/be/src/vec/sink/vdata_stream_sender.cpp:606
14# doris::PlanFragmentExecutor::close() at /root/doris/be/src/runtime/plan_fragment_executor.cpp:686
15# doris::PlanFragmentExecutor::~PlanFragmentExecutor() at /root/doris/be/src/runtime/plan_fragment_executor.cpp:75
16# std::Sp_counted_ptr<doris::FragmentExecState*, (_gnu_cxx::_Lock_policy)2>::_M_dispose() at /var/local/ldb-toolchain/include/c++/11/bits/shared_ptr_base.h:348
17# std::Sp_counted_base<(_gnu_cxx::_Lock_policy)2>::_M_release() at /var/local/ldb-toolchain/include/c++/11/bits/shared_ptr_base.h:161
18# std::_Function_handler<void (), doris::FragmentMgr::exec_plan_fragment(doris::TExecPlanFragmentParams const&, std::function<void (doris::PlanFragmentExecutor*)>):: {lambda()#1}
>::_M_manager(std::_Any_data&, std::_Any_data const&, std::_Manager_operation) at /var/local/ldb-toolchain/include/c++/11/bits/std_function.h:283
19# doris::FunctionRunnable::~FunctionRunnable() at /root/doris/be/src/util/threadpool.cpp:41
20# doris::ThreadPool::dispatch_thread() at /root/doris/be/src/util/threadpool.cpp:542
21# doris::Thread::supervise_thread(void*) at /root/doris/be/src/util/thread.cpp:455
22# start_thread in /lib64/libpthread.so.0
23# clone in /lib64/libc.so.6
```

ASAN debug found that it's heap-use-after-free error:
```
operator delete(void*)
??:0:0
doris::TupleDescriptor* doris::ObjectPool::add<doris::TupleDescriptor>(doris::TupleDescriptor*)::'lambda'(void*)::operator()(void*) const
/mnt/disk2/tengjianping/doris-1.2/be/src/common/object_pool.h:40:59
doris::TupleDescriptor* doris::ObjectPool::add<doris::TupleDescriptor>(doris::TupleDescriptor*)::'lambda'(void*)::__invoke(void*)
/mnt/disk2/tengjianping/doris-1.2/be/src/common/object_pool.h:40:43
doris::ObjectPool::clear()
/mnt/disk2/tengjianping/doris-1.2/be/src/common/object_pool.h:53:40
doris::ObjectPool::~ObjectPool()
/mnt/disk2/tengjianping/doris-1.2/be/src/common/object_pool.h:34:21
doris::QueryFragmentsCtx::~QueryFragmentsCtx()
/mnt/disk2/tengjianping/doris-1.2/be/src/runtime/query_fragments_ctx.h:63:5
std::_Sp_counted_ptr<doris::QueryFragmentsCtx*, (__gnu_cxx::_Lock_policy)2>::_M_dispose()
/mnt/disk2/tengjianping/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:348:9
std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release()
/mnt/disk2/tengjianping/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:168:6
std::__shared_count<(__gnu_cxx::_Lock_policy)2>::~__shared_count()
/mnt/disk2/tengjianping/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:702:11
std::__shared_ptr<doris::QueryFragmentsCtx, (__gnu_cxx::_Lock_policy)2>::~__shared_ptr()
/mnt/disk2/tengjianping/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:1149:31
std::shared_ptr<doris::QueryFragmentsCtx>::~shared_ptr()
/mnt/disk2/tengjianping/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr.h:122:11
doris::FragmentExecState::~FragmentExecState()
/mnt/disk2/tengjianping/doris-1.2/be/src/runtime/fragment_mgr.cpp:79:7
std::_Sp_counted_ptr<doris::FragmentExecState*, (__gnu_cxx::_Lock_policy)2>::_M_dispose()
/mnt/disk2/tengjianping/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:348:9
std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release()
/mnt/disk2/tengjianping/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:168:6
std::__shared_count<(__gnu_cxx::_Lock_policy)2>::~__shared_count()
/mnt/disk2/tengjianping/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:702:11
std::__shared_ptr<doris::FragmentExecState, (__gnu_cxx::_Lock_policy)2>::~__shared_ptr()
/mnt/disk2/tengjianping/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:1149:31
std::shared_ptr<doris::FragmentExecState>::~shared_ptr()
/mnt/disk2/tengjianping/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr.h:122:11
doris::FragmentMgr::exec_plan_fragment(doris::TExecPlanFragmentParams const&, std::function<void (doris::PlanFragmentExecutor*)>)::$_3::~$_3()
/mnt/disk2/tengjianping/doris-1.2/be/src/runtime/fragment_mgr.cpp:719:13
```


## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

