### PR TITLE
[pipeline](profile) Show each instance profile in FE

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
@@ -837,7 +837,6 @@ public class Coordinator {
                 }
 
                 // 3. group BackendExecState by BE. So that we can use one RPC to send all fragment instances of a BE.
-
                 for (Map.Entry<TNetworkAddress, TPipelineFragmentParams> entry : tParams.entrySet()) {
                     PipelineExecContext pipelineExecContext =
                             new PipelineExecContext(fragment.getFragmentId(),
@@ -2696,9 +2695,10 @@ public class Coordinator {
         volatile Map<TUniqueId, Boolean> doneFlags = new HashMap<TUniqueId, Boolean>();
         boolean hasCanceled;
         volatile Map<TUniqueId, Boolean> cancelFlags = new HashMap<TUniqueId, Boolean>();
+
+        volatile Map<TUniqueId, RuntimeProfile> profiles = new HashMap<TUniqueId, RuntimeProfile>();
         int cancelProgress = 0;
         int profileFragmentId;
-        RuntimeProfile profile;
         TNetworkAddress brpcAddress;
         TNetworkAddress address;
         Backend backend;
@@ -2715,6 +2715,11 @@ public class Coordinator {
             this.numInstances = rpcParams.local_params.size();
             for (int i = 0; i < this.numInstances; i++) {
                 this.doneFlags.put(rpcParams.local_params.get(i).fragment_instance_id, false);
+                this.cancelFlags.put(rpcParams.local_params.get(i).fragment_instance_id, false);
+
+                String name = "Instance " + DebugUtil.printId(rpcParams.local_params.get(i).fragment_instance_id)
+                        + " (host=" + addr + ")";
+                this.profiles.put(rpcParams.local_params.get(i).fragment_instance_id, new RuntimeProfile(name));
             }
             this.initiated = false;
             this.done = false;
@@ -2723,12 +2728,7 @@ public class Coordinator {
             this.backend = idToBackend.get(addressToBackendID.get(address));
             this.brpcAddress = new TNetworkAddress(backend.getIp(), backend.getBrpcPort());
 
-            String name = "Fragment " + profileFragmentId + " (host=" + address + ")";
-            this.profile = new RuntimeProfile(name);
             this.hasCanceled = false;
-            for (int i = 0; i < this.numInstances; i++) {
-                this.cancelFlags.put(rpcParams.local_params.get(i).fragment_instance_id, false);
-            }
             this.lastMissingHeartbeatTime = backend.getLastMissingHeartbeatTime();
         }
 
@@ -2754,7 +2754,7 @@ public class Coordinator {
                 return false;
             }
             if (params.isSetProfile()) {
-                profile.update(params.profile);
+                this.profiles.get(params.fragment_instance_id).update(params.profile);
             }
             if (params.done) {
                 this.doneFlags.replace(params.fragment_instance_id, true);
@@ -2767,8 +2767,10 @@ public class Coordinator {
         }
 
         public synchronized void printProfile(StringBuilder builder) {
-            this.profile.computeTimeInProfile();
-            this.profile.prettyPrint(builder, "");
+            this.profiles.values().stream().forEach(p -> {
+                p.computeTimeInProfile();
+                p.prettyPrint(builder, "");
+            });
         }
 
         // cancel all fragment instances.
@@ -2828,7 +2830,7 @@ public class Coordinator {
                 LOG.warn("profileFragmentId {} should be in [0, {})", profileFragmentId, maxFragmentId);
                 return false;
             }
-            profile.computeTimeInProfile();
+            // profile.computeTimeInProfile();
             return true;
         }
 
@@ -3331,7 +3333,8 @@ public class Coordinator {
                 if (!ctx.computeTimeInProfile(fragmentProfile.size())) {
                     return;
                 }
-                fragmentProfile.get(ctx.profileFragmentId).addChild(ctx.profile);
+                ctx.profiles.values().stream().forEach(p ->
+                        fragmentProfile.get(ctx.profileFragmentId).addChild(p));
             }
         } else {
             for (BackendExecState backendExecState : backendExecStates) {


### PR DESCRIPTION
# Proposed changes

After do the opt：
Each fragment can print all instance profile message， not only one

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

