### PR TITLE
[fix](non-vec expr) avoid crashing caused by big depth of expression tree

### DIFF
--- a/be/src/exprs/expr.cpp
+++ b/be/src/exprs/expr.cpp
@@ -516,9 +516,17 @@ Status Expr::prepare(const std::vector<ExprContext*>& ctxs, RuntimeState* state,
 
 Status Expr::prepare(RuntimeState* state, const RowDescriptor& row_desc, ExprContext* context) {
     DCHECK(_type.type != INVALID_TYPE);
+    ++context->_depth_num;
+    if (context->_depth_num > config::max_depth_of_expr_tree) {
+        return Status::InternalError(
+                fmt::format("The depth of the expression tree is too big, make it less than {}",
+                            config::max_depth_of_expr_tree));
+    }
     for (int i = 0; i < _children.size(); ++i) {
         RETURN_IF_ERROR(_children[i]->prepare(state, row_desc, context));
     }
+
+    --context->_depth_num;
     return Status::OK();
 }
 

--- a/be/src/exprs/expr_context.h
+++ b/be/src/exprs/expr_context.h
@@ -186,6 +186,9 @@ private:
     /// Calls the appropriate Get*Val() function on 'e' and stores the result in result_.
     /// This is used by Exprs to call GetValue() on a child expr, rather than root_.
     void* get_value(Expr* e, TupleRow* row);
+
+    /// The depth of expression-tree.
+    int _depth_num = 0;
 };
 
 inline void* ExprContext::get_value(TupleRow* row) {


### PR DESCRIPTION
# Proposed changes

Issue Number: close https://github.com/apache/doris/issues/18036

## Problem summary

Also add sql depth limit for **non-vec** engine, like https://github.com/apache/doris/pull/17346 for vec engine.


## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

