### PR TITLE
[chore](macOS) Specify the version of LLVM for Homebrew to install it

### DIFF
--- a/.github/workflows/be-ut-mac.yml
+++ b/.github/workflows/be-ut-mac.yml
@@ -67,7 +67,7 @@ jobs:
             'texinfo'
             'coreutils'
             'gnu-getopt'
-            'python'
+            'python@3'
             'cmake'
             'ninja'
             'ccache'
@@ -79,7 +79,7 @@ jobs:
             'openjdk@11'
             'maven'
             'node'
-            'llvm'
+            'llvm@15'
           )
           brew install "${cellars[@]}"
 

--- a/.github/workflows/build-thirdparty.yml
+++ b/.github/workflows/build-thirdparty.yml
@@ -89,7 +89,6 @@ jobs:
             'openjdk-11-jdk'
             'openjdk-11-jdk-headless'
             'maven'
-            'llvm'
           )
 
           sudo apt update
@@ -134,7 +133,7 @@ jobs:
             'texinfo'
             'coreutils'
             'gnu-getopt'
-            'python'
+            'python@3'
             'cmake'
             'ninja'
             'ccache'
@@ -146,6 +145,7 @@ jobs:
             'openjdk@11'
             'maven'
             'node'
+            'llvm@15'
           )
 
           brew install "${packages[@]}"

--- a/docs/en/docs/install/source-install/compilation-mac.md
+++ b/docs/en/docs/install/source-install/compilation-mac.md
@@ -38,7 +38,7 @@ This topic is about how to compile Doris from source with macOS (both x86_64 and
 1. Use [Homebrew](https://brew.sh/) to install dependencies.
     ```shell
     brew install automake autoconf libtool pkg-config texinfo coreutils gnu-getopt \
-        python cmake ninja ccache bison byacc gettext wget pcre maven llvm openjdk@11 npm
+        python@3 cmake ninja ccache bison byacc gettext wget pcre maven llvm@15 openjdk@11 npm
     ```
 
 2. Compile from source.

--- a/docs/zh-CN/docs/install/source-install/compilation-mac.md
+++ b/docs/zh-CN/docs/install/source-install/compilation-mac.md
@@ -38,7 +38,7 @@ under the License.
 1. 使用[Homebrew](https://brew.sh/)安装依赖
     ```shell
     brew install automake autoconf libtool pkg-config texinfo coreutils gnu-getopt \
-        python cmake ninja ccache bison byacc gettext wget pcre maven llvm openjdk@11 npm
+        python@3 cmake ninja ccache bison byacc gettext wget pcre maven llvm@15 openjdk@11 npm
     ```
 
 2. 编译源码

--- a/env.sh
+++ b/env.sh
@@ -51,7 +51,7 @@ CELLARS=(
     texinfo
     coreutils
     gnu-getopt
-    python
+    python@3
     cmake
     ninja
     ccache
@@ -61,7 +61,7 @@ CELLARS=(
     wget
     pcre
     maven
-    llvm
+    llvm@15
 )
 for cellar in "\${CELLARS[@]}"; do
     EXPORT_CELLARS="\${HOMEBREW_REPO_PREFIX}/opt/\${cellar}/bin:\${EXPORT_CELLARS}"


### PR DESCRIPTION
# Proposed changes

~~Issue Number: close #xxx~~

## Problem summary

Clang 16 was released last week and we haven't ported the codebase to it. If Homebrew bumped the version of LLVM, our workflows would fail.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

