### PR TITLE
[chore](third-party) Porting to GCC-12

### DIFF
--- a/thirdparty/CHANGELOG.md
+++ b/thirdparty/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 This file contains version of the third-party dependency libraries in the build-env image. The docker build-env image is apache/doris, and the tag is `build-env-${version}`
 
+## v20230411
+- Modified: clucene 2.4.8 -> 2.4.9
+
 ## v20230328
 - Modified: brpc 1.2.0 -> 1.4.0
 - Modified: boost 1.73.0 -> 1.81.0

--- a/thirdparty/vars.sh
+++ b/thirdparty/vars.sh
@@ -55,10 +55,10 @@ export TP_JAR_DIR="${TP_INSTALL_DIR}/lib/jar"
 #####################################################
 
 #clucene
-CLUCENE_DOWNLOAD="https://github.com/apache/doris-thirdparty/archive/refs/tags/libclucene-v2.4.8.tar.gz"
-CLUCENE_NAME="doris-thirdparty-libclucene-v2.4.8.tar.gz"
-CLUCENE_SOURCE="doris-thirdparty-libclucene-v2.4.8"
-CLUCENE_MD5SUM="4d77af3c2c0d3c47754ffa68c277b9d6"
+CLUCENE_DOWNLOAD="https://github.com/apache/doris-thirdparty/archive/refs/tags/libclucene-v2.4.9.tar.gz"
+CLUCENE_NAME="doris-thirdparty-libclucene-v2.4.9.tar.gz"
+CLUCENE_SOURCE="doris-thirdparty-libclucene-v2.4.9"
+CLUCENE_MD5SUM="2d5c48bd24b0757d0fecb74111b9b2ed"
 
 # libevent
 LIBEVENT_DOWNLOAD="https://github.com/libevent/libevent/archive/release-2.1.12-stable.tar.gz"


### PR DESCRIPTION
# Proposed changes

Issue Number: close #18559

## Problem summary

The definitions of `_mm_cvtsi128_si16` conflicts.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [x] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

