### PR TITLE
[fix](meta) void NPE when save meta

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/LoadJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/LoadJob.java
@@ -1118,6 +1118,8 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
                 userInfo.setIsAnalyzed();
             }
             comment = Text.readString(in);
+        } else {
+            comment = "";
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/LoadJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/LoadJob.java
@@ -132,7 +132,7 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
 
     protected List<ErrorTabletInfo> errorTabletInfos = Lists.newArrayList();
 
-    protected UserIdentity userInfo;
+    protected UserIdentity userInfo = UserIdentity.UNKNOWN;
 
     protected String comment = "";
 
@@ -1116,6 +1116,8 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
                 userInfo = UserIdentity.read(in);
                 // must set is as analyzed, because when write the user info to meta image, it will be checked.
                 userInfo.setIsAnalyzed();
+            } else {
+                userInfo = UserIdentity.UNKNOWN;
             }
             comment = Text.readString(in);
         } else {

--- a/fe/fe-core/src/main/java/org/apache/doris/load/routineload/RoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/routineload/RoutineLoadJob.java
@@ -1657,7 +1657,7 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback impl
         if (Env.getCurrentEnvJournalVersion() >= FeMetaVersion.VERSION_117) {
             comment = Text.readString(in);
         } else {
-            comment = null;
+            comment = "";
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/load/routineload/RoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/routineload/RoutineLoadJob.java
@@ -1572,7 +1572,7 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback impl
         Text.writeString(out, comment);
     }
 
-    public void readFields(DataInput in) throws IOException {
+    protected void readFields(DataInput in) throws IOException {
         if (!isTypeRead) {
             dataSourceType = LoadDataSourceType.valueOf(Text.readString(in));
             isTypeRead = true;
@@ -1651,7 +1651,7 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback impl
                 userIdentity = UserIdentity.read(in);
                 userIdentity.setIsAnalyzed();
             } else {
-                userIdentity = null;
+                userIdentity = UserIdentity.UNKNOWN;
             }
         }
         if (Env.getCurrentEnvJournalVersion() >= FeMetaVersion.VERSION_117) {


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

Introduced from #16878,
the newly added string field can not be null, or NPE will be thrown when calling `Text.writeString()`

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

