### PR TITLE
[feature](executor) Add memory limit for pip_scanner_context

### DIFF
--- a/be/src/pipeline/exec/scan_operator.cpp
+++ b/be/src/pipeline/exec/scan_operator.cpp
@@ -32,12 +32,13 @@ bool ScanOperator::can_read() {
             return false;
         }
     } else {
-        if (_node->_eos || _node->_scanner_ctx->done() || _node->_scanner_ctx->no_schedule()) {
+        if (_node->_eos || _node->_scanner_ctx->done()) {
             // _eos: need eos
             // _scanner_ctx->done(): need finish
             // _scanner_ctx->no_schedule(): should schedule _scanner_ctx
             return true;
         } else {
+            _node->_scanner_ctx->try_reschedule_scanner_ctx();
             return _node->ready_to_read(); // there are some blocks to process
         }
     }

--- a/be/src/vec/exec/scan/pip_scanner_context.h
+++ b/be/src/vec/exec/scan/pip_scanner_context.h
@@ -31,7 +31,9 @@ public:
                       const std::list<vectorized::VScanner*>& scanners, int64_t limit,
                       int64_t max_bytes_in_blocks_queue)
             : vectorized::ScannerContext(state, parent, input_tuple_desc, output_tuple_desc,
-                                         scanners, limit, max_bytes_in_blocks_queue) {}
+                                         scanners, limit, max_bytes_in_blocks_queue) {
+        _should_resche_after_scanner_finished = false;
+    }
 
     Status get_block_from_queue(RuntimeState* state, vectorized::BlockUPtr* block, bool* eos,
                                 int id, bool wait = false) override {
@@ -50,6 +52,8 @@ public:
             std::unique_lock<std::mutex> l(*_queue_mutexs[id]);
             if (!_blocks_queues[id].empty()) {
                 *block = std::move(_blocks_queues[id].front());
+                _current_used_bytes.fetch_sub((*block)->allocated_bytes(),
+                                              std::memory_order_relaxed);
                 _blocks_queues[id].pop_front();
                 return Status::OK();
             } else {
@@ -65,16 +69,19 @@ public:
     void append_blocks_to_queue(std::vector<vectorized::BlockUPtr>& blocks) override {
         const int queue_size = _queue_mutexs.size();
         const int block_size = blocks.size();
+        int64_t local_bytes = 0;
         for (int i = 0; i < queue_size && i < block_size; ++i) {
             int queue = _next_queue_to_feed;
             {
                 std::lock_guard<std::mutex> l(*_queue_mutexs[queue]);
                 for (int j = i; j < block_size; j += queue_size) {
+                    local_bytes += blocks[j]->allocated_bytes();
                     _blocks_queues[queue].emplace_back(std::move(blocks[j]));
                 }
             }
             _next_queue_to_feed = queue + 1 < queue_size ? queue + 1 : 0;
         }
+        _current_used_bytes.fetch_add(local_bytes, std::memory_order_relaxed);
     }
 
     bool empty_in_queue(int id) override {
@@ -89,10 +96,28 @@ public:
         }
     }
 
+    bool has_enough_space_in_blocks_queue() const override {
+        return _current_used_bytes.load(std::memory_order_relaxed) < (_max_bytes_in_queue / 2);
+    }
+
+    void try_reschedule_scanner_ctx() override {
+        if (has_enough_space_in_blocks_queue()) {
+            std::lock_guard l(_transfer_lock);
+            if (has_enough_space_in_blocks_queue()) {
+                auto submit_st = _scanner_scheduler->submit(this);
+                //todo(wb) rethinking is it better to mark current scan_context failed when submit failed many times?
+                if (submit_st.ok()) {
+                    _num_scheduling_ctx++;
+                }
+            }
+        }
+    }
+
 private:
     int _next_queue_to_feed = 0;
     std::vector<std::unique_ptr<std::mutex>> _queue_mutexs;
     std::vector<std::list<vectorized::BlockUPtr>> _blocks_queues;
+    std::atomic_int64_t _current_used_bytes = 0;
 };
 } // namespace pipeline
 } // namespace doris

--- a/be/src/vec/exec/scan/scanner_context.cpp
+++ b/be/src/vec/exec/scan/scanner_context.cpp
@@ -164,7 +164,7 @@ Status ScannerContext::get_block_from_queue(RuntimeState* state, vectorized::Blo
     // (if the scheduler continues to schedule, it will cause a lot of busy running).
     // At this point, consumers are required to trigger new scheduling to ensure that
     // data can be continuously fetched.
-    if (_has_enough_space_in_blocks_queue() && _num_running_scanners == 0) {
+    if (has_enough_space_in_blocks_queue() && _num_running_scanners == 0) {
         _num_scheduling_ctx++;
         _scanner_scheduler->submit(this);
     }
@@ -295,10 +295,12 @@ void ScannerContext::push_back_scanner_and_reschedule(VScanner* scanner) {
     }
 
     std::lock_guard l(_transfer_lock);
-    _num_scheduling_ctx++;
-    auto submit_st = _scanner_scheduler->submit(this);
-    if (!submit_st.ok()) {
-        _num_scheduling_ctx--;
+    if (_should_resche_after_scanner_finished) {
+        _num_scheduling_ctx++;
+        auto submit_st = _scanner_scheduler->submit(this);
+        if (!submit_st.ok()) {
+            _num_scheduling_ctx--;
+        }
     }
 
     // Notice that after calling "_scanners.push_front(scanner)", there may be other ctx in scheduler
@@ -321,7 +323,7 @@ void ScannerContext::get_next_batch_of_scanners(std::list<VScanner*>* current_ru
     int thread_slot_num = 0;
     {
         std::unique_lock l(_transfer_lock);
-        if (_has_enough_space_in_blocks_queue()) {
+        if (has_enough_space_in_blocks_queue()) {
             // If there are enough space in blocks queue,
             // the scanner number depends on the _free_blocks numbers
             std::lock_guard f(_free_blocks_lock);

--- a/be/src/vec/exec/scan/scanner_context.h
+++ b/be/src/vec/exec/scan/scanner_context.h
@@ -123,6 +123,13 @@ public:
 
     virtual void set_max_queue_size(int max_queue_size) {};
 
+    // todo(wb) rethinking how to calculate ```_max_bytes_in_queue``` when executing shared scan
+    virtual inline bool has_enough_space_in_blocks_queue() const {
+        return _cur_bytes_in_queue < _max_bytes_in_queue / 2;
+    }
+
+    virtual void try_reschedule_scanner_ctx() {};
+
     // the unique id of this context
     std::string ctx_id;
     int32_t queue_idx = -1;
@@ -131,10 +138,6 @@ public:
 
 private:
     Status _close_and_clear_scanners(VScanNode* node, RuntimeState* state);
-
-    inline bool _has_enough_space_in_blocks_queue() const {
-        return _cur_bytes_in_queue < _max_bytes_in_queue / 2;
-    }
 
 protected:
     RuntimeState* _state;
@@ -185,6 +188,7 @@ protected:
     int _batch_size;
     // The limit from SQL's limit clause
     int64_t limit;
+    bool _should_resche_after_scanner_finished = true;
 
     // Current number of running scanners.
     std::atomic_int32_t _num_running_scanners = 0;


### PR DESCRIPTION
# Proposed changes
#18125

pip_scanner_context's memory usage should be limited. Because:
1 It can reduce memory usage and reduce allocating new blocks when executing.
2 When the memory is limited, the schedule times of scanner_ctx and scanner can be limited.


## Problem summary

I'll add performance test later

## Checklist(Required)

* [x] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [x] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

