### PR TITLE
[bug](function) Fix bug in the process of generating template functions

### DIFF
--- a/gensrc/script/gen_builtins_functions.py
+++ b/gensrc/script/gen_builtins_functions.py
@@ -116,7 +116,7 @@ def generate_fe_datatype(str_type, template_types):
 
     # process template
     if str_type in template_types:
-        return 'new TemplateType("{}")'.format(str_type)
+        return 'new TemplateType("{0}")'.format(str_type)
 
     # process Array, Map, Struct template
     template_start = str_type.find('<')
@@ -125,10 +125,10 @@ def generate_fe_datatype(str_type, template_types):
         # exclude <>
         template = str_type[template_start + 1 : template_end]
         if str_type.startswith("ARRAY<"):
-            return 'new ArrayType({})'.format(generate_fe_datatype(template, template_types))
+            return 'new ArrayType({0})'.format(generate_fe_datatype(template, template_types))
         elif str_type.startswith("MAP<"):
             types = template.split(',', 2)
-            return 'new MapType({}, {})'.format(generate_fe_datatype(types[0], template_types), generate_fe_datatype(types[1], template_types))
+            return 'new MapType({0}, {1})'.format(generate_fe_datatype(types[0], template_types), generate_fe_datatype(types[1], template_types))
 
     # lagacy Array, Map syntax
     if str_type.startswith("ARRAY_"):


### PR DESCRIPTION
# Proposed changes

If users compile fe with python version <= 2.6

They will meet a compile error in gen_builtins_functions.py with following msg:

<img width="1236" alt="b48b487680afb55b899f19fc31029dc8" src="https://user-images.githubusercontent.com/22125576/224300009-eb1a2201-f68f-413f-8f16-f5ca2c7a2039.png">

The solution is add index in python format.

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

