### PR TITLE
[Fix](planner)fix targetTypeDef NPE when value is null

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/CastExpr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/CastExpr.java
@@ -438,7 +438,11 @@ public class CastExpr extends Expr {
 
     private Expr castTo(LiteralExpr value) throws AnalysisException {
         if (value instanceof NullLiteral) {
-            return NullLiteral.create(targetTypeDef.getType());
+            if (targetTypeDef != null) {
+                return NullLiteral.create(targetTypeDef.getType());
+            } else {
+                return NullLiteral.create(type);
+            }
         } else if (type.isIntegerType()) {
             return new IntLiteral(value.getLongValue(), type);
         } else if (type.isLargeIntType()) {

--- a/regression-test/suites/query_p0/literal_view/lietral_test.groovy
+++ b/regression-test/suites/query_p0/literal_view/lietral_test.groovy
@@ -116,4 +116,19 @@ suite("literal_view_test") {
         ) a
         where name != '1234';
     """
+
+    test {
+        sql "select * from (select null as top) t where top is not null"
+        result ([[]])
+    }
+
+    test {
+        sql "select * from (select null as top) t where top is null"
+        result ([[null]])
+    }
+
+    test {
+        sql "select * from (select null as top) t where top = 5"
+        result ([[]])
+    }
 }

--- a/regression-test/suites/query_p0/literal_view/lietral_test.groovy
+++ b/regression-test/suites/query_p0/literal_view/lietral_test.groovy
@@ -119,7 +119,7 @@ suite("literal_view_test") {
 
     test {
         sql "select * from (select null as top) t where top is not null"
-        result ([[]])
+        result ([])
     }
 
     test {
@@ -129,6 +129,6 @@ suite("literal_view_test") {
 
     test {
         sql "select * from (select null as top) t where top = 5"
-        result ([[]])
+        result ([])
     }
 }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

sql like:
select * from (select *, null as top from v1)t where top = 5;
select * from (select *, null as top from v1)t where top is not null;
will cause NPE because targetTypeDef is null when value is null. Now we use cast target type to the targetTypeDef.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [x] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [x] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

