### PR TITLE
[Improvement](DECIMALV3) multiply/plus DECIMAL32 and DECIMAL64 safely and not check overflow

### DIFF
--- a/be/src/vec/functions/function_binary_arithmetic.h
+++ b/be/src/vec/functions/function_binary_arithmetic.h
@@ -61,7 +61,8 @@ struct DivideIntegralImpl;
 template <typename, typename>
 struct ModuloImpl;
 
-template <template <typename, typename> typename Operation>
+template <template <typename, typename> typename Operation, typename OpA = UInt8,
+          typename OpB = UInt8>
 struct OperationTraits {
     using T = UInt8;
     using Op = Operation<T, T>;
@@ -76,7 +77,9 @@ struct OperationTraits {
             std::is_same_v<Op, MultiplyImpl<T, T>> || std::is_same_v<Op, ModuloImpl<T, T>> ||
             std::is_same_v<Op, DivideFloatingImpl<T, T>> ||
             std::is_same_v<Op, DivideIntegralImpl<T, T>>;
-    static constexpr bool can_overflow = is_plus_minus || is_multiply;
+    static constexpr bool can_overflow =
+            (is_plus_minus || is_multiply) &&
+            (IsDecimalV2<OpA> || IsDecimalV2<OpB> || IsDecimal128I<OpA> || IsDecimal128I<OpB>);
     static constexpr bool has_variadic_argument =
             !std::is_void_v<decltype(has_variadic_argument_types(std::declval<Op>()))>;
 };
@@ -220,7 +223,7 @@ template <typename A, typename B, template <typename, typename> typename Operati
           typename ResultType, bool is_to_null_type, bool return_nullable_type,
           bool check_overflow = true>
 struct DecimalBinaryOperation {
-    using OpTraits = OperationTraits<Operation>;
+    using OpTraits = OperationTraits<Operation, A, B>;
 
     using NativeResultType = typename NativeType<ResultType>::Type;
     using Op = Operation<NativeResultType, NativeResultType>;


### PR DESCRIPTION
# Proposed changes

multiply/plus DECIMAL32 and DECIMAL64 is safe and we do not need to check overflow.

I tested this PR on TPCH Q1: ~20s -> ~16s

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

