### PR TITLE
[regression-test](log) add log for malforamt response of stream load

### DIFF
--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/action/StreamLoadAction.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/action/StreamLoadAction.groovy
@@ -362,6 +362,7 @@ class StreamLoadAction implements SuiteAction {
             }
         } catch (Throwable t) {
             log.info("failed to waitForPublishOrFailure. response: ${responseText}", t);
+            throw t;
         }
     }
 }

--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/action/StreamLoadAction.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/action/StreamLoadAction.groovy
@@ -314,7 +314,6 @@ class StreamLoadAction implements SuiteAction {
             long numberLoadedRows = result.NumberLoadedRows.toLong()
             if (numberTotalRows != numberLoadedRows) {
                 throw new IllegalStateException("Stream load rows mismatch:\n${responseText}")
-
             }
 
             if (time > 0) {
@@ -333,32 +332,36 @@ class StreamLoadAction implements SuiteAction {
     // So here we wait for at most 60s, using "show transaction" to check the
     // status of txn, and return once it become ABORTED or VISIBLE.
     private String waitForPublishOrFailure(String responseText) {
-        long maxWaitSecond = 60;
-        def jsonSlurper = new JsonSlurper()
-        def parsed = jsonSlurper.parseText(responseText)
-        String status = parsed.Status
-        long txnId = parsed.TxnId
-        if (!status.equalsIgnoreCase("Publish Timeout")) {
-            return status;
-        }
-
-        log.info("Stream load with txn ${txnId} is publish timeout")
-        String sql = "show transaction from ${db} where id = ${txnId}"
-        String st = "PREPARE"
-        while (!st.equalsIgnoreCase("VISIBLE") && !st.equalsIgnoreCase("ABORTED") && maxWaitSecond > 0) {
-            Thread.sleep(2000)
-            maxWaitSecond -= 2
-            def (result, meta) = JdbcUtils.executeToStringList(context.getConnection(), sql)
-            if (result.size() != 1) {
-                throw new IllegalStateException("Failed to get txn's ${txnId}")
+        try {
+            long maxWaitSecond = 60;
+            def jsonSlurper = new JsonSlurper()
+            def parsed = jsonSlurper.parseText(responseText)
+            String status = parsed.Status
+            long txnId = parsed.TxnId
+            if (!status.equalsIgnoreCase("Publish Timeout")) {
+                return status;
             }
-            st = String.valueOf(result[0][3])
-        }
-        log.info("Stream load with txn ${txnId} is ${st}")
-        if (st.equalsIgnoreCase("VISIBLE")) {
-            return "Success";
-        } else {
-            return "Fail";
+
+            log.info("Stream load with txn ${txnId} is publish timeout")
+            String sql = "show transaction from ${db} where id = ${txnId}"
+            String st = "PREPARE"
+            while (!st.equalsIgnoreCase("VISIBLE") && !st.equalsIgnoreCase("ABORTED") && maxWaitSecond > 0) {
+                Thread.sleep(2000)
+                maxWaitSecond -= 2
+                def (result, meta) = JdbcUtils.executeToStringList(context.getConnection(), sql)
+                if (result.size() != 1) {
+                    throw new IllegalStateException("Failed to get txn's ${txnId}")
+                }
+                st = String.valueOf(result[0][3])
+            }
+            log.info("Stream load with txn ${txnId} is ${st}")
+            if (st.equalsIgnoreCase("VISIBLE")) {
+                return "Success";
+            } else {
+                return "Fail";
+            }
+        } catch (Throwable t) {
+            log.info("failed to waitForPublishOrFailure. response: ${responseText}", t);
         }
     }
 }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

When some of stream load failed, the response msg may not be in json format, causing:
```
java.lang.IllegalArgumentException: Text must not be null or empty
  at groovy.json.JsonSlurper.parseText(JsonSlurper.java:202)
  at groovy.json.JsonSlurper$parseText.call(Unknown Source)
  at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCall(CallSiteArray.java:47)
  at groovy.json.JsonSlurper$parseText.call(Unknown Source)
  at org.apache.doris.regression.action.StreamLoadAction.waitForPublishOrFailure(StreamLoadAction.groovy:338)
  at org.apache.doris.regression.action.StreamLoadAction.checkResult(StreamLoadAction.groovy:290)
  at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
```
Which is not good for debug.
This PR print the response msg when encounter error

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

