### PR TITLE
[fix](segment_iter) do not init segment_iterator twice

### DIFF
--- a/be/src/olap/rowset/beta_rowset_reader.cpp
+++ b/be/src/olap/rowset/beta_rowset_reader.cpp
@@ -215,11 +215,6 @@ Status BetaRowsetReader::get_segment_iterators(RowsetReaderContext* read_context
         if (iter->empty()) {
             continue;
         }
-        auto st = iter->init(_read_options);
-        if (!st.ok()) {
-            LOG(WARNING) << "failed to init iterator: " << st.to_string();
-            return Status::Error<ROWSET_READER_INIT>();
-        }
         out_iters->push_back(std::move(iter));
     }
 

--- a/be/src/olap/rowset/segment_v2/segment.cpp
+++ b/be/src/olap/rowset/segment_v2/segment.cpp
@@ -158,7 +158,7 @@ Status Segment::new_iterator(const Schema& schema, const StorageReadOptions& rea
     } else {
         iter->reset(new SegmentIterator(this->shared_from_this(), schema));
     }
-    return iter->get()->init(read_options);
+    return Status::OK();
 }
 
 Status Segment::_parse_footer() {

--- a/be/src/olap/rowset/segment_v2/segment.cpp
+++ b/be/src/olap/rowset/segment_v2/segment.cpp
@@ -158,7 +158,8 @@ Status Segment::new_iterator(const Schema& schema, const StorageReadOptions& rea
     } else {
         iter->reset(new SegmentIterator(this->shared_from_this(), schema));
     }
-    return Status::OK();
+
+    return iter->get()->init(read_options);
 }
 
 Status Segment::_parse_footer() {

--- a/be/test/olap/delta_writer_test.cpp
+++ b/be/test/olap/delta_writer_test.cpp
@@ -691,8 +691,6 @@ TEST_F(TestDeltaWriter, vec_sequence_col) {
     Schema schema(rowset->tablet_schema());
     auto s = segments[0]->new_iterator(schema, opts, &iter);
     ASSERT_TRUE(s.ok());
-    s = segments[0]->init(opts);
-    ASSERT_TRUE(s.ok());
     auto read_block = rowset->tablet_schema()->create_block();
     res = iter->next_batch(&read_block);
     ASSERT_TRUE(res.ok());

--- a/be/test/olap/delta_writer_test.cpp
+++ b/be/test/olap/delta_writer_test.cpp
@@ -689,7 +689,10 @@ TEST_F(TestDeltaWriter, vec_sequence_col) {
 
     std::unique_ptr<RowwiseIterator> iter;
     Schema schema(rowset->tablet_schema());
-    segments[0]->new_iterator(schema, opts, &iter);
+    auto s = segments[0]->new_iterator(schema, opts, &iter);
+    ASSERT_TRUE(s.ok());
+    s = segments[0]->init(opts);
+    ASSERT_TRUE(s.ok());
     auto read_block = rowset->tablet_schema()->create_block();
     res = iter->next_batch(&read_block);
     ASSERT_TRUE(res.ok());


### PR DESCRIPTION
Initing segment_iterator twice would duplicate predicates and we should not use like this.

# Proposed changes

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

