### PR TITLE
[Chore](materialized-view) forbiden create mv with where clause contained aggregate column

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateMaterializedViewStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateMaterializedViewStmt.java
@@ -165,6 +165,11 @@ public class CreateMaterializedViewStmt extends DdlStmt {
         analyzeSelectClause(analyzer);
         analyzeFromClause();
         if (selectStmt.getWhereClause() != null) {
+            if (!isReplay && selectStmt.getWhereClause().hasAggregateSlot()) {
+                throw new AnalysisException(
+                        "The where clause contained aggregate column is not supported, expr:"
+                                + selectStmt.getWhereClause().toSql());
+            }
             whereClauseItem = new MVColumnItem(selectStmt.getWhereClause());
         }
         if (selectStmt.getHavingPred() != null) {

--- a/regression-test/suites/mv_p0/test_mv_useless/agg_invalid/agg_invalid.groovy
+++ b/regression-test/suites/mv_p0/test_mv_useless/agg_invalid/agg_invalid.groovy
@@ -16,11 +16,6 @@
 // under the License.
 
 suite ("agg_invalid") {
-    def testTable = "test_agg_mv_useless_table"
-    def getJobState = { tableName ->
-        def jobStateResult = sql """  SHOW ALTER TABLE MATERIALIZED VIEW WHERE TableName='${testTable}' ORDER BY CreateTime DESC LIMIT 1; """
-        return jobStateResult[0][8]
-    }
     sql """drop table if exists t1;"""
 
     sql """
@@ -42,7 +37,7 @@ suite ("agg_invalid") {
         exception null
     }
 
-        test {
+    test {
         sql "CREATE MATERIALIZED VIEW mv_4 AS SELECT p1, SUM(abs(v1)) FROM t1 GROUP BY p1;"
         exception "errCode = 2,"
     }

--- a/regression-test/suites/mv_p0/test_mv_useless/where_invalid/where_invalid.groovy
+++ b/regression-test/suites/mv_p0/test_mv_useless/where_invalid/where_invalid.groovy
@@ -1,0 +1,49 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite ("where_invalid") {
+    sql """drop table if exists a_table;"""
+
+    sql """
+        create table a_table(
+            k1 int null,
+            k2 int not null,
+            k3 bigint null,
+            k4 bigint sum null,
+            k5 bitmap bitmap_union null,
+            k6 hll hll_union null
+        )
+        aggregate key (k1,k2,k3)
+        distributed BY hash(k1) buckets 3
+        properties("replication_num" = "1");
+        """
+
+    test {
+        sql "create materialized view where_1 as select k1,k4 from a_table where k4 =1;"
+        exception "errCode = 2,"
+    }
+
+    test {
+        sql "create materialized view where_2 as select k1,sum(k4) from a_table where k4 =1 group by k1;"
+        exception "errCode = 2,"
+    }
+
+    test {
+        sql "create materialized view where_2 as select k1,sum(k4) from a_table where k1+k4 =1 group by k1;"
+        exception "errCode = 2,"
+    }
+}


### PR DESCRIPTION
# Proposed changes

forbiden create mv with where clause contained aggregate column
```sql
create table a_table(
	k1 int null,
	k2 int not null,
    k3 bigint null,
	k4 bigint sum null,
    k5 bitmap bitmap_union null,
    k6 hll hll_union null
)
aggregate key (k1,k2,k3)
distributed BY hash(k1) buckets 3
properties("replication_num" = "1");
create materialized view where_1 as select k1,k4 from a_table where k4 =1; // invalid, mv on agg table need group by
create materialized view where_2 as select k1,sum(k4) from a_table where k4 =1 group by k1; // invalid, k4 is agg column
create materialized view where_2 as select k1,sum(k4) from a_table where k1+k4 =1 group by k1; // invalid, k4 is agg column
```

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

