### PR TITLE
[optimize](mutlti-catalog) Opt zlib performance by adding '-O3' cflags.

### DIFF
--- a/thirdparty/build-thirdparty.sh
+++ b/thirdparty/build-thirdparty.sh
@@ -559,7 +559,7 @@ build_zlib() {
     check_if_source_exist "${ZLIB_SOURCE}"
     cd "${TP_SOURCE_DIR}/${ZLIB_SOURCE}"
 
-    CFLAGS="-fPIC" \
+    CFLAGS="-O3 -fPIC" \
         CPPFLAGS="-I${TP_INCLUDE_DIR}" \
         LDFLAGS="-L${TP_LIB_DIR}" \
         ./configure --prefix="${TP_INSTALL_DIR}" --static


### PR DESCRIPTION
# Proposed changes

Opt zlib performance by adding '-O3' cflags.
From orc' reader test, it has 2.5x performance boost.

Before opt:
mysql> SELECT count(lo_extendedprice) FROM ssb100_orc.lineorder_flat;
+---------------------------+
| count(`lo_extendedprice`) |
+---------------------------+
|                 600037902 |
+---------------------------+
1 row in set (24.91 sec)

After opt:
mysql> SELECT count(lo_extendedprice) FROM ssb100_orc.lineorder_flat;
+---------------------------+
| count(`lo_extendedprice`) |
+---------------------------+
|                 600037902 |
+---------------------------+
1 row in set (10.70 sec)


## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

