### PR TITLE
[fix](merge-on-write) fix that missed rows don't match merged rows for base compaction

### DIFF
--- a/be/src/olap/compaction.cpp
+++ b/be/src/olap/compaction.cpp
@@ -436,10 +436,12 @@ Status Compaction::modify_rowsets(const Merger::Statistics* stats) {
             _tablet->calc_compaction_output_rowset_delete_bitmap(
                     _input_rowsets, _rowid_conversion, version.second, UINT64_MAX, &missed_rows,
                     &location_map, &output_rowset_delete_bitmap);
-            DCHECK_EQ(missed_rows.size(), missed_rows_size);
-            if (missed_rows.size() != missed_rows_size) {
-                LOG(WARNING) << "missed rows don't match, before: " << missed_rows_size
-                             << " after: " << missed_rows.size();
+            if (compaction_type() == READER_CUMULATIVE_COMPACTION) {
+                DCHECK_EQ(missed_rows.size(), missed_rows_size);
+                if (missed_rows.size() != missed_rows_size) {
+                    LOG(WARNING) << "missed rows don't match, before: " << missed_rows_size
+                                 << " after: " << missed_rows.size();
+                }
             }
 
             RETURN_IF_ERROR(_tablet->check_rowid_conversion(_output_rowset, location_map));


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

F0330 11:20:49.078764 1694214 compaction.cpp:439] Check failed: missed_rows.size() == missed_rows_size (30 vs. 29)
The `missed_rows.size()` may greater than `missed_rows_size`, because of delete sign will be merge in base compaction. The incremental delete map may delete the data row marked as delete sign, so the missed_rows set size  may will become larger. Only check that when cumulative compaction.



## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

