### PR TITLE
[fix](conf) fix be JAVA_OPTS  conf

### DIFF
--- a/conf/be.conf
+++ b/conf/be.conf
@@ -17,8 +17,8 @@
 
 PPROF_TMPDIR="$DORIS_HOME/log/"
 
-DATE = `date +%Y%m%d-%H%M%S`
-JAVA_OPTS="-Xmx1024m -DlogPath=$DORIS_HOME/log/jni.log -Xloggc:$DORIS_HOME/log/be.gc.log.$CUR_DATE -Dsun.java.command=DorisBE -XX:-CriticalJNINatives"
+CUR_DATE = `date +%Y%m%d-%H%M%S`
+JAVA_OPTS="-Xmx1024m -DlogPath=$DORIS_HOME/log/jni.log -Xlog:gc:$DORIS_HOME/log/be.gc.log.$CUR_DATE -Dsun.java.command=DorisBE -XX:-CriticalJNINatives"
 
 # since 1.2, the JAVA_HOME need to be set to run BE process.
 # JAVA_HOME=/path/to/jdk/


### PR DESCRIPTION
# Proposed changes
Fix be JAVA_OPTS  conf
(1) the be.gc.log  miss the date
![image](https://user-images.githubusercontent.com/67053339/229291822-ec61f3dd-4a22-4f43-b77d-a93d8c9230b5.png)

(2) -Xloggc  is deprecated,   now is -Xlog:gc 。 
    [warning][gc] -Xloggc is deprecated. Will use -Xlog:gc:/root/doris_dist/be/log/be.gc.log. instead.


![image](https://user-images.githubusercontent.com/67053339/229291597-11b6d569-1c83-4cec-b0bd-5a19415c7525.png)


Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

