### PR TITLE
[Improvement](multi catalog)Hive splitter. Get HDFS/S3 splits by using FileSystem api

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -1714,6 +1714,9 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true, masterOnly = false)
     public static long file_scan_node_split_num = 128;
 
+    @ConfField(mutable = true, masterOnly = false)
+    public static long file_split_size = 0; // 0 means use the block size in HDFS/S3 as split size
+
     /**
      * If set to TRUE, FE will:
      * 1. divide BE into high load and low load(no mid load) to force triggering tablet scheduling;
@@ -2056,6 +2059,7 @@ public class Config extends ConfigBase {
      */
     @ConfField(mutable = false, masterOnly = false)
     public static String mysql_load_server_secure_path = "";
+
 
     @ConfField(mutable = false, masterOnly = false)
     public static int mysql_load_thread_pool = 4;

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/HMSExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/HMSExternalCatalog.java
@@ -53,6 +53,7 @@ public class HMSExternalCatalog extends ExternalCatalog {
     protected PooledHiveMetaStoreClient client;
     // Record the latest synced event id when processing hive events
     private long lastSyncedEventId;
+    public static final String ENABLE_SELF_SPLITTER = "enable.self.splitter";
 
     /**
      * Default constructor for HMSExternalCatalog.

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HiveMetaStoreCache.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HiveMetaStoreCache.java
@@ -36,6 +36,7 @@ import org.apache.doris.metric.MetricRepo;
 import org.apache.doris.planner.ColumnBound;
 import org.apache.doris.planner.ListPartitionPrunerV2;
 import org.apache.doris.planner.PartitionPrunerV2Base.UniqueId;
+import org.apache.doris.planner.external.HiveSplitter;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
@@ -50,6 +51,7 @@ import com.google.common.collect.RangeMap;
 import com.google.common.collect.TreeRangeMap;
 import lombok.Data;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hdfs.HdfsConfiguration;
 import org.apache.hadoop.hive.metastore.api.Partition;
 import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
@@ -249,16 +251,20 @@ public class HiveMetaStoreCache {
             try {
                 InputFormat<?, ?> inputFormat = HiveUtil.getInputFormat(jobConf, key.inputFormat, false);
                 InputSplit[] splits;
-                String remoteUser = jobConf.get(HdfsResource.HADOOP_USER_NAME);
-
-                // TODO: Implement getSplits logic by ourselves, don't call inputFormat.getSplits anymore.
-                if (!Strings.isNullOrEmpty(remoteUser)) {
-                    UserGroupInformation ugi = UserGroupInformation.createRemoteUser(remoteUser);
-                    splits = ugi.doAs(
-                            (PrivilegedExceptionAction<InputSplit[]>) () -> inputFormat.getSplits(jobConf, 0));
+                // TODO: This is a temp config, will remove it after the HiveSplitter is stable.
+                if (key.useSelfSplitter) {
+                    splits = HiveSplitter.getHiveSplits(new Path(finalLocation), inputFormat, jobConf);
                 } else {
-                    splits = inputFormat.getSplits(jobConf, 0 /* use hdfs block size as default */);
+                    String remoteUser = jobConf.get(HdfsResource.HADOOP_USER_NAME);
+                    if (!Strings.isNullOrEmpty(remoteUser)) {
+                        UserGroupInformation ugi = UserGroupInformation.createRemoteUser(remoteUser);
+                        splits = ugi.doAs(
+                            (PrivilegedExceptionAction<InputSplit[]>) () -> inputFormat.getSplits(jobConf, 0));
+                    } else {
+                        splits = inputFormat.getSplits(jobConf, 0 /* use hdfs block size as default */);
+                    }
                 }
+
                 if (LOG.isDebugEnabled()) {
                     LOG.debug("load #{} files for {} in catalog {}", splits.length, key, catalog.getName());
                 }
@@ -310,10 +316,10 @@ public class HiveMetaStoreCache {
         }
     }
 
-    public List<InputSplit> getFilesByPartitions(List<HivePartition> partitions) {
+    public List<InputSplit> getFilesByPartitions(List<HivePartition> partitions, boolean useSelfSplitter) {
         long start = System.currentTimeMillis();
         List<FileCacheKey> keys = Lists.newArrayListWithExpectedSize(partitions.size());
-        partitions.stream().forEach(p -> keys.add(new FileCacheKey(p.getPath(), p.getInputFormat())));
+        partitions.stream().forEach(p -> keys.add(new FileCacheKey(p.getPath(), p.getInputFormat(), useSelfSplitter)));
 
         Stream<FileCacheKey> stream;
         if (partitions.size() < MIN_BATCH_FETCH_PARTITION_NUM) {
@@ -601,10 +607,20 @@ public class HiveMetaStoreCache {
         private String location;
         // not in key
         private String inputFormat;
+        // Temp variable, use self file splitter or use InputFormat.getSplits.
+        // Will remove after self splitter is stable.
+        private boolean useSelfSplitter;
 
         public FileCacheKey(String location, String inputFormat) {
             this.location = location;
             this.inputFormat = inputFormat;
+            this.useSelfSplitter = false;
+        }
+
+        public FileCacheKey(String location, String inputFormat, boolean useSelfSplitter) {
+            this.location = location;
+            this.inputFormat = inputFormat;
+            this.useSelfSplitter = useSelfSplitter;
         }
 
         @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/external/hive/util/HiveUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/external/hive/util/HiveUtil.java
@@ -25,6 +25,8 @@ import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.UserException;
 
 import com.google.common.collect.Lists;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.ql.io.SymlinkTextInputFormat;
 import org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat;
@@ -40,6 +42,8 @@ import org.apache.hadoop.util.ReflectionUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.List;
 
 /**
@@ -175,6 +179,34 @@ public final class HiveUtil {
             case UNION:
             default:
                 throw new UnsupportedOperationException("Unsupported type: " + hiveTypeInfo.toString());
+        }
+    }
+
+    public static boolean isSplittable(InputFormat<?, ?> inputFormat, FileSystem fileSystem, Path path) {
+        // ORC uses a custom InputFormat but is always splittable
+        if (inputFormat.getClass().getSimpleName().equals("OrcInputFormat")) {
+            return true;
+        }
+
+        // use reflection to get isSplittable method on FileInputFormat
+        Method method = null;
+        for (Class<?> clazz = inputFormat.getClass(); clazz != null; clazz = clazz.getSuperclass()) {
+            try {
+                method = clazz.getDeclaredMethod("isSplitable", FileSystem.class, Path.class);
+                break;
+            } catch (NoSuchMethodException ignored) {
+                LOG.warn("Class {} doesn't contain isSplitable method.", clazz);
+            }
+        }
+
+        if (method == null) {
+            return false;
+        }
+        try {
+            method.setAccessible(true);
+            return (boolean) method.invoke(inputFormat, fileSystem, path);
+        } catch (InvocationTargetException | IllegalAccessException e) {
+            throw new RuntimeException(e);
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/external/FileSplitStrategy.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/external/FileSplitStrategy.java
@@ -34,7 +34,7 @@ public class FileSplitStrategy {
     }
 
     public boolean hasNext() {
-        return totalSplitSize > Config.file_scan_node_split_size || splitNum > Config.file_scan_node_split_num;
+        return totalSplitSize >= Config.file_scan_node_split_size || splitNum >= Config.file_scan_node_split_num;
     }
 
     public void next() {


### PR DESCRIPTION
Use FileSystem API to get splits for file in HDFS/S3 instead of calling `InputFormat.getSplits`.
The splits is based on blocks in HDFS/S3.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

