### PR TITLE
[feature](jni) map c++ block to java vector table

### DIFF
--- a/be/src/vec/exec/jni_connector.cpp
+++ b/be/src/vec/exec/jni_connector.cpp
@@ -354,10 +354,11 @@ Status JniConnector::generate_meta_info(Block* block, std::unique_ptr<long[]>& m
         }
 
         switch (logical_type) {
-#define DISPATCH(NUMERIC_TYPE, CPP_NUMERIC_TYPE) \
-    case NUMERIC_TYPE:                           \
-        meta_data.emplace_back(_get_numeric_data_address<CPP_NUMERIC_TYPE>(data_column));
-            break;
+#define DISPATCH(NUMERIC_TYPE, CPP_NUMERIC_TYPE)                                          \
+    case NUMERIC_TYPE: {                                                                  \
+        meta_data.emplace_back(_get_numeric_data_address<CPP_NUMERIC_TYPE>(data_column)); \
+        break;                                                                            \
+    }
             FOR_LOGICAL_NUMERIC_TYPES(DISPATCH)
 #undef DISPATCH
         case TypeIndex::Decimal128:

--- a/be/src/vec/exec/jni_connector.cpp
+++ b/be/src/vec/exec/jni_connector.cpp
@@ -344,7 +344,7 @@ Status JniConnector::generate_meta_info(Block* block, std::unique_ptr<long[]>& m
         MutableColumnPtr data_column;
         if (column_ptr->is_nullable()) {
             auto* nullable_column = reinterpret_cast<vectorized::ColumnNullable*>(
-                    (*std::move(column_ptr)).mutate().get());
+                    column_ptr->assume_mutable().get());
             data_column = nullable_column->get_nested_column_ptr();
             NullMap& null_map = nullable_column->get_null_map_data();
             meta_data.emplace_back((long)null_map.data());

--- a/be/src/vec/exec/jni_connector.cpp
+++ b/be/src/vec/exec/jni_connector.cpp
@@ -329,4 +329,81 @@ std::string JniConnector::get_hive_type(const TypeDescriptor& desc) {
         return "unsupported";
     }
 }
+
+Status JniConnector::generate_meta_info(Block* block, std::unique_ptr<long[]>& meta) {
+    std::vector<long> meta_data;
+    // insert number of rows
+    meta_data.emplace_back(block->rows());
+    for (int i = 0; i < block->columns(); ++i) {
+        auto& column_with_type_and_name = block->get_by_position(i);
+        auto& column_ptr = column_with_type_and_name.column;
+        auto& column_type = column_with_type_and_name.type;
+        TypeIndex logical_type = remove_nullable(column_type)->get_type_id();
+
+        // insert null map address
+        MutableColumnPtr data_column;
+        if (column_ptr->is_nullable()) {
+            auto* nullable_column = reinterpret_cast<vectorized::ColumnNullable*>(
+                    (*std::move(column_ptr)).mutate().get());
+            data_column = nullable_column->get_nested_column_ptr();
+            NullMap& null_map = nullable_column->get_null_map_data();
+            meta_data.emplace_back((long)null_map.data());
+        } else {
+            meta_data.emplace_back(0);
+            data_column = column_ptr->assume_mutable();
+        }
+
+        switch (logical_type) {
+#define DISPATCH(NUMERIC_TYPE, CPP_NUMERIC_TYPE) \
+    case NUMERIC_TYPE:                           \
+        meta_data.emplace_back(_get_numeric_data_address<CPP_NUMERIC_TYPE>(data_column));
+            break;
+            FOR_LOGICAL_NUMERIC_TYPES(DISPATCH)
+#undef DISPATCH
+        case TypeIndex::Decimal128:
+            [[fallthrough]];
+        case TypeIndex::Decimal128I: {
+            meta_data.emplace_back(_get_decimal_data_address<Int128>(data_column));
+            break;
+        }
+        case TypeIndex::Decimal32: {
+            meta_data.emplace_back(_get_decimal_data_address<Int32>(data_column));
+            break;
+        }
+        case TypeIndex::Decimal64: {
+            meta_data.emplace_back(_get_decimal_data_address<Int64>(data_column));
+            break;
+        }
+        case TypeIndex::DateV2: {
+            meta_data.emplace_back(_get_time_data_address<UInt32>(data_column));
+            break;
+        }
+        case TypeIndex::DateTimeV2: {
+            meta_data.emplace_back(_get_time_data_address<UInt64>(data_column));
+            break;
+        }
+        case TypeIndex::String:
+            [[fallthrough]];
+        case TypeIndex::FixedString: {
+            auto& string_column = static_cast<ColumnString&>(*data_column);
+            // inert offsets
+            meta_data.emplace_back((long)string_column.get_offsets().data());
+            meta_data.emplace_back((long)string_column.get_chars().data());
+            break;
+        }
+        case TypeIndex::Array:
+            [[fallthrough]];
+        case TypeIndex::Struct:
+            [[fallthrough]];
+        case TypeIndex::Map:
+            return Status::IOError("Unhandled type {}", getTypeName(logical_type));
+        default:
+            return Status::IOError("Unsupported type {}", getTypeName(logical_type));
+        }
+    }
+
+    meta.reset(new long[meta_data.size()]);
+    memcpy(meta.get(), &meta_data[0], meta_data.size() * 8);
+    return Status::OK();
+}
 } // namespace doris::vectorized

--- a/be/src/vec/exec/jni_connector.h
+++ b/be/src/vec/exec/jni_connector.h
@@ -177,6 +177,8 @@ public:
      */
     static std::string get_hive_type(const TypeDescriptor& desc);
 
+    static Status generate_meta_info(Block* block, std::unique_ptr<long[]>& meta);
+
 private:
     std::string _connector_class;
     std::map<std::string, std::string> _scanner_params;
@@ -233,6 +235,11 @@ private:
         return Status::OK();
     }
 
+    template <typename CppType>
+    static long _get_numeric_data_address(MutableColumnPtr& doris_column) {
+        return (long)static_cast<ColumnVector<CppType>&>(*doris_column).get_data().data();
+    }
+
     template <typename DecimalPrimitiveType>
     Status _fill_decimal_column(MutableColumnPtr& doris_column, DecimalPrimitiveType* ptr,
                                 size_t num_rows) {
@@ -245,6 +252,13 @@ private:
         return Status::OK();
     }
 
+    template <typename DecimalPrimitiveType>
+    static long _get_decimal_data_address(MutableColumnPtr& doris_column) {
+        return (long)static_cast<ColumnDecimal<Decimal<DecimalPrimitiveType>>&>(*doris_column)
+                .get_data()
+                .data();
+    }
+
     template <typename CppType>
     Status _decode_time_column(MutableColumnPtr& doris_column, CppType* ptr, size_t num_rows) {
         auto& column_data = static_cast<ColumnVector<CppType>&>(*doris_column).get_data();
@@ -252,6 +266,11 @@ private:
         column_data.resize(origin_size + num_rows);
         memcpy(column_data.data() + origin_size, ptr, sizeof(CppType) * num_rows);
         return Status::OK();
+    }
+
+    template <typename CppType>
+    static long _get_time_data_address(MutableColumnPtr& doris_column) {
+        return (long)static_cast<ColumnVector<CppType>&>(*doris_column).get_data().data();
     }
 
     Status _fill_string_column(MutableColumnPtr& doris_column, size_t num_rows);

--- a/be/src/vec/exec/vjdbc_connector.cpp
+++ b/be/src/vec/exec/vjdbc_connector.cpp
@@ -706,13 +706,14 @@ Status JdbcConnector::exec_stmt_write(
     std::ostringstream required_fields;
     std::ostringstream columns_types;
     for (int i = 0; i < block->columns(); ++i) {
-        std::string field = block->get_by_position(i).name;
+        // column name maybe empty or has special characters
+        // std::string field = block->get_by_position(i).name;
         std::string type = JniConnector::get_hive_type(output_vexpr_ctxs[i]->root()->type());
         if (i == 0) {
-            required_fields << field;
+            required_fields << "_col" << i;
             columns_types << type;
         } else {
-            required_fields << "," << field;
+            required_fields << "," << "_col" << i;
             columns_types << "#" << type;
         }
     }
@@ -720,7 +721,7 @@ Status JdbcConnector::exec_stmt_write(
     // prepare table meta information
     std::unique_ptr<long[]> meta_data;
     RETURN_IF_ERROR(JniConnector::generate_meta_info(block, meta_data));
-    long meta_address = (long) meta_data.get();
+    long meta_address = (long)meta_data.get();
 
     // prepare constructor parameters
     std::map<String, String> write_params = {{"meta_address", std::to_string(meta_address)},

--- a/be/src/vec/exec/vjdbc_connector.cpp
+++ b/be/src/vec/exec/vjdbc_connector.cpp
@@ -33,6 +33,7 @@
 #include "vec/columns/column_string.h"
 #include "vec/data_types/data_type_factory.hpp"
 #include "vec/data_types/data_type_string.h"
+#include "vec/exec/jni_connector.h"
 #include "vec/exec/scan/new_jdbc_scanner.h"
 #include "vec/functions/simple_function_factory.h"
 
@@ -41,6 +42,7 @@ namespace vectorized {
 const char* JDBC_EXECUTOR_CLASS = "org/apache/doris/udf/JdbcExecutor";
 const char* JDBC_EXECUTOR_CTOR_SIGNATURE = "([B)V";
 const char* JDBC_EXECUTOR_WRITE_SIGNATURE = "(Ljava/lang/String;)I";
+const char* JDBC_EXECUTOR_STMT_WRITE_SIGNATURE = "(Ljava/util/Map;)I";
 const char* JDBC_EXECUTOR_HAS_NEXT_SIGNATURE = "()Z";
 const char* JDBC_EXECUTOR_GET_BLOCK_SIGNATURE = "(I)Ljava/util/List;";
 const char* JDBC_EXECUTOR_GET_TYPES_SIGNATURE = "()Ljava/util/List;";
@@ -570,6 +572,8 @@ Status JdbcConnector::_register_func_id(JNIEnv* env) {
                                 _executor_ctor_id));
     RETURN_IF_ERROR(register_id(_executor_clazz, "write", JDBC_EXECUTOR_WRITE_SIGNATURE,
                                 _executor_write_id));
+    RETURN_IF_ERROR(register_id(_executor_clazz, "write", JDBC_EXECUTOR_STMT_WRITE_SIGNATURE,
+                                _executor_stmt_write_id));
     RETURN_IF_ERROR(register_id(_executor_clazz, "read", "()I", _executor_read_id));
     RETURN_IF_ERROR(register_id(_executor_clazz, "close", JDBC_EXECUTOR_CLOSE_SIGNATURE,
                                 _executor_close_id));
@@ -688,6 +692,58 @@ Status JdbcConnector::exec_write_sql(const std::u16string& insert_stmt,
     jstring query_sql = env->NewString((const jchar*)insert_stmt.c_str(), insert_stmt.size());
     env->CallNonvirtualIntMethod(_executor_obj, _executor_clazz, _executor_write_id, query_sql);
     env->DeleteLocalRef(query_sql);
+    RETURN_IF_ERROR(JniUtil::GetJniExceptionMsg(env));
+    return Status::OK();
+}
+
+Status JdbcConnector::exec_stmt_write(
+        Block* block, const std::vector<vectorized::VExprContext*>& output_vexpr_ctxs) {
+    SCOPED_TIMER(_result_send_timer);
+    JNIEnv* env = nullptr;
+    RETURN_IF_ERROR(JniUtil::GetJNIEnv(&env));
+
+    // prepare table schema
+    std::ostringstream required_fields;
+    std::ostringstream columns_types;
+    for (int i = 0; i < block->columns(); ++i) {
+        std::string field = block->get_by_position(i).name;
+        std::string type = JniConnector::get_hive_type(output_vexpr_ctxs[i]->root()->type());
+        if (i == 0) {
+            required_fields << field;
+            columns_types << type;
+        } else {
+            required_fields << "," << field;
+            columns_types << "#" << type;
+        }
+    }
+
+    // prepare table meta information
+    std::unique_ptr<long[]> meta_data;
+    long meta_address = JniConnector::generate_meta_info(block, meta_data);
+
+    // prepare constructor parameters
+    std::map<String, String> write_params = {{"meta_address", std::to_string(meta_address)},
+                                             {"required_fields", required_fields.str()},
+                                             {"columns_types", columns_types.str()},
+                                             {"write_sql", "/* todo */"}};
+    jclass hashmap_class = env->FindClass("java/util/HashMap");
+    jmethodID hashmap_constructor = env->GetMethodID(hashmap_class, "<init>", "(I)V");
+    jobject hashmap_object =
+            env->NewObject(hashmap_class, hashmap_constructor, write_params.size());
+    jmethodID hashmap_put = env->GetMethodID(
+            hashmap_class, "put", "(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;");
+    RETURN_ERROR_IF_EXC(env);
+    for (const auto& it : write_params) {
+        jstring key = env->NewStringUTF(it.first.c_str());
+        jstring value = env->NewStringUTF(it.second.c_str());
+        env->CallObjectMethod(hashmap_object, hashmap_put, key, value);
+        env->DeleteLocalRef(key);
+        env->DeleteLocalRef(value);
+    }
+    env->DeleteLocalRef(hashmap_class);
+    env->CallNonvirtualIntMethod(_executor_obj, _executor_clazz, _executor_stmt_write_id,
+                                 hashmap_object);
+    env->DeleteLocalRef(hashmap_object);
     RETURN_IF_ERROR(JniUtil::GetJniExceptionMsg(env));
     return Status::OK();
 }

--- a/be/src/vec/exec/vjdbc_connector.cpp
+++ b/be/src/vec/exec/vjdbc_connector.cpp
@@ -713,7 +713,8 @@ Status JdbcConnector::exec_stmt_write(
             required_fields << "_col" << i;
             columns_types << type;
         } else {
-            required_fields << "," << "_col" << i;
+            required_fields << ","
+                            << "_col" << i;
             columns_types << "#" << type;
         }
     }

--- a/be/src/vec/exec/vjdbc_connector.cpp
+++ b/be/src/vec/exec/vjdbc_connector.cpp
@@ -719,7 +719,8 @@ Status JdbcConnector::exec_stmt_write(
 
     // prepare table meta information
     std::unique_ptr<long[]> meta_data;
-    long meta_address = JniConnector::generate_meta_info(block, meta_data);
+    RETURN_IF_ERROR(JniConnector::generate_meta_info(block, meta_data));
+    long meta_address = (long) meta_data.get();
 
     // prepare constructor parameters
     std::map<String, String> write_params = {{"meta_address", std::to_string(meta_address)},

--- a/be/src/vec/exec/vjdbc_connector.h
+++ b/be/src/vec/exec/vjdbc_connector.h
@@ -67,6 +67,9 @@ public:
     Status exec_write_sql(const std::u16string& insert_stmt,
                           const fmt::memory_buffer& insert_stmt_buffer) override;
 
+    Status exec_stmt_write(Block* block,
+                           const std::vector<vectorized::VExprContext*>& output_vexpr_ctxs);
+
     Status get_next(bool* eos, std::vector<MutableColumnPtr>& columns, Block* block,
                     int batch_size);
 
@@ -99,6 +102,7 @@ private:
     jobject _executor_obj;
     jmethodID _executor_ctor_id;
     jmethodID _executor_write_id;
+    jmethodID _executor_stmt_write_id;
     jmethodID _executor_read_id;
     jmethodID _executor_has_next_id;
     jmethodID _executor_block_rows_id;

--- a/fe/java-udf/src/main/java/org/apache/doris/udf/JdbcExecutor.java
+++ b/fe/java-udf/src/main/java/org/apache/doris/udf/JdbcExecutor.java
@@ -137,6 +137,7 @@ public class JdbcExecutor {
             columnTypes[i] = ColumnType.parseType(requiredFields[i], types[i]);
         }
         VectorTable batchTable = new VectorTable(columnTypes, requiredFields, metaAddress);
+        // todo: insert the batch table by PreparedStatement
         // Can't release or close batchTable, it's released by c++
         return batchTable.getNumRows();
     }

--- a/fe/java-udf/src/main/java/org/apache/doris/udf/JdbcExecutor.java
+++ b/fe/java-udf/src/main/java/org/apache/doris/udf/JdbcExecutor.java
@@ -17,6 +17,8 @@
 
 package org.apache.doris.udf;
 
+import org.apache.doris.jni.vec.ColumnType;
+import org.apache.doris.jni.vec.VectorTable;
 import org.apache.doris.thrift.TJdbcExecutorCtorParams;
 import org.apache.doris.thrift.TJdbcOperation;
 import org.apache.doris.thrift.TOdbcTableType;
@@ -122,6 +124,21 @@ public class JdbcExecutor {
         } catch (SQLException e) {
             throw new UdfRuntimeException("JDBC executor sql has error: ", e);
         }
+    }
+
+    public int write(Map<String, String> params) {
+        String[] requiredFields = params.get("required_fields").split(",");
+        String[] types = params.get("columns_types").split("#");
+        long metaAddress = Long.parseLong(params.get("meta_address"));
+        // Get sql string from configuration map
+        // String sql = params.get("write_sql");
+        ColumnType[] columnTypes = new ColumnType[types.length];
+        for (int i = 0; i < types.length; i++) {
+            columnTypes[i] = ColumnType.parseType(requiredFields[i], types[i]);
+        }
+        VectorTable batchTable = new VectorTable(columnTypes, requiredFields, metaAddress);
+        // Can't release or close batchTable, it's released by c++
+        return batchTable.getNumRows();
     }
 
     public List<String> getResultColumnTypeNames() {


### PR DESCRIPTION
# Proposed changes

PR(https://github.com/apache/doris/pull/17960) has introduced vector table which can map java table to c++ block. In some cases(java udf & jdbc exector), we should map c++ block to java table. This PR implements this function.

The memory structure of java vector table and c++ block is consistent, so the implementation doesn't copy the block, just passes the memory address.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

