### PR TITLE
[enhancement](storage) lazy-open necessary partitions when load

### DIFF
--- a/be/src/runtime/tablets_channel.h
+++ b/be/src/runtime/tablets_channel.h
@@ -99,8 +99,9 @@ private:
     template <typename Request>
     Status _get_current_seq(int64_t& cur_seq, const Request& request);
 
-    // open all writer
-    Status _open_all_writers(const PTabletWriterOpenRequest& request);
+    template <typename TabletWriterAddRequest>
+    Status _open_all_writers_in_partition(const int64_t& tablet_id,
+                                          const TabletWriterAddRequest& request);
 
     bool _try_to_wait_flushing();
 
@@ -109,6 +110,7 @@ private:
                      google::protobuf::RepeatedPtrField<PTabletInfo>* tablet_vec,
                      google::protobuf::RepeatedPtrField<PTabletError>* tablet_error,
                      PSlaveTabletNodes slave_tablet_nodes, const bool write_single_replica);
+    void _build_partition_tablets_relation(const PTabletWriterOpenRequest& request);
 
     void _add_broken_tablet(int64_t tablet_id);
     bool _is_broken_tablet(int64_t tablet_id);
@@ -144,6 +146,8 @@ private:
     // status to return when operate on an already closed/cancelled channel
     // currently it's OK.
     Status _close_status;
+    std::map<int64, std::vector<int64>> _partition_tablets_map;
+    std::map<int64, int64> _tablet_partition_map;
 
     // tablet_id -> TabletChannel
     std::unordered_map<int64_t, DeltaWriter*> _tablet_writers;


### PR DESCRIPTION
Previously, when loading data, NodeChannel would open all tablets in all partitions when opening. This could cause a large number of useless tablets to be opened and empty rowsets to be created. In this commit, we only open tablets in a partition when they are actually written.



Test Result (reuse regression case `test_datev2_partition`):
create table with 8 partitions, 10 buckets per partition:
```
        CREATE TABLE `${tblName1}` (
        `TIME_STAMP` datev2 NOT NULL COMMENT '采集日期'
        ) ENGINE=OLAP
        DUPLICATE KEY(`TIME_STAMP`)
        COMMENT 'OLAP'
        PARTITION BY RANGE(`TIME_STAMP`)
        (PARTITION p20221214 VALUES [('2022-12-14'), ('2022-12-15')),
        PARTITION p20221215 VALUES [('2022-12-15'), ('2022-12-16')),
        PARTITION p20221216 VALUES [('2022-12-16'), ('2022-12-17')),
        PARTITION p20221217 VALUES [('2022-12-17'), ('2022-12-18')),
        PARTITION p20221218 VALUES [('2022-12-18'), ('2022-12-19')),
        PARTITION p20221219 VALUES [('2022-12-19'), ('2022-12-20')),
        PARTITION p20221220 VALUES [('2022-12-20'), ('2022-12-21')),
        PARTITION p20221221 VALUES [('2022-12-21'), ('2022-12-22')))
        DISTRIBUTED BY HASH(`TIME_STAMP`) BUCKETS 10
        PROPERTIES (
        "replication_allocation" = "tag.location.default: 1"
        );
```
Then load data into 7 partitions:
```
insert into ${tblName1} values ('2022-12-14'), ('2022-12-15'), ('2022-12-16'), ('2022-12-17'), ('2022-12-18'), ('2022-12-19'), ('2022-12-20')
```
We get only 7x10 writer opened instead of 8x10, which proves it is effective:
```
I0413 16:11:22.265318 1381484 tablets_channel.cpp:283] OOXXOO: _s_tablet_writer_count=10
I0413 16:11:22.265527 1381484 tablets_channel.cpp:283] OOXXOO: _s_tablet_writer_count=20
I0413 16:11:22.265574 1381484 tablets_channel.cpp:283] OOXXOO: _s_tablet_writer_count=30
I0413 16:11:22.265642 1381484 tablets_channel.cpp:283] OOXXOO: _s_tablet_writer_count=40
I0413 16:11:22.265681 1381484 tablets_channel.cpp:283] OOXXOO: _s_tablet_writer_count=50
I0413 16:11:22.265719 1381484 tablets_channel.cpp:283] OOXXOO: _s_tablet_writer_count=60
I0413 16:11:22.265754 1381484 tablets_channel.cpp:283] OOXXOO: _s_tablet_writer_count=70
I0413 16:11:22.270346 1381484 tablets_channel.cpp:48] OOXXOO: _s_tablet_writer_count=0
```



# Proposed changes

Issue Number: close #18092

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

