### PR TITLE
[fix](Nereids) lock tables when analyze may lead to dead lock

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/CascadesContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/CascadesContext.java
@@ -386,6 +386,7 @@ public class CascadesContext implements ScheduleContext, PlanSource {
             cascadesContext.extractTables(plan);
             for (Table table : cascadesContext.tables) {
                 if (!table.tryReadLock(1, TimeUnit.MINUTES)) {
+                    close();
                     throw new RuntimeException(String.format("Failed to get read lock on table: %s", table.getName()));
                 }
                 locked.push(table);


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

Nereids use AutoCloseable to do tables read lock and unlock.
However, if AutoCloseable throw exception when open resource, its close function would not be called.
So, we do close manually when exception thrown in opening stage.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

