### PR TITLE
[fix](profile) fix problem on stream load profile log

### DIFF
--- a/be/src/http/action/stream_load.cpp
+++ b/be/src/http/action/stream_load.cpp
@@ -601,12 +601,6 @@ Status StreamLoadAction::_process_put(HttpRequest* http_req,
         return plan_status;
     }
 
-    auto& query_options = ctx->put_result.params.query_options;
-    if (query_options.__isset.is_report_success && query_options.is_report_success &&
-        !config::enable_stream_load_profile_log) {
-        query_options.is_report_success = false;
-    }
-
     VLOG_NOTICE << "params is " << apache::thrift::ThriftDebugString(ctx->put_result.params);
     // if we not use streaming, we must download total content before we begin
     // to process this load

--- a/be/src/runtime/plan_fragment_executor.cpp
+++ b/be/src/runtime/plan_fragment_executor.cpp
@@ -510,7 +510,7 @@ void PlanFragmentExecutor::close() {
             }
         }
 
-        if (_is_report_success) {
+        if (_is_report_success || config::enable_stream_load_profile_log) {
             std::stringstream ss;
             // Compute the _local_time_percent before pretty_print the runtime_profile
             // Before add this operation, the print out like that:

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/StreamLoadPlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/StreamLoadPlanner.java
@@ -47,7 +47,6 @@ import org.apache.doris.load.BrokerFileGroup;
 import org.apache.doris.load.loadv2.LoadTask;
 import org.apache.doris.load.routineload.RoutineLoadJob;
 import org.apache.doris.planner.external.ExternalFileScanNode;
-import org.apache.doris.qe.VariableMgr;
 import org.apache.doris.service.FrontendOptions;
 import org.apache.doris.task.LoadTaskInfo;
 import org.apache.doris.thrift.PaloInternalServiceVersion;
@@ -276,7 +275,6 @@ public class StreamLoadPlanner {
         queryOptions.setEnableVectorizedEngine(Config.enable_vectorized_load);
         queryOptions.setEnablePipelineEngine(Config.enable_pipeline_load);
         queryOptions.setBeExecVersion(Config.be_exec_version);
-        queryOptions.setIsReportSuccess(VariableMgr.newSessionVariable().enableProfile());
 
         params.setQueryOptions(queryOptions);
         TQueryGlobals queryGlobals = new TQueryGlobals();


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary
#18015 enable stream load profile log, however be will encounter rpc fail when loading tpch data like this :

```
I0329 14:22:50.843114  7251 plan_fragment_executor.cpp:471] PlanFragmentExecutor::cancel|query_id=xxx|instance_id=xxx|reason=3|error message=rpc fail 2
W0329 14:22:50.843132  7251 fragment_mgr.cpp:227] Got error while opening fragment xxx query id: xxx: [CANCELLED]Cancelled
I0329 14:22:50.843140  7251 plan_fragment_executor.cpp:471] PlanFragmentExecutor::cancel|query_id=xxx|instance_id=xxx|reason=3|error message=PlanFragmentExecutor open failed
I0329 14:22:50.843151  7251 exec_node.cpp:179] fragment_instance_id=xxx closed`
```

I think it's not a good idea to setIsReportSuccess to print stream load profile log, maybe there are some performance issues that haven't been fixed yet. And i move the enable option to PlanFragmentExecutor close to fix this problem.


Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

