### PR TITLE
[bug](be) fix accept null predicate mem leak

### DIFF
--- a/be/src/olap/accept_null_predicate.h
+++ b/be/src/olap/accept_null_predicate.h
@@ -60,7 +60,8 @@ public:
                       bool* flags) const override {
         if (column.has_null()) {
             // copy original flags
-            bool* original_flags = new bool[size];
+            auto original_flags_buf = std::make_unique<bool>(size);
+            auto original_flags = original_flags_buf.get();
             memcpy(original_flags, flags, size * sizeof(bool));
 
             // call evaluate_and and restore true for NULL rows
@@ -125,7 +126,8 @@ public:
                           bool* flags) const override {
         if (column.has_null()) {
             // copy original flags
-            bool* original_flags = new bool[size];
+            auto original_flags_buf = std::make_unique<bool>(size);
+            auto original_flags = original_flags_buf.get();
             memcpy(original_flags, flags, size * sizeof(bool));
 
             // call evaluate_and_vec and restore true for NULL rows

--- a/be/src/olap/accept_null_predicate.h
+++ b/be/src/olap/accept_null_predicate.h
@@ -60,7 +60,7 @@ public:
                       bool* flags) const override {
         if (column.has_null()) {
             // copy original flags
-            auto original_flags_buf = std::make_unique<bool>(size);
+            auto original_flags_buf = std::make_unique<bool[]>(size);
             auto original_flags = original_flags_buf.get();
             memcpy(original_flags, flags, size * sizeof(bool));
 
@@ -126,7 +126,7 @@ public:
                           bool* flags) const override {
         if (column.has_null()) {
             // copy original flags
-            auto original_flags_buf = std::make_unique<bool>(size);
+            auto original_flags_buf = std::make_unique<bool[]>(size);
             auto original_flags = original_flags_buf.get();
             memcpy(original_flags, flags, size * sizeof(bool));
 


### PR DESCRIPTION

# Proposed changes

Issue Number: close #xxx
The former logic inside accept null predicate would cause memory leak.
## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

