### PR TITLE
[bugfix](addlog) expr context is not closed and will core during deconstructor

### DIFF
--- a/be/src/exec/exec_node.cpp
+++ b/be/src/exec/exec_node.cpp
@@ -172,8 +172,11 @@ void ExecNode::release_resource(doris::RuntimeState* state) {
 
 Status ExecNode::close(RuntimeState* state) {
     if (_is_closed) {
+        LOG(INFO) << "fragment_instance_id=" << print_id(state->fragment_instance_id())
+                  << " already closed";
         return Status::OK();
     }
+    LOG(INFO) << "fragment_instance_id=" << print_id(state->fragment_instance_id()) << " closed";
     _is_closed = true;
 
     Status result;

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -795,7 +795,9 @@ Status Tablet::capture_consistent_versions(const Version& spec_version,
             }
         }
     }
-    return status;
+
+    return Status::InternalError("ygl test failed");
+    // return status;
 }
 
 Status Tablet::check_version_integrity(const Version& version, bool quiet) {

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -795,9 +795,7 @@ Status Tablet::capture_consistent_versions(const Version& spec_version,
             }
         }
     }
-
-    return Status::InternalError("ygl test failed");
-    // return status;
+    return status;
 }
 
 Status Tablet::check_version_integrity(const Version& version, bool quiet) {


### PR DESCRIPTION
# Proposed changes

VExprContext is not normally closed, so it will core during deconstructor. Could not find the reason, so that I add a log to ExecNode's close method.

## Problem summary

0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /home/zcp/repo_center/doris_master/doris/be/src/common/signal_handler.h:413
 1# 0x00007F787A11A090 in /lib/x86_64-linux-gnu/libc.so.6
 2# raise at ../sysdeps/unix/sysv/linux/raise.c:51
 3# abort at /build/glibc-SzIz7B/glibc-2.31/stdlib/abort.c:81
 4# 0x00005654B4AA3059 in /mnt/ssd01/doris-master/VEC_ASAN/be/lib/doris_be
 5# 0x00005654B4A9866D in /mnt/ssd01/doris-master/VEC_ASAN/be/lib/doris_be
 6# google::LogMessage::SendToLog() in /mnt/ssd01/doris-master/VEC_ASAN/be/lib/doris_be
 7# google::LogMessage::Flush() in /mnt/ssd01/doris-master/VEC_ASAN/be/lib/doris_be
 8# google::LogMessageFatal::~LogMessageFatal() in /mnt/ssd01/doris-master/VEC_ASAN/be/lib/doris_be
 9# doris::vectorized::VExprContext::~VExprContext() at /home/zcp/repo_center/doris_master/doris/be/src/vec/exprs/vexpr_context.cpp:36
10# doris::ObjectPool::add<doris::vectorized::VExprContext>(doris::vectorized::VExprContext*)::{lambda(void*)#1}::operator()(void*) const at /home/zcp/repo_center/doris_master/doris/be/src/common/object_pool.h:40
11# doris::ObjectPool::add<doris::vectorized::VExprContext>(doris::vectorized::VExprContext*)::{lambda(void*)#1}::__invoke(void*) at /home/zcp/repo_center/doris_master/doris/be/src/common/object_pool.h:40
12# doris::ObjectPool::clear() at /home/zcp/repo_center/doris_master/doris/be/src/common/object_pool.h:53
13# doris::RuntimeState::~RuntimeState() at /home/zcp/repo_center/doris_master/doris/be/src/runtime/runtime_state.cpp:181
14# std::default_delete<doris::RuntimeState>::operator()(doris::RuntimeState*) const at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/unique_ptr.h:85
15# std::unique_ptr<doris::RuntimeState, std::default_delete<doris::RuntimeState> >::~unique_ptr() at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/unique_ptr.h:361
16# doris::PlanFragmentExecutor::~PlanFragmentExecutor() at /home/zcp/repo_center/doris_master/doris/be/src/runtime/plan_fragment_executor.cpp:75
17# doris::FragmentExecState::~FragmentExecState() at /home/zcp/repo_center/doris_master/doris/be/src/runtime/fragment_mgr.cpp:80
18# std::Sp_counted_ptr<doris::FragmentExecState*, (_gnu_cxx::_Lock_policy)2>::_M_dispose() at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:348
19# std::Sp_counted_base<(_gnu_cxx::_Lock_policy)2>::_M_release() at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:168
20# std::_shared_count<(gnu_cxx::_Lock_policy)2>::~_shared_count() at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:703
21# std::_shared_ptr<doris::FragmentExecState, (gnu_cxx::_Lock_policy)2>::~_shared_ptr() at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:1149
22# std::shared_ptr<doris::FragmentExecState>::~shared_ptr() at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr.h:122
23# doris::FragmentMgr::exec_plan_fragment(doris::TExecPlanFragmentParams const&, std::function<void (doris::RuntimeState*, doris::Status*)> const&)::$_3::~$_3() at /home/zcp/repo_center/doris_master/doris/be/src/runtime/fragment_mgr.cpp:723
24# std::_Function_base::_Base_manager<doris::FragmentMgr::exec_plan_fragment(doris::TExecPlanFragmentParams const&, std::function<void (doris::RuntimeState*, doris::Status*)> const&)::$_3>::_M_destroy(std::_Any_data&, std::integral_constant<bool, false>) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:174
25# std::_Function_base::_Base_manager<doris::FragmentMgr::exec_plan_fragment(doris::TExecPlanFragmentParams const&, std::function<void (doris::RuntimeState*, doris::Status*)> const&)::$_3>::_M_manager(std::_Any_data&, std::_Any_data const&, std::_Manager_operation) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:202
26# std::_Function_handler<void (), doris::FragmentMgr::exec_plan_fragment(doris::TExecPlanFragmentParams const&, std::function<void (doris::RuntimeState*, doris::Status*)> const&)::$_3>::_M_manager(std::_Any_data&, std::_Any_data const&, std::_Manager_operation) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:284
27# std::_Function_base::~_Function_base() at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:245
28# std::function<void ()>::~function() at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/std_function.h:111
29# doris::FunctionRunnable::~FunctionRunnable() at /home/zcp/repo_center/doris_master/doris/be/src/util/threadpool.cpp:42
30# void __gnu_cxx::new_allocator<doris::FunctionRunnable>::destroy<doris::FunctionRunnable>(doris::FunctionRunnable*) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/ext/new_allocator.h:162
31# void std::allocator_traits<std::allocator<doris::FunctionRunnable> >::destroy<doris::FunctionRunnable>(std::allocator<doris::FunctionRunnable>&, doris::FunctionRunnable*) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/alloc_traits.h:535
32# std::Sp_counted_ptr_inplace<doris::FunctionRunnable, std::allocator<doris::FunctionRunnable>, (_gnu_cxx::_Lock_policy)2>::_M_dispose() at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:529
33# std::Sp_counted_base<(_gnu_cxx::_Lock_policy)2>::_M_release() at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:168
34# std::_shared_count<(gnu_cxx::_Lock_policy)2>::~_shared_count() at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:703
35# std::_shared_ptr<doris::Runnable, (gnu_cxx::_Lock_policy)2>::~_shared_ptr() at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:1149
36# std::_shared_ptr<doris::Runnable, (_gnu_cxx::_Lock_policy)2>::reset() at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/shared_ptr_base.h:1267
37# doris::ThreadPool::dispatch_thread() at /home/zcp/repo_center/doris_master/doris/be/src/util/threadpool.cpp:537
38# void std::_invoke_impl<void, void (doris::ThreadPool::&)(), doris::ThreadPool&>(std::_invoke_memfun_deref, void (doris::ThreadPool::&)(), doris::ThreadPool&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:74
39# std::_invoke_result<void (doris::ThreadPool::&)(), doris::ThreadPool&>::type std::_invoke<void (doris::ThreadPool::&)(), doris::ThreadPool&>(void (doris::ThreadPool::&)(), doris::ThreadPool&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:96
40# void std::Bind<void (doris::ThreadPool::(doris::ThreadPool))()>::_call<void, , 0ul>(std::tuple<>&&, std::_Index_tuple<0ul>) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/functional:420
41# void std::_Bind<void (doris::ThreadPool::(doris::ThreadPool))()>::operator()<, void>() at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/functional:503
42# void std::_invoke_impl<void, std::_Bind<void (doris::ThreadPool::(doris::ThreadPool))()>&>(std::_invoke_other, std::_Bind<void (doris::ThreadPool::(doris::ThreadPool))()>&) at /var/local/ldb_toolchain/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/invoke.h:61

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

