### PR TITLE
[fix](Nereids): fix JoinReorderContext in withXXX() of LogicalJoin.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Memo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Memo.java
@@ -393,7 +393,7 @@ public class Memo {
                 validateRewriteChildGroup(childGroup, targetGroup);
                 childrenGroups.add(childGroup);
             } else {
-                childrenGroups.add(copyIn(child, null, true).correspondingExpression.getOwnerGroup());
+                childrenGroups.add(doRewrite(child, null).correspondingExpression.getOwnerGroup());
             }
         }
         return childrenGroups;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/join/LogicalJoinSemiJoinTranspose.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/join/LogicalJoinSemiJoinTranspose.java
@@ -51,8 +51,8 @@ public class LogicalJoinSemiJoinTranspose implements ExplorationRuleFactory {
                             GroupPlan b = bottomJoin.right();
                             GroupPlan c = topJoin.right();
 
-                            Plan newBottomJoin = topJoin.withChildren(a, c);
-                            return bottomJoin.withChildren(newBottomJoin, b);
+                            Plan newBottomJoin = topJoin.withChildrenNoContext(a, c);
+                            return bottomJoin.withChildrenNoContext(newBottomJoin, b);
                         }).toRule(RuleType.LOGICAL_JOIN_LOGICAL_SEMI_JOIN_TRANSPOSE),
 
                 logicalJoin(group(), logicalJoin())
@@ -67,8 +67,8 @@ public class LogicalJoinSemiJoinTranspose implements ExplorationRuleFactory {
                             GroupPlan b = bottomJoin.left();
                             GroupPlan c = bottomJoin.right();
 
-                            Plan newBottomJoin = topJoin.withChildren(a, b);
-                            return bottomJoin.withChildren(newBottomJoin, c);
+                            Plan newBottomJoin = topJoin.withChildrenNoContext(a, b);
+                            return bottomJoin.withChildrenNoContext(newBottomJoin, c);
                         }).toRule(RuleType.LOGICAL_JOIN_LOGICAL_SEMI_JOIN_TRANSPOSE)
         );
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/join/LogicalJoinSemiJoinTransposeProject.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/join/LogicalJoinSemiJoinTransposeProject.java
@@ -53,8 +53,8 @@ public class LogicalJoinSemiJoinTransposeProject implements ExplorationRuleFacto
                             GroupPlan c = topJoin.right();
 
                             // Discard this project, because it is useless.
-                            Plan newBottomJoin = topJoin.withChildren(a, c);
-                            Plan newTopJoin = bottomJoin.withChildren(newBottomJoin, b);
+                            Plan newBottomJoin = topJoin.withChildrenNoContext(a, c);
+                            Plan newTopJoin = bottomJoin.withChildrenNoContext(newBottomJoin, b);
                             return JoinReorderUtils.projectOrSelf(new ArrayList<>(topJoin.getOutput()),
                                     newTopJoin);
                         }).toRule(RuleType.LOGICAL_JOIN_LOGICAL_SEMI_JOIN_TRANSPOSE_PROJECT),
@@ -71,8 +71,8 @@ public class LogicalJoinSemiJoinTransposeProject implements ExplorationRuleFacto
                             GroupPlan c = bottomJoin.right();
 
                             // Discard this project, because it is useless.
-                            Plan newBottomJoin = topJoin.withChildren(a, b);
-                            Plan newTopJoin = bottomJoin.withChildren(newBottomJoin, c);
+                            Plan newBottomJoin = topJoin.withChildrenNoContext(a, b);
+                            Plan newTopJoin = bottomJoin.withChildrenNoContext(newBottomJoin, c);
                             return JoinReorderUtils.projectOrSelf(new ArrayList<>(topJoin.getOutput()),
                                     newTopJoin);
                         }).toRule(RuleType.LOGICAL_JOIN_LOGICAL_SEMI_JOIN_TRANSPOSE_PROJECT)

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/join/OuterJoinAssoc.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/join/OuterJoinAssoc.java
@@ -70,9 +70,9 @@ public class OuterJoinAssoc extends OneExplorationRuleFactory {
                      * But because we have added eliminate_outer_rule, we don't need to consider this.
                      */
 
-                    LogicalJoin newBottomJoin = (LogicalJoin) topJoin.withChildren(b, c);
+                    LogicalJoin newBottomJoin = topJoin.withChildrenNoContext(b, c);
                     newBottomJoin.getJoinReorderContext().copyFrom(bottomJoin.getJoinReorderContext());
-                    LogicalJoin newTopJoin = (LogicalJoin) bottomJoin.withChildren(a, newBottomJoin);
+                    LogicalJoin newTopJoin = bottomJoin.withChildrenNoContext(a, newBottomJoin);
                     newTopJoin.getJoinReorderContext().copyFrom(topJoin.getJoinReorderContext());
                     setReorderContext(newTopJoin, newBottomJoin);
                     return newTopJoin;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/join/OuterJoinAssocProject.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/join/OuterJoinAssocProject.java
@@ -96,13 +96,13 @@ public class OuterJoinAssocProject extends OneExplorationRuleFactory {
 
                     bProjects.addAll(OuterJoinLAsscomProject.forceToNullable(c.getOutputSet()));
                     /* ********** new Plan ********** */
-                    LogicalJoin newBottomJoin = (LogicalJoin) topJoin.withChildren(b, c);
+                    LogicalJoin newBottomJoin = topJoin.withChildrenNoContext(b, c);
                     newBottomJoin.getJoinReorderContext().copyFrom(bottomJoin.getJoinReorderContext());
 
                     Plan left = JoinReorderUtils.projectOrSelf(aProjects, a);
                     Plan right = JoinReorderUtils.projectOrSelf(bProjects, newBottomJoin);
 
-                    LogicalJoin newTopJoin = (LogicalJoin) bottomJoin.withChildren(left, right);
+                    LogicalJoin newTopJoin = bottomJoin.withChildrenNoContext(left, right);
                     newTopJoin.getJoinReorderContext().copyFrom(topJoin.getJoinReorderContext());
                     OuterJoinAssoc.setReorderContext(newTopJoin, newBottomJoin);
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/join/OuterJoinLAsscom.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/join/OuterJoinLAsscom.java
@@ -71,12 +71,12 @@ public class OuterJoinLAsscom extends OneExplorationRuleFactory {
                     GroupPlan b = bottomJoin.right();
                     GroupPlan c = topJoin.right();
 
-                    LogicalJoin newBottomJoin = (LogicalJoin) topJoin.withChildren(a, c);
+                    LogicalJoin newBottomJoin = topJoin.withChildrenNoContext(a, c);
                     newBottomJoin.getJoinReorderContext().copyFrom(bottomJoin.getJoinReorderContext());
                     newBottomJoin.getJoinReorderContext().setHasLAsscom(false);
                     newBottomJoin.getJoinReorderContext().setHasCommute(false);
 
-                    LogicalJoin newTopJoin = (LogicalJoin) bottomJoin.withChildren(newBottomJoin, b);
+                    LogicalJoin newTopJoin = bottomJoin.withChildrenNoContext(newBottomJoin, b);
                     newTopJoin.getJoinReorderContext().copyFrom(topJoin.getJoinReorderContext());
                     newTopJoin.getJoinReorderContext().setHasLAsscom(true);
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/join/OuterJoinLAsscomProject.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/join/OuterJoinLAsscomProject.java
@@ -99,7 +99,7 @@ public class OuterJoinLAsscomProject extends OneExplorationRuleFactory {
                     aProjects.addAll(forceToNullable(c.getOutputSet()));
 
                     /* ********** new Plan ********** */
-                    LogicalJoin newBottomJoin = (LogicalJoin) topJoin.withChildren(a, c);
+                    LogicalJoin newBottomJoin = topJoin.withChildrenNoContext(a, c);
                     newBottomJoin.getJoinReorderContext().copyFrom(bottomJoin.getJoinReorderContext());
                     newBottomJoin.getJoinReorderContext().setHasLAsscom(false);
                     newBottomJoin.getJoinReorderContext().setHasCommute(false);
@@ -107,7 +107,7 @@ public class OuterJoinLAsscomProject extends OneExplorationRuleFactory {
                     Plan left = JoinReorderUtils.projectOrSelf(aProjects, newBottomJoin);
                     Plan right = JoinReorderUtils.projectOrSelf(bProjects, b);
 
-                    LogicalJoin newTopJoin = (LogicalJoin) bottomJoin.withChildren(left, right);
+                    LogicalJoin newTopJoin = bottomJoin.withChildrenNoContext(left, right);
                     newTopJoin.getJoinReorderContext().copyFrom(topJoin.getJoinReorderContext());
                     newTopJoin.getJoinReorderContext().setHasLAsscom(true);
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/join/PushdownProjectThroughInnerJoin.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/join/PushdownProjectThroughInnerJoin.java
@@ -93,7 +93,7 @@ public class PushdownProjectThroughInnerJoin extends OneExplorationRuleFactory {
                 Plan newLeft = JoinReorderUtils.projectOrSelf(newAProject.build(), join.left());
 
                 if (!rightContains) {
-                    Plan newJoin = join.withChildren(newLeft, join.right());
+                    Plan newJoin = join.withChildrenNoContext(newLeft, join.right());
                     return JoinReorderUtils.projectOrSelf(new ArrayList<>(project.getOutput()), newJoin);
                 }
 
@@ -103,7 +103,7 @@ public class PushdownProjectThroughInnerJoin extends OneExplorationRuleFactory {
                 bConditionSlots.stream().filter(slot -> !bProjectSlots.contains(slot)).forEach(newBProject::add);
                 Plan newRight = JoinReorderUtils.projectOrSelf(newBProject.build(), join.right());
 
-                Plan newJoin = join.withChildren(newLeft, newRight);
+                Plan newJoin = join.withChildrenNoContext(newLeft, newRight);
                 return JoinReorderUtils.projectOrSelfInOrder(new ArrayList<>(project.getOutput()), newJoin);
             }).toRule(RuleType.PUSH_DOWN_PROJECT_THROUGH_INNER_JOIN);
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/join/PushdownProjectThroughSemiJoin.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/join/PushdownProjectThroughSemiJoin.java
@@ -63,7 +63,7 @@ public class PushdownProjectThroughSemiJoin extends OneExplorationRuleFactory {
                 conditionLeftSlots.stream().filter(slot -> !projectUsedSlots.contains(slot)).forEach(newProject::add);
                 Plan newLeft = JoinReorderUtils.projectOrSelf(newProject, join.left());
 
-                Plan newJoin = join.withChildren(newLeft, join.right());
+                Plan newJoin = join.withChildrenNoContext(newLeft, join.right());
                 return JoinReorderUtils.projectOrSelfInOrder(new ArrayList<>(project.getOutput()), newJoin);
             }).toRule(RuleType.PUSH_DOWN_PROJECT_THROUGH_SEMI_JOIN);
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/join/SemiJoinSemiJoinTranspose.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/join/SemiJoinSemiJoinTranspose.java
@@ -70,8 +70,8 @@ public class SemiJoinSemiJoinTranspose extends OneExplorationRuleFactory {
                     GroupPlan b = bottomJoin.right();
                     GroupPlan c = topJoin.right();
 
-                    Plan newBottomJoin = topJoin.withChildren(a, c);
-                    Plan newTopJoin = bottomJoin.withChildren(newBottomJoin, b);
+                    Plan newBottomJoin = topJoin.withChildrenNoContext(a, c);
+                    Plan newTopJoin = bottomJoin.withChildrenNoContext(newBottomJoin, b);
                     return newTopJoin;
                 }).toRule(RuleType.LOGICAL_SEMI_JOIN_SEMI_JOIN_TRANSPOSE);
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/join/SemiJoinSemiJoinTransposeProject.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/join/SemiJoinSemiJoinTransposeProject.java
@@ -71,13 +71,13 @@ public class SemiJoinSemiJoinTransposeProject extends OneExplorationRuleFactory 
                                     acProjects.add(slot);
                                 }
                             });
-                    LogicalJoin newBottomSemi = (LogicalJoin) topSemi.withChildren(a, c);
+                    LogicalJoin newBottomSemi = topSemi.withChildrenNoContext(a, c);
                     newBottomSemi.getJoinReorderContext().copyFrom(bottomSemi.getJoinReorderContext());
                     newBottomSemi.getJoinReorderContext().setHasCommute(false);
                     newBottomSemi.getJoinReorderContext().setHasLAsscom(false);
 
                     LogicalProject acProject = new LogicalProject<>(Lists.newArrayList(acProjects), newBottomSemi);
-                    LogicalJoin newTopSemi = (LogicalJoin) bottomSemi.withChildren(acProject, b);
+                    LogicalJoin newTopSemi = bottomSemi.withChildrenNoContext(acProject, b);
                     newTopSemi.getJoinReorderContext().copyFrom(topSemi.getJoinReorderContext());
                     newTopSemi.getJoinReorderContext().setHasLAsscom(true);
                     return JoinReorderUtils.projectOrSelf(new ArrayList<>(topSemi.getOutput()), newTopSemi);


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

We should use original JoinReorderContext in withXXX()

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

