### PR TITLE
[fix](planner) should always execute projection plan

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/planner/OriginalPlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/OriginalPlanner.java
@@ -165,12 +165,8 @@ public class OriginalPlanner extends Planner {
             singleNodePlan.convertToVectorized();
         }
 
-        if (analyzer.getContext() != null
-                && analyzer.getContext().getSessionVariable().isEnableProjection()
-                && statement instanceof QueryStmt) {
-            ProjectPlanner projectPlanner = new ProjectPlanner(analyzer);
-            projectPlanner.projectSingleNodePlan(queryStmt.getResultExprs(), singleNodePlan);
-        }
+        ProjectPlanner projectPlanner = new ProjectPlanner(analyzer);
+        projectPlanner.projectSingleNodePlan(queryStmt.getResultExprs(), singleNodePlan);
 
         if (statement instanceof InsertStmt) {
             InsertStmt insertStmt = (InsertStmt) statement;


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

1. should always execute projection plan, whatever the statement it is.
2. should always execute projection plan, since we only have vectorized engine now

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

