### PR TITLE
[Improvement](aggregate) use fixed-length type to do aggregation for string with fixed length

### DIFF
--- a/be/src/runtime/types.h
+++ b/be/src/runtime/types.h
@@ -42,6 +42,8 @@ struct TypeDescriptor {
     PrimitiveType type;
     /// Only set if type == TYPE_CHAR or type == TYPE_VARCHAR
     int len;
+    // For Nereids, this field indicates the fixed length of string type.
+    int byte_size = -1;
     static constexpr int MAX_VARCHAR_LENGTH = 65535;
     static constexpr int MAX_CHAR_LENGTH = 255;
     static constexpr int MAX_CHAR_INLINE_LENGTH = 128;
@@ -130,6 +132,9 @@ struct TypeDescriptor {
         int idx = 0;
         TypeDescriptor result(t.types, &idx);
         DCHECK_EQ(idx, t.types.size() - 1);
+        if (t.__isset.byte_size) {
+            result.byte_size = t.byte_size;
+        }
         return result;
     }
 

--- a/be/src/vec/common/aggregation_common.h
+++ b/be/src/vec/common/aggregation_common.h
@@ -106,6 +106,13 @@ T pack_fixed(size_t i, size_t keys_size, const ColumnRawPtrs& key_columns, const
             }
         }
 
+        // For fixed-length string
+        if (const auto* str_col = check_and_get_column<const ColumnString>(*column)) {
+            memcpy(bytes + offset, str_col->get_chars().data() + index * key_sizes[j],
+                   key_sizes[j]);
+            offset += key_sizes[j];
+            continue;
+        }
         switch (key_sizes[j]) {
         case 1:
             memcpy(bytes + offset,

--- a/be/src/vec/common/unaligned.h
+++ b/be/src/vec/common/unaligned.h
@@ -31,6 +31,13 @@ T unaligned_load(const void* address) {
     return res;
 }
 
+template <typename T>
+T unaligned_load(const void* address, const size_t sz) {
+    T res {};
+    memcpy(&res, address, sz);
+    return res;
+}
+
 /// We've had troubles before with wrong store size due to integral promotions
 /// (e.g., unaligned_store(dest, uint16_t + uint16_t) stores an uint32_t).
 /// To prevent this, make the caller specify the stored type explicitly.

--- a/be/src/vec/data_types/data_type.h
+++ b/be/src/vec/data_types/data_type.h
@@ -73,6 +73,7 @@ public:
 
 protected:
     virtual String do_get_name() const;
+    int _byte_size = -1;
 
 public:
     /** Create empty column for corresponding type.
@@ -245,6 +246,8 @@ public:
     virtual void to_pb_column_meta(PColumnMeta* col_meta) const;
 
     static PGenericType_TypeId get_pdata_type(const IDataType* data_type);
+    void set_byte_size(int byte_size) { _byte_size = byte_size; }
+    int byte_size() const { return _byte_size; }
 
 private:
     friend class DataTypeFactory;

--- a/be/src/vec/data_types/data_type_factory.cpp
+++ b/be/src/vec/data_types/data_type_factory.cpp
@@ -144,6 +144,7 @@ DataTypePtr DataTypeFactory::create_data_type(const TypeDescriptor& col_desc, bo
     case TYPE_BINARY:
     case TYPE_LAMBDA_FUNCTION:
         nested = std::make_shared<vectorized::DataTypeString>();
+        const_cast<IDataType*>(nested.get())->set_byte_size(col_desc.byte_size);
         break;
     case TYPE_JSONB:
         nested = std::make_shared<vectorized::DataTypeJsonb>();

--- a/be/src/vec/data_types/data_type_string.h
+++ b/be/src/vec/data_types/data_type_string.h
@@ -60,6 +60,8 @@ public:
     std::string to_string(const IColumn& column, size_t row_num) const override;
     void to_string(const IColumn& column, size_t row_num, BufferWritable& ostr) const override;
     Status from_string(ReadBuffer& rb, IColumn* column) const override;
+    bool have_maximum_size_of_value() const override { return _byte_size > 0; }
+    size_t get_size_of_value_in_memory() const override { return _byte_size; }
 };
 
 } // namespace doris::vectorized

--- a/be/src/vec/exec/vaggregation_node.cpp
+++ b/be/src/vec/exec/vaggregation_node.cpp
@@ -217,6 +217,7 @@ void AggregationNode::_init_hash_method(std::vector<VExprContext*>& probe_exprs)
         case TYPE_CHAR:
         case TYPE_VARCHAR:
         case TYPE_STRING: {
+            // TODO:
             _agg_data->init(AggregatedDataVariants::Type::string_key, is_nullable);
             break;
         }


### PR DESCRIPTION
for sql ` AGG GROUP BY VARCHAR(1), VARCHAR(1)`, we can use int32 as the type of group by key
# Proposed changes

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

