### PR TITLE
[ehancement](fe) Tune for stats framework

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/FilterEstimation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/FilterEstimation.java
@@ -18,6 +18,7 @@
 package org.apache.doris.nereids.stats;
 
 import org.apache.doris.nereids.stats.FilterEstimation.EstimationContext;
+import org.apache.doris.nereids.trees.TreeNode;
 import org.apache.doris.nereids.trees.expressions.And;
 import org.apache.doris.nereids.trees.expressions.ComparisonPredicate;
 import org.apache.doris.nereids.trees.expressions.CompoundPredicate;
@@ -33,6 +34,7 @@ import org.apache.doris.nereids.trees.expressions.NullSafeEqual;
 import org.apache.doris.nereids.trees.expressions.Or;
 import org.apache.doris.nereids.trees.expressions.Slot;
 import org.apache.doris.nereids.trees.expressions.SlotReference;
+import org.apache.doris.nereids.trees.expressions.functions.Function;
 import org.apache.doris.nereids.trees.expressions.literal.Literal;
 import org.apache.doris.nereids.trees.expressions.visitor.ExpressionVisitor;
 import org.apache.doris.statistics.Bucket;
@@ -49,6 +51,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Predicate;
 
 /**
  * Calculate selectivity of expression that produces boolean value.
@@ -56,8 +59,20 @@ import java.util.Set;
  */
 public class FilterEstimation extends ExpressionVisitor<Statistics, EstimationContext> {
     public static final double DEFAULT_INEQUALITY_COEFFICIENT = 0.5;
+    public static final double DEFAULT_IN_COEFFICIENT = 1.0 / 3.0;
+
+    public static final double DEFAULT_HAVING_COEFFICIENT = 0.01;
 
     public static final double DEFAULT_EQUALITY_COMPARISON_SELECTIVITY = 0.1;
+
+    private Set<Slot> aggSlots;
+
+    public FilterEstimation() {
+    }
+
+    public FilterEstimation(Set<Slot> aggSlots) {
+        this.aggSlots = aggSlots;
+    }
 
     /**
      * This method will update the stats according to the selectivity.
@@ -104,7 +119,6 @@ public class FilterEstimation extends ExpressionVisitor<Statistics, EstimationCo
                     estimatedColStatsBuilder.setMaxValue(rightColStats.maxValue);
                     estimatedColStatsBuilder.setMaxExpr(rightColStats.maxExpr);
                 }
-                orStats.addColumnStats(entry.getKey(), estimatedColStatsBuilder.build());
             }
             return orStats;
         }
@@ -127,6 +141,24 @@ public class FilterEstimation extends ExpressionVisitor<Statistics, EstimationCo
         }
         ColumnStatistic statsForLeft = ExpressionEstimation.estimate(left, context.statistics);
         ColumnStatistic statsForRight = ExpressionEstimation.estimate(right, context.statistics);
+        if (aggSlots != null) {
+            Predicate<TreeNode<Expression>> containsAggSlot = e -> {
+                if (e instanceof SlotReference) {
+                    SlotReference slot = (SlotReference) e;
+                    return aggSlots.contains(slot);
+                }
+                return false;
+            };
+            boolean leftAgg = left.anyMatch(containsAggSlot);
+            boolean rightAgg = right.anyMatch(containsAggSlot);
+            // It means this predicate appears in HAVING clause.
+            if (leftAgg || rightAgg) {
+                double rowCount = context.statistics.getRowCount();
+                double newRowCount = Math.max(rowCount * DEFAULT_HAVING_COEFFICIENT,
+                        Math.max(statsForLeft.ndv, statsForRight.ndv));
+                return context.statistics.withRowCount(newRowCount);
+            }
+        }
         if (!(left instanceof Literal) && !(right instanceof Literal)) {
             return calculateWhenBothColumn(cp, context, statsForLeft, statsForRight);
         } else {
@@ -167,14 +199,11 @@ public class FilterEstimation extends ExpressionVisitor<Statistics, EstimationCo
         double ndv = statsForLeft.ndv;
         double val = statsForRight.maxValue;
         if (cp instanceof EqualTo || cp instanceof NullSafeEqual) {
-            if (statsForLeft == ColumnStatistic.UNKNOWN) {
-                selectivity = DEFAULT_EQUALITY_COMPARISON_SELECTIVITY;
+
+            if (val > statsForLeft.maxValue || val < statsForLeft.minValue) {
+                selectivity = 0.0;
             } else {
-                if (val > statsForLeft.maxValue || val < statsForLeft.minValue) {
-                    selectivity = 0.0;
-                } else {
-                    selectivity = StatsMathUtil.minNonNaN(1.0, 1.0 / ndv);
-                }
+                selectivity = StatsMathUtil.minNonNaN(1.0, 1.0 / ndv);
             }
             if (context.isNot) {
                 selectivity = 1 - selectivity;
@@ -249,8 +278,8 @@ public class FilterEstimation extends ExpressionVisitor<Statistics, EstimationCo
         boolean isNotIn = context != null && context.isNot;
         Expression compareExpr = inPredicate.getCompareExpr();
         ColumnStatistic compareExprStats = ExpressionEstimation.estimate(compareExpr, context.statistics);
-        if (compareExprStats.isUnKnown) {
-            return context.statistics.withSel(DEFAULT_INEQUALITY_COEFFICIENT);
+        if (compareExprStats.isUnKnown || compareExpr instanceof Function) {
+            return context.statistics.withSel(DEFAULT_IN_COEFFICIENT);
         }
         List<Expression> options = inPredicate.getOptions();
         double maxOption = 0;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/JoinEstimation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/JoinEstimation.java
@@ -21,10 +21,10 @@ import org.apache.doris.common.Pair;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.plans.JoinType;
 import org.apache.doris.nereids.trees.plans.algebra.Join;
-import org.apache.doris.nereids.util.ExpressionUtils;
 import org.apache.doris.statistics.Statistics;
 import org.apache.doris.statistics.StatisticsBuilder;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -33,6 +33,7 @@ import java.util.stream.Collectors;
  * TODO: Update other props in the ColumnStats properly.
  */
 public class JoinEstimation {
+
     private static Statistics estimateInnerJoin(Statistics crossJoinStats, List<Expression> joinConditions) {
         List<Pair<Expression, Double>> sortedJoinConditions = joinConditions.stream()
                 .map(expression -> Pair.of(expression, estimateJoinConditionSel(crossJoinStats, expression)))
@@ -51,7 +52,7 @@ public class JoinEstimation {
         for (int i = 0; i < sortedJoinConditions.size(); i++) {
             sel *= Math.pow(sortedJoinConditions.get(i).second, 1 / Math.pow(2, i));
         }
-        return crossJoinStats.withSel(sel);
+        return crossJoinStats.updateRowCountOnly(crossJoinStats.getRowCount() * sel);
     }
 
     private static double estimateJoinConditionSel(Statistics crossJoinStats, Expression joinCond) {
@@ -69,13 +70,19 @@ public class JoinEstimation {
                 .putColumnStatistics(leftStats.columnStatistics())
                 .putColumnStatistics(rightStats.columnStatistics())
                 .build();
-        List<Expression> joinConditions = join.getHashJoinConjuncts();
-        Statistics innerJoinStats = estimateInnerJoin(crossJoinStats, joinConditions);
-        if (!join.getOtherJoinConjuncts().isEmpty()) {
-            FilterEstimation filterEstimation = new FilterEstimation();
-            innerJoinStats = filterEstimation.estimate(
-                    ExpressionUtils.and(join.getOtherJoinConjuncts()), innerJoinStats);
+        Statistics innerJoinStats = null;
+        if (crossJoinStats.getRowCount() != 0) {
+            List<Expression> joinConditions = new ArrayList<>(join.getHashJoinConjuncts());
+            joinConditions.addAll(join.getOtherJoinConjuncts());
+            innerJoinStats = estimateInnerJoin(crossJoinStats, joinConditions);
+        } else {
+            innerJoinStats = crossJoinStats;
         }
+        // if (!join.getOtherJoinConjuncts().isEmpty()) {
+        //     FilterEstimation filterEstimation = new FilterEstimation();
+        //     innerJoinStats = filterEstimation.estimate(
+        //             ExpressionUtils.and(join.getOtherJoinConjuncts()), innerJoinStats);
+        // }
         innerJoinStats.setWidth(leftStats.getWidth() + rightStats.getWidth());
         innerJoinStats.setPenalty(0);
         double rowCount;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/StatsErrorEstimator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/StatsErrorEstimator.java
@@ -52,7 +52,7 @@ public class StatsErrorEstimator {
     }
 
     /**
-     * Map plan id to stats.
+     * Invoked by PhysicalPlanTranslator, put the translated plan node and corresponding physical plan to estimator.
      */
     public void updateLegacyPlanIdToPhysicalPlan(PlanNode planNode, AbstractPlan physicalPlan) {
         Statistics statistics = physicalPlan.getStats();

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticConstants.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticConstants.java
@@ -62,4 +62,6 @@ public class StatisticConstants {
 
     public static final int LOAD_TASK_LIMITS = 10;
 
+    public static final double DEFAULT_INNER_JOIN_FACTOR = 0.1;
+
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/Statistics.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/Statistics.java
@@ -83,14 +83,25 @@ public class Statistics {
         return rowCount;
     }
 
+    /*
+     * Return a stats with new rowCount and fix each column stats.
+     */
     public Statistics withRowCount(double rowCount) {
+        if (Double.isNaN(rowCount)) {
+            return this;
+        }
         Statistics statistics = new Statistics(rowCount, new HashMap<>(expressionToColumnStats), width, penalty);
         statistics.fix(rowCount, StatsMathUtil.nonZeroDivisor(this.rowCount));
         return statistics;
     }
 
+    public Statistics updateRowCountOnly(double rowCount) {
+        return new Statistics(rowCount, expressionToColumnStats);
+    }
+
     public void fix(double newRowCount, double originRowCount) {
         double sel = newRowCount / originRowCount;
+
         for (Entry<Expression, ColumnStatistic> entry : expressionToColumnStats.entrySet()) {
             ColumnStatistic columnStatistic = entry.getValue();
             ColumnStatisticBuilder columnStatisticBuilder = new ColumnStatisticBuilder(columnStatistic);

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/stats/FilterEstimationTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/stats/FilterEstimationTest.java
@@ -115,9 +115,7 @@ class FilterEstimationTest {
         Statistics stat = new Statistics(1000, slotToColumnStat);
         FilterEstimation filterEstimation = new FilterEstimation();
         Statistics expected = filterEstimation.estimate(in, stat);
-        Assertions.assertEquals(
-                FilterEstimation.DEFAULT_INEQUALITY_COEFFICIENT * stat.getRowCount(),
-                expected.getRowCount());
+        Assertions.assertTrue(Precision.equals(333.33, expected.getRowCount(), 0.01));
     }
 
     @Test
@@ -134,9 +132,7 @@ class FilterEstimationTest {
         Statistics stat = new Statistics(1000, slotToColumnStat);
         FilterEstimation filterEstimation = new FilterEstimation();
         Statistics expected = filterEstimation.estimate(notIn, stat);
-        Assertions.assertEquals(
-                FilterEstimation.DEFAULT_INEQUALITY_COEFFICIENT * stat.getRowCount(),
-                expected.getRowCount());
+        Assertions.assertTrue(Precision.equals(333.33, expected.getRowCount(), 0.01));
     }
 
     /**

--- a/tools/qerror.py
+++ b/tools/qerror.py
@@ -21,6 +21,7 @@ import subprocess
 
 import requests
 import json
+import time
 
 mycli_cmd = "mysql -h127.0.0.1 -P9030 -uroot -Dtpch1G"
 
@@ -36,6 +37,8 @@ sql_file_prefix_for_trace = """
     SET enable_nereids_planner=true;
     SET session_context='trace_id:{}';
 """
+
+q_err_list = []
 
 
 def extract_number(string):
@@ -73,6 +76,7 @@ def execute_sql(sql_file: str):
 
 
 def get_q_error(trace_id):
+    time.sleep(1)
     # 'YWRtaW46' is the base64 encoded result for 'admin:'
     headers = {'Authorization': 'BASIC YWRtaW46'}
     resp_wrapper = requests.get(trace_url.format(trace_id), headers=headers)
@@ -81,9 +85,13 @@ def get_q_error(trace_id):
     resp_wrapper = requests.get(qerror_url.format(query_id), headers=headers)
     resp_text = resp_wrapper.text
     write_result(str(trace_id), resp_text)
+    print(trace_id)
+    print(resp_text)
+    qerr = json.loads(resp_text)["qError"]
+    q_err_list.append(float(qerr))
 
 
-def iterates_sqls(path: str) -> list:
+def iterates_sqls(path: str, if_write_results: bool) -> list:
     cost_times = []
     files = os.listdir(path)
     files.sort(key=extract_number)
@@ -93,14 +101,22 @@ def iterates_sqls(path: str) -> list:
             traced_sql_file = filepath + ".traced"
             content = read_lines(filepath)
             sql_num = extract_number(filename)
-            write_results(traced_sql_file, str(sql_file_prefix_for_trace.format(sql_num)), content)
-            execute_sql(traced_sql_file)
-            get_q_error(sql_num)
-            os.remove(traced_sql_file)
+            print("sql num" + str(sql_num))
+            if if_write_results:
+                write_results(traced_sql_file, str(sql_file_prefix_for_trace.format(sql_num)), content)
+                execute_sql(traced_sql_file)
+                get_q_error(sql_num)
+                os.remove(traced_sql_file)
+            else:
+                execute_sql(filepath)
     return cost_times
 
 
 if __name__ == '__main__':
     execute_command("echo 'set global enable_nereids_planner=true' | mysql -h127.0.0.1 -P9030")
     execute_command("echo 'set global enable_fallback_to_original_planner=false' | mysql -h127.0.0.1 -P9030")
-    iterates_sqls(original_sql_dir)
+    print("Preparing")
+    iterates_sqls(original_sql_dir, False)
+    print("Started...")
+    iterates_sqls(original_sql_dir, True)
+    write_results(qerr_saved_file_path, "AVG\n", [sum(q_err_list) / len(qerror_url)])


### PR DESCRIPTION
# Proposed changes

1. Add a fix block time for qerr.py, if you request qerror immediately after query execution, its calculation might hasn't finished yet
2. Handle NPE caused by physical plan which without stats
3. When calculate inner join stats only update row count, since the selectivity based on cross join might be too low to cause npe,null count..etc be only 1
4. Fix the aggregate stats derive bug introduced by PR#17790 which would cause the row counts of agg always be `inputRowCount * DEFAULT_AGGREGATE_RATIO` and make the output of agg much overestimated even related table has been analyzed;
5. Upgrade the qerror.py to get stable output
6. Make the estimation for in predicate/ having clause much more precisely based on the test results on tpch-1G

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

