### PR TITLE
[chore](regression) print exception along with error sql when run sql file

### DIFF
--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/suite/ScriptSource.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/suite/ScriptSource.groovy
@@ -88,7 +88,7 @@ class SqlFileSource implements ScriptSource {
                         try {
                             quickTest(tagName, singleSql, order)
                         } catch (Throwable e) {
-                            exceptionStr += "\n${e.getMessage()}\n"
+                            exceptionStr += "\n${e.getMessage(), sql is : ${singleSql}}\n"
                         }
                     }
                     if (exceptionStr.size() != 0) {

--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/suite/ScriptSource.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/suite/ScriptSource.groovy
@@ -88,7 +88,8 @@ class SqlFileSource implements ScriptSource {
                         try {
                             quickTest(tagName, singleSql, order)
                         } catch (Throwable e) {
-                            exceptionStr += "\n${e.getMessage(), sql is : ${singleSql}}\n"
+                            String curException = "exception : ${e.getMessage()}\n" + "sql is :" + "${singleSql}\n"
+                            exceptionStr += curException
                         }
                     }
                     if (exceptionStr.size() != 0) {


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx
Previously when we run one sql file which would throw exception, the regression framework would not print the whole sql statement which cause this exception. It would be annoying when the sql file consists of numerous sql statement, this pr mainly helps debug.
## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

