### PR TITLE
[DORIS-17685][Broker] Unified Using log4j 1.x API

### DIFF
--- a/fs_brokers/apache_hdfs_broker/src/main/java/org/apache/doris/common/WildcardURI.java
+++ b/fs_brokers/apache_hdfs_broker/src/main/java/org/apache/doris/common/WildcardURI.java
@@ -20,8 +20,7 @@ package org.apache.doris.common;
 import org.apache.doris.broker.hdfs.BrokerException;
 import org.apache.doris.thrift.TBrokerOperationStatusCode;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import org.apache.log4j.Logger;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
@@ -41,7 +40,7 @@ import java.nio.charset.StandardCharsets;
  * getPath() will return: /testdata/20180[8-9]*
  */
 public class WildcardURI {
-    private static Logger logger = LogManager.getLogger(WildcardURI.class.getName());
+    private static Logger logger = Logger.getLogger(WildcardURI.class.getName());
 
     private URI uri;
 


### PR DESCRIPTION
# Proposed changes

Issue Number: close #17685 

## Problem summary

In the class org.apache.doris.common.WildcardURI, use log4j 1.x api instead of log4j 2.x api, same as other classes such as BrokerBootstrap, BrokerFileSystem etc

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

