### PR TITLE
[fix](nereids)move validate data types before EliminateUnnecessaryProject rule

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/batch/NereidsRewriter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/batch/NereidsRewriter.java
@@ -35,6 +35,7 @@ import org.apache.doris.nereids.rules.rewrite.logical.AdjustNullable;
 import org.apache.doris.nereids.rules.rewrite.logical.AggScalarSubQueryToWindowFunction;
 import org.apache.doris.nereids.rules.rewrite.logical.BuildAggForUnion;
 import org.apache.doris.nereids.rules.rewrite.logical.CheckAndStandardizeWindowFunctionAndFrame;
+import org.apache.doris.nereids.rules.rewrite.logical.CheckDataTypes;
 import org.apache.doris.nereids.rules.rewrite.logical.ColumnPruning;
 import org.apache.doris.nereids.rules.rewrite.logical.ConvertInnerOrCrossJoin;
 import org.apache.doris.nereids.rules.rewrite.logical.CountDistinctRewrite;
@@ -207,6 +208,8 @@ public class NereidsRewriter extends BatchRewriteJob {
                     new PushFilterInsideJoin()
                 )
             ),
+
+            custom(RuleType.CHECK_DATATYPES, CheckDataTypes::new),
 
             // this rule should invoke after ColumnPruning
             custom(RuleType.ELIMINATE_UNNECESSARY_PROJECT, EliminateUnnecessaryProject::new),

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/Validator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/Validator.java
@@ -19,25 +19,16 @@ package org.apache.doris.nereids.processor.post;
 
 import org.apache.doris.nereids.CascadesContext;
 import org.apache.doris.nereids.exceptions.AnalysisException;
-import org.apache.doris.nereids.exceptions.UnboundException;
-import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.MarkJoinSlotReference;
 import org.apache.doris.nereids.trees.expressions.Slot;
 import org.apache.doris.nereids.trees.expressions.VirtualSlotReference;
 import org.apache.doris.nereids.trees.expressions.literal.BooleanLiteral;
-import org.apache.doris.nereids.trees.expressions.visitor.DefaultExpressionVisitor;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.algebra.Aggregate;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalFilter;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalProject;
-import org.apache.doris.nereids.types.ArrayType;
-import org.apache.doris.nereids.types.DataType;
-import org.apache.doris.nereids.types.JsonType;
-import org.apache.doris.nereids.types.MapType;
-import org.apache.doris.nereids.types.StructType;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableSet;
 
 import java.util.List;
 import java.util.Optional;
@@ -48,9 +39,6 @@ import java.util.stream.Collectors;
  * validator plan.
  */
 public class Validator extends PlanPostProcessor {
-
-    private static final Set<Class<? extends DataType>> UNSUPPORTED_TYPE = ImmutableSet.of(
-            MapType.class, StructType.class, JsonType.class, ArrayType.class);
 
     @Override
     public Plan visitPhysicalProject(PhysicalProject<? extends Plan> project, CascadesContext context) {
@@ -80,7 +68,6 @@ public class Validator extends PlanPostProcessor {
 
     @Override
     public Plan visit(Plan plan, CascadesContext context) {
-        plan.getExpressions().forEach(ExpressionChecker.INSTANCE::check);
         plan.children().forEach(child -> child.accept(this, context));
         Optional<Slot> opt = checkAllSlotFromChildren(plan);
         if (opt.isPresent()) {
@@ -119,28 +106,5 @@ public class Validator extends PlanPostProcessor {
         }
         return Optional.empty();
     }
-
-    private static class ExpressionChecker extends DefaultExpressionVisitor<Expression, Void> {
-        public static final ExpressionChecker INSTANCE = new ExpressionChecker();
-
-        public void check(Expression expression) {
-            expression.accept(this, null);
-        }
-
-        public Expression visit(Expression expr, Void unused) {
-            try {
-                checkTypes(expr.getDataType());
-            } catch (UnboundException ignored) {
-                return expr;
-            }
-            expr.children().forEach(child -> child.accept(this, null));
-            return expr;
-        }
-
-        private void checkTypes(DataType dataType) {
-            if (UNSUPPORTED_TYPE.contains(dataType.getClass())) {
-                throw new AnalysisException(String.format("type %s is unsupported for Nereids", dataType));
-            }
-        }
-    }
 }
+

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/RuleType.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/RuleType.java
@@ -85,6 +85,7 @@ public enum RuleType {
     // check analysis rule
     CHECK_AGGREGATE_ANALYSIS(RuleTypeClass.CHECK),
     CHECK_ANALYSIS(RuleTypeClass.CHECK),
+    CHECK_DATATYPES(RuleTypeClass.CHECK),
 
     // rewrite rules
     NORMALIZE_AGGREGATE(RuleTypeClass.REWRITE),

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/logical/CheckDataTypes.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/logical/CheckDataTypes.java
@@ -1,0 +1,79 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.rules.rewrite.logical;
+
+import org.apache.doris.nereids.exceptions.AnalysisException;
+import org.apache.doris.nereids.exceptions.UnboundException;
+import org.apache.doris.nereids.jobs.JobContext;
+import org.apache.doris.nereids.trees.expressions.Expression;
+import org.apache.doris.nereids.trees.expressions.visitor.DefaultExpressionVisitor;
+import org.apache.doris.nereids.trees.plans.Plan;
+import org.apache.doris.nereids.trees.plans.visitor.CustomRewriter;
+import org.apache.doris.nereids.types.ArrayType;
+import org.apache.doris.nereids.types.DataType;
+import org.apache.doris.nereids.types.JsonType;
+import org.apache.doris.nereids.types.MapType;
+import org.apache.doris.nereids.types.StructType;
+
+import com.google.common.collect.ImmutableSet;
+
+import java.util.Set;
+
+/**
+ * Check all supported DataTypes
+ */
+public class CheckDataTypes implements CustomRewriter {
+
+    private static final Set<Class<? extends DataType>> UNSUPPORTED_TYPE = ImmutableSet.of(
+            MapType.class, StructType.class, JsonType.class, ArrayType.class);
+
+    @Override
+    public Plan rewriteRoot(Plan plan, JobContext jobContext) {
+        return rewrite(plan);
+    }
+
+    private Plan rewrite(Plan plan) {
+        plan.getExpressions().forEach(ExpressionChecker.INSTANCE::check);
+        plan.children().forEach(child -> rewrite(child));
+        return plan;
+    }
+
+    private static class ExpressionChecker extends DefaultExpressionVisitor<Expression, Void> {
+        public static final ExpressionChecker INSTANCE = new ExpressionChecker();
+
+        public void check(Expression expression) {
+            expression.accept(this, null);
+        }
+
+        public Expression visit(Expression expr, Void unused) {
+            try {
+                checkTypes(expr.getDataType());
+            } catch (UnboundException ignored) {
+                return expr;
+            }
+            expr.children().forEach(child -> child.accept(this, null));
+            return expr;
+        }
+
+        private void checkTypes(DataType dataType) {
+            if (UNSUPPORTED_TYPE.contains(dataType.getClass())) {
+                throw new AnalysisException(String.format("type %s is unsupported for Nereids", dataType));
+            }
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/UnsupportedTypeTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/UnsupportedTypeTest.java
@@ -67,9 +67,13 @@ public class UnsupportedTypeTest extends TestWithFeService {
                 "select karr from type_tb",
                 "select array_range(10)",
                 "select kmap from type_tb1",
+                "select * from type_tb",
+                "select * from type_tb1",
         };
         Class[] exceptions = {
                 null,
+                AnalysisException.class,
+                AnalysisException.class,
                 AnalysisException.class,
                 AnalysisException.class,
                 AnalysisException.class,

--- a/regression-test/suites/query_p0/aggregate/aggregate_group_by_metric_type.groovy
+++ b/regression-test/suites/query_p0/aggregate/aggregate_group_by_metric_type.groovy
@@ -92,21 +92,6 @@ suite("aggregate_group_by_metric_type") {
         exception "${error_msg}"
     }
 
-    sql 'set enable_nereids_planner=true'
-    test {
-        sql "select distinct c_array from test_group_by_array"
-        exception "${error_msg}"
-    }
-    test {
-        sql "select c_array from test_group_by_array order by c_array"
-        exception "${error_msg}"
-    }
-    test {
-        sql "select c_array,count(*) from test_group_by_array group by c_array"
-        exception "${error_msg}"
-    }
-    sql 'set enable_nereids_planner=false'
-
     sql "DROP TABLE test_group_by_array"
 
     sql "DROP TABLE IF EXISTS test_group_by_struct"


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

validate supported data types checks if a project node's output contains any unsupported data types like array, map, etc in nereids. So this validation should run before EliminateUnnecessaryProject rule

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

