### PR TITLE
[enhancement](Nereids) Simplify the codes for runtime filter validation

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/RuntimeFilterPruner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/processor/post/RuntimeFilterPruner.java
@@ -200,7 +200,7 @@ public class RuntimeFilterPruner extends PlanPostProcessor {
             return true;
         }
         return buildColumnStat.selectivity < 1
-                || probeColumnStat.coverage(buildColumnStat) < 1
+                || probeColumnStat.notEnclosed(buildColumnStat)
                 || buildColumnStat.ndv < probeColumnStat.ndv * 0.95;
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/ColumnStatistic.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/ColumnStatistic.java
@@ -251,26 +251,15 @@ public class ColumnStatistic {
         }
     }
 
+    public boolean notEnclosed(ColumnStatistic other) {
+        return !enclosed(other);
+    }
+
     /**
-     * the percentage of intersection range to this range
-     * @param other
-     * @return
+     * Return true if range of this is enclosed by another.
      */
-    public double coverage(ColumnStatistic other) {
-        if (isUnKnown) {
-            return 1.0;
-        }
-        if (minValue == maxValue) {
-            if (other.minValue <= minValue && minValue <= other.maxValue) {
-                return 1.0;
-            } else {
-                return 0.0;
-            }
-        } else {
-            double myRange = maxValue - minValue;
-            double interSection = Math.min(maxValue, other.maxValue) - Math.max(minValue, other.minValue);
-            return interSection / myRange;
-        }
+    public boolean enclosed(ColumnStatistic other) {
+        return this.maxValue >= other.maxValue && this.maxValue <= other.maxValue;
     }
 
     @Override


### PR DESCRIPTION
# Proposed changes

Since the goal of `ColumnStatistic#coverage` function is to determine whether the build side range is complete enclosed by the range of probe side, if so, as the comment of `RuntimeFilterPruner` explained, corresponding runtime filter might be thought as useless and get pruned.

Howerver, the original logic of this method is quite confused.

Simplify its logic by this formula:

```java
!(this.maxValue >= other.maxValue && this.maxValue <= other.maxValue)
```

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

