### PR TITLE
[Feat](Nereids) add byte size information in type description

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/catalog/ScalarType.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/catalog/ScalarType.java
@@ -80,6 +80,20 @@ public class ScalarType extends Type {
     public static final int DEFAULT_MIN_AVG_DECIMAL128_SCALE = 4;
     public static final int MAX_DATETIMEV2_SCALE = 6;
 
+    private long byteSize = -1;
+
+
+    /**
+     * Set byte size of expression
+     */
+    public void setByteSize(long byteSize) {
+        this.byteSize = byteSize;
+    }
+
+    public long getByteSize() {
+        return byteSize;
+    }
+
     private static final Logger LOG = LogManager.getLogger(ScalarType.class);
     @SerializedName(value = "type")
     private final PrimitiveType type;
@@ -638,6 +652,7 @@ public class ScalarType extends Type {
         node.setType(TTypeNodeType.SCALAR);
         TScalarType scalarType = new TScalarType();
         scalarType.setType(type.toThrift());
+        container.setByteSize(byteSize);
 
         switch (type) {
             case VARCHAR:

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/ExpressionTranslator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/ExpressionTranslator.java
@@ -109,6 +109,10 @@ public class ExpressionTranslator extends DefaultExpressionVisitor<Expr, PlanTra
     public static Expr translate(Expression expression, PlanTranslatorContext context) {
         Expr staleExpr = expression.accept(INSTANCE, context);
         try {
+            if (staleExpr.getType() instanceof ScalarType) {
+                ((ScalarType) staleExpr.getType()).setByteSize((long) expression.getDataType().width());
+            }
+
             staleExpr.finalizeForNereids();
         } catch (Exception e) {
             throw new AnalysisException(

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/types/CharType.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/types/CharType.java
@@ -35,6 +35,11 @@ public class CharType extends CharacterType {
         super(len);
     }
 
+    @Override
+    public int width() {
+        return len;
+    }
+
     public static CharType createCharType(int len) {
         if (len == SYSTEM_DEFAULT.len) {
             return SYSTEM_DEFAULT;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/types/StringType.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/types/StringType.java
@@ -33,6 +33,11 @@ public class StringType extends CharacterType {
     }
 
     @Override
+    public int width() {
+        return len;
+    }
+
+    @Override
     public Type toCatalogDataType() {
         return Type.STRING;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/types/VarcharType.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/types/VarcharType.java
@@ -35,6 +35,11 @@ public class VarcharType extends CharacterType {
         super(len);
     }
 
+    @Override
+    public int width() {
+        return len;
+    }
+
     public static VarcharType createVarcharType(int len) {
         if (len == SYSTEM_DEFAULT.len) {
             return SYSTEM_DEFAULT;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/types/coercion/NumericType.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/types/coercion/NumericType.java
@@ -47,4 +47,9 @@ public class NumericType extends PrimitiveType {
     public String simpleString() {
         return "numeric";
     }
+
+    @Override
+    public int width() {
+        return -1;
+    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/types/coercion/PrimitiveType.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/types/coercion/PrimitiveType.java
@@ -30,8 +30,4 @@ public abstract class PrimitiveType extends DataType {
         return simpleString().toUpperCase(Locale.ROOT);
     }
 
-    @Override
-    public int width() {
-        throw new RuntimeException("Unimplemented exception");
-    }
 }

--- a/gensrc/thrift/Types.thrift
+++ b/gensrc/thrift/Types.thrift
@@ -155,6 +155,7 @@ struct TTypeNode {
 struct TTypeDesc {
     1: list<TTypeNode> types
     2: optional bool is_nullable
+    3: optional i64  byte_size
 }
 
 enum TAggregationType {


### PR DESCRIPTION
# Proposed changes

In order to express bytesize of Arithmetic Expression and more common expression during optimization process. A common flag in Nereids is needed. 
In the whole process of query processing, bytesize is needed at least at three transfer process:
1、analyze of Nereids, which binds expression with data type
2、translator of Nereids, which translate data type from expression in nereids to Physical Plan
3、Physical Plan serialize and deserialize by thrift, which need to implement toThrift and fromThrift method

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [x] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

