### PR TITLE
[fix](file_cache) turn on file cache by FE session variable

### DIFF
--- a/be/src/io/file_factory.h
+++ b/be/src/io/file_factory.h
@@ -45,6 +45,8 @@ struct FileDescription {
 
 class FileFactory {
 public:
+    static io::FileCachePolicy get_cache_policy(RuntimeState* state);
+
     /// Create FileWriter
     static Status create_file_writer(TFileType::type type, ExecEnv* env,
                                      const std::vector<TNetworkAddress>& broker_addresses,
@@ -53,11 +55,11 @@ public:
                                      std::unique_ptr<io::FileWriter>& file_writer);
 
     /// Create FileReader
-    static Status create_file_reader(RuntimeProfile* profile,
-                                     const FileSystemProperties& system_properties,
-                                     const FileDescription& file_description,
-                                     std::shared_ptr<io::FileSystem>* file_system,
-                                     io::FileReaderSPtr* file_reader);
+    static Status create_file_reader(
+            RuntimeProfile* profile, const FileSystemProperties& system_properties,
+            const FileDescription& file_description, std::shared_ptr<io::FileSystem>* file_system,
+            io::FileReaderSPtr* file_reader,
+            io::FileCachePolicy cache_policy = io::FileCachePolicy::NO_CACHE);
 
     // Create FileReader for stream load pipe
     static Status create_pipe_reader(const TUniqueId& load_id, io::FileReaderSPtr* file_reader);

--- a/be/src/io/fs/buffered_reader.h
+++ b/be/src/io/fs/buffered_reader.h
@@ -156,11 +156,12 @@ public:
      * @param offset start offset ot read in stream
      * @param bytes_to_read bytes to read
      */
-    virtual Status read_bytes(const uint8_t** buf, uint64_t offset, const size_t bytes_to_read) = 0;
+    virtual Status read_bytes(const uint8_t** buf, uint64_t offset, const size_t bytes_to_read,
+                              const IOContext* io_ctx) = 0;
     /**
      * Save the data address to slice.data, and the slice.size is the bytes to read.
      */
-    virtual Status read_bytes(Slice& slice, uint64_t offset) = 0;
+    virtual Status read_bytes(Slice& slice, uint64_t offset, const IOContext* io_ctx) = 0;
     Statistics& statistics() { return _statistics; }
     virtual ~BufferedStreamReader() = default;
     // return the file path
@@ -176,8 +177,9 @@ public:
                              size_t max_buf_size);
     ~BufferedFileStreamReader() override = default;
 
-    Status read_bytes(const uint8_t** buf, uint64_t offset, const size_t bytes_to_read) override;
-    Status read_bytes(Slice& slice, uint64_t offset) override;
+    Status read_bytes(const uint8_t** buf, uint64_t offset, const size_t bytes_to_read,
+                      const IOContext* io_ctx) override;
+    Status read_bytes(Slice& slice, uint64_t offset, const IOContext* io_ctx) override;
     std::string path() override { return _file->path(); }
 
 private:

--- a/be/src/io/io_common.h
+++ b/be/src/io/io_common.h
@@ -55,15 +55,13 @@ public:
               is_persistent(is_presistent_),
               use_disposable_cache(use_disposable_cache_),
               read_segment_index(read_segment_index_),
-              file_cache_stats(stats_),
-              enable_file_cache(enable_file_cache) {}
+              file_cache_stats(stats_) {}
     ReaderType reader_type;
     const TUniqueId* query_id = nullptr;
     bool is_persistent = false;
     bool use_disposable_cache = false;
     bool read_segment_index = false;
     FileCacheStatistics* file_cache_stats = nullptr;
-    bool enable_file_cache = true;
 };
 
 } // namespace io

--- a/be/src/vec/exec/format/csv/csv_reader.cpp
+++ b/be/src/vec/exec/format/csv/csv_reader.cpp
@@ -142,8 +142,10 @@ Status CsvReader::init_reader(bool is_load) {
     if (_params.file_type == TFileType::FILE_STREAM) {
         RETURN_IF_ERROR(FileFactory::create_pipe_reader(_range.load_id, &csv_file_reader));
     } else {
-        RETURN_IF_ERROR(FileFactory::create_file_reader(
-                _profile, _system_properties, _file_description, &_file_system, &csv_file_reader));
+        io::FileCachePolicy cache_policy = FileFactory::get_cache_policy(_state);
+        RETURN_IF_ERROR(FileFactory::create_file_reader(_profile, _system_properties,
+                                                        _file_description, &_file_system,
+                                                        &_file_reader, cache_policy));
     }
     if (typeid_cast<io::S3FileReader*>(csv_file_reader.get()) != nullptr ||
         typeid_cast<io::BrokerFileReader*>(csv_file_reader.get()) != nullptr) {
@@ -634,9 +636,9 @@ Status CsvReader::_prepare_parse(size_t* read_line, bool* is_parse_name) {
     }
 
     _file_description.start_offset = start_offset;
-
+    io::FileCachePolicy cache_policy = FileFactory::get_cache_policy(_state);
     RETURN_IF_ERROR(FileFactory::create_file_reader(_profile, _system_properties, _file_description,
-                                                    &_file_system, &_file_reader));
+                                                    &_file_system, &_file_reader, cache_policy));
     if (_file_reader->size() == 0 && _params.file_type != TFileType::FILE_STREAM &&
         _params.file_type != TFileType::FILE_BROKER) {
         return Status::EndOfFile("get parsed schema failed, empty csv file: " + _range.path);

--- a/be/src/vec/exec/format/json/new_json_reader.cpp
+++ b/be/src/vec/exec/format/json/new_json_reader.cpp
@@ -339,8 +339,10 @@ Status NewJsonReader::_open_file_reader() {
     if (_params.file_type == TFileType::FILE_STREAM) {
         RETURN_IF_ERROR(FileFactory::create_pipe_reader(_range.load_id, &json_file_reader));
     } else {
-        RETURN_IF_ERROR(FileFactory::create_file_reader(
-                _profile, _system_properties, _file_description, &_file_system, &json_file_reader));
+        io::FileCachePolicy cache_policy = FileFactory::get_cache_policy(_state);
+        RETURN_IF_ERROR(FileFactory::create_file_reader(_profile, _system_properties,
+                                                        _file_description, &_file_system,
+                                                        &_file_reader, cache_policy));
     }
     if (typeid_cast<io::S3FileReader*>(json_file_reader.get()) != nullptr ||
         typeid_cast<io::BrokerFileReader*>(json_file_reader.get()) != nullptr) {

--- a/be/src/vec/exec/format/orc/vorc_reader.h
+++ b/be/src/vec/exec/format/orc/vorc_reader.h
@@ -45,7 +45,7 @@ public:
         int64_t decode_null_map_time = 0;
     };
 
-    OrcReader(RuntimeProfile* profile, const TFileScanRangeParams& params,
+    OrcReader(RuntimeProfile* profile, RuntimeState* state, const TFileScanRangeParams& params,
               const TFileRangeDesc& range, const std::vector<std::string>& column_names,
               size_t batch_size, const std::string& ctz, io::IOContext* io_ctx);
 
@@ -248,6 +248,7 @@ private:
 
 private:
     RuntimeProfile* _profile;
+    RuntimeState* _state;
     const TFileScanRangeParams& _scan_params;
     const TFileRangeDesc& _scan_range;
     FileSystemProperties _system_properties;

--- a/be/src/vec/exec/format/parquet/parquet_thrift_util.h
+++ b/be/src/vec/exec/format/parquet/parquet_thrift_util.h
@@ -35,12 +35,13 @@ namespace doris::vectorized {
 constexpr uint8_t PARQUET_VERSION_NUMBER[4] = {'P', 'A', 'R', '1'};
 constexpr uint32_t PARQUET_FOOTER_SIZE = 8;
 
-static Status parse_thrift_footer(io::FileReaderSPtr file, FileMetaData** file_metadata) {
+static Status parse_thrift_footer(io::FileReaderSPtr file, FileMetaData** file_metadata,
+                                  size_t* meta_size, io::IOContext* io_ctx) {
     uint8_t footer[PARQUET_FOOTER_SIZE];
     int64_t file_size = file->size();
     size_t bytes_read = 0;
     Slice result(footer, PARQUET_FOOTER_SIZE);
-    RETURN_IF_ERROR(file->read_at(file_size - PARQUET_FOOTER_SIZE, result, &bytes_read));
+    RETURN_IF_ERROR(file->read_at(file_size - PARQUET_FOOTER_SIZE, result, &bytes_read, io_ctx));
     DCHECK_EQ(bytes_read, PARQUET_FOOTER_SIZE);
 
     // validate magic
@@ -60,12 +61,13 @@ static Status parse_thrift_footer(io::FileReaderSPtr file, FileMetaData** file_m
     // deserialize footer
     std::unique_ptr<uint8_t[]> meta_buff(new uint8_t[metadata_size]);
     Slice res(meta_buff.get(), metadata_size);
-    RETURN_IF_ERROR(
-            file->read_at(file_size - PARQUET_FOOTER_SIZE - metadata_size, res, &bytes_read));
+    RETURN_IF_ERROR(file->read_at(file_size - PARQUET_FOOTER_SIZE - metadata_size, res, &bytes_read,
+                                  io_ctx));
     DCHECK_EQ(bytes_read, metadata_size);
     RETURN_IF_ERROR(deserialize_thrift_msg(meta_buff.get(), &metadata_size, true, &t_metadata));
     *file_metadata = new FileMetaData(t_metadata);
     RETURN_IF_ERROR((*file_metadata)->init_schema());
+    *meta_size = PARQUET_FOOTER_SIZE + metadata_size;
     return Status::OK();
 }
 } // namespace doris::vectorized

--- a/be/src/vec/exec/format/parquet/vparquet_column_chunk_reader.h
+++ b/be/src/vec/exec/format/parquet/vparquet_column_chunk_reader.h
@@ -65,7 +65,7 @@ public:
     };
 
     ColumnChunkReader(io::BufferedStreamReader* reader, tparquet::ColumnChunk* column_chunk,
-                      FieldSchema* field_schema, cctz::time_zone* ctz);
+                      FieldSchema* field_schema, cctz::time_zone* ctz, io::IOContext* io_ctx);
     ~ColumnChunkReader() = default;
 
     // Initialize chunk reader, will generate the decoder and codec.
@@ -175,6 +175,7 @@ private:
     io::BufferedStreamReader* _stream_reader;
     tparquet::ColumnMetaData _metadata;
     cctz::time_zone* _ctz;
+    io::IOContext* _io_ctx;
 
     std::unique_ptr<PageReader> _page_reader = nullptr;
     BlockCompressionCodec* _block_compress_codec = nullptr;

--- a/be/src/vec/exec/format/parquet/vparquet_group_reader.cpp
+++ b/be/src/vec/exec/format/parquet/vparquet_group_reader.cpp
@@ -34,7 +34,7 @@ const std::vector<int64_t> RowGroupReader::NO_DELETE = {};
 RowGroupReader::RowGroupReader(io::FileReaderSPtr file_reader,
                                const std::vector<ParquetReadColumn>& read_columns,
                                const int32_t row_group_id, const tparquet::RowGroup& row_group,
-                               cctz::time_zone* ctz,
+                               cctz::time_zone* ctz, io::IOContext* io_ctx,
                                const PositionDeleteContext& position_delete_ctx,
                                const LazyReadContext& lazy_read_ctx, RuntimeState* state)
         : _file_reader(file_reader),
@@ -43,6 +43,7 @@ RowGroupReader::RowGroupReader(io::FileReaderSPtr file_reader,
           _row_group_meta(row_group),
           _remaining_rows(row_group.num_rows),
           _ctz(ctz),
+          _io_ctx(io_ctx),
           _position_delete_ctx(position_delete_ctx),
           _lazy_read_ctx(lazy_read_ctx),
           _state(state),
@@ -85,7 +86,8 @@ Status RowGroupReader::init(
         auto field = const_cast<FieldSchema*>(schema.get_column(read_col._file_slot_name));
         std::unique_ptr<ParquetColumnReader> reader;
         RETURN_IF_ERROR(ParquetColumnReader::create(_file_reader, field, _row_group_meta,
-                                                    _read_ranges, _ctz, reader, max_buf_size));
+                                                    _read_ranges, _ctz, _io_ctx, reader,
+                                                    max_buf_size));
         auto col_iter = col_offsets.find(read_col._parquet_col_id);
         if (col_iter != col_offsets.end()) {
             tparquet::OffsetIndex oi = col_iter->second;

--- a/be/src/vec/exec/format/parquet/vparquet_group_reader.h
+++ b/be/src/vec/exec/format/parquet/vparquet_group_reader.h
@@ -107,7 +107,7 @@ public:
 
     RowGroupReader(io::FileReaderSPtr file_reader,
                    const std::vector<ParquetReadColumn>& read_columns, const int32_t row_group_id,
-                   const tparquet::RowGroup& row_group, cctz::time_zone* ctz,
+                   const tparquet::RowGroup& row_group, cctz::time_zone* ctz, io::IOContext* io_ctx,
                    const PositionDeleteContext& position_delete_ctx,
                    const LazyReadContext& lazy_read_ctx, RuntimeState* state);
 
@@ -167,6 +167,7 @@ private:
     const tparquet::RowGroup& _row_group_meta;
     int64_t _remaining_rows;
     cctz::time_zone* _ctz;
+    io::IOContext* _io_ctx;
     PositionDeleteContext _position_delete_ctx;
     // merge the row ranges generated from page index and position delete.
     std::vector<RowRange> _read_ranges;

--- a/be/src/vec/exec/format/parquet/vparquet_page_reader.cpp
+++ b/be/src/vec/exec/format/parquet/vparquet_page_reader.cpp
@@ -26,8 +26,9 @@ namespace doris::vectorized {
 
 static constexpr size_t INIT_PAGE_HEADER_SIZE = 128;
 
-PageReader::PageReader(io::BufferedStreamReader* reader, uint64_t offset, uint64_t length)
-        : _reader(reader), _start_offset(offset), _end_offset(offset + length) {}
+PageReader::PageReader(io::BufferedStreamReader* reader, io::IOContext* io_ctx, uint64_t offset,
+                       uint64_t length)
+        : _reader(reader), _io_ctx(io_ctx), _start_offset(offset), _end_offset(offset + length) {}
 
 Status PageReader::next_page_header() {
     if (UNLIKELY(_offset < _start_offset || _offset >= _end_offset)) {
@@ -47,7 +48,7 @@ Status PageReader::next_page_header() {
     uint32_t real_header_size = 0;
     while (true) {
         header_size = std::min(header_size, max_size);
-        RETURN_IF_ERROR(_reader->read_bytes(&page_header_buf, _offset, header_size));
+        RETURN_IF_ERROR(_reader->read_bytes(&page_header_buf, _offset, header_size, _io_ctx));
         real_header_size = header_size;
         SCOPED_RAW_TIMER(&_statistics.decode_header_time);
         auto st =
@@ -87,7 +88,7 @@ Status PageReader::get_page_data(Slice& slice) {
     } else {
         slice.size = _cur_page_header.compressed_page_size;
     }
-    RETURN_IF_ERROR(_reader->read_bytes(slice, _offset));
+    RETURN_IF_ERROR(_reader->read_bytes(slice, _offset, _io_ctx));
     _offset += slice.size;
     _state = INITIALIZED;
     return Status::OK();

--- a/be/src/vec/exec/format/parquet/vparquet_page_reader.h
+++ b/be/src/vec/exec/format/parquet/vparquet_page_reader.h
@@ -32,7 +32,8 @@ public:
         int64_t decode_header_time = 0;
     };
 
-    PageReader(io::BufferedStreamReader* reader, uint64_t offset, uint64_t length);
+    PageReader(io::BufferedStreamReader* reader, io::IOContext* io_ctx, uint64_t offset,
+               uint64_t length);
     ~PageReader() = default;
 
     bool has_next_page() const { return _offset < _end_offset; }
@@ -57,6 +58,7 @@ private:
     enum PageReaderState { INITIALIZED, HEADER_PARSED };
 
     io::BufferedStreamReader* _reader;
+    io::IOContext* _io_ctx;
     tparquet::PageHeader _cur_page_header;
     Statistics _statistics;
     PageReaderState _state = INITIALIZED;

--- a/be/src/vec/exec/format/parquet/vparquet_reader.cpp
+++ b/be/src/vec/exec/format/parquet/vparquet_reader.cpp
@@ -170,23 +170,27 @@ Status ParquetReader::_open_file() {
     if (_file_reader == nullptr) {
         SCOPED_RAW_TIMER(&_statistics.open_file_time);
         ++_statistics.open_file_num;
-        RETURN_IF_ERROR(FileFactory::create_file_reader(
-                _profile, _system_properties, _file_description, &_file_system, &_file_reader));
+        io::FileCachePolicy cache_policy = FileFactory::get_cache_policy(_state);
+        RETURN_IF_ERROR(FileFactory::create_file_reader(_profile, _system_properties,
+                                                        _file_description, &_file_system,
+                                                        &_file_reader, cache_policy));
     }
     if (_file_metadata == nullptr) {
         SCOPED_RAW_TIMER(&_statistics.parse_footer_time);
         if (_file_reader->size() == 0) {
             return Status::EndOfFile("open file failed, empty parquet file: " + _scan_range.path);
         }
+        size_t meta_size = 0;
         if (_kv_cache == nullptr) {
             _is_file_metadata_owned = true;
-            RETURN_IF_ERROR(parse_thrift_footer(_file_reader, &_file_metadata));
+            RETURN_IF_ERROR(
+                    parse_thrift_footer(_file_reader, &_file_metadata, &meta_size, _io_ctx));
         } else {
             _is_file_metadata_owned = false;
             _file_metadata = _kv_cache->get<FileMetaData>(
                     _meta_cache_key(_file_reader->path()), [&]() -> FileMetaData* {
                         FileMetaData* meta;
-                        Status st = parse_thrift_footer(_file_reader, &meta);
+                        Status st = parse_thrift_footer(_file_reader, &meta, &meta_size, _io_ctx);
                         if (!st) {
                             LOG(INFO) << "failed to parse parquet footer for "
                                       << _file_description.path << ", err: " << st;
@@ -200,6 +204,8 @@ Status ParquetReader::_open_file() {
             return Status::InternalError("failed to get file meta data: {}",
                                          _file_description.path);
         }
+        _column_statistics.read_bytes += meta_size;
+        _column_statistics.read_calls += 2;
     }
     return Status::OK();
 }
@@ -519,9 +525,9 @@ Status ParquetReader::_next_row_group_reader() {
 
     RowGroupReader::PositionDeleteContext position_delete_ctx =
             _get_position_delete_ctx(row_group, row_group_index);
-    _current_group_reader.reset(new RowGroupReader(_file_reader, _read_columns,
-                                                   row_group_index.row_group_id, row_group, _ctz,
-                                                   position_delete_ctx, _lazy_read_ctx, _state));
+    _current_group_reader.reset(
+            new RowGroupReader(_file_reader, _read_columns, row_group_index.row_group_id, row_group,
+                               _ctz, _io_ctx, position_delete_ctx, _lazy_read_ctx, _state));
     _row_group_eof = false;
     return _current_group_reader->init(_file_metadata->schema(), candidate_row_ranges, _col_offsets,
                                        _tuple_descriptor, _row_descriptor, _colname_to_slot_id,
@@ -617,12 +623,15 @@ Status ParquetReader::_process_page_index(const tparquet::RowGroup& row_group,
     Slice result(col_index_buff, page_index._column_index_size);
     RETURN_IF_ERROR(
             _file_reader->read_at(page_index._column_index_start, result, &bytes_read, _io_ctx));
+    _column_statistics.read_bytes += bytes_read;
     auto& schema_desc = _file_metadata->schema();
     std::vector<RowRange> skipped_row_ranges;
     uint8_t off_index_buff[page_index._offset_index_size];
     Slice res(off_index_buff, page_index._offset_index_size);
     RETURN_IF_ERROR(
             _file_reader->read_at(page_index._offset_index_start, res, &bytes_read, _io_ctx));
+    _column_statistics.read_bytes += bytes_read;
+    _column_statistics.read_calls += 2;
     for (auto& read_col : _read_columns) {
         auto conjunct_iter = _colname_to_value_range->find(read_col._file_slot_name);
         if (_colname_to_value_range->end() == conjunct_iter) {

--- a/be/src/vec/exec/scan/vfile_scanner.cpp
+++ b/be/src/vec/exec/scan/vfile_scanner.cpp
@@ -81,7 +81,6 @@ Status VFileScanner::prepare(
     _io_ctx.reset(new io::IOContext());
     _io_ctx->file_cache_stats = _file_cache_statistics.get();
     _io_ctx->query_id = &_state->query_id();
-    _io_ctx->enable_file_cache = _state->query_options().enable_file_cache;
 
     if (_is_load) {
         _src_row_desc.reset(new RowDescriptor(_state->desc_tbl(),
@@ -566,7 +565,7 @@ Status VFileScanner::_get_next_reader() {
             break;
         }
         case TFileFormatType::FORMAT_ORC: {
-            _cur_reader.reset(new OrcReader(_profile, _params, range, _file_col_names,
+            _cur_reader.reset(new OrcReader(_profile, _state, _params, range, _file_col_names,
                                             _state->query_options().batch_size, _state->timezone(),
                                             _io_ctx.get()));
             init_status = ((OrcReader*)(_cur_reader.get()))->init_reader(_colname_to_value_range);
@@ -832,7 +831,7 @@ Status VFileScanner::close(RuntimeState* state) {
         }
     }
 
-    if (config::enable_file_cache) {
+    if (config::enable_file_cache && _state->query_options().enable_file_cache) {
         io::FileCacheProfileReporter cache_profile(_profile);
         cache_profile.update(_file_cache_statistics.get());
     }

--- a/be/src/vec/exec/varrow_scanner.cpp
+++ b/be/src/vec/exec/varrow_scanner.cpp
@@ -80,9 +80,10 @@ Status VArrowScanner::_open_next_reader() {
         io::FileReaderSPtr file_reader;
         _init_system_properties(range);
         _init_file_description(range);
-        // no use
-        RETURN_IF_ERROR(FileFactory::create_file_reader(
-                _profile, _system_properties, _file_description, &_file_system, &file_reader));
+        io::FileCachePolicy cache_policy = FileFactory::get_cache_policy(_state);
+        RETURN_IF_ERROR(FileFactory::create_file_reader(_profile, _system_properties,
+                                                        _file_description, &_file_system,
+                                                        &file_reader, cache_policy));
 
         if (file_reader->size() == 0) {
             continue;

--- a/be/test/vec/exec/parquet/parquet_thrift_test.cpp
+++ b/be/test/vec/exec/parquet/parquet_thrift_test.cpp
@@ -55,7 +55,8 @@ TEST_F(ParquetThriftReaderTest, normal) {
     EXPECT_TRUE(st.ok());
 
     FileMetaData* meta_data;
-    parse_thrift_footer(reader, &meta_data);
+    size_t meta_size;
+    parse_thrift_footer(reader, &meta_data, &meta_size, nullptr);
     tparquet::FileMetaData t_metadata = meta_data->to_thrift();
 
     LOG(WARNING) << "=====================================";
@@ -88,7 +89,8 @@ TEST_F(ParquetThriftReaderTest, complex_nested_file) {
     EXPECT_TRUE(st.ok());
 
     FileMetaData* metadata;
-    parse_thrift_footer(reader, &metadata);
+    size_t meta_size;
+    parse_thrift_footer(reader, &metadata, &meta_size, nullptr);
     tparquet::FileMetaData t_metadata = metadata->to_thrift();
     FieldDescriptor schemaDescriptor;
     schemaDescriptor.parse_from_thrift(t_metadata.schema);
@@ -164,7 +166,7 @@ static Status get_column_values(io::FileReaderSPtr file_reader, tparquet::Column
 
     cctz::time_zone ctz;
     TimezoneUtils::find_cctz_time_zone(TimezoneUtils::default_time_zone, ctz);
-    ColumnChunkReader chunk_reader(&stream_reader, column_chunk, field_schema, &ctz);
+    ColumnChunkReader chunk_reader(&stream_reader, column_chunk, field_schema, &ctz, nullptr);
     // initialize chunk reader
     chunk_reader.init();
     // seek to next page header
@@ -361,7 +363,8 @@ static void read_parquet_data_and_check(const std::string& parquet_file,
     std::unique_ptr<vectorized::Block> block;
     create_block(block);
     FileMetaData* metadata;
-    parse_thrift_footer(reader, &metadata);
+    size_t meta_size;
+    parse_thrift_footer(reader, &metadata, &meta_size, nullptr);
     tparquet::FileMetaData t_metadata = metadata->to_thrift();
     FieldDescriptor schema_descriptor;
     schema_descriptor.parse_from_thrift(t_metadata.schema);
@@ -482,7 +485,8 @@ TEST_F(ParquetThriftReaderTest, group_reader) {
 
     // prepare metadata
     FileMetaData* meta_data;
-    parse_thrift_footer(file_reader, &meta_data);
+    size_t meta_size;
+    parse_thrift_footer(file_reader, &meta_data, &meta_size, nullptr);
     tparquet::FileMetaData t_metadata = meta_data->to_thrift();
 
     cctz::time_zone ctz;
@@ -491,7 +495,8 @@ TEST_F(ParquetThriftReaderTest, group_reader) {
     std::shared_ptr<RowGroupReader> row_group_reader;
     RowGroupReader::PositionDeleteContext position_delete_ctx(row_group.num_rows, 0);
     row_group_reader.reset(new RowGroupReader(file_reader, read_columns, 0, row_group, &ctz,
-                                              position_delete_ctx, lazy_read_ctx, nullptr));
+                                              nullptr, position_delete_ctx, lazy_read_ctx,
+                                              nullptr));
     std::vector<RowRange> row_ranges;
     row_ranges.emplace_back(0, row_group.num_rows);
 


### PR DESCRIPTION
# Proposed changes

Fix tow bugs:
1. Enabling file caching requires both `FE session` and `BE` configurations(enable_file_cache=true) to be enabled.
2. `ParquetReader` has not used `IOContext` previously, but `CachedRemoteFileReader::read_at` needs `IOContext` after PR(https://github.com/apache/doris/pull/17586).

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

