### PR TITLE
[fix](executor)fix error pending finish status for scan operator

### DIFF
--- a/be/src/pipeline/exec/scan_operator.cpp
+++ b/be/src/pipeline/exec/scan_operator.cpp
@@ -38,9 +38,6 @@ bool ScanOperator::can_read() {
             // _scanner_ctx->no_schedule(): should schedule _scanner_ctx
             return true;
         } else {
-            if (_node->_scanner_ctx->has_enough_space_in_blocks_queue()) {
-                _node->_scanner_ctx->reschedule_scanner_ctx();
-            }
             return _node->ready_to_read(); // there are some blocks to process
         }
     }

--- a/be/src/vec/exec/scan/pip_scanner_context.h
+++ b/be/src/vec/exec/scan/pip_scanner_context.h
@@ -57,6 +57,15 @@ public:
             }
         }
         _current_used_bytes -= (*block)->allocated_bytes();
+        {
+            if (!done() && has_enough_space_in_blocks_queue()) {
+                std::unique_lock<std::mutex> l(_transfer_lock);
+                auto submit_st = _scanner_scheduler->submit(this);
+                if (submit_st.ok()) {
+                    _num_scheduling_ctx++;
+                }
+            }
+        }
         return Status::OK();
     }
 

--- a/be/src/vec/exec/scan/scanner_context.cpp
+++ b/be/src/vec/exec/scan/scanner_context.cpp
@@ -288,15 +288,6 @@ std::string ScannerContext::debug_string() {
             _max_thread_num, _block_per_scanner, _cur_bytes_in_queue, _max_bytes_in_queue);
 }
 
-void ScannerContext::reschedule_scanner_ctx() {
-    std::lock_guard l(_transfer_lock);
-    auto submit_st = _scanner_scheduler->submit(this);
-    //todo(wb) rethinking is it better to mark current scan_context failed when submit failed many times?
-    if (submit_st.ok()) {
-        _num_scheduling_ctx++;
-    }
-}
-
 void ScannerContext::push_back_scanner_and_reschedule(VScanner* scanner) {
     {
         std::unique_lock l(_scanners_lock);

--- a/be/src/vec/exec/scan/scanner_context.h
+++ b/be/src/vec/exec/scan/scanner_context.h
@@ -128,8 +128,6 @@ public:
         return _cur_bytes_in_queue < _max_bytes_in_queue / 2;
     }
 
-    void reschedule_scanner_ctx();
-
     // the unique id of this context
     std::string ctx_id;
     int32_t queue_idx = -1;


### PR DESCRIPTION
# Proposed changes

a hot fix for https://github.com/apache/doris/pull/18306

May cause

```
F0404 15:54:47.688764 2530726 task_scheduler.cpp:230] Check failed: !task->is_pending_finish() must not pending close PipelineTask[id = 0, state = PENDING_FINISH]
operators: 
ScanOperator, is source: 1, is sink: 0, is closed: 0, is pending finish: 0, scanner_ctx is null: false , num_running_scanners = 0, num_scheduling_ctx = 0 
  AggSinkOperator, is source: 0, is sink: 1, is closed: 0, is pending finish: 0
*** Check failure stack trace: ***
    @     0x55b48d94c05d  google::LogMessage::Fail()
    @     0x55b48d94e599  google::LogMessage::SendToLog()
    @     0x55b48d94bbc6  google::LogMessage::Flush()
    @     0x55b48d94ec09  google::LogMessageFatal::~LogMessageFatal()
    @     0x55b48ce97282  doris::pipeline::TaskScheduler::_do_work()
    @     0x55b48ce993de  std::_Function_handler<>::_M_invoke()
    @     0x55b474ef2ee1  doris::FunctionRunnable::run()
    @     0x55b474ef0df9  doris::ThreadPool::dispatch_thread()
    @     0x55b474ef2a96  std::_Function_handler<>::_M_invoke()
    @     0x55b474ecb8f4  doris::Thread::supervise_thread()
    @     0x7f71b5d27609  start_thread
    @     0x7f71b5afd133  clone
    @              (nil)  (unknown)
```

## Problem summary

Describe your changes.

## Checklist(Required)

* [x] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [x] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

