### PR TITLE
[fix](nereids)remove redundant session Var ENABLE_NEREIDS_RUNTIME_FILTER

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/PlanPostProcessors.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/PlanPostProcessors.java
@@ -59,8 +59,7 @@ public class PlanPostProcessors {
         // add processor if we need
         Builder<PlanPostProcessor> builder = ImmutableList.builder();
         builder.add(new MergeProjectPostProcessor());
-        if (cascadesContext.getConnectContext().getSessionVariable().isEnableNereidsRuntimeFilter()
-                && !cascadesContext.getConnectContext().getSessionVariable().getRuntimeFilterMode()
+        if (!cascadesContext.getConnectContext().getSessionVariable().getRuntimeFilterMode()
                         .toUpperCase().equals(TRuntimeFilterMode.OFF.name())) {
             builder.add(new RuntimeFilterGenerator());
             if (ConnectContext.get().getSessionVariable().enableRuntimeFilterPrune) {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -207,8 +207,6 @@ public class SessionVariable implements Serializable, Writable {
     public static final String ENABLE_NEW_COST_MODEL = "enable_new_cost_model";
     public static final String ENABLE_FALLBACK_TO_ORIGINAL_PLANNER = "enable_fallback_to_original_planner";
 
-    public static final String ENABLE_NEREIDS_RUNTIME_FILTER = "enable_nereids_runtime_filter";
-
     public static final String BROADCAST_RIGHT_TABLE_SCALE_FACTOR = "broadcast_right_table_scale_factor";
     public static final String BROADCAST_ROW_COUNT_LIMIT = "broadcast_row_count_limit";
 
@@ -637,9 +635,6 @@ public class SessionVariable implements Serializable, Writable {
 
     @VariableMgr.VarAttr(name = ENABLE_NEREIDS_TRACE)
     private boolean enableNereidsTrace = false;
-
-    @VariableMgr.VarAttr(name = ENABLE_NEREIDS_RUNTIME_FILTER, needForward = true)
-    private boolean enableNereidsRuntimeFilter = true;
 
     @VariableMgr.VarAttr(name = BROADCAST_RIGHT_TABLE_SCALE_FACTOR)
     private double broadcastRightTableScaleFactor = 10.0;
@@ -1539,14 +1534,6 @@ public class SessionVariable implements Serializable, Writable {
 
     public boolean isEnableNereidsTrace() {
         return isEnableNereidsPlanner() && enableNereidsTrace;
-    }
-
-    public boolean isEnableNereidsRuntimeFilter() {
-        return enableNereidsRuntimeFilter;
-    }
-
-    public void setEnableNereidsRuntimeFilter(boolean enableNereidsRuntimeFilter) {
-        this.enableNereidsRuntimeFilter = enableNereidsRuntimeFilter;
     }
 
     public boolean isEnableSingleReplicaInsert() {

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/postprocess/RuntimeFilterTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/postprocess/RuntimeFilterTest.java
@@ -40,7 +40,7 @@ public class RuntimeFilterTest extends SSBTestBase {
     @Override
     public void runBeforeAll() throws Exception {
         super.runBeforeAll();
-        connectContext.getSessionVariable().setEnableNereidsRuntimeFilter(true);
+        connectContext.getSessionVariable().setRuntimeFilterMode("Global");
         connectContext.getSessionVariable().setRuntimeFilterType(8);
     }
 

--- a/regression-test/suites/nereids_datev2_p1/tpch/q2.groovy
+++ b/regression-test/suites/nereids_datev2_p1/tpch/q2.groovy
@@ -22,7 +22,7 @@ suite("nereids_tpch_q2") {
     sql "use ${db}"
     sql 'set enable_nereids_planner=true'
     sql 'set enable_fallback_to_original_planner=false'
-    sql "set enable_nereids_runtime_filter=false"
+    sql "set runtime_filter_mode='GLOBAL'"
     
     qt_select """
     select /*+SET_VAR(exec_mem_limit=8589934592)*/

--- a/regression-test/suites/nereids_tpch_p0/tpch/q2.groovy
+++ b/regression-test/suites/nereids_tpch_p0/tpch/q2.groovy
@@ -22,7 +22,7 @@ suite("nereids_tpch_q2") {
     sql "use ${db}"
     sql 'set enable_nereids_planner=true'
     sql 'set enable_fallback_to_original_planner=false'
-    sql "set enable_nereids_runtime_filter=false"
+    sql "set runtime_filter_mode='GLOBAL'"
     
     qt_select """
     select /*+SET_VAR(exec_mem_limit=8589934592)*/


### PR DESCRIPTION
# Proposed changes

ENABLE_NEREIDS_RUNTIME_FILTER is duplicated to runtime_filter_mode.
remove ENABLE_NEREIDS_RUNTIME_FILTER.

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

