### PR TITLE
[bug](txn) fix concurrent txns's status data race

### DIFF
--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -825,6 +825,8 @@ void TaskWorkerPool::_publish_version_worker_thread_callback() {
                     _tasks.push_back(agent_task_req);
                     _worker_thread_condition_variable.notify_one();
                 }
+                LOG_INFO("wait for previous publish version task to be done")
+                        .tag("transaction_id", publish_version_req.transaction_id);
                 break;
             } else {
                 LOG_WARNING("failed to publish version")

--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -825,8 +825,8 @@ void TaskWorkerPool::_publish_version_worker_thread_callback() {
                     _tasks.push_back(agent_task_req);
                     _worker_thread_condition_variable.notify_one();
                 }
-                LOG_INFO("wait for previous publish version task to be done")
-                        .tag("transaction_id", publish_version_req.transaction_id);
+                LOG(INFO) << "wait for previous publish version task to be done"
+                          << "transaction_id: " << publish_version_req.transaction_id;
                 break;
             } else {
                 LOG_WARNING("failed to publish version")

--- a/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
@@ -1221,7 +1221,12 @@ public class FrontendServiceImpl implements FrontendService.Iface {
             throw new MetaNotFoundException("db " + request.getDb() + " does not exist");
         }
         long dbId = db.getId();
-        List<Table> tableList = db.getTablesOnIdOrderIfExist(tableIdList);
+        DatabaseTransactionMgr dbTransactionMgr = Env.getCurrentGlobalTransactionMgr().getDatabaseTransactionMgr(dbId);
+        TransactionState transactionState = dbTransactionMgr.getTransactionState(request.getTxnId());
+        if (transactionState == null) {
+            throw new UserException("transaction [" + request.getTxnId() + "] not found");
+        }
+        List<Table> tableList = db.getTablesOnIdOrderIfExist(transactionState.getTableIdList());
         Env.getCurrentGlobalTransactionMgr().abortTransaction(dbId, request.getTxnId(),
                 request.isSetReason() ? request.getReason() : "system cancel",
                 TxnCommitAttachment.fromThrift(request.getTxnCommitAttachment()), tableList);

--- a/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
@@ -1099,7 +1099,7 @@ public class FrontendServiceImpl implements FrontendService.Iface {
             Env.getCurrentGlobalTransactionMgr()
                     .commitTransaction2PC(database, tableList, request.getTxnId(), 5000);
         } else if (txnOperation.equalsIgnoreCase("abort")) {
-            Env.getCurrentGlobalTransactionMgr().abortTransaction2PC(database.getId(), request.getTxnId());
+            Env.getCurrentGlobalTransactionMgr().abortTransaction2PC(database.getId(), request.getTxnId(), tableList);
         } else {
             throw new UserException("transaction operation should be \'commit\' or \'abort\'");
         }
@@ -1221,9 +1221,10 @@ public class FrontendServiceImpl implements FrontendService.Iface {
             throw new MetaNotFoundException("db " + request.getDb() + " does not exist");
         }
         long dbId = db.getId();
+        List<Table> tableList = db.getTablesOnIdOrderIfExist(tableIdList);
         Env.getCurrentGlobalTransactionMgr().abortTransaction(dbId, request.getTxnId(),
                 request.isSetReason() ? request.getReason() : "system cancel",
-                TxnCommitAttachment.fromThrift(request.getTxnCommitAttachment()));
+                TxnCommitAttachment.fromThrift(request.getTxnCommitAttachment()), tableList);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/transaction/GlobalTransactionMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/transaction/GlobalTransactionMgr.java
@@ -297,13 +297,29 @@ public class GlobalTransactionMgr implements Writable {
     }
 
     public void abortTransaction(long dbId, long transactionId, String reason) throws UserException {
-        abortTransaction(dbId, transactionId, reason, null);
+        Database db = Env.getCurrentInternalCatalog().getDbNullable(dbId);
+        TransactionState transactionState = getDatabaseTransactionMgr(dbId).getTransactionState(transactionId);
+        List<Table> tableList = db.getTablesOnIdOrderIfExist(transactionState.getTableIdList());
+        abortTransaction(dbId, transactionId, reason, null, tableList);
+    }
+
+    public void abortTransaction(long dbId, long transactionId, String reason, List<Table> tableList)
+            throws UserException {
+        abortTransaction(dbId, transactionId, reason, null, tableList);
     }
 
     public void abortTransaction(Long dbId, Long txnId, String reason,
-            TxnCommitAttachment txnCommitAttachment) throws UserException {
+            TxnCommitAttachment txnCommitAttachment, List<Table> tableList) throws UserException {
         DatabaseTransactionMgr dbTransactionMgr = getDatabaseTransactionMgr(dbId);
-        dbTransactionMgr.abortTransaction(txnId, reason, txnCommitAttachment);
+        if (!MetaLockUtils.tryWriteLockTablesOrMetaException(tableList, 5000, TimeUnit.MILLISECONDS)) {
+            throw new UserException("get tableList write lock timeout, tableList=("
+                    + StringUtils.join(tableList, ",") + ")");
+        }
+        try {
+            dbTransactionMgr.abortTransaction(txnId, reason, txnCommitAttachment);
+        } finally {
+            MetaLockUtils.writeUnlockTables(tableList);
+        }
     }
 
     // for http cancel stream load api
@@ -312,9 +328,17 @@ public class GlobalTransactionMgr implements Writable {
         dbTransactionMgr.abortTransaction(label, reason);
     }
 
-    public void abortTransaction2PC(Long dbId, long transactionId) throws UserException {
+    public void abortTransaction2PC(Long dbId, long transactionId, List<Table> tableList) throws UserException {
         DatabaseTransactionMgr dbTransactionMgr = getDatabaseTransactionMgr(dbId);
-        dbTransactionMgr.abortTransaction2PC(transactionId);
+        if (!MetaLockUtils.tryWriteLockTablesOrMetaException(tableList, 5000, TimeUnit.MILLISECONDS)) {
+            throw new UserException("get tableList write lock timeout, tableList=("
+                    + StringUtils.join(tableList, ",") + ")");
+        }
+        try {
+            dbTransactionMgr.abortTransaction2PC(transactionId);
+        } finally {
+            MetaLockUtils.writeUnlockTables(tableList);
+        }
     }
 
     /*

--- a/regression-test/suites/schema_change/test_schema_change_with_delete.groovy
+++ b/regression-test/suites/schema_change/test_schema_change_with_delete.groovy
@@ -43,7 +43,7 @@ suite("test_schema_change_with_delete") {
      sql """ delete from ${tbName} where username='aaa';"""
      sql """ insert into ${tbName} values(3, 3, 3, 'ccc');"""
 
-    qt_sql """select * from ${tbName};"""
+    qt_sql """select * from ${tbName} order by event_day;"""
 
     // Change column type to string
     sql """ alter  table ${tbName} modify column citycode string """
@@ -62,6 +62,6 @@ suite("test_schema_change_with_delete") {
           }
      }
     sql """ insert into ${tbName} values(4, 4, 'efg', 'ddd');"""
-    qt_sql """select * from ${tbName};"""
+    qt_sql """select * from ${tbName} order by event_day;"""
     sql """ DROP TABLE  ${tbName} force"""
 }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx
## Problem summary
Recently, we found that in a high-concurrency import scenario, one version was consistently missing across all three replicas of a certain tablet. However, when we ran grep ${tablet_id} | grep publish | grep missed_version on the backend, we could not find the corresponding logs. After checking the transaction numbers of the missed_version-1 and missed_version+1, we finally identified the transaction number of the missing version. We then used this transaction ID to search for logs in the frontend, and found the following:
![image](https://user-images.githubusercontent.com/43750022/225830572-37b30bf0-5aad-4bbd-8718-eff6d428134f.png)

The same transaction timed out while attempting to acquire a write lock and was aborted, but it was later successfully committed. However, the abort transaction was also cleared on the backend by "clear transaction" rpc. As a result, the publish task corresponding to this transaction can never succeed.

After reviewing the code related to transactions, it appears that there are many places where access to the transactionState is not thread-safe. Additionally, even the unprotectedCommitTransaction2PC method can successfully commit a transaction without satisfying the required status limitations.

The transaction code does not fully consider duplicate concurrent RPCs, and the current code is tightly coupled and difficult to modify. This pull request can only attempt to handle the issue with unprotectedCommitTransaction2PC on a case-by-case basis, while also adding a read lock to ensure thread-safe access to transactionState (although this may not be sufficient).

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

