### PR TITLE
[Fix](planner)fix nested udf bind arguments exception

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/FunctionCallExpr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/FunctionCallExpr.java
@@ -1708,6 +1708,7 @@ public class FunctionCallExpr extends Expr {
 
         retExpr.fnParams = new FunctionParams(oriExpr.fnParams.isDistinct(), oriParamsExprs);
 
+        // retExpr changed to original function, so the fn should be null.
         retExpr.fn = null;
 
         // reset children

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/FunctionCallExpr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/FunctionCallExpr.java
@@ -1708,6 +1708,8 @@ public class FunctionCallExpr extends Expr {
 
         retExpr.fnParams = new FunctionParams(oriExpr.fnParams.isDistinct(), oriParamsExprs);
 
+        retExpr.fn = null;
+
         // reset children
         retExpr.children.clear();
         retExpr.children.addAll(oriExpr.getChildren());

--- a/regression-test/suites/query_p0/sql_functions/test_alias_function.groovy
+++ b/regression-test/suites/query_p0/sql_functions/test_alias_function.groovy
@@ -1,0 +1,34 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite('test_alias_function') {
+    sql "use test_query_db"
+    sql '''
+        CREATE ALIAS FUNCTION f1(DATETIMEV2(3), INT)
+            with PARAMETER (datetime1, int1) as date_trunc(days_sub(datetime1, int1), 'day')'''
+    sql '''
+        CREATE ALIAS FUNCTION f2(DATETIMEV2(3), int)
+            with PARAMETER (datetime1, int1) as DATE_FORMAT(HOURS_ADD(
+                date_trunc(datetime1, 'day'),
+                add(multiply(floor(divide(HOUR(datetime1), divide(24,int1))), 1), 1)
+            ), '%Y%m%d:%H');'''
+
+    test {
+        sql 'select f2(f1(now(3), 2), 3)'
+        result([['20230327:01']])
+    }
+}

--- a/regression-test/suites/query_p0/sql_functions/test_alias_function.groovy
+++ b/regression-test/suites/query_p0/sql_functions/test_alias_function.groovy
@@ -18,10 +18,10 @@
 suite('test_alias_function') {
     sql "use test_query_db"
     sql '''
-        CREATE ALIAS FUNCTION f1(DATETIMEV2(3), INT)
+        CREATE ALIAS FUNCTION IF NOT EXISTS f1(DATETIMEV2(3), INT)
             with PARAMETER (datetime1, int1) as date_trunc(days_sub(datetime1, int1), 'day')'''
     sql '''
-        CREATE ALIAS FUNCTION f2(DATETIMEV2(3), int)
+        CREATE ALIAS FUNCTION IF NOT EXISTS f2(DATETIMEV2(3), int)
             with PARAMETER (datetime1, int1) as DATE_FORMAT(HOURS_ADD(
                 date_trunc(datetime1, 'day'),
                 add(multiply(floor(divide(HOUR(datetime1), divide(24,int1))), 1), 1)


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

nested alias function will cause bind argument exception, sql like:
``` sql
CREATE ALIAS FUNCTION f1(DATETIMEV2(3), INT)
            with PARAMETER (datetime1, int1) as date_trunc(days_sub(datetime1, int1), 'day')
```
``` sql
CREATE ALIAS FUNCTION f2(DATETIMEV2(3), int)
            with PARAMETER (datetime1, int1) as DATE_FORMAT(HOURS_ADD(
                date_trunc(datetime1, 'day'),
                add(multiply(floor(divide(HOUR(datetime1), divide(24,int1))), 1), 1)
            ), '%Y%m%d:%H')
```
``` sql
select f2(f1(now(3), 2), 3)
```
bug in FunctionCallExpr#rewriteExpr(), the retExpr will be replaced to originExpr to change the alias function to builtin function, but the retExpr.fn is not null, so when return to outer scope, the fn will be covered. That's the example:
```
f1(f1()) -> date_trunc(days_sub(date_trunc(days_sub()))) is correct and
f1(f1()) -> date_trunc(days_sub(days_sub())) is bug.
``` 
we fix it.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [x] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [x] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

