### PR TITLE
[Chore](planner) add error information for OnClause contain ExistsPredicates

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/FromClause.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/FromClause.java
@@ -137,8 +137,8 @@ public class FromClause implements ParseNode, Iterable<TableRef> {
             tblRef.analyze(analyzer);
             leftTblRef = tblRef;
             Expr clause = tblRef.getOnClause();
-            if (clause != null && StmtRewriter.childrenContainExists(clause)) {
-                throw new AnalysisException("Not support OnClause contain ExistsPredicates "
+            if (clause != null && clause.contains(Subquery.class)) {
+                throw new AnalysisException("Not support OnClause contain Subquery, expr:"
                         + clause.toSql());
             }
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/FromClause.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/FromClause.java
@@ -137,7 +137,7 @@ public class FromClause implements ParseNode, Iterable<TableRef> {
             tblRef.analyze(analyzer);
             leftTblRef = tblRef;
             Expr clause = tblRef.getOnClause();
-            if (clause != null && StmtRewriter.childrenContainInOrExists(clause)) {
+            if (clause != null && StmtRewriter.childrenContainExists(clause)) {
                 throw new AnalysisException("Not support OnClause contain ExistsPredicates "
                         + clause.toSql());
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/FromClause.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/FromClause.java
@@ -136,6 +136,11 @@ public class FromClause implements ParseNode, Iterable<TableRef> {
             }
             tblRef.analyze(analyzer);
             leftTblRef = tblRef;
+            Expr clause = tblRef.getOnClause();
+            if (clause != null && StmtRewriter.childrenContainInOrExists(clause)) {
+                throw new AnalysisException("Not support OnClause contain ExistsPredicates "
+                        + clause.toSql());
+            }
         }
         // Fix the problem of column nullable attribute error caused by inline view + outer join
         changeTblRefToNullable(analyzer);

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/StmtRewriter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/StmtRewriter.java
@@ -504,7 +504,8 @@ public class StmtRewriter {
                     + "expression: "
                     + exprWithSubquery.toSql());
         }
-        if (exprWithSubquery instanceof BinaryPredicate && (childrenContainInOrExists(exprWithSubquery))) {
+        if (exprWithSubquery instanceof BinaryPredicate
+                && (childrenContainIn(exprWithSubquery) || childrenContainExists(exprWithSubquery))) {
             throw new AnalysisException("Not support binaryOperator children at least one is in or exists subquery"
                     + exprWithSubquery.toSql());
         }
@@ -546,11 +547,23 @@ public class StmtRewriter {
         }
     }
 
-    public static boolean childrenContainInOrExists(Expr expr) {
+    public static boolean childrenContainExists(Expr expr) {
         boolean contain = false;
         for (Expr child : expr.getChildren()) {
-            contain = contain || child instanceof InPredicate || child instanceof ExistsPredicate
-                    || childrenContainInOrExists(child);
+            contain = contain || child instanceof ExistsPredicate
+                    || childrenContainExists(child);
+            if (contain) {
+                break;
+            }
+        }
+        return contain;
+    }
+
+    public static boolean childrenContainIn(Expr expr) {
+        boolean contain = false;
+        for (Expr child : expr.getChildren()) {
+            contain = contain || child instanceof InPredicate
+                    || childrenContainIn(child);
             if (contain) {
                 break;
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/StmtRewriter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/StmtRewriter.java
@@ -546,10 +546,11 @@ public class StmtRewriter {
         }
     }
 
-    private static boolean childrenContainInOrExists(Expr expr) {
+    public static boolean childrenContainInOrExists(Expr expr) {
         boolean contain = false;
         for (Expr child : expr.getChildren()) {
-            contain = contain || child instanceof InPredicate || child instanceof ExistsPredicate;
+            contain = contain || child instanceof InPredicate || child instanceof ExistsPredicate
+                    || childrenContainInOrExists(child);
             if (contain) {
                 break;
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/StmtRewriter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/StmtRewriter.java
@@ -504,8 +504,7 @@ public class StmtRewriter {
                     + "expression: "
                     + exprWithSubquery.toSql());
         }
-        if (exprWithSubquery instanceof BinaryPredicate
-                && (childrenContainIn(exprWithSubquery) || childrenContainExists(exprWithSubquery))) {
+        if (exprWithSubquery instanceof BinaryPredicate && (childrenContainInOrExists(exprWithSubquery))) {
             throw new AnalysisException("Not support binaryOperator children at least one is in or exists subquery"
                     + exprWithSubquery.toSql());
         }
@@ -547,23 +546,10 @@ public class StmtRewriter {
         }
     }
 
-    public static boolean childrenContainExists(Expr expr) {
+    private static boolean childrenContainInOrExists(Expr expr) {
         boolean contain = false;
         for (Expr child : expr.getChildren()) {
-            contain = contain || child instanceof ExistsPredicate
-                    || childrenContainExists(child);
-            if (contain) {
-                break;
-            }
-        }
-        return contain;
-    }
-
-    public static boolean childrenContainIn(Expr expr) {
-        boolean contain = false;
-        for (Expr child : expr.getChildren()) {
-            contain = contain || child instanceof InPredicate
-                    || childrenContainIn(child);
+            contain = contain || child instanceof InPredicate || child instanceof ExistsPredicate;
             if (contain) {
                 break;
             }

--- a/regression-test/suites/query_p0/join/test_join.groovy
+++ b/regression-test/suites/query_p0/join/test_join.groovy
@@ -1106,7 +1106,10 @@ suite("test_join", "query,p0") {
     qt_join_on_predicate6"""select count(a.k1) from baseall a join test b on a.k1 < 10 and a.k1 = b.k1"""
     qt_join_on_predicate7"""SELECT t2.k1,t2.k2,t3.k1,t3.k2 FROM baseall t2 LEFT JOIN test t3 ON t2.k2=t3.k2 WHERE t2.k1 = 4 OR (t2.k1 > 4 AND t3.k1 IS NULL) order by 1, 2, 3, 4"""
 
-
+    test {
+        sql "select a.k1 from baseall a join test b on b.k2 in (select 49) and a.k1 = b.k1 order by k1;"
+        exception "Not support OnClause contain Subquery"
+    }
 
     // <=> test cases
     qt_join41"""select 1 <=> 2, 1 <=> 1, "a"= \"a\""""


### PR DESCRIPTION
# Proposed changes
https://github.com/apache/doris/issues/18079
add error information
```sql
ERROR 1105 (HY000): errCode = 2, detailMessage = Not support OnClause contain ExistsPredicates `t`.`EMSECURITYCODE` = `t1`.`SECURITYCODE` AND `t`.`eisdel` = '0' AND `t`.`type` = '1' AND NOT EXISTS (SELECT 1 AS `1` FROM `default_cluster:test`.`index_ba_sample` s WHERE `s`.`secinnercode` = `t`.`secinnercode` AND `s`.`emsecuritycode` = `t`.`emsecuritycode` AND `s`.`type` = '0' AND `s`.`opdate` > `t`.`opdate` AND `s`.`eisdel` = '0') AND (`t`.`trademarketcode` LIKE '069001001%' OR `t`.`trademarketcode` LIKE '069001002%')
```

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

