### PR TITLE
[bugfix](vexprcontext) expr context not closed if scanner prepare failed

### DIFF
--- a/be/src/vec/exec/scan/new_es_scan_node.cpp
+++ b/be/src/vec/exec/scan/new_es_scan_node.cpp
@@ -208,7 +208,7 @@ Status NewEsScanNode::_init_scanners(std::list<VScanner*>* scanners) {
         Status st = scanner->prepare(_state, _vconjunct_ctx_ptr.get());
         if (!st.ok()) {
             // during prepare, scanner already cloned vexpr_context, should call close to release it.
-            scanner->close();
+            scanner->close(_state);
             return st;
         }
         scanners->push_back(static_cast<VScanner*>(scanner));

--- a/be/src/vec/exec/scan/new_jdbc_scan_node.cpp
+++ b/be/src/vec/exec/scan/new_jdbc_scan_node.cpp
@@ -53,7 +53,12 @@ Status NewJdbcScanNode::_init_scanners(std::list<VScanner*>* scanners) {
             new NewJdbcScanner(_state, this, _limit_per_scanner, _tuple_id, _query_string,
                                _table_type, _state->runtime_profile());
     _scanner_pool.add(scanner);
-    RETURN_IF_ERROR(scanner->prepare(_state, _vconjunct_ctx_ptr.get()));
+    Status st = scanner->prepare(_state, _vconjunct_ctx_ptr.get());
+    if (!st.ok()) {
+        // during prepare, scanner already cloned vexpr_context, should call close to release it.
+        scanner->close();
+        return st;
+    }
     scanners->push_back(static_cast<VScanner*>(scanner));
     return Status::OK();
 }

--- a/be/src/vec/exec/scan/new_jdbc_scan_node.cpp
+++ b/be/src/vec/exec/scan/new_jdbc_scan_node.cpp
@@ -56,7 +56,7 @@ Status NewJdbcScanNode::_init_scanners(std::list<VScanner*>* scanners) {
     Status st = scanner->prepare(_state, _vconjunct_ctx_ptr.get());
     if (!st.ok()) {
         // during prepare, scanner already cloned vexpr_context, should call close to release it.
-        scanner->close();
+        scanner->close(_state);
         return st;
     }
     scanners->push_back(static_cast<VScanner*>(scanner));

--- a/be/src/vec/exec/scan/new_olap_scan_node.cpp
+++ b/be/src/vec/exec/scan/new_olap_scan_node.cpp
@@ -398,9 +398,13 @@ Status NewOlapScanNode::_init_scanners(std::list<VScanner*>* scanners) {
             // add scanner to pool before doing prepare.
             // so that scanner can be automatically deconstructed if prepare failed.
             _scanner_pool.add(scanner);
-            RETURN_IF_ERROR(scanner->prepare(*scan_range, scanner_ranges, _vconjunct_ctx_ptr.get(),
-                                             _olap_filters, _filter_predicates,
-                                             _push_down_functions));
+            Status st = scanner->prepare(*scan_range, scanner_ranges, _vconjunct_ctx_ptr.get(),
+                                         _olap_filters, _filter_predicates, _push_down_functions);
+            if (!st.ok()) {
+                // during prepare, scanner already cloned vexpr_context, should call close to release it.
+                scanner->close();
+                return st;
+            }
             scanners->push_back((VScanner*)scanner);
             disk_set.insert(scanner->scan_disk());
         }

--- a/be/src/vec/exec/scan/new_olap_scan_node.cpp
+++ b/be/src/vec/exec/scan/new_olap_scan_node.cpp
@@ -402,7 +402,7 @@ Status NewOlapScanNode::_init_scanners(std::list<VScanner*>* scanners) {
                                          _olap_filters, _filter_predicates, _push_down_functions);
             if (!st.ok()) {
                 // during prepare, scanner already cloned vexpr_context, should call close to release it.
-                scanner->close();
+                scanner->close(_state);
                 return st;
             }
             scanners->push_back((VScanner*)scanner);

--- a/be/src/vec/exprs/vexpr_context.cpp
+++ b/be/src/vec/exprs/vexpr_context.cpp
@@ -33,11 +33,9 @@ VExprContext::VExprContext(VExpr* expr)
 
 VExprContext::~VExprContext() {
     // Should not use dcheck, should log fatal here, because maybe memory leak online.
-    if (!_prepared || _closed) {
-        LOG(FATAL) << "could not deconstruct vexprcontext normally! _prepared=" << _prepared
-                   << ", _closed=" << _closed << ", _opened=" << _opened << ", _stale=" << _stale
-                   << ",_is_clone=" << _is_clone;
-    }
+    DCHECK(!_prepared || _closed) << "could not deconstruct vexprcontext normally! _prepared="
+                                  << _prepared << ", _closed=" << _closed << ", _opened=" << _opened
+                                  << ", _stale=" << _stale << ",_is_clone=" << _is_clone;
 
     for (int i = 0; i < _fn_contexts.size(); ++i) {
         delete _fn_contexts[i];

--- a/be/src/vec/exprs/vexpr_context.cpp
+++ b/be/src/vec/exprs/vexpr_context.cpp
@@ -32,7 +32,12 @@ VExprContext::VExprContext(VExpr* expr)
           _stale(false) {}
 
 VExprContext::~VExprContext() {
-    DCHECK(!_prepared || _closed) << get_stack_trace();
+    // Should not use dcheck, should log fatal here, because maybe memory leak online.
+    if (!_prepared || _closed) {
+        LOG(FATAL) << "could not deconstruct vexprcontext normally! _prepared=" << _prepared
+                   << ", _closed=" << _closed << ", _opened=" << _opened << ", _stale=" << _stale
+                   << ",_is_clone=" << _is_clone;
+    }
 
     for (int i = 0; i < _fn_contexts.size(); ++i) {
         delete _fn_contexts[i];


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

