### PR TITLE
[Fix](Nereids) fix return type of substring function error

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/Substring.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/Substring.java
@@ -68,7 +68,7 @@ public class Substring extends ScalarFunction
     @Override
     public FunctionSignature computeSignature(FunctionSignature signature) {
         Optional<Expression> length = arity() == 3
-                ? Optional.of(getArgument(2))
+                ? Optional.of(getArgument(1))
                 : Optional.empty();
         DataType returnType = VarcharType.SYSTEM_DEFAULT;
         if (length.isPresent() && length.get() instanceof IntegerLiteral) {


### PR DESCRIPTION
# Proposed changes

Substring function return type is unknown. Be can only regard it as variable length array
## Problem summary

When analysis arithmetic expressions in nereids, return type will be detemined. The second parameter is get to set as the result of Substring function.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [x] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

