### PR TITLE
[refactor](jdbc) refactor jdbc connection num in datasource

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/external/jdbc/JdbcClient.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/external/jdbc/JdbcClient.java
@@ -99,7 +99,7 @@ public class JdbcClient {
             dataSource.setPassword(password);
             dataSource.setMinIdle(1);
             dataSource.setInitialSize(1);
-            dataSource.setMaxActive(10);
+            dataSource.setMaxActive(100);
             dataSource.setTimeBetweenEvictionRunsMillis(600000);
             dataSource.setMinEvictableIdleTimeMillis(300000);
             // set connection timeout to 5s.

--- a/fe/fe-core/src/main/java/org/apache/doris/external/jdbc/JdbcClient.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/external/jdbc/JdbcClient.java
@@ -98,8 +98,10 @@ public class JdbcClient {
             dataSource.setUsername(jdbcUser);
             dataSource.setPassword(password);
             dataSource.setMinIdle(1);
-            dataSource.setInitialSize(2);
-            dataSource.setMaxActive(5);
+            dataSource.setInitialSize(1);
+            dataSource.setMaxActive(10);
+            dataSource.setTimeBetweenEvictionRunsMillis(600000);
+            dataSource.setMinEvictableIdleTimeMillis(300000);
             // set connection timeout to 5s.
             // The default is 30s, which is too long.
             // Because when querying information_schema db, BE will call thrift rpc(default timeout is 30s)

--- a/fe/java-udf/src/main/java/org/apache/doris/udf/JdbcExecutor.java
+++ b/fe/java-udf/src/main/java/org/apache/doris/udf/JdbcExecutor.java
@@ -230,14 +230,15 @@ public class JdbcExecutor {
                 ds.setPassword(jdbcPassword);
                 ds.setMinIdle(1);
                 ds.setInitialSize(1);
-                ds.setMaxActive(10);
+                ds.setMaxActive(100);
                 ds.setMaxWait(5000);
                 ds.setTimeBetweenEvictionRunsMillis(600000);
                 ds.setMinEvictableIdleTimeMillis(300000);
                 druidDataSource = ds;
-                // here is a cache of datasource, which using the string(jdbcUrl + jdbcUser + jdbcPassword) as key.
-                // and the datasource init = 1, min = 1, max = 10, if one of connection idle time greater than 10 minutes.
-                // the connection will be retrieved.
+                // here is a cache of datasource, which using the string(jdbcUrl + jdbcUser +
+                // jdbcPassword) as key.
+                // and the datasource init = 1, min = 1, max = 100, if one of connection idle
+                // time greater than 10 minutes. then connection will be retrieved.
                 JdbcDataSource.getDataSource().putSource(jdbcUrl + jdbcUser + jdbcPassword, ds);
             }
             conn = druidDataSource.getConnection();

--- a/fe/java-udf/src/main/java/org/apache/doris/udf/JdbcExecutor.java
+++ b/fe/java-udf/src/main/java/org/apache/doris/udf/JdbcExecutor.java
@@ -229,10 +229,15 @@ public class JdbcExecutor {
                 ds.setUsername(jdbcUser);
                 ds.setPassword(jdbcPassword);
                 ds.setMinIdle(1);
-                ds.setInitialSize(2);
-                ds.setMaxActive(5);
+                ds.setInitialSize(1);
+                ds.setMaxActive(10);
                 ds.setMaxWait(5000);
+                ds.setTimeBetweenEvictionRunsMillis(60000);
+                ds.setMinEvictableIdleTimeMillis(30000);
                 druidDataSource = ds;
+                // here is a cache of datasource, which using the string(jdbcUrl + jdbcUser + jdbcPassword) as key.
+                // and the datasource init = 1, min = 1, max = 10, if one of connection idle time greater than 10 minutes.
+                // the connection will be retrieved.
                 JdbcDataSource.getDataSource().putSource(jdbcUrl + jdbcUser + jdbcPassword, ds);
             }
             conn = druidDataSource.getConnection();

--- a/fe/java-udf/src/main/java/org/apache/doris/udf/JdbcExecutor.java
+++ b/fe/java-udf/src/main/java/org/apache/doris/udf/JdbcExecutor.java
@@ -232,8 +232,8 @@ public class JdbcExecutor {
                 ds.setInitialSize(1);
                 ds.setMaxActive(10);
                 ds.setMaxWait(5000);
-                ds.setTimeBetweenEvictionRunsMillis(60000);
-                ds.setMinEvictableIdleTimeMillis(30000);
+                ds.setTimeBetweenEvictionRunsMillis(600000);
+                ds.setMinEvictableIdleTimeMillis(300000);
                 druidDataSource = ds;
                 // here is a cache of datasource, which using the string(jdbcUrl + jdbcUser + jdbcPassword) as key.
                 // and the datasource init = 1, min = 1, max = 10, if one of connection idle time greater than 10 minutes.


### PR DESCRIPTION
# Proposed changes
now maybe jdbc have problem that there are too many connections  and they do not release,
so change the property of datasource: init = 1, min = 1, max = 100, and idle time is 10 minutes.

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

