### PR TITLE
[Bug](datetimev2) Fix BE crash if scale is invalid

### DIFF
--- a/be/src/vec/data_types/data_type_factory.cpp
+++ b/be/src/vec/data_types/data_type_factory.cpp
@@ -125,7 +125,7 @@ DataTypePtr DataTypeFactory::create_data_type(const TypeDescriptor& col_desc, bo
         nested = std::make_shared<vectorized::DataTypeDateV2>();
         break;
     case TYPE_DATETIMEV2:
-        nested = std::make_shared<vectorized::DataTypeDateTimeV2>(col_desc.scale);
+        nested = vectorized::create_datetimev2(col_desc.scale);
         break;
     case TYPE_DATETIME:
         nested = std::make_shared<vectorized::DataTypeDateTime>();
@@ -238,7 +238,7 @@ DataTypePtr DataTypeFactory::_create_primitive_data_type(const FieldType& type, 
         result = std::make_shared<vectorized::DataTypeDateV2>();
         break;
     case OLAP_FIELD_TYPE_DATETIMEV2:
-        result = std::make_shared<vectorized::DataTypeDateTimeV2>(scale);
+        result = vectorized::create_datetimev2(scale);
         break;
     case OLAP_FIELD_TYPE_DATETIME:
         result = std::make_shared<vectorized::DataTypeDateTime>();

--- a/be/src/vec/data_types/data_type_time_v2.cpp
+++ b/be/src/vec/data_types/data_type_time_v2.cpp
@@ -178,4 +178,13 @@ void DataTypeDateTimeV2::cast_from_date_time(const Int64 from, UInt64& to) {
 void DataTypeDateTimeV2::cast_to_date_v2(const UInt64 from, UInt32& to) {
     to = from >> TIME_PART_LENGTH;
 }
+
+DataTypePtr create_datetimev2(UInt64 scale_value) {
+    if (scale_value > 6) {
+        LOG(WARNING) << "Wrong scale " << scale_value;
+        return nullptr;
+    }
+    return std::make_shared<DataTypeDateTimeV2>(scale_value);
+}
+
 } // namespace doris::vectorized

--- a/be/src/vec/data_types/data_type_time_v2.h
+++ b/be/src/vec/data_types/data_type_time_v2.h
@@ -91,6 +91,8 @@ private:
     UInt32 _scale;
 };
 
+DataTypePtr create_datetimev2(UInt64 scale);
+
 template <typename DataType>
 constexpr bool IsDataTypeDateTimeV2 = false;
 template <>

--- a/regression-test/suites/query_p0/sql_functions/datetime_functions/test_date_function.groovy
+++ b/regression-test/suites/query_p0/sql_functions/datetime_functions/test_date_function.groovy
@@ -647,6 +647,13 @@ suite("test_date_function") {
             where
               birth2 <= date_sub('2023-02-01 10:35:13', INTERVAL dayofmonth('2023-02-01 10:35:13')-1 DAY)
         """
+    test {
+        sql"""select current_timestamp(7);"""
+        check{result, exception, startTime, endTime ->
+            assertTrue(exception != null)
+            logger.info(exception.message)
+        }
+    }
     sql """ DROP TABLE IF EXISTS ${tableName}; """
 
 }


### PR DESCRIPTION
# Proposed changes

mysql [test]>select current_timestamp(7);
ERROR 1105 (HY000): RpcException, msg: io.grpc.StatusRuntimeException: UNAVAILABLE: Network closed for unknown reason

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

