### PR TITLE
[fix](Nereids): use CBO rule instead of using rewrite rule.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/StatementContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/StatementContext.java
@@ -45,6 +45,8 @@ public class StatementContext {
 
     private int maxNAryInnerJoin = 0;
 
+    private boolean isDpHyp = false;
+
     private final IdGenerator<ExprId> exprIdGenerator = ExprId.createGenerator();
 
     private final IdGenerator<ObjectId> objectIdGenerator = ObjectId.createGenerator();
@@ -91,6 +93,14 @@ public class StatementContext {
 
     public int getMaxNAryInnerJoin() {
         return maxNAryInnerJoin;
+    }
+
+    public boolean isDpHyp() {
+        return isDpHyp;
+    }
+
+    public void setDpHyp(boolean dpHyp) {
+        isDpHyp = dpHyp;
     }
 
     public StatementBase getParsedStatement() {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/cascades/OptimizeGroupExpressionJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/cascades/OptimizeGroupExpressionJob.java
@@ -24,6 +24,7 @@ import org.apache.doris.nereids.memo.GroupExpression;
 import org.apache.doris.nereids.rules.Rule;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 
@@ -57,10 +58,13 @@ public class OptimizeGroupExpressionJob extends Job {
     private List<Rule> getExplorationRules() {
         boolean isDisableJoinReorder = context.getCascadesContext().getConnectContext().getSessionVariable()
                 .isDisableJoinReorder();
+        boolean isDpHyp = context.getCascadesContext().getStatementContext().isDpHyp();
         boolean isEnableBushyTree = context.getCascadesContext().getConnectContext().getSessionVariable()
                 .isEnableBushyTree();
         if (isDisableJoinReorder) {
-            return getRuleSet().getExplorationRulesWithoutReorder();
+            return Collections.emptyList();
+        } else if (isDpHyp) {
+            return getRuleSet().getOtherReorderRules();
         } else if (isEnableBushyTree) {
             return getRuleSet().getBushyTreeJoinReorder();
         } else if (context.getCascadesContext().getStatementContext().getMaxNAryInnerJoin() <= 5) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/joinorder/hypergraph/receiver/PlanReceiver.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/joinorder/hypergraph/receiver/PlanReceiver.java
@@ -347,9 +347,6 @@ public class PlanReceiver implements AbstractReceiver {
             }
             // shadow all join order rule
             CopyInResult copyInResult = jobContext.getCascadesContext().getMemo().copyIn(logicalPlan, root, false);
-            for (Rule rule : jobContext.getCascadesContext().getRuleSet().getJoinOrderRule()) {
-                copyInResult.correspondingExpression.setApplied(rule);
-            }
             for (Rule rule : jobContext.getCascadesContext().getRuleSet().getImplementationRules()) {
                 copyInResult.correspondingExpression.setApplied(rule);
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/RuleSet.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/RuleSet.java
@@ -17,6 +17,8 @@
 
 package org.apache.doris.nereids.rules;
 
+import org.apache.doris.nereids.rules.exploration.MergeProjectsCBO;
+import org.apache.doris.nereids.rules.exploration.PushdownFilterThroughProjectCBO;
 import org.apache.doris.nereids.rules.exploration.join.InnerJoinLAsscom;
 import org.apache.doris.nereids.rules.exploration.join.InnerJoinLAsscomProject;
 import org.apache.doris.nereids.rules.exploration.join.InnerJoinLeftAssociate;
@@ -83,8 +85,8 @@ import java.util.List;
  */
 public class RuleSet {
     public static final List<Rule> EXPLORATION_RULES = planRuleFactories()
-            .add(new PushdownFilterThroughProject())
-            .add(new MergeProjects())
+            .add(new PushdownFilterThroughProjectCBO())
+            .add(new MergeProjectsCBO())
             .build();
 
     public static final List<Rule> OTHER_REORDER_RULES = planRuleFactories()
@@ -158,6 +160,13 @@ public class RuleSet {
             .add(JoinExchangeBothProject.INSTANCE)
             .build();
 
+    public List<Rule> getOtherReorderRules() {
+        List<Rule> rules = new ArrayList<>();
+        rules.addAll(OTHER_REORDER_RULES);
+        rules.addAll(EXPLORATION_RULES);
+        return rules;
+    }
+
     public List<Rule> getZigZagTreeJoinReorder() {
         List<Rule> rules = new ArrayList<>();
         rules.addAll(ZIG_ZAG_TREE_JOIN_REORDER);
@@ -172,14 +181,6 @@ public class RuleSet {
         rules.addAll(OTHER_REORDER_RULES);
         rules.addAll(EXPLORATION_RULES);
         return rules;
-    }
-
-    public List<Rule> getExplorationRulesWithoutReorder() {
-        return new ArrayList<>(EXPLORATION_RULES);
-    }
-
-    public List<Rule> getJoinOrderRule() {
-        return BUSHY_TREE_JOIN_REORDER;
     }
 
     public List<Rule> getImplementationRules() {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/MergeProjectsCBO.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/MergeProjectsCBO.java
@@ -15,40 +15,20 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package org.apache.doris.nereids.rules.rewrite.logical;
+package org.apache.doris.nereids.rules.exploration;
 
 import org.apache.doris.nereids.rules.Rule;
 import org.apache.doris.nereids.rules.RuleType;
-import org.apache.doris.nereids.rules.rewrite.OneRewriteRuleFactory;
-import org.apache.doris.nereids.trees.expressions.NamedExpression;
-import org.apache.doris.nereids.trees.plans.Plan;
-import org.apache.doris.nereids.trees.plans.logical.LogicalProject;
-
-import java.util.List;
+import org.apache.doris.nereids.rules.rewrite.logical.MergeProjects;
 
 /**
- * this rule aims to merge consecutive project. For example:
- * <pre>
- *   project(a)
- *       |
- *   project(a,b)    ->    project(a)
- *       |
- *   project(a, b, c)
- * </pre>
+ * this rule aims to merge projects.
  */
-public class MergeProjects extends OneRewriteRuleFactory {
-
+public class MergeProjectsCBO extends OneExplorationRuleFactory {
     @Override
     public Rule build() {
         return logicalProject(logicalProject())
-                .then(project -> mergeProjects(project))
+                .then(project -> MergeProjects.mergeProjects(project))
                 .toRule(RuleType.MERGE_PROJECTS);
-    }
-
-    public static Plan mergeProjects(LogicalProject project) {
-        LogicalProject childProject = (LogicalProject) project.child();
-        List<NamedExpression> projectExpressions = project.mergeProjections(childProject);
-        LogicalProject newProject = childProject.canEliminate() ? project : childProject;
-        return newProject.withProjectsAndChild(projectExpressions, childProject.child(0));
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/PushdownFilterThroughProjectCBO.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/PushdownFilterThroughProjectCBO.java
@@ -1,0 +1,38 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.rules.exploration;
+
+import org.apache.doris.nereids.rules.Rule;
+import org.apache.doris.nereids.rules.RuleType;
+import org.apache.doris.nereids.rules.rewrite.logical.PushdownFilterThroughProject;
+
+/**
+ * Push down filter through project.
+ * input:
+ * filter(a>2, b=0) -> project(c+d as a, e as b)
+ * output:
+ * project(c+d as a, e as b) -> filter(c+d>2, e=0).
+ */
+public class PushdownFilterThroughProjectCBO extends OneExplorationRuleFactory {
+    @Override
+    public Rule build() {
+        return logicalFilter(logicalProject())
+                .then(PushdownFilterThroughProject::pushdownFilterThroughProject)
+                .toRule(RuleType.PUSHDOWN_FILTER_THROUGH_PROJECT);
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/logical/PushdownFilterThroughProject.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/logical/PushdownFilterThroughProject.java
@@ -42,16 +42,8 @@ public class PushdownFilterThroughProject implements RewriteRuleFactory {
     public List<Rule> buildRules() {
         return ImmutableList.of(
             RuleType.PUSHDOWN_FILTER_THROUGH_PROJECT.build(
-                    logicalFilter(logicalProject()).then(filter -> {
-                        LogicalProject<Plan> project = filter.child();
-                        return project.withProjectsAndChild(
-                                project.getProjects(),
-                                new LogicalFilter<>(
-                                        ExpressionUtils.replace(filter.getConjuncts(), project.getAliasToProducer()),
-                                        project.child()
-                                )
-                        );
-                    })
+                    logicalFilter(logicalProject())
+                            .then(PushdownFilterThroughProject::pushdownFilterThroughProject)
             ),
             // filter(project(limit)) will change to filter(limit(project)) by PushdownProjectThroughLimit,
             // then we should change filter(limit(project)) to project(filter(limit))
@@ -69,6 +61,18 @@ public class PushdownFilterThroughProject implements RewriteRuleFactory {
                         );
                     })
             )
+        );
+    }
+
+    /** pushdown Filter through project */
+    public static Plan pushdownFilterThroughProject(LogicalFilter filter) {
+        LogicalProject<Plan> project = (LogicalProject) filter.child();
+        return project.withProjectsAndChild(
+                project.getProjects(),
+                new LogicalFilter<>(
+                        ExpressionUtils.replace(filter.getConjuncts(), project.getAliasToProducer()),
+                        project.child()
+                )
         );
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalProject.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalProject.java
@@ -78,12 +78,7 @@ public class LogicalProject<CHILD_TYPE extends Plan> extends LogicalUnary<CHILD_
         this(projects, excepts, canEliminate, Optional.empty(), Optional.empty(), child, isDistinct);
     }
 
-    /**
-     * Constructor for LogicalProject.
-     *
-     * @param projects project list
-     */
-    public LogicalProject(List<NamedExpression> projects, List<NamedExpression> excepts, boolean canEliminate,
+    private LogicalProject(List<NamedExpression> projects, List<NamedExpression> excepts, boolean canEliminate,
             Optional<GroupExpression> groupExpression, Optional<LogicalProperties> logicalProperties,
             CHILD_TYPE child, boolean isDistinct) {
         super(PlanType.LOGICAL_PROJECT, groupExpression, logicalProperties, child);


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

Currently, rewrite will use pattern `any()`, it will cause performance regression.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

