### PR TITLE
[ehancement](profile) Add HTTP interface for q-error

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/ProfileManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/ProfileManager.java
@@ -25,6 +25,7 @@ import org.apache.doris.common.Pair;
 import org.apache.doris.common.profile.MultiProfileTreeBuilder;
 import org.apache.doris.common.profile.ProfileTreeBuilder;
 import org.apache.doris.common.profile.ProfileTreeNode;
+import org.apache.doris.nereids.stats.StatsErrorEstimator;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
@@ -99,7 +100,7 @@ public class ProfileManager {
             Arrays.asList(ANALYSIS_TIME, PLAN_TIME, SCHEDULE_TIME, FETCH_RESULT_TIME,
               WRITE_RESULT_TIME, WAIT_FETCH_RESULT_TIME));
 
-    private class ProfileElement {
+    public static class ProfileElement {
         public ProfileElement(RuntimeProfile profile) {
             this.profile = profile;
         }
@@ -111,7 +112,7 @@ public class ProfileManager {
         public MultiProfileTreeBuilder builder = null;
         public String errMsg = "";
 
-        public double qError;
+        public StatsErrorEstimator statsErrorEstimator;
 
         // lazy load profileContent because sometimes profileContent is very large
         public String getProfileContent() {
@@ -123,14 +124,13 @@ public class ProfileManager {
             return profileContent;
         }
 
-        public double getqError() {
-            return qError;
+        public double getError() {
+            return statsErrorEstimator.getQError();
         }
 
-        public void setqError(double qError) {
-            this.qError = qError;
+        public void setStatsErrorEstimator(StatsErrorEstimator statsErrorEstimator) {
+            this.statsErrorEstimator = statsErrorEstimator;
         }
-
     }
 
     // only protect queryIdDeque; queryIdToProfileMap is concurrent, no need to protect
@@ -229,7 +229,7 @@ public class ProfileManager {
         try {
             Iterator reverse = queryIdDeque.descendingIterator();
             while (reverse.hasNext()) {
-                String  queryId = (String) reverse.next();
+                String queryId = (String) reverse.next();
                 ProfileElement profileElement = queryIdToProfileMap.get(queryId);
                 if (profileElement == null) {
                     continue;
@@ -387,10 +387,10 @@ public class ProfileManager {
         }
     }
 
-    public void setQErrorToProfileElementObject(String queryId, double qError) {
+    public void setStatsErrorEstimator(String queryId, StatsErrorEstimator statsErrorEstimator) {
         ProfileElement profileElement = findProfileElementObject(queryId);
         if (profileElement != null) {
-            profileElement.setqError(qError);
+            profileElement.setStatsErrorEstimator(statsErrorEstimator);
         }
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/manager/QueryProfileAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/manager/QueryProfileAction.java
@@ -27,10 +27,12 @@ import org.apache.doris.common.proc.ProcResult;
 import org.apache.doris.common.profile.ProfileTreeNode;
 import org.apache.doris.common.profile.ProfileTreePrinter;
 import org.apache.doris.common.util.ProfileManager;
+import org.apache.doris.common.util.ProfileManager.ProfileElement;
 import org.apache.doris.httpv2.entity.ResponseEntityBuilder;
 import org.apache.doris.httpv2.rest.RestBaseController;
 import org.apache.doris.mysql.privilege.Auth;
 import org.apache.doris.mysql.privilege.PrivPredicate;
+import org.apache.doris.nereids.stats.StatsErrorEstimator;
 import org.apache.doris.persist.gson.GsonUtils;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.service.ExecuteEnv;
@@ -333,6 +335,22 @@ public class QueryProfileAction extends RestBaseController {
             return ResponseEntityBuilder.ok(queryId);
         }
         return ResponseEntityBuilder.badRequest("not found query id");
+    }
+
+    /**
+     *  Query qError.
+     */
+    @RequestMapping(path = "/qerror/{id}", method = RequestMethod.GET)
+    public ResponseEntity<String> getStats(@PathVariable(value = "id") String id) {
+        ProfileElement profile = ProfileManager.getInstance().findProfileElementObject(id);
+        if (profile == null) {
+            return ResponseEntityBuilder.notFound(null);
+        }
+        StatsErrorEstimator statsErrorEstimator = profile.statsErrorEstimator;
+        if (statsErrorEstimator == null) {
+            return ResponseEntityBuilder.notFound(null);
+        }
+        return ResponseEntity.ok(GsonUtils.GSON.toJson(statsErrorEstimator));
     }
 
     @RequestMapping(path = "/profile/fragments/{query_id}", method = RequestMethod.GET)

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslator.java
@@ -333,6 +333,7 @@ public class PhysicalPlanTranslator extends DefaultPlanVisitor<PlanFragment, Pla
         if (aggregate.getStats() != null) {
             aggregationNode.setCardinality((long) aggregate.getStats().getRowCount());
         }
+        updateLegacyPlanIdToPhysicalPlan(currentFragment.getPlanRoot(), aggregate);
         return currentFragment;
     }
 
@@ -389,6 +390,7 @@ public class PhysicalPlanTranslator extends DefaultPlanVisitor<PlanFragment, Pla
         repeatNode.setNumInstances(inputPlanFragment.getPlanRoot().getNumInstances());
         addPlanRoot(inputPlanFragment, repeatNode, repeat);
         inputPlanFragment.updateDataPartition(DataPartition.RANDOM);
+        updateLegacyPlanIdToPhysicalPlan(inputPlanFragment.getPlanRoot(), repeat);
         return inputPlanFragment;
     }
 
@@ -409,6 +411,7 @@ public class PhysicalPlanTranslator extends DefaultPlanVisitor<PlanFragment, Pla
         PlanFragment planFragment = createPlanFragment(emptySetNode,
                 DataPartition.UNPARTITIONED, emptyRelation);
         context.addPlanFragment(planFragment);
+        updateLegacyPlanIdToPhysicalPlan(planFragment.getPlanRoot(), emptyRelation);
         return planFragment;
     }
 
@@ -441,6 +444,7 @@ public class PhysicalPlanTranslator extends DefaultPlanVisitor<PlanFragment, Pla
 
         PlanFragment planFragment = createPlanFragment(unionNode, DataPartition.UNPARTITIONED, oneRowRelation);
         context.addPlanFragment(planFragment);
+        updateLegacyPlanIdToPhysicalPlan(planFragment.getPlanRoot(), oneRowRelation);
         return planFragment;
     }
 
@@ -469,7 +473,7 @@ public class PhysicalPlanTranslator extends DefaultPlanVisitor<PlanFragment, Pla
                         + storageLayerAggregate.getAggOp());
         }
         olapScanNode.setPushDownAggNoGrouping(pushAggOp);
-
+        updateLegacyPlanIdToPhysicalPlan(planFragment.getPlanRoot(), storageLayerAggregate);
         return planFragment;
     }
 
@@ -541,6 +545,7 @@ public class PhysicalPlanTranslator extends DefaultPlanVisitor<PlanFragment, Pla
         }
         PlanFragment planFragment = createPlanFragment(olapScanNode, dataPartition, olapScan);
         context.addPlanFragment(planFragment);
+        updateLegacyPlanIdToPhysicalPlan(planFragment.getPlanRoot(), olapScan);
         return planFragment;
     }
 
@@ -592,6 +597,7 @@ public class PhysicalPlanTranslator extends DefaultPlanVisitor<PlanFragment, Pla
         DataPartition dataPartition = DataPartition.RANDOM;
         PlanFragment planFragment = createPlanFragment(fileScanNode, dataPartition, fileScan);
         context.addPlanFragment(planFragment);
+        updateLegacyPlanIdToPhysicalPlan(planFragment.getPlanRoot(), fileScan);
         return planFragment;
     }
 
@@ -640,6 +646,7 @@ public class PhysicalPlanTranslator extends DefaultPlanVisitor<PlanFragment, Pla
         DataPartition dataPartition = DataPartition.RANDOM;
         PlanFragment planFragment = new PlanFragment(context.nextFragmentId(), jdbcScanNode, dataPartition);
         context.addPlanFragment(planFragment);
+        updateLegacyPlanIdToPhysicalPlan(planFragment.getPlanRoot(), jdbcScan);
         return planFragment;
     }
 
@@ -661,6 +668,7 @@ public class PhysicalPlanTranslator extends DefaultPlanVisitor<PlanFragment, Pla
         DataPartition dataPartition = DataPartition.RANDOM;
         PlanFragment planFragment = new PlanFragment(context.nextFragmentId(), esScanNode, dataPartition);
         context.addPlanFragment(planFragment);
+        updateLegacyPlanIdToPhysicalPlan(planFragment.getPlanRoot(), esScan);
         return planFragment;
     }
 
@@ -873,6 +881,7 @@ public class PhysicalPlanTranslator extends DefaultPlanVisitor<PlanFragment, Pla
             exchangeNode.setLimit(topN.getLimit());
             exchangeNode.setOffset(topN.getOffset());
         }
+        updateLegacyPlanIdToPhysicalPlan(currentFragment.getPlanRoot(), topN);
         return currentFragment;
     }
 
@@ -903,6 +912,7 @@ public class PhysicalPlanTranslator extends DefaultPlanVisitor<PlanFragment, Pla
         if (sort.getStats() != null) {
             sortNode.setCardinality((long) sort.getStats().getRowCount());
         }
+        updateLegacyPlanIdToPhysicalPlan(sortNode, sort);
         return sortNode;
     }
 
@@ -1153,6 +1163,7 @@ public class PhysicalPlanTranslator extends DefaultPlanVisitor<PlanFragment, Pla
         if (hashJoin.getStats() != null) {
             hashJoinNode.setCardinality((long) hashJoin.getStats().getRowCount());
         }
+        updateLegacyPlanIdToPhysicalPlan(currentFragment.getPlanRoot(), hashJoin);
         return currentFragment;
     }
 
@@ -1330,6 +1341,7 @@ public class PhysicalPlanTranslator extends DefaultPlanVisitor<PlanFragment, Pla
             if (nestedLoopJoin.getStats() != null) {
                 nestedLoopJoinNode.setCardinality((long) nestedLoopJoin.getStats().getRowCount());
             }
+            updateLegacyPlanIdToPhysicalPlan(joinFragment.getPlanRoot(), nestedLoopJoin);
             return joinFragment;
         } else {
             throw new RuntimeException("Physical nested loop join could not execute with equal join condition.");
@@ -1453,6 +1465,7 @@ public class PhysicalPlanTranslator extends DefaultPlanVisitor<PlanFragment, Pla
         } else {
             if (!(filter.child(0) instanceof AbstractPhysicalJoin)) {
                 addConjunctsToPlanNode(filter, planNode, context);
+                updateLegacyPlanIdToPhysicalPlan(inputFragment.getPlanRoot(), filter);
             }
         }
         return inputFragment;
@@ -1487,6 +1500,7 @@ public class PhysicalPlanTranslator extends DefaultPlanVisitor<PlanFragment, Pla
         }
         child.setOffset(physicalLimit.getOffset());
         child.setLimit(physicalLimit.getLimit());
+        updateLegacyPlanIdToPhysicalPlan(child, physicalLimit);
         return inputFragment;
     }
 
@@ -1509,6 +1523,7 @@ public class PhysicalPlanTranslator extends DefaultPlanVisitor<PlanFragment, Pla
         ExchangeNode exchange = new ExchangeNode(context.nextPlanNodeId(), childFragment.getPlanRoot(), false);
         exchange.setNumInstances(childFragment.getPlanRoot().getNumInstances());
         childFragment.setPlanRoot(exchange);
+        updateLegacyPlanIdToPhysicalPlan(childFragment.getPlanRoot(), distribute);
         return childFragment;
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/JoinEstimation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/JoinEstimation.java
@@ -34,12 +34,9 @@ import java.util.stream.Collectors;
 public class JoinEstimation {
     private static Statistics estimateInnerJoin(Statistics crossJoinStats, List<Expression> joinConditions) {
         List<Pair<Expression, Double>> sortedJoinConditions = joinConditions.stream()
-                .map(expression -> Pair.of(expression, 0.0)).sorted((a, b) -> {
-                    double selA = estimateJoinConditionSel(crossJoinStats, a.first);
-                    a.second = selA;
-                    double selB = estimateJoinConditionSel(crossJoinStats, b.first);
-                    b.second = selB;
-                    double sub = selA - selB;
+                .map(expression -> Pair.of(expression, estimateJoinConditionSel(crossJoinStats, expression)))
+                .sorted((a, b) -> {
+                    double sub = a.second - b.second;
                     if (sub > 0) {
                         return -1;
                     } else if (sub < 0) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/StatsErrorEstimator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/StatsErrorEstimator.java
@@ -21,10 +21,13 @@ import org.apache.doris.common.Pair;
 import org.apache.doris.common.util.DebugUtil;
 import org.apache.doris.common.util.ProfileManager;
 import org.apache.doris.nereids.trees.plans.AbstractPlan;
+import org.apache.doris.persist.gson.GsonUtils;
 import org.apache.doris.planner.PlanNode;
 import org.apache.doris.thrift.TReportExecStatusParams;
 import org.apache.doris.thrift.TRuntimeProfileNode;
 import org.apache.doris.thrift.TUniqueId;
+
+import com.google.gson.annotations.SerializedName;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -36,14 +39,19 @@ import java.util.regex.Pattern;
  * Used to estimate the bias of stats estimation.
  */
 public class StatsErrorEstimator {
-    private Map<Integer, Pair<Double, Double>> legacyPlanIdToPhysicalPlan;
+
+    @SerializedName("legacyPlanIdToPhysicalPlan")
+    private Map<Integer, Pair<Double, Double>> legacyPlanIdStats;
+
+    @SerializedName("qError")
+    private double qError;
 
     public StatsErrorEstimator() {
-        legacyPlanIdToPhysicalPlan = new HashMap<>();
+        legacyPlanIdStats = new HashMap<>();
     }
 
     public void updateLegacyPlanIdToPhysicalPlan(PlanNode planNode, AbstractPlan physicalPlan) {
-        legacyPlanIdToPhysicalPlan.put(planNode.getId().asInt(), Pair.of(physicalPlan.getStats().getRowCount(),
+        legacyPlanIdStats.put(planNode.getId().asInt(), Pair.of(physicalPlan.getStats().getRowCount(),
                 (double) 0));
     }
 
@@ -53,7 +61,7 @@ public class StatsErrorEstimator {
      */
     public double calculateQError() {
         double qError = Double.NEGATIVE_INFINITY;
-        for (Entry<Integer, Pair<Double, Double>> entry : legacyPlanIdToPhysicalPlan.entrySet()) {
+        for (Entry<Integer, Pair<Double, Double>> entry : legacyPlanIdStats.entrySet()) {
             double exactReturnedRows = entry.getValue().second;
             double estimateReturnedRows = entry.getValue().first;
             qError = Math.max(qError,
@@ -76,15 +84,19 @@ public class StatsErrorEstimator {
             }
             double rowsReturned = runtimeProfileNode.counters.stream()
                     .filter(p -> p.name.equals("RowsReturned")).mapToDouble(p -> (double) p.getValue()).sum();
-            Pair<Double, Double> pair = legacyPlanIdToPhysicalPlan.get(planId);
+            Pair<Double, Double> pair = legacyPlanIdStats.get(planId);
             if (pair == null) {
                 continue;
             }
             pair.second = pair.second + rowsReturned;
         }
-        double qError = calculateQError();
+        this.qError = calculateQError();
+        updateProfile(tUniqueId);
+    }
+
+    public void updateProfile(TUniqueId tUniqueId) {
         ProfileManager.getInstance()
-                .setQErrorToProfileElementObject(DebugUtil.printId(tUniqueId), qError);
+                .setStatsErrorEstimator(DebugUtil.printId(tUniqueId), this);
     }
 
     /**
@@ -113,5 +125,13 @@ public class StatsErrorEstimator {
 
     private double oneIfZero(double d) {
         return d == 0.0 ? 1.0 : d;
+    }
+
+    public double getQError() {
+        return qError;
+    }
+
+    public String toJson() {
+        return GsonUtils.GSON.toJson(this);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectProcessor.java
@@ -55,6 +55,7 @@ import org.apache.doris.mysql.MysqlSerializer;
 import org.apache.doris.mysql.MysqlServerStatusFlag;
 import org.apache.doris.nereids.glue.LogicalPlanAdapter;
 import org.apache.doris.nereids.parser.NereidsParser;
+import org.apache.doris.nereids.stats.StatsErrorEstimator;
 import org.apache.doris.plugin.AuditEvent.EventType;
 import org.apache.doris.proto.Data;
 import org.apache.doris.qe.QueryState.MysqlStateType;
@@ -635,6 +636,10 @@ public class ConnectProcessor {
                 || executor.getParsedStmt() instanceof LogicalPlanAdapter
                 || executor.getParsedStmt() instanceof InsertStmt)) {
             executor.writeProfile(true);
+            StatsErrorEstimator statsErrorEstimator = ConnectContext.get().getStatsErrorEstimator();
+            if (statsErrorEstimator != null) {
+                statsErrorEstimator.updateProfile(ConnectContext.get().queryId());
+            }
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/QeProcessorImpl.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/QeProcessorImpl.java
@@ -187,10 +187,6 @@ public final class QeProcessorImpl implements QeProcessor {
         }
         final TReportExecStatusResult result = new TReportExecStatusResult();
         final QueryInfo info = coordinatorMap.get(params.query_id);
-        if (info != null && info.connectContext != null
-                && info.connectContext.getStatsErrorEstimator() != null) {
-            info.connectContext.getStatsErrorEstimator().updateExactReturnedRows(params);
-        }
 
         if (info == null) {
             result.setStatus(new TStatus(TStatusCode.RUNTIME_ERROR));
@@ -200,7 +196,7 @@ public final class QeProcessorImpl implements QeProcessor {
         try {
             info.getCoord().updateFragmentExecStatus(params);
             if (info.getCoord().getProfileWriter() != null && params.isSetProfile()) {
-                writeProfileExecutor.submit(new WriteProfileTask(params));
+                writeProfileExecutor.submit(new WriteProfileTask(params, info));
             }
         } catch (Exception e) {
             LOG.warn(e.getMessage());
@@ -258,8 +254,11 @@ public final class QeProcessorImpl implements QeProcessor {
     private class WriteProfileTask implements Runnable {
         private TReportExecStatusParams params;
 
-        WriteProfileTask(TReportExecStatusParams params) {
+        private QueryInfo queryInfo;
+
+        WriteProfileTask(TReportExecStatusParams params, QueryInfo queryInfo) {
             this.params = params;
+            this.queryInfo = queryInfo;
         }
 
         @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -1235,7 +1235,7 @@ public class StmtExecutor implements ProfileWriter {
         //
         // 2. If this is a query, send the result expr fields first, and send result data back to client.
         RowBatch batch;
-        coord = new Coordinator(context, analyzer, planner);
+        coord = new Coordinator(context, analyzer, planner, context.getStatsErrorEstimator());
         QeProcessorImpl.INSTANCE.registerQuery(context.queryId(),
                 new QeProcessorImpl.QueryInfo(context, originStmt.originStmt, coord));
         coord.setProfileWriter(this);
@@ -1581,7 +1581,7 @@ public class StmtExecutor implements ProfileWriter {
             LOG.info("Do insert [{}] with query id: {}", label, DebugUtil.printId(context.queryId()));
 
             try {
-                coord = new Coordinator(context, analyzer, planner);
+                coord = new Coordinator(context, analyzer, planner, context.getStatsErrorEstimator());
                 coord.setLoadZeroTolerance(context.getSessionVariable().getEnableInsertStrict());
                 coord.setQueryType(TQueryType.LOAD);
 
@@ -2059,7 +2059,7 @@ public class StmtExecutor implements ProfileWriter {
             }
             planner.getFragments();
             RowBatch batch;
-            coord = new Coordinator(context, analyzer, planner);
+            coord = new Coordinator(context, analyzer, planner, context.getStatsErrorEstimator());
             try {
                 QeProcessorImpl.INSTANCE.registerQuery(context.queryId(),
                         new QeProcessorImpl.QueryInfo(context, originStmt.originStmt, coord));

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/Statistics.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/Statistics.java
@@ -103,7 +103,7 @@ public class Statistics {
     }
 
     public double computeSize() {
-        if (computeSize < 0) {
+        if (computeSize <= 0) {
             computeSize = Math.max(1, expressionToColumnStats.values().stream()
                     .map(s -> s.dataSize).reduce(0D, Double::sum)
             ) * rowCount;

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/util/InternalQuery.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/util/InternalQuery.java
@@ -154,7 +154,7 @@ public class InternalQuery {
         TQueryOptions queryOptions = new TQueryOptions();
         originalPlanner.plan(stmt, queryOptions);
 
-        coord = new Coordinator(context, analyzer, originalPlanner);
+        coord = new Coordinator(context, analyzer, originalPlanner, null);
     }
 
     private void execute() throws Exception {

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/JoinHintTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/JoinHintTest.java
@@ -117,14 +117,14 @@ class JoinHintTest extends TestWithFeService implements MemoPatternMatchSupporte
                     physicalDistribute(
                             physicalProject(
                                     physicalHashJoin(
-                                            physicalDistribute(physicalHashJoin()).when(dis -> {
+                                            physicalHashJoin(physicalDistribute().when(dis -> {
                                                 DistributionSpec spec = dis.getDistributionSpec();
                                                 Assertions.assertTrue(spec instanceof DistributionSpecHash);
                                                 DistributionSpecHash hashSpec = (DistributionSpecHash) spec;
                                                 Assertions.assertEquals(ShuffleType.ENFORCED,
                                                         hashSpec.getShuffleType());
                                                 return true;
-                                            }),
+                                            }), physicalDistribute()),
                                             physicalDistribute()
                                     ).when(join -> join.getHint() == JoinHint.SHUFFLE_RIGHT)
                             )

--- a/tools/qerror.py
+++ b/tools/qerror.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import os
+import subprocess
+
+import requests
+import json
+
+mycli_cmd = "mysql -h127.0.0.1 -P9030 -uroot -Dtpch1G"
+
+feHttp = "http://localhost:8030"
+trace_url = feHttp + '/rest/v2/manager/query/trace_id/{}'
+qerror_url = feHttp + '/rest/v2/manager/query/qerror/{}'
+qerr_saved_file_path = "/home/kikyo/Documents/source/incubator-doris/tools/tpch-tools/RECORD"
+
+original_sql_dir = "/home/kikyo/Documents/source/incubator-doris/tools/tpch-tools/queries"
+sql_with_trace_context_dir = "/home/kikyo/Documents/source/incubator-doris/tools/tpch-tools/traced"
+
+sql_file_prefix_for_trace = """
+    SET enable_nereids_planner=true;
+    SET session_context='trace_id:{}';
+"""
+
+
+def extract_number(string):
+    return int(''.join([c for c in string if c.isdigit()]))
+
+
+def write_results(path: str, title: str, result: list):
+    with open(path, "a") as file:
+        file.write(title)
+        file.write("\n")
+        for item in result:
+            file.write(str(item) + " " + "\n")
+        file.write("\n")
+
+
+def read_lines(path: str) -> list:
+    with open(path, "r") as f:
+        return f.readlines()
+
+
+def write_result(title: str, result: str):
+    wrapped = [result]
+    write_results(qerr_saved_file_path, title, wrapped)
+
+
+def execute_command(cmd: str):
+    result = subprocess.run(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    return result.stdout
+
+
+def execute_sql(sql_file: str):
+    command = mycli_cmd + " < " + sql_file
+    result = execute_command(command).decode("utf-8")
+    return result
+
+
+def get_q_error(trace_id):
+    # 'YWRtaW46' is the base64 encoded result for 'admin:'
+    headers = {'Authorization': 'BASIC YWRtaW46'}
+    resp_wrapper = requests.get(trace_url.format(trace_id), headers=headers)
+    resp_text = resp_wrapper.text
+    query_id = json.loads(resp_text)["data"]
+    resp_wrapper = requests.get(qerror_url.format(query_id), headers=headers)
+    resp_text = resp_wrapper.text
+    write_result(str(trace_id), resp_text)
+
+
+def iterates_sqls(path: str) -> list:
+    cost_times = []
+    files = os.listdir(path)
+    files.sort(key=extract_number)
+    for filename in files:
+        if filename.endswith(".sql"):
+            filepath = os.path.join(path, filename)
+            traced_sql_file = filepath + ".traced"
+            content = read_lines(filepath)
+            sql_num = extract_number(filename)
+            write_results(traced_sql_file, str(sql_file_prefix_for_trace.format(sql_num)), content)
+            execute_sql(traced_sql_file)
+            get_q_error(sql_num)
+            os.remove(traced_sql_file)
+    return cost_times
+
+
+if __name__ == '__main__':
+    execute_command("echo 'set global enable_nereids_planner=true' | mysql -h127.0.0.1 -P9030")
+    execute_command("echo 'set global enable_fallback_to_original_planner=false' | mysql -h127.0.0.1 -P9030")
+    iterates_sqls(original_sql_dir)


### PR DESCRIPTION
# Proposed changes

1. Add Http interface for query q-error
2. Fix the selectivity calculation of inner join, it would always be 0 if there is only one join condition before

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

