### PR TITLE
[bugfix](buffercontrolblock) many query becomes very slow in 1.2.3

### DIFF
--- a/be/src/runtime/buffer_control_block.cpp
+++ b/be/src/runtime/buffer_control_block.cpp
@@ -111,7 +111,7 @@ Status BufferControlBlock::add_batch(std::unique_ptr<TFetchDataResult>& result) 
     int num_rows = result->result_batch.rows.size();
 
     while ((!_batch_queue.empty() && _buffer_rows > _buffer_limit) && !_is_cancelled) {
-        _data_removal.wait_for(l, std::chrono::seconds(1), [&]() { return _is_cancelled.load(); });
+        _data_removal.wait_for(l, std::chrono::seconds(1));
     }
 
     if (_is_cancelled) {


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

predicate in wait for is wrong, should not check is cancelled.

                VDataBufferSender  (dst_fragment_instance_id=-39f306bf41e3bafb--5dc95f12d4afdcdb):
                      -  AppendBatchTime:  7s50ms
                          -  ResultRendTime:  7s5ms
                          -  TupleConvertTime:  41.829ms
                      -  NumSentRows:  38.114K  (38114)

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

