### PR TITLE
[Refactor](multi catalog)BE assignment data structure.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/TableQueryPlanAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/TableQueryPlanAction.java
@@ -259,6 +259,9 @@ public class TableQueryPlanAction extends RestBaseController {
      */
     private Map<String, Node> assemblePrunedPartitions(List<TScanRangeLocations> scanRangeLocationsList) {
         Map<String, Node> result = new HashMap<>();
+        if (scanRangeLocationsList == null) {
+            return result;
+        }
         for (TScanRangeLocations scanRangeLocations : scanRangeLocationsList) {
             // only process palo(doris) scan range
             TPaloScanRange scanRange = scanRangeLocations.scan_range.palo_scan_range;

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/OlapSplit.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/OlapSplit.java
@@ -20,20 +20,8 @@ package org.apache.doris.planner;
 import lombok.Data;
 
 @Data
-public abstract class Split {
-    protected String[] hosts;
+public class OlapSplit extends Split {
+    private long tabletId;
 
-    public Split() {}
-
-    public Split(String[] hosts) {
-        this.hosts = hosts;
-    }
-
-    public String[] getHosts() {
-        if (this.hosts == null) {
-            return new String[]{};
-        } else {
-            return this.hosts;
-        }
-    }
+    public OlapSplit() {}
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/ScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/ScanNode.java
@@ -131,6 +131,15 @@ public abstract class ScanNode extends PlanNode {
     public abstract List<TScanRangeLocations> getScanRangeLocations(long maxScanRangeLength);
 
     /**
+     * Get the ScanInfoList of this ScanNode, each subclass need to override this method.
+     * This method will eventually replace the method getScanRangeLocations.
+     * @return ScanRangeList for this ScanNode
+     */
+    public ScanRangeList getScanRangeList() {
+        return null;
+    }
+
+    /**
      * Update required_slots in scan node contexts. This is called after Nereids planner do the projection.
      * In the projection process, some slots may be removed. So call this to update the slots info.
      * Currently, it is only used by ExternalFileScanNode, add the interface here to keep the Nereids code clean.

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/ScanRangeList.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/ScanRangeList.java
@@ -1,0 +1,50 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.planner;
+
+import org.apache.doris.thrift.TScanRange;
+
+import lombok.Data;
+
+import java.util.List;
+
+/**
+ * This class represents all the scan ranges for a scan node (including external scan node, olap scan node etc.)
+ * Each element in scanRanges is a range of the scan task. For example, a tablet for OlapScanNode,
+ * one or several file blocks for ExternalFileScanNode.
+ * ScanNode need to generate this scanRanges during init or finalize stage,
+ * and the Coordinator will get the scanRanges generated and assign each TScanRange a BE node to execute it.
+ */
+@Data
+public class ScanRangeList {
+    private List<TScanRange> scanRanges;
+
+    public void addToScanRanges(TScanRange range) {
+        if (scanRanges == null) {
+            scanRanges = new java.util.ArrayList<>();
+        }
+        scanRanges.add(range);
+    }
+
+    public int getScanRangeSize() {
+        if (scanRanges == null) {
+            return 0;
+        }
+        return scanRanges.size();
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/StreamLoadPlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/StreamLoadPlanner.java
@@ -59,7 +59,7 @@ import org.apache.doris.thrift.TPlanFragmentExecParams;
 import org.apache.doris.thrift.TQueryGlobals;
 import org.apache.doris.thrift.TQueryOptions;
 import org.apache.doris.thrift.TQueryType;
-import org.apache.doris.thrift.TScanRangeLocations;
+import org.apache.doris.thrift.TScanRange;
 import org.apache.doris.thrift.TScanRangeParams;
 import org.apache.doris.thrift.TUniqueId;
 
@@ -258,8 +258,8 @@ public class StreamLoadPlanner {
         execParams.destinations = Lists.newArrayList();
         Map<Integer, List<TScanRangeParams>> perNodeScanRange = Maps.newHashMap();
         List<TScanRangeParams> scanRangeParams = Lists.newArrayList();
-        for (TScanRangeLocations locations : scanNode.getScanRangeLocations(0)) {
-            scanRangeParams.add(new TScanRangeParams(locations.getScanRange()));
+        for (TScanRange range : scanNode.getScanRangeList().getScanRanges()) {
+            scanRangeParams.add(new TScanRangeParams(range));
         }
         // For stream load, only one sender
         execParams.setSenderId(0);

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/external/FileScanProviderIf.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/external/FileScanProviderIf.java
@@ -22,10 +22,10 @@ import org.apache.doris.catalog.TableIf;
 import org.apache.doris.common.DdlException;
 import org.apache.doris.common.MetaNotFoundException;
 import org.apache.doris.common.UserException;
+import org.apache.doris.planner.ScanRangeList;
 import org.apache.doris.planner.external.ExternalFileScanNode.ParamCreateContext;
 import org.apache.doris.thrift.TFileFormatType;
 import org.apache.doris.thrift.TFileType;
-import org.apache.doris.thrift.TScanRangeLocations;
 
 import java.util.List;
 import java.util.Map;
@@ -44,8 +44,7 @@ public interface FileScanProviderIf {
 
     ParamCreateContext createContext(Analyzer analyzer) throws UserException;
 
-    void createScanRangeLocations(ParamCreateContext context, FederationBackendPolicy backendPolicy,
-            List<TScanRangeLocations> scanRangeLocations) throws UserException;
+    void createScanRangeList(ParamCreateContext context, ScanRangeList scanRangeList) throws UserException;
 
     int getInputSplitNum();
 

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/external/FileSplit.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/external/FileSplit.java
@@ -41,12 +41,4 @@ public class FileSplit extends Split {
         this.fileLength = fileLength;
         this.hosts = hosts;
     }
-
-    public String[] getHosts() {
-        if (this.hosts == null) {
-            return new String[]{};
-        } else {
-            return this.hosts;
-        }
-    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/external/LoadScanProvider.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/external/LoadScanProvider.java
@@ -35,6 +35,7 @@ import org.apache.doris.common.util.VectorizedUtil;
 import org.apache.doris.load.BrokerFileGroup;
 import org.apache.doris.load.Load;
 import org.apache.doris.load.loadv2.LoadTask;
+import org.apache.doris.planner.ScanRangeList;
 import org.apache.doris.planner.external.ExternalFileScanNode.ParamCreateContext;
 import org.apache.doris.task.LoadTaskInfo;
 import org.apache.doris.thrift.TBrokerFileStatus;
@@ -45,7 +46,6 @@ import org.apache.doris.thrift.TFileScanSlotInfo;
 import org.apache.doris.thrift.TFileTextScanRangeParams;
 import org.apache.doris.thrift.TFileType;
 import org.apache.doris.thrift.THdfsParams;
-import org.apache.doris.thrift.TScanRangeLocations;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
@@ -138,11 +138,10 @@ public class LoadScanProvider implements FileScanProviderIf {
     }
 
     @Override
-    public void createScanRangeLocations(ParamCreateContext context, FederationBackendPolicy backendPolicy,
-            List<TScanRangeLocations> scanRangeLocations) throws UserException {
+    public void createScanRangeList(ParamCreateContext context, ScanRangeList scanRangeList) throws UserException {
         Preconditions.checkNotNull(fileGroupInfo);
-        fileGroupInfo.getFileStatusAndCalcInstance(backendPolicy);
-        fileGroupInfo.createScanRangeLocations(context, backendPolicy, scanRangeLocations);
+        fileGroupInfo.getFileStatusAndCalcInstance(new FederationBackendPolicy());
+        fileGroupInfo.createScanRangeList(context, scanRangeList);
     }
 
     @Override


### PR DESCRIPTION
Scan operation including two steps:
1. Generate scan range list. Each scan range is a basic scheduling unit. For OlapScanNode, a scan range is a tablet. For ExternalFileScanNode, it is one or several blocks of a file. 
2. Assign a BE for each scan range to execute.

This PR does two things:
1. Define the data structure for ScanNode scan range (ScanRangeList) and the interface in ScanNode to get it.
2. Implement the scan range generation logic and BE assign logic for ExternalFileScanNode. (ExternalFileScanNode is used by Hive, Iceberg, TVF query, broker load and stream load)

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

