### PR TITLE
[Feature-Wip](MySQL Load)Show load warnings for mysql load

### DIFF
--- a/docs/zh-CN/docs/data-operate/import/import-way/mysql-load-manual.md
+++ b/docs/zh-CN/docs/data-operate/import/import-way/mysql-load-manual.md
@@ -56,6 +56,14 @@ MySQL Load 支持数据格式：CSV（文本）。
 
 ## 基本操作举例
 
+### 客户端连接
+```bash
+mysql --local-infile  -h 127.0.0.1 -P 9030 -u root -D testdb
+```
+
+注意: 执行MySQL Load语句的时候, 客户端命令必须带有`--local-infile`, 否则执行可能会出现错误信息. 如果是通过JDBC方式连接的话, 在URL中需要加入配置`allowLoadLocalInfile=true`
+
+
 ### 创建测试表
 ```sql
 CREATE TABLE testdb.t1 (pk INT, v1 INT SUM) AGGREGATE KEY (pk) DISTRIBUTED BY hash (pk) PROPERTIES ('replication_num' = '1');
@@ -105,7 +113,7 @@ PROPERTIES ("strict_mode"="true")
 2. FE为多节点部署, 导入服务端文件功能只能够导入客户端连接的FE节点, 无法导入其他FE节点本地的文件.
 3. 服务端导入默认是关闭, 通过设置FE的配置`mysql_load_server_secure_path`开启, 导入文件的必须在该目录下.
 
-### 返回结果
+### 正常结果
 
 由于 MySQL load 是一种同步的导入方式，所以导入的结果会通过SQL语法返回给用户。
 如果导入执行失败, 会展示具体的报错信息. 如果导入成功, 则会显示导入的行数.
@@ -115,9 +123,25 @@ Query OK, 1 row affected (0.17 sec)
 Records: 1  Deleted: 0  Skipped: 0  Warnings: 0
 ```
 
+### 异常结果
+由如果执行出现异常, 会在客户端中出现异常显示, 例如下面最常见的异常
+```text
+ERROR 1105 (HY000): errCode = 2, detailMessage = [INTERNAL_ERROR]too many filtered rows with load id b612907c-ccf4-4ac2-82fe-107ece655f0f
+```
+
+当遇到这类异常错误, 可以找到其中的`loadId`, 可以通过`show load warnings`命令在客户端中直接展示详细的数据异常.
+```sql
+show load warnings where label='b612907c-ccf4-4ac2-82fe-107ece655f0f';
+```
+
+异常信息中的LoadId即为Warning命令中的label信息.
+
+
 ### 配置项
-1. `mysql_load_thread_pool`控制单个FE中MySQL Load并发执行线程个数, 默认为4. 线程池的排队对接大小为`mysql_load_thread_pool`的5倍, 因此默认情况下, 可以并发提交的任务为 4 + 4*5 = 24个. 如果并发个数超过24时, 可以调大该配置项.
+1. `mysql_load_thread_pool`控制单个FE中MySQL Load并发执行线程个数, 默认为4. 线程池的排队对接大小为`mysql_load_thread_pool`的5倍, 因此默认情况下, 可以并发提交的任务为 4 + 4\*5 = 24个. 如果并发个数超过24时, 可以调大该配置项.
 2. `mysql_load_server_secure_path`服务端导入的安全路径, 默认为空, 即不允许服务端导入. 如需开启这个功能, 建议在`DORIS_HOME`目录下创建一个`local_import_data`目录, 用于导入数据.
+3. `mysql_load_in_memory_record`失败的任务记录个数, 该记录会保留在内存中, 默认只会保留最近的20. 如果有需要可以调大该配置. 内存中的记录, 有效期为1天, 而且会有异步线程清理, 固定一天清理一次.
+
 
 ## 注意事项
 

--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -2053,6 +2053,8 @@ public class Config extends ConfigBase {
     @ConfField(mutable = false, masterOnly = false)
     public static String mysql_load_server_secure_path = "";
 
+    @ConfField(mutable = false, masterOnly = false)
+    public static int mysql_load_in_memory_record = 20;
 
     @ConfField(mutable = false, masterOnly = false)
     public static int mysql_load_thread_pool = 4;

--- a/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/MysqlLoadManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/MysqlLoadManager.java
@@ -35,6 +35,7 @@ import org.apache.doris.system.BeSelectionPolicy;
 import org.apache.doris.system.SystemInfoService;
 
 import com.google.common.base.Joiner;
+import com.google.common.collect.EvictingQueue;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -56,7 +57,10 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 
 public class MysqlLoadManager {
     private static final Logger LOG = LogManager.getLogger(MysqlLoadManager.class);
@@ -99,14 +103,43 @@ public class MysqlLoadManager {
         }
     }
 
-    private final Map<String, MySqlLoadContext> loadContextMap = new ConcurrentHashMap<>();
+    private static class MySqlLoadFailRecord {
+        private final String label;
 
+        private final String errorUrl;
+        private final long startTime;
+
+        public MySqlLoadFailRecord(String label, String errorUrl) {
+            this.label = label;
+            this.errorUrl = errorUrl;
+            this.startTime = System.currentTimeMillis();
+        }
+
+        public String getLabel() {
+            return label;
+        }
+
+        public String getErrorUrl() {
+            return errorUrl;
+        }
+
+        public boolean isExpired() {
+            // hard code the expired value for one day.
+            return System.currentTimeMillis() > startTime + 24 * 60 * 60 * 1000;
+        }
+    }
+
+    private final Map<String, MySqlLoadContext> loadContextMap = new ConcurrentHashMap<>();
+    private final EvictingQueue<MySqlLoadFailRecord> failedRecords;
+    private ScheduledExecutorService periodScheduler = Executors.newScheduledThreadPool(1);
 
     public MysqlLoadManager(TokenManager tokenManager) {
         int poolSize = Config.mysql_load_thread_pool;
         // MySqlLoad pool can accept 4 + 4 * 5 = 24  requests by default.
         this.mysqlLoadPool = ThreadPoolManager.newDaemonFixedThreadPool(poolSize, poolSize * 5, "Mysql Load", true);
         this.tokenManager = tokenManager;
+        this.failedRecords = EvictingQueue.create(Config.mysql_load_in_memory_record);
+        this.periodScheduler.scheduleAtFixedRate(this::cleanFailedRecords, 1, 24, TimeUnit.HOURS);
     }
 
     public LoadJobRowResult executeMySqlLoadJobFromStmt(ConnectContext context, LoadStmt stmt, String loadId)
@@ -124,20 +157,22 @@ public class MysqlLoadManager {
             context.setExecTimeout(newTimeOut);
         }
         String token = tokenManager.acquireToken();
+        boolean clientLocal = dataDesc.isClientLocal();
+        MySqlLoadContext loadContext = new MySqlLoadContext();
+        loadContextMap.put(loadId, loadContext);
         LOG.info("execute MySqlLoadJob for id: {}.", loadId);
         try (final CloseableHttpClient httpclient = HttpClients.createDefault()) {
             for (String file : filePaths) {
-                InputStreamEntity entity = getInputStreamEntity(context, dataDesc.isClientLocal(), file, loadId);
+                InputStreamEntity entity = getInputStreamEntity(context, clientLocal, file, loadId);
                 HttpPut request = generateRequestForMySqlLoad(entity, dataDesc, database, table, token);
-                MySqlLoadContext loadContext = new MySqlLoadContext();
                 loadContext.setRequest(request);
-                loadContextMap.put(loadId, loadContext);
                 try (final CloseableHttpResponse response = httpclient.execute(request)) {
                     String body = EntityUtils.toString(response.getEntity());
                     JsonObject result = JsonParser.parseString(body).getAsJsonObject();
                     if (!result.get("Status").getAsString().equalsIgnoreCase("Success")) {
+                        failedRecords.offer(new MySqlLoadFailRecord(loadId, result.get("ErrorURL").getAsString()));
                         LOG.warn("Execute mysql data load failed with request: {} and response: {}", request, body);
-                        throw new LoadException(result.get("Message").getAsString());
+                        throw new LoadException(result.get("Message").getAsString() + " with load id " + loadId);
                     }
                     loadResult.incRecords(result.get("NumberLoadedRows").getAsLong());
                     loadResult.incSkipped(result.get("NumberFilteredRows").getAsInt());
@@ -146,7 +181,7 @@ public class MysqlLoadManager {
         } catch (Throwable t) {
             LOG.warn("Execute mysql load {} failed", loadId, t);
             // drain the data from client conn util empty packet received, otherwise the connection will be reset
-            if (loadContextMap.containsKey(loadId) && !loadContextMap.get(loadId).isFinished()) {
+            if (clientLocal && loadContextMap.containsKey(loadId) && !loadContextMap.get(loadId).isFinished()) {
                 LOG.warn("not drained yet, try reading left data from client connection for load {}.", loadId);
                 ByteBuffer buffer = context.getMysqlChannel().fetchOnePacket();
                 // MySql client will send an empty packet when eof
@@ -181,7 +216,22 @@ public class MysqlLoadManager {
         }
     }
 
-    public int extractTimeOut(DataDescription desc) {
+    public String getErrorUrlByLoadId(String loadId) {
+        for (MySqlLoadFailRecord record : failedRecords) {
+            if (loadId.equals(record.getLabel())) {
+                return record.getErrorUrl();
+            }
+        }
+        return null;
+    }
+
+    private void cleanFailedRecords() {
+        while (!failedRecords.isEmpty() && failedRecords.peek().isExpired()) {
+            failedRecords.poll();
+        }
+    }
+
+    private int extractTimeOut(DataDescription desc) {
         if (desc.getProperties() != null && desc.getProperties().containsKey(LoadStmt.TIMEOUT_PROPERTY)) {
             return Integer.parseInt(desc.getProperties().get(LoadStmt.TIMEOUT_PROPERTY));
         }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary
1. Support the `show load warnings` for mysql load to get the detail error message.
2. Fix `fillByteBufferAsync` not mark the load as finished in same data load
3. Fix `drain data` only in client mode.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [x] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

