### PR TITLE
[Fix](regression-test)replace now to a fixed datetime.

### DIFF
--- a/regression-test/suites/query_p0/sql_functions/test_alias_function.groovy
+++ b/regression-test/suites/query_p0/sql_functions/test_alias_function.groovy
@@ -28,7 +28,7 @@ suite('test_alias_function') {
             ), '%Y%m%d:%H');'''
 
     test {
-        sql 'select f2(f1(now(3), 2), 3)'
+        sql '''select f2(f1('2023-03-29', 2), 3)'''
         result([['20230327:01']])
     }
 }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

in test_alias_function.groovy
```sql
f2(f1(now(3), 2), 3)  -> f2(f1('2023-03-29', 2), 3)
```
to fix the answer

## Checklist(Required)

* [ ] Does it affect the original behavior
* [x] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [x] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

