### PR TITLE
[fix](Nereids) Compare plan with their output rather than string in UnrankTest 

### DIFF
--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/memo/RankTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/memo/RankTest.java
@@ -61,7 +61,7 @@ public class RankTest extends TPCHTestBase {
                     .rewrite()
                     .optimize()
                     .getBestPlanTree(PhysicalProperties.GATHER);
-            Assertions.assertEquals(plan1.treeString(), plan2.treeString());
+            Assertions.assertTrue(PlanChecker.isPlanEqualWithoutID(plan1, plan2));
         }
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/util/PlanChecker.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/util/PlanChecker.java
@@ -596,4 +596,18 @@ public class PlanChecker {
         return this;
     }
 
+    public static boolean isPlanEqualWithoutID(Plan plan1, Plan plan2) {
+        if (plan1.arity() != plan2.arity()
+                || !plan1.getOutput().equals(plan2.getOutput()) || plan1.getClass() != plan2.getClass()) {
+            System.out.println(plan1);
+            System.out.println(plan2);
+            return false;
+        }
+        for (int i = 0; i < plan1.arity(); i++) {
+            if (!isPlanEqualWithoutID(plan1.child(i), plan2.child(i))) {
+                return false;
+            }
+        }
+        return true;
+    }
 }


### PR DESCRIPTION
# Proposed changes

After adding a unique ID, the unRankTest fail because each plan has a different ID in the string.

To avoid the effect of unique ID, Compare the plan with the output rather than the string

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

