### PR TITLE
[Improvement](statistics) Support for statistics removing and incremental collection

### DIFF
--- a/fe/fe-core/src/main/cup/sql_parser.cup
+++ b/fe/fe-core/src/main/cup/sql_parser.cup
@@ -2811,7 +2811,7 @@ analyze_stmt ::=
     :}
     | KW_ANALYZE KW_TABLE table_name:tbl KW_UPDATE KW_HISTOGRAM
     {:
-        RESULT = new AnalyzeStmt(tbl, null, null, new HashMap<>(), true, true);
+        RESULT = new AnalyzeStmt(tbl, null, null, new HashMap<>(), true, true, false);
     :}
     ;
 

--- a/fe/fe-core/src/main/cup/sql_parser.cup
+++ b/fe/fe-core/src/main/cup/sql_parser.cup
@@ -398,6 +398,7 @@ terminal String
     KW_IF,
     KW_IMMEDIATE,
     KW_IN,
+    KW_INCREMENTAL,
     KW_INDEX,
     KW_INDEXES,
     KW_INFILE,
@@ -2791,13 +2792,22 @@ analyze_stmt ::=
     {:
         boolean is_whole_tbl = (cols == null);
         boolean is_histogram = false;
-        RESULT = new AnalyzeStmt(tbl, cols, partitionNames, properties, is_whole_tbl, is_histogram);
+        boolean is_increment = false;
+        RESULT = new AnalyzeStmt(tbl, cols, partitionNames, properties, is_whole_tbl, is_histogram, is_increment);
+    :}
+    | KW_ANALYZE KW_INCREMENTAL KW_TABLE table_name:tbl opt_col_list:cols opt_partition_names:partitionNames opt_properties:properties
+    {:
+        boolean is_whole_tbl = (cols == null);
+        boolean is_histogram = false;
+        boolean is_increment = true;
+        RESULT = new AnalyzeStmt(tbl, cols, partitionNames, properties, is_whole_tbl, is_histogram, is_increment);
     :}
     | KW_ANALYZE KW_TABLE table_name:tbl KW_UPDATE KW_HISTOGRAM KW_ON ident_list:cols opt_partition_names:partitionNames opt_properties:properties
     {:
-        boolean is_whole_tbl = (cols == null);
+        boolean is_whole_tbl = false;
         boolean is_histogram = true;
-        RESULT = new AnalyzeStmt(tbl, cols, partitionNames, properties, is_whole_tbl, is_histogram);
+        boolean is_increment = false;
+        RESULT = new AnalyzeStmt(tbl, cols, partitionNames, properties, is_whole_tbl, is_histogram, is_increment);
     :}
     | KW_ANALYZE KW_TABLE table_name:tbl KW_UPDATE KW_HISTOGRAM
     {:
@@ -2980,9 +2990,9 @@ drop_stmt ::=
         RESULT = new DropPolicyStmt(PolicyTypeEnum.STORAGE, ifExists, policyName, null, null);
     :}
     /* statistics */
-    | KW_DROP KW_STATS opt_table_name:tbl opt_partition_names:partitionNames
+    | KW_DROP KW_STATS opt_table_name:tbl opt_col_list:cols opt_partition_names:partitionNames
     {:
-        RESULT = new DropTableStatsStmt(tbl, partitionNames);
+        RESULT = new DropTableStatsStmt(tbl, partitionNames, cols);
     :}
     ;
 

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/AnalyzeStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/AnalyzeStmt.java
@@ -69,6 +69,7 @@ public class AnalyzeStmt extends DdlStmt {
 
     public boolean isWholeTbl;
     public boolean isHistogram;
+    public boolean isIncrement;
 
     private final TableName tableName;
     private final PartitionNames partitionNames;
@@ -84,13 +85,15 @@ public class AnalyzeStmt extends DdlStmt {
                        PartitionNames partitionNames,
                        Map<String, String> properties,
                        Boolean isWholeTbl,
-                       Boolean isHistogram) {
+                       Boolean isHistogram,
+                       Boolean isIncrement) {
         this.tableName = tableName;
         this.columnNames = columnNames;
         this.partitionNames = partitionNames;
         this.properties = properties;
         this.isWholeTbl = isWholeTbl;
         this.isHistogram = isHistogram;
+        this.isIncrement = isIncrement;
     }
 
     @Override
@@ -231,6 +234,11 @@ public class AnalyzeStmt extends DdlStmt {
     public String toSql() {
         StringBuilder sb = new StringBuilder();
         sb.append("ANALYZE");
+
+        if (isIncrement) {
+            sb.append(" ");
+            sb.append("INCREMENTAL");
+        }
 
         if (tableName != null) {
             sb.append(" ");

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/DropTableStatsStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/DropTableStatsStmt.java
@@ -18,25 +18,25 @@
 package org.apache.doris.analysis;
 
 import org.apache.doris.catalog.Database;
+import org.apache.doris.catalog.DatabaseIf;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.Table;
+import org.apache.doris.catalog.TableIf;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.ErrorReport;
 import org.apache.doris.common.UserException;
 import org.apache.doris.common.util.Util;
+import org.apache.doris.datasource.CatalogIf;
 import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.qe.ConnectContext;
 
-import com.google.common.base.Preconditions;
-import com.google.common.base.Strings;
-import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+import org.apache.commons.lang.StringUtils;
 
-import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Manually drop statistics for tables or partitions.
@@ -48,20 +48,19 @@ import java.util.Set;
  */
 public class DropTableStatsStmt extends DdlStmt {
     private final TableName tableName;
-    private final PartitionNames optPartitionNames;
+    private final PartitionNames partitionNames;
+    private final List<String> columnNames;
 
     // after analyzed
-    private final Map<Long, Set<String>> tblIdToPartition = Maps.newHashMap();
+    private long dbId;
+    private final Set<Long> tbIds = Sets.newHashSet();
+    private final Set<Long> partitionIds = Sets.newHashSet();
 
-    public DropTableStatsStmt(TableName tableName, PartitionNames optPartitionNames) {
+    public DropTableStatsStmt(TableName tableName,
+            PartitionNames partitionNames, List<String> columnNames) {
         this.tableName = tableName;
-        this.optPartitionNames = optPartitionNames;
-    }
-
-    public Map<Long, Set<String>> getTblIdToPartition() {
-        Preconditions.checkArgument(isAnalyzed(),
-                "The partition name must be obtained after the parsing is complete");
-        return tblIdToPartition;
+        this.partitionNames = partitionNames;
+        this.columnNames = columnNames;
     }
 
     @Override
@@ -69,38 +68,102 @@ public class DropTableStatsStmt extends DdlStmt {
         super.analyze(analyzer);
 
         if (tableName != null) {
-            if (Strings.isNullOrEmpty(tableName.getDb())) {
-                tableName.setDb(analyzer.getDefaultDb());
-            }
-
             tableName.analyze(analyzer);
 
-            // check whether the deletion permission is granted
-            checkAnalyzePriv(tableName.getDb(), tableName.getTbl());
+            String catalogName = tableName.getCtl();
+            String dbName = tableName.getDb();
+            String tblName = tableName.getTbl();
+            CatalogIf catalog = analyzer.getEnv().getCatalogMgr()
+                    .getCatalogOrAnalysisException(catalogName);
+            DatabaseIf db = catalog.getDbOrAnalysisException(dbName);
+            TableIf table = db.getTableOrAnalysisException(tblName);
+
+            dbId = db.getId();
+            tbIds.add(table.getId());
 
             // disallow external catalog
-            Util.prohibitExternalCatalog(tableName.getCtl(), this.getClass().getSimpleName());
+            Util.prohibitExternalCatalog(tableName.getCtl(),
+                    this.getClass().getSimpleName());
 
-            Database db = analyzer.getEnv().getInternalCatalog()
-                    .getDbOrAnalysisException(tableName.getDb());
-            long tableId = db.getTableOrAnalysisException(tableName.getTbl()).getId();
+            // check permission
+            checkAnalyzePriv(db.getFullName(), table.getName());
 
-            if (optPartitionNames == null) {
-                tblIdToPartition.put(tableId, null);
-            } else {
-                optPartitionNames.analyze(analyzer);
-                List<String> pNames = optPartitionNames.getPartitionNames();
-                HashSet<String> partitionNames = Sets.newHashSet(pNames);
-                tblIdToPartition.put(tableId, partitionNames);
+            // check partitionNames
+            if (partitionNames != null) {
+                partitionNames.analyze(analyzer);
+                partitionIds.addAll(partitionNames.getPartitionNames().stream()
+                        .map(name -> table.getPartition(name).getId())
+                        .collect(Collectors.toList()));
+            }
+
+            // check columnNames
+            if (columnNames != null) {
+                for (String cName : columnNames) {
+                    if (table.getColumn(cName) == null) {
+                        ErrorReport.reportAnalysisException(
+                                ErrorCode.ERR_WRONG_COLUMN_NAME,
+                                "DROP",
+                                ConnectContext.get().getQualifiedUser(),
+                                ConnectContext.get().getRemoteIP(),
+                                cName);
+                    }
+                }
             }
         } else {
             Database db = analyzer.getEnv().getInternalCatalog()
                     .getDbOrAnalysisException(analyzer.getDefaultDb());
-            for (Table table : db.getTables()) {
+            List<Table> tables = db.getTables();
+            for (Table table : tables) {
                 checkAnalyzePriv(db.getFullName(), table.getName());
-                tblIdToPartition.put(table.getId(), null);
             }
+
+            dbId = db.getId();
+            tbIds.addAll(tables.stream().map(Table::getId).collect(Collectors.toList()));
         }
+    }
+
+    public long getDbId() {
+        return dbId;
+    }
+
+    public Set<Long> getTbIds() {
+        return tbIds;
+    }
+
+    public Set<Long> getPartitionIds() {
+        return partitionIds;
+    }
+
+    public Set<String> getColumnNames() {
+        return columnNames != null ? Sets.newHashSet(columnNames) : Sets.newHashSet();
+    }
+
+    @Override
+    public String toSql() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("DROP STATS ");
+
+        if (tableName != null) {
+            sb.append(tableName.toSql());
+        }
+
+        if (columnNames != null) {
+            sb.append("(");
+            sb.append(StringUtils.join(columnNames, ","));
+            sb.append(")");
+        }
+
+        if (partitionNames != null) {
+            sb.append(" ");
+            sb.append(partitionNames.toSql());
+        }
+
+        return sb.toString();
+    }
+
+    @Override
+    public String toString() {
+        return toSql();
     }
 
     private void checkAnalyzePriv(String dbName, String tblName) throws AnalysisException {
@@ -113,27 +176,5 @@ public class DropTableStatsStmt extends DdlStmt {
                     ConnectContext.get().getRemoteIP(),
                     dbName + "." + tblName);
         }
-    }
-
-    @Override
-    public String toSql() {
-        StringBuilder sb = new StringBuilder();
-        sb.append("DROP STATS ");
-
-        if (tableName != null) {
-            sb.append(tableName.toSql());
-        }
-
-        if (optPartitionNames != null) {
-            sb.append(" ");
-            sb.append(optPartitionNames.toSql());
-        }
-
-        return sb.toString();
-    }
-
-    @Override
-    public String toString() {
-        return toSql();
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/InternalSchemaInitializer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/InternalSchemaInitializer.java
@@ -120,12 +120,11 @@ public class InternalSchemaInitializer extends Thread {
         columnDefs.add(new ColumnDef("data_size_in_bytes", TypeDef.create(PrimitiveType.BIGINT)));
         columnDefs.add(new ColumnDef("update_time", TypeDef.create(PrimitiveType.DATETIME)));
         String engineName = "olap";
-        KeysDesc keysDesc = new KeysDesc(KeysType.UNIQUE_KEYS,
-                Lists.newArrayList("id"));
-
+        ArrayList<String> uniqueKeys = Lists.newArrayList("id", "catalog_id",
+                "db_id", "tbl_id", "idx_id", "col_id", "part_id");
+        KeysDesc keysDesc = new KeysDesc(KeysType.UNIQUE_KEYS, uniqueKeys);
         DistributionDesc distributionDesc = new HashDistributionDesc(
-                StatisticConstants.STATISTIC_TABLE_BUCKET_COUNT,
-                Lists.newArrayList("id"));
+                StatisticConstants.STATISTIC_TABLE_BUCKET_COUNT, uniqueKeys);
         Map<String, String> properties = new HashMap<String, String>() {
             {
                 put("replication_num", String.valueOf(Config.statistic_internal_table_replica_num));
@@ -154,11 +153,11 @@ public class InternalSchemaInitializer extends Thread {
         columnDefs.add(new ColumnDef("buckets", TypeDef.createVarchar(ScalarType.MAX_VARCHAR_LENGTH)));
         columnDefs.add(new ColumnDef("update_time", TypeDef.create(PrimitiveType.DATETIME)));
         String engineName = "olap";
-        KeysDesc keysDesc = new KeysDesc(KeysType.UNIQUE_KEYS,
-                Lists.newArrayList("id"));
+        ArrayList<String> uniqueKeys = Lists.newArrayList("id", "catalog_id",
+                "db_id", "tbl_id", "idx_id", "col_id");
+        KeysDesc keysDesc = new KeysDesc(KeysType.UNIQUE_KEYS, uniqueKeys);
         DistributionDesc distributionDesc = new HashDistributionDesc(
-                StatisticConstants.STATISTIC_TABLE_BUCKET_COUNT,
-                Lists.newArrayList("id"));
+                StatisticConstants.STATISTIC_TABLE_BUCKET_COUNT, uniqueKeys);
         Map<String, String> properties = new HashMap<String, String>() {
             {
                 put("replication_num", String.valueOf(Config.statistic_internal_table_replica_num));

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/DdlExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/DdlExecutor.java
@@ -325,7 +325,8 @@ public class DdlExecutor {
         } else if (ddlStmt instanceof CleanProfileStmt) {
             ProfileManager.getInstance().cleanProfile();
         } else if (ddlStmt instanceof DropTableStatsStmt) {
-            // TODO: support later
+            DropTableStatsStmt stmt = (DropTableStatsStmt) ddlStmt;
+            StatisticsRepository.dropTableStatistics(stmt);
         } else {
             throw new DdlException("Unknown statement.");
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/AnalysisTaskInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/AnalysisTaskInfo.java
@@ -74,7 +74,7 @@ public class AnalysisTaskInfo {
     public final AnalysisType analysisType;
 
     // TODO: define constants or get them from configuration properties
-    public final double sampleRate = 0.2;
+    public final double sampleRate = 1.0;
     public final int maxBucketNum = 128;
 
     public String message;

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/HistogramTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/HistogramTask.java
@@ -46,7 +46,7 @@ public class HistogramTask extends BaseAnalysisTask {
             + "    ${idxId} AS idx_id, "
             + "    '${colId}' AS col_id, "
             + "    ${sampleRate} AS sample_rate, "
-            + "    HISTOGRAM(`${colName}`, 1, ${maxBucketNum}) AS buckets, "
+            + "    HISTOGRAM(`${colName}`, ${maxBucketNum}) AS buckets, "
             + "    NOW() AS create_time "
             + "FROM "
             + "    `${dbName}`.`${tblName}`";
@@ -89,8 +89,9 @@ public class HistogramTask extends BaseAnalysisTask {
         } else {
             try {
                 tbl.readLock();
-                String partNames = info.partitionNames.stream()
+                String partNames = partitionNames.stream()
                         .filter(x -> tbl.getPartition(x) != null)
+                        .map(partName ->  "`" + partName + "`")
                         .collect(Collectors.joining(","));
                 params.put("partName", partNames);
                 StringSubstitutor stringSubstitutor = new StringSubstitutor(params);

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/OlapAnalysisTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/OlapAnalysisTask.java
@@ -80,7 +80,8 @@ public class OlapAnalysisTask extends BaseAnalysisTask {
                     continue;
                 }
                 params.put("partId", String.valueOf(tbl.getPartition(partName).getId()));
-                params.put("partName", String.valueOf(partName));
+                // Avoid error when get the default partition
+                params.put("partName", "`" + partName + "`");
                 StringSubstitutor stringSubstitutor = new StringSubstitutor(params);
                 partitionAnalysisSQLs.add(stringSubstitutor.replace(ANALYZE_PARTITION_SQL_TEMPLATE));
             }

--- a/fe/fe-core/src/main/jflex/sql_scanner.flex
+++ b/fe/fe-core/src/main/jflex/sql_scanner.flex
@@ -256,6 +256,7 @@ import org.apache.doris.qe.SqlModeHelper;
         keywordMap.put("if", new Integer(SqlParserSymbols.KW_IF));
         keywordMap.put("immediate", new Integer(SqlParserSymbols.KW_IMMEDIATE));
         keywordMap.put("in", new Integer(SqlParserSymbols.KW_IN));
+        keywordMap.put("incremental", new Integer(SqlParserSymbols.KW_INCREMENTAL));
         keywordMap.put("index", new Integer(SqlParserSymbols.KW_INDEX));
         keywordMap.put("indexes", new Integer(SqlParserSymbols.KW_INDEXES));
         keywordMap.put("infile", new Integer(SqlParserSymbols.KW_INFILE));


### PR DESCRIPTION
# Proposed changes

Drop statistics by using the drop statement, which drops statistics for a given table, partition, or column, depending on the parameters provided. 

Collect statistics incrementally by adding the `INCREMENTAL` keyword.

Drop statistics syntax：

```SQL
DROP STATS [ table_name [ (column_name [, ...]) ] [ PARTITION (partition_name, ...) ] ];
```

Incremental collection syntax:

```SQL
ANALYZE INCREMENTAL TABLE table_name
    [ (column_name [, ...]) ]
    PARTITION (partition_name, ...) 
    [ PROPERTIES ('key' = 'value', ...) ];
```

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

