### PR TITLE
[fix](inverted index) fix erroneous judgement for inverted index not read raw data

### DIFF
--- a/be/src/olap/comparison_predicate.h
+++ b/be/src/olap/comparison_predicate.h
@@ -38,6 +38,8 @@ public:
 
     void clone(ColumnPredicate** to) const override {
         *to = new ComparisonPredicateBase(_column_id, _value, _opposite);
+        (*to)->predicate_params()->value = _predicate_params->value;
+        (*to)->predicate_params()->marked_by_runtime_filter = _predicate_params->marked_by_runtime_filter;
     }
 
     bool need_to_clone() const override { return true; }

--- a/be/src/olap/comparison_predicate.h
+++ b/be/src/olap/comparison_predicate.h
@@ -39,7 +39,8 @@ public:
     void clone(ColumnPredicate** to) const override {
         *to = new ComparisonPredicateBase(_column_id, _value, _opposite);
         (*to)->predicate_params()->value = _predicate_params->value;
-        (*to)->predicate_params()->marked_by_runtime_filter = _predicate_params->marked_by_runtime_filter;
+        (*to)->predicate_params()->marked_by_runtime_filter =
+                _predicate_params->marked_by_runtime_filter;
     }
 
     bool need_to_clone() const override { return true; }

--- a/be/src/olap/rowset/segment_v2/segment_iterator.cpp
+++ b/be/src/olap/rowset/segment_v2/segment_iterator.cpp
@@ -175,6 +175,7 @@ SegmentIterator::~SegmentIterator() {
 Status SegmentIterator::init(const StorageReadOptions& opts) {
     _opts = opts;
 
+    _col_predicates.clear();
     for (auto& predicate : opts.column_predicates) {
         if (predicate->need_to_clone()) {
             ColumnPredicate* cloned;


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

when apply inverted index will use `predicate_params()` from `ColumnPredicate`, if comparison predicate be cloned, but the clone one not copy the `predicate_params()` together, that resulting when applying inverted index make the wrong choice.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

