### PR TITLE
[Bug](regression-test) be coredump in pipeline when grace exit in regression test

### DIFF
--- a/be/src/pipeline/task_queue.cpp
+++ b/be/src/pipeline/task_queue.cpp
@@ -139,7 +139,7 @@ void TaskQueue::close() {
 }
 
 PipelineTask* TaskQueue::try_take(size_t core_id) {
-    PipelineTask* task;
+    PipelineTask* task = nullptr;
     while (!_closed) {
         task = _async_queue[core_id].try_take(false);
         if (task) {


### PR DESCRIPTION
# Proposed changes

```
#0  0x0000562b7d98ee1c in doris::CustomStopWatch<1>::stop (this=0x562ba42161a1 <std::vector<doris::pipeline::PipelineTask*, std::allocator<doris::pipeline::PipelineTask*> >::clear()+97>) at /home/zcp/repo_center/doris_master/doris/be/src/util/stopwatch.hpp:50
#1  0x0000562ba4205a76 in doris::pipeline::PipelineTask::pop_out_runnable_queue (this=0x562ba4216049 <std::__shared_ptr_access<doris::pipeline::TaskQueue, (__gnu_cxx::_Lock_policy)2, false, false>::operator->() const+73>)
    at /home/zcp/repo_center/doris_master/doris/be/src/pipeline/pipeline_task.h:124
#2  0x0000562ba420290d in doris::pipeline::TaskQueue::try_take (this=0x7f3b7dc89410, core_id=19) at /home/zcp/repo_center/doris_master/doris/be/src/pipeline/task_queue.cpp:158
#3  0x0000562ba420fc73 in doris::pipeline::TaskScheduler::_do_work (this=0x7f3ba1a1f570, index=19) at /home/zcp/repo_center/doris_master/doris/be/src/pipeline/task_scheduler.cpp:219
#4  0x0000562ba4222402 in std::__invoke_impl<void, void (doris::pipeline::TaskScheduler::*&)(unsigned long), doris::pipeline::TaskScheduler*&, unsigned long&> (__f=
    @0x7f3b7ddd6260: (void (doris::pipeline::TaskScheduler::*)(doris::pipeline::TaskScheduler * const, unsigned long)) 0x562ba420fa20 <doris::pipeline::TaskScheduler::_do_work(unsigned long)>, __t=@0x7f3b7ddd6278: 0x7f3ba1a1f570, __args=@0x7f3b7ddd6270: 19)
    at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:74
#5  0x0000562ba4221ffb in std::__invoke<void (doris::pipeline::TaskScheduler::*&)(unsigned long), doris::pipeline::TaskScheduler*&, unsigned long&> (__fn=
    @0x7f3b7ddd6260: (void (doris::pipeline::TaskScheduler::*)(doris::pipeline::TaskScheduler * const, unsigned long)) 0x562ba420fa20 <doris::pipeline::TaskScheduler::_do_work(unsigned long)>, __args=@0x7f3b7ddd6270: 19, __args=@0x7f3b7ddd6270: 19)
    at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:96
#6  0x0000562ba4221f0b in std::_Bind<void (doris::pipeline::TaskScheduler::*(doris::pipeline::TaskScheduler*, unsigned long))(unsigned long)>::__call<void, , 0ul, 1ul>(std::tuple<>&&, std::_Index_tuple<0ul, 1ul>) (this=0x7f3b7ddd6260, __args=...)
    at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/functional:420
#7  0x0000562ba4221cb4 in std::_Bind<void (doris::pipeline::TaskScheduler::*(doris::pipeline::TaskScheduler*, unsigned long))(unsigned long)>::operator()<, void>() (this=0x7f3b7ddd6260)
    at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/functional:503
#8  0x0000562ba4221c43 in std::__invoke_impl<void, std::_Bind<void (doris::pipeline::TaskScheduler::*(doris::pipeline::TaskScheduler*, unsigned long))(unsigned long)>&>(std::__invoke_other, std::_Bind<void (doris::pipeline::TaskScheduler::*(doris::pipeline::TaskScheduler*, unsigned long))(unsigned long)>&) (__f=...) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61
#9  0x0000562ba4221b35 in std::__invoke_r<void, std::_Bind<void (doris::pipeline::TaskScheduler::*(doris::pipeline::TaskScheduler*, unsigned long))(unsigned long)>&>(std::_Bind<void (doris::pipeline::TaskScheduler::*(doris::pipeline::TaskScheduler*, unsigned long))(unsigned long)>&) (__fn=...) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:111
#10 0x0000562ba4220daf in std::_Function_handler<void (), std::_Bind<void (doris::pipeline::TaskScheduler::*(doris::pipeline::TaskScheduler*, unsigned long))(unsigned long)> >::_M_invoke(std::_Any_data const&) (__functor=...)
    at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291
#11 0x0000562b7c8474cd in std::function<void ()>::operator()() const (this=0x7f3b7ddd7258) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:560
#12 0x0000562b7f5154cb in doris::FunctionRunnable::run (this=0x7f3b7ddd7250) at /home/zcp/repo_center/doris_master/doris/be/src/util/threadpool.cpp:46
#13 0x0000562b7f4fdbd7 in doris::ThreadPool::dispatch_thread (this=0x7f3b85fdc980) at /home/zcp/repo_center/doris_master/doris/be/src/util/threadpool.cpp:529
#14 0x0000562b7f5341ab in std::__invoke_impl<void, void (doris::ThreadPool::*&)(), doris::ThreadPool*&> (__f=@0x7f3b7ddacea0: (void (doris::ThreadPool::*)(doris::ThreadPool * const)) 0x562b7f4fc250 <doris::ThreadPool::dispatch_thread()>,
    __t=@0x7f3b7ddaceb0: 0x7f3b85fdc980) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:74
#15 0x0000562b7f533f4f in std::__invoke<void (doris::ThreadPool::*&)(), doris::ThreadPool*&> (__fn=@0x7f3b7ddacea0: (void (doris::ThreadPool::*)(doris::ThreadPool * const)) 0x562b7f4fc250 <doris::ThreadPool::dispatch_thread()>, __args=@0x7f3b7ddaceb0: 0x7f3b85fdc980)
    at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:96
#16 0x0000562b7f533e9d in std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>::__call<void, , 0ul>(std::tuple<>&&, std::_Index_tuple<0ul>) (this=0x7f3b7ddacea0, __args=...)
    at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/functional:420
#17 0x0000562b7f533d24 in std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>::operator()<, void>() (this=0x7f3b7ddacea0) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/functional:503
#18 0x0000562b7f533cb3 in std::__invoke_impl<void, std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>&>(std::__invoke_other, std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>&) (__f=...)
    at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61
#19 0x0000562b7f533ba5 in std::__invoke_r<void, std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>&>(std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()>&) (__fn=...)
    at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:111
#20 0x0000562b7f53325f in std::_Function_handler<void (), std::_Bind<void (doris::ThreadPool::*(doris::ThreadPool*))()> >::_M_invoke(std::_Any_data const&) (__functor=...)
    at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:291
#21 0x0000562b7c8474cd in std::function<void ()>::operator()() const (this=0x7f3b7e245378) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:560
#22 0x0000562b7f4d4d38 in doris::Thread::supervise_thread (arg=0x7f3b7e245360) at /home/zcp/repo_center/doris_master/doris/be/src/util/thread.cpp:453
#23 0x00007f3ba365e609 in start_thread (arg=<optimized out>) at pthread_create.c:477
#24 0x00007f3ba38ed133 in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:95 
```

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

