### PR TITLE
[fix](nereids) when estimated rowCount is 0, adjust to 1

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/FilterEstimation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/FilterEstimation.java
@@ -319,10 +319,8 @@ public class FilterEstimation extends ExpressionVisitor<Statistics, EstimationCo
     @Override
     public Statistics visitNot(Not not, EstimationContext context) {
         Statistics childStats = new FilterEstimation().estimate(not.child(), context.statistics);
-        double rowCount = Math.max(context.statistics.getRowCount() - childStats.getRowCount(), 0);
-        if (rowCount == 0.0) {
-            return Statistics.zero(context.statistics);
-        }
+        //if estimated rowCount is 0, adjust to 1 to make upper join reorder reasonable.
+        double rowCount = Math.max(context.statistics.getRowCount() - childStats.getRowCount(), 1);
         StatisticsBuilder statisticsBuilder = new StatisticsBuilder(context.statistics).setRowCount(rowCount);
         for (Entry<Expression, ColumnStatistic> entry : context.statistics.columnStatistics().entrySet()) {
             Expression expr = entry.getKey();


### PR DESCRIPTION
# Proposed changes

if we use zero, it may cause upper joins in any order. but if we use 1, upper join orders could be more reasonable.

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

