### PR TITLE
[feature](function) support variadic template type in SQL function

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/catalog/StructType.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/catalog/StructType.java
@@ -31,6 +31,7 @@ import com.google.common.collect.Maps;
 import com.google.gson.annotations.SerializedName;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -68,6 +69,10 @@ public class StructType extends Type {
             newFields.add(new StructField(type));
         }
         this.fields = newFields;
+    }
+
+    public StructType(Type... types) {
+        this(Arrays.asList(types));
     }
 
     public StructType() {

--- a/fe/fe-common/src/main/java/org/apache/doris/catalog/TemplateType.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/catalog/TemplateType.java
@@ -25,7 +25,6 @@ import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.gson.annotations.SerializedName;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 

--- a/fe/fe-common/src/main/java/org/apache/doris/catalog/Type.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/catalog/Type.java
@@ -524,7 +524,12 @@ public abstract class Type {
         return false;
     }
 
-    // return a new type without template type, by specialize tempalte type in this type
+    // only used for struct type and variadic template type
+    public boolean needExpandTemplateType() {
+        return false;
+    }
+
+    // return a new type without template type, by specialize template type in this type
     public Type specializeTemplateType(Type specificType, Map<String, Type> specializedTypeMap,
                                        boolean useSpecializedType) throws TypeException {
         if (hasTemplateType()) {
@@ -533,6 +538,22 @@ public abstract class Type {
         } else {
             return this;
         }
+    }
+
+    /**
+     * Only used for struct type and variadic template type,
+     * collect variadic template's expand size based on the input arguments
+     */
+    public void collectTemplateExpandSize(Type[] args, Map<String, Integer> expandSizeMap)
+            throws TypeException {
+    }
+
+    /**
+     * Only used for struct type and variadic template type,
+     * Do expand variadic template type
+     */
+    public List<Type> expandVariadicTemplateType(Map<String, Integer> expandSizeMap) {
+        return Lists.newArrayList(this);
     }
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Function.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Function.java
@@ -873,11 +873,11 @@ public class Function implements Writable {
 
         // expand the variadic template in arg types
         List<Type> newArgTypes = Lists.newArrayList();
-        for (int i = 0; i < argTypes.length - 1; i++) {
-            if (argTypes[i].needExpandTemplateType()) {
-                newArgTypes.addAll(argTypes[i].expandVariadicTemplateType(expandSizeMap));
+        for (Type argType : argTypes) {
+            if (argType.needExpandTemplateType()) {
+                newArgTypes.addAll(argType.expandVariadicTemplateType(expandSizeMap));
             } else {
-                newArgTypes.add(argTypes[i]);
+                newArgTypes.add(argType);
             }
         }
         argTypes = newArgTypes.toArray(new Type[0]);

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Function.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Function.java
@@ -30,7 +30,6 @@ import org.apache.doris.thrift.TFunctionBinaryType;
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 import org.apache.commons.io.output.NullOutputStream;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -859,9 +858,8 @@ public class Function implements Writable {
         return false;
     }
 
-    public void expandVariadicTemplate(Type[] args) throws TypeException {
-        // collect expand size of variadic template
-        Map<String, Integer> expandSizeMap = Maps.newHashMap();
+    // collect expand size of variadic template
+    public void collectTemplateExpandSize(Type[] args, Map<String, Integer> expandSizeMap) throws TypeException {
         for (int i = argTypes.length - 1; i >= 0; i--) {
             if (argTypes[i].hasTemplateType()) {
                 if (argTypes[i].needExpandTemplateType()) {
@@ -869,24 +867,6 @@ public class Function implements Writable {
                             Arrays.copyOfRange(args, i, args.length), expandSizeMap);
                 }
             }
-        }
-
-        // expand the variadic template in arg types
-        List<Type> newArgTypes = Lists.newArrayList();
-        for (Type argType : argTypes) {
-            if (argType.needExpandTemplateType()) {
-                newArgTypes.addAll(argType.expandVariadicTemplateType(expandSizeMap));
-            } else {
-                newArgTypes.add(argType);
-            }
-        }
-        argTypes = newArgTypes.toArray(new Type[0]);
-
-        // expand the variadic template in ret type
-        if (retType.needExpandTemplateType()) {
-            List<Type> newRetType = retType.expandVariadicTemplateType(expandSizeMap);
-            Preconditions.checkState(newRetType.size() == 1);
-            retType = newRetType.get(0);
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/FunctionSet.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/FunctionSet.java
@@ -37,6 +37,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -1227,9 +1228,14 @@ public class FunctionSet<T> {
 
         List<Function> normalFunctions = Lists.newArrayList();
         List<Function> templateFunctions = Lists.newArrayList();
+        List<Function> variadicTemplateFunctions = Lists.newArrayList();
         for (Function fn : fns) {
             if (fn.hasTemplateArg()) {
-                templateFunctions.add(fn);
+                if (!fn.hasVariadicTemplateArg()) {
+                    templateFunctions.add(fn);
+                } else {
+                    variadicTemplateFunctions.add(fn);
+                }
             } else {
                 normalFunctions.add(fn);
             }
@@ -1244,12 +1250,29 @@ public class FunctionSet<T> {
         // then specialize template functions and try them
         List<Function> specializedTemplateFunctions = Lists.newArrayList();
         for (Function f : templateFunctions) {
-            f = FunctionSet.specializeTemplateFunction(f, desc);
+            f = FunctionSet.specializeTemplateFunction(f, desc, false);
             if (f != null) {
                 specializedTemplateFunctions.add(f);
             }
         }
-        return getFunction(desc, mode, specializedTemplateFunctions);
+
+        // try template function second
+        fn = getFunction(desc, mode, specializedTemplateFunctions);
+        if (fn != null) {
+            return fn;
+        }
+
+        // then specialize variadic template function and try them
+        List<Function> specializedVariadicTemplateFunctions = Lists.newArrayList();
+        for (Function f : variadicTemplateFunctions) {
+            f = FunctionSet.specializeTemplateFunction(f, desc, true);
+            if (f != null) {
+                specializedVariadicTemplateFunctions.add(f);
+            }
+        }
+
+        // try variadic template function
+        return getFunction(desc, mode, specializedVariadicTemplateFunctions);
     }
 
     private Function getFunction(Function desc, Function.CompareMode mode, List<Function> fns) {
@@ -1292,7 +1315,7 @@ public class FunctionSet<T> {
         return null;
     }
 
-    public static Function specializeTemplateFunction(Function templateFunction, Function requestFunction) {
+    public static Function specializeTemplateFunction(Function templateFunction, Function requestFunction, boolean isVariadic) {
         try {
             boolean hasTemplateType = false;
             LOG.debug("templateFunction signature: " + templateFunction.signatureString()
@@ -1300,6 +1323,9 @@ public class FunctionSet<T> {
             LOG.debug("requestFunction signature: " + requestFunction.signatureString()
                         + "  return: " + requestFunction.getReturnType());
             Function specializedFunction = templateFunction;
+            if (isVariadic) {
+                templateFunction.expandVariadicTemplate(requestFunction.getArgs());
+            }
             if (templateFunction instanceof ScalarFunction) {
                 ScalarFunction f = (ScalarFunction) templateFunction;
                 specializedFunction = new ScalarFunction(f.getFunctionName(), Lists.newArrayList(f.getArgs()),
@@ -1312,12 +1338,10 @@ public class FunctionSet<T> {
             Map<String, Type> specializedTypeMap = Maps.newHashMap();
             for (int i = 0; i < args.length; i++) {
                 if (args[i].hasTemplateType()) {
-                    hasTemplateType = true;
                     args[i] = args[i].specializeTemplateType(requestFunction.getArgs()[i], specializedTypeMap, false);
                 }
             }
             if (specializedFunction.getReturnType().hasTemplateType()) {
-                hasTemplateType = true;
                 specializedFunction.setReturnType(
                         specializedFunction.getReturnType().specializeTemplateType(
                         requestFunction.getReturnType(), specializedTypeMap, true));

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/FunctionSet.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/FunctionSet.java
@@ -37,7 +37,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;

--- a/gensrc/script/doris_builtins_functions.py
+++ b/gensrc/script/doris_builtins_functions.py
@@ -74,6 +74,10 @@ visible_functions = [
     [['map_keys'], 'ARRAY<K>', ['MAP<K, V>'], '', ['K', 'V']],
     [['map_values'], 'ARRAY<V>', ['MAP<K, V>'], '', ['K', 'V']],
 
+    # struct functions
+    [['struct'], 'STRUCT<TYPES>', ['TYPES'], 'ALWAYS_NOT_NULLABLE', ['...TYPES']],
+    [['named_struct'], 'STRUCT<TYPES>', ['TYPES'], 'ALWAYS_NOT_NULLABLE', ['...TYPES']],
+
     # array functions
     [['array'], 'ARRAY', ['BOOLEAN', '...'], 'ALWAYS_NOT_NULLABLE'],
     [['array'], 'ARRAY', ['TINYINT', '...'], 'ALWAYS_NOT_NULLABLE'],

--- a/gensrc/script/doris_builtins_functions.py
+++ b/gensrc/script/doris_builtins_functions.py
@@ -78,6 +78,9 @@ visible_functions = [
     [['struct'], 'STRUCT<TYPES>', ['TYPES'], 'ALWAYS_NOT_NULLABLE', ['...TYPES']],
     [['named_struct'], 'STRUCT<TYPES>', ['TYPES'], 'ALWAYS_NOT_NULLABLE', ['...TYPES']],
 
+    # test
+    [['struct'], 'STRUCT<T, TYPES>', ['T', 'TYPES'], 'ALWAYS_NOT_NULLABLE', ['T', '...TYPES']],
+
     # array functions
     [['array'], 'ARRAY', ['BOOLEAN', '...'], 'ALWAYS_NOT_NULLABLE'],
     [['array'], 'ARRAY', ['TINYINT', '...'], 'ALWAYS_NOT_NULLABLE'],

--- a/gensrc/script/doris_builtins_functions.py
+++ b/gensrc/script/doris_builtins_functions.py
@@ -37,6 +37,11 @@
 # eg. [['element_at', '%element_extract%'], 'V', ['MAP<K, V>', 'K'], 'ALWAYS_NULLABLE', ['K', 'V']],
 #     'K' and 'V' is type template and will be specialized at runtime in FE to match specific args.
 #
+# 'template_types' support variadic template is now support variadic template.
+# eg. [['struct'], 'STRUCT<TYPES>', ['TYPES...'], 'ALWAYS_NOT_NULLABLE', ['...TYPES']],
+#     Inspired by C++ std::vector::emplace_back() function. '...TYPES' is variadic template and will
+#     be expanded to normal templates at runtime in FE to match variadic args. Please ensure that the
+#     variadic template is placed at the last position of all templates.
 visible_functions = [
     # Bit and Byte functions
     # For functions corresponding to builtin operators, we can reuse the implementations
@@ -75,11 +80,9 @@ visible_functions = [
     [['map_values'], 'ARRAY<V>', ['MAP<K, V>'], '', ['K', 'V']],
 
     # struct functions
-    [['struct'], 'STRUCT<TYPES>', ['TYPES'], 'ALWAYS_NOT_NULLABLE', ['...TYPES']],
-    [['named_struct'], 'STRUCT<TYPES>', ['TYPES'], 'ALWAYS_NOT_NULLABLE', ['...TYPES']],
-
-    # test
-    [['struct'], 'STRUCT<T, TYPES>', ['T', 'TYPES'], 'ALWAYS_NOT_NULLABLE', ['T', '...TYPES']],
+    [['struct'], 'STRUCT<TYPES>', ['TYPES...'], 'ALWAYS_NOT_NULLABLE', ['...TYPES']],
+    [['named_struct'], 'STRUCT<TYPES>', ['TYPES...'], 'ALWAYS_NOT_NULLABLE', ['...TYPES']],
+    [['element_at', '%element_extract%'], 'VARCHAR', ['STRUCT<TYPES>', 'VARCHAR'], 'ALWAYS_NULLABLE', ['...TYPES']],
 
     # array functions
     [['array'], 'ARRAY', ['BOOLEAN', '...'], 'ALWAYS_NOT_NULLABLE'],

--- a/gensrc/script/doris_builtins_functions.py
+++ b/gensrc/script/doris_builtins_functions.py
@@ -38,8 +38,8 @@
 #     'K' and 'V' is type template and will be specialized at runtime in FE to match specific args.
 #
 # 'template_types' support variadic template is now support variadic template.
-# eg. [['struct'], 'STRUCT<TYPES>', ['TYPES...'], 'ALWAYS_NOT_NULLABLE', ['...TYPES']],
-#     Inspired by C++ std::vector::emplace_back() function. '...TYPES' is variadic template and will
+# eg. [['struct'], 'STRUCT<TYPES>', ['TYPES'], 'ALWAYS_NOT_NULLABLE', ['TYPES...']],
+#     Inspired by C++ std::vector::emplace_back() function. 'TYPES...' is variadic template and will
 #     be expanded to normal templates at runtime in FE to match variadic args. Please ensure that the
 #     variadic template is placed at the last position of all templates.
 visible_functions = [

--- a/gensrc/script/doris_builtins_functions.py
+++ b/gensrc/script/doris_builtins_functions.py
@@ -80,9 +80,7 @@ visible_functions = [
     [['map_values'], 'ARRAY<V>', ['MAP<K, V>'], '', ['K', 'V']],
 
     # struct functions
-    [['struct'], 'STRUCT<TYPES>', ['TYPES...'], 'ALWAYS_NOT_NULLABLE', ['...TYPES']],
-    [['named_struct'], 'STRUCT<TYPES>', ['TYPES...'], 'ALWAYS_NOT_NULLABLE', ['...TYPES']],
-    [['element_at', '%element_extract%'], 'VARCHAR', ['STRUCT<TYPES>', 'VARCHAR'], 'ALWAYS_NULLABLE', ['...TYPES']],
+    [['struct'], 'STRUCT<TYPES>', ['TYPES'], 'ALWAYS_NOT_NULLABLE', ['TYPES...']],
 
     # array functions
     [['array'], 'ARRAY', ['BOOLEAN', '...'], 'ALWAYS_NOT_NULLABLE'],

--- a/gensrc/script/gen_builtins_functions.py
+++ b/gensrc/script/gen_builtins_functions.py
@@ -117,6 +117,8 @@ def generate_fe_datatype(str_type, template_types):
     # process template
     if str_type in template_types:
         return 'new TemplateType("{0}")'.format(str_type)
+    else if "..." + str_type in template_types:
+        return 'new TemplateType("{0}", true)'.format(str_type)
 
     # process Array, Map, Struct template
     template_start = str_type.find('<')

--- a/gensrc/script/gen_builtins_functions.py
+++ b/gensrc/script/gen_builtins_functions.py
@@ -54,6 +54,7 @@ package org.apache.doris.builtins;\n\
 \n\
 import org.apache.doris.catalog.ArrayType;\n\
 import org.apache.doris.catalog.MapType;\n\
+import org.apache.doris.catalog.StructType;\n\
 import org.apache.doris.catalog.TemplateType;\n\
 import org.apache.doris.catalog.Type;\n\
 import org.apache.doris.catalog.Function;\n\
@@ -117,7 +118,7 @@ def generate_fe_datatype(str_type, template_types):
     # process template
     if str_type in template_types:
         return 'new TemplateType("{0}")'.format(str_type)
-    else if "..." + str_type in template_types:
+    elif "..." + str_type in template_types:
         return 'new TemplateType("{0}", true)'.format(str_type)
 
     # process Array, Map, Struct template
@@ -131,6 +132,12 @@ def generate_fe_datatype(str_type, template_types):
         elif str_type.startswith("MAP<"):
             types = template.split(',', 2)
             return 'new MapType({0}, {1})'.format(generate_fe_datatype(types[0], template_types), generate_fe_datatype(types[1], template_types))
+        elif str_type.startswith("STRUCT<"):
+            types = template.split(',')
+            field_str = generate_fe_datatype(types[0], template_types)
+            for i in range(1, len(types)):
+                field_str += ", " + generate_fe_datatype(types[i], template_types)
+            return 'new StructType({0})'.format(field_str)
 
     # lagacy Array, Map syntax
     if str_type.startswith("ARRAY_"):

--- a/gensrc/script/gen_builtins_functions.py
+++ b/gensrc/script/gen_builtins_functions.py
@@ -115,6 +115,9 @@ def generate_fe_datatype(str_type, template_types):
     # delete whitespace
     str_type = str_type.replace(' ', '').replace('\t', '')
 
+    # delete ellipsis dots
+    str_type = str_type.replace('...', '')
+
     # process template
     if str_type in template_types:
         return 'new TemplateType("{0}")'.format(str_type)

--- a/gensrc/script/gen_builtins_functions.py
+++ b/gensrc/script/gen_builtins_functions.py
@@ -121,7 +121,7 @@ def generate_fe_datatype(str_type, template_types):
     # process template
     if str_type in template_types:
         return 'new TemplateType("{0}")'.format(str_type)
-    elif "..." + str_type in template_types:
+    elif str_type + "..." in template_types:
         return 'new TemplateType("{0}", true)'.format(str_type)
 
     # process Array, Map, Struct template

--- a/regression-test/conf/regression-conf.groovy
+++ b/regression-test/conf/regression-conf.groovy
@@ -24,11 +24,11 @@ defaultDb = "regression_test"
 // init cmd like: select @@session.tx_read_only
 // at each time we connect.
 // add allowLoadLocalInfile so that the jdbc can execute mysql load data from client.
-jdbcUrl = "jdbc:mysql://127.0.0.1:9030/?useLocalSessionState=true&allowLoadLocalInfile=true"
+jdbcUrl = "jdbc:mysql://127.0.0.1:9032/?useLocalSessionState=true&allowLoadLocalInfile=true"
 jdbcUser = "root"
 jdbcPassword = ""
 
-feHttpAddress = "127.0.0.1:8030"
+feHttpAddress = "127.0.0.1:8032"
 feHttpUser = "root"
 feHttpPassword = ""
 

--- a/regression-test/conf/regression-conf.groovy
+++ b/regression-test/conf/regression-conf.groovy
@@ -24,11 +24,11 @@ defaultDb = "regression_test"
 // init cmd like: select @@session.tx_read_only
 // at each time we connect.
 // add allowLoadLocalInfile so that the jdbc can execute mysql load data from client.
-jdbcUrl = "jdbc:mysql://127.0.0.1:9032/?useLocalSessionState=true&allowLoadLocalInfile=true"
+jdbcUrl = "jdbc:mysql://127.0.0.1:9030/?useLocalSessionState=true&allowLoadLocalInfile=true"
 jdbcUser = "root"
 jdbcPassword = ""
 
-feHttpAddress = "127.0.0.1:8032"
+feHttpAddress = "127.0.0.1:8030"
 feHttpUser = "root"
 feHttpPassword = ""
 


### PR DESCRIPTION
# Proposed changes

In pr #17344, we already support template type in SQL function.
e.g.

```
[['map_keys'], 'ARRAY<K>', ['MAP<K, V>'], '', ['K', 'V']]
```

Then it raises a new issue, as some functions require variable length template types.
e.g.

```
[['struct'], 'STRUCT<T1, T2, T3, T4....>', ['T1', 'T2', 'T3', 'T4', '....'], '', ['T1', 'T2', 'T3', 'T4', '....']]
```

Inspired by c++ function `std::vector::emplace_back()`, we can use variadic template for this issue.

e.g.

```
[['struct'], 'STRUCT<TYPES>', ['TYPES'], 'ALWAYS_NOT_NULLABLE', ['TYPES...']]
```

`...TYPES` in template_types defines a variadic template `TYPE`.  Then the variadic template will be expanded to multiple normal templates based on actual input arguments at runtime in FE.

But make sure `TYPES...` is placed on the last position in all template type arguments.

BTW, the origin template function logic is not affected.

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

