### PR TITLE
[feature](log)check and log holding lock time when it exceeds threshold

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -2072,9 +2072,9 @@ public class Config extends ConfigBase {
     public static String bdbje_file_logging_level = "ALL";
 
     /**
-     * When the acquire/held lock time exceeds the threshold, need to report it.
+     * When holding lock time exceeds the threshold, need to report it.
      */
     @ConfField
-    public static long lock_reporting_threshold_ms = 500l;
+    public static long lock_reporting_threshold_ms = 500L;
 }
 

--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -2070,5 +2070,11 @@ public class Config extends ConfigBase {
      */
     @ConfField
     public static String bdbje_file_logging_level = "ALL";
+
+    /**
+     * When the acquire/held lock time exceeds the threshold, need to report it.
+     */
+    @ConfField
+    public static long lock_reporting_threshold_ms = 500l;
 }
 


### PR DESCRIPTION
Sometimes the competition of lock is fierce in DatabaseTransactionMgr, which may lead to publish time out, i think we should have a log to hint these lock competition.
# Proposed changes

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

