### PR TITLE
[enhancement](topn explain) display explain two phase read more precise

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/OlapScanNode.java
@@ -1078,9 +1078,6 @@ public class OlapScanNode extends ScanNode {
             sortInfo.getMaterializedOrderingExprs().forEach(expr -> {
                 output.append(prefix).append(prefix).append(expr.toSql()).append("\n");
             });
-            if (sortInfo.useTwoPhaseRead()) {
-                output.append(prefix).append("OPT TWO PHASE\n");
-            }
         }
         if (sortLimit != -1) {
             output.append(prefix).append("SORT LIMIT: ").append(sortLimit).append("\n");

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/OriginalPlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/OriginalPlanner.java
@@ -303,6 +303,7 @@ public class OriginalPlanner extends Planner {
                         && ((SortNode) singleNodePlan).getChild(0) instanceof OlapScanNode) {
                     // Double check this plan to ensure it's a general topn query
                     injectRowIdColumnSlot();
+                    ((SortNode) singleNodePlan).setUseTwoPhaseReadOpt(true);
                 } else {
                     // This is not a general topn query, rollback needMaterialize flag
                     for (SlotDescriptor slot : analyzer.getDescTbl().getSlotDescs().values()) {

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/SortNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/SortNode.java
@@ -63,6 +63,7 @@ public class SortNode extends PlanNode {
     private final SortInfo info;
     private final boolean  useTopN;
     private boolean useTopnOpt;
+    private boolean useTwoPhaseReadOpt;
 
     private boolean  isDefaultLimit;
     // if true, the output of this node feeds an AnalyticNode
@@ -142,6 +143,14 @@ public class SortNode extends PlanNode {
         this.useTopnOpt = useTopnOpt;
     }
 
+    public boolean getUseTwoPhaseReadOpt() {
+        return useTopnOpt;
+    }
+
+    public void setUseTwoPhaseReadOpt(boolean useTwoPhaseReadOpt) {
+        this.useTwoPhaseReadOpt = useTwoPhaseReadOpt;
+    }
+
     public List<Expr> getResolvedTupleExprs() {
         return resolvedTupleExprs;
     }
@@ -175,6 +184,9 @@ public class SortNode extends PlanNode {
 
         if (useTopnOpt) {
             output.append(detailPrefix + "TOPN OPT\n");
+        }
+        if (useTwoPhaseReadOpt) {
+            output.append(detailPrefix + "OPT TWO PHASE\n");
         }
         output.append(detailPrefix).append("offset: ").append(offset).append("\n");
         return output.toString();


### PR DESCRIPTION
# Proposed changes

before this PR, explain will lost `OPT TWO PHASE` when order by is not a key column

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

