### PR TITLE
[fix](catalog) all properties should be checked when create unpartitioned table

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
@@ -2175,6 +2175,10 @@ public class InternalCatalog implements CatalogIf<Database> {
         // create partition
         try {
             if (partitionInfo.getType() == PartitionType.UNPARTITIONED) {
+                if (storagePolicy.equals("") && properties != null && !properties.isEmpty()) {
+                    // here, all properties should be checked
+                    throw new DdlException("Unknown properties: " + properties);
+                }
                 // this is a 1-level partitioned table
                 // use table name as partition name
                 DistributionInfo partitionDistributionInfo = distributionDesc.toDistributionInfo(baseSchema);

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/CreateTableTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/CreateTableTest.java
@@ -244,6 +244,11 @@ public class CreateTableTest {
     @Test
     public void testAbnormal() throws DdlException, ConfigException {
         ExceptionChecker.expectThrowsWithMsg(DdlException.class,
+                "Unknown properties: {aa=bb}",
+                () -> createTable("create table test.atbl1\n" + "(k1 int, k2 float)\n" + "duplicate key(k1)\n"
+                        + "distributed by hash(k1) buckets 1\n" + "properties('replication_num' = '1','aa'='bb'); "));
+
+        ExceptionChecker.expectThrowsWithMsg(DdlException.class,
                 "Floating point type should not be used in distribution column",
                 () -> createTable("create table test.atbl1\n" + "(k1 int, k2 float)\n" + "duplicate key(k1)\n"
                         + "distributed by hash(k2) buckets 1\n" + "properties('replication_num' = '1'); "));

--- a/fe/fe-core/src/test/java/org/apache/doris/planner/QueryPlanTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/planner/QueryPlanTest.java
@@ -2031,7 +2031,6 @@ public class QueryPlanTest extends TestWithFeService {
                 + "PROPERTIES (\n"
                 + "\"replication_num\" = \"1\",\n"
                 + "\"in_memory\" = \"false\",\n"
-                + "\"business_key_column_name\" = \"\",\n"
                 + "\"storage_medium\" = \"HDD\",\n"
                 + "\"storage_format\" = \"V2\"\n"
                 + ");\n");

--- a/regression-test/suites/delete_p0/test_delete_sign_mow.sql
+++ b/regression-test/suites/delete_p0/test_delete_sign_mow.sql
@@ -7,7 +7,7 @@ CREATE TABLE IF NOT EXISTS delete_sign_test_mow (
 UNIQUE KEY(uid)
 DISTRIBUTED BY HASH(uid) BUCKETS 3
 PROPERTIES (
-    "unique_key_merge_on_write" = "true",
+    "enable_unique_key_merge_on_write" = "true",
     "replication_num" = "1"
 );
 

--- a/regression-test/suites/dynamic_table_p0/load.groovy
+++ b/regression-test/suites/dynamic_table_p0/load.groovy
@@ -86,7 +86,7 @@ suite("regression_test_dynamic_table", "dynamic_table"){
             )
             UNIQUE KEY(`id`)
             DISTRIBUTED BY HASH(`id`) BUCKETS 5 
-            properties("replication_num" = "1", "enable_merge_on_write" = "true");
+            properties("replication_num" = "1", "enable_unique_key_merge_on_write" = "true");
         """
 
         //stream load src_json

--- a/regression-test/suites/inverted_index_p0/test_array_index.groovy
+++ b/regression-test/suites/inverted_index_p0/test_array_index.groovy
@@ -41,8 +41,7 @@ suite("test_array_index"){
 	COMMENT 'OLAP'
 	DISTRIBUTED BY HASH(`id`) BUCKETS 1
 	PROPERTIES(
- 		"replication_allocation" = "tag.location.default: 1",
-		"persistent"="false"
+ 		"replication_allocation" = "tag.location.default: 1"
 	);
     """
     

--- a/regression-test/suites/nereids_p0/test_delete_sign_mow.sql
+++ b/regression-test/suites/nereids_p0/test_delete_sign_mow.sql
@@ -7,7 +7,7 @@ CREATE TABLE IF NOT EXISTS delete_sign_test_mow (
 UNIQUE KEY(uid)
 DISTRIBUTED BY HASH(uid) BUCKETS 3
 PROPERTIES (
-    "unique_key_merge_on_write" = "true",
+    "enable_unique_key_merge_on_write" = "true",
     "replication_num" = "1"
 );
 


### PR DESCRIPTION

# Proposed changes

Issue Number: close #xxx

## Problem summary

all properties should be checked when create unpartitioned table like partitioned table.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

