### PR TITLE
[feature](regression)return only if all sqls inside one sql file run out

### DIFF
--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/suite/ScriptSource.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/suite/ScriptSource.groovy
@@ -78,12 +78,21 @@ class SqlFileSource implements ScriptSource {
             Object run() {
                 suite(suiteName, groupName) {
                     String tag = suiteName
+                    String exceptionStr = ""
                     boolean order = suiteName.endsWith("_order")
                     List<String> sqls = getSqls(file.text)
+                    log.info("Try to execute group: ${groupName} suite: ${suiteName} with ${sqls.size()} stmts")
                     for (int i = 0; i < sqls.size(); ++i) {
                         String singleSql = sqls.get(i)
                         String tagName = (i == 0) ? tag : "${tag}_${i + 1}"
-                        quickTest(tagName, singleSql, order)
+                        try {
+                            quickTest(tagName, singleSql, order)
+                        } catch (Throwable e) {
+                            exceptionStr += "\n${e.getMessage()}\n"
+                        }
+                    }
+                    if (exceptionStr.size() != 0) {
+                        throw new IllegalStateException("exceptions : ${exceptionStr}")
                     }
                 }
             }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx
pick #14791 to run sqlsmith regression cases in branch1.2
## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

