### PR TITLE
[improve](nereids)adjust distribution stats derive and fix bug in join estimation

### DIFF
--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -818,7 +818,7 @@ under the License.
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>aspectj-maven-plugin</artifactId>
-                <version>1.11</version>
+                <version>1.14.0</version>
                 <executions>
                     <execution>
                         <phase>process-classes</phase>

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/cost/CostModelV1.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/cost/CostModelV1.java
@@ -60,8 +60,12 @@ class CostModelV1 extends PlanVisitor<Cost, PlanContext> {
 
     public static Cost addChildCost(Plan plan, Cost planCost, Cost childCost, int index) {
         Preconditions.checkArgument(childCost instanceof CostV1 && planCost instanceof CostV1);
-        double cost = planCost.getValue() + childCost.getValue();
-        return new CostV1(cost);
+        CostV1 childCostV1 = (CostV1) childCost;
+        CostV1 planCostV1 = (CostV1) planCost;
+        return new CostV1(childCostV1.getCpuCost() + planCostV1.getCpuCost(),
+                childCostV1.getMemoryCost() + planCostV1.getMemoryCost(),
+                childCostV1.getNetworkCost() + planCostV1.getNetworkCost(),
+                childCostV1.getPenalty() + planCostV1.getPenalty());
     }
 
     @Override
@@ -170,22 +174,17 @@ class CostModelV1 extends PlanVisitor<Cost, PlanContext> {
                     || childStatistics.getRowCount() > rowsLimit) {
                 return CostV1.of(Double.MAX_VALUE, Double.MAX_VALUE, Double.MAX_VALUE);
             }
-            /*
-            TODO：
-            srcBeNum and destBeNum are not available, assume destBeNum/srcBeNum = 1
-            1. cpu: row * destBeNum/srcBeNum
-            2. network: rows send = rows/srcBeNum * destBeNum.
-             */
             return CostV1.of(
-                    childStatistics.getRowCount(), // TODO:should multiply by destBeNum/srcBeNum
-                    childStatistics.getRowCount(), // only consider one BE, not the whole system.
-                    childStatistics.getRowCount() * instanceNumber); // TODO: remove instanceNumber when BE updated
+                    0,
+                    0,
+                    childStatistics.getRowCount());
+
         }
 
         // gather
         if (spec instanceof DistributionSpecGather) {
             return CostV1.of(
-                    childStatistics.getRowCount(),
+                    0,
                     0,
                     childStatistics.getRowCount());
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/cost/CostV1.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/cost/CostV1.java
@@ -105,8 +105,9 @@ class CostV1 implements Cost {
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();
-        sb.append((long) cpuCost).append("/").append((long) memoryCost).append("/").append((long) networkCost)
-                .append("/").append((long) penalty);
+        sb.append(cost).append("[").append((long) cpuCost).append("/")
+                .append((long) memoryCost).append("/").append((long) networkCost)
+                .append("/").append((long) penalty).append("]");
         return sb.toString();
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/JoinEstimation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/JoinEstimation.java
@@ -39,9 +39,9 @@ public class JoinEstimation {
                 .sorted((a, b) -> {
                     double sub = a.second - b.second;
                     if (sub > 0) {
-                        return -1;
-                    } else if (sub < 0) {
                         return 1;
+                    } else if (sub < 0) {
+                        return -1;
                     } else {
                         return 0;
                     }


### PR DESCRIPTION
# Proposed changes
## adjust distribution stats derive
replica distribution: 
estimation of replica distribution is too high. The cost of replica a table should be smaller than scan a table in cpuCost and memCost. 

## fix bug in join estimation
if there is more than one equal-condition in hash join, the dominate one should be the one whose sel is smallest.

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

