### PR TITLE
[enhancement](stmt-forward) make fe follower err msg shown to client be consistent with master

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/MasterOpExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/MasterOpExecutor.java
@@ -42,6 +42,8 @@ import java.util.Map;
 public class MasterOpExecutor {
     private static final Logger LOG = LogManager.getLogger(MasterOpExecutor.class);
 
+    private static final float RPC_TIMEOUT_COEFFICIENT = 1.2f;
+
     private final OriginStatement originStmt;
     private final ConnectContext ctx;
     private TMasterOpResult result;
@@ -56,11 +58,11 @@ public class MasterOpExecutor {
         this.originStmt = originStmt;
         this.ctx = ctx;
         if (status.isNeedToWaitJournalSync()) {
-            this.waitTimeoutMs = ctx.getExecTimeout() * 1000;
+            this.waitTimeoutMs = (int) (ctx.getExecTimeout() * 1000 * RPC_TIMEOUT_COEFFICIENT);
         } else {
             this.waitTimeoutMs = 0;
         }
-        this.thriftTimeoutMs = ctx.getExecTimeout() * 1000;
+        this.thriftTimeoutMs = (int) (ctx.getExecTimeout() * 1000 * RPC_TIMEOUT_COEFFICIENT);
         // if isQuery=false, we shouldn't retry twice when catch exception because of Idempotency
         this.shouldNotRetry = !isQuery;
     }
@@ -92,7 +94,7 @@ public class MasterOpExecutor {
 
         FrontendService.Client client;
         try {
-            client = ClientPool.frontendPool.borrowObject(thriftAddress, thriftTimeoutMs * 5);
+            client = ClientPool.frontendPool.borrowObject(thriftAddress, thriftTimeoutMs);
         } catch (Exception e) {
             // may throw NullPointerException. add err msg
             throw new Exception("Failed to get master client.", e);

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/MasterOpExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/MasterOpExecutor.java
@@ -92,7 +92,7 @@ public class MasterOpExecutor {
 
         FrontendService.Client client;
         try {
-            client = ClientPool.frontendPool.borrowObject(thriftAddress, thriftTimeoutMs);
+            client = ClientPool.frontendPool.borrowObject(thriftAddress, thriftTimeoutMs * 5);
         } catch (Exception e) {
             // may throw NullPointerException. add err msg
             throw new Exception("Failed to get master client.", e);

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -1849,6 +1849,7 @@ public class SessionVariable implements Serializable, Writable {
         TQueryOptions queryOptions = new TQueryOptions();
         queryOptions.setMemLimit(maxExecMemByte);
         queryOptions.setQueryTimeout(queryTimeoutS);
+        queryOptions.setInsertTimeout(insertTimeoutS);
         return queryOptions;
     }
 


### PR DESCRIPTION
# Proposed changes

Issue Number: close #16300

## Problem summary

Found that RPC timeout is too short that RPC client will close before execute result is return.

Therefor, use a coefficient to prolong the RPC client timeout, so that it can wait for the real cause to be recieved.

Before:
```
mysql> insert into lineorder select * from lineorder limit 10000000;
ERROR 1105 (HY000): ForwardToMasterException, msg: org.apache.doris.qe.MasterOpExecutor$ForwardToMasterException: Forward statement 21 to Master TNetworkAddress(hostname:127.0.0.1, port:9020) failed, cause: Unknown exception
```

After:
```
mysql> select count(*) from customer;
+----------+
| count(*) |
+----------+
| 19200000 |
+----------+
1 row in set (0.14 sec)

mysql> set query_timeout=1;
Query OK, 0 rows affected (0.00 sec)

mysql> set insert_timeout=1;
Query OK, 0 rows affected (0.00 sec)

mysql> insert into customer select * from customer limit 10000000;
ERROR 1105 (HY000): errCode = 2, detailMessage = Execute timeout

mysql> select * from customer;
ERROR 1105 (HY000): errCode = 2, detailMessage = query timeout

mysql> set forward_to_master=true;
Query OK, 0 rows affected (0.00 sec)

mysql> insert into customer select * from customer limit 10000000;
ERROR 1105 (HY000): errCode = 2, detailMessage = Execute timeout

mysql> select * from customer;
ERROR 1105 (HY000): errCode = 2, detailMessage = query timeout
```
## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [x] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

