### PR TITLE
[Fix](Nereids)Check bounding of expression in analyze process

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/analyzer/NereidsAnalyzer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/analyzer/NereidsAnalyzer.java
@@ -24,6 +24,7 @@ import org.apache.doris.nereids.rules.analysis.AdjustAggregateNullableForEmptySe
 import org.apache.doris.nereids.rules.analysis.BindExpression;
 import org.apache.doris.nereids.rules.analysis.BindRelation;
 import org.apache.doris.nereids.rules.analysis.CheckAnalysis;
+import org.apache.doris.nereids.rules.analysis.CheckBound;
 import org.apache.doris.nereids.rules.analysis.CheckPolicy;
 import org.apache.doris.nereids.rules.analysis.FillUpMissingSlots;
 import org.apache.doris.nereids.rules.analysis.NormalizeRepeat;
@@ -52,6 +53,9 @@ public class NereidsAnalyzer extends BatchRewriteJob {
                 new CheckPolicy(),
                 new UserAuthentication(),
                 new BindExpression()
+            ),
+            bottomUp(
+                new CheckBound()
             ),
             bottomUp(
                 new ProjectToGlobalAggregate(),

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/RuleType.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/RuleType.java
@@ -85,6 +85,7 @@ public enum RuleType {
     // check analysis rule
     CHECK_AGGREGATE_ANALYSIS(RuleTypeClass.CHECK),
     CHECK_ANALYSIS(RuleTypeClass.CHECK),
+    CHECK_BOUND(RuleTypeClass.CHECK),
     CHECK_DATATYPES(RuleTypeClass.CHECK),
 
     // rewrite rules

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/CheckBound.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/CheckBound.java
@@ -23,53 +23,31 @@ import org.apache.doris.nereids.analyzer.UnboundSlot;
 import org.apache.doris.nereids.exceptions.AnalysisException;
 import org.apache.doris.nereids.rules.Rule;
 import org.apache.doris.nereids.rules.RuleType;
-import org.apache.doris.nereids.trees.expressions.Expression;
-import org.apache.doris.nereids.trees.expressions.functions.agg.AggregateFunction;
-import org.apache.doris.nereids.trees.expressions.typecoercion.TypeCheckResult;
 import org.apache.doris.nereids.trees.plans.Plan;
-import org.apache.doris.nereids.trees.plans.logical.LogicalAggregate;
 
 import com.google.common.collect.ImmutableList;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
- * Check analysis rule to check semantic correct after analysis by Nereids.
+ * Check bound rule to check semantic correct after bounding of expression by Nereids.
+ * Also give operator information without LOGICAL_
  */
-public class CheckAnalysis implements AnalysisRuleFactory {
+public class CheckBound implements AnalysisRuleFactory {
 
     @Override
     public List<Rule> buildRules() {
         return ImmutableList.of(
-            RuleType.CHECK_ANALYSIS.build(
+            RuleType.CHECK_BOUND.build(
                 any().then(plan -> {
                     checkBound(plan);
-                    checkExpressionInputTypes(plan);
                     return null;
-                })
-            ),
-            RuleType.CHECK_AGGREGATE_ANALYSIS.build(
-                logicalAggregate().then(agg -> {
-                    checkAggregate(agg);
-                    return agg;
                 })
             )
         );
-    }
-
-    private void checkExpressionInputTypes(Plan plan) {
-        final Optional<TypeCheckResult> firstFailed = plan.getExpressions().stream()
-                .map(Expression::checkInputDataTypes)
-                .filter(TypeCheckResult::failed)
-                .findFirst();
-
-        if (firstFailed.isPresent()) {
-            throw new AnalysisException(firstFailed.get().getMessage());
-        }
     }
 
     private void checkBound(Plan plan) {
@@ -89,29 +67,8 @@ public class CheckAnalysis implements AnalysisRuleFactory {
                         return unbound.toString();
                     })
                     .collect(Collectors.toSet()), ", "),
-                plan.getType().toString().substring("LOGICAL_".length())
+                    plan.getType().toString().substring("LOGICAL_".length())
             ));
-        }
-    }
-
-    private void checkAggregate(LogicalAggregate<? extends Plan> aggregate) {
-        Set<AggregateFunction> aggregateFunctions = aggregate.getAggregateFunctions();
-        boolean distinctMultiColumns = aggregateFunctions.stream()
-                .anyMatch(fun -> fun.isDistinct() && fun.arity() > 1);
-        long distinctFunctionNum = aggregateFunctions.stream()
-                .filter(AggregateFunction::isDistinct)
-                .count();
-
-        if (distinctMultiColumns && distinctFunctionNum > 1) {
-            throw new AnalysisException(
-                    "The query contains multi count distinct or sum distinct, each can't have multi columns");
-        }
-        Optional<Expression> expr = aggregate.getGroupByExpressions().stream()
-                .filter(expression -> expression.containsType(AggregateFunction.class)).findFirst();
-        if (expr.isPresent()) {
-            throw new AnalysisException(
-                    "GROUP BY expression must not contain aggregate functions: "
-                            + expr.get().toSql());
         }
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/analysis/BindSlotReferenceTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/analysis/BindSlotReferenceTest.java
@@ -54,7 +54,7 @@ class BindSlotReferenceTest {
                 new LogicalOlapScan(RelationUtil.newRelationId(), PlanConstructor.student));
         AnalysisException exception = Assertions.assertThrows(AnalysisException.class,
                 () -> PlanChecker.from(MemoTestUtils.createConnectContext()).analyze(project));
-        Assertions.assertEquals("unbounded object foo.", exception.getMessage());
+        Assertions.assertEquals("unbounded object foo in PROJECT clause.", exception.getMessage());
     }
 
     @Test

--- a/regression-test/suites/nereids_p0/except/test_bound_exception.groovy
+++ b/regression-test/suites/nereids_p0/except/test_bound_exception.groovy
@@ -1,0 +1,55 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_bound_exception") {
+    sql "SET enable_nereids_planner=true"
+    sql "SET enable_fallback_to_original_planner=false"
+    def tbName = "test_bound_exception"
+    def dbName = "test_bound_db"
+    sql "CREATE DATABASE IF NOT EXISTS ${dbName}"
+    sql "USE ${dbName}"
+
+    sql """ DROP TABLE IF EXISTS ${tbName} """
+    sql """
+        create table if not exists ${tbName} (id int, name char(10))
+        distributed by hash(id) buckets 1 properties("replication_num"="1");
+    """
+    test {
+        sql "SELECT id FROM ${tbName} GROUP BY id ORDER BY id123"
+        exception "errCode = 2, detailMessage = Unexpected exception: unbounded object id123 in SORT clause."
+    }
+    test {
+        sql "SELECT id123 FROM ${tbName} ORDER BY id"
+        exception "errCode = 2, detailMessage = Unexpected exception: unbounded object id123 in PROJECT clause."
+    }
+    test {
+        sql "SELECT id123 FROM ${tbName} GROUP BY id ORDER BY id"
+        exception "errCode = 2, detailMessage = Unexpected exception: unbounded object id123 in AGGREGATE clause."
+    }
+    test {
+        sql "SELECT id FROM ${tbName} GROUP BY id123 ORDER BY id"
+        exception "errCode = 2, detailMessage = Unexpected exception: cannot bind GROUP BY KEY: id123"
+    }
+    test {
+        sql "SELECT id FROM ${tbName} WHERE id = (SELECT id from ${tbName} ORDER BY id123 LIMIT 1) ORDER BY id"
+        exception "errCode = 2, detailMessage = Unexpected exception: unbounded object id123 in SORT clause."
+    }
+    test {
+        sql "SELECT id FROM ${tbName} WHERE id123 = 123 ORDER BY id"
+        exception "errCode = 2, detailMessage = Unexpected exception: Invalid call to dataType on unbound object"
+    }
+}


### PR DESCRIPTION
Probleam:
Dead loop cause of keep pushing analyze tasks into job stack. When doing analyze process and generate new operators, the same analyze rule would be pushed again, so it cause dead loop. And analyze process generate new operators when trying to bound order by key and aggregate function.
Solve:
We need to make it throw exception before complex analyze and rewrite process, so checking whether all expressions being bound should be done twice. One is done after bounding all expression, another is done after all analyze process in case of generate new expressions and new operators.
Example:
Cases were put in file: regression-test/suites/nereids_p0/except/test_bound_exception.groovy

# Proposed changes

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [x] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

