### PR TITLE
[enhancement](Nereids) choose aggregate phase by group-by-key unique property

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/implementation/AggregateStrategies.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/implementation/AggregateStrategies.java
@@ -64,6 +64,7 @@ import org.apache.doris.nereids.trees.plans.physical.PhysicalStorageLayerAggrega
 import org.apache.doris.nereids.trees.plans.physical.PhysicalStorageLayerAggregate.PushDownAggOp;
 import org.apache.doris.nereids.util.ExpressionUtils;
 import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.statistics.Statistics;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
@@ -303,6 +304,35 @@ public class AggregateStrategies implements ImplementationRuleFactory {
         }
     }
 
+    private boolean aggregateOnUniqueColumn(
+            LogicalAggregate<? extends Plan> logicalAgg) {
+        if (logicalAgg.child() instanceof GroupPlan) {
+            Statistics childStats = ((GroupPlan) logicalAgg.child()).getGroup().getStatistics();
+            if (childStats != null) {
+                return logicalAgg.getGroupByExpressions().stream().anyMatch(
+                        expression ->
+                            childStats.almostUniqueExpression(expression)
+                );
+            }
+        }
+        return false;
+    }
+
+    private boolean aggregateOnStatsUnknownColumn(LogicalAggregate<? extends Plan> logicalAgg) {
+        if (logicalAgg.child() instanceof GroupPlan) {
+            Statistics childStats = ((GroupPlan) logicalAgg.child()).getGroup().getStatistics();
+            if (childStats != null) {
+                return logicalAgg.getGroupByExpressions().stream().anyMatch(
+                        expression ->
+                                childStats.isStatsUnknown(expression)
+                );
+            } else {
+                return true;
+            }
+        }
+        return true;
+    }
+
     /**
      * sql: select count(*) from tbl group by id
      *
@@ -331,6 +361,12 @@ public class AggregateStrategies implements ImplementationRuleFactory {
      */
     private List<PhysicalHashAggregate<Plan>> onePhaseAggregateWithoutDistinct(
             LogicalAggregate<? extends Plan> logicalAgg, ConnectContext connectContext) {
+        if (!logicalAgg.getGroupByExpressions().isEmpty()
+                && !aggregateOnUniqueColumn(logicalAgg)
+                && !aggregateOnStatsUnknownColumn(logicalAgg)) {
+            // twoPhaseAggregate beats onePhaseAggregate
+            return null;
+        }
         RequireProperties requireGather = RequireProperties.of(PhysicalProperties.GATHER);
         AggregateParam inputToResultParam = AggregateParam.localResult();
         List<NamedExpression> newOutput = ExpressionUtils.rewriteDownShortCircuit(
@@ -757,6 +793,11 @@ public class AggregateStrategies implements ImplementationRuleFactory {
      */
     private List<PhysicalHashAggregate<? extends Plan>> twoPhaseAggregateWithDistinct(
             LogicalAggregate<? extends Plan> logicalAgg, ConnectContext connectContext) {
+        if (!logicalAgg.getGroupByExpressions().isEmpty()
+                && !aggregateOnUniqueColumn(logicalAgg) && !aggregateOnStatsUnknownColumn(logicalAgg)) {
+            // threePhaseAggregate beats twoPhaseAggregate
+            return null;
+        }
         Set<AggregateFunction> aggregateFunctions = logicalAgg.getAggregateFunctions();
 
         Set<Expression> distinctArguments = aggregateFunctions.stream()

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/Statistics.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/Statistics.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.statistics;
 
+import org.apache.doris.nereids.stats.ExpressionEstimation;
 import org.apache.doris.nereids.stats.StatsMathUtil;
 import org.apache.doris.nereids.trees.expressions.Expression;
 
@@ -184,4 +185,21 @@ public class Statistics {
         }
         return zero;
     }
+
+    public boolean almostUniqueExpression(Expression expr) {
+        ExpressionEstimation estimator = new ExpressionEstimation();
+        double ndvErrorThreshold = 0.9;
+        ColumnStatistic colStats = expr.accept(estimator, this);
+        if (colStats.ndv > colStats.count * ndvErrorThreshold) {
+            return true;
+        }
+        return false;
+    }
+
+    public boolean isStatsUnknown(Expression expr) {
+        ExpressionEstimation estimator = new ExpressionEstimation();
+        ColumnStatistic colStats = expr.accept(estimator, this);
+        return colStats.isUnKnown;
+    }
+
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/logical/AggregateStrategiesTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/logical/AggregateStrategiesTest.java
@@ -250,7 +250,11 @@ public class AggregateStrategiesTest implements MemoPatternMatchSupported {
                 );
     }
 
+    // TODO aggregate estimation is not accurate enough.
+    //  we choose 3Phase as RBO. Re-open this case when we could compare cost between 2phase and 3phase.
     @Test
+    @Disabled
+    @Developing("reopen this case when we could choose agg phase by CBO")
     public void distinctWithNormalAggregateFunctionApply2PhaseRule() {
         Slot id = rStudent.getOutput().get(0);
         Slot name = rStudent.getOutput().get(2).toSlot();

--- a/regression-test/suites/nereids_syntax_p0/aggregate_strategies.groovy
+++ b/regression-test/suites/nereids_syntax_p0/aggregate_strategies.groovy
@@ -82,7 +82,7 @@ suite("aggregate_strategies") {
         explain {
             sql """
             select
-                /*+SET_VAR(disable_nereids_rules='ONE_PHASE_AGGREGATE_SINGLE_DISTINCT_TO_MULTI,TWO_PHASE_AGGREGATE_SINGLE_DISTINCT_TO_MULTI,THREE_PHASE_AGGREGATE_WITH_DISTINCT')*/
+                /*+SET_VAR(disable_nereids_rules='ONE_PHASE_AGGREGATE_SINGLE_DISTINCT_TO_MULTI,TWO_PHASE_AGGREGATE_SINGLE_DISTINCT_TO_MULTI,THREE_PHASE_AGGREGATE_WITH_DISTINCT, FOUR_PHASE_AGGREGATE_WITH_DISTINCT')*/
                 count(distinct id)
                 from $tableName
             """


### PR DESCRIPTION
# Proposed changes
when group-by-keys does not contain unique column, 
1. with out distinct: we prefer two phase aggregate to one phase aggregate
2. with distinct: we prefer three phase aggregate to two phase aggregate

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

