### PR TITLE
[fix][Nereids] fix not correct condition to checkReorder in InnerJoinRightAssociate.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/join/InnerJoinLeftAssociate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/join/InnerJoinLeftAssociate.java
@@ -111,12 +111,9 @@ public class InnerJoinLeftAssociate extends OneExplorationRuleFactory {
      * Check JoinReorderContext.
      */
     public static boolean checkReorder(LogicalJoin<GroupPlan, ? extends Plan> topJoin) {
-        if (topJoin.getJoinReorderContext().hasCommute()
-                || topJoin.getJoinReorderContext().hasLeftAssociate()
-                || topJoin.getJoinReorderContext().hasRightAssociate()
-                || topJoin.getJoinReorderContext().hasExchange()) {
-            return false;
-        }
-        return true;
+        return !topJoin.getJoinReorderContext().hasCommute()
+                && !topJoin.getJoinReorderContext().hasLeftAssociate()
+                && !topJoin.getJoinReorderContext().hasRightAssociate()
+                && !topJoin.getJoinReorderContext().hasExchange();
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/join/InnerJoinRightAssociate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/join/InnerJoinRightAssociate.java
@@ -111,7 +111,7 @@ public class InnerJoinRightAssociate extends OneExplorationRuleFactory {
     public static boolean checkReorder(LogicalJoin<? extends Plan, GroupPlan> topJoin) {
         return !topJoin.getJoinReorderContext().hasCommute()
                 && !topJoin.getJoinReorderContext().hasRightAssociate()
-                && !topJoin.getJoinReorderContext().hasRightAssociate()
+                && !topJoin.getJoinReorderContext().hasLeftAssociate()
                 && !topJoin.getJoinReorderContext().hasExchange();
     }
 }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

`InnerJoinRightAssociate#checkOrder` has a a duplicate condition `!topJoin.getJoinReorderContext().hasRightAssociate()`. 

IIUC, In order to keep consistent with `InnerJoinLeftAssociation`, It should be `!topJoin.getJoinReorderContext().hasLeftAssociate()`.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

