### PR TITLE
[improvement](merge-on-write) remove CHECK if lookup_row_key return unexpected status

### DIFF
--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -2519,7 +2519,8 @@ Status Tablet::calc_delete_bitmap(RowsetId rowset_id,
                 if (specified_rowset_ids != nullptr && !specified_rowset_ids->empty()) {
                     auto st = lookup_row_key(key, specified_rowset_ids, &loc,
                                              dummy_version.first - 1);
-                    CHECK(st.ok() || st.is<NOT_FOUND>() || st.is<ALREADY_EXIST>());
+                    CHECK(st.ok() || st.is<NOT_FOUND>() || st.is<ALREADY_EXIST>())
+                            << "unexpected error status while lookup_row_key:" << st;
                     if (st.is<NOT_FOUND>()) {
                         ++row_id;
                         continue;
@@ -2562,7 +2563,8 @@ Status Tablet::_check_pk_in_pre_segments(
         const Slice& key, DeleteBitmapPtr delete_bitmap, RowLocation* loc) {
     for (auto it = pre_segments.rbegin(); it != pre_segments.rend(); ++it) {
         auto st = (*it)->lookup_row_key(key, loc);
-        CHECK(st.ok() || st.is<NOT_FOUND>() || st.is<ALREADY_EXIST>());
+        CHECK(st.ok() || st.is<NOT_FOUND>() || st.is<ALREADY_EXIST>())
+                << "unexpected error status while lookup_row_key:" << st;
         if (st.is<NOT_FOUND>()) {
             continue;
         } else if (st.ok() && _schema->has_sequence_col() &&

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -2519,9 +2519,9 @@ Status Tablet::calc_delete_bitmap(RowsetId rowset_id,
                 if (specified_rowset_ids != nullptr && !specified_rowset_ids->empty()) {
                     auto st = lookup_row_key(key, specified_rowset_ids, &loc,
                                              dummy_version.first - 1);
-                    bool expect_st = st.ok() || st.is<NOT_FOUND>() || st.is<ALREADY_EXIST>();
-                    DCHECK(expect_st) << "unexpected error status while lookup_row_key:" << st;
-                    if (!expect_st) {
+                    bool expected_st = st.ok() || st.is<NOT_FOUND>() || st.is<ALREADY_EXIST>();
+                    DCHECK(expected_st) << "unexpected error status while lookup_row_key:" << st;
+                    if (!expected_st) {
                         return st;
                     }
                     if (st.is<NOT_FOUND>()) {

--- a/be/src/olap/task/engine_publish_version_task.cpp
+++ b/be/src/olap/task/engine_publish_version_task.cpp
@@ -148,7 +148,7 @@ Status EnginePublishVersionTask::finish() {
             auto submit_st =
                     StorageEngine::instance()->tablet_publish_txn_thread_pool()->submit_func(
                             [=]() { tablet_publish_txn_ptr->handle(); });
-            CHECK(submit_st.ok());
+            CHECK(submit_st.ok()) << submit_st;
         }
     }
     // wait for all publish txn finished


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary
user's BE cored with following message, we'd better just make the related task failed and print detailed error message
```
F0330 17:00:13.161013 20540 tablet.cpp:2078] Check failed: st.ok() || st.is<NOT_FOUND>() || st.is<ALREADY_EXIST>()
Check failure stack trace: ***
@ 0x55df8e07a18d google::LogMessage::Fail()
@ 0x55df8e07c6c9 google::LogMessage::SendToLog()
@ 0x55df8e079cf6 google::LogMessage::Flush()
@ 0x55df8e07cd39 google::LogMessageFatal::~LogMessageFatal()
@ 0x55df887aa795 doris::Tablet::calc_delete_bitmap()
@ 0x55df8873b594 doris::MemTable::_generate_delete_bitmap()
@ 0x55df8873d5db doris::MemTable::flush()
@ 0x55df887383ea doris::FlushToken::_flush_memtable()
@ 0x55df88739f9b doris::MemtableFlushTask::run()
@ 0x55df88ef9e25 doris::ThreadPool::dispatch_thread()
@ 0x55df88eef17f doris::Thread::supervise_thread()
@ 0x7f21022b9ea5 start_thread
@ 0x7f21025ccb0d __clone
@ (nil) (unknown)
Query id: 0-0 ***
Aborted at 1680166813 (unix time) try "date -d @1680166813" if you are using GNU date ***
Current BE git commitID: Unknown ***
SIGABRT unkown detail explain (@0x4d44) received by PID 19780 (TID 0x7f1fa98d6700) from PID 19780; stack trace: ***
0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) at /root/doris/be/src/common/signal_handler.h:420
1# 0x00007F2102504400 in /lib64/libc.so.6
2# gsignal in /lib64/libc.so.6
3# abort in /lib64/libc.so.6
4# 0x000055DF8E084B79 in /opt/apache-doris-1.2.3/be/lib/doris_be
5# 0x000055DF8E07A18D in /opt/apache-doris-1.2.3/be/lib/doris_be
6# google::LogMessage::SendToLog() in /opt/apache-doris-1.2.3/be/lib/doris_be
7# google::LogMessage::Flush() in /opt/apache-doris-1.2.3/be/lib/doris_be
8# google::LogMessageFatal::~LogMessageFatal() in /opt/apache-doris-1.2.3/be/lib/doris_be
9# doris::Tablet::calc_delete_bitmap(doris::RowsetId, std::vector<std::shared_ptr<doris::segment_v2::Segment>, std::allocator<std::shared_ptr<doris::segment_v2::Segment> > > const&, std::unordered_set<doris::RowsetId, doris::HashOfRowsetId, std::equal_to<doris::RowsetId>, std::allocator<doris::RowsetId> > const*, std::shared_ptr<doris::DeleteBitmap>, long, bool) at /root/doris/be/src/olap/tablet.cpp:2106
10# doris::MemTable::_generate_delete_bitmap(long, long) at /var/local/ldb-toolchain/include/c++/11/bits/shared_ptr.h:122
11# doris::MemTable::flush() at /root/doris/be/src/olap/memtable.cpp:462
12# doris::FlushToken::_flush_memtable(doris::MemTable*, long) at /root/doris/be/src/olap/memtable_flush_executor.cpp:94
13# doris::MemtableFlushTask::run() at /root/doris/be/src/olap/memtable_flush_executor.cpp:43
14# doris::ThreadPool::dispatch_thread() at /root/doris/be/src/util/threadpool.cpp:535
15# doris::Thread::supervise_thread(void*) at /root/doris/be/src/util/thread.cpp:455
16# start_thread in /lib64/libpthread.so.0
17# clone in /lib64/libc.so.6
```

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

