### PR TITLE
[chore](be) reduce log when trying to do async write cooldown meta

### DIFF
--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -128,6 +128,13 @@ void WriteCooldownMetaExecutors::WriteCooldownMetaExecutors::submit(TabletShared
     auto tablet_id = tablet->tablet_id();
 
     {
+        std::shared_lock rdlock(tablet->get_header_lock());
+        if (!tablet->tablet_meta()->cooldown_meta_id().initialized()) {
+            VLOG_NOTICE << "tablet " << tablet_id << " is not cooldown replica";
+            return;
+        }
+    }
+    {
         // one tablet could at most have one cooldown task to be done
         std::unique_lock<std::mutex> lck {_latch};
         if (_pengding_tablets.count(tablet_id) > 0) {
@@ -145,11 +152,13 @@ void WriteCooldownMetaExecutors::WriteCooldownMetaExecutors::submit(TabletShared
         if (s.ok()) {
             return;
         }
-        LOG_WARNING("write tablet {} cooldown meta failed because: {}", t->tablet_id(),
-                    s.to_string());
         if (!s.is<ABORTED>()) {
+            LOG_EVERY_SECOND(WARNING)
+                    << "write tablet " << t->tablet_id() << " cooldown meta failed because: " << s;
             submit(t);
+            return;
         }
+        VLOG_DEBUG << "tablet " << t->tablet_id() << " is not cooldown replica";
     };
 
     _executors[_get_executor_pos(tablet_id)]->submit_func(


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx
Reduce the nums of logs when doing async cooldown meta task.
## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

