### PR TITLE
[FixBug](jdbc Catalog) fix sqlserver column type mapping

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/external/jdbc/JdbcClient.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/external/jdbc/JdbcClient.java
@@ -711,7 +711,10 @@ public class JdbcClient {
     }
 
     public Type sqlserverTypeToDoris(JdbcFieldSchema fieldSchema) {
-        String sqlserverType = fieldSchema.getDataTypeName();
+        String originSqlserverType = fieldSchema.getDataTypeName();
+        // For sqlserver IDENTITY type, such as 'INT IDENTITY'
+        // originSqlserverType is "int identity", so we only get "int".
+        String sqlserverType = originSqlserverType.split(" ")[0];
         switch (sqlserverType) {
             case "bit":
                 return Type.BOOLEAN;


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

For type `int identity` of sqlserver, the column type read from JDBC is called `int indentity`. So we need deal with this case.

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

