### PR TITLE
[Docs](multi-catalog) add `yarn.resourcemanager.principal` for hive c…

### DIFF
--- a/docs/en/docs/lakehouse/multi-catalog/hive.md
+++ b/docs/en/docs/lakehouse/multi-catalog/hive.md
@@ -78,6 +78,7 @@ CREATE CATALOG hive PROPERTIES (
     'type'='hms',
     'hive.metastore.uris' = 'thrift://172.21.0.1:7004',
     'hive.metastore.sasl.enabled' = 'true',
+    'hive.metastore.kerberos.principal' = 'your-hms-principal',
     'dfs.nameservices'='your-nameservice',
     'dfs.namenode.rpc-address.your-nameservice.nn1'='172.21.0.2:4007',
     'dfs.namenode.rpc-address.your-nameservice.nn2'='172.21.0.3:4007',
@@ -85,7 +86,7 @@ CREATE CATALOG hive PROPERTIES (
     'hadoop.security.authentication' = 'kerberos',
     'hadoop.kerberos.keytab' = '/your-keytab-filepath/your.keytab',   
     'hadoop.kerberos.principal' = 'your-principal@YOUR.COM',
-    'hive.metastore.kerberos.principal' = 'your-hms-principal'
+    'yarn.resourcemanager.principal' = 'your-rm-principal'
 );
 ```
 

--- a/docs/zh-CN/docs/lakehouse/multi-catalog/hive.md
+++ b/docs/zh-CN/docs/lakehouse/multi-catalog/hive.md
@@ -76,6 +76,7 @@ CREATE CATALOG hive PROPERTIES (
     'type'='hms',
     'hive.metastore.uris' = 'thrift://172.21.0.1:7004',
     'hive.metastore.sasl.enabled' = 'true',
+    'hive.metastore.kerberos.principal' = 'your-hms-principal',
     'dfs.nameservices'='your-nameservice',
     'dfs.namenode.rpc-address.your-nameservice.nn1'='172.21.0.2:4007',
     'dfs.namenode.rpc-address.your-nameservice.nn2'='172.21.0.3:4007',
@@ -83,7 +84,7 @@ CREATE CATALOG hive PROPERTIES (
     'hadoop.security.authentication' = 'kerberos',
     'hadoop.kerberos.keytab' = '/your-keytab-filepath/your.keytab',   
     'hadoop.kerberos.principal' = 'your-principal@YOUR.COM',
-    'hive.metastore.kerberos.principal' = 'your-hms-principal'
+    'yarn.resourcemanager.principal' = 'your-rm-principal'
 );
 ```
 


### PR DESCRIPTION
…atalog with kerberos enabled.

# Proposed changes

Add neccessary `yarn.resourcemanager.principal` config for hive catalog with kerberos enabled.

## Problem summary

When creating a hive catalog with a kerberos enabled hive cluster, the config `yarn.resourcemanager.principal` is required, because hdfs client needs this principal otherwise we will encounter an exception like this:
![image](https://user-images.githubusercontent.com/5926365/226160301-0d554e95-fa09-4ca7-8c86-ca3f6eabe687.png)


## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

