### PR TITLE
[fix](planner) lateral view do not support lower case table name config

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/LateralViewRef.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/LateralViewRef.java
@@ -132,28 +132,40 @@ public class LateralViewRef extends TableRef {
             if (tableName == null) {
                 // t1 lateral view explode_split(k1, ",")
                 slotRef.setTblName(relatedTableName.cloneWithoutAnalyze());
-            } else if (tableName.getDb() == null && tableName.getTbl() != null) {
-                if (Config.lower_case_table_names != 0) {
-                    // TODO support case insensitive
-                    throw new AnalysisException("Not support specify table name in table function "
-                            + "when config.lower_case_table_names is not 0");
+                return;
+            }
+            if (tableName.getDb() != null && !tableName.getDb().equalsIgnoreCase(relatedTableName.getDb())) {
+                // db2.t1 lateral view explode_split(db1.t1.k1, ",")
+                throw new AnalysisException("The column " + slotRef.toMySql()
+                        + " in lateral view must come from the origin table "
+                        + relatedTableRef.toSql());
+            }
+
+            if (tableName.getTbl() != null) {
+                switch (Config.lower_case_table_names) {
+                    case 0:
+                        if (tableName.getTbl().equals(relatedTableName.getTbl())) {
+                            // t1 lateral view explode_split(t1.k1, ",")
+                            tableName.setDb(relatedTableName.getDb());
+                            return;
+                        }
+                        break;
+                    case 1:
+                    case 2:
+                        if (tableName.getTbl().equalsIgnoreCase(relatedTableName.getTbl())) {
+                            tableName.setTbl(relatedTableName.getTbl());
+                            tableName.setDb(relatedTableName.getDb());
+                            return;
+                        }
+                        break;
+                    default:
+                        throw new AnalysisException("Not support specify table name in table function "
+                                + "when config.lower_case_table_names is not 0, 1 or 2");
                 }
-                if (tableName.getTbl().equals(relatedTableName.getTbl())) {
-                    // t1 lateral view explode_split(t1.k1, ",")
-                    tableName.setDb(relatedTableName.getDb());
-                } else {
-                    // t1 lateral view explode_split(t2.k1, ",")
-                    throw new AnalysisException("The column " + slotRef.toMySql()
-                            + " in lateral view must come from the origin table "
-                            + relatedTableName.toSql());
-                }
-            } else {
-                if (!tableName.getDb().equalsIgnoreCase(relatedTableName.getDb())) {
-                    // db2.t1 lateral view explode_split(db1.t1.k1, ",")
-                    throw new AnalysisException("The column " + slotRef.toMySql()
-                            + " in lateral view must come from the origin table "
-                            + relatedTableRef.toSql());
-                }
+                // t1 lateral view explode_split(t2.k1, ",")
+                throw new AnalysisException("The column " + slotRef.toMySql()
+                        + " in lateral view must come from the origin table "
+                        + relatedTableName.toSql());
             }
         }
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/TableName.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/TableName.java
@@ -122,6 +122,10 @@ public class TableName implements Writable {
         return tbl;
     }
 
+    public void setTbl(String tbl) {
+        this.tbl = tbl;
+    }
+
     public boolean isEmpty() {
         return tbl.isEmpty();
     }


### PR DESCRIPTION
support TableFunctionNode lower_case_table_names set to 1 and 2

# Proposed changes

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

