### PR TITLE
[Refine](sql block)unify exception catching for sql block

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -465,7 +465,7 @@ public class StmtExecutor implements ProfileWriter {
 
     private boolean checkBlockRules() throws AnalysisException {
         Env.getCurrentEnv().getSqlBlockRuleMgr().matchSql(
-            originStmt.originStmt, context.getSqlHash(), context.getQualifiedUser());
+                originStmt.originStmt, context.getSqlHash(), context.getQualifiedUser());
 
         // limitations: partition_num, tablet_num, cardinality
         List<ScanNode> scanNodeList = planner.getScanNodes();

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -464,14 +464,8 @@ public class StmtExecutor implements ProfileWriter {
     }
 
     private boolean checkBlockRules() throws AnalysisException {
-        try {
-            Env.getCurrentEnv().getSqlBlockRuleMgr().matchSql(
-                    originStmt.originStmt, context.getSqlHash(), context.getQualifiedUser());
-        } catch (AnalysisException e) {
-            LOG.warn(e.getMessage());
-            context.getState().setError(e.getMysqlErrorCode(), e.getMessage());
-            return true;
-        }
+        Env.getCurrentEnv().getSqlBlockRuleMgr().matchSql(
+            originStmt.originStmt, context.getSqlHash(), context.getQualifiedUser());
 
         // limitations: partition_num, tablet_num, cardinality
         List<ScanNode> scanNodeList = planner.getScanNodes();


### PR DESCRIPTION
# Proposed changes

Unify the exception catching for AnalysisException  throw by sql block.

currently, the AnalysisException throw by matchSql will catch immediately. however, the AnalysisException throws by checkLimitations will catch as UserException.


## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

