### PR TITLE
[fix](regression-test) fix wrong http port in regression-test case compaction-with-delete

### DIFF
--- a/regression-test/suites/compaction/test_compacation_with_delete.groovy
+++ b/regression-test/suites/compaction/test_compacation_with_delete.groovy
@@ -28,7 +28,7 @@ suite("test_compaction_with_delete") {
             setConfigCommand.append("curl -X POST http://")
             setConfigCommand.append(backend[2])
             setConfigCommand.append(":")
-            setConfigCommand.append(backend[5])
+            setConfigCommand.append(backend[6])
             setConfigCommand.append("/api/update_config?")
             String command1 = setConfigCommand.toString() + "enable_vertical_compaction=true"
             logger.info(command1)
@@ -45,7 +45,7 @@ suite("test_compaction_with_delete") {
             setConfigCommand.append("curl -X POST http://")
             setConfigCommand.append(backend[2])
             setConfigCommand.append(":")
-            setConfigCommand.append(backend[5])
+            setConfigCommand.append(backend[6])
             setConfigCommand.append("/api/update_config?")
             String command1 = setConfigCommand.toString() + "enable_vertical_compaction=false"
             logger.info(command1)
@@ -64,7 +64,7 @@ suite("test_compaction_with_delete") {
         def backendId_to_backendHttpPort = [:]
         for (String[] backend in backends) {
             backendId_to_backendIP.put(backend[0], backend[2])
-            backendId_to_backendHttpPort.put(backend[0], backend[5])
+            backendId_to_backendHttpPort.put(backend[0], backend[6])
         }
 
         backend_id = backendId_to_backendIP.keySet()[0]


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

`show backends` fields have been changed, the `http-port`'s index is 6 now.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [x] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

