### PR TITLE
[Optimize](functions)Optimize function call for const columns.

### DIFF
--- a/be/src/vec/columns/column.h
+++ b/be/src/vec/columns/column.h
@@ -215,6 +215,7 @@ public:
 
     /// Appends range of elements from other column with the same type.
     /// Could be used to concatenate columns.
+    /// TODO: we need `insert_range_from_const` for every column type.
     virtual void insert_range_from(const IColumn& src, size_t start, size_t length) = 0;
 
     /// Appends one element from other column with the same type multiple times.

--- a/be/src/vec/columns/column_const.cpp
+++ b/be/src/vec/columns/column_const.cpp
@@ -224,16 +224,16 @@ void default_preprocess_parameter_columns(ColumnPtr* columns, const bool* col_co
                                           const std::initializer_list<size_t>& parameters,
                                           Block& block, const ColumnNumbers& arg_indexes) noexcept {
     if (std::all_of(parameters.begin(), parameters.end(),
-                    [&](const size_t& const_index) -> bool { return col_const[const_index]; })) {
+                    [&](size_t const_index) -> bool { return col_const[const_index]; })) {
         // only need to avoid expanding when all parameters are const
-        for (const auto& index : parameters) {
+        for (auto index : parameters) {
             columns[index] = static_cast<const ColumnConst&>(
                                      *block.get_by_position(arg_indexes[index]).column)
                                      .get_data_column_ptr();
         }
     } else {
         // no need to avoid expanding for this rare situation
-        for (const auto& index : parameters) {
+        for (auto index : parameters) {
             if (col_const[index]) {
                 columns[index] = static_cast<const ColumnConst&>(
                                          *block.get_by_position(arg_indexes[index]).column)

--- a/be/src/vec/columns/column_const.cpp
+++ b/be/src/vec/columns/column_const.cpp
@@ -209,4 +209,11 @@ std::pair<ColumnPtr, size_t> check_column_const_set_readability(const IColumn& c
     }
     return result;
 }
+
+std::pair<const ColumnPtr&, bool> unpack_if_const(const ColumnPtr& ptr) noexcept {
+    if (is_column_const(*ptr)) {
+        return std::make_pair(static_cast<const ColumnConst&>(*ptr).get_data_column_ptr(), true);
+    }
+    return std::make_pair(ptr, false);
+}
 } // namespace doris::vectorized

--- a/be/src/vec/columns/column_const.cpp
+++ b/be/src/vec/columns/column_const.cpp
@@ -212,8 +212,9 @@ std::pair<ColumnPtr, size_t> check_column_const_set_readability(const IColumn& c
 
 std::pair<const ColumnPtr&, bool> unpack_if_const(const ColumnPtr& ptr) noexcept {
     if (is_column_const(*ptr)) {
-        return std::make_pair(static_cast<const ColumnConst&>(*ptr).get_data_column_ptr(), true);
+        return std::make_pair(
+                std::cref(static_cast<const ColumnConst&>(*ptr).get_data_column_ptr()), true);
     }
-    return std::make_pair(ptr, false);
+    return std::make_pair(std::cref(ptr), false);
 }
 } // namespace doris::vectorized

--- a/be/src/vec/columns/column_const.cpp
+++ b/be/src/vec/columns/column_const.cpp
@@ -20,6 +20,8 @@
 
 #include "vec/columns/column_const.h"
 
+#include <algorithm>
+#include <cstddef>
 #include <utility>
 
 #include "gutil/port.h"
@@ -216,5 +218,30 @@ std::pair<const ColumnPtr&, bool> unpack_if_const(const ColumnPtr& ptr) noexcept
                 std::cref(static_cast<const ColumnConst&>(*ptr).get_data_column_ptr()), true);
     }
     return std::make_pair(std::cref(ptr), false);
+}
+
+void default_preprocess_parameter_columns(ColumnPtr* columns, const bool* col_const,
+                                          const std::initializer_list<size_t>& parameters,
+                                          Block& block, const ColumnNumbers& arg_indexes) noexcept {
+    if (std::all_of(parameters.begin(), parameters.end(),
+                    [&](const size_t& const_index) -> bool { return col_const[const_index]; })) {
+        // only need to avoid expanding when all parameters are const
+        for (const auto& index : parameters) {
+            columns[index] = static_cast<const ColumnConst&>(
+                                     *block.get_by_position(arg_indexes[index]).column)
+                                     .get_data_column_ptr();
+        }
+    } else {
+        // no need to avoid expanding for this rare situation
+        for (const auto& index : parameters) {
+            if (col_const[index]) {
+                columns[index] = static_cast<const ColumnConst&>(
+                                         *block.get_by_position(arg_indexes[index]).column)
+                                         .convert_to_full_column();
+            } else {
+                columns[index] = block.get_by_position(arg_indexes[index]).column;
+            }
+        }
+    }
 }
 } // namespace doris::vectorized

--- a/be/src/vec/columns/column_const.h
+++ b/be/src/vec/columns/column_const.h
@@ -21,11 +21,14 @@
 #pragma once
 
 #include <cstddef>
+#include <initializer_list>
 
 #include "vec/columns/column.h"
 #include "vec/columns/column_nullable.h"
 #include "vec/common/assert_cast.h"
 #include "vec/common/typeid_cast.h"
+#include "vec/core/block.h"
+#include "vec/core/column_numbers.h"
 #include "vec/core/field.h"
 
 namespace doris::vectorized {
@@ -240,4 +243,15 @@ std::pair<ColumnPtr, size_t> check_column_const_set_readability(const IColumn& c
  *         second : whether it's ColumnConst.
 */
 std::pair<const ColumnPtr&, bool> unpack_if_const(const ColumnPtr&) noexcept;
+
+/*
+ * For the functions that some columns of arguments are almost but not completely always const, we use this function to preprocessing its parameter columns
+ * (which are not data columns). When we have two or more columns which only provide parameter, use this to deal with corner case. So you can specialize you
+ * implementations for all const or all parameters const, without considering some of parameters are const.
+ 
+ * Do the transformation only for the columns whose arg_indexes in parameters.
+*/
+void default_preprocess_parameter_columns(ColumnPtr* columns, const bool* col_const,
+                                          const std::initializer_list<size_t>& parameters,
+                                          Block& block, const ColumnNumbers& arg_indexes) noexcept;
 } // namespace doris::vectorized

--- a/be/src/vec/columns/column_const.h
+++ b/be/src/vec/columns/column_const.h
@@ -234,4 +234,10 @@ public:
 */
 std::pair<ColumnPtr, size_t> check_column_const_set_readability(const IColumn& column,
                                                                 const size_t row_num) noexcept;
+
+/*
+ * @return first : data_column_ptr for ColumnConst, itself otherwise.
+ *         second : whether it's ColumnConst.
+*/
+std::pair<const ColumnPtr&, bool> unpack_if_const(const ColumnPtr&) noexcept;
 } // namespace doris::vectorized

--- a/be/src/vec/columns/column_nullable.h
+++ b/be/src/vec/columns/column_nullable.h
@@ -20,6 +20,8 @@
 
 #pragma once
 
+#include "vec/columns/column_vector.h"
+#include "vec/core/types.h"
 #ifdef __aarch64__
 #include <sse2neon.h>
 #endif
@@ -368,5 +370,7 @@ private:
 
 ColumnPtr make_nullable(const ColumnPtr& column, bool is_nullable = false);
 ColumnPtr remove_nullable(const ColumnPtr& column);
-
+// check if argument column is nullable. If so, extract its concrete column and set null_map.
+//TODO: use this to replace inner usages.
+void check_set_nullable(ColumnPtr&, ColumnVector<UInt8>::MutablePtr&);
 } // namespace doris::vectorized

--- a/be/src/vec/common/sort/sorter.cpp
+++ b/be/src/vec/common/sort/sorter.cpp
@@ -306,8 +306,9 @@ Status FullSorter::append_block(Block* block) {
                     << " type1: " << data[i].type->get_name()
                     << " type2: " << arrival_data[i].type->get_name();
             try {
+                //TODO: to eliminate unnecessary expansion, we need a `insert_range_from_const` for every column type.
                 RETURN_IF_CATCH_BAD_ALLOC(data[i].column->assume_mutable()->insert_range_from(
-                        *arrival_data[i].column->convert_to_full_column_if_const().get(), 0, sz));
+                        *arrival_data[i].column->convert_to_full_column_if_const(), 0, sz));
             } catch (const doris::Exception& e) {
                 return Status::Error(e.code(), e.to_string());
             }

--- a/be/src/vec/common/string_ref.cpp
+++ b/be/src/vec/common/string_ref.cpp
@@ -20,6 +20,8 @@
 
 #include "string_ref.h"
 
+#include "common/compiler_util.h"
+
 namespace doris {
 
 StringRef StringRef::trim() const {
@@ -51,6 +53,19 @@ StringRef StringRef::min_string_val() {
 
 StringRef StringRef::max_string_val() {
     return StringRef((char*)(&StringRef::MAX_CHAR), 1);
+}
+
+bool StringRef::start_with(char ch) const {
+    if (UNLIKELY(size == 0)) {
+        return false;
+    }
+    return data[0] == ch;
+}
+bool StringRef::end_with(char ch) const {
+    if (UNLIKELY(size == 0)) {
+        return false;
+    }
+    return data[size - 1] == ch;
 }
 
 bool StringRef::start_with(const StringRef& search_string) const {

--- a/be/src/vec/common/string_ref.h
+++ b/be/src/vec/common/string_ref.h
@@ -225,6 +225,12 @@ struct StringRef {
 
     StringRef substring(int start_pos) const { return substring(start_pos, size - start_pos); }
 
+    const char* begin() const { return data; }
+    const char* end() const { return data + size; }
+    // there's no border check in functions below. That's same with STL.
+    char front() const { return *data; }
+    char back() const { return *(data + size - 1); }
+
     // Trims leading and trailing spaces.
     StringRef trim() const;
 
@@ -237,6 +243,8 @@ struct StringRef {
     static StringRef min_string_val();
     static StringRef max_string_val();
 
+    bool start_with(char) const;
+    bool end_with(char) const;
     bool start_with(const StringRef& search_string) const;
     bool end_with(const StringRef& search_string) const;
 

--- a/be/src/vec/functions/array/function_array_range.cpp
+++ b/be/src/vec/functions/array/function_array_range.cpp
@@ -46,10 +46,6 @@ public:
 
     bool use_default_implementation_for_constants() const override { return true; }
 
-    ColumnNumbers get_arguments_that_are_always_constant() const override {
-        return {get_number_of_arguments()};
-    }
-
     size_t get_number_of_arguments() const override {
         return get_variadic_argument_types_impl().size();
     }

--- a/be/src/vec/functions/array/function_array_set.h
+++ b/be/src/vec/functions/array/function_array_set.h
@@ -150,7 +150,8 @@ public:
     }
 
     static Status execute(ColumnPtr& res_ptr, const ColumnArrayExecutionData& left_data,
-                          const ColumnArrayExecutionData& right_data) {
+                          const ColumnArrayExecutionData& right_data, bool left_const,
+                          bool right_const) {
         ColumnArrayMutableData dst;
         if (left_data.nested_nullmap_data || right_data.nested_nullmap_data) {
             dst = create_mutable_data(left_data.nested_col, true);
@@ -158,27 +159,77 @@ public:
             dst = create_mutable_data(left_data.nested_col, false);
         }
         ColumnPtr res_column;
-        if (_execute_internal<ColumnString>(dst, left_data, right_data) ||
-            _execute_internal<ColumnDate>(dst, left_data, right_data) ||
-            _execute_internal<ColumnDateTime>(dst, left_data, right_data) ||
-            _execute_internal<ColumnDateV2>(dst, left_data, right_data) ||
-            _execute_internal<ColumnDateTimeV2>(dst, left_data, right_data) ||
-            _execute_internal<ColumnUInt8>(dst, left_data, right_data) ||
-            _execute_internal<ColumnInt8>(dst, left_data, right_data) ||
-            _execute_internal<ColumnInt16>(dst, left_data, right_data) ||
-            _execute_internal<ColumnInt32>(dst, left_data, right_data) ||
-            _execute_internal<ColumnInt64>(dst, left_data, right_data) ||
-            _execute_internal<ColumnInt128>(dst, left_data, right_data) ||
-            _execute_internal<ColumnFloat32>(dst, left_data, right_data) ||
-            _execute_internal<ColumnFloat64>(dst, left_data, right_data) ||
-            _execute_internal<ColumnDecimal32>(dst, left_data, right_data) ||
-            _execute_internal<ColumnDecimal64>(dst, left_data, right_data) ||
-            _execute_internal<ColumnDecimal128I>(dst, left_data, right_data) ||
-            _execute_internal<ColumnDecimal128>(dst, left_data, right_data)) {
-            res_column = assemble_column_array(dst);
-            if (res_column) {
-                res_ptr = std::move(res_column);
-                return Status::OK();
+        if (left_const) {
+            if (_execute_internal_lconst<ColumnString>(dst, left_data, right_data) ||
+                _execute_internal_lconst<ColumnDate>(dst, left_data, right_data) ||
+                _execute_internal_lconst<ColumnDateTime>(dst, left_data, right_data) ||
+                _execute_internal_lconst<ColumnDateV2>(dst, left_data, right_data) ||
+                _execute_internal_lconst<ColumnDateTimeV2>(dst, left_data, right_data) ||
+                _execute_internal_lconst<ColumnUInt8>(dst, left_data, right_data) ||
+                _execute_internal_lconst<ColumnInt8>(dst, left_data, right_data) ||
+                _execute_internal_lconst<ColumnInt16>(dst, left_data, right_data) ||
+                _execute_internal_lconst<ColumnInt32>(dst, left_data, right_data) ||
+                _execute_internal_lconst<ColumnInt64>(dst, left_data, right_data) ||
+                _execute_internal_lconst<ColumnInt128>(dst, left_data, right_data) ||
+                _execute_internal_lconst<ColumnFloat32>(dst, left_data, right_data) ||
+                _execute_internal_lconst<ColumnFloat64>(dst, left_data, right_data) ||
+                _execute_internal_lconst<ColumnDecimal32>(dst, left_data, right_data) ||
+                _execute_internal_lconst<ColumnDecimal64>(dst, left_data, right_data) ||
+                _execute_internal_lconst<ColumnDecimal128I>(dst, left_data, right_data) ||
+                _execute_internal_lconst<ColumnDecimal128>(dst, left_data, right_data)) {
+                res_column = assemble_column_array(dst);
+                if (res_column) {
+                    res_ptr = std::move(res_column);
+                    return Status::OK();
+                }
+            }
+        } else if (right_const) {
+            if (_execute_internal_rconst<ColumnString>(dst, left_data, right_data) ||
+                _execute_internal_rconst<ColumnDate>(dst, left_data, right_data) ||
+                _execute_internal_rconst<ColumnDateTime>(dst, left_data, right_data) ||
+                _execute_internal_rconst<ColumnDateV2>(dst, left_data, right_data) ||
+                _execute_internal_rconst<ColumnDateTimeV2>(dst, left_data, right_data) ||
+                _execute_internal_rconst<ColumnUInt8>(dst, left_data, right_data) ||
+                _execute_internal_rconst<ColumnInt8>(dst, left_data, right_data) ||
+                _execute_internal_rconst<ColumnInt16>(dst, left_data, right_data) ||
+                _execute_internal_rconst<ColumnInt32>(dst, left_data, right_data) ||
+                _execute_internal_rconst<ColumnInt64>(dst, left_data, right_data) ||
+                _execute_internal_rconst<ColumnInt128>(dst, left_data, right_data) ||
+                _execute_internal_rconst<ColumnFloat32>(dst, left_data, right_data) ||
+                _execute_internal_rconst<ColumnFloat64>(dst, left_data, right_data) ||
+                _execute_internal_rconst<ColumnDecimal32>(dst, left_data, right_data) ||
+                _execute_internal_rconst<ColumnDecimal64>(dst, left_data, right_data) ||
+                _execute_internal_rconst<ColumnDecimal128I>(dst, left_data, right_data) ||
+                _execute_internal_rconst<ColumnDecimal128>(dst, left_data, right_data)) {
+                res_column = assemble_column_array(dst);
+                if (res_column) {
+                    res_ptr = std::move(res_column);
+                    return Status::OK();
+                }
+            }
+        } else {
+            if (_execute_internal<ColumnString>(dst, left_data, right_data) ||
+                _execute_internal<ColumnDate>(dst, left_data, right_data) ||
+                _execute_internal<ColumnDateTime>(dst, left_data, right_data) ||
+                _execute_internal<ColumnDateV2>(dst, left_data, right_data) ||
+                _execute_internal<ColumnDateTimeV2>(dst, left_data, right_data) ||
+                _execute_internal<ColumnUInt8>(dst, left_data, right_data) ||
+                _execute_internal<ColumnInt8>(dst, left_data, right_data) ||
+                _execute_internal<ColumnInt16>(dst, left_data, right_data) ||
+                _execute_internal<ColumnInt32>(dst, left_data, right_data) ||
+                _execute_internal<ColumnInt64>(dst, left_data, right_data) ||
+                _execute_internal<ColumnInt128>(dst, left_data, right_data) ||
+                _execute_internal<ColumnFloat32>(dst, left_data, right_data) ||
+                _execute_internal<ColumnFloat64>(dst, left_data, right_data) ||
+                _execute_internal<ColumnDecimal32>(dst, left_data, right_data) ||
+                _execute_internal<ColumnDecimal64>(dst, left_data, right_data) ||
+                _execute_internal<ColumnDecimal128I>(dst, left_data, right_data) ||
+                _execute_internal<ColumnDecimal128>(dst, left_data, right_data)) {
+                res_column = assemble_column_array(dst);
+                if (res_column) {
+                    res_ptr = std::move(res_column);
+                    return Status::OK();
+                }
             }
         }
         return Status::RuntimeError("Unexpected columns: {}, {}", left_data.nested_col->get_name(),
@@ -203,6 +254,66 @@ private:
             size_t left_len = (*left_data.offsets_ptr)[row] - left_off;
             size_t right_off = (*right_data.offsets_ptr)[row - 1];
             size_t right_len = (*right_data.offsets_ptr)[row] - right_off;
+            if constexpr (execute_left_column_first) {
+                impl.template apply<true>(left_data, left_off, left_len, dst, &count);
+                impl.template apply<false>(right_data, right_off, right_len, dst, &count);
+            } else {
+                impl.template apply<false>(right_data, right_off, right_len, dst, &count);
+                impl.template apply<true>(left_data, left_off, left_len, dst, &count);
+            }
+            current += count;
+            dst.offsets_ptr->push_back(current);
+            impl.reset();
+        }
+        return true;
+    }
+    template <typename ColumnType>
+    static bool _execute_internal_lconst(ColumnArrayMutableData& dst,
+                                         const ColumnArrayExecutionData& left_data,
+                                         const ColumnArrayExecutionData& right_data) {
+        using Impl = OpenSetImpl<operation, ColumnType>;
+        if (!check_column<ColumnType>(*left_data.nested_col)) {
+            return false;
+        }
+        constexpr auto execute_left_column_first = Impl::Action::execute_left_column_first;
+        size_t current = 0;
+        Impl impl;
+        for (size_t row = 0; row < left_data.offsets_ptr->size(); ++row) {
+            size_t count = 0;
+            size_t left_off = (*left_data.offsets_ptr)[-1];
+            size_t left_len = (*left_data.offsets_ptr)[0] - left_off;
+            size_t right_off = (*right_data.offsets_ptr)[row - 1];
+            size_t right_len = (*right_data.offsets_ptr)[row] - right_off;
+            if constexpr (execute_left_column_first) {
+                impl.template apply<true>(left_data, left_off, left_len, dst, &count);
+                impl.template apply<false>(right_data, right_off, right_len, dst, &count);
+            } else {
+                impl.template apply<false>(right_data, right_off, right_len, dst, &count);
+                impl.template apply<true>(left_data, left_off, left_len, dst, &count);
+            }
+            current += count;
+            dst.offsets_ptr->push_back(current);
+            impl.reset();
+        }
+        return true;
+    }
+    template <typename ColumnType>
+    static bool _execute_internal_rconst(ColumnArrayMutableData& dst,
+                                         const ColumnArrayExecutionData& left_data,
+                                         const ColumnArrayExecutionData& right_data) {
+        using Impl = OpenSetImpl<operation, ColumnType>;
+        if (!check_column<ColumnType>(*left_data.nested_col)) {
+            return false;
+        }
+        constexpr auto execute_left_column_first = Impl::Action::execute_left_column_first;
+        size_t current = 0;
+        Impl impl;
+        for (size_t row = 0; row < left_data.offsets_ptr->size(); ++row) {
+            size_t count = 0;
+            size_t left_off = (*left_data.offsets_ptr)[row - 1];
+            size_t left_len = (*left_data.offsets_ptr)[row] - left_off;
+            size_t right_off = (*right_data.offsets_ptr)[-1];
+            size_t right_len = (*right_data.offsets_ptr)[0] - right_off;
             if constexpr (execute_left_column_first) {
                 impl.template apply<true>(left_data, left_off, left_len, dst, &count);
                 impl.template apply<false>(right_data, right_off, right_len, dst, &count);

--- a/be/src/vec/functions/comparison_equal_for_null.cpp
+++ b/be/src/vec/functions/comparison_equal_for_null.cpp
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#include "common/compiler_util.h"
 #include "vec/columns/column_nullable.h"
 #include "vec/data_types/get_least_supertype.h"
 #include "vec/functions/function_string.h"
@@ -44,11 +45,10 @@ public:
         ColumnWithTypeAndName& col_left = block.get_by_position(arguments[0]);
         ColumnWithTypeAndName& col_right = block.get_by_position(arguments[1]);
 
-        // TODO: opt for the const column in the future
-        col_left.column = col_left.column->convert_to_full_column_if_const();
-        col_right.column = col_right.column->convert_to_full_column_if_const();
-        const auto left_column = check_and_get_column<ColumnNullable>(col_left.column.get());
-        const auto right_column = check_and_get_column<ColumnNullable>(col_right.column.get());
+        const auto& [left_col, left_const] = unpack_if_const(col_left.column);
+        const auto& [right_col, right_const] = unpack_if_const(col_right.column);
+        const auto left_column = check_and_get_column<ColumnNullable>(left_col);
+        const auto right_column = check_and_get_column<ColumnNullable>(left_col);
 
         bool left_nullable = left_column != nullptr;
         bool right_nullable = right_column != nullptr;
@@ -89,9 +89,7 @@ public:
                 auto* __restrict l = left_null_map.data();
                 auto* __restrict r = right_null_map.data();
 
-                for (int i = 0; i < input_rows_count; ++i) {
-                    res[i] |= l[i] & (l[i] == r[i]);
-                }
+                _exec_nullable_equal(res, l, r, input_rows_count, left_const, right_const);
             }
 
             block.get_by_position(result).column = temporary_block.get_by_position(2).column;
@@ -118,13 +116,47 @@ public:
 
             auto* __restrict res = res_map.data();
             auto* __restrict l = null_map.data();
-            for (int i = 0; i < input_rows_count; ++i) {
-                res[i] &= (l[i] != 1);
-            }
+            _exec_nullable_inequal(res, l, input_rows_count, left_const);
 
             block.get_by_position(result).column = res_nullable_column->get_nested_column_ptr();
         }
         return Status::OK();
+    }
+
+private:
+    static ALWAYS_INLINE void _exec_nullable_equal(unsigned char* result, const unsigned char* left,
+                                                   const unsigned char* right, size_t rows,
+                                                   bool left_const, bool right_const) {
+        if (left_const && right_const) {
+            for (int i = 0; i < rows; ++i) {
+                result[i] |= left[0] & (left[0] == right[0]);
+            }
+        } else if (left_const) {
+            for (int i = 0; i < rows; ++i) {
+                result[i] |= left[0] & (left[0] == right[i]);
+            }
+        } else if (right_const) {
+            for (int i = 0; i < rows; ++i) {
+                result[i] |= left[i] & (left[i] == right[0]);
+            }
+        } else {
+            for (int i = 0; i < rows; ++i) {
+                result[i] |= left[i] & (left[i] == right[i]);
+            }
+        }
+    }
+    static ALWAYS_INLINE void _exec_nullable_inequal(unsigned char* result,
+                                                     const unsigned char* left, size_t rows,
+                                                     bool left_const) {
+        if (left_const) {
+            for (int i = 0; i < rows; ++i) {
+                result[i] &= (left[0] != 1);
+            }
+        } else {
+            for (int i = 0; i < rows; ++i) {
+                result[i] &= (left[i] != 1);
+            }
+        }
     }
 };
 

--- a/be/src/vec/functions/function.cpp
+++ b/be/src/vec/functions/function.cpp
@@ -70,7 +70,7 @@ ColumnPtr wrap_in_nullable(const ColumnPtr& src, const Block& block, const Colum
             } else {
                 if (!mutable_result_null_map_column) {
                     mutable_result_null_map_column =
-                            (*std::move(result_null_map_column)).assume_mutable();
+                            std::move(result_null_map_column)->assume_mutable();
                 }
 
                 NullMap& result_null_map =
@@ -166,15 +166,24 @@ Status PreparedFunctionImpl::default_implementation_for_constant_arguments(
         !all_arguments_are_constant(block, args)) {
         return Status::OK();
     }
+
     // now all columns is const.
     Block temporary_block;
 
     size_t arguments_size = args.size();
     for (size_t arg_num = 0; arg_num < arguments_size; ++arg_num) {
         const ColumnWithTypeAndName& column = block.get_by_position(args[arg_num]);
-        temporary_block.insert(
-                {assert_cast<const ColumnConst*>(column.column.get())->get_data_column_ptr(),
-                 column.type, column.name});
+        // Columns in const_list --> column_const,    others --> nested_column
+        // that's because some functions supposes some specific columns always constant.
+        // If we unpack it, there will be unnecessary cost of virtual judge.
+        if (args_expect_const.end() !=
+            std::find(args_expect_const.begin(), args_expect_const.end(), arg_num)) {
+            temporary_block.insert({column.column->clone_resized(1), column.type, column.name});
+        } else {
+            temporary_block.insert(
+                    {assert_cast<const ColumnConst*>(column.column.get())->get_data_column_ptr(),
+                     column.type, column.name});
+        }
     }
 
     temporary_block.insert(block.get_by_position(result));

--- a/be/src/vec/functions/function.cpp
+++ b/be/src/vec/functions/function.cpp
@@ -178,7 +178,7 @@ Status PreparedFunctionImpl::default_implementation_for_constant_arguments(
         // If we unpack it, there will be unnecessary cost of virtual judge.
         if (args_expect_const.end() !=
             std::find(args_expect_const.begin(), args_expect_const.end(), arg_num)) {
-            temporary_block.insert({column.column->clone_resized(1), column.type, column.name});
+            temporary_block.insert({column.column, column.type, column.name});
         } else {
             temporary_block.insert(
                     {assert_cast<const ColumnConst*>(column.column.get())->get_data_column_ptr(),

--- a/be/src/vec/functions/function.h
+++ b/be/src/vec/functions/function.h
@@ -404,6 +404,8 @@ public:
     bool use_default_implementation_for_nulls() const override { return true; }
     bool use_default_implementation_for_constants() const override { return false; }
     bool use_default_implementation_for_low_cardinality_columns() const override { return true; }
+
+    /// all constancy check should use this function to do automatically
     ColumnNumbers get_arguments_that_are_always_constant() const override { return {}; }
     bool can_be_executed_on_low_cardinality_dictionary() const override {
         return is_deterministic_in_scope_of_query();

--- a/be/src/vec/functions/function_bitmap.cpp
+++ b/be/src/vec/functions/function_bitmap.cpp
@@ -444,13 +444,26 @@ struct BitmapNot {
     using T1 = typename RightDataType::FieldType;
     using TData = std::vector<BitmapValue>;
 
-    static Status vector_vector(const TData& lvec, const TData& rvec, TData& res) {
+    static void vector_vector(const TData& lvec, const TData& rvec, TData& res) {
         size_t size = lvec.size();
         for (size_t i = 0; i < size; ++i) {
             res[i] = lvec[i];
             res[i] -= rvec[i];
         }
-        return Status::OK();
+    }
+    static void vector_scalar(const TData& lvec, const BitmapValue& rval, TData& res) {
+        size_t size = lvec.size();
+        for (size_t i = 0; i < size; ++i) {
+            res[i] = lvec[i];
+            res[i] -= rval;
+        }
+    }
+    static void scalar_vector(const BitmapValue& lval, const TData& rvec, TData& res) {
+        size_t size = rvec.size();
+        for (size_t i = 0; i < size; ++i) {
+            res[i] = lval;
+            res[i] -= rvec[i];
+        }
     }
 };
 
@@ -465,7 +478,7 @@ struct BitmapAndNot {
     using T1 = typename RightDataType::FieldType;
     using TData = std::vector<BitmapValue>;
 
-    static Status vector_vector(const TData& lvec, const TData& rvec, TData& res) {
+    static void vector_vector(const TData& lvec, const TData& rvec, TData& res) {
         size_t size = lvec.size();
         BitmapValue mid_data;
         for (size_t i = 0; i < size; ++i) {
@@ -475,7 +488,28 @@ struct BitmapAndNot {
             res[i] -= mid_data;
             mid_data.clear();
         }
-        return Status::OK();
+    }
+    static void vector_scalar(const TData& lvec, const BitmapValue& rval, TData& res) {
+        size_t size = lvec.size();
+        BitmapValue mid_data;
+        for (size_t i = 0; i < size; ++i) {
+            mid_data = lvec[i];
+            mid_data &= rval;
+            res[i] = lvec[i];
+            res[i] -= mid_data;
+            mid_data.clear();
+        }
+    }
+    static void scalar_vector(const BitmapValue& lval, const TData& rvec, TData& res) {
+        size_t size = rvec.size();
+        BitmapValue mid_data;
+        for (size_t i = 0; i < size; ++i) {
+            mid_data = lval;
+            mid_data &= rvec[i];
+            res[i] = lval;
+            res[i] -= mid_data;
+            mid_data.clear();
+        }
     }
 };
 
@@ -491,7 +525,7 @@ struct BitmapAndNotCount {
     using TData = std::vector<BitmapValue>;
     using ResTData = typename ColumnVector<Int64>::Container::value_type;
 
-    static Status vector_vector(const TData& lvec, const TData& rvec, ResTData* res) {
+    static void vector_vector(const TData& lvec, const TData& rvec, ResTData* res) {
         size_t size = lvec.size();
         BitmapValue mid_data;
         for (size_t i = 0; i < size; ++i) {
@@ -500,7 +534,26 @@ struct BitmapAndNotCount {
             res[i] = lvec[i].andnot_cardinality(mid_data);
             mid_data.clear();
         }
-        return Status::OK();
+    }
+    static void scalar_vector(const BitmapValue& lval, const TData& rvec, ResTData* res) {
+        size_t size = rvec.size();
+        BitmapValue mid_data;
+        for (size_t i = 0; i < size; ++i) {
+            mid_data = lval;
+            mid_data &= rvec[i];
+            res[i] = lval.andnot_cardinality(mid_data);
+            mid_data.clear();
+        }
+    }
+    static void vector_scalar(const TData& lvec, const BitmapValue& rval, ResTData* res) {
+        size_t size = lvec.size();
+        BitmapValue mid_data;
+        for (size_t i = 0; i < size; ++i) {
+            mid_data = lvec[i];
+            mid_data &= rval;
+            res[i] = lvec[i].andnot_cardinality(mid_data);
+            mid_data.clear();
+        }
     }
 };
 
@@ -622,11 +675,6 @@ public:
     Status execute_impl_internal(FunctionContext* context, Block& block,
                                  const ColumnNumbers& arguments, size_t result,
                                  size_t input_rows_count) {
-        const auto& left = block.get_by_position(arguments[0]);
-        auto lcol = left.column->convert_to_full_column_if_const();
-        const auto& right = block.get_by_position(arguments[1]);
-        auto rcol = right.column->convert_to_full_column_if_const();
-
         using ResultType = typename ResultDataType::FieldType;
         using ColVecResult = ColumnVector<ResultType>;
 
@@ -634,10 +682,29 @@ public:
         auto& vec_res = col_res->get_data();
         vec_res.resize(block.rows());
 
-        const ColumnBitmap* l_bitmap_col = assert_cast<const ColumnBitmap*>(lcol.get());
-        const ColumnBitmap* r_bitmap_col = assert_cast<const ColumnBitmap*>(rcol.get());
-        BitmapAndNotCount<LeftDataType, RightDataType>::vector_vector(
-                l_bitmap_col->get_data(), r_bitmap_col->get_data(), vec_res.data());
+        const auto& left = block.get_by_position(arguments[0]);
+        auto lcol = left.column;
+        const auto& right = block.get_by_position(arguments[1]);
+        auto rcol = right.column;
+
+        if (is_column_const(*left.column)) {
+            BitmapAndNotCount<LeftDataType, RightDataType>::scalar_vector(
+                    assert_cast<const ColumnBitmap&>(
+                            assert_cast<const ColumnConst*>(lcol.get())->get_data_column())
+                            .get_data()[0],
+                    assert_cast<const ColumnBitmap*>(rcol.get())->get_data(), vec_res.data());
+        } else if (is_column_const(*right.column)) {
+            BitmapAndNotCount<LeftDataType, RightDataType>::vector_scalar(
+                    assert_cast<const ColumnBitmap*>(lcol.get())->get_data(),
+                    assert_cast<const ColumnBitmap&>(
+                            assert_cast<const ColumnConst*>(rcol.get())->get_data_column())
+                            .get_data()[0],
+                    vec_res.data());
+        } else {
+            BitmapAndNotCount<LeftDataType, RightDataType>::vector_vector(
+                    assert_cast<const ColumnBitmap*>(lcol.get())->get_data(),
+                    assert_cast<const ColumnBitmap*>(rcol.get())->get_data(), vec_res.data());
+        }
 
         auto& result_info = block.get_by_position(result);
         if (result_info.type->is_nullable()) {
@@ -664,12 +731,23 @@ struct BitmapContains {
     using RTData = typename ColumnVector<T1>::Container;
     using ResTData = typename ColumnVector<UInt8>::Container;
 
-    static Status vector_vector(const LTData& lvec, const RTData& rvec, ResTData& res) {
+    static void vector_vector(const LTData& lvec, const RTData& rvec, ResTData& res) {
         size_t size = lvec.size();
         for (size_t i = 0; i < size; ++i) {
             res[i] = lvec[i].contains(rvec[i]);
         }
-        return Status::OK();
+    }
+    static void vector_scalar(const LTData& lvec, const T1& rval, ResTData& res) {
+        size_t size = lvec.size();
+        for (size_t i = 0; i < size; ++i) {
+            res[i] = lvec[i].contains(rval);
+        }
+    }
+    static void scalar_vector(const BitmapValue& lval, const RTData& rvec, ResTData& res) {
+        size_t size = rvec.size();
+        for (size_t i = 0; i < size; ++i) {
+            res[i] = lval.contains(rvec[i]);
+        }
     }
 };
 
@@ -685,14 +763,29 @@ struct BitmapHasAny {
     using TData = std::vector<BitmapValue>;
     using ResTData = typename ColumnVector<UInt8>::Container;
 
-    static Status vector_vector(const TData& lvec, const TData& rvec, ResTData& res) {
+    static void vector_vector(const TData& lvec, const TData& rvec, ResTData& res) {
         size_t size = lvec.size();
         for (size_t i = 0; i < size; ++i) {
             auto bitmap = const_cast<BitmapValue&>(lvec[i]);
             bitmap &= rvec[i];
             res[i] = bitmap.cardinality() != 0;
         }
-        return Status::OK();
+    }
+    static void vector_scalar(const TData& lvec, const BitmapValue& rval, ResTData& res) {
+        size_t size = lvec.size();
+        for (size_t i = 0; i < size; ++i) {
+            auto bitmap = const_cast<BitmapValue&>(lvec[i]);
+            bitmap &= rval;
+            res[i] = bitmap.cardinality() != 0;
+        }
+    }
+    static void scalar_vector(const BitmapValue& lval, const TData& rvec, ResTData& res) {
+        size_t size = rvec.size();
+        for (size_t i = 0; i < size; ++i) {
+            auto bitmap = const_cast<BitmapValue&>(lval);
+            bitmap &= rvec[i];
+            res[i] = bitmap.cardinality() != 0;
+        }
     }
 };
 
@@ -708,7 +801,7 @@ struct BitmapHasAll {
     using TData = std::vector<BitmapValue>;
     using ResTData = typename ColumnVector<UInt8>::Container;
 
-    static Status vector_vector(const TData& lvec, const TData& rvec, ResTData& res) {
+    static void vector_vector(const TData& lvec, const TData& rvec, ResTData& res) {
         size_t size = lvec.size();
         for (size_t i = 0; i < size; ++i) {
             uint64_t lhs_cardinality = lvec[i].cardinality();
@@ -716,7 +809,24 @@ struct BitmapHasAll {
             bitmap |= rvec[i];
             res[i] = bitmap.cardinality() == lhs_cardinality;
         }
-        return Status::OK();
+    }
+    static void vector_scalar(const TData& lvec, const BitmapValue& rval, ResTData& res) {
+        size_t size = lvec.size();
+        for (size_t i = 0; i < size; ++i) {
+            uint64_t lhs_cardinality = lvec[i].cardinality();
+            auto bitmap = const_cast<BitmapValue&>(lvec[i]);
+            bitmap |= rval;
+            res[i] = bitmap.cardinality() == lhs_cardinality;
+        }
+    }
+    static void scalar_vector(const BitmapValue& lval, const TData& rvec, ResTData& res) {
+        size_t size = rvec.size();
+        for (size_t i = 0; i < size; ++i) {
+            uint64_t lhs_cardinality = lval.cardinality();
+            auto bitmap = const_cast<BitmapValue&>(lval);
+            bitmap |= rvec[i];
+            res[i] = bitmap.cardinality() == lhs_cardinality;
+        }
     }
 };
 
@@ -748,9 +858,9 @@ struct SubBitmap {
     using TData1 = std::vector<BitmapValue>;
     using TData2 = typename ColumnVector<Int64>::Container;
 
-    static Status vector_vector(const TData1& bitmap_data, const TData2& offset_data,
-                                const TData2& limit_data, NullMap& null_map,
-                                size_t input_rows_count, TData1& res) {
+    static void vector3(const TData1& bitmap_data, const TData2& offset_data,
+                        const TData2& limit_data, NullMap& null_map, size_t input_rows_count,
+                        TData1& res) {
         for (int i = 0; i < input_rows_count; ++i) {
             if (null_map[i]) {
                 continue;
@@ -764,7 +874,23 @@ struct SubBitmap {
                 null_map[i] = 1;
             }
         }
-        return Status::OK();
+    }
+    static void vector_scalars(const TData1& bitmap_data, const Int64& offset_data,
+                               const Int64& limit_data, NullMap& null_map, size_t input_rows_count,
+                               TData1& res) {
+        for (int i = 0; i < input_rows_count; ++i) {
+            if (null_map[i]) {
+                continue;
+            }
+            if (limit_data <= 0) {
+                null_map[i] = 1;
+                continue;
+            }
+            if (const_cast<TData1&>(bitmap_data)[i].offset_limit(offset_data, limit_data,
+                                                                 &res[i]) == 0) {
+                null_map[i] = 1;
+            }
+        }
     }
 };
 
@@ -773,9 +899,9 @@ struct BitmapSubsetLimit {
     using TData1 = std::vector<BitmapValue>;
     using TData2 = typename ColumnVector<Int64>::Container;
 
-    static Status vector_vector(const TData1& bitmap_data, const TData2& offset_data,
-                                const TData2& limit_data, NullMap& null_map,
-                                size_t input_rows_count, TData1& res) {
+    static void vector3(const TData1& bitmap_data, const TData2& offset_data,
+                        const TData2& limit_data, NullMap& null_map, size_t input_rows_count,
+                        TData1& res) {
         for (int i = 0; i < input_rows_count; ++i) {
             if (null_map[i]) {
                 continue;
@@ -786,7 +912,20 @@ struct BitmapSubsetLimit {
             }
             const_cast<TData1&>(bitmap_data)[i].sub_limit(offset_data[i], limit_data[i], &res[i]);
         }
-        return Status::OK();
+    }
+    static void vector_scalars(const TData1& bitmap_data, const Int64& offset_data,
+                               const Int64& limit_data, NullMap& null_map, size_t input_rows_count,
+                               TData1& res) {
+        for (int i = 0; i < input_rows_count; ++i) {
+            if (null_map[i]) {
+                continue;
+            }
+            if (offset_data < 0 || limit_data < 0) {
+                null_map[i] = 1;
+                continue;
+            }
+            const_cast<TData1&>(bitmap_data)[i].sub_limit(offset_data, limit_data, &res[i]);
+        }
     }
 };
 
@@ -795,9 +934,9 @@ struct BitmapSubsetInRange {
     using TData1 = std::vector<BitmapValue>;
     using TData2 = typename ColumnVector<Int64>::Container;
 
-    static Status vector_vector(const TData1& bitmap_data, const TData2& range_start,
-                                const TData2& range_end, NullMap& null_map, size_t input_rows_count,
-                                TData1& res) {
+    static void vector3(const TData1& bitmap_data, const TData2& range_start,
+                        const TData2& range_end, NullMap& null_map, size_t input_rows_count,
+                        TData1& res) {
         for (int i = 0; i < input_rows_count; ++i) {
             if (null_map[i]) {
                 continue;
@@ -808,7 +947,20 @@ struct BitmapSubsetInRange {
             }
             const_cast<TData1&>(bitmap_data)[i].sub_range(range_start[i], range_end[i], &res[i]);
         }
-        return Status::OK();
+    }
+    static void vector_scalars(const TData1& bitmap_data, const Int64& range_start,
+                               const Int64& range_end, NullMap& null_map, size_t input_rows_count,
+                               TData1& res) {
+        for (int i = 0; i < input_rows_count; ++i) {
+            if (null_map[i]) {
+                continue;
+            }
+            if (range_start >= range_end || range_start < 0 || range_end < 0) {
+                null_map[i] = 1;
+                continue;
+            }
+            const_cast<TData1&>(bitmap_data)[i].sub_range(range_start, range_end, &res[i]);
+        }
     }
 };
 
@@ -835,25 +987,33 @@ public:
         DCHECK_EQ(arguments.size(), 3);
         auto res_null_map = ColumnUInt8::create(input_rows_count, 0);
         auto res_data_column = ColumnBitmap::create(input_rows_count);
-        ColumnPtr argument_columns[3];
 
-        for (int i = 0; i < 3; ++i) {
-            argument_columns[i] =
-                    block.get_by_position(arguments[i]).column->convert_to_full_column_if_const();
-            if (auto* nullable = check_and_get_column<ColumnNullable>(*argument_columns[i])) {
-                VectorizedUtils::update_null_map(res_null_map->get_data(),
-                                                 nullable->get_null_map_data());
-                argument_columns[i] = nullable->get_nested_column_ptr();
-            }
+        const auto& col0 = block.get_by_position(arguments[0]).column;
+        bool col_const[3] = {is_column_const(*col0)};
+        ColumnPtr argument_columns[3] = {
+                col_const[0] ? static_cast<const ColumnConst&>(*col0).convert_to_full_column()
+                             : col0};
+        check_set_nullable(argument_columns[0], res_null_map);
+
+        for (int i = 1; i < 3; ++i) {
+            std::tie(argument_columns[i], col_const[i]) =
+                    unpack_if_const(block.get_by_position(arguments[i]).column);
+            check_set_nullable(argument_columns[i], res_null_map);
         }
 
         auto bitmap_column = assert_cast<const ColumnBitmap*>(argument_columns[0].get());
         auto offset_column = assert_cast<const ColumnVector<Int64>*>(argument_columns[1].get());
         auto limit_column = assert_cast<const ColumnVector<Int64>*>(argument_columns[2].get());
 
-        Impl::vector_vector(bitmap_column->get_data(), offset_column->get_data(),
-                            limit_column->get_data(), res_null_map->get_data(), input_rows_count,
-                            res_data_column->get_data());
+        if (col_const[1] && col_const[2]) {
+            Impl::vector_scalars(bitmap_column->get_data(), offset_column->get_element(0),
+                                 limit_column->get_element(0), res_null_map->get_data(),
+                                 input_rows_count, res_data_column->get_data());
+        } else {
+            Impl::vector3(bitmap_column->get_data(), offset_column->get_data(),
+                          limit_column->get_data(), res_null_map->get_data(), input_rows_count,
+                          res_data_column->get_data());
+        }
 
         block.get_by_position(result).column =
                 ColumnNullable::create(std::move(res_data_column), std::move(res_null_map));

--- a/be/src/vec/functions/function_conv.cpp
+++ b/be/src/vec/functions/function_conv.cpp
@@ -51,16 +51,19 @@ public:
         auto result_column = ColumnString::create();
         auto result_null_map_column = ColumnUInt8::create(input_rows_count, 0);
 
-        const auto& col0 = block.get_by_position(arguments[0]).column;
-        bool col_const[3] = {is_column_const(*col0)};
-        ColumnPtr argument_columns[3] = {
-                col_const[0] ? static_cast<const ColumnConst&>(*col0).convert_to_full_column()
-                             : col0};
-        check_set_nullable(argument_columns[0], result_null_map_column);
+        bool col_const[3];
+        ColumnPtr argument_columns[3];
+        for (int i = 0; i < 3; ++i) {
+            col_const[i] = is_column_const(*block.get_by_position(arguments[i]).column);
+        }
+        argument_columns[0] = col_const[0] ? static_cast<const ColumnConst&>(
+                                                     *block.get_by_position(arguments[0]).column)
+                                                     .convert_to_full_column()
+                                           : block.get_by_position(arguments[0]).column;
 
-        for (int i = 1; i < 3; ++i) {
-            std::tie(argument_columns[i], col_const[i]) =
-                    unpack_if_const(block.get_by_position(arguments[i]).column);
+        default_preprocess_parameter_columns(argument_columns, col_const, {1, 2}, block, arguments);
+
+        for (int i = 0; i < 3; i++) {
             check_set_nullable(argument_columns[i], result_null_map_column);
         }
 

--- a/be/src/vec/functions/function_conv.cpp
+++ b/be/src/vec/functions/function_conv.cpp
@@ -16,6 +16,8 @@
 // under the License.
 
 #include "exprs/math_functions.h"
+#include "vec/columns/column_const.h"
+#include "vec/columns/column_nullable.h"
 #include "vec/data_types/data_type_number.h"
 #include "vec/data_types/data_type_string.h"
 #include "vec/functions/simple_function_factory.h"
@@ -49,29 +51,39 @@ public:
         auto result_column = ColumnString::create();
         auto result_null_map_column = ColumnUInt8::create(input_rows_count, 0);
 
-        ColumnPtr argument_columns[3];
+        const auto& col0 = block.get_by_position(arguments[0]).column;
+        bool col_const[3] = {is_column_const(*col0)};
+        ColumnPtr argument_columns[3] = {
+                col_const[0] ? static_cast<const ColumnConst&>(*col0).convert_to_full_column()
+                             : col0};
+        check_set_nullable(argument_columns[0], result_null_map_column);
 
-        for (int i = 0; i < 3; ++i) {
-            argument_columns[i] =
-                    block.get_by_position(arguments[i]).column->convert_to_full_column_if_const();
-            if (auto* nullable = check_and_get_column<ColumnNullable>(*argument_columns[i])) {
-                // Danger: Here must dispose the null map data first! Because
-                // argument_columns[i]=nullable->get_nested_column_ptr(); will release the mem
-                // of column nullable mem of null map
-                VectorizedUtils::update_null_map(result_null_map_column->get_data(),
-                                                 nullable->get_null_map_data());
-                argument_columns[i] = nullable->get_nested_column_ptr();
-            }
+        for (int i = 1; i < 3; ++i) {
+            std::tie(argument_columns[i], col_const[i]) =
+                    unpack_if_const(block.get_by_position(arguments[i]).column);
+            check_set_nullable(argument_columns[i], result_null_map_column);
         }
 
-        execute_straight(
-                context,
-                assert_cast<const typename Impl::DataType::ColumnType*>(argument_columns[0].get()),
-                assert_cast<const ColumnInt8*>(argument_columns[1].get()),
-                assert_cast<const ColumnInt8*>(argument_columns[2].get()),
-                assert_cast<ColumnString*>(result_column.get()),
-                assert_cast<ColumnUInt8*>(result_null_map_column.get())->get_data(),
-                input_rows_count);
+        if (col_const[1] && col_const[2]) {
+            execute_const_args(
+                    context,
+                    assert_cast<const typename Impl::DataType::ColumnType*>(
+                            argument_columns[0].get()),
+                    assert_cast<const ColumnInt8*>(argument_columns[1].get())->get_element(0),
+                    assert_cast<const ColumnInt8*>(argument_columns[2].get())->get_element(0),
+                    assert_cast<ColumnString*>(result_column.get()),
+                    assert_cast<ColumnUInt8*>(result_null_map_column.get())->get_data(),
+                    input_rows_count);
+        } else {
+            execute_straight(context,
+                             assert_cast<const typename Impl::DataType::ColumnType*>(
+                                     argument_columns[0].get()),
+                             assert_cast<const ColumnInt8*>(argument_columns[1].get()),
+                             assert_cast<const ColumnInt8*>(argument_columns[2].get()),
+                             assert_cast<ColumnString*>(result_column.get()),
+                             assert_cast<ColumnUInt8*>(result_null_map_column.get())->get_data(),
+                             input_rows_count);
+        }
 
         block.get_by_position(result).column =
                 ColumnNullable::create(std::move(result_column), std::move(result_null_map_column));
@@ -79,11 +91,10 @@ public:
     }
 
 private:
-    void execute_straight(FunctionContext* context,
-                          const typename Impl::DataType::ColumnType* data_column,
-                          const ColumnInt8* src_base_column, const ColumnInt8* dst_base_column,
-                          ColumnString* result_column, NullMap& result_null_map,
-                          size_t input_rows_count) {
+    static ALWAYS_INLINE void execute_straight(
+            FunctionContext* context, const typename Impl::DataType::ColumnType* data_column,
+            const ColumnInt8* src_base_column, const ColumnInt8* dst_base_column,
+            ColumnString* result_column, NullMap& result_null_map, size_t input_rows_count) {
         for (size_t i = 0; i < input_rows_count; i++) {
             if (result_null_map[i]) {
                 result_column->insert_default();
@@ -92,6 +103,29 @@ private:
 
             Int8 src_base = src_base_column->get_element(i);
             Int8 dst_base = dst_base_column->get_element(i);
+            if (std::abs(src_base) < MathFunctions::MIN_BASE ||
+                std::abs(src_base) > MathFunctions::MAX_BASE ||
+                std::abs(dst_base) < MathFunctions::MIN_BASE ||
+                std::abs(dst_base) > MathFunctions::MAX_BASE) {
+                result_null_map[i] = true;
+                result_column->insert_default();
+                continue;
+            }
+
+            Impl::calculate_cell(context, data_column, src_base, dst_base, result_column,
+                                 result_null_map, i);
+        }
+    }
+    static ALWAYS_INLINE void execute_const_args(
+            FunctionContext* context, const typename Impl::DataType::ColumnType* data_column,
+            const Int8 src_base, const Int8 dst_base, ColumnString* result_column,
+            NullMap& result_null_map, size_t input_rows_count) {
+        for (size_t i = 0; i < input_rows_count; i++) {
+            if (result_null_map[i]) {
+                result_column->insert_default();
+                continue;
+            }
+
             if (std::abs(src_base) < MathFunctions::MIN_BASE ||
                 std::abs(src_base) > MathFunctions::MAX_BASE ||
                 std::abs(dst_base) < MathFunctions::MIN_BASE ||

--- a/be/src/vec/functions/function_convert_tz.h
+++ b/be/src/vec/functions/function_convert_tz.h
@@ -207,16 +207,19 @@ public:
                         size_t result, size_t input_rows_count) override {
         auto result_null_map_column = ColumnUInt8::create(input_rows_count, 0);
 
-        const auto& col0 = block.get_by_position(arguments[0]).column;
-        bool col_const[3] = {is_column_const(*col0)};
-        ColumnPtr argument_columns[3] = {
-                col_const[0] ? static_cast<const ColumnConst&>(*col0).convert_to_full_column()
-                             : col0};
-        check_set_nullable(argument_columns[0], result_null_map_column);
+        bool col_const[3];
+        ColumnPtr argument_columns[3];
+        for (int i = 0; i < 3; ++i) {
+            col_const[i] = is_column_const(*block.get_by_position(arguments[i]).column);
+        }
+        argument_columns[0] = col_const[0] ? static_cast<const ColumnConst&>(
+                                                     *block.get_by_position(arguments[0]).column)
+                                                     .convert_to_full_column()
+                                           : block.get_by_position(arguments[0]).column;
 
-        for (int i = 1; i < 3; ++i) {
-            std::tie(argument_columns[i], col_const[i]) =
-                    unpack_if_const(block.get_by_position(arguments[i]).column);
+        default_preprocess_parameter_columns(argument_columns, col_const, {1, 2}, block, arguments);
+
+        for (int i = 0; i < 3; i++) {
             check_set_nullable(argument_columns[i], result_null_map_column);
         }
 

--- a/be/src/vec/functions/function_convert_tz.h
+++ b/be/src/vec/functions/function_convert_tz.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include "vec/columns/column_const.h"
 #include "vec/columns/columns_number.h"
 #include "vec/common/string_ref.h"
 #include "vec/core/types.h"
@@ -63,6 +64,60 @@ struct ConvertTZImpl {
 
             auto from_tz = from_tz_column->get_data_at(i).to_string();
             auto to_tz = to_tz_column->get_data_at(i).to_string();
+
+            DateValueType ts_value =
+                    binary_cast<NativeType, DateValueType>(date_column->get_element(i));
+            int64_t timestamp;
+
+            if (time_zone_cache.find(from_tz) == time_zone_cache.cend()) {
+                if (!TimezoneUtils::find_cctz_time_zone(from_tz, time_zone_cache[from_tz])) {
+                    result_null_map[i] = true;
+                    result_column->insert_default();
+                    continue;
+                }
+            }
+
+            if (time_zone_cache.find(to_tz) == time_zone_cache.cend()) {
+                if (!TimezoneUtils::find_cctz_time_zone(to_tz, time_zone_cache[to_tz])) {
+                    result_null_map[i] = true;
+                    result_column->insert_default();
+                    continue;
+                }
+            }
+
+            if (!ts_value.unix_timestamp(&timestamp, time_zone_cache[from_tz])) {
+                result_null_map[i] = true;
+                result_column->insert_default();
+                continue;
+            }
+
+            ReturnDateType ts_value2;
+            if (!ts_value2.from_unixtime(timestamp, time_zone_cache[to_tz])) {
+                result_null_map[i] = true;
+                result_column->insert_default();
+                continue;
+            }
+
+            result_column->insert(binary_cast<ReturnDateType, ReturnNativeType>(ts_value2));
+        }
+    }
+
+    static void execute_tz_const(FunctionContext* context, const ColumnType* date_column,
+                                 const ColumnString* from_tz_column,
+                                 const ColumnString* to_tz_column, ReturnColumnType* result_column,
+                                 NullMap& result_null_map, size_t input_rows_count) {
+        auto convert_ctx = reinterpret_cast<ConvertTzCtx*>(
+                context->get_function_state(FunctionContext::FunctionStateScope::THREAD_LOCAL));
+        std::map<std::string, cctz::time_zone> time_zone_cache_;
+        auto& time_zone_cache = convert_ctx ? convert_ctx->time_zone_cache : time_zone_cache_;
+        for (size_t i = 0; i < input_rows_count; i++) {
+            if (result_null_map[i]) {
+                result_column->insert_default();
+                continue;
+            }
+
+            auto from_tz = from_tz_column->get_data_at(0).to_string();
+            auto to_tz = to_tz_column->get_data_at(0).to_string();
 
             DateValueType ts_value =
                     binary_cast<NativeType, DateValueType>(date_column->get_element(i));
@@ -152,56 +207,92 @@ public:
                         size_t result, size_t input_rows_count) override {
         auto result_null_map_column = ColumnUInt8::create(input_rows_count, 0);
 
-        ColumnPtr argument_columns[3];
+        const auto& col0 = block.get_by_position(arguments[0]).column;
+        bool col_const[3] = {is_column_const(*col0)};
+        ColumnPtr argument_columns[3] = {
+                col_const[0] ? static_cast<const ColumnConst&>(*col0).convert_to_full_column()
+                             : col0};
+        check_set_nullable(argument_columns[0], result_null_map_column);
 
-        for (int i = 0; i < 3; ++i) {
-            argument_columns[i] =
-                    block.get_by_position(arguments[i]).column->convert_to_full_column_if_const();
-            if (auto* nullable = check_and_get_column<ColumnNullable>(*argument_columns[i])) {
-                // Danger: Here must dispose the null map data first! Because
-                // argument_columns[i]=nullable->get_nested_column_ptr(); will release the mem
-                // of column nullable mem of null map
-                VectorizedUtils::update_null_map(result_null_map_column->get_data(),
-                                                 nullable->get_null_map_data());
-                argument_columns[i] = nullable->get_nested_column_ptr();
+        for (int i = 1; i < 3; ++i) {
+            std::tie(argument_columns[i], col_const[i]) =
+                    unpack_if_const(block.get_by_position(arguments[i]).column);
+            check_set_nullable(argument_columns[i], result_null_map_column);
+        }
+
+        if (col_const[1] && col_const[2]) {
+            if constexpr (std::is_same_v<DateType, DataTypeDateTime> ||
+                          std::is_same_v<DateType, DataTypeDate>) {
+                auto result_column = ColumnDateTime::create();
+                Transform::execute_tz_const(
+                        context, assert_cast<const ColumnDateTime*>(argument_columns[0].get()),
+                        assert_cast<const ColumnString*>(argument_columns[1].get()),
+                        assert_cast<const ColumnString*>(argument_columns[2].get()),
+                        assert_cast<ColumnDateTime*>(result_column.get()),
+                        assert_cast<ColumnUInt8*>(result_null_map_column.get())->get_data(),
+                        input_rows_count);
+                block.get_by_position(result).column = ColumnNullable::create(
+                        std::move(result_column), std::move(result_null_map_column));
+            } else if constexpr (std::is_same_v<DateType, DataTypeDateV2>) {
+                auto result_column = ColumnDateTimeV2::create();
+                Transform::execute_tz_const(
+                        context, assert_cast<const ColumnDateV2*>(argument_columns[0].get()),
+                        assert_cast<const ColumnString*>(argument_columns[1].get()),
+                        assert_cast<const ColumnString*>(argument_columns[2].get()),
+                        assert_cast<ColumnDateTimeV2*>(result_column.get()),
+                        assert_cast<ColumnUInt8*>(result_null_map_column.get())->get_data(),
+                        input_rows_count);
+                block.get_by_position(result).column = ColumnNullable::create(
+                        std::move(result_column), std::move(result_null_map_column));
+            } else {
+                auto result_column = ColumnDateTimeV2::create();
+                Transform::execute_tz_const(
+                        context, assert_cast<const ColumnDateTimeV2*>(argument_columns[0].get()),
+                        assert_cast<const ColumnString*>(argument_columns[1].get()),
+                        assert_cast<const ColumnString*>(argument_columns[2].get()),
+                        assert_cast<ColumnDateTimeV2*>(result_column.get()),
+                        assert_cast<ColumnUInt8*>(result_null_map_column.get())->get_data(),
+                        input_rows_count);
+                block.get_by_position(result).column = ColumnNullable::create(
+                        std::move(result_column), std::move(result_null_map_column));
             }
-        }
-
-        if constexpr (std::is_same_v<DateType, DataTypeDateTime> ||
-                      std::is_same_v<DateType, DataTypeDate>) {
-            auto result_column = ColumnDateTime::create();
-            Transform::execute(context,
-                               assert_cast<const ColumnDateTime*>(argument_columns[0].get()),
-                               assert_cast<const ColumnString*>(argument_columns[1].get()),
-                               assert_cast<const ColumnString*>(argument_columns[2].get()),
-                               assert_cast<ColumnDateTime*>(result_column.get()),
-                               assert_cast<ColumnUInt8*>(result_null_map_column.get())->get_data(),
-                               input_rows_count);
-            block.get_by_position(result).column = ColumnNullable::create(
-                    std::move(result_column), std::move(result_null_map_column));
-        } else if constexpr (std::is_same_v<DateType, DataTypeDateV2>) {
-            auto result_column = ColumnDateTimeV2::create();
-            Transform::execute(context, assert_cast<const ColumnDateV2*>(argument_columns[0].get()),
-                               assert_cast<const ColumnString*>(argument_columns[1].get()),
-                               assert_cast<const ColumnString*>(argument_columns[2].get()),
-                               assert_cast<ColumnDateTimeV2*>(result_column.get()),
-                               assert_cast<ColumnUInt8*>(result_null_map_column.get())->get_data(),
-                               input_rows_count);
-            block.get_by_position(result).column = ColumnNullable::create(
-                    std::move(result_column), std::move(result_null_map_column));
         } else {
-            auto result_column = ColumnDateTimeV2::create();
-            Transform::execute(context,
-                               assert_cast<const ColumnDateTimeV2*>(argument_columns[0].get()),
-                               assert_cast<const ColumnString*>(argument_columns[1].get()),
-                               assert_cast<const ColumnString*>(argument_columns[2].get()),
-                               assert_cast<ColumnDateTimeV2*>(result_column.get()),
-                               assert_cast<ColumnUInt8*>(result_null_map_column.get())->get_data(),
-                               input_rows_count);
-            block.get_by_position(result).column = ColumnNullable::create(
-                    std::move(result_column), std::move(result_null_map_column));
-        }
-
+            if constexpr (std::is_same_v<DateType, DataTypeDateTime> ||
+                          std::is_same_v<DateType, DataTypeDate>) {
+                auto result_column = ColumnDateTime::create();
+                Transform::execute(
+                        context, assert_cast<const ColumnDateTime*>(argument_columns[0].get()),
+                        assert_cast<const ColumnString*>(argument_columns[1].get()),
+                        assert_cast<const ColumnString*>(argument_columns[2].get()),
+                        assert_cast<ColumnDateTime*>(result_column.get()),
+                        assert_cast<ColumnUInt8*>(result_null_map_column.get())->get_data(),
+                        input_rows_count);
+                block.get_by_position(result).column = ColumnNullable::create(
+                        std::move(result_column), std::move(result_null_map_column));
+            } else if constexpr (std::is_same_v<DateType, DataTypeDateV2>) {
+                auto result_column = ColumnDateTimeV2::create();
+                Transform::execute(
+                        context, assert_cast<const ColumnDateV2*>(argument_columns[0].get()),
+                        assert_cast<const ColumnString*>(argument_columns[1].get()),
+                        assert_cast<const ColumnString*>(argument_columns[2].get()),
+                        assert_cast<ColumnDateTimeV2*>(result_column.get()),
+                        assert_cast<ColumnUInt8*>(result_null_map_column.get())->get_data(),
+                        input_rows_count);
+                block.get_by_position(result).column = ColumnNullable::create(
+                        std::move(result_column), std::move(result_null_map_column));
+            } else {
+                auto result_column = ColumnDateTimeV2::create();
+                Transform::execute(
+                        context, assert_cast<const ColumnDateTimeV2*>(argument_columns[0].get()),
+                        assert_cast<const ColumnString*>(argument_columns[1].get()),
+                        assert_cast<const ColumnString*>(argument_columns[2].get()),
+                        assert_cast<ColumnDateTimeV2*>(result_column.get()),
+                        assert_cast<ColumnUInt8*>(result_null_map_column.get())->get_data(),
+                        input_rows_count);
+                block.get_by_position(result).column = ColumnNullable::create(
+                        std::move(result_column), std::move(result_null_map_column));
+            } //if datatype
+        }     //if const
         return Status::OK();
     }
 };

--- a/be/src/vec/functions/function_json.cpp
+++ b/be/src/vec/functions/function_json.cpp
@@ -267,6 +267,65 @@ struct GetJsonNumberType {
             }
         }
     }
+    static void vector_scalar(FunctionContext* context, const ColumnString::Chars& ldata,
+                              const ColumnString::Offsets& loffsets, const StringRef& rdata,
+                              Container& res, NullMap& null_map) {
+        size_t size = loffsets.size();
+        res.resize(size);
+        for (size_t i = 0; i < size; ++i) {
+            const char* l_raw_str = reinterpret_cast<const char*>(&ldata[loffsets[i - 1]]);
+            int l_str_size = loffsets[i] - loffsets[i - 1];
+
+            if (null_map[i]) {
+                res[i] = 0;
+                continue;
+            }
+
+            std::string_view json_string(l_raw_str, l_str_size);
+            std::string_view path_string(rdata.data, rdata.size);
+
+            rapidjson::Document document;
+            rapidjson::Value* root = nullptr;
+
+            if constexpr (std::is_same_v<double, typename NumberType::T>) {
+                root = get_json_object<JSON_FUN_DOUBLE>(json_string, path_string, &document);
+                handle_result<double>(root, res[i], null_map[i]);
+            } else if constexpr (std::is_same_v<int32_t, typename NumberType::T>) {
+                root = get_json_object<JSON_FUN_DOUBLE>(json_string, path_string, &document);
+                handle_result<int32_t>(root, res[i], null_map[i]);
+            }
+        }
+    }
+    static void scalar_vector(FunctionContext* context, const StringRef& ldata,
+                              const ColumnString::Chars& rdata,
+                              const ColumnString::Offsets& roffsets, Container& res,
+                              NullMap& null_map) {
+        size_t size = roffsets.size();
+        res.resize(size);
+        for (size_t i = 0; i < size; ++i) {
+            const char* r_raw_str = reinterpret_cast<const char*>(&rdata[roffsets[i - 1]]);
+            int r_str_size = roffsets[i] - roffsets[i - 1];
+
+            if (null_map[i]) {
+                res[i] = 0;
+                continue;
+            }
+
+            std::string_view json_string(ldata.data, ldata.size);
+            std::string_view path_string(r_raw_str, r_str_size);
+
+            rapidjson::Document document;
+            rapidjson::Value* root = nullptr;
+
+            if constexpr (std::is_same_v<double, typename NumberType::T>) {
+                root = get_json_object<JSON_FUN_DOUBLE>(json_string, path_string, &document);
+                handle_result<double>(root, res[i], null_map[i]);
+            } else if constexpr (std::is_same_v<int32_t, typename NumberType::T>) {
+                root = get_json_object<JSON_FUN_DOUBLE>(json_string, path_string, &document);
+                handle_result<int32_t>(root, res[i], null_map[i]);
+            }
+        }
+    }
 
     template <typename T, std::enable_if_t<std::is_same_v<double, T>, T>* = nullptr>
     static void handle_result(rapidjson::Value* root, T& res, uint8_t& res_null) {
@@ -365,6 +424,88 @@ struct GetJsonString {
             }
 
             std::string_view json_string(l_raw, l_size);
+            std::string_view path_string(r_raw, r_size);
+
+            rapidjson::Document document;
+            rapidjson::Value* root = nullptr;
+
+            root = get_json_object<JSON_FUN_STRING>(json_string, path_string, &document);
+            const int max_string_len = 65535;
+
+            if (root == nullptr || root->IsNull()) {
+                StringOP::push_null_string(i, res_data, res_offsets, null_map);
+            } else if (root->IsString()) {
+                const auto ptr = root->GetString();
+                size_t len = strnlen(ptr, max_string_len);
+                StringOP::push_value_string(std::string_view(ptr, len), i, res_data, res_offsets);
+            } else {
+                rapidjson::StringBuffer buf;
+                rapidjson::Writer<rapidjson::StringBuffer> writer(buf);
+                root->Accept(writer);
+
+                const auto ptr = buf.GetString();
+                size_t len = strnlen(ptr, max_string_len);
+                StringOP::push_value_string(std::string_view(ptr, len), i, res_data, res_offsets);
+            }
+        }
+    }
+    static void vector_scalar(FunctionContext* context, const Chars& ldata, const Offsets& loffsets,
+                              const StringRef& rdata, Chars& res_data, Offsets& res_offsets,
+                              NullMap& null_map) {
+        size_t input_rows_count = loffsets.size();
+        res_offsets.resize(input_rows_count);
+
+        for (size_t i = 0; i < input_rows_count; ++i) {
+            int l_size = loffsets[i] - loffsets[i - 1];
+            const auto l_raw = reinterpret_cast<const char*>(&ldata[loffsets[i - 1]]);
+
+            if (null_map[i]) {
+                StringOP::push_null_string(i, res_data, res_offsets, null_map);
+                continue;
+            }
+
+            std::string_view json_string(l_raw, l_size);
+            std::string_view path_string(rdata.data, rdata.size);
+
+            rapidjson::Document document;
+            rapidjson::Value* root = nullptr;
+
+            root = get_json_object<JSON_FUN_STRING>(json_string, path_string, &document);
+            const int max_string_len = 65535;
+
+            if (root == nullptr || root->IsNull()) {
+                StringOP::push_null_string(i, res_data, res_offsets, null_map);
+            } else if (root->IsString()) {
+                const auto ptr = root->GetString();
+                size_t len = strnlen(ptr, max_string_len);
+                StringOP::push_value_string(std::string_view(ptr, len), i, res_data, res_offsets);
+            } else {
+                rapidjson::StringBuffer buf;
+                rapidjson::Writer<rapidjson::StringBuffer> writer(buf);
+                root->Accept(writer);
+
+                const auto ptr = buf.GetString();
+                size_t len = strnlen(ptr, max_string_len);
+                StringOP::push_value_string(std::string_view(ptr, len), i, res_data, res_offsets);
+            }
+        }
+    }
+    static void scalar_vector(FunctionContext* context, const StringRef& ldata, const Chars& rdata,
+                              const Offsets& roffsets, Chars& res_data, Offsets& res_offsets,
+                              NullMap& null_map) {
+        size_t input_rows_count = roffsets.size();
+        res_offsets.resize(input_rows_count);
+
+        for (size_t i = 0; i < input_rows_count; ++i) {
+            int r_size = roffsets[i] - roffsets[i - 1];
+            const auto r_raw = reinterpret_cast<const char*>(&rdata[roffsets[i - 1]]);
+
+            if (null_map[i]) {
+                StringOP::push_null_string(i, res_data, res_offsets, null_map);
+                continue;
+            }
+
+            std::string_view json_string(ldata.data, ldata.size);
             std::string_view path_string(r_raw, r_size);
 
             rapidjson::Document document;

--- a/be/src/vec/functions/function_map.cpp
+++ b/be/src/vec/functions/function_map.cpp
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#include <memory>
+
 #include "vec/columns/column_array.h"
 #include "vec/columns/column_const.h"
 #include "vec/columns/column_map.h"
@@ -90,10 +92,11 @@ public:
         auto& result_col_map_offsets = map_column->get_offsets();
         result_col_map_offsets.resize(input_rows_count);
 
+        std::unique_ptr<bool[]> col_const = std::make_unique<bool[]>(num_element);
         // convert to nullable column
         for (size_t i = 0; i < num_element; ++i) {
             auto& col = block.get_by_position(arguments[i]).column;
-            col = col->convert_to_full_column_if_const();
+            std::tie(col, col_const[i]) = unpack_if_const(col);
             bool is_nullable = i % 2 == 0 ? result_col_map_keys_data.is_nullable()
                                           : result_col_map_vals_data.is_nullable();
             if (is_nullable && !col->is_nullable()) {
@@ -102,13 +105,15 @@ public:
         }
 
         // insert value into array
+        // TODO: check to swap the order or loop.
         ColumnArray::Offset64 offset = 0;
         for (size_t row = 0; row < input_rows_count; ++row) {
             for (size_t i = 0; i < num_element; i += 2) {
                 result_col_map_keys_data.insert_from(*block.get_by_position(arguments[i]).column,
-                                                     row);
+                                                     col_const[i] ? 0 : row);
                 result_col_map_vals_data.insert_from(
-                        *block.get_by_position(arguments[i + 1]).column, row);
+                        *block.get_by_position(arguments[i + 1]).column,
+                        col_const[i + 1] ? 0 : row);
             }
             offset += num_element / 2;
             result_col_map_offsets[row] = offset;
@@ -142,8 +147,8 @@ public:
 
     Status execute_impl(FunctionContext* context, Block& block, const ColumnNumbers& arguments,
                         size_t result, size_t input_rows_count) override {
-        auto left_column =
-                block.get_by_position(arguments[0]).column->convert_to_full_column_if_const();
+        const auto& [left_column, left_const] =
+                unpack_if_const(block.get_by_position(arguments[0]).column);
         const ColumnMap* map_column = nullptr;
         // const UInt8* map_null_map = nullptr;
         if (left_column->is_nullable()) {
@@ -161,8 +166,14 @@ public:
         auto dst_column = ColumnInt64::create(input_rows_count);
         auto& dst_data = dst_column->get_data();
 
-        for (size_t i = 0; i < map_column->size(); i++) {
-            dst_data[i] = map_column->size_at(i);
+        if (left_const) {
+            for (size_t i = 0; i < map_column->size(); i++) {
+                dst_data[i] = map_column->size_at(0);
+            }
+        } else {
+            for (size_t i = 0; i < map_column->size(); i++) {
+                dst_data[i] = map_column->size_at(i);
+            }
         }
 
         block.replace_by_position(result, std::move(dst_column));

--- a/be/src/vec/functions/function_regexp.cpp
+++ b/be/src/vec/functions/function_regexp.cpp
@@ -511,16 +511,23 @@ public:
         auto& result_offset = result_data_column->get_offsets();
         result_offset.resize(input_rows_count);
 
-        const auto& col0 = block.get_by_position(arguments[0]).column;
-        bool col_const[3] = {is_column_const(*col0)};
-        ColumnPtr argument_columns[3] = {
-                col_const[0] ? static_cast<const ColumnConst&>(*col0).convert_to_full_column()
-                             : col0};
-        check_set_nullable(argument_columns[0], result_null_map);
-
-        for (int i = 1; i < argument_size; ++i) {
-            std::tie(argument_columns[i], col_const[i]) =
-                    unpack_if_const(block.get_by_position(arguments[i]).column);
+        bool col_const[3];
+        ColumnPtr argument_columns[3];
+        for (int i = 0; i < argument_size; ++i) {
+            col_const[i] = is_column_const(*block.get_by_position(arguments[i]).column);
+        }
+        argument_columns[0] = col_const[0] ? static_cast<const ColumnConst&>(
+                                                     *block.get_by_position(arguments[0]).column)
+                                                     .convert_to_full_column()
+                                           : block.get_by_position(arguments[0]).column;
+        if constexpr (std::is_same_v<Impl, RegexpExtractAllImpl>) {
+            default_preprocess_parameter_columns(argument_columns, col_const, {1}, block,
+                                                 arguments);
+        } else {
+            default_preprocess_parameter_columns(argument_columns, col_const, {1, 2}, block,
+                                                 arguments);
+        }
+        for (int i = 0; i < argument_size; i++) {
             check_set_nullable(argument_columns[i], result_null_map);
         }
 

--- a/be/src/vec/functions/function_regexp.cpp
+++ b/be/src/vec/functions/function_regexp.cpp
@@ -519,9 +519,8 @@ public:
         check_set_nullable(argument_columns[0], result_null_map);
 
         for (int i = 1; i < argument_size; ++i) {
-            // no need to unpack as we'll use its string_ref value.
-            argument_columns[i] = block.get_by_position(arguments[i]).column;
-            col_const[i] = is_column_const(*argument_columns[i]);
+            std::tie(argument_columns[i], col_const[i]) =
+                    unpack_if_const(block.get_by_position(arguments[i]).column);
             check_set_nullable(argument_columns[i], result_null_map);
         }
 
@@ -544,8 +543,6 @@ public:
                                    result_offset, result_null_map->get_data());
             }
         }
-        Impl::execute_impl(context, argument_columns, input_rows_count, result_data, result_offset,
-                           result_null_map->get_data());
 
         block.get_by_position(result).column =
                 ColumnNullable::create(std::move(result_data_column), std::move(result_null_map));

--- a/be/src/vec/functions/function_string.cpp
+++ b/be/src/vec/functions/function_string.cpp
@@ -25,7 +25,9 @@
 
 #include "runtime/string_search.hpp"
 #include "util/url_coding.h"
+#include "vec/columns/column_string.h"
 #include "vec/common/pod_array_fwd.h"
+#include "vec/common/string_ref.h"
 #include "vec/functions/function_reverse.h"
 #include "vec/functions/function_string_to_string.h"
 #include "vec/functions/function_totype.h"
@@ -212,10 +214,10 @@ struct StringFunctionImpl {
     using ResultDataType = typename OP::ResultDataType;
     using ResultPaddedPODArray = typename OP::ResultPaddedPODArray;
 
-    static Status vector_vector(const ColumnString::Chars& ldata,
-                                const ColumnString::Offsets& loffsets,
-                                const ColumnString::Chars& rdata,
-                                const ColumnString::Offsets& roffsets, ResultPaddedPODArray& res) {
+    static void vector_vector(const ColumnString::Chars& ldata,
+                              const ColumnString::Offsets& loffsets,
+                              const ColumnString::Chars& rdata,
+                              const ColumnString::Offsets& roffsets, ResultPaddedPODArray& res) {
         DCHECK_EQ(loffsets.size(), roffsets.size());
 
         auto size = loffsets.size();
@@ -232,8 +234,35 @@ struct StringFunctionImpl {
 
             OP::execute(lview, rview, res[i]);
         }
+    }
+    static void vector_scalar(const ColumnString::Chars& ldata,
+                              const ColumnString::Offsets& loffsets, const StringRef& rdata,
+                              ResultPaddedPODArray& res) {
+        auto size = loffsets.size();
+        res.resize(size);
+        for (int i = 0; i < size; ++i) {
+            const char* l_raw_str = reinterpret_cast<const char*>(&ldata[loffsets[i - 1]]);
+            int l_str_size = loffsets[i] - loffsets[i - 1];
 
-        return Status::OK();
+            std::string_view lview(l_raw_str, l_str_size);
+            std::string_view rview(rdata.data, rdata.size);
+
+            OP::execute(lview, rview, res[i]);
+        }
+    }
+    static void scalar_vector(const StringRef& ldata, const ColumnString::Chars& rdata,
+                              const ColumnString::Offsets& roffsets, ResultPaddedPODArray& res) {
+        auto size = roffsets.size();
+        res.resize(size);
+        for (int i = 0; i < size; ++i) {
+            const char* r_raw_str = reinterpret_cast<const char*>(&rdata[roffsets[i - 1]]);
+            int r_str_size = roffsets[i] - roffsets[i - 1];
+
+            std::string_view lview(ldata.data, ldata.size);
+            std::string_view rview(r_raw_str, r_str_size);
+
+            OP::execute(lview, rview, res[i]);
+        }
     }
 };
 
@@ -580,6 +609,66 @@ struct StringAppendTrailingCharIfAbsent {
                                         res_offsets);
         }
     }
+    static void vector_scalar(FunctionContext* context, const Chars& ldata, const Offsets& loffsets,
+                              const StringRef& rdata, Chars& res_data, Offsets& res_offsets,
+                              NullMap& null_map_data) {
+        size_t input_rows_count = loffsets.size();
+        res_offsets.resize(input_rows_count);
+        fmt::memory_buffer buffer;
+
+        if (rdata.size != 1) {
+            for (size_t i = 0; i < input_rows_count; ++i) {
+                StringOP::push_null_string(i, res_data, res_offsets, null_map_data);
+            }
+            return;
+        }
+
+        for (size_t i = 0; i < input_rows_count; ++i) {
+            buffer.clear();
+
+            int l_size = loffsets[i] - loffsets[i - 1];
+            const auto l_raw = reinterpret_cast<const char*>(&ldata[loffsets[i - 1]]);
+
+            if (l_raw[l_size - 1] == rdata.data[0]) {
+                StringOP::push_value_string(std::string_view(l_raw, l_size), i, res_data,
+                                            res_offsets);
+                continue;
+            }
+
+            buffer.append(l_raw, l_raw + l_size);
+            buffer.append(rdata.begin(), rdata.end());
+            StringOP::push_value_string(std::string_view(buffer.data(), buffer.size()), i, res_data,
+                                        res_offsets);
+        }
+    }
+    static void scalar_vector(FunctionContext* context, const StringRef& ldata, const Chars& rdata,
+                              const Offsets& roffsets, Chars& res_data, Offsets& res_offsets,
+                              NullMap& null_map_data) {
+        size_t input_rows_count = roffsets.size();
+        res_offsets.resize(input_rows_count);
+        fmt::memory_buffer buffer;
+
+        for (size_t i = 0; i < input_rows_count; ++i) {
+            buffer.clear();
+
+            int r_size = roffsets[i] - roffsets[i - 1];
+            const auto r_raw = reinterpret_cast<const char*>(&rdata[roffsets[i - 1]]);
+
+            if (r_size != 1) {
+                StringOP::push_null_string(i, res_data, res_offsets, null_map_data);
+                continue;
+            }
+            if (ldata.size == 0 || ldata.back() == r_raw[0]) {
+                StringOP::push_value_string(ldata.to_string_view(), i, res_data, res_offsets);
+                continue;
+            }
+
+            buffer.append(ldata.begin(), ldata.end());
+            buffer.append(r_raw, r_raw + 1);
+            StringOP::push_value_string(std::string_view(buffer.data(), buffer.size()), i, res_data,
+                                        res_offsets);
+        }
+    }
 };
 
 struct StringLPad {
@@ -623,8 +712,6 @@ using FunctionStringLocate =
 using FunctionStringFindInSet =
         FunctionBinaryToType<DataTypeString, DataTypeString, StringFindInSetImpl, NameFindInSet>;
 
-using FunctionUnHex = FunctionStringOperateToNullType<UnHexImpl>;
-
 using FunctionToLower = FunctionStringToString<TransferImpl<NameToLower>, NameToLower>;
 
 using FunctionToUpper = FunctionStringToString<TransferImpl<NameToUpper>, NameToUpper>;
@@ -637,8 +724,8 @@ using FunctionRTrim = FunctionStringToString<TrimImpl<false, true>, NameRTrim>;
 
 using FunctionTrim = FunctionStringToString<TrimImpl<true, true>, NameTrim>;
 
+using FunctionUnHex = FunctionStringOperateToNullType<UnHexImpl>;
 using FunctionToBase64 = FunctionStringOperateToNullType<ToBase64Impl>;
-
 using FunctionFromBase64 = FunctionStringOperateToNullType<FromBase64Impl>;
 
 using FunctionStringAppendTrailingCharIfAbsent =

--- a/be/src/vec/functions/function_timestamp.cpp
+++ b/be/src/vec/functions/function_timestamp.cpp
@@ -21,6 +21,7 @@
 #include "vec/columns/column_nullable.h"
 #include "vec/columns/column_string.h"
 #include "vec/columns/column_vector.h"
+#include "vec/common/string_ref.h"
 #include "vec/data_types/data_type_date.h"
 #include "vec/data_types/data_type_date_time.h"
 #include "vec/data_types/data_type_number.h"
@@ -45,22 +46,18 @@ struct StrToDate {
     static Status execute(FunctionContext* context, Block& block, const ColumnNumbers& arguments,
                           size_t result, size_t input_rows_count) {
         auto null_map = ColumnUInt8::create(input_rows_count, 0);
-        ColumnPtr argument_columns[2];
 
-        // focus convert const to full column to simply execute logic
-        // handle
-        for (int i = 0; i < 2; ++i) {
-            argument_columns[i] =
-                    block.get_by_position(arguments[i]).column->convert_to_full_column_if_const();
-            if (auto* nullable = check_and_get_column<ColumnNullable>(*argument_columns[i])) {
-                // Danger: Here must dispose the null map data first! Because
-                // argument_columns[i]=nullable->get_nested_column_ptr(); will release the mem
-                // of column nullable mem of null map
-                VectorizedUtils::update_null_map(null_map->get_data(),
-                                                 nullable->get_null_map_data());
-                argument_columns[i] = nullable->get_nested_column_ptr();
-            }
-        }
+        const auto& col0 = block.get_by_position(arguments[0]).column;
+        bool col_const[2] = {is_column_const(*col0)};
+        ColumnPtr argument_columns[2] = {
+                col_const[0] ? static_cast<const ColumnConst&>(*col0).convert_to_full_column()
+                             : col0};
+        check_set_nullable(argument_columns[0], null_map);
+        //TODO: when we set default implementation for nullable, the check_set_nullable for arguments is useless. consider to remove it.
+
+        std::tie(argument_columns[1], col_const[1]) =
+                unpack_if_const(block.get_by_position(arguments[1]).column);
+        check_set_nullable(argument_columns[1], null_map);
 
         auto specific_str_column = assert_cast<const ColumnString*>(argument_columns[0].get());
         auto specific_char_column = assert_cast<const ColumnString*>(argument_columns[1].get());
@@ -75,34 +72,56 @@ struct StrToDate {
         WhichDataType which(remove_nullable(block.get_by_position(result).type));
         if (which.is_date_time_v2()) {
             res = ColumnVector<UInt64>::create();
-            executeImpl<DateV2Value<DateTimeV2ValueType>, UInt64>(
-                    context, ldata, loffsets, rdata, roffsets,
-                    static_cast<ColumnVector<UInt64>*>(res->assume_mutable().get())->get_data(),
-                    null_map->get_data());
+            if (col_const[1]) {
+                execute_impl_const_right<DateV2Value<DateTimeV2ValueType>, UInt64>(
+                        context, ldata, loffsets, specific_char_column->get_data_at(0),
+                        static_cast<ColumnVector<UInt64>*>(res->assume_mutable().get())->get_data(),
+                        null_map->get_data());
+            } else {
+                execute_impl<DateV2Value<DateTimeV2ValueType>, UInt64>(
+                        context, ldata, loffsets, rdata, roffsets,
+                        static_cast<ColumnVector<UInt64>*>(res->assume_mutable().get())->get_data(),
+                        null_map->get_data());
+            }
         } else if (which.is_date_v2()) {
             res = ColumnVector<UInt32>::create();
-            executeImpl<DateV2Value<DateV2ValueType>, UInt32>(
-                    context, ldata, loffsets, rdata, roffsets,
-                    static_cast<ColumnVector<UInt32>*>(res->assume_mutable().get())->get_data(),
-                    null_map->get_data());
+            if (col_const[1]) {
+                execute_impl_const_right<DateV2Value<DateV2ValueType>, UInt32>(
+                        context, ldata, loffsets, specific_char_column->get_data_at(0),
+                        static_cast<ColumnVector<UInt32>*>(res->assume_mutable().get())->get_data(),
+                        null_map->get_data());
+            } else {
+                execute_impl<DateV2Value<DateV2ValueType>, UInt32>(
+                        context, ldata, loffsets, rdata, roffsets,
+                        static_cast<ColumnVector<UInt32>*>(res->assume_mutable().get())->get_data(),
+                        null_map->get_data());
+            }
         } else {
             res = ColumnVector<Int64>::create();
-            executeImpl<VecDateTimeValue, Int64>(
-                    context, ldata, loffsets, rdata, roffsets,
-                    static_cast<ColumnVector<Int64>*>(res->assume_mutable().get())->get_data(),
-                    null_map->get_data());
+            if (col_const[1]) {
+                execute_impl_const_right<VecDateTimeValue, Int64>(
+                        context, ldata, loffsets, specific_char_column->get_data_at(0),
+                        static_cast<ColumnVector<Int64>*>(res->assume_mutable().get())->get_data(),
+                        null_map->get_data());
+            } else {
+                execute_impl<VecDateTimeValue, Int64>(
+                        context, ldata, loffsets, rdata, roffsets,
+                        static_cast<ColumnVector<Int64>*>(res->assume_mutable().get())->get_data(),
+                        null_map->get_data());
+            }
         }
 
-        block.get_by_position(result).column =
-                ColumnNullable::create(std::move(res), std::move(null_map));
+        block.get_by_position(result).column = ColumnNullable::create(res, std::move(null_map));
         return Status::OK();
     }
 
+private:
     template <typename DateValueType, typename NativeType>
-    static void executeImpl(FunctionContext* context, const ColumnString::Chars& ldata,
-                            const ColumnString::Offsets& loffsets, const ColumnString::Chars& rdata,
-                            const ColumnString::Offsets& roffsets, PaddedPODArray<NativeType>& res,
-                            NullMap& null_map) {
+    static void execute_impl(FunctionContext* context, const ColumnString::Chars& ldata,
+                             const ColumnString::Offsets& loffsets,
+                             const ColumnString::Chars& rdata,
+                             const ColumnString::Offsets& roffsets, PaddedPODArray<NativeType>& res,
+                             NullMap& null_map) {
         size_t size = loffsets.size();
         res.resize(size);
         for (size_t i = 0; i < size; ++i) {
@@ -114,6 +133,30 @@ struct StrToDate {
 
             auto& ts_val = *reinterpret_cast<DateValueType*>(&res[i]);
             if (!ts_val.from_date_format_str(r_raw_str, r_str_size, l_raw_str, l_str_size)) {
+                null_map[i] = 1;
+            }
+            if constexpr (std::is_same_v<DateValueType, VecDateTimeValue>) {
+                if (context->get_return_type().type == doris::PrimitiveType::TYPE_DATETIME) {
+                    ts_val.to_datetime();
+                } else {
+                    ts_val.cast_to_date();
+                }
+            }
+        }
+    }
+    template <typename DateValueType, typename NativeType>
+    static void execute_impl_const_right(FunctionContext* context, const ColumnString::Chars& ldata,
+                                         const ColumnString::Offsets& loffsets,
+                                         const StringRef& rdata, PaddedPODArray<NativeType>& res,
+                                         NullMap& null_map) {
+        size_t size = loffsets.size();
+        res.resize(size);
+        for (size_t i = 0; i < size; ++i) {
+            const char* l_raw_str = reinterpret_cast<const char*>(&ldata[loffsets[i - 1]]);
+            int l_str_size = loffsets[i] - loffsets[i - 1];
+
+            auto& ts_val = *reinterpret_cast<DateValueType*>(&res[i]);
+            if (!ts_val.from_date_format_str(rdata.data, rdata.size, l_raw_str, l_str_size)) {
                 null_map[i] = 1;
             }
             if constexpr (std::is_same_v<DateValueType, VecDateTimeValue>) {
@@ -142,53 +185,87 @@ struct MakeDateImpl {
                           size_t result, size_t input_rows_count) {
         auto null_map = ColumnUInt8::create(input_rows_count, 0);
         DCHECK_EQ(arguments.size(), 2);
-        ColumnPtr argument_columns[2];
-        for (int i = 0; i < 2; ++i) {
-            argument_columns[i] =
-                    block.get_by_position(arguments[i]).column->convert_to_full_column_if_const();
-            if (auto* nullable = check_and_get_column<ColumnNullable>(*argument_columns[i])) {
-                // Danger: Here must dispose the null map data first! Because
-                // argument_columns[i]=nullable->get_nested_column_ptr(); will release the mem
-                // of column nullable mem of null map
-                VectorizedUtils::update_null_map(null_map->get_data(),
-                                                 nullable->get_null_map_data());
-                argument_columns[i] = nullable->get_nested_column_ptr();
-            }
-        }
+
+        const auto& col0 = block.get_by_position(arguments[0]).column;
+        bool col_const[2] = {is_column_const(*col0)};
+        ColumnPtr argument_columns[2] = {
+                col_const[0] ? static_cast<const ColumnConst&>(*col0).convert_to_full_column()
+                             : col0};
+        check_set_nullable(argument_columns[0], null_map);
+
+        std::tie(argument_columns[1], col_const[1]) =
+                unpack_if_const(block.get_by_position(arguments[1]).column);
+        check_set_nullable(argument_columns[1], null_map);
 
         ColumnPtr res = nullptr;
         WhichDataType which(remove_nullable(block.get_by_position(result).type));
         if (which.is_date_v2()) {
             res = ColumnVector<UInt32>::create();
-            executeImpl<DateV2Value<DateV2ValueType>, UInt32>(
-                    static_cast<const ColumnVector<Int32>*>(argument_columns[0].get())->get_data(),
-                    static_cast<const ColumnVector<Int32>*>(argument_columns[1].get())->get_data(),
-                    static_cast<ColumnVector<UInt32>*>(res->assume_mutable().get())->get_data(),
-                    null_map->get_data());
+            if (col_const[1]) {
+                execute_impl_right_const<DateV2Value<DateV2ValueType>, UInt32>(
+                        static_cast<const ColumnVector<Int32>*>(argument_columns[0].get())
+                                ->get_data(),
+                        static_cast<const ColumnVector<Int32>*>(argument_columns[1].get())
+                                ->get_element(0),
+                        static_cast<ColumnVector<UInt32>*>(res->assume_mutable().get())->get_data(),
+                        null_map->get_data());
+            } else {
+                execute_impl<DateV2Value<DateV2ValueType>, UInt32>(
+                        static_cast<const ColumnVector<Int32>*>(argument_columns[0].get())
+                                ->get_data(),
+                        static_cast<const ColumnVector<Int32>*>(argument_columns[1].get())
+                                ->get_data(),
+                        static_cast<ColumnVector<UInt32>*>(res->assume_mutable().get())->get_data(),
+                        null_map->get_data());
+            }
         } else if (which.is_date_time_v2()) {
             res = ColumnVector<UInt64>::create();
-            executeImpl<DateV2Value<DateTimeV2ValueType>, UInt64>(
-                    static_cast<const ColumnVector<Int32>*>(argument_columns[0].get())->get_data(),
-                    static_cast<const ColumnVector<Int32>*>(argument_columns[1].get())->get_data(),
-                    static_cast<ColumnVector<UInt64>*>(res->assume_mutable().get())->get_data(),
-                    null_map->get_data());
+            if (col_const[1]) {
+                execute_impl_right_const<DateV2Value<DateTimeV2ValueType>, UInt64>(
+                        static_cast<const ColumnVector<Int32>*>(argument_columns[0].get())
+                                ->get_data(),
+                        static_cast<const ColumnVector<Int32>*>(argument_columns[1].get())
+                                ->get_element(0),
+                        static_cast<ColumnVector<UInt64>*>(res->assume_mutable().get())->get_data(),
+                        null_map->get_data());
+            } else {
+                execute_impl<DateV2Value<DateTimeV2ValueType>, UInt64>(
+                        static_cast<const ColumnVector<Int32>*>(argument_columns[0].get())
+                                ->get_data(),
+                        static_cast<const ColumnVector<Int32>*>(argument_columns[1].get())
+                                ->get_data(),
+                        static_cast<ColumnVector<UInt64>*>(res->assume_mutable().get())->get_data(),
+                        null_map->get_data());
+            }
         } else {
             res = ColumnVector<Int64>::create();
-            executeImpl<VecDateTimeValue, Int64>(
-                    static_cast<const ColumnVector<Int32>*>(argument_columns[0].get())->get_data(),
-                    static_cast<const ColumnVector<Int32>*>(argument_columns[1].get())->get_data(),
-                    static_cast<ColumnVector<Int64>*>(res->assume_mutable().get())->get_data(),
-                    null_map->get_data());
+            if (col_const[1]) {
+                execute_impl_right_const<VecDateTimeValue, Int64>(
+                        static_cast<const ColumnVector<Int32>*>(argument_columns[0].get())
+                                ->get_data(),
+                        static_cast<const ColumnVector<Int32>*>(argument_columns[1].get())
+                                ->get_element(0),
+                        static_cast<ColumnVector<Int64>*>(res->assume_mutable().get())->get_data(),
+                        null_map->get_data());
+            } else {
+                execute_impl<VecDateTimeValue, Int64>(
+                        static_cast<const ColumnVector<Int32>*>(argument_columns[0].get())
+                                ->get_data(),
+                        static_cast<const ColumnVector<Int32>*>(argument_columns[1].get())
+                                ->get_data(),
+                        static_cast<ColumnVector<Int64>*>(res->assume_mutable().get())->get_data(),
+                        null_map->get_data());
+            }
         }
 
-        block.get_by_position(result).column =
-                ColumnNullable::create(std::move(res), std::move(null_map));
+        block.get_by_position(result).column = ColumnNullable::create(res, std::move(null_map));
         return Status::OK();
     }
 
+private:
     template <typename DateValueType, typename ReturnType>
-    static void executeImpl(const PaddedPODArray<Int32>& ldata, const PaddedPODArray<Int32>& rdata,
-                            PaddedPODArray<ReturnType>& res, NullMap& null_map) {
+    static void execute_impl(const PaddedPODArray<Int32>& ldata, const PaddedPODArray<Int32>& rdata,
+                             PaddedPODArray<ReturnType>& res, NullMap& null_map) {
         auto len = ldata.size();
         res.resize(len);
 
@@ -207,6 +284,48 @@ struct MakeDateImpl {
 
                 TimeInterval interval(DAY, r - 1, false);
                 res_val = ts_value;
+                if (!res_val.template date_add_interval<DAY>(interval)) {
+                    null_map[i] = 1;
+                    continue;
+                }
+                res_val.cast_to_date();
+            } else {
+                res_val.set_time(l, 1, 1, 0, 0, 0, 0);
+                TimeInterval interval(DAY, r - 1, false);
+                if (!res_val.template date_add_interval<DAY>(interval)) {
+                    null_map[i] = 1;
+                }
+            }
+        }
+    }
+    template <typename DateValueType, typename ReturnType>
+    static void execute_impl_right_const(const PaddedPODArray<Int32>& ldata, Int32 rdata,
+                                         PaddedPODArray<ReturnType>& res, NullMap& null_map) {
+        auto len = ldata.size();
+        res.resize(len);
+
+        const auto& r = rdata;
+        for (size_t i = 0; i < len; ++i) {
+            const auto& l = ldata[i];
+            if (r <= 0 || l < 0 || l > 9999) {
+                null_map[i] = 1;
+                continue;
+            }
+
+            auto& res_val = *reinterpret_cast<DateValueType*>(&res[i]);
+            if constexpr (std::is_same_v<DateValueType, VecDateTimeValue>) {
+                VecDateTimeValue ts_value = VecDateTimeValue();
+                ts_value.set_time(l, 1, 1, 0, 0, 0);
+
+                DateTimeVal ts_val;
+                ts_value.to_datetime_val(&ts_val);
+                if (ts_val.is_null) {
+                    null_map[i] = 1;
+                    continue;
+                }
+
+                TimeInterval interval(DAY, r - 1, false);
+                res_val = VecDateTimeValue::from_datetime_val(ts_val);
                 if (!res_val.template date_add_interval<DAY>(interval)) {
                     null_map[i] = 1;
                     continue;
@@ -248,34 +367,74 @@ struct DateTrunc {
     static Status execute(FunctionContext* context, Block& block, const ColumnNumbers& arguments,
                           size_t result, size_t input_rows_count) {
         DCHECK_EQ(arguments.size(), 2);
-        ColumnPtr argument_columns[2];
+
         auto null_map = ColumnUInt8::create(input_rows_count, 0);
-        argument_columns[0] =
-                block.get_by_position(arguments[0]).column->convert_to_full_column_if_const();
-        argument_columns[1] =
-                block.get_by_position(arguments[1]).column->convert_to_full_column_if_const();
+        const auto& col0 = block.get_by_position(arguments[0]).column;
+        bool col_const[2] = {is_column_const(*col0)};
+        ColumnPtr argument_columns[2] = {
+                col_const[0] ? static_cast<const ColumnConst&>(*col0).convert_to_full_column()
+                             : col0};
+
+        std::tie(argument_columns[1], col_const[1]) =
+                unpack_if_const(block.get_by_position(arguments[1]).column);
+
         auto datetime_column = static_cast<const ColumnVector<ArgType>*>(argument_columns[0].get());
         auto str_column = static_cast<const ColumnString*>(argument_columns[1].get());
         auto& rdata = str_column->get_chars();
         auto& roffsets = str_column->get_offsets();
 
         ColumnPtr res = ColumnVector<ArgType>::create();
-        executeImpl(datetime_column->get_data(), rdata, roffsets,
+        if (col_const[1]) {
+            execute_impl_right_const(
+                    datetime_column->get_data(), str_column->get_data_at(0),
                     static_cast<ColumnVector<ArgType>*>(res->assume_mutable().get())->get_data(),
                     null_map->get_data(), input_rows_count);
+        } else {
+            execute_impl(
+                    datetime_column->get_data(), rdata, roffsets,
+                    static_cast<ColumnVector<ArgType>*>(res->assume_mutable().get())->get_data(),
+                    null_map->get_data(), input_rows_count);
+        }
 
-        block.get_by_position(result).column =
-                ColumnNullable::create(std::move(res), std::move(null_map));
+        block.get_by_position(result).column = ColumnNullable::create(res, std::move(null_map));
         return Status::OK();
     }
 
-    static void executeImpl(const PaddedPODArray<ArgType>& ldata, const ColumnString::Chars& rdata,
-                            const ColumnString::Offsets& roffsets, PaddedPODArray<ArgType>& res,
-                            NullMap& null_map, size_t input_rows_count) {
+private:
+    static void execute_impl(const PaddedPODArray<ArgType>& ldata, const ColumnString::Chars& rdata,
+                             const ColumnString::Offsets& roffsets, PaddedPODArray<ArgType>& res,
+                             NullMap& null_map, size_t input_rows_count) {
         res.resize(input_rows_count);
         for (size_t i = 0; i < input_rows_count; ++i) {
             auto dt = binary_cast<ArgType, DateValueType>(ldata[i]);
             const char* str_data = reinterpret_cast<const char*>(&rdata[roffsets[i - 1]]);
+            if (std::strncmp("year", str_data, 4) == 0) {
+                null_map[i] = !dt.template datetime_trunc<YEAR>();
+            } else if (std::strncmp("quarter", str_data, 7) == 0) {
+                null_map[i] = !dt.template datetime_trunc<QUARTER>();
+            } else if (std::strncmp("month", str_data, 5) == 0) {
+                null_map[i] = !dt.template datetime_trunc<MONTH>();
+            } else if (std::strncmp("day", str_data, 3) == 0) {
+                null_map[i] = !dt.template datetime_trunc<DAY>();
+            } else if (std::strncmp("hour", str_data, 4) == 0) {
+                null_map[i] = !dt.template datetime_trunc<HOUR>();
+            } else if (std::strncmp("minute", str_data, 6) == 0) {
+                null_map[i] = !dt.template datetime_trunc<MINUTE>();
+            } else if (std::strncmp("second", str_data, 6) == 0) {
+                null_map[i] = !dt.template datetime_trunc<SECOND>();
+            } else {
+                null_map[i] = 1;
+            }
+            res[i] = binary_cast<DateValueType, ArgType>(dt);
+        }
+    }
+    static void execute_impl_right_const(const PaddedPODArray<ArgType>& ldata,
+                                         const StringRef& rdata, PaddedPODArray<ArgType>& res,
+                                         NullMap& null_map, size_t input_rows_count) {
+        res.resize(input_rows_count);
+        for (size_t i = 0; i < input_rows_count; ++i) {
+            auto dt = binary_cast<ArgType, DateValueType>(ldata[i]);
+            const char* const& str_data = rdata.data;
             if (std::strncmp("year", str_data, 4) == 0) {
                 null_map[i] = !dt.template datetime_trunc<YEAR>();
             } else if (std::strncmp("quarter", str_data, 7) == 0) {
@@ -669,8 +828,7 @@ struct LastDayImpl {
                                size_t input_rows_count) {
         const auto is_nullable = block.get_by_position(result).type->is_nullable();
         ColumnPtr res_column;
-        ColumnPtr argument_column = remove_nullable(block.get_by_position(arguments[0]).column)
-                                            ->convert_to_full_column_if_const();
+        ColumnPtr argument_column = remove_nullable(block.get_by_position(arguments[0]).column);
         if (is_nullable) {
             auto null_map = ColumnUInt8::create(input_rows_count, 0);
             if constexpr (std::is_same_v<DateType, DataTypeDateTime> ||
@@ -698,6 +856,7 @@ struct LastDayImpl {
                         static_cast<ColumnVector<UInt32>*>(res_column->assume_mutable().get())
                                 ->get_data());
             }
+
             if (const auto* nullable_col = check_and_get_column<ColumnNullable>(
                         block.get_by_position(arguments[0]).column.get())) {
                 NullMap& result_null_map = assert_cast<ColumnUInt8&>(*null_map).get_data();
@@ -822,8 +981,7 @@ struct MondayImpl {
                                const ColumnNumbers& arguments, size_t result,
                                size_t input_rows_count) {
         const auto is_nullable = block.get_by_position(result).type->is_nullable();
-        ColumnPtr argument_column = remove_nullable(block.get_by_position(arguments[0]).column)
-                                            ->convert_to_full_column_if_const();
+        ColumnPtr argument_column = remove_nullable(block.get_by_position(arguments[0]).column);
         ColumnPtr res_column;
         if (is_nullable) {
             auto null_map = ColumnUInt8::create(input_rows_count, 0);
@@ -1025,6 +1183,7 @@ public:
     }
 
     bool use_default_implementation_for_constants() const override { return true; }
+    ColumnNumbers get_arguments_that_are_always_constant() const override { return {1}; }
 
     Status execute_impl(FunctionContext* context, Block& block, const ColumnNumbers& arguments,
                         size_t result, size_t input_rows_count) override {

--- a/be/src/vec/functions/function_timestamp.cpp
+++ b/be/src/vec/functions/function_timestamp.cpp
@@ -1183,7 +1183,8 @@ public:
     }
 
     bool use_default_implementation_for_constants() const override { return true; }
-    ColumnNumbers get_arguments_that_are_always_constant() const override { return {1}; }
+    //TODO: add function below when we fixed be-ut.
+    //ColumnNumbers get_arguments_that_are_always_constant() const override { return {1}; }
 
     Status execute_impl(FunctionContext* context, Block& block, const ColumnNumbers& arguments,
                         size_t result, size_t input_rows_count) override {

--- a/be/src/vec/functions/function_timestamp.cpp
+++ b/be/src/vec/functions/function_timestamp.cpp
@@ -317,15 +317,8 @@ private:
                 VecDateTimeValue ts_value = VecDateTimeValue();
                 ts_value.set_time(l, 1, 1, 0, 0, 0);
 
-                DateTimeVal ts_val;
-                ts_value.to_datetime_val(&ts_val);
-                if (ts_val.is_null) {
-                    null_map[i] = 1;
-                    continue;
-                }
-
                 TimeInterval interval(DAY, r - 1, false);
-                res_val = VecDateTimeValue::from_datetime_val(ts_val);
+                res_val = ts_value;
                 if (!res_val.template date_add_interval<DAY>(interval)) {
                     null_map[i] = 1;
                     continue;

--- a/be/src/vec/functions/function_totype.h
+++ b/be/src/vec/functions/function_totype.h
@@ -19,6 +19,8 @@
 #include <fmt/format.h>
 
 #include "vec/columns/column_complex.h"
+#include "vec/columns/column_const.h"
+#include "vec/columns/column_nullable.h"
 #include "vec/columns/column_string.h"
 #include "vec/columns/column_vector.h"
 #include "vec/data_types/data_type.h"
@@ -57,7 +59,9 @@ public:
     }
 
     DataTypes get_variadic_argument_types_impl() const override {
-        if constexpr (has_variadic_argument) return Impl::get_variadic_argument_types();
+        if constexpr (has_variadic_argument) {
+            return Impl::get_variadic_argument_types();
+        }
         return {};
     }
 
@@ -143,10 +147,10 @@ public:
     Status execute_impl(FunctionContext* context, Block& block, const ColumnNumbers& arguments,
                         size_t result, size_t /*input_rows_count*/) override {
         DCHECK_EQ(arguments.size(), 2);
-        const auto& left = block.get_by_position(arguments[0]);
-        auto lcol = left.column->convert_to_full_column_if_const();
-        const auto& right = block.get_by_position(arguments[1]);
-        auto rcol = right.column->convert_to_full_column_if_const();
+        const auto& [lcol, left_const] =
+                unpack_if_const(block.get_by_position(arguments[0]).column);
+        const auto& [rcol, right_const] =
+                unpack_if_const(block.get_by_position(arguments[1]).column);
 
         using ResultDataType = typename Impl<LeftDataType, RightDataType>::ResultDataType;
 
@@ -171,8 +175,17 @@ public:
 
         if (auto col_left = check_and_get_column<ColVecLeft>(lcol.get())) {
             if (auto col_right = check_and_get_column<ColVecRight>(rcol.get())) {
-                Impl<LeftDataType, RightDataType>::vector_vector(col_left->get_data(),
-                                                                 col_right->get_data(), vec_res);
+                if (left_const) {
+                    Impl<LeftDataType, RightDataType>::scalar_vector(
+                            col_left->get_data()[0], col_right->get_data(), vec_res);
+                } else if (right_const) {
+                    Impl<LeftDataType, RightDataType>::vector_scalar(
+                            col_left->get_data(), col_right->get_data()[0], vec_res);
+                } else {
+                    Impl<LeftDataType, RightDataType>::vector_vector(
+                            col_left->get_data(), col_right->get_data(), vec_res);
+                }
+
                 block.replace_by_position(result, std::move(col_res));
                 return Status::OK();
             }
@@ -221,8 +234,8 @@ private:
                       nullptr>
     Status execute_inner_impl(const ColumnWithTypeAndName& left, const ColumnWithTypeAndName& right,
                               Block& block, const ColumnNumbers& arguments, size_t result) {
-        auto lcol = left.column->convert_to_full_column_if_const();
-        auto rcol = right.column->convert_to_full_column_if_const();
+        const auto& [lcol, left_const] = unpack_if_const(left.column);
+        const auto& [rcol, right_const] = unpack_if_const(right.column);
 
         using ResultType = typename ResultDataType::FieldType;
         using ColVecResult = ColumnVector<ResultType>;
@@ -233,9 +246,20 @@ private:
 
         if (auto col_left = check_and_get_column<ColVecLeft>(lcol.get())) {
             if (auto col_right = check_and_get_column<ColVecRight>(rcol.get())) {
-                Impl<LeftDataType, RightDataType>::vector_vector(
-                        col_left->get_chars(), col_left->get_offsets(), col_right->get_chars(),
-                        col_right->get_offsets(), vec_res);
+                if (left_const) {
+                    Impl<LeftDataType, RightDataType>::scalar_vector(
+                            col_left->get_data_at(0), col_right->get_chars(),
+                            col_right->get_offsets(), vec_res);
+                } else if (right_const) {
+                    Impl<LeftDataType, RightDataType>::vector_scalar(
+                            col_left->get_chars(), col_left->get_offsets(),
+                            col_right->get_data_at(0), vec_res);
+                } else {
+                    Impl<LeftDataType, RightDataType>::vector_vector(
+                            col_left->get_chars(), col_left->get_offsets(), col_right->get_chars(),
+                            col_right->get_offsets(), vec_res);
+                }
+
                 block.replace_by_position(result, std::move(col_res));
                 return Status::OK();
             }
@@ -248,16 +272,28 @@ private:
                       nullptr>
     Status execute_inner_impl(const ColumnWithTypeAndName& left, const ColumnWithTypeAndName& right,
                               Block& block, const ColumnNumbers& arguments, size_t result) {
-        auto lcol = left.column->convert_to_full_column_if_const();
-        auto rcol = right.column->convert_to_full_column_if_const();
+        const auto& [lcol, left_const] = unpack_if_const(left.column);
+        const auto& [rcol, right_const] = unpack_if_const(right.column);
 
         using ColVecResult = ColumnString;
         typename ColVecResult::MutablePtr col_res = ColVecResult::create();
         if (auto col_left = check_and_get_column<ColVecLeft>(lcol.get())) {
             if (auto col_right = check_and_get_column<ColVecRight>(rcol.get())) {
-                Impl<LeftDataType, RightDataType>::vector_vector(
-                        col_left->get_chars(), col_left->get_offsets(), col_right->get_chars(),
-                        col_right->get_offsets(), col_res->get_chars(), col_res->get_offsets());
+                if (left_const) {
+                    Impl<LeftDataType, RightDataType>::scalar_vector(
+                            col_left->get_data_at(0), col_right->get_chars(),
+                            col_right->get_offsets(), col_res->get_chars(), col_res->get_offsets());
+                } else if (right_const) {
+                    Impl<LeftDataType, RightDataType>::vector_scalar(
+                            col_left->get_chars(), col_left->get_offsets(),
+                            col_right->get_data_at(0), col_res->get_chars(),
+                            col_res->get_offsets());
+                } else {
+                    Impl<LeftDataType, RightDataType>::vector_vector(
+                            col_left->get_chars(), col_left->get_offsets(), col_right->get_chars(),
+                            col_right->get_offsets(), col_res->get_chars(), col_res->get_offsets());
+                }
+
                 block.replace_by_position(result, std::move(col_res));
                 return Status::OK();
             }
@@ -288,18 +324,13 @@ public:
                         size_t result, size_t input_rows_count) override {
         auto null_map = ColumnUInt8::create(input_rows_count, 0);
         DCHECK_EQ(arguments.size(), 2);
+
         ColumnPtr argument_columns[2];
+        bool col_const[2];
         for (int i = 0; i < 2; ++i) {
-            argument_columns[i] =
-                    block.get_by_position(arguments[i]).column->convert_to_full_column_if_const();
-            if (auto* nullable = check_and_get_column<ColumnNullable>(*argument_columns[i])) {
-                // Danger: Here must dispose the null map data first! Because
-                // argument_columns[i]=nullable->get_nested_column_ptr(); will release the mem
-                // of column nullable mem of null map
-                VectorizedUtils::update_null_map(null_map->get_data(),
-                                                 nullable->get_null_map_data());
-                argument_columns[i] = nullable->get_nested_column_ptr();
-            }
+            std::tie(argument_columns[i], col_const[i]) =
+                    unpack_if_const(block.get_by_position(arguments[i]).column);
+            check_set_nullable(argument_columns[i], null_map);
         }
 
         using ResultDataType = typename Impl<LeftDataType, RightDataType, ResultDateType,
@@ -326,8 +357,20 @@ public:
 
         if (auto col_left = check_and_get_column<ColVecLeft>(argument_columns[0].get())) {
             if (auto col_right = check_and_get_column<ColVecRight>(argument_columns[1].get())) {
-                Impl<LeftDataType, RightDataType, ResultDateType, ReturnType>::vector_vector(
-                        col_left->get_data(), col_right->get_data(), vec_res, null_map->get_data());
+                if (col_const[0]) {
+                    Impl<LeftDataType, RightDataType, ResultDateType, ReturnType>::scalar_vector(
+                            col_left->get_data()[0], col_right->get_data(), vec_res,
+                            null_map->get_data());
+                } else if (col_const[1]) {
+                    Impl<LeftDataType, RightDataType, ResultDateType, ReturnType>::vector_scalar(
+                            col_left->get_data(), col_right->get_data()[0], vec_res,
+                            null_map->get_data());
+                } else {
+                    Impl<LeftDataType, RightDataType, ResultDateType, ReturnType>::vector_vector(
+                            col_left->get_data(), col_right->get_data(), vec_res,
+                            null_map->get_data());
+                }
+
                 block.get_by_position(result).column =
                         ColumnNullable::create(std::move(col_res), std::move(null_map));
                 return Status::OK();
@@ -355,20 +398,11 @@ public:
                         size_t result, size_t input_rows_count) override {
         auto null_map = ColumnUInt8::create(input_rows_count, 0);
         ColumnPtr argument_columns[2];
-
-        // focus convert const to full column to simply execute logic
-        // handle
+        bool col_const[2];
         for (int i = 0; i < 2; ++i) {
-            argument_columns[i] =
-                    block.get_by_position(arguments[i]).column->convert_to_full_column_if_const();
-            if (auto* nullable = check_and_get_column<ColumnNullable>(*argument_columns[i])) {
-                // Danger: Here must dispose the null map data first! Because
-                // argument_columns[i]=nullable->get_nested_column_ptr(); will release the mem
-                // of column nullable mem of null map
-                VectorizedUtils::update_null_map(null_map->get_data(),
-                                                 nullable->get_null_map_data());
-                argument_columns[i] = nullable->get_nested_column_ptr();
-            }
+            std::tie(argument_columns[i], col_const[i]) =
+                    unpack_if_const(block.get_by_position(arguments[i]).column);
+            check_set_nullable(argument_columns[i], null_map);
         }
 
         auto res = Impl::ColumnType::create();
@@ -386,11 +420,27 @@ public:
         if constexpr (std::is_same_v<typename Impl::ReturnType, DataTypeString>) {
             auto& res_data = res->get_chars();
             auto& res_offsets = res->get_offsets();
-            Impl::vector_vector(context, ldata, loffsets, rdata, roffsets, res_data, res_offsets,
-                                null_map->get_data());
+            if (col_const[0]) {
+                Impl::scalar_vector(context, specific_str_column->get_data_at(0), rdata, roffsets,
+                                    res_data, res_offsets, null_map->get_data());
+            } else if (col_const[1]) {
+                Impl::vector_scalar(context, ldata, loffsets, specific_char_column->get_data_at(0),
+                                    res_data, res_offsets, null_map->get_data());
+            } else {
+                Impl::vector_vector(context, ldata, loffsets, rdata, roffsets, res_data,
+                                    res_offsets, null_map->get_data());
+            }
         } else {
-            Impl::vector_vector(context, ldata, loffsets, rdata, roffsets, res->get_data(),
-                                null_map->get_data());
+            if (col_const[0]) {
+                Impl::scalar_vector(context, specific_str_column->get_data_at(0), rdata, roffsets,
+                                    res->get_data(), null_map->get_data());
+            } else if (col_const[1]) {
+                Impl::vector_scalar(context, ldata, loffsets, specific_char_column->get_data_at(0),
+                                    res->get_data(), null_map->get_data());
+            } else {
+                Impl::vector_vector(context, ldata, loffsets, rdata, roffsets, res->get_data(),
+                                    null_map->get_data());
+            }
         }
 
         block.get_by_position(result).column =

--- a/be/src/vec/functions/functions_comparison.h
+++ b/be/src/vec/functions/functions_comparison.h
@@ -61,11 +61,6 @@ struct NumComparisonImpl {
     /// If you don't specify NO_INLINE, the compiler will inline this function, but we don't need this as this function contains tight loop inside.
     static void NO_INLINE vector_vector(const PaddedPODArray<A>& a, const PaddedPODArray<B>& b,
                                         PaddedPODArray<UInt8>& c) {
-        /** GCC 4.8.2 vectorized a loop only if it is written in this form.
-          * In this case, if you loop through the array index (the code will look simpler),
-          *  the loop will not be vectorized.
-          */
-
         size_t size = a.size();
         const A* a_pos = a.data();
         const B* b_pos = b.data();
@@ -104,17 +99,17 @@ struct NumComparisonImpl {
 /// Generic version, implemented for columns of same type.
 template <typename Op>
 struct GenericComparisonImpl {
-    static void NO_INLINE vector_vector(const IColumn& a, const IColumn& b,
-                                        PaddedPODArray<UInt8>& c) {
-        for (size_t i = 0, size = a.size(); i < size; ++i)
+    static void vector_vector(const IColumn& a, const IColumn& b, PaddedPODArray<UInt8>& c) {
+        for (size_t i = 0, size = a.size(); i < size; ++i) {
             c[i] = Op::apply(a.compare_at(i, i, b, 1), 0);
+        }
     }
 
-    static void NO_INLINE vector_constant(const IColumn& a, const IColumn& b,
-                                          PaddedPODArray<UInt8>& c) {
-        auto b_materialized = b.clone_resized(1)->convert_to_full_column_if_const();
-        for (size_t i = 0, size = a.size(); i < size; ++i)
-            c[i] = Op::apply(a.compare_at(i, 0, *b_materialized, 1), 0);
+    static void vector_constant(const IColumn& a, const IColumn& b, PaddedPODArray<UInt8>& c) {
+        const auto& col_right = assert_cast<const ColumnConst&>(b).get_data_column();
+        for (size_t i = 0, size = a.size(); i < size; ++i) {
+            c[i] = Op::apply(a.compare_at(i, 0, col_right, 1), 0);
+        }
     }
 
     static void constant_vector(const IColumn& a, const IColumn& b, PaddedPODArray<UInt8>& c) {
@@ -532,7 +527,7 @@ public:
         if (left_type->equals(*right_type) && !left_type->is_nullable() &&
             col_left_untyped == col_right_untyped) {
             /// Always true: =, <=, >=
-            // TODO: Return const column in the future
+            // TODO: Return const column in the future. But seems so far to do. We need a unified approach for passing const column.
             if constexpr (std::is_same_v<Op<int, int>, EqualsOp<int, int>> ||
                           std::is_same_v<Op<int, int>, LessOrEqualsOp<int, int>> ||
                           std::is_same_v<Op<int, int>, GreaterOrEqualsOp<int, int>>) {

--- a/be/src/vec/functions/least_greast.cpp
+++ b/be/src/vec/functions/least_greast.cpp
@@ -34,8 +34,68 @@ struct CompareMultiImpl {
 
     static DataTypePtr get_return_type_impl(const DataTypes& arguments) { return arguments[0]; }
 
+    static ColumnPtr execute(Block& block, const ColumnNumbers& arguments,
+                             size_t input_rows_count) {
+        if (arguments.size() == 1) {
+            return block.get_by_position(arguments.back()).column;
+        }
+
+        const auto& data_type = block.get_by_position(arguments.back()).type;
+        MutableColumnPtr result_column = data_type->create_column();
+
+        Columns cols(arguments.size());
+        std::unique_ptr<bool[]> col_const = std::make_unique<bool[]>(arguments.size());
+        for (int i = 0; i < arguments.size(); ++i) {
+            std::tie(cols[i], col_const[i]) =
+                    unpack_if_const(block.get_by_position(arguments[i]).column);
+        }
+        // because now the string types does not support random position writing,
+        // so insert into result data have two methods, one is for string types, one is for others type remaining
+        if (result_column->is_column_string()) {
+            result_column->reserve(input_rows_count);
+            const auto& column_string = reinterpret_cast<const ColumnString&>(*cols[0]);
+            auto& column_res = reinterpret_cast<ColumnString&>(*result_column);
+
+            //TODO: consider swap order of these cycles.
+            for (int i = 0; i < input_rows_count; ++i) {
+                auto str_data = column_string.get_data_at(i);
+                for (int cmp_col = 1; cmp_col < arguments.size(); ++cmp_col) {
+                    auto temp_data =
+                            reinterpret_cast<const ColumnString&>(*cols[cmp_col]).get_data_at(i);
+                    str_data = Op<StringRef, StringRef>::apply(temp_data, str_data) ? temp_data
+                                                                                    : str_data;
+                }
+                column_res.insert_data(str_data.data, str_data.size);
+            }
+
+        } else {
+            result_column->insert_range_from(*(cols[0]), 0, input_rows_count);
+            WhichDataType which(data_type);
+
+#define DISPATCH(TYPE, COLUMN_TYPE)                                                              \
+    if (which.idx == TypeIndex::TYPE) {                                                          \
+        for (int i = 1; i < arguments.size(); ++i) {                                             \
+            if (col_const[i]) {                                                                  \
+                insert_result_data_const<COLUMN_TYPE>(result_column, cols[i], input_rows_count); \
+            } else {                                                                             \
+                insert_result_data<COLUMN_TYPE>(result_column, cols[i], input_rows_count);       \
+            }                                                                                    \
+        }                                                                                        \
+    }
+
+            NUMERIC_TYPE_TO_COLUMN_TYPE(DISPATCH)
+            DISPATCH(Decimal128, ColumnDecimal<Decimal128>)
+            TIME_TYPE_TO_COLUMN_TYPE(DISPATCH)
+#undef DISPATCH
+        }
+
+        return result_column;
+    }
+
+private:
     template <typename ColumnType>
-    static void insert_result_data(MutableColumnPtr& result_column, ColumnPtr& argument_column,
+    static void insert_result_data(const MutableColumnPtr& result_column,
+                                   const ColumnPtr& argument_column,
                                    const size_t input_rows_count) {
         auto* __restrict result_raw_data =
                 reinterpret_cast<ColumnType*>(result_column.get())->get_data().data();
@@ -59,56 +119,30 @@ struct CompareMultiImpl {
         }
     }
 
-    static ColumnPtr execute(Block& block, const ColumnNumbers& arguments,
-                             size_t input_rows_count) {
-        if (arguments.size() == 1) return block.get_by_position(arguments.back()).column;
+    template <typename ColumnType>
+    static void insert_result_data_const(const MutableColumnPtr& result_column,
+                                         const ColumnPtr& argument_column,
+                                         const size_t input_rows_count) {
+        auto* __restrict result_raw_data =
+                reinterpret_cast<ColumnType*>(result_column.get())->get_data().data();
+        auto* __restrict column_raw_data =
+                reinterpret_cast<const ColumnType*>(argument_column.get())->get_data().data();
 
-        const auto& data_type = block.get_by_position(arguments.back()).type;
-        MutableColumnPtr result_column = data_type->create_column();
-
-        Columns args;
-        for (int i = 0; i < arguments.size(); ++i) {
-            args.emplace_back(
-                    block.get_by_position(arguments[i]).column->convert_to_full_column_if_const());
-        }
-        // because now the string types does not support random position writing,
-        // so insert into result data have two methods, one is for string types, one is for others type remaining
-        bool is_string_result = result_column->is_column_string();
-        if (is_string_result) {
-            result_column->reserve(input_rows_count);
-        } else {
-            result_column->insert_range_from(*(args[0]), 0, input_rows_count);
-        }
-
-        if (is_string_result) {
-            const auto& column_string = reinterpret_cast<const ColumnString&>(*args[0]);
-            auto& column_res = reinterpret_cast<ColumnString&>(*result_column);
-
-            for (int i = 0; i < input_rows_count; ++i) {
-                auto str_data = column_string.get_data_at(i);
-                for (int j = 1; j < arguments.size(); ++j) {
-                    auto temp_data = reinterpret_cast<const ColumnString&>(*args[j]).get_data_at(i);
-                    str_data = Op<StringRef, StringRef>::apply(temp_data, str_data) ? temp_data
-                                                                                    : str_data;
-                }
-                column_res.insert_data(str_data.data, str_data.size);
+        if constexpr (std::is_same_v<ColumnType, ColumnDecimal128>) {
+            for (size_t i = 0; i < input_rows_count; ++i) {
+                result_raw_data[i] = Op<DecimalV2Value, DecimalV2Value>::apply(column_raw_data[0],
+                                                                               result_raw_data[i])
+                                             ? column_raw_data[0]
+                                             : result_raw_data[i];
             }
-
         } else {
-            WhichDataType which(data_type);
-#define DISPATCH(TYPE, COLUMN_TYPE)                                                    \
-    if (which.idx == TypeIndex::TYPE) {                                                \
-        for (int i = 1; i < arguments.size(); ++i) {                                   \
-            insert_result_data<COLUMN_TYPE>(result_column, args[i], input_rows_count); \
-        }                                                                              \
-    }
-            NUMERIC_TYPE_TO_COLUMN_TYPE(DISPATCH)
-            DISPATCH(Decimal128, ColumnDecimal<Decimal128>)
-            TIME_TYPE_TO_COLUMN_TYPE(DISPATCH)
-#undef DISPATCH
+            for (size_t i = 0; i < input_rows_count; ++i) {
+                using type = std::decay_t<decltype(result_raw_data[0])>;
+                result_raw_data[i] = Op<type, type>::apply(column_raw_data[0], result_raw_data[i])
+                                             ? column_raw_data[0]
+                                             : result_raw_data[i];
+            }
         }
-
-        return result_column;
     }
 };
 
@@ -169,6 +203,31 @@ private:
     static void insert_result_data(PaddedPODArray<Int32>& __restrict res_data,
                                    ColumnPtr first_column, ColumnPtr argument_column,
                                    const size_t input_rows_count, const int col) {
+        auto* __restrict first_raw_data =
+                reinterpret_cast<const ColumnType*>(first_column.get())->get_data().data();
+        const auto& column_raw_data =
+                reinterpret_cast<const ColumnConst&>(*argument_column).get_data_column();
+        const auto& arg_data =
+                reinterpret_cast<const ColumnType&>(column_raw_data).get_data().data()[0];
+        if constexpr (std::is_same_v<ColumnType, ColumnDecimal128>) {
+            for (size_t i = 0; i < input_rows_count; ++i) {
+                res_data[i] |= (!res_data[i] *
+                                (EqualsOp<DecimalV2Value, DecimalV2Value>::apply(first_raw_data[i],
+                                                                                 arg_data)) *
+                                col);
+            }
+        } else {
+            for (size_t i = 0; i < input_rows_count; ++i) {
+                using type = std::decay_t<decltype(first_raw_data[0])>;
+                res_data[i] |= (!res_data[i] *
+                                (EqualsOp<type, type>::apply(first_raw_data[i], arg_data)) * col);
+            }
+        }
+    }
+    template <typename ColumnType>
+    static void insert_result_data_const(PaddedPODArray<Int32>& __restrict res_data,
+                                         ColumnPtr first_column, ColumnPtr argument_column,
+                                         const size_t input_rows_count, const int col) {
         auto* __restrict first_raw_data =
                 reinterpret_cast<const ColumnType*>(first_column.get())->get_data().data();
         const auto& column_raw_data =

--- a/be/src/vec/functions/round.h
+++ b/be/src/vec/functions/round.h
@@ -503,12 +503,9 @@ public:
     static Status get_scale_arg(const ColumnWithTypeAndName& arguments, Int16* scale) {
         const IColumn& scale_column = *arguments.column;
 
-        Int32 scale64 = static_cast<const ColumnInt32*>(
-                                &(is_column_const(scale_column)
-                                          ? static_cast<const ColumnConst*>(&scale_column)
-                                                    ->get_data_column()
-                                          : scale_column))
-                                ->get_element(0);
+        Int32 scale64 = static_cast<const ColumnInt32&>(
+                                static_cast<const ColumnConst*>(&scale_column)->get_data_column())
+                                .get_element(0);
 
         if (scale64 > std::numeric_limits<Int16>::max() ||
             scale64 < std::numeric_limits<Int16>::min()) {

--- a/be/test/vec/function/function_string_test.cpp
+++ b/be/test/vec/function/function_string_test.cpp
@@ -1093,6 +1093,7 @@ TEST(function_string_test, function_str_to_date_test) {
             TypeIndex::String,
             TypeIndex::String,
     };
+    //TODO: set column1 to const.
     DataSet data_set = {
             {{Null(), std::string("%Y-%m-%d %H:%i:%s")}, {Null()}},
             {{std::string("2014-12-21 12:34:56"), std::string("%Y-%m-%d %H:%i:%s")},

--- a/docs/en/docs/sql-manual/sql-functions/array-functions/array_apply.md
+++ b/docs/en/docs/sql-manual/sql-functions/array-functions/array_apply.md
@@ -43,8 +43,8 @@ array_apply(arr, op, val)
 #### Arguments
 
 `arr` — The array to inspect. If it null, null will be returned.
-`op` — The compare operation, op includes `=`, `>=`, `<=`, `>`, `<`, `!=`
-`val` — The compared value.If it null, null will be returned.
+`op` — The compare operation, op includes `=`, `>=`, `<=`, `>`, `<`, `!=`. Support const value only.
+`val` — The compared value.If it null, null will be returned. Support const value only.
 
 #### Returned value
 

--- a/docs/en/docs/sql-manual/sql-functions/string-functions/mask/mask.md
+++ b/docs/en/docs/sql-manual/sql-functions/string-functions/mask/mask.md
@@ -61,6 +61,7 @@ mysql> select mask(name, '*', '#', '$') from test;
 | NULL                        |
 | $$$*#*#*#                   |
 +-----------------------------+
+```
 
 ### keywords
     mask

--- a/docs/zh-CN/docs/sql-manual/sql-functions/array-functions/array_apply.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/array-functions/array_apply.md
@@ -42,8 +42,8 @@ array_apply(arr, op, val)
 #### Arguments
 
 `arr` — 输入的数组， 如果是null， 则返回null
-`op` — 过滤条件， 条件包括 `=`, `>=`, `<=`, `>`, `<`, `!=`
-`val` — 过滤的条件值， 如果是null， 则返回null
+`op` — 过滤条件， 条件包括 `=`, `>=`, `<=`, `>`, `<`, `!=`，仅支持常量
+`val` — 过滤的条件值， 如果是null， 则返回null，仅支持常量
 
 #### Returned value
 

--- a/docs/zh-CN/docs/sql-manual/sql-functions/string-functions/mask/mask.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/string-functions/mask/mask.md
@@ -61,6 +61,7 @@ mysql> select mask(name, '*', '#', '$') from test;
 | NULL                        |
 | $$$*#*#*#                   |
 +-----------------------------+
+```
 
 ### keywords
     mask


### PR DESCRIPTION
# Proposed changes

Since there are many function tasks under construction, it's necessary to standardize the behavior of convert a column may be const to a concrete column. 
The basic method to replace previous usgae `convert_to_full_column_if_const` is like:
```c++
ColumnPtr argument_columns[2];
bool col_const[2];
for (int i = 0; i < 2; ++i) {
    std::tie(argument_columns[i], col_const[i]) =
            unpack_if_const(block.get_by_position(arguments[i]).column);
    check_set_nullable(argument_columns[i], null_map); // set null map if you need.
}
```
Then, specialize the function like `vector_scalar` to distinguish the implementation by `col_const`.

## Problem summary

Made specialization for some function calls for its' some columns' ColumnConst. Avoid expanding those columns.

## Performance Improvement

before:
```
mysql [tpch]>Select substring(c_name, 5, 10), substring(c_address, 10, 15), substring(c_comment, 50, 75) from customer;
......
15000000 rows in set (18.30 sec)
```

after:
```
mysql [tpch]>Select substring(c_name, 5, 10), substring(c_address, 10, 15), substring(c_comment, 50, 75) from customer;
......
15000000 rows in set (15.92 sec)
```

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [x] Is this PR support rollback (If NO, please explain WHY)

## Further comments

There are still some pervious usage haven't update.