### PR TITLE
[fix](audit-log) fix slow query missing in audit log

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/AuditLogBuilder.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/AuditLogBuilder.java
@@ -111,7 +111,7 @@ public class AuditLogBuilder extends Plugin implements AuditPlugin {
                 continue;
             }
 
-            if (af.value().equals("Time")) {
+            if (af.value().equals("Time(ms)")) {
                 queryTime = (long) f.get(event);
             }
             sb.append("|").append(af.value()).append("=").append(String.valueOf(f.get(event)));
@@ -161,3 +161,4 @@ public class AuditLogBuilder extends Plugin implements AuditPlugin {
         AuditLog.getStreamLoadAudit().log(auditLog);
     }
 }
+


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

#17738 changed the column name in audit log, causing "slow_query" will not be recorded in fe.audit.log

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

