### PR TITLE
[fix](nereids)move AdjustAggregateNullableForEmptySet before NormalizeAggregate

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/batch/NereidsRewriter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/batch/NereidsRewriter.java
@@ -123,6 +123,11 @@ public class NereidsRewriter extends BatchRewriteJob {
                 )
             ),
 
+            // please note: this rule must run before NormalizeAggregate
+            topDown(
+                new AdjustAggregateNullableForEmptySet()
+            ),
+
             // The rule modification needs to be done after the subquery is unnested,
             // because for scalarSubQuery, the connection condition is stored in apply in the analyzer phase,
             // but when normalizeAggregate/normalizeSort is performed, the members in apply cannot be obtained,
@@ -130,10 +135,6 @@ public class NereidsRewriter extends BatchRewriteJob {
             topDown(
                 new NormalizeAggregate(),
                 new NormalizeSort()
-            ),
-
-            topDown(
-                new AdjustAggregateNullableForEmptySet()
             ),
 
             topic("Window analysis",


### PR DESCRIPTION

# Proposed changes

Issue Number: close #xxx

## Problem summary

NormalizeAggregate may split some project nodes, so AdjustAggregateNullableForEmptySet should be done before this splitting

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

