### PR TITLE
[tpch](nereids) trustable join condition

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/cost/CostModelV1.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/cost/CostModelV1.java
@@ -56,7 +56,7 @@ class CostModelV1 extends PlanVisitor<Cost, PlanContext> {
      * <p>
      * An example is tpch q15.
      */
-    static final double HEAVY_OPERATOR_PUNISH_FACTOR = 6.0;
+    static final double HEAVY_OPERATOR_PUNISH_FACTOR = 1.0;
 
     public static Cost addChildCost(Plan plan, Cost planCost, Cost childCost, int index) {
         Preconditions.checkArgument(childCost instanceof CostV1 && planCost instanceof CostV1);

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/FilterEstimation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/FilterEstimation.java
@@ -30,6 +30,7 @@ import org.apache.doris.nereids.trees.expressions.GreaterThanEqual;
 import org.apache.doris.nereids.trees.expressions.InPredicate;
 import org.apache.doris.nereids.trees.expressions.LessThan;
 import org.apache.doris.nereids.trees.expressions.LessThanEqual;
+import org.apache.doris.nereids.trees.expressions.Like;
 import org.apache.doris.nereids.trees.expressions.Not;
 import org.apache.doris.nereids.trees.expressions.NullSafeEqual;
 import org.apache.doris.nereids.trees.expressions.Or;
@@ -64,7 +65,7 @@ public class FilterEstimation extends ExpressionVisitor<Statistics, EstimationCo
     public static final double DEFAULT_HAVING_COEFFICIENT = 0.01;
 
     public static final double DEFAULT_EQUALITY_COMPARISON_SELECTIVITY = 0.1;
-
+    public static final double DEFAULT_LIKE_COMPARISON_SELECTIVITY = 0.2;
     private Set<Slot> aggSlots;
 
     public FilterEstimation() {
@@ -538,5 +539,10 @@ public class FilterEstimation extends ExpressionVisitor<Statistics, EstimationCo
                 .setMinValue(numVal)
                 .build();
         return context.statistics.withSel(sel).addColumnStats(leftExpr, columnStatistic);
+    }
+
+    @Override
+    public Statistics visitLike(Like like, EstimationContext context) {
+        return context.statistics.withSel(DEFAULT_LIKE_COMPARISON_SELECTIVITY);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/JoinEstimation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/JoinEstimation.java
@@ -28,7 +28,10 @@ import org.apache.doris.statistics.ColumnStatistic;
 import org.apache.doris.statistics.Statistics;
 import org.apache.doris.statistics.StatisticsBuilder;
 
+import com.google.common.collect.Lists;
+
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 /**
@@ -37,30 +40,75 @@ import java.util.stream.Collectors;
  */
 public class JoinEstimation {
 
+    private static EqualTo normalizeHashJoinCondition(EqualTo equalTo, Statistics leftStats, Statistics rightStats) {
+        boolean changeOrder = equalTo.left().getInputSlots().stream().anyMatch(
+                slot -> rightStats.findColumnStatistics(slot) != null
+        );
+        if (changeOrder) {
+            return new EqualTo(equalTo.right(), equalTo.left());
+        } else {
+            return equalTo;
+        }
+    }
+
     private static Statistics estimateInnerJoin(Statistics leftStats, Statistics rightStats, Join join) {
+        List<Double> unTrustEqualRatio = Lists.newArrayList();
+        boolean leftBigger = leftStats.getRowCount() > rightStats.getRowCount();
+        List<EqualTo> trustableConditions = join.getHashJoinConjuncts().stream()
+                .map(expression -> (EqualTo) expression)
+                .filter(
+                    expression -> {
+                        EqualTo equal = normalizeHashJoinCondition(expression, leftStats, rightStats);
+                        ColumnStatistic eqLeftColStats = ExpressionEstimation.estimate(equal.left(), leftStats);
+                        ColumnStatistic eqRightColStats = ExpressionEstimation.estimate(equal.right(), rightStats);
+                        boolean trustable = eqRightColStats.ndv / rightStats.getRowCount() > 0.9
+                                || eqLeftColStats.ndv / leftStats.getRowCount() > 0.9;
+                        if (!trustable) {
+                            if (leftBigger) {
+                                unTrustEqualRatio.add((rightStats.getRowCount() / eqRightColStats.ndv)
+                                        * Math.min(eqLeftColStats.ndv, eqRightColStats.ndv) / eqLeftColStats.ndv);
+                            } else {
+                                unTrustEqualRatio.add((leftStats.getRowCount() / eqLeftColStats.ndv)
+                                        * Math.min(eqLeftColStats.ndv, eqRightColStats.ndv) / eqRightColStats.ndv);
+                            }
+                        }
+                        return trustable;
+                    }
+                ).collect(Collectors.toList());
+
+        Statistics innerJoinStats;
         Statistics crossJoinStats = new StatisticsBuilder()
                 .setRowCount(leftStats.getRowCount() * rightStats.getRowCount())
                 .putColumnStatistics(leftStats.columnStatistics())
                 .putColumnStatistics(rightStats.columnStatistics())
                 .build();
-        List<Pair<Expression, Double>> sortedJoinConditions = join.getHashJoinConjuncts().stream()
-                .map(expression -> Pair.of(expression, estimateJoinConditionSel(crossJoinStats, expression)))
-                .sorted((a, b) -> {
-                    double sub = a.second - b.second;
-                    if (sub > 0) {
-                        return 1;
-                    } else if (sub < 0) {
-                        return -1;
-                    } else {
-                        return 0;
-                    }
-                }).collect(Collectors.toList());
+        if (!trustableConditions.isEmpty()) {
+            List<Pair<Expression, Double>> sortedJoinConditions = join.getHashJoinConjuncts().stream()
+                    .map(expression -> Pair.of(expression, estimateJoinConditionSel(crossJoinStats, expression)))
+                    .sorted((a, b) -> {
+                        double sub = a.second - b.second;
+                        if (sub > 0) {
+                            return 1;
+                        } else if (sub < 0) {
+                            return -1;
+                        } else {
+                            return 0;
+                        }
+                    }).collect(Collectors.toList());
 
-        double sel = 1.0;
-        for (int i = 0; i < sortedJoinConditions.size(); i++) {
-            sel *= Math.pow(sortedJoinConditions.get(i).second, 1 / Math.pow(2, i));
+            double sel = 1.0;
+            for (int i = 0; i < sortedJoinConditions.size(); i++) {
+                sel *= Math.pow(sortedJoinConditions.get(i).second, 1 / Math.pow(2, i));
+            }
+            innerJoinStats = crossJoinStats.updateRowCountOnly(crossJoinStats.getRowCount() * sel);
+        } else {
+            double outputRowCount = Math.max(leftStats.getRowCount(), rightStats.getRowCount());
+            Optional<Double> ratio = unTrustEqualRatio.stream().max(Double::compareTo);
+            if (ratio.isPresent()) {
+                outputRowCount = outputRowCount * ratio.get();
+            }
+            innerJoinStats = crossJoinStats.updateRowCountOnly(outputRowCount);
         }
-        Statistics innerJoinStats = crossJoinStats.updateRowCountOnly(crossJoinStats.getRowCount() * sel);
 
         if (!join.getOtherJoinConjuncts().isEmpty()) {
             FilterEstimation filterEstimation = new FilterEstimation();


### PR DESCRIPTION
# Proposed changes
tpch q14/7/9

1. about inner join estimation
    Introduce trust factor for each hash join condition. For euqalTo, if any side is almost unique, it is trustable.
    TODO: the trust factor is a boolean, it is better to use a [0,1] double
2. `like` estimation factor: 0.2
    give a separate default shrink ratio for `like` operator, default ratio is 0.2
3. disable fat-child-penalty
    set HEAVY_OPERATOR_PUNISH_FACTOR=1
    this change affect tpch q15. This factor should be adaptive to the implementation of BE.

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

