### PR TITLE
[Enhancement](streamload) print profile for streamload

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -418,6 +418,8 @@ CONF_mInt32(stream_load_record_batch_size, "50");
 CONF_Int32(stream_load_record_expire_time_secs, "28800");
 // time interval to clean expired stream load records
 CONF_mInt64(clean_stream_load_record_interval_secs, "1800");
+// Whether to enable stream load profile to be printed to the log, the default is false.
+CONF_mBool(enable_stream_load_log, "false");
 
 // OlapTableSink sender's send interval, should be less than the real response time of a tablet writer rpc.
 // You may need to lower the speed when the sink receiver bes are too busy.

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -419,7 +419,7 @@ CONF_Int32(stream_load_record_expire_time_secs, "28800");
 // time interval to clean expired stream load records
 CONF_mInt64(clean_stream_load_record_interval_secs, "1800");
 // Whether to enable stream load profile to be printed to the log, the default is false.
-CONF_mBool(enable_stream_load_log, "false");
+CONF_mBool(enable_stream_load_profile_log, "false");
 
 // OlapTableSink sender's send interval, should be less than the real response time of a tablet writer rpc.
 // You may need to lower the speed when the sink receiver bes are too busy.

--- a/be/src/http/action/stream_load.cpp
+++ b/be/src/http/action/stream_load.cpp
@@ -28,6 +28,7 @@
 #include <rapidjson/prettywriter.h>
 #include <thrift/protocol/TDebugProtocol.h>
 
+#include "common/config.h"
 #include "common/consts.h"
 #include "common/logging.h"
 #include "common/utils.h"
@@ -599,6 +600,13 @@ Status StreamLoadAction::_process_put(HttpRequest* http_req,
         LOG(WARNING) << "plan streaming load failed. errmsg=" << plan_status << ctx->brief();
         return plan_status;
     }
+
+    auto& query_options = ctx->put_result.params.query_options;
+    if (query_options.__isset.is_report_success && query_options.is_report_success &&
+        !config::enable_stream_load_log) {
+        query_options.is_report_success = false;
+    }
+
     VLOG_NOTICE << "params is " << apache::thrift::ThriftDebugString(ctx->put_result.params);
     // if we not use streaming, we must download total content before we begin
     // to process this load

--- a/be/src/http/action/stream_load.cpp
+++ b/be/src/http/action/stream_load.cpp
@@ -603,7 +603,7 @@ Status StreamLoadAction::_process_put(HttpRequest* http_req,
 
     auto& query_options = ctx->put_result.params.query_options;
     if (query_options.__isset.is_report_success && query_options.is_report_success &&
-        !config::enable_stream_load_log) {
+        !config::enable_stream_load_profile_log) {
         query_options.is_report_success = false;
     }
 

--- a/docs/en/docs/admin-manual/config/be-config.md
+++ b/docs/en/docs/admin-manual/config/be-config.md
@@ -769,6 +769,13 @@ Metrics: {"filtered_rows":0,"input_row_num":3346807,"input_rowsets_count":42,"in
 * Default value: 100
 * Dynamically modifiable: Yes
 
+#### `enable_stream_load_log`
+
+* Type: bool
+* Description: Whether to enable stream load profile to be printed to the log.
+* Default value: false
+* Dynamically modifiable: Yes
+
 ### Thread
 
 #### `delete_worker_count`

--- a/docs/en/docs/admin-manual/config/be-config.md
+++ b/docs/en/docs/admin-manual/config/be-config.md
@@ -769,7 +769,7 @@ Metrics: {"filtered_rows":0,"input_row_num":3346807,"input_rowsets_count":42,"in
 * Default value: 100
 * Dynamically modifiable: Yes
 
-#### `enable_stream_load_log`
+#### `enable_stream_load_profile_log`
 
 * Type: bool
 * Description: Whether to enable stream load profile to be printed to the log.

--- a/docs/zh-CN/docs/admin-manual/config/be-config.md
+++ b/docs/zh-CN/docs/admin-manual/config/be-config.md
@@ -783,6 +783,13 @@ Metrics: {"filtered_rows":0,"input_row_num":3346807,"input_rowsets_count":42,"in
 * 默认值： 100
 * 可动态修改：是
 
+#### `enable_stream_load_log`
+
+* 类型：bool
+* 描述：是否将 stream load profile 打印到日志。
+* 默认值： false
+* 可动态修改：是
+
 ### 线程
 
 #### `delete_worker_count`

--- a/docs/zh-CN/docs/admin-manual/config/be-config.md
+++ b/docs/zh-CN/docs/admin-manual/config/be-config.md
@@ -783,7 +783,7 @@ Metrics: {"filtered_rows":0,"input_row_num":3346807,"input_rowsets_count":42,"in
 * 默认值： 100
 * 可动态修改：是
 
-#### `enable_stream_load_log`
+#### `enable_stream_load_profile_log`
 
 * 类型：bool
 * 描述：是否将 stream load profile 打印到日志。

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/StreamLoadPlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/StreamLoadPlanner.java
@@ -47,6 +47,7 @@ import org.apache.doris.load.BrokerFileGroup;
 import org.apache.doris.load.loadv2.LoadTask;
 import org.apache.doris.load.routineload.RoutineLoadJob;
 import org.apache.doris.planner.external.ExternalFileScanNode;
+import org.apache.doris.qe.VariableMgr;
 import org.apache.doris.service.FrontendOptions;
 import org.apache.doris.task.LoadTaskInfo;
 import org.apache.doris.thrift.PaloInternalServiceVersion;
@@ -275,6 +276,7 @@ public class StreamLoadPlanner {
         queryOptions.setEnableVectorizedEngine(Config.enable_vectorized_load);
         queryOptions.setEnablePipelineEngine(Config.enable_pipeline_load);
         queryOptions.setBeExecVersion(Config.be_exec_version);
+        queryOptions.setIsReportSuccess(VariableMgr.newSessionVariable().enableProfile());
 
         params.setQueryOptions(queryOptions);
         TQueryGlobals queryGlobals = new TQueryGlobals();


### PR DESCRIPTION
# Proposed changes

Issue Number: close #17169

## Problem summary

When both `enable_profile` and `enable_stream_load_profile_log` is true, stream load profile is printed to the log:
```
I0322 19:49:53.000802 2990646 plan_fragment_executor.cpp:534] Fragment bc419b20fd50e30a-5860a2ee0c8c9998:(Active: 3.724ms, non-child: 0.00%)
   - FragmentCpuTime: 732.917us
   - RowsProduced: 2
  OlapTableSink:(Active: 3.899ms, non-child: 100.00%)
     - CloseWaitTime: 3.206ms
     - MaxAddBatchExecTime: 2.719ms
     - NonBlockingSendTime: 1.106ms
       - NonBlockingSendWorkTime: 68.512us
         - SerializeBatchTime: 13.590us
     - NumberBatchAdded: 1
     - NumberNodeChannels: 1
     - OpenTime: 581.217us
     - RowsFiltered: 0
     - RowsRead: 2
     - RowsReturned: 2
     - SendDataTime: 33.451us
       - WaitMemLimitTime: 0.000ns
     - TotalAddBatchExecTime: 2.719ms
     - ValidateDataTime: 5.081us
  VFILE_SCAN_NODE (id=0):(Active: 832.459us, non-child: 22.35%)
     - UseSpecificThreadToken: False
     - AcuireRuntimeFilterTime: 5.587us
     - BytesDecompressed: 0
     - BytesRead: 21.00 B
     - DecompressTime: 0.000ns
     - FileReadTime: 13.283us
     - GetNextTime: 11.849us
     - MaxScannerThreadNum: 1
     - NumScanners: 1
     - PeakMemoryUsage: 0
     - PreAllocFreeBlocksNum: 8
     - ProjectionTime: 0.000ns
     - RowsRead: 2
     - RowsReturned: 2
     - RowsReturnedRate: 2.40 K/sec
     - ScannerWorkerWaitTime: 38.946us
     - TotalReadThroughput: 0
    VScanner:
       - PerScannerRunningTime: [205.858us, ]
       - PerScannerRowsRead: [2, ]
       - FileScannerCastInputBlockTime: 30.539us
       - FileScannerConvertOuputBlockTime: 51.586us
       - FileScannerFillMissingColumnTime: 0.000ns
       - FileScannerFillPathColumnTime: 0.000ns
       - FileScannerGetBlockTime: 48.873us
       - FileScannerPreFilterTimer: 0.000ns
       - NewlyCreateFreeBlocksNum: 0
       - ScannerBatchWaitTime: 91.000ns
       - ScannerConvertBlockTime: 0.000ns
       - ScannerCpuTime: 362.469us
       - ScannerCtxSchedCount: 4
       - ScannerFilterTime: 87.000ns
       - ScannerGetBlockTime: 205.329us
       - ScannerPrefilterTime: 0.000ns
       - ScannerSchedCount: 1
      MemoryUsage:
         - FreeBlocks: 704.00 KB
         - QueuedBlocks: 4.50 KB
  MemoryUsage:
     - FreeBlocks: 704.00 KB
     - QueuedBlocks: 4.50 KB

```
Otherwise the stream load profile will not be printed to the log.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [X] Has document been added or modified
* [ ] Does it need to update dependencies
* [X] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

