### PR TITLE
[Bug](regression-test) Fix grace stop be coredump in pipeline

### DIFF
--- a/be/src/runtime/exec_env_init.cpp
+++ b/be/src/runtime/exec_env_init.cpp
@@ -345,8 +345,8 @@ void ExecEnv::_destroy() {
     SAFE_DELETE(_tmp_file_mgr);
     SAFE_DELETE(_load_path_mgr);
     SAFE_DELETE(_master_info);
-    SAFE_DELETE(_fragment_mgr);
     SAFE_DELETE(_pipeline_task_scheduler);
+    SAFE_DELETE(_fragment_mgr);
     SAFE_DELETE(_cgroups_mgr);
     SAFE_DELETE(_broker_client_cache);
     SAFE_DELETE(_frontend_client_cache);


### PR DESCRIPTION
# Proposed changes

```
Aborted at 1679472373 (unix time) try "date -d @1679472373" if you are using GNU date ***
Current BE git commitID: cb79e42e5c ***
SIGSEGV invalid permissions for mapped object (@0x563751ada25f) received by PID 3722773 (TID 3723032 OR 0x7f272b7dd700) from PID 1370333791; stack trace: ***
 0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /home/zcp/repo_center/doris_master/doris/be/src/common/signal_handler.h:413
 1# 0x00007F28EA620BF9 in /usr/lib/jvm/java-1.11.0-openjdk-amd64/lib/server/libjvm.so
 2# JVM_handle_linux_signal in /usr/lib/jvm/java-1.11.0-openjdk-amd64/lib/server/libjvm.so
 3# 0x00007F28EA61993C in /usr/lib/jvm/java-1.11.0-openjdk-amd64/lib/server/libjvm.so
 4# 0x00007F28F2F470C0 in /lib/x86_64-linux-gnu/libc.so.6
 5# doris::CustomStopWatch<1>::stop() at /home/zcp/repo_center/doris_master/doris/be/src/util/stopwatch.hpp:50
 6# doris::pipeline::PipelineTask::pop_out_runnable_queue() at /home/zcp/repo_center/doris_master/doris/be/src/pipeline/pipeline_task.h:124
 7# doris::pipeline::TaskQueue::try_take(unsigned long) at /home/zcp/repo_center/doris_master/doris/be/src/pipeline/task_queue.cpp:160
 8# doris::pipeline::TaskScheduler::_do_work(unsigned long) at /home/zcp/repo_center/doris_master/doris/be/src/pipeline/task_scheduler.cpp:219
 9# void std::_invoke_impl<void, void (doris::pipeline::TaskScheduler::&)(unsigned long), doris::pipeline::TaskScheduler&, unsigned long&>(std::_invoke_memfun_deref, void (doris::pipeline::TaskScheduler::&)(unsigned long), doris::pipeline::TaskScheduler&, unsigned long&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:74
10# std::_invoke_result<void (doris::pipeline::TaskScheduler::&)(unsigned long), doris::pipeline::TaskScheduler&, unsigned long&>::type std::_invoke<void (doris::pipeline::TaskScheduler::&)(unsigned long), doris::pipeline::TaskScheduler&, unsigned long&>(void (doris::pipeline::TaskScheduler::&)(unsigned long), doris::pipeline::TaskScheduler&, unsigned long&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:96
11# void std::Bind<void (doris::pipeline::TaskScheduler::(doris::pipeline::TaskScheduler, unsigned long))(unsigned long)>::_call<void, , 0ul, 1ul>(std::tuple<>&&, std::_Index_tuple<0ul, 1ul>) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/functional:420
12# void std::_Bind<void (doris::pipeline::TaskScheduler::(doris::pipeline::TaskScheduler, unsigned long))(unsigned long)>::operator()<, void>() at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/functional:503
13# void std::_invoke_impl<void, std::_Bind<void (doris::pipeline::TaskScheduler::(doris::pipeline::TaskScheduler, unsigned long))(unsigned long)>&>(std::_invoke_other, std::_Bind<void (doris::pipeline::TaskScheduler::(doris::pipeline::TaskScheduler, unsigned long))(unsigned long)>&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61
14# std::enable_if<is_invocable_r_v<void, std::Bind<void (doris::pipeline::TaskScheduler::(doris::pipeline::TaskScheduler, unsigned long))(unsigned long)>&>, void>::type std::_invoke_r<void, std::_Bind<void (doris::pipeline::TaskScheduler::(doris::pipeline::TaskScheduler, unsigned long))(unsigned long)>&>(std::_Bind<void (doris::pipeline::TaskScheduler::(doris::pipeline::TaskScheduler, unsigned long))(unsigned long)>&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:117
15# std::_Function_handler<void (), std::_Bind<void (doris::pipeline::TaskScheduler::(doris::pipeline::TaskScheduler, unsigned long))(unsigned long)> >::_M_invoke(std::_Any_data const&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291
16# std::function<void ()>::operator()() const at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:560
17# doris::FunctionRunnable::run() at /home/zcp/repo_center/doris_master/doris/be/src/util/threadpool.cpp:46
18# doris::ThreadPool::dispatch_thread() at /home/zcp/repo_center/doris_master/doris/be/src/util/threadpool.cpp:529
19# void std::_invoke_impl<void, void (doris::ThreadPool::&)(), doris::ThreadPool&>(std::_invoke_memfun_deref, void (doris::ThreadPool::&)(), doris::ThreadPool&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:74
20# std::_invoke_result<void (doris::ThreadPool::&)(), doris::ThreadPool&>::type std::_invoke<void (doris::ThreadPool::&)(), doris::ThreadPool&>(void (doris::ThreadPool::&)(), doris::ThreadPool&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:96
21# void std::Bind<void (doris::ThreadPool::(doris::ThreadPool))()>::_call<void, , 0ul>(std::tuple<>&&, std::_Index_tuple<0ul>) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/functional:420
22# void std::_Bind<void (doris::ThreadPool::(doris::ThreadPool))()>::operator()<, void>() at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/functional:503
23# void std::_invoke_impl<void, std::_Bind<void (doris::ThreadPool::(doris::ThreadPool))()>&>(std::_invoke_other, std::_Bind<void (doris::ThreadPool::(doris::ThreadPool))()>&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61
24# std::enable_if<is_invocable_r_v<void, std::Bind<void (doris::ThreadPool::(doris::ThreadPool))()>&>, void>::type std::_invoke_r<void, std::_Bind<void (doris::ThreadPool::(doris::ThreadPool))()>&>(std::_Bind<void (doris::ThreadPool::(doris::ThreadPool))()>&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:117
25# std::_Function_handler<void (), std::_Bind<void (doris::ThreadPool::(doris::ThreadPool))()> >::_M_invoke(std::_Any_data const&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291

26# std::function<void ()>::operator()() const at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:560
27# doris::Thread::supervise_thread(void*) at /home/zcp/repo_center/doris_master/doris/be/src/util/thread.cpp:453
28# start_thread at /build/glibc-sMfBJT/glibc-2.31/nptl/pthread_create.c:478
29# __clone in /lib/x86_64-linux-gnu/libc.so.6
```

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

