### PR TITLE
[fix](multi-catalog) fix forward to master throw NPE

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/external/ExternalDatabase.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/external/ExternalDatabase.java
@@ -110,7 +110,8 @@ public class ExternalDatabase<T extends ExternalTable> implements DatabaseIf<T>,
         if (!initialized) {
             if (!Env.getCurrentEnv().isMaster()) {
                 // Forward to master and wait the journal to replay.
-                MasterCatalogExecutor remoteExecutor = new MasterCatalogExecutor(ConnectContext.get());
+                int waitTimeOut = ConnectContext.get() == null ? 300 : ConnectContext.get().getExecTimeout();
+                MasterCatalogExecutor remoteExecutor = new MasterCatalogExecutor(waitTimeOut * 1000);
                 try {
                     remoteExecutor.forward(extCatalog.getId(), id);
                 } catch (Exception e) {

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/external/ExternalDatabase.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/external/ExternalDatabase.java
@@ -110,7 +110,7 @@ public class ExternalDatabase<T extends ExternalTable> implements DatabaseIf<T>,
         if (!initialized) {
             if (!Env.getCurrentEnv().isMaster()) {
                 // Forward to master and wait the journal to replay.
-                MasterCatalogExecutor remoteExecutor = new MasterCatalogExecutor();
+                MasterCatalogExecutor remoteExecutor = new MasterCatalogExecutor(ConnectContext.get());
                 try {
                     remoteExecutor.forward(extCatalog.getId(), id);
                 } catch (Exception e) {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalCatalog.java
@@ -126,7 +126,8 @@ public abstract class ExternalCatalog implements CatalogIf<ExternalDatabase>, Wr
         if (!initialized) {
             if (!Env.getCurrentEnv().isMaster()) {
                 // Forward to master and wait the journal to replay.
-                MasterCatalogExecutor remoteExecutor = new MasterCatalogExecutor(ConnectContext.get());
+                int waitTimeOut = ConnectContext.get() == null ? 300 : ConnectContext.get().getExecTimeout();
+                MasterCatalogExecutor remoteExecutor = new MasterCatalogExecutor(waitTimeOut * 1000);
                 try {
                     remoteExecutor.forward(id, -1);
                 } catch (Exception e) {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalCatalog.java
@@ -32,6 +32,7 @@ import org.apache.doris.common.io.Writable;
 import org.apache.doris.common.util.Util;
 import org.apache.doris.persist.gson.GsonPostProcessable;
 import org.apache.doris.persist.gson.GsonUtils;
+import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.MasterCatalogExecutor;
 
 import com.google.common.collect.Lists;
@@ -125,7 +126,7 @@ public abstract class ExternalCatalog implements CatalogIf<ExternalDatabase>, Wr
         if (!initialized) {
             if (!Env.getCurrentEnv().isMaster()) {
                 // Forward to master and wait the journal to replay.
-                MasterCatalogExecutor remoteExecutor = new MasterCatalogExecutor();
+                MasterCatalogExecutor remoteExecutor = new MasterCatalogExecutor(ConnectContext.get());
                 try {
                     remoteExecutor.forward(id, -1);
                 } catch (Exception e) {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/MasterCatalogExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/MasterCatalogExecutor.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.qe;
 
+import org.apache.doris.catalog.Env;
 import org.apache.doris.common.ClientPool;
 import org.apache.doris.thrift.FrontendService;
 import org.apache.doris.thrift.TInitExternalCtlMetaRequest;
@@ -32,14 +33,11 @@ import org.apache.logging.log4j.Logger;
  * This client will wait for the journal ID replayed at this Observer FE before return.
  */
 public class MasterCatalogExecutor {
-
     private static final Logger LOG = LogManager.getLogger(MasterCatalogExecutor.class);
 
-    private final ConnectContext ctx;
     private int waitTimeoutMs;
 
-    public MasterCatalogExecutor() {
-        ctx = ConnectContext.get();
+    public MasterCatalogExecutor(ConnectContext ctx) {
         if (ctx == null) {
             // The method may be called by FrontendServiceImpl from BE, which does not have ConnectContext.
             waitTimeoutMs = 300 * 1000;
@@ -49,11 +47,11 @@ public class MasterCatalogExecutor {
     }
 
     public void forward(long catalogId, long dbId) throws Exception {
-        if (!ctx.getEnv().isReady()) {
+        if (!Env.getCurrentEnv().isReady()) {
             throw new Exception("Current catalog is not ready, please wait for a while.");
         }
-        String masterHost = ctx.getEnv().getMasterIp();
-        int masterRpcPort = ctx.getEnv().getMasterRpcPort();
+        String masterHost = Env.getCurrentEnv().getMasterIp();
+        int masterRpcPort = Env.getCurrentEnv().getMasterRpcPort();
         TNetworkAddress thriftAddress = new TNetworkAddress(masterHost, masterRpcPort);
 
         FrontendService.Client client = null;

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/MasterCatalogExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/MasterCatalogExecutor.java
@@ -37,13 +37,8 @@ public class MasterCatalogExecutor {
 
     private int waitTimeoutMs;
 
-    public MasterCatalogExecutor(ConnectContext ctx) {
-        if (ctx == null) {
-            // The method may be called by FrontendServiceImpl from BE, which does not have ConnectContext.
-            waitTimeoutMs = 300 * 1000;
-        } else {
-            waitTimeoutMs = ctx.getExecTimeout() * 1000;
-        }
+    public MasterCatalogExecutor(int waitTimeoutMs) {
+        this.waitTimeoutMs = waitTimeoutMs;
     }
 
     public void forward(long catalogId, long dbId) throws Exception {


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

The ConnectionContext maybe null, and actually, we don't need ConnectionContext in MasterCatalogExecutor

```
2023-03-14 01:09:19,201 WARN (thrift-server-pool-1|261) [Util.logAndThrowRuntimeException():545] failed to forward init external db iceberg_catalog operation to master
java.lang.NullPointerException: null
at org.apache.doris.qe.MasterCatalogExecutor.forward(MasterCatalogExecutor.java:52) ~[doris-fe.jar:1.2-SNAPSHOT]
at org.apache.doris.catalog.external.ExternalDatabase.makeSureInitialized(ExternalDatabase.java:115) ~[doris-fe.jar:1.2-SNAPSHOT]
at org.apache.doris.catalog.external.HMSExternalDatabase.getTableNamesWithLock(HMSExternalDatabase.java:137) ~[doris-fe.jar:1.2-SNAPSHOT]
at org.apache.doris.catalog.DatabaseIf.getTableNamesOrEmptyWithLock(DatabaseIf.java:103) ~[doris-fe.jar:1.2-SNAPSHOT]
at org.apache.doris.service.FrontendServiceImpl.getTableNames(FrontendServiceImpl.java:531) ~[doris-fe.jar:1.2-SNAPSHOT]
at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:?]
at jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:?]
at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:?]
at java.lang.reflect.Method.invoke(Method.java:566) ~[?:?]
at org.apache.doris.service.FeServer.lambda$start$0(FeServer.java:57) ~[doris-fe.jar:1.2-SNAPSHOT]
at com.sun.proxy.$Proxy30.getTableNames(Unknown Source) ~[?:?]
at org.apache.doris.thrift.FrontendService$Processor$getTableNames.getResult(FrontendService.java:1912) ~[fe-common-1.2-SNAPSHOT.jar:1.2-SNAPSHOT]
at org.apache.doris.thrift.FrontendService$Processor$getTableNames.getResult(FrontendService.java:1892) ~[fe-common-1.2-SNAPSHOT.jar:1.2-SNAPSHOT]
at org.apache.thrift.ProcessFunction.process(ProcessFunction.java:38) ~[libthrift-0.16.0.jar:0.16.0]
at org.apache.thrift.TBaseProcessor.process(TBaseProcessor.java:38) ~[libthrift-0.16.0.jar:0.16.0]
at org.apache.thrift.server.TThreadPoolServer$WorkerProcess.run(TThreadPoolServer.java:250) ~[libthrift-0.16.0.jar:0.16.0]
at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) ~[?:?]
at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) ~[?:?]
at java.lang.Thread.run(Thread.java:829) ~[?:?]
```

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

