### PR TITLE
[Fix](Planner)Add call once logic to analyze of function aes_decrypt

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/FunctionCallExpr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/FunctionCallExpr.java
@@ -64,6 +64,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 // TODO: for aggregations, we need to unify the code paths for builtins and UDAs.
 public class FunctionCallExpr extends Expr {
@@ -77,6 +78,8 @@ public class FunctionCallExpr extends Expr {
             String.CASE_INSENSITIVE_ORDER)
             .add("round").add("round_bankers").add("ceil").add("floor")
             .add("truncate").add("dround").add("dceil").add("dfloor").build();
+
+    private final AtomicBoolean addOnce = new AtomicBoolean(false);
 
     static {
         java.util.function.BiFunction<ArrayList<Expr>, Type, Type> sumRule = (children, returnType) -> {
@@ -1016,7 +1019,9 @@ public class FunctionCallExpr extends Expr {
                     }
                 }
             }
-            children.add(new StringLiteral(blockEncryptionMode));
+            if (!blockEncryptionMode.equals(children.get(children.size() - 1))) {
+                children.add(new StringLiteral(blockEncryptionMode));
+            }
         }
 
     }

--- a/regression-test/suites/query_p0/sql_functions/encryption_digest/test_encryption_function.groovy
+++ b/regression-test/suites/query_p0/sql_functions/encryption_digest/test_encryption_function.groovy
@@ -16,6 +16,18 @@
 // under the License.
 
 suite("test_encryption_function") {
+    def tableName = "dwd_candidates"
+    sql "DROP TABLE IF EXISTS ${tableName}"
+    sql """
+        CREATE TABLE IF NOT EXISTS ${tableName} (
+          c_int INT,
+          `name` varchar(65530) NULL COMMENT ""
+        )
+        DISTRIBUTED BY HASH(c_int) BUCKETS 1
+        PROPERTIES (
+          "replication_num" = "1"
+        )
+    """
     sql "set batch_size = 4096;"
 
     sql "set block_encryption_mode=\"AES_128_ECB\";"
@@ -46,6 +58,10 @@ suite("test_encryption_function") {
     }
     qt_sql "SELECT AES_DECRYPT(FROM_BASE64('mvZT1KJw7N0RJf27aipUpg=='),'F3229A0B371ED2D9441B830D21A390C3', '0123456789');"
     qt_sql "SELECT AES_DECRYPT(FROM_BASE64('tsmK1HzbpnEdR2//WhO+MA=='),'F3229A0B371ED2D9441B830D21A390C3', '0123456789');"
+    explain {
+        sql "SELECT AES_DECRYPT(UNHEX(r_2_3.`name`), 'namePnhe3E0MWyfZivUnVzDy12caymnrKp', '0123456789') AS x0 FROM dwd_candidates AS r_2_3\n" +
+                "GROUP BY x0;"
+    }
 
     sql "set block_encryption_mode=\"SM4_128_CBC\";"
     test {


### PR DESCRIPTION
# Proposed changes

Add call once to adding third parameter of aes_decrypt type function.

## Problem summary

The problem is an exception when doing analyze:
java.lang.IllegalStateException: exceptions :
errCode = 2, detailMessage = select list expression not produced by aggregation output (missing from GROUP BY clause?): xxx

The scenario is: 
select aes_decrypt(xxx,xxx) as c0 from table group by c0;

Analyze of problem:
The direct problem is mismatched of slotref, and this mismatched due to the mismatched of parameter number of aes_decrypt function. When debuging, we can see the slotref of group column is added to ExprSubstitutionMap, but can not matching with select result columns. And this is because when substiting expr it will analyze again, so the parameter would be added twice. This will cause the mismatching of function, so it would not be substitute as a slotref, the exception would be throw.

Fix:
Add call once to adding third parameter of aes_decrypt type function. Compare the child we want to add to the last child of function. If they are the same, do not add it.

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [x] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

