### PR TITLE
[fix](hdfs) not setting hadoop username when kerberos enabled

### DIFF
--- a/be/src/io/fs/local_file_system.cpp
+++ b/be/src/io/fs/local_file_system.cpp
@@ -116,18 +116,17 @@ Status LocalFileSystem::delete_directory_impl(const Path& dir) {
 }
 
 Status LocalFileSystem::delete_directory_or_file(const Path& path) {
+    auto the_path = absolute_path(path);
+    FILESYSTEM_M(delete_directory_or_file_impl(the_path));
+}
+
+Status LocalFileSystem::delete_directory_or_file_impl(const Path& path) {
     bool is_dir;
-    Status ret = is_directory(path, &is_dir);
-    if (ret.ok()) {
-        Status s;
-        if (is_dir) {
-            s = delete_directory_impl(path);
-        } else {
-            s = delete_file_impl(path);
-        }
-        return s;
+    RETURN_IF_ERROR(is_directory(path, &is_dir));
+    if (is_dir) {
+        return delete_directory_impl(path);
     } else {
-        return ret;
+        return delete_file_impl(path);
     }
 }
 

--- a/be/src/io/fs/local_file_system.h
+++ b/be/src/io/fs/local_file_system.h
@@ -79,6 +79,7 @@ protected:
     Status delete_and_create_directory_impl(const Path& dir);
     Status get_space_info_impl(const Path& path, size_t* capacity, size_t* available);
     Status copy_dirs_impl(const Path& src, const Path& dest);
+    Status delete_directory_or_file_impl(const Path& path);
 
 private:
     LocalFileSystem(Path&& root_path, std::string&& id = "");

--- a/be/src/io/hdfs_builder.cpp
+++ b/be/src/io/hdfs_builder.cpp
@@ -97,10 +97,6 @@ THdfsParams parse_properties(const std::map<std::string, std::string>& propertie
 Status createHDFSBuilder(const THdfsParams& hdfsParams, HDFSCommonBuilder* builder) {
     RETURN_IF_ERROR(builder->init_hdfs_builder());
     hdfsBuilderSetNameNode(builder->get(), hdfsParams.fs_name.c_str());
-    // set hdfs user
-    if (hdfsParams.__isset.user) {
-        hdfsBuilderSetUserName(builder->get(), hdfsParams.user.c_str());
-    }
     // set kerberos conf
     if (hdfsParams.__isset.hdfs_kerberos_principal) {
         builder->need_kinit = true;
@@ -119,6 +115,9 @@ Status createHDFSBuilder(const THdfsParams& hdfsParams, HDFSCommonBuilder* build
 
     if (builder->is_need_kinit()) {
         RETURN_IF_ERROR(builder->run_kinit());
+    } else if (hdfsParams.__isset.user) {
+        // set hdfs user
+        hdfsBuilderSetUserName(builder->get(), hdfsParams.user.c_str());
     }
 
     return Status::OK();

--- a/be/src/olap/rowset/rowset_meta_manager.cpp
+++ b/be/src/olap/rowset/rowset_meta_manager.cpp
@@ -45,8 +45,7 @@ bool RowsetMetaManager::check_rowset_meta(OlapMeta* meta, TabletUid tablet_uid,
 Status RowsetMetaManager::exists(OlapMeta* meta, TabletUid tablet_uid, const RowsetId& rowset_id) {
     std::string key = ROWSET_PREFIX + tablet_uid.to_string() + "_" + rowset_id.to_string();
     std::string value;
-    Status s = meta->get(META_COLUMN_FAMILY_INDEX, key, &value);
-    return s;
+    return meta->get(META_COLUMN_FAMILY_INDEX, key, &value);
 }
 
 Status RowsetMetaManager::get_rowset_meta(OlapMeta* meta, TabletUid tablet_uid,

--- a/be/test/io/fs/local_file_system_test.cpp
+++ b/be/test/io/fs/local_file_system_test.cpp
@@ -84,13 +84,7 @@ public:
             if (!exists) {
                 continue;
             }
-            bool is_dir = true;
-            RETURN_IF_ERROR(io::global_local_filesystem()->is_directory(p, &is_dir));
-            if (is_dir) {
-                RETURN_IF_ERROR(io::global_local_filesystem()->delete_directory(p));
-            } else {
-                RETURN_IF_ERROR(io::global_local_filesystem()->delete_file(p));
-            }
+            RETURN_IF_ERROR(io::global_local_filesystem()->delete_directory_or_file(p));
         }
         return Status::OK();
     }

--- a/fe/fe-core/src/main/cup/sql_parser.cup
+++ b/fe/fe-core/src/main/cup/sql_parser.cup
@@ -7060,6 +7060,8 @@ keyword ::=
     {: RESULT = id; :}
     | KW_HELP:id
     {: RESULT = id; :}
+    | KW_HOSTNAME:id
+    {: RESULT = id; :}
     | KW_HUB:id
     {: RESULT = id; :}
     | KW_IDENTIFIED:id


### PR DESCRIPTION
# Proposed changes

1. If we set hadoop user property along with kerberos info, the authentication will fail.
2. fix some minor issue of local fs, follow up #18397
3. Add KW_HOSTNAME to keywords region, follow up #17329
4. Fix tvf not working with pipeline engine, follow up #18376

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

