### PR TITLE
[feature](executor) Add memory limit for pip_scanner_context

### DIFF
--- a/be/src/pipeline/exec/scan_operator.cpp
+++ b/be/src/pipeline/exec/scan_operator.cpp
@@ -32,12 +32,15 @@ bool ScanOperator::can_read() {
             return false;
         }
     } else {
-        if (_node->_eos || _node->_scanner_ctx->done() || _node->_scanner_ctx->no_schedule()) {
+        if (_node->_eos || _node->_scanner_ctx->done()) {
             // _eos: need eos
             // _scanner_ctx->done(): need finish
             // _scanner_ctx->no_schedule(): should schedule _scanner_ctx
             return true;
         } else {
+            if (_node->_scanner_ctx->no_schedule()) {
+                _node->_scanner_ctx->reschedule_scanner_ctx();
+            }
             return _node->ready_to_read(); // there are some blocks to process
         }
     }

--- a/be/src/pipeline/exec/scan_operator.cpp
+++ b/be/src/pipeline/exec/scan_operator.cpp
@@ -38,7 +38,7 @@ bool ScanOperator::can_read() {
             // _scanner_ctx->no_schedule(): should schedule _scanner_ctx
             return true;
         } else {
-            if (_node->_scanner_ctx->no_schedule()) {
+            if (_node->_scanner_ctx->has_enough_space_in_blocks_queue()) {
                 _node->_scanner_ctx->reschedule_scanner_ctx();
             }
             return _node->ready_to_read(); // there are some blocks to process

--- a/be/src/vec/exec/scan/scanner_context.h
+++ b/be/src/vec/exec/scan/scanner_context.h
@@ -123,6 +123,13 @@ public:
 
     virtual void set_max_queue_size(int max_queue_size) {};
 
+    // todo(wb) rethinking how to calculate ```_max_bytes_in_queue``` when executing shared scan
+    virtual inline bool has_enough_space_in_blocks_queue() const {
+        return _cur_bytes_in_queue < _max_bytes_in_queue / 2;
+    }
+
+    void reschedule_scanner_ctx();
+
     // the unique id of this context
     std::string ctx_id;
     int32_t queue_idx = -1;
@@ -131,10 +138,6 @@ public:
 
 private:
     Status _close_and_clear_scanners(VScanNode* node, RuntimeState* state);
-
-    inline bool _has_enough_space_in_blocks_queue() const {
-        return _cur_bytes_in_queue < _max_bytes_in_queue / 2;
-    }
 
 protected:
     RuntimeState* _state;
@@ -185,6 +188,7 @@ protected:
     int _batch_size;
     // The limit from SQL's limit clause
     int64_t limit;
+    bool _should_resche_after_scanner_finished = true;
 
     // Current number of running scanners.
     std::atomic_int32_t _num_running_scanners = 0;

--- a/be/src/vec/exec/scan/scanner_context.h
+++ b/be/src/vec/exec/scan/scanner_context.h
@@ -188,7 +188,6 @@ protected:
     int _batch_size;
     // The limit from SQL's limit clause
     int64_t limit;
-    bool _should_resche_after_scanner_finished = true;
 
     // Current number of running scanners.
     std::atomic_int32_t _num_running_scanners = 0;


### PR DESCRIPTION
# Proposed changes
#18125

pip_scanner_context's memory usage should be limited. Because:
1 It can reduce memory usage and reduce allocating new blocks when executing.
2 When the memory is limited, the schedule times of scanner_ctx and scanner can be limited.

Co-authored-by: wangbo <506340561@qq.com>

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

