### PR TITLE
[ehancement](stats) Tune for stats framework

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/FilterEstimation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/FilterEstimation.java
@@ -35,7 +35,6 @@ import org.apache.doris.nereids.trees.expressions.Or;
 import org.apache.doris.nereids.trees.expressions.Slot;
 import org.apache.doris.nereids.trees.expressions.SlotReference;
 import org.apache.doris.nereids.trees.expressions.functions.Function;
-import org.apache.doris.nereids.trees.expressions.literal.Literal;
 import org.apache.doris.nereids.trees.expressions.visitor.ExpressionVisitor;
 import org.apache.doris.statistics.Bucket;
 import org.apache.doris.statistics.ColumnStatistic;
@@ -159,7 +158,7 @@ public class FilterEstimation extends ExpressionVisitor<Statistics, EstimationCo
                 return context.statistics.withRowCount(newRowCount);
             }
         }
-        if (!(left instanceof Literal) && !(right instanceof Literal)) {
+        if (!left.isConstant() && !right.isConstant()) {
             return calculateWhenBothColumn(cp, context, statsForLeft, statsForRight);
         } else {
             // For literal, it's max min is same value.

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/ColumnLevelStatisticCache.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/ColumnLevelStatisticCache.java
@@ -32,7 +32,7 @@ public class ColumnLevelStatisticCache {
     }
 
     public Histogram getHistogram() {
-        return null;
+        return histogram;
     }
 
     public void setHistogram(Histogram histogram) {

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/Statistics.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/Statistics.java
@@ -95,10 +95,26 @@ public class Statistics {
         return statistics;
     }
 
+    /**
+     * Update by count.
+     */
     public Statistics updateRowCountOnly(double rowCount) {
-        return new Statistics(rowCount, expressionToColumnStats);
+        Statistics statistics = new Statistics(rowCount, expressionToColumnStats);
+        for (Entry<Expression, ColumnStatistic> entry : expressionToColumnStats.entrySet()) {
+            ColumnStatistic columnStatistic = entry.getValue();
+            ColumnStatisticBuilder columnStatisticBuilder = new ColumnStatisticBuilder(columnStatistic);
+            columnStatisticBuilder.setNdv(Math.min(columnStatistic.ndv, rowCount));
+            double nullFactor = (rowCount - columnStatistic.numNulls) / rowCount;
+            columnStatisticBuilder.setNumNulls(nullFactor * rowCount);
+            columnStatisticBuilder.setCount(rowCount);
+            statistics.addColumnStats(entry.getKey(), columnStatisticBuilder.build());
+        }
+        return statistics;
     }
 
+    /**
+     * Fix by sel.
+     */
     public void fix(double newRowCount, double originRowCount) {
         double sel = newRowCount / originRowCount;
 

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/jobs/cascades/DeriveStatsJobTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/jobs/cascades/DeriveStatsJobTest.java
@@ -40,6 +40,7 @@ import org.apache.doris.statistics.Statistics;
 import com.google.common.collect.ImmutableList;
 import mockit.Expectations;
 import mockit.Mocked;
+import org.apache.commons.math3.util.Precision;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -69,7 +70,7 @@ public class DeriveStatsJobTest {
         }
         Statistics statistics = cascadesContext.getMemo().getRoot().getStatistics();
         Assertions.assertNotNull(statistics);
-        Assertions.assertEquals(0, statistics.getRowCount());
+        Assertions.assertTrue(Precision.equals(0.5, statistics.getRowCount(), 0.1));
     }
 
     private LogicalOlapScan constructOlapSCan() {

--- a/tools/qerror.py
+++ b/tools/qerror.py
@@ -23,15 +23,32 @@ import requests
 import json
 import time
 
+# Change the host port username password and database name on your need
 mycli_cmd = "mysql -h127.0.0.1 -P9030 -uroot -Dtpch1G"
 
+# FE http://host:port
 feHttp = "http://localhost:8030"
 trace_url = feHttp + '/rest/v2/manager/query/trace_id/{}'
 qerror_url = feHttp + '/rest/v2/manager/query/qerror/{}'
-qerr_saved_file_path = "/home/kikyo/Documents/source/incubator-doris/tools/tpch-tools/RECORD"
 
-original_sql_dir = "/home/kikyo/Documents/source/incubator-doris/tools/tpch-tools/queries"
-sql_with_trace_context_dir = "/home/kikyo/Documents/source/incubator-doris/tools/tpch-tools/traced"
+# File path to save test results.
+# Sample:
+# 8
+# {
+#   "legacyPlanIdToPhysicalPlan": {
+#     "0": {
+#       "first": 1.0,
+#       "second": 1.0
+#     },
+#    .......
+#   "qError": 34.5
+# }
+# `8` represents q8 in the tpc-h test
+# `first` is the estimated row count for plan which with plan id 0, `second` is the actual returned row count
+qerr_saved_file_path = ""
+
+# SQL under this directory would be tested.
+original_sql_dir = "add your tpc-h/tpch-ds/ssb sql directory path here"
 
 sql_file_prefix_for_trace = """
     SET enable_nereids_planner=true;
@@ -119,4 +136,4 @@ if __name__ == '__main__':
     iterates_sqls(original_sql_dir, False)
     print("Started...")
     iterates_sqls(original_sql_dir, True)
-    write_results(qerr_saved_file_path, "AVG\n", [sum(q_err_list) / len(qerror_url)])
+    write_results(qerr_saved_file_path, "AVG\n", [sum(q_err_list) / len(q_err_list)])


### PR DESCRIPTION
# Proposed changes

1. Estimate timearithmeticexpr instead of setting Double.MAX Double.MIN directly
2. Enable histogram to derive stats
3. Loose the condition for histogram usage
4. Improve the accuracy for agg on TPC-H 1G greatly
5. Fix avg qerror calculation

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

