### PR TITLE
[Optimize](functions)Optimize function call for const columns.

### DIFF
--- a/be/src/vec/columns/column.h
+++ b/be/src/vec/columns/column.h
@@ -215,6 +215,7 @@ public:
 
     /// Appends range of elements from other column with the same type.
     /// Could be used to concatenate columns.
+    /// TODO: we need `insert_range_from_const` for every column type.
     virtual void insert_range_from(const IColumn& src, size_t start, size_t length) = 0;
 
     /// Appends one element from other column with the same type multiple times.

--- a/be/src/vec/columns/column_const.h
+++ b/be/src/vec/columns/column_const.h
@@ -21,11 +21,15 @@
 #pragma once
 
 #include <cstddef>
+#include <initializer_list>
+#include <type_traits>
 
 #include "vec/columns/column.h"
 #include "vec/columns/column_nullable.h"
 #include "vec/common/assert_cast.h"
 #include "vec/common/typeid_cast.h"
+#include "vec/core/block.h"
+#include "vec/core/column_numbers.h"
 #include "vec/core/field.h"
 
 namespace doris::vectorized {
@@ -234,4 +238,29 @@ public:
 */
 std::pair<ColumnPtr, size_t> check_column_const_set_readability(const IColumn& column,
                                                                 const size_t row_num) noexcept;
+
+/*
+ * @warning use this function sometimes cause performance problem in GCC.
+*/
+template <typename T, std::enable_if_t<std::is_integral_v<T>, T> = 0>
+T index_check_const(T arg, bool constancy) noexcept {
+    return constancy ? 0 : arg;
+}
+
+/*
+ * @return first : data_column_ptr for ColumnConst, itself otherwise.
+ *         second : whether it's ColumnConst.
+*/
+std::pair<const ColumnPtr&, bool> unpack_if_const(const ColumnPtr&) noexcept;
+
+/*
+ * For the functions that some columns of arguments are almost but not completely always const, we use this function to preprocessing its parameter columns
+ * (which are not data columns). When we have two or more columns which only provide parameter, use this to deal with corner case. So you can specialize you
+ * implementations for all const or all parameters const, without considering some of parameters are const.
+ 
+ * Do the transformation only for the columns whose arg_indexes in parameters.
+*/
+void default_preprocess_parameter_columns(ColumnPtr* columns, const bool* col_const,
+                                          const std::initializer_list<size_t>& parameters,
+                                          Block& block, const ColumnNumbers& arg_indexes) noexcept;
 } // namespace doris::vectorized

--- a/be/src/vec/columns/column_nullable.h
+++ b/be/src/vec/columns/column_nullable.h
@@ -20,6 +20,8 @@
 
 #pragma once
 
+#include "vec/columns/column_vector.h"
+#include "vec/core/types.h"
 #ifdef __aarch64__
 #include <sse2neon.h>
 #endif
@@ -368,5 +370,7 @@ private:
 
 ColumnPtr make_nullable(const ColumnPtr& column, bool is_nullable = false);
 ColumnPtr remove_nullable(const ColumnPtr& column);
-
+// check if argument column is nullable. If so, extract its concrete column and set null_map.
+//TODO: use this to replace inner usages.
+void check_set_nullable(ColumnPtr&, ColumnVector<UInt8>::MutablePtr&);
 } // namespace doris::vectorized

--- a/be/src/vec/common/sort/sorter.cpp
+++ b/be/src/vec/common/sort/sorter.cpp
@@ -306,8 +306,9 @@ Status FullSorter::append_block(Block* block) {
                     << " type1: " << data[i].type->get_name()
                     << " type2: " << arrival_data[i].type->get_name();
             try {
+                //TODO: to eliminate unnecessary expansion, we need a `insert_range_from_const` for every column type.
                 RETURN_IF_CATCH_BAD_ALLOC(data[i].column->assume_mutable()->insert_range_from(
-                        *arrival_data[i].column->convert_to_full_column_if_const().get(), 0, sz));
+                        *arrival_data[i].column->convert_to_full_column_if_const(), 0, sz));
             } catch (const doris::Exception& e) {
                 return Status::Error(e.code(), e.to_string());
             }

--- a/be/src/vec/common/string_ref.cpp
+++ b/be/src/vec/common/string_ref.cpp
@@ -20,6 +20,8 @@
 
 #include "string_ref.h"
 
+#include "common/compiler_util.h"
+
 namespace doris {
 
 StringRef StringRef::trim() const {
@@ -51,6 +53,19 @@ StringRef StringRef::min_string_val() {
 
 StringRef StringRef::max_string_val() {
     return StringRef((char*)(&StringRef::MAX_CHAR), 1);
+}
+
+bool StringRef::start_with(char ch) const {
+    if (UNLIKELY(size == 0)) {
+        return false;
+    }
+    return data[0] == ch;
+}
+bool StringRef::end_with(char ch) const {
+    if (UNLIKELY(size == 0)) {
+        return false;
+    }
+    return data[size - 1] == ch;
 }
 
 bool StringRef::start_with(const StringRef& search_string) const {

--- a/be/src/vec/common/string_ref.h
+++ b/be/src/vec/common/string_ref.h
@@ -225,6 +225,12 @@ struct StringRef {
 
     StringRef substring(int start_pos) const { return substring(start_pos, size - start_pos); }
 
+    const char* begin() const { return data; }
+    const char* end() const { return data + size; }
+    // there's no border check in functions below. That's same with STL.
+    char front() const { return *data; }
+    char back() const { return *(data + size - 1); }
+
     // Trims leading and trailing spaces.
     StringRef trim() const;
 
@@ -237,6 +243,8 @@ struct StringRef {
     static StringRef min_string_val();
     static StringRef max_string_val();
 
+    bool start_with(char) const;
+    bool end_with(char) const;
     bool start_with(const StringRef& search_string) const;
     bool end_with(const StringRef& search_string) const;
 

--- a/be/src/vec/functions/least_greast.cpp
+++ b/be/src/vec/functions/least_greast.cpp
@@ -15,8 +15,10 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#include "vec/columns/column_const.h"
 #include "vec/columns/column_vector.h"
 #include "vec/columns/columns_number.h"
+#include "vec/common/assert_cast.h"
 #include "vec/core/accurate_comparison.h"
 #include "vec/data_types/data_type.h"
 #include "vec/data_types/data_type_number.h"
@@ -34,60 +36,33 @@ struct CompareMultiImpl {
 
     static DataTypePtr get_return_type_impl(const DataTypes& arguments) { return arguments[0]; }
 
-    template <typename ColumnType>
-    static void insert_result_data(MutableColumnPtr& result_column, ColumnPtr& argument_column,
-                                   const size_t input_rows_count) {
-        auto* __restrict result_raw_data =
-                reinterpret_cast<ColumnType*>(result_column.get())->get_data().data();
-        auto* __restrict column_raw_data =
-                reinterpret_cast<const ColumnType*>(argument_column.get())->get_data().data();
-
-        if constexpr (std::is_same_v<ColumnType, ColumnDecimal128>) {
-            for (size_t i = 0; i < input_rows_count; ++i) {
-                result_raw_data[i] = Op<DecimalV2Value, DecimalV2Value>::apply(column_raw_data[i],
-                                                                               result_raw_data[i])
-                                             ? column_raw_data[i]
-                                             : result_raw_data[i];
-            }
-        } else {
-            for (size_t i = 0; i < input_rows_count; ++i) {
-                using type = std::decay_t<decltype(result_raw_data[0])>;
-                result_raw_data[i] = Op<type, type>::apply(column_raw_data[i], result_raw_data[i])
-                                             ? column_raw_data[i]
-                                             : result_raw_data[i];
-            }
-        }
-    }
-
     static ColumnPtr execute(Block& block, const ColumnNumbers& arguments,
                              size_t input_rows_count) {
-        if (arguments.size() == 1) return block.get_by_position(arguments.back()).column;
+        if (arguments.size() == 1) {
+            return block.get_by_position(arguments.back()).column;
+        }
 
         const auto& data_type = block.get_by_position(arguments.back()).type;
         MutableColumnPtr result_column = data_type->create_column();
 
-        Columns args;
+        Columns cols(arguments.size());
+        std::unique_ptr<bool[]> col_const = std::make_unique<bool[]>(arguments.size());
         for (int i = 0; i < arguments.size(); ++i) {
-            args.emplace_back(
-                    block.get_by_position(arguments[i]).column->convert_to_full_column_if_const());
+            std::tie(cols[i], col_const[i]) =
+                    unpack_if_const(block.get_by_position(arguments[i]).column);
         }
         // because now the string types does not support random position writing,
         // so insert into result data have two methods, one is for string types, one is for others type remaining
-        bool is_string_result = result_column->is_column_string();
-        if (is_string_result) {
+        if (result_column->is_column_string()) {
             result_column->reserve(input_rows_count);
-        } else {
-            result_column->insert_range_from(*(args[0]), 0, input_rows_count);
-        }
-
-        if (is_string_result) {
-            const auto& column_string = reinterpret_cast<const ColumnString&>(*args[0]);
+            const auto& column_string = reinterpret_cast<const ColumnString&>(*cols[0]);
             auto& column_res = reinterpret_cast<ColumnString&>(*result_column);
 
             for (int i = 0; i < input_rows_count; ++i) {
                 auto str_data = column_string.get_data_at(i);
-                for (int j = 1; j < arguments.size(); ++j) {
-                    auto temp_data = reinterpret_cast<const ColumnString&>(*args[j]).get_data_at(i);
+                for (int cmp_col = 1; cmp_col < arguments.size(); ++cmp_col) {
+                    auto temp_data = assert_cast<const ColumnString&>(*cols[cmp_col])
+                                             .get_data_at(index_check_const(i, col_const[i]));
                     str_data = Op<StringRef, StringRef>::apply(temp_data, str_data) ? temp_data
                                                                                     : str_data;
                 }
@@ -95,12 +70,15 @@ struct CompareMultiImpl {
             }
 
         } else {
+            result_column->insert_range_from(*(cols[0]), 0, input_rows_count);
             WhichDataType which(data_type);
-#define DISPATCH(TYPE, COLUMN_TYPE)                                                    \
-    if (which.idx == TypeIndex::TYPE) {                                                \
-        for (int i = 1; i < arguments.size(); ++i) {                                   \
-            insert_result_data<COLUMN_TYPE>(result_column, args[i], input_rows_count); \
-        }                                                                              \
+
+#define DISPATCH(TYPE, COLUMN_TYPE)                                                   \
+    if (which.idx == TypeIndex::TYPE) {                                               \
+        for (int i = 1; i < arguments.size(); ++i) {                                  \
+            insert_result_data<COLUMN_TYPE>(result_column, cols[i], input_rows_count, \
+                                            col_const[i]);                            \
+        }                                                                             \
     }
             NUMERIC_TYPE_TO_COLUMN_TYPE(DISPATCH)
             DISPATCH(Decimal128, ColumnDecimal<Decimal128>)
@@ -109,6 +87,36 @@ struct CompareMultiImpl {
         }
 
         return result_column;
+    }
+
+private:
+    template <typename ColumnType>
+    static void insert_result_data(const MutableColumnPtr& result_column,
+                                   const ColumnPtr& argument_column, const size_t input_rows_count,
+                                   const bool arg_const) {
+        auto* __restrict result_raw_data =
+                reinterpret_cast<ColumnType*>(result_column.get())->get_data().data();
+        auto* __restrict column_raw_data =
+                reinterpret_cast<const ColumnType*>(argument_column.get())->get_data().data();
+
+        if constexpr (std::is_same_v<ColumnType, ColumnDecimal128>) {
+            for (size_t i = 0; i < input_rows_count; ++i) {
+                result_raw_data[i] = Op<DecimalV2Value, DecimalV2Value>::apply(
+                                             column_raw_data[index_check_const(i, arg_const)],
+                                             result_raw_data[i])
+                                             ? column_raw_data[index_check_const(i, arg_const)]
+                                             : result_raw_data[i];
+            }
+        } else {
+            for (size_t i = 0; i < input_rows_count; ++i) {
+                using type = std::decay_t<decltype(result_raw_data[0])>;
+                result_raw_data[i] =
+                        Op<type, type>::apply(column_raw_data[index_check_const(i, arg_const)],
+                                              result_raw_data[i])
+                                ? column_raw_data[index_check_const(i, arg_const)]
+                                : result_raw_data[i];
+            }
+        }
     }
 };
 


### PR DESCRIPTION
# Problem summary

Introduced new methods to avoid expanding const column in some functions.

## Performance Improvement
before:
```
mysql [tpch]>Select substring(c_name, 5, 10), substring(c_address, 10, 15), substring(c_comment, 50, 75) from customer;
......
15000000 rows in set (18.30 sec)
```
after:
```
mysql [tpch]>Select substring(c_name, 5, 10), substring(c_address, 10, 15), substring(c_comment, 50, 75) from customer;
......
15000000 rows in set (15.92 sec)
```

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [x] Is this PR support rollback (If NO, please explain WHY)

## Further comments
