### PR TITLE
[refactor](dynamic table) add `get_type_as_tprimitive_type` and `get_…

### DIFF
--- a/be/src/runtime/primitive_type.cpp
+++ b/be/src/runtime/primitive_type.cpp
@@ -491,45 +491,4 @@ TTypeDesc gen_type_desc(const TPrimitiveType::type val, const std::string& name)
     return type_desc;
 }
 
-PrimitiveType get_primitive_type(vectorized::TypeIndex v_type) {
-    switch (v_type) {
-    case vectorized::TypeIndex::Int8:
-        return PrimitiveType::TYPE_TINYINT;
-    case vectorized::TypeIndex::Int16:
-        return PrimitiveType::TYPE_SMALLINT;
-    case vectorized::TypeIndex::Int32:
-        return PrimitiveType::TYPE_INT;
-    case vectorized::TypeIndex::Int64:
-        return PrimitiveType::TYPE_BIGINT;
-    case vectorized::TypeIndex::Float32:
-        return PrimitiveType::TYPE_FLOAT;
-    case vectorized::TypeIndex::Float64:
-        return PrimitiveType::TYPE_DOUBLE;
-    case vectorized::TypeIndex::Decimal32:
-        return PrimitiveType::TYPE_DECIMALV2;
-    case vectorized::TypeIndex::Array:
-        return PrimitiveType::TYPE_ARRAY;
-    case vectorized::TypeIndex::String:
-        return PrimitiveType::TYPE_STRING;
-    case vectorized::TypeIndex::Date:
-        return PrimitiveType::TYPE_DATE;
-    case vectorized::TypeIndex::DateTime:
-        return PrimitiveType::TYPE_DATETIME;
-    case vectorized::TypeIndex::Tuple:
-        return PrimitiveType::TYPE_STRUCT;
-    case vectorized::TypeIndex::Decimal128:
-        return PrimitiveType::TYPE_DECIMAL128I;
-    case vectorized::TypeIndex::JSONB:
-        return PrimitiveType::TYPE_JSONB;
-    case vectorized::TypeIndex::DateTimeV2:
-        return PrimitiveType::TYPE_DATETIMEV2;
-    case vectorized::TypeIndex::DateV2:
-        return PrimitiveType::TYPE_DATEV2;
-    // TODO add vectorized::more types
-    default:
-        LOG(FATAL) << "unknow data_type: " << getTypeName(v_type);
-        return PrimitiveType::INVALID_TYPE;
-    }
-}
-
 } // namespace doris

--- a/be/src/runtime/primitive_type.h
+++ b/be/src/runtime/primitive_type.h
@@ -97,8 +97,6 @@ constexpr bool has_variable_type(PrimitiveType type) {
 
 bool is_type_compatible(PrimitiveType lhs, PrimitiveType rhs);
 
-PrimitiveType get_primitive_type(vectorized::TypeIndex v_type);
-
 TExprOpcode::type to_in_opcode(PrimitiveType t);
 PrimitiveType thrift_to_type(TPrimitiveType::type ttype);
 TPrimitiveType::type to_thrift(PrimitiveType ptype);

--- a/be/src/vec/common/schema_util.cpp
+++ b/be/src/vec/common/schema_util.cpp
@@ -183,7 +183,7 @@ static void get_column_def(const vectorized::DataTypePtr& data_type, const std::
         get_column_def(real_type.get_nested_type(), "", column);
         return;
     }
-    column->columnDesc.__set_columnType(to_thrift(get_primitive_type(data_type->get_type_id())));
+    column->columnDesc.__set_columnType(data_type->get_type_as_tprimitive_type());
     if (data_type->get_type_id() == TypeIndex::Array) {
         TColumnDef child;
         column->columnDesc.__set_children({});

--- a/be/src/vec/data_types/data_type.h
+++ b/be/src/vec/data_types/data_type.h
@@ -24,6 +24,7 @@
 #include <memory>
 
 #include "gen_cpp/data.pb.h"
+#include "runtime/define_primitive_type.h"
 #include "vec/common/cow.h"
 #include "vec/common/string_buffer.hpp"
 #include "vec/core/types.h"
@@ -66,6 +67,9 @@ public:
 
     /// Data type id. It's used for runtime type checks.
     virtual TypeIndex get_type_id() const = 0;
+
+    virtual PrimitiveType get_type_as_primitive_type() const = 0;
+    virtual TPrimitiveType::type get_type_as_tprimitive_type() const = 0;
 
     virtual void to_string(const IColumn& column, size_t row_num, BufferWritable& ostr) const;
     virtual std::string to_string(const IColumn& column, size_t row_num) const;

--- a/be/src/vec/data_types/data_type_array.h
+++ b/be/src/vec/data_types/data_type_array.h
@@ -20,6 +20,8 @@
 
 #pragma once
 
+#include <gen_cpp/Types_types.h>
+
 #include "vec/data_types/data_type.h"
 
 namespace doris::vectorized {
@@ -35,6 +37,11 @@ public:
     DataTypeArray(const DataTypePtr& nested_);
 
     TypeIndex get_type_id() const override { return TypeIndex::Array; }
+
+    PrimitiveType get_type_as_primitive_type() const override { return TYPE_ARRAY; }
+    TPrimitiveType::type get_type_as_tprimitive_type() const override {
+        return TPrimitiveType::ARRAY;
+    }
 
     std::string do_get_name() const override { return "Array(" + nested->get_name() + ")"; }
 

--- a/be/src/vec/data_types/data_type_bitmap.h
+++ b/be/src/vec/data_types/data_type_bitmap.h
@@ -16,6 +16,8 @@
 // under the License.
 
 #pragma once
+#include <gen_cpp/Types_types.h>
+
 #include "util/bitmap_value.h"
 #include "vec/columns/column.h"
 #include "vec/columns/column_complex.h"
@@ -35,6 +37,11 @@ public:
     const char* get_family_name() const override { return "BitMap"; }
 
     TypeIndex get_type_id() const override { return TypeIndex::BitMap; }
+
+    PrimitiveType get_type_as_primitive_type() const override { return TYPE_OBJECT; }
+    TPrimitiveType::type get_type_as_tprimitive_type() const override {
+        return TPrimitiveType::OBJECT;
+    }
 
     int64_t get_uncompressed_serialized_bytes(const IColumn& column,
                                               int be_exec_version) const override;

--- a/be/src/vec/data_types/data_type_date.h
+++ b/be/src/vec/data_types/data_type_date.h
@@ -27,6 +27,10 @@ namespace doris::vectorized {
 class DataTypeDate final : public DataTypeNumberBase<Int64> {
 public:
     TypeIndex get_type_id() const override { return TypeIndex::Date; }
+    PrimitiveType get_type_as_primitive_type() const override { return TYPE_DATE; }
+    TPrimitiveType::type get_type_as_tprimitive_type() const override {
+        return TPrimitiveType::DATE;
+    }
     const char* get_family_name() const override { return "DateTime"; }
     std::string do_get_name() const override { return "Date"; }
 

--- a/be/src/vec/data_types/data_type_date_time.h
+++ b/be/src/vec/data_types/data_type_date_time.h
@@ -20,6 +20,7 @@
 
 #pragma once
 
+#include "runtime/define_primitive_type.h"
 #include "vec/data_types/data_type_date.h"
 #include "vec/data_types/data_type_number_base.h"
 #include "vec/data_types/data_type_time_v2.h"
@@ -55,6 +56,10 @@ public:
     const char* get_family_name() const override { return "DateTime"; }
     std::string do_get_name() const override { return "DateTime"; }
     TypeIndex get_type_id() const override { return TypeIndex::DateTime; }
+    PrimitiveType get_type_as_primitive_type() const override { return TYPE_DATETIME; }
+    TPrimitiveType::type get_type_as_tprimitive_type() const override {
+        return TPrimitiveType::DATETIME;
+    }
 
     bool can_be_used_as_version() const override { return true; }
     bool can_be_inside_nullable() const override { return true; }

--- a/be/src/vec/data_types/data_type_decimal.h
+++ b/be/src/vec/data_types/data_type_decimal.h
@@ -20,11 +20,14 @@
 
 #pragma once
 #include <cmath>
+#include <type_traits>
 
 #include "common/config.h"
+#include "runtime/define_primitive_type.h"
 #include "vec/columns/column_decimal.h"
 #include "vec/common/arithmetic_overflow.h"
 #include "vec/common/typeid_cast.h"
+#include "vec/core/types.h"
 #include "vec/data_types/data_type.h"
 #include "vec/data_types/data_type_number.h"
 
@@ -138,6 +141,31 @@ public:
     const char* get_family_name() const override { return "Decimal"; }
     std::string do_get_name() const override;
     TypeIndex get_type_id() const override { return TypeId<T>::value; }
+    PrimitiveType get_type_as_primitive_type() const override {
+        if constexpr (std::is_same_v<TypeId<T>, TypeId<Decimal32>>) {
+            return TYPE_DECIMAL32;
+        }
+        if constexpr (std::is_same_v<TypeId<T>, TypeId<Decimal64>>) {
+            return TYPE_DECIMAL64;
+        }
+        if constexpr (std::is_same_v<TypeId<T>, TypeId<Decimal128I>>) {
+            return TYPE_DECIMAL128I;
+        }
+        __builtin_unreachable();
+    }
+
+    TPrimitiveType::type get_type_as_tprimitive_type() const override {
+        if constexpr (std::is_same_v<TypeId<T>, TypeId<Decimal32>>) {
+            return TPrimitiveType::DECIMAL32;
+        }
+        if constexpr (std::is_same_v<TypeId<T>, TypeId<Decimal64>>) {
+            return TPrimitiveType::DECIMAL64;
+        }
+        if constexpr (std::is_same_v<TypeId<T>, TypeId<Decimal128I>>) {
+            return TPrimitiveType::DECIMAL128I;
+        }
+        __builtin_unreachable();
+    }
 
     int64_t get_uncompressed_serialized_bytes(const IColumn& column,
                                               int be_exec_version) const override;

--- a/be/src/vec/data_types/data_type_fixed_length_object.h
+++ b/be/src/vec/data_types/data_type_fixed_length_object.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include "vec/columns/column_fixed_length_object.h"
+#include "vec/core/types.h"
 #include "vec/data_types/data_type.h"
 
 namespace doris::vectorized {
@@ -33,6 +34,12 @@ public:
     const char* get_family_name() const override { return "DataTypeFixedLengthObject"; }
 
     TypeIndex get_type_id() const override { return TypeIndex::FixedLengthObject; }
+
+    PrimitiveType get_type_as_primitive_type() const override { return INVALID_TYPE; }
+
+    TPrimitiveType::type get_type_as_tprimitive_type() const override {
+        return TPrimitiveType::INVALID_TYPE;
+    }
 
     Field get_default() const override { return String(); }
 

--- a/be/src/vec/data_types/data_type_hll.h
+++ b/be/src/vec/data_types/data_type_hll.h
@@ -35,6 +35,10 @@ public:
     const char* get_family_name() const override { return "HLL"; }
 
     TypeIndex get_type_id() const override { return TypeIndex::HLL; }
+    PrimitiveType get_type_as_primitive_type() const override { return TYPE_HLL; }
+    TPrimitiveType::type get_type_as_tprimitive_type() const override {
+        return TPrimitiveType::HLL;
+    }
 
     int64_t get_uncompressed_serialized_bytes(const IColumn& column,
                                               int be_exec_version) const override;

--- a/be/src/vec/data_types/data_type_jsonb.h
+++ b/be/src/vec/data_types/data_type_jsonb.h
@@ -33,6 +33,10 @@ public:
 
     const char* get_family_name() const override { return "JSONB"; }
     TypeIndex get_type_id() const override { return TypeIndex::JSONB; }
+    PrimitiveType get_type_as_primitive_type() const override { return TYPE_JSONB; }
+    TPrimitiveType::type get_type_as_tprimitive_type() const override {
+        return TPrimitiveType::JSONB;
+    }
 
     int64_t get_uncompressed_serialized_bytes(const IColumn& column,
                                               int data_version) const override;

--- a/be/src/vec/data_types/data_type_map.h
+++ b/be/src/vec/data_types/data_type_map.h
@@ -43,6 +43,10 @@ public:
     DataTypeMap(const DataTypePtr& key_type_, const DataTypePtr& value_type_);
 
     TypeIndex get_type_id() const override { return TypeIndex::Map; }
+    PrimitiveType get_type_as_primitive_type() const override { return TYPE_MAP; }
+    TPrimitiveType::type get_type_as_tprimitive_type() const override {
+        return TPrimitiveType::MAP;
+    }
     std::string do_get_name() const override {
         return "Map(" + key_type->get_name() + ", " + value_type->get_name() + ")";
     }

--- a/be/src/vec/data_types/data_type_nothing.h
+++ b/be/src/vec/data_types/data_type_nothing.h
@@ -35,6 +35,10 @@ public:
 
     const char* get_family_name() const override { return "Nothing"; }
     TypeIndex get_type_id() const override { return TypeIndex::Nothing; }
+    PrimitiveType get_type_as_primitive_type() const override { return INVALID_TYPE; }
+    TPrimitiveType::type get_type_as_tprimitive_type() const override {
+        return TPrimitiveType::INVALID_TYPE;
+    }
 
     MutableColumnPtr create_column() const override;
 

--- a/be/src/vec/data_types/data_type_nullable.h
+++ b/be/src/vec/data_types/data_type_nullable.h
@@ -35,6 +35,12 @@ public:
     }
     const char* get_family_name() const override { return "Nullable"; }
     TypeIndex get_type_id() const override { return TypeIndex::Nullable; }
+    PrimitiveType get_type_as_primitive_type() const override {
+        return nested_data_type->get_type_as_primitive_type();
+    }
+    TPrimitiveType::type get_type_as_tprimitive_type() const override {
+        return nested_data_type->get_type_as_tprimitive_type();
+    }
 
     int64_t get_uncompressed_serialized_bytes(const IColumn& column,
                                               int be_exec_version) const override;

--- a/be/src/vec/data_types/data_type_number_base.h
+++ b/be/src/vec/data_types/data_type_number_base.h
@@ -20,6 +20,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include "vec/columns/column_vector.h"
 #include "vec/core/types.h"
 #include "vec/data_types/data_type.h"
@@ -39,6 +41,54 @@ public:
 
     const char* get_family_name() const override { return TypeName<T>::get(); }
     TypeIndex get_type_id() const override { return TypeId<T>::value; }
+    PrimitiveType get_type_as_primitive_type() const override {
+        if constexpr (std::is_same_v<TypeId<T>, TypeId<Int8>>) {
+            return TYPE_TINYINT;
+        }
+        if constexpr (std::is_same_v<TypeId<T>, TypeId<Int16>>) {
+            return TYPE_SMALLINT;
+        }
+        if constexpr (std::is_same_v<TypeId<T>, TypeId<Int32>>) {
+            return TYPE_INT;
+        }
+        if constexpr (std::is_same_v<TypeId<T>, TypeId<Int64>>) {
+            return TYPE_BIGINT;
+        }
+        if constexpr (std::is_same_v<TypeId<T>, TypeId<Int128>>) {
+            return TYPE_LARGEINT;
+        }
+        if constexpr (std::is_same_v<TypeId<T>, TypeId<Float32>>) {
+            return TYPE_FLOAT;
+        }
+        if constexpr (std::is_same_v<TypeId<T>, TypeId<Float64>>) {
+            return TYPE_DOUBLE;
+        }
+        __builtin_unreachable();
+    }
+    TPrimitiveType::type get_type_as_tprimitive_type() const override {
+        if constexpr (std::is_same_v<TypeId<T>, TypeId<Int8>>) {
+            return TPrimitiveType::TINYINT;
+        }
+        if constexpr (std::is_same_v<TypeId<T>, TypeId<Int16>>) {
+            return TPrimitiveType::SMALLINT;
+        }
+        if constexpr (std::is_same_v<TypeId<T>, TypeId<Int32>>) {
+            return TPrimitiveType::INT;
+        }
+        if constexpr (std::is_same_v<TypeId<T>, TypeId<Int64>>) {
+            return TPrimitiveType::BIGINT;
+        }
+        if constexpr (std::is_same_v<TypeId<T>, TypeId<Int128>>) {
+            return TPrimitiveType::LARGEINT;
+        }
+        if constexpr (std::is_same_v<TypeId<T>, TypeId<Float32>>) {
+            return TPrimitiveType::FLOAT;
+        }
+        if constexpr (std::is_same_v<TypeId<T>, TypeId<Float64>>) {
+            return TPrimitiveType::DOUBLE;
+        }
+        __builtin_unreachable();
+    }
     Field get_default() const override;
 
     int64_t get_uncompressed_serialized_bytes(const IColumn& column,

--- a/be/src/vec/data_types/data_type_object.h
+++ b/be/src/vec/data_types/data_type_object.h
@@ -32,6 +32,10 @@ public:
     DataTypeObject(const String& schema_format_, bool is_nullable_);
     const char* get_family_name() const override { return "Variant"; }
     TypeIndex get_type_id() const override { return TypeIndex::VARIANT; }
+    PrimitiveType get_type_as_primitive_type() const override { return TYPE_VARIANT; }
+    TPrimitiveType::type get_type_as_tprimitive_type() const override {
+        return TPrimitiveType::VARIANT;
+    }
     MutableColumnPtr create_column() const override { return ColumnObject::create(is_nullable); }
     bool is_object() const override { return true; }
     bool equals(const IDataType& rhs) const override;

--- a/be/src/vec/data_types/data_type_quantilestate.h
+++ b/be/src/vec/data_types/data_type_quantilestate.h
@@ -34,6 +34,10 @@ public:
     const char* get_family_name() const override { return "QuantileState"; }
 
     TypeIndex get_type_id() const override { return TypeIndex::QuantileState; }
+    PrimitiveType get_type_as_primitive_type() const override { return TYPE_QUANTILE_STATE; }
+    TPrimitiveType::type get_type_as_tprimitive_type() const override {
+        return TPrimitiveType::QUANTILE_STATE;
+    }
     int64_t get_uncompressed_serialized_bytes(const IColumn& column,
                                               int be_exec_version) const override;
     char* serialize(const IColumn& column, char* buf, int be_exec_version) const override;

--- a/be/src/vec/data_types/data_type_string.h
+++ b/be/src/vec/data_types/data_type_string.h
@@ -36,6 +36,11 @@ public:
 
     TypeIndex get_type_id() const override { return TypeIndex::String; }
 
+    PrimitiveType get_type_as_primitive_type() const override { return TYPE_STRING; }
+    TPrimitiveType::type get_type_as_tprimitive_type() const override {
+        return TPrimitiveType::STRING;
+    }
+
     int64_t get_uncompressed_serialized_bytes(const IColumn& column,
                                               int be_exec_version) const override;
     char* serialize(const IColumn& column, char* buf, int be_exec_version) const override;

--- a/be/src/vec/data_types/data_type_struct.h
+++ b/be/src/vec/data_types/data_type_struct.h
@@ -56,6 +56,10 @@ public:
     DataTypeStruct(const DataTypes& elems, const Strings& names);
 
     TypeIndex get_type_id() const override { return TypeIndex::Struct; }
+    PrimitiveType get_type_as_primitive_type() const override { return TYPE_STRUCT; }
+    TPrimitiveType::type get_type_as_tprimitive_type() const override {
+        return TPrimitiveType::STRUCT;
+    }
     std::string do_get_name() const override;
     const char* get_family_name() const override { return "Struct"; }
 

--- a/be/src/vec/data_types/data_type_time.h
+++ b/be/src/vec/data_types/data_type_time.h
@@ -32,6 +32,10 @@ public:
     bool equals(const IDataType& rhs) const override;
 
     std::string to_string(const IColumn& column, size_t row_num) const override;
+    PrimitiveType get_type_as_primitive_type() const override { return TYPE_TIME; }
+    TPrimitiveType::type get_type_as_tprimitive_type() const override {
+        return TPrimitiveType::TIME;
+    }
 
     void to_string(const IColumn& column, size_t row_num, BufferWritable& ostr) const override;
 

--- a/be/src/vec/data_types/data_type_time_v2.h
+++ b/be/src/vec/data_types/data_type_time_v2.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include "runtime/define_primitive_type.h"
 #include "vec/data_types/data_type_number_base.h"
 
 namespace doris::vectorized {
@@ -28,6 +29,10 @@ namespace doris::vectorized {
 class DataTypeDateV2 final : public DataTypeNumberBase<UInt32> {
 public:
     TypeIndex get_type_id() const override { return TypeIndex::DateV2; }
+    PrimitiveType get_type_as_primitive_type() const override { return TYPE_DATEV2; }
+    TPrimitiveType::type get_type_as_tprimitive_type() const override {
+        return TPrimitiveType::DATEV2;
+    }
     const char* get_family_name() const override { return "DateV2"; }
     std::string do_get_name() const override { return "DateV2"; }
 
@@ -66,6 +71,10 @@ public:
 
     DataTypeDateTimeV2(const DataTypeDateTimeV2& rhs) : _scale(rhs._scale) {}
     TypeIndex get_type_id() const override { return TypeIndex::DateTimeV2; }
+    PrimitiveType get_type_as_primitive_type() const override { return TYPE_DATETIMEV2; }
+    TPrimitiveType::type get_type_as_tprimitive_type() const override {
+        return TPrimitiveType::DATETIMEV2;
+    }
     const char* get_family_name() const override { return "DateTimeV2"; }
     std::string do_get_name() const override { return "DateTimeV2"; }
 


### PR DESCRIPTION
…type_as_primitive_type` in IDataType to get `PrimitiveType` and `TPrimitiveType`

in order to remove to many switch cases

# Proposed changes

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

