### PR TITLE
[fix](streamload) fix stream load failed when enable profile

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -420,8 +420,6 @@ CONF_mInt32(stream_load_record_batch_size, "50");
 CONF_Int32(stream_load_record_expire_time_secs, "28800");
 // time interval to clean expired stream load records
 CONF_mInt64(clean_stream_load_record_interval_secs, "1800");
-// Whether to enable stream load profile to be printed to the log, the default is false.
-CONF_mBool(enable_stream_load_profile_log, "false");
 
 // OlapTableSink sender's send interval, should be less than the real response time of a tablet writer rpc.
 // You may need to lower the speed when the sink receiver bes are too busy.

--- a/be/src/http/action/stream_load.cpp
+++ b/be/src/http/action/stream_load.cpp
@@ -581,6 +581,13 @@ Status StreamLoadAction::_process_put(HttpRequest* http_req,
     if (!http_req->header(HTTP_SKIP_LINES).empty()) {
         request.__set_skip_lines(std::stoi(http_req->header(HTTP_SKIP_LINES)));
     }
+    if (!http_req->header(HTTP_ENABLE_PROFILE).empty()) {
+        if (iequal(http_req->header(HTTP_ENABLE_PROFILE), "true")) {
+            request.__set_enable_profile(true);
+        } else {
+            request.__set_enable_profile(false);
+        }
+    }
 
 #ifndef BE_TEST
     // plan this load
@@ -599,12 +606,6 @@ Status StreamLoadAction::_process_put(HttpRequest* http_req,
     if (!plan_status.ok()) {
         LOG(WARNING) << "plan streaming load failed. errmsg=" << plan_status << ctx->brief();
         return plan_status;
-    }
-
-    auto& query_options = ctx->put_result.params.query_options;
-    if (query_options.__isset.is_report_success && query_options.is_report_success &&
-        !config::enable_stream_load_profile_log) {
-        query_options.is_report_success = false;
     }
 
     VLOG_NOTICE << "params is " << apache::thrift::ThriftDebugString(ctx->put_result.params);

--- a/be/src/http/http_common.h
+++ b/be/src/http/http_common.h
@@ -54,6 +54,7 @@ static const std::string HTTP_HIDDEN_COLUMNS = "hidden_columns";
 static const std::string HTTP_TRIM_DOUBLE_QUOTES = "trim_double_quotes";
 static const std::string HTTP_SKIP_LINES = "skip_lines";
 static const std::string HTTP_COMMENT = "comment";
+static const std::string HTTP_ENABLE_PROFILE = "enable_profile";
 
 static const std::string HTTP_TWO_PHASE_COMMIT = "two_phase_commit";
 static const std::string HTTP_TXN_ID_KEY = "txn_id";

--- a/be/src/runtime/fragment_mgr.cpp
+++ b/be/src/runtime/fragment_mgr.cpp
@@ -354,6 +354,7 @@ void FragmentMgr::coordinator_callback(const ReportStatusRequest& req) {
     params.__set_fragment_id(req.fragment_id);
     exec_status.set_t_status(&params);
     params.__set_done(req.done);
+    params.__set_query_type(req.runtime_state->query_type());
 
     DCHECK(req.runtime_state != nullptr);
     if (req.runtime_state->query_type() == TQueryType::LOAD && !req.done && req.status.ok()) {

--- a/docs/en/docs/admin-manual/config/be-config.md
+++ b/docs/en/docs/admin-manual/config/be-config.md
@@ -769,13 +769,6 @@ Metrics: {"filtered_rows":0,"input_row_num":3346807,"input_rowsets_count":42,"in
 * Default value: 100
 * Dynamically modifiable: Yes
 
-#### `enable_stream_load_profile_log`
-
-* Type: bool
-* Description: Whether to enable stream load profile to be printed to the log.
-* Default value: false
-* Dynamically modifiable: Yes
-
 ### Thread
 
 #### `delete_worker_count`

--- a/docs/en/docs/data-operate/import/import-way/stream-load-manual.md
+++ b/docs/en/docs/data-operate/import/import-way/stream-load-manual.md
@@ -181,6 +181,12 @@ The number of rows in the original file = `dpp.abnorm.ALL + dpp.norm.ALL`
 
   Stream load import can enable two-stage transaction commit mode: in the stream load process, the data is written and the information is returned to the user. At this time, the data is invisible and the transaction status is `PRECOMMITTED`. After the user manually triggers the commit operation, the data is visible.
 
++ enable_profile
+  <version since="1.2.4">
+  </version>
+
+  When `enable_profile` is true, the Stream Load profile will be printed to the log. Otherwise it won't print.
+
   Example：
 
     1. Initiate a stream load pre-commit operation

--- a/docs/zh-CN/docs/admin-manual/config/be-config.md
+++ b/docs/zh-CN/docs/admin-manual/config/be-config.md
@@ -783,13 +783,6 @@ Metrics: {"filtered_rows":0,"input_row_num":3346807,"input_rowsets_count":42,"in
 * 默认值： 100
 * 可动态修改：是
 
-#### `enable_stream_load_profile_log`
-
-* 类型：bool
-* 描述：是否将 stream load profile 打印到日志。
-* 默认值： false
-* 可动态修改：是
-
 ### 线程
 
 #### `delete_worker_count`

--- a/docs/zh-CN/docs/data-operate/import/import-way/stream-load-manual.md
+++ b/docs/zh-CN/docs/data-operate/import/import-way/stream-load-manual.md
@@ -191,6 +191,12 @@ Stream Load 由于使用的是 HTTP 协议，所以所有导入任务有关的�
 
   Stream load 导入可以开启两阶段事务提交模式：在Stream load过程中，数据写入完成即会返回信息给用户，此时数据不可见，事务状态为`PRECOMMITTED`，用户手动触发commit操作之后，数据才可见。
 
+- enable_profile
+  <version since="1.2.4">
+  </version>
+
+  当 `enable_profile` 为 true 时，Stream Load profile将会打印到日志中。否则不会打印。
+
   示例：
 
   1. 发起stream load预提交操作

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/StreamLoadPlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/StreamLoadPlanner.java
@@ -47,7 +47,6 @@ import org.apache.doris.load.BrokerFileGroup;
 import org.apache.doris.load.loadv2.LoadTask;
 import org.apache.doris.load.routineload.RoutineLoadJob;
 import org.apache.doris.planner.external.ExternalFileScanNode;
-import org.apache.doris.qe.VariableMgr;
 import org.apache.doris.service.FrontendOptions;
 import org.apache.doris.task.LoadTaskInfo;
 import org.apache.doris.thrift.PaloInternalServiceVersion;
@@ -276,7 +275,7 @@ public class StreamLoadPlanner {
         queryOptions.setEnableVectorizedEngine(Config.enable_vectorized_load);
         queryOptions.setEnablePipelineEngine(Config.enable_pipeline_load);
         queryOptions.setBeExecVersion(Config.be_exec_version);
-        queryOptions.setIsReportSuccess(VariableMgr.newSessionVariable().enableProfile());
+        queryOptions.setIsReportSuccess(taskInfo.getEnableProfile());
 
         params.setQueryOptions(queryOptions);
         TQueryGlobals queryGlobals = new TQueryGlobals();

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/QeProcessorImpl.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/QeProcessorImpl.java
@@ -24,6 +24,7 @@ import org.apache.doris.common.util.DebugUtil;
 import org.apache.doris.common.util.ProfileWriter;
 import org.apache.doris.metric.MetricRepo;
 import org.apache.doris.thrift.TNetworkAddress;
+import org.apache.doris.thrift.TQueryType;
 import org.apache.doris.thrift.TReportExecStatusParams;
 import org.apache.doris.thrift.TReportExecStatusResult;
 import org.apache.doris.thrift.TStatus;
@@ -189,8 +190,14 @@ public final class QeProcessorImpl implements QeProcessor {
         final QueryInfo info = coordinatorMap.get(params.query_id);
 
         if (info == null) {
-            result.setStatus(new TStatus(TStatusCode.RUNTIME_ERROR));
-            LOG.info("ReportExecStatus() runtime error, query {} does not exist", DebugUtil.printId(params.query_id));
+            // There is no QueryInfo for StreamLoad, so we return OK
+            if (params.query_type == TQueryType.LOAD) {
+                result.setStatus(new TStatus(TStatusCode.OK));
+            } else {
+                result.setStatus(new TStatus(TStatusCode.RUNTIME_ERROR));
+            }
+            LOG.info("ReportExecStatus() runtime error, query {} with type {} does not exist",
+                    DebugUtil.printId(params.query_id), params.query_type);
             return result;
         }
         try {

--- a/fe/fe-core/src/main/java/org/apache/doris/task/LoadTaskInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/task/LoadTaskInfo.java
@@ -105,6 +105,10 @@ public interface LoadTaskInfo {
         return 0;
     }
 
+    default boolean getEnableProfile() {
+        return false;
+    }
+
     class ImportColumnDescs {
         public List<ImportColumnDesc> descs = Lists.newArrayList();
         public boolean isColumnDescsRewrited = false;

--- a/fe/fe-core/src/main/java/org/apache/doris/task/StreamLoadTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/task/StreamLoadTask.java
@@ -83,8 +83,8 @@ public class StreamLoadTask implements LoadTaskInfo {
     private String headerType = "";
     private List<String> hiddenColumns;
     private boolean trimDoubleQuotes = false;
-
     private int skipLines = 0;
+    private boolean enableProfile = false;
 
     public StreamLoadTask(TUniqueId id, long txnId, TFileType fileType, TFileFormatType formatType,
             TFileCompressType compressType) {
@@ -263,6 +263,11 @@ public class StreamLoadTask implements LoadTaskInfo {
         return skipLines;
     }
 
+    @Override
+    public boolean getEnableProfile() {
+        return enableProfile;
+    }
+
     public static StreamLoadTask fromTStreamLoadPutRequest(TStreamLoadPutRequest request) throws UserException {
         StreamLoadTask streamLoadTask = new StreamLoadTask(request.getLoadId(), request.getTxnId(),
                 request.getFileType(), request.getFormatType(),
@@ -367,6 +372,9 @@ public class StreamLoadTask implements LoadTaskInfo {
         }
         if (request.isSetSkipLines()) {
             skipLines = request.getSkipLines();
+        }
+        if (request.isSetEnableProfile()) {
+            enableProfile = request.isEnableProfile();
         }
     }
 

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -429,6 +429,8 @@ struct TReportExecStatusParams {
   18: optional list<Types.TErrorTabletInfo> errorTabletInfos
 
   19: optional i32 fragment_id
+
+  20: optional PaloInternalService.TQueryType query_type
 }
 
 struct TFeResult {
@@ -570,6 +572,7 @@ struct TStreamLoadPutRequest {
     41: optional i64 file_size // only for stream load with parquet or orc
     42: optional bool trim_double_quotes // trim double quotes for csv
     43: optional i32 skip_lines // csv skip line num, only used when csv header_type is not set.
+    44: optional bool enable_profile
 }
 
 struct TStreamLoadPutResult {


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

#18015 enables stream load profile log,  however be will encounter rpc fail when loading tpch data(see #18291). This is because when `is_report_success` is true, be will reportExecStatus to fe, but fe cannot find QueryInfo in `coordinatorMap`, thus it will return error to be.
https://github.com/apache/doris/blob/a724443eb92a84a2c0167033cf08ec95b1369d96/fe/fe-core/src/main/java/org/apache/doris/qe/QeProcessorImpl.java#L181-L195

To solve this problem, we add a field named `query_type` to `TReportExecStatusParams` to distinguish whether the query is `SELECT` or `LOAD`. If fe cannot find QueryInfo in `coordinatorMap` and the `query_type` is `LOAD`, it means this query is stream load, and we can return OK.

And in #18015 , it's not a good idea to use a globle BE config `enable_stream_load_profile_log` to control whether print profile to log. Thus we add a new param `enable_profile` to stream load to control whether each stream load job prints profile to log.

I tested loading tpch data, it can be loaded without error. When `enable_profile` is true, stream load profile is printed to the log:
```
I0404 10:12:21.240705 2336167 plan_fragment_executor.cpp:523] Fragment c54fa880c606e9ae-b43f30b6927103a6:(Active: 1m2s, non-child: 0.04%)
   - BlocksProduced: 12.00M
   - FragmentCpuTime: 4s384ms
   - RowsProduced: 12.00M
  OlapTableSink:(Active: 1m2s, non-child: 99.01%)
     - CloseWaitTime: 5s166ms
     - MaxAddBatchExecTime: 56s833ms
     - NonBlockingSendTime: 59s837ms
       - NonBlockingSendWorkTime: 4s884ms
         - SerializeBatchTime: 4s028ms
     - NumberBatchAdded: 985
     - NumberNodeChannels: 1
     - OpenTime: 787.612us
     - RowsFiltered: 0
     - RowsRead: 12.00M
     - RowsReturned: 12.00M
     - SendDataTime: 56s611ms
       - WaitMemLimitTime: 52s676ms
     - TotalAddBatchExecTime: 56s833ms
     - ValidateDataTime: 355.313ms
  VFILE_SCAN_NODE (id=0):(Active: 596.764ms, non-child: 0.95%)
     - UseSpecificThreadToken: False
     - AcuireRuntimeFilterTime: 462.000ns
     - BytesDecompressed: 0
     - BytesRead: 1.45 GB
     - DecompressTime: 0.000ns
     - FileReadTime: 496.605ms
     - GetNextTime: 595.397ms
     - MaxScannerThreadNum: 1
     - NumScanners: 1
     - PeakMemoryUsage: 0
     - PreAllocFreeBlocksNum: 8
     - ProjectionTime: 0.000ns
     - RowsRead: 12.00M
     - RowsReturned: 12.00M
     - RowsReturnedRate: 20.11 M/sec
     - ScannerWorkerWaitTime: 21.051ms
     - TotalReadThroughput: 0
    VScanner:
       - PerScannerRunningTime: [13s612ms, ]
       - PerScannerRowsRead: [12.00M, ]
       - EmptyFileNum: 0
       - FileScannerCastInputBlockTime: 291.989ms
       - FileScannerConvertOuputBlockTime: 4s568ms
       - FileScannerFillMissingColumnTime: 0.000ns
       - FileScannerFillPathColumnTime: 0.000ns
       - FileScannerGetBlockTime: 8s700ms
       - FileScannerPreFilterTimer: 0.000ns
       - NewlyCreateFreeBlocksNum: 88
       - ScannerBatchWaitTime: 572.725ms
       - ScannerConvertBlockTime: 0.000ns
       - ScannerCpuTime: 13s542ms
       - ScannerCtxSchedCount: 741
       - ScannerFilterTime: 420.815us
       - ScannerGetBlockTime: 13s609ms
       - ScannerPrefilterTime: 0.000ns
       - ScannerSchedCount: 648
      MemoryUsage:
         - FreeBlocks: 53.25 MB
         - QueuedBlocks: 53.25 MB
  MemoryUsage:
     - FreeBlocks: 53.25 MB
     - QueuedBlocks: 53.25 MB
```

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [X] Has document been added or modified
* [ ] Does it need to update dependencies
* [X] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

