### PR TITLE
[Improve](FileCahe) Support the file cache profile in olap scan node and Update the profile

### DIFF
--- a/be/src/io/cache/block/cached_remote_file_reader.cpp
+++ b/be/src/io/cache/block/cached_remote_file_reader.cpp
@@ -78,7 +78,6 @@ Status CachedRemoteFileReader::read_at_impl(size_t offset, Slice result, size_t*
         return _remote_file_reader->read_at(offset, result, bytes_read, io_ctx);
     }
     ReadStatistics stats;
-    stats.bytes_read = bytes_req;
     // if state == nullptr, the method is called for read footer
     // if state->read_segment_index, read all the end of file
     size_t align_left = offset, align_size = size() - offset;
@@ -93,17 +92,27 @@ Status CachedRemoteFileReader::read_at_impl(size_t offset, Slice result, size_t*
             cache->get_or_set(_cache_key, align_left, align_size, is_persistent, query_id);
     std::vector<FileBlockSPtr> empty_segments;
     for (auto& segment : holder.file_segments) {
-        if (segment->state() == FileBlock::State::EMPTY) {
+        switch (segment->state()) {
+        case FileBlock::State::EMPTY:
             segment->get_or_set_downloader();
             if (segment->is_downloader()) {
                 empty_segments.push_back(segment);
             }
-        } else if (segment->state() == FileBlock::State::SKIP_CACHE) {
+            stats.hit_cache = false;
+            break;
+        case FileBlock::State::SKIP_CACHE:
             empty_segments.push_back(segment);
-            stats.bytes_skip_cache += segment->range().size();
+            stats.hit_cache = false;
+            stats.skip_cache = true;
+            break;
+        case FileBlock::State::DOWNLOADING:
+            stats.hit_cache = false;
+            break;
+        case FileBlock::State::DOWNLOADED:
+            break;
         }
     }
-
+    stats.bytes_read += bytes_req;
     size_t empty_start = 0;
     size_t empty_end = 0;
     if (!empty_segments.empty()) {
@@ -111,18 +120,21 @@ Status CachedRemoteFileReader::read_at_impl(size_t offset, Slice result, size_t*
         empty_end = empty_segments.back()->range().right;
         size_t size = empty_end - empty_start + 1;
         std::unique_ptr<char[]> buffer(new char[size]);
-        RETURN_IF_ERROR(_remote_file_reader->read_at(empty_start, Slice(buffer.get(), size), &size,
+        {
+            SCOPED_RAW_TIMER(&stats.remote_read_timer);
+            RETURN_IF_ERROR(_remote_file_reader->read_at(empty_start, Slice(buffer.get(), size), &size,
                                                      io_ctx));
+        }
         for (auto& segment : empty_segments) {
             if (segment->state() == FileBlock::State::SKIP_CACHE) {
                 continue;
             }
+            SCOPED_RAW_TIMER(&stats.local_write_timer);
             char* cur_ptr = buffer.get() + segment->range().left - empty_start;
             size_t segment_size = segment->range().size();
             RETURN_IF_ERROR(segment->append(Slice(cur_ptr, segment_size)));
             RETURN_IF_ERROR(segment->finalize_write());
-            stats.write_in_file_cache++;
-            stats.bytes_write_in_file_cache += segment_size;
+            stats.bytes_write_into_file_cache += segment_size;
         }
         // copy from memory directly
         size_t right_offset = offset + result.size - 1;
@@ -134,8 +146,6 @@ Status CachedRemoteFileReader::read_at_impl(size_t offset, Slice result, size_t*
             size_t copy_size = copy_right_offset - copy_left_offset + 1;
             memcpy(dst, src, copy_size);
         }
-    } else {
-        stats.hit_cache = true;
     }
 
     size_t current_offset = offset;
@@ -160,25 +170,33 @@ Status CachedRemoteFileReader::read_at_impl(size_t offset, Slice result, size_t*
         FileBlock::State segment_state;
         int64_t wait_time = 0;
         static int64_t MAX_WAIT_TIME = 10;
-        do {
-            segment_state = segment->wait();
-            if (segment_state == FileBlock::State::DOWNLOADED) {
-                break;
-            }
-            if (segment_state != FileBlock::State::DOWNLOADING) {
-                return Status::IOError(
-                        "File Cache State is {}, the cache downloader encounters an error, please "
-                        "retry it",
-                        segment_state);
-            }
-        } while (++wait_time < MAX_WAIT_TIME);
+        if (segment->state() != FileBlock::State::DOWNLOADED) {
+            do {
+                {
+                    SCOPED_RAW_TIMER(&stats.remote_read_timer);
+                    segment_state = segment->wait();
+                }
+                if (segment_state == FileBlock::State::DOWNLOADED) {
+                    break;
+                }
+                if (segment_state != FileBlock::State::DOWNLOADING) {
+                    return Status::IOError(
+                            "File Cache State is {}, the cache downloader encounters an error, "
+                            "please "
+                            "retry it",
+                            segment_state);
+                }
+            } while (++wait_time < MAX_WAIT_TIME);
+        }
         if (UNLIKELY(wait_time) == MAX_WAIT_TIME) {
             return Status::IOError("Waiting too long for the download to complete");
         }
         size_t file_offset = current_offset - left;
-        RETURN_IF_ERROR(segment->read_at(Slice(result.data + (current_offset - offset), read_size),
-                                         file_offset));
-        stats.bytes_read_from_file_cache += read_size;
+        {
+            SCOPED_RAW_TIMER(&stats.local_read_timer);
+            RETURN_IF_ERROR(segment->read_at(
+                    Slice(result.data + (current_offset - offset), read_size), file_offset));
+        }
         *bytes_read += read_size;
         current_offset = right + 1;
     }
@@ -193,15 +211,18 @@ void CachedRemoteFileReader::_update_state(const ReadStatistics& read_stats,
     if (statis == nullptr) {
         return;
     }
-    statis->num_io_total++;
-    statis->num_io_bytes_read_total += read_stats.bytes_read;
-    statis->num_io_bytes_written_in_file_cache += read_stats.bytes_write_in_file_cache;
     if (read_stats.hit_cache) {
-        statis->num_io_hit_cache++;
+        statis->num_local_io_total++;
+        statis->bytes_read_from_local += read_stats.bytes_read;
+    } else {
+        statis->num_remote_io_total++;
+        statis->bytes_read_from_remote += read_stats.bytes_read;
     }
-    statis->num_io_bytes_read_from_file_cache += read_stats.bytes_read_from_file_cache;
-    statis->num_io_written_in_file_cache += read_stats.write_in_file_cache;
-    statis->num_io_bytes_skip_cache += read_stats.bytes_skip_cache;
+    statis->remote_io_timer += read_stats.remote_read_timer;
+    statis->local_io_timer += read_stats.local_read_timer;
+    statis->num_skip_cache_io_total += read_stats.skip_cache ? 1 : 0;
+    statis->bytes_write_into_cache += read_stats.bytes_write_into_file_cache;
+    statis->write_cache_io_timer += read_stats.local_write_timer;
 }
 
 } // namespace io

--- a/be/src/io/cache/block/cached_remote_file_reader.cpp
+++ b/be/src/io/cache/block/cached_remote_file_reader.cpp
@@ -122,8 +122,8 @@ Status CachedRemoteFileReader::read_at_impl(size_t offset, Slice result, size_t*
         std::unique_ptr<char[]> buffer(new char[size]);
         {
             SCOPED_RAW_TIMER(&stats.remote_read_timer);
-            RETURN_IF_ERROR(_remote_file_reader->read_at(empty_start, Slice(buffer.get(), size), &size,
-                                                     io_ctx));
+            RETURN_IF_ERROR(_remote_file_reader->read_at(empty_start, Slice(buffer.get(), size),
+                                                         &size, io_ctx));
         }
         for (auto& segment : empty_segments) {
             if (segment->state() == FileBlock::State::SKIP_CACHE) {

--- a/be/src/io/cache/block/cached_remote_file_reader.h
+++ b/be/src/io/cache/block/cached_remote_file_reader.h
@@ -58,12 +58,13 @@ private:
     CloudFileCachePtr _disposable_cache;
 
     struct ReadStatistics {
-        bool hit_cache = false;
+        bool hit_cache = true;
+        bool skip_cache = false;
         int64_t bytes_read = 0;
-        int64_t bytes_read_from_file_cache = 0;
-        int64_t bytes_write_in_file_cache = 0;
-        int64_t write_in_file_cache = 0;
-        int64_t bytes_skip_cache = 0;
+        int64_t bytes_write_into_file_cache = 0;
+        int64_t remote_read_timer = 0;
+        int64_t local_read_timer = 0;
+        int64_t local_write_timer = 0;
     };
     void _update_state(const ReadStatistics& stats, FileCacheStatistics* state) const;
 };

--- a/be/src/io/io_common.h
+++ b/be/src/io/io_common.h
@@ -34,14 +34,15 @@ enum ReaderType {
 namespace io {
 
 struct FileCacheStatistics {
-    int64_t num_io_total = 0;
-    int64_t num_io_hit_cache = 0;
-    int64_t num_io_bytes_read_total = 0;
-    int64_t num_io_bytes_read_from_file_cache = 0;
-    int64_t num_io_bytes_read_from_write_cache = 0;
-    int64_t num_io_written_in_file_cache = 0;
-    int64_t num_io_bytes_written_in_file_cache = 0;
-    int64_t num_io_bytes_skip_cache = 0;
+    int64_t num_local_io_total = 0;
+    int64_t num_remote_io_total = 0;
+    int64_t local_io_timer = 0;
+    int64_t bytes_read_from_local = 0;
+    int64_t bytes_read_from_remote = 0;
+    int64_t remote_io_timer = 0;
+    int64_t write_cache_io_timer = 0;
+    int64_t bytes_write_into_cache = 0;
+    int64_t num_skip_cache_io_total = 0;
 };
 
 class IOContext {

--- a/be/src/vec/exec/scan/new_olap_scanner.cpp
+++ b/be/src/vec/exec/scan/new_olap_scanner.cpp
@@ -17,11 +17,10 @@
 
 #include "vec/exec/scan/new_olap_scanner.h"
 
+#include "io/cache/block/block_file_cache_profile.h"
 #include "olap/storage_engine.h"
 #include "vec/exec/scan/new_olap_scan_node.h"
 #include "vec/olap/block_reader.h"
-#include "io/cache/block/block_file_cache_profile.h"
-
 
 namespace doris::vectorized {
 
@@ -542,7 +541,7 @@ void NewOlapScanner::_update_counters_before_close() {
                    stats.inverted_index_searcher_open_timer);
     COUNTER_UPDATE(olap_parent->_inverted_index_searcher_search_timer,
                    stats.inverted_index_searcher_search_timer);
-    
+
     if (config::enable_file_cache) {
         io::FileCacheProfileReporter cache_profile(olap_parent->_segment_profile.get());
         cache_profile.update(&stats.file_cache_stats);

--- a/be/src/vec/exec/scan/new_olap_scanner.cpp
+++ b/be/src/vec/exec/scan/new_olap_scanner.cpp
@@ -20,6 +20,8 @@
 #include "olap/storage_engine.h"
 #include "vec/exec/scan/new_olap_scan_node.h"
 #include "vec/olap/block_reader.h"
+#include "io/cache/block/block_file_cache_profile.h"
+
 
 namespace doris::vectorized {
 
@@ -540,6 +542,11 @@ void NewOlapScanner::_update_counters_before_close() {
                    stats.inverted_index_searcher_open_timer);
     COUNTER_UPDATE(olap_parent->_inverted_index_searcher_search_timer,
                    stats.inverted_index_searcher_search_timer);
+    
+    if (config::enable_file_cache) {
+        io::FileCacheProfileReporter cache_profile(olap_parent->_segment_profile.get());
+        cache_profile.update(&stats.file_cache_stats);
+    }
 
     COUNTER_UPDATE(olap_parent->_output_index_result_column_timer,
                    stats.output_index_result_column_timer);


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

We want to use file cache for caching cold data in S3. When reading them, we want to know where the data come from and the time taken to read the datas. So we support the metrics in olap scan node. And for clearing the information, i also update the fields about the metrics.
 
## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

