### PR TITLE
[enhancement](nereids) update FilterEstimation and Agg in stats derive

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/GroupExpression.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/GroupExpression.java
@@ -57,7 +57,7 @@ public class GroupExpression {
     private final BitSet ruleMasks;
     private boolean statDerived;
 
-    private long estOutputRowCount = -1;
+    private double estOutputRowCount = -1;
 
     //Record the rule that generate this plan. It's used for debugging
     private Rule fromRule;
@@ -301,16 +301,13 @@ public class GroupExpression {
         return new Statistics(child(idx).getStatistics());
     }
 
-    public void setEstOutputRowCount(long estOutputRowCount) {
+    public void setEstOutputRowCount(double estOutputRowCount) {
         this.estOutputRowCount = estOutputRowCount;
-    }
-
-    public long getEstOutputRowCount() {
-        return estOutputRowCount;
     }
 
     @Override
     public String toString() {
+        DecimalFormat format = new DecimalFormat("#,###.##");
         StringBuilder builder = new StringBuilder("id:");
         builder.append(id.asInt());
         if (ownerGroup == null) {
@@ -318,11 +315,8 @@ public class GroupExpression {
         } else {
             builder.append("#").append(ownerGroup.getGroupId().asInt());
         }
-
-        DecimalFormat decimalFormat = new DecimalFormat();
-        decimalFormat.setGroupingSize(3);
-        builder.append(" cost=").append(decimalFormat.format((long) cost));
-        builder.append(" estRows=").append(estOutputRowCount);
+        builder.append(" cost=").append(format.format((long) cost));
+        builder.append(" estRows=").append(format.format(estOutputRowCount));
         builder.append(" (plan=").append(plan.toString()).append(") children=[");
         for (Group group : children) {
             builder.append(group.getGroupId()).append(" ");

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/JoinEstimation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/JoinEstimation.java
@@ -21,6 +21,7 @@ import org.apache.doris.common.Pair;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.plans.JoinType;
 import org.apache.doris.nereids.trees.plans.algebra.Join;
+import org.apache.doris.nereids.util.ExpressionUtils;
 import org.apache.doris.statistics.Statistics;
 import org.apache.doris.statistics.StatisticsBuilder;
 
@@ -70,6 +71,11 @@ public class JoinEstimation {
                 .build();
         List<Expression> joinConditions = join.getHashJoinConjuncts();
         Statistics innerJoinStats = estimateInnerJoin(crossJoinStats, joinConditions);
+        if (!join.getOtherJoinConjuncts().isEmpty()) {
+            FilterEstimation filterEstimation = new FilterEstimation();
+            innerJoinStats = filterEstimation.estimate(
+                    ExpressionUtils.and(join.getOtherJoinConjuncts()), innerJoinStats);
+        }
         innerJoinStats.setWidth(leftStats.getWidth() + rightStats.getWidth());
         innerJoinStats.setPenalty(0);
         double rowCount;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalHashAggregate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalHashAggregate.java
@@ -257,7 +257,7 @@ public class PhysicalHashAggregate<CHILD_TYPE extends Plan> extends PhysicalUnar
     @Override
     public PhysicalHashAggregate<CHILD_TYPE> withAggOutput(List<NamedExpression> newOutput) {
         return new PhysicalHashAggregate<>(groupByExpressions, newOutput, partitionExpressions,
-                aggregateParam, maybeUsingStream, groupExpression, getLogicalProperties(),
+                aggregateParam, maybeUsingStream, Optional.empty(), getLogicalProperties(),
                 requireProperties, physicalProperties, statistics, child());
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalNestedLoopJoin.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalNestedLoopJoin.java
@@ -119,7 +119,8 @@ public class PhysicalNestedLoopJoin<
                 "type", joinType,
                 "otherJoinCondition", otherJoinConjuncts,
                 "isMarkJoin", markJoinSlotReference.isPresent(),
-                "markJoinSlotReference", markJoinSlotReference.isPresent() ? markJoinSlotReference.get() : "empty"
+                "markJoinSlotReference", markJoinSlotReference.isPresent() ? markJoinSlotReference.get() : "empty",
+                "stats", statistics
         );
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/Statistics.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/Statistics.java
@@ -119,7 +119,7 @@ public class Statistics {
     public double computeSize() {
         if (computeSize <= 0) {
             computeSize = Math.max(1, expressionToColumnStats.values().stream()
-                    .map(s -> s.dataSize).reduce(0D, Double::sum)
+                    .map(s -> s.avgSizeByte).reduce(0D, Double::sum)
             ) * rowCount;
         }
         return computeSize;

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/Statistics.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/Statistics.java
@@ -20,12 +20,12 @@ package org.apache.doris.statistics;
 import org.apache.doris.nereids.stats.StatsMathUtil;
 import org.apache.doris.nereids.trees.expressions.Expression;
 
+import java.text.DecimalFormat;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 
 public class Statistics {
-
     private final double rowCount;
 
     private final Map<Expression, ColumnStatistic> expressionToColumnStats;
@@ -37,6 +37,19 @@ public class Statistics {
 
     @Deprecated
     private double penalty;
+
+    /**
+     * after filter, compute the new ndv of a column
+     * @param ndv original ndv of column
+     * @param newRowCount the row count of table after filter
+     * @param oldRowCount the row count of table before filter
+     * @return the new ndv after filter
+     */
+    public static double computeNdv(double ndv, double newRowCount, double oldRowCount) {
+        double selectOneTuple = newRowCount / StatsMathUtil.nonZeroDivisor(oldRowCount);
+        double allTuplesOfSameDistinctValueNotSelected = Math.pow((1 - selectOneTuple), oldRowCount / ndv);
+        return Math.min(ndv * (1 - allTuplesOfSameDistinctValueNotSelected), newRowCount);
+    }
 
     public Statistics(Statistics another) {
         this.rowCount = another.rowCount;
@@ -72,17 +85,18 @@ public class Statistics {
 
     public Statistics withRowCount(double rowCount) {
         Statistics statistics = new Statistics(rowCount, new HashMap<>(expressionToColumnStats), width, penalty);
-        statistics.fix(rowCount / StatsMathUtil.nonZeroDivisor(this.rowCount));
+        statistics.fix(rowCount, StatsMathUtil.nonZeroDivisor(this.rowCount));
         return statistics;
     }
 
-    public void fix(double sel) {
+    public void fix(double newRowCount, double originRowCount) {
+        double sel = newRowCount / originRowCount;
         for (Entry<Expression, ColumnStatistic> entry : expressionToColumnStats.entrySet()) {
             ColumnStatistic columnStatistic = entry.getValue();
             ColumnStatisticBuilder columnStatisticBuilder = new ColumnStatisticBuilder(columnStatistic);
-            columnStatisticBuilder.setNdv(Math.min(Math.ceil(columnStatistic.ndv * sel), rowCount));
-            columnStatisticBuilder.setNumNulls(Math.min(Math.ceil(columnStatistic.numNulls * sel), rowCount));
-            columnStatisticBuilder.setCount(Math.min(Math.ceil(columnStatistic.count * sel), rowCount));
+            columnStatisticBuilder.setNdv(computeNdv(columnStatistic.ndv, newRowCount, originRowCount));
+            columnStatisticBuilder.setNumNulls(Math.min(columnStatistic.numNulls * sel, rowCount));
+            columnStatisticBuilder.setCount(newRowCount);
             expressionToColumnStats.put(entry.getKey(), columnStatisticBuilder.build());
         }
     }
@@ -113,7 +127,8 @@ public class Statistics {
 
     @Override
     public String toString() {
-        return String.format("rows=%.4f", rowCount);
+        DecimalFormat format = new DecimalFormat("#,###.##");
+        return format.format(rowCount);
     }
 
     public void setWidth(double width) {

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/memo/RankTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/memo/RankTest.java
@@ -55,12 +55,13 @@ public class RankTest extends TPCHTestBase {
                     .optimize()
                     .getCascadesContext()
                     .getMemo();
-            PhysicalPlan plan1 = memo.unrank(memo.rank(1).first);
             PhysicalPlan plan2 = PlanChecker.from(connectContext)
                     .analyze(field.get(null).toString())
                     .rewrite()
                     .optimize()
                     .getBestPlanTree(PhysicalProperties.GATHER);
+            PhysicalPlan plan1 = memo.unrank(memo.rank(1).first);
+
             Assertions.assertTrue(PlanChecker.isPlanEqualWithoutID(plan1, plan2));
         }
     }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/stats/FilterEstimationTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/stats/FilterEstimationTest.java
@@ -197,8 +197,7 @@ class FilterEstimationTest {
         Statistics stat = new Statistics(1000, slotToColumnStat);
         FilterEstimation filterEstimation = new FilterEstimation();
         Statistics expected = filterEstimation.estimate(or, stat);
-        Assertions.assertTrue(
-                Precision.equals(50, expected.getRowCount(), 0.01));
+        Assertions.assertEquals(51, expected.getRowCount(), 0.1);
     }
 
     // a > 500 and b < 100 or a > c
@@ -450,9 +449,9 @@ class FilterEstimationTest {
         Assertions.assertEquals(1000 * 7.0 / 10.0, estimated.getRowCount());
     }
 
-    //c>100
+    // c>100
     // a is primary-key, a.ndv is reduced
-    // b is normal, b.ndv is not changed
+    // b is normal, b.ndv is smaller: newNdv = ndv * (1 - Math.pow(1 - selectivity, rowCount / ndv));
     // c.selectivity is still 1, but its range becomes half
     @Test
     public void test12() {
@@ -466,8 +465,8 @@ class FilterEstimationTest {
                 .setNdv(1000)
                 .setAvgSizeByte(4)
                 .setNumNulls(0)
-                .setMinValue(10000)
-                .setMaxValue(1000)
+                .setMinValue(1000)
+                .setMaxValue(10000)
                 .setSelectivity(1.0);
         ColumnStatisticBuilder builderB = new ColumnStatisticBuilder()
                 .setNdv(100)
@@ -492,7 +491,7 @@ class FilterEstimationTest {
         ColumnStatistic statsA = estimated.findColumnStatistics(a);
         Assertions.assertEquals(500, statsA.ndv);
         ColumnStatistic statsB = estimated.findColumnStatistics(b);
-        Assertions.assertEquals(50, statsB.ndv);
+        Assertions.assertEquals(100, statsB.ndv, 0.1);
         ColumnStatistic statsC = estimated.findColumnStatistics(c);
         Assertions.assertEquals(50, statsC.ndv);
         Assertions.assertEquals(100, statsC.minValue);
@@ -502,9 +501,10 @@ class FilterEstimationTest {
     /**
      * test filter estimation, like 20>c>10, c in (0,40)
      * filter range has intersection with (c.min, c.max)
-     *     a primary key, a.ndv reduced by 1/4, a.selectivity=0.25
-     *     b normal field, b.ndv not changed, b.selectivity=1.0
-     *     c.ndv = 10/40 * c.ndv, c.selectivity=1
+     *      rows = 100
+     *     a primary key, a.ndv reduced by 1/4
+     *     b normal field, b.ndv=20 =>
+     *     c.ndv = 10/40 * c.ndv
      */
     @Test
     public void testFilterInsideMinMax() {
@@ -547,13 +547,13 @@ class FilterEstimationTest {
         Statistics estimated = filterEstimation.estimate(and, stat);
         Assertions.assertEquals(25, estimated.getRowCount());
         ColumnStatistic statsA = estimated.findColumnStatistics(a);
-        Assertions.assertEquals(25, statsA.ndv);
+        Assertions.assertEquals(25, statsA.ndv, 0.1);
         //Assertions.assertEquals(0.25, statsA.selectivity);
         Assertions.assertEquals(0, statsA.minValue);
         Assertions.assertEquals(100, statsA.maxValue);
 
         ColumnStatistic statsB = estimated.findColumnStatistics(b);
-        Assertions.assertEquals(5, statsB.ndv);
+        Assertions.assertEquals(15.6, statsB.ndv, 0.1);
         Assertions.assertEquals(0, statsB.minValue);
         Assertions.assertEquals(500, statsB.maxValue);
         Assertions.assertEquals(1.0, statsB.selectivity);
@@ -686,10 +686,10 @@ class FilterEstimationTest {
         ColumnStatistic statsA = estimated.findColumnStatistics(a);
         ColumnStatistic statsB = estimated.findColumnStatistics(b);
         ColumnStatistic statsC = estimated.findColumnStatistics(c);
-        Assertions.assertEquals(5, statsA.ndv);
+        Assertions.assertEquals(5, statsA.ndv, 0.1);
         Assertions.assertEquals(0, statsA.minValue);
         Assertions.assertEquals(100, statsA.maxValue);
-        Assertions.assertEquals(1, statsB.ndv);
+        Assertions.assertEquals(4.5, statsB.ndv, 0.1);
         Assertions.assertEquals(0, statsB.minValue);
         Assertions.assertEquals(500, statsB.maxValue);
         Assertions.assertEquals(2, statsC.ndv);
@@ -763,10 +763,10 @@ class FilterEstimationTest {
         System.out.println(statsA);
         System.out.println(statsB);
         System.out.println(statsC);
-        Assertions.assertEquals(5, statsA.ndv);
+        Assertions.assertEquals(5, statsA.ndv, 0.1);
         Assertions.assertEquals(0, statsA.minValue);
         Assertions.assertEquals(100, statsA.maxValue);
-        Assertions.assertEquals(1, statsB.ndv);
+        Assertions.assertEquals(4.5, statsB.ndv, 0.1);
         Assertions.assertEquals(0, statsB.minValue);
         Assertions.assertEquals(500, statsB.maxValue);
         Assertions.assertEquals(2, statsC.ndv);
@@ -832,13 +832,10 @@ class FilterEstimationTest {
         ColumnStatistic statsA = estimated.findColumnStatistics(a);
         ColumnStatistic statsB = estimated.findColumnStatistics(b);
         ColumnStatistic statsC = estimated.findColumnStatistics(c);
-        System.out.println(statsA);
-        System.out.println(statsB);
-        System.out.println(statsC);
         Assertions.assertEquals(75, statsA.ndv);
         Assertions.assertEquals(0, statsA.minValue);
         Assertions.assertEquals(100, statsA.maxValue);
-        Assertions.assertEquals(15, statsB.ndv);
+        Assertions.assertEquals(19.9, statsB.ndv, 0.1);
         Assertions.assertEquals(0, statsB.minValue);
         Assertions.assertEquals(500, statsB.maxValue);
         Assertions.assertEquals(30, statsC.ndv);

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/stats/StatsCalculatorTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/stats/StatsCalculatorTest.java
@@ -145,14 +145,14 @@ public class StatsCalculatorTest {
         Group ownerGroup = newGroup();
         groupExpression.setOwnerGroup(ownerGroup);
         StatsCalculator.estimate(groupExpression);
-        Assertions.assertEquals((long) 500, ownerGroup.getStatistics().getRowCount(), 0.001);
+        Assertions.assertEquals((10000 * 0.1 * 0.05), ownerGroup.getStatistics().getRowCount(), 0.001);
 
         LogicalFilter<GroupPlan> logicalFilterOr = new LogicalFilter<>(or, groupPlan);
         GroupExpression groupExpressionOr = new GroupExpression(logicalFilterOr, ImmutableList.of(childGroup));
         Group ownerGroupOr = newGroup();
         groupExpressionOr.setOwnerGroup(ownerGroupOr);
         StatsCalculator.estimate(groupExpressionOr);
-        Assertions.assertEquals((long) 1000,
+        Assertions.assertEquals((long) (10000 * (0.1 + 0.05 - 0.1 * 0.05)),
                 ownerGroupOr.getStatistics().getRowCount(), 0.001);
     }
 
@@ -292,7 +292,7 @@ public class StatsCalculatorTest {
         Statistics limitStats = ownerGroup.getStatistics();
         Assertions.assertEquals(1, limitStats.getRowCount());
         ColumnStatistic slot1Stats = limitStats.columnStatistics().get(slot1);
-        Assertions.assertEquals(1, slot1Stats.ndv);
+        Assertions.assertEquals(1, slot1Stats.ndv, 0.1);
         Assertions.assertEquals(1, slot1Stats.numNulls);
     }
 
@@ -322,7 +322,7 @@ public class StatsCalculatorTest {
         Statistics topNStats = ownerGroup.getStatistics();
         Assertions.assertEquals(1, topNStats.getRowCount());
         ColumnStatistic slot1Stats = topNStats.columnStatistics().get(slot1);
-        Assertions.assertEquals(1, slot1Stats.ndv);
+        Assertions.assertEquals(1, slot1Stats.ndv, 0.1);
         Assertions.assertEquals(1, slot1Stats.numNulls);
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/stats/StatsCalculatorTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/stats/StatsCalculatorTest.java
@@ -293,7 +293,7 @@ public class StatsCalculatorTest {
         Assertions.assertEquals(1, limitStats.getRowCount());
         ColumnStatistic slot1Stats = limitStats.columnStatistics().get(slot1);
         Assertions.assertEquals(1, slot1Stats.ndv, 0.1);
-        Assertions.assertEquals(1, slot1Stats.numNulls);
+        Assertions.assertEquals(0.5, slot1Stats.numNulls);
     }
 
     @Test
@@ -323,6 +323,6 @@ public class StatsCalculatorTest {
         Assertions.assertEquals(1, topNStats.getRowCount());
         ColumnStatistic slot1Stats = topNStats.columnStatistics().get(slot1);
         Assertions.assertEquals(1, slot1Stats.ndv, 0.1);
-        Assertions.assertEquals(1, slot1Stats.numNulls);
+        Assertions.assertEquals(0.5, slot1Stats.numNulls);
     }
 }

--- a/regression-test/suites/nereids_syntax_p0/join.groovy
+++ b/regression-test/suites/nereids_syntax_p0/join.groovy
@@ -204,33 +204,6 @@ suite("join") {
         insert into outerjoin_D values( 1 );
     """
 
-    def explainStr =
-        sql(""" explain SELECT count(1)
-                FROM 
-                    (SELECT sub1.wtid,
-                        count(*)
-                    FROM 
-                        (SELECT a.wtid ,
-                        a.wfid
-                        FROM test_table_b a ) sub1
-                        INNER JOIN [shuffle] 
-                            (SELECT a.wtid,
-                        a.wfid
-                            FROM test_table_a a ) sub2
-                                ON sub1.wtid = sub2.wtid
-                                    AND sub1.wfid = sub2.wfid
-                            GROUP BY  sub1.wtid ) qqqq;""").toString()
-    logger.info(explainStr)
-    assertTrue(
-        //if analyze finished
-            explainStr.contains("VAGGREGATE (update serialize)") && explainStr.contains("VAGGREGATE (merge finalize)")
-                    && explainStr.contains("wtid[#8] = wtid[#3]") && explainStr.contains("projections: wtid[#5], wfid[#6]")
-                    ||
-        //analyze not finished
-                    explainStr.contains("VAGGREGATE (update finalize)") && explainStr.contains("VAGGREGATE (update finalize)")
-                    && explainStr.contains("VEXCHANGE") && explainStr.contains("VHASH JOIN")
-    )
-
     test {
         sql"""select * from test_table_a a cross join test_table_b b on a.wtid > b.wtid"""
         check{result, exception, startTime, endTime ->


### PR DESCRIPTION
# Proposed changes
1. after filter "T1.A=c", column stats for A should be updated
2. skip __DORIS_DELETE_SIGN__=0 in stats derive, 
3. after filter, we need to update column ndv. use new formula: 
newNdv = originNdv * (1 - Math.pow(1 - sel, originRowCount / originNdv))
4. agg stats derive: support the case when all group_by_key's stats are unknown

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

