### PR TITLE
[Bug](planner) fix use wrong result expr list

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/planner/SingleNodePlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/SingleNodePlanner.java
@@ -1199,10 +1199,10 @@ public class SingleNodePlanner {
             // create left-deep sequence of binary hash joins; assign node ids as we go along
             TableRef tblRef = selectStmt.getTableRefs().get(0);
             materializeTableResultForCrossJoinOrCountStar(tblRef, analyzer);
-            if (selectStmt.getSelectList().getItems().size() == 1) {
+            if (selectStmt.getResultExprs().size() == 1) {
                 final List<SlotId> slotIds = Lists.newArrayList();
                 final List<TupleId> tupleIds = Lists.newArrayList();
-                Expr resultExprSelected = selectStmt.getSelectList().getItems().get(0).getExpr();
+                Expr resultExprSelected = selectStmt.getResultExprs().get(0);
                 if (resultExprSelected != null && resultExprSelected instanceof SlotRef) {
                     resultExprSelected.getIds(tupleIds, slotIds);
                     for (SlotId id : slotIds) {


### PR DESCRIPTION
# Proposed changes
cherry-pick from https://github.com/apache/doris/pull/16750/files
 fix use wrong result expr list
-- 该语句报错。DataGrip和Mysql-client都报错。ERROR 1105 (HY000): errCode = 2, detailMessage = Unexpected exception: null
select *except(D_DATE)
from test_dim_base_date

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

