### PR TITLE
[Fix](Nereids)change bytesize setting from translate process to catalog datatype switching process

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/ExpressionTranslator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/ExpressionTranslator.java
@@ -107,11 +107,7 @@ public class ExpressionTranslator extends DefaultExpressionVisitor<Expr, PlanTra
      * @return stale planner's expr
      */
     public static Expr translate(Expression expression, PlanTranslatorContext context) {
-        Expr staleExpr = expression.accept(INSTANCE, context);
-        if (staleExpr.getType() instanceof ScalarType) {
-            ((ScalarType) staleExpr.getType()).setByteSize(expression.getDataType().width());
-        }
-        return staleExpr;
+        return expression.accept(INSTANCE, context);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/types/VarcharType.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/types/VarcharType.java
@@ -49,7 +49,9 @@ public class VarcharType extends CharacterType {
 
     @Override
     public Type toCatalogDataType() {
-        return ScalarType.createVarcharType(len);
+        ScalarType catalogDataType = ScalarType.createVarcharType(len);
+        catalogDataType.setByteSize(len);
+        return catalogDataType;
     }
 
     @Override


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

Problem: when used nereids to generate scalarType, byteSize would be set. After switch the optimizer to planner, planner would reuse scalarType in some cases. 
Fix: change byteSize setting from Plan translator to toCatalogDataType

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

