### PR TITLE
[docs](plugins) Fix the information in auditlog plugin documentation

### DIFF
--- a/docs/en/docs/sql-manual/sql-reference/Database-Administration-Statements/INSTALL-PLUGIN.md
+++ b/docs/en/docs/sql-manual/sql-reference/Database-Administration-Statements/INSTALL-PLUGIN.md
@@ -66,6 +66,9 @@ source supports three types:
     INSTALL PLUGIN FROM "http://mywebsite.com/plugin.zip";
     ````
 
+    Note than an md5 file with the same name as the `.zip` file needs to be placed, such as `http://mywebsite.com/plugin.zip.md5` . 
+    The content is the MD5 value of the .zip file.
+
 4. Download and install a plugin, and set the md5sum value of the zip file at the same time:
 
     ```sql

--- a/docs/zh-CN/docs/sql-manual/sql-reference/Database-Administration-Statements/INSTALL-PLUGIN.md
+++ b/docs/zh-CN/docs/sql-manual/sql-reference/Database-Administration-Statements/INSTALL-PLUGIN.md
@@ -66,6 +66,8 @@ source 支持三种类型：
     INSTALL PLUGIN FROM "http://mywebsite.com/plugin.zip";
     ```
 
+    注意需要放置一个和 `.zip` 文件同名的 md5 文件, 如 `http://mywebsite.com/plugin.zip.md5` 。其中内容为 .zip 文件的 MD5 值。
+
 4. 下载并安装一个插件,同时设置了zip文件的md5sum的值：
 
     ```sql


### PR DESCRIPTION
# Proposed changes


The information in the document is incomplete, user may be get error message like:

```
mysql> INSTALL PLUGIN FROM "http://127.0.0.1:8039/auditloader.zip";
ERROR 1105 (HY000): errCode = 2, detailMessage = http://127.0.0.1:8039/auditloader.zip.md5. you should set md5sum in plugin properties or provide a md5 URI to check plugin file
```

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

