### PR TITLE
[fix](load) handle null map right in OlapDataConvertor

### DIFF
--- a/be/src/vec/olap/olap_data_convertor.cpp
+++ b/be/src/vec/olap/olap_data_convertor.cpp
@@ -195,8 +195,9 @@ void OlapBlockDataConvertor::OlapColumnDataConvertorBase::clear_source_column() 
     _nullmap = nullptr;
 }
 
-// This should be called only in SegmentWriter. If you want to access nullmap in Convertor,
-// use `_nullmap` directly.
+// Obtain the converted nullmap with an offset of _row_pos.
+// This should be called only in SegmentWriter and `get_data_at` in Convertor.
+// If you want to access origin nullmap without offset, use `_nullmap` directly.
 const UInt8* OlapBlockDataConvertor::OlapColumnDataConvertorBase::get_nullmap() const {
     assert(_typed_column.column);
     return _nullmap ? _nullmap + _row_pos : nullptr;
@@ -218,8 +219,8 @@ const void* OlapBlockDataConvertor::OlapColumnDataConvertorObject::get_data() co
 const void* OlapBlockDataConvertor::OlapColumnDataConvertorObject::get_data_at(
         size_t offset) const {
     UInt8 null_flag = 0;
-    if (_nullmap) {
-        null_flag = _nullmap[offset];
+    if (get_nullmap()) {
+        null_flag = get_nullmap()[offset];
     }
     return null_flag ? nullptr : _slice.data() + offset;
 }
@@ -474,8 +475,8 @@ const void* OlapBlockDataConvertor::OlapColumnDataConvertorChar::get_data() cons
 
 const void* OlapBlockDataConvertor::OlapColumnDataConvertorChar::get_data_at(size_t offset) const {
     UInt8 null_flag = 0;
-    if (_nullmap) {
-        null_flag = _nullmap[offset];
+    if (get_nullmap()) {
+        null_flag = get_nullmap()[offset];
     }
     return null_flag ? nullptr : _slice.data() + offset;
 }
@@ -530,8 +531,8 @@ const void* OlapBlockDataConvertor::OlapColumnDataConvertorVarChar::get_data_at(
         size_t offset) const {
     assert(offset < _slice.size());
     UInt8 null_flag = 0;
-    if (_nullmap) {
-        null_flag = _nullmap[offset];
+    if (get_nullmap()) {
+        null_flag = get_nullmap()[offset];
     }
     return null_flag ? nullptr : _slice.data() + offset;
 }

--- a/be/src/vec/olap/olap_data_convertor.h
+++ b/be/src/vec/olap/olap_data_convertor.h
@@ -191,8 +191,8 @@ private:
         const void* get_data() const override { return _values.data(); }
         const void* get_data_at(size_t offset) const override {
             UInt8 null_flag = 0;
-            if (_nullmap) {
-                null_flag = _nullmap[offset];
+            if (get_nullmap()) {
+                null_flag = get_nullmap()[offset];
             }
             return null_flag ? nullptr : _values.data() + offset;
         }
@@ -233,8 +233,8 @@ private:
         const void* get_data_at(size_t offset) const override {
             assert(offset < _num_rows);
             UInt8 null_flag = 0;
-            if (_nullmap) {
-                null_flag = _nullmap[offset];
+            if (get_nullmap()) {
+                null_flag = get_nullmap()[offset];
             }
             return null_flag ? nullptr : _values + offset;
         }
@@ -275,8 +275,8 @@ private:
         const void* get_data_at(size_t offset) const override {
             assert(offset < _num_rows);
             UInt8 null_flag = 0;
-            if (_nullmap) {
-                null_flag = _nullmap[offset];
+            if (get_nullmap()) {
+                null_flag = get_nullmap()[offset];
             }
             return null_flag ? nullptr : values_ + offset;
         }
@@ -317,8 +317,8 @@ private:
         const void* get_data_at(size_t offset) const override {
             assert(offset < _num_rows);
             UInt8 null_flag = 0;
-            if (_nullmap) {
-                null_flag = _nullmap[offset];
+            if (get_nullmap()) {
+                null_flag = get_nullmap()[offset];
             }
             return null_flag ? nullptr : values_ + offset;
         }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

The offset of `_nullmap` and `_value` are inconsistent in OlapDataConvertor, so the obtained null flag is incorrect when calling `get_ data_ at` function. When the key column or sequence column has null values, the encoding of the short key index or primary key index may be wrong.
This was introduced by #10883 #10925.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

