### PR TITLE
[log](load) print detailed error message when publish failed

### DIFF
--- a/be/src/olap/task/engine_publish_version_task.cpp
+++ b/be/src/olap/task/engine_publish_version_task.cpp
@@ -218,7 +218,7 @@ void TabletPublishTxnTask::handle() {
     if (publish_status != Status::OK()) {
         LOG(WARNING) << "failed to publish version. rowset_id=" << _rowset->rowset_id()
                      << ", tablet_id=" << _tablet_info.tablet_id << ", txn_id=" << _transaction_id
-                     << ", res" << publish_status;
+                     << ", res=" << publish_status;
         _engine_publish_version_task->add_error_tablet_id(_tablet_info.tablet_id);
         return;
     }

--- a/be/src/olap/task/engine_publish_version_task.cpp
+++ b/be/src/olap/task/engine_publish_version_task.cpp
@@ -217,7 +217,8 @@ void TabletPublishTxnTask::handle() {
             _partition_id, _tablet, _transaction_id, _version);
     if (publish_status != Status::OK()) {
         LOG(WARNING) << "failed to publish version. rowset_id=" << _rowset->rowset_id()
-                     << ", tablet_id=" << _tablet_info.tablet_id << ", txn_id=" << _transaction_id;
+                     << ", tablet_id=" << _tablet_info.tablet_id << ", txn_id=" << _transaction_id
+                     << ", res" << publish_status;
         _engine_publish_version_task->add_error_tablet_id(_tablet_info.tablet_id);
         return;
     }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

W0326 22:46:21.081120 30803 engine_publish_version_task.cpp:215] failed to publish version. rowset_id=0200000000010b38154fe7bb7ca4314a18698cb6a0efc9a3, tablet_id=63390785, txn_id=43714869

The log missed detailed error message

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

