### PR TITLE
[Fix](Nereids)fix nereids is failed to parse union with query covered parenthesis

### DIFF
--- a/fe/fe-core/src/main/antlr4/org/apache/doris/nereids/DorisParser.g4
+++ b/fe/fe-core/src/main/antlr4/org/apache/doris/nereids/DorisParser.g4
@@ -57,8 +57,8 @@ planType
 
 //  -----------------Query-----------------
 query
-    : {!doris_legacy_SQL_syntax}? cte? queryTerm queryOrganization
-    | {doris_legacy_SQL_syntax}? queryTerm
+    // : {!doris_legacy_SQL_syntax}? cte? queryTerm queryOrganization
+    : {doris_legacy_SQL_syntax}? queryTerm
     ;
 
 queryTerm

--- a/fe/fe-core/src/main/antlr4/org/apache/doris/nereids/DorisParser.g4
+++ b/fe/fe-core/src/main/antlr4/org/apache/doris/nereids/DorisParser.g4
@@ -58,17 +58,15 @@ planType
 //  -----------------Query-----------------
 query
     : {!doris_legacy_SQL_syntax}? cte? queryTerm queryOrganization
-    | {doris_legacy_SQL_syntax}? queryTerm
+    | {doris_legacy_SQL_syntax}? queryTerm queryOrganization
     ;
 
+// add queryOrganization for parse (q1) union (q2) union (q3) order by keys, otherwise 'order' will be recognized to be
+// identifier.
 queryTerm
     : queryPrimary                                                                       #queryTermDefault
-    | left=setOpQueryTerm operator=(UNION | EXCEPT | INTERSECT)
-      setQuantifier? right=setOpQueryTerm                                                     #setOperation
-    ;
-
-setOpQueryTerm
-    : LEFT_PAREN queryTerm RIGHT_PAREN
+    | left=queryTerm operator=(UNION | EXCEPT | INTERSECT)
+      setQuantifier? right=queryTerm                                                     #setOperation
     ;
 
 setQuantifier

--- a/fe/fe-core/src/main/antlr4/org/apache/doris/nereids/DorisParser.g4
+++ b/fe/fe-core/src/main/antlr4/org/apache/doris/nereids/DorisParser.g4
@@ -56,13 +56,13 @@ planType
     ;
 
 //  -----------------Query-----------------
+// add queryOrganization for parse (q1) union (q2) union (q3) order by keys, otherwise 'order' will be recognized to be
+// identifier.
 query
     : {!doris_legacy_SQL_syntax}? cte? queryTerm queryOrganization
     | {doris_legacy_SQL_syntax}? queryTerm queryOrganization
     ;
 
-// add queryOrganization for parse (q1) union (q2) union (q3) order by keys, otherwise 'order' will be recognized to be
-// identifier.
 queryTerm
     : queryPrimary                                                                       #queryTermDefault
     | left=queryTerm operator=(UNION | EXCEPT | INTERSECT)

--- a/fe/fe-core/src/main/antlr4/org/apache/doris/nereids/DorisParser.g4
+++ b/fe/fe-core/src/main/antlr4/org/apache/doris/nereids/DorisParser.g4
@@ -174,7 +174,7 @@ queryOrganization
     ;
 
 sortClause
-    : (ORDER BY sortItem (COMMA sortItem)*)
+    : ORDER BY sortItem (COMMA sortItem)*
     ;
 
 sortItem

--- a/fe/fe-core/src/main/antlr4/org/apache/doris/nereids/DorisParser.g4
+++ b/fe/fe-core/src/main/antlr4/org/apache/doris/nereids/DorisParser.g4
@@ -57,14 +57,18 @@ planType
 
 //  -----------------Query-----------------
 query
-    // : {!doris_legacy_SQL_syntax}? cte? queryTerm queryOrganization
-    : {doris_legacy_SQL_syntax}? queryTerm
+    : {!doris_legacy_SQL_syntax}? cte? queryTerm queryOrganization
+    | {doris_legacy_SQL_syntax}? queryTerm
     ;
 
 queryTerm
     : queryPrimary                                                                       #queryTermDefault
-    | left=queryTerm operator=(UNION | EXCEPT | INTERSECT)
-      setQuantifier? right=queryTerm                                                     #setOperation
+    | left=setOpQueryTerm operator=(UNION | EXCEPT | INTERSECT)
+      setQuantifier? right=setOpQueryTerm                                                     #setOperation
+    ;
+
+setOpQueryTerm
+    : LEFT_PAREN queryTerm RIGHT_PAREN
     ;
 
 setQuantifier

--- a/fe/fe-core/src/main/antlr4/org/apache/doris/nereids/DorisParser.g4
+++ b/fe/fe-core/src/main/antlr4/org/apache/doris/nereids/DorisParser.g4
@@ -66,7 +66,7 @@ query
 queryTerm
     : queryPrimary                                                                       #queryTermDefault
     | left=queryTerm operator=(UNION | EXCEPT | INTERSECT)
-      setQuantifier? right=queryTerm                                                     #setOperation
+      setQuantifier? right=queryTerm                                                    #setOperation
     ;
 
 setQuantifier

--- a/fe/fe-core/src/main/antlr4/org/apache/doris/nereids/DorisParser.g4
+++ b/fe/fe-core/src/main/antlr4/org/apache/doris/nereids/DorisParser.g4
@@ -66,7 +66,7 @@ query
 queryTerm
     : queryPrimary                                                                       #queryTermDefault
     | left=queryTerm operator=(UNION | EXCEPT | INTERSECT)
-      setQuantifier? right=queryTerm                                                    #setOperation
+      setQuantifier? right=queryTerm                                                     #setOperation
     ;
 
 setQuantifier

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/LogicalPlanBuilder.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/LogicalPlanBuilder.java
@@ -370,17 +370,16 @@ public class LogicalPlanBuilder extends DorisParserBaseVisitor<Object> {
         return ParserUtils.withOrigin(ctx, () -> {
             // TODO: need to add withQueryResultClauses and withCTE
             LogicalPlan query = plan(ctx.queryTerm());
-            return query;
-            // query = withCte(query, ctx.cte());
-            // return withQueryOrganization(query, ctx.queryOrganization());
+            query = withCte(query, ctx.cte());
+            return withQueryOrganization(query, ctx.queryOrganization());
         });
     }
 
     @Override
     public LogicalPlan visitSetOperation(SetOperationContext ctx) {
         return ParserUtils.withOrigin(ctx, () -> {
-            LogicalPlan leftQuery = plan(ctx.left);
-            LogicalPlan rightQuery = plan(ctx.right);
+            LogicalPlan leftQuery = plan(ctx.left.queryTerm());
+            LogicalPlan rightQuery = plan(ctx.right.queryTerm());
             Qualifier qualifier;
             if (ctx.setQuantifier() == null || ctx.setQuantifier().DISTINCT() != null) {
                 qualifier = Qualifier.DISTINCT;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/LogicalPlanBuilder.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/LogicalPlanBuilder.java
@@ -378,8 +378,8 @@ public class LogicalPlanBuilder extends DorisParserBaseVisitor<Object> {
     @Override
     public LogicalPlan visitSetOperation(SetOperationContext ctx) {
         return ParserUtils.withOrigin(ctx, () -> {
-            LogicalPlan leftQuery = plan(ctx.left.queryTerm());
-            LogicalPlan rightQuery = plan(ctx.right.queryTerm());
+            LogicalPlan leftQuery = plan(ctx.left);
+            LogicalPlan rightQuery = plan(ctx.right);
             Qualifier qualifier;
             if (ctx.setQuantifier() == null || ctx.setQuantifier().DISTINCT() != null) {
                 qualifier = Qualifier.DISTINCT;
@@ -392,14 +392,17 @@ public class LogicalPlanBuilder extends DorisParserBaseVisitor<Object> {
                     .add(rightQuery)
                     .build();
 
+            LogicalPlan plan = null;
             if (ctx.UNION() != null) {
-                return new LogicalUnion(qualifier, newChildren);
+                plan = new LogicalUnion(qualifier, newChildren);
             } else if (ctx.EXCEPT() != null) {
-                return new LogicalExcept(qualifier, newChildren);
+                plan = new LogicalExcept(qualifier, newChildren);
             } else if (ctx.INTERSECT() != null) {
-                return new LogicalIntersect(qualifier, newChildren);
+                plan = new LogicalIntersect(qualifier, newChildren);
+            } else {
+                throw new ParseException("not support", ctx);
             }
-            throw new ParseException("not support", ctx);
+            return plan;
         });
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/LogicalPlanBuilder.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/LogicalPlanBuilder.java
@@ -370,8 +370,9 @@ public class LogicalPlanBuilder extends DorisParserBaseVisitor<Object> {
         return ParserUtils.withOrigin(ctx, () -> {
             // TODO: need to add withQueryResultClauses and withCTE
             LogicalPlan query = plan(ctx.queryTerm());
-            query = withCte(query, ctx.cte());
-            return withQueryOrganization(query, ctx.queryOrganization());
+            return query;
+            // query = withCte(query, ctx.cte());
+            // return withQueryOrganization(query, ctx.queryOrganization());
         });
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/LogicalPlanBuilder.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/LogicalPlanBuilder.java
@@ -392,7 +392,7 @@ public class LogicalPlanBuilder extends DorisParserBaseVisitor<Object> {
                     .add(rightQuery)
                     .build();
 
-            LogicalPlan plan = null;
+            LogicalPlan plan;
             if (ctx.UNION() != null) {
                 plan = new LogicalUnion(qualifier, newChildren);
             } else if (ctx.EXCEPT() != null) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalSetOperation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalSetOperation.java
@@ -120,8 +120,7 @@ public abstract class LogicalSetOperation extends AbstractLogicalPlan implements
                         cast.child().nullable()));
             } else if (expression instanceof Slot) {
                 Slot slot = ((Slot) expression);
-                newOutputs.add(new SlotReference(slot.toSql(), slot.getDataType(),
-                        slot.nullable(), slot.getQualifier()));
+                newOutputs.add(new SlotReference(slot.toSql(), slot.getDataType(), slot.nullable()));
             }
         }
         return newOutputs.build();

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalSetOperation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalSetOperation.java
@@ -114,12 +114,14 @@ public abstract class LogicalSetOperation extends AbstractLogicalPlan implements
         ImmutableList.Builder<NamedExpression> newOutputs = new Builder<>();
         for (Expression expression : leftCastExpressions) {
             if (expression instanceof Cast) {
+                Cast cast = ((Cast) expression);
                 newOutputs.add(new SlotReference(
-                        ((Cast) expression).child().toSql(), expression.getDataType(),
-                        ((Cast) expression).child().nullable()));
+                        cast.child().toSql(), expression.getDataType(),
+                        cast.child().nullable()));
             } else if (expression instanceof Slot) {
-                newOutputs.add(new SlotReference(
-                        expression.toSql(), expression.getDataType(), expression.nullable()));
+                Slot slot = ((Slot) expression);
+                newOutputs.add(new SlotReference(slot.toSql(), slot.getDataType(),
+                        slot.nullable(), slot.getQualifier()));
             }
         }
         return newOutputs.build();

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/parser/NereidsParserTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/parser/NereidsParserTest.java
@@ -276,6 +276,14 @@ public class NereidsParserTest extends ParserTestBase {
         NereidsParser nereidsParser1 = new NereidsParser();
         LogicalPlan logicalPlan1 = nereidsParser1.parseSingle(union1);
         System.out.println(logicalPlan1.treeString());
+
+        String union2 = "(SELECT K1, K2, K3, K4, K5, K6, K7, K8, K9, K10, K11 FROM test WHERE K1 > 0)"
+                + " UNION ALL (SELECT 1, 2, 3, 4, 3.14, 'HELLO', 'WORLD', 0.0, 1.1, CAST('1989-03-21' AS DATE), CAST('1989-03-21 13:00:00' AS DATETIME))"
+                + " UNION ALL (SELECT K1, K2, K3, K4, K5, K6, K7, K8, K9, K10, K11 FROM baseall WHERE K3 > 0)"
+                + " ORDER BY K1, K2, K3, K4";
+        NereidsParser nereidsParser2 = new NereidsParser();
+        LogicalPlan logicalPlan2 = nereidsParser2.parseSingle(union2);
+        System.out.println(logicalPlan2.treeString());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/parser/NereidsParserTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/parser/NereidsParserTest.java
@@ -41,7 +41,6 @@ import org.apache.doris.nereids.types.DecimalV2Type;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/parser/NereidsParserTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/parser/NereidsParserTest.java
@@ -273,17 +273,22 @@ public class NereidsParserTest extends ParserTestBase {
         System.out.println(logicalPlan.treeString());
 
         String union1 = "select * from t1 union (select * from t2 union all select * from t3)";
-        NereidsParser nereidsParser1 = new NereidsParser();
-        LogicalPlan logicalPlan1 = nereidsParser1.parseSingle(union1);
+        LogicalPlan logicalPlan1 = nereidsParser.parseSingle(union1);
         System.out.println(logicalPlan1.treeString());
 
         String union2 = "(SELECT K1, K2, K3, K4, K5, K6, K7, K8, K9, K10, K11 FROM test WHERE K1 > 0)"
                 + " UNION ALL (SELECT 1, 2, 3, 4, 3.14, 'HELLO', 'WORLD', 0.0, 1.1, CAST('1989-03-21' AS DATE), CAST('1989-03-21 13:00:00' AS DATETIME))"
                 + " UNION ALL (SELECT K1, K2, K3, K4, K5, K6, K7, K8, K9, K10, K11 FROM baseall WHERE K3 > 0)"
                 + " ORDER BY K1, K2, K3, K4";
-        NereidsParser nereidsParser2 = new NereidsParser();
-        LogicalPlan logicalPlan2 = nereidsParser2.parseSingle(union2);
+        LogicalPlan logicalPlan2 = nereidsParser.parseSingle(union2);
         System.out.println(logicalPlan2.treeString());
+
+        String union3 = "select a.k1 k1, a.k2, a.k3, b.k1, b.k2, b.k3 from test a left outer join baseall b"
+                + " on a.k1 = b.k1 and a.k2 > b.k2 union (select a.k1, a.k2, a.k3, b.k1, b.k2, b.k3"
+                + " from test a right outer join baseall b on a.k1 = b.k1 and a.k2 > b.k2)"
+                + " order by isnull(k1), 1, 2, 3, 4, 5 limit 65535";
+        LogicalPlan logicalPlan3 = nereidsParser.parseSingle(union3);
+        System.out.println(logicalPlan3.treeString());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/parser/NereidsParserTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/parser/NereidsParserTest.java
@@ -41,6 +41,7 @@ import org.apache.doris.nereids.types.DecimalV2Type;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -283,10 +284,10 @@ public class NereidsParserTest extends ParserTestBase {
         LogicalPlan logicalPlan2 = nereidsParser.parseSingle(union2);
         System.out.println(logicalPlan2.treeString());
 
-        String union3 = "select a.k1 k1, a.k2, a.k3, b.k1, b.k2, b.k3 from test a left outer join baseall b"
+        String union3 = "select a.k1, a.k2, a.k3, b.k1, b.k2, b.k3 from test a left outer join baseall b"
                 + " on a.k1 = b.k1 and a.k2 > b.k2 union (select a.k1, a.k2, a.k3, b.k1, b.k2, b.k3"
                 + " from test a right outer join baseall b on a.k1 = b.k1 and a.k2 > b.k2)"
-                + " order by isnull(k1), 1, 2, 3, 4, 5 limit 65535";
+                + " order by isnull(a.k1), 1, 2, 3, 4, 5 limit 65535";
         LogicalPlan logicalPlan3 = nereidsParser.parseSingle(union3);
         System.out.println(logicalPlan3.treeString());
     }

--- a/regression-test/suites/nereids_p0/join/test_join.groovy
+++ b/regression-test/suites/nereids_p0/join/test_join.groovy
@@ -398,12 +398,12 @@ suite("test_join", "nereids_p0") {
         sql"""select ${s} from ${tbName1} a left outer join ${tbName2} b on a.k1 = b.k1 
                  left outer join ${tbName3} c on a.k2 = c.k2 order by 1, 2, 3, 4, 5 limit 65535"""
     }
-    sql"""select a.k1 k1, a.k2, a.k3, b.k1, b.k2, b.k3 from ${tbName1} a full outer join ${tbName2} b 
-             on a.k1 = b.k1 and a.k2 > b.k2 order by isnull(k1), 1, 2, 3, 4, 5 limit 65535"""
-    sql"""select a.k1 k1, a.k2, a.k3, b.k1, b.k2, b.k3 from ${tbName1} a left outer join ${tbName2} b 
+    sql"""select a.k1 k, a.k2, a.k3, b.k1, b.k2, b.k3 from ${tbName1} a full outer join ${tbName2} b 
+             on a.k1 = b.k1 and a.k2 > b.k2 order by isnull(k), 1, 2, 3, 4, 5 limit 65535"""
+    sql"""select a.k1 k, a.k2, a.k3, b.k1, b.k2, b.k3 from ${tbName1} a left outer join ${tbName2} b 
              on a.k1 = b.k1 and a.k2 > b.k2 union (select a.k1, a.k2, a.k3, b.k1, b.k2, b.k3 
              from ${tbName1} a right outer join ${tbName2} b on a.k1 = b.k1 and a.k2 > b.k2) 
-             order by isnull(k1), 1, 2, 3, 4, 5 limit 65535"""
+             order by isnull(k), 1, 2, 3, 4, 5 limit 65535"""
     sql"""select count(*) from ${tbName1} a full outer join ${tbName2} b on a.k2 = b.k2 and a.k1 > 0 
             full outer join ${tbName3} c on a.k3 = c.k3 and b.k1 = c.k1 and c.k3 > 0"""
     sql"""select count(*) from ((select a.k1 as k1, b.k1 as k2, a.k2 as k3, b.k2 as k4, a.k3 as k5, b.k3 as k6, c.k1 as k7, c.k2 as k8, c.k3 as k9 from ${tbName1} a 

--- a/regression-test/suites/nereids_p0/join/test_join.groovy
+++ b/regression-test/suites/nereids_p0/join/test_join.groovy
@@ -398,12 +398,12 @@ suite("test_join", "nereids_p0") {
         sql"""select ${s} from ${tbName1} a left outer join ${tbName2} b on a.k1 = b.k1 
                  left outer join ${tbName3} c on a.k2 = c.k2 order by 1, 2, 3, 4, 5 limit 65535"""
     }
-    sql"""select a.k1 k1, a.k2, a.k3, b.k1, b.k2, b.k3 from ${tbName1} a full outer join ${tbName2} b 
-             on a.k1 = b.k1 and a.k2 > b.k2 order by isnull(k1), 1, 2, 3, 4, 5 limit 65535"""
-    sql"""select a.k1 k1, a.k2, a.k3, b.k1, b.k2, b.k3 from ${tbName1} a left outer join ${tbName2} b 
+    sql"""select a.k1, a.k2, a.k3, b.k1, b.k2, b.k3 from ${tbName1} a full outer join ${tbName2} b 
+             on a.k1 = b.k1 and a.k2 > b.k2 order by isnull(a.k1), 1, 2, 3, 4, 5 limit 65535"""
+    sql"""select a.k1, a.k2, a.k3, b.k1, b.k2, b.k3 from ${tbName1} a left outer join ${tbName2} b 
              on a.k1 = b.k1 and a.k2 > b.k2 union (select a.k1, a.k2, a.k3, b.k1, b.k2, b.k3 
              from ${tbName1} a right outer join ${tbName2} b on a.k1 = b.k1 and a.k2 > b.k2) 
-             order by isnull(k1), 1, 2, 3, 4, 5 limit 65535"""
+             order by isnull(a.k1), 1, 2, 3, 4, 5 limit 65535"""
     sql"""select count(*) from ${tbName1} a full outer join ${tbName2} b on a.k2 = b.k2 and a.k1 > 0 
             full outer join ${tbName3} c on a.k3 = c.k3 and b.k1 = c.k1 and c.k3 > 0"""
     sql"""select count(*) from ((select a.k1 as k1, b.k1 as k2, a.k2 as k3, b.k2 as k4, a.k3 as k5, b.k3 as k6, c.k1 as k7, c.k2 as k8, c.k3 as k9 from ${tbName1} a 

--- a/regression-test/suites/nereids_p0/join/test_join.groovy
+++ b/regression-test/suites/nereids_p0/join/test_join.groovy
@@ -398,12 +398,12 @@ suite("test_join", "nereids_p0") {
         sql"""select ${s} from ${tbName1} a left outer join ${tbName2} b on a.k1 = b.k1 
                  left outer join ${tbName3} c on a.k2 = c.k2 order by 1, 2, 3, 4, 5 limit 65535"""
     }
-    sql"""select a.k1, a.k2, a.k3, b.k1, b.k2, b.k3 from ${tbName1} a full outer join ${tbName2} b 
-             on a.k1 = b.k1 and a.k2 > b.k2 order by isnull(a.k1), 1, 2, 3, 4, 5 limit 65535"""
-    sql"""select a.k1, a.k2, a.k3, b.k1, b.k2, b.k3 from ${tbName1} a left outer join ${tbName2} b 
+    sql"""select a.k1 k, a.k2, a.k3, b.k1, b.k2, b.k3 from ${tbName1} a full outer join ${tbName2} b 
+             on a.k1 = b.k1 and a.k2 > b.k2 order by isnull(k), 1, 2, 3, 4, 5 limit 65535"""
+    sql"""select a.k1 k, a.k2, a.k3, b.k1, b.k2, b.k3 from ${tbName1} a left outer join ${tbName2} b 
              on a.k1 = b.k1 and a.k2 > b.k2 union (select a.k1, a.k2, a.k3, b.k1, b.k2, b.k3 
              from ${tbName1} a right outer join ${tbName2} b on a.k1 = b.k1 and a.k2 > b.k2) 
-             order by isnull(a.k1), 1, 2, 3, 4, 5 limit 65535"""
+             order by isnull(k), 1, 2, 3, 4, 5 limit 65535"""
     sql"""select count(*) from ${tbName1} a full outer join ${tbName2} b on a.k2 = b.k2 and a.k1 > 0 
             full outer join ${tbName3} c on a.k3 = c.k3 and b.k1 = c.k1 and c.k3 > 0"""
     sql"""select count(*) from ((select a.k1 as k1, b.k1 as k2, a.k2 as k3, b.k2 as k4, a.k3 as k5, b.k3 as k6, c.k1 as k7, c.k2 as k8, c.k3 as k9 from ${tbName1} a 

--- a/regression-test/suites/nereids_p0/join/test_join.groovy
+++ b/regression-test/suites/nereids_p0/join/test_join.groovy
@@ -398,12 +398,12 @@ suite("test_join", "nereids_p0") {
         sql"""select ${s} from ${tbName1} a left outer join ${tbName2} b on a.k1 = b.k1 
                  left outer join ${tbName3} c on a.k2 = c.k2 order by 1, 2, 3, 4, 5 limit 65535"""
     }
-    sql"""select a.k1 k, a.k2, a.k3, b.k1, b.k2, b.k3 from ${tbName1} a full outer join ${tbName2} b 
-             on a.k1 = b.k1 and a.k2 > b.k2 order by isnull(k), 1, 2, 3, 4, 5 limit 65535"""
-    sql"""select a.k1 k, a.k2, a.k3, b.k1, b.k2, b.k3 from ${tbName1} a left outer join ${tbName2} b 
+    sql"""select a.k1 k1, a.k2, a.k3, b.k1, b.k2, b.k3 from ${tbName1} a full outer join ${tbName2} b 
+             on a.k1 = b.k1 and a.k2 > b.k2 order by isnull(k1), 1, 2, 3, 4, 5 limit 65535"""
+    sql"""select a.k1 k1, a.k2, a.k3, b.k1, b.k2, b.k3 from ${tbName1} a left outer join ${tbName2} b 
              on a.k1 = b.k1 and a.k2 > b.k2 union (select a.k1, a.k2, a.k3, b.k1, b.k2, b.k3 
              from ${tbName1} a right outer join ${tbName2} b on a.k1 = b.k1 and a.k2 > b.k2) 
-             order by isnull(k), 1, 2, 3, 4, 5 limit 65535"""
+             order by isnull(k1), 1, 2, 3, 4, 5 limit 65535"""
     sql"""select count(*) from ${tbName1} a full outer join ${tbName2} b on a.k2 = b.k2 and a.k1 > 0 
             full outer join ${tbName3} c on a.k3 = c.k3 and b.k1 = c.k1 and c.k3 > 0"""
     sql"""select count(*) from ((select a.k1 as k1, b.k1 as k2, a.k2 as k3, b.k2 as k4, a.k3 as k5, b.k3 as k6, c.k1 as k7, c.k2 as k8, c.k3 as k9 from ${tbName1} a 

--- a/regression-test/suites/nereids_p0/union/test_union.groovy
+++ b/regression-test/suites/nereids_p0/union/test_union.groovy
@@ -204,7 +204,7 @@ suite("test_union") {
     test {
         sql "(select k1, k1 from ${tbName2}) union (select k2, 1 from ${tbName1}) order by k1"
         check{result, exception, startTime, endTime ->
-            assertTrue(exception == null)
+            assertTrue(exception != null)
         }
     }
     test {

--- a/regression-test/suites/nereids_p0/union/test_union.groovy
+++ b/regression-test/suites/nereids_p0/union/test_union.groovy
@@ -204,8 +204,7 @@ suite("test_union") {
     test {
         sql "(select k1, k1 from ${tbName2}) union (select k2, 1 from ${tbName1}) order by k1"
         check{result, exception, startTime, endTime ->
-            assertTrue(exception != null)
-            logger.info(exception.message)
+            assertTrue(exception == null)
         }
     }
     test {


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

sql like the format (q1, q2, q3 is a query): 
``` sql
(q1) 
UNION ALL (q2)
UNION ALL (q3)
ORDER BY keys
```
cannot be parsed by nereids, because order will be recognized as an alias of query, we add queryOrganization to avoid it.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [x] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [x] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

