### PR TITLE
 [refactor](planner) In the runtime filter, use crc_hash replace original murmur_hash

### DIFF
--- a/be/src/exprs/block_bloom_filter.hpp
+++ b/be/src/exprs/block_bloom_filter.hpp
@@ -49,6 +49,8 @@ namespace doris {
     0x47b6137bU, 0x44974d91U, 0x8824ad5bU, 0xa2b7289dU, 0x705495c7U, 0x2df1424bU, 0x9efc4947U, \
             0x5c6bfb31U
 
+
+
 class BlockBloomFilter {
 public:
     explicit BlockBloomFilter();
@@ -77,6 +79,49 @@ public:
             insert(HashUtil::murmur_hash3_32(key.data, key.size, _hash_seed));
         }
     }
+
+    // This function is only to be used if the be_exec_version may be less than 2. If updated, please delete it.
+    void insert_new_hash(const Slice& key) noexcept {
+        if (key.data) {
+            insert(HashUtil::crc_hash(key.data, key.size, _hash_seed));
+        }
+    }
+
+#ifdef __AVX2__
+
+    static inline ATTRIBUTE_ALWAYS_INLINE __attribute__((__target__("avx2"))) __m256i make_mark(
+            const uint32_t hash) {
+        const __m256i ones = _mm256_set1_epi32(1);
+        const __m256i rehash = _mm256_setr_epi32(BLOOM_HASH_CONSTANTS);
+        // Load hash into a YMM register, repeated eight times
+        __m256i hash_data = _mm256_set1_epi32(hash);
+        // Multiply-shift hashing ala Dietzfelbinger et al.: multiply 'hash' by eight different
+        // odd constants, then keep the 5 most significant bits from each product.
+        hash_data = _mm256_mullo_epi32(rehash, hash_data);
+        hash_data = _mm256_srli_epi32(hash_data, 27);
+        // Use these 5 bits to shift a single bit to a location in each 32-bit lane
+        return _mm256_sllv_epi32(ones, hash_data);
+    }
+#endif
+
+
+
+#ifdef __AVX2__
+
+    static inline ATTRIBUTE_ALWAYS_INLINE __attribute__((__target__("avx2"))) __m256i make_mark(
+            const uint32_t hash) {
+        const __m256i ones = _mm256_set1_epi32(1);
+        const __m256i rehash = _mm256_setr_epi32(BLOOM_HASH_CONSTANTS);
+        // Load hash into a YMM register, repeated eight times
+        __m256i hash_data = _mm256_set1_epi32(hash);
+        // Multiply-shift hashing ala Dietzfelbinger et al.: multiply 'hash' by eight different
+        // odd constants, then keep the 5 most significant bits from each product.
+        hash_data = _mm256_mullo_epi32(rehash, hash_data);
+        hash_data = _mm256_srli_epi32(hash_data, 27);
+        // Use these 5 bits to shift a single bit to a location in each 32-bit lane
+        return _mm256_sllv_epi32(ones, hash_data);
+    }
+#endif
 
 #ifdef __AVX2__
 
@@ -115,10 +160,38 @@ public:
         return bucket_find(bucket_idx, hash);
 #endif
     }
+    ALWAYS_INLINE bool find(uint32_t hash) const noexcept {
+        if (_always_false) {
+            return false;
+        }
+        const uint32_t bucket_idx = rehash32to32(hash) & _directory_mask;
+#ifdef __AVX2__
+        const __m256i mask = make_mark(hash);
+        const __m256i bucket = reinterpret_cast<__m256i*>(_directory)[bucket_idx];
+        // We should return true if 'bucket' has a one wherever 'mask' does. _mm256_testc_si256
+        // takes the negation of its first argument and ands that with its second argument. In
+        // our case, the result is zero everywhere iff there is a one in 'bucket' wherever
+        // 'mask' is one. testc returns 1 if the result is 0 everywhere and returns 0 otherwise.
+        const bool result = _mm256_testc_si256(bucket, mask);
+        _mm256_zeroupper();
+        return result;
+#else
+        return bucket_find(bucket_idx, hash);
+#endif
+    }
     // Same as above with convenience of hashing the key.
     bool find(const Slice& key) const noexcept {
         if (key.data) {
             return find(HashUtil::murmur_hash3_32(key.data, key.size, _hash_seed));
+        } else {
+            return false;
+        }
+    }
+
+    // This function is only to be used if the be_exec_version may be less than 2. If updated, please delete it.
+    bool find_new_hash(const Slice& key) const noexcept {
+        if (key.data) {
+            return find(HashUtil::crc_hash(key.data, key.size, _hash_seed));
         } else {
             return false;
         }

--- a/be/src/exprs/bloom_filter_func.h
+++ b/be/src/exprs/bloom_filter_func.h
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#include <type_traits>
+
 #include "exprs/block_bloom_filter.hpp"
 #include "exprs/runtime_filter.h"
 
@@ -52,8 +54,19 @@ public:
         return _bloom_filter->find(data);
     }
 
+    template <typename T>
+    bool test_new_hash(T data) const {
+        if constexpr (std::is_same_v<T, Slice>) {
+            return _bloom_filter->find_new_hash(data);
+        } else {
+            return _bloom_filter->find(data);
+        }
+    }
     void add_bytes(const char* data, size_t len) { _bloom_filter->insert(Slice(data, len)); }
-
+    // This function is only to be used if the be_exec_version may be less than 2. If updated, please delete it.
+    void add_bytes_new_hash(const char* data, size_t len) {
+        _bloom_filter->insert_new_hash(Slice(data, len));
+    }
     // test_element/find_element only used on vectorized engine
     template <typename T>
     bool test_element(T element) const {
@@ -172,8 +185,13 @@ public:
     }
 
     virtual void insert(const void* data) = 0;
+    // This function is only to be used if the be_exec_version may be less than 2. If updated, please delete it.
+    virtual void insert_new_hash(const void* data) = 0;
 
     virtual bool find(const void* data) const = 0;
+
+    // This function is only to be used if the be_exec_version may be less than 2. If updated, please delete it.
+    virtual bool find_new_hash(const void* data) const = 0;
 
     virtual bool find_olap_engine(const void* data) const = 0;
 
@@ -317,6 +335,15 @@ struct StringFindOp {
             bloom_filter.add_bytes(value->data, value->size);
         }
     }
+
+    // This function is only to be used if the be_exec_version may be less than 2. If updated, please delete it.
+    void insert_new_hash(BloomFilterAdaptor& bloom_filter, const void* data) const {
+        const auto* value = reinterpret_cast<const StringRef*>(data);
+        if (value) {
+            bloom_filter.add_bytes_new_hash(value->data, value->size);
+        }
+    }
+
     bool find(const BloomFilterAdaptor& bloom_filter, const void* data) const {
         const auto* value = reinterpret_cast<const StringRef*>(data);
         if (value == nullptr) {
@@ -324,6 +351,16 @@ struct StringFindOp {
         }
         return bloom_filter.test(Slice(value->data, value->size));
     }
+
+    //This function is only to be used if the be_exec_version may be less than 2. If updated, please delete it.
+    bool find_new_hash(const BloomFilterAdaptor& bloom_filter, const void* data) const {
+        const auto* value = reinterpret_cast<const StringRef*>(data);
+        if (value == nullptr) {
+            return false;
+        }
+        return bloom_filter.test_new_hash(Slice(value->data, value->size));
+    }
+
     bool find_olap_engine(const BloomFilterAdaptor& bloom_filter, const void* data) const {
         return StringFindOp::find(bloom_filter, data);
     }
@@ -436,6 +473,13 @@ public:
         DCHECK(_bloom_filter != nullptr);
         dummy.insert(*_bloom_filter, data);
     }
+    // This function is only to be used if the be_exec_version may be less than 2. If updated, please delete it.
+    void insert_new_hash(const void* data) override {
+        if constexpr (std::is_same_v<typename BloomFilterTypeTraits<type>::FindOp, StringFindOp>) {
+            DCHECK(_bloom_filter != nullptr);
+            dummy.insert_new_hash(*_bloom_filter, data);
+        }
+    }
 
     void insert_fixed_len(const char* data, const int* offsets, int number) override {
         DCHECK(_bloom_filter != nullptr);
@@ -461,6 +505,15 @@ public:
     bool find(const void* data) const override {
         DCHECK(_bloom_filter != nullptr);
         return dummy.find(*_bloom_filter, data);
+    }
+
+    // This function is only to be used if the be_exec_version may be less than 2. If updated, please delete it.
+    bool find_new_hash(const void* data) const override {
+        if constexpr (std::is_same_v<typename BloomFilterTypeTraits<type>::FindOp, StringFindOp>) {
+            DCHECK(_bloom_filter != nullptr);
+            return dummy.find_new_hash(*_bloom_filter, data);
+        }
+        return false;
     }
 
     bool find_olap_engine(const void* data) const override {

--- a/be/src/exprs/runtime_filter.cpp
+++ b/be/src/exprs/runtime_filter.cpp
@@ -334,7 +334,8 @@ public:
               _fragment_instance_id(params->fragment_instance_id),
               _filter_id(params->filter_id),
               _use_batch(IRuntimeFilter::enable_use_batch(_state->be_exec_version(),
-                                                          _column_return_type)) {}
+                                                          _column_return_type)),
+              _use_new_hash(_state->be_exec_version() >= 2) {}
     // for a 'tmp' runtime predicate wrapper
     // only could called assign method or as a param for merge
     RuntimePredicateWrapper(RuntimeState* state, ObjectPool* pool, PrimitiveType column_type,
@@ -347,7 +348,8 @@ public:
               _fragment_instance_id(fragment_instance_id),
               _filter_id(filter_id),
               _use_batch(IRuntimeFilter::enable_use_batch(_state->be_exec_version(),
-                                                          _column_return_type)) {}
+                                                          _column_return_type)),
+              _use_new_hash(_state->be_exec_version() >= 2) {}
     // init runtime filter wrapper
     // alloc memory to init runtime filter function
     Status init(const RuntimeFilterParams* params) {
@@ -433,7 +435,11 @@ public:
         }
         case RuntimeFilterType::IN_OR_BLOOM_FILTER: {
             if (_is_bloomfilter) {
-                _context.bloom_filter_func->insert(data);
+                if (_use_new_hash) {
+                    _context.bloom_filter_func->insert_new_hash(data);
+                } else {
+                    _context.bloom_filter_func->insert(data);
+                }
             } else {
                 _context.hybrid_set->insert(data);
             }
@@ -1011,6 +1017,10 @@ private:
 
     // When _column_return_type is invalid, _use_batch will be always false.
     bool _use_batch;
+
+    // When _use_new_hash is set to true, use the new hash method.
+    // This is only to be used if the be_exec_version may be less than 2. If updated, please delete it.
+    const bool _use_new_hash;
 };
 
 Status IRuntimeFilter::create(RuntimeState* state, ObjectPool* pool, const TRuntimeFilterDesc* desc,

--- a/be/src/vec/exprs/vbloom_predicate.cpp
+++ b/be/src/vec/exprs/vbloom_predicate.cpp
@@ -67,10 +67,20 @@ Status VBloomPredicate::execute(VExprContext* context, Block* block, int* result
     auto ptr = ((ColumnVector<UInt8>*)res_data_column.get())->get_data().data();
     auto type = WhichDataType(remove_nullable(block->get_by_position(arguments[0]).type));
     if (type.is_string_or_fixed_string()) {
-        for (size_t i = 0; i < sz; i++) {
-            auto ele = argument_column->get_data_at(i);
-            const StringRef v(ele.data, ele.size);
-            ptr[i] = _filter->find(reinterpret_cast<const void*>(&v));
+        // When _be_exec_version is equal to or greater than 2, we use the new hash method.
+        // This is only to be used if the be_exec_version may be less than 2. If updated, please delete it.
+        if (_be_exec_version >= 2) {
+            for (size_t i = 0; i < sz; i++) {
+                auto ele = argument_column->get_data_at(i);
+                const StringRef v(ele.data, ele.size);
+                ptr[i] = _filter->find_new_hash(reinterpret_cast<const void*>(&v));
+            }
+        } else {
+            for (size_t i = 0; i < sz; i++) {
+                auto ele = argument_column->get_data_at(i);
+                const StringRef v(ele.data, ele.size);
+                ptr[i] = _filter->find(reinterpret_cast<const void*>(&v));
+            }
         }
     } else if (_be_exec_version > 0 && (type.is_int_or_uint() || type.is_float())) {
         if (argument_column->is_nullable()) {


### PR DESCRIPTION
# Proposed changes

After testing, crchash is 4 to 5 times faster than murmurhash.

## Problem summary

When be_exec_version is 1, the original murmurhash method is still used. If updated, the new crchash method will be used.

Describe your changes.


## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

