### PR TITLE
[fix](string_ref) Incorrect result caused by the improperly comparing of StringRef on macOS with Apple silicon or using non-avx2

### DIFF
--- a/be/src/vec/common/string_ref.h
+++ b/be/src/vec/common/string_ref.h
@@ -182,9 +182,6 @@ inline int string_compare(const char* s1, int64_t n1, const char* s2, int64_t n2
         if (u1 != u2) {
             return u1 - u2;
         }
-        if (u1 == '\0') {
-            return n1 - n2;
-        }
     }
 
     return n1 - n2;


### PR DESCRIPTION
# Proposed changes

On macOS systems with Apple silicon, the '==' operator of `StringRef `uses string_compare, which takes `StringRef` as a C-String with null-terminated chars.

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

