### PR TITLE
[fix](FE)partitionInfo is null, fe not start service

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/CatalogRecycleBin.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/CatalogRecycleBin.java
@@ -512,9 +512,11 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
         RecyclePartitionInfo partitionInfo = idToPartition.remove(partitionId);
         idToRecycleTime.remove(partitionId);
 
-        Partition partition = partitionInfo.getPartition();
-        if (!Env.isCheckpointThread()) {
-            Env.getCurrentEnv().onErasePartition(partition);
+        if (null != partitionInfo){
+            Partition partition = partitionInfo.getPartition();
+            if (!Env.isCheckpointThread()) {
+                Env.getCurrentEnv().onErasePartition(partition);
+            }
         }
 
         LOG.info("replay erase partition[{}]", partitionId);

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/CatalogRecycleBin.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/CatalogRecycleBin.java
@@ -512,7 +512,7 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
         RecyclePartitionInfo partitionInfo = idToPartition.remove(partitionId);
         idToRecycleTime.remove(partitionId);
 
-        if (null != partitionInfo){
+        if (null != partitionInfo) {
             Partition partition = partitionInfo.getPartition();
             if (!Env.isCheckpointThread()) {
                 Env.getCurrentEnv().onErasePartition(partition);


### PR DESCRIPTION
# If the partitionInfo null is abnormal, fe exits abnormally and fe cannot be started


## Problem summary
  - The same problem is repeated in both versions 0.15.3 and 1.1.5, but the latest version of master has not been fixed
```
2023-03-14 16:03:35,748 ERROR (replayer|100) [EditLog.loadJournal():828] Operation Type 16
java.lang.NullPointerException: null
        at org.apache.doris.catalog.CatalogRecycleBin.replayErasePartition(CatalogRecycleBin.java:278) ~[doris-fe.jar:1.0-SNAPSHOT]
        at org.apache.doris.catalog.Catalog.replayErasePartition(Catalog.java:3509) ~[doris-fe.jar:1.0-SNAPSHOT]
        at org.apache.doris.persist.EditLog.loadJournal(EditLog.java:237) ~[doris-fe.jar:1.0-SNAPSHOT]
        at org.apache.doris.catalog.Catalog.replayJournal(Catalog.java:2459) ~[doris-fe.jar:1.0-SNAPSHOT]
        at org.apache.doris.catalog.Catalog$3.runOneCycle(Catalog.java:2243) ~[doris-fe.jar:1.0-SNAPSHOT]
        at org.apache.doris.common.util.Daemon.run(Daemon.java:116) ~[doris-fe.jar:1.0-SNAPSHOT]
```

