### PR TITLE
[enhancement](fe query schedule) use try write lock to avoid too much wait time for planner

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/TabletStatMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/TabletStatMgr.java
@@ -35,6 +35,7 @@ import org.apache.logging.log4j.Logger;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.TimeUnit;
 
 /*
  * TabletStatMgr is for collecting tablet(replica) statistics from backends.
@@ -94,7 +95,13 @@ public class TabletStatMgr extends MasterDaemon {
                     continue;
                 }
                 OlapTable olapTable = (OlapTable) table;
-                if (!table.writeLockIfExist()) {
+                // Use try write lock to avoid such cases
+                //    Time1: Thread1 hold read lock for 5min
+                //    Time2: Thread2 want to add write lock, then it will be the first element in lock queue
+                //    Time3: Thread3 want to add read lock, but it will not, because thread 2 want to add write lock
+                // In this case, thread 3 has to wait more than 5min, because it has to wait thread 2 to add 
+                // write lock and release write lock and thread 2 has to wait thread 1 to release read lock
+                if (!table.tryWriteLockIfExist(3000, TimeUnit.MILLISECONDS)) {
                     continue;
                 }
                 try {

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/TabletStatMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/TabletStatMgr.java
@@ -99,7 +99,7 @@ public class TabletStatMgr extends MasterDaemon {
                 //    Time1: Thread1 hold read lock for 5min
                 //    Time2: Thread2 want to add write lock, then it will be the first element in lock queue
                 //    Time3: Thread3 want to add read lock, but it will not, because thread 2 want to add write lock
-                // In this case, thread 3 has to wait more than 5min, because it has to wait thread 2 to add 
+                // In this case, thread 3 has to wait more than 5min, because it has to wait thread 2 to add
                 // write lock and release write lock and thread 2 has to wait thread 1 to release read lock
                 if (!table.tryWriteLockIfExist(3000, TimeUnit.MILLISECONDS)) {
                     continue;


### PR DESCRIPTION
# Proposed changes

1.use try write lock to avoid too much wait time for planner.
2. wait time for planner; print ascii id instead of big int because be always print ascii 

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

