### PR TITLE
[Improve](point query) improve column match performance when doing `c…

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/OlapScanNode.java
@@ -1027,12 +1027,12 @@ public class OlapScanNode extends ScanNode {
         return result;
     }
 
-    // Only called when Coordinator exec in point query
+    // Only called when Coordinator exec in high performance point query
     public List<TScanRangeLocations> lazyEvaluateRangeLocations() throws UserException {
         // Lazy evaluation
         selectedIndexId = olapTable.getBaseIndexId();
-        // TODO(lhy) this function is a heavy operation for point query
-        computeColumnFilter();
+        // Only key columns
+        computeColumnFilter(olapTable.getBaseSchemaKeyColumns());
         computePartitionInfo();
         scanBackendIds.clear();
         scanTabletIds.clear();

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/ScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/ScanNode.java
@@ -140,8 +140,8 @@ public abstract class ScanNode extends PlanNode {
     }
 
     // TODO(ML): move it into PrunerOptimizer
-    public void computeColumnFilter() {
-        for (Column column : desc.getTable().getBaseSchema()) {
+    public void computeColumnFilter(List<Column> columns) {
+        for (Column column : columns) {
             SlotDescriptor slotDesc = desc.getColumnSlot(column.getName());
             if (null == slotDesc) {
                 continue;
@@ -159,6 +159,10 @@ public abstract class ScanNode extends PlanNode {
                 columnNameToRange.put(column.getName(), columnRange);
             }
         }
+    }
+
+    public void computeColumnFilter() {
+        computeColumnFilter(desc.getTable().getBaseSchema());
     }
 
     public static ColumnRange createColumnRange(SlotDescriptor desc,


### PR DESCRIPTION
…omputeColumnFilter` to prune partition

Only use key columns when `computeColumnFilter` otherwise for wide tables the match process could be very slow
500 columns table QPS:
6186 -> 13208

# Proposed changes

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

