### PR TITLE
[fix](multi-catalog) key and value columns of map are normal column type

### DIFF
--- a/be/src/vec/exec/format/orc/vorc_reader.cpp
+++ b/be/src/vec/exec/format/orc/vorc_reader.cpp
@@ -805,10 +805,8 @@ Status OrcReader::_orc_column_to_doris_column(const std::string& col_name,
                         ->get_value_type());
         const orc::Type* orc_key_type = orc_column_type->getSubtype(0);
         const orc::Type* orc_value_type = orc_column_type->getSubtype(1);
-        const ColumnPtr& doris_key_column =
-                typeid_cast<const ColumnArray*>(doris_map.get_keys_ptr().get())->get_data_ptr();
-        const ColumnPtr& doris_value_column =
-                typeid_cast<const ColumnArray*>(doris_map.get_values_ptr().get())->get_data_ptr();
+        const ColumnPtr& doris_key_column = doris_map.get_keys_ptr();
+        const ColumnPtr& doris_value_column = doris_map.get_values_ptr();
         RETURN_IF_ERROR(_orc_column_to_doris_column(col_name, doris_key_column, doris_key_type,
                                                     orc_key_type, orc_map->keys.get(),
                                                     element_size));

--- a/be/src/vec/exec/format/parquet/vparquet_column_reader.cpp
+++ b/be/src/vec/exec/format/parquet/vparquet_column_reader.cpp
@@ -580,10 +580,8 @@ Status MapColumnReader::read_column_data(ColumnPtr& doris_column, DataTypePtr& t
             reinterpret_cast<const DataTypeMap*>(remove_nullable(type).get())->get_key_type());
     DataTypePtr& value_type = const_cast<DataTypePtr&>(
             reinterpret_cast<const DataTypeMap*>(remove_nullable(type).get())->get_value_type());
-    ColumnPtr& key_column =
-            typeid_cast<ColumnArray*>(map.get_keys_ptr()->assume_mutable().get())->get_data_ptr();
-    ColumnPtr& value_column =
-            typeid_cast<ColumnArray*>(map.get_values_ptr()->assume_mutable().get())->get_data_ptr();
+    ColumnPtr& key_column = map.get_keys_ptr();
+    ColumnPtr& value_column = map.get_values_ptr();
 
     size_t key_rows = 0;
     size_t value_rows = 0;


### PR DESCRIPTION
# Proposed changes

## Problem summary

PR(https://github.com/apache/doris/pull/17330) has changed the column type of kay and value from array to normal column, but orc&parquet reader still cast to array column, resulting in cast error.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

