### PR TITLE
[fix](Nereids): construct project with all slots in `semi-semi-transpose-project` rule

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/join/SemiJoinSemiJoinTransposeProject.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/join/SemiJoinSemiJoinTransposeProject.java
@@ -65,14 +65,12 @@ public class SemiJoinSemiJoinTransposeProject extends OneExplorationRuleFactory 
                     Set<ExprId> aOutputExprIdSet = a.getOutputExprIdSet();
                     Set<NamedExpression> acProjects = new HashSet<NamedExpression>(abProject.getProjects());
 
-                    bottomSemi.getHashJoinConjuncts().forEach(
-                            expression -> expression.getInputSlots().forEach(
-                                    slot -> {
-                                        if (aOutputExprIdSet.contains(slot.getExprId())) {
-                                            acProjects.add(slot);
-                                        }
-                                    })
-                    );
+                    bottomSemi.getConditionSlot()
+                            .forEach(slot -> {
+                                if (aOutputExprIdSet.contains(slot.getExprId())) {
+                                    acProjects.add(slot);
+                                }
+                            });
                     LogicalJoin newBottomSemi = (LogicalJoin) topSemi.withChildren(a, c);
                     newBottomSemi.getJoinReorderContext().copyFrom(bottomSemi.getJoinReorderContext());
                     newBottomSemi.getJoinReorderContext().setHasCommute(false);


### PR DESCRIPTION
# Proposed changes

error msg in tpch 20
```
SlotRef have invalid slot id: , desc: 22, slot_desc: tuple_desc_map: [Tuple(id=10 slots=[Slot(id=51 type=DECIMALV2(27, 9) col=-1, colname= null=(offset=0 mask=80)), Slot(id=52 type=INT col=-1, colname= null=(offset=0 mask=0)), Slot(id=53 type=INT col=-1, colname= null=(offset=0 mask=0)), Slot(id=54 type=INT col=-1, colname= null=(offset=0 mask=0)), Slot(id=55 type=INT col=-1, colname= null=(offset=0 mask=0))] has_varlen_slots=0)] tuple_id_map: [-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 0] tuple_is_nullable: [0] , desc_tbl: Slot(id=22 type=INT col=-1, colname= null=(offset=0 mask=0))
```

Before we only use slots in `hashJoin` conditions to construct projects, which may lost some slots in `project`, such as 
```
LOGICAL_SEMI_JOIN_LOGICAL_JOIN_TRANSPOSE_PROJECT

LogicalJoin[1135] ( type=LEFT_SEMI_JOIN, markJoinSlotReference=Optional.empty, hashJoinConjuncts=[(PS_PARTKEY#0 = P_PARTKEY#6)], otherJoinConjuncts=[] )
|--LogicalProject[1128] ( distinct=false, projects=[PS_PARTKEY#0, PS_SUPPKEY#1], excepts=[], canEliminate=true )
|  +--LogicalJoin[1120] ( type=LEFT_SEMI_JOIN, markJoinSlotReference=Optional.empty, hashJoinConjuncts=[(L_PARTKEY#17 = PS_PARTKEY#0), (L_SUPPKEY#18 = PS_SUPPKEY#1)], otherJoinConjuncts=[(cast(PS_AVAILQTY#2 as DECIMAL(27, 9)) > (0.5 * sum(L_QUANTITY))#33)] )
|     |--GroupPlan( GroupId#2 )
|     +--GroupPlan( GroupId#7 )
+--GroupPlan( GroupId#12 )
----------------------after----------------------
LogicalJoin[1141] ( type=LEFT_SEMI_JOIN, markJoinSlotReference=Optional.empty, hashJoinConjuncts=[(L_PARTKEY#17 = PS_PARTKEY#0), (L_SUPPKEY#18 = PS_SUPPKEY#1)], otherJoinConjuncts=[(cast(PS_AVAILQTY#2 as DECIMAL(27, 9)) > (0.5 * sum(L_QUANTITY))#33)] )
|--LogicalProject[1140] ( distinct=false, projects=[PS_PARTKEY#0, PS_SUPPKEY#1], excepts=[], canEliminate=true )
|  +--LogicalJoin[1139] ( type=LEFT_SEMI_JOIN, markJoinSlotReference=Optional.empty, hashJoinConjuncts=[(PS_PARTKEY#0 = P_PARTKEY#6)], otherJoinConjuncts=[] )
|     |--GroupPlan( GroupId#2 )
|     +--GroupPlan( GroupId#12 )
+--GroupPlan( GroupId#7 )
```
`PS_AVAILQTY#2` lost in project

Now we use all slots to construct projest

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

