### PR TITLE
[Improve](hana catalog)Currently logged in users should only see the schemas they can access

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/external/jdbc/JdbcClient.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/external/jdbc/JdbcClient.java
@@ -191,7 +191,7 @@ public class JdbcClient {
                     rs = stmt.executeQuery("SELECT name FROM sys.schemas");
                     break;
                 case JdbcResource.SAP_HANA:
-                    rs = stmt.executeQuery("SELECT SCHEMA_NAME FROM SYS.SCHEMAS");
+                    rs = stmt.executeQuery("SELECT SCHEMA_NAME FROM SYS.SCHEMAS WHERE HAS_PRIVILEGES = 'TRUE'");
                     break;
                 default:
                     throw new JdbcClientException("Not supported jdbc type");


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

In the case of hana catalog, I think the current logged-in users should only see the schemas they can access.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

