### PR TITLE
[FIX](complex-type)fix get_default to return real nested default value

### DIFF
--- a/be/src/vec/data_types/data_type_array.cpp
+++ b/be/src/vec/data_types/data_type_array.cpp
@@ -42,7 +42,9 @@ MutableColumnPtr DataTypeArray::create_column() const {
 }
 
 Field DataTypeArray::get_default() const {
-    return Array();
+    Array a = Array(1);
+    a.push_back(nested->get_default());
+    return a;
 }
 
 bool DataTypeArray::equals(const IDataType& rhs) const {

--- a/be/src/vec/data_types/data_type_map.cpp
+++ b/be/src/vec/data_types/data_type_map.cpp
@@ -26,6 +26,16 @@ DataTypeMap::DataTypeMap(const DataTypePtr& key_type_, const DataTypePtr& value_
     value_type = value_type_;
 }
 
+Field DataTypeMap::get_default() const {
+    Map m(2);
+    Array key(1), val(1);
+    key.push_back(key_type->get_default());
+    val.push_back(value_type->get_default());
+    m.push_back(key);
+    m.push_back(val);
+    return m;
+};
+
 std::string DataTypeMap::to_string(const IColumn& column, size_t row_num) const {
     const ColumnMap& map_column = assert_cast<const ColumnMap&>(column);
     const ColumnArray::Offsets64& offsets = map_column.get_offsets();

--- a/be/src/vec/data_types/data_type_map.h
+++ b/be/src/vec/data_types/data_type_map.h
@@ -54,7 +54,7 @@ public:
 
     bool can_be_inside_nullable() const override { return true; }
     MutableColumnPtr create_column() const override;
-    Field get_default() const override { return Map(); };
+    Field get_default() const override;
     bool equals(const IDataType& rhs) const override;
     bool get_is_parametric() const override { return true; }
     bool have_subtypes() const override { return true; }

--- a/be/src/vec/data_types/data_type_struct.cpp
+++ b/be/src/vec/data_types/data_type_struct.cpp
@@ -344,7 +344,12 @@ MutableColumnPtr DataTypeStruct::create_column() const {
 }
 
 Field DataTypeStruct::get_default() const {
-    return Tuple();
+    size_t size = elems.size();
+    Tuple t(size);
+    for (size_t i = 0; i < size; ++i) {
+        t.push_back(elems[i]->get_default());
+    }
+    return t;
 }
 
 void DataTypeStruct::insert_default_into(IColumn& column) const {


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary
when create_column_with_default_value() return a empty field in memory 
then call insert() with default value will meet size inconsistent in MAP and STRUCT,  skipping this default value In Array.

Describe your changes.
make real default value to return with nested type in complex type  

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

