### PR TITLE
[enhancement](Nereids) disable heavy operator penalty in cost model v1

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/cost/CostModelV1.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/cost/CostModelV1.java
@@ -56,7 +56,7 @@ class CostModelV1 extends PlanVisitor<Cost, PlanContext> {
      * <p>
      * An example is tpch q15.
      */
-    static final double HEAVY_OPERATOR_PUNISH_FACTOR = 1.0;
+    static final double HEAVY_OPERATOR_PUNISH_FACTOR = 0.0;
 
     public static Cost addChildCost(Plan plan, Cost planCost, Cost childCost, int index) {
         Preconditions.checkArgument(childCost instanceof CostV1 && planCost instanceof CostV1);


### PR DESCRIPTION
# Proposed changes
disable heavy operator penalty, 
let  HEAVY_OPERATOR_PUNISH_FACTOR = 0.0

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

