### PR TITLE
[fix](scan) Avoid using incorrect cache code in ComparisonPredicate

### DIFF
--- a/regression-test/suites/schema_change/test_schema_change_with_delete.groovy
+++ b/regression-test/suites/schema_change/test_schema_change_with_delete.groovy
@@ -18,50 +18,50 @@
 // Test schema change for a table, the table has a delete predicate on string column
 suite("test_schema_change_with_delete") {
 
-//    def tbName = "test_schema_change_with_delete"
-//    def getJobState = { tableName ->
-//          def jobStateResult = sql """  SHOW ALTER TABLE COLUMN WHERE IndexName='${tableName}' ORDER BY createtime DESC LIMIT 1 """
-//          return jobStateResult[0][9]
-//     }
-//
-//     sql """ DROP TABLE IF EXISTS ${tbName} FORCE"""
-//     // Create table and disable light weight schema change
-//     sql """
-//            CREATE TABLE IF NOT EXISTS ${tbName}
-//            (
-//                event_day int,
-//                siteid INT ,
-//                citycode int,
-//                username VARCHAR(32) DEFAULT ''
-//            )
-//            DUPLICATE  KEY(event_day,siteid)
-//            DISTRIBUTED BY HASH(event_day) BUCKETS 1
-//            PROPERTIES("replication_num" = "1", "light_schema_change" = "true");
-//         """
-//     sql """ insert into ${tbName} values(1, 1, 1, 'aaa');"""
-//     sql """ insert into ${tbName} values(2, 2, 2, 'bbb');"""
-//     sql """ delete from ${tbName} where username='aaa';"""
-//     sql """ insert into ${tbName} values(3, 3, 3, 'ccc');"""
-//
-//    qt_sql """select * from ${tbName} order by event_day;"""
-//
-//    // Change column type to string
-//    sql """ alter  table ${tbName} modify column citycode string """
-//
-//    int max_try_time = 1000
-//    while(max_try_time--){
-//          String result = getJobState(tbName)
-//          if (result == "FINISHED") {
-//               sleep(3000)
-//               break
-//          } else {
-//               sleep(100)
-//               if (max_try_time < 1){
-//                    assertEquals(1,2)
-//               }
-//          }
-//     }
-//    sql """ insert into ${tbName} values(4, 4, 'efg', 'ddd');"""
-//    qt_sql """select * from ${tbName} order by event_day;"""
-//    sql """ DROP TABLE  ${tbName} force"""
+   def tbName = "test_schema_change_with_delete"
+   def getJobState = { tableName ->
+         def jobStateResult = sql """  SHOW ALTER TABLE COLUMN WHERE IndexName='${tableName}' ORDER BY createtime DESC LIMIT 1 """
+         return jobStateResult[0][9]
+    }
+
+    sql """ DROP TABLE IF EXISTS ${tbName} FORCE"""
+    // Create table and disable light weight schema change
+    sql """
+           CREATE TABLE IF NOT EXISTS ${tbName}
+           (
+               event_day int,
+               siteid INT ,
+               citycode int,
+               username VARCHAR(32) DEFAULT ''
+           )
+           DUPLICATE  KEY(event_day,siteid)
+           DISTRIBUTED BY HASH(event_day) BUCKETS 1
+           PROPERTIES("replication_num" = "1", "light_schema_change" = "true", "disable_auto_compaction" = "true");
+        """
+    sql """ insert into ${tbName} values(1, 1, 1, 'aaa');"""
+    sql """ insert into ${tbName} values(2, 2, 2, 'bbb');"""
+    sql """ delete from ${tbName} where username='aaa';"""
+    sql """ insert into ${tbName} values(3, 3, 3, 'ccc');"""
+
+   qt_sql """select * from ${tbName} order by event_day;"""
+
+   // Change column type to string
+   sql """ alter  table ${tbName} modify column citycode string """
+
+   int max_try_time = 1000
+   while(max_try_time--){
+         String result = getJobState(tbName)
+         if (result == "FINISHED") {
+              sleep(3000)
+              break
+         } else {
+              sleep(100)
+              if (max_try_time < 1){
+                   assertEquals(1,2)
+              }
+         }
+    }
+   sql """ insert into ${tbName} values(4, 4, 'efg', 'ddd');"""
+   qt_sql """select * from ${tbName} order by event_day;"""
+   sql """ DROP TABLE  ${tbName} force"""
 }


### PR DESCRIPTION
# Proposed changes

The cache code for ComparisonPredicate can only be used by predicates that have been newly cloned.

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

