### PR TITLE
[refactor](planner) using crchash replace murmurhash in the runtime filter

### DIFF
--- a/be/src/exprs/block_bloom_filter.hpp
+++ b/be/src/exprs/block_bloom_filter.hpp
@@ -78,6 +78,13 @@ public:
         }
     }
 
+    // This function is only to be used if the be_exec_version may be less than 2. If updated, please delete it.
+    void insert_new_hash(const Slice& key) noexcept {
+        if (key.data) {
+            insert(HashUtil::crc_hash(key.data, key.size, _hash_seed));
+        }
+    }
+
 #ifdef __AVX2__
 
     static inline ATTRIBUTE_ALWAYS_INLINE __attribute__((__target__("avx2"))) __m256i make_mark(
@@ -124,6 +131,14 @@ public:
         }
     }
 
+    // This function is only to be used if the be_exec_version may be less than 2. If updated, please delete it.
+    bool find_new_hash(const Slice& key) const noexcept {
+        if (key.data) {
+            return find(HashUtil::crc_hash(key.data, key.size, _hash_seed));
+        } else {
+            return false;
+        }
+    }
     // Computes the logical OR of this filter with 'other' and stores the result in this
     // filter.
     // Notes:

--- a/be/src/exprs/block_bloom_filter.hpp
+++ b/be/src/exprs/block_bloom_filter.hpp
@@ -79,7 +79,7 @@ public:
     }
 
     // This function is only to be used if the be_exec_version may be less than 2. If updated, please delete it.
-    void insert_new_hash(const Slice& key) noexcept {
+    void insert_crc32_hash(const Slice& key) noexcept {
         if (key.data) {
             insert(HashUtil::crc_hash(key.data, key.size, _hash_seed));
         }
@@ -132,7 +132,7 @@ public:
     }
 
     // This function is only to be used if the be_exec_version may be less than 2. If updated, please delete it.
-    bool find_new_hash(const Slice& key) const noexcept {
+    bool find_crc32_hash(const Slice& key) const noexcept {
         if (key.data) {
             return find(HashUtil::crc_hash(key.data, key.size, _hash_seed));
         } else {

--- a/be/src/exprs/bloom_filter_func.h
+++ b/be/src/exprs/bloom_filter_func.h
@@ -52,7 +52,22 @@ public:
         return _bloom_filter->find(data);
     }
 
+    // This function is only to be used if the be_exec_version may be less than 2. If updated, please delete it.
+    template <typename T>
+    bool test_new_hash(T data) const {
+        if constexpr (std::is_same_v<T, Slice>) {
+            return _bloom_filter->find_new_hash(data);
+        } else {
+            return _bloom_filter->find(data);
+        }
+    }
+
     void add_bytes(const char* data, size_t len) { _bloom_filter->insert(Slice(data, len)); }
+
+    // This function is only to be used if the be_exec_version may be less than 2. If updated, please delete it.
+    void add_bytes_new_hash(const char* data, size_t len) {
+        _bloom_filter->insert_new_hash(Slice(data, len));
+    }
 
     // test_element/find_element only used on vectorized engine
     template <typename T>
@@ -173,7 +188,13 @@ public:
 
     virtual void insert(const void* data) = 0;
 
+    // This function is only to be used if the be_exec_version may be less than 2. If updated, please delete it.
+    virtual void insert_new_hash(const void* data) = 0;
+
     virtual bool find(const void* data) const = 0;
+
+    // This function is only to be used if the be_exec_version may be less than 2. If updated, please delete it.
+    virtual bool find_new_hash(const void* data) const = 0;
 
     virtual bool find_olap_engine(const void* data) const = 0;
 
@@ -317,6 +338,15 @@ struct StringFindOp {
             bloom_filter.add_bytes(value->data, value->size);
         }
     }
+
+    // This function is only to be used if the be_exec_version may be less than 2. If updated, please delete it.
+    void insert_new_hash(BloomFilterAdaptor& bloom_filter, const void* data) const {
+        const auto* value = reinterpret_cast<const StringRef*>(data);
+        if (value) {
+            bloom_filter.add_bytes_new_hash(value->data, value->size);
+        }
+    }
+
     bool find(const BloomFilterAdaptor& bloom_filter, const void* data) const {
         const auto* value = reinterpret_cast<const StringRef*>(data);
         if (value == nullptr) {
@@ -324,6 +354,16 @@ struct StringFindOp {
         }
         return bloom_filter.test(Slice(value->data, value->size));
     }
+
+    //This function is only to be used if the be_exec_version may be less than 2. If updated, please delete it.
+    bool find_new_hash(const BloomFilterAdaptor& bloom_filter, const void* data) const {
+        const auto* value = reinterpret_cast<const StringRef*>(data);
+        if (value == nullptr) {
+            return false;
+        }
+        return bloom_filter.test_new_hash(Slice(value->data, value->size));
+    }
+
     bool find_olap_engine(const BloomFilterAdaptor& bloom_filter, const void* data) const {
         return StringFindOp::find(bloom_filter, data);
     }
@@ -437,6 +477,14 @@ public:
         dummy.insert(*_bloom_filter, data);
     }
 
+    // This function is only to be used if the be_exec_version may be less than 2. If updated, please delete it.
+    void insert_new_hash(const void* data) override {
+        if constexpr (std::is_same_v<typename BloomFilterTypeTraits<type>::FindOp, StringFindOp>) {
+            DCHECK(_bloom_filter != nullptr);
+            dummy.insert_new_hash(*_bloom_filter, data);
+        }
+    }
+
     void insert_fixed_len(const char* data, const int* offsets, int number) override {
         DCHECK(_bloom_filter != nullptr);
         dummy.insert_batch(*_bloom_filter, data, offsets, number);
@@ -461,6 +509,15 @@ public:
     bool find(const void* data) const override {
         DCHECK(_bloom_filter != nullptr);
         return dummy.find(*_bloom_filter, data);
+    }
+
+    // This function is only to be used if the be_exec_version may be less than 2. If updated, please delete it.
+    bool find_new_hash(const void* data) const override {
+        if constexpr (std::is_same_v<typename BloomFilterTypeTraits<type>::FindOp, StringFindOp>) {
+            DCHECK(_bloom_filter != nullptr);
+            return dummy.find_new_hash(*_bloom_filter, data);
+        }
+        return false;
     }
 
     bool find_olap_engine(const void* data) const override {

--- a/be/src/exprs/runtime_filter.cpp
+++ b/be/src/exprs/runtime_filter.cpp
@@ -334,7 +334,8 @@ public:
               _fragment_instance_id(params->fragment_instance_id),
               _filter_id(params->filter_id),
               _use_batch(IRuntimeFilter::enable_use_batch(_state->be_exec_version(),
-                                                          _column_return_type)) {}
+                                                          _column_return_type)),
+              _use_new_hash(_state->be_exec_version() >= 2) {}
     // for a 'tmp' runtime predicate wrapper
     // only could called assign method or as a param for merge
     RuntimePredicateWrapper(RuntimeState* state, ObjectPool* pool, PrimitiveType column_type,
@@ -347,7 +348,8 @@ public:
               _fragment_instance_id(fragment_instance_id),
               _filter_id(filter_id),
               _use_batch(IRuntimeFilter::enable_use_batch(_state->be_exec_version(),
-                                                          _column_return_type)) {}
+                                                          _column_return_type)),
+              _use_new_hash(_state->be_exec_version() >= 2) {}
     // init runtime filter wrapper
     // alloc memory to init runtime filter function
     Status init(const RuntimeFilterParams* params) {
@@ -433,7 +435,11 @@ public:
         }
         case RuntimeFilterType::IN_OR_BLOOM_FILTER: {
             if (_is_bloomfilter) {
-                _context.bloom_filter_func->insert(data);
+                if (_use_new_hash) {
+                    _context.bloom_filter_func->insert_new_hash(data);
+                } else {
+                    _context.bloom_filter_func->insert(data);
+                }
             } else {
                 _context.hybrid_set->insert(data);
             }
@@ -1011,6 +1017,10 @@ private:
 
     // When _column_return_type is invalid, _use_batch will be always false.
     bool _use_batch;
+
+    // When _use_new_hash is set to true, use the new hash method.
+    // This is only to be used if the be_exec_version may be less than 2. If updated, please delete it.
+    const bool _use_new_hash;
 };
 
 Status IRuntimeFilter::create(RuntimeState* state, ObjectPool* pool, const TRuntimeFilterDesc* desc,

--- a/be/src/exprs/runtime_filter.cpp
+++ b/be/src/exprs/runtime_filter.cpp
@@ -436,7 +436,7 @@ public:
         case RuntimeFilterType::IN_OR_BLOOM_FILTER: {
             if (_is_bloomfilter) {
                 if (_use_new_hash) {
-                    _context.bloom_filter_func->insert_new_hash(data);
+                    _context.bloom_filter_func->insert_crc32_hash(data);
                 } else {
                     _context.bloom_filter_func->insert(data);
                 }

--- a/be/src/vec/exprs/vbloom_predicate.cpp
+++ b/be/src/vec/exprs/vbloom_predicate.cpp
@@ -73,7 +73,7 @@ Status VBloomPredicate::execute(VExprContext* context, Block* block, int* result
             for (size_t i = 0; i < sz; i++) {
                 auto ele = argument_column->get_data_at(i);
                 const StringRef v(ele.data, ele.size);
-                ptr[i] = _filter->find_new_hash(reinterpret_cast<const void*>(&v));
+                ptr[i] = _filter->find_crc32_hash(reinterpret_cast<const void*>(&v));
             }
         } else {
             for (size_t i = 0; i < sz; i++) {

--- a/be/src/vec/exprs/vbloom_predicate.cpp
+++ b/be/src/vec/exprs/vbloom_predicate.cpp
@@ -67,10 +67,20 @@ Status VBloomPredicate::execute(VExprContext* context, Block* block, int* result
     auto ptr = ((ColumnVector<UInt8>*)res_data_column.get())->get_data().data();
     auto type = WhichDataType(remove_nullable(block->get_by_position(arguments[0]).type));
     if (type.is_string_or_fixed_string()) {
-        for (size_t i = 0; i < sz; i++) {
-            auto ele = argument_column->get_data_at(i);
-            const StringRef v(ele.data, ele.size);
-            ptr[i] = _filter->find(reinterpret_cast<const void*>(&v));
+        // When _be_exec_version is equal to or greater than 2, we use the new hash method.
+        // This is only to be used if the be_exec_version may be less than 2. If updated, please delete it.
+        if (_be_exec_version >= 2) {
+            for (size_t i = 0; i < sz; i++) {
+                auto ele = argument_column->get_data_at(i);
+                const StringRef v(ele.data, ele.size);
+                ptr[i] = _filter->find_new_hash(reinterpret_cast<const void*>(&v));
+            }
+        } else {
+            for (size_t i = 0; i < sz; i++) {
+                auto ele = argument_column->get_data_at(i);
+                const StringRef v(ele.data, ele.size);
+                ptr[i] = _filter->find(reinterpret_cast<const void*>(&v));
+            }
         }
     } else if (_be_exec_version > 0 && (type.is_int_or_uint() || type.is_float())) {
         if (argument_column->is_nullable()) {


### PR DESCRIPTION
# Proposed changes

According to the test results, the time consumption ratio of murmurhash to crc32 is 12:5.

![ce877780764dfd57ca1734cce0afafd6](https://user-images.githubusercontent.com/59914473/230601409-5b90fb01-5379-483f-8bd0-073e9e39ee37.png)


## Problem summary

When the be_exec_version is less than 2, murmurhash will still be used, otherwise crc32 will be used. When the be_exec_version is upgraded to 2, please remove.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

