### PR TITLE
[Feature](Nereids) support new mv

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Column.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Column.java
@@ -264,6 +264,10 @@ public class Column implements Writable, GsonPostProcessable {
         return CreateMaterializedViewStmt.mvColumnBreaker(name);
     }
 
+    public static String getNameWithoutMvPrefix(String originalName) {
+        return CreateMaterializedViewStmt.mvColumnBreaker(originalName);
+    }
+
     public String getDisplayName() {
         if (defineExpr == null) {
             return getNameWithoutMvPrefix();

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/CaseWhen.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/CaseWhen.java
@@ -104,7 +104,7 @@ public class CaseWhen extends Expression {
 
     @Override
     public String toSql() throws UnboundException {
-        StringBuilder output = new StringBuilder("CASE ");
+        StringBuilder output = new StringBuilder("CASE");
         for (Expression child : children()) {
             if (child instanceof WhenClause) {
                 output.append(child.toSql());

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalOlapScan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalOlapScan.java
@@ -40,13 +40,13 @@ import org.apache.doris.qe.ConnectContext;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Maps;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
@@ -72,6 +72,8 @@ public class LogicalOlapScan extends LogicalRelation implements CatalogRelation,
      * Status to indicate using pre-aggregation or not.
      */
     private final PreAggStatus preAggStatus;
+
+    private final Map<String, Slot> mvNameToSlot;
 
     ///////////////////////////////////////////////////////////////////////////
     // Members for tablet ids.
@@ -107,27 +109,27 @@ public class LogicalOlapScan extends LogicalRelation implements CatalogRelation,
         this(id, table, qualifier, Optional.empty(), Optional.empty(),
                 table.getPartitionIds(), false,
                 ImmutableList.of(),
-                -1, false, PreAggStatus.on(), ImmutableList.of(), ImmutableList.of());
+                -1, false, PreAggStatus.on(), ImmutableList.of(), ImmutableList.of(), Maps.newHashMap());
     }
 
     public LogicalOlapScan(ObjectId id, OlapTable table, List<String> qualifier, List<String> hints) {
         this(id, table, qualifier, Optional.empty(), Optional.empty(),
                 table.getPartitionIds(), false,
                 ImmutableList.of(),
-                -1, false, PreAggStatus.on(), ImmutableList.of(), hints);
+                -1, false, PreAggStatus.on(), ImmutableList.of(), hints, Maps.newHashMap());
     }
 
     public LogicalOlapScan(ObjectId id, OlapTable table, List<String> qualifier, List<Long> specifiedPartitions,
             List<String> hints) {
         this(id, table, qualifier, Optional.empty(), Optional.empty(),
                 specifiedPartitions, false, ImmutableList.of(),
-                -1, false, PreAggStatus.on(), specifiedPartitions, hints);
+                -1, false, PreAggStatus.on(), specifiedPartitions, hints, Maps.newHashMap());
     }
 
     public LogicalOlapScan(ObjectId id, Table table, List<String> qualifier) {
         this(id, table, qualifier, Optional.empty(), Optional.empty(),
                 ((OlapTable) table).getPartitionIds(), false, ImmutableList.of(),
-                -1, false, PreAggStatus.on(), ImmutableList.of(), ImmutableList.of());
+                -1, false, PreAggStatus.on(), ImmutableList.of(), ImmutableList.of(), Maps.newHashMap());
     }
 
     /**
@@ -137,7 +139,7 @@ public class LogicalOlapScan extends LogicalRelation implements CatalogRelation,
             Optional<GroupExpression> groupExpression, Optional<LogicalProperties> logicalProperties,
             List<Long> selectedPartitionIds, boolean partitionPruned,
             List<Long> selectedTabletIds, long selectedIndexId, boolean indexSelected,
-            PreAggStatus preAggStatus, List<Long> partitions, List<String> hints) {
+            PreAggStatus preAggStatus, List<Long> partitions, List<String> hints, Map<String, Slot> mvNameToSlot) {
 
         super(id, PlanType.LOGICAL_OLAP_SCAN, table, qualifier,
                 groupExpression, logicalProperties);
@@ -150,6 +152,7 @@ public class LogicalOlapScan extends LogicalRelation implements CatalogRelation,
         this.selectedPartitionIds = ImmutableList.copyOf(
                 Objects.requireNonNull(selectedPartitionIds, "selectedPartitionIds can not be null"));
         this.hints = Objects.requireNonNull(hints, "hints can not be null");
+        this.mvNameToSlot = Objects.requireNonNull(mvNameToSlot, "mvNameToSlot can not be null");
     }
 
     public List<Long> getSelectedPartitionIds() {
@@ -193,7 +196,8 @@ public class LogicalOlapScan extends LogicalRelation implements CatalogRelation,
                 && Objects.equals(selectedIndexId, ((LogicalOlapScan) o).selectedIndexId)
                 && Objects.equals(indexSelected, ((LogicalOlapScan) o).indexSelected)
                 && Objects.equals(selectedTabletIds, ((LogicalOlapScan) o).selectedTabletIds)
-                && Objects.equals(hints, ((LogicalOlapScan) o).hints);
+                && Objects.equals(hints, ((LogicalOlapScan) o).hints)
+                && Objects.equals(mvNameToSlot, ((LogicalOlapScan) o).mvNameToSlot);
     }
 
     @Override
@@ -202,45 +206,45 @@ public class LogicalOlapScan extends LogicalRelation implements CatalogRelation,
                 selectedPartitionIds, partitionPruned,
                 selectedIndexId, indexSelected,
                 selectedTabletIds,
-                hints);
+                hints, mvNameToSlot);
     }
 
     @Override
     public LogicalOlapScan withGroupExpression(Optional<GroupExpression> groupExpression) {
         return new LogicalOlapScan(id, (Table) table, qualifier, groupExpression, Optional.of(getLogicalProperties()),
                 selectedPartitionIds, partitionPruned, selectedTabletIds,
-                selectedIndexId, indexSelected, preAggStatus, manuallySpecifiedPartitions, hints);
+                selectedIndexId, indexSelected, preAggStatus, manuallySpecifiedPartitions, hints, mvNameToSlot);
     }
 
     @Override
     public LogicalOlapScan withLogicalProperties(Optional<LogicalProperties> logicalProperties) {
         return new LogicalOlapScan(id, (Table) table, qualifier, Optional.empty(), logicalProperties,
                 selectedPartitionIds, partitionPruned, selectedTabletIds,
-                selectedIndexId, indexSelected, preAggStatus, manuallySpecifiedPartitions, hints);
+                selectedIndexId, indexSelected, preAggStatus, manuallySpecifiedPartitions, hints, mvNameToSlot);
     }
 
     public LogicalOlapScan withSelectedPartitionIds(List<Long> selectedPartitionIds) {
         return new LogicalOlapScan(id, (Table) table, qualifier, Optional.empty(), Optional.of(getLogicalProperties()),
                 selectedPartitionIds, true, selectedTabletIds,
-                selectedIndexId, indexSelected, preAggStatus, manuallySpecifiedPartitions, hints);
+                selectedIndexId, indexSelected, preAggStatus, manuallySpecifiedPartitions, hints, mvNameToSlot);
     }
 
     public LogicalOlapScan withMaterializedIndexSelected(PreAggStatus preAgg, long indexId) {
         return new LogicalOlapScan(id, (Table) table, qualifier, Optional.empty(), Optional.of(getLogicalProperties()),
                 selectedPartitionIds, partitionPruned, selectedTabletIds,
-                indexId, true, preAgg, manuallySpecifiedPartitions, hints);
+                indexId, true, preAgg, manuallySpecifiedPartitions, hints, mvNameToSlot);
     }
 
     public LogicalOlapScan withSelectedTabletIds(List<Long> selectedTabletIds) {
         return new LogicalOlapScan(id, (Table) table, qualifier, Optional.empty(), Optional.of(getLogicalProperties()),
                 selectedPartitionIds, partitionPruned, selectedTabletIds,
-                selectedIndexId, indexSelected, preAggStatus, manuallySpecifiedPartitions, hints);
+                selectedIndexId, indexSelected, preAggStatus, manuallySpecifiedPartitions, hints, mvNameToSlot);
     }
 
     public LogicalOlapScan withPreAggStatus(PreAggStatus preAggStatus) {
         return new LogicalOlapScan(id, (Table) table, qualifier, Optional.empty(), Optional.of(getLogicalProperties()),
                 selectedPartitionIds, partitionPruned, selectedTabletIds,
-                selectedIndexId, indexSelected, preAggStatus, manuallySpecifiedPartitions, hints);
+                selectedIndexId, indexSelected, preAggStatus, manuallySpecifiedPartitions, hints, mvNameToSlot);
     }
 
     @Override
@@ -290,24 +294,38 @@ public class LogicalOlapScan extends LogicalRelation implements CatalogRelation,
 
     @Override
     public List<Slot> computeNonUserVisibleOutput() {
-        // if (getTable().getIndexIdToMeta().size() == 1) {
-        //     return ImmutableList.of();
-        // }
-        Set<String> baseSchemaColNames = table.getBaseSchema().stream()
-                .map(Column::getName)
-                .collect(Collectors.toSet());
-
         OlapTable olapTable = (OlapTable) table;
-        // extra columns in materialized index, such as `mv_bitmap_union_xxx`
         return olapTable.getVisibleIndexIdToMeta().values()
                 .stream()
                 .filter(index -> index.getIndexId() != ((OlapTable) table).getBaseIndexId())
-                .flatMap(index -> index.getSchema()
-                        .stream()
-                        .filter(col -> !baseSchemaColNames.contains(col.getName()))
-                )
-                .map(col -> SlotReference.fromColumn(col, qualified()))
+                .flatMap(index -> index.getSchema().stream())
+                .map(this::generateUniqueSlot)
                 .collect(ImmutableList.toImmutableList());
+    }
+
+    /**
+     * Get the slot under the index,
+     * and create a new slotReference for the slot that has not appeared in the materialized view.
+     */
+    public List<Slot> getOutputByMvIndex(long indexId) {
+        if (indexId == ((OlapTable) table).getBaseIndexId()) {
+            return getOutput();
+        }
+
+        OlapTable olapTable = (OlapTable) table;
+        return olapTable.getVisibleIndexIdToMeta().get(indexId).getSchema()
+                .stream()
+                .map(this::generateUniqueSlot)
+                .collect(ImmutableList.toImmutableList());
+    }
+
+    private Slot generateUniqueSlot(Column column) {
+        if (mvNameToSlot.containsKey(column.getName())) {
+            return mvNameToSlot.get(column.getName());
+        }
+        Slot slot = SlotReference.fromColumn(column, qualified());
+        mvNameToSlot.put(column.getName(), slot);
+        return slot;
     }
 
     public List<Long> getManuallySpecifiedPartitions() {


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

The metadata storage format of the materialized view has changed, and the new optimizer adapts to the new storage method.

The column storage format of the metadata for the materialized view is changed to start with mv_ or start with mva_
This pr allows the new optimizer to recognize the new materialized view columns and select the correct materialized view.

TODO: support advance mv

## Checklist(Required)

* [x] Does it affect the original behavior
* [x] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

