### PR TITLE
[Optimization](String) Optimize q20 q21 q22 q23 LIKE_SUBSTRING (like '%xxx%') 

### DIFF
--- a/be/src/vec/common/string_searcher.h
+++ b/be/src/vec/common/string_searcher.h
@@ -162,39 +162,6 @@ public:
 
         const auto needle_size = needle_end - needle;
 
-#ifdef __SSE4_1__
-        /// Here is the quick path when needle_size is 1. Compare the first and second characters if the needle_size >= 2.
-        if (needle_size == 1) {
-            while (haystack < haystack_end) {
-                if (haystack + n <= haystack_end && page_safe(haystack)) {
-                    const auto v_haystack =
-                            _mm_loadu_si128(reinterpret_cast<const __m128i*>(haystack));
-                    const auto v_against_pattern = _mm_cmpeq_epi8(v_haystack, first_pattern);
-                    const auto mask = _mm_movemask_epi8(v_against_pattern);
-                    if (mask == 0) {
-                        haystack += n;
-                        continue;
-                    }
-
-                    const auto offset = __builtin_ctz(mask);
-                    haystack += offset;
-
-                    return haystack;
-                }
-
-                if (haystack == haystack_end) {
-                    return haystack_end;
-                }
-
-                if (*haystack == first) {
-                    return haystack;
-                }
-                ++haystack;
-            }
-            return haystack_end;
-        }
-#endif
-
         while (haystack < haystack_end && haystack_end - haystack >= needle_size) {
 #ifdef __SSE4_1__
             if ((haystack + 1 + n) <= haystack_end && page_safe(haystack)) {

--- a/be/src/vec/common/string_searcher.h
+++ b/be/src/vec/common/string_searcher.h
@@ -161,8 +161,40 @@ public:
         if (needle == needle_end) return haystack;
 
         const auto needle_size = needle_end - needle;
+#ifdef __SSE4_1__
+        /// Here is the quick path when needle_size is 1.
+        if (needle_size == 1) {
+            while (haystack < haystack_end) {
+                if (haystack + n <= haystack_end && page_safe(haystack)) {
+                    const auto v_haystack =
+                            _mm_loadu_si128(reinterpret_cast<const __m128i*>(haystack));
+                    const auto v_against_pattern = _mm_cmpeq_epi8(v_haystack, first_pattern);
+                    const auto mask = _mm_movemask_epi8(v_against_pattern);
+                    if (mask == 0) {
+                        haystack += n;
+                        continue;
+                    }
 
-        while (haystack_end - haystack >= needle_size) {
+                    const auto offset = __builtin_ctz(mask);
+                    haystack += offset;
+
+                    return haystack;
+                }
+
+                if (haystack == haystack_end) {
+                    return haystack_end;
+                }
+
+                if (*haystack == first) {
+                    return haystack;
+                }
+                ++haystack;
+            }
+            return haystack_end;
+        }
+#endif
+
+        while (haystack < haystack_end && haystack_end - haystack >= needle_size) {
 #ifdef __SSE4_1__
             if ((haystack + 1 + n) <= haystack_end && page_safe(haystack)) {
                 /// find first and second characters

--- a/be/src/vec/common/string_searcher.h
+++ b/be/src/vec/common/string_searcher.h
@@ -77,8 +77,10 @@ private:
     uint8_t first {};
 
 #ifdef __SSE4_1__
-    /// vector filled `first` for determining leftmost position of the first symbol
-    __m128i pattern;
+    uint8_t second {};
+    /// vector filled `first` or `second` for determining leftmost position of the first and second symbols
+    __m128i first_pattern;
+    __m128i second_pattern;
     /// vector of first 16 characters of `needle`
     __m128i cache = _mm_setzero_si128();
     int cachemask {};
@@ -95,8 +97,11 @@ public:
         first = *needle;
 
 #ifdef __SSE4_1__
-        pattern = _mm_set1_epi8(first);
-
+        first_pattern = _mm_set1_epi8(first);
+        if (needle + 1 < needle_end) {
+            second = *(needle + 1);
+            second_pattern = _mm_set1_epi8(second);
+        }
         const auto* needle_pos = needle;
 
         //for (const auto i : collections::range(0, n))
@@ -155,16 +160,58 @@ public:
     const CharT* search(const CharT* haystack, const CharT* const haystack_end) const {
         if (needle == needle_end) return haystack;
 
-        while (haystack < haystack_end) {
+        const auto needle_size = needle_end - needle;
+
 #ifdef __SSE4_1__
-            if (haystack + n <= haystack_end && page_safe(haystack)) {
-                /// find first character
-                const auto v_haystack = _mm_loadu_si128(reinterpret_cast<const __m128i*>(haystack));
-                const auto v_against_pattern = _mm_cmpeq_epi8(v_haystack, pattern);
+        /// Here is the quick path when needle_size is 1. Compare the first and second characters if the needle_size >= 2.
+        if (needle_size == 1) {
+            while (haystack < haystack_end) {
+                if (haystack + n <= haystack_end && page_safe(haystack)) {
+                    const auto v_haystack =
+                            _mm_loadu_si128(reinterpret_cast<const __m128i*>(haystack));
+                    const auto v_against_pattern = _mm_cmpeq_epi8(v_haystack, first_pattern);
+                    const auto mask = _mm_movemask_epi8(v_against_pattern);
+                    if (mask == 0) {
+                        haystack += n;
+                        continue;
+                    }
 
-                const auto mask = _mm_movemask_epi8(v_against_pattern);
+                    const auto offset = __builtin_ctz(mask);
+                    haystack += offset;
 
-                /// first character not present in 16 octets starting at `haystack`
+                    return haystack;
+                }
+
+                if (haystack == haystack_end) {
+                    return haystack_end;
+                }
+
+                if (*haystack == first) {
+                    return haystack;
+                }
+                ++haystack;
+            }
+            return haystack_end;
+        }
+#endif
+
+        while (haystack < haystack_end && haystack_end - haystack >= needle_size) {
+#ifdef __SSE4_1__
+            if ((haystack + 1 + n) <= haystack_end && page_safe(haystack)) {
+                /// find first and second characters
+                const auto v_haystack_block_first =
+                        _mm_loadu_si128(reinterpret_cast<const __m128i*>(haystack));
+                const auto v_haystack_block_second =
+                        _mm_loadu_si128(reinterpret_cast<const __m128i*>(haystack + 1));
+
+                const auto v_against_pattern_first =
+                        _mm_cmpeq_epi8(v_haystack_block_first, first_pattern);
+                const auto v_against_pattern_second =
+                        _mm_cmpeq_epi8(v_haystack_block_second, second_pattern);
+
+                const auto mask = _mm_movemask_epi8(
+                        _mm_and_si128(v_against_pattern_first, v_against_pattern_second));
+                /// first and second characters not present in 16 octets starting at `haystack`
                 if (mask == 0) {
                     haystack += n;
                     continue;

--- a/be/src/vec/common/string_searcher.h
+++ b/be/src/vec/common/string_searcher.h
@@ -162,7 +162,7 @@ public:
 
         const auto needle_size = needle_end - needle;
 
-        while (haystack < haystack_end && haystack_end - haystack >= needle_size) {
+        while (haystack_end - haystack >= needle_size) {
 #ifdef __SSE4_1__
             if ((haystack + 1 + n) <= haystack_end && page_safe(haystack)) {
                 /// find first and second characters

--- a/be/src/vec/common/volnitsky.h
+++ b/be/src/vec/common/volnitsky.h
@@ -203,6 +203,10 @@ public:
 
         const auto* haystack_end = haystack + haystack_size;
 
+#ifdef __SSE4_1__
+        return fallback_searcher.search(haystack, haystack_end);
+#endif
+
         if (fallback || haystack_size <= needle_size || fallback_searcher.force_fallback)
             return fallback_searcher.search(haystack, haystack_end);
 


### PR DESCRIPTION
# Proposed changes

Optimize q20, q21, q22, q23 LIKE_SUBSTRING (like '%xxxx%').  Idea is from clickhouse stringsearcher:

1.  Stringsearcher is about 10%~20% faster than volnitsky algorithm when needle size is less than 10 using two chars at beginning search in SIMD .
2. Stringsearcher is faster than volnitsky algorithm, when needle size is less than 21.

**The changes are as follows:**

1.  Using first two chars of needle at beginning search. We can compare two chars of needle and [n:n+17) chars in haystack in SIMD in one loop. Filter efficiency will be higher.
2. When env support SIMD, we use stringsearcher.

**Test result in clickbench:**

1. q20 is about 15% up. 
```
q20: SELECT COUNT(*) FROM hits WHERE URL LIKE '%google%';
```
2.  q21, q22 is about 1%~5% up.  
```
q21: SELECT SearchPhrase, MIN(URL), COUNT(*) AS c FROM hits WHERE URL LIKE '%google%' AND SearchPhrase <> '' GROUP BY SearchPhrase ORDER BY c DESC LIMIT 10;
q22: SELECT SearchPhrase, MIN(URL), MIN(Title), COUNT(*) AS c, COUNT(DISTINCT UserID) FROM hits WHERE Title LIKE '%Google%' AND URL NOT LIKE '%.google.%' AND SearchPhrase <> '' GROUP BY SearchPhrase ORDER BY c DESC LIMIT 10;
```
3.  q23 is about 30%~40% up and not stable.
```
q23: SELECT * FROM hits WHERE URL LIKE '%google%' ORDER BY EventTime LIMIT 10;
```



-------
after：
https://doris-community-test-1308700295.cos.ap-hongkong.myqcloud.com/tmp/20230402003237_clickbench_pr_123705.html
![image](https://user-images.githubusercontent.com/67053339/229327075-b5181a9c-3e5b-4c94-8230-2bde08dfdc8e.png)

https://doris-community-test-1308700295.cos.ap-hongkong.myqcloud.com/tmp/20230402030931_clickbench_pr_123726.html
![image](https://user-images.githubusercontent.com/67053339/229332899-315b92b8-1eec-43cd-9f30-4399e3d2b16e.png)

before:
https://doris-community-test-1308700295.cos.ap-hongkong.myqcloud.com/tmp/20230402003741_clickbench_pr_123714.html
![image](https://user-images.githubusercontent.com/67053339/229327087-301da53f-2e85-430c-8be9-f8873a571bc3.png)

https://doris-community-test-1308700295.cos.ap-hongkong.myqcloud.com/tmp/20230402063546_clickbench_pr_123743.html
![image](https://user-images.githubusercontent.com/67053339/229336806-6d385311-cbdb-4a8a-be71-13c4702e16d5.png)
Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

