### PR TITLE
[chore](regression) prevent creating stmt failed in cold heat separation regression case

### DIFF
--- a/regression-test/suites/cold_heat_separation/empty_table_use_policy/alter_table_add_policy.groovy
+++ b/regression-test/suites/cold_heat_separation/empty_table_use_policy/alter_table_add_policy.groovy
@@ -51,7 +51,7 @@ suite("add_table_policy_by_alter_table") {
 
     if (!storage_exist.call("created_create_table_alter_policy")) {
         def create_s3_resource = try_sql """
-            CREATE RESOURCE "test_create_alter_table_use_resource"
+            CREATE RESOURCE IF NOT EXISTS "test_create_alter_table_use_resource"
             PROPERTIES(
                 "type"="s3",
                 "AWS_REGION" = "bj",
@@ -64,7 +64,7 @@ suite("add_table_policy_by_alter_table") {
             );
         """
         def create_succ_1 = try_sql """
-            CREATE STORAGE POLICY created_create_table_alter_policy
+            CREATE STORAGE POLICY IF NOT EXISTS created_create_table_alter_policy
             PROPERTIES(
             "storage_resource" = "test_create_alter_table_use_resource",
             "cooldown_datetime" = "2025-06-08 00:00:00"
@@ -87,7 +87,7 @@ suite("add_table_policy_by_alter_table") {
 
     if (!storage_exist.call("created_create_table_alter_policy_1")) {
         def create_s3_resource = try_sql """
-            CREATE RESOURCE "test_create_alter_table_use_resource_1"
+            CREATE RESOURCE IF NOT EXISTS "test_create_alter_table_use_resource_1"
             PROPERTIES(
                 "type"="s3",
                 "AWS_REGION" = "bj",
@@ -100,7 +100,7 @@ suite("add_table_policy_by_alter_table") {
             );
         """
         def create_succ_1 = try_sql """
-            CREATE STORAGE POLICY created_create_table_alter_policy_1
+            CREATE STORAGE POLICY IF NOT EXISTS created_create_table_alter_policy_1
             PROPERTIES(
             "storage_resource" = "test_create_alter_table_use_resource_1",
             "cooldown_datetime" = "2025-06-08 00:00:00"

--- a/regression-test/suites/cold_heat_separation/empty_table_use_policy/create_table_use_partition_policy.groovy
+++ b/regression-test/suites/cold_heat_separation/empty_table_use_policy/create_table_use_partition_policy.groovy
@@ -47,7 +47,7 @@ suite("create_table_use_partition_policy") {
 
     if (!storage_exist.call("test_create_table_partition_use_policy_1")) {
         def create_s3_resource = try_sql """
-            CREATE RESOURCE "test_create_table_partition_use_resource_1"
+            CREATE RESOURCE IF NOT EXISTS "test_create_table_partition_use_resource_1"
             PROPERTIES(
                 "type"="s3",
                 "AWS_REGION" = "bj",
@@ -60,7 +60,7 @@ suite("create_table_use_partition_policy") {
             );
         """
         def create_succ_1 = try_sql """
-            CREATE STORAGE POLICY test_create_table_partition_use_policy_1
+            CREATE STORAGE POLICY IF NOT EXISTS test_create_table_partition_use_policy_1
             PROPERTIES(
             "storage_resource" = "test_create_table_partition_use_resource_1",
             "cooldown_ttl" = "$cooldown_ttl"
@@ -72,7 +72,7 @@ suite("create_table_use_partition_policy") {
 
     if (!storage_exist.call("test_create_table_partition_use_policy_2")) {
         def create_s3_resource = try_sql """
-            CREATE RESOURCE "test_create_table_partition_use_resource_2"
+            CREATE RESOURCE IF NOT EXISTS "test_create_table_partition_use_resource_2"
             PROPERTIES(
                 "type"="s3",
                 "AWS_REGION" = "bj",
@@ -85,7 +85,7 @@ suite("create_table_use_partition_policy") {
             );
         """
         def create_succ_1 = try_sql """
-            CREATE STORAGE POLICY test_create_table_partition_use_policy_2
+            CREATE STORAGE POLICY IF NOT EXISTS test_create_table_partition_use_policy_2
             PROPERTIES(
             "storage_resource" = "test_create_table_partition_use_resource_2",
             "cooldown_ttl" = "$cooldown_ttl"

--- a/regression-test/suites/cold_heat_separation/empty_table_use_policy/disable_storage_policy_MoW.groovy
+++ b/regression-test/suites/cold_heat_separation/empty_table_use_policy/disable_storage_policy_MoW.groovy
@@ -33,7 +33,7 @@ suite("disable_storage_policy_MoW"){
 
     if(!storage_exist.call("${storage_policy_name}")){
         def create_s3_resource = sql """
-            CREATE RESOURCE "${s3_source_name}"
+            CREATE RESOURCE IF NOT EXISTS "${s3_source_name}"
             PROPERTIES(
                 "type"="s3",
                 "AWS_REGION" = "bj",
@@ -46,7 +46,7 @@ suite("disable_storage_policy_MoW"){
             );
         """
         def create_storage_policy = sql """
-            CREATE STORAGE POLICY ${storage_policy_name} PROPERTIES(
+            CREATE STORAGE POLICY IF NOT EXISTS ${storage_policy_name} PROPERTIES(
                 "storage_resource" = "${s3_source_name}",
                 "cooldown_ttl" = "1008611"
             );

--- a/regression-test/suites/cold_heat_separation/empty_table_use_policy/use_default_storage_policy.groovy
+++ b/regression-test/suites/cold_heat_separation/empty_table_use_policy/use_default_storage_policy.groovy
@@ -52,7 +52,7 @@ suite("use_default_storage_policy") {
         assertEquals(create_table_use_default_policy_but_not_set_default_policy_result, null);
 
         def create_s3_resource = try_sql """
-            CREATE RESOURCE "default_s3_resource"
+            CREATE RESOURCE IF NOT EXISTS "default_s3_resource"
             PROPERTIES(
                 "type"="s3",
                 "AWS_REGION" = "bj",
@@ -65,7 +65,7 @@ suite("use_default_storage_policy") {
             );
         """
         def create_succ_1 = try_sql """
-            CREATE STORAGE POLICY default_storage_policy PROPERTIES(
+            CREATE STORAGE POLICY IF NOT EXISTS default_storage_policy PROPERTIES(
                 "storage_resource" = "default_s3_resource",
                 "cooldown_ttl" = "1008611"
             );

--- a/regression-test/suites/cold_heat_separation/policy/alter.groovy
+++ b/regression-test/suites/cold_heat_separation/policy/alter.groovy
@@ -31,7 +31,7 @@ suite("alter_policy") {
     // create resource
     def create_source = { resource_name ->
         sql """
-        CREATE RESOURCE "${resource_name}"
+        CREATE RESOURCE IF NOT EXISTS "${resource_name}"
         PROPERTIES(
             "type"="s3",
             "AWS_ENDPOINT" = "bj.s3.comaaaa",
@@ -188,7 +188,7 @@ suite("alter_policy") {
     check_resource_delete_if_exist(has_resource_policy_alter)
     create_source(has_resource_policy_alter)
     sql """
-        CREATE STORAGE POLICY has_resouce_policy_alter_policy
+        CREATE STORAGE POLICY IF NOT EXISTS has_resouce_policy_alter_policy
         PROPERTIES(
             "storage_resource" = "${has_resource_policy_alter}",
             "cooldown_ttl" = "1d"

--- a/regression-test/suites/cold_heat_separation/policy/create.groovy
+++ b/regression-test/suites/cold_heat_separation/policy/create.groovy
@@ -24,7 +24,7 @@ suite("create_policy") {
     // normal
     if(has_created_1.size() == 0) {
         sql """
-        CREATE RESOURCE "crete_policy_1"
+        CREATE RESOURCE IF NOT EXISTS "crete_policy_1"
         PROPERTIES(
             "type" = "s3",
             "AWS_ENDPOINT" = "bj.s3.comaaaa",

--- a/regression-test/suites/cold_heat_separation/policy/drop.groovy
+++ b/regression-test/suites/cold_heat_separation/policy/drop.groovy
@@ -63,7 +63,7 @@ suite("drop_policy") {
 
         def resource_table_use = "resource_table_use"
         sql """
-        CREATE RESOURCE "${resource_table_use}"
+        CREATE RESOURCE IF NOT EXISTS "${resource_table_use}"
         PROPERTIES(
             "type"="s3",
             "AWS_ENDPOINT" = "bj.s3.comaaaa",
@@ -102,7 +102,7 @@ suite("drop_policy") {
         assertEquals(drop_policy_ret.size(), 1)
 
         def create_succ_2 = try_sql """
-            CREATE STORAGE POLICY drop_policy_test_has_table_binded
+            CREATE STORAGE POLICY IF NOT EXISTS drop_policy_test_has_table_binded
             PROPERTIES(
             "storage_resource" = "${resource_table_use}",
             "cooldown_datetime" = "2025-06-08 00:00:00"

--- a/regression-test/suites/cold_heat_separation_p2/create_table_use_partition_policy.groovy
+++ b/regression-test/suites/cold_heat_separation_p2/create_table_use_partition_policy.groovy
@@ -132,7 +132,7 @@ suite("create_table_use_partition_policy") {
     }
 
     sql """
-        CREATE RESOURCE "${resource_name}"
+        CREATE RESOURCE IF NOT EXISTS "${resource_name}"
         PROPERTIES(
             "type"="s3",
             "AWS_ENDPOINT" = "${getS3Endpoint()}",
@@ -149,7 +149,7 @@ suite("create_table_use_partition_policy") {
     """
 
     sql """
-        CREATE STORAGE POLICY ${policy_name}
+        CREATE STORAGE POLICY IF NOT EXISTS ${policy_name}
         PROPERTIES(
             "storage_resource" = "${resource_name}",
             "cooldown_ttl" = "300"

--- a/regression-test/suites/cold_heat_separation_p2/create_table_use_policy.groovy
+++ b/regression-test/suites/cold_heat_separation_p2/create_table_use_policy.groovy
@@ -132,7 +132,7 @@ suite("create_table_use_policy") {
     }
 
     sql """
-        CREATE RESOURCE "${resource_name}"
+        CREATE RESOURCE IF NOT EXISTS "${resource_name}"
         PROPERTIES(
             "type"="s3",
             "AWS_ENDPOINT" = "${getS3Endpoint()}",
@@ -149,7 +149,7 @@ suite("create_table_use_policy") {
     """
 
     sql """
-        CREATE STORAGE POLICY ${policy_name}
+        CREATE STORAGE POLICY IF NOT EXISTS ${policy_name}
         PROPERTIES(
             "storage_resource" = "${resource_name}",
             "cooldown_ttl" = "300"

--- a/regression-test/suites/cold_heat_separation_p2/modify_replica_use_partition.groovy
+++ b/regression-test/suites/cold_heat_separation_p2/modify_replica_use_partition.groovy
@@ -147,7 +147,7 @@ suite("modify_replica_use_partition") {
     }
 
     sql """
-        CREATE RESOURCE "${resource_name}"
+        CREATE RESOURCE IF NOT EXISTS "${resource_name}"
         PROPERTIES(
             "type"="s3",
             "AWS_ENDPOINT" = "${getS3Endpoint()}",
@@ -164,7 +164,7 @@ suite("modify_replica_use_partition") {
     """
 
     sql """
-        CREATE STORAGE POLICY ${policy_name}
+        CREATE STORAGE POLICY IF NOT EXISTS ${policy_name}
         PROPERTIES(
             "storage_resource" = "${resource_name}",
             "cooldown_ttl" = "300"

--- a/regression-test/suites/cold_heat_separation_p2/table_modify_resouce_and_policy.groovy
+++ b/regression-test/suites/cold_heat_separation_p2/table_modify_resouce_and_policy.groovy
@@ -132,7 +132,7 @@ suite("table_modify_resouce") {
     }
 
     sql """
-        CREATE RESOURCE "${resource_name}"
+        CREATE RESOURCE IF NOT EXISTS "${resource_name}"
         PROPERTIES(
             "type"="s3",
             "AWS_ENDPOINT" = "${getS3Endpoint()}",
@@ -149,7 +149,7 @@ suite("table_modify_resouce") {
     """
 
     sql """
-        CREATE STORAGE POLICY ${policy_name}
+        CREATE STORAGE POLICY IF NOT EXISTS ${policy_name}
         PROPERTIES(
             "storage_resource" = "${resource_name}",
             "cooldown_ttl" = "300"


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx
Previously in cold_heat_separation regression, it just tries to create resources/policies. Sometimes if the former cases failed or BE crashed when doing cases the resources would not be cleared so the next time invoking this regression cases would result in failure.

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

