### PR TITLE
[Enhancement](HttpServer) Add http interface authentication for BE

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -376,7 +376,7 @@ CONF_String(ssl_certificate_path, "");
 // Path of private key
 CONF_String(ssl_private_key_path, "");
 // Whether to check authorization
-CONF_Bool(enable_auth, "false");
+CONF_Bool(enable_http_auth, "false");
 // Number of webserver workers
 CONF_Int32(webserver_num_workers, "48");
 // Period to update rate counters and sampling counters in ms.

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -375,6 +375,8 @@ CONF_Bool(enable_https, "false");
 CONF_String(ssl_certificate_path, "");
 // Path of private key
 CONF_String(ssl_private_key_path, "");
+// Whether to check authorization
+CONF_Bool(enable_auth, "false");
 // Number of webserver workers
 CONF_Int32(webserver_num_workers, "48");
 // Period to update rate counters and sampling counters in ms.

--- a/be/src/http/CMakeLists.txt
+++ b/be/src/http/CMakeLists.txt
@@ -28,13 +28,13 @@ add_library(Webserver STATIC
   http_channel.cpp
   http_status.cpp
   http_parser.cpp
+  http_handler_with_auth.cpp
   web_page_handler.cpp
   default_path_handlers.cpp
   utils.cpp
   ev_http_server.cpp
   http_client.cpp
   action/download_action.cpp
-  action/monitor_action.cpp
   action/pad_rowset_action.cpp
   action/health_action.cpp
   action/tablet_migration_action.cpp

--- a/be/src/http/action/check_rpc_channel_action.cpp
+++ b/be/src/http/action/check_rpc_channel_action.cpp
@@ -36,7 +36,7 @@
 #include "util/md5.h"
 
 namespace doris {
-CheckRPCChannelAction::CheckRPCChannelAction(ExecEnv* exec_env) : _exec_env(exec_env) {}
+CheckRPCChannelAction::CheckRPCChannelAction(ExecEnv* exec_env) : HttpHandlerWithAuth(exec_env) {}
 void CheckRPCChannelAction::handle(HttpRequest* req) {
     std::string req_ip = req->param("ip");
     std::string req_port = req->param("port");

--- a/be/src/http/action/check_rpc_channel_action.cpp
+++ b/be/src/http/action/check_rpc_channel_action.cpp
@@ -36,7 +36,9 @@
 #include "util/md5.h"
 
 namespace doris {
-CheckRPCChannelAction::CheckRPCChannelAction(ExecEnv* exec_env) : HttpHandlerWithAuth(exec_env) {}
+CheckRPCChannelAction::CheckRPCChannelAction(ExecEnv* exec_env, TPrivilegeHier::type hier,
+                                             TPrivilegeType::type type)
+        : HttpHandlerWithAuth(exec_env, hier, type) {}
 void CheckRPCChannelAction::handle(HttpRequest* req) {
     std::string req_ip = req->param("ip");
     std::string req_port = req->param("port");

--- a/be/src/http/action/check_rpc_channel_action.h
+++ b/be/src/http/action/check_rpc_channel_action.h
@@ -35,8 +35,10 @@ private:
     ExecEnv* _exec_env;
 
     bool on_privilege(const HttpRequest& req, TCheckAuthRequest& auth_request) override {
-        auth_request.priv_ctrl.priv_hier = TPrivilegeHier::GLOBAL;
-        auth_request.priv_type = TPrivilegeType::ADMIN;
+        TPrivilegeCtrl priv_ctrl;
+        priv_ctrl.priv_hier = TPrivilegeHier::GLOBAL;
+        auth_request.__set_priv_ctrl(priv_ctrl);
+        auth_request.__set_priv_type(TPrivilegeType::ADMIN);
         return true;
     }
 };

--- a/be/src/http/action/check_rpc_channel_action.h
+++ b/be/src/http/action/check_rpc_channel_action.h
@@ -17,21 +17,27 @@
 
 #pragma once
 
-#include "http/http_handler.h"
+#include "http/http_handler_with_auth.h"
 
 namespace doris {
 class ExecEnv;
 class HttpRequest;
 
-class CheckRPCChannelAction : public HttpHandler {
+class CheckRPCChannelAction : public HttpHandlerWithAuth {
 public:
     explicit CheckRPCChannelAction(ExecEnv* exec_env);
 
-    virtual ~CheckRPCChannelAction() {}
+    ~CheckRPCChannelAction() override = default;
 
     void handle(HttpRequest* req) override;
 
 private:
     ExecEnv* _exec_env;
+
+    bool on_privilege(const HttpRequest& req, TCheckAuthRequest& auth_request) override {
+        auth_request.priv_ctrl.priv_hier = TPrivilegeHier::GLOBAL;
+        auth_request.priv_type = TPrivilegeType::ADMIN;
+        return true;
+    }
 };
 } // namespace doris

--- a/be/src/http/action/check_rpc_channel_action.h
+++ b/be/src/http/action/check_rpc_channel_action.h
@@ -33,13 +33,5 @@ public:
 
 private:
     ExecEnv* _exec_env;
-
-    bool on_privilege(const HttpRequest& req, TCheckAuthRequest& auth_request) override {
-        TPrivilegeCtrl priv_ctrl;
-        priv_ctrl.priv_hier = TPrivilegeHier::GLOBAL;
-        auth_request.__set_priv_ctrl(priv_ctrl);
-        auth_request.__set_priv_type(TPrivilegeType::ADMIN);
-        return true;
-    }
 };
 } // namespace doris

--- a/be/src/http/action/check_rpc_channel_action.h
+++ b/be/src/http/action/check_rpc_channel_action.h
@@ -25,7 +25,8 @@ class HttpRequest;
 
 class CheckRPCChannelAction : public HttpHandlerWithAuth {
 public:
-    explicit CheckRPCChannelAction(ExecEnv* exec_env);
+    explicit CheckRPCChannelAction(ExecEnv* exec_env, TPrivilegeHier::type hier,
+                                   TPrivilegeType::type type);
 
     ~CheckRPCChannelAction() override = default;
 

--- a/be/src/http/action/check_tablet_segment_action.cpp
+++ b/be/src/http/action/check_tablet_segment_action.cpp
@@ -37,8 +37,9 @@ namespace doris {
 
 const static std::string HEADER_JSON = "application/json";
 
-CheckTabletSegmentAction::CheckTabletSegmentAction(ExecEnv* exec_env)
-        : HttpHandlerWithAuth(exec_env) {
+CheckTabletSegmentAction::CheckTabletSegmentAction(ExecEnv* exec_env, TPrivilegeHier::type hier,
+                                                   TPrivilegeType::type type)
+        : HttpHandlerWithAuth(exec_env, hier, type) {
     _host = BackendOptions::get_localhost();
 }
 

--- a/be/src/http/action/check_tablet_segment_action.cpp
+++ b/be/src/http/action/check_tablet_segment_action.cpp
@@ -37,7 +37,8 @@ namespace doris {
 
 const static std::string HEADER_JSON = "application/json";
 
-CheckTabletSegmentAction::CheckTabletSegmentAction() {
+CheckTabletSegmentAction::CheckTabletSegmentAction(ExecEnv* exec_env)
+        : HttpHandlerWithAuth(exec_env) {
     _host = BackendOptions::get_localhost();
 }
 

--- a/be/src/http/action/check_tablet_segment_action.h
+++ b/be/src/http/action/check_tablet_segment_action.h
@@ -41,8 +41,10 @@ private:
     std::string _host;
 
     bool on_privilege(const HttpRequest& req, TCheckAuthRequest& auth_request) override {
-        auth_request.priv_ctrl.priv_hier = TPrivilegeHier::GLOBAL;
-        auth_request.priv_type = TPrivilegeType::ADMIN;
+        TPrivilegeCtrl priv_ctrl;
+        priv_ctrl.priv_hier = TPrivilegeHier::GLOBAL;
+        auth_request.__set_priv_ctrl(priv_ctrl);
+        auth_request.__set_priv_type(TPrivilegeType::ADMIN);
         return true;
     }
 };

--- a/be/src/http/action/check_tablet_segment_action.h
+++ b/be/src/http/action/check_tablet_segment_action.h
@@ -29,7 +29,8 @@ class ExecEnv;
 
 class CheckTabletSegmentAction : public HttpHandlerWithAuth {
 public:
-    CheckTabletSegmentAction(ExecEnv* exec_env);
+    CheckTabletSegmentAction(ExecEnv* exec_env, TPrivilegeHier::type hier,
+                             TPrivilegeType::type type);
 
     ~CheckTabletSegmentAction() override = default;
 

--- a/be/src/http/action/check_tablet_segment_action.h
+++ b/be/src/http/action/check_tablet_segment_action.h
@@ -39,13 +39,5 @@ public:
 
 private:
     std::string _host;
-
-    bool on_privilege(const HttpRequest& req, TCheckAuthRequest& auth_request) override {
-        TPrivilegeCtrl priv_ctrl;
-        priv_ctrl.priv_hier = TPrivilegeHier::GLOBAL;
-        auth_request.__set_priv_ctrl(priv_ctrl);
-        auth_request.__set_priv_type(TPrivilegeType::ADMIN);
-        return true;
-    }
 };
 } // namespace doris

--- a/be/src/http/action/check_tablet_segment_action.h
+++ b/be/src/http/action/check_tablet_segment_action.h
@@ -19,18 +19,31 @@
 
 #include <string>
 
-#include "http/http_handler.h"
+#include "http/http_handler_with_auth.h"
+#include "util/easy_json.h"
 
 namespace doris {
 class HttpRequest;
 
-class CheckTabletSegmentAction : public HttpHandler {
+class ExecEnv;
+
+class CheckTabletSegmentAction : public HttpHandlerWithAuth {
 public:
-    CheckTabletSegmentAction();
+    CheckTabletSegmentAction(ExecEnv* exec_env);
+
+    ~CheckTabletSegmentAction() override = default;
+
     void handle(HttpRequest* req) override;
+
     std::string host() { return _host; }
 
 private:
     std::string _host;
+
+    bool on_privilege(const HttpRequest& req, TCheckAuthRequest& auth_request) override {
+        auth_request.priv_ctrl.priv_hier = TPrivilegeHier::GLOBAL;
+        auth_request.priv_type = TPrivilegeType::ADMIN;
+        return true;
+    }
 };
 } // namespace doris

--- a/be/src/http/action/checksum_action.cpp
+++ b/be/src/http/action/checksum_action.cpp
@@ -37,7 +37,7 @@ const std::string TABLET_ID = "tablet_id";
 const std::string TABLET_VERSION = "version";
 const std::string SCHEMA_HASH = "schema_hash";
 
-ChecksumAction::ChecksumAction() {}
+ChecksumAction::ChecksumAction(ExecEnv* exec_env) : HttpHandlerWithAuth(exec_env) {}
 
 void ChecksumAction::handle(HttpRequest* req) {
     LOG(INFO) << "accept one request " << req->debug_string();

--- a/be/src/http/action/checksum_action.cpp
+++ b/be/src/http/action/checksum_action.cpp
@@ -37,7 +37,9 @@ const std::string TABLET_ID = "tablet_id";
 const std::string TABLET_VERSION = "version";
 const std::string SCHEMA_HASH = "schema_hash";
 
-ChecksumAction::ChecksumAction(ExecEnv* exec_env) : HttpHandlerWithAuth(exec_env) {}
+ChecksumAction::ChecksumAction(ExecEnv* exec_env, TPrivilegeHier::type hier,
+                               TPrivilegeType::type type)
+        : HttpHandlerWithAuth(exec_env, hier, type) {}
 
 void ChecksumAction::handle(HttpRequest* req) {
     LOG(INFO) << "accept one request " << req->debug_string();

--- a/be/src/http/action/checksum_action.h
+++ b/be/src/http/action/checksum_action.h
@@ -27,7 +27,8 @@ class HttpRequest;
 
 class ChecksumAction : public HttpHandlerWithAuth {
 public:
-    explicit ChecksumAction(ExecEnv* exec_env);
+    explicit ChecksumAction(ExecEnv* exec_env, TPrivilegeHier::type hier,
+                            TPrivilegeType::type type);
 
     ~ChecksumAction() override = default;
 

--- a/be/src/http/action/checksum_action.h
+++ b/be/src/http/action/checksum_action.h
@@ -19,21 +19,27 @@
 
 #include <cstdint>
 
-#include "http/http_handler.h"
+#include "http/http_handler_with_auth.h"
 
 namespace doris {
 
 class HttpRequest;
 
-class ChecksumAction : public HttpHandler {
+class ChecksumAction : public HttpHandlerWithAuth {
 public:
-    explicit ChecksumAction();
+    explicit ChecksumAction(ExecEnv* exec_env);
 
-    virtual ~ChecksumAction() {}
+    ~ChecksumAction() override = default;
 
     void handle(HttpRequest* req) override;
 
 private:
+    bool on_privilege(const HttpRequest& req, TCheckAuthRequest& auth_request) override {
+        auth_request.priv_ctrl.priv_hier = TPrivilegeHier::GLOBAL;
+        auth_request.priv_type = TPrivilegeType::ADMIN;
+        return true;
+    }
+
     int64_t do_checksum(int64_t tablet_id, int64_t version, int32_t schema_hash, HttpRequest* req);
 }; // end class ChecksumAction
 

--- a/be/src/http/action/checksum_action.h
+++ b/be/src/http/action/checksum_action.h
@@ -35,8 +35,10 @@ public:
 
 private:
     bool on_privilege(const HttpRequest& req, TCheckAuthRequest& auth_request) override {
-        auth_request.priv_ctrl.priv_hier = TPrivilegeHier::GLOBAL;
-        auth_request.priv_type = TPrivilegeType::ADMIN;
+        TPrivilegeCtrl priv_ctrl;
+        priv_ctrl.priv_hier = TPrivilegeHier::GLOBAL;
+        auth_request.__set_priv_ctrl(priv_ctrl);
+        auth_request.__set_priv_type(TPrivilegeType::ADMIN);
         return true;
     }
 

--- a/be/src/http/action/checksum_action.h
+++ b/be/src/http/action/checksum_action.h
@@ -34,14 +34,6 @@ public:
     void handle(HttpRequest* req) override;
 
 private:
-    bool on_privilege(const HttpRequest& req, TCheckAuthRequest& auth_request) override {
-        TPrivilegeCtrl priv_ctrl;
-        priv_ctrl.priv_hier = TPrivilegeHier::GLOBAL;
-        auth_request.__set_priv_ctrl(priv_ctrl);
-        auth_request.__set_priv_type(TPrivilegeType::ADMIN);
-        return true;
-    }
-
     int64_t do_checksum(int64_t tablet_id, int64_t version, int32_t schema_hash, HttpRequest* req);
 }; // end class ChecksumAction
 

--- a/be/src/http/action/compaction_action.cpp
+++ b/be/src/http/action/compaction_action.cpp
@@ -48,8 +48,9 @@ using namespace ErrorCode;
 
 const static std::string HEADER_JSON = "application/json";
 
-CompactionAction::CompactionAction(CompactionActionType type, ExecEnv* exec_env)
-        : HttpHandlerWithAuth(exec_env), _type(type) {}
+CompactionAction::CompactionAction(CompactionActionType ctype, ExecEnv* exec_env,
+                                   TPrivilegeHier::type hier, TPrivilegeType::type ptype)
+        : HttpHandlerWithAuth(exec_env, hier, ptype), _type(ctype) {}
 Status CompactionAction::_check_param(HttpRequest* req, uint64_t* tablet_id) {
     std::string req_tablet_id = req->param(TABLET_ID_KEY);
     if (req_tablet_id == "") {

--- a/be/src/http/action/compaction_action.cpp
+++ b/be/src/http/action/compaction_action.cpp
@@ -48,6 +48,8 @@ using namespace ErrorCode;
 
 const static std::string HEADER_JSON = "application/json";
 
+CompactionAction::CompactionAction(CompactionActionType type, ExecEnv* exec_env)
+        : HttpHandlerWithAuth(exec_env), _type(type) {}
 Status CompactionAction::_check_param(HttpRequest* req, uint64_t* tablet_id) {
     std::string req_tablet_id = req->param(TABLET_ID_KEY);
     if (req_tablet_id == "") {

--- a/be/src/http/action/compaction_action.h
+++ b/be/src/http/action/compaction_action.h
@@ -70,8 +70,10 @@ private:
     CompactionActionType _type;
 
     bool on_privilege(const HttpRequest& req, TCheckAuthRequest& auth_request) override {
-        auth_request.priv_ctrl.priv_hier = TPrivilegeHier::GLOBAL;
-        auth_request.priv_type = TPrivilegeType::ADMIN;
+        TPrivilegeCtrl priv_ctrl;
+        priv_ctrl.priv_hier = TPrivilegeHier::GLOBAL;
+        auth_request.__set_priv_ctrl(priv_ctrl);
+        auth_request.__set_priv_type(TPrivilegeType::ADMIN);
         return true;
     }
 };

--- a/be/src/http/action/compaction_action.h
+++ b/be/src/http/action/compaction_action.h
@@ -68,14 +68,6 @@ private:
 
 private:
     CompactionActionType _type;
-
-    bool on_privilege(const HttpRequest& req, TCheckAuthRequest& auth_request) override {
-        TPrivilegeCtrl priv_ctrl;
-        priv_ctrl.priv_hier = TPrivilegeHier::GLOBAL;
-        auth_request.__set_priv_ctrl(priv_ctrl);
-        auth_request.__set_priv_type(TPrivilegeType::ADMIN);
-        return true;
-    }
 };
 
 } // end namespace doris

--- a/be/src/http/action/compaction_action.h
+++ b/be/src/http/action/compaction_action.h
@@ -44,7 +44,8 @@ const std::string PARAM_COMPACTION_CUMULATIVE = "cumulative";
 /// See compaction-action.md for details.
 class CompactionAction : public HttpHandlerWithAuth {
 public:
-    CompactionAction(CompactionActionType type, ExecEnv* exec_env);
+    CompactionAction(CompactionActionType ctype, ExecEnv* exec_env, TPrivilegeHier::type hier,
+                     TPrivilegeType::type ptype);
 
     ~CompactionAction() override = default;
 

--- a/be/src/http/action/compaction_action.h
+++ b/be/src/http/action/compaction_action.h
@@ -22,11 +22,13 @@
 #include <string>
 
 #include "common/status.h"
-#include "http/http_handler.h"
+#include "http/http_handler_with_auth.h"
 #include "olap/tablet.h"
 
 namespace doris {
 class HttpRequest;
+
+class ExecEnv;
 
 enum class CompactionActionType {
     SHOW_INFO = 1,
@@ -40,9 +42,9 @@ const std::string PARAM_COMPACTION_CUMULATIVE = "cumulative";
 
 /// This action is used for viewing the compaction status.
 /// See compaction-action.md for details.
-class CompactionAction : public HttpHandler {
+class CompactionAction : public HttpHandlerWithAuth {
 public:
-    CompactionAction(CompactionActionType type) : _type(type) {}
+    CompactionAction(CompactionActionType type, ExecEnv* exec_env);
 
     ~CompactionAction() override = default;
 
@@ -66,6 +68,12 @@ private:
 
 private:
     CompactionActionType _type;
+
+    bool on_privilege(const HttpRequest& req, TCheckAuthRequest& auth_request) override {
+        auth_request.priv_ctrl.priv_hier = TPrivilegeHier::GLOBAL;
+        auth_request.priv_type = TPrivilegeType::ADMIN;
+        return true;
+    }
 };
 
 } // end namespace doris

--- a/be/src/http/action/download_action.cpp
+++ b/be/src/http/action/download_action.cpp
@@ -34,8 +34,6 @@
 namespace doris {
 
 const std::string FILE_PARAMETER = "file";
-const std::string DB_PARAMETER = "db";
-const std::string LABEL_PARAMETER = "label";
 const std::string TOKEN_PARAMETER = "token";
 
 DownloadAction::DownloadAction(ExecEnv* exec_env, const std::vector<std::string>& allow_dirs)

--- a/be/src/http/action/meta_action.cpp
+++ b/be/src/http/action/meta_action.cpp
@@ -46,8 +46,7 @@ const static std::string OP = "op";
 const static std::string DATA_SIZE = "data_size";
 const static std::string HEADER = "header";
 
-MetaAction::MetaAction(META_TYPE meta_type, ExecEnv* exec_env)
-        : HttpHandlerWithAuth(exec_env), _meta_type(meta_type) {}
+MetaAction::MetaAction(ExecEnv* exec_env) : HttpHandlerWithAuth(exec_env) {}
 
 Status MetaAction::_handle_header(HttpRequest* req, std::string* json_meta) {
     req->add_output_header(HttpHeaders::CONTENT_TYPE, HEADER_JSON.c_str());

--- a/be/src/http/action/meta_action.cpp
+++ b/be/src/http/action/meta_action.cpp
@@ -46,6 +46,9 @@ const static std::string OP = "op";
 const static std::string DATA_SIZE = "data_size";
 const static std::string HEADER = "header";
 
+MetaAction::MetaAction(META_TYPE meta_type, ExecEnv* exec_env)
+        : HttpHandlerWithAuth(exec_env), _meta_type(meta_type) {}
+
 Status MetaAction::_handle_header(HttpRequest* req, std::string* json_meta) {
     req->add_output_header(HttpHeaders::CONTENT_TYPE, HEADER_JSON.c_str());
     std::string req_tablet_id = req->param(TABLET_ID_KEY);

--- a/be/src/http/action/meta_action.cpp
+++ b/be/src/http/action/meta_action.cpp
@@ -46,8 +46,8 @@ const static std::string OP = "op";
 const static std::string DATA_SIZE = "data_size";
 const static std::string HEADER = "header";
 
-MetaAction::MetaAction(ExecEnv* exec_env) : HttpHandlerWithAuth(exec_env) {}
-
+MetaAction::MetaAction(ExecEnv* exec_env, TPrivilegeHier::type hier, TPrivilegeType::type type)
+        : HttpHandlerWithAuth(exec_env, hier, type) {}
 Status MetaAction::_handle_header(HttpRequest* req, std::string* json_meta) {
     req->add_output_header(HttpHeaders::CONTENT_TYPE, HEADER_JSON.c_str());
     std::string req_tablet_id = req->param(TABLET_ID_KEY);

--- a/be/src/http/action/meta_action.h
+++ b/be/src/http/action/meta_action.h
@@ -29,7 +29,7 @@ class HttpRequest;
 // Get Meta Info
 class MetaAction : public HttpHandlerWithAuth {
 public:
-    MetaAction(ExecEnv* exec_env);
+    MetaAction(ExecEnv* exec_env, TPrivilegeHier::type hier, TPrivilegeType::type type);
 
     ~MetaAction() override = default;
 

--- a/be/src/http/action/meta_action.h
+++ b/be/src/http/action/meta_action.h
@@ -40,8 +40,10 @@ private:
 
 private:
     bool on_privilege(const HttpRequest& req, TCheckAuthRequest& auth_request) override {
-        auth_request.priv_ctrl.priv_hier = TPrivilegeHier::GLOBAL;
-        auth_request.priv_type = TPrivilegeType::ADMIN;
+        TPrivilegeCtrl priv_ctrl;
+        priv_ctrl.priv_hier = TPrivilegeHier::GLOBAL;
+        auth_request.__set_priv_ctrl(priv_ctrl);
+        auth_request.__set_priv_type(TPrivilegeType::ADMIN);
         return true;
     }
 };

--- a/be/src/http/action/meta_action.h
+++ b/be/src/http/action/meta_action.h
@@ -37,15 +37,6 @@ public:
 
 private:
     Status _handle_header(HttpRequest* req, std::string* json_header);
-
-private:
-    bool on_privilege(const HttpRequest& req, TCheckAuthRequest& auth_request) override {
-        TPrivilegeCtrl priv_ctrl;
-        priv_ctrl.priv_hier = TPrivilegeHier::GLOBAL;
-        auth_request.__set_priv_ctrl(priv_ctrl);
-        auth_request.__set_priv_type(TPrivilegeType::ADMIN);
-        return true;
-    }
 };
 
 } // end namespace doris

--- a/be/src/http/action/meta_action.h
+++ b/be/src/http/action/meta_action.h
@@ -20,23 +20,30 @@
 #include <string>
 
 #include "common/status.h"
-#include "http/http_handler.h"
+#include "http/http_handler_with_auth.h"
 
 namespace doris {
 
 class HttpRequest;
 
 // Get Meta Info
-class MetaAction : public HttpHandler {
+class MetaAction : public HttpHandlerWithAuth {
 public:
-    MetaAction() = default;
+    MetaAction(ExecEnv* exec_env);
 
-    virtual ~MetaAction() {}
+    ~MetaAction() override = default;
 
     void handle(HttpRequest* req) override;
 
 private:
     Status _handle_header(HttpRequest* req, std::string* json_header);
+
+private:
+    bool on_privilege(const HttpRequest& req, TCheckAuthRequest& auth_request) override {
+        auth_request.priv_ctrl.priv_hier = TPrivilegeHier::GLOBAL;
+        auth_request.priv_type = TPrivilegeType::ADMIN;
+        return true;
+    }
 };
 
 } // end namespace doris

--- a/be/src/http/action/metrics_action.h
+++ b/be/src/http/action/metrics_action.h
@@ -26,8 +26,9 @@ class MetricRegistry;
 
 class MetricsAction : public HttpHandlerWithAuth {
 public:
-    MetricsAction(MetricRegistry* metric_registry, ExecEnv* exec_env)
-            : HttpHandlerWithAuth(exec_env), _metric_registry(metric_registry) {}
+    MetricsAction(MetricRegistry* metric_registry, ExecEnv* exec_env, TPrivilegeHier::type hier,
+                  TPrivilegeType::type type)
+            : HttpHandlerWithAuth(exec_env, hier, type), _metric_registry(metric_registry) {}
 
     ~MetricsAction() override = default;
 

--- a/be/src/http/action/metrics_action.h
+++ b/be/src/http/action/metrics_action.h
@@ -17,22 +17,28 @@
 
 #pragma once
 
-#include "http/http_handler.h"
+#include "http/http_handler_with_auth.h"
 
 namespace doris {
 
 class HttpRequest;
 class MetricRegistry;
 
-class MetricsAction : public HttpHandler {
+class MetricsAction : public HttpHandlerWithAuth {
 public:
-    MetricsAction(MetricRegistry* metric_registry) : _metric_registry(metric_registry) {}
-    virtual ~MetricsAction() {}
+    MetricsAction(MetricRegistry* metric_registry, ExecEnv* exec_env)
+            : HttpHandlerWithAuth(exec_env), _metric_registry(metric_registry) {}
+
+    ~MetricsAction() override = default;
 
     void handle(HttpRequest* req) override;
 
 private:
     MetricRegistry* _metric_registry;
+
+    bool on_privilege(const HttpRequest& req, TCheckAuthRequest& auth_request) override {
+        return true;
+    }
 };
 
 } // namespace doris

--- a/be/src/http/action/metrics_action.h
+++ b/be/src/http/action/metrics_action.h
@@ -35,10 +35,6 @@ public:
 
 private:
     MetricRegistry* _metric_registry;
-
-    bool on_privilege(const HttpRequest& req, TCheckAuthRequest& auth_request) override {
-        return true;
-    }
 };
 
 } // namespace doris

--- a/be/src/http/action/pad_rowset_action.h
+++ b/be/src/http/action/pad_rowset_action.h
@@ -30,7 +30,8 @@ class ExecEnv;
 
 class PadRowsetAction : public HttpHandlerWithAuth {
 public:
-    PadRowsetAction(ExecEnv* exec_env) : HttpHandlerWithAuth(exec_env) {}
+    PadRowsetAction(ExecEnv* exec_env, TPrivilegeHier::type hier, TPrivilegeType::type type)
+            : HttpHandlerWithAuth(exec_env, hier, type) {}
 
     ~PadRowsetAction() override = default;
 

--- a/be/src/http/action/pad_rowset_action.h
+++ b/be/src/http/action/pad_rowset_action.h
@@ -38,8 +38,10 @@ public:
 
 private:
     bool on_privilege(const HttpRequest& req, TCheckAuthRequest& auth_request) override {
-        auth_request.priv_ctrl.priv_hier = TPrivilegeHier::GLOBAL;
-        auth_request.priv_type = TPrivilegeType::ADMIN;
+        TPrivilegeCtrl priv_ctrl;
+        priv_ctrl.priv_hier = TPrivilegeHier::GLOBAL;
+        auth_request.__set_priv_ctrl(priv_ctrl);
+        auth_request.__set_priv_type(TPrivilegeType::ADMIN);
         return true;
     }
 

--- a/be/src/http/action/pad_rowset_action.h
+++ b/be/src/http/action/pad_rowset_action.h
@@ -37,14 +37,6 @@ public:
     void handle(HttpRequest* req) override;
 
 private:
-    bool on_privilege(const HttpRequest& req, TCheckAuthRequest& auth_request) override {
-        TPrivilegeCtrl priv_ctrl;
-        priv_ctrl.priv_hier = TPrivilegeHier::GLOBAL;
-        auth_request.__set_priv_ctrl(priv_ctrl);
-        auth_request.__set_priv_type(TPrivilegeType::ADMIN);
-        return true;
-    }
-
     Status _handle(HttpRequest* req);
     Status check_param(HttpRequest* req);
 

--- a/be/src/http/action/pad_rowset_action.h
+++ b/be/src/http/action/pad_rowset_action.h
@@ -18,22 +18,31 @@
 #pragma once
 
 #include "common/status.h"
-#include "http/http_handler.h"
+#include "http/http_handler_with_auth.h"
+#include "http/http_request.h"
 #include "olap/tablet.h"
 
 namespace doris {
 class HttpRequest;
 struct Version;
 
-class PadRowsetAction : public HttpHandler {
+class ExecEnv;
+
+class PadRowsetAction : public HttpHandlerWithAuth {
 public:
-    PadRowsetAction() = default;
+    PadRowsetAction(ExecEnv* exec_env) : HttpHandlerWithAuth(exec_env) {}
 
     ~PadRowsetAction() override = default;
 
     void handle(HttpRequest* req) override;
 
 private:
+    bool on_privilege(const HttpRequest& req, TCheckAuthRequest& auth_request) override {
+        auth_request.priv_ctrl.priv_hier = TPrivilegeHier::GLOBAL;
+        auth_request.priv_type = TPrivilegeType::ADMIN;
+        return true;
+    }
+
     Status _handle(HttpRequest* req);
     Status check_param(HttpRequest* req);
 

--- a/be/src/http/action/reload_tablet_action.cpp
+++ b/be/src/http/action/reload_tablet_action.cpp
@@ -38,7 +38,7 @@ const std::string PATH = "path";
 const std::string TABLET_ID = "tablet_id";
 const std::string SCHEMA_HASH = "schema_hash";
 
-ReloadTabletAction::ReloadTabletAction(ExecEnv* exec_env) : _exec_env(exec_env) {}
+ReloadTabletAction::ReloadTabletAction(ExecEnv* exec_env) : HttpHandlerWithAuth(exec_env) {}
 
 void ReloadTabletAction::handle(HttpRequest* req) {
     LOG(INFO) << "accept one request " << req->debug_string();

--- a/be/src/http/action/reload_tablet_action.cpp
+++ b/be/src/http/action/reload_tablet_action.cpp
@@ -38,7 +38,9 @@ const std::string PATH = "path";
 const std::string TABLET_ID = "tablet_id";
 const std::string SCHEMA_HASH = "schema_hash";
 
-ReloadTabletAction::ReloadTabletAction(ExecEnv* exec_env) : HttpHandlerWithAuth(exec_env) {}
+ReloadTabletAction::ReloadTabletAction(ExecEnv* exec_env, TPrivilegeHier::type hier,
+                                       TPrivilegeType::type type)
+        : HttpHandlerWithAuth(exec_env, hier, type) {}
 
 void ReloadTabletAction::handle(HttpRequest* req) {
     LOG(INFO) << "accept one request " << req->debug_string();

--- a/be/src/http/action/reload_tablet_action.h
+++ b/be/src/http/action/reload_tablet_action.h
@@ -41,8 +41,10 @@ private:
     ExecEnv* _exec_env;
 
     bool on_privilege(const HttpRequest& req, TCheckAuthRequest& auth_request) override {
-        auth_request.priv_ctrl.priv_hier = TPrivilegeHier::GLOBAL;
-        auth_request.priv_type = TPrivilegeType::ADMIN;
+        TPrivilegeCtrl priv_ctrl;
+        priv_ctrl.priv_hier = TPrivilegeHier::GLOBAL;
+        auth_request.__set_priv_ctrl(priv_ctrl);
+        auth_request.__set_priv_type(TPrivilegeType::ADMIN);
         return true;
     }
 

--- a/be/src/http/action/reload_tablet_action.h
+++ b/be/src/http/action/reload_tablet_action.h
@@ -30,7 +30,7 @@ class HttpRequest;
 
 class ReloadTabletAction : public HttpHandlerWithAuth {
 public:
-    ReloadTabletAction(ExecEnv* exec_env);
+    ReloadTabletAction(ExecEnv* exec_env, TPrivilegeHier::type hier, TPrivilegeType::type type);
 
     ~ReloadTabletAction() override = default;
 

--- a/be/src/http/action/reload_tablet_action.h
+++ b/be/src/http/action/reload_tablet_action.h
@@ -18,21 +18,20 @@
 #pragma once
 
 #include <stdint.h>
-
 #include <string>
 
-#include "http/http_handler.h"
+#include "http/http_handler_with_auth.h"
 
 namespace doris {
 
 class ExecEnv;
 class HttpRequest;
 
-class ReloadTabletAction : public HttpHandler {
+class ReloadTabletAction : public HttpHandlerWithAuth {
 public:
     ReloadTabletAction(ExecEnv* exec_env);
 
-    virtual ~ReloadTabletAction() {}
+    ~ReloadTabletAction() override = default;
 
     void handle(HttpRequest* req) override;
 
@@ -40,6 +39,12 @@ private:
     void reload(const std::string& path, int64_t tablet_id, int32_t schema_hash, HttpRequest* req);
 
     ExecEnv* _exec_env;
+
+    bool on_privilege(const HttpRequest& req, TCheckAuthRequest& auth_request) override {
+        auth_request.priv_ctrl.priv_hier = TPrivilegeHier::GLOBAL;
+        auth_request.priv_type = TPrivilegeType::ADMIN;
+        return true;
+    }
 
 }; // end class ReloadTabletAction
 

--- a/be/src/http/action/reload_tablet_action.h
+++ b/be/src/http/action/reload_tablet_action.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <stdint.h>
+
 #include <string>
 
 #include "http/http_handler_with_auth.h"
@@ -39,15 +40,6 @@ private:
     void reload(const std::string& path, int64_t tablet_id, int32_t schema_hash, HttpRequest* req);
 
     ExecEnv* _exec_env;
-
-    bool on_privilege(const HttpRequest& req, TCheckAuthRequest& auth_request) override {
-        TPrivilegeCtrl priv_ctrl;
-        priv_ctrl.priv_hier = TPrivilegeHier::GLOBAL;
-        auth_request.__set_priv_ctrl(priv_ctrl);
-        auth_request.__set_priv_type(TPrivilegeType::ADMIN);
-        return true;
-    }
-
 }; // end class ReloadTabletAction
 
 } // end namespace doris

--- a/be/src/http/action/reset_rpc_channel_action.cpp
+++ b/be/src/http/action/reset_rpc_channel_action.cpp
@@ -32,7 +32,7 @@
 #include "util/string_util.h"
 
 namespace doris {
-ResetRPCChannelAction::ResetRPCChannelAction(ExecEnv* exec_env) : _exec_env(exec_env) {}
+ResetRPCChannelAction::ResetRPCChannelAction(ExecEnv* exec_env) : HttpHandlerWithAuth(exec_env) {}
 void ResetRPCChannelAction::handle(HttpRequest* req) {
     std::string endpoints = req->param("endpoints");
     if (iequal(endpoints, "all")) {

--- a/be/src/http/action/reset_rpc_channel_action.cpp
+++ b/be/src/http/action/reset_rpc_channel_action.cpp
@@ -32,7 +32,9 @@
 #include "util/string_util.h"
 
 namespace doris {
-ResetRPCChannelAction::ResetRPCChannelAction(ExecEnv* exec_env) : HttpHandlerWithAuth(exec_env) {}
+ResetRPCChannelAction::ResetRPCChannelAction(ExecEnv* exec_env, TPrivilegeHier::type hier,
+                                             TPrivilegeType::type type)
+        : HttpHandlerWithAuth(exec_env, hier, type) {}
 void ResetRPCChannelAction::handle(HttpRequest* req) {
     std::string endpoints = req->param("endpoints");
     if (iequal(endpoints, "all")) {

--- a/be/src/http/action/reset_rpc_channel_action.h
+++ b/be/src/http/action/reset_rpc_channel_action.h
@@ -33,13 +33,5 @@ public:
 
 private:
     ExecEnv* _exec_env;
-
-    bool on_privilege(const HttpRequest& req, TCheckAuthRequest& auth_request) override {
-        TPrivilegeCtrl priv_ctrl;
-        priv_ctrl.priv_hier = TPrivilegeHier::GLOBAL;
-        auth_request.__set_priv_ctrl(priv_ctrl);
-        auth_request.__set_priv_type(TPrivilegeType::ADMIN);
-        return false;
-    }
 };
 } // namespace doris

--- a/be/src/http/action/reset_rpc_channel_action.h
+++ b/be/src/http/action/reset_rpc_channel_action.h
@@ -25,7 +25,8 @@ class HttpRequest;
 
 class ResetRPCChannelAction : public HttpHandlerWithAuth {
 public:
-    explicit ResetRPCChannelAction(ExecEnv* exec_env);
+    explicit ResetRPCChannelAction(ExecEnv* exec_env, TPrivilegeHier::type hier,
+                                   TPrivilegeType::type type);
 
     ~ResetRPCChannelAction() override = default;
 

--- a/be/src/http/action/reset_rpc_channel_action.h
+++ b/be/src/http/action/reset_rpc_channel_action.h
@@ -17,21 +17,27 @@
 
 #pragma once
 
-#include "http/http_handler.h"
+#include "http/http_handler_with_auth.h"
 
 namespace doris {
 class ExecEnv;
 class HttpRequest;
 
-class ResetRPCChannelAction : public HttpHandler {
+class ResetRPCChannelAction : public HttpHandlerWithAuth {
 public:
     explicit ResetRPCChannelAction(ExecEnv* exec_env);
 
-    virtual ~ResetRPCChannelAction() {}
+    ~ResetRPCChannelAction() override = default;
 
     void handle(HttpRequest* req) override;
 
 private:
     ExecEnv* _exec_env;
+
+    bool on_privilege(const HttpRequest& req, TCheckAuthRequest& auth_request) override {
+        auth_request.priv_ctrl.priv_hier = TPrivilegeHier::GLOBAL;
+        auth_request.priv_type = TPrivilegeType::ADMIN;
+        return false;
+    }
 };
 } // namespace doris

--- a/be/src/http/action/reset_rpc_channel_action.h
+++ b/be/src/http/action/reset_rpc_channel_action.h
@@ -35,8 +35,10 @@ private:
     ExecEnv* _exec_env;
 
     bool on_privilege(const HttpRequest& req, TCheckAuthRequest& auth_request) override {
-        auth_request.priv_ctrl.priv_hier = TPrivilegeHier::GLOBAL;
-        auth_request.priv_type = TPrivilegeType::ADMIN;
+        TPrivilegeCtrl priv_ctrl;
+        priv_ctrl.priv_hier = TPrivilegeHier::GLOBAL;
+        auth_request.__set_priv_ctrl(priv_ctrl);
+        auth_request.__set_priv_type(TPrivilegeType::ADMIN);
         return false;
     }
 };

--- a/be/src/http/action/restore_tablet_action.cpp
+++ b/be/src/http/action/restore_tablet_action.cpp
@@ -51,7 +51,9 @@ namespace doris {
 const std::string TABLET_ID = "tablet_id";
 const std::string SCHEMA_HASH = "schema_hash";
 
-RestoreTabletAction::RestoreTabletAction(ExecEnv* exec_env) : HttpHandlerWithAuth(exec_env) {}
+RestoreTabletAction::RestoreTabletAction(ExecEnv* exec_env, TPrivilegeHier::type hier,
+                                         TPrivilegeType::type type)
+        : HttpHandlerWithAuth(exec_env, hier, type) {}
 
 void RestoreTabletAction::handle(HttpRequest* req) {
     LOG(INFO) << "accept one request " << req->debug_string();

--- a/be/src/http/action/restore_tablet_action.cpp
+++ b/be/src/http/action/restore_tablet_action.cpp
@@ -51,7 +51,7 @@ namespace doris {
 const std::string TABLET_ID = "tablet_id";
 const std::string SCHEMA_HASH = "schema_hash";
 
-RestoreTabletAction::RestoreTabletAction(ExecEnv* exec_env) : _exec_env(exec_env) {}
+RestoreTabletAction::RestoreTabletAction(ExecEnv* exec_env) : HttpHandlerWithAuth(exec_env) {}
 
 void RestoreTabletAction::handle(HttpRequest* req) {
     LOG(INFO) << "accept one request " << req->debug_string();

--- a/be/src/http/action/restore_tablet_action.h
+++ b/be/src/http/action/restore_tablet_action.h
@@ -24,18 +24,18 @@
 #include <string>
 
 #include "common/status.h"
-#include "http/http_handler.h"
+#include "http/http_handler_with_auth.h"
 
 namespace doris {
 
 class ExecEnv;
 class HttpRequest;
 
-class RestoreTabletAction : public HttpHandler {
+class RestoreTabletAction : public HttpHandlerWithAuth {
 public:
     RestoreTabletAction(ExecEnv* exec_env);
 
-    virtual ~RestoreTabletAction() {}
+    ~RestoreTabletAction() override = default;
 
     void handle(HttpRequest* req) override;
 
@@ -64,6 +64,12 @@ private:
     // key: tablet_id + schema_hash
     // value: "" or tablet path in trash
     std::map<std::string, std::string> _tablet_path_map;
+
+    bool on_privilege(const HttpRequest& req, TCheckAuthRequest& auth_request) override {
+        auth_request.priv_ctrl.priv_hier = TPrivilegeHier::GLOBAL;
+        auth_request.priv_type = TPrivilegeType::ADMIN;
+        return true;
+    }
 }; // end class RestoreTabletAction
 
 } // end namespace doris

--- a/be/src/http/action/restore_tablet_action.h
+++ b/be/src/http/action/restore_tablet_action.h
@@ -66,8 +66,10 @@ private:
     std::map<std::string, std::string> _tablet_path_map;
 
     bool on_privilege(const HttpRequest& req, TCheckAuthRequest& auth_request) override {
-        auth_request.priv_ctrl.priv_hier = TPrivilegeHier::GLOBAL;
-        auth_request.priv_type = TPrivilegeType::ADMIN;
+        TPrivilegeCtrl priv_ctrl;
+        priv_ctrl.priv_hier = TPrivilegeHier::GLOBAL;
+        auth_request.__set_priv_ctrl(priv_ctrl);
+        auth_request.__set_priv_type(TPrivilegeType::ADMIN);
         return true;
     }
 }; // end class RestoreTabletAction

--- a/be/src/http/action/restore_tablet_action.h
+++ b/be/src/http/action/restore_tablet_action.h
@@ -33,7 +33,7 @@ class HttpRequest;
 
 class RestoreTabletAction : public HttpHandlerWithAuth {
 public:
-    RestoreTabletAction(ExecEnv* exec_env);
+    RestoreTabletAction(ExecEnv* exec_env, TPrivilegeHier::type hier, TPrivilegeType::type type);
 
     ~RestoreTabletAction() override = default;
 

--- a/be/src/http/action/restore_tablet_action.h
+++ b/be/src/http/action/restore_tablet_action.h
@@ -64,14 +64,6 @@ private:
     // key: tablet_id + schema_hash
     // value: "" or tablet path in trash
     std::map<std::string, std::string> _tablet_path_map;
-
-    bool on_privilege(const HttpRequest& req, TCheckAuthRequest& auth_request) override {
-        TPrivilegeCtrl priv_ctrl;
-        priv_ctrl.priv_hier = TPrivilegeHier::GLOBAL;
-        auth_request.__set_priv_ctrl(priv_ctrl);
-        auth_request.__set_priv_type(TPrivilegeType::ADMIN);
-        return true;
-    }
 }; // end class RestoreTabletAction
 
 } // end namespace doris

--- a/be/src/http/action/snapshot_action.cpp
+++ b/be/src/http/action/snapshot_action.cpp
@@ -36,7 +36,9 @@ namespace doris {
 const std::string TABLET_ID = "tablet_id";
 const std::string SCHEMA_HASH = "schema_hash";
 
-SnapshotAction::SnapshotAction(ExecEnv* exec_env) : HttpHandlerWithAuth(exec_env) {}
+SnapshotAction::SnapshotAction(ExecEnv* exec_env, TPrivilegeHier::type hier,
+                               TPrivilegeType::type type)
+        : HttpHandlerWithAuth(exec_env, hier, type) {}
 
 void SnapshotAction::handle(HttpRequest* req) {
     LOG(INFO) << "accept one request " << req->debug_string();

--- a/be/src/http/action/snapshot_action.cpp
+++ b/be/src/http/action/snapshot_action.cpp
@@ -36,7 +36,7 @@ namespace doris {
 const std::string TABLET_ID = "tablet_id";
 const std::string SCHEMA_HASH = "schema_hash";
 
-SnapshotAction::SnapshotAction() {}
+SnapshotAction::SnapshotAction(ExecEnv* exec_env) : HttpHandlerWithAuth(exec_env) {}
 
 void SnapshotAction::handle(HttpRequest* req) {
     LOG(INFO) << "accept one request " << req->debug_string();

--- a/be/src/http/action/snapshot_action.h
+++ b/be/src/http/action/snapshot_action.h
@@ -20,7 +20,7 @@
 #include <cstdint>
 #include <string>
 
-#include "http/http_handler.h"
+#include "http/http_handler_with_auth.h"
 
 namespace doris {
 
@@ -28,16 +28,22 @@ class HttpRequest;
 
 // make snapshot
 // be_host:be_http_port/api/snapshot?tablet_id=123&schema_hash=456
-class SnapshotAction : public HttpHandler {
+class SnapshotAction : public HttpHandlerWithAuth {
 public:
-    explicit SnapshotAction();
+    explicit SnapshotAction(ExecEnv* exec_env);
 
-    virtual ~SnapshotAction() {}
+    ~SnapshotAction() override = default;
 
     void handle(HttpRequest* req) override;
 
 private:
     int64_t _make_snapshot(int64_t tablet_id, int schema_hash, std::string* snapshot_path);
+
+    bool on_privilege(const HttpRequest& req, TCheckAuthRequest& auth_request) override {
+        auth_request.priv_ctrl.priv_hier = TPrivilegeHier::GLOBAL;
+        auth_request.priv_type = TPrivilegeType::ADMIN;
+        return true;
+    }
 }; // end class SnapshotAction
 
 } // end namespace doris

--- a/be/src/http/action/snapshot_action.h
+++ b/be/src/http/action/snapshot_action.h
@@ -30,7 +30,8 @@ class HttpRequest;
 // be_host:be_http_port/api/snapshot?tablet_id=123&schema_hash=456
 class SnapshotAction : public HttpHandlerWithAuth {
 public:
-    explicit SnapshotAction(ExecEnv* exec_env);
+    explicit SnapshotAction(ExecEnv* exec_env, TPrivilegeHier::type hier,
+                            TPrivilegeType::type type);
 
     ~SnapshotAction() override = default;
 

--- a/be/src/http/action/snapshot_action.h
+++ b/be/src/http/action/snapshot_action.h
@@ -38,14 +38,6 @@ public:
 
 private:
     int64_t _make_snapshot(int64_t tablet_id, int schema_hash, std::string* snapshot_path);
-
-    bool on_privilege(const HttpRequest& req, TCheckAuthRequest& auth_request) override {
-        TPrivilegeCtrl priv_ctrl;
-        priv_ctrl.priv_hier = TPrivilegeHier::GLOBAL;
-        auth_request.__set_priv_ctrl(priv_ctrl);
-        auth_request.__set_priv_type(TPrivilegeType::ADMIN);
-        return true;
-    }
 }; // end class SnapshotAction
 
 } // end namespace doris

--- a/be/src/http/action/snapshot_action.h
+++ b/be/src/http/action/snapshot_action.h
@@ -40,8 +40,10 @@ private:
     int64_t _make_snapshot(int64_t tablet_id, int schema_hash, std::string* snapshot_path);
 
     bool on_privilege(const HttpRequest& req, TCheckAuthRequest& auth_request) override {
-        auth_request.priv_ctrl.priv_hier = TPrivilegeHier::GLOBAL;
-        auth_request.priv_type = TPrivilegeType::ADMIN;
+        TPrivilegeCtrl priv_ctrl;
+        priv_ctrl.priv_hier = TPrivilegeHier::GLOBAL;
+        auth_request.__set_priv_ctrl(priv_ctrl);
+        auth_request.__set_priv_type(TPrivilegeType::ADMIN);
         return true;
     }
 }; // end class SnapshotAction

--- a/be/src/http/action/tablet_migration_action.cpp
+++ b/be/src/http/action/tablet_migration_action.cpp
@@ -36,10 +36,6 @@ namespace doris {
 
 const static std::string HEADER_JSON = "application/json";
 
-TabletMigrationAction::TabletMigrationAction() {
-    _init_migration_action();
-}
-
 void TabletMigrationAction::_init_migration_action() {
     int32_t max_thread_num = config::max_tablet_migration_threads;
     int32_t min_thread_num = config::min_tablet_migration_threads;

--- a/be/src/http/action/tablet_migration_action.h
+++ b/be/src/http/action/tablet_migration_action.h
@@ -99,8 +99,10 @@ private:
     std::deque<std::pair<MigrationTask, Status>> _finished_migration_tasks;
 
     bool on_privilege(const HttpRequest& req, TCheckAuthRequest& auth_request) override {
-        auth_request.priv_ctrl.priv_hier = TPrivilegeHier::GLOBAL;
-        auth_request.priv_type = TPrivilegeType::ADMIN;
+        TPrivilegeCtrl priv_ctrl;
+        priv_ctrl.priv_hier = TPrivilegeHier::GLOBAL;
+        auth_request.__set_priv_ctrl(priv_ctrl);
+        auth_request.__set_priv_type(TPrivilegeType::ADMIN);
         return true;
     }
 };

--- a/be/src/http/action/tablet_migration_action.h
+++ b/be/src/http/action/tablet_migration_action.h
@@ -28,9 +28,9 @@
 #include <utility>
 
 #include "common/status.h"
-#include "gutil/strings/substitute.h"
 #include "gutil/stringprintf.h"
 #include "gutil/strings/numbers.h"
+#include "gutil/strings/substitute.h"
 #include "http/http_handler_with_auth.h"
 #include "olap/data_dir.h"
 #include "olap/tablet.h"
@@ -97,13 +97,5 @@ private:
     std::mutex _migration_status_mutex;
     std::map<MigrationTask, std::string> _migration_tasks;
     std::deque<std::pair<MigrationTask, Status>> _finished_migration_tasks;
-
-    bool on_privilege(const HttpRequest& req, TCheckAuthRequest& auth_request) override {
-        TPrivilegeCtrl priv_ctrl;
-        priv_ctrl.priv_hier = TPrivilegeHier::GLOBAL;
-        auth_request.__set_priv_ctrl(priv_ctrl);
-        auth_request.__set_priv_type(TPrivilegeType::ADMIN);
-        return true;
-    }
 };
 } // namespace doris

--- a/be/src/http/action/tablet_migration_action.h
+++ b/be/src/http/action/tablet_migration_action.h
@@ -45,7 +45,8 @@ class ExecEnv;
 // Migrate a tablet from a disk to another.
 class TabletMigrationAction : public HttpHandlerWithAuth {
 public:
-    TabletMigrationAction(ExecEnv* exec_env) : HttpHandlerWithAuth(exec_env) {
+    TabletMigrationAction(ExecEnv* exec_env, TPrivilegeHier::type hier, TPrivilegeType::type type)
+            : HttpHandlerWithAuth(exec_env, hier, type) {
         _init_migration_action();
     }
 

--- a/be/src/http/action/tablets_distribution_action.cpp
+++ b/be/src/http/action/tablets_distribution_action.cpp
@@ -42,7 +42,8 @@ namespace doris {
 
 const static std::string HEADER_JSON = "application/json";
 
-TabletsDistributionAction::TabletsDistributionAction() {
+TabletsDistributionAction::TabletsDistributionAction(ExecEnv* exec_env)
+        : HttpHandlerWithAuth(exec_env) {
     _host = BackendOptions::get_localhost();
 }
 

--- a/be/src/http/action/tablets_distribution_action.cpp
+++ b/be/src/http/action/tablets_distribution_action.cpp
@@ -42,8 +42,9 @@ namespace doris {
 
 const static std::string HEADER_JSON = "application/json";
 
-TabletsDistributionAction::TabletsDistributionAction(ExecEnv* exec_env)
-        : HttpHandlerWithAuth(exec_env) {
+TabletsDistributionAction::TabletsDistributionAction(ExecEnv* exec_env, TPrivilegeHier::type hier,
+                                                     TPrivilegeType::type type)
+        : HttpHandlerWithAuth(exec_env, hier, type) {
     _host = BackendOptions::get_localhost();
 }
 

--- a/be/src/http/action/tablets_distribution_action.h
+++ b/be/src/http/action/tablets_distribution_action.h
@@ -46,8 +46,10 @@ private:
     std::string _host;
 
     bool on_privilege(const HttpRequest& req, TCheckAuthRequest& auth_request) override {
-        auth_request.priv_ctrl.priv_hier = TPrivilegeHier::GLOBAL;
-        auth_request.priv_type = TPrivilegeType::ADMIN;
+        TPrivilegeCtrl priv_ctrl;
+        priv_ctrl.priv_hier = TPrivilegeHier::GLOBAL;
+        auth_request.__set_priv_ctrl(priv_ctrl);
+        auth_request.__set_priv_type(TPrivilegeType::ADMIN);
         return true;
     }
 };

--- a/be/src/http/action/tablets_distribution_action.h
+++ b/be/src/http/action/tablets_distribution_action.h
@@ -32,7 +32,8 @@ class ExecEnv;
 // Get BE tablets distribution info from http API.
 class TabletsDistributionAction : public HttpHandlerWithAuth {
 public:
-    TabletsDistributionAction(ExecEnv* exec_env);
+    TabletsDistributionAction(ExecEnv* exec_env, TPrivilegeHier::type hier,
+                              TPrivilegeType::type type);
 
     ~TabletsDistributionAction() override = default;
 

--- a/be/src/http/action/tablets_distribution_action.h
+++ b/be/src/http/action/tablets_distribution_action.h
@@ -44,13 +44,5 @@ public:
 
 private:
     std::string _host;
-
-    bool on_privilege(const HttpRequest& req, TCheckAuthRequest& auth_request) override {
-        TPrivilegeCtrl priv_ctrl;
-        priv_ctrl.priv_hier = TPrivilegeHier::GLOBAL;
-        auth_request.__set_priv_ctrl(priv_ctrl);
-        auth_request.__set_priv_type(TPrivilegeType::ADMIN);
-        return true;
-    }
 };
 } // namespace doris

--- a/be/src/http/action/tablets_distribution_action.h
+++ b/be/src/http/action/tablets_distribution_action.h
@@ -21,21 +21,34 @@
 
 #include <string>
 
-#include "http/http_handler.h"
+#include "http/http_handler_with_auth.h"
 #include "util/easy_json.h"
 
 namespace doris {
 class HttpRequest;
 
+class ExecEnv;
+
 // Get BE tablets distribution info from http API.
-class TabletsDistributionAction : public HttpHandler {
+class TabletsDistributionAction : public HttpHandlerWithAuth {
 public:
-    TabletsDistributionAction();
+    TabletsDistributionAction(ExecEnv* exec_env);
+
+    ~TabletsDistributionAction() override = default;
+
     void handle(HttpRequest* req) override;
+
     EasyJson get_tablets_distribution_group_by_partition(uint64_t partition_id);
+
     std::string host() { return _host; }
 
 private:
     std::string _host;
+
+    bool on_privilege(const HttpRequest& req, TCheckAuthRequest& auth_request) override {
+        auth_request.priv_ctrl.priv_hier = TPrivilegeHier::GLOBAL;
+        auth_request.priv_type = TPrivilegeType::ADMIN;
+        return true;
+    }
 };
 } // namespace doris

--- a/be/src/http/action/tablets_info_action.cpp
+++ b/be/src/http/action/tablets_info_action.cpp
@@ -40,7 +40,9 @@ namespace doris {
 
 const static std::string HEADER_JSON = "application/json";
 
-TabletsInfoAction::TabletsInfoAction(ExecEnv* exec_env) : HttpHandlerWithAuth(exec_env) {}
+TabletsInfoAction::TabletsInfoAction(ExecEnv* exec_env, TPrivilegeHier::type hier,
+                                     TPrivilegeType::type type)
+        : HttpHandlerWithAuth(exec_env, hier, type) {}
 
 void TabletsInfoAction::handle(HttpRequest* req) {
     const std::string& tablet_num_to_return = req->param("limit");

--- a/be/src/http/action/tablets_info_action.cpp
+++ b/be/src/http/action/tablets_info_action.cpp
@@ -40,9 +40,7 @@ namespace doris {
 
 const static std::string HEADER_JSON = "application/json";
 
-TabletsInfoAction::TabletsInfoAction() {
-    _host = BackendOptions::get_localhost();
-}
+TabletsInfoAction::TabletsInfoAction(ExecEnv* exec_env) : HttpHandlerWithAuth(exec_env) {}
 
 void TabletsInfoAction::handle(HttpRequest* req) {
     const std::string& tablet_num_to_return = req->param("limit");
@@ -74,7 +72,7 @@ EasyJson TabletsInfoAction::get_tablets_info(string tablet_num_to_return) {
     tablets_info_ej["msg"] = msg;
     tablets_info_ej["code"] = 0;
     EasyJson data = tablets_info_ej.Set("data", EasyJson::kObject);
-    data["host"] = _host;
+    data["host"] = BackendOptions::get_localhost();
     EasyJson tablets = data.Set("tablets", EasyJson::kArray);
     for (TabletInfo tablet_info : tablets_info) {
         EasyJson tablet = tablets.PushBack(EasyJson::kObject);
@@ -84,4 +82,5 @@ EasyJson TabletsInfoAction::get_tablets_info(string tablet_num_to_return) {
     tablets_info_ej["count"] = tablets_info.size();
     return tablets_info_ej;
 }
+
 } // namespace doris

--- a/be/src/http/action/tablets_info_action.h
+++ b/be/src/http/action/tablets_info_action.h
@@ -19,21 +19,30 @@
 
 #include <string>
 
-#include "http/http_handler.h"
+#include "http/http_handler_with_auth.h"
 #include "util/easy_json.h"
 
 namespace doris {
 class HttpRequest;
 
+class ExecEnv;
+
 // Get BE tablets info from http API.
-class TabletsInfoAction : public HttpHandler {
+class TabletsInfoAction : public HttpHandlerWithAuth {
 public:
-    TabletsInfoAction();
+    TabletsInfoAction(ExecEnv* exec_env);
+
+    ~TabletsInfoAction() override = default;
+
     void handle(HttpRequest* req) override;
-    EasyJson get_tablets_info(std::string tablet_num_to_return);
-    std::string host() { return _host; }
+
+    static EasyJson get_tablets_info(std::string tablet_num_to_return);
 
 private:
-    std::string _host;
+    bool on_privilege(const HttpRequest& req, TCheckAuthRequest& auth_request) override {
+        auth_request.priv_ctrl.priv_hier = TPrivilegeHier::GLOBAL;
+        auth_request.priv_type = TPrivilegeType::ADMIN;
+        return true;
+    }
 };
 } // namespace doris

--- a/be/src/http/action/tablets_info_action.h
+++ b/be/src/http/action/tablets_info_action.h
@@ -37,14 +37,5 @@ public:
     void handle(HttpRequest* req) override;
 
     static EasyJson get_tablets_info(std::string tablet_num_to_return);
-
-private:
-    bool on_privilege(const HttpRequest& req, TCheckAuthRequest& auth_request) override {
-        TPrivilegeCtrl priv_ctrl;
-        priv_ctrl.priv_hier = TPrivilegeHier::GLOBAL;
-        auth_request.__set_priv_ctrl(priv_ctrl);
-        auth_request.__set_priv_type(TPrivilegeType::ADMIN);
-        return true;
-    }
 };
 } // namespace doris

--- a/be/src/http/action/tablets_info_action.h
+++ b/be/src/http/action/tablets_info_action.h
@@ -30,7 +30,7 @@ class ExecEnv;
 // Get BE tablets info from http API.
 class TabletsInfoAction : public HttpHandlerWithAuth {
 public:
-    TabletsInfoAction(ExecEnv* exec_env);
+    TabletsInfoAction(ExecEnv* exec_env, TPrivilegeHier::type hier, TPrivilegeType::type type);
 
     ~TabletsInfoAction() override = default;
 

--- a/be/src/http/action/tablets_info_action.h
+++ b/be/src/http/action/tablets_info_action.h
@@ -40,8 +40,10 @@ public:
 
 private:
     bool on_privilege(const HttpRequest& req, TCheckAuthRequest& auth_request) override {
-        auth_request.priv_ctrl.priv_hier = TPrivilegeHier::GLOBAL;
-        auth_request.priv_type = TPrivilegeType::ADMIN;
+        TPrivilegeCtrl priv_ctrl;
+        priv_ctrl.priv_hier = TPrivilegeHier::GLOBAL;
+        auth_request.__set_priv_ctrl(priv_ctrl);
+        auth_request.__set_priv_type(TPrivilegeType::ADMIN);
         return true;
     }
 };

--- a/be/src/http/action/version_action.cpp
+++ b/be/src/http/action/version_action.cpp
@@ -31,7 +31,7 @@ namespace doris {
 
 const static std::string HEADER_JSON = "application/json";
 
-VersionAction::VersionAction() {}
+VersionAction::VersionAction(ExecEnv* exec_env) : HttpHandlerWithAuth(exec_env) {}
 
 void VersionAction::handle(HttpRequest* req) {
     EasyJson be_version_info;

--- a/be/src/http/action/version_action.cpp
+++ b/be/src/http/action/version_action.cpp
@@ -31,7 +31,9 @@ namespace doris {
 
 const static std::string HEADER_JSON = "application/json";
 
-VersionAction::VersionAction(ExecEnv* exec_env) : HttpHandlerWithAuth(exec_env) {}
+VersionAction::VersionAction(ExecEnv* exec_env, TPrivilegeHier::type hier,
+                             TPrivilegeType::type type)
+        : HttpHandlerWithAuth(exec_env, hier, type) {}
 
 void VersionAction::handle(HttpRequest* req) {
     EasyJson be_version_info;

--- a/be/src/http/action/version_action.h
+++ b/be/src/http/action/version_action.h
@@ -15,25 +15,27 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#ifndef DORIS_BE_SRC_HTTP_ACTION_VERSION_ACTION_H
-#define DORIS_BE_SRC_HTTP_ACTION_VERSION_ACTION_H
+#pragma once
 
-#include "http/http_handler.h"
+#include "http/http_handler_with_auth.h"
 
 namespace doris {
 
 class HttpRequest;
 
 // Get BE version info from http API.
-class VersionAction : public HttpHandler {
+class VersionAction : public HttpHandlerWithAuth {
 public:
-    VersionAction();
+    VersionAction(ExecEnv* exec_env);
 
     ~VersionAction() override = default;
 
     void handle(HttpRequest* req) override;
+
+private:
+    bool on_privilege(const HttpRequest& req, TCheckAuthRequest& auth_request) override {
+        return true;
+    }
 };
 
 } // end namespace doris
-
-#endif // DORIS_BE_SRC_HTTP_ACTION_VERSION_ACTION_H

--- a/be/src/http/action/version_action.h
+++ b/be/src/http/action/version_action.h
@@ -26,7 +26,7 @@ class HttpRequest;
 // Get BE version info from http API.
 class VersionAction : public HttpHandlerWithAuth {
 public:
-    VersionAction(ExecEnv* exec_env);
+    VersionAction(ExecEnv* exec_env, TPrivilegeHier::type hier, TPrivilegeType::type type);
 
     ~VersionAction() override = default;
 

--- a/be/src/http/action/version_action.h
+++ b/be/src/http/action/version_action.h
@@ -31,11 +31,6 @@ public:
     ~VersionAction() override = default;
 
     void handle(HttpRequest* req) override;
-
-private:
-    bool on_privilege(const HttpRequest& req, TCheckAuthRequest& auth_request) override {
-        return true;
-    }
 };
 
 } // end namespace doris

--- a/be/src/http/default_path_handlers.cpp
+++ b/be/src/http/default_path_handlers.cpp
@@ -126,7 +126,6 @@ void mem_usage_handler(const WebPageHandler::ArgumentMap& args, std::stringstrea
 }
 
 void display_tablets_callback(const WebPageHandler::ArgumentMap& args, EasyJson* ej) {
-    TabletsInfoAction tablet_info_action;
     std::string tablet_num_to_return;
     WebPageHandler::ArgumentMap::const_iterator it = args.find("limit");
     if (it != args.end()) {
@@ -134,7 +133,7 @@ void display_tablets_callback(const WebPageHandler::ArgumentMap& args, EasyJson*
     } else {
         tablet_num_to_return = "1000"; // default
     }
-    (*ej) = tablet_info_action.get_tablets_info(tablet_num_to_return);
+    (*ej) = TabletsInfoAction::get_tablets_info(tablet_num_to_return);
 }
 
 // Registered to handle "/mem_tracker", and prints out memory tracker information.

--- a/be/src/http/http_handler_with_auth.cpp
+++ b/be/src/http/http_handler_with_auth.cpp
@@ -15,9 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include "http_handler_with_auth.h"
+#include <gen_cpp/HeartbeatService_types.h>
 
-#include "gen_cpp/HeartbeatService_types.h"
+#include "http_handler_with_auth.h"
 #include "http/http_channel.h"
 #include "runtime/client_cache.h"
 #include "util/thrift_rpc_helper.h"
@@ -31,6 +31,8 @@ class ThriftRpcHelper;
 
 HttpHandlerWithAuth::HttpHandlerWithAuth(ExecEnv* exec_env) {
     _exec_env = exec_env;
+    _hier = TPrivilegeHier::GLOBAL;
+    _type = TPrivilegeType::NONE;
 }
 
 int HttpHandlerWithAuth::on_header(HttpRequest* req) {

--- a/be/src/http/http_handler_with_auth.cpp
+++ b/be/src/http/http_handler_with_auth.cpp
@@ -1,0 +1,83 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "http_handler_with_auth.h"
+
+#include "gen_cpp/HeartbeatService_types.h"
+#include "http/http_channel.h"
+#include "runtime/client_cache.h"
+#include "util/thrift_rpc_helper.h"
+#include "utils.h"
+
+namespace doris {
+
+class TPrivilegeType;
+class TPrivilegeHier;
+class ThriftRpcHelper;
+
+HttpHandlerWithAuth::HttpHandlerWithAuth(ExecEnv* exec_env) {
+    _exec_env = exec_env;
+}
+
+int HttpHandlerWithAuth::on_header(HttpRequest* req) {
+    TCheckAuthRequest auth_request;
+    TCheckAuthResult auth_result;
+    AuthInfo auth_info;
+
+    if (!config::enable_auth) {
+        return 0;
+    }
+
+    if (!parse_basic_auth(*req, &auth_info)) {
+        LOG(WARNING) << "parse basic authorization failed"
+                     << ", request: " << req->debug_string();
+        HttpChannel::send_error(req, HttpStatus::BAD_REQUEST);
+        return -1;
+    }
+
+    auth_request.cluster = auth_info.cluster;
+    auth_request.user = auth_info.user;
+    auth_request.passwd = auth_info.passwd;
+    auth_request.user_ip = auth_info.user_ip;
+    auth_request.thrift_rpc_timeout_ms = config::thrift_rpc_timeout_ms;
+
+    if (!on_privilege(*req, auth_request)) {
+        LOG(WARNING) << "invalid privilege, request: " << req->debug_string();
+        HttpChannel::send_error(req, HttpStatus::BAD_REQUEST);
+        return -1;
+    }
+
+#ifndef BE_TEST
+    TNetworkAddress master_addr = _exec_env->master_info()->network_address;
+    RETURN_WITH_WARN_IF_ERROR(
+            ThriftRpcHelper::rpc<FrontendServiceClient>(
+                    master_addr.hostname, master_addr.port,
+                    [&auth_result, &auth_request](FrontendServiceConnection& client) {
+                        client->checkAuth(auth_result, auth_request);
+                    }),
+            -1, "checkAuth failed");
+#endif
+    Status status(auth_result.status);
+    if (!status.ok()) {
+        LOG(WARNING) << "permission verification failed, request: " << auth_request;
+        HttpChannel::send_error(req, HttpStatus::FORBIDDEN);
+        return -1;
+    }
+    return 0;
+}
+
+} // namespace doris

--- a/be/src/http/http_handler_with_auth.cpp
+++ b/be/src/http/http_handler_with_auth.cpp
@@ -45,15 +45,15 @@ int HttpHandlerWithAuth::on_header(HttpRequest* req) {
     if (!parse_basic_auth(*req, &auth_info)) {
         LOG(WARNING) << "parse basic authorization failed"
                      << ", request: " << req->debug_string();
-        HttpChannel::send_error(req, HttpStatus::BAD_REQUEST);
+        HttpChannel::send_error(req, HttpStatus::UNAUTHORIZED);
         return -1;
     }
 
-    auth_request.cluster = auth_info.cluster;
     auth_request.user = auth_info.user;
     auth_request.passwd = auth_info.passwd;
-    auth_request.user_ip = auth_info.user_ip;
-    auth_request.thrift_rpc_timeout_ms = config::thrift_rpc_timeout_ms;
+    auth_request.__set_cluster(auth_info.cluster);
+    auth_request.__set_user_ip(auth_info.user_ip);
+    auth_request.__set_thrift_rpc_timeout_ms(config::thrift_rpc_timeout_ms);
 
     if (!on_privilege(*req, auth_request)) {
         LOG(WARNING) << "invalid privilege, request: " << req->debug_string();

--- a/be/src/http/http_handler_with_auth.h
+++ b/be/src/http/http_handler_with_auth.h
@@ -35,7 +35,7 @@ class TPrivilegeType;
 // Handler for on http request with auth
 class HttpHandlerWithAuth : public HttpHandler {
 public:
-    HttpHandlerWithAuth(ExecEnv* exec_env);
+    HttpHandlerWithAuth(ExecEnv* exec_env, TPrivilegeHier::type hier, TPrivilegeType::type type);
 
     ~HttpHandlerWithAuth() override = default;
 
@@ -49,11 +49,6 @@ public:
         auth_request.__set_priv_ctrl(priv_ctrl);
         auth_request.__set_priv_type(_type);
         return true;
-    }
-
-    void auth(TPrivilegeHier::type hier, TPrivilegeType::type type) {
-        _hier = hier;
-        _type = type;
     }
 
 private:

--- a/be/src/http/http_handler_with_auth.h
+++ b/be/src/http/http_handler_with_auth.h
@@ -17,28 +17,31 @@
 
 #pragma once
 
-#include <map>
-#include <string>
-
-#include "http/http_handler.h"
+#include "http_handler.h"
+#include "runtime/exec_env.h"
 
 namespace doris {
 
+class ExecEnv;
 class HttpRequest;
 class RestMonitorIface;
+class TCheckAuthRequest;
 
-class MonitorAction : public HttpHandler {
+// Handler for on http request with auth
+class HttpHandlerWithAuth : public HttpHandler {
 public:
-    MonitorAction();
+    HttpHandlerWithAuth(ExecEnv* exec_env);
 
-    virtual ~MonitorAction() {}
+    virtual ~HttpHandlerWithAuth() {}
 
-    void register_module(const std::string& name, RestMonitorIface* module);
+    // return 0 if auth pass, otherwise -1.
+    virtual int on_header(HttpRequest* req) override;
 
-    void handle(HttpRequest* req) override;
+    // return true if fill privilege success, otherwise false.
+    virtual bool on_privilege(const HttpRequest& req, TCheckAuthRequest& auth_request) = 0;
 
 private:
-    std::map<std::string, RestMonitorIface*> _module_by_name;
+    ExecEnv* _exec_env;
 };
 
 } // namespace doris

--- a/be/src/http/utils.h
+++ b/be/src/http/utils.h
@@ -19,6 +19,7 @@
 
 #include <string>
 
+#include "common/utils.h"
 #include "http/http_request.h"
 
 namespace doris {

--- a/be/src/service/http_service.cpp
+++ b/be/src/service/http_service.cpp
@@ -108,16 +108,19 @@ Status HttpService::start() {
 
     // Register Tablets Info action
     TabletsInfoAction* tablets_info_action = _pool.add(new TabletsInfoAction(_env));
+    tablets_info_action->auth(TPrivilegeHier::GLOBAL, TPrivilegeType::ADMIN);
     _ev_http_server->register_handler(HttpMethod::GET, "/tablets_json", tablets_info_action);
 
     // Register Tablets Distribution action
     TabletsDistributionAction* tablets_distribution_action =
             _pool.add(new TabletsDistributionAction(_env));
+    tablets_distribution_action->auth(TPrivilegeHier::GLOBAL, TPrivilegeType::ADMIN);
     _ev_http_server->register_handler(HttpMethod::GET, "/api/tablets_distribution",
                                       tablets_distribution_action);
 
     // Register tablet migration action
     TabletMigrationAction* tablet_migration_action = _pool.add(new TabletMigrationAction(_env));
+    tablet_migration_action->auth(TPrivilegeHier::GLOBAL, TPrivilegeType::ADMIN);
     _ev_http_server->register_handler(HttpMethod::GET, "/api/tablet_migration",
                                       tablet_migration_action);
 
@@ -135,37 +138,45 @@ Status HttpService::start() {
     }
 
     MetaAction* meta_action = _pool.add(new MetaAction(_env));
+    meta_action->auth(TPrivilegeHier::GLOBAL, TPrivilegeType::ADMIN);
     _ev_http_server->register_handler(HttpMethod::GET, "/api/meta/{op}/{tablet_id}", meta_action);
 
 #ifndef BE_TEST
     // Register BE checksum action
     ChecksumAction* checksum_action = _pool.add(new ChecksumAction(_env));
+    checksum_action->auth(TPrivilegeHier::GLOBAL, TPrivilegeType::ADMIN);
     _ev_http_server->register_handler(HttpMethod::GET, "/api/checksum", checksum_action);
 
     // Register BE reload tablet action
     ReloadTabletAction* reload_tablet_action = _pool.add(new ReloadTabletAction(_env));
+    reload_tablet_action->auth(TPrivilegeHier::GLOBAL, TPrivilegeType::ADMIN);
     _ev_http_server->register_handler(HttpMethod::GET, "/api/reload_tablet", reload_tablet_action);
 
     RestoreTabletAction* restore_tablet_action = _pool.add(new RestoreTabletAction(_env));
+    restore_tablet_action->auth(TPrivilegeHier::GLOBAL, TPrivilegeType::ADMIN);
     _ev_http_server->register_handler(HttpMethod::POST, "/api/restore_tablet",
                                       restore_tablet_action);
 
     // Register BE snapshot action
     SnapshotAction* snapshot_action = _pool.add(new SnapshotAction(_env));
+    snapshot_action->auth(TPrivilegeHier::GLOBAL, TPrivilegeType::ADMIN);
     _ev_http_server->register_handler(HttpMethod::GET, "/api/snapshot", snapshot_action);
 #endif
 
     // 2 compaction actions
     CompactionAction* show_compaction_action =
             _pool.add(new CompactionAction(CompactionActionType::SHOW_INFO, _env));
+    show_compaction_action->auth(TPrivilegeHier::GLOBAL, TPrivilegeType::ADMIN);
     _ev_http_server->register_handler(HttpMethod::GET, "/api/compaction/show",
                                       show_compaction_action);
     CompactionAction* run_compaction_action =
             _pool.add(new CompactionAction(CompactionActionType::RUN_COMPACTION, _env));
+    run_compaction_action->auth(TPrivilegeHier::GLOBAL, TPrivilegeType::ADMIN);
     _ev_http_server->register_handler(HttpMethod::POST, "/api/compaction/run",
                                       run_compaction_action);
     CompactionAction* run_status_compaction_action =
             _pool.add(new CompactionAction(CompactionActionType::RUN_COMPACTION_STATUS, _env));
+    run_status_compaction_action->auth(TPrivilegeHier::GLOBAL, TPrivilegeType::ADMIN);
     _ev_http_server->register_handler(HttpMethod::GET, "/api/compaction/run_status",
                                       run_status_compaction_action);
 
@@ -178,20 +189,24 @@ Status HttpService::start() {
 
     // 3 check action
     CheckRPCChannelAction* check_rpc_channel_action = _pool.add(new CheckRPCChannelAction(_env));
+    check_rpc_channel_action->auth(TPrivilegeHier::GLOBAL, TPrivilegeType::ADMIN);
     _ev_http_server->register_handler(HttpMethod::GET,
                                       "/api/check_rpc_channel/{ip}/{port}/{payload_size}",
                                       check_rpc_channel_action);
 
     ResetRPCChannelAction* reset_rpc_channel_action = _pool.add(new ResetRPCChannelAction(_env));
+    reset_rpc_channel_action->auth(TPrivilegeHier::GLOBAL, TPrivilegeType::ADMIN);
     _ev_http_server->register_handler(HttpMethod::GET, "/api/reset_rpc_channel/{endpoints}",
                                       reset_rpc_channel_action);
 
     CheckTabletSegmentAction* check_tablet_segment_action =
             _pool.add(new CheckTabletSegmentAction(_env));
+    check_tablet_segment_action->auth(TPrivilegeHier::GLOBAL, TPrivilegeType::ADMIN);
     _ev_http_server->register_handler(HttpMethod::POST, "/api/check_tablet_segment_lost",
                                       check_tablet_segment_action);
 
     PadRowsetAction* pad_rowset_action = _pool.add(new PadRowsetAction(_env));
+    pad_rowset_action->auth(TPrivilegeHier::GLOBAL, TPrivilegeType::ADMIN);
     _ev_http_server->register_handler(HttpMethod::POST, "api/pad_rowset", pad_rowset_action);
 
     _ev_http_server->start();

--- a/be/src/service/http_service.cpp
+++ b/be/src/service/http_service.cpp
@@ -99,7 +99,7 @@ Status HttpService::start() {
                                       error_log_download_action);
 
     // Register BE version action
-    VersionAction* version_action = _pool.add(new VersionAction());
+    VersionAction* version_action = _pool.add(new VersionAction(_env));
     _ev_http_server->register_handler(HttpMethod::GET, "/api/be_version_info", version_action);
 
     // Register BE health action
@@ -107,17 +107,17 @@ Status HttpService::start() {
     _ev_http_server->register_handler(HttpMethod::GET, "/api/health", health_action);
 
     // Register Tablets Info action
-    TabletsInfoAction* tablets_info_action = _pool.add(new TabletsInfoAction());
+    TabletsInfoAction* tablets_info_action = _pool.add(new TabletsInfoAction(_env));
     _ev_http_server->register_handler(HttpMethod::GET, "/tablets_json", tablets_info_action);
 
     // Register Tablets Distribution action
     TabletsDistributionAction* tablets_distribution_action =
-            _pool.add(new TabletsDistributionAction());
+            _pool.add(new TabletsDistributionAction(_env));
     _ev_http_server->register_handler(HttpMethod::GET, "/api/tablets_distribution",
                                       tablets_distribution_action);
 
     // Register tablet migration action
-    TabletMigrationAction* tablet_migration_action = _pool.add(new TabletMigrationAction());
+    TabletMigrationAction* tablet_migration_action = _pool.add(new TabletMigrationAction(_env));
     _ev_http_server->register_handler(HttpMethod::GET, "/api/tablet_migration",
                                       tablet_migration_action);
 
@@ -129,16 +129,17 @@ Status HttpService::start() {
 
     // register metrics
     {
-        auto action = _pool.add(new MetricsAction(DorisMetrics::instance()->metric_registry()));
+        auto action =
+                _pool.add(new MetricsAction(DorisMetrics::instance()->metric_registry(), _env));
         _ev_http_server->register_handler(HttpMethod::GET, "/metrics", action);
     }
 
-    MetaAction* meta_action = _pool.add(new MetaAction());
+    MetaAction* meta_action = _pool.add(new MetaAction(_env));
     _ev_http_server->register_handler(HttpMethod::GET, "/api/meta/{op}/{tablet_id}", meta_action);
 
 #ifndef BE_TEST
     // Register BE checksum action
-    ChecksumAction* checksum_action = _pool.add(new ChecksumAction());
+    ChecksumAction* checksum_action = _pool.add(new ChecksumAction(_env));
     _ev_http_server->register_handler(HttpMethod::GET, "/api/checksum", checksum_action);
 
     // Register BE reload tablet action
@@ -150,21 +151,21 @@ Status HttpService::start() {
                                       restore_tablet_action);
 
     // Register BE snapshot action
-    SnapshotAction* snapshot_action = _pool.add(new SnapshotAction());
+    SnapshotAction* snapshot_action = _pool.add(new SnapshotAction(_env));
     _ev_http_server->register_handler(HttpMethod::GET, "/api/snapshot", snapshot_action);
 #endif
 
     // 2 compaction actions
     CompactionAction* show_compaction_action =
-            _pool.add(new CompactionAction(CompactionActionType::SHOW_INFO));
+            _pool.add(new CompactionAction(CompactionActionType::SHOW_INFO, _env));
     _ev_http_server->register_handler(HttpMethod::GET, "/api/compaction/show",
                                       show_compaction_action);
     CompactionAction* run_compaction_action =
-            _pool.add(new CompactionAction(CompactionActionType::RUN_COMPACTION));
+            _pool.add(new CompactionAction(CompactionActionType::RUN_COMPACTION, _env));
     _ev_http_server->register_handler(HttpMethod::POST, "/api/compaction/run",
                                       run_compaction_action);
     CompactionAction* run_status_compaction_action =
-            _pool.add(new CompactionAction(CompactionActionType::RUN_COMPACTION_STATUS));
+            _pool.add(new CompactionAction(CompactionActionType::RUN_COMPACTION_STATUS, _env));
     _ev_http_server->register_handler(HttpMethod::GET, "/api/compaction/run_status",
                                       run_status_compaction_action);
 
@@ -186,11 +187,11 @@ Status HttpService::start() {
                                       reset_rpc_channel_action);
 
     CheckTabletSegmentAction* check_tablet_segment_action =
-            _pool.add(new CheckTabletSegmentAction());
+            _pool.add(new CheckTabletSegmentAction(_env));
     _ev_http_server->register_handler(HttpMethod::POST, "/api/check_tablet_segment_lost",
                                       check_tablet_segment_action);
 
-    PadRowsetAction* pad_rowset_action = _pool.add(new PadRowsetAction());
+    PadRowsetAction* pad_rowset_action = _pool.add(new PadRowsetAction(_env));
     _ev_http_server->register_handler(HttpMethod::POST, "api/pad_rowset", pad_rowset_action);
 
     _ev_http_server->start();

--- a/be/src/service/http_service.cpp
+++ b/be/src/service/http_service.cpp
@@ -99,7 +99,8 @@ Status HttpService::start() {
                                       error_log_download_action);
 
     // Register BE version action
-    VersionAction* version_action = _pool.add(new VersionAction(_env));
+    VersionAction* version_action =
+            _pool.add(new VersionAction(_env, TPrivilegeHier::GLOBAL, TPrivilegeType::NONE));
     _ev_http_server->register_handler(HttpMethod::GET, "/api/be_version_info", version_action);
 
     // Register BE health action
@@ -107,20 +108,19 @@ Status HttpService::start() {
     _ev_http_server->register_handler(HttpMethod::GET, "/api/health", health_action);
 
     // Register Tablets Info action
-    TabletsInfoAction* tablets_info_action = _pool.add(new TabletsInfoAction(_env));
-    tablets_info_action->auth(TPrivilegeHier::GLOBAL, TPrivilegeType::ADMIN);
+    TabletsInfoAction* tablets_info_action =
+            _pool.add(new TabletsInfoAction(_env, TPrivilegeHier::GLOBAL, TPrivilegeType::ADMIN));
     _ev_http_server->register_handler(HttpMethod::GET, "/tablets_json", tablets_info_action);
 
     // Register Tablets Distribution action
-    TabletsDistributionAction* tablets_distribution_action =
-            _pool.add(new TabletsDistributionAction(_env));
-    tablets_distribution_action->auth(TPrivilegeHier::GLOBAL, TPrivilegeType::ADMIN);
+    TabletsDistributionAction* tablets_distribution_action = _pool.add(
+            new TabletsDistributionAction(_env, TPrivilegeHier::GLOBAL, TPrivilegeType::ADMIN));
     _ev_http_server->register_handler(HttpMethod::GET, "/api/tablets_distribution",
                                       tablets_distribution_action);
 
     // Register tablet migration action
-    TabletMigrationAction* tablet_migration_action = _pool.add(new TabletMigrationAction(_env));
-    tablet_migration_action->auth(TPrivilegeHier::GLOBAL, TPrivilegeType::ADMIN);
+    TabletMigrationAction* tablet_migration_action = _pool.add(
+            new TabletMigrationAction(_env, TPrivilegeHier::GLOBAL, TPrivilegeType::ADMIN));
     _ev_http_server->register_handler(HttpMethod::GET, "/api/tablet_migration",
                                       tablet_migration_action);
 
@@ -132,51 +132,50 @@ Status HttpService::start() {
 
     // register metrics
     {
-        auto action =
-                _pool.add(new MetricsAction(DorisMetrics::instance()->metric_registry(), _env));
+        auto action = _pool.add(new MetricsAction(DorisMetrics::instance()->metric_registry(), _env,
+                                                  TPrivilegeHier::GLOBAL, TPrivilegeType::NONE));
         _ev_http_server->register_handler(HttpMethod::GET, "/metrics", action);
     }
 
-    MetaAction* meta_action = _pool.add(new MetaAction(_env));
-    meta_action->auth(TPrivilegeHier::GLOBAL, TPrivilegeType::ADMIN);
+    MetaAction* meta_action =
+            _pool.add(new MetaAction(_env, TPrivilegeHier::GLOBAL, TPrivilegeType::ADMIN));
     _ev_http_server->register_handler(HttpMethod::GET, "/api/meta/{op}/{tablet_id}", meta_action);
 
 #ifndef BE_TEST
     // Register BE checksum action
-    ChecksumAction* checksum_action = _pool.add(new ChecksumAction(_env));
-    checksum_action->auth(TPrivilegeHier::GLOBAL, TPrivilegeType::ADMIN);
+    ChecksumAction* checksum_action =
+            _pool.add(new ChecksumAction(_env, TPrivilegeHier::GLOBAL, TPrivilegeType::ADMIN));
     _ev_http_server->register_handler(HttpMethod::GET, "/api/checksum", checksum_action);
 
     // Register BE reload tablet action
-    ReloadTabletAction* reload_tablet_action = _pool.add(new ReloadTabletAction(_env));
-    reload_tablet_action->auth(TPrivilegeHier::GLOBAL, TPrivilegeType::ADMIN);
+    ReloadTabletAction* reload_tablet_action =
+            _pool.add(new ReloadTabletAction(_env, TPrivilegeHier::GLOBAL, TPrivilegeType::ADMIN));
     _ev_http_server->register_handler(HttpMethod::GET, "/api/reload_tablet", reload_tablet_action);
 
-    RestoreTabletAction* restore_tablet_action = _pool.add(new RestoreTabletAction(_env));
-    restore_tablet_action->auth(TPrivilegeHier::GLOBAL, TPrivilegeType::ADMIN);
+    RestoreTabletAction* restore_tablet_action =
+            _pool.add(new RestoreTabletAction(_env, TPrivilegeHier::GLOBAL, TPrivilegeType::ADMIN));
     _ev_http_server->register_handler(HttpMethod::POST, "/api/restore_tablet",
                                       restore_tablet_action);
 
     // Register BE snapshot action
-    SnapshotAction* snapshot_action = _pool.add(new SnapshotAction(_env));
-    snapshot_action->auth(TPrivilegeHier::GLOBAL, TPrivilegeType::ADMIN);
+    SnapshotAction* snapshot_action =
+            _pool.add(new SnapshotAction(_env, TPrivilegeHier::GLOBAL, TPrivilegeType::ADMIN));
     _ev_http_server->register_handler(HttpMethod::GET, "/api/snapshot", snapshot_action);
 #endif
 
     // 2 compaction actions
-    CompactionAction* show_compaction_action =
-            _pool.add(new CompactionAction(CompactionActionType::SHOW_INFO, _env));
-    show_compaction_action->auth(TPrivilegeHier::GLOBAL, TPrivilegeType::ADMIN);
+    CompactionAction* show_compaction_action = _pool.add(new CompactionAction(
+            CompactionActionType::SHOW_INFO, _env, TPrivilegeHier::GLOBAL, TPrivilegeType::ADMIN));
     _ev_http_server->register_handler(HttpMethod::GET, "/api/compaction/show",
                                       show_compaction_action);
     CompactionAction* run_compaction_action =
-            _pool.add(new CompactionAction(CompactionActionType::RUN_COMPACTION, _env));
-    run_compaction_action->auth(TPrivilegeHier::GLOBAL, TPrivilegeType::ADMIN);
+            _pool.add(new CompactionAction(CompactionActionType::RUN_COMPACTION, _env,
+                                           TPrivilegeHier::GLOBAL, TPrivilegeType::ADMIN));
     _ev_http_server->register_handler(HttpMethod::POST, "/api/compaction/run",
                                       run_compaction_action);
     CompactionAction* run_status_compaction_action =
-            _pool.add(new CompactionAction(CompactionActionType::RUN_COMPACTION_STATUS, _env));
-    run_status_compaction_action->auth(TPrivilegeHier::GLOBAL, TPrivilegeType::ADMIN);
+            _pool.add(new CompactionAction(CompactionActionType::RUN_COMPACTION_STATUS, _env,
+                                           TPrivilegeHier::GLOBAL, TPrivilegeType::ADMIN));
     _ev_http_server->register_handler(HttpMethod::GET, "/api/compaction/run_status",
                                       run_status_compaction_action);
 
@@ -188,25 +187,24 @@ Status HttpService::start() {
     _ev_http_server->register_handler(HttpMethod::GET, "/api/show_config", show_config_action);
 
     // 3 check action
-    CheckRPCChannelAction* check_rpc_channel_action = _pool.add(new CheckRPCChannelAction(_env));
-    check_rpc_channel_action->auth(TPrivilegeHier::GLOBAL, TPrivilegeType::ADMIN);
+    CheckRPCChannelAction* check_rpc_channel_action = _pool.add(
+            new CheckRPCChannelAction(_env, TPrivilegeHier::GLOBAL, TPrivilegeType::ADMIN));
     _ev_http_server->register_handler(HttpMethod::GET,
                                       "/api/check_rpc_channel/{ip}/{port}/{payload_size}",
                                       check_rpc_channel_action);
 
-    ResetRPCChannelAction* reset_rpc_channel_action = _pool.add(new ResetRPCChannelAction(_env));
-    reset_rpc_channel_action->auth(TPrivilegeHier::GLOBAL, TPrivilegeType::ADMIN);
+    ResetRPCChannelAction* reset_rpc_channel_action = _pool.add(
+            new ResetRPCChannelAction(_env, TPrivilegeHier::GLOBAL, TPrivilegeType::ADMIN));
     _ev_http_server->register_handler(HttpMethod::GET, "/api/reset_rpc_channel/{endpoints}",
                                       reset_rpc_channel_action);
 
-    CheckTabletSegmentAction* check_tablet_segment_action =
-            _pool.add(new CheckTabletSegmentAction(_env));
-    check_tablet_segment_action->auth(TPrivilegeHier::GLOBAL, TPrivilegeType::ADMIN);
+    CheckTabletSegmentAction* check_tablet_segment_action = _pool.add(
+            new CheckTabletSegmentAction(_env, TPrivilegeHier::GLOBAL, TPrivilegeType::ADMIN));
     _ev_http_server->register_handler(HttpMethod::POST, "/api/check_tablet_segment_lost",
                                       check_tablet_segment_action);
 
-    PadRowsetAction* pad_rowset_action = _pool.add(new PadRowsetAction(_env));
-    pad_rowset_action->auth(TPrivilegeHier::GLOBAL, TPrivilegeType::ADMIN);
+    PadRowsetAction* pad_rowset_action =
+            _pool.add(new PadRowsetAction(_env, TPrivilegeHier::GLOBAL, TPrivilegeType::ADMIN));
     _ev_http_server->register_handler(HttpMethod::POST, "api/pad_rowset", pad_rowset_action);
 
     _ev_http_server->start();

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -62,6 +62,7 @@ set(HTTP_TEST_FILES
     http/message_body_sink_test.cpp
     http/http_utils_test.cpp
     http/http_client_test.cpp
+    http/http_auth_test.cpp
     # TODO this will overide HttpChannel and make other test failed
     # http/metrics_action_test.cpp
 )

--- a/be/test/http/http_auth_test.cpp
+++ b/be/test/http/http_auth_test.cpp
@@ -22,6 +22,7 @@
 #include "http/http_channel.h"
 #include "http/http_handler.h"
 #include "http/http_handler_with_auth.h"
+#include "http/http_headers.h"
 #include "http/http_request.h"
 #include "http/utils.h"
 

--- a/be/test/http/http_auth_test.cpp
+++ b/be/test/http/http_auth_test.cpp
@@ -30,7 +30,8 @@ namespace doris {
 
 class HttpAuthTestHandler : public HttpHandlerWithAuth {
 public:
-    HttpAuthTestHandler(ExecEnv* exec_env) : HttpHandlerWithAuth(exec_env) {}
+    HttpAuthTestHandler(ExecEnv* exec_env, TPrivilegeHier::type hier, TPrivilegeType::type type)
+            : HttpHandlerWithAuth(exec_env, hier, type) {}
 
     ~HttpAuthTestHandler() override = default;
 
@@ -42,12 +43,13 @@ private:
     };
 };
 
-static HttpAuthTestHandler s_auth_handler = HttpAuthTestHandler(nullptr);
+static HttpAuthTestHandler s_auth_handler =
+        HttpAuthTestHandler(nullptr, TPrivilegeHier::GLOBAL, TPrivilegeType::ADMIN);
 
 class HttpAuthTest : public testing::Test {};
 
 TEST_F(HttpAuthTest, disable_auth) {
-    EXPECT_FALSE(config::enable_auth);
+    EXPECT_FALSE(config::enable_http_auth);
 
     auto evhttp_req = evhttp_request_new(nullptr, nullptr);
     HttpRequest req(evhttp_req);
@@ -55,8 +57,8 @@ TEST_F(HttpAuthTest, disable_auth) {
     evhttp_request_free(evhttp_req);
 }
 
-TEST_F(HttpAuthTest, enable_auth) {
-    config::enable_auth = true;
+TEST_F(HttpAuthTest, enable_http_auth) {
+    config::enable_http_auth = true;
 
     // 1. empty auth info
     {

--- a/be/test/http/http_auth_test.cpp
+++ b/be/test/http/http_auth_test.cpp
@@ -1,0 +1,88 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <gtest/gtest.h>
+
+#include "common/config.h"
+#include "http/ev_http_server.h"
+#include "http/http_channel.h"
+#include "http/http_handler.h"
+#include "http/http_handler_with_auth.h"
+#include "http/http_request.h"
+#include "http/utils.h"
+
+namespace doris {
+
+class HttpAuthTestHandler : public HttpHandlerWithAuth {
+public:
+    HttpAuthTestHandler(ExecEnv* exec_env) : HttpHandlerWithAuth(exec_env) {}
+
+    ~HttpAuthTestHandler() override = default;
+
+    void handle(HttpRequest* req) override {}
+
+private:
+    bool on_privilege(const HttpRequest& req, TCheckAuthRequest& auth_request) override {
+        return !req.param("table").empty();
+    };
+};
+
+static HttpAuthTestHandler s_auth_handler = HttpAuthTestHandler(nullptr);
+
+class HttpAuthTest : public testing::Test {};
+
+TEST_F(HttpAuthTest, disable_auth) {
+    EXPECT_FALSE(config::enable_auth);
+
+    auto evhttp_req = evhttp_request_new(nullptr, nullptr);
+    HttpRequest req(evhttp_req);
+    EXPECT_EQ(s_auth_handler.on_header(&req), 0);
+    evhttp_request_free(evhttp_req);
+}
+
+TEST_F(HttpAuthTest, enable_auth) {
+    config::enable_auth = true;
+
+    // 1. empty auth info
+    {
+        auto evhttp_req = evhttp_request_new(nullptr, nullptr);
+        HttpRequest req1(evhttp_req);
+        EXPECT_EQ(s_auth_handler.on_header(&req1), -1);
+    }
+
+    // 2. empty param
+    {
+        auto evhttp_req = evhttp_request_new(nullptr, nullptr);
+        HttpRequest req2(evhttp_req);
+        auto auth = encode_basic_auth("doris", "passwd");
+        req2._headers.emplace(HttpHeaders::AUTHORIZATION, auth);
+        EXPECT_EQ(s_auth_handler.on_header(&req2), -1);
+    }
+
+    // 3. OK
+    {
+        auto evhttp_req = evhttp_request_new(nullptr, nullptr);
+        HttpRequest req3(evhttp_req);
+        auto auth = encode_basic_auth("doris", "passwd");
+        req3._headers.emplace(HttpHeaders::AUTHORIZATION, auth);
+        req3._params.emplace("table", "T");
+        EXPECT_EQ(s_auth_handler.on_header(&req3), 0);
+        evhttp_request_free(evhttp_req);
+    }
+}
+
+} // namespace doris

--- a/be/test/olap/tablet_test.cpp
+++ b/be/test/olap/tablet_test.cpp
@@ -41,8 +41,6 @@
 using namespace std;
 
 namespace doris {
-using namespace ErrorCode;
-
 using RowsetMetaSharedContainerPtr = std::shared_ptr<std::vector<RowsetMetaSharedPtr>>;
 
 static StorageEngine* k_engine = nullptr;
@@ -275,7 +273,7 @@ TEST_F(TestTablet, pad_rowset) {
     ASSERT_FALSE(_tablet->capture_rs_readers(version, &readers).ok());
     readers.clear();
 
-    PadRowsetAction action;
+    PadRowsetAction action(nullptr);
     action._pad_rowset(_tablet, version);
     ASSERT_TRUE(_tablet->capture_rs_readers(version, &readers).ok());
 }
@@ -418,23 +416,23 @@ TEST_F(TestTablet, rowset_tree_update) {
 
     RowLocation loc;
     // Key not in range.
-    ASSERT_TRUE(tablet->lookup_row_key("99", true, &rowset_ids, &loc, 7).is<NOT_FOUND>());
+    ASSERT_TRUE(tablet->lookup_row_key("99", true, &rowset_ids, &loc, 7).is<ErrorCode::NOT_FOUND>());
     // Version too low.
-    ASSERT_TRUE(tablet->lookup_row_key("101", true, &rowset_ids, &loc, 3).is<NOT_FOUND>());
+    ASSERT_TRUE(tablet->lookup_row_key("101", true, &rowset_ids, &loc, 3).is<ErrorCode::NOT_FOUND>());
     // Hit a segment, but since we don't have real data, return an internal error when loading the
     // segment.
     LOG(INFO) << tablet->lookup_row_key("101", true, &rowset_ids, &loc, 7).to_string();
-    ASSERT_TRUE(tablet->lookup_row_key("101", true, &rowset_ids, &loc, 7).is<IO_ERROR>());
+    ASSERT_TRUE(tablet->lookup_row_key("101", true, &rowset_ids, &loc, 7).is<ErrorCode::IO_ERROR>());
     // Key not in range.
-    ASSERT_TRUE(tablet->lookup_row_key("201", true, &rowset_ids, &loc, 7).is<NOT_FOUND>());
-    ASSERT_TRUE(tablet->lookup_row_key("300", true, &rowset_ids, &loc, 7).is<IO_ERROR>());
+    ASSERT_TRUE(tablet->lookup_row_key("201", true, &rowset_ids, &loc, 7).is<ErrorCode::NOT_FOUND>());
+    ASSERT_TRUE(tablet->lookup_row_key("300", true, &rowset_ids, &loc, 7).is<ErrorCode::IO_ERROR>());
     // Key not in range.
-    ASSERT_TRUE(tablet->lookup_row_key("499", true, &rowset_ids, &loc, 7).is<NOT_FOUND>());
+    ASSERT_TRUE(tablet->lookup_row_key("499", true, &rowset_ids, &loc, 7).is<ErrorCode::NOT_FOUND>());
     // Version too low.
-    ASSERT_TRUE(tablet->lookup_row_key("500", true, &rowset_ids, &loc, 7).is<NOT_FOUND>());
+    ASSERT_TRUE(tablet->lookup_row_key("500", true, &rowset_ids, &loc, 7).is<ErrorCode::NOT_FOUND>());
     // Hit a segment, but since we don't have real data, return an internal error when loading the
     // segment.
-    ASSERT_TRUE(tablet->lookup_row_key("500", true, &rowset_ids, &loc, 8).is<IO_ERROR>());
+    ASSERT_TRUE(tablet->lookup_row_key("500", true, &rowset_ids, &loc, 8).is<ErrorCode::IO_ERROR>());
 }
 
 } // namespace doris

--- a/be/test/olap/tablet_test.cpp
+++ b/be/test/olap/tablet_test.cpp
@@ -273,7 +273,7 @@ TEST_F(TestTablet, pad_rowset) {
     ASSERT_FALSE(_tablet->capture_rs_readers(version, &readers).ok());
     readers.clear();
 
-    PadRowsetAction action(nullptr);
+    PadRowsetAction action(nullptr, TPrivilegeHier::GLOBAL, TPrivilegeType::ADMIN);
     action._pad_rowset(_tablet, version);
     ASSERT_TRUE(_tablet->capture_rs_readers(version, &readers).ok());
 }
@@ -416,23 +416,31 @@ TEST_F(TestTablet, rowset_tree_update) {
 
     RowLocation loc;
     // Key not in range.
-    ASSERT_TRUE(tablet->lookup_row_key("99", true, &rowset_ids, &loc, 7).is<ErrorCode::NOT_FOUND>());
+    ASSERT_TRUE(
+            tablet->lookup_row_key("99", true, &rowset_ids, &loc, 7).is<ErrorCode::NOT_FOUND>());
     // Version too low.
-    ASSERT_TRUE(tablet->lookup_row_key("101", true, &rowset_ids, &loc, 3).is<ErrorCode::NOT_FOUND>());
+    ASSERT_TRUE(
+            tablet->lookup_row_key("101", true, &rowset_ids, &loc, 3).is<ErrorCode::NOT_FOUND>());
     // Hit a segment, but since we don't have real data, return an internal error when loading the
     // segment.
     LOG(INFO) << tablet->lookup_row_key("101", true, &rowset_ids, &loc, 7).to_string();
-    ASSERT_TRUE(tablet->lookup_row_key("101", true, &rowset_ids, &loc, 7).is<ErrorCode::IO_ERROR>());
+    ASSERT_TRUE(
+            tablet->lookup_row_key("101", true, &rowset_ids, &loc, 7).is<ErrorCode::IO_ERROR>());
     // Key not in range.
-    ASSERT_TRUE(tablet->lookup_row_key("201", true, &rowset_ids, &loc, 7).is<ErrorCode::NOT_FOUND>());
-    ASSERT_TRUE(tablet->lookup_row_key("300", true, &rowset_ids, &loc, 7).is<ErrorCode::IO_ERROR>());
+    ASSERT_TRUE(
+            tablet->lookup_row_key("201", true, &rowset_ids, &loc, 7).is<ErrorCode::NOT_FOUND>());
+    ASSERT_TRUE(
+            tablet->lookup_row_key("300", true, &rowset_ids, &loc, 7).is<ErrorCode::IO_ERROR>());
     // Key not in range.
-    ASSERT_TRUE(tablet->lookup_row_key("499", true, &rowset_ids, &loc, 7).is<ErrorCode::NOT_FOUND>());
+    ASSERT_TRUE(
+            tablet->lookup_row_key("499", true, &rowset_ids, &loc, 7).is<ErrorCode::NOT_FOUND>());
     // Version too low.
-    ASSERT_TRUE(tablet->lookup_row_key("500", true, &rowset_ids, &loc, 7).is<ErrorCode::NOT_FOUND>());
+    ASSERT_TRUE(
+            tablet->lookup_row_key("500", true, &rowset_ids, &loc, 7).is<ErrorCode::NOT_FOUND>());
     // Hit a segment, but since we don't have real data, return an internal error when loading the
     // segment.
-    ASSERT_TRUE(tablet->lookup_row_key("500", true, &rowset_ids, &loc, 8).is<ErrorCode::IO_ERROR>());
+    ASSERT_TRUE(
+            tablet->lookup_row_key("500", true, &rowset_ids, &loc, 8).is<ErrorCode::IO_ERROR>());
 }
 
 } // namespace doris

--- a/conf/be.conf
+++ b/conf/be.conf
@@ -43,6 +43,9 @@ ssl_certificate_path = "$DORIS_HOME/conf/cert.pem"
 # path of private key in PEM format.
 ssl_private_key_path = "$DORIS_HOME/conf/key.pem"
 
+# enable auth check
+enable_auth = false
+
 # Choose one if there are more than one ip except loopback address. 
 # Note that there should at most one ip match this list.
 # If no ip match this rule, will choose one randomly.

--- a/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
@@ -1522,6 +1522,9 @@ public class FrontendServiceImpl implements FrontendService.Iface {
     }
 
     private PrivPredicate getPrivPredicate(TPrivilegeType privType) {
+        if (privType == null) {
+            return null;
+        }
         switch (privType) {
             case SHOW:
                 return PrivPredicate.SHOW;

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -799,6 +799,7 @@ struct TPrivilegeCtrl {
 }
 
 enum TPrivilegeType {
+  NONE = -1,
   SHOW = 0,
   SHOW_RESOURCES = 1,
   GRANT = 2,


### PR DESCRIPTION
# Proposed changes

Issue Number: close #15658

## Problem summary

1. Organize http documents
2. Add http interface authentication for FE
3. Support https interface for FE
4. Provide authentication interface
5. **Add http interface authentication for BE**
6. Support https interface for BE

### Interface with authentication


- [x] check_rpc_channel   (**admin**)
- [x] checksum   (**admin**)
- [x] check_tablet_segment   (**admin**)
- [x] compaction   (**admin**)
- [ ] config   (**none** for FE)
- [ ] download   (**already** authenticated)
- [ ] health   (**none** for monitor)
- [ ] jeprofile   (**none** for web)
- [x] meta   (**admin**)
- [x] metrics   (**none** for prometheus)
- [ ] monitor   (_deleted_)
- [x] pad_rowset   (**admin**)
- [ ] pprof   (**none** for web)
- [x] reload_tablet   (**admin**)
- [x] reset_rpc_channel   (**admin**)
- [x] restore_tablet   (**admin**)
- [x] snapshot   (**admin**)
- [ ] stream_load_2pc (**already** authenticated)
- [ ] stream_load (**already** authenticated)
- [x] tablet_migration   (**admin**)
- [x] tablets_distribution   (**admin**)
- [x] tablets_info   (**admin**)
- [x] version   (**none**)

## Checklist(Required)

* [x] Does it affect the original behavior
* [x] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [x] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

