### PR TITLE
[improve](clickhouse jdbc) support clickhouse array type

### DIFF
--- a/be/src/vec/exec/vjdbc_connector.cpp
+++ b/be/src/vec/exec/vjdbc_connector.cpp
@@ -313,7 +313,8 @@ Status JdbcConnector::_check_type(SlotDescriptor* slot_desc, const std::string& 
         break;
     }
     case TYPE_ARRAY: {
-        if (type_str != "java.sql.Array" && type_str != "java.lang.String") {
+        if (type_str != "java.sql.Array" && type_str != "java.lang.String" &&
+            type_str != "java.lang.Object") {
             return Status::InternalError(error_msg);
         }
         if (!slot_desc->type().children[0].children.empty()) {

--- a/docs/en/docs/lakehouse/external-table/jdbc.md
+++ b/docs/en/docs/lakehouse/external-table/jdbc.md
@@ -275,29 +275,32 @@ The followings list how data types in different databases are mapped in Doris.
 
 ### ClickHouse
 
-| ClickHouse |  Doris   |
-| :--------: | :------: |
-|  BOOLEAN   | BOOLEAN  |
-|    CHAR    |   CHAR   |
-|  VARCHAR   | VARCHAR  |
-|   STRING   |  STRING  |
-|    DATE    |   DATE   |
-|  Float32   |  FLOAT   |
-|  Float64   |  DOUBLE  |
-|    Int8    | TINYINT  |
-|   Int16    | SMALLINT |
-|   Int32    |   INT    |
-|   Int64    |  BIGINT  |
-|   Int128   | LARGEINT |
-|  DATETIME  | DATETIME |
-|  DECIMAL   | DECIMAL  |
+|                  ClickHouse                  |          Doris           |
+|:--------------------------------------------:|:------------------------:|
+|                   Boolean                    |         BOOLEAN          |
+|                    String                    |          STRING          |
+|                 Date/Date32                  |       DATE/DATEV2        |
+|             DateTime/DateTime64              |   DATETIME/DATETIMEV2    |
+|                   Float32                    |          FLOAT           |
+|                   Float64                    |          DOUBLE          |
+|                     Int8                     |         TINYINT          |
+|                 Int16/UInt8                  |         SMALLINT         |
+|                 Int32/UInt16                 |           INT            |
+|                 Int64/Uint32                 |          BIGINT          |
+|                Int128/UInt64                 |         LARGEINT         |
+|            Int256/UInt128/UInt256            |          STRING          |
+|                   Decimal                    | DECIMAL/DECIMALV3/STRING |
+|             Enum/IPv4/IPv6/UUID              |          STRING          |
+| <version since="dev" type="inline"> Array(T) |         Array<T>         |
 
-Note:
 
+**Note:**
+
+- <version since="dev" type="inline"> For Array types in ClickHouse, use Doris's Array type to match them. For basic types in an Array, see Basic type matching rules. Nested arrays are not supported
 - Some data types in ClickHouse, such as UUID, IPv4, IPv6, and Enum8, will be mapped to Varchar/String in Doris. IPv4 and IPv6 will be displayed with an `/` as a prefix. You can use the `split_part` function to remove the `/` .
 - The Point Geo type in ClickHouse cannot be mapped in Doris by far. 
 
-### SAP_HANA
+### SAP HANA
 
 |   SAP_HANA   |        Doris        |
 |:------------:|:-------------------:|

--- a/docs/en/docs/lakehouse/external-table/jdbc.md
+++ b/docs/en/docs/lakehouse/external-table/jdbc.md
@@ -177,7 +177,8 @@ Test information on more versions will be provided in the future.
 
 | ClickHouse Version | ClickHouse JDBC Driver Version        |
 | ------------------ | ------------------------------------- |
-| 22                 | clickhouse-jdbc-0.3.2-patch11-all.jar |
+| 22           | clickhouse-jdbc-0.3.2-patch11-all.jar |
+| 22           | clickhouse-jdbc-0.4.1-all.jar         |
 
 #### 6.Sap_HanaTest
 

--- a/docs/en/docs/lakehouse/external-table/jdbc.md
+++ b/docs/en/docs/lakehouse/external-table/jdbc.md
@@ -276,28 +276,28 @@ The followings list how data types in different databases are mapped in Doris.
 
 ### ClickHouse
 
-|                       ClickHouse                        |          Doris           |
-|:-------------------------------------------------------:|:------------------------:|
-|                         Boolean                         |         BOOLEAN          |
-|                         String                          |          STRING          |
-|                       Date/Date32                       |       DATE/DATEV2        |
-|                   DateTime/DateTime64                   |   DATETIME/DATETIMEV2    |
-|                         Float32                         |          FLOAT           |
-|                         Float64                         |          DOUBLE          |
-|                          Int8                           |         TINYINT          |
-|                       Int16/UInt8                       |         SMALLINT         |
-|                      Int32/UInt16                       |           INT            |
-|                      Int64/Uint32                       |          BIGINT          |
-|                      Int128/UInt64                      |         LARGEINT         |
-|                 Int256/UInt128/UInt256                  |          STRING          |
-|                         Decimal                         | DECIMAL/DECIMALV3/STRING |
-|                   Enum/IPv4/IPv6/UUID                   |          STRING          |
-| <version since="dev" type="inline"> Array(T) </version> |         Array<T>         |
+|       ClickHouse       |          Doris           |
+|:----------------------:|:------------------------:|
+|        Boolean         |         BOOLEAN          |
+|         String         |          STRING          |
+|      Date/Date32       |       DATE/DATEV2        |
+|  DateTime/DateTime64   |   DATETIME/DATETIMEV2    |
+|        Float32         |          FLOAT           |
+|        Float64         |          DOUBLE          |
+|          Int8          |         TINYINT          |
+|      Int16/UInt8       |         SMALLINT         |
+|      Int32/UInt16      |           INT            |
+|      Int64/Uint32      |          BIGINT          |
+|     Int128/UInt64      |         LARGEINT         |
+| Int256/UInt128/UInt256 |          STRING          |
+|        Decimal         | DECIMAL/DECIMALV3/STRING |
+|  Enum/IPv4/IPv6/UUID   |          STRING          |
+|        Array(T)        |         Array<T>         |
 
 
 **Note:**
 
-- <version since="dev" type="inline"> For Array types in ClickHouse, use Doris's Array type to match them. For basic types in an Array, see Basic type matching rules. Nested arrays are not supported. </version> 
+- For Array types in ClickHouse, use Doris's Array type to match them. For basic types in an Array, see Basic type matching rules. Nested arrays are not supported. 
 - Some data types in ClickHouse, such as UUID, IPv4, IPv6, and Enum8, will be mapped to Varchar/String in Doris. IPv4 and IPv6 will be displayed with an `/` as a prefix. You can use the `split_part` function to remove the `/` .
 - The Point Geo type in ClickHouse cannot be mapped in Doris by far. 
 

--- a/docs/en/docs/lakehouse/external-table/jdbc.md
+++ b/docs/en/docs/lakehouse/external-table/jdbc.md
@@ -276,23 +276,23 @@ The followings list how data types in different databases are mapped in Doris.
 
 ### ClickHouse
 
-|                  ClickHouse                  |          Doris           |
-|:--------------------------------------------:|:------------------------:|
-|                   Boolean                    |         BOOLEAN          |
-|                    String                    |          STRING          |
-|                 Date/Date32                  |       DATE/DATEV2        |
-|             DateTime/DateTime64              |   DATETIME/DATETIMEV2    |
-|                   Float32                    |          FLOAT           |
-|                   Float64                    |          DOUBLE          |
-|                     Int8                     |         TINYINT          |
-|                 Int16/UInt8                  |         SMALLINT         |
-|                 Int32/UInt16                 |           INT            |
-|                 Int64/Uint32                 |          BIGINT          |
-|                Int128/UInt64                 |         LARGEINT         |
-|            Int256/UInt128/UInt256            |          STRING          |
-|                   Decimal                    | DECIMAL/DECIMALV3/STRING |
-|             Enum/IPv4/IPv6/UUID              |          STRING          |
-| <version since="dev" type="inline"> Array(T) |   Array<T> </version>    |
+|                       ClickHouse                        |          Doris           |
+|:-------------------------------------------------------:|:------------------------:|
+|                         Boolean                         |         BOOLEAN          |
+|                         String                          |          STRING          |
+|                       Date/Date32                       |       DATE/DATEV2        |
+|                   DateTime/DateTime64                   |   DATETIME/DATETIMEV2    |
+|                         Float32                         |          FLOAT           |
+|                         Float64                         |          DOUBLE          |
+|                          Int8                           |         TINYINT          |
+|                       Int16/UInt8                       |         SMALLINT         |
+|                      Int32/UInt16                       |           INT            |
+|                      Int64/Uint32                       |          BIGINT          |
+|                      Int128/UInt64                      |         LARGEINT         |
+|                 Int256/UInt128/UInt256                  |          STRING          |
+|                         Decimal                         | DECIMAL/DECIMALV3/STRING |
+|                   Enum/IPv4/IPv6/UUID                   |          STRING          |
+| <version since="dev" type="inline"> Array(T) </version> |         Array<T>         |
 
 
 **Note:**

--- a/docs/en/docs/lakehouse/external-table/jdbc.md
+++ b/docs/en/docs/lakehouse/external-table/jdbc.md
@@ -276,28 +276,28 @@ The followings list how data types in different databases are mapped in Doris.
 
 ### ClickHouse
 
-|       ClickHouse       |          Doris           |
-|:----------------------:|:------------------------:|
-|        Boolean         |         BOOLEAN          |
-|         String         |          STRING          |
-|      Date/Date32       |       DATE/DATEV2        |
-|  DateTime/DateTime64   |   DATETIME/DATETIMEV2    |
-|        Float32         |          FLOAT           |
-|        Float64         |          DOUBLE          |
-|          Int8          |         TINYINT          |
-|      Int16/UInt8       |         SMALLINT         |
-|      Int32/UInt16      |           INT            |
-|      Int64/Uint32      |          BIGINT          |
-|     Int128/UInt64      |         LARGEINT         |
-| Int256/UInt128/UInt256 |          STRING          |
-|        Decimal         | DECIMAL/DECIMALV3/STRING |
-|  Enum/IPv4/IPv6/UUID   |          STRING          |
-|        Array(T)        |         Array<T>         |
+|                  ClickHouse                  |          Doris           |
+|:--------------------------------------------:|:------------------------:|
+|                   Boolean                    |         BOOLEAN          |
+|                    String                    |          STRING          |
+|                 Date/Date32                  |       DATE/DATEV2        |
+|             DateTime/DateTime64              |   DATETIME/DATETIMEV2    |
+|                   Float32                    |          FLOAT           |
+|                   Float64                    |          DOUBLE          |
+|                     Int8                     |         TINYINT          |
+|                 Int16/UInt8                  |         SMALLINT         |
+|                 Int32/UInt16                 |           INT            |
+|                 Int64/Uint32                 |          BIGINT          |
+|                Int128/UInt64                 |         LARGEINT         |
+|            Int256/UInt128/UInt256            |          STRING          |
+|                   Decimal                    | DECIMAL/DECIMALV3/STRING |
+|             Enum/IPv4/IPv6/UUID              |          STRING          |
+| <version since="dev" type="inline"> Array(T) |  ARRAY\<T\> </version>   |
 
 
 **Note:**
 
-- For Array types in ClickHouse, use Doris's Array type to match them. For basic types in an Array, see Basic type matching rules. Nested arrays are not supported. 
+- <version since="dev" type="inline"> For Array types in ClickHouse, use Doris's Array type to match them. For basic types in an Array, see Basic type matching rules. Nested arrays are not supported. </version>
 - Some data types in ClickHouse, such as UUID, IPv4, IPv6, and Enum8, will be mapped to Varchar/String in Doris. IPv4 and IPv6 will be displayed with an `/` as a prefix. You can use the `split_part` function to remove the `/` .
 - The Point Geo type in ClickHouse cannot be mapped in Doris by far. 
 

--- a/docs/en/docs/lakehouse/external-table/jdbc.md
+++ b/docs/en/docs/lakehouse/external-table/jdbc.md
@@ -276,23 +276,23 @@ The followings list how data types in different databases are mapped in Doris.
 
 ### ClickHouse
 
-|                  ClickHouse                  |          Doris           |
-|:--------------------------------------------:|:------------------------:|
-|                   Boolean                    |         BOOLEAN          |
-|                    String                    |          STRING          |
-|                 Date/Date32                  |       DATE/DATEV2        |
-|             DateTime/DateTime64              |   DATETIME/DATETIMEV2    |
-|                   Float32                    |          FLOAT           |
-|                   Float64                    |          DOUBLE          |
-|                     Int8                     |         TINYINT          |
-|                 Int16/UInt8                  |         SMALLINT         |
-|                 Int32/UInt16                 |           INT            |
-|                 Int64/Uint32                 |          BIGINT          |
-|                Int128/UInt64                 |         LARGEINT         |
-|            Int256/UInt128/UInt256            |          STRING          |
-|                   Decimal                    | DECIMAL/DECIMALV3/STRING |
-|             Enum/IPv4/IPv6/UUID              |          STRING          |
-| <version since="dev" type="inline"> Array(T) |  ARRAY\<T\> </version>   |
+|                       ClickHouse                        |          Doris           |
+|:-------------------------------------------------------:|:------------------------:|
+|                         Boolean                         |         BOOLEAN          |
+|                         String                          |          STRING          |
+|                       Date/Date32                       |       DATE/DATEV2        |
+|                   DateTime/DateTime64                   |   DATETIME/DATETIMEV2    |
+|                         Float32                         |          FLOAT           |
+|                         Float64                         |          DOUBLE          |
+|                          Int8                           |         TINYINT          |
+|                       Int16/UInt8                       |         SMALLINT         |
+|                      Int32/UInt16                       |           INT            |
+|                      Int64/Uint32                       |          BIGINT          |
+|                      Int128/UInt64                      |         LARGEINT         |
+|                 Int256/UInt128/UInt256                  |          STRING          |
+|                         Decimal                         | DECIMAL/DECIMALV3/STRING |
+|                   Enum/IPv4/IPv6/UUID                   |          STRING          |
+| <version since="dev" type="inline"> Array(T) </version> |        ARRAY\<T\>        |
 
 
 **Note:**

--- a/docs/en/docs/lakehouse/external-table/jdbc.md
+++ b/docs/en/docs/lakehouse/external-table/jdbc.md
@@ -292,12 +292,12 @@ The followings list how data types in different databases are mapped in Doris.
 |            Int256/UInt128/UInt256            |          STRING          |
 |                   Decimal                    | DECIMAL/DECIMALV3/STRING |
 |             Enum/IPv4/IPv6/UUID              |          STRING          |
-| <version since="dev" type="inline"> Array(T) |         Array<T>         |
+| <version since="dev" type="inline"> Array(T) |   Array<T> </version>    |
 
 
 **Note:**
 
-- <version since="dev" type="inline"> For Array types in ClickHouse, use Doris's Array type to match them. For basic types in an Array, see Basic type matching rules. Nested arrays are not supported
+- <version since="dev" type="inline"> For Array types in ClickHouse, use Doris's Array type to match them. For basic types in an Array, see Basic type matching rules. Nested arrays are not supported. </version> 
 - Some data types in ClickHouse, such as UUID, IPv4, IPv6, and Enum8, will be mapped to Varchar/String in Doris. IPv4 and IPv6 will be displayed with an `/` as a prefix. You can use the `split_part` function to remove the `/` .
 - The Point Geo type in ClickHouse cannot be mapped in Doris by far. 
 

--- a/docs/en/docs/lakehouse/multi-catalog/jdbc.md
+++ b/docs/en/docs/lakehouse/multi-catalog/jdbc.md
@@ -329,24 +329,24 @@ The transaction mechanism ensures the atomicity of data writing to JDBC External
 
 ### Clickhouse
 
-| ClickHouse Type                                | Doris Type               | Comment                                                                                                                              |
-|------------------------------------------------|--------------------------|--------------------------------------------------------------------------------------------------------------------------------------|
-| Bool                                           | BOOLEAN                  |                                                                                                                                      |
-| String                                         | STRING                   |                                                                                                                                      |
-| Date/Date32                                    | DATEV2                   | JDBC CATLOG uses Datev2 type default when connecting DORIS                                                                           |
-| DateTime/DateTime64                            | DATETIMEV2               | JDBC CATLOG uses DateTimev2 type default when connecting DORIS                                                                       |
-| Float32                                        | FLOAT                    |                                                                                                                                      |
-| Float64                                        | DOUBLE                   |                                                                                                                                      |
-| Int8                                           | TINYINT                  |                                                                                                                                      |
-| Int16/UInt8                                    | SMALLINT                 | Doris does not support UNSIGNED data types so UInt8 will be mapped to SMALLINT.                                                      |
-| Int32/UInt16                                   | INT                      | Doris does not support UNSIGNED data types so UInt16 will be mapped to INT.                                                          |
-| Int64/Uint32                                   | BIGINT                   | Doris does not support UNSIGNED data types so UInt32 will be mapped to BIGINT.                                                       |
-| Int128/UInt64                                  | LARGEINT                 | Doris does not support UNSIGNED data types so UInt64 will be mapped to LARGEINT.                                                     |
-| Int256/UInt128/UInt256                         | STRING                   | Doris does not support data types of such orders of magnitude so these will be mapped to STRING.                                     |
-| DECIMAL                                        | DECIMAL/DECIMALV3/STRING | The Data type is based on the DECIMAL field's (precision, scale) and the `enable_decimal_conversion` configuration.                  |
-| Enum/IPv4/IPv6/UUID                            | STRING                   | Data of IPv4 and IPv6 type will be displayed with an extra `/` as a prefix. To remove the `/`, you can use the `split_part`function. |
-| <version since="dev" type="inline"> Array(T)   | Array<T>                 | Array internal basic type adaptation logic refers to the preceding types. Nested types are not supported </version>                  |
-| Other                                          | UNSUPPORTED              |                                                                                                                                      |
+| ClickHouse Type        | Doris Type               | Comment                                                                                                                             |
+|------------------------|--------------------------|-------------------------------------------------------------------------------------------------------------------------------------|
+| Bool                   | BOOLEAN                  |                                                                                                                                     |
+| String                 | STRING                   |                                                                                                                                     |
+| Date/Date32            | DATEV2                   | JDBC CATLOG uses Datev2 type default when connecting DORIS                                                                          |
+| DateTime/DateTime64    | DATETIMEV2               | JDBC CATLOG uses DateTimev2 type default when connecting DORIS                                                                      |
+| Float32                | FLOAT                    |                                                                                                                                     |
+| Float64                | DOUBLE                   |                                                                                                                                     |
+| Int8                   | TINYINT                  |                                                                                                                                     |
+| Int16/UInt8            | SMALLINT                 | Doris does not support UNSIGNED data types so UInt8 will be mapped to SMALLINT.                                                     |
+| Int32/UInt16           | INT                      | Doris does not support UNSIGNED data types so UInt16 will be mapped to INT.                                                         |
+| Int64/Uint32           | BIGINT                   | Doris does not support UNSIGNED data types so UInt32 will be mapped to BIGINT.                                                      |
+| Int128/UInt64          | LARGEINT                 | Doris does not support UNSIGNED data types so UInt64 will be mapped to LARGEINT.                                                    |
+| Int256/UInt128/UInt256 | STRING                   | Doris does not support data types of such orders of magnitude so these will be mapped to STRING.                                    |
+| DECIMAL                | DECIMAL/DECIMALV3/STRING | The Data type is based on the DECIMAL field's (precision, scale) and the `enable_decimal_conversion` configuration.                 |
+| Enum/IPv4/IPv6/UUID    | STRING                   | Data of IPv4 and IPv6 type will be displayed with an extra `/` as a prefix. To remove the `/`, you can use the `split_part`function. |
+| Array(T)               | Array<T>                 | Array internal basic type adaptation logic refers to the preceding types. Nested types are not supported                 |
+| Other                  | UNSUPPORTED              |                                                                                                                                     |
 
 ### Doris
 

--- a/docs/en/docs/lakehouse/multi-catalog/jdbc.md
+++ b/docs/en/docs/lakehouse/multi-catalog/jdbc.md
@@ -329,24 +329,24 @@ The transaction mechanism ensures the atomicity of data writing to JDBC External
 
 ### Clickhouse
 
-| ClickHouse Type                                          | Doris Type               | Comment                                                                                                                              |
-|----------------------------------------------------------|--------------------------|--------------------------------------------------------------------------------------------------------------------------------------|
-| Bool                                                     | BOOLEAN                  |                                                                                                                                      |
-| String                                                   | STRING                   |                                                                                                                                      |
-| Date/Date32                                              | DATEV2                   | JDBC CATLOG uses Datev2 type default when connecting DORIS                                                                           |
-| DateTime/DateTime64                                      | DATETIMEV2               | JDBC CATLOG uses DateTimev2 type default when connecting DORIS                                                                       |
-| Float32                                                  | FLOAT                    |                                                                                                                                      |
-| Float64                                                  | DOUBLE                   |                                                                                                                                      |
-| Int8                                                     | TINYINT                  |                                                                                                                                      |
-| Int16/UInt8                                              | SMALLINT                 | Doris does not support UNSIGNED data types so UInt8 will be mapped to SMALLINT.                                                      |
-| Int32/UInt16                                             | INT                      | Doris does not support UNSIGNED data types so UInt16 will be mapped to INT.                                                          |
-| Int64/Uint32                                             | BIGINT                   | Doris does not support UNSIGNED data types so UInt32 will be mapped to BIGINT.                                                       |
-| Int128/UInt64                                            | LARGEINT                 | Doris does not support UNSIGNED data types so UInt64 will be mapped to LARGEINT.                                                     |
-| Int256/UInt128/UInt256                                   | STRING                   | Doris does not support data types of such orders of magnitude so these will be mapped to STRING.                                     |
-| DECIMAL                                                  | DECIMAL/DECIMALV3/STRING | The Data type is based on the DECIMAL field's (precision, scale) and the `enable_decimal_conversion` configuration.                  |
-| Enum/IPv4/IPv6/UUID                                      | STRING                   | Data of IPv4 and IPv6 type will be displayed with an extra `/` as a prefix. To remove the `/`, you can use the `split_part`function. |
-| <version since="dev" type="inline"> Array(T) </version>  | Array<T>                 | Array internal basic type adaptation logic refers to the preceding types. Nested types are not supported                             |
-| Other                                                    | UNSUPPORTED              |                                                                                                                                      |
+| ClickHouse Type                                | Doris Type               | Comment                                                                                                                              |
+|------------------------------------------------|--------------------------|--------------------------------------------------------------------------------------------------------------------------------------|
+| Bool                                           | BOOLEAN                  |                                                                                                                                      |
+| String                                         | STRING                   |                                                                                                                                      |
+| Date/Date32                                    | DATEV2                   | JDBC CATLOG uses Datev2 type default when connecting DORIS                                                                           |
+| DateTime/DateTime64                            | DATETIMEV2               | JDBC CATLOG uses DateTimev2 type default when connecting DORIS                                                                       |
+| Float32                                        | FLOAT                    |                                                                                                                                      |
+| Float64                                        | DOUBLE                   |                                                                                                                                      |
+| Int8                                           | TINYINT                  |                                                                                                                                      |
+| Int16/UInt8                                    | SMALLINT                 | Doris does not support UNSIGNED data types so UInt8 will be mapped to SMALLINT.                                                      |
+| Int32/UInt16                                   | INT                      | Doris does not support UNSIGNED data types so UInt16 will be mapped to INT.                                                          |
+| Int64/Uint32                                   | BIGINT                   | Doris does not support UNSIGNED data types so UInt32 will be mapped to BIGINT.                                                       |
+| Int128/UInt64                                  | LARGEINT                 | Doris does not support UNSIGNED data types so UInt64 will be mapped to LARGEINT.                                                     |
+| Int256/UInt128/UInt256                         | STRING                   | Doris does not support data types of such orders of magnitude so these will be mapped to STRING.                                     |
+| DECIMAL                                        | DECIMAL/DECIMALV3/STRING | The Data type is based on the DECIMAL field's (precision, scale) and the `enable_decimal_conversion` configuration.                  |
+| Enum/IPv4/IPv6/UUID                            | STRING                   | Data of IPv4 and IPv6 type will be displayed with an extra `/` as a prefix. To remove the `/`, you can use the `split_part`function. |
+| <version since="dev" type="inline"> Array(T)   | Array<T>                 | Array internal basic type adaptation logic refers to the preceding types. Nested types are not supported </version>                  |
+| Other                                          | UNSUPPORTED              |                                                                                                                                      |
 
 ### Doris
 

--- a/docs/en/docs/lakehouse/multi-catalog/jdbc.md
+++ b/docs/en/docs/lakehouse/multi-catalog/jdbc.md
@@ -329,24 +329,24 @@ The transaction mechanism ensures the atomicity of data writing to JDBC External
 
 ### Clickhouse
 
-| ClickHouse Type                              | Doris Type               | Comment                                                                                                                              |
-|----------------------------------------------|--------------------------|--------------------------------------------------------------------------------------------------------------------------------------|
-| Bool                                         | BOOLEAN                  |                                                                                                                                      |
-| String                                       | STRING                   |                                                                                                                                      |
-| Date/Date32                                  | DATEV2                   | JDBC CATLOG uses Datev2 type default when connecting DORIS                                                                           |
-| DateTime/DateTime64                          | DATETIMEV2               | JDBC CATLOG uses DateTimev2 type default when connecting DORIS                                                                       |
-| Float32                                      | FLOAT                    |                                                                                                                                      |
-| Float64                                      | DOUBLE                   |                                                                                                                                      |
-| Int8                                         | TINYINT                  |                                                                                                                                      |
-| Int16/UInt8                                  | SMALLINT                 | Doris does not support UNSIGNED data types so UInt8 will be mapped to SMALLINT.                                                      |
-| Int32/UInt16                                 | INT                      | Doris does not support UNSIGNED data types so UInt16 will be mapped to INT.                                                          |
-| Int64/Uint32                                 | BIGINT                   | Doris does not support UNSIGNED data types so UInt32 will be mapped to BIGINT.                                                       |
-| Int128/UInt64                                | LARGEINT                 | Doris does not support UNSIGNED data types so UInt64 will be mapped to LARGEINT.                                                     |
-| Int256/UInt128/UInt256                       | STRING                   | Doris does not support data types of such orders of magnitude so these will be mapped to STRING.                                     |
-| DECIMAL                                      | DECIMAL/DECIMALV3/STRING | The Data type is based on the DECIMAL field's (precision, scale) and the `enable_decimal_conversion` configuration.                  |
-| Enum/IPv4/IPv6/UUID                          | STRING                   | Data of IPv4 and IPv6 type will be displayed with an extra `/` as a prefix. To remove the `/`, you can use the `split_part`function. |
-| <version since="dev" type="inline"> Array(T) | Array<T>                 | Array internal basic type adaptation logic refers to the preceding types. Nested types are not supported                             |
-| Other                                        | UNSUPPORTED              |                                                                                                                                      |
+| ClickHouse Type                                          | Doris Type               | Comment                                                                                                                              |
+|----------------------------------------------------------|--------------------------|--------------------------------------------------------------------------------------------------------------------------------------|
+| Bool                                                     | BOOLEAN                  |                                                                                                                                      |
+| String                                                   | STRING                   |                                                                                                                                      |
+| Date/Date32                                              | DATEV2                   | JDBC CATLOG uses Datev2 type default when connecting DORIS                                                                           |
+| DateTime/DateTime64                                      | DATETIMEV2               | JDBC CATLOG uses DateTimev2 type default when connecting DORIS                                                                       |
+| Float32                                                  | FLOAT                    |                                                                                                                                      |
+| Float64                                                  | DOUBLE                   |                                                                                                                                      |
+| Int8                                                     | TINYINT                  |                                                                                                                                      |
+| Int16/UInt8                                              | SMALLINT                 | Doris does not support UNSIGNED data types so UInt8 will be mapped to SMALLINT.                                                      |
+| Int32/UInt16                                             | INT                      | Doris does not support UNSIGNED data types so UInt16 will be mapped to INT.                                                          |
+| Int64/Uint32                                             | BIGINT                   | Doris does not support UNSIGNED data types so UInt32 will be mapped to BIGINT.                                                       |
+| Int128/UInt64                                            | LARGEINT                 | Doris does not support UNSIGNED data types so UInt64 will be mapped to LARGEINT.                                                     |
+| Int256/UInt128/UInt256                                   | STRING                   | Doris does not support data types of such orders of magnitude so these will be mapped to STRING.                                     |
+| DECIMAL                                                  | DECIMAL/DECIMALV3/STRING | The Data type is based on the DECIMAL field's (precision, scale) and the `enable_decimal_conversion` configuration.                  |
+| Enum/IPv4/IPv6/UUID                                      | STRING                   | Data of IPv4 and IPv6 type will be displayed with an extra `/` as a prefix. To remove the `/`, you can use the `split_part`function. |
+| <version since="dev" type="inline"> Array(T) </version>  | Array<T>                 | Array internal basic type adaptation logic refers to the preceding types. Nested types are not supported                             |
+| Other                                                    | UNSUPPORTED              |                                                                                                                                      |
 
 ### Doris
 

--- a/docs/en/docs/lakehouse/multi-catalog/jdbc.md
+++ b/docs/en/docs/lakehouse/multi-catalog/jdbc.md
@@ -329,24 +329,24 @@ The transaction mechanism ensures the atomicity of data writing to JDBC External
 
 ### Clickhouse
 
-| ClickHouse Type                              | Doris Type               | Comment                                                                                                                             |
-|----------------------------------------------|--------------------------|-------------------------------------------------------------------------------------------------------------------------------------|
-| Bool                                         | BOOLEAN                  |                                                                                                                                     |
-| String                                       | STRING                   |                                                                                                                                     |
-| Date/Date32                                  | DATEV2                   | JDBC CATLOG uses Datev2 type default when connecting DORIS                                                                          |
-| DateTime/DateTime64                          | DATETIMEV2               | JDBC CATLOG uses DateTimev2 type default when connecting DORIS                                                                      |
-| Float32                                      | FLOAT                    |                                                                                                                                     |
-| Float64                                      | DOUBLE                   |                                                                                                                                     |
-| Int8                                         | TINYINT                  |                                                                                                                                     |
-| Int16/UInt8                                  | SMALLINT                 | Doris does not support UNSIGNED data types so UInt8 will be mapped to SMALLINT.                                                     |
-| Int32/UInt16                                 | INT                      | Doris does not support UNSIGNED data types so UInt16 will be mapped to INT.                                                         |
-| Int64/Uint32                                 | BIGINT                   | Doris does not support UNSIGNED data types so UInt32 will be mapped to BIGINT.                                                      |
-| Int128/UInt64                                | LARGEINT                 | Doris does not support UNSIGNED data types so UInt64 will be mapped to LARGEINT.                                                    |
-| Int256/UInt128/UInt256                       | STRING                   | Doris does not support data types of such orders of magnitude so these will be mapped to STRING.                                    |
-| DECIMAL                                      | DECIMAL/DECIMALV3/STRING | The Data type is based on the DECIMAL field's (precision, scale) and the `enable_decimal_conversion` configuration.                 |
-| Enum/IPv4/IPv6/UUID                          | STRING                   | Data of IPv4 and IPv6 type will be displayed with an extra `/` as a prefix. To remove the `/`, you can use the `split_part`function. |
-| <version since="dev" type="inline"> Array(T) | ARRAY\<T\>               | Array internal basic type adaptation logic refers to the preceding types. Nested types are not supported </version>                |
-| Other                                        | UNSUPPORTED              |                                                                                                                                     |
+| ClickHouse Type                                         | Doris Type               | Comment                                                                                                                              |
+|---------------------------------------------------------|--------------------------|--------------------------------------------------------------------------------------------------------------------------------------|
+| Bool                                                    | BOOLEAN                  |                                                                                                                                      |
+| String                                                  | STRING                   |                                                                                                                                      |
+| Date/Date32                                             | DATEV2                   | JDBC CATLOG uses Datev2 type default when connecting DORIS                                                                           |
+| DateTime/DateTime64                                     | DATETIMEV2               | JDBC CATLOG uses DateTimev2 type default when connecting DORIS                                                                       |
+| Float32                                                 | FLOAT                    |                                                                                                                                      |
+| Float64                                                 | DOUBLE                   |                                                                                                                                      |
+| Int8                                                    | TINYINT                  |                                                                                                                                      |
+| Int16/UInt8                                             | SMALLINT                 | Doris does not support UNSIGNED data types so UInt8 will be mapped to SMALLINT.                                                      |
+| Int32/UInt16                                            | INT                      | Doris does not support UNSIGNED data types so UInt16 will be mapped to INT.                                                          |
+| Int64/Uint32                                            | BIGINT                   | Doris does not support UNSIGNED data types so UInt32 will be mapped to BIGINT.                                                       |
+| Int128/UInt64                                           | LARGEINT                 | Doris does not support UNSIGNED data types so UInt64 will be mapped to LARGEINT.                                                     |
+| Int256/UInt128/UInt256                                  | STRING                   | Doris does not support data types of such orders of magnitude so these will be mapped to STRING.                                     |
+| DECIMAL                                                 | DECIMAL/DECIMALV3/STRING | The Data type is based on the DECIMAL field's (precision, scale) and the `enable_decimal_conversion` configuration.                  |
+| Enum/IPv4/IPv6/UUID                                     | STRING                   | Data of IPv4 and IPv6 type will be displayed with an extra `/` as a prefix. To remove the `/`, you can use the `split_part`function. |
+| <version since="dev" type="inline"> Array(T) </version> | ARRAY\<T\>               | Array internal basic type adaptation logic refers to the preceding types. Nested types are not supported                             |
+| Other                                                   | UNSUPPORTED              |                                                                                                                                      |
 
 ### Doris
 

--- a/docs/en/docs/lakehouse/multi-catalog/jdbc.md
+++ b/docs/en/docs/lakehouse/multi-catalog/jdbc.md
@@ -329,23 +329,24 @@ The transaction mechanism ensures the atomicity of data writing to JDBC External
 
 ### Clickhouse
 
-| ClickHouse Type        | Doris Type  | Comment                                                      |
-| ---------------------- | ----------- | ------------------------------------------------------------ |
-| Bool                   | BOOLEAN     |                                                              |
-| String                 | STRING      |                                                              |
-| Date/Date32            | DATE        |                                                              |
-| DateTime/DateTime64    | DATETIME    | Data beyond the maximum precision of DateTime in Doris will be truncated. |
-| Float32                | FLOAT       |                                                              |
-| Float64                | DOUBLE      |                                                              |
-| Int8                   | TINYINT     |                                                              |
-| Int16/UInt8            | SMALLINT    | Doris does not support UNSIGNED data types so UInt8 will be mapped to SMALLINT. |
-| Int32/UInt16           | INT         | Doris does not support UNSIGNED data types so UInt16 will be mapped to INT. |
-| Int64/Uint32           | BIGINT      | Doris does not support UNSIGNED data types so UInt32 will be mapped to BIGINT. |
-| Int128/UInt64          | LARGEINT    | Doris does not support UNSIGNED data types so UInt64 will be mapped to LARGEINT. |
-| Int256/UInt128/UInt256 | STRING      | Doris does not support data types of such orders of magnitude so these will be mapped to STRING. |
-| DECIMAL                | DECIMAL     | Data beyond the maximum decimal precision in Doris will be truncated. |
-| Enum/IPv4/IPv6/UUID    | STRING      | Data of IPv4 and IPv6 type will be displayed with an extra `/` as a prefix. To remove the `/`, you can use the `split_part`function. |
-| Other                  | UNSUPPORTED |                                                              |
+| ClickHouse Type                              | Doris Type               | Comment                                                                                                                              |
+|----------------------------------------------|--------------------------|--------------------------------------------------------------------------------------------------------------------------------------|
+| Bool                                         | BOOLEAN                  |                                                                                                                                      |
+| String                                       | STRING                   |                                                                                                                                      |
+| Date/Date32                                  | DATEV2                   | JDBC CATLOG uses Datev2 type default when connecting DORIS                                                                           |
+| DateTime/DateTime64                          | DATETIMEV2               | JDBC CATLOG uses DateTimev2 type default when connecting DORIS                                                                       |
+| Float32                                      | FLOAT                    |                                                                                                                                      |
+| Float64                                      | DOUBLE                   |                                                                                                                                      |
+| Int8                                         | TINYINT                  |                                                                                                                                      |
+| Int16/UInt8                                  | SMALLINT                 | Doris does not support UNSIGNED data types so UInt8 will be mapped to SMALLINT.                                                      |
+| Int32/UInt16                                 | INT                      | Doris does not support UNSIGNED data types so UInt16 will be mapped to INT.                                                          |
+| Int64/Uint32                                 | BIGINT                   | Doris does not support UNSIGNED data types so UInt32 will be mapped to BIGINT.                                                       |
+| Int128/UInt64                                | LARGEINT                 | Doris does not support UNSIGNED data types so UInt64 will be mapped to LARGEINT.                                                     |
+| Int256/UInt128/UInt256                       | STRING                   | Doris does not support data types of such orders of magnitude so these will be mapped to STRING.                                     |
+| DECIMAL                                      | DECIMAL/DECIMALV3/STRING | The Data type is based on the DECIMAL field's (precision, scale) and the `enable_decimal_conversion` configuration.                  |
+| Enum/IPv4/IPv6/UUID                          | STRING                   | Data of IPv4 and IPv6 type will be displayed with an extra `/` as a prefix. To remove the `/`, you can use the `split_part`function. |
+| <version since="dev" type="inline"> Array(T) | Array<T>                 | Array internal basic type adaptation logic refers to the preceding types. Nested types are not supported                             |
+| Other                                        | UNSUPPORTED              |                                                                                                                                      |
 
 ### Doris
 
@@ -370,7 +371,7 @@ The transaction mechanism ensures the atomicity of data writing to JDBC External
 | TEXT | STRING | |
 |Other| UNSUPPORTED |
 
-### SAP_HANA
+### SAP HANA
 
 | SAP_HANA     | Doris                    | Comment                                                                                                            |
 |--------------|--------------------------|--------------------------------------------------------------------------------------------------------------------|

--- a/docs/en/docs/lakehouse/multi-catalog/jdbc.md
+++ b/docs/en/docs/lakehouse/multi-catalog/jdbc.md
@@ -329,24 +329,24 @@ The transaction mechanism ensures the atomicity of data writing to JDBC External
 
 ### Clickhouse
 
-| ClickHouse Type        | Doris Type               | Comment                                                                                                                             |
-|------------------------|--------------------------|-------------------------------------------------------------------------------------------------------------------------------------|
-| Bool                   | BOOLEAN                  |                                                                                                                                     |
-| String                 | STRING                   |                                                                                                                                     |
-| Date/Date32            | DATEV2                   | JDBC CATLOG uses Datev2 type default when connecting DORIS                                                                          |
-| DateTime/DateTime64    | DATETIMEV2               | JDBC CATLOG uses DateTimev2 type default when connecting DORIS                                                                      |
-| Float32                | FLOAT                    |                                                                                                                                     |
-| Float64                | DOUBLE                   |                                                                                                                                     |
-| Int8                   | TINYINT                  |                                                                                                                                     |
-| Int16/UInt8            | SMALLINT                 | Doris does not support UNSIGNED data types so UInt8 will be mapped to SMALLINT.                                                     |
-| Int32/UInt16           | INT                      | Doris does not support UNSIGNED data types so UInt16 will be mapped to INT.                                                         |
-| Int64/Uint32           | BIGINT                   | Doris does not support UNSIGNED data types so UInt32 will be mapped to BIGINT.                                                      |
-| Int128/UInt64          | LARGEINT                 | Doris does not support UNSIGNED data types so UInt64 will be mapped to LARGEINT.                                                    |
-| Int256/UInt128/UInt256 | STRING                   | Doris does not support data types of such orders of magnitude so these will be mapped to STRING.                                    |
-| DECIMAL                | DECIMAL/DECIMALV3/STRING | The Data type is based on the DECIMAL field's (precision, scale) and the `enable_decimal_conversion` configuration.                 |
-| Enum/IPv4/IPv6/UUID    | STRING                   | Data of IPv4 and IPv6 type will be displayed with an extra `/` as a prefix. To remove the `/`, you can use the `split_part`function. |
-| Array(T)               | Array<T>                 | Array internal basic type adaptation logic refers to the preceding types. Nested types are not supported                 |
-| Other                  | UNSUPPORTED              |                                                                                                                                     |
+| ClickHouse Type                              | Doris Type               | Comment                                                                                                                             |
+|----------------------------------------------|--------------------------|-------------------------------------------------------------------------------------------------------------------------------------|
+| Bool                                         | BOOLEAN                  |                                                                                                                                     |
+| String                                       | STRING                   |                                                                                                                                     |
+| Date/Date32                                  | DATEV2                   | JDBC CATLOG uses Datev2 type default when connecting DORIS                                                                          |
+| DateTime/DateTime64                          | DATETIMEV2               | JDBC CATLOG uses DateTimev2 type default when connecting DORIS                                                                      |
+| Float32                                      | FLOAT                    |                                                                                                                                     |
+| Float64                                      | DOUBLE                   |                                                                                                                                     |
+| Int8                                         | TINYINT                  |                                                                                                                                     |
+| Int16/UInt8                                  | SMALLINT                 | Doris does not support UNSIGNED data types so UInt8 will be mapped to SMALLINT.                                                     |
+| Int32/UInt16                                 | INT                      | Doris does not support UNSIGNED data types so UInt16 will be mapped to INT.                                                         |
+| Int64/Uint32                                 | BIGINT                   | Doris does not support UNSIGNED data types so UInt32 will be mapped to BIGINT.                                                      |
+| Int128/UInt64                                | LARGEINT                 | Doris does not support UNSIGNED data types so UInt64 will be mapped to LARGEINT.                                                    |
+| Int256/UInt128/UInt256                       | STRING                   | Doris does not support data types of such orders of magnitude so these will be mapped to STRING.                                    |
+| DECIMAL                                      | DECIMAL/DECIMALV3/STRING | The Data type is based on the DECIMAL field's (precision, scale) and the `enable_decimal_conversion` configuration.                 |
+| Enum/IPv4/IPv6/UUID                          | STRING                   | Data of IPv4 and IPv6 type will be displayed with an extra `/` as a prefix. To remove the `/`, you can use the `split_part`function. |
+| <version since="dev" type="inline"> Array(T) | ARRAY\<T\>               | Array internal basic type adaptation logic refers to the preceding types. Nested types are not supported </version>                |
+| Other                                        | UNSUPPORTED              |                                                                                                                                     |
 
 ### Doris
 

--- a/docs/zh-CN/docs/lakehouse/external-table/jdbc.md
+++ b/docs/zh-CN/docs/lakehouse/external-table/jdbc.md
@@ -270,23 +270,23 @@ PROPERTIES (
 
 ### ClickHouse
 
-|                  ClickHouse                  |          Doris           |
-|:--------------------------------------------:|:------------------------:|
-|                   Boolean                    |         BOOLEAN          |
-|                    String                    |          STRING          |
-|                 Date/Date32                  |       DATE/DATEV2        |
-|             DateTime/DateTime64              |   DATETIME/DATETIMEV2    |
-|                   Float32                    |          FLOAT           |
-|                   Float64                    |          DOUBLE          |
-|                     Int8                     |         TINYINT          |
-|                 Int16/UInt8                  |         SMALLINT         |
-|                 Int32/UInt16                 |           INT            |
-|                 Int64/Uint32                 |          BIGINT          |
-|                Int128/UInt64                 |         LARGEINT         |
-|            Int256/UInt128/UInt256            |          STRING          |
-|                   Decimal                    | DECIMAL/DECIMALV3/STRING |
-|             Enum/IPv4/IPv6/UUID              |          STRING          |
-| <version since="dev" type="inline"> Array(T) |   Array<T> </version>    |
+|                       ClickHouse                        |          Doris           |
+|:-------------------------------------------------------:|:------------------------:|
+|                         Boolean                         |         BOOLEAN          |
+|                         String                          |          STRING          |
+|                       Date/Date32                       |       DATE/DATEV2        |
+|                   DateTime/DateTime64                   |   DATETIME/DATETIMEV2    |
+|                         Float32                         |          FLOAT           |
+|                         Float64                         |          DOUBLE          |
+|                          Int8                           |         TINYINT          |
+|                       Int16/UInt8                       |         SMALLINT         |
+|                      Int32/UInt16                       |           INT            |
+|                      Int64/Uint32                       |          BIGINT          |
+|                      Int128/UInt64                      |         LARGEINT         |
+|                 Int256/UInt128/UInt256                  |          STRING          |
+|                         Decimal                         | DECIMAL/DECIMALV3/STRING |
+|                   Enum/IPv4/IPv6/UUID                   |          STRING          |
+| <version since="dev" type="inline"> Array(T) </version> |         Array<T>         |
 
 **注意：**
 

--- a/docs/zh-CN/docs/lakehouse/external-table/jdbc.md
+++ b/docs/zh-CN/docs/lakehouse/external-table/jdbc.md
@@ -286,11 +286,11 @@ PROPERTIES (
 |            Int256/UInt128/UInt256            |          STRING          |
 |                   Decimal                    | DECIMAL/DECIMALV3/STRING |
 |             Enum/IPv4/IPv6/UUID              |          STRING          |
-| <version since="dev" type="inline"> Array(T) |         Array<T>         |
+| <version since="dev" type="inline"> Array(T) |   Array<T> </version>    |
 
 **注意：**
 
-- <version since="dev" type="inline"> 对于ClickHouse里的Array类型,可用Doris的Array类型来匹配，Array内的基础类型匹配参考基础类型匹配规则即可，不支持嵌套Array
+- <version since="dev" type="inline"> 对于ClickHouse里的Array类型,可用Doris的Array类型来匹配，Array内的基础类型匹配参考基础类型匹配规则即可，不支持嵌套Array </version>
 - 对于ClickHouse里的一些特殊类型，如UUID,IPv4,IPv6,Enum8可以用Doris的Varchar/String类型来匹配,但是在显示上IPv4,IPv6会额外在数据最前面显示一个`/`,需要自己用`split_part`函数处理
 - 对于ClickHouse的Geo类型Point,无法进行匹配
 

--- a/docs/zh-CN/docs/lakehouse/external-table/jdbc.md
+++ b/docs/zh-CN/docs/lakehouse/external-table/jdbc.md
@@ -270,27 +270,27 @@ PROPERTIES (
 
 ### ClickHouse
 
-|                       ClickHouse                        |          Doris           |
-|:-------------------------------------------------------:|:------------------------:|
-|                         Boolean                         |         BOOLEAN          |
-|                         String                          |          STRING          |
-|                       Date/Date32                       |       DATE/DATEV2        |
-|                   DateTime/DateTime64                   |   DATETIME/DATETIMEV2    |
-|                         Float32                         |          FLOAT           |
-|                         Float64                         |          DOUBLE          |
-|                          Int8                           |         TINYINT          |
-|                       Int16/UInt8                       |         SMALLINT         |
-|                      Int32/UInt16                       |           INT            |
-|                      Int64/Uint32                       |          BIGINT          |
-|                      Int128/UInt64                      |         LARGEINT         |
-|                 Int256/UInt128/UInt256                  |          STRING          |
-|                         Decimal                         | DECIMAL/DECIMALV3/STRING |
-|                   Enum/IPv4/IPv6/UUID                   |          STRING          |
-| <version since="dev" type="inline"> Array(T) </version> |         Array<T>         |
+|       ClickHouse       |          Doris           |
+|:----------------------:|:------------------------:|
+|        Boolean         |         BOOLEAN          |
+|         String         |          STRING          |
+|      Date/Date32       |       DATE/DATEV2        |
+|  DateTime/DateTime64   |   DATETIME/DATETIMEV2    |
+|        Float32         |          FLOAT           |
+|        Float64         |          DOUBLE          |
+|          Int8          |         TINYINT          |
+|      Int16/UInt8       |         SMALLINT         |
+|      Int32/UInt16      |           INT            |
+|      Int64/Uint32      |          BIGINT          |
+|     Int128/UInt64      |         LARGEINT         |
+| Int256/UInt128/UInt256 |          STRING          |
+|        Decimal         | DECIMAL/DECIMALV3/STRING |
+|  Enum/IPv4/IPv6/UUID   |          STRING          |
+|        Array(T)        |         Array<T>         |
 
 **注意：**
 
-- <version since="dev" type="inline"> 对于ClickHouse里的Array类型,可用Doris的Array类型来匹配，Array内的基础类型匹配参考基础类型匹配规则即可，不支持嵌套Array </version>
+- 对于ClickHouse里的Array类型,可用Doris的Array类型来匹配，Array内的基础类型匹配参考基础类型匹配规则即可，不支持嵌套Array
 - 对于ClickHouse里的一些特殊类型，如UUID,IPv4,IPv6,Enum8可以用Doris的Varchar/String类型来匹配,但是在显示上IPv4,IPv6会额外在数据最前面显示一个`/`,需要自己用`split_part`函数处理
 - 对于ClickHouse的Geo类型Point,无法进行匹配
 

--- a/docs/zh-CN/docs/lakehouse/external-table/jdbc.md
+++ b/docs/zh-CN/docs/lakehouse/external-table/jdbc.md
@@ -169,9 +169,10 @@ PROPERTIES (
 目前只测试了这一个版本其他版本测试后补充
 
 #### 5.ClickHouse测试
-| ClickHouse版本 | ClickHouse JDBC驱动版本 |
-|----------| ------------------- |
-| 22       | clickhouse-jdbc-0.3.2-patch11-all.jar |
+| ClickHouse版本 | ClickHouse JDBC驱动版本                   |
+|--------------|---------------------------------------|
+| 22           | clickhouse-jdbc-0.3.2-patch11-all.jar |
+| 22           | clickhouse-jdbc-0.4.1-all.jar         |
 
 #### 6.Sap_Hana测试
 
@@ -269,28 +270,31 @@ PROPERTIES (
 
 ### ClickHouse
 
-| ClickHouse |  Doris   |
-|:----------:|:--------:|
-|  BOOLEAN   | BOOLEAN  |
-|    CHAR    |   CHAR   |
-|  VARCHAR   | VARCHAR  |
-|   STRING   |  STRING  |
-|    DATE    |   DATE   |
-|  Float32   |  FLOAT   |
-|  Float64   |  DOUBLE  |
-|    Int8    | TINYINT  |
-|   Int16    | SMALLINT |
-|   Int32    |   INT    |
-|   Int64    |  BIGINT  |
-|   Int128   | LARGEINT |
-|  DATETIME  | DATETIME |
-|  DECIMAL   | DECIMAL  |
+|                  ClickHouse                  |          Doris           |
+|:--------------------------------------------:|:------------------------:|
+|                   Boolean                    |         BOOLEAN          |
+|                    String                    |          STRING          |
+|                 Date/Date32                  |       DATE/DATEV2        |
+|             DateTime/DateTime64              |   DATETIME/DATETIMEV2    |
+|                   Float32                    |          FLOAT           |
+|                   Float64                    |          DOUBLE          |
+|                     Int8                     |         TINYINT          |
+|                 Int16/UInt8                  |         SMALLINT         |
+|                 Int32/UInt16                 |           INT            |
+|                 Int64/Uint32                 |          BIGINT          |
+|                Int128/UInt64                 |         LARGEINT         |
+|            Int256/UInt128/UInt256            |          STRING          |
+|                   Decimal                    | DECIMAL/DECIMALV3/STRING |
+|             Enum/IPv4/IPv6/UUID              |          STRING          |
+| <version since="dev" type="inline"> Array(T) |         Array<T>         |
 
 **注意：**
+
+- <version since="dev" type="inline"> 对于ClickHouse里的Array类型,可用Doris的Array类型来匹配，Array内的基础类型匹配参考基础类型匹配规则即可，不支持嵌套Array
 - 对于ClickHouse里的一些特殊类型，如UUID,IPv4,IPv6,Enum8可以用Doris的Varchar/String类型来匹配,但是在显示上IPv4,IPv6会额外在数据最前面显示一个`/`,需要自己用`split_part`函数处理
 - 对于ClickHouse的Geo类型Point,无法进行匹配
 
-### SAP_HANA
+### SAP HANA
 
 |   SAP_HANA   |        Doris        |
 |:------------:|:-------------------:|

--- a/docs/zh-CN/docs/lakehouse/external-table/jdbc.md
+++ b/docs/zh-CN/docs/lakehouse/external-table/jdbc.md
@@ -270,27 +270,27 @@ PROPERTIES (
 
 ### ClickHouse
 
-|       ClickHouse       |          Doris           |
-|:----------------------:|:------------------------:|
-|        Boolean         |         BOOLEAN          |
-|         String         |          STRING          |
-|      Date/Date32       |       DATE/DATEV2        |
-|  DateTime/DateTime64   |   DATETIME/DATETIMEV2    |
-|        Float32         |          FLOAT           |
-|        Float64         |          DOUBLE          |
-|          Int8          |         TINYINT          |
-|      Int16/UInt8       |         SMALLINT         |
-|      Int32/UInt16      |           INT            |
-|      Int64/Uint32      |          BIGINT          |
-|     Int128/UInt64      |         LARGEINT         |
-| Int256/UInt128/UInt256 |          STRING          |
-|        Decimal         | DECIMAL/DECIMALV3/STRING |
-|  Enum/IPv4/IPv6/UUID   |          STRING          |
-|        Array(T)        |         Array<T>         |
+|                  ClickHouse                  |          Doris           |
+|:--------------------------------------------:|:------------------------:|
+|                   Boolean                    |         BOOLEAN          |
+|                    String                    |          STRING          |
+|                 Date/Date32                  |       DATE/DATEV2        |
+|             DateTime/DateTime64              |   DATETIME/DATETIMEV2    |
+|                   Float32                    |          FLOAT           |
+|                   Float64                    |          DOUBLE          |
+|                     Int8                     |         TINYINT          |
+|                 Int16/UInt8                  |         SMALLINT         |
+|                 Int32/UInt16                 |           INT            |
+|                 Int64/Uint32                 |          BIGINT          |
+|                Int128/UInt64                 |         LARGEINT         |
+|            Int256/UInt128/UInt256            |          STRING          |
+|                   Decimal                    | DECIMAL/DECIMALV3/STRING |
+|             Enum/IPv4/IPv6/UUID              |          STRING          |
+| <version since="dev" type="inline"> Array(T) |  ARRAY\<T\> </version>   |
 
 **注意：**
 
-- 对于ClickHouse里的Array类型,可用Doris的Array类型来匹配，Array内的基础类型匹配参考基础类型匹配规则即可，不支持嵌套Array
+- <version since="dev" type="inline"> 对于ClickHouse里的Array类型,可用Doris的Array类型来匹配，Array内的基础类型匹配参考基础类型匹配规则即可，不支持嵌套Array </version>
 - 对于ClickHouse里的一些特殊类型，如UUID,IPv4,IPv6,Enum8可以用Doris的Varchar/String类型来匹配,但是在显示上IPv4,IPv6会额外在数据最前面显示一个`/`,需要自己用`split_part`函数处理
 - 对于ClickHouse的Geo类型Point,无法进行匹配
 

--- a/docs/zh-CN/docs/lakehouse/external-table/jdbc.md
+++ b/docs/zh-CN/docs/lakehouse/external-table/jdbc.md
@@ -270,23 +270,23 @@ PROPERTIES (
 
 ### ClickHouse
 
-|                  ClickHouse                  |          Doris           |
-|:--------------------------------------------:|:------------------------:|
-|                   Boolean                    |         BOOLEAN          |
-|                    String                    |          STRING          |
-|                 Date/Date32                  |       DATE/DATEV2        |
-|             DateTime/DateTime64              |   DATETIME/DATETIMEV2    |
-|                   Float32                    |          FLOAT           |
-|                   Float64                    |          DOUBLE          |
-|                     Int8                     |         TINYINT          |
-|                 Int16/UInt8                  |         SMALLINT         |
-|                 Int32/UInt16                 |           INT            |
-|                 Int64/Uint32                 |          BIGINT          |
-|                Int128/UInt64                 |         LARGEINT         |
-|            Int256/UInt128/UInt256            |          STRING          |
-|                   Decimal                    | DECIMAL/DECIMALV3/STRING |
-|             Enum/IPv4/IPv6/UUID              |          STRING          |
-| <version since="dev" type="inline"> Array(T) |  ARRAY\<T\> </version>   |
+|                        ClickHouse                        |          Doris           |
+|:--------------------------------------------------------:|:------------------------:|
+|                         Boolean                          |         BOOLEAN          |
+|                          String                          |          STRING          |
+|                       Date/Date32                        |       DATE/DATEV2        |
+|                   DateTime/DateTime64                    |   DATETIME/DATETIMEV2    |
+|                         Float32                          |          FLOAT           |
+|                         Float64                          |          DOUBLE          |
+|                           Int8                           |         TINYINT          |
+|                       Int16/UInt8                        |         SMALLINT         |
+|                       Int32/UInt16                       |           INT            |
+|                       Int64/Uint32                       |          BIGINT          |
+|                      Int128/UInt64                       |         LARGEINT         |
+|                  Int256/UInt128/UInt256                  |          STRING          |
+|                         Decimal                          | DECIMAL/DECIMALV3/STRING |
+|                   Enum/IPv4/IPv6/UUID                    |          STRING          |
+| <version since="dev" type="inline"> Array(T)  </version> |        ARRAY\<T\>        |
 
 **注意：**
 

--- a/docs/zh-CN/docs/lakehouse/multi-catalog/jdbc.md
+++ b/docs/zh-CN/docs/lakehouse/multi-catalog/jdbc.md
@@ -328,23 +328,24 @@ set enable_odbc_transcation = true;
 
 ### Clickhouse
 
-| ClickHouse Type        | Doris Type | Comment                                             |
-|------------------------|------------|-----------------------------------------------------|
-| Bool                   | BOOLEAN    |                                                     |
-| String                 | STRING     |                                                     |
-| Date/Date32            | DATE       |                                                     |
-| DateTime/DateTime64    | DATETIME   | 对于超过了Doris最大的DateTime精度的数据，将截断处理                    |
-| Float32                | FLOAT      |                                                     |
-| Float64                | DOUBLE     |                                                     |
-| Int8                   | TINYINT    |                                                     |
-| Int16/UInt8            | SMALLINT   | Doris没有UNSIGNED数据类型，所以扩大一个数量级                       |
-| Int32/UInt16           | INT        | Doris没有UNSIGNED数据类型，所以扩大一个数量级                       |
-| Int64/Uint32           | BIGINT     | Doris没有UNSIGNED数据类型，所以扩大一个数量级                       |
-| Int128/UInt64          | LARGEINT   | Doris没有UNSIGNED数据类型，所以扩大一个数量级                       |
-| Int256/UInt128/UInt256 | STRING     | Doris没有这个数量级的数据类型，采用STRING处理                        |
-| DECIMAL                | DECIMAL    | 对于超过了Doris最大的Decimal精度的数据，将映射为STRING                |
-| Enum/IPv4/IPv6/UUID    | STRING     | 在显示上IPv4,IPv6会额外在数据最前面显示一个`/`,需要自己用`split_part`函数处理 |
-|Other| UNSUPPORTED |
+| ClickHouse Type                              | Doris Type               | Comment                                             |
+|----------------------------------------------|--------------------------|-----------------------------------------------------|
+| Bool                                         | BOOLEAN                  |                                                     |
+| String                                       | STRING                   |                                                     |
+| Date/Date32                                  | DATEV2                   | Jdbc Catlog连接Doris时默认使用DATEV2类型                     |
+| DateTime/DateTime64                          | DATETIMEV2               | Jdbc Catlog连接Doris时默认使用DATETIMEV2类型                 |
+| Float32                                      | FLOAT                    |                                                     |
+| Float64                                      | DOUBLE                   |                                                     |
+| Int8                                         | TINYINT                  |                                                     |
+| Int16/UInt8                                  | SMALLINT                 | Doris没有UNSIGNED数据类型，所以扩大一个数量级                       |
+| Int32/UInt16                                 | INT                      | Doris没有UNSIGNED数据类型，所以扩大一个数量级                       |
+| Int64/Uint32                                 | BIGINT                   | Doris没有UNSIGNED数据类型，所以扩大一个数量级                       |
+| Int128/UInt64                                | LARGEINT                 | Doris没有UNSIGNED数据类型，所以扩大一个数量级                       |
+| Int256/UInt128/UInt256                       | STRING                   | Doris没有这个数量级的数据类型，采用STRING处理                        |
+| DECIMAL                                      | DECIMAL/DECIMALV3/STRING | 将根据Doris DECIMAL字段的（precision, scale）和`enable_decimal_conversion`开关选择用何种类型|
+| Enum/IPv4/IPv6/UUID                          | STRING                   | 在显示上IPv4,IPv6会额外在数据最前面显示一个`/`,需要自己用`split_part`函数处理 |
+| <version since="dev" type="inline"> Array(T) | Array<T>                 | Array内部类型适配逻辑参考上述类型，不支持嵌套类型                         |
+| Other                                        | UNSUPPORTED              |                                                     |
 
 ### Doris
 
@@ -369,7 +370,7 @@ set enable_odbc_transcation = true;
 | TEXT | STRING | |
 |Other| UNSUPPORTED |
 
-### SAP_HANA
+### SAP HANA
 
 | SAP_HANA     | Doris                    | Comment                                                                               |
 |--------------|--------------------------|---------------------------------------------------------------------------------------|

--- a/docs/zh-CN/docs/lakehouse/multi-catalog/jdbc.md
+++ b/docs/zh-CN/docs/lakehouse/multi-catalog/jdbc.md
@@ -328,24 +328,24 @@ set enable_odbc_transcation = true;
 
 ### Clickhouse
 
-| ClickHouse Type                              | Doris Type               | Comment                                           |
-|----------------------------------------------|--------------------------|---------------------------------------------------|
-| Bool                                         | BOOLEAN                  |                                                   |
-| String                                       | STRING                   |                                                   |
-| Date/Date32                                  | DATEV2                   | Jdbc Catlog连接Doris时默认使用DATEV2类型                   |
-| DateTime/DateTime64                          | DATETIMEV2               | Jdbc Catlog连接Doris时默认使用DATETIMEV2类型               |
-| Float32                                      | FLOAT                    |                                                   |
-| Float64                                      | DOUBLE                   |                                                   |
-| Int8                                         | TINYINT                  |                                                   |
-| Int16/UInt8                                  | SMALLINT                 | Doris没有UNSIGNED数据类型，所以扩大一个数量级                     |
-| Int32/UInt16                                 | INT                      | Doris没有UNSIGNED数据类型，所以扩大一个数量级                     |
-| Int64/Uint32                                 | BIGINT                   | Doris没有UNSIGNED数据类型，所以扩大一个数量级                     |
-| Int128/UInt64                                | LARGEINT                 | Doris没有UNSIGNED数据类型，所以扩大一个数量级                     |
-| Int256/UInt128/UInt256                       | STRING                   | Doris没有这个数量级的数据类型，采用STRING处理                      |
-| DECIMAL                                      | DECIMAL/DECIMALV3/STRING | 将根据Doris DECIMAL字段的（precision, scale）和`enable_decimal_conversion`开关选择用何种类型|
-| Enum/IPv4/IPv6/UUID                          | STRING                   | 在显示上IPv4,IPv6会额外在数据最前面显示一个`/`,需要自己用`split_part`函数处理 |
-| <version since="dev" type="inline"> Array(T) | ARRAY\<T\>               | Array内部类型适配逻辑参考上述类型，不支持嵌套类型 </version>        |
-| Other                                        | UNSUPPORTED              |                                                   |
+| ClickHouse Type                                         | Doris Type               | Comment                                           |
+|---------------------------------------------------------|--------------------------|---------------------------------------------------|
+| Bool                                                    | BOOLEAN                  |                                                   |
+| String                                                  | STRING                   |                                                   |
+| Date/Date32                                             | DATEV2                   | Jdbc Catlog连接Doris时默认使用DATEV2类型                   |
+| DateTime/DateTime64                                     | DATETIMEV2               | Jdbc Catlog连接Doris时默认使用DATETIMEV2类型               |
+| Float32                                                 | FLOAT                    |                                                   |
+| Float64                                                 | DOUBLE                   |                                                   |
+| Int8                                                    | TINYINT                  |                                                   |
+| Int16/UInt8                                             | SMALLINT                 | Doris没有UNSIGNED数据类型，所以扩大一个数量级                     |
+| Int32/UInt16                                            | INT                      | Doris没有UNSIGNED数据类型，所以扩大一个数量级                     |
+| Int64/Uint32                                            | BIGINT                   | Doris没有UNSIGNED数据类型，所以扩大一个数量级                     |
+| Int128/UInt64                                           | LARGEINT                 | Doris没有UNSIGNED数据类型，所以扩大一个数量级                     |
+| Int256/UInt128/UInt256                                  | STRING                   | Doris没有这个数量级的数据类型，采用STRING处理                      |
+| DECIMAL                                                 | DECIMAL/DECIMALV3/STRING | 将根据Doris DECIMAL字段的（precision, scale）和`enable_decimal_conversion`开关选择用何种类型|
+| Enum/IPv4/IPv6/UUID                                     | STRING                   | 在显示上IPv4,IPv6会额外在数据最前面显示一个`/`,需要自己用`split_part`函数处理 |
+| <version since="dev" type="inline"> Array(T) </version> | ARRAY\<T\>               | Array内部类型适配逻辑参考上述类型，不支持嵌套类型        |
+| Other                                                   | UNSUPPORTED              |                                                   |
 
 ### Doris
 

--- a/docs/zh-CN/docs/lakehouse/multi-catalog/jdbc.md
+++ b/docs/zh-CN/docs/lakehouse/multi-catalog/jdbc.md
@@ -328,24 +328,24 @@ set enable_odbc_transcation = true;
 
 ### Clickhouse
 
-| ClickHouse Type                              | Doris Type               | Comment                                             |
-|----------------------------------------------|--------------------------|-----------------------------------------------------|
-| Bool                                         | BOOLEAN                  |                                                     |
-| String                                       | STRING                   |                                                     |
-| Date/Date32                                  | DATEV2                   | Jdbc Catlog连接Doris时默认使用DATEV2类型                     |
-| DateTime/DateTime64                          | DATETIMEV2               | Jdbc Catlog连接Doris时默认使用DATETIMEV2类型                 |
-| Float32                                      | FLOAT                    |                                                     |
-| Float64                                      | DOUBLE                   |                                                     |
-| Int8                                         | TINYINT                  |                                                     |
-| Int16/UInt8                                  | SMALLINT                 | Doris没有UNSIGNED数据类型，所以扩大一个数量级                       |
-| Int32/UInt16                                 | INT                      | Doris没有UNSIGNED数据类型，所以扩大一个数量级                       |
-| Int64/Uint32                                 | BIGINT                   | Doris没有UNSIGNED数据类型，所以扩大一个数量级                       |
-| Int128/UInt64                                | LARGEINT                 | Doris没有UNSIGNED数据类型，所以扩大一个数量级                       |
-| Int256/UInt128/UInt256                       | STRING                   | Doris没有这个数量级的数据类型，采用STRING处理                        |
-| DECIMAL                                      | DECIMAL/DECIMALV3/STRING | 将根据Doris DECIMAL字段的（precision, scale）和`enable_decimal_conversion`开关选择用何种类型|
-| Enum/IPv4/IPv6/UUID                          | STRING                   | 在显示上IPv4,IPv6会额外在数据最前面显示一个`/`,需要自己用`split_part`函数处理 |
-| <version since="dev" type="inline"> Array(T) | Array<T>                 | Array内部类型适配逻辑参考上述类型，不支持嵌套类型                         |
-| Other                                        | UNSUPPORTED              |                                                     |
+| ClickHouse Type                               | Doris Type               | Comment                                             |
+|-----------------------------------------------|--------------------------|-----------------------------------------------------|
+| Bool                                          | BOOLEAN                  |                                                     |
+| String                                        | STRING                   |                                                     |
+| Date/Date32                                   | DATEV2                   | Jdbc Catlog连接Doris时默认使用DATEV2类型                     |
+| DateTime/DateTime64                           | DATETIMEV2               | Jdbc Catlog连接Doris时默认使用DATETIMEV2类型                 |
+| Float32                                       | FLOAT                    |                                                     |
+| Float64                                       | DOUBLE                   |                                                     |
+| Int8                                          | TINYINT                  |                                                     |
+| Int16/UInt8                                   | SMALLINT                 | Doris没有UNSIGNED数据类型，所以扩大一个数量级                       |
+| Int32/UInt16                                  | INT                      | Doris没有UNSIGNED数据类型，所以扩大一个数量级                       |
+| Int64/Uint32                                  | BIGINT                   | Doris没有UNSIGNED数据类型，所以扩大一个数量级                       |
+| Int128/UInt64                                 | LARGEINT                 | Doris没有UNSIGNED数据类型，所以扩大一个数量级                       |
+| Int256/UInt128/UInt256                        | STRING                   | Doris没有这个数量级的数据类型，采用STRING处理                        |
+| DECIMAL                                       | DECIMAL/DECIMALV3/STRING | 将根据Doris DECIMAL字段的（precision, scale）和`enable_decimal_conversion`开关选择用何种类型|
+| Enum/IPv4/IPv6/UUID                           | STRING                   | 在显示上IPv4,IPv6会额外在数据最前面显示一个`/`,需要自己用`split_part`函数处理 |
+| <version since="dev" type="inline"> Array(T)  | Array<T>                 | Array内部类型适配逻辑参考上述类型，不支持嵌套类型  </version>                         |
+| Other                                         | UNSUPPORTED              |                                                     |
 
 ### Doris
 

--- a/docs/zh-CN/docs/lakehouse/multi-catalog/jdbc.md
+++ b/docs/zh-CN/docs/lakehouse/multi-catalog/jdbc.md
@@ -328,24 +328,24 @@ set enable_odbc_transcation = true;
 
 ### Clickhouse
 
-| ClickHouse Type        | Doris Type               | Comment                                             |
-|------------------------|--------------------------|-----------------------------------------------------|
-| Bool                   | BOOLEAN                  |                                                     |
-| String                 | STRING                   |                                                     |
-| Date/Date32            | DATEV2                   | Jdbc Catlog连接Doris时默认使用DATEV2类型                     |
-| DateTime/DateTime64    | DATETIMEV2               | Jdbc Catlog连接Doris时默认使用DATETIMEV2类型                 |
-| Float32                | FLOAT                    |                                                     |
-| Float64                | DOUBLE                   |                                                     |
-| Int8                   | TINYINT                  |                                                     |
-| Int16/UInt8            | SMALLINT                 | Doris没有UNSIGNED数据类型，所以扩大一个数量级                       |
-| Int32/UInt16           | INT                      | Doris没有UNSIGNED数据类型，所以扩大一个数量级                       |
-| Int64/Uint32           | BIGINT                   | Doris没有UNSIGNED数据类型，所以扩大一个数量级                       |
-| Int128/UInt64          | LARGEINT                 | Doris没有UNSIGNED数据类型，所以扩大一个数量级                       |
-| Int256/UInt128/UInt256 | STRING                   | Doris没有这个数量级的数据类型，采用STRING处理                        |
-| DECIMAL                | DECIMAL/DECIMALV3/STRING | 将根据Doris DECIMAL字段的（precision, scale）和`enable_decimal_conversion`开关选择用何种类型|
-| Enum/IPv4/IPv6/UUID    | STRING                   | 在显示上IPv4,IPv6会额外在数据最前面显示一个`/`,需要自己用`split_part`函数处理 |
-| Array(T)               | Array<T>                 | Array内部类型适配逻辑参考上述类型，不支持嵌套类型                          |
-| Other                  | UNSUPPORTED              |                                                     |
+| ClickHouse Type                              | Doris Type               | Comment                                           |
+|----------------------------------------------|--------------------------|---------------------------------------------------|
+| Bool                                         | BOOLEAN                  |                                                   |
+| String                                       | STRING                   |                                                   |
+| Date/Date32                                  | DATEV2                   | Jdbc Catlog连接Doris时默认使用DATEV2类型                   |
+| DateTime/DateTime64                          | DATETIMEV2               | Jdbc Catlog连接Doris时默认使用DATETIMEV2类型               |
+| Float32                                      | FLOAT                    |                                                   |
+| Float64                                      | DOUBLE                   |                                                   |
+| Int8                                         | TINYINT                  |                                                   |
+| Int16/UInt8                                  | SMALLINT                 | Doris没有UNSIGNED数据类型，所以扩大一个数量级                     |
+| Int32/UInt16                                 | INT                      | Doris没有UNSIGNED数据类型，所以扩大一个数量级                     |
+| Int64/Uint32                                 | BIGINT                   | Doris没有UNSIGNED数据类型，所以扩大一个数量级                     |
+| Int128/UInt64                                | LARGEINT                 | Doris没有UNSIGNED数据类型，所以扩大一个数量级                     |
+| Int256/UInt128/UInt256                       | STRING                   | Doris没有这个数量级的数据类型，采用STRING处理                      |
+| DECIMAL                                      | DECIMAL/DECIMALV3/STRING | 将根据Doris DECIMAL字段的（precision, scale）和`enable_decimal_conversion`开关选择用何种类型|
+| Enum/IPv4/IPv6/UUID                          | STRING                   | 在显示上IPv4,IPv6会额外在数据最前面显示一个`/`,需要自己用`split_part`函数处理 |
+| <version since="dev" type="inline"> Array(T) | ARRAY\<T\>               | Array内部类型适配逻辑参考上述类型，不支持嵌套类型 </version>        |
+| Other                                        | UNSUPPORTED              |                                                   |
 
 ### Doris
 

--- a/docs/zh-CN/docs/lakehouse/multi-catalog/jdbc.md
+++ b/docs/zh-CN/docs/lakehouse/multi-catalog/jdbc.md
@@ -328,24 +328,24 @@ set enable_odbc_transcation = true;
 
 ### Clickhouse
 
-| ClickHouse Type                               | Doris Type               | Comment                                             |
-|-----------------------------------------------|--------------------------|-----------------------------------------------------|
-| Bool                                          | BOOLEAN                  |                                                     |
-| String                                        | STRING                   |                                                     |
-| Date/Date32                                   | DATEV2                   | Jdbc Catlog连接Doris时默认使用DATEV2类型                     |
-| DateTime/DateTime64                           | DATETIMEV2               | Jdbc Catlog连接Doris时默认使用DATETIMEV2类型                 |
-| Float32                                       | FLOAT                    |                                                     |
-| Float64                                       | DOUBLE                   |                                                     |
-| Int8                                          | TINYINT                  |                                                     |
-| Int16/UInt8                                   | SMALLINT                 | Doris没有UNSIGNED数据类型，所以扩大一个数量级                       |
-| Int32/UInt16                                  | INT                      | Doris没有UNSIGNED数据类型，所以扩大一个数量级                       |
-| Int64/Uint32                                  | BIGINT                   | Doris没有UNSIGNED数据类型，所以扩大一个数量级                       |
-| Int128/UInt64                                 | LARGEINT                 | Doris没有UNSIGNED数据类型，所以扩大一个数量级                       |
-| Int256/UInt128/UInt256                        | STRING                   | Doris没有这个数量级的数据类型，采用STRING处理                        |
-| DECIMAL                                       | DECIMAL/DECIMALV3/STRING | 将根据Doris DECIMAL字段的（precision, scale）和`enable_decimal_conversion`开关选择用何种类型|
-| Enum/IPv4/IPv6/UUID                           | STRING                   | 在显示上IPv4,IPv6会额外在数据最前面显示一个`/`,需要自己用`split_part`函数处理 |
-| <version since="dev" type="inline"> Array(T)  | Array<T>                 | Array内部类型适配逻辑参考上述类型，不支持嵌套类型  </version>                         |
-| Other                                         | UNSUPPORTED              |                                                     |
+| ClickHouse Type        | Doris Type               | Comment                                             |
+|------------------------|--------------------------|-----------------------------------------------------|
+| Bool                   | BOOLEAN                  |                                                     |
+| String                 | STRING                   |                                                     |
+| Date/Date32            | DATEV2                   | Jdbc Catlog连接Doris时默认使用DATEV2类型                     |
+| DateTime/DateTime64    | DATETIMEV2               | Jdbc Catlog连接Doris时默认使用DATETIMEV2类型                 |
+| Float32                | FLOAT                    |                                                     |
+| Float64                | DOUBLE                   |                                                     |
+| Int8                   | TINYINT                  |                                                     |
+| Int16/UInt8            | SMALLINT                 | Doris没有UNSIGNED数据类型，所以扩大一个数量级                       |
+| Int32/UInt16           | INT                      | Doris没有UNSIGNED数据类型，所以扩大一个数量级                       |
+| Int64/Uint32           | BIGINT                   | Doris没有UNSIGNED数据类型，所以扩大一个数量级                       |
+| Int128/UInt64          | LARGEINT                 | Doris没有UNSIGNED数据类型，所以扩大一个数量级                       |
+| Int256/UInt128/UInt256 | STRING                   | Doris没有这个数量级的数据类型，采用STRING处理                        |
+| DECIMAL                | DECIMAL/DECIMALV3/STRING | 将根据Doris DECIMAL字段的（precision, scale）和`enable_decimal_conversion`开关选择用何种类型|
+| Enum/IPv4/IPv6/UUID    | STRING                   | 在显示上IPv4,IPv6会额外在数据最前面显示一个`/`,需要自己用`split_part`函数处理 |
+| Array(T)               | Array<T>                 | Array内部类型适配逻辑参考上述类型，不支持嵌套类型                          |
+| Other                  | UNSUPPORTED              |                                                     |
 
 ### Doris
 

--- a/fe/fe-core/src/main/java/org/apache/doris/external/jdbc/JdbcClient.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/external/jdbc/JdbcClient.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.external.jdbc;
 
+import org.apache.doris.catalog.ArrayType;
 import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.JdbcResource;
 import org.apache.doris.catalog.PrimitiveType;
@@ -578,6 +579,11 @@ public class JdbcClient {
             return ScalarType.createStringType();
         } else if (ckType.startsWith("DateTime")) {
             return ScalarType.createDatetimeV2Type(0);
+        } else if (ckType.startsWith("Array")) {
+            String cktype = ckType.substring(6, ckType.length() - 1);
+            fieldSchema.setDataTypeName(cktype);
+            Type type = clickhouseTypeToDoris(fieldSchema);
+            return ArrayType.create(type, true);
         }
         switch (ckType) {
             case "Bool":

--- a/fe/fe-core/src/main/java/org/apache/doris/external/jdbc/JdbcClient.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/external/jdbc/JdbcClient.java
@@ -560,12 +560,15 @@ public class JdbcClient {
 
     public Type clickhouseTypeToDoris(JdbcFieldSchema fieldSchema) {
         String ckType = fieldSchema.getDataTypeName();
+        boolean isNull = false;
         if (ckType.startsWith("LowCardinality")) {
             ckType = ckType.substring(15, ckType.length() - 1);
             if (ckType.startsWith("Nullable")) {
+                isNull = true;
                 ckType = ckType.substring(9, ckType.length() - 1);
             }
         } else if (ckType.startsWith("Nullable")) {
+            isNull = true;
             ckType = ckType.substring(9, ckType.length() - 1);
         }
         if (ckType.startsWith("Decimal")) {
@@ -583,7 +586,7 @@ public class JdbcClient {
             String cktype = ckType.substring(6, ckType.length() - 1);
             fieldSchema.setDataTypeName(cktype);
             Type type = clickhouseTypeToDoris(fieldSchema);
-            return ArrayType.create(type, true);
+            return ArrayType.create(type, isNull);
         }
         switch (ckType) {
             case "Bool":

--- a/fe/fe-core/src/main/java/org/apache/doris/external/jdbc/JdbcClient.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/external/jdbc/JdbcClient.java
@@ -560,15 +560,12 @@ public class JdbcClient {
 
     public Type clickhouseTypeToDoris(JdbcFieldSchema fieldSchema) {
         String ckType = fieldSchema.getDataTypeName();
-        boolean isNull = false;
         if (ckType.startsWith("LowCardinality")) {
             ckType = ckType.substring(15, ckType.length() - 1);
             if (ckType.startsWith("Nullable")) {
-                isNull = true;
                 ckType = ckType.substring(9, ckType.length() - 1);
             }
         } else if (ckType.startsWith("Nullable")) {
-            isNull = true;
             ckType = ckType.substring(9, ckType.length() - 1);
         }
         if (ckType.startsWith("Decimal")) {
@@ -586,7 +583,7 @@ public class JdbcClient {
             String cktype = ckType.substring(6, ckType.length() - 1);
             fieldSchema.setDataTypeName(cktype);
             Type type = clickhouseTypeToDoris(fieldSchema);
-            return ArrayType.create(type, isNull);
+            return ArrayType.create(type, true);
         }
         switch (ckType) {
             case "Bool":

--- a/fe/java-udf/src/main/java/org/apache/doris/udf/JdbcExecutor.java
+++ b/fe/java-udf/src/main/java/org/apache/doris/udf/JdbcExecutor.java
@@ -197,8 +197,14 @@ public class JdbcExecutor {
         Object[] columnData = (Object[]) obj;
         if (columnData[idx] instanceof String) {
             return (String) columnData[idx];
-        } else {
+        } else if (columnData[idx] instanceof java.sql.Array) {
             return (java.sql.Array) columnData[idx];
+        } else {
+            // For the ClickHouse array type, we need the concatenated string[] after toString
+            Byte[] res = (Byte[]) columnData[idx];
+            LOG.info("Byte" + Arrays.toString(res));
+            LOG.info("res" + columnData[idx] + columnData[idx].getClass().toString());
+            return columnData[idx];
         }
     }
 


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

Describe your changes.

In this PR, I match the array type of ClickHouse to the array type of Doris's jdbc external.
Thanks to @zhangstar333 for helping

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [x] Has document been added or modified
* [ ] Does it need to update dependencies
* [x] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

