### PR TITLE
[ehancement](fe) remove lock in statistics cache loader 

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticsCacheLoader.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticsCacheLoader.java
@@ -33,8 +33,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Executor;
 
+/**
+ * Use to load stats cache.
+ */
 public class StatisticsCacheLoader implements AsyncCacheLoader<StatisticsCacheKey, Statistic> {
 
     private static final Logger LOG = LogManager.getLogger(StatisticsCacheLoader.class);
@@ -47,72 +52,68 @@ public class StatisticsCacheLoader implements AsyncCacheLoader<StatisticsCacheKe
             + "." + StatisticConstants.HISTOGRAM_TBL_NAME + " WHERE "
             + "id = CONCAT('${tblId}', '-', ${idxId}, '-', '${colId}')";
 
-    private static int CUR_RUNNING_LOAD = 0;
-
-    private static final Object LOCK = new Object();
+    private final ConcurrentMap<StatisticsCacheKey, CompletableFuture<Statistic>>
+            inProgressing = new ConcurrentHashMap<>();
 
     // TODO: Maybe we should trigger a analyze job when the required ColumnStatistic doesn't exists.
     @Override
     public @NonNull CompletableFuture<Statistic> asyncLoad(@NonNull StatisticsCacheKey key,
             @NonNull Executor executor) {
-        synchronized (LOCK) {
-            if (CUR_RUNNING_LOAD > StatisticConstants.LOAD_TASK_LIMITS) {
-                try {
-                    LOCK.wait();
-                } catch (InterruptedException e) {
-                    LOG.warn("Ignore interruption", e);
-                }
-            }
-            CUR_RUNNING_LOAD++;
-            return CompletableFuture.supplyAsync(() -> {
-                Statistic statistic = new Statistic();
-
-                try {
-                    Map<String, String> params = new HashMap<>();
-                    params.put("tblId", String.valueOf(key.tableId));
-                    params.put("idxId", String.valueOf(key.idxId));
-                    params.put("colId", String.valueOf(key.colName));
-
-                    List<ColumnStatistic> columnStatistics;
-                    List<ResultRow> columnResult =
-                            StatisticsUtil.execStatisticQuery(new StringSubstitutor(params)
-                                    .replace(QUERY_COLUMN_STATISTICS));
-                    try {
-                        columnStatistics = StatisticsUtil.deserializeToColumnStatistics(columnResult);
-                    } catch (Exception e) {
-                        LOG.warn("Failed to deserialize column statistics", e);
-                        throw new CompletionException(e);
-                    }
-                    if (CollectionUtils.isEmpty(columnStatistics)) {
-                        statistic.setColumnStatistic(ColumnStatistic.DEFAULT);
-                    } else {
-                        statistic.setColumnStatistic(columnStatistics.get(0));
-                    }
-
-                    List<Histogram> histogramStatistics;
-                    List<ResultRow> histogramResult =
-                            StatisticsUtil.execStatisticQuery(new StringSubstitutor(params)
-                                    .replace(QUERY_HISTOGRAM_STATISTICS));
-                    try {
-                        histogramStatistics = StatisticsUtil.deserializeToHistogramStatistics(histogramResult);
-                    } catch (Exception e) {
-                        LOG.warn("Failed to deserialize histogram statistics", e);
-                        throw new CompletionException(e);
-                    }
-                    if (CollectionUtils.isEmpty(histogramStatistics)) {
-                        statistic.setHistogram(Histogram.DEFAULT);
-                    } else {
-                        statistic.setHistogram(histogramStatistics.get(0));
-                    }
-                } finally {
-                    synchronized (LOCK) {
-                        CUR_RUNNING_LOAD--;
-                        LOCK.notify();
-                    }
-                }
-
-                return statistic;
-            });
+        CompletableFuture<Statistic> future = inProgressing.get(key);
+        if (future != null) {
+            return future;
         }
+        future = CompletableFuture.supplyAsync(() -> {
+            Statistic statistic = new Statistic();
+            long startTime = 0;
+            try {
+                LOG.info("Query BE for column stats:{}-{} start time:{}", key.tableId, key.colName,
+                        startTime);
+                Map<String, String> params = new HashMap<>();
+                params.put("tblId", String.valueOf(key.tableId));
+                params.put("idxId", String.valueOf(key.idxId));
+                params.put("colId", String.valueOf(key.colName));
+
+                List<ColumnStatistic> columnStatistics;
+                List<ResultRow> columnResult =
+                        StatisticsUtil.execStatisticQuery(new StringSubstitutor(params)
+                                .replace(QUERY_COLUMN_STATISTICS));
+                try {
+                    columnStatistics = StatisticsUtil.deserializeToColumnStatistics(columnResult);
+                } catch (Exception e) {
+                    LOG.warn("Failed to deserialize column statistics", e);
+                    throw new CompletionException(e);
+                }
+                if (CollectionUtils.isEmpty(columnStatistics)) {
+                    statistic.setColumnStatistic(ColumnStatistic.DEFAULT);
+                } else {
+                    statistic.setColumnStatistic(columnStatistics.get(0));
+                }
+
+                List<Histogram> histogramStatistics;
+                List<ResultRow> histogramResult =
+                        StatisticsUtil.execStatisticQuery(new StringSubstitutor(params)
+                                .replace(QUERY_HISTOGRAM_STATISTICS));
+                try {
+                    histogramStatistics = StatisticsUtil.deserializeToHistogramStatistics(histogramResult);
+                } catch (Exception e) {
+                    LOG.warn("Failed to deserialize histogram statistics", e);
+                    throw new CompletionException(e);
+                }
+                if (CollectionUtils.isEmpty(histogramStatistics)) {
+                    statistic.setHistogram(Histogram.DEFAULT);
+                } else {
+                    statistic.setHistogram(histogramStatistics.get(0));
+                }
+            } finally {
+                long endTime = System.currentTimeMillis();
+                LOG.info("Query BE for column stats:{}-{} end time:{} cost time:{}", key.tableId, key.colName,
+                        endTime, endTime - startTime);
+                inProgressing.remove(key);
+            }
+            return statistic;
+        });
+        inProgressing.put(key, future);
+        return future;
     }
 }


### PR DESCRIPTION
# Proposed changes

1. remove the redandunt lock in the CacheLoader, since it use the forkjoinpool in default
2. Add execute time log for collect stats
3. Avoid submit duplicate task, when there already has a task to load for the same column

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

