### PR TITLE
[Feature](metric) use bvar to refactor metric framework

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -933,6 +933,9 @@ CONF_Int32(max_depth_of_expr_tree, "600");
 // Report a tablet as bad when io errors occurs more than this value.
 CONF_mInt64(max_tablet_io_errors, "-1");
 
+// use bvar to replace original metric counter.
+CONF_mBool(enable_bvar_metrics,"true");
+
 // Page size of row column, default 4KB
 CONF_mInt64(row_column_page_size, "4096");
 

--- a/be/src/common/daemon.cpp
+++ b/be/src/common/daemon.cpp
@@ -37,6 +37,7 @@
 #include "util/cpu_info.h"
 #include "util/debug_util.h"
 #include "util/disk_info.h"
+#include "util/doris_bvar_metrics.h"
 #include "util/doris_metrics.h"
 #include "util/mem_info.h"
 #include "util/network_util.h"
@@ -363,6 +364,7 @@ static void init_doris_metrics(const std::vector<StorePath>& store_paths) {
         }
     }
     DorisMetrics::instance()->initialize(init_system_metrics, disk_devices, network_interfaces);
+    DorisBvarMetrics::instance()->initialize();
 }
 
 void signal_handler(int signal) {

--- a/be/src/http/action/metrics_action.cpp
+++ b/be/src/http/action/metrics_action.cpp
@@ -29,6 +29,7 @@
 #include "http/http_request.h"
 #include "http/http_response.h"
 #include "runtime/exec_env.h"
+#include "util/doris_bvar_metrics.h"
 #include "util/metrics.h"
 
 namespace doris {
@@ -42,7 +43,11 @@ void MetricsAction::handle(HttpRequest* req) {
     } else if (type == "json") {
         str = _metric_registry->to_json(with_tablet == "true");
     } else {
-        str = _metric_registry->to_prometheus(with_tablet == "true");
+        if (config::enable_bvar_metrics) {
+            str = DorisBvarMetrics::instance()->to_prometheus();
+        } else {
+            str = _metric_registry->to_prometheus(with_tablet == "true");
+        }
     }
 
     req->add_output_header(HttpHeaders::CONTENT_TYPE, "text/plain; version=0.0.4");

--- a/be/src/io/fs/local_file_writer.cpp
+++ b/be/src/io/fs/local_file_writer.cpp
@@ -28,6 +28,7 @@
 #include "io/fs/file_writer.h"
 #include "io/fs/local_file_system.h"
 #include "io/fs/path.h"
+#include "util/doris_bvar_metrics.h"
 #include "util/doris_metrics.h"
 
 namespace doris {
@@ -188,6 +189,7 @@ Status LocalFileWriter::_close(bool sync) {
 
     DorisMetrics::instance()->local_file_open_writing->increment(-1);
     DorisMetrics::instance()->file_created_total->increment(1);
+    g_adder_file_created_total.increment(1);
     DorisMetrics::instance()->local_bytes_written_total->increment(_bytes_appended);
 
     if (0 != ::close(_fd)) {

--- a/be/src/runtime/fragment_mgr.cpp
+++ b/be/src/runtime/fragment_mgr.cpp
@@ -46,6 +46,7 @@
 #include "runtime/task_group/task_group_manager.h"
 #include "runtime/thread_context.h"
 #include "service/backend_options.h"
+#include "util/doris_bvar_metrics.h"
 #include "util/doris_metrics.h"
 #include "util/network_util.h"
 #include "util/stopwatch.hpp"
@@ -1025,6 +1026,7 @@ void FragmentMgr::cancel_worker() {
             }
         }
         timeout_canceled_fragment_count->increment(to_cancel.size());
+        g_adder_timeout_canceled_fragment_count.increment(to_cancel.size());
         for (auto& id : to_cancel) {
             cancel(id, PPlanFragmentCancelReason::TIMEOUT);
             LOG(INFO) << "FragmentMgr cancel worker going to cancel timeout fragment "

--- a/be/src/util/CMakeLists.txt
+++ b/be/src/util/CMakeLists.txt
@@ -100,7 +100,9 @@ set(UTIL_FILES
   jni-util.cpp
   libjvm_loader.cpp
   jni_native_method.cpp
-)
+  bvar_metrics.cpp
+  doris_bvar_metrics.cpp
+  )
 
 if (OS_MACOSX)
     list(REMOVE_ITEM UTIL_FILES perf_counters.cpp disk_info.cpp)

--- a/be/src/util/bvar_metrics.cpp
+++ b/be/src/util/bvar_metrics.cpp
@@ -1,0 +1,110 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "util/bvar_metrics.h"
+
+namespace doris {
+
+std::ostream& operator<<(std::ostream& os, BvarMetricType type) {
+    switch (type) {
+    case BvarMetricType::COUNTER:
+        os << "counter";
+        break;
+    case BvarMetricType::GAUGE:
+        os << "gauge";
+        break;
+    case BvarMetricType::HISTOGRAM:
+        os << "histogram";
+        break;
+    case BvarMetricType::SUMMARY:
+        os << "summary";
+        break;
+    case BvarMetricType::UNTYPED:
+        os << "untyped";
+        break;
+    default:
+        os << "unknown";
+        break;
+    }
+    return os;
+}
+
+template <typename T>
+void BvarAdderMetric<T>::increment(T value) {
+    (*adder_) << value;
+}
+
+template <typename T>
+void BvarAdderMetric<T>::set_value(T value) {
+    adder_->reset();
+    (*adder_) << value;
+}
+
+template <typename T>
+std::string BvarAdderMetric<T>::to_prometheus(const std::string& registry_name) const {
+    return registry_name + "_" + name_ + label_string() + " " + value_string() + "\n";
+}
+
+template <typename T>
+std::string BvarAdderMetric<T>::label_string() const {
+    if (labels_.empty()) {
+        return "";
+    }
+
+    std::stringstream ss;
+    ss << "{";
+    int i = 0;
+    for (auto label : labels_) {
+        if (i++ > 0) {
+            ss << ",";
+        }
+        ss << label.first << "=\"" << label.second << "\"";
+    }
+    ss << "}";
+    return ss.str();
+}
+
+template <typename T>
+std::string BvarAdderMetric<T>::value_string() const {
+    return std::to_string(adder_->get_value());
+}
+
+template <typename T>
+void BvarMetricEntity::put(std::string name, T metric) {
+    {
+        std::lock_guard<bthread::Mutex> l(mutex_);
+        auto it = map_.find(name);
+        if (it == map_.end()) {
+            map_[name] = std::make_shared<T>(metric);
+        }
+    }
+}
+
+std::string BvarMetricEntity::to_prometheus(const std::string& registry_name) {
+    std::stringstream ss;
+    ss << "# TYPE " << registry_name << "_" << entity_name_ << " " << type_ << "\n";
+    for (auto metric_pair : map_) {
+        ss << metric_pair.second->to_prometheus(registry_name);
+    }
+    return ss.str();
+}
+
+template class BvarAdderMetric<int64_t>;
+template class BvarAdderMetric<double>;
+template void BvarMetricEntity::put(std::string name, BvarAdderMetric<int64_t> metric);
+
+} // namespace doris

--- a/be/src/util/bvar_metrics.h
+++ b/be/src/util/bvar_metrics.h
@@ -1,0 +1,118 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <bthread/mutex.h>
+#include <bvar/latency_recorder.h>
+#include <bvar/reducer.h>
+#include <bvar/status.h>
+
+#include <memory>
+#include <string>
+#include <unordered_map>
+
+namespace doris {
+
+enum class BvarMetricType { COUNTER, GAUGE, HISTOGRAM, SUMMARY, UNTYPED };
+enum class BvarMetricUnit {
+    NANOSECONDS,
+    MICROSECONDS,
+    MILLISECONDS,
+    SECONDS,
+    BYTES,
+    ROWS,
+    PERCENT,
+    REQUESTS,
+    OPERATIONS,
+    BLOCKS,
+    ROWSETS,
+    CONNECTIONS,
+    PACKETS,
+    NOUNIT,
+    FILESYSTEM
+};
+std::ostream& operator<<(std::ostream& os, BvarMetricType type);
+
+using Labels = std::unordered_map<std::string, std::string>;
+
+class BvarMetric {
+public:
+    BvarMetric() = default;
+    virtual ~BvarMetric() = default;
+    BvarMetric(BvarMetric&) = default;
+    BvarMetric(BvarMetricType type, BvarMetricUnit unit, std::string name, std::string description,
+               std::string group_name, Labels labels, bool is_core_metric)
+            : type_(type),
+              unit_(unit),
+              name_(name),
+              description_(description),
+              group_name_(group_name),
+              labels_(labels),
+              is_core_metric_(is_core_metric) {}
+    virtual std::string to_prometheus(const std::string& registry_name) const = 0;
+    // std::string to_json(bool with_tablet_metrics = false) const;
+    // std::string to_core_string() const;
+protected:
+    BvarMetricType type_;
+    BvarMetricUnit unit_;
+    std::string name_;
+    std::string description_;
+    std::string group_name_;
+    Labels labels_;
+    bool is_core_metric_;
+};
+
+template <typename T>
+class BvarAdderMetric : public BvarMetric {
+public:
+    BvarAdderMetric(BvarMetricType type, BvarMetricUnit unit, std::string name,
+                    std::string description, std::string group_name, Labels labels,
+                    bool is_core_metric = false)
+            : BvarMetric(type, unit, name, description, group_name, labels, is_core_metric) {
+        adder_ = std::make_shared<bvar::Adder<T>>(group_name, name + '_' + description);
+    }
+    ~BvarAdderMetric() override = default;
+    void increment(T value);
+    void set_value(T value);
+    std::string to_prometheus(const std::string& registry_name) const override;
+    std::string label_string() const;
+    std::string value_string() const;
+
+private:
+    std::shared_ptr<bvar::Adder<T>> adder_;
+};
+
+class BvarMetricEntity {
+public:
+    BvarMetricEntity() = default;
+    BvarMetricEntity(std::string entity_name, BvarMetricType type)
+            : entity_name_(entity_name), type_(type) {}
+    BvarMetricEntity(const BvarMetricEntity& entity)
+            : entity_name_(entity.entity_name_), type_(entity.type_), map_(entity.map_) {}
+    template <typename T>
+    void put(std::string name, T metric);
+    std::string to_prometheus(const std::string& registry_name);
+
+private:
+    std::string entity_name_;
+    BvarMetricType type_;
+    std::unordered_map<std::string, std::shared_ptr<BvarMetric>> map_;
+    bthread::Mutex mutex_;
+};
+
+} // namespace doris

--- a/be/src/util/doris_bvar_metrics.cpp
+++ b/be/src/util/doris_bvar_metrics.cpp
@@ -1,0 +1,86 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "doris_bvar_metrics.h"
+
+namespace doris {
+
+void DorisBvarMetrics::put(BvarMetricEntity entity) {
+    {
+        std::lock_guard<bthread::Mutex> l(mutex_);
+        std::shared_ptr<BvarMetricEntity> entity_ptr(new BvarMetricEntity(entity));
+        if (std::find(vec_.begin(), vec_.end(), entity_ptr) == vec_.end()) {
+            vec_.push_back(entity_ptr);
+        }
+    }
+}
+
+std::string DorisBvarMetrics::to_prometheus() {
+    std::stringstream ss;
+    for (auto entity : vec_) {
+        ss << entity->to_prometheus(name_);
+    }
+    return ss.str();
+}
+
+void DorisBvarMetrics::initialize() {
+    auto file_create_total_ptr =
+            std::make_shared<BvarMetricEntity>("file_create_total", BvarMetricType::COUNTER);
+    vec_.push_back(file_create_total_ptr);
+    file_create_total_ptr->put("file_create_total", g_adder_file_created_total);
+
+    auto timeout_canceled_fragment_count =
+            std::make_shared<BvarMetricEntity>("timeout_canceled", BvarMetricType::GAUGE);
+    vec_.push_back(timeout_canceled_fragment_count);
+    timeout_canceled_fragment_count->put("timeout_canceled_fragment_count",
+                                         g_adder_timeout_canceled_fragment_count);
+
+    auto test_ptr = std::make_shared<BvarMetricEntity>("test", BvarMetricType::COUNTER);
+    vec_.push_back(test_ptr);
+    test_ptr->put("fragment_request_total", g_adder_fragment_requests_total);
+    test_ptr->put("fragment_request_duration", g_adder_fragment_request_duration_us);
+    test_ptr->put("query_scan_byte", g_adder_query_scan_bytes);
+    test_ptr->put("segment_read_total", g_adder_segment_read_total);
+}
+
+// timeout_canceled_fragment_count_entity
+BvarAdderMetric<int64_t> g_adder_timeout_canceled_fragment_count(BvarMetricType::GAUGE,
+                                                                 BvarMetricUnit::NOUNIT,
+                                                                 "timeout_canceled_fragment_count",
+                                                                 "", "", Labels());
+BvarAdderMetric<int64_t> g_adder_file_created_total(BvarMetricType::COUNTER,
+                                                    BvarMetricUnit::FILESYSTEM,
+                                                    "file_created_total", "", "", Labels());
+// test_entity
+BvarAdderMetric<int64_t> g_adder_fragment_requests_total(BvarMetricType::COUNTER,
+                                                         BvarMetricUnit::REQUESTS,
+                                                         "fragment_requests_total",
+                                                         "Total fragment requests received.", "",
+                                                         Labels());
+BvarAdderMetric<int64_t> g_adder_fragment_request_duration_us(BvarMetricType::COUNTER,
+                                                              BvarMetricUnit::REQUESTS,
+                                                              "fragment_request_duration_us", "",
+                                                              "", Labels());
+BvarAdderMetric<int64_t> g_adder_query_scan_bytes(BvarMetricType::COUNTER, BvarMetricUnit::BYTES,
+                                                  "query_scan_bytes", "", "", Labels());
+BvarAdderMetric<int64_t> g_adder_segment_read_total(BvarMetricType::COUNTER,
+                                                    BvarMetricUnit::OPERATIONS,
+                                                    "segment_read_total",
+                                                    "(segment_v2) toal number of segments read",
+                                                    "segment_read",
+                                                    Labels({{"type", "segment_read_total"}}));
+} // namespace doris

--- a/be/src/util/doris_bvar_metrics.h
+++ b/be/src/util/doris_bvar_metrics.h
@@ -1,0 +1,50 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <memory>
+
+#include "util/bvar_metrics.h"
+
+namespace doris {
+
+class DorisBvarMetrics {
+public:
+    static DorisBvarMetrics* instance() {
+        static DorisBvarMetrics metrics;
+        return &metrics;
+    }
+    void initialize();
+    void put(BvarMetricEntity entity);
+    std::string to_prometheus();
+
+private:
+    DorisBvarMetrics() = default;
+    std::string name_ = "doris_be";
+    std::vector<std::shared_ptr<BvarMetricEntity>> vec_;
+    bthread::Mutex mutex_;
+};
+
+extern BvarAdderMetric<int64_t> g_adder_timeout_canceled_fragment_count;
+extern BvarAdderMetric<int64_t> g_adder_file_created_total;
+extern BvarAdderMetric<int64_t> g_adder_fragment_requests_total;
+extern BvarAdderMetric<int64_t> g_adder_fragment_request_duration_us;
+extern BvarAdderMetric<int64_t> g_adder_query_scan_bytes;
+extern BvarAdderMetric<int64_t> g_adder_segment_read_total;
+
+} // namespace doris


### PR DESCRIPTION
# Proposed changes

Issue Number: close #15684 close #14332

## Problem summary

Background:
Bvar is much more efficient than metric in be, so we can use bvar instead.

Solution:
- todo
  
Signed-off-by: Yukang Lian <yukang.lian2022@gmail.com>

## Checklist(Required)

* [x] Does it affect the original behavior
* [x] Has unit tests been added
* [x] Has document been added or modified
* [ ] Does it need to update dependencies
* [x] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

