### PR TITLE
[fix](planner)use base index if the where clause is a constant value

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/OlapScanNode.java
@@ -1436,9 +1436,4 @@ public class OlapScanNode extends ScanNode {
             }
         }
     }
-
-    @Override
-    public void setProjectList(List<Expr> projectList) {
-        this.projectList = projectList;
-    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/OlapScanNode.java
@@ -474,7 +474,9 @@ public class OlapScanNode extends ScanNode {
             if (mvColumn == null) {
                 boolean isBound = false;
                 for (Expr conjunct : conjuncts) {
-                    if (conjunct.isBound(slotDescriptor.getId())) {
+                    List<TupleId> tids = Lists.newArrayList();
+                    conjunct.getIds(tids, null);
+                    if (!tids.isEmpty() && conjunct.isBound(slotDescriptor.getId())) {
                         isBound = true;
                         break;
                     }
@@ -1433,5 +1435,10 @@ public class OlapScanNode extends ScanNode {
                 outputColumnUniqueIds.add(slot.getColumn().getUniqueId());
             }
         }
+    }
+
+    @Override
+    public void setProjectList(List<Expr> projectList) {
+        this.projectList = projectList;
     }
 }

--- a/regression-test/data/mv_p0/where/k123/k123.out
+++ b/regression-test/data/mv_p0/where/k123/k123.out
@@ -39,3 +39,11 @@
 2	4
 2	4
 
+-- !select_mv_constant --
+\N
+\N
+\N
+\N
+\N
+\N
+

--- a/regression-test/suites/mv_p0/where/k123/k123.groovy
+++ b/regression-test/suites/mv_p0/where/k123/k123.groovy
@@ -86,4 +86,6 @@ suite ("k123p") {
         contains "(k123p4w)"
     }
     qt_select_mv """select k1,k2+k3 from d_table where k1 = 2 and k4 = "b" order by k1;"""
+
+    qt_select_mv_constant """select bitmap_empty() from d_table where true;"""
 }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary
sql : select bitmap_empty() from d_table where true;
should always use base index instead of any mv, because the conjuncts is constant (true) and use none of the column from any mv

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

