### PR TITLE
[fix](memory) Fix `bthread_setspecific` log fatal on UBSAN build

### DIFF
--- a/be/src/runtime/thread_context.h
+++ b/be/src/runtime/thread_context.h
@@ -191,7 +191,11 @@ private:
     TUniqueId _fragment_instance_id;
 };
 
-#if !defined(UNDEFINED_BEHAVIOR_SANITIZER)
+#if defined(UNDEFINED_BEHAVIOR_SANITIZER)
+static ThreadContext* thread_context() {
+    return thread_context_ptr._ptr;
+}
+#else
 // Cache the pointer of bthread local in pthead local,
 // Avoid calling bthread_getspecific frequently to get bthread local, which has performance problems.
 static void pthread_attach_bthread() {
@@ -225,10 +229,6 @@ static ThreadContext* thread_context() {
     } else {
         return thread_context_ptr._ptr;
     }
-}
-#else
-static ThreadContext* thread_context() {
-    return thread_context_ptr._ptr;
 }
 #endif
 

--- a/be/src/runtime/thread_context.h
+++ b/be/src/runtime/thread_context.h
@@ -191,6 +191,7 @@ private:
     TUniqueId _fragment_instance_id;
 };
 
+#if !defined(UNDEFINED_BEHAVIOR_SANITIZER)
 // Cache the pointer of bthread local in pthead local,
 // Avoid calling bthread_getspecific frequently to get bthread local, which has performance problems.
 static void pthread_attach_bthread() {
@@ -225,6 +226,11 @@ static ThreadContext* thread_context() {
         return thread_context_ptr._ptr;
     }
 }
+#else
+static ThreadContext* thread_context() {
+    return thread_context_ptr._ptr;
+}
+#endif
 
 class ScopeMemCount {
 public:


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

This is most likely a brpc bug...
```
#0  __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:50
#1  0x00007f5d6b9bc859 in __GI_abort () at abort.c:79
#2  0x000056049cdc1a19 in ?? ()
#3  0x000056049cdb702d in google::LogMessage::Fail() ()
#4  0x000056049cdb9569 in google::LogMessage::SendToLog() ()
#5  0x000056049cdb6b96 in google::LogMessage::Flush() ()
#6  0x000056049cdb9bd9 in google::LogMessageFatal::~LogMessageFatal() ()
#7  0x000056049d575ef5 in bthread_setspecific ()
#8  0x0000560476c31604 in doris::pthread_attach_bthread () at /doris_master/doris/be/src/runtime/thread_context.h:211
#9  0x0000560476c2cd38 in doris::thread_context () at /doris_master/doris/be/src/runtime/thread_context.h:220
#10 0x0000560476c2cde0 in doris_free (p=0x7f5a8e852000) at /doris_master/doris/be/src/runtime/memory/jemalloc_hook.cpp:43
#11 0x000056049d53278b in butil::iobuf::release_tls_block_chain(butil::IOBuf::Block*) ()
#12 0x000056049d535ca1 in butil::IOPortal::pappend_from_file_descriptor(int, long, unsigned long) ()
#13 0x000056049d5f632f in brpc::InputMessenger::OnNewMessages(brpc::Socket*) ()
#14 0x000056049d71a00e in brpc::Socket::ProcessEvent(void*) ()
#15 0x000056049d5897ff in bthread::TaskGroup::task_runner(long) ()
#16 0x000056049d575091 in bthread_make_fcontext ()
```

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

