### PR TITLE
[fix](fe) fix drop frontend removeUnReadyElectableNode incorrectly

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
@@ -2530,7 +2530,7 @@ public class Env {
                 haProtocol.removeElectableNode(fe.getNodeName());
                 removeHelperNode(ip, hostname, port);
                 BDBHA ha = (BDBHA) haProtocol;
-                ha.removeUnReadyElectableNode(nodeName, getFollowerCount());
+                ha.removeUnReadyElectableNode(fe.getNodeName(), getFollowerCount());
             }
             editLog.logRemoveFrontend(fe);
         } finally {


### PR DESCRIPTION
* when add two not exist fe and drop two not exit fe, we may meet exception like this: 
'''
    java.lang.IllegalArgumentException: com.sleepycat.je.config.IntConfigParam:
            param je.rep.electableGroupSizeOverride doesn't validate, -1 is less than min of 0
    at com.sleepycat.je.config.IntConfigParam.validate(IntConfigParam.java:47)
    at com.sleepycat.je.config.IntConfigParam.validateValue(IntConfigParam.java:75)
    at com.sleepycat.je.dbi.DbConfigManager.setVal(DbConfigManager.java:648)
    at com.sleepycat.je.dbi.DbConfigManager.setIntVal(DbConfigManager.java:694)
    at com.sleepycat.je.rep.ReplicationMutableConfig
            .setElectableGroupSizeOverrideVoid(ReplicationMutableConfig.java:523)
    at com.sleepycat.je.rep.ReplicationMutableConfig.setElectableGroupSizeOverride(ReplicationMutableConfig.java:512)
    at org.apache.doris.ha.BDBHA.removeUnReadyElectableNode(BDBHA.java:236)
    at org.apache.doris.catalog.Env.dropFrontend(Env.java:2533)
'''

# Proposed changes

Issue Number: close #17679 

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

