### PR TITLE
[fix](fqdn) Add UnknownHostException handle logic in FQDNManager to avoid that active ip could be incorrectly assigned to dead be or dead fe

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/system/FQDNManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/system/FQDNManager.java
@@ -34,6 +34,8 @@ import java.net.UnknownHostException;
 public class FQDNManager extends MasterDaemon {
     private static final Logger LOG = LogManager.getLogger(FQDNManager.class);
 
+    public static final String  UNKNOWN_HOST_IP = "unknown";
+
     private SystemInfoService nodeMgr;
 
     public FQDNManager(SystemInfoService nodeMgr) {
@@ -64,6 +66,13 @@ public class FQDNManager extends MasterDaemon {
                     }
                 } catch (UnknownHostException e) {
                     LOG.warn("unknown host name for fe, {}", fe.getHostName(), e);
+                    // add fe alive check to make ip work when fe is still alive and dns has some problem.
+                    if (!fe.isAlive() && !fe.getIp().equalsIgnoreCase(UNKNOWN_HOST_IP)) {
+                        String ip = fe.getIp();
+                        fe.setIp(UNKNOWN_HOST_IP);
+                        Env.getCurrentEnv().getEditLog().logModifyFrontend(fe);
+                        LOG.warn("ip for {} of fe has been changed from {} to {}", fe.getHostName(), ip, "unknown");
+                    }
                 } catch (DdlException e) {
                     LOG.warn("fail to update ip for fe, {}", fe.getHostName(), e);
                 }
@@ -85,6 +94,14 @@ public class FQDNManager extends MasterDaemon {
                     }
                 } catch (UnknownHostException e) {
                     LOG.warn("unknown host name for be, {}", be.getHostName(), e);
+                    // add be alive check to make ip work when be is still alive and dns has some problem.
+                    if (!be.isAlive() && !be.getIp().equalsIgnoreCase(UNKNOWN_HOST_IP)) {
+                        String ip = be.getIp();
+                        ClientPool.backendPool.clearPool(new TNetworkAddress(ip, be.getBePort()));
+                        be.setIp(UNKNOWN_HOST_IP);
+                        Env.getCurrentEnv().getEditLog().logBackendStateChange(be);
+                        LOG.warn("ip for {} of be has been changed from {} to {}", be.getHostName(), ip, "unknown");
+                    }
                 }
             }
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/system/FQDNManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/system/FQDNManager.java
@@ -34,7 +34,7 @@ import java.net.UnknownHostException;
 public class FQDNManager extends MasterDaemon {
     private static final Logger LOG = LogManager.getLogger(FQDNManager.class);
 
-    public static final String  UNKNOWN_HOST_IP = "unknown";
+    public static final String UNKNOWN_HOST_IP = "unknown";
 
     private SystemInfoService nodeMgr;
 

--- a/fe/fe-core/src/main/java/org/apache/doris/system/SystemInfoService.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/system/SystemInfoService.java
@@ -192,10 +192,6 @@ public class SystemInfoService {
     public void addBackends(List<HostInfo> hostInfos, boolean isFree, String destCluster,
             Map<String, String> tagMap) throws UserException {
         for (HostInfo hostInfo : hostInfos) {
-            //if not enable_fqdn,ignore hostName
-            if (!Config.enable_fqdn_mode) {
-                hostInfo.setHostName(null);
-            }
             if (Config.enable_fqdn_mode && StringUtils.isEmpty(hostInfo.getHostName())) {
                 throw new DdlException("backend's hostName should not be empty while enable_fqdn_mode is true");
             }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx
1. if be is dead and be ip not changed by FQDNManager，A situation may occur that after a while the old ip is used by other new alive pod，this may cause two be share same ip which is unexpected.
2. when enable_fqdn is false, user can still set hostname in be when add backend  


Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

