### PR TITLE
[enhance](nereids) broadcast cost calculate

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/cost/CostModelV1.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/cost/CostModelV1.java
@@ -170,10 +170,16 @@ class CostModelV1 extends PlanVisitor<Cost, PlanContext> {
                     || childStatistics.getRowCount() > rowsLimit) {
                 return CostV1.of(Double.MAX_VALUE, Double.MAX_VALUE, Double.MAX_VALUE);
             }
+            /*
+            TODO：
+            srcBeNum and destBeNum are not available, assume destBeNum/srcBeNum = 1
+            1. cpu: row * destBeNum/srcBeNum
+            2. network: rows send = rows/srcBeNum * destBeNum.
+             */
             return CostV1.of(
-                    childStatistics.getRowCount() * beNumber,
-                    childStatistics.getRowCount() * beNumber * instanceNumber,
-                    childStatistics.getRowCount() * beNumber * instanceNumber);
+                    childStatistics.getRowCount(), // TODO:should multiply by destBeNum/srcBeNum
+                    childStatistics.getRowCount(), // only consider one BE, not the whole system.
+                    childStatistics.getRowCount() * instanceNumber); // TODO: remove instanceNumber when BE updated
         }
 
         // gather


### PR DESCRIPTION
# Proposed changes
update broadcast join cost estimate according to BE implementation.
there is an enhancement on BE. in broadcast join, BE only build one hash table, not instanceNum hash tables.

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

