### PR TITLE
[feature](function) support any type in SQL function

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/catalog/AnyType.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/catalog/AnyType.java
@@ -1,0 +1,48 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.catalog;
+
+import org.apache.doris.thrift.TColumnType;
+import org.apache.doris.thrift.TTypeDesc;
+
+/**
+ * Describes a AnyType type, used for SQL function return type,
+ *  NOT used for table column type.
+ */
+public class AnyType extends Type {
+
+    @Override
+    protected String toSql(int depth) {
+        return null;
+    }
+
+    @Override
+    protected String prettyPrint(int lpad) {
+        return null;
+    }
+
+    @Override
+    public void toThrift(TTypeDesc container) {
+        throw new RuntimeException("can not call toThrift on AnyType.");
+    }
+
+    @Override
+    public TColumnType toColumnTypeThrift() {
+        throw new RuntimeException("can not call toColumnTypeThrift on AnyType");
+    }
+}

--- a/fe/fe-common/src/main/java/org/apache/doris/catalog/StructType.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/catalog/StructType.java
@@ -276,6 +276,15 @@ public class StructType extends Type {
         return Lists.newArrayList(this);
     }
 
+    public StructType replaceFieldsWithNames(List<String> names) {
+        Preconditions.checkState(names.size() == fields.size());
+        ArrayList<StructField> newFields = Lists.newArrayList();
+        for (int i = 0; i < names.size(); i++) {
+            newFields.add(new StructField(names.get(i), fields.get(i).type));
+        }
+        return new StructType(newFields);
+    }
+
     @Override
     public boolean equals(Object other) {
         if (!(other instanceof StructType)) {

--- a/fe/fe-common/src/main/java/org/apache/doris/catalog/TemplateType.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/catalog/TemplateType.java
@@ -117,8 +117,8 @@ public class TemplateType extends Type {
         expandSizeMap.computeIfAbsent(name, k -> args.length);
         if (expandSizeMap.get(name) != args.length) {
             throw new TypeException(
-                    String.format("can not expand variadic template type %s to %s size since it's "
-                            + "already expand as %s size", name, args.length, expandSizeMap.get(name)));
+                String.format("can not expand variadic template type %s to %s size since it's "
+                    + "already expand as %s size", name, args.length, expandSizeMap.get(name)));
         }
     }
 

--- a/fe/fe-common/src/main/java/org/apache/doris/catalog/Type.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/catalog/Type.java
@@ -111,6 +111,7 @@ public abstract class Type {
             new StructField("generic_struct", new ScalarType(PrimitiveType.NULL_TYPE))));
     public static final StructType STRUCT = new StructType();
     public static final VariantType VARIANT = new VariantType();
+    public static final AnyType ANY_TYPE = new AnyType();
 
     private static final Logger LOG = LogManager.getLogger(Type.class);
     private static final ArrayList<ScalarType> integerTypes;

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/FunctionCallExpr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/FunctionCallExpr.java
@@ -1448,21 +1448,6 @@ public class FunctionCallExpr extends Expr {
             fn.getReturnType().getPrimitiveType().setTimeType();
         }
 
-        if (fnName.getFunction().equalsIgnoreCase("named_struct")) {
-            if ((children.size() & 1) == 1) {
-                throw new AnalysisException("named_struct can't be odd parameters, need even parameters: "
-                        + this.toSql());
-            }
-            for (int i = 0; i < children.size(); i++) {
-                if ((i & 1) == 0) {
-                    if (!(getChild(i) instanceof StringLiteral)) {
-                        throw new AnalysisException(
-                                "named_struct only allows constant string parameter in odd position: " + this.toSql());
-                    }
-                }
-            }
-        }
-
         if (isAggregateFunction()) {
             final String functionName = fnName.getFunction();
             // subexprs must not contain aggregates
@@ -1627,15 +1612,6 @@ public class FunctionCallExpr extends Expr {
             if (children.size() > 1) {
                 this.type = new MapType(children.get(0).getType(), children.get(1).getType());
             }
-        } else if (fnName.getFunction().equalsIgnoreCase("named_struct")) {
-            List<String> fieldNames = Lists.newArrayList();
-            for (int i = 0; i < children.size(); i++) {
-                if ((i & 1) == 0) {
-                    StringLiteral nameLiteral = (StringLiteral) children.get(i);
-                    fieldNames.add(nameLiteral.getStringValue());
-                }
-            }
-            this.type = ((StructType) type).replaceFieldsWithNames(fieldNames);
         } else if (fnName.getFunction().equalsIgnoreCase("if")) {
             if (children.get(1).getType().isArrayType() && (
                     ((ArrayType) children.get(1).getType()).getItemType().isDecimalV3()

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/FunctionCallExpr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/FunctionCallExpr.java
@@ -1448,6 +1448,21 @@ public class FunctionCallExpr extends Expr {
             fn.getReturnType().getPrimitiveType().setTimeType();
         }
 
+        if (fnName.getFunction().equalsIgnoreCase("named_struct")) {
+            if ((children.size() & 1) == 1) {
+                throw new AnalysisException("named_struct can't be odd parameters, need even parameters: "
+                        + this.toSql());
+            }
+            for (int i = 0; i < children.size(); i++) {
+                if ((i & 1) == 0) {
+                    if (!(getChild(i) instanceof StringLiteral)) {
+                        throw new AnalysisException(
+                                "named_struct only allows constant string parameter in odd position: " + this.toSql());
+                    }
+                }
+            }
+        }
+
         if (isAggregateFunction()) {
             final String functionName = fnName.getFunction();
             // subexprs must not contain aggregates
@@ -1612,6 +1627,15 @@ public class FunctionCallExpr extends Expr {
             if (children.size() > 1) {
                 this.type = new MapType(children.get(0).getType(), children.get(1).getType());
             }
+        } else if (fnName.getFunction().equalsIgnoreCase("named_struct")) {
+            List<String> fieldNames = Lists.newArrayList();
+            for (int i = 0; i < children.size(); i++) {
+                if ((i & 1) == 0) {
+                    StringLiteral nameLiteral = (StringLiteral) children.get(i);
+                    fieldNames.add(nameLiteral.getStringValue());
+                }
+            }
+            this.type = ((StructType) type).replaceFieldsWithNames(fieldNames);
         } else if (fnName.getFunction().equalsIgnoreCase("if")) {
             if (children.get(1).getType().isArrayType() && (
                     ((ArrayType) children.get(1).getType()).getItemType().isDecimalV3()

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Function.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Function.java
@@ -493,6 +493,10 @@ public class Function implements Writable {
         }
     }
 
+    public boolean isInferenceFunction() {
+        return retType instanceof AnyType;
+    }
+
     public TFunction toThrift(Type realReturnType, Type[] realArgTypes) {
         TFunction fn = new TFunction();
         fn.setSignature(signatureString());

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Function.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Function.java
@@ -494,6 +494,11 @@ public class Function implements Writable {
     }
 
     public boolean isInferenceFunction() {
+        for (Type arg : argTypes) {
+            if (arg instanceof AnyType) {
+                return true;
+            }
+        }
         return retType instanceof AnyType;
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/FunctionSet.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/FunctionSet.java
@@ -1409,7 +1409,7 @@ public class FunctionSet<T> {
     public Function resolveInferenceFunction(Function inferenceFunction, Function requestFunction) {
         Type[] args = requestFunction.getArgs();
         Type newRetType = FunctionTypeDeducers.deduce(inferenceFunction.functionName(), args);
-        if (inferenceFunction instanceof ScalarFunction) {
+        if (newRetType != null && inferenceFunction instanceof ScalarFunction) {
             ScalarFunction f = (ScalarFunction) inferenceFunction;
             return new ScalarFunction(f.getFunctionName(), Lists.newArrayList(f.getArgs()), newRetType, f.hasVarArgs(),
                     f.getSymbolName(), f.getBinaryType(), f.isUserVisible(), f.isVectorized(), f.getNullableMode());

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/FunctionSet.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/FunctionSet.java
@@ -1232,7 +1232,12 @@ public class FunctionSet<T> {
         List<Function> normalFunctions = Lists.newArrayList();
         List<Function> templateFunctions = Lists.newArrayList();
         List<Function> variadicTemplateFunctions = Lists.newArrayList();
+        List<Function> inferenceFunctions = Lists.newArrayList();
         for (Function fn : fns) {
+            if (fn.isInferenceFunction()) {
+                inferenceFunctions.add(fn);
+                continue;
+            }
             if (fn.hasTemplateArg()) {
                 if (!fn.hasVariadicTemplateArg()) {
                     templateFunctions.add(fn);
@@ -1274,8 +1279,25 @@ public class FunctionSet<T> {
             }
         }
 
-        // try variadic template function
-        return getFunction(desc, mode, specializedVariadicTemplateFunctions);
+        // try variadic template function third
+        fn = getFunction(desc, mode, specializedVariadicTemplateFunctions);
+        if (fn != null) {
+            return fn;
+        }
+
+        List<Function> inferredFunctions = Lists.newArrayList();
+        for (Function f : inferenceFunctions) {
+            if (f.hasTemplateArg()) {
+                f = specializeTemplateFunction(f, desc, f.hasVariadicTemplateArg());
+            }
+            f = resolveInferenceFunction(f, desc);
+            if (f != null) {
+                inferredFunctions.add(f);
+            }
+        }
+
+        // try inference function at last
+        return getFunction(desc, mode, inferredFunctions);
     }
 
     private Function getFunction(Function desc, Function.CompareMode mode, List<Function> fns) {
@@ -1382,6 +1404,17 @@ public class FunctionSet<T> {
             }
             return null;
         }
+    }
+
+    public Function resolveInferenceFunction(Function inferenceFunction, Function requestFunction) {
+        Type[] args = requestFunction.getArgs();
+        Type newRetType = FunctionTypeDeducers.deduce(inferenceFunction.functionName(), args);
+        if (inferenceFunction instanceof ScalarFunction) {
+            ScalarFunction f = (ScalarFunction) inferenceFunction;
+            return new ScalarFunction(f.getFunctionName(), Lists.newArrayList(f.getArgs()), newRetType, f.hasVarArgs(),
+                    f.getSymbolName(), f.getBinaryType(), f.isUserVisible(), f.isVectorized(), f.getNullableMode());
+        }
+        return null;
     }
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/FunctionTypeDeducers.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/FunctionTypeDeducers.java
@@ -1,0 +1,63 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.catalog;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+
+import java.util.List;
+
+public class FunctionTypeDeducers {
+
+    public interface TypeDeducer {
+        public Type deduce(Type[] args);
+    }
+
+    public static final ImmutableMap<String, TypeDeducer> DEDUCERS = ImmutableMap.<String, TypeDeducer>builder()
+            .put("named_struct", new NamedStructDeducer())
+            .put("element_at", new ElementAtDeducer())
+            .build();
+
+    public static Type deduce(String fnName, Type[] args) {
+        if (DEDUCERS.containsKey(fnName)) {
+            return DEDUCERS.get(fnName).deduce(args);
+        }
+        return null;
+    }
+
+    public static class NamedStructDeducer implements TypeDeducer {
+        @Override
+        public Type deduce(Type[] args) {
+            List<Type> evenArgs = Lists.newArrayList();
+            for (int i = 0; i < args.length; i++) {
+                if (i % 2 == 1) {
+                    evenArgs.add(args[i]);
+                }
+            }
+            return new StructType(evenArgs);
+        }
+    }
+
+    public static class ElementAtDeducer implements TypeDeducer {
+        @Override
+        public Type deduce(Type[] args) {
+            // todo(xy)
+            return null;
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/FunctionTypeDeducers.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/FunctionTypeDeducers.java
@@ -45,7 +45,7 @@ public class FunctionTypeDeducers {
         public Type deduce(Type[] args) {
             List<Type> evenArgs = Lists.newArrayList();
             for (int i = 0; i < args.length; i++) {
-                if (i % 2 == 1) {
+                if ((i & 1) == 1) {
                     evenArgs.add(args[i]);
                 }
             }

--- a/gensrc/script/doris_builtins_functions.py
+++ b/gensrc/script/doris_builtins_functions.py
@@ -81,6 +81,7 @@ visible_functions = [
 
     # struct functions
     [['struct'], 'STRUCT<TYPES>', ['TYPES'], 'ALWAYS_NOT_NULLABLE', ['TYPES...']],
+    [['named_struct'], 'ANY_TYPE', ['TYPES'], 'ALWAYS_NOT_NULLABLE', ['TYPES...']],
 
     # array functions
     [['array'], 'ARRAY', ['BOOLEAN', '...'], 'ALWAYS_NOT_NULLABLE'],


### PR DESCRIPTION
# Proposed changes

In #17344 , we support template and variadic template function.

e.g.

```
[['element_at', '%element_extract%'], 'V', ['MAP<K, V>', 'K'], 'ALWAYS_NULLABLE', ['K', 'V']],
```

Then it raises a new issue, as some functions has unpredictable return type.
e.g.

```
[['element_at', '%element_extract%'], '???', ['STRUCT<TYPES>', 'VARCHAR'], 'ALWAYS_NULLABLE', ['TYPES...']],
```

This commit support `ANY_TYPE`.

If a function has `ANY_TYPE` as return type, then this function is an inference function.

e.g.

```
[['element_at', '%element_extract%'], 'ANY_TYPE', ['STRUCT<TYPES>', 'VARCHAR'], 'ALWAYS_NULLABLE', ['TYPES...']],
```

An inference function's return type will be analyze to actual type at runtime in FE.

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

