### PR TITLE
[fix](memory) Fix memtable flush mem tracker

### DIFF
--- a/be/src/common/daemon.cpp
+++ b/be/src/common/daemon.cpp
@@ -194,8 +194,9 @@ void Daemon::memory_maintenance_thread() {
                 DorisMetrics::instance()->system_metrics()->update_allocator_metrics();
             }
 #endif
+            LOG(INFO) << MemTrackerLimiter::
+                            process_mem_log_str(); // print mem log when memory state by 100M
             if (doris::config::memory_debug) {
-                LOG(INFO) << MemTrackerLimiter::process_mem_log_str();
                 LOG_EVERY_N(INFO, 10)
                         << doris::MemTrackerLimiter::log_process_usage_str("memory debug", false);
             }

--- a/be/src/olap/memtable.cpp
+++ b/be/src/olap/memtable.cpp
@@ -350,7 +350,6 @@ Status MemTable::_generate_delete_bitmap(int64_t atomic_num_segments_before_flus
 }
 
 Status MemTable::flush() {
-    SCOPED_CONSUME_MEM_TRACKER(_flush_mem_tracker);
     VLOG_CRITICAL << "begin to flush memtable for tablet: " << tablet_id()
                   << ", memsize: " << memory_usage() << ", rows: " << _rows;
     int64_t duration_ns = 0;
@@ -372,6 +371,7 @@ Status MemTable::flush() {
 }
 
 Status MemTable::_do_flush(int64_t& duration_ns) {
+    SCOPED_CONSUME_MEM_TRACKER(_flush_mem_tracker);
     SCOPED_RAW_TIMER(&duration_ns);
     _collect_vskiplist_results<true>();
     vectorized::Block block = _output_mutable_block.to_block();


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

In MOV table load, memtable flush will generate delete bitmap, this part of memory will not be counted in memtable flush

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

