### PR TITLE
[Bug](materialized-view) fix mv define expr persistence replay incorrect after schema change

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
@@ -100,6 +100,7 @@ import com.google.common.collect.Sets;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -2360,7 +2361,11 @@ public class SchemaChangeHandler extends AlterHandler {
         }
 
         //update base index schema
-        updateBaseIndexSchema(olapTable, indexSchemaMap, indexes);
+        try {
+            updateBaseIndexSchema(olapTable, indexSchemaMap, indexes);
+        } catch (Exception e) {
+            throw new DdlException(e.getMessage());
+        }
 
         if (!isReplay) {
             TableAddOrDropColumnsInfo info = new TableAddOrDropColumnsInfo(db.getId(), olapTable.getId(),
@@ -2481,7 +2486,7 @@ public class SchemaChangeHandler extends AlterHandler {
     }
 
     public void updateBaseIndexSchema(OlapTable olapTable, Map<Long, LinkedList<Column>> indexSchemaMap,
-            List<Index> indexes) {
+            List<Index> indexes) throws IOException {
         long baseIndexId = olapTable.getBaseIndexId();
         List<Long> indexIds = new ArrayList<Long>();
         indexIds.add(baseIndexId);
@@ -2542,8 +2547,12 @@ public class SchemaChangeHandler extends AlterHandler {
             throw new DdlException("Nothing is changed. please check your alter stmt.");
         }
 
-        //update base index schema
-        updateBaseIndexSchema(olapTable, indexSchemaMap, indexes);
+        // update base index schema
+        try {
+            updateBaseIndexSchema(olapTable, indexSchemaMap, indexes);
+        } catch (Exception e) {
+            throw new UserException(e.getMessage());
+        }
 
         if (!isReplay) {
             TableAddOrDropInvertedIndicesInfo info = new TableAddOrDropInvertedIndicesInfo(

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/MaterializedIndexMeta.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/MaterializedIndexMeta.java
@@ -129,8 +129,9 @@ public class MaterializedIndexMeta implements Writable, GsonPostProcessable {
         }
     }
 
-    public void setSchema(List<Column> newSchema) {
+    public void setSchema(List<Column> newSchema) throws IOException {
         this.schema = newSchema;
+        parseStmt(null);
         initColumnNameMap();
     }
 


### PR DESCRIPTION
# Proposed changes

fix mv define expr persistence replay incorrect after schema change

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

