### PR TITLE
[fix](chore) fix BE compile and FE protoc artifact issue

### DIFF
--- a/be/src/vec/data_types/data_type_struct.h
+++ b/be/src/vec/data_types/data_type_struct.h
@@ -21,6 +21,7 @@
 #pragma once
 
 #include <exception>
+#include <optional>
 
 #include "gen_cpp/data.pb.h"
 #include "util/stack_util.h"

--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -34,7 +34,7 @@ under the License.
         <doris.thirdparty>${basedir}/../../thirdparty</doris.thirdparty>
         <antlr4.version>4.9.3</antlr4.version>
         <awssdk.version>2.17.257</awssdk.version>
-        <protoc.artifact>com.google.protobuf:protoc:${protobuf.version}</protoc.artifact>
+        <protoc.artifact>com.google.protobuf:protoc:${protoc.artifact.version}</protoc.artifact>
         <grpc.java.artifact>io.grpc:protoc-gen-grpc-java:${grpc.version}</grpc.java.artifact>
     </properties>
     <profiles>

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -199,6 +199,9 @@ under the License.
         <objenesis.version>2.1</objenesis.version>
         <grpc.version>1.30.0</grpc.version>
         <protobuf.version>3.21.12</protobuf.version>
+        <!-- we use protoc-jar-maven-plugin to generate protobuf generated code -->
+        <!-- see https://repo.maven.apache.org/maven2/com/google/protobuf/protoc/ to get correct version -->
+        <protoc.artifact.version>3.21.9</protoc.artifact.version>
         <protoparser.version>3.1.5</protoparser.version>
         <snappy-java.version>1.1.7.2</snappy-java.version>
         <automaton.version>1.11-8</automaton.version>

--- a/thirdparty/download-thirdparty.sh
+++ b/thirdparty/download-thirdparty.sh
@@ -108,7 +108,7 @@ download_func() {
             rm -f "${DESC_DIR}/${FILENAME}"
         else
             echo "Downloading ${FILENAME} from ${DOWNLOAD_URL} to ${DESC_DIR}"
-            if wget --no-check-certificate -q --show-progress "${DOWNLOAD_URL}" -O "${DESC_DIR}/${FILENAME}"; then
+            if wget --no-check-certificate -q "${DOWNLOAD_URL}" -O "${DESC_DIR}/${FILENAME}"; then
                 if md5sum_func "${FILENAME}" "${DESC_DIR}" "${MD5SUM}"; then
                     STATUS=0
                     echo "Success to download ${FILENAME}"
@@ -377,7 +377,7 @@ echo "Finished patching ${HYPERSCAN_SOURCE}"
 cd "${TP_SOURCE_DIR}/${AWS_SDK_SOURCE}"
 if [[ ! -f "${PATCHED_MARK}" ]]; then
     if [[ "${AWS_SDK_SOURCE}" == "aws-sdk-cpp-1.9.211" ]]; then
-        if wget --no-check-certificate -q --show-progress https://doris-thirdparty-repo.bj.bcebos.com/thirdparty/aws-crt-cpp-1.9.211.tar.gz -O aws-crt-cpp-1.9.211.tar.gz; then
+        if wget --no-check-certificate -q https://doris-thirdparty-repo.bj.bcebos.com/thirdparty/aws-crt-cpp-1.9.211.tar.gz -O aws-crt-cpp-1.9.211.tar.gz; then
             tar xzf aws-crt-cpp-1.9.211.tar.gz
         else
             bash ./prefetch_crt_dependency.sh


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

1. add `<optional>` head to solve the compilation issue
2. use `3.12.9` as the protoc.artifact's version, because there is no 3.12.21
    See: https://repo.maven.apache.org/maven2/com/google/protobuf/protoc/
3. Remove `--show-progress` arguments of `wget` because it is not supported in low version `wget`

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

