### PR TITLE
[fix](thrift_server) do not check started state in ThriftServer::join

### DIFF
--- a/be/src/util/thrift_server.cpp
+++ b/be/src/util/thrift_server.cpp
@@ -151,6 +151,8 @@ void ThriftServer::ThriftServerEventProcessor::supervise() {
                    << ") exited due to TException: " << e.what();
     }
 
+    LOG(INFO) << "ThriftServer " << _thrift_server->_name << " exited";
+
     {
         // _signal_lock ensures mutual exclusion of access to _thrift_server
         std::lock_guard<std::mutex> lock(_signal_lock);
@@ -364,7 +366,6 @@ void ThriftServer::stop() {
 
 void ThriftServer::join() {
     DCHECK(_server_thread != nullptr);
-    DCHECK(_started);
     _server_thread->join();
 }
 


### PR DESCRIPTION
started may be set to false when server thread is stopped.

# Proposed changes

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

