### PR TITLE
[improvement](inverted index)UNIQUE_KEYS table only supports inverted…

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
@@ -2206,7 +2206,8 @@ public class SchemaChangeHandler extends AlterHandler {
         for (String col : indexDef.getColumns()) {
             Column column = olapTable.getColumn(col);
             if (column != null) {
-                indexDef.checkColumn(column, olapTable.getKeysType());
+                indexDef.checkColumn(column, olapTable.getKeysType(),
+                        olapTable.getTableProperty().getEnableUniqueKeyMergeOnWrite());
             } else {
                 throw new DdlException("index column does not exist in table. invalid column: " + col);
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateTableStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateTableStmt.java
@@ -552,7 +552,7 @@ public class CreateTableStmt extends DdlStmt {
                     boolean found = false;
                     for (Column column : columns) {
                         if (column.getName().equalsIgnoreCase(indexColName)) {
-                            indexDef.checkColumn(column, getKeysDesc().getKeysType());
+                            indexDef.checkColumn(column, getKeysDesc().getKeysType(), enableUniqueKeyMergeOnWrite);
                             found = true;
                             break;
                         }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/IndexDef.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/IndexDef.java
@@ -179,7 +179,8 @@ public class IndexDef {
         return (this.indexType == IndexType.INVERTED);
     }
 
-    public void checkColumn(Column column, KeysType keysType) throws AnalysisException {
+    public void checkColumn(Column column, KeysType keysType, boolean enableUniqueKeyMergeOnWrite)
+            throws AnalysisException {
         if (indexType == IndexType.BITMAP || indexType == IndexType.INVERTED || indexType == IndexType.BLOOMFILTER
                 || indexType == IndexType.NGRAM_BF) {
             String indexColName = column.getName();
@@ -192,10 +193,17 @@ public class IndexDef {
                     || colType.isFixedPointType() || colType.isStringType() || colType == PrimitiveType.BOOLEAN)) {
                 throw new AnalysisException(colType + " is not supported in " + indexType.toString() + " index. "
                         + "invalid column: " + indexColName);
-            } else if ((keysType == KeysType.AGG_KEYS && !column.isKey())) {
+            } else if (keysType == KeysType.AGG_KEYS && !column.isKey() && indexType != IndexType.INVERTED) {
                 throw new AnalysisException(indexType.toString()
-                        + " index only used in columns of DUP_KEYS/UNIQUE_KEYS table or key columns of"
-                                + " AGG_KEYS table. invalid column: " + indexColName);
+                    + " index only used in columns of DUP_KEYS/UNIQUE_KEYS table or key columns of"
+                    + " AGG_KEYS table. invalid column: " + indexColName);
+            } else if ((keysType == KeysType.AGG_KEYS && !column.isKey())
+                    || (keysType == KeysType.UNIQUE_KEYS && indexType == IndexType.INVERTED
+                        && !enableUniqueKeyMergeOnWrite)) {
+                throw new AnalysisException(indexType.toString()
+                    + " index only used in columns of DUP_KEYS table"
+                    + " or UNIQUE_KEYS table with merge_on_write enabled"
+                    + " or key columns of AGG_KEYS table. invalid column: " + indexColName);
             }
 
             if (indexType == IndexType.INVERTED) {
@@ -228,14 +236,6 @@ public class IndexDef {
             }
         } else {
             throw new AnalysisException("Unsupported index type: " + indexType);
-        }
-    }
-
-    public void checkColumns(List<Column> columns, KeysType keysType) throws AnalysisException {
-        if (indexType == IndexType.BITMAP || indexType == IndexType.INVERTED || indexType == IndexType.BLOOMFILTER) {
-            for (Column col : columns) {
-                checkColumn(col, keysType);
-            }
         }
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/IndexDef.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/IndexDef.java
@@ -193,17 +193,17 @@ public class IndexDef {
                     || colType.isFixedPointType() || colType.isStringType() || colType == PrimitiveType.BOOLEAN)) {
                 throw new AnalysisException(colType + " is not supported in " + indexType.toString() + " index. "
                         + "invalid column: " + indexColName);
-            } else if (keysType == KeysType.AGG_KEYS && !column.isKey() && indexType != IndexType.INVERTED) {
-                throw new AnalysisException(indexType.toString()
-                    + " index only used in columns of DUP_KEYS/UNIQUE_KEYS table or key columns of"
-                    + " AGG_KEYS table. invalid column: " + indexColName);
-            } else if ((keysType == KeysType.AGG_KEYS && !column.isKey())
-                    || (keysType == KeysType.UNIQUE_KEYS && indexType == IndexType.INVERTED
-                        && !enableUniqueKeyMergeOnWrite)) {
+            } else if (indexType == IndexType.INVERTED
+                    && ((keysType == KeysType.AGG_KEYS && !column.isKey())
+                        || (keysType == KeysType.UNIQUE_KEYS && !enableUniqueKeyMergeOnWrite))) {
                 throw new AnalysisException(indexType.toString()
                     + " index only used in columns of DUP_KEYS table"
                     + " or UNIQUE_KEYS table with merge_on_write enabled"
                     + " or key columns of AGG_KEYS table. invalid column: " + indexColName);
+            } else if (keysType == KeysType.AGG_KEYS && !column.isKey() && indexType != IndexType.INVERTED) {
+                throw new AnalysisException(indexType.toString()
+                    + " index only used in columns of DUP_KEYS/UNIQUE_KEYS table or key columns of"
+                    + " AGG_KEYS table. invalid column: " + indexColName);
             }
 
             if (indexType == IndexType.INVERTED) {

--- a/fe/fe-core/src/test/java/org/apache/doris/alter/SchemaChangeHandlerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/alter/SchemaChangeHandlerTest.java
@@ -65,7 +65,8 @@ public class SchemaChangeHandlerTest extends TestWithFeService {
                 + "username VARCHAR(50) NOT NULL,\n" + "city VARCHAR(20),\n" + "age SMALLINT,\n" + "sex TINYINT,\n"
                 + "phone LARGEINT,\n" + "address VARCHAR(500),\n" + "register_time DATETIME)\n"
                 + "UNIQUE  KEY(user_id, username)\n" + "DISTRIBUTED BY HASH(user_id) BUCKETS 1\n"
-                + "PROPERTIES ('replication_num' = '1', 'light_schema_change' = 'true');";
+                + "PROPERTIES ('replication_num' = '1', 'light_schema_change' = 'true',\n"
+                + "'enable_unique_key_merge_on_write' = 'true');";
         createTable(createUniqTblStmtStr);
 
         String createDupTblStmtStr = "CREATE TABLE IF NOT EXISTS test.sc_dup (\n" + "timestamp DATETIME,\n"

--- a/regression-test/suites/mysql_fulltext/ddl/articles_uk.sql
+++ b/regression-test/suites/mysql_fulltext/ddl/articles_uk.sql
@@ -8,5 +8,6 @@ CREATE TABLE IF NOT EXISTS articles_uk (
 UNIQUE KEY(id)
 DISTRIBUTED BY HASH(id) BUCKETS 3
 PROPERTIES ( 
-    "replication_num" = "1" 
+    "replication_num" = "1",
+    "enable_unique_key_merge_on_write" = "true"
 );

--- a/regression-test/suites/mysql_fulltext/ddl/fulltext_t1_uk.sql
+++ b/regression-test/suites/mysql_fulltext/ddl/fulltext_t1_uk.sql
@@ -7,5 +7,6 @@ CREATE TABLE IF NOT EXISTS fulltext_t1_uk (
 UNIQUE KEY(a)
 DISTRIBUTED BY HASH(a) BUCKETS 3
 PROPERTIES ( 
-    "replication_num" = "1" 
+    "replication_num" = "1",
+    "enable_unique_key_merge_on_write" = "true"
 );

--- a/regression-test/suites/mysql_fulltext/ddl/join_t1_uk.sql
+++ b/regression-test/suites/mysql_fulltext/ddl/join_t1_uk.sql
@@ -6,6 +6,7 @@ CREATE TABLE IF NOT EXISTS join_t1_uk (
 UNIQUE KEY(venue_id)
 DISTRIBUTED BY HASH(venue_id) BUCKETS 3
 PROPERTIES ( 
-    "replication_num" = "1" 
+    "replication_num" = "1",
+    "enable_unique_key_merge_on_write" = "true"
 );
 

--- a/regression-test/suites/mysql_fulltext/ddl/join_t2_uk.sql
+++ b/regression-test/suites/mysql_fulltext/ddl/join_t2_uk.sql
@@ -6,5 +6,6 @@ CREATE TABLE IF NOT EXISTS join_t2_uk (
 UNIQUE KEY(entity_id)
 DISTRIBUTED BY HASH(entity_id) BUCKETS 3
 PROPERTIES ( 
-    "replication_num" = "1" 
+    "replication_num" = "1",
+    "enable_unique_key_merge_on_write" = "true"
 );

--- a/regression-test/suites/mysql_fulltext/ddl/large_records_t1_uk.sql
+++ b/regression-test/suites/mysql_fulltext/ddl/large_records_t1_uk.sql
@@ -8,5 +8,6 @@ CREATE TABLE IF NOT EXISTS large_records_t1_uk (
 UNIQUE KEY(FTS_DOC_ID)
 DISTRIBUTED BY HASH(FTS_DOC_ID) BUCKETS 3
 PROPERTIES ( 
-    "replication_num" = "1" 
+    "replication_num" = "1",
+    "enable_unique_key_merge_on_write" = "true"
 );

--- a/regression-test/suites/mysql_fulltext/ddl/large_records_t2_uk.sql
+++ b/regression-test/suites/mysql_fulltext/ddl/large_records_t2_uk.sql
@@ -8,5 +8,6 @@ CREATE TABLE IF NOT EXISTS large_records_t2_uk (
 UNIQUE KEY(FTS_DOC_ID)
 DISTRIBUTED BY HASH(FTS_DOC_ID) BUCKETS 3
 PROPERTIES ( 
-    "replication_num" = "1" 
+    "replication_num" = "1",
+    "enable_unique_key_merge_on_write" = "true"
 );

--- a/regression-test/suites/mysql_fulltext/ddl/large_records_t3_uk.sql
+++ b/regression-test/suites/mysql_fulltext/ddl/large_records_t3_uk.sql
@@ -8,5 +8,6 @@ CREATE TABLE IF NOT EXISTS large_records_t3_uk (
 UNIQUE KEY(FTS_DOC_ID)
 DISTRIBUTED BY HASH(FTS_DOC_ID) BUCKETS 3
 PROPERTIES ( 
-    "replication_num" = "1" 
+    "replication_num" = "1",
+    "enable_unique_key_merge_on_write" = "true"
 );

--- a/regression-test/suites/mysql_fulltext/ddl/large_records_t4_uk.sql
+++ b/regression-test/suites/mysql_fulltext/ddl/large_records_t4_uk.sql
@@ -8,5 +8,6 @@ CREATE TABLE IF NOT EXISTS large_records_t4_uk (
 UNIQUE KEY(FTS_DOC_ID)
 DISTRIBUTED BY HASH(FTS_DOC_ID) BUCKETS 3
 PROPERTIES ( 
-    "replication_num" = "1" 
+    "replication_num" = "1",
+    "enable_unique_key_merge_on_write" = "true"
 );


### PR DESCRIPTION
… index when merge_on_write is enabled.

# Proposed changes
When adding inverted index to UNIQUE_KEYS table without merge_on_write enabled, the match query may failed before the segment is compacted. 
So we add the restriction here.

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

