### PR TITLE
[fix](multi catalog) fix show catalogs after drop

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/CatalogMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/CatalogMgr.java
@@ -368,7 +368,7 @@ public class CatalogMgr implements Writable, GsonPostProcessable {
                         row.add(String.valueOf(catalog.getId()));
                         row.add(name);
                         row.add(catalog.getType());
-                        if (name.equals(currentCtlg)) {
+                        if (currentCtlg != null && name.equals(currentCtlg)) {
                             row.add(YES);
                         } else {
                             row.add("");

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ShowExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ShowExecutor.java
@@ -2434,10 +2434,8 @@ public class ShowExecutor {
 
     public void handleShowCatalogs() throws AnalysisException {
         ShowCatalogStmt showStmt = (ShowCatalogStmt) stmt;
-        if (ctx.getCurrentCatalog() == null) {
-            throw new AnalysisException("Current catalog is not exist, please switch catalog.");
-        }
-        resultSet = Env.getCurrentEnv().getCatalogMgr().showCatalogs(showStmt, ctx.getCurrentCatalog().getName());
+        resultSet = Env.getCurrentEnv().getCatalogMgr().showCatalogs(showStmt, ctx.getCurrentCatalog() != null
+            ? ctx.getCurrentCatalog().getName() : null);
     }
 
     // Show create catalog

--- a/regression-test/suites/query_p0/show/test_show_catalogs.groovy
+++ b/regression-test/suites/query_p0/show/test_show_catalogs.groovy
@@ -1,0 +1,33 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_show_catalogs") {
+    // define a catalog name
+    String catalog_name = "test_show_catalogs";
+
+    sql """drop catalog if exists ${catalog_name} """
+    sql """CREATE CATALOG ${catalog_name}  PROPERTIES (
+           "hive.metastore.uris" = "thrift://11.119.172.189:9083",
+           "type" = "hms"
+        );"""
+
+    sql """switch ${catalog_name};"""
+    sql """drop catalog ${catalog_name};"""
+
+    //should be OK to call show catalogs after drop current catalog
+    sql """show catalogs;"""
+}


### PR DESCRIPTION
# Proposed changes

steps to repo:
1, create any catalog re; [OK]
2, switch re  [OK] 
3, show catalogs [OK]
4, drop catalog re [OK]
5, show catalogs  [FAIL with "Current catalog is not exist, please switch catalog." ]

expect:
show catalogs should always be OK, not depends on current catalog.


## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

