### PR TITLE
[wip][fix](storage) free dict_page immediately after usage to save memory

### DIFF
--- a/be/src/olap/rowset/segment_v2/column_reader.h
+++ b/be/src/olap/rowset/segment_v2/column_reader.h
@@ -359,7 +359,7 @@ private:
     std::unique_ptr<PageDecoder> _dict_decoder;
 
     // keep dict page handle to avoid released
-    PageHandle _dict_page_handle;
+    std::unique_ptr<PageHandle> _dict_page_handle = nullptr;
 
     // page iterator used to get next page when current page is finished.
     // This value will be reset when a new seek is issued


### PR DESCRIPTION
The dictionary may be used for first few data pages but after a certain point, it will no longer be needed. Free it immediately to save memory.

# Proposed changes

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

