### PR TITLE
[fix](fe) add fe isReady check before getMasterIp

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/meta/ColocateMetaService.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/meta/ColocateMetaService.java
@@ -84,7 +84,7 @@ public class ColocateMetaService extends RestBaseController {
     }
 
     public Object executeWithoutPassword(HttpServletRequest request, HttpServletResponse response)
-            throws DdlException {
+            throws Exception {
         executeCheckPassword(request, response);
         RedirectView redirectView = redirectToMaster(request, response);
         if (redirectView != null) {
@@ -95,14 +95,14 @@ public class ColocateMetaService extends RestBaseController {
     }
 
     @RequestMapping(path = "/api/colocate", method = RequestMethod.GET)
-    public Object colocate(HttpServletRequest request, HttpServletResponse response) throws DdlException {
+    public Object colocate(HttpServletRequest request, HttpServletResponse response) throws Exception {
         executeWithoutPassword(request, response);
         return ResponseEntityBuilder.ok(Env.getCurrentColocateIndex());
     }
 
     @RequestMapping(path = "/api/colocate/group_stable", method = {RequestMethod.POST, RequestMethod.DELETE})
     public Object group_stable(HttpServletRequest request, HttpServletResponse response)
-            throws DdlException {
+            throws Exception {
         if (needRedirect(request.getScheme())) {
             return redirectToHttps(request);
         }
@@ -121,7 +121,7 @@ public class ColocateMetaService extends RestBaseController {
 
     @RequestMapping(path = "/api/colocate/bucketseq", method = RequestMethod.POST)
     public Object bucketseq(HttpServletRequest request, HttpServletResponse response, @RequestBody String meta)
-            throws DdlException {
+            throws Exception {
         if (needRedirect(request.getScheme())) {
             return redirectToHttps(request);
         }
@@ -165,7 +165,7 @@ public class ColocateMetaService extends RestBaseController {
     }
 
     private void updateBackendPerBucketSeq(GroupId groupId, List<List<Long>> backendsPerBucketSeq)
-            throws DdlException {
-        throw new DdlException("Currently not support");
+            throws Exception {
+        throw new Exception("Currently not support");
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/meta/ColocateMetaService.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/meta/ColocateMetaService.java
@@ -86,7 +86,7 @@ public class ColocateMetaService extends RestBaseController {
     public Object executeWithoutPassword(HttpServletRequest request, HttpServletResponse response)
             throws Exception {
         executeCheckPassword(request, response);
-        RedirectView redirectView = redirectToMaster(request, response);
+        RedirectView redirectView = redirectToMasterOrException(request, response);
         if (redirectView != null) {
             return redirectView;
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/CancelLoadAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/CancelLoadAction.java
@@ -50,9 +50,13 @@ public class CancelLoadAction extends RestBaseController {
         }
 
         executeCheckPassword(request, response);
-        RedirectView redirectView = redirectToMaster(request, response);
-        if (redirectView != null) {
-            return redirectView;
+        try {
+            RedirectView redirectView = redirectToMaster(request, response);
+            if (redirectView != null) {
+                return redirectView;
+            }
+        } catch (Exception e) {
+            return ResponseEntityBuilder.okWithCommonError(e.getMessage());
         }
 
         if (Strings.isNullOrEmpty(dbName)) {

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/CancelLoadAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/CancelLoadAction.java
@@ -31,7 +31,6 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.servlet.view.RedirectView;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -50,13 +49,9 @@ public class CancelLoadAction extends RestBaseController {
         }
 
         executeCheckPassword(request, response);
-        try {
-            RedirectView redirectView = redirectToMaster(request, response);
-            if (redirectView != null) {
-                return redirectView;
-            }
-        } catch (Exception e) {
-            return ResponseEntityBuilder.okWithCommonError(e.getMessage());
+        Object redirectView = redirectToMaster(request, response);
+        if (redirectView != null) {
+            return redirectView;
         }
 
         if (Strings.isNullOrEmpty(dbName)) {

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/GetLoadInfoAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/GetLoadInfoAction.java
@@ -77,9 +77,13 @@ public class GetLoadInfoAction extends RestBaseController {
             return new RestBaseResult("No cluster selected");
         }
 
-        RedirectView redirectView = redirectToMaster(request, response);
-        if (redirectView != null) {
-            return redirectView;
+        try {
+            RedirectView redirectView = redirectToMaster(request, response);
+            if (redirectView != null) {
+                return redirectView;
+            }
+        } catch (Exception e) {
+            return new RestBaseResult(e.getMessage());
         }
 
         try {

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/GetLoadInfoAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/GetLoadInfoAction.java
@@ -30,7 +30,6 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.servlet.view.RedirectView;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -77,13 +76,9 @@ public class GetLoadInfoAction extends RestBaseController {
             return new RestBaseResult("No cluster selected");
         }
 
-        try {
-            RedirectView redirectView = redirectToMaster(request, response);
-            if (redirectView != null) {
-                return redirectView;
-            }
-        } catch (Exception e) {
-            return new RestBaseResult(e.getMessage());
+        Object redirectView = redirectToMaster(request, response);
+        if (redirectView != null) {
+            return redirectView;
         }
 
         try {

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/GetStreamLoadState.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/GetStreamLoadState.java
@@ -40,9 +40,13 @@ public class GetStreamLoadState extends RestBaseController {
                           HttpServletRequest request, HttpServletResponse response) {
         executeCheckPassword(request, response);
 
-        RedirectView redirectView = redirectToMaster(request, response);
-        if (redirectView != null) {
-            return redirectView;
+        try {
+            RedirectView redirectView = redirectToMaster(request, response);
+            if (redirectView != null) {
+                return redirectView;
+            }
+        } catch (Exception e) {
+            return ResponseEntityBuilder.okWithCommonError(e.getMessage());
         }
 
         String label = request.getParameter(LABEL_KEY);

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/GetStreamLoadState.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/GetStreamLoadState.java
@@ -27,7 +27,6 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.servlet.view.RedirectView;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -40,13 +39,9 @@ public class GetStreamLoadState extends RestBaseController {
                           HttpServletRequest request, HttpServletResponse response) {
         executeCheckPassword(request, response);
 
-        try {
-            RedirectView redirectView = redirectToMaster(request, response);
-            if (redirectView != null) {
-                return redirectView;
-            }
-        } catch (Exception e) {
-            return ResponseEntityBuilder.okWithCommonError(e.getMessage());
+        Object redirectView = redirectToMaster(request, response);
+        if (redirectView != null) {
+            return redirectView;
         }
 
         String label = request.getParameter(LABEL_KEY);

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/LoadAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/LoadAction.java
@@ -154,7 +154,7 @@ public class LoadAction extends RestBaseController {
             if (!isStreamLoad && !Strings.isNullOrEmpty(request.getParameter(SUB_LABEL_NAME_PARAM))) {
                 // only multi mini load need to redirect to Master, because only Master has the info of table to
                 // the Backend which the file exists.
-                RedirectView redirectView = redirectToMaster(request, response);
+                Object redirectView = redirectToMaster(request, response);
                 if (redirectView != null) {
                     return redirectView;
                 }

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/MultiAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/MultiAction.java
@@ -31,7 +31,6 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.servlet.view.RedirectView;
 
 import java.util.List;
 import java.util.Map;
@@ -69,7 +68,7 @@ public class MultiAction extends RestBaseController {
             checkDbAuth(ConnectContext.get().getCurrentUserIdentity(), fullDbName, PrivPredicate.LOAD);
 
             // only Master has these load info
-            RedirectView redirectView = redirectToMaster(request, response);
+            Object redirectView = redirectToMaster(request, response);
             if (redirectView != null) {
                 return redirectView;
             }
@@ -100,7 +99,7 @@ public class MultiAction extends RestBaseController {
             checkDbAuth(ConnectContext.get().getCurrentUserIdentity(), fullDbName, PrivPredicate.LOAD);
 
             // only Master has these load info
-            RedirectView redirectView = redirectToMaster(request, response);
+            Object redirectView = redirectToMaster(request, response);
             if (redirectView != null) {
                 return redirectView;
             }
@@ -136,7 +135,7 @@ public class MultiAction extends RestBaseController {
             // Multi start request must redirect to master, because all following sub requests will be handled
             // on Master
 
-            RedirectView redirectView = redirectToMaster(request, response);
+            Object redirectView = redirectToMaster(request, response);
             if (redirectView != null) {
                 return redirectView;
             }
@@ -187,7 +186,7 @@ public class MultiAction extends RestBaseController {
             String fullDbName = getFullDbName(dbName);
             checkDbAuth(ConnectContext.get().getCurrentUserIdentity(), fullDbName, PrivPredicate.LOAD);
 
-            RedirectView redirectView = redirectToMaster(request, response);
+            Object redirectView = redirectToMaster(request, response);
             if (redirectView != null) {
                 return redirectView;
             }
@@ -222,7 +221,7 @@ public class MultiAction extends RestBaseController {
 
             // only Master has these load info
 
-            RedirectView redirectView = redirectToMaster(request, response);
+            Object redirectView = redirectToMaster(request, response);
             if (redirectView != null) {
                 return redirectView;
             }
@@ -259,7 +258,7 @@ public class MultiAction extends RestBaseController {
             checkDbAuth(ConnectContext.get().getCurrentUserIdentity(), fullDbName, PrivPredicate.LOAD);
 
             // only Master has these load info
-            RedirectView redirectView = redirectToMaster(request, response);
+            Object redirectView = redirectToMaster(request, response);
             if (redirectView != null) {
                 return redirectView;
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/RestBaseController.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/RestBaseController.java
@@ -108,10 +108,13 @@ public class RestBaseController extends BaseController {
         return redirectView;
     }
 
-    public RedirectView redirectToMaster(HttpServletRequest request, HttpServletResponse response) {
+    public RedirectView redirectToMaster(HttpServletRequest request, HttpServletResponse response) throws Exception {
         Env env = Env.getCurrentEnv();
         if (env.isMaster()) {
             return null;
+        }
+        if (!env.isReady()) {
+            throw new Exception("Node catalog is not ready, please wait for a while.");
         }
         return redirectTo(request, new TNetworkAddress(env.getMasterIp(), env.getMasterHttpPort()));
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/RestBaseController.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/RestBaseController.java
@@ -22,6 +22,7 @@ import org.apache.doris.catalog.Env;
 import org.apache.doris.cluster.ClusterNamespace;
 import org.apache.doris.common.Config;
 import org.apache.doris.httpv2.controller.BaseController;
+import org.apache.doris.httpv2.entity.ResponseEntityBuilder;
 import org.apache.doris.httpv2.exception.UnauthorizedException;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.system.SystemInfoService;
@@ -108,7 +109,8 @@ public class RestBaseController extends BaseController {
         return redirectView;
     }
 
-    public RedirectView redirectToMaster(HttpServletRequest request, HttpServletResponse response) throws Exception {
+    public RedirectView redirectToMasterOrException(HttpServletRequest request, HttpServletResponse response)
+                    throws Exception {
         Env env = Env.getCurrentEnv();
         if (env.isMaster()) {
             return null;
@@ -117,6 +119,14 @@ public class RestBaseController extends BaseController {
             throw new Exception("Node catalog is not ready, please wait for a while.");
         }
         return redirectTo(request, new TNetworkAddress(env.getMasterIp(), env.getMasterHttpPort()));
+    }
+
+    public Object redirectToMaster(HttpServletRequest request, HttpServletResponse response) {
+        try {
+            return redirectToMasterOrException(request, response);
+        } catch (Exception e) {
+            return ResponseEntityBuilder.okWithCommonError(e.getMessage());
+        }
     }
 
     public void getFile(HttpServletRequest request, HttpServletResponse response, Object obj, String fileName)

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/ShowAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/ShowAction.java
@@ -116,7 +116,7 @@ public class ShowAction extends RestBaseController {
         // forward to master if necessary
         if (!Env.getCurrentEnv().isMaster() && isForward) {
             try {
-                RedirectView redirectView = redirectToMaster(request, response);
+                RedirectView redirectView = redirectToMasterOrException(request, response);
                 Preconditions.checkNotNull(redirectView);
                 return redirectView;
             } catch (Exception e) {

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/ShowAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/ShowAction.java
@@ -115,9 +115,13 @@ public class ShowAction extends RestBaseController {
 
         // forward to master if necessary
         if (!Env.getCurrentEnv().isMaster() && isForward) {
-            RedirectView redirectView = redirectToMaster(request, response);
-            Preconditions.checkNotNull(redirectView);
-            return redirectView;
+            try {
+                RedirectView redirectView = redirectToMaster(request, response);
+                Preconditions.checkNotNull(redirectView);
+                return redirectView;
+            } catch (Exception e) {
+                return ResponseEntityBuilder.okWithCommonError(e.getMessage());
+            }
         } else {
             ProcNodeInterface procNode = null;
             ProcService instance = ProcService.getInstance();

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/manager/NodeAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/manager/NodeAction.java
@@ -144,7 +144,7 @@ public class NodeAction extends RestBaseController {
             throws Exception {
         try {
             if (!Env.getCurrentEnv().isMaster()) {
-                return redirectToMaster(request, response);
+                return redirectToMasterOrException(request, response);
             }
 
             ProcResult procResult = ProcService.getInstance().open(procPath).fetchResult();
@@ -597,7 +597,7 @@ public class NodeAction extends RestBaseController {
             @RequestBody BackendReqInfo reqInfo) {
         try {
             if (!Env.getCurrentEnv().isMaster()) {
-                return redirectToMaster(request, response);
+                return redirectToMasterOrException(request, response);
             }
 
             List<String> hostPorts = reqInfo.getHostPorts();
@@ -641,7 +641,7 @@ public class NodeAction extends RestBaseController {
             @PathVariable String action, @RequestBody FrontendReqInfo reqInfo) {
         try {
             if (!Env.getCurrentEnv().isMaster()) {
-                return redirectToMaster(request, response);
+                return redirectToMasterOrException(request, response);
             }
 
             String role = reqInfo.getRole();

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/manager/NodeAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/manager/NodeAction.java
@@ -18,13 +18,11 @@
 package org.apache.doris.httpv2.rest.manager;
 
 import org.apache.doris.catalog.Env;
-import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.ConfigBase;
 import org.apache.doris.common.MarkedCountDownLatch;
 import org.apache.doris.common.Pair;
 import org.apache.doris.common.ThreadPoolManager;
-import org.apache.doris.common.UserException;
 import org.apache.doris.common.proc.ProcResult;
 import org.apache.doris.common.proc.ProcService;
 import org.apache.doris.common.util.PropertyAnalyzer;
@@ -107,7 +105,7 @@ public class NodeAction extends RestBaseController {
 
     // Returns all fe information, similar to 'show frontends'.
     @RequestMapping(path = "/frontends", method = RequestMethod.GET)
-    public Object frontends_info(HttpServletRequest request, HttpServletResponse response) throws AnalysisException {
+    public Object frontends_info(HttpServletRequest request, HttpServletResponse response) throws Exception {
         executeCheckPassword(request, response);
         checkGlobalAuth(ConnectContext.get().getCurrentUserIdentity(), PrivPredicate.ADMIN);
 
@@ -116,7 +114,7 @@ public class NodeAction extends RestBaseController {
 
     // Returns all be information, similar to 'show backends'.
     @RequestMapping(path = "/backends", method = RequestMethod.GET)
-    public Object backends_info(HttpServletRequest request, HttpServletResponse response) throws AnalysisException {
+    public Object backends_info(HttpServletRequest request, HttpServletResponse response) throws Exception {
         executeCheckPassword(request, response);
         checkGlobalAuth(ConnectContext.get().getCurrentUserIdentity(), PrivPredicate.ADMIN);
 
@@ -125,7 +123,7 @@ public class NodeAction extends RestBaseController {
 
     // Returns all broker information, similar to 'show broker'.
     @RequestMapping(path = "/brokers", method = RequestMethod.GET)
-    public Object brokers_info(HttpServletRequest request, HttpServletResponse response) throws AnalysisException {
+    public Object brokers_info(HttpServletRequest request, HttpServletResponse response) throws Exception {
         executeCheckPassword(request, response);
         checkGlobalAuth(ConnectContext.get().getCurrentUserIdentity(), PrivPredicate.ADMIN);
 
@@ -143,12 +141,12 @@ public class NodeAction extends RestBaseController {
     //   ]
     // }
     private Object fetchNodeInfo(HttpServletRequest request, HttpServletResponse response, String procPath)
-            throws AnalysisException {
-        if (!Env.getCurrentEnv().isMaster()) {
-            return redirectToMaster(request, response);
-        }
-
+            throws Exception {
         try {
+            if (!Env.getCurrentEnv().isMaster()) {
+                return redirectToMaster(request, response);
+            }
+
             ProcResult procResult = ProcService.getInstance().open(procPath).fetchResult();
             List<String> columnNames = Lists.newArrayList(procResult.getColumnNames());
             return ResponseEntityBuilder.ok(new NodeInfo(columnNames, procResult.getRows()));
@@ -597,10 +595,11 @@ public class NodeAction extends RestBaseController {
     @PostMapping("/{action}/be")
     public Object operateBackend(HttpServletRequest request, HttpServletResponse response, @PathVariable String action,
             @RequestBody BackendReqInfo reqInfo) {
-        if (!Env.getCurrentEnv().isMaster()) {
-            return redirectToMaster(request, response);
-        }
         try {
+            if (!Env.getCurrentEnv().isMaster()) {
+                return redirectToMaster(request, response);
+            }
+
             List<String> hostPorts = reqInfo.getHostPorts();
             List<HostInfo> hostInfos = new ArrayList<>();
             for (String hostPort : hostPorts) {
@@ -631,8 +630,8 @@ public class NodeAction extends RestBaseController {
                             });
                 });
             }
-        } catch (UserException userException) {
-            return ResponseEntityBuilder.okWithCommonError(userException.getMessage());
+        } catch (Exception e) {
+            return ResponseEntityBuilder.okWithCommonError(e.getMessage());
         }
         return ResponseEntityBuilder.ok();
     }
@@ -640,10 +639,11 @@ public class NodeAction extends RestBaseController {
     @PostMapping("/{action}/fe")
     public Object operateFrontends(HttpServletRequest request, HttpServletResponse response,
             @PathVariable String action, @RequestBody FrontendReqInfo reqInfo) {
-        if (!Env.getCurrentEnv().isMaster()) {
-            return redirectToMaster(request, response);
-        }
         try {
+            if (!Env.getCurrentEnv().isMaster()) {
+                return redirectToMaster(request, response);
+            }
+
             String role = reqInfo.getRole();
             Env currentEnv = Env.getCurrentEnv();
             FrontendNodeType frontendNodeType;
@@ -658,8 +658,8 @@ public class NodeAction extends RestBaseController {
             } else if ("DROP".equals(action)) {
                 currentEnv.dropFrontend(frontendNodeType, info.getIp(), info.getHostName(), info.getPort());
             }
-        } catch (UserException userException) {
-            return ResponseEntityBuilder.okWithCommonError(userException.getMessage());
+        } catch (Exception e) {
+            return ResponseEntityBuilder.okWithCommonError(e.getMessage());
         }
         return ResponseEntityBuilder.ok();
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/restv2/StatisticAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/restv2/StatisticAction.java
@@ -50,9 +50,14 @@ public class StatisticAction extends RestBaseController {
             executeCheckPassword(request, response);
         }
 
-        if (!Env.getCurrentEnv().isMaster()) {
-            return redirectToMaster(request, response);
+        try {
+            if (!Env.getCurrentEnv().isMaster()) {
+                return redirectToMaster(request, response);
+            }
+        } catch (Exception e) {
+            return ResponseEntityBuilder.okWithCommonError(e.getMessage());
         }
+
         Map<String, Object> resultMap = Maps.newHashMap();
         Env env = Env.getCurrentEnv();
         SystemInfoService infoService = Env.getCurrentSystemInfo();

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/restv2/StatisticAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/restv2/StatisticAction.java
@@ -52,7 +52,7 @@ public class StatisticAction extends RestBaseController {
 
         try {
             if (!Env.getCurrentEnv().isMaster()) {
-                return redirectToMaster(request, response);
+                return redirectToMasterOrException(request, response);
             }
         } catch (Exception e) {
             return ResponseEntityBuilder.okWithCommonError(e.getMessage());

--- a/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/TokenManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/TokenManager.java
@@ -117,7 +117,10 @@ public class TokenManager {
     }
 
 
-    private TNetworkAddress getMasterAddress() {
+    private TNetworkAddress getMasterAddress() throws TException {
+        if (!Env.getCurrentEnv().isReady()) {
+            throw new TException("Node catalog is not ready, please wait for a while.");
+        }
         String masterHost = Env.getCurrentEnv().getMasterIp();
         int masterRpcPort = Env.getCurrentEnv().getMasterRpcPort();
         return new TNetworkAddress(masterHost, masterRpcPort);


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

when fe node is not ready, will get "" for master ip, and redirect will get error

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

