### PR TITLE
[Enhancement](multi-catalog) add config for external meta cache loader's thread-pool size.

### DIFF
--- a/docs/en/docs/admin-manual/config/fe-config.md
+++ b/docs/en/docs/admin-manual/config/fe-config.md
@@ -2328,9 +2328,19 @@ Is it possible to dynamically configure: true
 
 Is it a configuration item unique to the Master FE node: true
 
+#### `max_external_cache_loader_thread_pool_size`
+
+Maximum thread pool size for loading external meta cache.
+
+Default: 10
+
+Is it possible to dynamically configure: false
+
+Is it a configuration item unique to the Master FE node: false
+
 #### `max_external_file_cache_num`
 
-Maximum number of file cache to use for external external tables.
+Maximum number of file cache to use for external tables.
 
 Default: 100000
 

--- a/docs/zh-CN/docs/admin-manual/config/fe-config.md
+++ b/docs/zh-CN/docs/admin-manual/config/fe-config.md
@@ -2328,6 +2328,16 @@ hive metastore 的默认超时时间
 
 是否为 Master FE 节点独有的配置项：true
 
+#### `max_external_cache_loader_thread_pool_size`
+
+用于 external 外部表的 meta 缓存加载线程池的最大线程数。
+
+默认值：10
+
+是否可以动态配置：false
+
+是否为 Master FE 节点独有的配置项：false
+
 #### `max_external_file_cache_num`
 
 用于 external 外部表的最大文件缓存数量。

--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -1905,6 +1905,13 @@ public class Config extends ConfigBase {
     public static long max_hive_partition_cache_num = 100000;
 
     /**
+     * Max cache loader thread-pool size.
+     * Max thread pool size for loading external meta cache
+     */
+    @ConfField(mutable = false, masterOnly = false)
+    public static int max_external_cache_loader_thread_pool_size = 10;
+
+    /**
      * Max cache num of external catalog's file
      * Decrease this value if FE's memory is small
      */

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalMetaCacheMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalMetaCacheMgr.java
@@ -20,6 +20,7 @@ package org.apache.doris.datasource;
 import org.apache.doris.catalog.external.ExternalTable;
 import org.apache.doris.catalog.external.HMSExternalTable;
 import org.apache.doris.cluster.ClusterNamespace;
+import org.apache.doris.common.Config;
 import org.apache.doris.common.ThreadPoolManager;
 import org.apache.doris.datasource.hive.HiveMetaStoreCache;
 
@@ -46,7 +47,8 @@ public class ExternalMetaCacheMgr {
     private Executor executor;
 
     public ExternalMetaCacheMgr() {
-        executor = ThreadPoolManager.newDaemonCacheThreadPool(10, "ExternalMetaCacheMgr", false);
+        executor = ThreadPoolManager.newDaemonCacheThreadPool(Config.max_external_cache_loader_thread_pool_size,
+                "ExternalMetaCacheMgr", false);
     }
 
     public HiveMetaStoreCache getMetaStoreCache(HMSExternalCatalog catalog) {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalMetaCacheMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalMetaCacheMgr.java
@@ -48,7 +48,7 @@ public class ExternalMetaCacheMgr {
 
     public ExternalMetaCacheMgr() {
         executor = ThreadPoolManager.newDaemonCacheThreadPool(Config.max_external_cache_loader_thread_pool_size,
-                "ExternalMetaCacheMgr", false);
+                "ExternalMetaCacheMgr", true);
     }
 
     public HiveMetaStoreCache getMetaStoreCache(HMSExternalCatalog catalog) {


### PR DESCRIPTION
…r's thread-pool size.

# Proposed changes

Add config for external cache-loader's max thread-pool size.

## Problem summary

We should expose a configuration for external cache-loader's max thread-pool size, current value(10) may be not enough for some user's situations. 

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

