### PR TITLE
 [Improve](query) improve column match performance by introducing a column name map in `MaterializedIndexMeta`

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/MaterializedIndexMeta.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/MaterializedIndexMeta.java
@@ -130,6 +130,7 @@ public class MaterializedIndexMeta implements Writable, GsonPostProcessable {
 
     public void setSchema(List<Column> newSchema) {
         this.schema = newSchema;
+        initColumnNameMap();
     }
 
     public void setSchemaHash(int newSchemaHash) {
@@ -308,8 +309,9 @@ public class MaterializedIndexMeta implements Writable, GsonPostProcessable {
     }
 
     public void initColumnNameMap() {
-        nameToColumn = Maps.newHashMap();
-        definedNameToColumn = Maps.newHashMap();
+        // case insensitive
+        nameToColumn = Maps.newTreeMap(String.CASE_INSENSITIVE_ORDER);
+        definedNameToColumn = Maps.newTreeMap(String.CASE_INSENSITIVE_ORDER);
         for (Column column : schema) {
             nameToColumn.put(normalizeName(column.getName()), column);
             definedNameToColumn.put(normalizeName(column.getDefineName()), column);

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/MaterializedIndexMeta.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/MaterializedIndexMeta.java
@@ -33,6 +33,7 @@ import org.apache.doris.thrift.TStorageType;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import com.google.gson.annotations.SerializedName;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -68,6 +69,8 @@ public class MaterializedIndexMeta implements Writable, GsonPostProcessable {
     private int maxColUniqueId = Column.COLUMN_UNIQUE_ID_INIT_VALUE;
 
     private Expr whereClause;
+    private Map<String, Column> nameToColumn;
+    private Map<String, Column> definedNameToColumn;
 
     private static final Logger LOG = LogManager.getLogger(MaterializedIndexMeta.class);
 
@@ -86,6 +89,7 @@ public class MaterializedIndexMeta implements Writable, GsonPostProcessable {
         Preconditions.checkState(keysType != null);
         this.keysType = keysType;
         this.defineStmt = defineStmt;
+        initColumnNameMap();
     }
 
     public void setWhereClause(Expr whereClause) {
@@ -215,13 +219,14 @@ public class MaterializedIndexMeta implements Writable, GsonPostProcessable {
         return normalizeName(lhs).equalsIgnoreCase(normalizeName(rhs));
     }
 
+    public Column getColumnByDefineName(String colDefineName) {
+        String normalizedName = normalizeName(colDefineName);
+        return definedNameToColumn.getOrDefault(normalizedName, null);
+    }
+
     public Column getColumnByName(String columnName) {
-        for (Column column : schema) {
-            if (matchColumnName(column.getName(), columnName)) {
-                return column;
-            }
-        }
-        return null;
+        String normalizedName = normalizeName(columnName);
+        return nameToColumn.getOrDefault(normalizedName, null);
     }
 
     public OriginStatement getDefineStmt() {
@@ -258,6 +263,7 @@ public class MaterializedIndexMeta implements Writable, GsonPostProcessable {
 
     @Override
     public void gsonPostProcess() throws IOException {
+        initColumnNameMap();
         // analyze define stmt
         if (defineStmt == null) {
             return;
@@ -299,5 +305,14 @@ public class MaterializedIndexMeta implements Writable, GsonPostProcessable {
             LOG.debug("indexId: {},  column:{}, uniqueId:{}",
                     indexId, column, column.getUniqueId());
         });
+    }
+
+    public void initColumnNameMap() {
+        nameToColumn = Maps.newHashMap();
+        definedNameToColumn = Maps.newHashMap();
+        for (Column column : schema) {
+            nameToColumn.put(normalizeName(column.getName()), column);
+            definedNameToColumn.put(normalizeName(column.getDefineName()), column);
+        }
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
@@ -343,6 +343,8 @@ public class OlapTable extends Table {
                     nameToColumn.put(column.getDefineName(), column);
                 }
             }
+            // Column maybe renamed, rebuild the column name map
+            indexMeta.initColumnNameMap();
         }
         LOG.debug("after rebuild full schema. table {}, schema size: {}", id, fullSchema.size());
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/OlapTable.java
@@ -407,10 +407,9 @@ public class OlapTable extends Table {
 
     public Column getVisibleColumn(String columnName) {
         for (MaterializedIndexMeta meta : getVisibleIndexIdToMeta().values()) {
-            for (Column column : meta.getSchema()) {
-                if (MaterializedIndexMeta.matchColumnName(column.getDefineName(), columnName)) {
-                    return column;
-                }
+            Column target = meta.getColumnByDefineName(columnName);
+            if (target != null) {
+                return target;
             }
         }
         return null;


### PR DESCRIPTION
# Proposed changes

`getVisbleColumn` is slow due to the linear search process, using a map to speed up search.

![image](https://user-images.githubusercontent.com/64513324/228437977-2d46a0fc-95af-46a1-83c2-78bd0279fef8.png)

270列select * limit 1
200qps -> 1000qps

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

