### PR TITLE
[fe](test)Add MicroBench module to make it easier for developers to write JMH Test

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,6 +14,12 @@ Describe your changes.
 * [ ] Does it need to update dependencies
 * [ ] Is this PR support rollback (If NO, please explain WHY)
 
+
+* 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👇 *
+### Improve the performance of <class or module or ...>
+- [ ] Add a benchmark for the improvement, refer to [docs](../docs/en/community/developer-guide/java-microbench-test.md)
+- [ ] The benchmark result.
+
 ## Further comments
 
 If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,7 +15,7 @@ Describe your changes.
 * [ ] Is this PR support rollback (If NO, please explain WHY)
 
 
-* 📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👇 *
+📈 Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist 👇
 ### Improve the performance of <class or module or ...>
 - [ ] Add a benchmark for the improvement, refer to [docs](../docs/en/community/developer-guide/java-microbench-test.md)
 - [ ] The benchmark result.

--- a/docs/en/community/developer-guide/java-microbench-test.md
+++ b/docs/en/community/developer-guide/java-microbench-test.md
@@ -79,5 +79,15 @@ public class BenchmarkExample extends AbstractMicrobenchmark {
 }
 
 ```
+
+You can run benchmarks just like normal unit tests, and you can also run benchmarks through packaged jar packages.
+
+```shell
+mvn clean package
+# Run the benchmark for all tests (not recommended)
+java -jar doris-microbench-0.15.0-SNAPSHOT.jar
+# Run the benchmark for the specified test
+java -jar doris-microbench-0.15.0-SNAPSHOT.jar BenchmarkExample
+```
 more information about JMH, please refer to [JMH](http://openjdk.java.net/projects/code-tools/jmh/)
 

--- a/docs/en/community/developer-guide/java-microbench-test.md
+++ b/docs/en/community/developer-guide/java-microbench-test.md
@@ -1,0 +1,83 @@
+---
+{
+"title": "Java Microbenchmark Harness",
+"language": "zh-CN"
+}
+---
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements. See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership. The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied. See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Java Microbenchmark Harness
+Java Microbenchmark Harness (JMH) is a Java harness for building, running, and analysing nano/micro/milli/macro 
+benchmarks written in Java and other languages targeting the JVM.
+
+## Why use JMH
+Writing benchmarks that correctly measure the performance of a small part of a larger application is hard. There are 
+many optimizations that the JVM or underlying hardware may apply to your component when the benchmark executes that 
+component in isolation. These optimizations may not be possible to apply when the component is running as part of a 
+larger application. Badly implemented microbenchmarks may thus make you believe that your component's performance is 
+better than it will be in reality.↳
+
+Writing a correct Java microbenchmark typically entails preventung the optimizations the JVM and hardware may apply 
+during microbenchmark execution which could not have been applied in a real production system. 
+That is what JMH - the Java Microbenchmark Harness - is helping you do.
+
+## Features of JMH
+* **Benchmarked correctness**. JMH prevents the JVM and hardware from optimizing the benchmark code as much as possible, making the benchmark results more reliable.
+* **Repeatability of benchmarks**. JMH tries to prevent external factors (such as GC) from affecting the benchmark results as much as possible, so that the benchmark results are more reliable.
+* **Comparability of benchmarks**. JMH makes benchmark results more reliable by preventing external factors such as CPU frequency from affecting benchmark results as much as possible.
+* **Scalability of benchmarks**. JMH can run benchmarks in multiple threads and processes, making benchmark results more reliable.
+* **Benchmark Configurability**. JMH provides a large number of configuration options so that users can adjust it according to their needs.
+
+## How to use JMH
+
+Apache Doris provides the `microbench` module, which encapsulates some basic classes for writing JMH benchmarks, 
+so we can write benchmark codes like ordinary unit tests,
+But it is also possible to customize the configuration to override the default configuration.
+
+We encourage you to use the basic classes provided by the `microbench` module as much as possible when writing 
+benchmarks, which can reduce the workload of writing benchmarks and ensure the correctness of benchmarks.
+At the same time, for some performance-sensitive code, we also encourage writing benchmark tests to verify its 
+performance. All benchmark code should be placed in the `microbench` module
+
+example:
+
+```java
+
+import org.apache.doris.benchmark.BenchmarkBase;
+
+public class BenchmarkExample extends AbstractMicrobenchmark {
+
+    @Benchmark
+    @Warmup(iterations = 3)// warmup 3 times
+    public void testMethod() {
+        // do something
+    }
+    
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput) @OutputTimeUnit(TimeUnit.MINUTES) // throughput mode, output time unit is minutes
+    public void testMethod2() {
+        // do something
+    }
+}
+
+```
+more information about JMH, please refer to [JMH](http://openjdk.java.net/projects/code-tools/jmh/)
+

--- a/docs/en/community/developer-guide/java-microbench-test.md
+++ b/docs/en/community/developer-guide/java-microbench-test.md
@@ -1,7 +1,7 @@
 ---
 {
 "title": "Java Microbenchmark Harness",
-"language": "zh-CN"
+"language": "en"
 }
 ---
 

--- a/docs/sidebarsCommunity.json
+++ b/docs/sidebarsCommunity.json
@@ -56,7 +56,8 @@
                 "developer-guide/how-to-share-blogs",
                 "developer-guide/bitmap-hll-file-format",
                 "developer-guide/github-checks",
-                "developer-guide/regression-testing"
+                "developer-guide/regression-testing",
+                "developer-guide/java-microbench-test"
             ]
         },
         {

--- a/docs/zh-CN/community/developer-guide/java-microbench-test.md
+++ b/docs/zh-CN/community/developer-guide/java-microbench-test.md
@@ -1,0 +1,76 @@
+---
+{
+"title": "Java 微基准测试",
+"language": "zh-CN"
+}
+---
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements. See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership. The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied. See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Java 微基准测试
+Java 微基准测试（Java Microbenchmark Harness）是一个 Java 工具，用于构建、运行和分析用 Java 和其他针对 JVM 的语言编写的纳米/微米/毫/宏观基准测试。
+
+## 为什么要使用 JMH
+编写能够正确衡量大型应用程序的一小部分性能的基准是很困难的。当基准测试单独执行该组件时，JVM 或底层硬件可能会对您的组件应用许多优化。当组件作为大型
+应用程序的一部分运行时，这些优化可能无法应用。因此，执行不当的微基准测试可能会让您相信您的组件的性能比实际情况要好。
+
+编写正确的 Java 微基准通常需要防止 JVM 和硬件在微基准执行期间可能应用的优化，而这在实际生产系统中是不可能应用的。
+这就是 为什么我们要使用 JMH。
+
+## JMH 的特点
+* **基准测试的正确性**。JMH 会尽可能地防止 JVM 和硬件优化基准测试代码，从而使基准测试结果更加可靠。
+* **基准测试的可重复性**。JMH 会尽可能地防止外部因素（例如 GC）影响基准测试结果，从而使基准测试结果更加可靠。
+* **基准测试的可比性**。JMH 会尽可能地防止外部因素（例如 CPU 频率）影响基准测试结果，从而使基准测试结果更加可靠。
+* **基准测试的可扩展性**。JMH 可以在多个线程和多个进程中运行基准测试，从而使基准测试结果更加可靠。
+* **基准测试的可配置性**。JMH 提供了大量的配置选项，以便用户可以根据需要进行调整。
+
+## JMH 的使用
+
+Apache Doris 提供了 `microbench` 模块，封装了一些编写 JMH 基准测试的基础类，因此，我们可以像编写普通的单元测试一样来编写基准测试代码，
+但同时也可以自定义配置来覆盖默认配置。
+
+我们鼓励在编写基准测试时，尽可能地使用 `microbench` 模块提供的基础类，这样可以减少编写基准测试的工作量，同时也可以保证基准测试的正确性。
+同时对于一些性能敏感的代码，我们也鼓励编写基准测试来验证其性能。而所有基准测试的代码都应该放在 `microbench` 模块中。
+
+
+example:
+
+```java
+
+import org.apache.doris.benchmark.BenchmarkBase;
+
+public class BenchmarkExample extends AbstractMicrobenchmark {
+
+    @Benchmark
+    @Warmup(iterations = 3)// 预热次数
+    public void testMethod() {
+        // do something
+    }
+    
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput) @OutputTimeUnit(TimeUnit.MINUTES) // 测试模式，输出时间单位
+    public void testMethod2() {
+        // do something
+    }
+}
+
+```
+更多使用方法请参考 [JMH 官方文档](http://openjdk.java.net/projects/code-tools/jmh/)
+

--- a/docs/zh-CN/community/developer-guide/java-microbench-test.md
+++ b/docs/zh-CN/community/developer-guide/java-microbench-test.md
@@ -72,5 +72,15 @@ public class BenchmarkExample extends AbstractMicrobenchmark {
 }
 
 ```
+
+你可以像运行普通的单元测试一样来运行基准测试，同时你也可以通过打包好的 jar 包来运行基准测试。
+
+```shell
+mvn clean package
+# 运行基准测试所有测试（不建议）
+java -jar doris-microbench-0.15.0-SNAPSHOT.jar 
+# 运行基准测试指定测试
+java -jar doris-microbench-0.15.0-SNAPSHOT.jar BenchmarkExample
+```
 更多使用方法请参考 [JMH 官方文档](http://openjdk.java.net/projects/code-tools/jmh/)
 

--- a/fe/microbench/pom.xml
+++ b/fe/microbench/pom.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.doris</groupId>
+        <artifactId>fe</artifactId>
+        <version>${revision}</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>microbench</artifactId>
+    <properties>
+        <jmh.version>1.25</jmh.version>
+        <uberjar.name>doris-benchmarks</uberjar.name>
+        <junit.version>5.9.2</junit.version>
+        <maven-shade-plugin.version>3.1.1</maven-shade-plugin.version>
+    </properties>
+
+    <dependencies>
+        <!--JMH-->
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-core</artifactId>
+            <version>${jmh.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-generator-annprocess</artifactId>
+            <version>${jmh.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <!--SLF4j-->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>${slf4j.version}</version>
+        </dependency>
+        <!--JUNIT-->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>compile</scope>
+            <version>${junit.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>${maven-shade-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <finalName>${uberjar.name}</finalName>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>org.openjdk.jmh.Main</mainClass>
+                                </transformer>
+                            </transformers>
+                            <filters>
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/fe/microbench/src/main/java/org/apache/doris/microbench/base/AbstractMicrobenchmark.java
+++ b/fe/microbench/src/main/java/org/apache/doris/microbench/base/AbstractMicrobenchmark.java
@@ -1,0 +1,114 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.microbench.base;
+
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.profile.GCProfiler;
+import org.openjdk.jmh.results.format.ResultFormatType;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.ChainedOptionsBuilder;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * All JMH tests need to extend this class to make it easier for you to complete JMHTest, you can also choose to
+ * customize runtime conditions (Measurement, Fork, Warmup, etc.)
+ * <p>
+ * You can run any of the JMH tests as a normal UT, or you can package it and get all the reported results via `java
+ * -jar benchmark.jar`, or get the results of a particular Test via `java -jar /benchmarks.jar exampleClassName`.
+ */
+@Warmup(iterations = AbstractMicrobenchmark.DEFAULT_WARMUP_ITERATIONS)
+@Measurement(iterations = AbstractMicrobenchmark.DEFAULT_MEASURE_ITERATIONS)
+@Fork(AbstractMicrobenchmark.DEFAULT_FORKS)
+@State(Scope.Thread)
+@Slf4j
+public abstract class AbstractMicrobenchmark {
+    static final int DEFAULT_WARMUP_ITERATIONS = 1;
+
+    static final int DEFAULT_MEASURE_ITERATIONS = 1;
+
+    static final int DEFAULT_FORKS = 2;
+
+    public static class JmhThreadExecutor extends ThreadPoolExecutor {
+        public JmhThreadExecutor(int size, String name) {
+            super(size, size, 10, TimeUnit.SECONDS, new LinkedBlockingQueue<>(), Executors.defaultThreadFactory());
+        }
+    }
+
+    private ChainedOptionsBuilder newOptionsBuilder() throws IOException {
+
+        String className = getClass().getSimpleName();
+
+        ChainedOptionsBuilder optBuilder = new OptionsBuilder()
+                // set benchmark class name
+                .include(".*" + className + ".*")
+                // add GC profiler
+                .addProfiler(GCProfiler.class)
+                //set jvm args
+                .jvmArgsAppend("-Xmx512m", "-Xms512m", "-XX:MaxDirectMemorySize=512m",
+                "-XX:BiasedLockingStartupDelay=0",
+                "-Djmh.executor=CUSTOM",
+                "-Djmh.executor.class=org.apache.doris.microbench.base.AbstractMicrobenchmark$JmhThreadExecutor"
+            );
+
+        String output = getReportDir();
+        if (output != null) {
+            boolean createFileStatus = false;
+            String filePath = getReportDir() + className + ".json";
+            File file = new File(filePath);
+
+            if (file.exists()) {
+                Files.delete(file.toPath());
+            }
+            try {
+                createFileStatus = file.createNewFile();
+            } catch (IOException e) {
+                log.warn("jmh test create file error", e);
+            }
+            if (createFileStatus) {
+                optBuilder.resultFormat(ResultFormatType.JSON)
+                        .result(filePath);
+            }
+        }
+        return optBuilder;
+    }
+
+    @Test
+    public void run() throws Exception {
+        new Runner(newOptionsBuilder().build()).run();
+    }
+
+    private static String getReportDir() {
+        System.setProperty("perfReportDir","/Users/calvinkirs/IdeaProjects/incubator-doris/fe/microbench/target/");
+        return System.getProperty("perfReportDir");
+    }
+
+}

--- a/fe/microbench/src/main/java/org/apache/doris/microbench/base/AbstractMicrobenchmark.java
+++ b/fe/microbench/src/main/java/org/apache/doris/microbench/base/AbstractMicrobenchmark.java
@@ -51,9 +51,9 @@ import java.util.concurrent.TimeUnit;
 @State(Scope.Thread)
 @Slf4j
 public abstract class AbstractMicrobenchmark {
-    static final int DEFAULT_WARMUP_ITERATIONS = 1;
+    static final int DEFAULT_WARMUP_ITERATIONS = 10;
 
-    static final int DEFAULT_MEASURE_ITERATIONS = 1;
+    static final int DEFAULT_MEASURE_ITERATIONS = 10;
 
     static final int DEFAULT_FORKS = 2;
 
@@ -107,7 +107,6 @@ public abstract class AbstractMicrobenchmark {
     }
 
     private static String getReportDir() {
-        System.setProperty("perfReportDir","/Users/calvinkirs/IdeaProjects/incubator-doris/fe/microbench/target/");
         return System.getProperty("perfReportDir");
     }
 

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -158,6 +158,7 @@ under the License.
         <module>fe-core</module>
         <module>hive-udf</module>
         <module>java-udf</module>
+        <module>microbench</module>
     </modules>
     <properties>
         <doris.home>${basedir}/../</doris.home>


### PR DESCRIPTION
Writing the benchmark itself is not hard, but getting it right is. Thankfully, the JMH suite provides helpful annotations and features to mitigate most of them. To get started, you need to make your benchmark extend the AbstractMicrobenchmark, which makes sure the test gets run through JUnit and configures some defaults:
```
@BenchmarkMode({Mode.Throughput})
public class LinkedArrayBenchmark extends AbstractMicrobenchmark {
}
```
For most benchmark tests, you can write it as a normal JUnit.
We could also choose Customizing Runtime Conditions.
At present, you can run all JMH Tests by running the jar directly after packaging.

How to used:

  All JMH tests need to extend this class to make it easier for you to complete JMHTest, you can also choose to
 customize runtime conditions (Measurement, Fork, Warmup, etc.)
 <p>
 You can run any of the JMH tests as a normal UT, or you can package it and get all the reported results via `java
 -jar doris-benchmark.jar`, or get the results of a particular Test via `java -jar dorisbenchmarks.jar exampleClassName`.

