### PR TITLE
[enchancement](memory) tracking lru cache memory and page memory not in cache

### DIFF
--- a/be/src/olap/lru_cache.cpp
+++ b/be/src/olap/lru_cache.cpp
@@ -373,6 +373,7 @@ Cache::Handle* LRUCache::insert(const CacheKey& key, uint32_t hash, void* value,
     // The memory of the parameter value should be recorded in the tls mem tracker,
     // transfer the memory ownership of the value to ShardedLRUCache::_mem_tracker.
     THREAD_MEM_TRACKER_TRANSFER_TO(e->bytes, tracker);
+    DorisMetrics::instance()->lru_cache_memory_bytes->increment(e->bytes);
     LRUHandle* to_remove_head = nullptr;
     {
         std::lock_guard l(_mutex);

--- a/be/src/olap/lru_cache.h
+++ b/be/src/olap/lru_cache.h
@@ -17,6 +17,7 @@
 #include "olap/olap_common.h"
 #include "runtime/memory/mem_tracker.h"
 #include "runtime/thread_context.h"
+#include "util/doris_metrics.h"
 #include "util/lock.h"
 #include "util/metrics.h"
 #include "util/slice.h"
@@ -266,6 +267,7 @@ typedef struct LRUHandle {
     void free() {
         (*deleter)(key(), value);
         THREAD_MEM_TRACKER_TRANSFER_FROM(bytes, mem_tracker);
+        DorisMetrics::instance()->lru_cache_memory_bytes->increment(-bytes);
         ::free(this);
     }
 

--- a/be/src/olap/tablet_manager.cpp
+++ b/be/src/olap/tablet_manager.cpp
@@ -63,7 +63,8 @@ DEFINE_GAUGE_METRIC_PROTOTYPE_5ARG(tablet_meta_mem_consumption, MetricUnit::BYTE
 TabletManager::TabletManager(int32_t tablet_map_lock_shard_size)
         : _mem_tracker(std::make_shared<MemTracker>(
                   "TabletManager", ExecEnv::GetInstance()->experimental_mem_tracker())),
-          _tablet_meta_mem_tracker(std::make_shared<MemTracker>("TabletMeta")),
+          _tablet_meta_mem_tracker(std::make_shared<MemTracker>(
+                  "TabletMeta", ExecEnv::GetInstance()->experimental_mem_tracker())),
           _tablets_shards_size(tablet_map_lock_shard_size),
           _tablets_shards_mask(tablet_map_lock_shard_size - 1) {
     CHECK_GT(_tablets_shards_size, 0);

--- a/be/src/runtime/exec_env.h
+++ b/be/src/runtime/exec_env.h
@@ -122,6 +122,8 @@ public:
     std::shared_ptr<MemTrackerLimiter> orphan_mem_tracker() { return _orphan_mem_tracker; }
     MemTrackerLimiter* orphan_mem_tracker_raw() { return _orphan_mem_tracker_raw; }
     MemTrackerLimiter* experimental_mem_tracker() { return _experimental_mem_tracker.get(); }
+    MemTracker* page_no_cache_mem_tracker() { return _page_no_cache_mem_tracker.get(); }
+
     ThreadPool* send_batch_thread_pool() { return _send_batch_thread_pool.get(); }
     ThreadPool* download_cache_thread_pool() { return _download_cache_thread_pool.get(); }
     ThreadPool* send_report_thread_pool() { return _send_report_thread_pool.get(); }
@@ -211,6 +213,8 @@ private:
     std::shared_ptr<MemTrackerLimiter> _orphan_mem_tracker;
     MemTrackerLimiter* _orphan_mem_tracker_raw;
     std::shared_ptr<MemTrackerLimiter> _experimental_mem_tracker;
+    // page size not in cache, data page/index page/etc.
+    std::shared_ptr<MemTracker> _page_no_cache_mem_tracker;
 
     std::unique_ptr<ThreadPool> _send_batch_thread_pool;
 

--- a/be/src/runtime/exec_env_init.cpp
+++ b/be/src/runtime/exec_env_init.cpp
@@ -290,7 +290,8 @@ void ExecEnv::init_mem_tracker() {
     _orphan_mem_tracker_raw = _orphan_mem_tracker.get();
     _experimental_mem_tracker = std::make_shared<MemTrackerLimiter>(
             MemTrackerLimiter::Type::EXPERIMENTAL, "ExperimentalSet");
-    _page_no_cache_mem_tracker = std::make_shared<MemTracker>("PageNoCache");
+    _page_no_cache_mem_tracker =
+            std::make_shared<MemTracker>("PageNoCache", _orphan_mem_tracker_raw);
 }
 
 void ExecEnv::init_download_cache_buf() {

--- a/be/src/runtime/exec_env_init.cpp
+++ b/be/src/runtime/exec_env_init.cpp
@@ -290,6 +290,7 @@ void ExecEnv::init_mem_tracker() {
     _orphan_mem_tracker_raw = _orphan_mem_tracker.get();
     _experimental_mem_tracker = std::make_shared<MemTrackerLimiter>(
             MemTrackerLimiter::Type::EXPERIMENTAL, "ExperimentalSet");
+    _page_no_cache_mem_tracker = std::make_shared<MemTracker>("PageNoCache");
 }
 
 void ExecEnv::init_download_cache_buf() {

--- a/be/src/util/doris_metrics.cpp
+++ b/be/src/util/doris_metrics.cpp
@@ -165,6 +165,7 @@ DEFINE_GAUGE_CORE_METRIC_PROTOTYPE_2ARG(query_cache_partition_total_count, Metri
 
 DEFINE_COUNTER_METRIC_PROTOTYPE_2ARG(tablet_schema_cache_count, MetricUnit::NOUNIT);
 DEFINE_GAUGE_CORE_METRIC_PROTOTYPE_2ARG(tablet_schema_cache_memory_bytes, MetricUnit::BYTES);
+DEFINE_GAUGE_CORE_METRIC_PROTOTYPE_2ARG(lru_cache_memory_bytes, MetricUnit::BYTES);
 
 DEFINE_GAUGE_CORE_METRIC_PROTOTYPE_2ARG(upload_total_byte, MetricUnit::BYTES);
 DEFINE_COUNTER_METRIC_PROTOTYPE_2ARG(upload_rowset_count, MetricUnit::ROWSETS);
@@ -303,6 +304,7 @@ DorisMetrics::DorisMetrics() : _metric_registry(_s_registry_name) {
 
     INT_COUNTER_METRIC_REGISTER(_server_metric_entity, tablet_schema_cache_count);
     INT_UGAUGE_METRIC_REGISTER(_server_metric_entity, tablet_schema_cache_memory_bytes);
+    INT_GAUGE_METRIC_REGISTER(_server_metric_entity, lru_cache_memory_bytes);
 
     INT_COUNTER_METRIC_REGISTER(_server_metric_entity, local_file_reader_total);
     INT_COUNTER_METRIC_REGISTER(_server_metric_entity, s3_file_reader_total);

--- a/be/src/util/doris_metrics.h
+++ b/be/src/util/doris_metrics.h
@@ -208,6 +208,7 @@ public:
 
     IntCounter* tablet_schema_cache_count;
     UIntGauge* tablet_schema_cache_memory_bytes;
+    IntGauge* lru_cache_memory_bytes;
 
     UIntGauge* scanner_thread_pool_queue_size;
     UIntGauge* add_batch_task_queue_size;


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

1. Statistics lru cache memory in metrics
2. Statistics page memory not in cache in mem tracker

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

