### PR TITLE
[fix](json_reader) Do not increase the value of read_rows for empty line

### DIFF
--- a/be/src/vec/exec/format/json/new_json_reader.cpp
+++ b/be/src/vec/exec/format/json/new_json_reader.cpp
@@ -168,11 +168,11 @@ Status NewJsonReader::get_next_block(Block* block, size_t* read_rows, bool* eof)
         bool is_empty_row = false;
 
         RETURN_IF_ERROR(_read_json_column(*block, _file_slot_descs, &is_empty_row, &_reader_eof));
-        ++(*read_rows);
         if (is_empty_row) {
             // Read empty row, just continue
             continue;
         }
+        ++(*read_rows);
     }
 
     return Status::OK();


### PR DESCRIPTION
# Proposed changes

If read an empty row the row num++, the row num will be larger than actual column size, it will core.

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

