### PR TITLE
[Fix](Nereids)fix runtime filter generation terminate incorrectly when meet NLJNode.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/RuntimeFilterGenerator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/RuntimeFilterGenerator.java
@@ -35,7 +35,6 @@ import org.apache.doris.nereids.trees.plans.physical.PhysicalNestedLoopJoin;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalPlan;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalProject;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalRelation;
-import org.apache.doris.nereids.trees.plans.physical.PhysicalStorageLayerAggregate;
 import org.apache.doris.nereids.trees.plans.physical.RuntimeFilter;
 import org.apache.doris.nereids.util.ExpressionUtils;
 import org.apache.doris.nereids.util.JoinUtils;
@@ -202,13 +201,6 @@ public class RuntimeFilterGenerator extends PlanPostProcessor {
         RuntimeFilterContext ctx = context.getRuntimeFilterContext();
         scan.getOutput().forEach(slot -> ctx.getAliasTransferMap().put(slot, Pair.of(scan.getId(), slot)));
         return scan;
-    }
-
-    @Override
-    public PhysicalStorageLayerAggregate visitPhysicalStorageLayerAggregate(
-            PhysicalStorageLayerAggregate storageLayerAggregate, CascadesContext context) {
-        storageLayerAggregate.getRelation().accept(this, context);
-        return storageLayerAggregate;
     }
 
     private static Slot checkTargetChild(Expression leftChild) {


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

if inner join implemented by NLJ, the runtime filter generation phase will be terminated and children are not be travelled. we fix it by adjust the order of travelling children and handle the node itself.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [x] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

