### PR TITLE
[Improvement](statistics) Improve the statistical information display function.

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -1689,6 +1689,18 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true, masterOnly = true)
     public static int cbo_default_sample_percentage = 10;
 
+    /*
+     * if true, statistics will be updated automatically
+     */
+    @ConfField(mutable = true, masterOnly = true)
+    public static boolean enable_auto_collect_statistics = false;
+
+    /*
+     * the system automatically checks the time interval for statistical information
+     */
+    @ConfField(mutable = true, masterOnly = true)
+    public static int auto_check_statistics_in_min = 5;
+
     /**
      * If this configuration is enabled, you should also specify the trace_export_url.
      */

--- a/fe/fe-core/src/main/cup/sql_parser.cup
+++ b/fe/fe-core/src/main/cup/sql_parser.cup
@@ -3938,10 +3938,20 @@ show_param ::=
     {:
         RESULT = new ShowSyncJobStmt(dbName);
     :}
-    /* show column stats */
-    | KW_COLUMN KW_STATS table_name:tbl opt_partition_names:partitionNames
+    /* show table stats */
+    | KW_TABLE KW_STATS table_name:tbl opt_partition_names:partitionNames
     {:
-        RESULT = new ShowColumnStatsStmt(tbl, partitionNames);
+        RESULT = new ShowTableStatsStmt(tbl, partitionNames);
+    :}
+    /* show column stats */
+    | KW_COLUMN KW_STATS table_name:tbl opt_col_list:cols opt_partition_names:partitionNames
+    {:
+        RESULT = new ShowColumnStatsStmt(tbl, cols, partitionNames);
+    :}
+    /* show column histogram */
+    | KW_COLUMN KW_HISTOGRAM table_name:tbl opt_col_list:cols
+    {:
+        RESULT = new ShowColumnHistStmt(tbl, cols);
     :}
     /* show table creation statement */
     | KW_TABLE KW_CREATION opt_db:db opt_wild_where

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
@@ -212,6 +212,7 @@ import org.apache.doris.qe.JournalObservable;
 import org.apache.doris.qe.VariableMgr;
 import org.apache.doris.resource.Tag;
 import org.apache.doris.service.FrontendOptions;
+import org.apache.doris.statistics.AnalysisHelper;
 import org.apache.doris.statistics.AnalysisManager;
 import org.apache.doris.statistics.AnalysisTaskScheduler;
 import org.apache.doris.statistics.StatisticsCache;
@@ -441,6 +442,8 @@ public class Env {
 
     private AnalysisManager analysisManager;
 
+    private AnalysisHelper analysisHelper;
+
     private ExternalMetaCacheMgr extMetaCacheMgr;
 
     private FQDNManager fqdnManager;
@@ -647,6 +650,7 @@ public class Env {
         this.fqdnManager = new FQDNManager(systemInfo);
         if (!isCheckpointCatalog) {
             this.analysisManager = new AnalysisManager();
+            this.analysisHelper = new AnalysisHelper();
         }
         this.globalFunctionMgr = new GlobalFunctionMgr();
     }
@@ -1431,6 +1435,9 @@ public class Env {
         // start mtmv jobManager
         mtmvJobManager.start();
         getRefreshManager().start();
+
+        // for statistics
+        analysisHelper.start();
     }
 
     // start threads that should running on all FE
@@ -5326,6 +5333,9 @@ public class Env {
         return analysisManager;
     }
 
+    public AnalysisHelper getAnalysisHelper() {
+        return analysisHelper;
+    }
 
     public GlobalFunctionMgr getGlobalFunctionMgr() {
         return globalFunctionMgr;

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/InternalSchemaInitializer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/InternalSchemaInitializer.java
@@ -79,6 +79,7 @@ public class InternalSchemaInitializer extends Thread {
     }
 
     private void createTbl() throws UserException {
+        Env.getCurrentEnv().getInternalCatalog().createTable(buildTableStatisticsTblStmt());
         Env.getCurrentEnv().getInternalCatalog().createTable(buildStatisticsTblStmt());
         Env.getCurrentEnv().getInternalCatalog().createTable(buildHistogramTblStmt());
         Env.getCurrentEnv().getInternalCatalog().createTable(buildAnalysisJobTblStmt());
@@ -99,9 +100,50 @@ public class InternalSchemaInitializer extends Thread {
     }
 
     @VisibleForTesting
+    public CreateTableStmt buildTableStatisticsTblStmt() throws UserException {
+        TableName tableName = new TableName("",
+                FeConstants.INTERNAL_DB_NAME, StatisticConstants.TBL_STATISTIC_TBL_NAME);
+        List<ColumnDef> columnDefs = new ArrayList<>();
+        columnDefs.add(new ColumnDef("id", TypeDef.createVarchar(StatisticConstants.ID_LEN)));
+        columnDefs.add(new ColumnDef("catalog_id", TypeDef.createVarchar(StatisticConstants.MAX_NAME_LEN)));
+        columnDefs.add(new ColumnDef("db_id", TypeDef.createVarchar(StatisticConstants.MAX_NAME_LEN)));
+        columnDefs.add(new ColumnDef("tbl_id", TypeDef.createVarchar(StatisticConstants.MAX_NAME_LEN)));
+        columnDefs.add(new ColumnDef("idx_id", TypeDef.createVarchar(StatisticConstants.MAX_NAME_LEN)));
+        ColumnDef partId = new ColumnDef("part_id", TypeDef.createVarchar(StatisticConstants.MAX_NAME_LEN));
+        partId.setAllowNull(true);
+        columnDefs.add(partId);
+        columnDefs.add(new ColumnDef("row_count", TypeDef.create(PrimitiveType.BIGINT)));
+        columnDefs.add(new ColumnDef("update_rows", TypeDef.create(PrimitiveType.BIGINT)));
+        columnDefs.add(new ColumnDef("healthy", TypeDef.create(PrimitiveType.INT)));
+        columnDefs.add(new ColumnDef("data_size_in_bytes", TypeDef.create(PrimitiveType.BIGINT)));
+        columnDefs.add(new ColumnDef("update_time", TypeDef.create(PrimitiveType.DATETIME)));
+        ColumnDef lastAnalyzeTime = new ColumnDef("last_analyze_time", TypeDef.create(PrimitiveType.DATETIME));
+        lastAnalyzeTime.setAllowNull(true);
+        columnDefs.add(lastAnalyzeTime);
+
+        String engineName = "olap";
+        ArrayList<String> uniqueKeys = Lists.newArrayList("id", "catalog_id",
+                "db_id", "tbl_id", "idx_id", "part_id");
+        KeysDesc keysDesc = new KeysDesc(KeysType.UNIQUE_KEYS, uniqueKeys);
+        DistributionDesc distributionDesc = new HashDistributionDesc(
+                StatisticConstants.STATISTIC_TABLE_BUCKET_COUNT, uniqueKeys);
+        Map<String, String> properties = new HashMap<String, String>() {
+            {
+                put("replication_num", String.valueOf(Config.statistic_internal_table_replica_num));
+            }
+        };
+        CreateTableStmt createTableStmt = new CreateTableStmt(true, false,
+                tableName, columnDefs, engineName, keysDesc, null, distributionDesc,
+                properties, null, "Doris internal statistics table, don't modify it", null);
+        // createTableStmt.setClusterName(SystemInfoService.DEFAULT_CLUSTER);
+        StatisticsUtil.analyze(createTableStmt);
+        return createTableStmt;
+    }
+
+    @VisibleForTesting
     public CreateTableStmt buildStatisticsTblStmt() throws UserException {
         TableName tableName = new TableName("",
-                FeConstants.INTERNAL_DB_NAME, StatisticConstants.STATISTIC_TBL_NAME);
+                FeConstants.INTERNAL_DB_NAME, StatisticConstants.COL_STATISTIC_TBL_NAME);
         List<ColumnDef> columnDefs = new ArrayList<>();
         columnDefs.add(new ColumnDef("id", TypeDef.createVarchar(StatisticConstants.ID_LEN)));
         columnDefs.add(new ColumnDef("catalog_id", TypeDef.createVarchar(StatisticConstants.MAX_NAME_LEN)));
@@ -141,7 +183,7 @@ public class InternalSchemaInitializer extends Thread {
     @VisibleForTesting
     public CreateTableStmt buildHistogramTblStmt() throws UserException {
         TableName tableName = new TableName("",
-                FeConstants.INTERNAL_DB_NAME, StatisticConstants.HISTOGRAM_TBL_NAME);
+                FeConstants.INTERNAL_DB_NAME, StatisticConstants.COL_HISTOGRAM_TBL_NAME);
         List<ColumnDef> columnDefs = new ArrayList<>();
         columnDefs.add(new ColumnDef("id", TypeDef.createVarchar(StatisticConstants.ID_LEN)));
         columnDefs.add(new ColumnDef("catalog_id", TypeDef.createVarchar(StatisticConstants.MAX_NAME_LEN)));
@@ -217,8 +259,10 @@ public class InternalSchemaInitializer extends Thread {
             return false;
         }
         Database db = optionalDatabase.get();
-        return db.getTable(StatisticConstants.STATISTIC_TBL_NAME).isPresent()
-                && db.getTable(StatisticConstants.ANALYSIS_JOB_TABLE).isPresent();
+        return db.getTable(StatisticConstants.COL_STATISTIC_TBL_NAME).isPresent()
+                && db.getTable(StatisticConstants.ANALYSIS_JOB_TABLE).isPresent()
+                && db.getTable(StatisticConstants.COL_HISTOGRAM_TBL_NAME).isPresent()
+                && db.getTable(StatisticConstants.TBL_STATISTIC_TBL_NAME).isPresent();
     }
 
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/AnalysisHelper.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/AnalysisHelper.java
@@ -1,0 +1,355 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.statistics;
+
+import org.apache.doris.catalog.DatabaseIf;
+import org.apache.doris.catalog.Env;
+import org.apache.doris.catalog.InfoSchemaDb;
+import org.apache.doris.catalog.MaterializedIndex;
+import org.apache.doris.catalog.Partition;
+import org.apache.doris.catalog.Table;
+import org.apache.doris.catalog.TableIf;
+import org.apache.doris.cluster.ClusterNamespace;
+import org.apache.doris.common.Config;
+import org.apache.doris.common.FeConstants;
+import org.apache.doris.common.util.MasterDaemon;
+import org.apache.doris.datasource.CatalogIf;
+import org.apache.doris.datasource.CatalogMgr;
+import org.apache.doris.statistics.util.InternalQueryResult.ResultRow;
+import org.apache.doris.statistics.util.StatisticsUtil;
+
+import com.google.common.collect.Lists;
+import org.apache.commons.text.StringSubstitutor;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.StringJoiner;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * Check the statistics and if they need to be collected again based on their health.
+ *
+ * Health = 100 * (1 - 1.0 * updateRows / RowCount), it ranges from 0 to 100,
+ * with higher values indicating better health.
+ */
+public class AnalysisHelper extends MasterDaemon {
+
+    private static final String ID_DELIMITER = "-";
+    private static final String VALUES_DELIMITER = ",";
+    private static final String DATE_FORMAT = "yyyy-MM-dd HH:mm:ss";
+
+    private static final Logger LOG = LogManager.getLogger(AnalysisHelper.class);
+
+    private static final String COLUMN_STATS_FULL_NAME =
+            FeConstants.INTERNAL_DB_NAME + "." + StatisticConstants.COL_STATISTIC_TBL_NAME;
+
+    private static final String TABLES_STATS_FULL_NAME =
+            FeConstants.INTERNAL_DB_NAME + "." + StatisticConstants.TBL_STATISTIC_TBL_NAME;
+
+    private static final String FETCH_LATEST_PART_STATISTICS = "SELECT\n"
+            + "  part_id,\n"
+            + "  MAX(count) AS row_count,\n"
+            + "  MAX(update_time) AS update_time\n"
+            + "FROM\n"
+            + "  ${tableFullName}\n"
+            + "WHERE\n"
+            + "  catalog_id = '${catalogId}'\n"
+            + "  AND db_id = '${dbId}'\n"
+            + "  AND tbl_id = '${tblId}'\n"
+            + "  AND idx_id = '${idxId}'\n"
+            + "  AND part_id IS NOT NULL\n"
+            + "GROUP BY\n"
+            + "  part_id";
+
+    private static final String INSERT_TABLE_STATISTICS_TEMPLATE =
+            "INSERT INTO ${tableFullName} (id, catalog_id, db_id, tbl_id, idx_id, part_id, row_count, update_rows, "
+                    + "healthy, data_size_in_bytes, update_time, last_analyze_time) VALUES ${values}";
+
+    private static final String TABLE_STATISTICS_VALUES_TEMPLATE =
+            "('${id}', '${catalogId}', '${dbId}', '${tblId}', '${idxId}', '${partId}', '${rowCount}', "
+                    + "'${updateRows}', '${healthy}', '${dataSize}', '${updateTime}', '${lastAnalyzeTime}')";
+
+    private final List<String> excludedDbs = Lists.newArrayList(
+            InfoSchemaDb.DATABASE_NAME,
+            FeConstants.INTERNAL_DB_NAME
+    );
+
+    public AnalysisHelper() {
+        super("Analysis Helper", TimeUnit.MINUTES.toMillis(Config.auto_check_statistics_in_min));
+    }
+
+    @Override
+    protected void runAfterCatalogReady() {
+        if (!Config.enable_auto_collect_statistics) {
+            return;
+        }
+
+        CatalogMgr catalogMgr = Env.getCurrentEnv().getCatalogMgr();
+        catalogMgr.getCatalogIds().forEach(catalogId -> {
+            CatalogIf catalog = catalogMgr.getCatalog(catalogId);
+
+            if (catalog != null) {
+                catalog.getDbIds().forEach(obj -> {
+                    long dbId = (long) obj;
+                    DatabaseIf database = catalog.getDbNullable(dbId);
+
+                    if (database != null) {
+                        String dbName = ClusterNamespace.getNameFromFullName(database.getFullName());
+
+                        if (!excludedDbs.contains(dbName)) {
+                            database.getTables().forEach(tableObj -> {
+                                TableIf table = (Table) tableObj;
+                                try {
+                                    updateTableStatistics(catalogId, dbId, table);
+                                } catch (Exception e) {
+                                    LOG.info("Failed to update table granularity statistics.");
+                                    e.printStackTrace();
+                                }
+                            });
+                        }
+                    }
+                });
+            }
+        });
+
+        // TODO start creating analytics tasks to collect statistics based on table health
+    }
+
+    private void updateTableStatistics(long catalogId, long dbId, TableIf table)
+            throws Exception {
+        // 1. Update table-level statistics for the table
+        // which statistics have been collected
+        if (existTableStatsCache(table)) {
+            long tableId = table.getId();
+            // 2. Get the latest statistics for the table that has been analyzed
+            List<ResultRow> statsTableInfo = getStatsTableInfo(catalogId, dbId, tableId);
+            Map<Long, Partition> idToPartition = getIdToPartitionMap(table);
+
+            List<String> values = Lists.newArrayList();
+            List<Long> analyzedPartIds = Lists.newArrayList();
+
+            long tableUpdateRowcount = 0L;
+            long tableRelatedRowcount = 0L;
+            long tableLatestAnalyzeTime = 0L;
+
+            // 2.1 Process old (statistics already collected) partitions
+            for (ResultRow row : statsTableInfo) {
+                long partId = Long.parseLong(row.getColumnValue("part_id"));
+
+                if (idToPartition.containsKey(partId)) {
+                    String updateTimeStr = row.getColumnValue("update_time");
+                    long statUpdateTimestamp = getTimestampFromStr(updateTimeStr);
+                    Partition partition = idToPartition.get(partId);
+                    long ptVisibleTime = partition.getVisibleVersionTime();
+                    MaterializedIndex baseIndex = partition.getBaseIndex();
+                    long ptRowCount = baseIndex.getRowCount();
+                    long ptDataSize = baseIndex.getDataSize();
+
+                    Map<String, String> valueParams = getCommonParams(catalogId, dbId, tableId);
+                    valueParams.put("id", constructId(tableId, -1, partId));
+                    valueParams.put("partId", String.valueOf(partId));
+                    valueParams.put("rowCount", String.valueOf(ptRowCount));
+                    valueParams.put("dataSize", String.valueOf(ptDataSize));
+                    valueParams.put("updateTime", getDateStrFromTimestamp(ptVisibleTime));
+                    valueParams.put("lastAnalyzeTime", updateTimeStr);
+
+                    long updateRows = 0;
+
+                    if (statUpdateTimestamp >= ptVisibleTime) {
+                        valueParams.put("healthy", "100");
+                        valueParams.put("updateRows", String.valueOf(updateRows));
+                    } else {
+                        // If partition changes after statistics are collected,
+                        // it needs to be updated, otherwise we consider the stats to be "healthy".
+                        long rowCount = Long.parseLong(row.getColumnValue("row_count"));
+                        updateRows = ptRowCount - rowCount;
+
+                        int healthy = 100;
+                        if (updateRows > 0) {
+                            // updateRows > 0 increased the number of lines
+                            healthy = (int) (100 * (1 - 1.0 * updateRows / ptRowCount));
+                        } else if (updateRows < 0) {
+                            // updateRows < 0 decreased the number of lines
+                            healthy = (int) (100 * (1 - 1.0 * Math.abs(updateRows) / rowCount));
+                        }
+
+                        // TODO updateRows = 0 it may be update-operation,
+                        //  We should monitor the number of updated rows for the partition.
+
+                        valueParams.put("healthy", String.valueOf(healthy));
+                        valueParams.put("updateRows", String.valueOf(Math.abs(updateRows)));
+
+                        tableUpdateRowcount += Math.abs(updateRows);
+                        tableRelatedRowcount += Math.max(ptRowCount, rowCount);
+                    }
+
+                    StringSubstitutor stringSubstitutor = new StringSubstitutor(valueParams);
+                    values.add(stringSubstitutor.replace(TABLE_STATISTICS_VALUES_TEMPLATE));
+                    analyzedPartIds.add(partId);
+
+                    tableLatestAnalyzeTime = Math.max(tableLatestAnalyzeTime, statUpdateTimestamp);
+                }
+            }
+
+            // 2.2 Handle new (no stats collected and newer update time) partitions
+            long finalPartLatestAnalyzeTime = tableLatestAnalyzeTime;
+            idToPartition.entrySet().stream()
+                    .filter(p -> !analyzedPartIds.contains(p.getKey())
+                            && p.getValue().getVisibleVersionTime() > finalPartLatestAnalyzeTime)
+                    .collect(Collectors.toList())
+                    .forEach(idPartition -> {
+                        long partId = idPartition.getKey();
+                        Partition partition = idPartition.getValue();
+                        long ptVisibleTime = partition.getVisibleVersionTime();
+                        MaterializedIndex baseIndex = partition.getBaseIndex();
+
+                        Map<String, String> valueParams = getCommonParams(catalogId, dbId, tableId);
+                        valueParams.put("id", constructId(tableId, -1, partId));
+                        valueParams.put("partId", String.valueOf(partId));
+                        valueParams.put("rowCount", String.valueOf(baseIndex.getRowCount()));
+                        valueParams.put("dataSize", String.valueOf(baseIndex.getDataSize()));
+                        valueParams.put("updateTime", getDateStrFromTimestamp(ptVisibleTime));
+                        valueParams.put("updateRows", "0");
+                        valueParams.put("healthy", "0");
+                        valueParams.put("lastAnalyzeTime", "NULL");
+
+                        StringSubstitutor stringSubstitutor = new StringSubstitutor(valueParams);
+                        values.add(stringSubstitutor.replace(TABLE_STATISTICS_VALUES_TEMPLATE));
+                    });
+
+            // 3. Updating Statistics at Table Granularity
+            if (!values.isEmpty()) {
+                Map<String, String> insertParams = getCommonParams(catalogId, dbId, tableId);
+                Map<String, String> tblValueParams = getCommonParams(catalogId, dbId, tableId);
+
+                tblValueParams.put("id", constructId(tableId, -1));
+                tblValueParams.put("partId", "NULL");
+
+                long rowCount = table.getRowCount();
+                tblValueParams.put("rowCount", String.valueOf(rowCount));
+
+                long dataSize = table.getDataLength();
+                tblValueParams.put("dataSize", String.valueOf(dataSize));
+
+                if (tableLatestAnalyzeTime == 0) {
+                    tblValueParams.put("lastAnalyzeTime", "NULL");
+                } else {
+                    tblValueParams.put("lastAnalyzeTime", getDateStrFromTimestamp(tableLatestAnalyzeTime));
+                }
+
+                if (tableUpdateRowcount == 0) {
+                    tblValueParams.put("healthy", "100");
+                } else {
+                    int healthy = (int) (100 * (1 - 1.0 * tableUpdateRowcount / tableRelatedRowcount));
+                    tblValueParams.put("healthy", String.valueOf(healthy));
+                }
+
+                tblValueParams.put("updateTime", getDateStrFromTimestamp(table.getUpdateTime()));
+                tblValueParams.put("updateRows", String.valueOf(tableUpdateRowcount));
+
+                StringSubstitutor stringSubstitutor = new StringSubstitutor(tblValueParams);
+                values.add(stringSubstitutor.replace(TABLE_STATISTICS_VALUES_TEMPLATE));
+
+                String valuesStr = getCommaJoinerStr(values, VALUES_DELIMITER);
+                insertParams.put("values", valuesStr);
+
+                insertParams.put("tableFullName", TABLES_STATS_FULL_NAME);
+                StatisticsUtil.execUpdate(INSERT_TABLE_STATISTICS_TEMPLATE, insertParams);
+            }
+        }
+
+        // 4. Else the table has not collected statistics, skip them
+    }
+
+    private List<ResultRow> getStatsTableInfo(long catalogId, long dbId, long tableId) {
+        Map<String, String> queryParams = getCommonParams(catalogId, dbId, tableId);
+        queryParams.put("tableFullName", COLUMN_STATS_FULL_NAME);
+        return StatisticsUtil.executeQuery(FETCH_LATEST_PART_STATISTICS, queryParams);
+    }
+
+    private String constructId(long... items) {
+        if (items == null || items.length == 0) {
+            return "";
+        }
+        List<String> idElements = Arrays.stream(items)
+                .mapToObj(String::valueOf)
+                .collect(Collectors.toList());
+        return getCommaJoinerStr(idElements, ID_DELIMITER);
+    }
+
+    private Map<String, String> getCommonParams(long catalogId, long dbId, long tableId) {
+        return new HashMap<String, String>() {
+            {
+                put("catalogId", String.valueOf(catalogId));
+                put("dbId", String.valueOf(dbId));
+                put("tblId", String.valueOf(tableId));
+                put("idxId", "-1");
+            }
+        };
+    }
+
+    private Map<Long, Partition> getIdToPartitionMap(TableIf table) {
+        return table.getPartitionNames().stream()
+                .map(table::getPartition)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toMap(Partition::getId, Function.identity()));
+    }
+
+    private String getCommaJoinerStr(List<String> values, String delimiter) {
+        StringJoiner builder = new StringJoiner(delimiter);
+        values.forEach(builder::add);
+        return builder.toString();
+    }
+
+    private static long getTimestampFromStr(String dateString) {
+        SimpleDateFormat format = new SimpleDateFormat(DATE_FORMAT);
+        try {
+            Date date = format.parse(dateString);
+            return date.getTime();
+        } catch (ParseException e) {
+            LOG.warn("Fail to parse Timestamp from {}, {}", dateString, e.getMessage());
+            return 0;
+        }
+    }
+
+    private static String getDateStrFromTimestamp(long timestamp) {
+        SimpleDateFormat format = new SimpleDateFormat(DATE_FORMAT);
+        return format.format(new Date(timestamp));
+    }
+
+    private boolean existTableStatsCache(TableIf table) {
+        StatisticsCache statisticsCache = Env.getCurrentEnv().getStatisticsCache();
+        return table.getColumns()
+                .stream()
+                .anyMatch(column -> {
+                    ColumnLevelStatisticCache colStatCache = statisticsCache
+                            .getColumnStatistics(table.getId(), -1, column.getName());
+                    return colStatCache != null && colStatCache.columnStatistic != null;
+                });
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/Bucket.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/Bucket.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.statistics;
 
+import org.apache.doris.analysis.LiteralExpr;
 import org.apache.doris.catalog.Type;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.statistics.util.StatisticsUtil;
@@ -31,6 +32,10 @@ public class Bucket {
     public double preSum;
     public double ndv;
 
+    // For display only.
+    public LiteralExpr lowerExpr;
+    public LiteralExpr upperExpr;
+
     public Bucket() {
     }
 
@@ -42,44 +47,15 @@ public class Bucket {
         this.ndv = ndv;
     }
 
-    public double getLower() {
-        return lower;
-    }
-
-    public void setLower(double lower) {
+    public Bucket(double lower, double upper, double count, double preSum, double ndv,
+            LiteralExpr lowerExpr, LiteralExpr upperExpr) {
         this.lower = lower;
-    }
-
-    public double getUpper() {
-        return upper;
-    }
-
-    public void setUpper(double upper) {
         this.upper = upper;
-    }
-
-    public double getCount() {
-        return count;
-    }
-
-    public void setCount(int count) {
         this.count = count;
-    }
-
-    public double getPreSum() {
-        return preSum;
-    }
-
-    public void setPreSum(int preSum) {
         this.preSum = preSum;
-    }
-
-    public double getNdv() {
-        return ndv;
-    }
-
-    public void setNdv(int ndv) {
         this.ndv = ndv;
+        this.lowerExpr = lowerExpr;
+        this.upperExpr = upperExpr;
     }
 
     public static Bucket deserializeFromJson(Type datatype, String json) throws AnalysisException {
@@ -90,6 +66,11 @@ public class Bucket {
         bucket.count = bucketJson.get("count").getAsInt();
         bucket.preSum = bucketJson.get("pre_sum").getAsInt();
         bucket.ndv = bucketJson.get("ndv").getAsInt();
+
+        // LowerExpr and upperExpr for display only.
+        bucket.lowerExpr = StatisticsUtil.readableValue(datatype, bucketJson.get("lower").getAsString());
+        bucket.upperExpr = StatisticsUtil.readableValue(datatype, bucketJson.get("upper").getAsString());
+
         return bucket;
     }
 
@@ -99,8 +80,8 @@ public class Bucket {
         }
 
         JsonObject bucketJson = new JsonObject();
-        bucketJson.addProperty("upper", bucket.upper);
-        bucketJson.addProperty("lower", bucket.lower);
+        bucketJson.addProperty("lower_expr", bucket.lowerExpr.getStringValue());
+        bucketJson.addProperty("upper_expr", bucket.upperExpr.getStringValue());
         bucketJson.addProperty("count", bucket.count);
         bucketJson.addProperty("pre_sum", bucket.preSum);
         bucketJson.addProperty("ndv", bucket.ndv);

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/Histogram.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/Histogram.java
@@ -33,6 +33,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.parquet.Strings;
 
+import java.util.Collections;
 import java.util.List;
 
 public class Histogram {
@@ -44,13 +45,18 @@ public class Histogram {
 
     public final List<Bucket> buckets;
 
-    public Histogram(Type dataType, double sampleRate, List<Bucket> buckets) {
+    public final int numBuckets;
+
+    public Histogram(Type dataType, double sampleRate, int numBuckets, List<Bucket> buckets) {
         this.dataType = dataType;
         this.sampleRate = sampleRate;
+        this.numBuckets = numBuckets;
         this.buckets = buckets;
     }
 
-
+    public static Histogram UNKNOWN = new HistogramBuilder().setDataType(Type.NULL)
+            .setSampleRate(0).setNumBuckets(0).setBuckets(Collections.emptyList())
+            .build();
 
     // TODO: use thrift
     public static Histogram fromResultRow(ResultRow resultRow) {
@@ -151,11 +157,20 @@ public class Histogram {
         histogramJson.addProperty("sample_rate", histogram.sampleRate);
         histogramJson.addProperty("num_buckets", histogram.buckets.size());
 
-        JsonArray bucketsJsonArray = new JsonArray();
-        histogram.buckets.stream().map(Bucket::serializeToJsonObj).forEach(bucketsJsonArray::add);
-        histogramJson.add("buckets", bucketsJsonArray);
+        JsonArray bucketsJson = getBucketsJson(histogram.buckets);
+        histogramJson.add("buckets", bucketsJson);
 
         return histogramJson.toString();
+    }
+
+    public static JsonArray getBucketsJson(List<Bucket> buckets) {
+        if (buckets == null) {
+            return null;
+        }
+        JsonArray bucketsJsonArray = new JsonArray();
+        buckets.stream().map(Bucket::serializeToJsonObj).forEach(bucketsJsonArray::add);
+        return bucketsJsonArray;
+
     }
 
     public double size() {
@@ -163,6 +178,6 @@ public class Histogram {
             return 0;
         }
         Bucket lastBucket = buckets.get(buckets.size() - 1);
-        return lastBucket.getPreSum() + lastBucket.getCount();
+        return lastBucket.preSum + lastBucket.count;
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/HistogramBuilder.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/HistogramBuilder.java
@@ -64,6 +64,6 @@ public class HistogramBuilder {
     }
 
     public Histogram build() {
-        return new Histogram(dataType, sampleRate, buckets);
+        return new Histogram(dataType, sampleRate, numBuckets, buckets);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/HistogramTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/HistogramTask.java
@@ -67,7 +67,7 @@ public class HistogramTask extends BaseAnalysisTask {
     public void execute() throws Exception {
         Map<String, String> params = new HashMap<>();
         params.put("internalDB", FeConstants.INTERNAL_DB_NAME);
-        params.put("histogramStatTbl", StatisticConstants.HISTOGRAM_TBL_NAME);
+        params.put("histogramStatTbl", StatisticConstants.COL_HISTOGRAM_TBL_NAME);
         params.put("catalogId", String.valueOf(catalog.getId()));
         params.put("dbId", String.valueOf(db.getId()));
         params.put("tblId", String.valueOf(tbl.getId()));

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/HiveAnalysisTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/HiveAnalysisTask.java
@@ -77,7 +77,7 @@ public class HiveAnalysisTask extends HMSAnalysisTask {
         columns.add(col.getName());
         Map<String, String> params = new HashMap<>();
         params.put("internalDB", FeConstants.INTERNAL_DB_NAME);
-        params.put("columnStatTbl", StatisticConstants.STATISTIC_TBL_NAME);
+        params.put("columnStatTbl", StatisticConstants.COL_STATISTIC_TBL_NAME);
         params.put("catalogId", String.valueOf(catalog.getId()));
         params.put("dbId", String.valueOf(db.getId()));
         params.put("tblId", String.valueOf(tbl.getId()));

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/IcebergAnalysisTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/IcebergAnalysisTask.java
@@ -98,7 +98,7 @@ public class IcebergAnalysisTask extends HMSAnalysisTask {
     private void updateStats() throws Exception {
         Map<String, String> params = new HashMap<>();
         params.put("internalDB", FeConstants.INTERNAL_DB_NAME);
-        params.put("columnStatTbl", StatisticConstants.STATISTIC_TBL_NAME);
+        params.put("columnStatTbl", StatisticConstants.COL_STATISTIC_TBL_NAME);
         params.put("id", tbl.getId() + "-" + col.getName());
         params.put("catalogId", String.valueOf(catalog.getId()));
         params.put("dbId", String.valueOf(db.getId()));

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/MVAnalysisTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/MVAnalysisTask.java
@@ -103,7 +103,7 @@ public class MVAnalysisTask extends BaseAnalysisTask {
                 tableRef.setPartitionNames(partitionName);
                 String sql = selectOne.toSql();
                 params.put("internalDB", FeConstants.INTERNAL_DB_NAME);
-                params.put("columnStatTbl", StatisticConstants.STATISTIC_TBL_NAME);
+                params.put("columnStatTbl", StatisticConstants.COL_STATISTIC_TBL_NAME);
                 params.put("catalogId", String.valueOf(catalog.getId()));
                 params.put("dbId", String.valueOf(db.getId()));
                 params.put("tblId", String.valueOf(tbl.getId()));

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/OlapAnalysisTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/OlapAnalysisTask.java
@@ -60,7 +60,7 @@ public class OlapAnalysisTask extends BaseAnalysisTask {
     public void execute() throws Exception {
         Map<String, String> params = new HashMap<>();
         params.put("internalDB", FeConstants.INTERNAL_DB_NAME);
-        params.put("columnStatTbl", StatisticConstants.STATISTIC_TBL_NAME);
+        params.put("columnStatTbl", StatisticConstants.COL_STATISTIC_TBL_NAME);
         params.put("catalogId", String.valueOf(catalog.getId()));
         params.put("dbId", String.valueOf(db.getId()));
         params.put("tblId", String.valueOf(tbl.getId()));

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticConstants.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticConstants.java
@@ -20,9 +20,11 @@ package org.apache.doris.statistics;
 import java.util.concurrent.TimeUnit;
 
 public class StatisticConstants {
-    public static final String STATISTIC_TBL_NAME = "column_statistics";
+    public static final String TBL_STATISTIC_TBL_NAME = "table_statistics";
 
-    public static final String HISTOGRAM_TBL_NAME = "histogram_statistics";
+    public static final String COL_STATISTIC_TBL_NAME = "column_statistics";
+
+    public static final String COL_HISTOGRAM_TBL_NAME = "histogram_statistics";
 
     public static final String ANALYSIS_JOB_TABLE = "analysis_jobs";
 

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticsCacheLoader.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticsCacheLoader.java
@@ -41,11 +41,11 @@ public class StatisticsCacheLoader implements AsyncCacheLoader<StatisticsCacheKe
     private static final Logger LOG = LogManager.getLogger(StatisticsCacheLoader.class);
 
     private static final String QUERY_COLUMN_STATISTICS = "SELECT * FROM " + FeConstants.INTERNAL_DB_NAME
-            + "." + StatisticConstants.STATISTIC_TBL_NAME + " WHERE "
+            + "." + StatisticConstants.COL_STATISTIC_TBL_NAME + " WHERE "
             + "id = CONCAT('${tblId}', '-', ${idxId}, '-', '${colId}')";
 
     private static final String QUERY_HISTOGRAM_STATISTICS = "SELECT * FROM " + FeConstants.INTERNAL_DB_NAME
-            + "." + StatisticConstants.HISTOGRAM_TBL_NAME + " WHERE "
+            + "." + StatisticConstants.COL_HISTOGRAM_TBL_NAME + " WHERE "
             + "id = CONCAT('${tblId}', '-', ${idxId}, '-', '${colId}')";
 
     // TODO: Maybe we should trigger a analyze job when the required ColumnStatistic doesn't exists.

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticsRepository.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticsRepository.java
@@ -53,11 +53,21 @@ public class StatisticsRepository {
     private static final String FULL_QUALIFIED_DB_NAME = "`" + SystemInfoService.DEFAULT_CLUSTER + ":"
             + FeConstants.INTERNAL_DB_NAME + "`";
 
+    private static final String FULL_QUALIFIED_TABLE_STATISTICS_NAME = FULL_QUALIFIED_DB_NAME + "."
+            + "`" + StatisticConstants.TBL_STATISTIC_TBL_NAME + "`";
+
     private static final String FULL_QUALIFIED_COLUMN_STATISTICS_NAME = FULL_QUALIFIED_DB_NAME + "."
-            + "`" + StatisticConstants.STATISTIC_TBL_NAME + "`";
+            + "`" + StatisticConstants.COL_STATISTIC_TBL_NAME + "`";
+
+    private static final String FULL_QUALIFIED_COLUMN_HISTOGRAM_NAME = FULL_QUALIFIED_DB_NAME + "."
+            + "`" + StatisticConstants.COL_HISTOGRAM_TBL_NAME + "`";
 
     private static final String FULL_QUALIFIED_ANALYSIS_JOB_TABLE_NAME = FULL_QUALIFIED_DB_NAME + "."
             + "`" + StatisticConstants.ANALYSIS_JOB_TABLE + "`";
+
+    private static final String FETCH_TABLE_STATISTIC_TEMPLATE = "SELECT * FROM "
+            + FULL_QUALIFIED_TABLE_STATISTICS_NAME
+            + " WHERE `id` = '${id}'";
 
     private static final String FETCH_COLUMN_STATISTIC_TEMPLATE = "SELECT * FROM "
             + FULL_QUALIFIED_COLUMN_STATISTICS_NAME
@@ -66,6 +76,10 @@ public class StatisticsRepository {
     private static final String FETCH_PARTITIONS_STATISTIC_TEMPLATE = "SELECT * FROM "
             + FULL_QUALIFIED_COLUMN_STATISTICS_NAME
             + " WHERE `id` IN (${idList})";
+
+    private static final String FETCH_COLUMN_HISTOGRAM_TEMPLATE = "SELECT * FROM "
+            + FULL_QUALIFIED_COLUMN_HISTOGRAM_NAME
+            + " WHERE `id` = '${id}'";
 
     private static final String PERSIST_ANALYSIS_TASK_SQL_TEMPLATE = "INSERT INTO "
             + FULL_QUALIFIED_ANALYSIS_JOB_TABLE_NAME + " VALUES(${jobId}, ${taskId}, '${catalogName}', '${dbName}',"
@@ -78,10 +92,28 @@ public class StatisticsRepository {
             + "'${colId}', ${partId}, ${count}, ${ndv}, ${nullCount}, '${min}', '${max}', ${dataSize}, NOW())";
 
     private static final String DROP_TABLE_STATISTICS_TEMPLATE = "DELETE FROM " + FeConstants.INTERNAL_DB_NAME
-            + "." + StatisticConstants.STATISTIC_TBL_NAME + " WHERE ${condition}";
+            + "." + StatisticConstants.COL_STATISTIC_TBL_NAME + " WHERE ${condition}";
 
     private static final String DROP_TABLE_HISTOGRAM_TEMPLATE = "DELETE FROM " + FeConstants.INTERNAL_DB_NAME
-            + "." + StatisticConstants.HISTOGRAM_TBL_NAME + " WHERE ${condition}";
+            + "." + StatisticConstants.COL_HISTOGRAM_TBL_NAME + " WHERE ${condition}";
+
+    public static TableStatistic queryTableStatisticById(long tblId) {
+        return queryTableStatisticById(tblId, -1);
+    }
+
+    public static TableStatistic queryTableStatisticById(long tblId, long partId) {
+        Map<String, String> map = new HashMap<>();
+        String id = partId == -1 ? constructId(tblId, -1) :
+                constructId(tblId, -1, partId);
+        map.put("id", id);
+        List<ResultRow> rows = StatisticsUtil.executeQuery(FETCH_TABLE_STATISTIC_TEMPLATE, map);
+        int size = rows.size();
+        if (size > 1) {
+            throw new IllegalStateException(String.format("id: %s should be unique, but return more than one row", id));
+        }
+
+        return size == 0 ? TableStatistic.UNKNOWN : TableStatistic.fromResultRow(rows.get(0));
+    }
 
     public static ColumnStatistic queryColumnStatisticsByName(long tableId, String colName) {
         ResultRow resultRow = queryColumnStatisticById(tableId, colName);
@@ -108,10 +140,19 @@ public class StatisticsRepository {
     }
 
     public static ResultRow queryColumnStatisticById(long tblId, String colName) {
+        return queryColumnStatisticById(tblId, colName, false);
+    }
+
+    public static ResultRow queryColumnHistogramById(long tblId, String colName) {
+        return queryColumnStatisticById(tblId, colName, true);
+    }
+
+    private static ResultRow queryColumnStatisticById(long tblId, String colName, boolean isHistogram) {
         Map<String, String> map = new HashMap<>();
         String id = constructId(tblId, -1, colName);
         map.put("id", id);
-        List<ResultRow> rows = StatisticsUtil.executeQuery(FETCH_COLUMN_STATISTIC_TEMPLATE, map);
+        List<ResultRow> rows = isHistogram ? StatisticsUtil.executeQuery(FETCH_COLUMN_HISTOGRAM_TEMPLATE, map) :
+                StatisticsUtil.executeQuery(FETCH_COLUMN_STATISTIC_TEMPLATE, map);
         int size = rows.size();
         if (size > 1) {
             throw new IllegalStateException(String.format("id: %s should be unique, but return more than one row", id));
@@ -128,6 +169,14 @@ public class StatisticsRepository {
         params.put("idList", sj.toString());
         List<ResultRow> rows = StatisticsUtil.executeQuery(FETCH_PARTITIONS_STATISTIC_TEMPLATE, params);
         return rows == null ? Collections.emptyList() : rows;
+    }
+
+    public static Histogram queryColumnHistogramByName(long tableId, String colName) {
+        ResultRow resultRow = queryColumnHistogramById(tableId, colName);
+        if (resultRow == null) {
+            return Histogram.UNKNOWN;
+        }
+        return Histogram.fromResultRow(resultRow);
     }
 
     private static String constructId(Object... params) {

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticsTableCleaner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticsTableCleaner.java
@@ -100,7 +100,7 @@ public class StatisticsTableCleaner extends MasterDaemon {
     private void deleteExpired(String colName, List<String> constants) {
         // TODO: must promise count of children of predicate is less than the FE limits.
         String deleteTemplate = "DELETE FROM " + FeConstants.INTERNAL_DB_NAME
-                + "." + StatisticConstants.STATISTIC_TBL_NAME + "WHERE ${colName} NOT IN ${predicate}";
+                + "." + StatisticConstants.COL_STATISTIC_TBL_NAME + "WHERE ${colName} NOT IN ${predicate}";
         StringJoiner predicateBuilder = new StringJoiner(",", "(", ")");
         constants.forEach(predicateBuilder::add);
         Map<String, String> map = new HashMap<String, String>() {

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/TableStatistic.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/TableStatistic.java
@@ -1,0 +1,75 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.statistics;
+
+import org.apache.doris.common.DdlException;
+import org.apache.doris.statistics.util.InternalQueryResult.ResultRow;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class TableStatistic {
+
+    private static final Logger LOG = LogManager.getLogger(TableStatistic.class);
+
+    public static TableStatistic UNKNOWN = new TableStatisticBuilder()
+            .setRowCount(0).setUpdateRows(0).setHealthy(0)
+            .setUpdateTime("NULL").setLastAnalyzeTime("NULL")
+            .build();
+
+    public final long rowCount;
+    public final long updateRows;
+    public final int healthy;
+    public final long dataSizeInBytes;
+    public final String updateTime;
+    public final String lastAnalyzeTime;
+
+    public TableStatistic(long rowCount, long updateRows,
+            int healthy, long dataSizeInBytes, String updateTime,
+            String lastAnalyzeTime) {
+        this.rowCount = rowCount;
+        this.updateRows = updateRows;
+        this.healthy = healthy;
+        this.dataSizeInBytes = dataSizeInBytes;
+        this.updateTime = updateTime;
+        this.lastAnalyzeTime = lastAnalyzeTime;
+    }
+
+    // TODO: use thrift
+    public static TableStatistic fromResultRow(ResultRow resultRow) {
+        try {
+            TableStatisticBuilder tableStatisticBuilder = new TableStatisticBuilder();
+            long rowCount = Long.parseLong(resultRow.getColumnValue("row_count"));
+            tableStatisticBuilder.setRowCount(rowCount);
+            long updateRows = Long.parseLong(resultRow.getColumnValue("update_rows"));
+            tableStatisticBuilder.setUpdateRows(updateRows);
+            int healthy = Integer.parseInt(resultRow.getColumnValue("healthy"));
+            tableStatisticBuilder.setHealthy(healthy);
+            long dataSizeInBytes = Long.parseLong(resultRow.getColumnValue("data_size_in_bytes"));
+            tableStatisticBuilder.setDataSizeInBytes(dataSizeInBytes);
+            String updateTime = resultRow.getColumnValue("update_time");
+            tableStatisticBuilder.setUpdateTime(updateTime);
+            String lastAnalyzeTime = resultRow.getColumnValue("last_analyze_time");
+            tableStatisticBuilder.setLastAnalyzeTime(lastAnalyzeTime);
+            return tableStatisticBuilder.build();
+        } catch (DdlException e) {
+            LOG.warn("Failed to deserialize table statistics", e);
+            return TableStatistic.UNKNOWN;
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/TableStatisticBuilder.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/TableStatisticBuilder.java
@@ -1,0 +1,99 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.statistics;
+
+public class TableStatisticBuilder {
+    public long rowCount;
+    public long updateRows;
+    public int healthy;
+    public long dataSizeInBytes;
+    public String updateTime;
+    public String lastAnalyzeTime;
+
+    public TableStatisticBuilder() {
+    }
+
+    public TableStatisticBuilder(TableStatistic tableStatistic) {
+        this.rowCount = tableStatistic.rowCount;
+        this.updateRows = tableStatistic.updateRows;
+        this.healthy = tableStatistic.healthy;
+        this.dataSizeInBytes = tableStatistic.dataSizeInBytes;
+        this.updateTime = tableStatistic.updateTime;
+        this.lastAnalyzeTime = tableStatistic.lastAnalyzeTime;
+    }
+
+    public long getRowCount() {
+        return rowCount;
+    }
+
+    public TableStatisticBuilder setRowCount(long rowCount) {
+        this.rowCount = rowCount;
+        return this;
+    }
+
+    public long getUpdateRows() {
+        return updateRows;
+    }
+
+    public TableStatisticBuilder setUpdateRows(long updateRows) {
+        this.updateRows = updateRows;
+        return this;
+    }
+
+    public double getHealthy() {
+        return healthy;
+    }
+
+    public TableStatisticBuilder setHealthy(int healthy) {
+        this.healthy = healthy;
+        return this;
+    }
+
+    public long getDataSizeInBytes() {
+        return dataSizeInBytes;
+    }
+
+    public TableStatisticBuilder setDataSizeInBytes(long dataSizeInBytes) {
+        this.dataSizeInBytes = dataSizeInBytes;
+        return this;
+    }
+
+    public String getUpdateTime() {
+        return updateTime;
+    }
+
+    public TableStatisticBuilder setUpdateTime(String updateTime) {
+        this.updateTime = updateTime;
+        return this;
+    }
+
+    public String getLastAnalyzeTime() {
+        return lastAnalyzeTime;
+    }
+
+    public TableStatisticBuilder setLastAnalyzeTime(String lastAnalyzeTime) {
+        this.lastAnalyzeTime = lastAnalyzeTime;
+        return this;
+    }
+
+
+    public TableStatistic build() {
+        return new TableStatistic(rowCount, updateRows,
+                healthy, dataSizeInBytes, updateTime, lastAnalyzeTime);
+    }
+}


### PR DESCRIPTION
# Proposed changes

1. Display the histogram
2. Add and display table level statistics

```SQL
SHOW TABLE  STATS tablename
```

The statistics **health** of the table and a rough estimate of the accuracy of the statistics on the table, It's also a condition of whether or not to recollect:
- When `modify_count` >= `row_count`, the health is `0`; 
- when `modify_count` < `row_count`, the health is `(1 - modify_count/row_count) * 100`.

Some work before automatic collection.


 preposition：#18069

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

