### PR TITLE
[FE](mysql) support mysql protocol with precision and scale info for decimal type

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/OutFileClause.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/OutFileClause.java
@@ -62,7 +62,7 @@ public class OutFileClause {
     private static final Logger LOG = LogManager.getLogger(OutFileClause.class);
 
     public static final List<String> RESULT_COL_NAMES = Lists.newArrayList();
-    public static final List<PrimitiveType> RESULT_COL_TYPES = Lists.newArrayList();
+    public static final List<Type> RESULT_COL_TYPES = Lists.newArrayList();
     public static final Map<String, TParquetRepetitionType> PARQUET_REPETITION_TYPE_MAP = Maps.newHashMap();
     public static final Map<String, TParquetDataType> PARQUET_DATA_TYPE_MAP = Maps.newHashMap();
     public static final Map<String, TParquetCompressionType> PARQUET_COMPRESSION_TYPE_MAP = Maps.newHashMap();
@@ -75,10 +75,10 @@ public class OutFileClause {
         RESULT_COL_NAMES.add("FileSize");
         RESULT_COL_NAMES.add("URL");
 
-        RESULT_COL_TYPES.add(PrimitiveType.INT);
-        RESULT_COL_TYPES.add(PrimitiveType.BIGINT);
-        RESULT_COL_TYPES.add(PrimitiveType.BIGINT);
-        RESULT_COL_TYPES.add(PrimitiveType.VARCHAR);
+        RESULT_COL_TYPES.add(ScalarType.createType(PrimitiveType.INT));
+        RESULT_COL_TYPES.add(ScalarType.createType(PrimitiveType.BIGINT));
+        RESULT_COL_TYPES.add(ScalarType.createType(PrimitiveType.BIGINT));
+        RESULT_COL_TYPES.add(ScalarType.createType(PrimitiveType.VARCHAR));
 
         PARQUET_REPETITION_TYPE_MAP.put("required", TParquetRepetitionType.REQUIRED);
         PARQUET_REPETITION_TYPE_MAP.put("repeated", TParquetRepetitionType.REPEATED);

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/MysqlCapability.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/MysqlCapability.java
@@ -74,7 +74,8 @@ public class MysqlCapability {
 
     private static final int DEFAULT_FLAGS = Flag.CLIENT_PROTOCOL_41.getFlagBit()
             | Flag.CLIENT_CONNECT_WITH_DB.getFlagBit() | Flag.CLIENT_SECURE_CONNECTION.getFlagBit()
-            | Flag.CLIENT_PLUGIN_AUTH.getFlagBit() | Flag.CLIENT_LOCAL_FILES.getFlagBit() | Flag.CLIENT_LONG_FLAG.getFlagBit();
+            | Flag.CLIENT_PLUGIN_AUTH.getFlagBit() | Flag.CLIENT_LOCAL_FILES.getFlagBit() | Flag.CLIENT_LONG_FLAG
+            .getFlagBit();
 
     private static final int SSL_FLAGS = Flag.CLIENT_PROTOCOL_41.getFlagBit()
             | Flag.CLIENT_CONNECT_WITH_DB.getFlagBit() | Flag.CLIENT_SECURE_CONNECTION.getFlagBit()

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/MysqlCapability.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/MysqlCapability.java
@@ -74,7 +74,7 @@ public class MysqlCapability {
 
     private static final int DEFAULT_FLAGS = Flag.CLIENT_PROTOCOL_41.getFlagBit()
             | Flag.CLIENT_CONNECT_WITH_DB.getFlagBit() | Flag.CLIENT_SECURE_CONNECTION.getFlagBit()
-            | Flag.CLIENT_PLUGIN_AUTH.getFlagBit() | Flag.CLIENT_LOCAL_FILES.getFlagBit();
+            | Flag.CLIENT_PLUGIN_AUTH.getFlagBit() | Flag.CLIENT_LOCAL_FILES.getFlagBit() | Flag.CLIENT_LONG_FLAG.getFlagBit();
 
     private static final int SSL_FLAGS = Flag.CLIENT_PROTOCOL_41.getFlagBit()
             | Flag.CLIENT_CONNECT_WITH_DB.getFlagBit() | Flag.CLIENT_SECURE_CONNECTION.getFlagBit()

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/MysqlSerializer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/MysqlSerializer.java
@@ -227,7 +227,8 @@ public class MysqlSerializer {
 
     /**
      * Specify the display width of the returned data according to the MySQL type
-     * todo:The driver determines the number of bytes per character according to different character sets index
+     * todo:The driver determines the number of bytes per character according to
+     * different character sets index
      *
      * @param type
      * @return
@@ -265,8 +266,11 @@ public class MysqlSerializer {
             case DECIMAL32:
             case DECIMAL64:
             case DECIMAL128: {
-                // f.getDecimals() > 0 ? clampedGetLength(f) - 1 + f.getPrecisionAdjustFactor() :
-                // clampedGetLength(f) + f.getPrecisionAdjustFactor();
+                // https://github.com/mysql/mysql-connector-j/blob/release/5.1/src/com/mysql/jdbc/ResultSetMetaData.java
+                // in function: int getPrecision(int column)
+                // f.getDecimals() > 0 ? clampedGetLength(f) - 1 + f.getPrecisionAdjustFactor()
+                // :clampedGetLength(f) + f.getPrecisionAdjustFactor();
+                // f.getDecimals() is return the value of scale, and precisionAdjustFactor = -1
                 ScalarType decimalType = (ScalarType) type;
                 int precision = decimalType.decimalPrecision();
                 int scale = decimalType.decimalScale();
@@ -277,13 +281,9 @@ public class MysqlSerializer {
                 }
                 return precision;
             }
-            case VARCHAR:
-            case CHAR: {
-                //lengthInBytes / f.getMaxBytesPerCharacter();
-                return 3 * ((ScalarType) type).getLength();
-            }
             // todo:It needs to be obtained according to the field length set during the actual creation,
             // todo:which is not supported for the time being.default is 255
+            // CHAR,VARCHAR:
             default:
                 return 255;
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/MysqlSerializer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/MysqlSerializer.java
@@ -18,7 +18,8 @@
 package org.apache.doris.mysql;
 
 import org.apache.doris.catalog.Column;
-import org.apache.doris.catalog.PrimitiveType;
+import org.apache.doris.catalog.ScalarType;
+import org.apache.doris.catalog.Type;
 
 import com.google.common.base.Strings;
 import org.apache.logging.log4j.LogManager;
@@ -178,13 +179,13 @@ public class MysqlSerializer {
         // Character set: two byte integer
         writeInt2(33);
         // TODO(zhaochun): fix Column length: four byte integer
-        writeInt4(255);
+        writeInt4(getMysqlTypeLength(column.getType()));
         // Column type: one byte integer
         writeInt1(column.getDataType().toMysqlType().getCode());
         // Flags: two byte integer
         writeInt2(0);
         // Decimals: one byte integer
-        writeInt1(0);
+        writeInt1(getMysqlDecimals(column.getType()));
         // filler: two byte integer
         writeInt2(0);
 
@@ -195,7 +196,7 @@ public class MysqlSerializer {
     }
 
     // Format field with name and type.
-    public void writeField(String colName, PrimitiveType type) {
+    public void writeField(String colName, Type type) {
         // Catalog Name: length encoded string
         writeLenEncodedString("def");
         // Schema: length encoded string
@@ -215,11 +216,11 @@ public class MysqlSerializer {
         // Column length: four byte integer
         writeInt4(getMysqlTypeLength(type));
         // Column type: one byte integer
-        writeInt1(type.toMysqlType().getCode());
+        writeInt1(type.getPrimitiveType().toMysqlType().getCode());
         // Flags: two byte integer
         writeInt2(0);
         // Decimals: one byte integer
-        writeInt1(0);
+        writeInt1(getMysqlDecimals(type));
         // filler: two byte integer
         writeInt2(0);
     }
@@ -227,11 +228,12 @@ public class MysqlSerializer {
     /**
      * Specify the display width of the returned data according to the MySQL type
      * todo:The driver determines the number of bytes per character according to different character sets index
+     *
      * @param type
      * @return
      */
-    private int getMysqlTypeLength(PrimitiveType type) {
-        switch (type) {
+    private int getMysqlTypeLength(Type type) {
+        switch (type.getPrimitiveType()) {
             // MySQL use Tinyint(1) to represent boolean
             case BOOLEAN:
                 return 1;
@@ -253,17 +255,51 @@ public class MysqlSerializer {
                 return 10;
             case DATETIME:
             case DATETIMEV2: {
-                if (type.isTimeType()) {
+                if (type.getPrimitiveType().isTimeType()) {
                     return 10;
-                }  else {
+                } else {
                     return 19;
                 }
             }
+            case DECIMALV2:
+            case DECIMAL32:
+            case DECIMAL64:
+            case DECIMAL128: {
+                //f.getDecimals() > 0 ? clampedGetLength(f) - 1 + f.getPrecisionAdjustFactor() : clampedGetLength(f) + f.getPrecisionAdjustFactor();
+                ScalarType decimalType = (ScalarType) type;
+                int precision = decimalType.decimalPrecision();
+                int scale = decimalType.decimalScale();
+                if (scale > 0) {
+                    precision += 2;
+                } else {
+                    precision += 1;
+                }
+                return precision;
+            }
+            case VARCHAR:
+            case CHAR: {
+                //lengthInBytes / f.getMaxBytesPerCharacter();
+                return 3 * ((ScalarType) type).getLength();
+            }
             // todo:It needs to be obtained according to the field length set during the actual creation,
             // todo:which is not supported for the time being.default is 255
-            //  DECIMAL,DECIMALV2,CHAR,VARCHAR:
             default:
                 return 255;
+        }
+    }
+    // this is used for decimal scale
+    public int getMysqlDecimals(Type type) {
+        switch (type.getPrimitiveType()) {
+            case DECIMALV2:
+            case DECIMAL32:
+            case DECIMAL64:
+            case DECIMAL128:
+                return ((ScalarType) type).decimalScale();
+            case FLOAT:
+            case DOUBLE:
+                return 31;
+            default:
+                return 0;
         }
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/MysqlSerializer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/MysqlSerializer.java
@@ -265,7 +265,8 @@ public class MysqlSerializer {
             case DECIMAL32:
             case DECIMAL64:
             case DECIMAL128: {
-                //f.getDecimals() > 0 ? clampedGetLength(f) - 1 + f.getPrecisionAdjustFactor() : clampedGetLength(f) + f.getPrecisionAdjustFactor();
+                // f.getDecimals() > 0 ? clampedGetLength(f) - 1 + f.getPrecisionAdjustFactor() :
+                // clampedGetLength(f) + f.getPrecisionAdjustFactor();
                 ScalarType decimalType = (ScalarType) type;
                 int precision = decimalType.decimalPrecision();
                 int scale = decimalType.decimalScale();
@@ -287,6 +288,7 @@ public class MysqlSerializer {
                 return 255;
         }
     }
+
     // this is used for decimal scale
     public int getMysqlDecimals(Type type) {
         switch (type.getPrimitiveType()) {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -1862,7 +1862,7 @@ public class StmtExecutor implements ProfileWriter {
         for (Column col : metaData.getColumns()) {
             serializer.reset();
             // TODO(zhaochun): only support varchar type
-            serializer.writeField(col.getName(), col.getType().getPrimitiveType());
+            serializer.writeField(col.getName(), col.getType());
             context.getMysqlChannel().sendOnePacket(serializer.toByteBuffer());
         }
         // send EOF
@@ -1895,7 +1895,7 @@ public class StmtExecutor implements ProfileWriter {
         context.getState().setOk();
     }
 
-    private void sendFields(List<String> colNames, List<PrimitiveType> types) throws IOException {
+    private void sendFields(List<String> colNames, List<Type> types) throws IOException {
         // sends how many columns
         serializer.reset();
         serializer.writeVInt(colNames.size());
@@ -2147,8 +2147,8 @@ public class StmtExecutor implements ProfileWriter {
         return statisticsForAuditLog.build();
     }
 
-    private List<PrimitiveType> exprToType(List<Expr> exprs) {
-        return exprs.stream().map(e -> e.getType().getPrimitiveType()).collect(Collectors.toList());
+    private List<Type> exprToType(List<Expr> exprs) {
+        return exprs.stream().map(e -> e.getType()).collect(Collectors.toList());
     }
 
     public StatementBase setParsedStmt(StatementBase parsedStmt) {

--- a/fe/fe-core/src/test/java/org/apache/doris/mysql/MysqlCapabilityTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/mysql/MysqlCapabilityTest.java
@@ -43,8 +43,8 @@ public class MysqlCapabilityTest {
     @Test
     public void testDefaultFlags() {
         MysqlCapability capability = MysqlCapability.DEFAULT_CAPABILITY;
-        Assert.assertEquals("CLIENT_CONNECT_WITH_DB | CLIENT_LOCAL_FILES | CLIENT_PROTOCOL_41"
-                + " | CLIENT_SECURE_CONNECTION | CLIENT_PLUGIN_AUTH | CLIENT_LONG_FLAG",
+        Assert.assertEquals("CLIENT_LONG_FLAG | CLIENT_CONNECT_WITH_DB | CLIENT_LOCAL_FILES | CLIENT_PROTOCOL_41"
+                + " | CLIENT_SECURE_CONNECTION | CLIENT_PLUGIN_AUTH",
                 capability.toString());
         Assert.assertTrue(capability.supportClientLocalFile());
     }

--- a/fe/fe-core/src/test/java/org/apache/doris/mysql/MysqlCapabilityTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/mysql/MysqlCapabilityTest.java
@@ -44,7 +44,7 @@ public class MysqlCapabilityTest {
     public void testDefaultFlags() {
         MysqlCapability capability = MysqlCapability.DEFAULT_CAPABILITY;
         Assert.assertEquals("CLIENT_CONNECT_WITH_DB | CLIENT_LOCAL_FILES | CLIENT_PROTOCOL_41"
-                + " | CLIENT_SECURE_CONNECTION | CLIENT_PLUGIN_AUTH",
+                + " | CLIENT_SECURE_CONNECTION | CLIENT_PLUGIN_AUTH | CLIENT_LONG_FLAG",
                 capability.toString());
         Assert.assertTrue(capability.supportClientLocalFile());
     }


### PR DESCRIPTION
now if use jdbc mysql driver connect to doris,
when the sql query of result has decimal type,
and user want to get the column meta info, eg: resultSetMetaData.getPrecision(i)   resultSetMetaData.getScale(i)
the precision and scale info it's wrong for the column

# Proposed changes

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

