### PR TITLE
[feature](jni) JNI table scanner framework

### DIFF
--- a/be/src/util/jni-util.cpp
+++ b/be/src/util/jni-util.cpp
@@ -277,11 +277,20 @@ Status JniUtil::Init() {
     if (env->ExceptionOccurred()) {
         return Status::InternalError("Failed to delete local reference to JNINativeMethod class.");
     }
-    std::string function_name = "resizeColumn";
-    std::string function_sign = "(JI)J";
+    std::string resize_column_name = "resizeStringColumn";
+    std::string resize_column_sign = "(JI)J";
+    std::string memory_alloc_name = "memoryTrackerMalloc";
+    std::string memory_alloc_sign = "(J)J";
+    std::string memory_free_name = "memoryTrackerFree";
+    std::string memory_free_sign = "(J)V";
     static JNINativeMethod java_native_methods[] = {
-            {const_cast<char*>(function_name.c_str()), const_cast<char*>(function_sign.c_str()),
-             (void*)&JavaNativeMethods::resizeColumn},
+            {const_cast<char*>(resize_column_name.c_str()),
+             const_cast<char*>(resize_column_sign.c_str()),
+             (void*)&JavaNativeMethods::resizeStringColumn},
+            {const_cast<char*>(memory_alloc_name.c_str()),
+             const_cast<char*>(memory_alloc_sign.c_str()), (void*)&JavaNativeMethods::memoryMalloc},
+            {const_cast<char*>(memory_free_name.c_str()),
+             const_cast<char*>(memory_free_sign.c_str()), (void*)&JavaNativeMethods::memoryFree},
     };
 
     int res = env->RegisterNatives(jni_native_method_exc_cl_, java_native_methods,

--- a/be/src/util/jni_native_method.cpp
+++ b/be/src/util/jni_native_method.cpp
@@ -21,10 +21,19 @@
 
 namespace doris {
 
-jlong JavaNativeMethods::resizeColumn(JNIEnv* env, jclass clazz, jlong columnAddr, jint length) {
+jlong JavaNativeMethods::resizeStringColumn(JNIEnv* env, jclass clazz, jlong columnAddr,
+                                            jint length) {
     auto column = reinterpret_cast<vectorized::ColumnString::Chars*>(columnAddr);
     column->resize(length);
     return reinterpret_cast<jlong>(column->data());
+}
+
+jlong JavaNativeMethods::memoryMalloc(JNIEnv* env, jclass clazz, jlong bytes) {
+    return reinterpret_cast<long>(malloc(bytes));
+}
+
+void JavaNativeMethods::memoryFree(JNIEnv* env, jclass clazz, jlong address) {
+    free(reinterpret_cast<void*>(address));
 }
 
 } // namespace doris

--- a/be/src/util/jni_native_method.h
+++ b/be/src/util/jni_native_method.h
@@ -21,8 +21,24 @@
 
 namespace doris {
 
+/**
+ * Java native methods for org.apache.doris.udf.JNINativeMethod.
+ */
 struct JavaNativeMethods {
-    static jlong resizeColumn(JNIEnv* env, jclass clazz, jlong columnAddr, jint length);
+    /**
+     * Resize string column and return the new column address.
+     */
+    static jlong resizeStringColumn(JNIEnv* env, jclass clazz, jlong columnAddr, jint length);
+
+    /**
+     * Allocate memory, which will be tracked by memory tracker.
+     */
+    static jlong memoryMalloc(JNIEnv* env, jclass clazz, jlong bytes);
+
+    /**
+     * Free memory, which will be tracked by memory tracker.
+     */
+    static void memoryFree(JNIEnv* env, jclass clazz, jlong address);
 };
 
 } // namespace doris

--- a/be/src/vec/CMakeLists.txt
+++ b/be/src/vec/CMakeLists.txt
@@ -323,6 +323,8 @@ set(VEC_FILES
   exec/format/file_reader/new_plain_binary_line_reader.cpp
   exec/format/parquet/delta_bit_pack_decoder.cpp
   exec/format/parquet/bool_rle_decoder.cpp
+  exec/jni_connector.cpp
+  exec/scan/jni_reader.cpp
   )
 
 if (WITH_MYSQL)

--- a/be/src/vec/exec/jni_connector.cpp
+++ b/be/src/vec/exec/jni_connector.cpp
@@ -1,0 +1,332 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "jni_connector.h"
+
+#include <sstream>
+
+namespace doris::vectorized {
+
+#define FOR_LOGICAL_NUMERIC_TYPES(M) \
+    M(TypeIndex::Int8, Int8)         \
+    M(TypeIndex::UInt8, UInt8)       \
+    M(TypeIndex::Int16, Int16)       \
+    M(TypeIndex::UInt16, UInt16)     \
+    M(TypeIndex::Int32, Int32)       \
+    M(TypeIndex::UInt32, UInt32)     \
+    M(TypeIndex::Int64, Int64)       \
+    M(TypeIndex::UInt64, UInt64)     \
+    M(TypeIndex::Float32, Float32)   \
+    M(TypeIndex::Float64, Float64)
+
+JniConnector::~JniConnector() {
+    Status st = close();
+    if (!st.ok()) {
+        // Ensure successful resource release
+        LOG(FATAL) << "Failed to release jni resource: " << st.to_string();
+    }
+}
+
+Status JniConnector::open(RuntimeState* state, RuntimeProfile* profile) {
+    RETURN_IF_ERROR(JniUtil::GetJNIEnv(&_env));
+    if (_env == nullptr) {
+        return Status::InternalError("Failed to get/create JVM");
+    }
+    RETURN_IF_ERROR(_init_jni_scanner(_env, state->batch_size()));
+    // Call org.apache.doris.jni.JniScanner#open
+    _env->CallVoidMethod(_jni_scanner_obj, _jni_scanner_open);
+    RETURN_ERROR_IF_EXC(_env);
+    return Status::OK();
+}
+
+Status JniConnector::init(
+        std::unordered_map<std::string, ColumnValueRangeType>* colname_to_value_range) {
+    _generate_predicates(colname_to_value_range);
+    if (_predicates_length != 0 && _predicates != nullptr) {
+        int64_t predicates_address = (int64_t)_predicates.get();
+        // We can call org.apache.doris.jni.vec.ScanPredicate#parseScanPredicates to parse the
+        // serialized predicates in java side.
+        _scanner_params.emplace("push_down_predicates", std::to_string(predicates_address));
+    }
+    return Status::OK();
+}
+
+Status JniConnector::get_nex_block(Block* block, size_t* read_rows, bool* eof) {
+    JniLocalFrame jni_frame;
+    RETURN_IF_ERROR(jni_frame.push(_env));
+    // Call org.apache.doris.jni.JniScanner#getNextBatchMeta
+    // return the address of meta information
+    long meta_address = _env->CallLongMethod(_jni_scanner_obj, _jni_scanner_get_next_batch);
+    RETURN_ERROR_IF_EXC(_env);
+    if (meta_address == 0) {
+        // Address == 0 when there's no data in scanner
+        *read_rows = 0;
+        *eof = true;
+        return Status::OK();
+    }
+    _set_meta(meta_address);
+    long num_rows = _next_meta_as_long();
+    if (num_rows == 0) {
+        *read_rows = 0;
+        *eof = true;
+        return Status::OK();
+    }
+    RETURN_IF_ERROR(_fill_block(block, num_rows));
+    *read_rows = num_rows;
+    *eof = false;
+    _env->CallVoidMethod(_jni_scanner_obj, _jni_scanner_release_table);
+    RETURN_ERROR_IF_EXC(_env);
+    _has_read += num_rows;
+    return Status::OK();
+}
+
+Status JniConnector::close() {
+    if (!_closed) {
+        // _fill_block may be failed and returned, we should release table in close.
+        // org.apache.doris.jni.JniScanner#releaseTable is idempotent
+        _env->CallVoidMethod(_jni_scanner_obj, _jni_scanner_release_table);
+        _env->CallVoidMethod(_jni_scanner_obj, _jni_scanner_close);
+        _env->DeleteLocalRef(_jni_scanner_obj);
+        _env->DeleteLocalRef(_jni_scanner_cls);
+        _closed = true;
+        jthrowable exc = (_env)->ExceptionOccurred();
+        if (exc != nullptr) {
+            LOG(FATAL) << "Failed to release jni resource: "
+                       << JniUtil::GetJniExceptionMsg(_env).to_string();
+        }
+    }
+    return Status::OK();
+}
+
+Status JniConnector::_init_jni_scanner(JNIEnv* env, int batch_size) {
+    RETURN_IF_ERROR(JniUtil::GetGlobalClassRef(env, _connector_class.c_str(), &_jni_scanner_cls));
+    jmethodID scanner_constructor =
+            env->GetMethodID(_jni_scanner_cls, "<init>", "(ILjava/util/Map;)V");
+    RETURN_ERROR_IF_EXC(env);
+
+    // prepare constructor parameters
+    jclass hashmap_class = env->FindClass("java/util/HashMap");
+    jmethodID hashmap_constructor = env->GetMethodID(hashmap_class, "<init>", "(I)V");
+    jobject hashmap_object =
+            env->NewObject(hashmap_class, hashmap_constructor, _scanner_params.size());
+    jmethodID hashmap_put = env->GetMethodID(
+            hashmap_class, "put", "(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;");
+    RETURN_ERROR_IF_EXC(env);
+    for (const auto& it : _scanner_params) {
+        jstring key = env->NewStringUTF(it.first.c_str());
+        jstring value = env->NewStringUTF(it.second.c_str());
+        env->CallObjectMethod(hashmap_object, hashmap_put, key, value);
+        env->DeleteLocalRef(key);
+        env->DeleteLocalRef(value);
+    }
+    env->DeleteLocalRef(hashmap_class);
+    _jni_scanner_obj =
+            env->NewObject(_jni_scanner_cls, scanner_constructor, batch_size, hashmap_object);
+    env->DeleteLocalRef(hashmap_object);
+    RETURN_ERROR_IF_EXC(env);
+
+    _jni_scanner_open = env->GetMethodID(_jni_scanner_cls, "open", "()V");
+    RETURN_ERROR_IF_EXC(env);
+    _jni_scanner_get_next_batch = env->GetMethodID(_jni_scanner_cls, "getNextBatchMeta", "()J");
+    RETURN_ERROR_IF_EXC(env);
+    _jni_scanner_close = env->GetMethodID(_jni_scanner_cls, "close", "()V");
+    RETURN_ERROR_IF_EXC(env);
+    _jni_scanner_release_column = env->GetMethodID(_jni_scanner_cls, "releaseColumn", "(I)V");
+    RETURN_ERROR_IF_EXC(env);
+    _jni_scanner_release_table = env->GetMethodID(_jni_scanner_cls, "releaseTable", "()V");
+    RETURN_ERROR_IF_EXC(env);
+
+    return Status::OK();
+}
+
+Status JniConnector::_fill_block(Block* block, size_t num_rows) {
+    for (int i = 0; i < _column_names.size(); ++i) {
+        auto& column_with_type_and_name = block->get_by_name(_column_names[i]);
+        auto& column_ptr = column_with_type_and_name.column;
+        auto& column_type = column_with_type_and_name.type;
+        RETURN_IF_ERROR(_fill_column(column_ptr, column_type, num_rows));
+        // Column is not released when _fill_column failed. It will be released when releasing table.
+        _env->CallVoidMethod(_jni_scanner_obj, _jni_scanner_release_column, i);
+        RETURN_ERROR_IF_EXC(_env);
+    }
+    return Status::OK();
+}
+
+Status JniConnector::_fill_column(ColumnPtr& doris_column, DataTypePtr& data_type,
+                                  size_t num_rows) {
+    TypeIndex logical_type = remove_nullable(data_type)->get_type_id();
+    void* null_map_ptr = _next_meta_as_ptr();
+    if (null_map_ptr == nullptr) {
+        // org.apache.doris.jni.vec.ColumnType.Type#UNSUPPORTED will set column address as 0
+        return Status::InternalError("Unsupported type {} in java side", getTypeName(logical_type));
+    }
+    MutableColumnPtr data_column;
+    if (doris_column->is_nullable()) {
+        auto* nullable_column = reinterpret_cast<vectorized::ColumnNullable*>(
+                (*std::move(doris_column)).mutate().get());
+        data_column = nullable_column->get_nested_column_ptr();
+        NullMap& null_map = nullable_column->get_null_map_data();
+        size_t origin_size = null_map.size();
+        null_map.resize(origin_size + num_rows);
+        memcpy(null_map.data() + origin_size, static_cast<bool*>(null_map_ptr), num_rows);
+    } else {
+        data_column = doris_column->assume_mutable();
+    }
+    // Date and DateTime are deprecated and not supported.
+    switch (logical_type) {
+#define DISPATCH(NUMERIC_TYPE, CPP_NUMERIC_TYPE)       \
+    case NUMERIC_TYPE:                                 \
+        return _fill_numeric_column<CPP_NUMERIC_TYPE>( \
+                data_column, reinterpret_cast<CPP_NUMERIC_TYPE*>(_next_meta_as_ptr()), num_rows);
+        FOR_LOGICAL_NUMERIC_TYPES(DISPATCH)
+#undef DISPATCH
+    case TypeIndex::Decimal128:
+        [[fallthrough]];
+    case TypeIndex::Decimal128I:
+        return _fill_decimal_column<Int128>(
+                data_column, reinterpret_cast<Int128*>(_next_meta_as_ptr()), num_rows);
+    case TypeIndex::Decimal32:
+        return _fill_decimal_column<Int32>(data_column,
+                                           reinterpret_cast<Int32*>(_next_meta_as_ptr()), num_rows);
+    case TypeIndex::Decimal64:
+        return _fill_decimal_column<Int64>(data_column,
+                                           reinterpret_cast<Int64*>(_next_meta_as_ptr()), num_rows);
+    case TypeIndex::DateV2:
+        return _decode_time_column<UInt32>(
+                data_column, reinterpret_cast<UInt32*>(_next_meta_as_ptr()), num_rows);
+    case TypeIndex::DateTimeV2:
+        return _decode_time_column<UInt64>(
+                data_column, reinterpret_cast<UInt64*>(_next_meta_as_ptr()), num_rows);
+    case TypeIndex::String:
+        [[fallthrough]];
+    case TypeIndex::FixedString:
+        return _fill_string_column(data_column, num_rows);
+    default:
+        return Status::InvalidArgument("Unsupported type {} in jni scanner",
+                                       getTypeName(logical_type));
+    }
+    return Status::OK();
+}
+
+Status JniConnector::_fill_string_column(MutableColumnPtr& doris_column, size_t num_rows) {
+    int* offsets = reinterpret_cast<int*>(_next_meta_as_ptr());
+    char* data = reinterpret_cast<char*>(_next_meta_as_ptr());
+    std::vector<StringRef> string_values;
+    string_values.reserve(num_rows);
+    for (size_t i = 0; i < num_rows; ++i) {
+        int start_offset = i == 0 ? 0 : offsets[i - 1];
+        int end_offset = offsets[i];
+        string_values.emplace_back(data + start_offset, end_offset - start_offset);
+    }
+    doris_column->insert_many_strings(&string_values[0], num_rows);
+    return Status::OK();
+}
+
+void JniConnector::_generate_predicates(
+        std::unordered_map<std::string, ColumnValueRangeType>* colname_to_value_range) {
+    if (colname_to_value_range == nullptr) {
+        return;
+    }
+    for (auto& kv : *colname_to_value_range) {
+        const std::string& column_name = kv.first;
+        const ColumnValueRangeType& col_val_range = kv.second;
+        std::visit([&](auto&& range) { _parse_value_range(range, column_name); }, col_val_range);
+    }
+}
+
+std::string JniConnector::get_hive_type(const TypeDescriptor& desc) {
+    std::ostringstream buffer;
+    switch (desc.type) {
+    case TYPE_BOOLEAN:
+        return "boolean";
+    case TYPE_TINYINT:
+        return "tinyint";
+    case TYPE_SMALLINT:
+        return "smallint";
+    case TYPE_INT:
+        return "int";
+    case TYPE_BIGINT:
+        return "bigint";
+    case TYPE_FLOAT:
+        return "float";
+    case TYPE_DOUBLE:
+        return "double";
+    case TYPE_VARCHAR: {
+        buffer << "varchar(" << desc.len << ")";
+        return buffer.str();
+    }
+    case TYPE_DATE:
+        [[fallthrough]];
+    case TYPE_DATEV2:
+        return "date";
+    case TYPE_DATETIME:
+        [[fallthrough]];
+    case TYPE_DATETIMEV2:
+        [[fallthrough]];
+    case TYPE_TIME:
+        [[fallthrough]];
+    case TYPE_TIMEV2:
+        return "timestamp";
+    case TYPE_BINARY:
+        return "binary";
+    case TYPE_CHAR: {
+        buffer << "char(" << desc.len << ")";
+        return buffer.str();
+    }
+    case TYPE_STRING:
+        return "string";
+    case TYPE_DECIMALV2: {
+        buffer << "decimalv2(" << DecimalV2Value::PRECISION << "," << DecimalV2Value::SCALE << ")";
+        return buffer.str();
+    }
+    case TYPE_DECIMAL32: {
+        buffer << "decimal32(" << desc.precision << "," << desc.scale << ")";
+        return buffer.str();
+    }
+    case TYPE_DECIMAL64: {
+        buffer << "decimal64(" << desc.precision << "," << desc.scale << ")";
+        return buffer.str();
+    }
+    case TYPE_DECIMAL128I: {
+        buffer << "decimal128(" << desc.precision << "," << desc.scale << ")";
+        return buffer.str();
+    }
+    case TYPE_STRUCT: {
+        buffer << "struct<";
+        for (int i = 0; i < desc.children.size(); ++i) {
+            if (i != 0) {
+                buffer << ",";
+            }
+            buffer << desc.field_names[i] << ":" << get_hive_type(desc.children[i]);
+        }
+        buffer << ">";
+        return buffer.str();
+    }
+    case TYPE_ARRAY: {
+        buffer << "array<" << get_hive_type(desc.children[0]) << ">";
+        return buffer.str();
+    }
+    case TYPE_MAP: {
+        buffer << "map<" << get_hive_type(desc.children[0]) << ","
+               << get_hive_type(desc.children[1]) << ">";
+        return buffer.str();
+    }
+    default:
+        return "unsupported";
+    }
+}
+} // namespace doris::vectorized

--- a/be/src/vec/exec/jni_connector.h
+++ b/be/src/vec/exec/jni_connector.h
@@ -1,0 +1,313 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <jni.h>
+
+#include "runtime/runtime_state.h"
+#include "util/jni-util.h"
+
+namespace doris::vectorized {
+
+/**
+ * Connector to java jni scanner, which should extend org.apache.doris.jni.JniScanner
+ */
+class JniConnector {
+public:
+    /**
+     * The predicates that can be pushed down to java side.
+     * Reference to java class org.apache.doris.jni.vec.ScanPredicate
+     */
+    template <typename CppType>
+    struct ScanPredicate {
+        ScanPredicate() = default;
+        ~ScanPredicate() = default;
+        const std::string column_name;
+        SQLFilterOp op;
+        std::vector<const CppType*> values;
+        int scale;
+
+        ScanPredicate(const std::string column_name) : column_name(std::move(column_name)) {}
+
+        ScanPredicate(const ScanPredicate& other) {
+            column_name = other.column_name;
+            op = other.op;
+            for (auto v : other.values) {
+                values.emplace_back(v);
+            }
+            scale = other.scale;
+        }
+
+        int length() {
+            // name_length(4) + column_name + operator(4) + scale(4) + num_values(4)
+            int len = 4 + column_name.size() + 4 + 4 + 4;
+            if constexpr (std::is_same_v<CppType, StringRef>) {
+                for (const StringRef* s : values) {
+                    // string_length(4) + string
+                    len += 4 + s->size;
+                }
+            } else {
+                int type_len = sizeof(CppType);
+                // value_length(4) + value
+                len += (4 + type_len) * values.size();
+            }
+            return len;
+        }
+
+        /**
+         * The value ranges can be stored as byte array as following format:
+         * number_filters(4) | length(4) | column_name | op(4) | scale(4) | num_values(4) | value_length(4) | value | ...
+         * The read method is implemented in org.apache.doris.jni.vec.ScanPredicate#parseScanPredicates
+         */
+        int write(std::unique_ptr<char[]>& predicates, int origin_length) {
+            int num_filters = 0;
+            if (origin_length != 0) {
+                num_filters = *reinterpret_cast<int*>(predicates.get());
+            } else {
+                origin_length = 4;
+            }
+            num_filters += 1;
+            int new_length = origin_length + length();
+            char* new_bytes = new char[new_length];
+            if (origin_length != 4) {
+                memcpy(new_bytes, predicates.get(), origin_length);
+            }
+            *reinterpret_cast<int*>(new_bytes) = num_filters;
+
+            char* char_ptr = new_bytes + origin_length;
+            *reinterpret_cast<int*>(char_ptr) = column_name.size();
+            char_ptr += 4;
+            memcpy(char_ptr, column_name.data(), column_name.size());
+            char_ptr += column_name.size();
+            *reinterpret_cast<int*>(char_ptr) = op;
+            char_ptr += 4;
+            *reinterpret_cast<int*>(char_ptr) = scale;
+            char_ptr += 4;
+            *reinterpret_cast<int*>(char_ptr) = values.size();
+            char_ptr += 4;
+            if constexpr (std::is_same_v<CppType, StringRef>) {
+                for (const StringRef* s : values) {
+                    *reinterpret_cast<int*>(char_ptr) = s->size;
+                    char_ptr += 4;
+                    memcpy(char_ptr, s->data, s->size);
+                    char_ptr += s->size;
+                }
+            } else {
+                for (const CppType* v : values) {
+                    int type_len = sizeof(CppType);
+                    *reinterpret_cast<int*>(char_ptr) = type_len;
+                    char_ptr += 4;
+                    *reinterpret_cast<CppType*>(char_ptr) = *v;
+                    char_ptr += type_len;
+                }
+            }
+
+            predicates.reset(new_bytes);
+            return new_length;
+        }
+    };
+
+    /**
+     * Use configuration map to provide scan information. The java side should determine how the parameters
+     * are parsed. For example, using "required_fields=col0,col1,...,colN" to provide the scan fields.
+     * @param connector_class Java scanner class
+     * @param scanner_params Provided configuration map
+     * @param column_names Fields to read, also the required_fields in scanner_params
+     */
+    JniConnector(std::string connector_class, std::map<std::string, std::string> scanner_params,
+                 std::vector<std::string> column_names)
+            : _connector_class(std::move(connector_class)),
+              _scanner_params(std::move(scanner_params)),
+              _column_names(std::move(column_names)) {}
+
+    /// Should release jni resources if other functions are failed.
+    ~JniConnector();
+
+    /**
+     * Open java scanner, and get the following scanner methods by jni:
+     * 1. getNextBatchMeta: read next batch and return the address of meta information
+     * 2. close: close java scanner, and release jni resources
+     * 3. releaseColumn: release a single column
+     * 4. releaseTable: release current batch, which will also release columns and meta information
+     */
+    Status open(RuntimeState* state, RuntimeProfile* profile);
+
+    /**
+     * Should call before open, parse the pushed down filters. The value ranges can be stored as byte array in heap:
+     * number_filters(4) | length(4) | column_name | op(4) | scale(4) | num_values(4) | value_length(4) | value | ...
+     * Then, pass the byte array address in configuration map, like "push_down_predicates=${address}"
+     */
+    Status init(std::unordered_map<std::string, ColumnValueRangeType>* colname_to_value_range);
+
+    /**
+     * Call java side function JniScanner.getNextBatchMeta. The columns information are stored as long array:
+     *                            | number of rows |
+     *                            | null indicator start address of fixed length column-A |
+     *                            | data column start address of the fixed length column-A  |
+     *                            | ... |
+     *                            | null indicator start address of variable length column-B |
+     *                            | offset column start address of the variable length column-B |
+     *                            | data column start address of the variable length column-B |
+     *                            | ... |
+     */
+    Status get_nex_block(Block* block, size_t* read_rows, bool* eof);
+
+    /**
+     * Close scanner and release jni resources.
+     */
+    Status close();
+
+    /**
+     * Map PrimitiveType to hive type.
+     */
+    static std::string get_hive_type(const TypeDescriptor& desc);
+
+private:
+    std::string _connector_class;
+    std::map<std::string, std::string> _scanner_params;
+    std::vector<std::string> _column_names;
+
+    size_t _has_read = 0;
+
+    bool _closed = false;
+    jclass _jni_scanner_cls;
+    jobject _jni_scanner_obj;
+    jmethodID _jni_scanner_open;
+    jmethodID _jni_scanner_get_next_batch;
+    jmethodID _jni_scanner_close;
+    jmethodID _jni_scanner_release_column;
+    jmethodID _jni_scanner_release_table;
+
+    long* _meta_ptr;
+    int _meta_index;
+    JNIEnv* _env = nullptr;
+
+    int _predicates_length = 0;
+    std::unique_ptr<char[]> _predicates = nullptr;
+
+    /**
+     * Set the address of meta information, which is returned by org.apache.doris.jni.JniScanner#getNextBatchMeta
+     */
+    void _set_meta(long meta_addr) {
+        _meta_ptr = static_cast<long*>(reinterpret_cast<void*>(meta_addr));
+        _meta_index = 0;
+    }
+
+    /**
+     * Get the number of rows in next batch.
+     */
+    long _next_meta_as_long() { return _meta_ptr[_meta_index++]; }
+
+    /**
+     * Get the next column address
+     */
+    void* _next_meta_as_ptr() { return reinterpret_cast<void*>(_meta_ptr[_meta_index++]); }
+
+    Status _init_jni_scanner(JNIEnv* env, int batch_size);
+
+    Status _fill_block(Block* block, size_t num_rows);
+
+    Status _fill_column(ColumnPtr& doris_column, DataTypePtr& data_type, size_t num_rows);
+
+    template <typename CppType>
+    Status _fill_numeric_column(MutableColumnPtr& doris_column, CppType* ptr, size_t num_rows) {
+        auto& column_data = static_cast<ColumnVector<CppType>&>(*doris_column).get_data();
+        size_t origin_size = column_data.size();
+        column_data.resize(origin_size + num_rows);
+        memcpy(column_data.data() + origin_size, ptr, sizeof(CppType) * num_rows);
+        return Status::OK();
+    }
+
+    template <typename DecimalPrimitiveType>
+    Status _fill_decimal_column(MutableColumnPtr& doris_column, DecimalPrimitiveType* ptr,
+                                size_t num_rows) {
+        auto& column_data =
+                static_cast<ColumnDecimal<Decimal<DecimalPrimitiveType>>&>(*doris_column)
+                        .get_data();
+        size_t origin_size = column_data.size();
+        column_data.resize(origin_size + num_rows);
+        memcpy(column_data.data() + origin_size, ptr, sizeof(DecimalPrimitiveType) * num_rows);
+        return Status::OK();
+    }
+
+    template <typename CppType>
+    Status _decode_time_column(MutableColumnPtr& doris_column, CppType* ptr, size_t num_rows) {
+        auto& column_data = static_cast<ColumnVector<CppType>&>(*doris_column).get_data();
+        size_t origin_size = column_data.size();
+        column_data.resize(origin_size + num_rows);
+        memcpy(column_data.data() + origin_size, ptr, sizeof(CppType) * num_rows);
+        return Status::OK();
+    }
+
+    Status _fill_string_column(MutableColumnPtr& doris_column, size_t num_rows);
+
+    void _generate_predicates(
+            std::unordered_map<std::string, ColumnValueRangeType>* colname_to_value_range);
+
+    template <PrimitiveType primitive_type>
+    void _parse_value_range(const ColumnValueRange<primitive_type>& col_val_range,
+                            const std::string& column_name) {
+        using CppType = typename PrimitiveTypeTraits<primitive_type>::CppType;
+
+        if (col_val_range.is_fixed_value_range()) {
+            ScanPredicate<CppType> in_predicate(column_name);
+            in_predicate.op = SQLFilterOp::FILTER_IN;
+            in_predicate.scale = col_val_range.scale();
+            for (const auto& value : col_val_range.get_fixed_value_set()) {
+                in_predicate.values.emplace_back(&value);
+            }
+            if (!in_predicate.values.empty()) {
+                _predicates_length = in_predicate.write(_predicates, _predicates_length);
+            }
+            return;
+        }
+
+        const CppType high_value = col_val_range.get_range_max_value();
+        const CppType low_value = col_val_range.get_range_min_value();
+        const SQLFilterOp high_op = col_val_range.get_range_high_op();
+        const SQLFilterOp low_op = col_val_range.get_range_low_op();
+
+        // orc can only push down is_null. When col_value_range._contain_null = true, only indicating that
+        // value can be null, not equals null, so ignore _contain_null in col_value_range
+        if (col_val_range.is_high_value_maximum() && high_op == SQLFilterOp::FILTER_LESS_OR_EQUAL &&
+            col_val_range.is_low_value_mininum() && low_op == SQLFilterOp::FILTER_LARGER_OR_EQUAL) {
+            return;
+        }
+
+        if (low_value < high_value) {
+            if (!col_val_range.is_low_value_mininum() ||
+                SQLFilterOp::FILTER_LARGER_OR_EQUAL != low_op) {
+                ScanPredicate<CppType> low_predicate(column_name);
+                low_predicate.scale = col_val_range.scale();
+                low_predicate.op = low_op;
+                low_predicate.values.emplace_back(col_val_range.get_range_min_value_ptr());
+                _predicates_length = low_predicate.write(_predicates, _predicates_length);
+            }
+            if (!col_val_range.is_high_value_maximum() ||
+                SQLFilterOp::FILTER_LESS_OR_EQUAL != high_op) {
+                ScanPredicate<CppType> high_predicate(column_name);
+                high_predicate.scale = col_val_range.scale();
+                high_predicate.op = high_op;
+                high_predicate.values.emplace_back(col_val_range.get_range_max_value_ptr());
+                _predicates_length = high_predicate.write(_predicates, _predicates_length);
+            }
+        }
+    }
+};
+
+} // namespace doris::vectorized

--- a/be/src/vec/exec/scan/jni_reader.cpp
+++ b/be/src/vec/exec/scan/jni_reader.cpp
@@ -1,0 +1,71 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "jni_reader.h"
+
+namespace doris::vectorized {
+
+MockJniReader::MockJniReader(const std::vector<SlotDescriptor*>& file_slot_descs,
+                             RuntimeState* state, RuntimeProfile* profile)
+        : _file_slot_descs(file_slot_descs), _state(state), _profile(profile) {
+    std::ostringstream required_fields;
+    std::ostringstream columns_types;
+    std::vector<std::string> column_names;
+    int index = 0;
+    for (auto& desc : _file_slot_descs) {
+        std::string field = desc->col_name();
+        std::string type = JniConnector::get_hive_type(desc->type());
+        column_names.emplace_back(field);
+        if (index == 0) {
+            required_fields << field;
+            columns_types << type;
+        } else {
+            required_fields << "," << field;
+            columns_types << "#" << type;
+        }
+        index++;
+    }
+    std::map<String, String> params = {{"mock_rows", "10240"},
+                                       {"required_fields", required_fields.str()},
+                                       {"columns_types", columns_types.str()}};
+    _jni_connector = std::make_unique<JniConnector>("org/apache/doris/jni/MockJniScanner", params,
+                                                    column_names);
+}
+
+Status MockJniReader::get_next_block(Block* block, size_t* read_rows, bool* eof) {
+    RETURN_IF_ERROR(_jni_connector->get_nex_block(block, read_rows, eof));
+    if (*eof) {
+        RETURN_IF_ERROR(_jni_connector->close());
+    }
+    return Status::OK();
+}
+
+Status MockJniReader::get_columns(std::unordered_map<std::string, TypeDescriptor>* name_to_type,
+                                  std::unordered_set<std::string>* missing_cols) {
+    for (auto& desc : _file_slot_descs) {
+        name_to_type->emplace(desc->col_name(), desc->type());
+    }
+    return Status::OK();
+}
+
+Status MockJniReader::init_reader(
+        std::unordered_map<std::string, ColumnValueRangeType>* colname_to_value_range) {
+    _colname_to_value_range = colname_to_value_range;
+    RETURN_IF_ERROR(_jni_connector->init(colname_to_value_range));
+    return _jni_connector->open(_state, _profile);
+}
+} // namespace doris::vectorized

--- a/be/src/vec/exec/scan/jni_reader.h
+++ b/be/src/vec/exec/scan/jni_reader.h
@@ -1,0 +1,54 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include "vec/exec/format/generic_reader.h"
+#include "vec/exec/jni_connector.h"
+
+namespace doris::vectorized {
+
+/**
+ * The demo usage of JniReader, showing how to read data from java scanner.
+ * The java side is also a mock reader that provide values for each type.
+ * This class will only be retained during the functional testing phase to verify that
+ * the communication and data exchange with the jvm are correct.
+ */
+class MockJniReader : public GenericReader {
+public:
+    MockJniReader(const std::vector<SlotDescriptor*>& file_slot_descs, RuntimeState* state,
+                  RuntimeProfile* profile);
+
+    ~MockJniReader() override = default;
+
+    Status get_next_block(Block* block, size_t* read_rows, bool* eof) override;
+
+    Status get_columns(std::unordered_map<std::string, TypeDescriptor>* name_to_type,
+                       std::unordered_set<std::string>* missing_cols) override;
+
+    Status init_reader(
+            std::unordered_map<std::string, ColumnValueRangeType>* colname_to_value_range);
+
+private:
+    const std::vector<SlotDescriptor*>& _file_slot_descs;
+    RuntimeState* _state;
+    RuntimeProfile* _profile;
+    std::unordered_map<std::string, ColumnValueRangeType>* _colname_to_value_range;
+    std::unique_ptr<JniConnector> _jni_connector;
+};
+
+} // namespace doris::vectorized

--- a/fe/java-udf/src/main/java/org/apache/doris/jni/JniScanner.java
+++ b/fe/java-udf/src/main/java/org/apache/doris/jni/JniScanner.java
@@ -1,0 +1,99 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.jni;
+
+import org.apache.doris.jni.vec.ColumnType;
+import org.apache.doris.jni.vec.ColumnValue;
+import org.apache.doris.jni.vec.ScanPredicate;
+import org.apache.doris.jni.vec.VectorTable;
+
+import java.io.IOException;
+
+public abstract class JniScanner {
+    protected VectorTable vectorTable;
+    protected String[] fields;
+    protected ColumnType[] types;
+    protected ScanPredicate[] predicates;
+    protected int batchSize;
+
+    // Initialize JniScanner
+    public abstract void open() throws IOException;
+
+    // Close JniScanner and release resources
+    public abstract void close() throws IOException;
+
+    // Scan data and save as vector table
+    protected abstract int getNext() throws IOException;
+
+    protected void initTableInfo(ColumnType[] requiredTypes, String[] requiredFields, ScanPredicate[] predicates,
+            int batchSize) {
+        this.types = requiredTypes;
+        this.fields = requiredFields;
+        this.predicates = predicates;
+        this.batchSize = batchSize;
+    }
+
+    protected void appendData(int index, ColumnValue value) {
+        vectorTable.appendData(index, value);
+    }
+
+    protected int getBatchSize() {
+        return batchSize;
+    }
+
+    public VectorTable getTable() {
+        return vectorTable;
+    }
+
+    public long getNextBatchMeta() throws IOException {
+        if (vectorTable == null) {
+            vectorTable = new VectorTable(types, fields, predicates, batchSize);
+        }
+        int numRows;
+        try {
+            numRows = getNext();
+        } catch (IOException e) {
+            releaseTable();
+            throw e;
+        }
+        if (numRows == 0) {
+            return 0;
+        }
+        return getMetaAddress(numRows);
+    }
+
+    private long getMetaAddress(int numRows) {
+        vectorTable.setNumRows(numRows);
+        return vectorTable.getMetaAddress();
+    }
+
+    protected void resetTable() {
+        vectorTable.reset();
+    }
+
+    protected void releaseColumn(int fieldId) {
+        vectorTable.releaseColumn(fieldId);
+    }
+
+    protected void releaseTable() {
+        if (vectorTable != null) {
+            vectorTable.close();
+        }
+        vectorTable = null;
+    }
+}

--- a/fe/java-udf/src/main/java/org/apache/doris/jni/MockJniScanner.java
+++ b/fe/java-udf/src/main/java/org/apache/doris/jni/MockJniScanner.java
@@ -1,0 +1,181 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.jni;
+
+import org.apache.doris.jni.vec.ColumnType;
+import org.apache.doris.jni.vec.ColumnValue;
+import org.apache.doris.jni.vec.ScanPredicate;
+
+import org.apache.log4j.Logger;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * The demo usage of JniScanner. This class will only be retained during the functional testing phase to
+ * verify that the communication and data exchange with the BE are correct.
+ */
+public class MockJniScanner extends JniScanner {
+    public static class MockColumnValue implements ColumnValue {
+        private int i;
+        private int j;
+
+        public MockColumnValue() {
+        }
+
+        public void set(int i, int j) {
+            this.i = i;
+            this.j = j;
+        }
+
+        @Override
+        public boolean getBoolean() {
+            return (i + j) % 2 == 0;
+        }
+
+        @Override
+        public byte getByte() {
+            return (byte) (i + j);
+        }
+
+        @Override
+        public short getShort() {
+            return (short) (i - j);
+        }
+
+        @Override
+        public int getInt() {
+            return i + j;
+        }
+
+        @Override
+        public float getFloat() {
+            return (float) (j + i - 11) / (i + 1);
+        }
+
+        @Override
+        public long getLong() {
+            return (long) (i - 13) * (j + 1);
+        }
+
+        @Override
+        public double getDouble() {
+            return (double) (j + i - 15) / (i + 1);
+        }
+
+        @Override
+        public BigDecimal getDecimal() {
+            return BigDecimal.valueOf(getDouble());
+        }
+
+        @Override
+        public String getString() {
+            return "row-" + i + "-column-" + j;
+        }
+
+        @Override
+        public LocalDate getDate() {
+            return LocalDate.now();
+        }
+
+        @Override
+        public LocalDateTime getDateTime() {
+            return LocalDateTime.now();
+        }
+
+        @Override
+        public byte[] getBytes() {
+            return ("row-" + i + "-column-" + j).getBytes(StandardCharsets.UTF_8);
+        }
+
+        @Override
+        public void unpackArray(List<ColumnValue> values) {
+
+        }
+
+        @Override
+        public void unpackMap(List<ColumnValue> keys, List<ColumnValue> values) {
+
+        }
+
+        @Override
+        public void unpackStruct(List<Integer> structFieldIndex, List<ColumnValue> values) {
+
+        }
+    }
+
+    private static final Logger LOG = Logger.getLogger(MockJniScanner.class);
+
+    private final int mockRows;
+    private int readRows = 0;
+    private final MockColumnValue columnValue = new MockColumnValue();
+
+    public MockJniScanner(int batchSize, Map<String, String> params) {
+        mockRows = Integer.parseInt(params.get("mock_rows"));
+        String[] requiredFields = params.get("required_fields").split(",");
+        String[] types = params.get("columns_types").split("#");
+        ColumnType[] columnTypes = new ColumnType[types.length];
+        for (int i = 0; i < types.length; i++) {
+            columnTypes[i] = ColumnType.parseType(requiredFields[i], types[i]);
+        }
+        ScanPredicate[] predicates = new ScanPredicate[0];
+        if (params.containsKey("push_down_predicates")) {
+            long predicatesAddress = Long.parseLong(params.get("push_down_predicates"));
+            if (predicatesAddress != 0) {
+                predicates = ScanPredicate.parseScanPredicates(predicatesAddress, columnTypes);
+                LOG.info("MockJniScanner gets pushed-down predicates:  " + ScanPredicate.dump(predicates));
+            }
+        }
+        initTableInfo(columnTypes, requiredFields, predicates, batchSize);
+    }
+
+    @Override
+    public void open() throws IOException {
+
+    }
+
+    @Override
+    public void close() throws IOException {
+
+    }
+
+    @Override
+    protected int getNext() throws IOException {
+        if (readRows == mockRows) {
+            return 0;
+        }
+        int rows = Math.min(batchSize, mockRows - readRows);
+        for (int i = 0; i < rows; ++i) {
+            for (int j = 0; j < types.length; ++j) {
+                if ((i + j) % 16 == 0) {
+                    appendData(j, null);
+                } else {
+                    columnValue.set(i, j);
+                    appendData(j, columnValue);
+                }
+            }
+        }
+        readRows += rows;
+        return rows;
+    }
+}

--- a/fe/java-udf/src/main/java/org/apache/doris/jni/utils/OffHeap.java
+++ b/fe/java-udf/src/main/java/org/apache/doris/jni/utils/OffHeap.java
@@ -1,0 +1,184 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.jni.utils;
+
+import org.apache.doris.udf.JNINativeMethod;
+
+import sun.misc.Unsafe;
+
+import java.lang.reflect.Field;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+
+/**
+ * Reference to Apache Spark with some customization.
+ * Default call native method to allocate and release memory, which will be tracked by memory tracker in BE.
+ * Call {@link OffHeap#setTesting()} in test scenario.
+ */
+public class OffHeap {
+    private static final long UNSAFE_COPY_THRESHOLD = 1024L * 1024L;
+
+    private static boolean IS_TESTING = false;
+
+    private static final Unsafe UNSAFE;
+
+    public static final int BOOLEAN_ARRAY_OFFSET;
+
+    public static final int BYTE_ARRAY_OFFSET;
+
+    public static final int SHORT_ARRAY_OFFSET;
+
+    public static final int INT_ARRAY_OFFSET;
+
+    public static final int LONG_ARRAY_OFFSET;
+
+    public static final int FLOAT_ARRAY_OFFSET;
+
+    public static final int DOUBLE_ARRAY_OFFSET;
+
+    static {
+        UNSAFE = (Unsafe) AccessController.doPrivileged(
+                (PrivilegedAction<Object>) () -> {
+                    try {
+                        Field f = Unsafe.class.getDeclaredField("theUnsafe");
+                        f.setAccessible(true);
+                        return f.get(null);
+                    } catch (NoSuchFieldException | IllegalAccessException e) {
+                        throw new Error();
+                    }
+                });
+        BOOLEAN_ARRAY_OFFSET = UNSAFE.arrayBaseOffset(boolean[].class);
+        BYTE_ARRAY_OFFSET = UNSAFE.arrayBaseOffset(byte[].class);
+        SHORT_ARRAY_OFFSET = UNSAFE.arrayBaseOffset(short[].class);
+        INT_ARRAY_OFFSET = UNSAFE.arrayBaseOffset(int[].class);
+        LONG_ARRAY_OFFSET = UNSAFE.arrayBaseOffset(long[].class);
+        FLOAT_ARRAY_OFFSET = UNSAFE.arrayBaseOffset(float[].class);
+        DOUBLE_ARRAY_OFFSET = UNSAFE.arrayBaseOffset(double[].class);
+    }
+
+    public static void setTesting() {
+        IS_TESTING = true;
+    }
+
+    public static int getInt(Object object, long offset) {
+        return UNSAFE.getInt(object, offset);
+    }
+
+    public static void putInt(Object object, long offset, int value) {
+        UNSAFE.putInt(object, offset, value);
+    }
+
+    public static boolean getBoolean(Object object, long offset) {
+        return UNSAFE.getBoolean(object, offset);
+    }
+
+    public static void putBoolean(Object object, long offset, boolean value) {
+        UNSAFE.putBoolean(object, offset, value);
+    }
+
+    public static byte getByte(Object object, long offset) {
+        return UNSAFE.getByte(object, offset);
+    }
+
+    public static void putByte(Object object, long offset, byte value) {
+        UNSAFE.putByte(object, offset, value);
+    }
+
+    public static short getShort(Object object, long offset) {
+        return UNSAFE.getShort(object, offset);
+    }
+
+    public static void putShort(Object object, long offset, short value) {
+        UNSAFE.putShort(object, offset, value);
+    }
+
+    public static long getLong(Object object, long offset) {
+        return UNSAFE.getLong(object, offset);
+    }
+
+    public static void putLong(Object object, long offset, long value) {
+        UNSAFE.putLong(object, offset, value);
+    }
+
+    public static float getFloat(Object object, long offset) {
+        return UNSAFE.getFloat(object, offset);
+    }
+
+    public static void putFloat(Object object, long offset, float value) {
+        UNSAFE.putFloat(object, offset, value);
+    }
+
+    public static double getDouble(Object object, long offset) {
+        return UNSAFE.getDouble(object, offset);
+    }
+
+    public static void putDouble(Object object, long offset, double value) {
+        UNSAFE.putDouble(object, offset, value);
+    }
+
+    public static void setMemory(long address, byte value, long size) {
+        UNSAFE.setMemory(address, size, value);
+    }
+
+    public static long allocateMemory(long size) {
+        if (IS_TESTING) {
+            return UNSAFE.allocateMemory(size);
+        } else {
+            return JNINativeMethod.memoryTrackerMalloc(size);
+        }
+    }
+
+    public static void freeMemory(long address) {
+        if (IS_TESTING) {
+            UNSAFE.freeMemory(address);
+        } else {
+            JNINativeMethod.memoryTrackerFree(address);
+        }
+    }
+
+    public static long reallocateMemory(long address, long oldSize, long newSize) {
+        long newMemory = allocateMemory(newSize);
+        copyMemory(null, address, null, newMemory, oldSize);
+        freeMemory(address);
+        return newMemory;
+    }
+
+    public static void copyMemory(Object src, long srcOffset, Object dst, long dstOffset, long length) {
+        // Check if dstOffset is before or after srcOffset to determine if we should copy
+        // forward or backwards. This is necessary in case src and dst overlap.
+        if (dstOffset < srcOffset) {
+            while (length > 0) {
+                long size = Math.min(length, UNSAFE_COPY_THRESHOLD);
+                UNSAFE.copyMemory(src, srcOffset, dst, dstOffset, size);
+                length -= size;
+                srcOffset += size;
+                dstOffset += size;
+            }
+        } else {
+            srcOffset += length;
+            dstOffset += length;
+            while (length > 0) {
+                long size = Math.min(length, UNSAFE_COPY_THRESHOLD);
+                srcOffset -= size;
+                dstOffset -= size;
+                UNSAFE.copyMemory(src, srcOffset, dst, dstOffset, size);
+                length -= size;
+            }
+        }
+    }
+}

--- a/fe/java-udf/src/main/java/org/apache/doris/jni/utils/TypeNativeBytes.java
+++ b/fe/java-udf/src/main/java/org/apache/doris/jni/utils/TypeNativeBytes.java
@@ -1,0 +1,103 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.jni.utils;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.math.RoundingMode;
+import java.time.DateTimeException;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Arrays;
+
+public class TypeNativeBytes {
+    /**
+     * Change the order of the bytes, Because JVM is Big-Endian , x86 is Little-Endian.
+     */
+    public static byte[] convertByteOrder(byte[] bytes) {
+        int length = bytes.length;
+        for (int i = 0; i < length / 2; ++i) {
+            byte temp = bytes[i];
+            bytes[i] = bytes[length - 1 - i];
+            bytes[length - 1 - i] = temp;
+        }
+        return bytes;
+    }
+
+    public static byte[] getDecimalBytes(BigDecimal v, int scale, int size) {
+        BigDecimal retValue = v.setScale(scale, RoundingMode.HALF_EVEN);
+        BigInteger data = retValue.unscaledValue();
+        byte[] bytes = convertByteOrder(data.toByteArray());
+        byte[] value = new byte[size];
+        if (data.signum() == -1) {
+            Arrays.fill(value, (byte) -1);
+        }
+
+        System.arraycopy(bytes, 0, value, 0, Math.min(bytes.length, value.length));
+        return value;
+    }
+
+    public static BigDecimal getDecimal(byte[] bytes, int scale) {
+        BigInteger value = new BigInteger(convertByteOrder(bytes));
+        return new BigDecimal(value, scale);
+    }
+
+    public static int convertToDateV2(int year, int month, int day) {
+        return (int) (day | (long) month << 5 | (long) year << 9);
+    }
+
+    public static long convertToDateTimeV2(int year, int month, int day, int hour, int minute, int second) {
+        // todo: Has lost precision ? How about millisecond, microsecond ...
+        return (long) second << 20 | (long) minute << 26 | (long) hour << 32
+                | (long) day << 37 | (long) month << 42 | (long) year << 46;
+    }
+
+    public static LocalDate convertToJavaDate(int date) {
+        int year = date >> 9;
+        int month = (date >> 5) & 0XF;
+        int day = date & 0X1F;
+        LocalDate value;
+        try {
+            value = LocalDate.of(year, month, day);
+        } catch (DateTimeException e) {
+            value = LocalDate.MAX;
+        }
+        return value;
+    }
+
+    public static LocalDateTime convertToJavaDateTime(long time) {
+        int year = (int) (time >> 46);
+        int yearMonth = (int) (time >> 42);
+        int yearMonthDay = (int) (time >> 37);
+
+        int month = (yearMonth & 0XF);
+        int day = (yearMonthDay & 0X1F);
+
+        int hour = (int) ((time >> 32) & 0X1F);
+        int minute = (int) ((time >> 26) & 0X3F);
+        int second = (int) ((time >> 20) & 0X3F);
+
+        LocalDateTime value;
+        try {
+            value = LocalDateTime.of(year, month, day, hour, minute, second);
+        } catch (DateTimeException e) {
+            value = LocalDateTime.MAX;
+        }
+        return value;
+    }
+}

--- a/fe/java-udf/src/main/java/org/apache/doris/jni/vec/ColumnType.java
+++ b/fe/java-udf/src/main/java/org/apache/doris/jni/vec/ColumnType.java
@@ -1,0 +1,350 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.jni.vec;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Column type for fields in vector table. Support complex nested types.
+ * date & datetime is deprecated, use datev2 & datetimev2 only.
+ * If decimalv2 is deprecated, we can unify decimal32 & decimal64 & decimal128 into decimal.
+ */
+public class ColumnType {
+    public enum Type {
+        UNSUPPORTED(-1),
+        BYTE(1), // only for string, generated as array<byte>
+        BOOLEAN(1),
+        TINYINT(1),
+        SMALLINT(2),
+        INT(4),
+        BIGINT(8),
+        FLOAT(4),
+        DOUBLE(8),
+        DATEV2(4),
+        DATETIMEV2(8),
+        CHAR(-1),
+        VARCHAR(-1),
+        BINARY(-1),
+        DECIMALV2(16),
+        DECIMAL32(4),
+        DECIMAL64(8),
+        DECIMAL128(16),
+        STRING(-1),
+        ARRAY(-1),
+        MAP(-1),
+        STRUCT(-1);
+
+        public final int size;
+
+        Type(int size) {
+            this.size = size;
+        }
+    }
+
+    private final Type type;
+    private final String name;
+    private List<String> childNames;
+    private List<ColumnType> childTypes;
+    private List<Integer> fieldIndex;
+    // only used in char & varchar
+    private final int length;
+    // only used in decimal
+    private final int precision;
+    private final int scale;
+
+    public ColumnType(String name, Type type) {
+        this.name = name;
+        this.type = type;
+        this.length = -1;
+        this.precision = -1;
+        this.scale = -1;
+    }
+
+    public ColumnType(String name, Type type, int length) {
+        this.name = name;
+        this.type = type;
+        this.length = length;
+        this.precision = -1;
+        this.scale = -1;
+    }
+
+    public ColumnType(String name, Type type, int precision, int scale) {
+        this.name = name;
+        this.type = type;
+        this.length = -1;
+        this.precision = precision;
+        this.scale = scale;
+    }
+
+    public ColumnType(String name, Type type, int length, int precision, int scale) {
+        this.name = name;
+        this.type = type;
+        this.length = length;
+        this.precision = precision;
+        this.scale = scale;
+    }
+
+    public List<String> getChildNames() {
+        return childNames;
+    }
+
+    public void setChildNames(List<String> childNames) {
+        this.childNames = childNames;
+    }
+
+    public List<ColumnType> getChildTypes() {
+        return childTypes;
+    }
+
+    public void setChildTypes(List<ColumnType> childTypes) {
+        this.childTypes = childTypes;
+    }
+
+    public List<Integer> getFieldIndex() {
+        return fieldIndex;
+    }
+
+    public void setFieldIndex(List<Integer> fieldIndex) {
+        this.fieldIndex = fieldIndex;
+    }
+
+    public int getTypeSize() {
+        return type.size;
+    }
+
+    public boolean isUnsupported() {
+        return type == Type.UNSUPPORTED;
+    }
+
+    public boolean isStringType() {
+        return type == Type.STRING || type == Type.BINARY || type == Type.CHAR || type == Type.VARCHAR;
+    }
+
+    public boolean isComplexType() {
+        return type == Type.ARRAY || type == Type.MAP || type == Type.STRUCT;
+    }
+
+    public boolean isArray() {
+        return type == Type.ARRAY;
+    }
+
+    public boolean isMap() {
+        return type == Type.MAP;
+    }
+
+    public boolean isStruct() {
+        return type == Type.STRUCT;
+    }
+
+    public Type getType() {
+        return type;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public int getLength() {
+        return length;
+    }
+
+    public int getPrecision() {
+        return precision;
+    }
+
+    public int getScale() {
+        return scale;
+    }
+
+    public int metaSize() {
+        switch (type) {
+            case UNSUPPORTED:
+                // set nullMap address as 0.
+                return 1;
+            case ARRAY:
+            case MAP:
+            case STRUCT:
+                // array & map : [nullMap | offsets | ... ]
+                // struct : [nullMap | ... ]
+                int size = 2;
+                if (type == Type.STRUCT) {
+                    size = 1;
+                }
+                for (ColumnType c : childTypes) {
+                    size += c.metaSize();
+                }
+                return size;
+            case STRING:
+            case BINARY:
+            case CHAR:
+            case VARCHAR:
+                // [nullMap | offsets | data ]
+                return 3;
+            default:
+                // [nullMap | data]
+                return 2;
+        }
+    }
+
+    private static final Pattern digitPattern = Pattern.compile("(\\d+)");
+
+    private static int findNextNestedField(String commaSplitFields) {
+        int numLess = 0;
+        int numBracket = 0;
+        for (int i = 0; i < commaSplitFields.length(); i++) {
+            char c = commaSplitFields.charAt(i);
+            if (c == '<') {
+                numLess++;
+            } else if (c == '>') {
+                numLess--;
+            } else if (c == '(') {
+                numBracket++;
+            } else if (c == ')') {
+                numBracket--;
+            } else if (c == ',' && numLess == 0 && numBracket == 0) {
+                return i;
+            }
+        }
+        return commaSplitFields.length();
+    }
+
+    public static ColumnType parseType(String columnName, String hiveType) {
+        String lowerCaseType = hiveType.toLowerCase();
+        Type type = Type.UNSUPPORTED;
+        int length = -1;
+        int precision = -1;
+        int scale = -1;
+        switch (lowerCaseType) {
+            case "boolean":
+                type = Type.BOOLEAN;
+                break;
+            case "tinyint":
+                type = Type.TINYINT;
+                break;
+            case "smallint":
+                type = Type.SMALLINT;
+                break;
+            case "int":
+                type = Type.INT;
+                break;
+            case "bigint":
+                type = Type.BIGINT;
+                break;
+            case "float":
+                type = Type.FLOAT;
+                break;
+            case "double":
+                type = Type.DOUBLE;
+                break;
+            case "date":
+                type = Type.DATEV2;
+                break;
+            case "timestamp":
+                type = Type.DATETIMEV2;
+                break;
+            case "binary":
+                type = Type.BINARY;
+                break;
+            case "string":
+                type = Type.STRING;
+                break;
+            default:
+                break;
+        }
+
+        if (lowerCaseType.startsWith("char")) {
+            Matcher match = digitPattern.matcher(lowerCaseType);
+            if (match.find()) {
+                type = Type.CHAR;
+                length = Integer.parseInt(match.group(1));
+            }
+        } else if (lowerCaseType.startsWith("varchar")) {
+            Matcher match = digitPattern.matcher(lowerCaseType);
+            if (match.find()) {
+                type = Type.VARCHAR;
+                length = Integer.parseInt(match.group(1));
+            }
+        } else if (lowerCaseType.startsWith("decimal")) {
+            int s = lowerCaseType.indexOf('(');
+            int e = lowerCaseType.indexOf(')');
+            if (s != -1 && e != -1) {
+                String[] ps = lowerCaseType.substring(s + 1, e).split(",");
+                precision = Integer.parseInt(ps[0]);
+                scale = Integer.parseInt(ps[1]);
+                if (lowerCaseType.startsWith("decimalv2")) {
+                    type = Type.DECIMALV2;
+                } else if (lowerCaseType.startsWith("decimal32")) {
+                    type = Type.DECIMAL32;
+                } else if (lowerCaseType.startsWith("decimal64")) {
+                    type = Type.DECIMAL64;
+                } else if (lowerCaseType.startsWith("decimal128")) {
+                    type = Type.DECIMAL128;
+                }
+            }
+        } else if (lowerCaseType.startsWith("array")) {
+            if (lowerCaseType.indexOf("<") == 5 && lowerCaseType.lastIndexOf(">") == lowerCaseType.length() - 1) {
+                ColumnType nestedType = parseType("element", lowerCaseType.substring(6, lowerCaseType.length() - 1));
+                ColumnType arrayType = new ColumnType(columnName, Type.ARRAY);
+                arrayType.setChildTypes(Collections.singletonList(nestedType));
+                return arrayType;
+            }
+        } else if (lowerCaseType.startsWith("map")) {
+            if (lowerCaseType.indexOf("<") == 3 && lowerCaseType.lastIndexOf(">") == lowerCaseType.length() - 1) {
+                String keyValue = lowerCaseType.substring(4, lowerCaseType.length() - 1);
+                int index = findNextNestedField(keyValue);
+                if (index != keyValue.length() && index != 0) {
+                    ColumnType keyType = parseType("key", keyValue.substring(0, index));
+                    ColumnType valueType = parseType("value", keyValue.substring(index + 1));
+                    ColumnType mapType = new ColumnType(columnName, Type.MAP);
+                    mapType.setChildTypes(Arrays.asList(keyType, valueType));
+                    return mapType;
+                }
+            }
+        } else if (lowerCaseType.startsWith("struct")) {
+            if (lowerCaseType.indexOf("<") == 6 && lowerCaseType.lastIndexOf(">") == lowerCaseType.length() - 1) {
+                String listFields = lowerCaseType.substring(7, lowerCaseType.length() - 1);
+                ArrayList<ColumnType> fields = new ArrayList<>();
+                ArrayList<String> names = new ArrayList<>();
+                while (listFields.length() > 0) {
+                    int index = findNextNestedField(listFields);
+                    int pivot = listFields.indexOf(':');
+                    if (pivot > 0 && pivot < listFields.length() - 1) {
+                        fields.add(parseType(listFields.substring(0, pivot), listFields.substring(pivot + 1, index)));
+                        names.add(listFields.substring(0, pivot));
+                        listFields = listFields.substring(Math.min(index + 1, listFields.length()));
+                    } else {
+                        break;
+                    }
+                }
+                if (listFields.isEmpty()) {
+                    ColumnType structType = new ColumnType(columnName, Type.STRUCT);
+                    structType.setChildTypes(fields);
+                    structType.setChildNames(names);
+                    return structType;
+                }
+            }
+        }
+
+        return new ColumnType(columnName, type, length, precision, scale);
+    }
+}

--- a/fe/java-udf/src/main/java/org/apache/doris/jni/vec/ColumnValue.java
+++ b/fe/java-udf/src/main/java/org/apache/doris/jni/vec/ColumnValue.java
@@ -1,0 +1,61 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.jni.vec;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * Column value in vector column
+ */
+public interface ColumnValue {
+    public boolean getBoolean();
+
+    // tinyint
+    public byte getByte();
+
+    // smallint
+    public short getShort();
+
+    public int getInt();
+
+    public float getFloat();
+
+    // bigint
+    public long getLong();
+
+    public double getDouble();
+
+    public BigDecimal getDecimal();
+
+    public String getString();
+
+    public LocalDate getDate();
+
+    public LocalDateTime getDateTime();
+
+    public byte[] getBytes();
+
+    public void unpackArray(List<ColumnValue> values);
+
+    public void unpackMap(List<ColumnValue> keys, List<ColumnValue> values);
+
+    public void unpackStruct(List<Integer> structFieldIndex, List<ColumnValue> values);
+}

--- a/fe/java-udf/src/main/java/org/apache/doris/jni/vec/ScanPredicate.java
+++ b/fe/java-udf/src/main/java/org/apache/doris/jni/vec/ScanPredicate.java
@@ -1,0 +1,274 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.jni.vec;
+
+import org.apache.doris.jni.utils.OffHeap;
+import org.apache.doris.jni.utils.TypeNativeBytes;
+import org.apache.doris.jni.vec.ColumnType.Type;
+
+import org.apache.commons.lang.StringUtils;
+
+import java.math.BigDecimal;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Reference to doris::JniConnector::ScanPredicate
+ */
+public class ScanPredicate {
+    public enum FilterOp {
+        FILTER_LARGER(">"),
+        FILTER_LARGER_OR_EQUAL(">="),
+        FILTER_LESS("<"),
+        FILTER_LESS_OR_EQUAL("<="),
+        FILTER_IN("in"),
+        FILTER_NOT_IN("not in");
+
+        public final String op;
+
+        FilterOp(String op) {
+            this.op = op;
+        }
+    }
+
+    private static FilterOp parseFilterOp(int op) {
+        switch (op) {
+            case 0:
+                return FilterOp.FILTER_LARGER;
+            case 1:
+                return FilterOp.FILTER_LARGER_OR_EQUAL;
+            case 2:
+                return FilterOp.FILTER_LESS;
+            case 3:
+                return FilterOp.FILTER_LESS_OR_EQUAL;
+            case 4:
+                return FilterOp.FILTER_IN;
+            default:
+                return FilterOp.FILTER_NOT_IN;
+        }
+    }
+
+    public static class PredicateValue implements ColumnValue {
+        private final byte[] valueBytes;
+        private final ColumnType.Type type;
+        private final int scale;
+
+        public PredicateValue(byte[] valueBytes, ColumnType.Type type, int scale) {
+            this.valueBytes = valueBytes;
+            this.type = type;
+            this.scale = scale;
+        }
+
+        private Object inspectObject() {
+            ByteBuffer byteBuffer = ByteBuffer.wrap(
+                    TypeNativeBytes.convertByteOrder(Arrays.copyOf(valueBytes, valueBytes.length)));
+            switch (type) {
+                case BOOLEAN:
+                    return byteBuffer.get() == 1;
+                case TINYINT:
+                    return byteBuffer.get();
+                case SMALLINT:
+                    return byteBuffer.getShort();
+                case INT:
+                    return byteBuffer.getInt();
+                case BIGINT:
+                    return byteBuffer.getLong();
+                case FLOAT:
+                    return byteBuffer.getFloat();
+                case DOUBLE:
+                    return byteBuffer.getDouble();
+                case DECIMALV2:
+                case DECIMAL32:
+                case DECIMAL64:
+                case DECIMAL128:
+                    return TypeNativeBytes.getDecimal(Arrays.copyOf(valueBytes, valueBytes.length), scale);
+                case CHAR:
+                case VARCHAR:
+                case STRING:
+                    return new String(valueBytes, StandardCharsets.UTF_8);
+                case BINARY:
+                    return valueBytes;
+                default:
+                    return new Object();
+            }
+        }
+
+        @Override
+        public String toString() {
+            return inspectObject().toString();
+        }
+
+        @Override
+        public boolean getBoolean() {
+            return (boolean) inspectObject();
+        }
+
+        @Override
+        public byte getByte() {
+            return (byte) inspectObject();
+        }
+
+        @Override
+        public short getShort() {
+            return (short) inspectObject();
+        }
+
+        @Override
+        public int getInt() {
+            return (int) inspectObject();
+        }
+
+        @Override
+        public float getFloat() {
+            return (float) inspectObject();
+        }
+
+        @Override
+        public long getLong() {
+            return (long) inspectObject();
+        }
+
+        @Override
+        public double getDouble() {
+            return (double) inspectObject();
+        }
+
+        @Override
+        public BigDecimal getDecimal() {
+            return (BigDecimal) inspectObject();
+        }
+
+        @Override
+        public String getString() {
+            return toString();
+        }
+
+        @Override
+        public LocalDate getDate() {
+            return LocalDate.now();
+        }
+
+        @Override
+        public LocalDateTime getDateTime() {
+            return LocalDateTime.now();
+        }
+
+        @Override
+        public byte[] getBytes() {
+            return (byte[]) inspectObject();
+        }
+
+        @Override
+        public void unpackArray(List<ColumnValue> values) {
+
+        }
+
+        @Override
+        public void unpackMap(List<ColumnValue> keys, List<ColumnValue> values) {
+
+        }
+
+        @Override
+        public void unpackStruct(List<Integer> structFieldIndex, List<ColumnValue> values) {
+
+        }
+    }
+
+    private final long bytesLength;
+    public final String columName;
+    public final ColumnType.Type type;
+    public final FilterOp op;
+    private final byte[][] values;
+    public final int scale;
+
+    private ScanPredicate(long predicateAddress, Map<String, ColumnType.Type> nameToType) {
+        long address = predicateAddress;
+        int length = OffHeap.getInt(null, address);
+        address += 4;
+        byte[] nameBytes = new byte[length];
+        OffHeap.copyMemory(null, address, nameBytes, OffHeap.BYTE_ARRAY_OFFSET, length);
+        columName = new String(nameBytes, StandardCharsets.UTF_8);
+        type = nameToType.getOrDefault(columName, Type.UNSUPPORTED);
+        address += length;
+        op = parseFilterOp(OffHeap.getInt(null, address));
+        address += 4;
+        scale = OffHeap.getInt(null, address);
+        address += 4;
+        int numValues = OffHeap.getInt(null, address);
+        address += 4;
+        values = new byte[numValues][];
+        for (int i = 0; i < numValues; i++) {
+            int valueLength = OffHeap.getInt(null, address);
+            address += 4;
+            byte[] valueBytes = new byte[valueLength];
+            OffHeap.copyMemory(null, address, valueBytes, OffHeap.BYTE_ARRAY_OFFSET, valueLength);
+            address += valueLength;
+            values[i] = valueBytes;
+        }
+        bytesLength = address - predicateAddress;
+    }
+
+    public PredicateValue[] predicateValues() {
+        PredicateValue[] result = new PredicateValue[values.length];
+        for (int i = 0; i < values.length; i++) {
+            result[i] = new PredicateValue(values[i], type, scale);
+        }
+        return result;
+    }
+
+    public static ScanPredicate[] parseScanPredicates(long predicatesAddress, ColumnType[] types) {
+        Map<String, ColumnType.Type> nameToType = new HashMap<>();
+        for (ColumnType columnType : types) {
+            nameToType.put(columnType.getName(), columnType.getType());
+        }
+        int numPredicates = OffHeap.getInt(null, predicatesAddress);
+        long nextPredicateAddress = predicatesAddress + 4;
+        ScanPredicate[] predicates = new ScanPredicate[numPredicates];
+        for (int i = 0; i < numPredicates; i++) {
+            predicates[i] = new ScanPredicate(nextPredicateAddress, nameToType);
+            nextPredicateAddress += predicates[i].bytesLength;
+        }
+        return predicates;
+    }
+
+    public void dump(StringBuilder sb) {
+        sb.append(columName).append(' ').append(op.op).append(' ');
+        if (op == FilterOp.FILTER_IN || op == FilterOp.FILTER_NOT_IN) {
+            sb.append('(').append(StringUtils.join(predicateValues(), ", ")).append(')');
+        } else {
+            sb.append(predicateValues()[0]);
+        }
+    }
+
+    public static String dump(ScanPredicate[] scanPredicates) {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < scanPredicates.length; i++) {
+            if (i != 0) {
+                sb.append(" and ");
+            }
+            scanPredicates[i].dump(sb);
+        }
+        return sb.toString();
+    }
+}

--- a/fe/java-udf/src/main/java/org/apache/doris/jni/vec/VectorColumn.java
+++ b/fe/java-udf/src/main/java/org/apache/doris/jni/vec/VectorColumn.java
@@ -1,0 +1,573 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.jni.vec;
+
+import org.apache.doris.jni.utils.OffHeap;
+import org.apache.doris.jni.utils.TypeNativeBytes;
+import org.apache.doris.jni.vec.ColumnType.Type;
+
+import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * Reference to Apache Spark
+ * see <a href="https://github.com/apache/spark/blob/master/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/WritableColumnVector.java">WritableColumnVector</a>
+ */
+public class VectorColumn {
+    // String is stored as array<byte>
+    // The default string length to initialize the capacity.
+    private static final int DEFAULT_STRING_LENGTH = 4;
+
+    // NullMap column address
+    private long nullMap;
+    // Data column address
+    private long data;
+
+    // For String / Array / Map.
+    private long offsets;
+    // Number of elements in vector column
+    private int capacity;
+    // Upper limit for the maximum capacity for this column.
+    private static final int MAX_CAPACITY = Integer.MAX_VALUE - 15;
+    private final ColumnType columnType;
+
+    private int numNulls;
+
+    private int appendIndex;
+
+    // For nested column type: String / Array/ Map / Struct
+    private VectorColumn[] childColumns;
+
+    public VectorColumn(ColumnType columnType, int capacity) {
+        this.columnType = columnType;
+        this.capacity = 0;
+        this.nullMap = 0;
+        this.data = 0;
+        this.offsets = 0;
+        this.numNulls = 0;
+        this.appendIndex = 0;
+        if (columnType.isComplexType()) {
+            List<ColumnType> children = columnType.getChildTypes();
+            childColumns = new VectorColumn[children.size()];
+            for (int i = 0; i < children.size(); ++i) {
+                childColumns[i] = new VectorColumn(children.get(i), capacity);
+            }
+        } else if (columnType.isStringType()) {
+            childColumns = new VectorColumn[1];
+            childColumns[0] = new VectorColumn(new ColumnType("#data", Type.BYTE), capacity * DEFAULT_STRING_LENGTH);
+        }
+
+        reserveCapacity(capacity);
+    }
+
+    public long nullMapAddress() {
+        return nullMap;
+    }
+
+    public long dataAddress() {
+        return data;
+    }
+
+    public long offsetAddress() {
+        return offsets;
+    }
+
+    /**
+     * Release columns and meta information
+     */
+    public void close() {
+        if (childColumns != null) {
+            for (int i = 0; i < childColumns.length; i++) {
+                childColumns[i].close();
+                childColumns[i] = null;
+            }
+            childColumns = null;
+        }
+
+        if (nullMap != 0) {
+            OffHeap.freeMemory(nullMap);
+        }
+        if (data != 0) {
+            OffHeap.freeMemory(data);
+        }
+        if (offsets != 0) {
+            OffHeap.freeMemory(offsets);
+        }
+        nullMap = 0;
+        data = 0;
+        offsets = 0;
+        capacity = 0;
+        numNulls = 0;
+        appendIndex = 0;
+    }
+
+    private void throwReserveException(int requiredCapacity, Throwable cause) {
+        String message = "Cannot reserve enough bytes in off heap memory ("
+                + (requiredCapacity >= 0 ? "requested " + requiredCapacity + " bytes" : "integer overflow).");
+        throw new RuntimeException(message, cause);
+    }
+
+    private void reserve(int requiredCapacity) {
+        if (requiredCapacity < 0) {
+            throwReserveException(requiredCapacity, null);
+        } else if (requiredCapacity > capacity) {
+            int newCapacity = (int) Math.min(MAX_CAPACITY, requiredCapacity * 2L);
+            if (requiredCapacity <= newCapacity) {
+                try {
+                    reserveCapacity(newCapacity);
+                } catch (OutOfMemoryError outOfMemoryError) {
+                    throwReserveException(requiredCapacity, outOfMemoryError);
+                }
+            } else {
+                // overflow
+                throwReserveException(requiredCapacity, null);
+            }
+        }
+    }
+
+    private void reserveCapacity(int newCapacity) {
+        long oldCapacity = capacity;
+        long oldOffsetSize = capacity * 4L;
+        long newOffsetSize = newCapacity * 4L;
+        long typeSize = columnType.getTypeSize();
+        if (columnType.isUnsupported()) {
+            // do nothing
+            return;
+        } else if (typeSize != -1) {
+            this.data = OffHeap.reallocateMemory(data, oldCapacity * typeSize, newCapacity * typeSize);
+        } else if (columnType.isStringType()) {
+            this.offsets = OffHeap.reallocateMemory(offsets, oldOffsetSize, newOffsetSize);
+        } else {
+            throw new RuntimeException("Unhandled type: " + columnType);
+        }
+        // todo: support complex type
+        this.nullMap = OffHeap.reallocateMemory(nullMap, oldCapacity, newCapacity);
+        OffHeap.setMemory(nullMap + oldCapacity, (byte) 0, newCapacity - oldCapacity);
+        capacity = newCapacity;
+    }
+
+    public void reset() {
+        if (childColumns != null) {
+            for (VectorColumn c : childColumns) {
+                c.reset();
+            }
+        }
+        appendIndex = 0;
+        if (numNulls > 0) {
+            putNotNulls(0, capacity);
+            numNulls = 0;
+        }
+    }
+
+    public boolean isNullAt(int rowId) {
+        return OffHeap.getByte(null, nullMap + rowId) == 1;
+    }
+
+    public boolean hasNull() {
+        return numNulls > 0;
+    }
+
+    private void putNotNulls(int rowId, int count) {
+        if (!hasNull()) {
+            return;
+        }
+        long offset = nullMap + rowId;
+        for (int i = 0; i < count; ++i, ++offset) {
+            OffHeap.putByte(null, offset, (byte) 0);
+        }
+    }
+
+    public int appendNull(ColumnType.Type typeValue) {
+        reserve(appendIndex + 1);
+        putNull(appendIndex);
+        // append default value
+        switch (typeValue) {
+            case BOOLEAN:
+                return appendBoolean(false);
+            case TINYINT:
+                return appendByte((byte) 0);
+            case SMALLINT:
+                return appendShort((short) 0);
+            case INT:
+                return appendInt(0);
+            case BIGINT:
+                return appendLong(0);
+            case FLOAT:
+                return appendFloat(0);
+            case DOUBLE:
+                return appendDouble(0);
+            case DECIMALV2:
+            case DECIMAL32:
+            case DECIMAL64:
+            case DECIMAL128:
+                return appendDecimal(new BigDecimal(0));
+            case DATEV2:
+                return appendDate(LocalDate.MIN);
+            case DATETIMEV2:
+                return appendDateTime(LocalDateTime.MIN);
+            case CHAR:
+            case VARCHAR:
+            case STRING:
+            case BINARY:
+                return appendBytesAndOffset(new byte[0]);
+            default:
+                throw new RuntimeException("Unknown type value: " + typeValue);
+        }
+    }
+
+    private void putNull(int rowId) {
+        OffHeap.putByte(null, nullMap + rowId, (byte) 1);
+        ++numNulls;
+    }
+
+    public int appendBoolean(boolean v) {
+        reserve(appendIndex + 1);
+        putBoolean(appendIndex, v);
+        return appendIndex++;
+    }
+
+    private void putBoolean(int rowId, boolean value) {
+        OffHeap.putByte(null, data + rowId, (byte) ((value) ? 1 : 0));
+    }
+
+    public boolean getBoolean(int rowId) {
+        return OffHeap.getByte(null, data + rowId) == 1;
+    }
+
+    public int appendByte(byte v) {
+        reserve(appendIndex + 1);
+        putByte(appendIndex, v);
+        return appendIndex++;
+    }
+
+    public void putByte(int rowId, byte value) {
+        OffHeap.putByte(null, data + (long) rowId, value);
+    }
+
+    public byte getByte(int rowId) {
+        return OffHeap.getByte(null, data + (long) rowId);
+    }
+
+    public int appendShort(short v) {
+        reserve(appendIndex + 1);
+        putShort(appendIndex, v);
+        return appendIndex++;
+    }
+
+    private void putShort(int rowId, short value) {
+        OffHeap.putShort(null, data + 2L * rowId, value);
+    }
+
+    public short getShort(int rowId) {
+        return OffHeap.getShort(null, data + 2L * rowId);
+    }
+
+    public int appendInt(int v) {
+        reserve(appendIndex + 1);
+        putInt(appendIndex, v);
+        return appendIndex++;
+    }
+
+    private void putInt(int rowId, int value) {
+        OffHeap.putInt(null, data + 4L * rowId, value);
+    }
+
+    public int getInt(int rowId) {
+        return OffHeap.getInt(null, data + 4L * rowId);
+    }
+
+    public int appendFloat(float v) {
+        reserve(appendIndex + 1);
+        putFloat(appendIndex, v);
+        return appendIndex++;
+    }
+
+    private void putFloat(int rowId, float value) {
+        OffHeap.putFloat(null, data + rowId * 4L, value);
+    }
+
+    public float getFloat(int rowId) {
+        return OffHeap.getFloat(null, data + rowId * 4L);
+    }
+
+    public int appendLong(long v) {
+        reserve(appendIndex + 1);
+        putLong(appendIndex, v);
+        return appendIndex++;
+    }
+
+    private void putLong(int rowId, long value) {
+        OffHeap.putLong(null, data + 8L * rowId, value);
+    }
+
+    public long getLong(int rowId) {
+        return OffHeap.getLong(null, data + 8L * rowId);
+    }
+
+    public int appendDouble(double v) {
+        reserve(appendIndex + 1);
+        putDouble(appendIndex, v);
+        return appendIndex++;
+    }
+
+    private void putDouble(int rowId, double value) {
+        OffHeap.putDouble(null, data + rowId * 8L, value);
+    }
+
+    public double getDouble(int rowId) {
+        return OffHeap.getDouble(null, data + rowId * 8L);
+    }
+
+    public int appendDecimal(BigDecimal v) {
+        reserve(appendIndex + 1);
+        putDecimal(appendIndex, v);
+        return appendIndex++;
+    }
+
+    private void putDecimal(int rowId, BigDecimal v) {
+        int typeSize = columnType.getTypeSize();
+        byte[] bytes = TypeNativeBytes.getDecimalBytes(v, columnType.getScale(), typeSize);
+        OffHeap.copyMemory(bytes, OffHeap.BYTE_ARRAY_OFFSET, null, data + (long) rowId * typeSize, typeSize);
+    }
+
+    public byte[] getDecimalBytes(int rowId) {
+        int typeSize = columnType.getTypeSize();
+        byte[] bytes = new byte[typeSize];
+        OffHeap.copyMemory(null, data + (long) rowId * typeSize, bytes, OffHeap.BYTE_ARRAY_OFFSET, typeSize);
+        return bytes;
+    }
+
+    public BigDecimal getDecimal(int rowId) {
+        return TypeNativeBytes.getDecimal(getDecimalBytes(rowId), columnType.getScale());
+    }
+
+    public int appendDate(LocalDate v) {
+        reserve(appendIndex + 1);
+        putDate(appendIndex, v);
+        return appendIndex++;
+    }
+
+    private void putDate(int rowId, LocalDate v) {
+        int date = TypeNativeBytes.convertToDateV2(v.getYear(), v.getMonthValue(), v.getDayOfMonth());
+        OffHeap.putInt(null, data + rowId * 4L, date);
+    }
+
+    public LocalDate getDate(int rowId) {
+        int date = OffHeap.getInt(null, data + rowId * 4L);
+        return TypeNativeBytes.convertToJavaDate(date);
+    }
+
+    public int appendDateTime(LocalDateTime v) {
+        reserve(appendIndex + 1);
+        putDateTime(appendIndex, v);
+        return appendIndex++;
+    }
+
+    public LocalDateTime getDateTime(int rowId) {
+        long time = OffHeap.getLong(null, data + rowId * 8L);
+        return TypeNativeBytes.convertToJavaDateTime(time);
+    }
+
+    private void putDateTime(int rowId, LocalDateTime v) {
+        long time = TypeNativeBytes.convertToDateTimeV2(v.getYear(), v.getMonthValue(), v.getDayOfMonth(), v.getHour(),
+                v.getMinute(), v.getSecond());
+        OffHeap.putLong(null, data + rowId * 8L, time);
+    }
+
+    private void putBytes(int rowId, byte[] src, int offset, int length) {
+        OffHeap.copyMemory(src, OffHeap.BYTE_ARRAY_OFFSET + offset, null, data + rowId, length);
+    }
+
+    private byte[] getBytes(int rowId, int length) {
+        byte[] array = new byte[length];
+        OffHeap.copyMemory(null, data + rowId, array, OffHeap.BYTE_ARRAY_OFFSET, length);
+        return array;
+    }
+
+    public int appendBytes(byte[] src, int offset, int length) {
+        reserve(appendIndex + length);
+        int result = appendIndex;
+        putBytes(appendIndex, src, offset, length);
+        appendIndex += length;
+        return result;
+    }
+
+    public int appendString(String str) {
+        byte[] bytes = str.getBytes(StandardCharsets.UTF_8);
+        return appendBytes(bytes, 0, bytes.length);
+    }
+
+    public int appendBytesAndOffset(byte[] src) {
+        return appendBytesAndOffset(src, 0, src.length);
+    }
+
+    public int appendBytesAndOffset(byte[] src, int offset, int length) {
+        int startOffset = childColumns[0].appendBytes(src, offset, length);
+        reserve(appendIndex + 1);
+        OffHeap.putInt(null, offsets + 4L * appendIndex, startOffset + length);
+        return appendIndex++;
+    }
+
+    public int appendStringAndOffset(String str) {
+        byte[] bytes = str.getBytes(StandardCharsets.UTF_8);
+        return appendBytesAndOffset(bytes, 0, bytes.length);
+    }
+
+    public byte[] getBytesWithOffset(int rowId) {
+        long endOffsetAddress = offsets + 4L * rowId;
+        int startOffset = rowId == 0 ? 0 : OffHeap.getInt(null, endOffsetAddress - 4);
+        int endOffset = OffHeap.getInt(null, endOffsetAddress);
+        return childColumns[0].getBytes(startOffset, endOffset - startOffset);
+    }
+
+    public String getStringWithOffset(int rowId) {
+        byte[] bytes = getBytesWithOffset(rowId);
+        return new String(bytes, StandardCharsets.UTF_8);
+    }
+
+    public void updateMeta(VectorColumn meta) {
+        if (columnType.isUnsupported()) {
+            meta.appendLong(0);
+        } else if (columnType.isStringType()) {
+            meta.appendLong(nullMap);
+            meta.appendLong(offsets);
+            meta.appendLong(childColumns[0].data);
+        } else if (columnType.isComplexType()) {
+            meta.appendLong(nullMap);
+            if (columnType.isArray() || columnType.isMap()) {
+                meta.appendLong(offsets);
+            }
+            for (VectorColumn c : childColumns) {
+                c.updateMeta(meta);
+            }
+        } else {
+            meta.appendLong(nullMap);
+            meta.appendLong(data);
+        }
+    }
+
+    public void appendValue(ColumnValue o) {
+        ColumnType.Type typeValue = columnType.getType();
+        if (o == null) {
+            appendNull(typeValue);
+            return;
+        }
+
+        switch (typeValue) {
+            case BOOLEAN:
+                appendBoolean(o.getBoolean());
+                break;
+            case TINYINT:
+                appendByte(o.getByte());
+                break;
+            case SMALLINT:
+                appendShort(o.getShort());
+                break;
+            case INT:
+                appendInt(o.getInt());
+                break;
+            case BIGINT:
+                appendLong(o.getLong());
+                break;
+            case FLOAT:
+                appendFloat(o.getFloat());
+                break;
+            case DOUBLE:
+                appendDouble(o.getDouble());
+                break;
+            case DECIMALV2:
+            case DECIMAL32:
+            case DECIMAL64:
+            case DECIMAL128:
+                appendDecimal(o.getDecimal());
+                break;
+            case DATEV2:
+                appendDate(o.getDate());
+                break;
+            case DATETIMEV2:
+                appendDateTime(o.getDateTime());
+                break;
+            case CHAR:
+            case VARCHAR:
+            case STRING:
+                appendStringAndOffset(o.getString());
+                break;
+            case BINARY:
+                appendBytesAndOffset(o.getBytes());
+                break;
+            default:
+                throw new RuntimeException("Unknown type value: " + typeValue);
+        }
+    }
+
+    // for test only.
+    public void dump(StringBuilder sb, int i) {
+        if (isNullAt(i)) {
+            sb.append("NULL");
+            return;
+        }
+
+        ColumnType.Type typeValue = columnType.getType();
+        switch (typeValue) {
+            case BOOLEAN:
+                sb.append(getBoolean(i));
+                break;
+            case TINYINT:
+                sb.append(getByte(i));
+                break;
+            case SMALLINT:
+                sb.append(getShort(i));
+                break;
+            case INT:
+                sb.append(getInt(i));
+                break;
+            case BIGINT:
+                sb.append(getLong(i));
+                break;
+            case FLOAT:
+                sb.append(getFloat(i));
+                break;
+            case DOUBLE:
+                sb.append(getDouble(i));
+                break;
+            case DECIMALV2:
+            case DECIMAL32:
+            case DECIMAL64:
+            case DECIMAL128:
+                sb.append(getDecimal(i));
+                break;
+            case DATEV2:
+                sb.append(getDate(i));
+                break;
+            case DATETIMEV2:
+                sb.append(getDateTime(i));
+                break;
+            case CHAR:
+            case VARCHAR:
+            case STRING:
+            case BINARY:
+                sb.append(getStringWithOffset(i));
+                break;
+            default:
+                throw new RuntimeException("Unknown type value: " + typeValue);
+        }
+    }
+}

--- a/fe/java-udf/src/main/java/org/apache/doris/jni/vec/VectorTable.java
+++ b/fe/java-udf/src/main/java/org/apache/doris/jni/vec/VectorTable.java
@@ -1,0 +1,98 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.jni.vec;
+
+import org.apache.doris.jni.vec.ColumnType.Type;
+
+/**
+ * Store a batch of data as vector table.
+ */
+public class VectorTable {
+    private final VectorColumn[] columns;
+    private final String[] fields;
+    private final ScanPredicate[] predicates;
+    private final VectorColumn meta;
+    private int numRows;
+
+    public VectorTable(ColumnType[] types, String[] fields, ScanPredicate[] predicates, int capacity) {
+        this.fields = fields;
+        this.columns = new VectorColumn[types.length];
+        this.predicates = predicates;
+        int metaSize = 1; // number of rows
+        for (int i = 0; i < types.length; i++) {
+            columns[i] = new VectorColumn(types[i], capacity);
+            metaSize += types[i].metaSize();
+        }
+        this.meta = new VectorColumn(new ColumnType("#meta", Type.BIGINT), metaSize);
+        this.numRows = 0;
+    }
+
+    public void appendData(int fieldId, ColumnValue o) {
+        columns[fieldId].appendValue(o);
+    }
+
+    public void releaseColumn(int fieldId) {
+        columns[fieldId].close();
+    }
+
+    public void setNumRows(int numRows) {
+        this.numRows = numRows;
+    }
+
+    public int getNumRows() {
+        return this.numRows;
+    }
+
+    public long getMetaAddress() {
+        meta.reset();
+        meta.appendLong(numRows);
+        for (VectorColumn c : columns) {
+            c.updateMeta(meta);
+        }
+        return meta.dataAddress();
+    }
+
+    public void reset() {
+        for (VectorColumn column : columns) {
+            column.reset();
+        }
+        meta.reset();
+    }
+
+    public void close() {
+        for (int i = 0; i < columns.length; i++) {
+            releaseColumn(i);
+        }
+        meta.close();
+    }
+
+    // for test only.
+    public String dump(int rowLimit) {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < rowLimit && i < numRows; i++) {
+            for (int j = 0; j < columns.length; j++) {
+                if (j != 0) {
+                    sb.append(", ");
+                }
+                columns[j].dump(sb, i);
+            }
+            sb.append('\n');
+        }
+        return sb.toString();
+    }
+}

--- a/fe/java-udf/src/main/java/org/apache/doris/udf/JNINativeMethod.java
+++ b/fe/java-udf/src/main/java/org/apache/doris/udf/JNINativeMethod.java
@@ -17,6 +17,22 @@
 
 package org.apache.doris.udf;
 
+/**
+ * Native method in doris::JavaNativeMethods.
+ */
 public class JNINativeMethod {
-    public static native long resizeColumn(long columnAddr, int byteSize);
+    /**
+     * Resize string column and return the new column address in off heap.
+     */
+    public static native long resizeStringColumn(long columnAddr, int byteSize);
+
+    /**
+     * Allocate memory in off heap, which will be tracked by memory tracker.
+     */
+    public static native long memoryTrackerMalloc(long size);
+
+    /**
+     * Free memory in off heap, which will be tracked by memory tracker.
+     */
+    public static native void memoryTrackerFree(long address);
 }

--- a/fe/java-udf/src/main/java/org/apache/doris/udf/JdbcExecutor.java
+++ b/fe/java-udf/src/main/java/org/apache/doris/udf/JdbcExecutor.java
@@ -1071,7 +1071,7 @@ public class JdbcExecutor {
             }
         }
         byte[] bytes = new byte[offsets[numRows - 1]];
-        long bytesAddr = JNINativeMethod.resizeColumn(charsAddr, offsets[numRows - 1]);
+        long bytesAddr = JNINativeMethod.resizeStringColumn(charsAddr, offsets[numRows - 1]);
         int dst = 0;
         for (int i = 0; i < numRows; i++) {
             for (int j = 0; j < byteRes[i].length; j++) {
@@ -1106,7 +1106,7 @@ public class JdbcExecutor {
             }
         }
         byte[] bytes = new byte[offsets[numRows - 1]];
-        long bytesAddr = JNINativeMethod.resizeColumn(charsAddr, offsets[numRows - 1]);
+        long bytesAddr = JNINativeMethod.resizeStringColumn(charsAddr, offsets[numRows - 1]);
         int dst = 0;
         for (int i = 0; i < numRows; i++) {
             for (int j = 0; j < byteRes[i].length; j++) {

--- a/fe/java-udf/src/test/java/org/apache/doris/jni/JniScannerTest.java
+++ b/fe/java-udf/src/test/java/org/apache/doris/jni/JniScannerTest.java
@@ -1,0 +1,57 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.jni;
+
+import org.apache.doris.jni.utils.OffHeap;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.HashMap;
+
+public class JniScannerTest {
+    @Test
+    public void testMockJniScanner() throws IOException {
+        OffHeap.setTesting();
+        MockJniScanner scanner = new MockJniScanner(32, new HashMap<String, String>() {
+            {
+                put("mock_rows", "128");
+                put("required_fields", "boolean,tinyint,smallint,int,bigint,float,double,"
+                        + "date,timestamp,char,varchar,string,decimalv2,decimal64");
+                put("columns_types", "boolean#tinyint#smallint#int#bigint#float#double#"
+                        + "date#timestamp#char(10)#varchar(10)#string#decimalv2(12,4)#decimal64(10,3)");
+            }
+        });
+        StringBuilder result = new StringBuilder();
+        scanner.open();
+        long metaAddress = 0;
+        do {
+            metaAddress = scanner.getNextBatchMeta();
+            if (metaAddress != 0) {
+                result.append(scanner.getTable().dump(32));
+                long rows = OffHeap.getLong(null, metaAddress);
+                Assert.assertEquals(32, rows);
+            }
+            scanner.resetTable();
+        } while (metaAddress != 0);
+        scanner.releaseTable();
+        scanner.close();
+        System.out.print(result);
+    }
+}


### PR DESCRIPTION
# Proposed changes

A framework that read data from jni scanner, which can support the data source from java ecosystem(java API).

## Java Interface
Java scanner should extends `org.apache.doris.jni.JniScanner`, implements the following methods:
```
// Initialize JniScanner
public abstract void open() throws IOException;
// Close JniScanner and release resources
public abstract void close() throws IOException;
// Scan data and save as vector table
public abstract int getNext() throws IOException;
```
See demo usage in `org.apache.doris.jni.MockJniScanner`

## c++ interface
C++ reader should use `doris::JniConnector` to get data from `org.apache.doris.jni.JniScanner`. See demo usage in `doris::MockJniReader`. 

## Pushed-down predicates
Java scanner can get pushed-down predicates by `org.apache.doris.jni.vec.ScanPredicate`.

## Remaining works:
1. Implement complex nested types.
2. Read hudi MOR table as the end-to-end demo usage.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [x] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

