### PR TITLE
[Enhancement](multi catalog) Support hive meta cache TTL

### DIFF
--- a/docs/en/docs/lakehouse/multi-catalog/hive.md
+++ b/docs/en/docs/lakehouse/multi-catalog/hive.md
@@ -156,6 +156,23 @@ CREATE CATALOG hive WITH RESOURCE hms_resource PROPERTIES(
 );
 ```
 
+<version since="dev"></version> 
+You can use the config `file.meta.cache.ttl-second` to set TTL(Time-to-Live) config of File Cache, so that the stale file info will be invalidated automatically after expiring. The unit of time is second.
+You can also set file_meta_cache_ttl_second to 0 to disable file cache.Here is an example:
+```sql
+CREATE CATALOG hive PROPERTIES (
+    'type'='hms',
+    'hive.metastore.uris' = 'thrift://172.21.0.1:7004',
+    'hadoop.username' = 'hive',
+    'dfs.nameservices'='your-nameservice',
+    'dfs.ha.namenodes.your-nameservice'='nn1,nn2',
+    'dfs.namenode.rpc-address.your-nameservice.nn1'='172.21.0.2:4007',
+    'dfs.namenode.rpc-address.your-nameservice.nn2'='172.21.0.3:4007',
+    'dfs.client.failover.proxy.provider.your-nameservice'='org.apache.hadoop.hdfs.server.namenode.ha.ConfiguredFailoverProxyProvider',
+    'file.meta.cache.ttl-second' = '60'
+);
+```
+
 You can also put the `hive-site.xml` file in the `conf`  directories of FE and BE. This will enable Doris to automatically read information from `hive-site.xml`. The relevant information will be overwritten based on the following rules :
 	
 

--- a/docs/zh-CN/docs/lakehouse/multi-catalog/hive.md
+++ b/docs/zh-CN/docs/lakehouse/multi-catalog/hive.md
@@ -151,6 +151,22 @@ CREATE CATALOG hive WITH RESOURCE hms_resource PROPERTIES(
 	'key' = 'value'
 );
 ```
+<version since="dev"></version>
+创建 Catalog 时可以采用参数 `file.meta.cache.ttl-second` 来设置 File Cache 自动失效时间，也可以将该值设置为 0 来禁用 File Cache。时间单位为：秒。示例如下：
+```sql
+CREATE CATALOG hive PROPERTIES (
+    'type'='hms',
+    'hive.metastore.uris' = 'thrift://172.21.0.1:7004',
+    'hadoop.username' = 'hive',
+    'dfs.nameservices'='your-nameservice',
+    'dfs.ha.namenodes.your-nameservice'='nn1,nn2',
+    'dfs.namenode.rpc-address.your-nameservice.nn1'='172.21.0.2:4007',
+    'dfs.namenode.rpc-address.your-nameservice.nn2'='172.21.0.3:4007',
+    'dfs.client.failover.proxy.provider.your-nameservice'='org.apache.hadoop.hdfs.server.namenode.ha.ConfiguredFailoverProxyProvider',
+    'file.meta.cache.ttl-second' = '60'
+);
+```
+
 
 我们也可以直接将 hive-site.xml 放到 FE 和 BE 的 conf 目录下，系统也会自动读取 hive-site.xml 中的信息。信息覆盖的规则如下：
 	

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Resource.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Resource.java
@@ -203,7 +203,7 @@ public abstract class Resource implements Writable, GsonPostProcessable {
      * @throws DdlException
      */
     public void modifyProperties(Map<String, String> properties) throws DdlException {
-        notifyUpdate();
+        notifyUpdate(properties);
     }
 
     /**
@@ -274,7 +274,7 @@ public abstract class Resource implements Writable, GsonPostProcessable {
         return copied;
     }
 
-    private void notifyUpdate() {
+    private void notifyUpdate(Map<String, String> properties) {
         references.entrySet().stream().collect(Collectors.groupingBy(Entry::getValue)).forEach((type, refs) -> {
             if (type == ReferenceType.CATALOG) {
                 for (Map.Entry<String, ReferenceType> ref : refs) {
@@ -289,7 +289,7 @@ public abstract class Resource implements Writable, GsonPostProcessable {
                                 + "names(resource={}, catalog.resource={})", catalogName, name, catalog.getResource());
                         continue;
                     }
-                    catalog.notifyPropertiesUpdated();
+                    catalog.notifyPropertiesUpdated(properties);
                 }
             }
         });

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/CatalogIf.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/CatalogIf.java
@@ -74,7 +74,7 @@ public interface CatalogIf<T extends DatabaseIf> {
         return null;
     }
 
-    default void notifyPropertiesUpdated() {
+    default void notifyPropertiesUpdated(Map<String, String> updatedProps) {
         if (this instanceof ExternalCatalog) {
             ((ExternalCatalog) this).setUninitialized(false);
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalCatalog.java
@@ -307,7 +307,7 @@ public abstract class ExternalCatalog implements CatalogIf<ExternalDatabase>, Wr
     @Override
     public void modifyCatalogProps(Map<String, String> props) {
         catalogProperty.modifyCatalogProps(props);
-        notifyPropertiesUpdated();
+        notifyPropertiesUpdated(props);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/HMSExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/HMSExternalCatalog.java
@@ -31,6 +31,7 @@ import org.apache.doris.datasource.hive.event.MetastoreNotificationFetchExceptio
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import org.apache.commons.lang.math.NumberUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.api.CurrentNotificationEventId;
@@ -42,6 +43,7 @@ import org.apache.logging.log4j.Logger;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * External catalog for hive metastore compatible data sources.
@@ -54,6 +56,12 @@ public class HMSExternalCatalog extends ExternalCatalog {
     // Record the latest synced event id when processing hive events
     private long lastSyncedEventId;
     public static final String ENABLE_SELF_SPLITTER = "enable.self.splitter";
+    public static final String FILE_META_CACHE_TTL_SECOND = "file.meta.cache.ttl-second";
+
+    // -1 means file cache no ttl set
+    public static final int FILE_META_CACHE_NO_TTL = -1;
+    // 0 means file cache is disabled; >0 means file cache with ttl;
+    public static final int FILE_META_CACHE_TTL_DISABLE_CACHE = 0;
 
     /**
      * Default constructor for HMSExternalCatalog.
@@ -69,6 +77,14 @@ public class HMSExternalCatalog extends ExternalCatalog {
     @Override
     public void checkProperties() throws DdlException {
         super.checkProperties();
+        // check file.meta.cache.ttl-second parameter
+        String fileMetaCacheTtlSecond = catalogProperty.getOrDefault(FILE_META_CACHE_TTL_SECOND, null);
+        if (Objects.nonNull(fileMetaCacheTtlSecond) && NumberUtils.toInt(fileMetaCacheTtlSecond, FILE_META_CACHE_NO_TTL)
+                < FILE_META_CACHE_TTL_DISABLE_CACHE) {
+            throw new DdlException(
+                    "The parameter " + FILE_META_CACHE_TTL_SECOND + " is wrong, value is " + fileMetaCacheTtlSecond);
+        }
+
         // check the dfs.ha properties
         // 'dfs.nameservices'='your-nameservice',
         // 'dfs.ha.namenodes.your-nameservice'='nn1,nn2',
@@ -266,5 +282,14 @@ public class HMSExternalCatalog extends ExternalCatalog {
         dbNameToId.put(dbName, dbId);
         HMSExternalDatabase db = new HMSExternalDatabase(this, dbId, dbName);
         idToDb.put(dbId, db);
+    }
+
+    @Override
+    public void notifyPropertiesUpdated(Map<String, String> updatedProps) {
+        super.notifyPropertiesUpdated(updatedProps);
+        String fileMetaCacheTtl = updatedProps.getOrDefault(FILE_META_CACHE_TTL_SECOND, null);
+        if (Objects.nonNull(fileMetaCacheTtl)) {
+            Env.getCurrentEnv().getExtMetaCacheMgr().getMetaStoreCache(this).setNewFileCache();
+        }
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HiveMetaStoreCache.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HiveMetaStoreCache.java
@@ -50,6 +50,7 @@ import com.google.common.collect.Range;
 import com.google.common.collect.RangeMap;
 import com.google.common.collect.TreeRangeMap;
 import lombok.Data;
+import org.apache.commons.lang.math.NumberUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hdfs.HdfsConfiguration;
@@ -73,6 +74,7 @@ import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -87,20 +89,24 @@ public class HiveMetaStoreCache {
 
     private HMSExternalCatalog catalog;
 
+    private Executor executor;
+
     // cache from <dbname-tblname> -> <values of partitions>
     private LoadingCache<PartitionValueCacheKey, HivePartitionValues> partitionValuesCache;
     // cache from <dbname-tblname-partition_values> -> <partition info>
     private LoadingCache<PartitionCacheKey, HivePartition> partitionCache;
-    // cache from <location> -> <file list>
-    private LoadingCache<FileCacheKey, ImmutableList<InputSplit>> fileCache;
+    // the ref of cache from <location> -> <file list>
+    private volatile AtomicReference<LoadingCache<FileCacheKey, ImmutableList<InputSplit>>> fileCacheRef
+            = new AtomicReference<>();
 
     public HiveMetaStoreCache(HMSExternalCatalog catalog, Executor executor) {
         this.catalog = catalog;
-        init(executor);
+        this.executor = executor;
+        init();
         initMetrics();
     }
 
-    private void init(Executor executor) {
+    private void init() {
         partitionValuesCache = CacheBuilder.newBuilder().maximumSize(Config.max_hive_partition_cache_num)
                 .expireAfterAccess(Config.external_cache_expire_time_minutes_after_access, TimeUnit.MINUTES)
                 .build(CacheLoader.asyncReloading(
@@ -120,14 +126,36 @@ public class HiveMetaStoreCache {
                     }
                 }, executor));
 
-        fileCache = CacheBuilder.newBuilder().maximumSize(Config.max_external_file_cache_num)
-                .expireAfterAccess(Config.external_cache_expire_time_minutes_after_access, TimeUnit.MINUTES)
-                .build(CacheLoader.asyncReloading(new CacheLoader<FileCacheKey, ImmutableList<InputSplit>>() {
-                    @Override
-                    public ImmutableList<InputSplit> load(FileCacheKey key) throws Exception {
-                        return loadFiles(key);
-                    }
-                }, executor));
+        setNewFileCache();
+    }
+
+    /***
+     * generate a filecache and set to fileCacheRef
+     */
+    public void setNewFileCache() {
+        // if the file.meta.cache.ttl-second is equal or greater than 0, the cache expired will be set to that value
+        int fileMetaCacheTtlSecond = NumberUtils.toInt(
+                (catalog.getProperties().get(HMSExternalCatalog.FILE_META_CACHE_TTL_SECOND)),
+                HMSExternalCatalog.FILE_META_CACHE_NO_TTL);
+
+        CacheBuilder<Object, Object> fileCacheBuilder = CacheBuilder.newBuilder()
+                .maximumSize(Config.max_external_file_cache_num)
+                .expireAfterAccess(Config.external_cache_expire_time_minutes_after_access, TimeUnit.MINUTES);
+
+        if (fileMetaCacheTtlSecond >= HMSExternalCatalog.FILE_META_CACHE_TTL_DISABLE_CACHE) {
+            fileCacheBuilder.expireAfterWrite(fileMetaCacheTtlSecond, TimeUnit.SECONDS);
+        }
+        // if the file.meta.cache.ttl-second is equal 0, use the synchronous loader
+        // if the file.meta.cache.ttl-second greater than 0, use the asynchronous loader
+        CacheLoader<FileCacheKey, ImmutableList<InputSplit>> loader = getGuavaCacheLoader(executor,
+                fileMetaCacheTtlSecond);
+
+        LoadingCache<FileCacheKey, ImmutableList<InputSplit>> preFileCache = fileCacheRef.get();
+
+        fileCacheRef.set(fileCacheBuilder.build(loader));
+        if (Objects.nonNull(preFileCache)) {
+            preFileCache.invalidateAll();
+        }
     }
 
     private void initMetrics() {
@@ -158,7 +186,7 @@ public class HiveMetaStoreCache {
                 Metric.MetricUnit.NOUNIT, "hive file cache number") {
             @Override
             public Long getValue() {
-                return fileCache.size();
+                return fileCacheRef.get().size();
             }
         };
         fileCacheGauge.addLabel(new MetricLabel("type", "file"));
@@ -330,7 +358,7 @@ public class HiveMetaStoreCache {
         }
         List<ImmutableList<InputSplit>> fileLists = stream.map(k -> {
             try {
-                return fileCache.get(k);
+                return fileCacheRef.get().get(k);
             } catch (ExecutionException e) {
                 throw new RuntimeException(e);
             }
@@ -375,7 +403,7 @@ public class HiveMetaStoreCache {
                 PartitionCacheKey partKey = new PartitionCacheKey(dbName, tblName, values);
                 HivePartition partition = partitionCache.getIfPresent(partKey);
                 if (partition != null) {
-                    fileCache.invalidate(new FileCacheKey(partition.getPath(), null));
+                    fileCacheRef.get().invalidate(new FileCacheKey(partition.getPath(), null));
                     partitionCache.invalidate(partKey);
                 }
             }
@@ -393,7 +421,7 @@ public class HiveMetaStoreCache {
             Table table = catalog.getClient().getTable(dbName, tblName);
             // we just need to assign the `location` filed because the `equals` method of `FileCacheKey`
             // just compares the value of `location`
-            fileCache.invalidate(new FileCacheKey(table.getSd().getLocation(), null));
+            fileCacheRef.get().invalidate(new FileCacheKey(table.getSd().getLocation(), null));
         }
     }
 
@@ -406,7 +434,7 @@ public class HiveMetaStoreCache {
             PartitionCacheKey partKey = new PartitionCacheKey(dbName, tblName, values);
             HivePartition partition = partitionCache.getIfPresent(partKey);
             if (partition != null) {
-                fileCache.invalidate(new FileCacheKey(partition.getPath(), null));
+                fileCacheRef.get().invalidate(new FileCacheKey(partition.getPath(), null));
                 partitionCache.invalidate(partKey);
             }
         }
@@ -427,7 +455,7 @@ public class HiveMetaStoreCache {
     public void invalidateAll() {
         partitionValuesCache.invalidateAll();
         partitionCache.invalidateAll();
-        fileCache.invalidateAll();
+        fileCacheRef.get().invalidateAll();
         LOG.debug("invalid all meta cache in catalog {}", catalog.getName());
     }
 
@@ -536,6 +564,38 @@ public class HiveMetaStoreCache {
 
     public void putPartitionValuesCacheForTest(PartitionValueCacheKey key, HivePartitionValues values) {
         partitionValuesCache.put(key, values);
+    }
+
+    /***
+     * get the guava CacheLoader
+     * if the fileMetaCacheTtlSecond equal 0 , the synchronous loader is used
+     * if the fileMetaCacheTtlSecond greater than 0 , the asynchronous loader is used
+     * @param executor
+     * @param fileMetaCacheTtlSecond
+     * @return
+     */
+    private CacheLoader<FileCacheKey, ImmutableList<InputSplit>> getGuavaCacheLoader(Executor executor,
+            int fileMetaCacheTtlSecond) {
+        CacheLoader<FileCacheKey, ImmutableList<InputSplit>> loader =
+                new CacheLoader<FileCacheKey, ImmutableList<InputSplit>>() {
+                    @Override
+                    public ImmutableList<InputSplit> load(FileCacheKey key) throws Exception {
+                        return loadFiles(key);
+                    }
+                };
+        if (fileMetaCacheTtlSecond == HMSExternalCatalog.FILE_META_CACHE_TTL_DISABLE_CACHE) {
+            return loader;
+        } else {
+            return CacheLoader.asyncReloading(loader, executor);
+        }
+    }
+
+    /***
+     * get fileCache ref
+     * @return
+     */
+    public AtomicReference<LoadingCache<FileCacheKey, ImmutableList<InputSplit>>> getFileCacheRef() {
+        return fileCacheRef;
     }
 
     /**


### PR DESCRIPTION
# Proposed changes

Issue Number: #17947

Currently, if user modify the file on hdfs directly, no through hive. The changes of file will not be noticed by Doris and user
will get wrong data. Support the TTL(Time-to-Live) config of File Cache, so that the stale file info will be invalidated automatically after expiring.

## Problem summary
1.Add a parameter configuration to set file cache ttl. "file.meta.cache.ttl-second".
2.Set the value corresponding to guava expireAfterAccess to the configuration value.


## Checklist(Required)

* [ ] Does it affect the original behavior
* [x] Has unit tests been added
* [x] Has document been added or modified
* [ ] Does it need to update dependencies
* [x] Is this PR support rollback (If NO, please explain WHY)

## Further comments
