### PR TITLE
[bugfix](txn) return when txn state is null when doing abort txn

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/transaction/GlobalTransactionMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/transaction/GlobalTransactionMgr.java
@@ -299,6 +299,10 @@ public class GlobalTransactionMgr implements Writable {
     public void abortTransaction(long dbId, long transactionId, String reason) throws UserException {
         Database db = Env.getCurrentInternalCatalog().getDbNullable(dbId);
         TransactionState transactionState = getDatabaseTransactionMgr(dbId).getTransactionState(transactionId);
+        if (transactionState == null) {
+            LOG.info("try to cancel one txn which has no txn state. txn id: {}.", transactionId);
+            return;
+        }
         List<Table> tableList = db.getTablesOnIdOrderIfExist(transactionState.getTableIdList());
         abortTransaction(dbId, transactionId, reason, null, tableList);
     }


### PR DESCRIPTION
# Proposed changes

follower #17893
When doing broker load, if we encountered one error before the txn starts, then there would be one abort txn rpc. Unfortunately, there is no txn state for the corresponding txn, so the following procedure would throw NPE when accessing the null state.
This pr makes it just return if there is no corresponding txn state.
## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

