### PR TITLE
[fix](profile) fix show load query profile

### DIFF
--- a/be/src/pipeline/pipeline_fragment_context.cpp
+++ b/be/src/pipeline/pipeline_fragment_context.cpp
@@ -259,6 +259,12 @@ Status PipelineFragmentContext::prepare(const doris::TPipelineFragmentParams& re
             const std::vector<TScanRangeParams>& scan_ranges = find_with_default(
                     local_params.per_node_scan_ranges, scan_node->id(), no_scan_ranges);
             scan_node->set_scan_ranges(scan_ranges);
+        } else {
+            ScanNode* scan_node = static_cast<ScanNode*>(node);
+            const std::vector<TScanRangeParams>& scan_ranges = find_with_default(
+                    local_params.per_node_scan_ranges, scan_node->id(), no_scan_ranges);
+            scan_node->set_scan_ranges(scan_ranges);
+            VLOG_CRITICAL << "scan_node_Id=" << scan_node->id() << " size=" << scan_ranges.size();
         }
     }
 

--- a/be/src/pipeline/pipeline_fragment_context.cpp
+++ b/be/src/pipeline/pipeline_fragment_context.cpp
@@ -385,6 +385,7 @@ Status PipelineFragmentContext::_build_pipelines(ExecNode* node, PipelinePtr cur
     case TPlanNodeType::JDBC_SCAN_NODE:
     case TPlanNodeType::ODBC_SCAN_NODE:
     case TPlanNodeType::FILE_SCAN_NODE:
+    case TPlanNodeType::META_SCAN_NODE:
     case TPlanNodeType::ES_SCAN_NODE: {
         OperatorBuilderPtr operator_t =
                 std::make_shared<ScanOperatorBuilder>(next_operator_builder_id(), node);

--- a/be/src/vec/exec/scan/new_olap_scanner.cpp
+++ b/be/src/vec/exec/scan/new_olap_scanner.cpp
@@ -44,6 +44,10 @@ NewOlapScanner::NewOlapScanner(RuntimeState* state, NewOlapScanNode* parent, int
 
 static std::string read_columns_to_string(TabletSchemaSPtr tablet_schema,
                                           const std::vector<uint32_t>& read_columns) {
+    // avoid too long for one line,
+    // it is hard to display in `show profile` stmt if one line is too long.
+    const int col_per_line = 10;
+    int i = 0;
     std::string read_columns_string;
     read_columns_string += "[";
     for (auto it = read_columns.cbegin(); it != read_columns.cend(); it++) {
@@ -51,6 +55,12 @@ static std::string read_columns_to_string(TabletSchemaSPtr tablet_schema,
             read_columns_string += ", ";
         }
         read_columns_string += tablet_schema->columns().at(*it).name();
+        if (i >= col_per_line) {
+            read_columns_string += "\n";
+            i = 0;
+        } else {
+            ++i;
+        }
     }
     read_columns_string += "]";
     return read_columns_string;

--- a/docs/en/docs/admin-manual/query-profile.md
+++ b/docs/en/docs/admin-manual/query-profile.md
@@ -28,6 +28,11 @@ under the License.
 
 This document focuses on introducing the **Running Profile** which recorded runtime status of Doris in query execution. Using these statistical information, we can understand the execution of frgment to become a expert of Doris's **debugging and tuning**.
 
+You can also refer to following statements to view profile in command line:
+
+- [SHOW QUERY PROFILE](../sql-manual/sql-reference/Show-Statements/SHOW-QUERY-PROFILE.md)
+- [SHOW LOAD PROFILE](../sql-manual/sql-reference/Show-Statements/SHOW-LOAD-PROFILE.md)
+
 ## Noun Interpretation
 
 * **FE**: Frontend, frontend node of Doris. Responsible for metadata management and request access.
@@ -39,6 +44,7 @@ This document focuses on introducing the **Running Profile** which recorded runt
 ## Basic concepts
 
 FE splits the query plan into fragments and distributes them to BE for task execution. BE records the statistics of **Running State** when executing fragment. BE print the outputs statistics of fragment execution into the log. FE can also collect these statistics recorded by each fragment and print the results on FE's web page.
+
 ## Specific operation
 
 Turn on the report switch on FE through MySQL command

--- a/docs/en/docs/lakehouse/multi-catalog/hive.md
+++ b/docs/en/docs/lakehouse/multi-catalog/hive.md
@@ -162,8 +162,11 @@ CREATE CATALOG hive WITH RESOURCE hms_resource PROPERTIES(
 ```
 
 <version since="dev"></version> 
+
 You can use the config `file.meta.cache.ttl-second` to set TTL(Time-to-Live) config of File Cache, so that the stale file info will be invalidated automatically after expiring. The unit of time is second.
+
 You can also set file_meta_cache_ttl_second to 0 to disable file cache.Here is an example:
+
 ```sql
 CREATE CATALOG hive PROPERTIES (
     'type'='hms',

--- a/docs/zh-CN/docs/admin-manual/query-profile.md
+++ b/docs/zh-CN/docs/admin-manual/query-profile.md
@@ -30,6 +30,10 @@ under the License.
 
 本文档主要介绍Doris在查询执行的统计结果。利用这些统计的信息，可以更好的帮助我们了解Doris的执行情况，并有针对性的进行相应**Debug与调优工作**。
 
+也可以参考如下语法在命令行中查看导入和查询的 Profile：
+
+- [SHOW QUERY PROFILE](../sql-manual/sql-reference/Show-Statements/SHOW-QUERY-PROFILE.md)
+- [SHOW LOAD PROFILE](../sql-manual/sql-reference/Show-Statements/SHOW-LOAD-PROFILE.md)
 
 ## 名词解释
 

--- a/docs/zh-CN/docs/lakehouse/multi-catalog/hive.md
+++ b/docs/zh-CN/docs/lakehouse/multi-catalog/hive.md
@@ -159,6 +159,7 @@ CREATE CATALOG hive WITH RESOURCE hms_resource PROPERTIES(
 <version since="dev"></version>
 
 创建 Catalog 时可以采用参数 `file.meta.cache.ttl-second` 来设置 File Cache 自动失效时间，也可以将该值设置为 0 来禁用 File Cache。时间单位为：秒。示例如下：
+
 ```sql
 CREATE CATALOG hive PROPERTIES (
     'type'='hms',

--- a/docs/zh-CN/docs/sql-manual/sql-reference/Show-Statements/SHOW-LOAD-PROFILE.md
+++ b/docs/zh-CN/docs/sql-manual/sql-reference/Show-Statements/SHOW-LOAD-PROFILE.md
@@ -50,6 +50,12 @@ SET [GLOBAL] enable_profile=true;
 show load profile "/";
 
 show load profile "/[queryId]"
+
+show load profile "/[queryId]/[TaskId]"
+
+show load profile "/[queryId]/[TaskId]/[FragmentId]/"
+
+show load profile "/[queryId]/[TaskId]/[FragmentId]/[InstanceId]"
 ```
 
 这个命令会列出当前保存的所有导入 Profile。每行对应一个导入。其中 QueryId 列为导入作业的 ID。这个 ID 也可以通过 SHOW LOAD 语句查看拿到。我们可以选择我们想看的 Profile 对应的 QueryId，查看具体情况
@@ -108,11 +114,56 @@ WaitAndFetchResultTime: N/A
    | 980014623046410a-af5d36f23381017f | 3m14s      |
    +-----------------------------------+------------+
    ```
-
-3. 查看指定子任务的 Instance 概况
+3. 查看子任务的执行树：
 
    ```sql
-   mysql> show load profile "/980014623046410a-af5d36f23381017f/980014623046410a-af5d36f23381017f";
+   show load profile "/980014623046410a-af5d36f23381017f/980014623046410a-af5d36f23381017f";
+
+                         ┌───────────────────────┐
+                         │[-1: OlapTableSink]    │
+                         │Fragment: 0            │
+                         │MaxActiveTime: 86.541ms│
+                         └───────────────────────┘
+                                     │
+                                     │
+                           ┌───────────────────┐
+                           │[1: VEXCHANGE_NODE]│
+                           │Fragment: 0        │
+                           └───────────────────┘
+           ┌─────────────────────────┴───────┐
+           │                                 │
+    ┌─────────────┐              ┌───────────────────────┐
+    │[MemoryUsage]│              │[1: VDataStreamSender] │
+    │Fragment: 0  │              │Fragment: 1            │
+    └─────────────┘              │MaxActiveTime: 34.882ms│
+                                 └───────────────────────┘
+                                             │
+                                             │
+                               ┌───────────────────────────┐
+                               │[0: VNewOlapScanNode(tbl1)]│
+                               │Fragment: 1                │
+                               └───────────────────────────┘
+                           ┌─────────────────┴───────┐
+                           │                         │
+                    ┌─────────────┐            ┌───────────┐
+                    │[MemoryUsage]│            │[VScanner] │
+                    │Fragment: 1  │            │Fragment: 1│
+                    └─────────────┘            └───────────┘
+                                             ┌───────┴─────────┐
+                                             │                 │
+                                    ┌─────────────────┐ ┌─────────────┐
+                                    │[SegmentIterator]│ │[MemoryUsage]│
+                                    │Fragment: 1      │ │Fragment: 1  │
+                                    └─────────────────┘ └─────────────┘
+
+   ```sql
+
+   这一层会显示子任务的查询树，其中标注了 Fragment id。
+
+4. 查看指定Fragment 的 Instance 概况
+
+   ```sql
+   mysql> show load profile "/980014623046410a-af5d36f23381017f/980014623046410a-af5d36f23381017f/1";
    +-----------------------------------+------------------+------------+
    | Instances                         | Host             | ActiveTime |
    +-----------------------------------+------------------+------------+
@@ -123,87 +174,51 @@ WaitAndFetchResultTime: N/A
    +-----------------------------------+------------------+------------+
    ```
 
-4. 继续查看某一个具体的 Instance 上各个算子的详细 Profile
+5. 继续查看某一个具体的 Instance 上各个算子的详细 Profile
 
    ```sql
-   mysql> show load profile "/980014623046410a-af5d36f23381017f/980014623046410a-af5d36f23381017f/980014623046410a-88e260f0c43031f5"\G
+   mysql> show load profile "/980014623046410a-af5d36f23381017f/980014623046410a-af5d36f23381017f/1/980014623046410a-88e260f0c43031f5"\G
    
    *************************** 1. row ***************************
    
    Instance:
    
          ┌-----------------------------------------┐
-   
          │[-1: OlapTableSink]                      │
-   
          │(Active: 2m17s, non-child: 70.91)        │
-   
          │  - Counters:                            │
-   
          │      - CloseWaitTime: 1m53s             │
-   
          │      - ConvertBatchTime: 0ns            │
-   
          │      - MaxAddBatchExecTime: 1m46s       │
-   
          │      - NonBlockingSendTime: 3m11s       │
-   
          │      - NumberBatchAdded: 782            │
-   
          │      - NumberNodeChannels: 1            │
-   
          │      - OpenTime: 743.822us              │
-   
          │      - RowsFiltered: 0                  │
-   
          │      - RowsRead: 1.599729M (1599729)    │
-   
          │      - RowsReturned: 1.599729M (1599729)│
-   
          │      - SendDataTime: 11s761ms           │
-   
          │      - TotalAddBatchExecTime: 1m46s     │
-   
          │      - ValidateDataTime: 9s802ms        │
-   
          └-----------------------------------------┘
-   
                               │
-   
    ┌-----------------------------------------------------┐
-   
    │[0: BROKER_SCAN_NODE]                                │
-   
    │(Active: 56s537ms, non-child: 29.06)                 │
-   
    │  - Counters:                                        │
-   
    │      - BytesDecompressed: 0.00                      │
-   
    │      - BytesRead: 5.77 GB                           │
-   
    │      - DecompressTime: 0ns                          │
-   
    │      - FileReadTime: 34s263ms                       │
-   
    │      - MaterializeTupleTime(*): 45s54ms             │
-   
    │      - NumDiskAccess: 0                             │
-   
    │      - PeakMemoryUsage: 33.03 MB                    │
-   
    │      - RowsRead: 1.599729M (1599729)                │
-   
    │      - RowsReturned: 1.599729M (1599729)            │
-   
-   │      - RowsReturnedRate: 28.295K sec               │
-   
+   │      - RowsReturnedRate: 28.295K sec                │
    │      - TotalRawReadTime(*): 1m20s                   │
-   
    │      - TotalReadThroughput: 30.39858627319336 MB/sec│
-   
    │      - WaitScannerTime: 56s528ms                    │
-   
    └-----------------------------------------------------┘
    ```
 

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowLoadProfileStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowLoadProfileStmt.java
@@ -40,6 +40,7 @@ public class ShowLoadProfileStmt extends ShowStmt {
     public enum PathType {
         QUERY_IDS,
         TASK_IDS,
+        FRAGMENTS,
         INSTANCES,
         SINGLE_INSTANCE
     }
@@ -49,6 +50,7 @@ public class ShowLoadProfileStmt extends ShowStmt {
 
     private String jobId = "";
     private String taskId = "";
+    private String fragmentId = "";
     private String instanceId = "";
 
     public ShowLoadProfileStmt(String idPath) {
@@ -65,6 +67,10 @@ public class ShowLoadProfileStmt extends ShowStmt {
 
     public String getTaskId() {
         return taskId;
+    }
+
+    public String getFragmentId() {
+        return fragmentId;
     }
 
     public String getInstanceId() {
@@ -85,8 +91,8 @@ public class ShowLoadProfileStmt extends ShowStmt {
         }
         pathType = PathType.QUERY_IDS;
         String[] parts = idPath.split("/");
-        if (parts.length > 4) {
-            throw new AnalysisException("Path must in format '/jobId/taskId/instanceId'");
+        if (parts.length > 5) {
+            throw new AnalysisException("Path must in format '/jobId/taskId/fragmentId/instanceId'");
         }
 
         for (int i = 0; i < parts.length; i++) {
@@ -100,9 +106,13 @@ public class ShowLoadProfileStmt extends ShowStmt {
                     break;
                 case 2:
                     taskId = parts[i];
-                    pathType = PathType.INSTANCES;
+                    pathType = PathType.FRAGMENTS;
                     break;
                 case 3:
+                    fragmentId = parts[i];
+                    pathType = PathType.INSTANCES;
+                    break;
+                case 4:
                     instanceId = parts[i];
                     pathType = PathType.SINGLE_INSTANCE;
                     break;
@@ -130,6 +140,8 @@ public class ShowLoadProfileStmt extends ShowStmt {
                 return ShowQueryProfileStmt.META_DATA_QUERY_IDS;
             case TASK_IDS:
                 return META_DATA_TASK_IDS;
+            case FRAGMENTS:
+                return ShowQueryProfileStmt.META_DATA_FRAGMENTS;
             case INSTANCES:
                 return ShowQueryProfileStmt.META_DATA_INSTANCES;
             case SINGLE_INSTANCE:
@@ -139,3 +151,4 @@ public class ShowLoadProfileStmt extends ShowStmt {
         }
     }
 }
+

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowQueryProfileStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/ShowQueryProfileStmt.java
@@ -70,7 +70,7 @@ public class ShowQueryProfileStmt extends ShowStmt {
 
     public enum PathType {
         QUERY_IDS,
-        FRAGMETNS,
+        FRAGMENTS,
         INSTANCES,
         SINGLE_INSTANCE
     }
@@ -127,7 +127,7 @@ public class ShowQueryProfileStmt extends ShowStmt {
                     continue;
                 case 1:
                     queryId = parts[i];
-                    pathType = PathType.FRAGMETNS;
+                    pathType = PathType.FRAGMENTS;
                     break;
                 case 2:
                     fragmentId = parts[i];
@@ -159,7 +159,7 @@ public class ShowQueryProfileStmt extends ShowStmt {
         switch (pathType) {
             case QUERY_IDS:
                 return META_DATA_QUERY_IDS;
-            case FRAGMETNS:
+            case FRAGMENTS:
                 return META_DATA_FRAGMENTS;
             case INSTANCES:
                 return META_DATA_INSTANCES;
@@ -170,3 +170,4 @@ public class ShowQueryProfileStmt extends ShowStmt {
         }
     }
 }
+

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ShowExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ShowExecutor.java
@@ -2084,7 +2084,7 @@ public class ShowExecutor {
             case QUERY_IDS:
                 rows = ProfileManager.getInstance().getQueryWithType(ProfileManager.ProfileType.QUERY);
                 break;
-            case FRAGMETNS: {
+            case FRAGMENTS: {
                 ProfileTreeNode treeRoot = ProfileManager.getInstance().getFragmentProfileTree(showStmt.getQueryId(),
                         showStmt.getQueryId());
                 if (treeRoot == null) {
@@ -2143,12 +2143,22 @@ public class ShowExecutor {
                 rows = ProfileManager.getInstance().getLoadJobTaskList(showStmt.getJobId());
                 break;
             }
+            case FRAGMENTS: {
+                ProfileTreeNode treeRoot = ProfileManager.getInstance().getFragmentProfileTree(showStmt.getJobId(),
+                        showStmt.getJobId());
+                if (treeRoot == null) {
+                    throw new AnalysisException("Failed to get fragment tree for load: " + showStmt.getJobId());
+                }
+                List<String> row = Lists.newArrayList(ProfileTreePrinter.printFragmentTree(treeRoot));
+                rows.add(row);
+                break;
+            }
             case INSTANCES: {
                 // For load profile, there should be only one fragment in each execution profile
                 // And the fragment id is 0.
                 List<Triple<String, String, Long>> instanceList
                         = ProfileManager.getInstance().getFragmentInstanceList(showStmt.getJobId(),
-                        showStmt.getTaskId(), "0");
+                        showStmt.getTaskId(), ((ShowLoadProfileStmt) stmt).getFragmentId());
                 if (instanceList == null) {
                     throw new AnalysisException("Failed to get instance list for task: " + showStmt.getTaskId());
                 }
@@ -2163,7 +2173,7 @@ public class ShowExecutor {
                 // For load profile, there should be only one fragment in each execution profile.
                 // And the fragment id is 0.
                 ProfileTreeNode treeRoot = ProfileManager.getInstance().getInstanceProfileTree(showStmt.getJobId(),
-                        showStmt.getTaskId(), "0", showStmt.getInstanceId());
+                        showStmt.getTaskId(), showStmt.getFragmentId(), showStmt.getInstanceId());
                 if (treeRoot == null) {
                     throw new AnalysisException("Failed to get instance tree for instance: "
                             + showStmt.getInstanceId());
@@ -2644,3 +2654,4 @@ public class ShowExecutor {
         resultSet = new ShowResultSet(showMetaData, resultRowSet);
     }
 }
+


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

Sometimes, `show load profile` will only show part of the insert opertion's profile.
This is because we assume that for all load operation(including insert), there is only one fragment in the plan.
But actually, there will be more than 1 fragment in plan. eg:

`insert into tbl1 select * from tbl1 limit 1` will have 2 fragments.

This PR mainly changes:

1. modify the `show load profile`
   Before:  `show load profile "/queryid/taskid/instanceid";`
   After: `show load profile "/queryid/taskid/fragmentid/instanceid";`

2. Modify the display of `ReadColumns` in OlapScanNode
    Because for wide table, the line of `ReadColumns` may be too long for show in profile.
    So I wrap it and each line contains at most 10 columns names.

3. Fix tvf not working with pipeline engine, follow up #18376

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

