### PR TITLE
[Bug](materialized-view) fix mv match failed when aggregate function not materialized

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/planner/MaterializedViewSelector.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/MaterializedViewSelector.java
@@ -43,6 +43,7 @@ import com.google.common.collect.Sets;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
@@ -455,6 +456,14 @@ public class MaterializedViewSelector {
                 aggExpr.getTableIdToColumnNames(tableIdToAggColumnNames);
                 // count(*): tableIdToAggColumnNames is empty which must forbidden the SPJG MV.
                 // TODO(ml): support count(*)
+                List<SlotRef> slots = new ArrayList<>();
+                aggExpr.collect(SlotRef.class, slots);
+                if (!slots.isEmpty()) {
+                    SlotDescriptor desc = ((SlotRef) slots.get(0)).getDesc();
+                    if (desc != null && !desc.isMaterialized()) {
+                        continue;
+                    }
+                }
                 if (tableIdToAggColumnNames.size() != 1) {
                     reasonOfDisable = "aggExpr[" + aggExpr.debugString() + "] should involved only one column";
                     disableSPJGView = true;


### PR DESCRIPTION
# Proposed changes

fix mv match failed when aggregate function not materialized

```sql
explain select a,b from (select a,b,sum(c) 
from test group by a,b) as t
```

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

