### PR TITLE
[Improvement](multi catalog)Move split size config to session variable.

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -1736,18 +1736,6 @@ public class Config extends ConfigBase {
     @ConfField(mutable = false, masterOnly = true)
     public static int backend_rpc_timeout_ms = 60000; // 1 min
 
-    @ConfField(mutable = true, masterOnly = false)
-    public static long file_scan_node_split_size = 256 * 1024 * 1024; // 256mb
-
-    @ConfField(mutable = true, masterOnly = false)
-    public static long file_scan_node_split_num = 128;
-
-    // 0 means use the block size in HDFS/S3 as split size.
-    // HDFS block size is 128MB, while S3 block size is 32MB.
-    // 32MB is too small for a S3 file split, so set 128MB as default split size.
-    @ConfField(mutable = true, masterOnly = false)
-    public static long file_split_size = 134217728;
-
     /**
      * If set to TRUE, FE will:
      * 1. divide BE into high load and low load(no mid load) to force triggering tablet scheduling;

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/Splitter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/Splitter.java
@@ -23,7 +23,7 @@ import org.apache.doris.common.UserException;
 import java.util.List;
 
 public interface Splitter {
-    static final long DEFAULT_SPLIT_SIZE = 32 * 1024 * 1024; // 32mb
+    static final long DEFAULT_SPLIT_SIZE = 128 * 1024 * 1024; // 128MB
 
     List<Split> getSplits(List<Expr> exprs) throws UserException;
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/external/FileSplitStrategy.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/external/FileSplitStrategy.java
@@ -17,8 +17,9 @@
 
 package org.apache.doris.planner.external;
 
-import org.apache.doris.common.Config;
-
+/**
+ * TODO: This class would be used later for split assignment.
+ */
 public class FileSplitStrategy {
     private long totalSplitSize;
     private int splitNum;
@@ -34,7 +35,7 @@ public class FileSplitStrategy {
     }
 
     public boolean hasNext() {
-        return totalSplitSize >= Config.file_scan_node_split_size || splitNum >= Config.file_scan_node_split_num;
+        return true;
     }
 
     public void next() {

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/external/QueryScanProvider.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/external/QueryScanProvider.java
@@ -104,11 +104,9 @@ public abstract class QueryScanProvider implements FileScanProviderIf {
         } else if (locationType == TFileType.FILE_S3) {
             context.params.setProperties(locationProperties);
         }
-        TScanRangeLocations curLocations = newLocations(context.params, backendPolicy);
-
-        FileSplitStrategy fileSplitStrategy = new FileSplitStrategy();
 
         for (Split split : inputSplits) {
+            TScanRangeLocations curLocations = newLocations(context.params, backendPolicy);
             FileSplit fileSplit = (FileSplit) split;
             List<String> pathPartitionKeys = getPathPartitionKeys();
             List<String> partitionValuesFromPath = BrokerUtil.parseColumnsFromPath(fileSplit.getPath().toString(),
@@ -124,18 +122,8 @@ public abstract class QueryScanProvider implements FileScanProviderIf {
             LOG.debug("assign to backend {} with table split: {} ({}, {}), location: {}",
                     curLocations.getLocations().get(0).getBackendId(), fileSplit.getPath(), fileSplit.getStart(),
                     fileSplit.getLength(), Joiner.on("|").join(fileSplit.getHosts()));
-
-            fileSplitStrategy.update(fileSplit);
-            // Add a new location when it's can be split
-            if (fileSplitStrategy.hasNext()) {
-                scanRangeLocations.add(curLocations);
-                curLocations = newLocations(context.params, backendPolicy);
-                fileSplitStrategy.next();
-            }
-            this.inputFileSize += fileSplit.getLength();
-        }
-        if (curLocations.getScanRange().getExtScanRange().getFileScanRange().getRangesSize() > 0) {
             scanRangeLocations.add(curLocations);
+            this.inputFileSize += fileSplit.getLength();
         }
         LOG.debug("create #{} ScanRangeLocations cost: {} ms",
                 scanRangeLocations.size(), (System.currentTimeMillis() - start));

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -295,6 +295,9 @@ public class SessionVariable implements Serializable, Writable {
 
     public static final String DRY_RUN_QUERY = "dry_run_query";
 
+    // Split size for ExternalFileScanNode. Default value 0 means use the block size of HDFS/S3.
+    public static final String FILE_SPLIT_SIZE = "file_split_size";
+
     public static final List<String> DEBUG_VARIABLES = ImmutableList.of(
             SKIP_DELETE_PREDICATE,
             SKIP_DELETE_BITMAP,
@@ -789,6 +792,9 @@ public class SessionVariable implements Serializable, Writable {
     // If set to true, all query will be executed without returning result
     @VariableMgr.VarAttr(name = DRY_RUN_QUERY, needForward = true)
     public boolean dryRunQuery = false;
+
+    @VariableMgr.VarAttr(name = FILE_SPLIT_SIZE, needForward = true)
+    public long fileSplitSize = 0;
 
     // If this fe is in fuzzy mode, then will use initFuzzyModeVariables to generate some variables,
     // not the default value set in the code.
@@ -1361,6 +1367,14 @@ public class SessionVariable implements Serializable, Writable {
 
     public boolean getEnableCboStatistics() {
         return enableCboStatistics;
+    }
+
+    public long getFileSplitSize() {
+        return fileSplitSize;
+    }
+
+    public void setFileSplitSize(long fileSplitSize) {
+        this.fileSplitSize = fileSplitSize;
     }
 
     /**


### PR DESCRIPTION
Move split size config to session variable. Before, it was in Config class, user need to restart FE after change it.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

