### PR TITLE
[branch-1.2](jvm) add JAVA_OPTS env var for BE jvm

### DIFF
--- a/be/src/util/jni-util.cpp
+++ b/be/src/util/jni-util.cpp
@@ -70,28 +70,68 @@ void FindOrCreateJavaVM() {
     int num_vms;
     int rv = LibJVMLoader::JNI_GetCreatedJavaVMs(&g_vm, 1, &num_vms);
     if (rv == 0) {
+        JavaVMOption* options;
         auto classpath = GetDorisJNIClasspath();
+        // The following 4 opts are default opts,
+        // they can be override by JAVA_OPTS env var.
         std::string heap_size = fmt::format("-Xmx{}", config::jvm_max_heap_size);
         std::string log_path = fmt::format("-DlogPath={}/log/udf-jdbc.log", getenv("DORIS_HOME"));
-        JavaVMOption options[] = {
-                {const_cast<char*>(classpath.c_str()), nullptr},
-                {const_cast<char*>(heap_size.c_str()), nullptr},
-                {const_cast<char*>(log_path.c_str()), nullptr},
-                // avoid BE crash, the reason is still unknown.
-                {const_cast<char*>("-Djava.compiler=NONE"), nullptr},
+        std::string critical_jni = "-XX:-CriticalJNINatives";
+        std::string max_fd_limit = "-XX:-MaxFDLimit";
+
+        char* java_opts = getenv("JAVA_OPTS");
+        int no_args;
+        if (java_opts == nullptr) {
+            no_args = 4; // classpath, heapsize, log path, critical
 #ifdef __APPLE__
-                // On macOS, we should disable MaxFDLimit, otherwise the RLIMIT_NOFILE
-                // will be assigned the minimum of OPEN_MAX (10240) and rlim_cur (See src/hotspot/os/bsd/os_bsd.cpp)
-                // and it can not pass the check performed by storage engine.
-                // The newer JDK has fixed this issue.
-                {const_cast<char*>("-XX:-MaxFDLimit"), nullptr},
+            no_args++; // -XX:-MaxFDLimit
 #endif
-        };
+            options = (JavaVMOption*)calloc(no_args, sizeof(JavaVMOption));
+            options[0].optionString = const_cast<char*>(classpath.c_str());
+            options[1].optionString = const_cast<char*>(heap_size.c_str());
+            options[2].optionString = const_cast<char*>(log_path.c_str());
+            options[3].optionString = const_cast<char*>(critical_jni.c_str());
+#ifdef __APPLE__
+            // On macOS, we should disable MaxFDLimit, otherwise the RLIMIT_NOFILE
+            // will be assigned the minimum of OPEN_MAX (10240) and rlim_cur (See src/hotspot/os/bsd/os_bsd.cpp)
+            // and it can not pass the check performed by storage engine.
+            // The newer JDK has fixed this issue.
+            options[4].optionString = const_cast<char*>(max_fd_limit.c_str());
+#endif
+        } else {
+            // user specified opts
+            // 1. find the number of args
+            java_opts = strdup(java_opts);
+            char *str, *token, *save_ptr;
+            char jvm_arg_delims[] = " ";
+            for (no_args = 1, str = java_opts;; no_args++, str = nullptr) {
+                token = strtok_r(str, jvm_arg_delims, &save_ptr);
+                if (token == nullptr) {
+                    break;
+                }
+            }
+            free(java_opts);
+            // 2. set args
+            options = (JavaVMOption*)calloc(no_args, sizeof(JavaVMOption));
+            options[0].optionString = const_cast<char*>(classpath.c_str());
+            java_opts = getenv("JAVA_OPTS");
+            if (java_opts != NULL) {
+                java_opts = strdup(java_opts);
+                for (no_args = 1, str = java_opts;; no_args++, str = nullptr) {
+                    token = strtok_r(str, jvm_arg_delims, &save_ptr);
+                    if (token == nullptr) {
+                        break;
+                    }
+                    options[no_args].optionString = token;
+                }
+            }
+        }
+
         JNIEnv* env;
         JavaVMInitArgs vm_args;
         vm_args.version = JNI_VERSION_1_8;
         vm_args.options = options;
-        vm_args.nOptions = sizeof(options) / sizeof(JavaVMOption);
+        vm_args.nOptions = no_args;
         // Set it to JNI_FALSE because JNI_TRUE will let JVM ignore the max size config.
         vm_args.ignoreUnrecognized = JNI_FALSE;
 
@@ -99,6 +139,11 @@ void FindOrCreateJavaVM() {
         if (JNI_OK != res) {
             DCHECK(false) << "Failed to create JVM, code= " << res;
         }
+
+        if (java_opts != nullptr) {
+            free(java_opts);
+        }
+        free(options);
     } else {
         CHECK_EQ(rv, 0) << "Could not find any created Java VM";
         CHECK_EQ(num_vms, 1) << "No VMs returned";

--- a/conf/be.conf
+++ b/conf/be.conf
@@ -17,6 +17,9 @@
 
 PPROF_TMPDIR="$DORIS_HOME/log/"
 
+# if JAVA_OPTS is set, it will override the jvm opts for BE jvm.
+#JAVA_OPTS="-Xmx8192m -DlogPath=$DORIS_HOME/log/udf-jdbc.log -Djava.compiler=NONE -XX::-CriticalJNINatives"
+
 # since 1.2, the JAVA_HOME need to be set to run BE process.
 # JAVA_HOME=/path/to/jdk/
 


### PR DESCRIPTION
# Proposed changes

And revert #17690
because -Djava_compiler=NONE cause very poor performace.
Use JAVA_OPTS so that we can set different jvm opts in be.conf

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

