### PR TITLE
[improvement](fetch data) Merge result into batch to reduce rpc times

### DIFF
--- a/be/src/runtime/buffer_control_block.cpp
+++ b/be/src/runtime/buffer_control_block.cpp
@@ -125,8 +125,6 @@ Status BufferControlBlock::add_batch(std::unique_ptr<TFetchDataResult>& result) 
             !result->eos) {
             std::vector<std::string>& back_rows = _batch_queue.back()->result_batch.rows;
             std::vector<std::string>& result_rows = result->result_batch.rows;
-            auto back_size = back_rows.size();
-            back_rows.resize(back_size + num_rows);
             back_rows.insert(back_rows.end(), std::make_move_iterator(result_rows.begin()),
                              std::make_move_iterator(result_rows.end()));
         } else {

--- a/be/src/runtime/buffer_control_block.cpp
+++ b/be/src/runtime/buffer_control_block.cpp
@@ -127,9 +127,8 @@ Status BufferControlBlock::add_batch(std::unique_ptr<TFetchDataResult>& result) 
             std::vector<std::string>& result_rows = result->result_batch.rows;
             auto back_size = back_rows.size();
             back_rows.resize(back_size + num_rows);
-            for (int i = 0; i < num_rows; ++i) {
-                back_rows[back_size + i].assign(result_rows[i].c_str(), result_rows[i].length());
-            }
+            back_rows.insert(back_rows.end(), std::make_move_iterator(result_rows.begin()),
+                             std::make_move_iterator(result_rows.end()));
         } else {
             _batch_queue.push_back(std::move(result));
         }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx
In some queries, there are thousands of batches in fragment 0, and there is only one row of data in each batch, so FE sends a fetch_data rpc request to fetch only one row of data at a time. Occasionally, rpc jitter is encountered, and an rpc request takes tens of milliseconds, so that the query that was originally returned in a few seconds becomes returned in tens of seconds.
Therefore, some small batches are merged in Fragment 0 to reduce the number of rpc.

## Problem summary

before:
![image](https://user-images.githubusercontent.com/21984011/231040845-6aa26325-d243-4fac-a5c4-5c1829ef854b.png)

- Schedule  Time:  2s886ms，Fetch  Result  Time:  19s447ms，Execution  Profile Active:  23s526ms

after:
- Schedule  Time:  1s597ms，Fetch  Result  Time:  2s288ms，Execution  Profile Active:  3s961ms


## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [x] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

