### PR TITLE
[Fix](planner)fix conjunct planned on exchange node

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/planner/PlanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/PlanNode.java
@@ -717,6 +717,7 @@ public abstract class PlanNode extends TreeNode<PlanNode> implements PlanStats {
      * Assign remaining unassigned conjuncts.
      */
     protected void assignConjuncts(Analyzer analyzer) {
+        // we cannot plan conjuncts on exchange node, so we just skip the node.
         if (this instanceof ExchangeNode) {
             return;
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/PlanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/PlanNode.java
@@ -717,6 +717,9 @@ public abstract class PlanNode extends TreeNode<PlanNode> implements PlanStats {
      * Assign remaining unassigned conjuncts.
      */
     protected void assignConjuncts(Analyzer analyzer) {
+        if (this instanceof ExchangeNode) {
+            return;
+        }
         List<Expr> unassigned = analyzer.getUnassignedConjuncts(this);
         for (Expr unassignedConjunct : unassigned) {
             addConjunct(unassignedConjunct);

--- a/regression-test/suites/correctness_p0/test_distinct_agg.groovy
+++ b/regression-test/suites/correctness_p0/test_distinct_agg.groovy
@@ -1,0 +1,58 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_distinct_agg") {
+    sql 'drop table if exists t'
+
+    sql '''
+        CREATE TABLE `t` (
+            `k1` bigint(20) NULL,
+            `k2` varchar(20) NULL,
+            `k3` varchar(20) NULL,
+            `k4` varchar(20) NULL,
+            `k5` varchar(20) NULL,
+            `k6` datetime NULL
+        ) ENGINE=OLAP
+        UNIQUE KEY(`k1`, `k2`)
+        DISTRIBUTED BY HASH(`k1`, `k2`) BUCKETS 3
+        PROPERTIES (
+        "replication_allocation" = "tag.location.default: 1",
+    );
+    '''
+
+    sql '''
+        INSERT INTO `dws_task_campaign_wide` (`id`, `shard_key`, `user_id`, `customer_id`, `popu_cust_channel`, `trans_time`)
+        VALUES (1, '1234', 'A0', 'C0', '1', '2023-01-10 23:00:00');
+    '''
+
+    test {
+        sql '''
+            select k5, k6, SUM(k3) AS k3 
+            from ( 
+                select
+                    k5,
+                    date_format(k6, '%Y-%m-%d') as k6,
+                    count(distinct k3) as k3 
+                from t 
+                where 1=1 
+                group by k5, k6
+            ) AS temp where 1=1
+            group by k5, k6;
+        '''
+        result([[1L, '2013-01-10', 1L]])
+    }
+}

--- a/regression-test/suites/correctness_p0/test_distinct_agg.groovy
+++ b/regression-test/suites/correctness_p0/test_distinct_agg.groovy
@@ -30,12 +30,12 @@ suite("test_distinct_agg") {
         UNIQUE KEY(`k1`, `k2`)
         DISTRIBUTED BY HASH(`k1`, `k2`) BUCKETS 3
         PROPERTIES (
-        "replication_allocation" = "tag.location.default: 1",
-    );
+            "replication_allocation" = "tag.location.default: 1"
+        );
     '''
 
     sql '''
-        INSERT INTO `dws_task_campaign_wide` (`id`, `shard_key`, `user_id`, `customer_id`, `popu_cust_channel`, `trans_time`)
+        INSERT INTO `t` (`k1`, `k2`, `k3`, `k4`, `k5`, `k6`)
         VALUES (1, '1234', 'A0', 'C0', '1', '2023-01-10 23:00:00');
     '''
 

--- a/regression-test/suites/correctness_p0/test_distinct_agg.groovy
+++ b/regression-test/suites/correctness_p0/test_distinct_agg.groovy
@@ -35,8 +35,8 @@ suite("test_distinct_agg") {
     '''
 
     sql '''
-        INSERT INTO `t` (`k1`, `k2`, `k3`, `k4`, `k5`, `k6`)
-        VALUES (1, '1234', 'A0', 'C0', '1', '2023-01-10 23:00:00');
+        INSERT INTO `t` (`k1`, `k2`, `k3`, `k4`, `k5`, `k6`) VALUES
+            (1, '1234', 'A0', 'C0', '1', '2023-01-10 23:00:00');
     '''
 
     test {
@@ -53,6 +53,6 @@ suite("test_distinct_agg") {
             ) AS temp where 1=1
             group by k5, k6;
         '''
-        result([[1L, '2013-01-10', 1L]])
+        result([['1', '2023-01-10', 1L]])
     }
 }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

sql like: 
select k5, k6, SUM(k3) AS k3 
from ( 
    select
        k5,
        date_format(k6, '%Y-%m-%d') as k6,
        count(distinct k3) as k3 
    from t 
    group by k5, k6
) AS temp where 1=1
group by k5, k6;

will throw exception since conjuncts planned on exchange node, because exchange node cannot handle conjuncts, now we skip exchange node when planning conjuncts, which fixes the bug. 
notice: the bug occurs iff the conjunct is always true like 1=1 above.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [x] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [x] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

