### PR TITLE
[feature](Nereids): deduplicate InPredicate.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rewrite/ExpressionNormalization.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rewrite/ExpressionNormalization.java
@@ -21,6 +21,7 @@ import org.apache.doris.nereids.rules.expression.rewrite.rules.BetweenToCompound
 import org.apache.doris.nereids.rules.expression.rewrite.rules.CharacterLiteralTypeCoercion;
 import org.apache.doris.nereids.rules.expression.rewrite.rules.DigitalMaskingConvert;
 import org.apache.doris.nereids.rules.expression.rewrite.rules.FoldConstantRule;
+import org.apache.doris.nereids.rules.expression.rewrite.rules.InPredicateDedup;
 import org.apache.doris.nereids.rules.expression.rewrite.rules.InPredicateToEqualToRule;
 import org.apache.doris.nereids.rules.expression.rewrite.rules.NormalizeBinaryPredicatesRule;
 import org.apache.doris.nereids.rules.expression.rewrite.rules.SimplifyArithmeticComparisonRule;
@@ -45,6 +46,7 @@ public class ExpressionNormalization extends ExpressionRewrite {
             SupportJavaDateFormatter.INSTANCE,
             NormalizeBinaryPredicatesRule.INSTANCE,
             BetweenToCompoundRule.INSTANCE,
+            InPredicateDedup.INSTANCE,
             InPredicateToEqualToRule.INSTANCE,
             SimplifyNotExprRule.INSTANCE,
             // TODO(morrySnow): remove type coercion from here after we could process subquery type coercion when bind

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rewrite/rules/InPredicateDedup.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rewrite/rules/InPredicateDedup.java
@@ -1,0 +1,51 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.rules.expression.rewrite.rules;
+
+import org.apache.doris.nereids.rules.expression.rewrite.AbstractExpressionRewriteRule;
+import org.apache.doris.nereids.rules.expression.rewrite.ExpressionRewriteContext;
+import org.apache.doris.nereids.trees.expressions.Expression;
+import org.apache.doris.nereids.trees.expressions.InPredicate;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Deduplicate InPredicate, For example:
+ * where A in (x, x) ==> where A in (x)
+ */
+public class InPredicateDedup extends AbstractExpressionRewriteRule {
+
+    public static InPredicateDedup INSTANCE = new InPredicateDedup();
+
+    @Override
+    public Expression visitInPredicate(InPredicate inPredicate, ExpressionRewriteContext context) {
+        Set<Expression> dedupExpr = new HashSet<>();
+        List<Expression> newOptions = new ArrayList<>();
+        for (Expression option : inPredicate.getOptions()) {
+            if (dedupExpr.contains(option)) {
+                continue;
+            }
+            dedupExpr.add(option);
+            newOptions.add(option);
+        }
+        return new InPredicate(inPredicate.getCompareExpr(), newOptions);
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rewrite/rules/InPredicateDedup.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rewrite/rules/InPredicateDedup.java
@@ -37,6 +37,11 @@ public class InPredicateDedup extends AbstractExpressionRewriteRule {
 
     @Override
     public Expression visitInPredicate(InPredicate inPredicate, ExpressionRewriteContext context) {
+        // In many BI scenarios, the sql is auto-generated, and hence there may be thousands of options.
+        // It takes a long time to apply this rule. So set a threshold for the max number.
+        if (inPredicate.getOptions().size() > 200) {
+            return inPredicate;
+        }
         Set<Expression> dedupExpr = new HashSet<>();
         List<Expression> newOptions = new ArrayList<>();
         for (Expression option : inPredicate.getOptions()) {

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/rewrite/ExpressionRewriteTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/rewrite/ExpressionRewriteTest.java
@@ -20,6 +20,7 @@ package org.apache.doris.nereids.rules.expression.rewrite;
 import org.apache.doris.nereids.rules.expression.rewrite.rules.BetweenToCompoundRule;
 import org.apache.doris.nereids.rules.expression.rewrite.rules.DistinctPredicatesRule;
 import org.apache.doris.nereids.rules.expression.rewrite.rules.ExtractCommonFactorRule;
+import org.apache.doris.nereids.rules.expression.rewrite.rules.InPredicateDedup;
 import org.apache.doris.nereids.rules.expression.rewrite.rules.InPredicateToEqualToRule;
 import org.apache.doris.nereids.rules.expression.rewrite.rules.NormalizeBinaryPredicatesRule;
 import org.apache.doris.nereids.rules.expression.rewrite.rules.SimplifyCastRule;
@@ -193,6 +194,13 @@ public class ExpressionRewriteTest extends ExpressionRewriteTestHelper {
     }
 
     @Test
+    public void testInPredicateDedup() {
+        executor = new ExpressionRuleExecutor(ImmutableList.of(InPredicateDedup.INSTANCE));
+
+        assertRewrite("a in (1, 2, 1, 2)", "a in (1, 2)");
+    }
+
+    @Test
     public void testSimplifyCastRule() {
         executor = new ExpressionRuleExecutor(ImmutableList.of(SimplifyCastRule.INSTANCE));
 
@@ -233,7 +241,7 @@ public class ExpressionRewriteTest extends ExpressionRewriteTestHelper {
         Expression dv2 = new DateV2Literal(1, 1, 1);
         Expression dv2PlusOne = new DateV2Literal(1, 1, 2);
         Expression d = new DateLiteral(1, 1, 1);
-        //Expression dPlusOne = new DateLiteral(1, 1, 2);
+        // Expression dPlusOne = new DateLiteral(1, 1, 2);
 
         // DateTimeV2 -> DateTime
         assertRewrite(


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary
deduplicate InPredicate.

tpcds-q27 

```sql
(s_state IN (
     'TN'
   , 'TN'
   , 'TN'
   , 'TN'
   , 'TN'
   , 'TN')
```

## Checklist(Required)

* [x] Does it affect the original behavior
* [x] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [x] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

