### PR TITLE
[enhancement](load) add slow log for memtable flush

### DIFF
--- a/be/src/olap/memtable_flush_executor.cpp
+++ b/be/src/olap/memtable_flush_executor.cpp
@@ -80,7 +80,8 @@ Status FlushToken::wait() {
 }
 
 void FlushToken::_flush_memtable(MemTable* memtable, int64_t submit_task_time) {
-    _stats.flush_wait_time_ns += (MonotonicNanos() - submit_task_time);
+    uint64_t flush_wait_time_ns = MonotonicNanos() - submit_task_time;
+    _stats.flush_wait_time_ns += flush_wait_time_ns;
     // If previous flush has failed, return directly
     if (_flush_status.load() != OK) {
         return;
@@ -99,8 +100,9 @@ void FlushToken::_flush_memtable(MemTable* memtable, int64_t submit_task_time) {
         return;
     }
 
-    VLOG_CRITICAL << "flush memtable cost: " << timer.elapsed_time()
-                  << ", running count: " << _stats.flush_running_count
+    VLOG_CRITICAL << "flush memtable wait time:" << flush_wait_time_ns
+                  << "(ns), flush memtable cost: " << timer.elapsed_time()
+                  << "(ns), running count: " << _stats.flush_running_count
                   << ", finish count: " << _stats.flush_finish_count
                   << ", mem size: " << memory_usage << ", disk size: " << memtable->flush_size();
     _stats.flush_time_ns += timer.elapsed_time();


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

Some slow load is caused by close wait for too long time, we can print log if close wait too slow.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

