### PR TITLE
[enhance](nereids)filter estimation, column stats update strategy

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/ColumnStatsAdjustVisitor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/ColumnStatsAdjustVisitor.java
@@ -1,0 +1,64 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.stats;
+
+import org.apache.doris.nereids.trees.expressions.Cast;
+import org.apache.doris.nereids.trees.expressions.Expression;
+import org.apache.doris.nereids.trees.expressions.visitor.ExpressionVisitor;
+import org.apache.doris.statistics.ColumnStatistic;
+import org.apache.doris.statistics.Statistics;
+
+/**
+ * table: T(A, B)
+ * T.stats = (rows=10,
+ *            {
+ *                A->ndv=10, rows=10
+ *                B->...
+ *            }
+ *           )
+ * after node: filter(cast(A as double)=1.0)
+ * filter.stats = (rows = 1
+ *          {
+ *           A->ndv=m, rows=1
+ *           B->ndv=m, rows=1
+ *           cast(A as double) -> ndv=1, rows=1
+ *          }
+ *         )
+ *
+ * m is computed by function computeNdv()
+ *
+ * filter.stats should be adjusted.
+ * A.columnStats should be equal to "cast(A as double)".columnStats
+ * for other expressions(except cast), we also need to adjust their input column stats.
+ *
+ */
+public class ColumnStatsAdjustVisitor extends ExpressionVisitor<ColumnStatistic, Statistics> {
+    @Override
+    public ColumnStatistic visit(Expression expr, Statistics context) {
+        expr.children().forEach(child -> child.accept(this, context));
+        return null;
+    }
+
+    public ColumnStatistic visitCast(Cast cast, Statistics context) {
+        ColumnStatistic colStats = context.findColumnStatistics(cast);
+        if (colStats != null) {
+            context.addColumnStats(cast.child(), colStats);
+        }
+        return null;
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/ExpressionEstimation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/ExpressionEstimation.java
@@ -141,6 +141,10 @@ public class ExpressionEstimation extends ExpressionVisitor<ColumnStatistic, Sta
     }
 
     public ColumnStatistic visitCast(Cast cast, Statistics context) {
+        ColumnStatistic stats = context.findColumnStatistics(cast);
+        if (stats != null) {
+            return stats;
+        }
         return cast.child().accept(this, context);
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticRange.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticRange.java
@@ -110,6 +110,18 @@ public class StatisticRange {
         return empty();
     }
 
+    public StatisticRange cover(StatisticRange other) {
+        double newLow = Math.max(low, other.low);
+        double newHigh = Math.min(high, other.high);
+        if (newLow <= newHigh) {
+            double overlapPercentOfLeft = overlapPercentWith(other);
+            double overlapDistinctValuesLeft = overlapPercentOfLeft * distinctValues;
+            double coveredDistinctValues = minExcludeNaN(distinctValues, overlapDistinctValuesLeft);
+            return new StatisticRange(newLow, newHigh, coveredDistinctValues);
+        }
+        return empty();
+    }
+
     public StatisticRange union(StatisticRange other) {
         double overlapPercentThis = this.overlapPercentWith(other);
         double overlapPercentOther = other.overlapPercentWith(this);

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/stats/FilterEstimationTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/stats/FilterEstimationTest.java
@@ -18,6 +18,7 @@
 package org.apache.doris.nereids.stats;
 
 import org.apache.doris.nereids.trees.expressions.And;
+import org.apache.doris.nereids.trees.expressions.Cast;
 import org.apache.doris.nereids.trees.expressions.EqualTo;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.GreaterThan;
@@ -28,7 +29,9 @@ import org.apache.doris.nereids.trees.expressions.LessThanEqual;
 import org.apache.doris.nereids.trees.expressions.Not;
 import org.apache.doris.nereids.trees.expressions.Or;
 import org.apache.doris.nereids.trees.expressions.SlotReference;
+import org.apache.doris.nereids.trees.expressions.literal.DoubleLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.IntegerLiteral;
+import org.apache.doris.nereids.types.DoubleType;
 import org.apache.doris.nereids.types.IntegerType;
 import org.apache.doris.statistics.ColumnStatistic;
 import org.apache.doris.statistics.ColumnStatisticBuilder;
@@ -837,5 +840,31 @@ class FilterEstimationTest {
         Assertions.assertEquals(30, statsC.ndv);
         Assertions.assertEquals(10, statsC.minValue);
         Assertions.assertEquals(40, statsC.maxValue);
+    }
+
+    @Test
+    public void testBetweenCastFilter() {
+        SlotReference a = new SlotReference("a", IntegerType.INSTANCE);
+        ColumnStatisticBuilder builder = new ColumnStatisticBuilder()
+                .setNdv(100)
+                .setAvgSizeByte(4)
+                .setNumNulls(0)
+                .setMaxValue(100)
+                .setMinValue(0)
+                .setSelectivity(1.0)
+                .setCount(100);
+        DoubleLiteral begin = new DoubleLiteral(40.0);
+        DoubleLiteral end = new DoubleLiteral(50.0);
+        LessThan less = new LessThan(new Cast(a, DoubleType.INSTANCE), end);
+        GreaterThan greater = new GreaterThan(new Cast(a, DoubleType.INSTANCE), begin);
+        And and = new And(less, greater);
+        Statistics stats = new Statistics(100, new HashMap<>());
+        stats.addColumnStats(a, builder.build());
+        FilterEstimation filterEstimation = new FilterEstimation();
+        Statistics result = filterEstimation.estimate(and, stats);
+        Assertions.assertEquals(result.getRowCount(), 10, 0.01);
+        ColumnStatistic colStats = result.findColumnStatistics(a);
+        Assertions.assertTrue(colStats != null);
+        Assertions.assertEquals(10, colStats.ndv, 0.1);
     }
 }


### PR DESCRIPTION
# Proposed changes
T(A,B)
1. after filter `A=1`, the columnStats of A and B should be updated in different way.
2. columnStats of some expressions should be passed to input slots
for example:
for filter `cast(A as double)=1.0`, we compute column stats for `cast(A as double)` in FilterEstimation. this columnStats should be assigned to column A.

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

