### PR TITLE
[Improvement](TVF)Support file split for TableValueFunction.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/backup/BrokerStorage.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/backup/BrokerStorage.java
@@ -538,7 +538,7 @@ public class BrokerStorage extends BlobStorage {
 
             List<TBrokerFileStatus> fileStatus = rep.getFiles();
             for (TBrokerFileStatus tFile : fileStatus) {
-                RemoteFile file = new RemoteFile(tFile.path, !tFile.isDir, tFile.size);
+                RemoteFile file = new RemoteFile(tFile.path, !tFile.isDir, tFile.size, 0);
                 result.add(file);
             }
             LOG.info("finished to list remote path {}. get files: {}", remotePath, result);

--- a/fe/fe-core/src/main/java/org/apache/doris/backup/HdfsStorage.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/backup/HdfsStorage.java
@@ -529,7 +529,8 @@ public class HdfsStorage extends BlobStorage {
             for (FileStatus fileStatus : files) {
                 RemoteFile remoteFile = new RemoteFile(
                         fileNameOnly ? fileStatus.getPath().getName() : fileStatus.getPath().toString(),
-                        !fileStatus.isDirectory(), fileStatus.isDirectory() ? -1 : fileStatus.getLen());
+                        !fileStatus.isDirectory(), fileStatus.isDirectory() ? -1 : fileStatus.getLen(),
+                        fileStatus.getBlockSize());
                 result.add(remoteFile);
             }
         } catch (FileNotFoundException e) {

--- a/fe/fe-core/src/main/java/org/apache/doris/backup/RemoteFile.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/backup/RemoteFile.java
@@ -26,12 +26,17 @@ public class RemoteFile {
     private String name;
     private boolean isFile;
     private long size;
+    // Block size of underlying file system. e.g. HDFS and S3.
+    // A large file will split into multiple blocks. The blocks are transparent to the user.
+    // Default block size for HDFS 2.x is 128M.
+    private long blockSize;
 
-    public RemoteFile(String name, boolean isFile, long size) {
+    public RemoteFile(String name, boolean isFile, long size, long blockSize) {
         Preconditions.checkState(!Strings.isNullOrEmpty(name));
         this.name = name;
         this.isFile = isFile;
         this.size = size;
+        this.blockSize = blockSize;
     }
 
     public String getName() {
@@ -44,6 +49,10 @@ public class RemoteFile {
 
     public long getSize() {
         return size;
+    }
+
+    public long getBlockSize() {
+        return blockSize;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/backup/S3Storage.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/backup/S3Storage.java
@@ -365,7 +365,8 @@ public class S3Storage extends BlobStorage {
             for (FileStatus fileStatus : files) {
                 RemoteFile remoteFile = new RemoteFile(
                         fileNameOnly ? fileStatus.getPath().getName() : fileStatus.getPath().toString(),
-                        !fileStatus.isDirectory(), fileStatus.isDirectory() ? -1 : fileStatus.getLen());
+                        !fileStatus.isDirectory(), fileStatus.isDirectory() ? -1 : fileStatus.getLen(),
+                        fileStatus.getBlockSize());
                 result.add(remoteFile);
             }
         } catch (FileNotFoundException e) {

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/BrokerUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/BrokerUtil.java
@@ -99,7 +99,9 @@ public class BrokerUtil {
         }
         for (RemoteFile r : rfiles) {
             if (r.isFile()) {
-                fileStatuses.add(new TBrokerFileStatus(r.getName(), !r.isFile(), r.getSize(), r.isFile()));
+                TBrokerFileStatus status = new TBrokerFileStatus(r.getName(), !r.isFile(), r.getSize(), r.isFile());
+                status.setBlockSize(r.getBlockSize());
+                fileStatuses.add(status);
             }
         }
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/Splitter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/Splitter.java
@@ -23,5 +23,7 @@ import org.apache.doris.common.UserException;
 import java.util.List;
 
 public interface Splitter {
+    static final long DEFAULT_SPLIT_SIZE = 32 * 1024 * 1024; // 32mb
+
     List<Split> getSplits(List<Expr> exprs) throws UserException;
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/backup/RepositoryTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/backup/RepositoryTest.java
@@ -182,8 +182,8 @@ public class RepositoryTest {
                 minTimes = 0;
                 result = new Delegate() {
                     public Status list(String remotePath, List<RemoteFile> result) {
-                        result.add(new RemoteFile(Repository.PREFIX_SNAPSHOT_DIR + "a", false, 100));
-                        result.add(new RemoteFile("_ss_b", true, 100));
+                        result.add(new RemoteFile(Repository.PREFIX_SNAPSHOT_DIR + "a", false, 100, 0));
+                        result.add(new RemoteFile("_ss_b", true, 100, 0));
                         return Status.OK;
                     }
                 };
@@ -252,7 +252,7 @@ public class RepositoryTest {
                     minTimes = 0;
                     result = new Delegate() {
                         public Status list(String remotePath, List<RemoteFile> result) {
-                            result.add(new RemoteFile("remote_file.0cc175b9c0f1b6a831c399e269772661", true, 100));
+                            result.add(new RemoteFile("remote_file.0cc175b9c0f1b6a831c399e269772661", true, 100, 0));
                             return Status.OK;
                         }
                     };
@@ -290,10 +290,11 @@ public class RepositoryTest {
                         if (remotePath.contains(Repository.PREFIX_JOB_INFO)) {
                             result.add(new RemoteFile(" __info_2018-04-18-20-11-00.12345678123456781234567812345678",
                                     true,
-                                    100));
+                                    100,
+                                    0));
                         } else {
-                            result.add(new RemoteFile(Repository.PREFIX_SNAPSHOT_DIR + "s1", false, 100));
-                            result.add(new RemoteFile(Repository.PREFIX_SNAPSHOT_DIR + "s2", false, 100));
+                            result.add(new RemoteFile(Repository.PREFIX_SNAPSHOT_DIR + "s1", false, 100, 0));
+                            result.add(new RemoteFile(Repository.PREFIX_SNAPSHOT_DIR + "s2", false, 100, 0));
                         }
                         return Status.OK;
                     }

--- a/gensrc/thrift/PaloBrokerService.thrift
+++ b/gensrc/thrift/PaloBrokerService.thrift
@@ -55,6 +55,7 @@ struct TBrokerFileStatus {
     4: required bool isSplitable; //false mean indicates that the file is indivisible,
                                   //and the entire file must be imported as a complete map task.
                                   //the return value of the compressed file is false
+    5: optional i64 blockSize; //Block size in FS. e.g. HDFS and S3
 }
 
 struct TBrokerFD {


### PR DESCRIPTION
Current getSplits for TVF is to create one split for each file. In this case, large file scan performance maybe bad. This pr is to implement the getSplits function in TVFSplitter to support split file to multiple blocks which may improve the performance for large files.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

