### PR TITLE
[opt](string) optimize constant empty string compare

### DIFF
--- a/be/src/vec/functions/functions_comparison.h
+++ b/be/src/vec/functions/functions_comparison.h
@@ -211,15 +211,28 @@ struct StringEqualsImpl {
                                                  ColumnString::Offset b_size,
                                                  PaddedPODArray<UInt8>& c) {
         size_t size = a_offsets.size();
-        ColumnString::Offset prev_a_offset = 0;
-
-        for (size_t i = 0; i < size; ++i) {
-            auto a_size = a_offsets[i] - prev_a_offset;
-
-            c[i] = positive == memequal_small_allow_overflow15(a_data.data() + prev_a_offset,
-                                                               a_size, b_data.data(), b_size);
-
-            prev_a_offset = a_offsets[i];
+        if (b_size == 0) {
+            auto* __restrict data = c.data();
+            auto* __restrict offsets = a_offsets.data();
+            if (positive) {
+                for (size_t i = 0; i < size; ++i) {
+                    data[i] = (offsets[i] == offsets[i - 1]);
+                }
+            } else {
+                for (size_t i = 0; i < size; ++i) {
+                    data[i] = (offsets[i] != offsets[i - 1]);
+                }
+            }
+        } else {
+            ColumnString::Offset prev_a_offset = 0;
+            const auto* a_pos = a_data.data();
+            const auto* b_pos = b_data.data();
+            for (size_t i = 0; i < size; ++i) {
+                auto a_size = a_offsets[i] - prev_a_offset;
+                c[i] = positive == memequal_small_allow_overflow15(a_pos + prev_a_offset, a_size,
+                                                                   b_pos, b_size);
+                prev_a_offset = a_offsets[i];
+            }
         }
     }
 


### PR DESCRIPTION
# Proposed changes
Optimize constant empty string compare:
(1) When the constant empy string  '' (size is 0), we can compare offsets in SIMD directly.
 
````
q10: SELECT MobilePhoneModel, COUNT(DISTINCT UserID) AS u FROM hits WHERE MobilePhoneModel <> '' GROUP BY MobilePhoneModel ORDER BY u DESC LIMIT 10;
q11: SELECT MobilePhone, MobilePhoneModel, COUNT(DISTINCT UserID) AS u FROM hits WHERE MobilePhoneModel <> '' GROUP BY MobilePhone, MobilePhoneModel ORDER BY u DESC LIMIT 10;
q12: SELECT SearchPhrase, COUNT(*) AS c FROM hits WHERE SearchPhrase <> '' GROUP BY SearchPhrase ORDER BY c DESC LIMIT 10;
q13: SELECT SearchPhrase, COUNT(DISTINCT UserID) AS u FROM hits WHERE SearchPhrase <> '' GROUP BY SearchPhrase ORDER BY u DESC LIMIT 10;
q14: SELECT SearchEngineID, SearchPhrase, COUNT(*) AS c FROM hits WHERE SearchPhrase <> '' GROUP BY SearchEngineID, SearchPhrase ORDER BY c DESC LIMIT 10;
````

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

