### PR TITLE
[optimize](string) optimize concat function by SIMD memcpy

### DIFF
--- a/be/src/vec/functions/function_string.cpp
+++ b/be/src/vec/functions/function_string.cpp
@@ -255,8 +255,9 @@ struct TransferImpl {
         }
 
         res_offsets.resize(offset_size);
-        memcpy(res_offsets.data(), offsets.data(),
-               offset_size * sizeof(ColumnString::Offsets::value_type));
+        memcpy_small_allow_read_write_overflow15(
+                res_offsets.data(), offsets.data(),
+                offset_size * sizeof(ColumnString::Offsets::value_type));
 
         size_t data_length = data.size();
         res_data.resize(data_length);
@@ -279,8 +280,9 @@ struct InitcapImpl {
                          ColumnString::Chars& res_data, ColumnString::Offsets& res_offsets) {
         size_t offset_size = offsets.size();
         res_offsets.resize(offsets.size());
-        memcpy(res_offsets.data(), offsets.data(),
-               offset_size * sizeof(ColumnString::Offsets::value_type));
+        memcpy_small_allow_read_write_overflow15(
+                res_offsets.data(), offsets.data(),
+                offset_size * sizeof(ColumnString::Offsets::value_type));
 
         size_t data_length = data.size();
         res_data.resize(data_length);

--- a/be/src/vec/functions/function_string.h
+++ b/be/src/vec/functions/function_string.h
@@ -368,8 +368,9 @@ private:
                             const char lower, const char number) {
         result.get_chars().resize(source.get_chars().size());
         result.get_offsets().resize(source.get_offsets().size());
-        memcpy_small_allow_read_write_overflow15(result.get_offsets().data(), source.get_offsets().data(),
-               source.get_offsets().size() * sizeof(ColumnString::Offset));
+        memcpy_small_allow_read_write_overflow15(
+                result.get_offsets().data(), source.get_offsets().data(),
+                source.get_offsets().size() * sizeof(ColumnString::Offset));
 
         const unsigned char* src = source.get_chars().data();
         const size_t size = source.get_chars().size();
@@ -452,8 +453,9 @@ private:
         auto* offsets = src.get_offsets().data();
         result.get_chars().resize(src.get_chars().size());
         result.get_offsets().resize(src.get_offsets().size());
-        memcpy_small_allow_read_write_overflow15(result.get_offsets().data(), src.get_offsets().data(),
-               src.get_offsets().size() * sizeof(ColumnString::Offset));
+        memcpy_small_allow_read_write_overflow15(
+                result.get_offsets().data(), src.get_offsets().data(),
+                src.get_offsets().size() * sizeof(ColumnString::Offset));
         auto* res = result.get_chars().data();
 
         for (ssize_t i = 0; i != num_rows; ++i) {
@@ -710,8 +712,9 @@ public:
 
                 int size = current_offsets[i] - current_offsets[i - 1];
                 if (size > 0) {
-                    memcpy_small_allow_read_write_overflow15(&res_data[res_offset[i - 1]] + current_length,
-                        &current_chars[current_offsets[i - 1]], size);
+                    memcpy_small_allow_read_write_overflow15(
+                            &res_data[res_offset[i - 1]] + current_length,
+                            &current_chars[current_offsets[i - 1]], size);
                     current_length += size;
                 }
             }

--- a/be/src/vec/functions/function_string.h
+++ b/be/src/vec/functions/function_string.h
@@ -368,7 +368,7 @@ private:
                             const char lower, const char number) {
         result.get_chars().resize(source.get_chars().size());
         result.get_offsets().resize(source.get_offsets().size());
-        memcpy(result.get_offsets().data(), source.get_offsets().data(),
+        memcpy_small_allow_read_write_overflow15(result.get_offsets().data(), source.get_offsets().data(),
                source.get_offsets().size() * sizeof(ColumnString::Offset));
 
         const unsigned char* src = source.get_chars().data();
@@ -452,7 +452,7 @@ private:
         auto* offsets = src.get_offsets().data();
         result.get_chars().resize(src.get_chars().size());
         result.get_offsets().resize(src.get_offsets().size());
-        memcpy(result.get_offsets().data(), src.get_offsets().data(),
+        memcpy_small_allow_read_write_overflow15(result.get_offsets().data(), src.get_offsets().data(),
                src.get_offsets().size() * sizeof(ColumnString::Offset));
         auto* res = result.get_chars().data();
 
@@ -709,9 +709,11 @@ public:
                 auto& current_chars = *chars_list[j];
 
                 int size = current_offsets[i] - current_offsets[i - 1];
-                memcpy(&res_data[res_offset[i - 1]] + current_length,
-                       &current_chars[current_offsets[i - 1]], size);
-                current_length += size;
+                if (size > 0) {
+                    memcpy_small_allow_read_write_overflow15(&res_data[res_offset[i - 1]] + current_length,
+                        &current_chars[current_offsets[i - 1]], size);
+                    current_length += size;
+                }
             }
             res_offset[i] = res_offset[i - 1] + current_length;
         }
@@ -2530,7 +2532,7 @@ public:
 
     void _utf8_to_pinyin(const char* in, size_t in_len, char* out, size_t* out_len) {
         auto do_memcpy = [](char*& dest, const char*& from, size_t size) {
-            memcpy(dest, from, size);
+            memcpy_small_allow_read_write_overflow15(dest, from, size);
             dest += size;
             from += size;
         };


### PR DESCRIPTION
# Proposed changes
Optimize concat function 29% up by memcpy_small_allow_read_write_overflow15.
Optimize string functions list: concat, convert_to, mask, initcap, lower, upper.

concat function has 29% up:
(1) after
![image](https://user-images.githubusercontent.com/67053339/230547907-174bd8fb-ad6c-44ec-acde-d3c60f2d0f5c.png)

(2) before
![image](https://user-images.githubusercontent.com/67053339/230547898-26f0fc78-183e-44a3-9894-aadee21807bd.png)

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

