### PR TITLE
[improve](nereids)compute statsRange.length() according to the column datatype

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/FilterEstimation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/FilterEstimation.java
@@ -176,7 +176,8 @@ public class FilterEstimation extends ExpressionVisitor<Statistics, EstimationCo
             return estimateLessThanLiteralWithHistogram(leftExpr, statsForLeft, val, context, contains);
         }
         //rightRange.distinctValues should not be used
-        StatisticRange rightRange = new StatisticRange(statsForLeft.minValue, val, statsForLeft.ndv);
+        StatisticRange rightRange = new StatisticRange(statsForLeft.minValue, val, statsForLeft.ndv,
+                leftExpr.getDataType());
         return estimateBinaryComparisonFilter(leftExpr,
                 statsForLeft,
                 rightRange, context);
@@ -189,7 +190,7 @@ public class FilterEstimation extends ExpressionVisitor<Statistics, EstimationCo
         }
         //rightRange.distinctValues should not be used
         StatisticRange rightRange = new StatisticRange(val, statsForLeft.maxValue,
-                statsForLeft.ndv);
+                statsForLeft.ndv, leftExpr.getDataType());
         return estimateBinaryComparisonFilter(leftExpr, statsForLeft, rightRange, context);
     }
 
@@ -360,7 +361,7 @@ public class FilterEstimation extends ExpressionVisitor<Statistics, EstimationCo
     private Statistics estimateBinaryComparisonFilter(Expression leftExpr, ColumnStatistic leftStats,
             StatisticRange rightRange, EstimationContext context) {
         StatisticRange leftRange =
-                new StatisticRange(leftStats.minValue, leftStats.maxValue, leftStats.ndv);
+                new StatisticRange(leftStats.minValue, leftStats.maxValue, leftStats.ndv, leftExpr.getDataType());
         StatisticRange intersectRange = leftRange.cover(rightRange);
         ColumnStatisticBuilder leftColumnStatisticBuilder = new ColumnStatisticBuilder(leftStats)
                 .setMinValue(intersectRange.getLow())
@@ -375,8 +376,8 @@ public class FilterEstimation extends ExpressionVisitor<Statistics, EstimationCo
 
     private Statistics estimateColumnEqualToColumn(Expression leftExpr, ColumnStatistic leftStats,
             Expression rightExpr, ColumnStatistic rightStats, EstimationContext context) {
-        StatisticRange leftRange = StatisticRange.from(leftStats);
-        StatisticRange rightRange = StatisticRange.from(rightStats);
+        StatisticRange leftRange = StatisticRange.from(leftStats, leftExpr.getDataType());
+        StatisticRange rightRange = StatisticRange.from(rightStats, rightExpr.getDataType());
         StatisticRange leftIntersectRight = leftRange.intersect(rightRange);
         StatisticRange rightIntersectLeft = rightRange.intersect(leftIntersectRight);
         ColumnStatisticBuilder leftBuilder = new ColumnStatisticBuilder(leftStats);
@@ -396,8 +397,8 @@ public class FilterEstimation extends ExpressionVisitor<Statistics, EstimationCo
 
     private Statistics estimateColumnLessThanColumn(Expression leftExpr, ColumnStatistic leftStats,
             Expression rightExpr, ColumnStatistic rightStats, EstimationContext context) {
-        StatisticRange leftRange = StatisticRange.from(leftStats);
-        StatisticRange rightRange = StatisticRange.from(rightStats);
+        StatisticRange leftRange = StatisticRange.from(leftStats, leftExpr.getDataType());
+        StatisticRange rightRange = StatisticRange.from(rightStats, rightExpr.getDataType());
         Statistics statistics = null;
         // Left always less than Right
         if (leftRange.getHigh() < rightRange.getLow()) {
@@ -414,7 +415,7 @@ public class FilterEstimation extends ExpressionVisitor<Statistics, EstimationCo
             return context.statistics.withRowCount(0.0);
         }
         StatisticRange leftAlwaysLessThanRightRange = new StatisticRange(leftStats.minValue,
-                rightStats.minValue, Double.NaN);
+                rightStats.minValue, Double.NaN, leftExpr.getDataType());
         double leftAlwaysLessThanRightPercent = 0;
         if (leftRange.getLow() < rightRange.getLow()) {
             leftAlwaysLessThanRightPercent = leftRange.overlapPercentWith(leftAlwaysLessThanRightRange);
@@ -429,7 +430,7 @@ public class FilterEstimation extends ExpressionVisitor<Statistics, EstimationCo
         double rightAlwaysGreaterRangeFraction = 0;
         if (leftRange.getHigh() < rightRange.getHigh()) {
             rightAlwaysGreaterRangeFraction = rightRange.overlapPercentWith(new StatisticRange(leftRange.getHigh(),
-                    rightRange.getHigh(), Double.NaN));
+                    rightRange.getHigh(), Double.NaN, rightExpr.getDataType()));
         }
         ColumnStatistic rightColumnStatistic = new ColumnStatisticBuilder(rightStats)
                 .setMinValue(Math.max(leftRange.getLow(), rightRange.getLow()))

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/DateLiteral.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/DateLiteral.java
@@ -149,6 +149,11 @@ public class DateLiteral extends Literal {
     }
 
     @Override
+    public double getDouble() {
+        return (double) getValue();
+    }
+
+    @Override
     public String getStringValue() {
         return String.format("%04d-%02d-%02d", year, month, day);
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/DateTimeLiteral.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/DateTimeLiteral.java
@@ -248,6 +248,11 @@ public class DateTimeLiteral extends DateLiteral {
     }
 
     @Override
+    public double getDouble() {
+        return (double) getValue();
+    }
+
+    @Override
     public String toSql() {
         return toString();
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/types/DataType.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/types/DataType.java
@@ -587,4 +587,8 @@ public abstract class DataType implements AbstractDataType {
             return (Map) ImmutableMap.copyOf(promotionMap);
         }
     }
+
+    public double length(double high, double low) {
+        return high - low;
+    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/types/DataType.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/types/DataType.java
@@ -588,7 +588,7 @@ public abstract class DataType implements AbstractDataType {
         }
     }
 
-    public double length(double high, double low) {
+    public double rangeLength(double high, double low) {
         return high - low;
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/types/coercion/DateLikeType.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/types/coercion/DateLikeType.java
@@ -38,7 +38,7 @@ public abstract class DateLikeType extends PrimitiveType {
     }
 
     @Override
-    public double length(double high, double low) {
+    public double rangeLength(double high, double low) {
         Calendar to = toCalendar(high);
         Calendar from = toCalendar(low);
         return ChronoUnit.DAYS.between(from.toInstant(), to.toInstant());

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/types/coercion/DateLikeType.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/types/coercion/DateLikeType.java
@@ -17,8 +17,30 @@
 
 package org.apache.doris.nereids.types.coercion;
 
+import java.time.temporal.ChronoUnit;
+import java.util.Calendar;
+
 /**
  * date like type.
  */
 public abstract class DateLikeType extends PrimitiveType {
+    private Calendar toCalendar(double d) {
+        //d = (year * 10000 + month * 100 + day) * 1000000L;
+        int date = (int) (d / 1000000);
+        int day = date % 100;
+        int month = (date / 100) % 100;
+        int year = date / 10000;
+        Calendar calendar = Calendar.getInstance();
+        calendar.set(Calendar.YEAR, year);
+        calendar.set(Calendar.MONDAY, month);
+        calendar.set(Calendar.DAY_OF_MONTH, day);
+        return calendar;
+    }
+
+    @Override
+    public double length(double high, double low) {
+        Calendar to = toCalendar(high);
+        Calendar from = toCalendar(low);
+        return ChronoUnit.DAYS.between(from.toInstant(), to.toInstant());
+    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticRange.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticRange.java
@@ -55,7 +55,7 @@ public class StatisticRange {
             return 1.0;
         }
 
-        double lengthOfIntersect = dataType.length(Math.min(this.high, other.high), Math.max(this.low, other.low));
+        double lengthOfIntersect = dataType.rangeLength(Math.min(this.high, other.high), Math.max(this.low, other.low));
         if (Double.isInfinite(lengthOfIntersect)) {
             if (Double.isFinite(this.distinctValues) && Double.isFinite(other.distinctValues)) {
                 return Math.min(other.distinctValues / this.distinctValues, 1);
@@ -103,7 +103,7 @@ public class StatisticRange {
     }
 
     public double length() {
-        return dataType.length(this.high, this.low);
+        return dataType.rangeLength(this.high, this.low);
     }
 
     public StatisticRange intersect(StatisticRange other) {

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticRange.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticRange.java
@@ -17,6 +17,8 @@
 
 package org.apache.doris.statistics;
 
+import org.apache.doris.nereids.types.DataType;
+
 import java.util.Objects;
 
 public class StatisticRange {
@@ -34,10 +36,13 @@ public class StatisticRange {
 
     private final double distinctValues;
 
-    public StatisticRange(double low, double high, double distinctValues) {
+    private final DataType dataType;
+
+    public StatisticRange(double low, double high, double distinctValues, DataType dataType) {
         this.low = low;
         this.high = high;
         this.distinctValues = distinctValues;
+        this.dataType = dataType;
     }
 
     public double overlapPercentWith(StatisticRange other) {
@@ -50,7 +55,7 @@ public class StatisticRange {
             return 1.0;
         }
 
-        double lengthOfIntersect = Math.min(this.high, other.high) - Math.max(this.low, other.low);
+        double lengthOfIntersect = dataType.length(Math.min(this.high, other.high), Math.max(this.low, other.low));
         if (Double.isInfinite(lengthOfIntersect)) {
             if (Double.isFinite(this.distinctValues) && Double.isFinite(other.distinctValues)) {
                 return Math.min(other.distinctValues / this.distinctValues, 1);
@@ -73,8 +78,8 @@ public class StatisticRange {
         return INFINITE_TO_FINITE_RANGE_INTERSECT_OVERLAP_HEURISTIC_FACTOR;
     }
 
-    public static StatisticRange empty() {
-        return new StatisticRange(Double.NaN, Double.NaN, 0);
+    public static StatisticRange empty(DataType dataType) {
+        return new StatisticRange(Double.NaN, Double.NaN, 0, dataType);
     }
 
     public boolean isEmpty() {
@@ -85,8 +90,8 @@ public class StatisticRange {
         return Double.isInfinite(low) && Double.isInfinite(high);
     }
 
-    public static StatisticRange from(ColumnStatistic column) {
-        return new StatisticRange(column.minValue, column.maxValue, column.ndv);
+    public static StatisticRange from(ColumnStatistic column, DataType dataType) {
+        return new StatisticRange(column.minValue, column.maxValue, column.ndv, dataType);
     }
 
     public double getLow() {
@@ -98,16 +103,16 @@ public class StatisticRange {
     }
 
     public double length() {
-        return this.high - this.low;
+        return dataType.length(this.high, this.low);
     }
 
     public StatisticRange intersect(StatisticRange other) {
         double newLow = Math.max(low, other.low);
         double newHigh = Math.min(high, other.high);
         if (newLow <= newHigh) {
-            return new StatisticRange(newLow, newHigh, overlappingDistinctValues(other));
+            return new StatisticRange(newLow, newHigh, overlappingDistinctValues(other), dataType);
         }
-        return empty();
+        return empty(dataType);
     }
 
     public StatisticRange cover(StatisticRange other) {
@@ -117,9 +122,9 @@ public class StatisticRange {
             double overlapPercentOfLeft = overlapPercentWith(other);
             double overlapDistinctValuesLeft = overlapPercentOfLeft * distinctValues;
             double coveredDistinctValues = minExcludeNaN(distinctValues, overlapDistinctValuesLeft);
-            return new StatisticRange(newLow, newHigh, coveredDistinctValues);
+            return new StatisticRange(newLow, newHigh, coveredDistinctValues, dataType);
         }
-        return empty();
+        return empty(dataType);
     }
 
     public StatisticRange union(StatisticRange other) {
@@ -130,7 +135,7 @@ public class StatisticRange {
         double maxOverlapNDV = Math.max(overlapNDVThis, overlapNDVOther);
         double newNDV = maxOverlapNDV + ((1 - overlapPercentThis) * distinctValues)
                 + ((1 - overlapPercentOther) * other.distinctValues);
-        return new StatisticRange(Math.min(low, other.low), Math.max(high, other.high), newNDV);
+        return new StatisticRange(Math.min(low, other.low), Math.max(high, other.high), newNDV, dataType);
     }
 
     private double overlappingDistinctValues(StatisticRange other) {
@@ -168,7 +173,7 @@ public class StatisticRange {
         return distinctValues;
     }
 
-    public static StatisticRange fromColumnStatistics(ColumnStatistic columnStatistic) {
-        return new StatisticRange(columnStatistic.minValue, columnStatistic.maxValue, columnStatistic.ndv);
+    public static StatisticRange fromColumnStatistics(ColumnStatistic columnStatistic, DataType dataType) {
+        return new StatisticRange(columnStatistic.minValue, columnStatistic.maxValue, columnStatistic.ndv, dataType);
     }
 }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary
we map date/datetime/V2 to double. this map reserves date order, but it does not reserve range length.
For example, from 1990-01-01 to 1991-01-01, there are 12 months. for filter `A < 1990-02-01`, the selectivity 
should be 1/12. 

if we compute this filter by their corresponding double value, 
`sel = (19900201 - 19900101) / (19910101 - 19900101) = 100/10000 = 1/100`

the error is about 10 times.
This pr aims to fix this error.
Describe your changes.

Solution:
convert double to its corresponding dataType(date/datev2), then compute the range length with respect to its datatype.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

