### PR TITLE
[fix](datetime) fix get String index out of range exception

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/DateLiteral.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/DateLiteral.java
@@ -1630,8 +1630,8 @@ public class DateLiteral extends LiteralExpr {
                 continue;
             }
             // escape separator
-            while (pre < dateStr.length() && (Character.toString(dateStr.charAt(pre)).matches("\\p{Punct}"))
-                    || Character.isSpaceChar(dateStr.charAt(pre))) {
+            while (pre < dateStr.length() && ((Character.toString(dateStr.charAt(pre)).matches("\\p{Punct}"))
+                    || Character.isSpaceChar(dateStr.charAt(pre)))) {
                 if (Character.isSpaceChar(dateStr.charAt(pre))) {
                     if (((1 << fieldIdx) & ALLOW_SPACE_MASK) == 0) {
                         throw new AnalysisException("parse datetime value failed: " + dateStr);


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

will get String index out of range exception when use error datetime values like '2020-02-01'
before:
MySQL [test]> select test121.k1 from test121 where k1 != ('9102-12-');
ERROR 1105 (HY000): errCode = 2, detailMessage = Unexpected exception: String index out of range: 8

after:
MySQL [test]> select test121.k1 from test121 where k1 = '9102-12-';
ERROR 1105 (HY000): errCode = 2, detailMessage = Incorrect datetime value: '9102-12-' in expression: `k1` = '9102-12-'

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

