### PR TITLE
[fix](es) ClassCastException when getting root schema

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/external/elasticsearch/EsUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/external/elasticsearch/EsUtil.java
@@ -152,6 +152,8 @@ public class EsUtil {
         }
         // remove `dynamic_templates` field
         mappings.remove("dynamic_templates");
+        // remove `dynamic` field
+        // mappings.remove("dynamic");
         // check explicit mapping
         if (mappings.isEmpty()) {
             throw new DorisEsException("Do not support index without explicit mapping.");

--- a/fe/fe-core/src/main/java/org/apache/doris/external/elasticsearch/EsUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/external/elasticsearch/EsUtil.java
@@ -153,7 +153,7 @@ public class EsUtil {
         // remove `dynamic_templates` field
         mappings.remove("dynamic_templates");
         // remove `dynamic` field
-        // mappings.remove("dynamic");
+        mappings.remove("dynamic");
         // check explicit mapping
         if (mappings.isEmpty()) {
             throw new DorisEsException("Do not support index without explicit mapping.");

--- a/fe/fe-core/src/test/java/org/apache/doris/external/elasticsearch/EsUtilTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/external/elasticsearch/EsUtilTest.java
@@ -268,4 +268,15 @@ public class EsUtilTest extends EsTestCase {
         Assertions.assertEquals(3, columns.size());
     }
 
+    @Test
+    public void testDynamicMapping() throws IOException, URISyntaxException {
+
+        ObjectNode testAliases = EsUtil.getMappingProps("test", loadJsonFromFile("data/es/dynamic_mappings.json"),
+                null);
+        Assertions.assertEquals("{\"time\":{\"type\":\"long\"},\"type\":{\"type\":\"keyword\"},\"userId\":{\"type\":\"text\",\"fields\":{\"keyword\":{\"type\":\"keyword\"}}}}",
+                testAliases.toString());
+
+    }
+
+
 }

--- a/fe/fe-core/src/test/resources/data/es/dynamic_mappings.json
+++ b/fe/fe-core/src/test/resources/data/es/dynamic_mappings.json
@@ -1,0 +1,23 @@
+{
+  "test_index": {
+    "mappings": {
+      "dynamic": "false",
+      "properties": {
+        "time": {
+          "type": "long"
+        },
+        "type": {
+          "type": "keyword"
+        },
+        "userId": {
+          "type": "text",
+          "fields": {
+            "keyword": {
+              "type": "keyword"
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

When the dynamic parameter in the mapping and mapping type is set to null, getting the root schema will cause ClassCastException

example:
```json
{
  "test_index": {
    "mappings": {
      "dynamic": "false",
      "properties": {
        "time": {
          "type": "long"
        },
        "type": {
          "type": "keyword"
        },
        "userId": {
          "type": "text",
          "fields": {
            "keyword": {
              "type": "keyword"
            }
          }
        }
      }
    }
  }
}
```

When the mapping structure is as above



The exception that occurs in the latest version is `java.lang.ClassCastException: com.fasterxml.jackson.databind.node.TextNode cannot be cast to com.fasterxml.jackson.databind.node.ObjectNode`,
and for elder version is `java.lang.ClassCastException: java.lang.String cannot be cast to org.json.simple.JSONObject`

Describe your changes.

## Checklist(Required)

* [x] Does it affect the original behavior
* [x] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [x] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

