### PR TITLE
[Enhancement] sort result by BackendId when show backends like show backends

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ShowExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ShowExecutor.java
@@ -1719,6 +1719,13 @@ public class ShowExecutor {
         for (List<String> row : backendInfos) {
             row.remove(BackendsProcDir.HOSTNAME_INDEX);
         }
+        
+        backendInfos.sort(new Comparator<List<String>>() {
+            @Override
+            public int compare(List<String> o1, List<String> o2) {
+                return Integer.parseInt(o1.get(0)) - Integer.parseInt(o2.get(0));
+            }
+        });
 
         resultSet = new ShowResultSet(showStmt.getMetaData(), backendInfos);
     }


### PR DESCRIPTION
# Proposed changes
before:
+-----------+
| BackendId |
+-----------+
| 99412 |
| 11003 |
| 11002 |
| 60616 |
| 60673 |
+----------+

after:

+-----------+
| BackendId |
+-----------+
| 11002 |
| 11003 |
| 60616 |
| 60673 |
| 99412 |
+----------+

Issue Number: open #17935 

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

