### PR TITLE
[Refactor](multi catalog)Remove redundant param context for FileQueryScanNode

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/planner/external/ExternalScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/external/ExternalScanNode.java
@@ -42,12 +42,6 @@ public abstract class ExternalScanNode extends ScanNode {
     // set to false means this scan node does not need to check column priv.
     protected boolean needCheckColumnPriv;
 
-    // For explain
-    protected long inputSplitsNum = 0;
-    protected long totalFileSize = 0;
-    protected long totalPartitionNum = 0;
-    protected long readPartitionNum = 0;
-
     // Final output of this file scan node
     protected List<TScanRangeLocations> scanRangeLocations = Lists.newArrayList();
 

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/external/FileGroupInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/external/FileGroupInfo.java
@@ -29,6 +29,7 @@ import org.apache.doris.common.UserException;
 import org.apache.doris.common.util.BrokerUtil;
 import org.apache.doris.common.util.Util;
 import org.apache.doris.load.BrokerFileGroup;
+import org.apache.doris.planner.FileLoadScanNode;
 import org.apache.doris.system.Backend;
 import org.apache.doris.thrift.TBrokerFileStatus;
 import org.apache.doris.thrift.TExternalScanRange;
@@ -187,7 +188,7 @@ public class FileGroupInfo {
         LOG.info("number instance of file scan node is: {}, bytes per instance: {}", numInstances, bytesPerInstance);
     }
 
-    public void createScanRangeLocations(FileScanNode.ParamCreateContext context,
+    public void createScanRangeLocations(FileLoadScanNode.ParamCreateContext context,
                                          FederationBackendPolicy backendPolicy,
                                          List<TScanRangeLocations> scanRangeLocations) throws UserException {
         TScanRangeLocations curLocations = newLocations(context.params, brokerDesc, backendPolicy);

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/external/FileScanProviderIf.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/external/FileScanProviderIf.java
@@ -18,11 +18,14 @@
 package org.apache.doris.planner.external;
 
 import org.apache.doris.analysis.Analyzer;
+import org.apache.doris.analysis.Expr;
 import org.apache.doris.catalog.TableIf;
 import org.apache.doris.common.DdlException;
 import org.apache.doris.common.MetaNotFoundException;
 import org.apache.doris.common.UserException;
+import org.apache.doris.planner.FileLoadScanNode;
 import org.apache.doris.thrift.TFileFormatType;
+import org.apache.doris.thrift.TFileScanRangeParams;
 import org.apache.doris.thrift.TFileType;
 import org.apache.doris.thrift.TScanRangeLocations;
 
@@ -41,9 +44,13 @@ public interface FileScanProviderIf {
 
     List<String> getPathPartitionKeys() throws DdlException, MetaNotFoundException;
 
-    FileScanNode.ParamCreateContext createContext(Analyzer analyzer) throws UserException;
+    FileLoadScanNode.ParamCreateContext createContext(Analyzer analyzer) throws UserException;
 
-    void createScanRangeLocations(FileScanNode.ParamCreateContext context, FederationBackendPolicy backendPolicy,
+    void createScanRangeLocations(FileLoadScanNode.ParamCreateContext context, FederationBackendPolicy backendPolicy,
+                                  List<TScanRangeLocations> scanRangeLocations) throws UserException;
+
+    void createScanRangeLocations(List<Expr> conjuncts, TFileScanRangeParams params,
+                                  FederationBackendPolicy backendPolicy,
                                   List<TScanRangeLocations> scanRangeLocations) throws UserException;
 
     int getInputSplitNum();

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/external/HiveScanProvider.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/external/HiveScanProvider.java
@@ -17,10 +17,7 @@
 
 package org.apache.doris.planner.external;
 
-import org.apache.doris.analysis.Analyzer;
-import org.apache.doris.analysis.SlotDescriptor;
 import org.apache.doris.analysis.TupleDescriptor;
-import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.HiveMetaStoreClientHelper;
 import org.apache.doris.catalog.TableIf;
 import org.apache.doris.catalog.external.HMSExternalTable;
@@ -28,12 +25,9 @@ import org.apache.doris.common.DdlException;
 import org.apache.doris.common.FeConstants;
 import org.apache.doris.common.MetaNotFoundException;
 import org.apache.doris.common.UserException;
-import org.apache.doris.load.BrokerFileGroup;
 import org.apache.doris.planner.ColumnRange;
 import org.apache.doris.thrift.TFileAttributes;
 import org.apache.doris.thrift.TFileFormatType;
-import org.apache.doris.thrift.TFileScanRangeParams;
-import org.apache.doris.thrift.TFileScanSlotInfo;
 import org.apache.doris.thrift.TFileTextScanRangeParams;
 import org.apache.doris.thrift.TFileType;
 
@@ -60,9 +54,6 @@ public class HiveScanProvider extends HMSTableScanProvider {
     protected HMSExternalTable hmsTable;
     protected final TupleDescriptor desc;
     protected Map<String, ColumnRange> columnNameToRange;
-
-    protected int totalPartitionNum = 0;
-    protected int readPartitionNum = 0;
 
     public HiveScanProvider(HMSExternalTable hmsTable, TupleDescriptor desc,
             Map<String, ColumnRange> columnNameToRange) {
@@ -149,34 +140,6 @@ public class HiveScanProvider extends HMSTableScanProvider {
     @Override
     public List<String> getPathPartitionKeys() throws DdlException, MetaNotFoundException {
         return getRemoteHiveTable().getPartitionKeys().stream().map(FieldSchema::getName).collect(Collectors.toList());
-    }
-
-    @Override
-    public FileScanNode.ParamCreateContext createContext(Analyzer analyzer) throws UserException {
-        FileScanNode.ParamCreateContext context = new FileScanNode.ParamCreateContext();
-        context.params = new TFileScanRangeParams();
-        context.destTupleDescriptor = desc;
-        context.params.setDestTupleId(desc.getId().asInt());
-        context.fileGroup = new BrokerFileGroup(hmsTable.getId(),
-                hmsTable.getRemoteTable().getSd().getLocation(), hmsTable.getRemoteTable().getSd().getInputFormat());
-
-
-        // Hive table must extract partition value from path and hudi/iceberg table keep
-        // partition field in file.
-        List<String> partitionKeys = getPathPartitionKeys();
-        List<Column> columns = hmsTable.getBaseSchema(false);
-        context.params.setNumOfColumnsFromFile(columns.size() - partitionKeys.size());
-        for (SlotDescriptor slot : desc.getSlots()) {
-            if (!slot.isMaterialized()) {
-                continue;
-            }
-
-            TFileScanSlotInfo slotInfo = new TFileScanSlotInfo();
-            slotInfo.setSlotId(slot.getId().asInt());
-            slotInfo.setIsFileSlot(!partitionKeys.contains(slot.getColumn().getName()));
-            context.params.addToRequiredSlots(slotInfo);
-        }
-        return context;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/external/LoadScanProvider.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/external/LoadScanProvider.java
@@ -18,6 +18,7 @@
 package org.apache.doris.planner.external;
 
 import org.apache.doris.analysis.Analyzer;
+import org.apache.doris.analysis.Expr;
 import org.apache.doris.analysis.ImportColumnDesc;
 import org.apache.doris.analysis.IntLiteral;
 import org.apache.doris.analysis.SlotRef;
@@ -35,6 +36,7 @@ import org.apache.doris.common.util.VectorizedUtil;
 import org.apache.doris.load.BrokerFileGroup;
 import org.apache.doris.load.Load;
 import org.apache.doris.load.loadv2.LoadTask;
+import org.apache.doris.planner.FileLoadScanNode;
 import org.apache.doris.task.LoadTaskInfo;
 import org.apache.doris.thrift.TBrokerFileStatus;
 import org.apache.doris.thrift.TFileAttributes;
@@ -84,8 +86,8 @@ public class LoadScanProvider implements FileScanProviderIf {
     }
 
     @Override
-    public FileScanNode.ParamCreateContext createContext(Analyzer analyzer) throws UserException {
-        FileScanNode.ParamCreateContext ctx = new FileScanNode.ParamCreateContext();
+    public FileLoadScanNode.ParamCreateContext createContext(Analyzer analyzer) throws UserException {
+        FileLoadScanNode.ParamCreateContext ctx = new FileLoadScanNode.ParamCreateContext();
         ctx.destTupleDescriptor = destTupleDesc;
         ctx.fileGroup = fileGroupInfo.getFileGroup();
         ctx.timezone = analyzer.getTimezone();
@@ -137,12 +139,18 @@ public class LoadScanProvider implements FileScanProviderIf {
     }
 
     @Override
-    public void createScanRangeLocations(FileScanNode.ParamCreateContext context,
+    public void createScanRangeLocations(FileLoadScanNode.ParamCreateContext context,
                                          FederationBackendPolicy backendPolicy,
                                          List<TScanRangeLocations> scanRangeLocations) throws UserException {
         Preconditions.checkNotNull(fileGroupInfo);
         fileGroupInfo.getFileStatusAndCalcInstance(backendPolicy);
         fileGroupInfo.createScanRangeLocations(context, backendPolicy, scanRangeLocations);
+    }
+
+    @Override
+    public void createScanRangeLocations(List<Expr> conjuncts, TFileScanRangeParams params,
+                                         FederationBackendPolicy backendPolicy,
+                                         List<TScanRangeLocations> scanRangeLocations) throws UserException {
     }
 
     @Override
@@ -169,7 +177,7 @@ public class LoadScanProvider implements FileScanProviderIf {
      * @param context
      * @throws UserException
      */
-    private void initColumns(FileScanNode.ParamCreateContext context, Analyzer analyzer) throws UserException {
+    private void initColumns(FileLoadScanNode.ParamCreateContext context, Analyzer analyzer) throws UserException {
         context.srcTupleDescriptor = analyzer.getDescTbl().createTupleDescriptor();
         context.srcSlotDescByName = Maps.newTreeMap(String.CASE_INSENSITIVE_ORDER);
         context.exprMap = Maps.newTreeMap(String.CASE_INSENSITIVE_ORDER);

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/external/QueryScanProvider.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/external/QueryScanProvider.java
@@ -17,6 +17,8 @@
 
 package org.apache.doris.planner.external;
 
+import org.apache.doris.analysis.Analyzer;
+import org.apache.doris.analysis.Expr;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.FsBroker;
 import org.apache.doris.catalog.HdfsResource;
@@ -24,6 +26,7 @@ import org.apache.doris.common.DdlException;
 import org.apache.doris.common.MetaNotFoundException;
 import org.apache.doris.common.UserException;
 import org.apache.doris.common.util.BrokerUtil;
+import org.apache.doris.planner.FileLoadScanNode;
 import org.apache.doris.planner.Split;
 import org.apache.doris.planner.Splitter;
 import org.apache.doris.planner.external.iceberg.IcebergScanProvider;
@@ -58,22 +61,33 @@ public abstract class QueryScanProvider implements FileScanProviderIf {
     public abstract TFileAttributes getFileAttributes() throws UserException;
 
     @Override
-    public void createScanRangeLocations(FileScanNode.ParamCreateContext context,
+    public void createScanRangeLocations(FileLoadScanNode.ParamCreateContext context,
+                                         FederationBackendPolicy backendPolicy,
+                                         List<TScanRangeLocations> scanRangeLocations) throws UserException {
+    }
+
+    @Override
+    public FileLoadScanNode.ParamCreateContext createContext(Analyzer analyzer) throws UserException {
+        return null;
+    }
+
+    @Override
+    public void createScanRangeLocations(List<Expr> conjuncts, TFileScanRangeParams params,
                                          FederationBackendPolicy backendPolicy,
                                          List<TScanRangeLocations> scanRangeLocations) throws UserException {
         long start = System.currentTimeMillis();
-        List<Split> inputSplits = splitter.getSplits(context.conjuncts);
+        List<Split> inputSplits = splitter.getSplits(conjuncts);
         this.inputSplitNum = inputSplits.size();
         if (inputSplits.isEmpty()) {
             return;
         }
         FileSplit inputSplit = (FileSplit) inputSplits.get(0);
         TFileType locationType = getLocationType();
-        context.params.setFileType(locationType);
+        params.setFileType(locationType);
         TFileFormatType fileFormatType = getFileFormatType();
-        context.params.setFormatType(getFileFormatType());
+        params.setFormatType(getFileFormatType());
         if (fileFormatType == TFileFormatType.FORMAT_CSV_PLAIN || fileFormatType == TFileFormatType.FORMAT_JSON) {
-            context.params.setFileAttributes(getFileAttributes());
+            params.setFileAttributes(getFileAttributes());
         }
 
         // set hdfs params for hdfs file type.
@@ -92,21 +106,21 @@ public abstract class QueryScanProvider implements FileScanProviderIf {
             }
             THdfsParams tHdfsParams = HdfsResource.generateHdfsParam(locationProperties);
             tHdfsParams.setFsName(fsName);
-            context.params.setHdfsParams(tHdfsParams);
+            params.setHdfsParams(tHdfsParams);
 
             if (locationType == TFileType.FILE_BROKER) {
                 FsBroker broker = Env.getCurrentEnv().getBrokerMgr().getAnyAliveBroker();
                 if (broker == null) {
                     throw new UserException("No alive broker.");
                 }
-                context.params.addToBrokerAddresses(new TNetworkAddress(broker.ip, broker.port));
+                params.addToBrokerAddresses(new TNetworkAddress(broker.ip, broker.port));
             }
         } else if (locationType == TFileType.FILE_S3) {
-            context.params.setProperties(locationProperties);
+            params.setProperties(locationProperties);
         }
 
         for (Split split : inputSplits) {
-            TScanRangeLocations curLocations = newLocations(context.params, backendPolicy);
+            TScanRangeLocations curLocations = newLocations(params, backendPolicy);
             FileSplit fileSplit = (FileSplit) split;
             List<String> pathPartitionKeys = getPathPartitionKeys();
             List<String> partitionValuesFromPath = BrokerUtil.parseColumnsFromPath(fileSplit.getPath().toString(),

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/external/TVFScanProvider.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/external/TVFScanProvider.java
@@ -17,21 +17,15 @@
 
 package org.apache.doris.planner.external;
 
-import org.apache.doris.analysis.Analyzer;
-import org.apache.doris.analysis.SlotDescriptor;
 import org.apache.doris.analysis.TupleDescriptor;
-import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.FunctionGenTable;
 import org.apache.doris.catalog.TableIf;
 import org.apache.doris.common.DdlException;
 import org.apache.doris.common.MetaNotFoundException;
 import org.apache.doris.common.UserException;
-import org.apache.doris.load.BrokerFileGroup;
 import org.apache.doris.tablefunction.ExternalFileTableValuedFunction;
 import org.apache.doris.thrift.TFileAttributes;
 import org.apache.doris.thrift.TFileFormatType;
-import org.apache.doris.thrift.TFileScanRangeParams;
-import org.apache.doris.thrift.TFileScanSlotInfo;
 import org.apache.doris.thrift.TFileType;
 
 import com.google.common.collect.Lists;
@@ -82,34 +76,6 @@ public class TVFScanProvider extends QueryScanProvider {
     @Override
     public List<String> getPathPartitionKeys() throws DdlException, MetaNotFoundException {
         return Lists.newArrayList();
-    }
-
-    @Override
-    public FileScanNode.ParamCreateContext createContext(Analyzer analyzer) throws UserException {
-        FileScanNode.ParamCreateContext context = new FileScanNode.ParamCreateContext();
-        context.params = new TFileScanRangeParams();
-        context.destTupleDescriptor = desc;
-        context.params.setDestTupleId(desc.getId().asInt());
-        // no use, only for avoid null exception.
-        context.fileGroup = new BrokerFileGroup(tvfTable.getId(), "", "");
-
-
-        // Hive table must extract partition value from path and hudi/iceberg table keep
-        // partition field in file.
-        List<String> partitionKeys = getPathPartitionKeys();
-        List<Column> columns = tvfTable.getBaseSchema(false);
-        context.params.setNumOfColumnsFromFile(columns.size() - partitionKeys.size());
-        for (SlotDescriptor slot : desc.getSlots()) {
-            if (!slot.isMaterialized()) {
-                continue;
-            }
-
-            TFileScanSlotInfo slotInfo = new TFileScanSlotInfo();
-            slotInfo.setSlotId(slot.getId().asInt());
-            slotInfo.setIsFileSlot(!partitionKeys.contains(slot.getColumn().getName()));
-            context.params.addToRequiredSlots(slotInfo);
-        }
-        return context;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/external/iceberg/IcebergApiSource.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/external/iceberg/IcebergApiSource.java
@@ -17,29 +17,20 @@
 
 package org.apache.doris.planner.external.iceberg;
 
-import org.apache.doris.analysis.SlotDescriptor;
 import org.apache.doris.analysis.TupleDescriptor;
-import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.TableIf;
 import org.apache.doris.catalog.external.IcebergExternalTable;
 import org.apache.doris.common.MetaNotFoundException;
 import org.apache.doris.common.UserException;
 import org.apache.doris.datasource.ExternalCatalog;
 import org.apache.doris.datasource.iceberg.IcebergExternalCatalog;
-import org.apache.doris.load.BrokerFileGroup;
 import org.apache.doris.planner.ColumnRange;
-import org.apache.doris.planner.external.FileQueryScanNode;
 import org.apache.doris.thrift.TFileAttributes;
-import org.apache.doris.thrift.TFileScanRangeParams;
-import org.apache.doris.thrift.TFileScanSlotInfo;
 
-import org.apache.iceberg.PartitionField;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableProperties;
 
-import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 /**
  * Get metadata from iceberg api (all iceberg table like hive, rest, glue...)
@@ -78,32 +69,6 @@ public class IcebergApiSource implements IcebergSource {
     @Override
     public TableIf getTargetTable() {
         return icebergExtTable;
-    }
-
-    @Override
-    public FileQueryScanNode.ParamCreateContext createContext() throws UserException {
-        FileQueryScanNode.ParamCreateContext context = new FileQueryScanNode.ParamCreateContext();
-        context.params = new TFileScanRangeParams();
-        context.destTupleDescriptor = desc;
-        context.params.setDestTupleId(desc.getId().asInt());
-        context.fileGroup = new BrokerFileGroup(icebergExtTable.getId(), originTable.location(), getFileFormat());
-
-        // Hive table must extract partition value from path and hudi/iceberg table keep
-        // partition field in file.
-        List<String> partitionKeys =  originTable.spec().fields().stream()
-                .map(PartitionField::name).collect(Collectors.toList());
-        List<Column> columns = icebergExtTable.getBaseSchema(false);
-        context.params.setNumOfColumnsFromFile(columns.size() - partitionKeys.size());
-        for (SlotDescriptor slot : desc.getSlots()) {
-            if (!slot.isMaterialized()) {
-                continue;
-            }
-            TFileScanSlotInfo slotInfo = new TFileScanSlotInfo();
-            slotInfo.setSlotId(slot.getId().asInt());
-            slotInfo.setIsFileSlot(!partitionKeys.contains(slot.getColumn().getName()));
-            context.params.addToRequiredSlots(slotInfo);
-        }
-        return context;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/external/iceberg/IcebergHMSSource.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/external/iceberg/IcebergHMSSource.java
@@ -26,7 +26,6 @@ import org.apache.doris.common.MetaNotFoundException;
 import org.apache.doris.common.UserException;
 import org.apache.doris.datasource.ExternalCatalog;
 import org.apache.doris.planner.ColumnRange;
-import org.apache.doris.planner.external.FileQueryScanNode;
 import org.apache.doris.planner.external.HiveScanProvider;
 import org.apache.doris.thrift.TFileAttributes;
 
@@ -61,11 +60,6 @@ public class IcebergHMSSource implements IcebergSource {
 
     public org.apache.iceberg.Table getIcebergTable() throws MetaNotFoundException {
         return HiveMetaStoreClientHelper.getIcebergTable(hmsTable);
-    }
-
-    @Override
-    public FileQueryScanNode.ParamCreateContext createContext() throws UserException {
-        return hiveScanProvider.createContext(null);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/external/iceberg/IcebergScanProvider.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/external/iceberg/IcebergScanProvider.java
@@ -23,7 +23,6 @@ import org.apache.doris.common.DdlException;
 import org.apache.doris.common.FeConstants;
 import org.apache.doris.common.MetaNotFoundException;
 import org.apache.doris.common.UserException;
-import org.apache.doris.planner.external.FileQueryScanNode;
 import org.apache.doris.planner.external.IcebergSplitter;
 import org.apache.doris.planner.external.QueryScanProvider;
 import org.apache.doris.thrift.TFileAttributes;
@@ -143,11 +142,6 @@ public class IcebergScanProvider extends QueryScanProvider {
     @Override
     public Map<String, String> getLocationProperties() throws MetaNotFoundException, DdlException {
         return icebergSource.getCatalog().getProperties();
-    }
-
-    @Override
-    public FileQueryScanNode.ParamCreateContext createContext(Analyzer analyzer) throws UserException {
-        return icebergSource.createContext();
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/external/iceberg/IcebergSource.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/external/iceberg/IcebergSource.java
@@ -23,7 +23,6 @@ import org.apache.doris.common.DdlException;
 import org.apache.doris.common.MetaNotFoundException;
 import org.apache.doris.common.UserException;
 import org.apache.doris.datasource.ExternalCatalog;
-import org.apache.doris.planner.external.FileQueryScanNode;
 import org.apache.doris.thrift.TFileAttributes;
 
 public interface IcebergSource {
@@ -31,8 +30,6 @@ public interface IcebergSource {
     TupleDescriptor getDesc();
 
     org.apache.iceberg.Table getIcebergTable() throws MetaNotFoundException;
-
-    FileQueryScanNode.ParamCreateContext createContext() throws UserException;
 
     TableIf getTargetTable();
 

--- a/regression-test/suites/account_p0/test_nereids_row_policy.groovy
+++ b/regression-test/suites/account_p0/test_nereids_row_policy.groovy
@@ -23,16 +23,16 @@ suite("test_nereids_row_policy") {
     def url=tokens[0] + "//" + tokens[2] + "/" + dbName + "?"
 
     def assertQueryResult = { size ->
-        def result1 = connect(user=user, password='123456', url=url) {
+        def result1 = connect(user=user, password='123456abc', url=url) {
             sql "set enable_nereids_planner = false"
             sql "SELECT * FROM ${tableName}"
         }
-        def result2 = connect(user=user, password='123456', url=url) {
+        def result2 = connect(user=user, password='123456abc', url=url) {
             sql "set enable_nereids_planner = true"
             sql "set enable_fallback_to_original_planner = false"
             sql "SELECT * FROM ${tableName}"
         }
-        def result3 = connect(user=user, password='123456', url=url) {
+        def result3 = connect(user=user, password='123456abc', url=url) {
             sql "set enable_nereids_planner = true"
             sql "set enable_fallback_to_original_planner = false"
             sql "SELECT * FROM ${viewName}"
@@ -76,7 +76,7 @@ suite("test_nereids_row_policy") {
     
     // create user
     sql "DROP USER IF EXISTS ${user}"
-    sql "CREATE USER ${user} IDENTIFIED BY '123456'"
+    sql "CREATE USER ${user} IDENTIFIED BY '123456abc'"
     sql "GRANT SELECT_PRIV ON internal.${dbName}.${tableName} TO ${user}"
 
 


### PR DESCRIPTION
Remove redundant param context for FileQueryScanNode.
Remove duplicated code for QueryScanProviders.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

