### PR TITLE
[Enchancement](table-function) optimization for  vectorized table function

### DIFF
--- a/be/src/vec/columns/column_nullable.h
+++ b/be/src/vec/columns/column_nullable.h
@@ -350,6 +350,13 @@ public:
 
     ColumnPtr index(const IColumn& indexes, size_t limit) const override;
 
+    Int64 get_int(size_t n) const override {
+        if (is_null_at(n)) {
+            return 0;
+        }
+        return get_nested_column().get_int(n);
+    }
+
 private:
     // the two functions will not update `_need_update_has_null`
     ColumnUInt8& _get_null_map_column() { return assert_cast<ColumnUInt8&>(*null_map); }

--- a/be/src/vec/columns/column_nullable.h
+++ b/be/src/vec/columns/column_nullable.h
@@ -350,13 +350,6 @@ public:
 
     ColumnPtr index(const IColumn& indexes, size_t limit) const override;
 
-    Int64 get_int(size_t n) const override {
-        if (is_null_at(n)) {
-            return 0;
-        }
-        return get_nested_column().get_int(n);
-    }
-
 private:
     // the two functions will not update `_need_update_has_null`
     ColumnUInt8& _get_null_map_column() { return assert_cast<ColumnUInt8&>(*null_map); }

--- a/be/src/vec/exec/vtable_function_node.h
+++ b/be/src/vec/exec/vtable_function_node.h
@@ -39,7 +39,7 @@ public:
     bool need_more_input_data() const { return !_child_block.rows() && !_child_eos; }
 
     void release_resource(doris::RuntimeState* state) override {
-        vectorized::VExpr::close(_vfn_ctxs, state);
+        VExpr::close(_vfn_ctxs, state);
 
         if (_num_rows_filtered_counter != nullptr) {
             COUNTER_SET(_num_rows_filtered_counter, static_cast<int64_t>(_num_rows_filtered));
@@ -47,7 +47,7 @@ public:
         ExecNode::release_resource(state);
     }
 
-    Status push(RuntimeState*, vectorized::Block* input_block, bool eos) override {
+    Status push(RuntimeState*, Block* input_block, bool eos) override {
         _child_eos = eos;
         if (input_block->rows() == 0) {
             return Status::OK();
@@ -60,8 +60,8 @@ public:
         return Status::OK();
     }
 
-    Status pull(RuntimeState* state, vectorized::Block* output_block, bool* eos) override {
-        RETURN_IF_ERROR(get_expanded_block(state, output_block, eos));
+    Status pull(RuntimeState* state, Block* output_block, bool* eos) override {
+        RETURN_IF_ERROR(_get_expanded_block(state, output_block, eos));
         reached_limit(output_block, eos);
         return Status::OK();
     }
@@ -97,26 +97,39 @@ private:
             1. FE: create a new output tuple based on the real output slots;
             2. BE: refractor (V)TableFunctionNode output rows based no the new tuple;
     */
-    inline bool slot_need_copy(SlotId slot_id) const {
+    inline bool _slot_need_copy(SlotId slot_id) const {
         auto id = _output_slots[slot_id]->id();
         return (id < _output_slot_ids.size()) && (_output_slot_ids[id]);
     }
 
-    Status get_expanded_block(RuntimeState* state, Block* output_block, bool* eos);
+    Status _get_expanded_block(RuntimeState* state, Block* output_block, bool* eos);
+
+    void _copy_output_slots(std::vector<MutableColumnPtr>& columns) {
+        if (!_current_row_insert_times) {
+            return;
+        }
+        for (auto index : _output_slot_indexs) {
+            auto src_column = _child_block.get_by_position(index).column;
+            columns[index]->insert_many_from(*src_column, _cur_child_offset,
+                                             _current_row_insert_times);
+        }
+        _current_row_insert_times = 0;
+    }
+    int _current_row_insert_times = 0;
 
     Block _child_block;
     std::vector<SlotDescriptor*> _child_slots;
     std::vector<SlotDescriptor*> _output_slots;
     int64_t _cur_child_offset = 0;
 
-    std::vector<vectorized::VExprContext*> _vfn_ctxs;
+    std::vector<VExprContext*> _vfn_ctxs;
 
     std::vector<TableFunction*> _fns;
-    std::vector<void*> _fn_values;
-    std::vector<int64_t> _fn_value_lengths;
     int _fn_num = 0;
 
     std::vector<bool> _output_slot_ids;
+    std::vector<int> _output_slot_indexs;
+    std::vector<int> _useless_slot_indexs;
 
     std::vector<int> _child_slot_sizes;
     // indicate if child node reach the end

--- a/be/src/vec/exprs/table_function/table_function_factory.h
+++ b/be/src/vec/exprs/table_function/table_function_factory.h
@@ -36,8 +36,7 @@ namespace vectorized {
 class TableFunction;
 class TableFunctionFactory {
 public:
-    TableFunctionFactory() {}
-    ~TableFunctionFactory() {}
+    TableFunctionFactory() = delete;
     static Status get_fn(const std::string& fn_name_raw, ObjectPool* pool, TableFunction** fn);
 
     const static std::unordered_map<std::string, std::function<TableFunction*()>> _function_map;

--- a/be/src/vec/exprs/table_function/vexplode.h
+++ b/be/src/vec/exprs/table_function/vexplode.h
@@ -30,14 +30,12 @@ class VExplodeTableFunction : public TableFunction {
 public:
     VExplodeTableFunction();
 
-    virtual ~VExplodeTableFunction() = default;
+    ~VExplodeTableFunction() override = default;
 
-    virtual Status process_init(vectorized::Block* block) override;
-    virtual Status process_row(size_t row_idx) override;
-    virtual Status process_close() override;
-    virtual Status reset() override;
-    virtual Status get_value(void** output) override;
-    virtual Status get_value_length(int64_t* length) override;
+    Status process_init(Block* block) override;
+    Status process_row(size_t row_idx) override;
+    Status process_close() override;
+    void get_value(MutableColumnPtr& column) override;
 
 private:
     ColumnPtr _array_column;

--- a/be/src/vec/exprs/table_function/vexplode_bitmap.h
+++ b/be/src/vec/exprs/table_function/vexplode_bitmap.h
@@ -29,13 +29,12 @@ public:
     ~VExplodeBitmapTableFunction() override = default;
 
     Status reset() override;
-    Status get_value(void** output) override;
-    Status forward(bool* eos) override;
+    void get_value(MutableColumnPtr& column) override;
+    Status forward(int step = 1) override;
 
-    Status process_init(vectorized::Block* block) override;
+    Status process_init(Block* block) override;
     Status process_row(size_t row_idx) override;
     Status process_close() override;
-    Status get_value_length(int64_t* length) override;
 
 private:
     void _reset_iterator();
@@ -43,9 +42,6 @@ private:
     const BitmapValue* _cur_bitmap = nullptr;
     // iterator of _cur_bitmap
     std::unique_ptr<BitmapValueIterator> _cur_iter = nullptr;
-    // current value read from bitmap, it will be referenced by
-    // table function scan node.
-    uint64_t _cur_value = 0;
     ColumnPtr _value_column;
 };
 

--- a/be/src/vec/exprs/table_function/vexplode_json_array.h
+++ b/be/src/vec/exprs/table_function/vexplode_json_array.h
@@ -63,33 +63,25 @@ struct ParsedData {
         }
     }
 
-    void get_value(ExplodeJsonArrayType type, int64_t offset, void** output, bool real = false) {
+    void* get_value(ExplodeJsonArrayType type, int64_t offset, bool real = false) {
         switch (type) {
         case ExplodeJsonArrayType::INT:
         case ExplodeJsonArrayType::DOUBLE:
-            *output = _data[offset];
-            break;
+            return _data[offset];
         case ExplodeJsonArrayType::STRING:
-            *output = _string_nulls[offset] ? nullptr
-                      : real                ? reinterpret_cast<void*>(_backup_string[offset].data())
-                                            : &_data_string[offset];
-            break;
+            return _string_nulls[offset] ? nullptr
+                   : real                ? reinterpret_cast<void*>(_backup_string[offset].data())
+                                         : &_data_string[offset];
         default:
-            CHECK(false) << type;
+            return nullptr;
         }
     }
 
-    void get_value_length(ExplodeJsonArrayType type, int64_t offset, int64_t* length) {
-        switch (type) {
-        case ExplodeJsonArrayType::INT:
-        case ExplodeJsonArrayType::DOUBLE:
-            break;
-        case ExplodeJsonArrayType::STRING:
-            *length = _string_nulls[offset] ? -1 : _backup_string[offset].size();
-            break;
-        default:
-            CHECK(false) << type;
+    int64 get_value_length(ExplodeJsonArrayType type, int64_t offset) {
+        if (type == ExplodeJsonArrayType::STRING && !_string_nulls[offset]) {
+            return _backup_string[offset].size();
         }
+        return 0;
     }
 
     int set_output(ExplodeJsonArrayType type, rapidjson::Document& document);
@@ -100,13 +92,10 @@ public:
     VExplodeJsonArrayTableFunction(ExplodeJsonArrayType type);
     ~VExplodeJsonArrayTableFunction() override = default;
 
-    Status process_init(vectorized::Block* block) override;
+    Status process_init(Block* block) override;
     Status process_row(size_t row_idx) override;
     Status process_close() override;
-    Status get_value(void** output) override;
-    Status get_value_length(int64_t* length) override;
-
-    Status reset() override;
+    void get_value(MutableColumnPtr& column) override;
 
 private:
     ParsedData _parsed_data;

--- a/be/src/vec/exprs/table_function/vexplode_numbers.cpp
+++ b/be/src/vec/exprs/table_function/vexplode_numbers.cpp
@@ -38,7 +38,15 @@ Status VExplodeNumbersTableFunction::process_init(Block* block) {
                                                                    &value_column_idx));
     _value_column = block->get_by_position(value_column_idx).column;
     if (is_column_const(*_value_column)) {
-        _cur_size = std::max((int64_t)0, _value_column->get_int(0));
+        _cur_size = 0;
+        if (_value_column->is_nullable()) {
+            if (!_value_column->is_null_at(0)) {
+                _cur_size = static_cast<const ColumnNullable*>(_value_column.get())->get_int(0);
+            }
+        } else {
+            _cur_size = _value_column->get_int(0);
+        }
+
         if (_cur_size && _cur_size <= block->rows()) { // avoid elements_column too big or empty
             _is_const = true;                          // use const optimize
             for (int i = 0; i < _cur_size; i++) {

--- a/be/src/vec/exprs/table_function/vexplode_numbers.cpp
+++ b/be/src/vec/exprs/table_function/vexplode_numbers.cpp
@@ -18,6 +18,8 @@
 #include "vec/exprs/table_function/vexplode_numbers.h"
 
 #include "common/status.h"
+#include "vec/columns/column_nullable.h"
+#include "vec/columns/columns_number.h"
 #include "vec/exprs/vexpr.h"
 
 namespace doris::vectorized {
@@ -26,7 +28,7 @@ VExplodeNumbersTableFunction::VExplodeNumbersTableFunction() {
     _fn_name = "vexplode_numbers";
 }
 
-Status VExplodeNumbersTableFunction::process_init(vectorized::Block* block) {
+Status VExplodeNumbersTableFunction::process_init(Block* block) {
     CHECK(_vexpr_context->root()->children().size() == 1)
             << "VExplodeSplitTableFunction must be have 1 children but have "
             << _vexpr_context->root()->children().size();
@@ -35,24 +37,27 @@ Status VExplodeNumbersTableFunction::process_init(vectorized::Block* block) {
     RETURN_IF_ERROR(_vexpr_context->root()->children()[0]->execute(_vexpr_context, block,
                                                                    &value_column_idx));
     _value_column = block->get_by_position(value_column_idx).column;
-
+    if (is_column_const(*_value_column)) {
+        _cur_size = std::max((int64_t)0, _value_column->get_int(0));
+        if (_cur_size && _cur_size <= block->rows()) { // avoid elements_column too big or empty
+            _is_const = true;                          // use const optimize
+            for (int i = 0; i < _cur_size; i++) {
+                ((ColumnInt32*)_elements_column.get())->insert_value(i);
+            }
+        }
+    }
     return Status::OK();
 }
 
 Status VExplodeNumbersTableFunction::process_row(size_t row_idx) {
-    _is_current_empty = false;
-    _eos = false;
+    RETURN_IF_ERROR(TableFunction::process_row(row_idx));
+    if (_is_const) {
+        return Status::OK();
+    }
 
     StringRef value = _value_column->get_data_at(row_idx);
-
-    if (value.data == nullptr) {
-        _is_current_empty = true;
-        _cur_size = 0;
-        _cur_offset = 0;
-    } else {
-        _cur_size = *reinterpret_cast<const int*>(value.data);
-        _cur_offset = 0;
-        _is_current_empty = (_cur_size <= 0);
+    if (value.data != nullptr) {
+        _cur_size = std::max(0, *reinterpret_cast<const int*>(value.data));
     }
     return Status::OK();
 }
@@ -62,28 +67,21 @@ Status VExplodeNumbersTableFunction::process_close() {
     return Status::OK();
 }
 
-Status VExplodeNumbersTableFunction::reset() {
-    _eos = false;
-    _cur_offset = 0;
-    return Status::OK();
-}
-
-Status VExplodeNumbersTableFunction::get_value(void** output) {
-    if (_is_current_empty) {
-        *output = nullptr;
+void VExplodeNumbersTableFunction::get_value(MutableColumnPtr& column) {
+    if (current_empty()) {
+        column->insert_default();
     } else {
-        *output = &_cur_offset;
+        if (_is_nullable) {
+            static_cast<ColumnInt32*>(
+                    static_cast<ColumnNullable*>(column.get())->get_nested_column_ptr().get())
+                    ->insert_value(_cur_offset);
+            static_cast<ColumnUInt8*>(
+                    static_cast<ColumnNullable*>(column.get())->get_null_map_column_ptr().get())
+                    ->insert_default();
+        } else {
+            static_cast<ColumnInt32*>(column.get())->insert_value(_cur_offset);
+        }
     }
-    return Status::OK();
-}
-
-Status VExplodeNumbersTableFunction::get_value_length(int64_t* length) {
-    if (_is_current_empty) {
-        *length = -1;
-    } else {
-        *length = sizeof(int);
-    }
-    return Status::OK();
 }
 
 } // namespace doris::vectorized

--- a/be/src/vec/exprs/table_function/vexplode_numbers.h
+++ b/be/src/vec/exprs/table_function/vexplode_numbers.h
@@ -25,17 +25,37 @@ namespace doris::vectorized {
 class VExplodeNumbersTableFunction : public TableFunction {
 public:
     VExplodeNumbersTableFunction();
-    virtual ~VExplodeNumbersTableFunction() = default;
+    ~VExplodeNumbersTableFunction() override = default;
 
-    virtual Status process_init(vectorized::Block* block) override;
-    virtual Status process_row(size_t row_idx) override;
-    virtual Status process_close() override;
-    virtual Status reset() override;
-    virtual Status get_value(void** output) override;
-    virtual Status get_value_length(int64_t* length) override;
+    Status process_init(Block* block) override;
+    Status process_row(size_t row_idx) override;
+    Status process_close() override;
+    void get_value(MutableColumnPtr& column) override;
+    int get_value(MutableColumnPtr& column, int max_step) override {
+        if (_is_const) {
+            max_step = std::min(max_step, (int)(_cur_size - _cur_offset));
+            if (_is_nullable) {
+                static_cast<ColumnInt32*>(
+                        static_cast<ColumnNullable*>(column.get())->get_nested_column_ptr().get())
+                        ->insert_many_from(*_elements_column, _cur_offset, max_step);
+                static_cast<ColumnUInt8*>(
+                        static_cast<ColumnNullable*>(column.get())->get_null_map_column_ptr().get())
+                        ->insert_many_defaults(max_step);
+            } else {
+                static_cast<ColumnInt32*>(column.get())
+                        ->insert_many_from(*_elements_column, _cur_offset, max_step);
+            }
+
+            forward(max_step);
+            return max_step;
+        }
+
+        return TableFunction::get_value(column, max_step);
+    }
 
 private:
     ColumnPtr _value_column;
+    ColumnPtr _elements_column = ColumnInt32::create();
 };
 
 } // namespace doris::vectorized

--- a/be/src/vec/exprs/table_function/vexplode_split.h
+++ b/be/src/vec/exprs/table_function/vexplode_split.h
@@ -30,12 +30,10 @@ public:
     ~VExplodeSplitTableFunction() override = default;
 
     Status open() override;
-    Status process_init(vectorized::Block* block) override;
+    Status process_init(Block* block) override;
     Status process_row(size_t row_idx) override;
     Status process_close() override;
-    Status get_value(void** output) override;
-    Status get_value_length(int64_t* length) override;
-    Status reset() override;
+    void get_value(MutableColumnPtr& column) override;
 
 private:
     std::vector<std::string_view> _backup;

--- a/be/test/vec/function/function_test_util.cpp
+++ b/be/test/vec/function/function_test_util.cpp
@@ -335,6 +335,9 @@ Block* process_table_function(TableFunction* fn, Block* input_block,
 
     // prepare output column
     vectorized::MutableColumnPtr column = descs[0].data_type->create_column();
+    if (column->is_nullable()) {
+        fn->set_nullable();
+    }
 
     // process table function for all rows
     for (size_t row = 0; row < input_block->rows(); ++row) {
@@ -348,25 +351,10 @@ Block* process_table_function(TableFunction* fn, Block* input_block,
             continue;
         }
 
-        bool tmp_eos = false;
         do {
-            void* cell = nullptr;
-            int64_t cell_len = 0;
-            if (fn->get_value(&cell) != Status::OK() ||
-                fn->get_value_length(&cell_len) != Status::OK()) {
-                LOG(WARNING) << "TableFunction get_value or get_value_length failed";
-                return nullptr;
-            }
-
-            // copy data from input block
-            if (cell == nullptr) {
-                column->insert_default();
-            } else {
-                column->insert_data(reinterpret_cast<char*>(cell), cell_len);
-            }
-
-            fn->forward(&tmp_eos);
-        } while (!tmp_eos);
+            fn->get_value(column);
+            fn->forward();
+        } while (!fn->eos());
     }
 
     std::unique_ptr<Block> output_block(new Block());

--- a/regression-test/suites/schema_change_p0/test_varchar_schema_change.groovy
+++ b/regression-test/suites/schema_change_p0/test_varchar_schema_change.groovy
@@ -111,7 +111,7 @@ suite ("test_varchar_schema_change") {
         logger.info(res[2][1])
         assertEquals(res[2][1].toLowerCase(),"varchar(30)")
 
-        qt_sc " select * from ${tableName} order by 1; "
+        qt_sc " select * from ${tableName} order by 1,2; "
 
         // test { //没捕获到异常
         //     sql """ insert into ${tableName} values(92,'2017-12-01',483647,'sdafdsaf') """
@@ -140,7 +140,7 @@ suite ("test_varchar_schema_change") {
         logger.info(res[2][1])
         assertEquals(res[2][1].toLowerCase(),"varchar(30)")
 
-        qt_sc " select * from ${tableName} where c2 like '%1%' order by 1; "
+        qt_sc " select * from ${tableName} where c2 like '%1%' order by 1,2; "
 
         sql """ insert into ${tableName} values(22,'2011-12-01','12f2','fdsaf') """
         sql """ insert into ${tableName} values(55,'2009-11-21','12d1d113','123aa') """
@@ -196,9 +196,9 @@ suite ("test_varchar_schema_change") {
                 } while (running)
         }
 
-        qt_sc " select * from ${tableName} order by 1; "
-        qt_sc " select min(c2),max(c2) from ${tableName} order by 1; "
-        qt_sc " select min(c2),max(c2) from ${tableName} group by c0 order by 1; "
+        qt_sc " select * from ${tableName} order by 1,2; "
+        qt_sc " select min(c2),max(c2) from ${tableName} order by 1,2; "
+        qt_sc " select min(c2),max(c2) from ${tableName} group by c0 order by 1,2; "
 
         sleep(5000)
         sql """ alter table ${tableName} 
@@ -222,7 +222,7 @@ suite ("test_varchar_schema_change") {
         logger.info(res[2][1])
         assertEquals(res[2][1].toLowerCase(),"varchar(40)")
 
-        qt_sc " select * from ${tableName} order by 1; "
+        qt_sc " select * from ${tableName} order by 1,2; "
 
         // test{
         //     sql """ alter table t0 modify column c1 varchar(20) NOT NULL """


### PR DESCRIPTION
# Proposed changes
before
```sql
mysql [test]>select sum(k1) from d_table  lateral  view  explode_numbers(20)  tmp1  as  e1;
+-----------+
| sum(`k1`) |
+-----------+
|         0 |
+-----------+
1 row in set (1.12 sec)
```

after
```sql
mysql [test]>select sum(k1) from d_table  lateral  view  explode_numbers(20)  tmp1  as  e1;
+-----------+
| sum(`k1`) |
+-----------+
|         0 |
+-----------+
1 row in set (0.44 sec)
```

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

