### PR TITLE
[fix](regression-test) Remove the assert check to prevent wrong results 

### DIFF
--- a/regression-test/suites/ssb_sf0.1_p1/load.groovy
+++ b/regression-test/suites/ssb_sf0.1_p1/load.groovy
@@ -89,7 +89,6 @@ suite("load") {
         sql new File("""${context.file.parent}/ddl/${table}_delete.sql""").text
         sql "set global insert_timeout=3600"
         def r = sql "select @@insert_timeout"
-        assertEquals(3600, r[0][0])
         year_cons = [
             'lo_orderdate<19930101',
             'lo_orderdate>=19930101 and lo_orderdate<19940101',


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

Since set global cannot take effect immediately in the current session.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

