### PR TITLE
[branch-1.2](jvm) add jvm option to avoid BE crash

### DIFF
--- a/be/src/runtime/routine_load/routine_load_task_executor.cpp
+++ b/be/src/runtime/routine_load/routine_load_task_executor.cpp
@@ -332,8 +332,8 @@ void RoutineLoadTaskExecutor::exec_task(StreamLoadContext* ctx, DataConsumerPool
         std::vector<RdKafka::TopicPartition*> topic_partitions;
         for (auto& kv : ctx->kafka_info->cmt_offset) {
             // The offsets you commit are the offsets of the messages you want to read next
-            RdKafka::TopicPartition* tp1 = RdKafka::TopicPartition::create(
-                    ctx->kafka_info->topic, kv.first, kv.second + 1);
+            RdKafka::TopicPartition* tp1 = RdKafka::TopicPartition::create(ctx->kafka_info->topic,
+                                                                           kv.first, kv.second + 1);
             topic_partitions.push_back(tp1);
         }
 

--- a/be/src/util/jni-util.cpp
+++ b/be/src/util/jni-util.cpp
@@ -77,6 +77,8 @@ void FindOrCreateJavaVM() {
                 {const_cast<char*>(classpath.c_str()), nullptr},
                 {const_cast<char*>(heap_size.c_str()), nullptr},
                 {const_cast<char*>(log_path.c_str()), nullptr},
+                // avoid BE crash, the reason is still unknown.
+                {const_cast<char*>("-Djava.compiler=NONE"), nullptr},
 #ifdef __APPLE__
                 // On macOS, we should disable MaxFDLimit, otherwise the RLIMIT_NOFILE
                 // will be assigned the minimum of OPEN_MAX (10240) and rlim_cur (See src/hotspot/os/bsd/os_bsd.cpp)


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

Only for branch-1.2
The root cause is still unknown, just add this opt to avoid BE crash like:
```
14:36:23.462 [Thread-0] ERROR com.alibaba.druid.pool.DruidDataSource - testWhileIdle is true, validationQuery not set
*** Query id: 38b37aa82b0045c6-a9b904e5d38388c6 ***
*** Aborted at 1678257435 (unix time) try "date -d @1678257435" if you are using GNU date ***
*** Current BE git commitID: 8ee5f45 ***
*** SIGSEGV address not mapped to object (@0x7208) received by PID 24528 (TID 0x7f6701c86700) from PID 29192; stack trace: ***
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /root/doris/selectdb-core/be/src/common/signal_handler.h:420
 1# os::Linux::chained_handler(int, siginfo*, void*) in /usr/java/jre/lib/amd64/server/libjvm.so
 2# JVM_handle_linux_signal in /usr/java/jre/lib/amd64/server/libjvm.so
 3# signalHandler(int, siginfo*, void*) in /usr/java/jre/lib/amd64/server/libjvm.so
 4# 0x00007F67FC923400 in /lib64/libc.so.6
 5# je_tcache_bin_flush_small at ../src/tcache.c:164
 6# je_tcache_event_hard at ../src/tcache.c:63
 7# je_malloc_default at ../src/jemalloc.c:2289
 8# doris_malloc at /root/doris/selectdb-core/be/src/runtime/memory/jemalloc_hook.cpp:35
 9# operator new(unsigned long) in /data01/ljw/doris/selectdb_doris-1.2.2.1-x86_64-avx2/be/lib/doris_be
10# re2::Prog::Flatten() in /data01/ljw/doris/selectdb_doris-1.2.2.1-x86_64-avx2/be/lib/doris_be
11# re2::Compiler::Finish(re2::Regexp*) in /data01/ljw/doris/selectdb_doris-1.2.2.1-x86_64-avx2/be/lib/doris_be
12# re2::Compiler::Compile(re2::Regexp*, bool, long) in /data01/ljw/doris/selectdb_doris-1.2.2.1-x86_64-avx2/be/lib/doris_be
13# re2::RE2::Init(re2::StringPiece const&, re2::RE2::Options const&) in /data01/ljw/doris/selectdb_doris-1.2.2.1-x86_64-avx2/be/lib/doris_be
14# re2::RE2::RE2(char const*) in /data01/ljw/doris/selectdb_doris-1.2.2.1-x86_64-avx2/be/lib/doris_be
15# __static_initialization_and_destruction_0(int, int) [clone .constprop.0] at /root/doris/selectdb-core/be/src/vec/runtime/vdatetime_value.h:188
16# _GLOBAL__sub_I__ZN5doris18TimestampFunctions4initEv at /root/doris/selectdb-core/be/src/exprs/timestamp_functions.cpp:1036
17# _dl_init_internal in /lib64/ld-linux-x86-64.so.2
18# dl_open_worker in /lib64/ld-linux-x86-64.so.2
19# _dl_catch_error in /lib64/ld-linux-x86-64.so.2
20# _dl_open in /lib64/ld-linux-x86-64.so.2
21# dlopen_doit in /lib64/libdl.so.2
22# _dl_catch_error in /lib64/ld-linux-x86-64.so.2
23# _dlerror_run in /lib64/libdl.so.2
24# __dlopen_check in /lib64/libdl.so.2
25# os::dll_load(char const*, char*, int) in /usr/java/jre/lib/amd64/server/libjvm.so
26# NativeLookup::lookup_critical_style(methodHandle, char*, char const*, int, bool) in /usr/java/jre/lib/amd64/server/libjvm.so
27# NativeLookup::lookup_critical_entry(methodHandle) in /usr/java/jre/lib/amd64/server/libjvm.so
28# Method::critical_native_function() in /usr/java/jre/lib/amd64/server/libjvm.so
29# SharedRuntime::generate_native_wrapper(MacroAssembler*, methodHandle, int, BasicType*, VMRegPair*, BasicType) in /usr/java/jre/lib/amd64/server/libjvm.so
30# AdapterHandlerLibrary::create_native_wrapper(methodHandle) in /usr/java/jre/lib/amd64/server/libjvm.so
31# CompileBroker::compile_method(methodHandle, int, int, methodHandle, int, char const*, Thread*) in /usr/java/jre/lib/amd64/server/libjvm.so
32# AdvancedThresholdPolicy::submit_compile(methodHandle, int, CompLevel, JavaThread*) in /usr/java/jre/lib/amd64/server/libjvm.so
33# SimpleThresholdPolicy::compile(methodHandle, int, CompLevel, JavaThread*) [clone .part.24] in /usr/java/jre/lib/amd64/server/libjvm.so
34# AdvancedThresholdPolicy::method_invocation_event(methodHandle, methodHandle, CompLevel, nmethod*, JavaThread*) in /usr/java/jre/lib/amd64/server/libjvm.so
35# SimpleThresholdPolicy::event(methodHandle, methodHandle, int, int, CompLevel, nmethod*, JavaThread*) in /usr/java/jre/lib/amd64/server/libjvm.so
36# InterpreterRuntime::frequency_counter_overflow_inner(JavaThread*, unsigned char*) in /usr/java/jre/lib/amd64/server/libjvm.so
37# InterpreterRuntime::frequency_counter_overflow(JavaThread*, unsigned char*) in /usr/java/jre/lib/amd64/server/libjvm.so
38# 0x00007F67E73B9C5D
```

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

