### PR TITLE
[enhancement](regression-test) prove setting default value to session var will be detected

### DIFF
--- a/regression-test/suites/correctness/test_set_session_default_val.groovy
+++ b/regression-test/suites/correctness/test_set_session_default_val.groovy
@@ -1,0 +1,24 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_set_session_default_val") {
+    def default_timeout = sql """show variables where variable_name = 'insert_timeout';"""
+    sql """set global insert_timeout=3000;"""
+    sql """set session insert_timeout=${default_timeout[0][1]};"""
+    def session_timeout = sql """show variables where variable_name = 'insert_timeout';"""
+    assertEquals(default_timeout, session_timeout)
+}


### PR DESCRIPTION
# Proposed changes

introduce:#17837

## Problem summary

Add a regression test to prove setting default value to session var will be detected

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [x] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

