### PR TITLE
[chore](fe) Add the character_set_database for compatibility with MySQL clients

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -71,6 +71,7 @@ public class SessionVariable implements Serializable, Writable {
     public static final String CHARACTER_SET_CONNNECTION = "character_set_connection";
     public static final String CHARACTER_SET_RESULTS = "character_set_results";
     public static final String CHARACTER_SET_SERVER = "character_set_server";
+    public static final String CHARACTER_SET_DATABASE = "character_set_database";
     public static final String COLLATION_CONNECTION = "collation_connection";
     public static final String COLLATION_DATABASE = "collation_database";
     public static final String COLLATION_SERVER = "collation_server";
@@ -367,6 +368,8 @@ public class SessionVariable implements Serializable, Writable {
     public String charsetResults = "utf8";
     @VariableMgr.VarAttr(name = CHARACTER_SET_SERVER)
     public String charsetServer = "utf8";
+    @VariableMgr.VarAttr(name = CHARACTER_SET_DATABASE)
+    public String charsetDatabase = "utf8";
     @VariableMgr.VarAttr(name = COLLATION_CONNECTION)
     public String collationConnection = "utf8_general_ci";
     @VariableMgr.VarAttr(name = COLLATION_DATABASE)
@@ -971,6 +974,10 @@ public class SessionVariable implements Serializable, Writable {
 
     public String getCharsetServer() {
         return charsetServer;
+    }
+
+    public String getCharsetDatabase() {
+        return charsetDatabase;
     }
 
     public String getCollationConnection() {


### PR DESCRIPTION

# Proposed changes

Issue Number: close #xxx

## Problem summary

Describe your changes.
When using the mysql client to execute `status`, it shows that the variable character_set_database cannot be found
![KfjN8Qx9vV](https://user-images.githubusercontent.com/11573612/225505190-6bec6120-1989-4815-9614-e7888019f5ae.jpg)

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

