### PR TITLE
[opt](nereids) optimze  aggregation estimation

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/StatsCalculator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/StatsCalculator.java
@@ -479,11 +479,8 @@ public class StatsCalculator extends DefaultPlanVisitor<Statistics, Void> {
                     //all column stats are unknown, use default ratio
                     resultSetCount = inputRowCount * DEFAULT_AGGREGATE_RATIO;
                 } else {
-                    resultSetCount = groupByKeyStats.stream()
-                            .map(s -> s.ndv)
-                            .reduce(1.0, (a, b) -> a * b);
-                    //agg output tuples should be less than input tuples
-                    resultSetCount = Math.min(resultSetCount, inputRowCount);
+                    resultSetCount = groupByKeyStats.stream().map(s -> s.ndv)
+                            .max(Double::compare).get();
                 }
             }
         }

--- a/regression-test/data/nereids_tpchPlanShape_p0/shape/q10.out
+++ b/regression-test/data/nereids_tpchPlanShape_p0/shape/q10.out
@@ -4,24 +4,23 @@ PhysicalTopN
 --PhysicalDistribute
 ----PhysicalTopN
 ------PhysicalProject
---------hashAgg[GLOBAL]
+--------hashAgg[LOCAL]
 ----------PhysicalDistribute
-------------hashAgg[LOCAL]
---------------PhysicalProject
-----------------hashJoin[INNER_JOIN](lineitem.l_orderkey = orders.o_orderkey)
-------------------PhysicalProject
---------------------filter((lineitem.l_returnflag = 'R'))
-----------------------PhysicalOlapScan[lineitem]
-------------------PhysicalDistribute
---------------------hashJoin[INNER_JOIN](customer.c_nationkey = nation.n_nationkey)
-----------------------hashJoin[INNER_JOIN](customer.c_custkey = orders.o_custkey)
-------------------------PhysicalProject
---------------------------PhysicalOlapScan[customer]
-------------------------PhysicalDistribute
---------------------------PhysicalProject
-----------------------------filter((orders.o_orderdate < 1994-01-01)(orders.o_orderdate >= 1993-10-01))
-------------------------------PhysicalOlapScan[orders]
+------------PhysicalProject
+--------------hashJoin[INNER_JOIN](lineitem.l_orderkey = orders.o_orderkey)
+----------------PhysicalProject
+------------------filter((lineitem.l_returnflag = 'R'))
+--------------------PhysicalOlapScan[lineitem]
+----------------PhysicalDistribute
+------------------hashJoin[INNER_JOIN](customer.c_nationkey = nation.n_nationkey)
+--------------------hashJoin[INNER_JOIN](customer.c_custkey = orders.o_custkey)
+----------------------PhysicalProject
+------------------------PhysicalOlapScan[customer]
 ----------------------PhysicalDistribute
 ------------------------PhysicalProject
---------------------------PhysicalOlapScan[nation]
+--------------------------filter((orders.o_orderdate < 1994-01-01)(orders.o_orderdate >= 1993-10-01))
+----------------------------PhysicalOlapScan[orders]
+--------------------PhysicalDistribute
+----------------------PhysicalProject
+------------------------PhysicalOlapScan[nation]
 

--- a/regression-test/data/nereids_tpchPlanShape_p0/shape/q13.out
+++ b/regression-test/data/nereids_tpchPlanShape_p0/shape/q13.out
@@ -7,14 +7,13 @@ PhysicalQuickSort
 --------PhysicalDistribute
 ----------hashAgg[LOCAL]
 ------------PhysicalProject
---------------hashAgg[GLOBAL]
-----------------hashAgg[LOCAL]
-------------------PhysicalProject
---------------------hashJoin[RIGHT_OUTER_JOIN](customer.c_custkey = orders.o_custkey)
-----------------------PhysicalDistribute
-------------------------PhysicalProject
---------------------------filter(( not (o_comment like '%special%requests%')))
-----------------------------PhysicalOlapScan[orders]
+--------------hashAgg[LOCAL]
+----------------PhysicalProject
+------------------hashJoin[RIGHT_OUTER_JOIN](customer.c_custkey = orders.o_custkey)
+--------------------PhysicalDistribute
 ----------------------PhysicalProject
-------------------------PhysicalOlapScan[customer]
+------------------------filter(( not (o_comment like '%special%requests%')))
+--------------------------PhysicalOlapScan[orders]
+--------------------PhysicalProject
+----------------------PhysicalOlapScan[customer]
 

--- a/regression-test/data/nereids_tpchPlanShape_p0/shape/q18.out
+++ b/regression-test/data/nereids_tpchPlanShape_p0/shape/q18.out
@@ -3,25 +3,23 @@
 PhysicalTopN
 --PhysicalDistribute
 ----PhysicalTopN
-------hashAgg[GLOBAL]
---------hashAgg[LOCAL]
-----------PhysicalProject
-------------hashJoin[INNER_JOIN](orders.o_orderkey = lineitem.l_orderkey)
+------hashAgg[LOCAL]
+--------PhysicalProject
+----------hashJoin[INNER_JOIN](orders.o_orderkey = lineitem.l_orderkey)
+------------PhysicalProject
+--------------PhysicalOlapScan[lineitem]
+------------PhysicalDistribute
 --------------PhysicalProject
-----------------PhysicalOlapScan[lineitem]
---------------PhysicalDistribute
-----------------PhysicalProject
-------------------hashJoin[INNER_JOIN](customer.c_custkey = orders.o_custkey)
---------------------PhysicalProject
-----------------------PhysicalOlapScan[customer]
---------------------PhysicalDistribute
-----------------------hashJoin[LEFT_SEMI_JOIN](orders.o_orderkey = lineitem.l_orderkey)
-------------------------PhysicalProject
---------------------------PhysicalOlapScan[orders]
-------------------------PhysicalProject
---------------------------filter((sum(l_quantity) > 300.000000000))
-----------------------------hashAgg[GLOBAL]
-------------------------------hashAgg[LOCAL]
---------------------------------PhysicalProject
-----------------------------------PhysicalOlapScan[lineitem]
+----------------hashJoin[INNER_JOIN](customer.c_custkey = orders.o_custkey)
+------------------PhysicalProject
+--------------------PhysicalOlapScan[customer]
+------------------PhysicalDistribute
+--------------------hashJoin[LEFT_SEMI_JOIN](orders.o_orderkey = lineitem.l_orderkey)
+----------------------PhysicalProject
+------------------------PhysicalOlapScan[orders]
+----------------------PhysicalProject
+------------------------filter((sum(l_quantity) > 300.000000000))
+--------------------------hashAgg[LOCAL]
+----------------------------PhysicalProject
+------------------------------PhysicalOlapScan[lineitem]
 


### PR DESCRIPTION
# Proposed changes
`select count(*) from T group by A, B`
suppose `ndv(A) > ndv(B)`
the estimated row count of aggregate is between `ndv(A)`  and `ndv(A) * ndv(B)`

in previous version, we choose upper bound, that is `ndv(A) * ndv(B)`. The drawback of this choice is the estimated row is often bigger that row count of T.

In this version, we choose the lower bound.
 
Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

