### PR TITLE
[Opt](pipeline) disable coloagg when the para instance num >= tablet_num * 2

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/planner/DistributedPlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/DistributedPlanner.java
@@ -925,7 +925,8 @@ public class DistributedPlanner {
         if (isDistinct) {
             return createPhase2DistinctAggregationFragment(node, childFragment, fragments);
         } else {
-            if (canColocateAgg(node.getAggInfo(), childFragment.getDataPartition())) {
+            if (canColocateAgg(node.getAggInfo(), childFragment.getDataPartition())
+                    && childFragment.getPlanRoot().shouldColoAgg()) {
                 childFragment.addPlanRoot(node);
                 childFragment.setHasColocatePlanNode(true);
                 return childFragment;

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/OlapScanNode.java
@@ -1143,6 +1143,18 @@ public class OlapScanNode extends ScanNode {
     }
 
     @Override
+    public boolean shouldColoAgg() {
+        // In pipeline exec engine, the instance num is parallel instance. we should disable colo agg
+        // in parallelInstance >= tablet_num * 2 to use more thread to speed up the query
+        if (ConnectContext.get().getSessionVariable().enablePipelineEngine()) {
+            int parallelInstance = ConnectContext.get().getSessionVariable().getParallelExecInstanceNum();
+            return parallelInstance < result.size() * 2;
+        } else {
+            return true;
+        }
+    }
+
+    @Override
     protected void toThrift(TPlanNode msg) {
         List<String> keyColumnNames = new ArrayList<String>();
         List<TPrimitiveType> keyColumnTypes = new ArrayList<TPrimitiveType>();

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/PlanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/PlanNode.java
@@ -829,6 +829,10 @@ public abstract class PlanNode extends TreeNode<PlanNode> implements PlanStats {
         return numInstances;
     }
 
+    public boolean shouldColoAgg() {
+        return true;
+    }
+
     public void setNumInstances(int numInstances) {
         this.numInstances = numInstances;
     }


### PR DESCRIPTION
# Proposed changes

opt pipeline exec performance in 1 tablet ckbench:

before:
```
mysql> set enable_pipeline_engine = false;                                                                                                                                                    Query OK, 0 rows affected (0.00 sec)

mysql> SELECT UserID, COUNT(*) FROM hits GROUP BY UserID ORDER BY COUNT(*) DESC LIMIT 10;
+---------------------+----------+
| UserID              | count(*) |
+---------------------+----------+
| 1313338681122956954 |    29097 |
| 1907779576417363396 |    25333 |
| 2305303682471783379 |    10597 |
| 7982623143712728547 |     7584 |
| 6018350421959114808 |     6678 |
| 7280399273658728997 |     6411 |
| 1090981537032625727 |     6197 |
| 5730251990344211405 |     6019 |
|  835157184735512989 |     5211 |
|  770542365400669095 |     4906 |
+---------------------+----------+
10 rows in set (3.40 sec)
```

after:
```
mysql> SELECT UserID, COUNT(*) FROM hits GROUP BY UserID ORDER BY COUNT(*) DESC LIMIT 10;
+---------------------+----------+
| UserID              | count(*) |
+---------------------+----------+
| 1313338681122956954 |    29097 |
| 1907779576417363396 |    25333 |
| 2305303682471783379 |    10597 |
| 7982623143712728547 |     7584 |
| 6018350421959114808 |     6678 |
| 7280399273658728997 |     6411 |
| 1090981537032625727 |     6197 |
| 5730251990344211405 |     6019 |
|  835157184735512989 |     5211 |
|  770542365400669095 |     4906 |
+---------------------+----------+
10 rows in set (0.58 sec)

```

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

