### PR TITLE
[chore](fe) update aspectj-maven-plugin to 1.14.0 version

### DIFF
--- a/fe/fe-common/pom.xml
+++ b/fe/fe-common/pom.xml
@@ -89,7 +89,12 @@ under the License.
         <dependency>
             <groupId>org.aspectj</groupId>
             <artifactId>aspectjweaver</artifactId>
-            <version>1.8.13</version>
+            <version>${aspectj.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.aspectj</groupId>
+            <artifactId>aspectjrt</artifactId>
+            <version>${aspectj.version}</version>
         </dependency>
     </dependencies>
     <build>

--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -818,7 +818,7 @@ under the License.
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>aspectj-maven-plugin</artifactId>
-                <version>1.11</version>
+                <version>1.14.0</version>
                 <executions>
                     <execution>
                         <phase>process-classes</phase>

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -167,6 +167,7 @@ under the License.
         <maven.compiler.target>1.8</maven.compiler.target>
         <sonar.organization>apache</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
+        <aspectj.version>1.9.7</aspectj.version>
         <cglib.version>2.2</cglib.version>
         <commons-cli.version>1.4</commons-cli.version>
         <commons-filerupload.version>1.5</commons-filerupload.version>


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary
In #17797 , we introduced aspectj to help log exception easily.
However, the plugin version 1.11 do not support jdk9 and later. 
For support compile FE with jdk11
1. update aspectj-maven-plugin to 1.14.0 version
2. add new dependency org.aspectj.aspectjrt 1.9.7 to fe-core

according to:
1. [aspectj java version compatibility](https://github.com/eclipse/org.aspectj/blob/master/docs/dist/doc/JavaVersionCompatibility.md)
2. [aspectj-maven-plugin issue](https://github.com/mojohaus/aspectj-maven-plugin/issues/24)
3. [aspectj release note](https://github.com/mojohaus/aspectj-maven-plugin/releases/tag/aspectj-maven-plugin-1.14.0)
4. [intro to aspectj](https://www.baeldung.com/aspectj)

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

