### PR TITLE
[fix](planner)need add LateralViewRef's id into TableRef's allTableRefIds

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/SelectStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/SelectStmt.java
@@ -776,6 +776,16 @@ public class SelectStmt extends QueryStmt {
         return result;
     }
 
+    public List<TupleId> getAllTableRefIds() {
+        List<TupleId> result = Lists.newArrayList();
+
+        for (TableRef ref : fromClause) {
+            result.addAll(ref.getAllTableRefIds());
+        }
+
+        return result;
+    }
+
     public List<TupleId> getTableRefIdsWithoutInlineView() {
         List<TupleId> result = Lists.newArrayList();
 
@@ -876,7 +886,7 @@ public class SelectStmt extends QueryStmt {
         // can also be safely evaluated below the join (picked up by getBoundPredicates()).
         // Such predicates will be marked twice and that is ok.
         List<Expr> unassigned =
-                analyzer.getUnassignedConjuncts(getTableRefIds(), true);
+                analyzer.getUnassignedConjuncts(getAllTableRefIds(), true);
         List<Expr> unassignedJoinConjuncts = Lists.newArrayList();
         for (Expr e : unassigned) {
             if (analyzer.evalAfterJoin(e)) {

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/TableRef.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/TableRef.java
@@ -681,6 +681,12 @@ public class TableRef implements ParseNode, Writable {
             // Indicate that this table ref has an empty ON-clause.
             analyzer.registerOnClauseConjuncts(Collections.<Expr>emptyList(), this);
         }
+
+        if (lateralViewRefs != null) {
+            for (LateralViewRef lateralViewRef : lateralViewRefs) {
+                allTableRefIds.add(lateralViewRef.getId());
+            }
+        }
     }
 
     public void rewriteExprs(ExprRewriter rewriter, Analyzer analyzer)

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/AnalyticPlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/AnalyticPlanner.java
@@ -301,7 +301,7 @@ public class AnalyticPlanner {
         ExprSubstitutionMap sortSmap = new ExprSubstitutionMap();
         List<Expr> sortSlotExprs = Lists.newArrayList();
         sortTupleDesc.setIsMaterialized(true);
-        for (TupleId tid : input.getTupleIds()) {
+        for (TupleId tid : input.getOutputTupleIds()) {
             TupleDescriptor tupleDesc = analyzer.getTupleDesc(tid);
             for (SlotDescriptor inputSlotDesc : tupleDesc.getSlots()) {
                 if (!inputSlotDesc.isMaterialized()) {

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/TableFunctionNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/TableFunctionNode.java
@@ -68,7 +68,7 @@ public class TableFunctionNode extends PlanNode {
 
     protected TableFunctionNode(PlanNodeId id, PlanNode inputNode, List<LateralViewRef> lateralViewRefs) {
         super(id, "TABLE FUNCTION NODE", StatisticalType.TABLE_FUNCTION_NODE);
-        tupleIds.addAll(inputNode.getTupleIds());
+        tupleIds.addAll(inputNode.getOutputTupleIds());
         tblRefIds.addAll(inputNode.getTupleIds());
         tblRefIds.addAll(inputNode.getTblRefIds());
         lateralViewTupleIds = lateralViewRefs.stream().map(e -> e.getDesc().getId())

--- a/regression-test/suites/correctness_p0/test_inlineview_with_window_function.groovy
+++ b/regression-test/suites/correctness_p0/test_inlineview_with_window_function.groovy
@@ -1,0 +1,73 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_inlineview_with_window_function") {
+    sql """
+        drop view if exists test_table_aa;
+    """
+
+    sql """
+        drop table if exists test_table_bb;
+    """
+    
+    sql """
+        CREATE TABLE `test_table_bb` (
+        `event_date` datetime NULL,
+        `event_content` text NULL,
+        `animal_id` bigint(20) NULL
+        ) ENGINE=OLAP
+        DUPLICATE KEY(`event_date`)
+        COMMENT 'OLAP'
+        DISTRIBUTED BY HASH(`event_date`) BUCKETS 48
+        PROPERTIES (
+        "replication_allocation" = "tag.location.default: 1",
+        "in_memory" = "false",
+        "storage_format" = "V2",
+        "disable_auto_compaction" = "false"
+        );
+    """
+
+    sql """
+        CREATE VIEW test_table_aa AS
+        SELECT 
+        ev.event_date,
+        ev.animal_id,
+        get_json_int(ev.event_content, "\$.nurseOns") as nurseons
+        FROM test_table_bb ev;
+    """
+
+    sql """
+        SELECT row_number() over(PARTITION BY animal_id ORDER BY event_date DESC) rw
+        FROM test_table_aa;
+    """
+
+    sql """
+        select  
+        e1
+        from test_table_aa
+        lateral view explode([0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23]) tmp1 as e1
+        where animal_id <= e1;
+    """
+
+    sql """
+        drop view if exists test_table_aa;
+    """
+
+    sql """
+        drop table if exists test_table_bb;
+    """
+}


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx
https://github.com/apache/doris/issues/18171

## Problem summary
1. add LateralViewRef's id into TableRef's allTableRefIds, so the caller won't miss LateralViewRef when trying to get all the tableref ids.
2. TableFunctionNode should use child node's output tuple id as the input tuple id

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

