### PR TITLE
[enhancement](MTMV) Add a timeout for regression tests

### DIFF
--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/suite/Suite.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/suite/Suite.groovy
@@ -400,9 +400,9 @@ class Suite implements GroovyInterceptable {
         List<List<String>> showTaskMetaResult = sql_meta(showTasks)
         int index = showTaskMetaResult.indexOf(['State', 'CHAR'])
         String status = "PENDING"
-        int count = 0
-        int retryTimes = 300
         List<List<Object>> result
+        long startTime = System.currentTimeMillis()
+        long timeoutTimestamp = startTime + 30 * 60 * 1000 // 30 min
         do {
             result = sql(showTasks)
             if (!result.isEmpty()) {
@@ -410,8 +410,7 @@ class Suite implements GroovyInterceptable {
             }
             println "The state of ${showTasks} is ${status}"
             Thread.sleep(1000);
-            count += 1
-        } while (count < retryTimes && (status == 'PENDING' || status == 'RUNNING'))
+        } while (timeoutTimestamp > System.currentTimeMillis() && (status == 'PENDING' || status == 'RUNNING'))
         if (status != "SUCCESS") {
             println "status is not success"
             println result.toString()

--- a/regression-test/suites/mtmv_p0/test_alter_mtmv.groovy
+++ b/regression-test/suites/mtmv_p0/test_alter_mtmv.groovy
@@ -69,19 +69,7 @@ suite("test_alter_mtmv") {
     """
 
     // waiting the task to be finished.
-    def show_task_meta = sql_meta "SHOW MTMV TASK ON ${mvName}"
-    def index = show_task_meta.indexOf(['State', 'CHAR'])
-    def query = "SHOW MTMV TASK ON ${mvName}"
-    def show_task_result
-    def state = "PENDING"
-    do {
-        show_task_result = sql "${query}"
-        if (!show_task_result.isEmpty()) {
-            state = show_task_result.last().get(index)
-        }
-        println "The state of ${query} is ${state}"
-        Thread.sleep(1000);
-    } while (state.equals('PENDING') || state.equals('RUNNING'))
+    waitingMTMVTaskFinished(mvName)
 
     // test alter mtmv
     sql """

--- a/regression-test/suites/mtmv_p0/test_create_both_mtmv.groovy
+++ b/regression-test/suites/mtmv_p0/test_create_both_mtmv.groovy
@@ -70,19 +70,7 @@ suite("test_create_both_mtmv") {
         SELECT ${tableName}.username, ${tableNamePv}.pv FROM ${tableName}, ${tableNamePv} WHERE ${tableName}.id=${tableNamePv}.id;
     """
     // wait task to be finished to avoid task leak in suite.
-    def show_task_meta = sql_meta "SHOW MTMV TASK ON ${mvName}"
-    def index = show_task_meta.indexOf(['State', 'CHAR'])
-    def query = "SHOW MTMV TASK ON ${mvName}"
-    def show_task_result
-    def state = "PENDING"
-    do {
-        show_task_result = sql "${query}"
-        if (!show_task_result.isEmpty()) {
-            state = show_task_result.last().get(index)
-        }
-        println "The state of ${query} is ${state}"
-        Thread.sleep(1000);
-    } while (state.equals('PENDING') || state.equals('RUNNING'))
+    waitingMTMVTaskFinished(mvName)
 
     def show_job_result = sql "SHOW MTMV JOB ON ${mvName}"
     assertEquals 1, show_job_result.size(), show_job_result.toString()

--- a/regression-test/suites/mtmv_p0/test_create_mtmv.groovy
+++ b/regression-test/suites/mtmv_p0/test_create_mtmv.groovy
@@ -68,21 +68,8 @@ suite("test_create_mtmv") {
         SELECT ${tableName}.username, ${tableNamePv}.pv FROM ${tableName}, ${tableNamePv} WHERE ${tableName}.id=${tableNamePv}.id;
     """
 
-    def show_task_meta = sql_meta "SHOW MTMV TASK ON ${mvName}"
-    def index = show_task_meta.indexOf(['State', 'CHAR'])
-    def query = "SHOW MTMV TASK ON ${mvName}"
-    def show_task_result
-    def state = "PENDING"
-    do {
-        show_task_result = sql "${query}"
-        if (!show_task_result.isEmpty()) {
-            state = show_task_result.last().get(index)
-        }
-        println "The state of ${query} is ${state}"
-        Thread.sleep(1000);
-    } while (state.equals('PENDING') || state.equals('RUNNING'))
+    waitingMTMVTaskFinished(mvName)
 
-    assertEquals 'SUCCESS', state, show_task_result.last().toString()
     order_qt_select "SELECT * FROM ${mvName}"
 
     sql """

--- a/regression-test/suites/mtmv_p0/test_refresh_mtmv.groovy
+++ b/regression-test/suites/mtmv_p0/test_refresh_mtmv.groovy
@@ -69,38 +69,17 @@ suite("test_refresh_mtmv") {
     """
 
    // waiting the task to be finished.
-    def show_task_meta = sql_meta "SHOW MTMV TASK ON ${mvName}"
-    def index = show_task_meta.indexOf(['State', 'CHAR'])
-    def query = "SHOW MTMV TASK ON ${mvName}"
-    def show_task_result
-    def state = "PENDING"
-    do {
-        show_task_result = sql "${query}"
-        if (!show_task_result.isEmpty()) {
-            state = show_task_result.last().get(index)
-        }
-        println "The state of ${query} is ${state}"
-        Thread.sleep(1000);
-    } while (state.equals('PENDING') || state.equals('RUNNING'))
+    waitingMTMVTaskFinished(mvName)
 
-    assertEquals 'SUCCESS', state, show_task_result.last().toString()
     order_qt_select "SELECT * FROM ${mvName}"
 
     // test REFRESH make sure only define one mv and already run a task.
     sql """
         REFRESH MATERIALIZED VIEW ${mvName} COMPLETE
     """
-    state = "PENDING"
-    do {
-        show_task_result = sql "${query}"
-        if (!show_task_result.isEmpty()) {
-            state = show_task_result.last().get(index)
-        }
-        println "The state of ${query} is ${state}"
-        Thread.sleep(1000);
-    } while (state.equals('PENDING') || state.equals('RUNNING'))
+    waitingMTMVTaskFinished(mvName)
 
-    assertEquals 'SUCCESS', state, show_task_result.last().toString()
+    def show_task_result = sql "SHOW MTMV TASK ON ${mvName}"
     assertEquals 2, show_task_result.size(), show_task_result.toString()
 
     sql """


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary
MTMV regresiion will loop forever when some bug cause the state not change.

So add a timeout to avoid endless loop. Now it's hard code of 30 mins. 

## Checklist(Required)

* [ ] Does it affect the original behavior
* [x] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

