### PR TITLE
[fix](Nereids) extract complicated time string in evaluating cost model framework

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalHashAggregate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalHashAggregate.java
@@ -223,7 +223,9 @@ public class PhysicalHashAggregate<CHILD_TYPE extends Plan> extends PhysicalUnar
     public PhysicalHashAggregate<Plan> withChildren(List<Plan> children) {
         Preconditions.checkArgument(children.size() == 1);
         return new PhysicalHashAggregate<>(groupByExpressions, outputExpressions, partitionExpressions,
-                aggregateParam, maybeUsingStream, getLogicalProperties(), requireProperties, children.get(0));
+                aggregateParam, maybeUsingStream, groupExpression, getLogicalProperties(),
+                requireProperties, physicalProperties, statistics,
+                children.get(0));
     }
 
     public PhysicalHashAggregate<CHILD_TYPE> withPartitionExpressions(List<Expression> partitionExpressions) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalQuickSort.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalQuickSort.java
@@ -75,7 +75,8 @@ public class PhysicalQuickSort<CHILD_TYPE extends Plan> extends AbstractPhysical
     @Override
     public PhysicalQuickSort<Plan> withChildren(List<Plan> children) {
         Preconditions.checkArgument(children.size() == 1);
-        return new PhysicalQuickSort<>(orderKeys, phase, getLogicalProperties(), children.get(0));
+        return new PhysicalQuickSort<>(orderKeys, phase, groupExpression, getLogicalProperties(), physicalProperties,
+                statistics, children.get(0));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalStorageLayerAggregate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalStorageLayerAggregate.java
@@ -131,7 +131,9 @@ public class PhysicalStorageLayerAggregate extends PhysicalRelation {
     @Override
     public PhysicalPlan withPhysicalPropertiesAndStats(PhysicalProperties physicalProperties,
             Statistics statistics) {
-        return new PhysicalStorageLayerAggregate(relation, aggOp, groupExpression,
+        return new PhysicalStorageLayerAggregate(
+                (PhysicalRelation) relation.withPhysicalPropertiesAndStats(null, statistics),
+                aggOp, groupExpression,
                 getLogicalProperties(), physicalProperties, statistics);
     }
 

--- a/tools/cost_model_evaluate/sql_executor.py
+++ b/tools/cost_model_evaluate/sql_executor.py
@@ -18,6 +18,7 @@
 from unittest import result
 import mysql.connector
 from typing import List, Tuple
+import re
 
 
 class SQLExecutor:
@@ -43,7 +44,28 @@ class SQLExecutor:
     def get_execute_time(self, query: str) -> float:
         self.execute_query(query, None)
         profile = self.execute_query("show query profile\"\"", None)
-        return float(profile[0][self.wait_fetch_time_index].replace("ms", ""))
+        return self.get_n_ms(profile[0][self.wait_fetch_time_index])
+
+    def get_n_ms(self, t: str):
+        res = re.search(r"(\d+h)*(\d+min)*(\d+s)*(\d+ms)", t)
+        if res is None:
+            raise Exception(f"invalid time {t}")
+        n = 0
+
+        h = res.group(1)
+        if h is not None:
+            n += int(h.replace("h", "")) * 60 * 60 * 1000
+        min = res.group(2)
+        if min is not None != 0:
+            n += int(min.replace("min", "")) * 60 * 1000
+        s = res.group(3)
+        if s is not None != 0:
+            n += int(s.replace("s", "")) * 1000
+        ms = res.group(4)
+        if len(ms) != 0:
+            n += int(ms.replace("ms", ""))
+        
+        return n
 
     def execute_many_queries(self, queries: List[Tuple[str, Tuple]]) -> List[List[Tuple]]:
         results = []


### PR DESCRIPTION
# Proposed changes

1. The time string in the profile can be "xx s xx ms". The framework should extract time with re package to support more complicated time string
2. Add stats for sortNode and AggNode in `withChildren`

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

