### PR TITLE
[improvement](executor) Reduce ScannnerCtx Scheduling times

### DIFF
--- a/be/src/pipeline/exec/scan_operator.cpp
+++ b/be/src/pipeline/exec/scan_operator.cpp
@@ -38,9 +38,6 @@ bool ScanOperator::can_read() {
             // _scanner_ctx->no_schedule(): should schedule _scanner_ctx
             return true;
         } else {
-            if (_node->_scanner_ctx->has_enough_space_in_blocks_queue()) {
-                _node->_scanner_ctx->reschedule_scanner_ctx();
-            }
             return _node->ready_to_read(); // there are some blocks to process
         }
     }

--- a/be/src/vec/exec/scan/pip_scanner_context.h
+++ b/be/src/vec/exec/scan/pip_scanner_context.h
@@ -56,6 +56,15 @@ public:
                 return Status::OK();
             }
         }
+        {
+            std::unique_lock<std::mutex> l(_transfer_lock);
+            if (has_enough_space_in_blocks_queue()) {
+                auto submit_st = _scanner_scheduler->submit(this);
+                if (submit_st.ok()) {
+                    _num_scheduling_ctx++;
+                }
+            }
+        }
         _current_used_bytes -= (*block)->allocated_bytes();
         return Status::OK();
     }

--- a/be/src/vec/exec/scan/pip_scanner_context.h
+++ b/be/src/vec/exec/scan/pip_scanner_context.h
@@ -56,16 +56,16 @@ public:
                 return Status::OK();
             }
         }
+        _current_used_bytes -= (*block)->allocated_bytes();
         {
-            std::unique_lock<std::mutex> l(_transfer_lock);
             if (has_enough_space_in_blocks_queue()) {
+                std::unique_lock<std::mutex> l(_transfer_lock);
                 auto submit_st = _scanner_scheduler->submit(this);
                 if (submit_st.ok()) {
                     _num_scheduling_ctx++;
                 }
             }
         }
-        _current_used_bytes -= (*block)->allocated_bytes();
         return Status::OK();
     }
 

--- a/be/src/vec/exec/scan/scanner_context.cpp
+++ b/be/src/vec/exec/scan/scanner_context.cpp
@@ -288,15 +288,6 @@ std::string ScannerContext::debug_string() {
             _max_thread_num, _block_per_scanner, _cur_bytes_in_queue, _max_bytes_in_queue);
 }
 
-void ScannerContext::reschedule_scanner_ctx() {
-    std::lock_guard l(_transfer_lock);
-    auto submit_st = _scanner_scheduler->submit(this);
-    //todo(wb) rethinking is it better to mark current scan_context failed when submit failed many times?
-    if (submit_st.ok()) {
-        _num_scheduling_ctx++;
-    }
-}
-
 void ScannerContext::push_back_scanner_and_reschedule(VScanner* scanner) {
     {
         std::unique_lock l(_scanners_lock);

--- a/be/src/vec/exec/scan/scanner_context.h
+++ b/be/src/vec/exec/scan/scanner_context.h
@@ -128,8 +128,6 @@ public:
         return _cur_bytes_in_queue < _max_bytes_in_queue / 2;
     }
 
-    void reschedule_scanner_ctx();
-
     // the unique id of this context
     std::string ctx_id;
     int32_t queue_idx = -1;


### PR DESCRIPTION
# Proposed changes
If we keep ScannerCtx Schedule Thread Group exsits(maybe we can delete it later) currently, we'd better keep the same logic with non-pipeline engine for rescheduling ScannerCtx(that means only resubmit ScannerCtx for getting block or a scanner finished), this can reduce scannnerCtx scheduling times.

Before:
```
ScannerCtxSchedCount:  268.48K  (268480)
```
After
```
ScannerCtxSchedCount:  10.105K  (10105)
```

## Performance Rollback Test
ckbench
```
before(non-pipline engine)
c8:
38.39/35.51/35.51 (total time costs)
c16:
26.29/23.39/23.31

after
c8:
39.57/35.39/36.34
c16:
27.33/23.84/23.83

```

## Checklist(Required)

* [x] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [x] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

