### PR TITLE
[Fix](multi-catalog) Fix crashed when hdfs get path info returning nullptr.

### DIFF
--- a/be/src/io/hdfs_builder.cpp
+++ b/be/src/io/hdfs_builder.cpp
@@ -31,7 +31,8 @@ namespace doris {
 Status HDFSCommonBuilder::init_hdfs_builder() {
     hdfs_builder = hdfsNewBuilder();
     if (hdfs_builder == nullptr) {
-        LOG(INFO) << "failed to init HDFSCommonBuilder, please check be/conf/hdfs-site.xml and be.out";
+        LOG(INFO) << "failed to init HDFSCommonBuilder, please check be/conf/hdfs-site.xml and "
+                     "be.out";
         return Status::InternalError(
                 "failed to init HDFSCommonBuilder, please check be/conf/hdfs-site.xml and be.out");
     }

--- a/be/src/io/hdfs_file_reader.cpp
+++ b/be/src/io/hdfs_file_reader.cpp
@@ -178,6 +178,10 @@ int64_t HdfsFileReader::size() {
     if (_file_size == -1) {
         if (_hdfs_fs != nullptr) {
             hdfsFileInfo* file_info = hdfsGetPathInfo(_hdfs_fs, _path.c_str());
+            if (file_info == nullptr) {
+                return Status::IOError("failed to get path info, path: {}, error: {}", _path,
+                                       hdfsGetLastError());
+            }
             _file_size = file_info->mSize;
             hdfsFreeFileInfo(file_info, 1);
         }


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

```
(gdb) bt
#0  doris::HdfsFileReader::size (this=0x7fe5bf4ad7c0) at /home/zcp/repo_center/zcp_repo/be/src/io/hdfs_file_reader.cpp:181
#1  0x000056060300f027 in doris::vectorized::ORCFileInputStream::getLength (this=<optimized out>) at /home/zcp/repo_center/zcp_repo/be/src/vec/exec/format/orc/vorc_reader.h:50
#2  doris::vectorized::OrcReader::init_reader (this=this@entry=0x7ff0d5768200, colname_to_value_range=0x7ff1275f7850) at /home/zcp/repo_center/zcp_repo/be/src/vec/exec/format/orc/vorc_reader.cpp:144
#3  0x0000560602fca090 in doris::vectorized::VFileScanner::_get_next_reader (this=this@entry=0x7ff03cf0ca00) at /var/local/ldb_toolchain/include/c++/11/bits/unique_ptr.h:173
#4  0x0000560602fceec2 in doris::vectorized::VFileScanner::_get_block_impl (this=0x7ff03cf0ca00, state=<optimized out>, block=0x7ff084e0a4a0, eof=0x7fc84655949a) at /home/zcp/repo_center/zcp_repo/be/src/vec/exec/scan/vfile_scanner.cpp:132
#5  0x0000560602f9a5b9 in doris::vectorized::VScanner::get_block (this=this@entry=0x7ff03cf0ca00, state=state@entry=0x7ff1275f6d00, block=block@entry=0x7ff084e0a4a0, eof=eof@entry=0x7fc84655949a) at /home/zcp/repo_center/zcp_repo/be/src/vec/exec/scan/vscanner.cpp:57
#6  0x0000560602f978c3 in doris::vectorized::ScannerScheduler::_scanner_scan (this=<optimized out>, scheduler=<optimized out>, ctx=0x7ff0f7a97600, scanner=0x7ff03cf0ca00) at /home/zcp/repo_center/zcp_repo/be/src/vec/exec/scan/scanner_scheduler.cpp:247
#7  0x00005605fe2e4365 in std::function<void ()>::operator()() const (this=<optimized out>) at /var/local/ldb_toolchain/include/c++/11/bits/std_function.h:560
#8  doris::FunctionRunnable::run (this=<optimized out>) at /home/zcp/repo_center/zcp_repo/be/src/util/threadpool.cpp:46
#9  doris::ThreadPool::dispatch_thread (this=0x7ff358fe7540) at /home/zcp/repo_center/zcp_repo/be/src/util/threadpool.cpp:535
#10 0x00005605fe2d9a9f in std::function<void ()>::operator()() const (this=0x7fe06e055f78) at /var/local/ldb_toolchain/include/c++/11/bits/std_function.h:560
#11 doris::Thread::supervise_thread (arg=0x7fe06e055f60) at /home/zcp/repo_center/zcp_repo/be/src/util/thread.cpp:454 
```

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

