### PR TITLE
[fix](alter inverted index) Temporary deal with add or drop inverted index by directly schema change

### DIFF
--- a/be/src/olap/schema_change.cpp
+++ b/be/src/olap/schema_change.cpp
@@ -1765,7 +1765,9 @@ Status SchemaChangeHandler::_parse_request(const SchemaChangeParams& sc_params,
                 column_new.frac() != column_old.frac() ||
                 column_new.length() != column_old.length() ||
                 column_new.is_bf_column() != column_old.is_bf_column() ||
-                column_new.has_bitmap_index() != column_old.has_bitmap_index()) {
+                column_new.has_bitmap_index() != column_old.has_bitmap_index() ||
+                new_tablet_schema->has_inverted_index(column_new.unique_id()) !=
+                        base_tablet_schema->has_inverted_index(column_old.unique_id())) {
                 *sc_directly = true;
                 return Status::OK();
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
@@ -27,7 +27,6 @@ import org.apache.doris.analysis.CreateIndexClause;
 import org.apache.doris.analysis.DropColumnClause;
 import org.apache.doris.analysis.DropIndexClause;
 import org.apache.doris.analysis.IndexDef;
-import org.apache.doris.analysis.IndexDef.IndexType;
 import org.apache.doris.analysis.ModifyColumnClause;
 import org.apache.doris.analysis.ModifyTablePropertiesClause;
 import org.apache.doris.analysis.ReorderColumnsClause;
@@ -1827,32 +1826,32 @@ public class SchemaChangeHandler extends AlterHandler {
                         return;
                     }
                     lightSchemaChange = false;
-                    CreateIndexClause createIndexClause = (CreateIndexClause) alterClause;
-                    if (createIndexClause.getIndexDef().isInvertedIndex()) {
-                        alterInvertedIndexes.add(createIndexClause.getIndex());
-                        isDropInvertedIndex = false;
-                        lightSchemaChangeWithInvertedIndex = true;
-                    }
+                    // CreateIndexClause createIndexClause = (CreateIndexClause) alterClause;
+                    // if (createIndexClause.getIndexDef().isInvertedIndex()) {
+                    //     alterInvertedIndexes.add(createIndexClause.getIndex());
+                    //     isDropInvertedIndex = false;
+                    //     lightSchemaChangeWithInvertedIndex = true;
+                    // }
                 } else if (alterClause instanceof DropIndexClause) {
                     if (processDropIndex((DropIndexClause) alterClause, olapTable, newIndexes)) {
                         return;
                     }
                     lightSchemaChange = false;
-                    DropIndexClause dropIndexClause = (DropIndexClause) alterClause;
-                    List<Index> existedIndexes = olapTable.getIndexes();
-                    Index found = null;
-                    for (Index existedIdx : existedIndexes) {
-                        if (existedIdx.getIndexName().equalsIgnoreCase(dropIndexClause.getIndexName())) {
-                            found = existedIdx;
-                            break;
-                        }
-                    }
-                    IndexDef.IndexType indexType = found.getIndexType();
-                    if (indexType == IndexType.INVERTED) {
-                        alterInvertedIndexes.add(found);
-                        isDropInvertedIndex = true;
-                        lightSchemaChangeWithInvertedIndex = true;
-                    }
+                    // DropIndexClause dropIndexClause = (DropIndexClause) alterClause;
+                    // List<Index> existedIndexes = olapTable.getIndexes();
+                    // Index found = null;
+                    // for (Index existedIdx : existedIndexes) {
+                    //     if (existedIdx.getIndexName().equalsIgnoreCase(dropIndexClause.getIndexName())) {
+                    //         found = existedIdx;
+                    //         break;
+                    //     }
+                    // }
+                    // IndexDef.IndexType indexType = found.getIndexType();
+                    // if (indexType == IndexType.INVERTED) {
+                    //     alterInvertedIndexes.add(found);
+                    //     isDropInvertedIndex = true;
+                    //     lightSchemaChangeWithInvertedIndex = true;
+                    // }
                 } else {
                     Preconditions.checkState(false);
                 }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

In the current implementation of the function of dynamically add and drop inverted index, there is a problem that the inverted index information of historical data is out of date after compaction on the base tablet. 

In the future, I will submit PRs to solve this problem. Now, temporarily add or drop inverted index by the directly schema change logic

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

