### PR TITLE
[fix](planner) enable fallback to legacy planner when execute internal query

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVTaskProcessor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVTaskProcessor.java
@@ -119,6 +119,7 @@ public class MTMVTaskProcessor {
         ctx.setThreadLocalInfo();
         ctx.getState().reset();
         try {
+            ctx.getSessionVariable().disableNereidsPlannerOnce();
             StmtExecutor executor = new StmtExecutor(ctx, sql);
             ctx.setExecutor(executor);
             executor.execute();

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/pre/EliminateLogicalSelectHint.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/pre/EliminateLogicalSelectHint.java
@@ -76,13 +76,10 @@ public class EliminateLogicalSelectHint extends PlanPreprocessor {
         // enable_fallback_to_original_planner=true and revert it after executing.
         // throw exception to fall back to original planner
         if (!sessionVariable.isEnableNereidsPlanner()) {
-            String key = SessionVariable.ENABLE_FALLBACK_TO_ORIGINAL_PLANNER;
-            Optional<String> value = Optional.of("true");
             try {
-                VariableMgr.setVar(sessionVariable, new SetVar(key, new StringLiteral(value.get())));
+                sessionVariable.enableFallbackToOriginalPlannerOnce();
             } catch (Throwable t) {
-                throw new AnalysisException("Can not set session variable '"
-                        + key + "' = '" + value.get() + "'", t);
+                throw new AnalysisException("failed to set fallback to original planner to true", t);
             }
             throw new AnalysisException("The nereids is disabled in this sql, fallback to original planner");
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -17,7 +17,10 @@
 
 package org.apache.doris.qe;
 
+import org.apache.doris.analysis.SetVar;
+import org.apache.doris.analysis.StringLiteral;
 import org.apache.doris.common.Config;
+import org.apache.doris.common.DdlException;
 import org.apache.doris.common.io.Text;
 import org.apache.doris.common.io.Writable;
 import org.apache.doris.common.util.TimeUtils;
@@ -1908,5 +1911,23 @@ public class SessionVariable implements Serializable, Writable {
 
     public void setDumpNereidsMemo(boolean dumpNereidsMemo) {
         this.dumpNereidsMemo = dumpNereidsMemo;
+    }
+
+    public void enableFallbackToOriginalPlannerOnce() throws DdlException {
+        if (enableFallbackToOriginalPlanner) {
+            return;
+        }
+        setIsSingleSetVar(true);
+        VariableMgr.setVar(this,
+                new SetVar(SessionVariable.ENABLE_FALLBACK_TO_ORIGINAL_PLANNER, new StringLiteral("true")));
+    }
+
+    public void disableNereidsPlannerOnce() throws DdlException {
+        if (!enableNereidsPlanner) {
+            return;
+        }
+        setIsSingleSetVar(true);
+        VariableMgr.setVar(this,
+                new SetVar(SessionVariable.ENABLE_NEREIDS_PLANNER, new StringLiteral("false")));
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/HistogramTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/HistogramTask.java
@@ -104,6 +104,7 @@ public class HistogramTask extends BaseAnalysisTask {
         LOG.info("SQL to collect the histogram:\n {}", histogramSql);
 
         try (AutoCloseConnectContext r = StatisticsUtil.buildConnectContext()) {
+            r.connectContext.getSessionVariable().disableNereidsPlannerOnce();
             this.stmtExecutor = new StmtExecutor(r.connectContext, histogramSql);
             this.stmtExecutor.execute();
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/HiveAnalysisTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/HiveAnalysisTask.java
@@ -100,6 +100,7 @@ public class HiveAnalysisTask extends HMSAnalysisTask {
         StringSubstitutor stringSubstitutor = new StringSubstitutor(params);
         String sql = stringSubstitutor.replace(ANALYZE_TABLE_SQL_TEMPLATE);
         try (AutoCloseConnectContext r = StatisticsUtil.buildConnectContext()) {
+            r.connectContext.getSessionVariable().disableNereidsPlannerOnce();
             this.stmtExecutor = new StmtExecutor(r.connectContext, sql);
             this.stmtExecutor.execute();
         }
@@ -136,6 +137,7 @@ public class HiveAnalysisTask extends HMSAnalysisTask {
         // Update partition level stats for this column.
         for (String partitionSql : partitionAnalysisSQLs) {
             try (AutoCloseConnectContext r = StatisticsUtil.buildConnectContext()) {
+                r.connectContext.getSessionVariable().disableNereidsPlannerOnce();
                 this.stmtExecutor = new StmtExecutor(r.connectContext, partitionSql);
                 this.stmtExecutor.execute();
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/IcebergAnalysisTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/IcebergAnalysisTask.java
@@ -114,6 +114,7 @@ public class IcebergAnalysisTask extends HMSAnalysisTask {
         StringSubstitutor stringSubstitutor = new StringSubstitutor(params);
         String sql = stringSubstitutor.replace(INSERT_TABLE_SQL_TEMPLATE);
         try (AutoCloseConnectContext r = StatisticsUtil.buildConnectContext()) {
+            r.connectContext.getSessionVariable().disableNereidsPlannerOnce();
             this.stmtExecutor = new StmtExecutor(r.connectContext, sql);
             this.stmtExecutor.execute();
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/OlapAnalysisTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/OlapAnalysisTask.java
@@ -107,6 +107,7 @@ public class OlapAnalysisTask extends BaseAnalysisTask {
     @VisibleForTesting
     public void execSQL(String sql) throws Exception {
         try (AutoCloseConnectContext r = StatisticsUtil.buildConnectContext()) {
+            r.connectContext.getSessionVariable().disableNereidsPlannerOnce();
             this.stmtExecutor = new StmtExecutor(r.connectContext, sql);
             this.stmtExecutor.execute();
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/util/StatisticsUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/util/StatisticsUtil.java
@@ -92,6 +92,7 @@ public class StatisticsUtil {
 
     public static void execUpdate(String sql) throws Exception {
         try (AutoCloseConnectContext r = StatisticsUtil.buildConnectContext()) {
+            r.connectContext.getSessionVariable().disableNereidsPlannerOnce();
             StmtExecutor stmtExecutor = new StmtExecutor(r.connectContext, sql);
             r.connectContext.setExecutor(stmtExecutor);
             stmtExecutor.execute();


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

