### PR TITLE
[fix](chore) compile failed in JdbcExecutor and be crash when enable pipeline

### DIFF
--- a/be/src/pipeline/exec/scan_operator.cpp
+++ b/be/src/pipeline/exec/scan_operator.cpp
@@ -38,6 +38,9 @@ bool ScanOperator::can_read() {
             // _scanner_ctx->no_schedule(): should schedule _scanner_ctx
             return true;
         } else {
+            if (_node->_scanner_ctx->has_enough_space_in_blocks_queue()) {
+                _node->_scanner_ctx->reschedule_scanner_ctx();
+            }
             return _node->ready_to_read(); // there are some blocks to process
         }
     }

--- a/be/src/vec/exec/scan/pip_scanner_context.h
+++ b/be/src/vec/exec/scan/pip_scanner_context.h
@@ -57,15 +57,6 @@ public:
             }
         }
         _current_used_bytes -= (*block)->allocated_bytes();
-        {
-            if (has_enough_space_in_blocks_queue()) {
-                std::unique_lock<std::mutex> l(_transfer_lock);
-                auto submit_st = _scanner_scheduler->submit(this);
-                if (submit_st.ok()) {
-                    _num_scheduling_ctx++;
-                }
-            }
-        }
         return Status::OK();
     }
 

--- a/be/src/vec/exec/scan/scanner_context.cpp
+++ b/be/src/vec/exec/scan/scanner_context.cpp
@@ -288,6 +288,15 @@ std::string ScannerContext::debug_string() {
             _max_thread_num, _block_per_scanner, _cur_bytes_in_queue, _max_bytes_in_queue);
 }
 
+void ScannerContext::reschedule_scanner_ctx() {
+    std::lock_guard l(_transfer_lock);
+    auto submit_st = _scanner_scheduler->submit(this);
+    //todo(wb) rethinking is it better to mark current scan_context failed when submit failed many times?
+    if (submit_st.ok()) {
+        _num_scheduling_ctx++;
+    }
+}
+
 void ScannerContext::push_back_scanner_and_reschedule(VScanner* scanner) {
     {
         std::unique_lock l(_scanners_lock);

--- a/be/src/vec/exec/scan/scanner_context.h
+++ b/be/src/vec/exec/scan/scanner_context.h
@@ -128,6 +128,8 @@ public:
         return _cur_bytes_in_queue < _max_bytes_in_queue / 2;
     }
 
+    void reschedule_scanner_ctx();
+
     // the unique id of this context
     std::string ctx_id;
     int32_t queue_idx = -1;

--- a/fe/java-udf/src/main/java/org/apache/doris/udf/JdbcExecutor.java
+++ b/fe/java-udf/src/main/java/org/apache/doris/udf/JdbcExecutor.java
@@ -1289,7 +1289,7 @@ public class JdbcExecutor {
             }
         }
         byte[] bytes = new byte[offsets[numRows - 1]];
-        long bytesAddr = JNINativeMethod.resizeColumn(charsAddr, offsets[numRows - 1]);
+        long bytesAddr = JNINativeMethod.resizeStringColumn(charsAddr, offsets[numRows - 1]);
         int dst = 0;
         for (int i = 0; i < numRows; i++) {
             for (int j = 0; j < byteRes[i].length; j++) {
@@ -1336,7 +1336,7 @@ public class JdbcExecutor {
             }
         }
         byte[] bytes = new byte[offsets[numRows - 1]];
-        long bytesAddr = JNINativeMethod.resizeColumn(charsAddr, offsets[numRows - 1]);
+        long bytesAddr = JNINativeMethod.resizeStringColumn(charsAddr, offsets[numRows - 1]);
         int dst = 0;
         for (int i = 0; i < numRows; i++) {
             for (int j = 0; j < byteRes[i].length; j++) {


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

fix 2 problems:
1. PR #18187 use the api resizeColumn in JNINativeMethod has been removed by #17960
2. revert PR #18306 to fix pipeline core when load

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

