### PR TITLE
[fix](jdbc-catalog) avoid calculate driver's md5 when replaying edit log

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/JdbcExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/JdbcExternalCatalog.java
@@ -85,7 +85,7 @@ public class JdbcExternalCatalog extends ExternalCatalog {
             properties.put(JdbcResource.JDBC_URL, jdbcUrl);
         }
 
-        if (properties.containsKey(JdbcResource.DRIVER_URL)) {
+        if (properties.containsKey(JdbcResource.DRIVER_URL) && !properties.containsKey(JdbcResource.CHECK_SUM)) {
             properties.put(JdbcResource.CHECK_SUM,
                     JdbcResource.computeObjectChecksum(properties.get(JdbcResource.DRIVER_URL)));
         }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

1. create a jdbc catalog
2. drop the jdbc catalog
3. remove the driver from origin dir
4. restart FE will throw exception:

```
IOException: /xxxx/mysql-connector-j-8.0.32.jar (No such file or directory)
    at org.apache.doris.catalog.JdbcResource.computeObjectChecksum(JdbcResource.java:209) ~[doris-fe.jar:1.0-SNAPSHOT]
    at org.apache.doris.datasource.JdbcExternalCatalog.processCompatibleProperties(JdbcExternalCatalog.java:74) ~[doris-fe.jar:1.0-SNAPSHOT]
    at org.apache.doris.datasource.JdbcExternalCatalog.<init>(JdbcExternalCatalog.java:51) ~[doris-fe.jar:1.0-SNAPSHOT]
    at org.apache.doris.datasource.CatalogFactory.constructorCatalog(CatalogFactory.java:103) ~[doris-fe.jar:1.0-SNAPSHOT]
    at org.apache.doris.datasource.CatalogFactory.constructorFromLog(CatalogFactory.java:71) ~[doris-fe.jar:1.0-SNAPSHOT]
    at org.apache.doris.datasource.CatalogMgr.replayCreateCatalog(CatalogMgr.java:455) ~[doris-fe.jar:1.0-SNAPSHOT]
    at org.apache.doris.persist.EditLog.loadJournal(EditLog.java:864) ~[doris-fe.jar:1.0-SNAPSHOT]
    at org.apache.doris.catalog.Env.replayJournal(Env.java:2512) ~[doris-fe.jar:1.0-SNAPSHOT]
    at org.apache.doris.master.Checkpoint.doCheckpoint(Checkpoint.java:124) ~[doris-fe.jar:1.0-SNAPSHOT]
    at org.apache.doris.master.Checkpoint.runAfterCatalogReady(Checkpoint.java:76) ~[doris-fe.jar:1.0-SNAPSHOT]
    at org.apache.doris.common.util.MasterDaemon.runOneCycle(MasterDaemon.java:58) ~[doris-fe.jar:1.0-SNAPSHOT]
    at org.apache.doris.common.util.Daemon.run(Daemon.java:116) ~[doris-fe.jar:1.0-SNAPSHOT]
```

We should avoid calculating md5 when replaying edit log

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

