### PR TITLE
[typo](docs) fix the error of markdown  syntax

### DIFF
--- a/docs/en/docs/sql-manual/sql-functions/string-functions/mask/mask.md
+++ b/docs/en/docs/sql-manual/sql-functions/string-functions/mask/mask.md
@@ -61,6 +61,7 @@ mysql> select mask(name, '*', '#', '$') from test;
 | NULL                        |
 | $$$*#*#*#                   |
 +-----------------------------+
+```
 
 ### keywords
     mask

--- a/docs/en/docs/sql-manual/sql-functions/string-functions/mask/mask_first_n.md
+++ b/docs/en/docs/sql-manual/sql-functions/string-functions/mask/mask_first_n.md
@@ -52,6 +52,7 @@ mysql> select mask_first_n(name, 5) from test;
 | NULL                    |
 | nnnXxCdEf               |
 +-------------------------+
+```
 
 ### keywords
     mask_first_n

--- a/docs/en/docs/sql-manual/sql-functions/string-functions/mask/mask_last_n.md
+++ b/docs/en/docs/sql-manual/sql-functions/string-functions/mask/mask_last_n.md
@@ -52,6 +52,7 @@ mysql> select mask_last_n(name, 5) from test;
 | NULL                   |
 | 456AxXxXx              |
 +------------------------+
+```
 
 ### keywords
     mask_last_n

--- a/docs/zh-CN/docs/sql-manual/sql-functions/string-functions/mask/mask.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/string-functions/mask/mask.md
@@ -61,6 +61,7 @@ mysql> select mask(name, '*', '#', '$') from test;
 | NULL                        |
 | $$$*#*#*#                   |
 +-----------------------------+
+```
 
 ### keywords
     mask

--- a/docs/zh-CN/docs/sql-manual/sql-functions/string-functions/mask/mask_first_n.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/string-functions/mask/mask_first_n.md
@@ -52,6 +52,7 @@ mysql> select mask_first_n(name, 5) from test;
 | NULL                    |
 | nnnXxCdEf               |
 +-------------------------+
+```
 
 ### keywords
     mask_first_n

--- a/docs/zh-CN/docs/sql-manual/sql-functions/string-functions/mask/mask_last_n.md
+++ b/docs/zh-CN/docs/sql-manual/sql-functions/string-functions/mask/mask_last_n.md
@@ -52,6 +52,7 @@ mysql> select mask_last_n(name, 5) from test;
 | NULL                   |
 | 456AxXxXx              |
 +------------------------+
+```
 
 ### keywords
     mask_last_n


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [x] Has document been added or modified
* [ ] Does it need to update dependencies
* [x] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

