### PR TITLE
[fix](expr) Fix `VRuntimeFilterWrapper` cannot get children

### DIFF
--- a/be/src/vec/exprs/vexpr.h
+++ b/be/src/vec/exprs/vexpr.h
@@ -130,7 +130,7 @@ public:
     static Status create_tree_from_thrift(doris::ObjectPool* pool,
                                           const std::vector<doris::TExprNode>& nodes, int* node_idx,
                                           VExpr** root_expr, VExprContext** ctx);
-    const std::vector<VExpr*>& children() const { return _children; }
+    virtual const std::vector<VExpr*>& children() const { return _children; }
     void set_children(std::vector<VExpr*> children) { _children = children; }
     virtual std::string debug_string() const;
     static std::string debug_string(const std::vector<VExpr*>& exprs);

--- a/be/src/vec/exprs/vruntimefilter_wrapper.h
+++ b/be/src/vec/exprs/vruntimefilter_wrapper.h
@@ -39,6 +39,7 @@ public:
         return pool->add(new VRuntimeFilterWrapper(*this));
     }
     const std::string& expr_name() const override;
+    const std::vector<VExpr*>& children() const override { return _impl->children(); }
 
     const VExpr* get_impl() const override { return _impl; }
 


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

When expr is pushed down, this bug may cause the column of runtime filter to not be read in time

```
0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /projects/doris/be/src/common/signal_handler.h:413
1# 0x00007F79B5FDD400 in /lib64/libc.so.6
2# __GI_raise in /lib64/libc.so.6
3# __GI_abort in /lib64/libc.so.6
4# 0x000055764CF50329 in /projects/doris/output/be/lib/doris_be
5# google::LogMessage::SendToLog() in /projects/doris/output/be/lib/doris_be
6# google::LogMessage::Flush() in /projects/doris/output/be/lib/doris_be
7# google::LogMessageFatal::~LogMessageFatal() in /projects/doris/output/be/lib/doris_be
8# doris::vectorized::create_block_with_nested_columns(doris::vectorized::Block const&, std::vector<unsigned long, std::allocator<unsigned long> > const&, bool) in /projects/doris/output/be/lib/doris_be
9# doris::vectorized::FunctionCast::prepare_remove_nullable(doris::FunctionContext*, std::shared_ptr<doris::vectorized::IDataType const> const&, std::shared_ptr<doris::vectorized::IDataType const> const&, bool) const::
```

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

