### PR TITLE
[fix](compile) fix compile error when compile with mysql

### DIFF
--- a/be/src/util/mysql_load_error_hub.cpp
+++ b/be/src/util/mysql_load_error_hub.cpp
@@ -18,6 +18,7 @@
 #include <mysql/mysql.h>
 
 #define __DorisMysql MYSQL
+#include "common/logging.h"
 #include "mysql_load_error_hub.h"
 #include "util/defer_op.h"
 


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

fix compile for the following error:
error: 'VLOG_PROGRESS' was not declared in this scope
error: 'VLOG_ROW' was not declared in this scope

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

