### PR TITLE
[improve] Refactor file cache and Improve the file cache strategy

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -898,9 +898,8 @@ CONF_Bool(enable_index_apply_preds_except_leafnode_of_andnode, "true");
 
 // block file cache
 CONF_Bool(enable_file_cache, "false");
-// format: [{"path":"/path/to/file_cache","normal":21474836480,"persistent":10737418240,"query_limit":10737418240}]
+// format: [{"path":"/mnt/disk3/selectdb_cloud/file_cache","total_size":21474836480,"query_limit":10737418240}]
 CONF_String(file_cache_path, "");
-CONF_String(disposable_file_cache_path, "");
 CONF_Int64(file_cache_max_file_segment_size, "4194304"); // 4MB
 CONF_Validator(file_cache_max_file_segment_size,
                [](const int64_t config) -> bool { return config >= 4096; }); // 4KB

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -898,7 +898,8 @@ CONF_Bool(enable_index_apply_preds_except_leafnode_of_andnode, "true");
 
 // block file cache
 CONF_Bool(enable_file_cache, "false");
-// format: [{"path":"/mnt/disk3/selectdb_cloud/file_cache","total_size":21474836480,"query_limit":10737418240}]
+// format: [{"path":"/path/to/file_cache","total_size":21474836480,"query_limit":10737418240}]
+// format: [{"path":"/path/to/file_cache","total_size":21474836480,"query_limit":10737418240},{"path":"/path/to/file_cache2","total_size":21474836480,"query_limit":10737418240}]
 CONF_String(file_cache_path, "");
 CONF_Int64(file_cache_max_file_segment_size, "4194304"); // 4MB
 CONF_Validator(file_cache_max_file_segment_size,

--- a/be/src/io/cache/block/block_file_cache.cpp
+++ b/be/src/io/cache/block/block_file_cache.cpp
@@ -38,12 +38,12 @@ namespace io {
 
 IFileCache::IFileCache(const std::string& cache_base_path, const FileCacheSettings& cache_settings)
         : _cache_base_path(cache_base_path),
-          _max_size(cache_settings.max_size),
-          _max_element_size(cache_settings.max_elements),
-          _persistent_max_size(cache_settings.persistent_max_size),
-          _persistent_max_element_size(cache_settings.persistent_max_elements),
+          _total_size(cache_settings.total_size),
           _max_file_segment_size(cache_settings.max_file_segment_size),
-          _max_query_cache_size(cache_settings.max_query_cache_size) {}
+          _max_query_cache_size(cache_settings.max_query_cache_size) {
+    _cur_size_metrics =
+            std::make_shared<bvar::Status<size_t>>(_cache_base_path.c_str(), "cur_size", 0);
+}
 
 std::string IFileCache::Key::to_string() const {
     return vectorized::get_hex_uint_lowercase(key);
@@ -55,16 +55,34 @@ IFileCache::Key IFileCache::hash(const std::string& path) {
     return Key(key);
 }
 
-std::string IFileCache::get_path_in_local_cache(const Key& key, size_t offset,
-                                                bool is_persistent) const {
-    auto key_str = key.to_string();
-    std::string suffix = is_persistent ? "_persistent" : "";
-    if constexpr (USE_CACHE_VERSION2) {
-        return fs::path(_cache_base_path) / key_str.substr(0, KEY_PREFIX_LENGTH) / key_str /
-               (std::to_string(offset) + suffix);
-    } else {
-        return fs::path(_cache_base_path) / key_str / (std::to_string(offset) + suffix);
+std::string IFileCache::cache_type_to_string(CacheType type) {
+    switch (type) {
+    case CacheType::INDEX:
+        return "_idx";
+    case CacheType::DISPOSABLE:
+        return "_disposable";
+    case CacheType::NORMAL:
+        return "";
     }
+    return "";
+}
+
+CacheType IFileCache::string_to_cache_type(const std::string& str) {
+    switch (str[0]) {
+    case 'i':
+        return CacheType::INDEX;
+    case 'd':
+        return CacheType::DISPOSABLE;
+    default:
+        DCHECK(false);
+    }
+    return CacheType::DISPOSABLE;
+}
+
+std::string IFileCache::get_path_in_local_cache(const Key& key, size_t offset,
+                                                CacheType type) const {
+    return get_path_in_local_cache(key) + "/" +
+           (std::to_string(offset) + cache_type_to_string(type));
 }
 
 std::string IFileCache::get_path_in_local_cache(const Key& key) const {
@@ -125,20 +143,24 @@ IFileCache::QueryFileCacheContextPtr IFileCache::get_or_set_query_context(
     return query_iter->second;
 }
 
-void IFileCache::QueryFileCacheContext::remove(const Key& key, size_t offset, bool is_presistent,
-                                               size_t size,
+void IFileCache::QueryFileCacheContext::remove(const Key& key, size_t offset,
                                                std::lock_guard<std::mutex>& cache_lock) {
-    auto record = records.find({key, offset, is_presistent});
+    auto pair = std::make_pair(key, offset);
+    auto record = records.find(pair);
     DCHECK(record != records.end());
-    lru_queue.remove(record->second, cache_lock);
-    records.erase({key, offset, is_presistent});
+    auto iter = record->second;
+    records.erase(pair);
+    lru_queue.remove(iter, cache_lock);
 }
 
-void IFileCache::QueryFileCacheContext::reserve(const Key& key, size_t offset, bool is_presistent,
+void IFileCache::QueryFileCacheContext::reserve(const Key& key, size_t offset,
                                                 size_t size,
                                                 std::lock_guard<std::mutex>& cache_lock) {
-    auto queue_iter = lru_queue.add(key, offset, is_presistent, size, cache_lock);
-    records.insert({{key, offset, is_presistent}, queue_iter});
+    auto pair = std::make_pair(key, offset);
+    if (records.find(pair) == records.end()) {
+        auto queue_iter = lru_queue.add(key, offset, size, cache_lock);
+        records.insert({pair, queue_iter});
+    }
 }
 
 } // namespace io

--- a/be/src/io/cache/block/block_file_cache.cpp
+++ b/be/src/io/cache/block/block_file_cache.cpp
@@ -153,8 +153,7 @@ void IFileCache::QueryFileCacheContext::remove(const Key& key, size_t offset,
     lru_queue.remove(iter, cache_lock);
 }
 
-void IFileCache::QueryFileCacheContext::reserve(const Key& key, size_t offset,
-                                                size_t size,
+void IFileCache::QueryFileCacheContext::reserve(const Key& key, size_t offset, size_t size,
                                                 std::lock_guard<std::mutex>& cache_lock) {
     auto pair = std::make_pair(key, offset);
     if (records.find(pair) == records.end()) {

--- a/be/src/io/cache/block/block_file_cache.h
+++ b/be/src/io/cache/block/block_file_cache.h
@@ -24,6 +24,8 @@
 #include <stdint.h>
 
 #include <cstddef>
+#include <bvar/bvar.h>
+
 #include <list>
 #include <memory>
 #include <mutex>
@@ -37,6 +39,7 @@
 #include "io/cache/block/block_file_cache_fwd.h"
 #include "util/hash_util.hpp"
 #include "vec/common/uint128.h"
+#include "io/io_common.h"
 
 namespace doris {
 namespace io {
@@ -46,6 +49,27 @@ struct FileCacheSettings;
 using FileBlockSPtr = std::shared_ptr<FileBlock>;
 using FileBlocks = std::list<FileBlockSPtr>;
 struct FileBlocksHolder;
+
+enum CacheType {
+    INDEX,
+    NORMAL,
+    DISPOSABLE,
+};
+struct CacheContext {
+    CacheContext(const IOContext* io_ctx) {
+        if (io_ctx->read_segment_index) {
+            cache_type = CacheType::INDEX;
+        } else if (io_ctx->is_disposable) {
+            cache_type = CacheType::DISPOSABLE;
+        } else {
+            cache_type = CacheType::NORMAL;
+        }
+        query_id = io_ctx->query_id ? *io_ctx->query_id : TUniqueId();
+    }
+    CacheContext() = default;
+    TUniqueId query_id;
+    CacheType cache_type;
+};
 
 /**
  * Local cache for remote filesystem files, represented as a set of non-overlapping non-empty file segments.
@@ -66,7 +90,7 @@ public:
         std::string to_string() const;
 
         Key() = default;
-        explicit Key(const uint128_t& key_) : key(key_) {}
+        explicit Key(const uint128_t& key) : key(key) {}
 
         bool operator==(const Key& other) const { return key == other.key; }
     };
@@ -78,24 +102,18 @@ public:
     /// Restore cache from local filesystem.
     virtual Status initialize() = 0;
 
-    virtual void remove_if_exists(const Key& key, bool is_persistent) = 0;
-
-    virtual void remove_if_releasable(bool is_persistent) = 0;
-
     /// Cache capacity in bytes.
-    size_t capacity() const { return _max_size; }
+    size_t capacity() const { return _total_size; }
 
     static Key hash(const std::string& path);
 
-    std::string get_path_in_local_cache(const Key& key, size_t offset, bool is_persistent) const;
+    std::string get_path_in_local_cache(const Key& key, size_t offset, CacheType type) const;
 
     std::string get_path_in_local_cache(const Key& key) const;
 
     std::string get_version_path() const;
 
     const std::string& get_base_path() const { return _cache_base_path; }
-
-    virtual std::vector<std::string> try_get_cache_paths(const Key& key, bool is_persistent) = 0;
 
     /**
      * Given an `offset` and `size` representing [offset, offset + size) bytes interval,
@@ -109,52 +127,59 @@ public:
      * it is guaranteed that these file segments are not removed from cache.
      */
     virtual FileBlocksHolder get_or_set(const Key& key, size_t offset, size_t size,
-                                        bool is_persistent, const TUniqueId& query_id) = 0;
+                                          const CacheContext& context) = 0;
 
     /// For debug.
-    virtual std::string dump_structure(const Key& key, bool is_persistent) = 0;
+    virtual std::string dump_structure(const Key& key) = 0;
 
-    virtual size_t get_used_cache_size(bool is_persistent) const = 0;
+    virtual size_t get_used_cache_size(CacheType type) const = 0;
 
-    virtual size_t get_file_segments_num(bool is_persistent) const = 0;
+    virtual size_t get_file_segments_num(CacheType type) const = 0;
+
+    static std::string cache_type_to_string(CacheType type);
+    static CacheType string_to_cache_type(const std::string& str);
 
     IFileCache& operator=(const IFileCache&) = delete;
     IFileCache(const IFileCache&) = delete;
 
 protected:
     std::string _cache_base_path;
-    size_t _max_size = 0;
-    size_t _max_element_size = 0;
-    size_t _persistent_max_size = 0;
-    size_t _persistent_max_element_size = 0;
+    size_t _total_size = 0;
     size_t _max_file_segment_size = 0;
     size_t _max_query_cache_size = 0;
+    // metrics
+    std::shared_ptr<bvar::Status<size_t>> _cur_size_metrics;
 
     bool _is_initialized = false;
 
     mutable std::mutex _mutex;
 
-    virtual bool try_reserve(const Key& key, const TUniqueId& query_id, bool is_persistent,
-                             size_t offset, size_t size,
-                             std::lock_guard<std::mutex>& cache_lock) = 0;
+    virtual bool try_reserve(const Key& key, const CacheContext& context, size_t offset,
+                             size_t size, std::lock_guard<std::mutex>& cache_lock) = 0;
 
-    virtual void remove(const Key& key, bool is_persistent, size_t offset,
-                        std::lock_guard<std::mutex>& cache_lock,
+    virtual void remove(FileBlockSPtr file_segment, std::lock_guard<std::mutex>& cache_lock,
                         std::lock_guard<std::mutex>& segment_lock) = 0;
 
     class LRUQueue {
     public:
+        LRUQueue() = default;
+        LRUQueue(size_t max_size, size_t max_element_size, int64_t hot_data_interval)
+                : max_size(max_size),
+                  max_element_size(max_element_size),
+                  hot_data_interval(hot_data_interval) {}
         struct FileKeyAndOffset {
             Key key;
             size_t offset;
             size_t size;
-            bool is_persistent;
 
-            FileKeyAndOffset(const Key& key, size_t offset, size_t size, bool is_persistent)
-                    : key(key), offset(offset), size(size), is_persistent(is_persistent) {}
+            FileKeyAndOffset(const Key& key, size_t offset, size_t size)
+                    : key(key), offset(offset), size(size) {}
         };
 
         using Iterator = typename std::list<FileKeyAndOffset>::iterator;
+
+        size_t get_max_size() const { return max_size; }
+        size_t get_max_element_size() const { return max_element_size; }
 
         size_t get_total_cache_size(std::lock_guard<std::mutex>& /* cache_lock */) const {
             return cache_size;
@@ -164,7 +189,7 @@ protected:
             return queue.size();
         }
 
-        Iterator add(const Key& key, size_t offset, bool is_persistent, size_t size,
+        Iterator add(const Key& key, size_t offset, size_t size,
                      std::lock_guard<std::mutex>& cache_lock);
 
         void remove(Iterator queue_it, std::lock_guard<std::mutex>& cache_lock);
@@ -181,12 +206,17 @@ protected:
 
         void remove_all(std::lock_guard<std::mutex>& cache_lock);
 
+        int64_t get_hot_data_interval() const { return hot_data_interval; }
+
     private:
+        size_t max_size;
+        size_t max_element_size;
         std::list<FileKeyAndOffset> queue;
         size_t cache_size = 0;
+        int64_t hot_data_interval {0};
     };
 
-    using AccessKeyAndOffset = std::tuple<Key, size_t, bool>;
+    using AccessKeyAndOffset = std::tuple<Key, size_t>;
     struct KeyAndOffsetHash {
         std::size_t operator()(const AccessKeyAndOffset& key) const {
             return UInt128Hash()(std::get<0>(key).key) ^ std::hash<uint64_t>()(std::get<1>(key));
@@ -206,10 +236,10 @@ protected:
 
         QueryFileCacheContext(size_t max_cache_size) : max_cache_size(max_cache_size) {}
 
-        void remove(const Key& key, size_t offset, bool is_presistent, size_t size,
+        void remove(const Key& key, size_t offset,
                     std::lock_guard<std::mutex>& cache_lock);
 
-        void reserve(const Key& key, size_t offset, bool is_presistent, size_t size,
+        void reserve(const Key& key, size_t offset, size_t size,
                      std::lock_guard<std::mutex>& cache_lock);
 
         size_t get_max_cache_size() const { return max_cache_size; }

--- a/be/src/io/cache/block/block_file_cache.h
+++ b/be/src/io/cache/block/block_file_cache.h
@@ -20,11 +20,11 @@
 
 #pragma once
 
+#include <bvar/bvar.h>
 #include <gen_cpp/Types_types.h>
 #include <stdint.h>
 
 #include <cstddef>
-#include <bvar/bvar.h>
 
 #include <list>
 #include <memory>
@@ -38,9 +38,9 @@
 #include "common/status.h"
 #include "io/cache/block/block_file_cache_fwd.h"
 #include "io/cache/block/block_file_cache_settings.h"
+#include "io/io_common.h"
 #include "util/hash_util.hpp"
 #include "vec/common/uint128.h"
-#include "io/io_common.h"
 
 namespace doris {
 namespace io {

--- a/be/src/io/cache/block/block_file_cache.h
+++ b/be/src/io/cache/block/block_file_cache.h
@@ -127,7 +127,7 @@ public:
      * it is guaranteed that these file segments are not removed from cache.
      */
     virtual FileBlocksHolder get_or_set(const Key& key, size_t offset, size_t size,
-                                          const CacheContext& context) = 0;
+                                        const CacheContext& context) = 0;
 
     /// For debug.
     virtual std::string dump_structure(const Key& key) = 0;
@@ -236,8 +236,7 @@ protected:
 
         QueryFileCacheContext(size_t max_cache_size) : max_cache_size(max_cache_size) {}
 
-        void remove(const Key& key, size_t offset,
-                    std::lock_guard<std::mutex>& cache_lock);
+        void remove(const Key& key, size_t offset, std::lock_guard<std::mutex>& cache_lock);
 
         void reserve(const Key& key, size_t offset, size_t size,
                      std::lock_guard<std::mutex>& cache_lock);

--- a/be/src/io/cache/block/block_file_cache.h
+++ b/be/src/io/cache/block/block_file_cache.h
@@ -25,7 +25,6 @@
 #include <stdint.h>
 
 #include <cstddef>
-
 #include <list>
 #include <memory>
 #include <mutex>

--- a/be/src/io/cache/block/block_file_cache.h
+++ b/be/src/io/cache/block/block_file_cache.h
@@ -37,6 +37,7 @@
 #include "common/config.h"
 #include "common/status.h"
 #include "io/cache/block/block_file_cache_fwd.h"
+#include "io/cache/block/block_file_cache_settings.h"
 #include "util/hash_util.hpp"
 #include "vec/common/uint128.h"
 #include "io/io_common.h"
@@ -44,7 +45,6 @@
 namespace doris {
 namespace io {
 class FileBlock;
-struct FileCacheSettings;
 
 using FileBlockSPtr = std::shared_ptr<FileBlock>;
 using FileBlocks = std::list<FileBlockSPtr>;

--- a/be/src/io/cache/block/block_file_cache_factory.cpp
+++ b/be/src/io/cache/block/block_file_cache_factory.cpp
@@ -43,49 +43,27 @@ FileCacheFactory& FileCacheFactory::instance() {
 }
 
 Status FileCacheFactory::create_file_cache(const std::string& cache_base_path,
-                                           const FileCacheSettings& file_cache_settings,
-                                           FileCacheType type) {
+                                           const FileCacheSettings& file_cache_settings) {
     if (config::clear_file_cache) {
         auto fs = global_local_filesystem();
         bool res = false;
         fs->exists(cache_base_path, &res);
         if (res) {
             fs->delete_directory(cache_base_path);
-            fs->create_directory(cache_base_path);
         }
     }
 
     std::unique_ptr<IFileCache> cache =
             std::make_unique<LRUFileCache>(cache_base_path, file_cache_settings);
     RETURN_IF_ERROR(cache->initialize());
-    std::string file_cache_type;
-    switch (type) {
-    case NORMAL:
-        _caches.push_back(std::move(cache));
-        file_cache_type = "NORMAL";
-        break;
-    case DISPOSABLE:
-        _disposable_cache.push_back(std::move(cache));
-        file_cache_type = "DISPOSABLE";
-        break;
-    }
-    LOG(INFO) << "[FileCache] path: " << cache_base_path << " type: " << file_cache_type
-              << " normal_size: " << file_cache_settings.max_size
-              << " normal_element_size: " << file_cache_settings.max_elements
-              << " persistent_size: " << file_cache_settings.persistent_max_size
-              << " persistent_element_size: " << file_cache_settings.persistent_max_elements;
+    _caches.push_back(std::move(cache));
+    LOG(INFO) << "[FileCache] path: " << cache_base_path
+              << " total_size: " << file_cache_settings.total_size;
     return Status::OK();
 }
 
 CloudFileCachePtr FileCacheFactory::get_by_path(const IFileCache::Key& key) {
     return _caches[KeyHash()(key) % _caches.size()].get();
-}
-
-CloudFileCachePtr FileCacheFactory::get_disposable_cache(const IFileCache::Key& key) {
-    if (_disposable_cache.empty()) {
-        return nullptr;
-    }
-    return _disposable_cache[KeyHash()(key) % _caches.size()].get();
 }
 
 std::vector<IFileCache::QueryFileCacheContextHolderPtr> FileCacheFactory::get_query_context_holders(

--- a/be/src/io/cache/block/block_file_cache_factory.h
+++ b/be/src/io/cache/block/block_file_cache_factory.h
@@ -26,17 +26,13 @@
 
 #include "common/status.h"
 #include "io/cache/block/block_file_cache.h"
-
+#include "io/cache/block/block_file_cache_settings.h"
 namespace doris {
 class TUniqueId;
 
 namespace io {
 struct FileCacheSettings;
 
-enum FileCacheType {
-    NORMAL,
-    DISPOSABLE,
-};
 /**
  * Creates a FileCache object for cache_base_path.
  */
@@ -45,10 +41,9 @@ public:
     static FileCacheFactory& instance();
 
     Status create_file_cache(const std::string& cache_base_path,
-                             const FileCacheSettings& file_cache_settings, FileCacheType type);
+                             const FileCacheSettings& file_cache_settings);
 
     CloudFileCachePtr get_by_path(const IFileCache::Key& key);
-    CloudFileCachePtr get_disposable_cache(const IFileCache::Key& key);
     std::vector<IFileCache::QueryFileCacheContextHolderPtr> get_query_context_holders(
             const TUniqueId& query_id);
     FileCacheFactory() = default;
@@ -57,7 +52,6 @@ public:
 
 private:
     std::vector<std::unique_ptr<IFileCache>> _caches;
-    std::vector<std::unique_ptr<IFileCache>> _disposable_cache;
 };
 
 } // namespace io

--- a/be/src/io/cache/block/block_file_cache_factory.h
+++ b/be/src/io/cache/block/block_file_cache_factory.h
@@ -31,7 +31,6 @@ namespace doris {
 class TUniqueId;
 
 namespace io {
-struct FileCacheSettings;
 
 /**
  * Creates a FileCache object for cache_base_path.

--- a/be/src/io/cache/block/block_file_cache_fwd.h
+++ b/be/src/io/cache/block/block_file_cache_fwd.h
@@ -32,6 +32,5 @@ using uint128_t = vectorized::UInt128;
 using UInt128Hash = vectorized::UInt128Hash;
 static constexpr size_t REMOTE_FS_OBJECTS_CACHE_DEFAULT_ELEMENTS = 100 * 1024;
 
-struct FileCacheSettings;
 } // namespace io
 } // namespace doris

--- a/be/src/io/cache/block/block_file_cache_settings.h
+++ b/be/src/io/cache/block/block_file_cache_settings.h
@@ -25,15 +25,19 @@
 namespace doris {
 namespace io {
 
+// [query:disposable:index:total]
+constexpr std::array<size_t, 4> percentage {17, 2, 1, 20};
+static_assert(percentage[0] + percentage[1] + percentage[2] == percentage[3]);
 struct FileCacheSettings {
-    size_t max_size = 0;
-    size_t max_elements = REMOTE_FS_OBJECTS_CACHE_DEFAULT_ELEMENTS;
-    // use a priority policy to eliminate
-    size_t persistent_max_size = 0;
-    size_t persistent_max_elements = REMOTE_FS_OBJECTS_CACHE_DEFAULT_ELEMENTS;
-
-    size_t max_file_segment_size = 0;
-    size_t max_query_cache_size = 0;
+    size_t total_size {0};
+    size_t disposable_queue_size {0};
+    size_t disposable_queue_elements {0};
+    size_t index_queue_size {0};
+    size_t index_queue_elements {0};
+    size_t query_queue_size {0};
+    size_t query_queue_elements {0};
+    size_t max_file_segment_size {0};
+    size_t max_query_cache_size {0};
 };
 
 } // namespace io

--- a/be/src/io/cache/block/block_file_segment.cpp
+++ b/be/src/io/cache/block/block_file_segment.cpp
@@ -36,12 +36,12 @@ namespace doris {
 namespace io {
 
 FileBlock::FileBlock(size_t offset_, size_t size_, const Key& key_, IFileCache* cache_,
-                     State download_state_, bool is_persistent)
+                     State download_state_, CacheType cache_type)
         : _segment_range(offset_, offset_ + size_ - 1),
           _download_state(download_state_),
           _file_key(key_),
           _cache(cache_),
-          _is_persistent(is_persistent) {
+          _cache_type(cache_type) {
     /// On creation, file segment state can be EMPTY, DOWNLOADED, DOWNLOADING.
     switch (_download_state) {
     /// EMPTY is used when file segment is not in cache and
@@ -129,6 +129,7 @@ void FileBlock::reset_downloader_impl(std::lock_guard<std::mutex>& segment_lock)
         _downloaded_size = 0;
         _download_state = State::EMPTY;
         _downloader_id.clear();
+        _cache_writer.reset();
     }
 }
 
@@ -148,10 +149,14 @@ bool FileBlock::is_downloader_impl(std::lock_guard<std::mutex>& /* segment_lock 
 
 Status FileBlock::append(Slice data) {
     DCHECK(data.size != 0) << "Writing zero size is not allowed";
-
+    Status st = Status::OK();
     if (!_cache_writer) {
         auto download_path = get_path_in_local_cache();
-        RETURN_IF_ERROR(global_local_filesystem()->create_file(download_path, &_cache_writer));
+        st = global_local_filesystem()->create_file(download_path, &_cache_writer);
+        if (!st) {
+            _cache_writer.reset();
+            return st;
+        }
     }
 
     RETURN_IF_ERROR(_cache_writer->append(data));
@@ -159,25 +164,30 @@ Status FileBlock::append(Slice data) {
     std::lock_guard download_lock(_download_mutex);
 
     _downloaded_size += data.size;
-    return Status::OK();
+    return st;
 }
 
 std::string FileBlock::get_path_in_local_cache() const {
-    return _cache->get_path_in_local_cache(key(), offset(), _is_persistent);
+    return _cache->get_path_in_local_cache(key(), offset(), _cache_type);
 }
 
 Status FileBlock::read_at(Slice buffer, size_t offset) {
+    Status st = Status::OK();
     if (!_cache_reader) {
         std::lock_guard segment_lock(_mutex);
         if (!_cache_reader) {
             auto download_path = get_path_in_local_cache();
-            RETURN_IF_ERROR(global_local_filesystem()->open_file(download_path, &_cache_reader));
+            st = global_local_filesystem()->open_file(download_path, &_cache_reader);
+            if (!st) {
+                _cache_reader.reset();
+                return st;
+            }
         }
     }
     size_t bytes_reads = buffer.size;
     RETURN_IF_ERROR(_cache_reader->read_at(offset, buffer, &bytes_reads));
     DCHECK(bytes_reads == buffer.size);
-    return Status::OK();
+    return st;
 }
 
 Status FileBlock::finalize_write() {
@@ -221,14 +231,7 @@ Status FileBlock::set_downloaded(std::lock_guard<std::mutex>& /* segment_lock */
     return Status::OK();
 }
 
-void FileBlock::complete(std::lock_guard<std::mutex>& cache_lock) {
-    std::lock_guard segment_lock(_mutex);
-
-    complete_unlocked(cache_lock, segment_lock);
-}
-
-void FileBlock::complete_unlocked(std::lock_guard<std::mutex>& cache_lock,
-                                  std::lock_guard<std::mutex>& segment_lock) {
+void FileBlock::complete_unlocked(std::lock_guard<std::mutex>& segment_lock) {
     if (is_downloader_impl(segment_lock)) {
         reset_downloader(segment_lock);
         _cv.notify_all();
@@ -251,6 +254,10 @@ std::string FileBlock::get_info_for_log_impl(std::lock_guard<std::mutex>& segmen
     return info.str();
 }
 
+FileBlock::State FileBlock::state_unlock(std::lock_guard<std::mutex>&) const {
+    return _download_state;
+}
+
 std::string FileBlock::state_to_string(FileBlock::State state) {
     switch (state) {
     case FileBlock::State::DOWNLOADED:
@@ -271,10 +278,6 @@ bool FileBlock::has_finalized_state() const {
     return _download_state == State::DOWNLOADED;
 }
 
-FileBlock::~FileBlock() {
-    std::lock_guard segment_lock(_mutex);
-}
-
 FileBlocksHolder::~FileBlocksHolder() {
     /// In CacheableReadBufferFromRemoteFS file segment's downloader removes file segments from
     /// FileBlocksHolder right after calling file_segment->complete(), so on destruction here
@@ -290,11 +293,17 @@ FileBlocksHolder::~FileBlocksHolder() {
             cache = file_segment->_cache;
         }
 
-        /// File segment pointer must be reset right after calling complete() and
-        /// under the same mutex, because complete() checks for segment pointers.
-        std::lock_guard cache_lock(cache->_mutex);
-
-        file_segment->complete(cache_lock);
+        {
+            std::lock_guard cache_lock(cache->_mutex);
+            std::lock_guard segment_lock(file_segment->_mutex);
+            file_segment->complete_unlocked(segment_lock);
+            if (file_segment->state_unlock(segment_lock) == FileBlock::State::EMPTY) {
+                // one in cache, one in here
+                if (file_segment.use_count() == 2) {
+                    cache->remove(file_segment, cache_lock, segment_lock);
+                }
+            }
+        }
 
         file_segment_it = file_segments.erase(current_file_segment_it);
     }

--- a/be/src/io/cache/block/block_file_segment.h
+++ b/be/src/io/cache/block/block_file_segment.h
@@ -71,10 +71,10 @@ public:
         SKIP_CACHE,
     };
 
-    FileBlock(size_t offset_, size_t size_, const Key& key_, IFileCache* cache_,
-              State download_state_, bool is_persistent);
+    FileBlock(size_t offset, size_t size, const Key& key, IFileCache* cache,
+              State download_state, CacheType cache_type);
 
-    ~FileBlock();
+    ~FileBlock() = default;
 
     State state() const;
 
@@ -85,7 +85,7 @@ public:
         size_t left;
         size_t right;
 
-        Range(size_t left_, size_t right_) : left(left_), right(right_) {}
+        Range(size_t left, size_t right) : left(left), right(right) {}
 
         bool operator==(const Range& other) const {
             return left == other.left && right == other.right;
@@ -126,7 +126,7 @@ public:
 
     bool is_downloaded() const { return _is_downloaded.load(); }
 
-    bool is_persistent() const { return _is_persistent; }
+    CacheType cache_type() const { return _cache_type; }
 
     static std::string get_caller_id();
 
@@ -137,6 +137,8 @@ public:
     std::string get_info_for_log() const;
 
     std::string get_path_in_local_cache() const;
+
+    State state_unlock(std::lock_guard<std::mutex>&) const;
 
     FileBlock& operator=(const FileBlock&) = delete;
     FileBlock(const FileBlock&) = delete;
@@ -149,13 +151,7 @@ private:
     Status set_downloaded(std::lock_guard<std::mutex>& segment_lock);
     bool is_downloader_impl(std::lock_guard<std::mutex>& segment_lock) const;
 
-    /// complete() without any completion state is called from destructor of
-    /// FileBlocksHolder. complete() might check if the caller of the method
-    /// is the last alive holder of the segment. Therefore, complete() and destruction
-    /// of the file segment pointer must be done under the same cache mutex.
-    void complete(std::lock_guard<std::mutex>& cache_lock);
-    void complete_unlocked(std::lock_guard<std::mutex>& cache_lock,
-                           std::lock_guard<std::mutex>& segment_lock);
+    void complete_unlocked(std::lock_guard<std::mutex>& segment_lock);
 
     void reset_downloader_impl(std::lock_guard<std::mutex>& segment_lock);
 
@@ -189,7 +185,7 @@ private:
     IFileCache* _cache;
 
     std::atomic<bool> _is_downloaded {false};
-    bool _is_persistent = false;
+    CacheType _cache_type;
 };
 
 struct FileBlocksHolder {

--- a/be/src/io/cache/block/block_file_segment.h
+++ b/be/src/io/cache/block/block_file_segment.h
@@ -71,8 +71,8 @@ public:
         SKIP_CACHE,
     };
 
-    FileBlock(size_t offset, size_t size, const Key& key, IFileCache* cache,
-              State download_state, CacheType cache_type);
+    FileBlock(size_t offset, size_t size, const Key& key, IFileCache* cache, State download_state,
+              CacheType cache_type);
 
     ~FileBlock() = default;
 

--- a/be/src/io/cache/block/block_lru_file_cache.cpp
+++ b/be/src/io/cache/block/block_lru_file_cache.cpp
@@ -693,8 +693,9 @@ void LRUFileCache::remove(FileBlockSPtr file_block, std::lock_guard<std::mutex>&
     auto type = file_block->cache_type();
     auto* cell = get_cell(key, offset, cache_lock);
     // It will be removed concurrently
-    if (!cell) [[unlikely]]
+    if (!cell) [[unlikely]] {
         return;
+    }
 
     if (cell->queue_iterator) {
         auto& queue = get_queue(file_block->cache_type());

--- a/be/src/io/cache/block/block_lru_file_cache.cpp
+++ b/be/src/io/cache/block/block_lru_file_cache.cpp
@@ -339,7 +339,7 @@ void LRUFileCache::fill_holes_with_empty_file_blocks(FileBlocks& file_blocks, co
 }
 
 FileBlocksHolder LRUFileCache::get_or_set(const Key& key, size_t offset, size_t size,
-                                            const CacheContext& context) {
+                                          const CacheContext& context) {
     FileBlock::Range range(offset, offset + size - 1);
 
     std::lock_guard cache_lock(_mutex);
@@ -787,7 +787,7 @@ Status LRUFileCache::load_cache_info_into_memory(std::lock_guard<std::mutex>& ca
                             std::error_code ec;
                             std::filesystem::remove(offset_it->path(), ec);
                             if (ec) {
-                                st =  Status::IOError(ec.message());
+                                st = Status::IOError(ec.message());
                                 break;
                             }
                             continue;
@@ -815,8 +815,7 @@ Status LRUFileCache::load_cache_info_into_memory(std::lock_guard<std::mutex>& ca
                 }
                 context.cache_type = cache_type;
                 if (try_reserve(key, context, offset, size, cache_lock)) {
-                    add_cell(key, context, offset, size, FileBlock::State::DOWNLOADED,
-                             cache_lock);
+                    add_cell(key, context, offset, size, FileBlock::State::DOWNLOADED, cache_lock);
                     queue_entries.emplace_back(key, offset);
                 } else {
                     std::error_code ec;
@@ -938,7 +937,7 @@ size_t LRUFileCache::get_file_segments_num(CacheType cache_type) const {
 }
 
 size_t LRUFileCache::get_file_segments_num_unlocked(CacheType cache_type,
-                                                  std::lock_guard<std::mutex>& cache_lock) const {
+                                                    std::lock_guard<std::mutex>& cache_lock) const {
     return get_queue(cache_type).get_elements_num(cache_lock);
 }
 

--- a/be/src/io/cache/block/block_lru_file_cache.cpp
+++ b/be/src/io/cache/block/block_lru_file_cache.cpp
@@ -687,7 +687,7 @@ void LRUFileCache::remove(FileBlockSPtr file_block, std::lock_guard<std::mutex>&
     auto type = file_block->cache_type();
     auto* cell = get_cell(key, offset, cache_lock);
     // It will be removed concurrently
-    if (!cell) [[unlikely]] {
+    if (!cell) {
         return;
     }
 
@@ -778,7 +778,7 @@ Status LRUFileCache::load_cache_info_into_memory(std::lock_guard<std::mutex>& ca
                         offset = stoull(offset_with_suffix.substr(0, delim_pos));
                         std::string suffix = offset_with_suffix.substr(delim_pos + 1);
                         // not need persistent any more
-                        if (suffix == "persistent") [[unlikely]] {
+                        if (suffix == "persistent") {
                             std::error_code ec;
                             std::filesystem::remove(offset_it->path(), ec);
                             if (ec) {

--- a/be/src/io/cache/block/block_lru_file_cache.cpp
+++ b/be/src/io/cache/block/block_lru_file_cache.cpp
@@ -63,15 +63,31 @@ namespace fs = std::filesystem;
 namespace doris {
 namespace io {
 
-LRUFileCache::LRUFileCache(const std::string& cache_base_path_,
-                           const FileCacheSettings& cache_settings_)
-        : IFileCache(cache_base_path_, cache_settings_) {}
+LRUFileCache::LRUFileCache(const std::string& cache_base_path,
+                           const FileCacheSettings& cache_settings)
+        : IFileCache(cache_base_path, cache_settings) {
+    _disposable_queue = LRUQueue(cache_settings.disposable_queue_size,
+                                 cache_settings.disposable_queue_elements, 60 * 60);
+    _index_queue = LRUQueue(cache_settings.index_queue_size, cache_settings.index_queue_elements,
+                            7 * 24 * 60 * 60);
+    _normal_queue = LRUQueue(cache_settings.query_queue_size, cache_settings.query_queue_elements,
+                             24 * 60 * 60);
+
+    LOG(INFO) << fmt::format(
+            "file cache path={}, disposable queue size={} elements={}, index queue size={} "
+            "elements={}, query queue "
+            "size={} elements={}",
+            cache_base_path, cache_settings.disposable_queue_size,
+            cache_settings.disposable_queue_elements, cache_settings.index_queue_size,
+            cache_settings.index_queue_elements, cache_settings.query_queue_size,
+            cache_settings.query_queue_elements);
+}
 
 Status LRUFileCache::initialize() {
     std::lock_guard cache_lock(_mutex);
     if (!_is_initialized) {
         if (fs::exists(_cache_base_path)) {
-            load_cache_info_into_memory(cache_lock);
+            RETURN_IF_ERROR(load_cache_info_into_memory(cache_lock));
         } else {
             std::error_code ec;
             fs::create_directories(_cache_base_path, ec);
@@ -83,31 +99,44 @@ Status LRUFileCache::initialize() {
         }
     }
     _is_initialized = true;
+    _cache_background_thread = std::thread(&LRUFileCache::run_background_operation, this);
+    LOG(INFO) << fmt::format(
+            "After initialize file cache path={}, disposable queue size={} elements={}, index "
+            "queue size={} "
+            "elements={}, query queue "
+            "size={} elements={}",
+            _cache_base_path, _disposable_queue.get_total_cache_size(cache_lock),
+            _disposable_queue.get_elements_num(cache_lock),
+            _index_queue.get_total_cache_size(cache_lock),
+            _index_queue.get_elements_num(cache_lock),
+            _normal_queue.get_total_cache_size(cache_lock),
+            _normal_queue.get_elements_num(cache_lock));
     return Status::OK();
 }
 
-void LRUFileCache::use_cell(const FileBlockCell& cell, const TUniqueId& query_id,
-                            bool is_persistent, FileBlocks& result,
+void LRUFileCache::use_cell(const FileBlockCell& cell, FileBlocks& result, bool move_iter_flag,
                             std::lock_guard<std::mutex>& cache_lock) {
-    auto file_segment = cell.file_segment;
-    LRUQueue* queue = is_persistent ? &_persistent_queue : &_queue;
-    DCHECK(!(file_segment->is_downloaded() &&
-             fs::file_size(get_path_in_local_cache(file_segment->key(), file_segment->offset(),
-                                                   is_persistent)) == 0))
+    auto file_block = cell.file_block;
+    auto& queue = get_queue(cell.cache_type);
+    DCHECK(!(file_block->is_downloaded() &&
+             fs::file_size(get_path_in_local_cache(file_block->key(), file_block->offset(),
+                                                   cell.cache_type)) == 0))
             << "Cannot have zero size downloaded file segments. Current file segment: "
-            << file_segment->range().to_string();
+            << file_block->range().to_string();
 
-    result.push_back(cell.file_segment);
+    result.push_back(cell.file_block);
 
     DCHECK(cell.queue_iterator);
-    /// Move to the end of the queue. The iterator remains valid.
-    queue->move_to_end(*cell.queue_iterator, cache_lock);
+    // Move to the end of the queue. The iterator remains valid.
+    if (move_iter_flag) {
+        queue.move_to_end(*cell.queue_iterator, cache_lock);
+    }
+    cell.update_atime();
 }
 
-LRUFileCache::FileBlockCell* LRUFileCache::get_cell(const Key& key, bool is_persistent,
-                                                    size_t offset,
+LRUFileCache::FileBlockCell* LRUFileCache::get_cell(const Key& key, size_t offset,
                                                     std::lock_guard<std::mutex>& /* cache_lock */) {
-    auto it = _files.find(std::make_pair(key, is_persistent));
+    auto it = _files.find(key);
     if (it == _files.end()) {
         return nullptr;
     }
@@ -121,22 +150,25 @@ LRUFileCache::FileBlockCell* LRUFileCache::get_cell(const Key& key, bool is_pers
     return &cell_it->second;
 }
 
-FileBlocks LRUFileCache::get_impl(const Key& key, const TUniqueId& query_id, bool is_persistent,
+bool LRUFileCache::need_to_move(CacheType cell_type, CacheType query_type) const {
+    return query_type != CacheType::DISPOSABLE || cell_type == CacheType::DISPOSABLE ? true : false;
+}
+
+FileBlocks LRUFileCache::get_impl(const Key& key, const CacheContext& context,
                                   const FileBlock::Range& range,
                                   std::lock_guard<std::mutex>& cache_lock) {
     /// Given range = [left, right] and non-overlapping ordered set of file segments,
     /// find list [segment1, ..., segmentN] of segments which intersect with given range.
-    auto file_key = std::make_pair(key, is_persistent);
-    auto it = _files.find(file_key);
+    auto it = _files.find(key);
     if (it == _files.end()) {
         return {};
     }
 
-    const auto& file_segments = it->second;
-    if (file_segments.empty()) {
+    const auto& file_blocks = it->second;
+    if (file_blocks.empty()) {
         auto key_path = get_path_in_local_cache(key);
 
-        _files.erase(file_key);
+        _files.erase(key);
 
         /// Note: it is guaranteed that there is no concurrency with files deletion,
         /// because cache files are deleted only inside IFileCache and under cache lock.
@@ -152,8 +184,8 @@ FileBlocks LRUFileCache::get_impl(const Key& key, const TUniqueId& query_id, boo
     }
 
     FileBlocks result;
-    auto segment_it = file_segments.lower_bound(range.left);
-    if (segment_it == file_segments.end()) {
+    auto segment_it = file_blocks.lower_bound(range.left);
+    if (segment_it == file_blocks.end()) {
         /// N - last cached segment for given file key, segment{N}.offset < range.left:
         ///   segment{N}                       segment{N}
         /// [________                         [_______]
@@ -161,16 +193,16 @@ FileBlocks LRUFileCache::get_impl(const Key& key, const TUniqueId& query_id, boo
         ///     ^                                        ^
         ///     range.left                               range.left
 
-        const auto& cell = file_segments.rbegin()->second;
-        if (cell.file_segment->range().right < range.left) {
+        const auto& cell = file_blocks.rbegin()->second;
+        if (cell.file_block->range().right < range.left) {
             return {};
         }
 
-        use_cell(cell, query_id, is_persistent, result, cache_lock);
+        use_cell(cell, result, need_to_move(cell.cache_type, context.cache_type), cache_lock);
     } else { /// segment_it <-- segmment{k}
-        if (segment_it != file_segments.begin()) {
+        if (segment_it != file_blocks.begin()) {
             const auto& prev_cell = std::prev(segment_it)->second;
-            const auto& prev_cell_range = prev_cell.file_segment->range();
+            const auto& prev_cell_range = prev_cell.file_block->range();
 
             if (range.left <= prev_cell_range.right) {
                 ///   segment{k-1}  segment{k}
@@ -179,7 +211,8 @@ FileBlocks LRUFileCache::get_impl(const Key& key, const TUniqueId& query_id, boo
                 ///       ^
                 ///       range.left
 
-                use_cell(prev_cell, query_id, is_persistent, result, cache_lock);
+                use_cell(prev_cell, result, need_to_move(prev_cell.cache_type, context.cache_type),
+                         cache_lock);
             }
         }
 
@@ -189,13 +222,13 @@ FileBlocks LRUFileCache::get_impl(const Key& key, const TUniqueId& query_id, boo
         ///  ^                              ^                           ^   segment{k}.offset
         ///  range.left                     range.left                  range.right
 
-        while (segment_it != file_segments.end()) {
+        while (segment_it != file_blocks.end()) {
             const auto& cell = segment_it->second;
-            if (range.right < cell.file_segment->range().left) {
+            if (range.right < cell.file_block->range().left) {
                 break;
             }
 
-            use_cell(cell, query_id, is_persistent, result, cache_lock);
+            use_cell(cell, result, need_to_move(cell.cache_type, context.cache_type), cache_lock);
             ++segment_it;
         }
     }
@@ -203,9 +236,8 @@ FileBlocks LRUFileCache::get_impl(const Key& key, const TUniqueId& query_id, boo
     return result;
 }
 
-FileBlocks LRUFileCache::split_range_into_cells(const Key& key, const TUniqueId& query_id,
-                                                bool is_persistent, size_t offset, size_t size,
-                                                FileBlock::State state,
+FileBlocks LRUFileCache::split_range_into_cells(const Key& key, const CacheContext& context,
+                                                size_t offset, size_t size, FileBlock::State state,
                                                 std::lock_guard<std::mutex>& cache_lock) {
     DCHECK(size > 0);
 
@@ -215,37 +247,37 @@ FileBlocks LRUFileCache::split_range_into_cells(const Key& key, const TUniqueId&
     size_t current_size = 0;
     size_t remaining_size = size;
 
-    FileBlocks file_segments;
+    FileBlocks file_blocks;
     while (current_pos < end_pos_non_included) {
         current_size = std::min(remaining_size, _max_file_segment_size);
         remaining_size -= current_size;
-        state = try_reserve(key, query_id, is_persistent, current_pos, current_size, cache_lock)
+        state = try_reserve(key, context, current_pos, current_size, cache_lock)
                         ? state
                         : FileBlock::State::SKIP_CACHE;
         if (UNLIKELY(state == FileBlock::State::SKIP_CACHE)) {
-            auto file_segment =
+            auto file_block =
                     std::make_shared<FileBlock>(current_pos, current_size, key, this,
-                                                FileBlock::State::SKIP_CACHE, is_persistent);
-            file_segments.push_back(std::move(file_segment));
+                                                FileBlock::State::SKIP_CACHE, context.cache_type);
+            file_blocks.push_back(std::move(file_block));
         } else {
-            auto* cell = add_cell(key, is_persistent, current_pos, current_size, state, cache_lock);
+            auto* cell = add_cell(key, context, current_pos, current_size, state, cache_lock);
             if (cell) {
-                file_segments.push_back(cell->file_segment);
+                file_blocks.push_back(cell->file_block);
+                cell->update_atime();
             }
         }
 
         current_pos += current_size;
     }
 
-    DCHECK(file_segments.empty() || offset + size - 1 == file_segments.back()->range().right);
-    return file_segments;
+    DCHECK(file_blocks.empty() || offset + size - 1 == file_blocks.back()->range().right);
+    return file_blocks;
 }
 
-void LRUFileCache::fill_holes_with_empty_file_segments(FileBlocks& file_segments, const Key& key,
-                                                       const TUniqueId& query_id,
-                                                       bool is_persistent,
-                                                       const FileBlock::Range& range,
-                                                       std::lock_guard<std::mutex>& cache_lock) {
+void LRUFileCache::fill_holes_with_empty_file_blocks(FileBlocks& file_blocks, const Key& key,
+                                                     const CacheContext& context,
+                                                     const FileBlock::Range& range,
+                                                     std::lock_guard<std::mutex>& cache_lock) {
     /// There are segments [segment1, ..., segmentN]
     /// (non-overlapping, non-empty, ascending-ordered) which (maybe partially)
     /// intersect with given range.
@@ -256,7 +288,7 @@ void LRUFileCache::fill_holes_with_empty_file_segments(FileBlocks& file_segments
     ///
     /// For each such hole create a cell with file segment state EMPTY.
 
-    auto it = file_segments.begin();
+    auto it = file_blocks.begin();
     auto segment_range = (*it)->range();
 
     size_t current_pos;
@@ -272,7 +304,7 @@ void LRUFileCache::fill_holes_with_empty_file_segments(FileBlocks& file_segments
         current_pos = range.left;
     }
 
-    while (current_pos <= range.right && it != file_segments.end()) {
+    while (current_pos <= range.right && it != file_blocks.end()) {
         segment_range = (*it)->range();
 
         if (current_pos == segment_range.left) {
@@ -285,9 +317,8 @@ void LRUFileCache::fill_holes_with_empty_file_segments(FileBlocks& file_segments
 
         auto hole_size = segment_range.left - current_pos;
 
-        file_segments.splice(
-                it, split_range_into_cells(key, query_id, is_persistent, current_pos, hole_size,
-                                           FileBlock::State::EMPTY, cache_lock));
+        file_blocks.splice(it, split_range_into_cells(key, context, current_pos, hole_size,
+                                                      FileBlock::State::EMPTY, cache_lock));
 
         current_pos = segment_range.right + 1;
         ++it;
@@ -301,35 +332,33 @@ void LRUFileCache::fill_holes_with_empty_file_segments(FileBlocks& file_segments
 
         auto hole_size = range.right - current_pos + 1;
 
-        file_segments.splice(
-                file_segments.end(),
-                split_range_into_cells(key, query_id, is_persistent, current_pos, hole_size,
-                                       FileBlock::State::EMPTY, cache_lock));
+        file_blocks.splice(file_blocks.end(),
+                           split_range_into_cells(key, context, current_pos, hole_size,
+                                                  FileBlock::State::EMPTY, cache_lock));
     }
 }
 
 FileBlocksHolder LRUFileCache::get_or_set(const Key& key, size_t offset, size_t size,
-                                          bool is_persistent, const TUniqueId& query_id) {
+                                            const CacheContext& context) {
     FileBlock::Range range(offset, offset + size - 1);
 
     std::lock_guard cache_lock(_mutex);
 
     /// Get all segments which intersect with the given range.
-    auto file_segments = get_impl(key, query_id, is_persistent, range, cache_lock);
+    auto file_blocks = get_impl(key, context, range, cache_lock);
 
-    if (file_segments.empty()) {
-        file_segments = split_range_into_cells(key, query_id, is_persistent, offset, size,
-                                               FileBlock::State::EMPTY, cache_lock);
+    if (file_blocks.empty()) {
+        file_blocks = split_range_into_cells(key, context, offset, size, FileBlock::State::EMPTY,
+                                             cache_lock);
     } else {
-        fill_holes_with_empty_file_segments(file_segments, key, query_id, is_persistent, range,
-                                            cache_lock);
+        fill_holes_with_empty_file_blocks(file_blocks, key, context, range, cache_lock);
     }
 
-    DCHECK(!file_segments.empty());
-    return FileBlocksHolder(std::move(file_segments));
+    DCHECK(!file_blocks.empty());
+    return FileBlocksHolder(std::move(file_blocks));
 }
 
-LRUFileCache::FileBlockCell* LRUFileCache::add_cell(const Key& key, bool is_persistent,
+LRUFileCache::FileBlockCell* LRUFileCache::add_cell(const Key& key, const CacheContext& context,
                                                     size_t offset, size_t size,
                                                     FileBlock::State state,
                                                     std::lock_guard<std::mutex>& cache_lock) {
@@ -337,14 +366,12 @@ LRUFileCache::FileBlockCell* LRUFileCache::add_cell(const Key& key, bool is_pers
     if (size == 0) {
         return nullptr; /// Empty files are not cached.
     }
-    auto file_key = std::make_pair(key, is_persistent);
-    LRUQueue* queue = is_persistent ? &_persistent_queue : &_queue;
-    DCHECK(_files[file_key].count(offset) == 0)
+    DCHECK(_files[key].count(offset) == 0)
             << "Cache already exists for key: " << key.to_string() << ", offset: " << offset
-            << ", size: " << size << ".\nCurrent cache structure: "
-            << dump_structure_unlocked(key, is_persistent, cache_lock);
+            << ", size: " << size
+            << ".\nCurrent cache structure: " << dump_structure_unlocked(key, cache_lock);
 
-    auto& offsets = _files[file_key];
+    auto& offsets = _files[key];
     if (offsets.empty()) {
         auto key_path = get_path_in_local_cache(key);
         if (!fs::exists(key_path)) {
@@ -358,11 +385,13 @@ LRUFileCache::FileBlockCell* LRUFileCache::add_cell(const Key& key, bool is_pers
         }
     }
 
-    FileBlockCell cell(std::make_shared<FileBlock>(offset, size, key, this, state, is_persistent),
-                       this, cache_lock);
-
-    cell.queue_iterator = queue->add(key, offset, is_persistent, size, cache_lock);
+    FileBlockCell cell(
+            std::make_shared<FileBlock>(offset, size, key, this, state, context.cache_type),
+            context.cache_type, cache_lock);
+    auto& queue = get_queue(context.cache_type);
+    cell.queue_iterator = queue.add(key, offset, size, cache_lock);
     auto [it, inserted] = offsets.insert({offset, std::move(cell)});
+    _cur_cache_size += size;
 
     DCHECK(inserted) << "Failed to insert into cache key: " << key.to_string()
                      << ", offset: " << offset << ", size: " << size;
@@ -370,33 +399,71 @@ LRUFileCache::FileBlockCell* LRUFileCache::add_cell(const Key& key, bool is_pers
     return &(it->second);
 }
 
-bool LRUFileCache::try_reserve(const Key& key, const TUniqueId& query_id, bool is_persistent,
-                               size_t offset, size_t size,
-                               std::lock_guard<std::mutex>& cache_lock) {
-    auto query_context = _enable_file_cache_query_limit && (query_id.hi != 0 || query_id.lo != 0)
-                                 ? get_query_context(query_id, cache_lock)
-                                 : nullptr;
+LRUFileCache::LRUQueue& LRUFileCache::get_queue(CacheType type) {
+    switch (type) {
+    case CacheType::INDEX:
+        return _index_queue;
+    case CacheType::DISPOSABLE:
+        return _disposable_queue;
+    case CacheType::NORMAL:
+        return _normal_queue;
+    default:
+        DCHECK(false);
+    }
+    return _normal_queue;
+}
+
+const LRUFileCache::LRUQueue& LRUFileCache::get_queue(CacheType type) const {
+    switch (type) {
+    case CacheType::INDEX:
+        return _index_queue;
+    case CacheType::DISPOSABLE:
+        return _disposable_queue;
+    case CacheType::NORMAL:
+        return _normal_queue;
+    default:
+        DCHECK(false);
+    }
+    return _normal_queue;
+}
+
+// 1. if dont reach query limit or dont have query limit
+//     a. evict from other queue
+//     b. evict from current queue
+//         a.1 if the data belong write, then just evict cold data
+// 2. if reach query limit
+//     a. evict from query queue
+//     b. evict from other queue
+bool LRUFileCache::try_reserve(const Key& key, const CacheContext& context, size_t offset,
+                               size_t size, std::lock_guard<std::mutex>& cache_lock) {
+    auto query_context =
+            _enable_file_cache_query_limit && (context.query_id.hi != 0 || context.query_id.lo != 0)
+                    ? get_query_context(context.query_id, cache_lock)
+                    : nullptr;
     if (!query_context) {
-        return try_reserve_for_main_list(key, nullptr, is_persistent, offset, size, cache_lock);
+        return try_reserve_for_lru(key, nullptr, context, offset, size, cache_lock);
     } else if (query_context->get_cache_size(cache_lock) + size <=
                query_context->get_max_cache_size()) {
-        return try_reserve_for_main_list(key, query_context, is_persistent, offset, size,
-                                         cache_lock);
+        return try_reserve_for_lru(key, query_context, context, offset, size, cache_lock);
     }
-    LRUQueue* queue = is_persistent ? &_persistent_queue : &_queue;
+    int64_t cur_time = std::chrono::duration_cast<std::chrono::seconds>(
+                               std::chrono::steady_clock::now().time_since_epoch())
+                               .count();
+    auto& queue = get_queue(context.cache_type);
     size_t removed_size = 0;
-    size_t queue_size = queue->get_elements_num(cache_lock);
+    size_t queue_size = queue.get_total_cache_size(cache_lock);
+    size_t cur_cache_size = _cur_cache_size;
+    size_t query_context_cache_size = query_context->get_cache_size(cache_lock);
 
     std::vector<IFileCache::LRUQueue::Iterator> ghost;
     std::vector<FileBlockCell*> trash;
     std::vector<FileBlockCell*> to_evict;
 
-    size_t max_size = is_persistent ? _persistent_max_size : _max_size;
-    size_t max_element_size = is_persistent ? _persistent_max_element_size : _max_element_size;
+    size_t max_size = queue.get_max_size();
     auto is_overflow = [&] {
-        return (queue->get_total_cache_size(cache_lock) + size - removed_size > max_size) ||
-               queue_size > max_element_size ||
-               (query_context->get_cache_size(cache_lock) + size - removed_size >
+        return cur_cache_size + size - removed_size > _total_size ||
+               (queue_size + size - removed_size > max_size) ||
+               (query_context_cache_size + size - removed_size >
                 query_context->get_max_cache_size());
     };
 
@@ -406,7 +473,7 @@ bool LRUFileCache::try_reserve(const Key& key, const TUniqueId& query_id, bool i
             break;
         }
 
-        auto* cell = get_cell(iter->key, iter->is_persistent, iter->offset, cache_lock);
+        auto* cell = get_cell(iter->key, iter->offset, cache_lock);
 
         if (!cell) {
             /// The cache corresponding to this record may be swapped out by
@@ -418,10 +485,10 @@ bool LRUFileCache::try_reserve(const Key& key, const TUniqueId& query_id, bool i
             DCHECK(iter->size == cell_size);
 
             if (cell->releasable()) {
-                auto& file_segment = cell->file_segment;
-                std::lock_guard segment_lock(file_segment->_mutex);
+                auto& file_block = cell->file_block;
+                std::lock_guard segment_lock(file_block->_mutex);
 
-                switch (file_segment->_download_state) {
+                switch (file_block->_download_state) {
                 case FileBlock::State::DOWNLOADED: {
                     to_evict.push_back(cell);
                     break;
@@ -432,235 +499,231 @@ bool LRUFileCache::try_reserve(const Key& key, const TUniqueId& query_id, bool i
                 }
                 }
                 removed_size += cell_size;
-                --queue_size;
             }
         }
     }
 
-    auto remove_file_segment_if = [&](FileBlockCell* cell) {
-        FileBlockSPtr file_segment = cell->file_segment;
-        if (file_segment) {
-            size_t file_segment_size = cell->size();
-            query_context->remove(file_segment->key(), file_segment->offset(),
-                                  file_segment->is_persistent(), file_segment_size, cache_lock);
-
-            std::lock_guard segment_lock(file_segment->_mutex);
-            remove(file_segment->key(), file_segment->is_persistent(), file_segment->offset(),
-                   cache_lock, segment_lock);
+    auto remove_file_block_if = [&](FileBlockCell* cell) {
+        FileBlockSPtr file_block = cell->file_block;
+        if (file_block) {
+            query_context->remove(file_block->key(), file_block->offset(), cache_lock);
+            std::lock_guard segment_lock(file_block->_mutex);
+            remove(file_block, cache_lock, segment_lock);
         }
     };
 
     for (auto& iter : ghost) {
-        query_context->remove(iter->key, iter->offset, iter->is_persistent, iter->size, cache_lock);
+        query_context->remove(iter->key, iter->offset, cache_lock);
     }
 
-    std::for_each(trash.begin(), trash.end(), remove_file_segment_if);
-    std::for_each(to_evict.begin(), to_evict.end(), remove_file_segment_if);
+    std::for_each(trash.begin(), trash.end(), remove_file_block_if);
+    std::for_each(to_evict.begin(), to_evict.end(), remove_file_block_if);
 
-    if (is_overflow()) {
+    if (is_overflow() &&
+        !try_reserve_from_other_queue(context.cache_type, size, cur_time, cache_lock)) {
         return false;
     }
-
-    query_context->reserve(key, offset, is_persistent, size, cache_lock);
+    query_context->reserve(key, offset, size, cache_lock);
     return true;
 }
 
-bool LRUFileCache::try_reserve_for_main_list(const Key& key, QueryFileCacheContextPtr query_context,
-                                             bool is_persistent, size_t offset, size_t size,
-                                             std::lock_guard<std::mutex>& cache_lock) {
-    LRUQueue* queue = is_persistent ? &_persistent_queue : &_queue;
-    auto removed_size = 0;
-    size_t queue_size = queue->get_elements_num(cache_lock);
+std::vector<CacheType> LRUFileCache::get_other_cache_type(CacheType cur_cache_type) {
+    switch (cur_cache_type) {
+    case CacheType::INDEX:
+        return {CacheType::DISPOSABLE, CacheType::NORMAL};
+    case CacheType::NORMAL:
+        return {CacheType::DISPOSABLE, CacheType::INDEX};
+    case CacheType::DISPOSABLE:
+        return {CacheType::NORMAL, CacheType::INDEX};
+    default:
+        return {};
+    }
+    return {};
+}
 
-    size_t max_size = is_persistent ? _persistent_max_size : _max_size;
-    size_t max_element_size = is_persistent ? _persistent_max_element_size : _max_element_size;
-    auto is_overflow = [&] {
-        return (queue->get_total_cache_size(cache_lock) + size - removed_size > max_size) ||
-               queue_size >= max_element_size;
-    };
-
+bool LRUFileCache::try_reserve_from_other_queue(CacheType cur_cache_type, size_t size,
+                                                int64_t cur_time,
+                                                std::lock_guard<std::mutex>& cache_lock) {
+    auto other_cache_types = get_other_cache_type(cur_cache_type);
+    size_t removed_size = 0;
+    size_t cur_cache_size = _cur_cache_size;
+    auto is_overflow = [&] { return cur_cache_size + size - removed_size > _total_size; };
     std::vector<FileBlockCell*> to_evict;
     std::vector<FileBlockCell*> trash;
-
-    for (const auto& [entry_key, entry_offset, entry_size, _] : *queue) {
-        if (!is_overflow()) {
-            break;
-        }
-        auto* cell = get_cell(entry_key, is_persistent, entry_offset, cache_lock);
-
-        DCHECK(cell) << "Cache became inconsistent. Key: " << key.to_string()
-                     << ", offset: " << offset;
-
-        size_t cell_size = cell->size();
-        DCHECK(entry_size == cell_size);
-
-        /// It is guaranteed that cell is not removed from cache as long as
-        /// pointer to corresponding file segment is hold by any other thread.
-
-        if (cell->releasable()) {
-            auto& file_segment = cell->file_segment;
-
-            std::lock_guard segment_lock(file_segment->_mutex);
-
-            switch (file_segment->_download_state) {
-            case FileBlock::State::DOWNLOADED: {
-                /// Cell will actually be removed only if
-                /// we managed to reserve enough space.
-
-                to_evict.push_back(cell);
+    for (CacheType cache_type : other_cache_types) {
+        auto& queue = get_queue(cache_type);
+        for (const auto& [entry_key, entry_offset, entry_size] : queue) {
+            if (!is_overflow()) {
                 break;
             }
-            default: {
-                trash.push_back(cell);
+            auto* cell = get_cell(entry_key, entry_offset, cache_lock);
+            DCHECK(cell) << "Cache became inconsistent. Key: " << entry_key.to_string()
+                         << ", offset: " << entry_offset;
+
+            size_t cell_size = cell->size();
+            DCHECK(entry_size == cell_size);
+
+            if (cell->atime == 0 ? true : cell->atime + queue.get_hot_data_interval() > cur_time) {
                 break;
             }
-            }
 
-            removed_size += cell_size;
-            --queue_size;
+            if (cell->releasable()) {
+                auto& file_block = cell->file_block;
+
+                std::lock_guard segment_lock(file_block->_mutex);
+
+                switch (file_block->_download_state) {
+                case FileBlock::State::DOWNLOADED: {
+                    to_evict.push_back(cell);
+                    break;
+                }
+                default: {
+                    trash.push_back(cell);
+                    break;
+                }
+                }
+
+                removed_size += cell_size;
+            }
         }
     }
-
-    auto remove_file_segment_if = [&](FileBlockCell* cell) {
-        FileBlockSPtr file_segment = cell->file_segment;
-        if (file_segment) {
-            std::lock_guard segment_lock(file_segment->_mutex);
-            remove(file_segment->key(), file_segment->is_persistent(), file_segment->offset(),
-                   cache_lock, segment_lock);
+    auto remove_file_block_if = [&](FileBlockCell* cell) {
+        FileBlockSPtr file_block = cell->file_block;
+        if (file_block) {
+            std::lock_guard segment_lock(file_block->_mutex);
+            remove(file_block, cache_lock, segment_lock);
         }
     };
 
-    std::for_each(trash.begin(), trash.end(), remove_file_segment_if);
-    std::for_each(to_evict.begin(), to_evict.end(), remove_file_segment_if);
+    std::for_each(trash.begin(), trash.end(), remove_file_block_if);
+    std::for_each(to_evict.begin(), to_evict.end(), remove_file_block_if);
 
     if (is_overflow()) {
         return false;
+    }
+
+    return true;
+}
+
+bool LRUFileCache::try_reserve_for_lru(const Key& key, QueryFileCacheContextPtr query_context,
+                                       const CacheContext& context, size_t offset, size_t size,
+                                       std::lock_guard<std::mutex>& cache_lock) {
+    int64_t cur_time = std::chrono::duration_cast<std::chrono::seconds>(
+                               std::chrono::steady_clock::now().time_since_epoch())
+                               .count();
+    if (!try_reserve_from_other_queue(context.cache_type, size, cur_time, cache_lock)) {
+        auto& queue = get_queue(context.cache_type);
+        size_t removed_size = 0;
+        size_t queue_element_size = queue.get_elements_num(cache_lock);
+        size_t queue_size = queue.get_total_cache_size(cache_lock);
+        size_t cur_cache_size = _cur_cache_size;
+
+        size_t max_size = queue.get_max_size();
+        size_t max_element_size = queue.get_max_element_size();
+        auto is_overflow = [&] {
+            return cur_cache_size + size - removed_size > _total_size ||
+                   (queue_size + size - removed_size > max_size) ||
+                   queue_element_size >= max_element_size;
+        };
+
+        std::vector<FileBlockCell*> to_evict;
+        std::vector<FileBlockCell*> trash;
+        for (const auto& [entry_key, entry_offset, entry_size] : queue) {
+            if (!is_overflow()) {
+                break;
+            }
+            auto* cell = get_cell(entry_key, entry_offset, cache_lock);
+
+            DCHECK(cell) << "Cache became inconsistent. Key: " << entry_key.to_string()
+                         << ", offset: " << entry_offset;
+
+            size_t cell_size = cell->size();
+            DCHECK(entry_size == cell_size);
+
+            if (cell->releasable()) {
+                auto& file_block = cell->file_block;
+
+                std::lock_guard segment_lock(file_block->_mutex);
+
+                switch (file_block->_download_state) {
+                case FileBlock::State::DOWNLOADED: {
+                    /// Cell will actually be removed only if
+                    /// we managed to reserve enough space.
+
+                    to_evict.push_back(cell);
+                    break;
+                }
+                default: {
+                    trash.push_back(cell);
+                    break;
+                }
+                }
+
+                removed_size += cell_size;
+                --queue_element_size;
+            }
+        }
+
+        auto remove_file_block_if = [&](FileBlockCell* cell) {
+            FileBlockSPtr file_block = cell->file_block;
+            if (file_block) {
+                std::lock_guard segment_lock(file_block->_mutex);
+                remove(file_block, cache_lock, segment_lock);
+            }
+        };
+
+        std::for_each(trash.begin(), trash.end(), remove_file_block_if);
+        std::for_each(to_evict.begin(), to_evict.end(), remove_file_block_if);
+
+        if (is_overflow()) {
+            return false;
+        }
     }
 
     if (query_context) {
-        query_context->reserve(key, offset, is_persistent, size, cache_lock);
+        query_context->reserve(key, offset, size, cache_lock);
     }
     return true;
 }
 
-void LRUFileCache::remove_if_exists(const Key& key, bool is_persistent) {
-    std::lock_guard cache_lock(_mutex);
-
-    auto file_key = std::make_pair(key, is_persistent);
-    auto it = _files.find(file_key);
-    if (it == _files.end()) {
+void LRUFileCache::remove(FileBlockSPtr file_block, std::lock_guard<std::mutex>& cache_lock,
+                          std::lock_guard<std::mutex>&) {
+    auto key = file_block->key();
+    auto offset = file_block->offset();
+    auto type = file_block->cache_type();
+    auto* cell = get_cell(key, offset, cache_lock);
+    // It will be removed concurrently
+    if (!cell) [[unlikely]]
         return;
-    }
-
-    auto& offsets = it->second;
-
-    std::vector<FileBlockCell*> to_remove;
-    to_remove.reserve(offsets.size());
-
-    for (auto& [offset, cell] : offsets) {
-        to_remove.push_back(&cell);
-    }
-
-    bool some_cells_were_skipped = false;
-    for (auto& cell : to_remove) {
-        /// In ordinary case we remove data from cache when it's not used by anyone.
-        /// But if we have multiple replicated zero-copy tables on the same server
-        /// it became possible to start removing something from cache when it is used
-        /// by other "zero-copy" tables. That is why it's not an error.
-        if (!cell->releasable()) {
-            some_cells_were_skipped = true;
-            continue;
-        }
-
-        auto file_segment = cell->file_segment;
-        if (file_segment) {
-            std::lock_guard<std::mutex> segment_lock(file_segment->_mutex);
-            remove(file_segment->key(), is_persistent, file_segment->offset(), cache_lock,
-                   segment_lock);
-        }
-    }
-
-    auto key_path = get_path_in_local_cache(key);
-
-    if (!some_cells_were_skipped) {
-        _files.erase(file_key);
-
-        if (fs::exists(key_path)) {
-            std::error_code ec;
-            fs::remove_all(key_path, ec);
-            if (ec) {
-                LOG(WARNING) << ec.message();
-            }
-        }
-    }
-}
-
-void LRUFileCache::remove_if_releasable(bool is_persistent) {
-    /// Try remove all cached files by cache_base_path.
-    /// Only releasable file segments are evicted.
-    /// `remove_persistent_files` defines whether non-evictable by some criteria files
-    /// (they do not comply with the cache eviction policy) should also be removed.
-
-    std::lock_guard cache_lock(_mutex);
-    LRUQueue* queue = is_persistent ? &_persistent_queue : &_queue;
-    for (auto it = queue->begin(); it != queue->end();) {
-        const auto& [key, offset, size, _] = *it++;
-        auto* cell = get_cell(key, is_persistent, offset, cache_lock);
-
-        DCHECK(cell) << "Cache is in inconsistent state: LRU queue contains entries with no "
-                        "cache cell";
-
-        if (cell->releasable()) {
-            auto file_segment = cell->file_segment;
-            if (file_segment) {
-                std::lock_guard segment_lock(file_segment->_mutex);
-                remove(file_segment->key(), is_persistent, file_segment->offset(), cache_lock,
-                       segment_lock);
-            }
-        }
-    }
-}
-
-void LRUFileCache::remove(const Key& key, bool is_persistent, size_t offset,
-                          std::lock_guard<std::mutex>& cache_lock,
-                          std::lock_guard<std::mutex>& /* segment_lock */) {
-    LRUQueue* queue = is_persistent ? &_persistent_queue : &_queue;
-    auto* cell = get_cell(key, is_persistent, offset, cache_lock);
-    DCHECK(cell) << "No cache cell for key: " << key.to_string() << ", offset: " << offset;
 
     if (cell->queue_iterator) {
-        queue->remove(*cell->queue_iterator, cache_lock);
+        auto& queue = get_queue(file_block->cache_type());
+        queue.remove(*cell->queue_iterator, cache_lock);
     }
-    auto file_key = std::make_pair(key, is_persistent);
-    auto& offsets = _files[file_key];
-    offsets.erase(offset);
+    _cur_cache_size -= file_block->range().size();
+    auto& offsets = _files[file_block->key()];
+    offsets.erase(file_block->offset());
 
-    auto cache_file_path = get_path_in_local_cache(key, offset, is_persistent);
-    if (fs::exists(cache_file_path)) {
+    auto cache_file_path = get_path_in_local_cache(key, offset, type);
+    if (std::filesystem::exists(cache_file_path)) {
         std::error_code ec;
-        fs::remove(cache_file_path, ec);
+        std::filesystem::remove(cache_file_path, ec);
         if (ec) {
-            LOG(WARNING) << ec.message();
+            LOG(ERROR) << ec.message();
         }
-
-        if (_is_initialized && offsets.empty()) {
-            auto key_path = get_path_in_local_cache(key);
-
-            _files.erase(file_key);
-
-            auto another_key = std::make_pair(key, !is_persistent);
-            if (_files.count(another_key) < 1 && fs::exists(key_path)) {
-                std::error_code ec;
-                fs::remove_all(key_path, ec);
-                if (ec) {
-                    LOG(WARNING) << ec.message();
-                }
-            }
+    }
+    if (offsets.empty()) {
+        auto key_path = get_path_in_local_cache(key);
+        _files.erase(key);
+        std::error_code ec;
+        std::filesystem::remove_all(key_path, ec);
+        if (ec) {
+            LOG(ERROR) << ec.message();
         }
     }
 }
 
-void LRUFileCache::load_cache_info_into_memory(std::lock_guard<std::mutex>& cache_lock) {
+Status LRUFileCache::load_cache_info_into_memory(std::lock_guard<std::mutex>& cache_lock) {
     /// version 1.0: cache_base_path / key / offset
     /// version 2.0: cache_base_path / key_prefix / key / offset
     if (USE_CACHE_VERSION2 && read_file_cache_version() != "2.0") {
@@ -698,32 +761,47 @@ void LRUFileCache::load_cache_info_into_memory(std::lock_guard<std::mutex>& cach
     Key key;
     uint64_t offset = 0;
     size_t size = 0;
-    std::vector<std::pair<LRUQueue::Iterator, bool>> queue_entries;
+    std::vector<std::pair<Key, size_t>> queue_entries;
+    std::vector<std::string> need_to_check_if_empty_dir;
+    Status st = Status::OK();
     auto scan_file_cache = [&](fs::directory_iterator& key_it) {
         for (; key_it != fs::directory_iterator(); ++key_it) {
             key = Key(
                     vectorized::unhex_uint<uint128_t>(key_it->path().filename().native().c_str()));
-
+            CacheContext context;
+            context.query_id = TUniqueId();
             fs::directory_iterator offset_it {key_it->path()};
             for (; offset_it != fs::directory_iterator(); ++offset_it) {
                 auto offset_with_suffix = offset_it->path().filename().native();
                 auto delim_pos = offset_with_suffix.find('_');
-                bool is_persistent = false;
+                CacheType cache_type = CacheType::NORMAL;
                 bool parsed = true;
                 try {
                     if (delim_pos == std::string::npos) {
                         offset = stoull(offset_with_suffix);
                     } else {
                         offset = stoull(offset_with_suffix.substr(0, delim_pos));
-                        is_persistent = offset_with_suffix.substr(delim_pos + 1) == "persistent";
+                        std::string suffix = offset_with_suffix.substr(delim_pos + 1);
+                        // not need persistent any more
+                        if (suffix == "persistent") [[unlikely]] {
+                            std::error_code ec;
+                            std::filesystem::remove(offset_it->path(), ec);
+                            if (ec) {
+                                st =  Status::IOError(ec.message());
+                                break;
+                            }
+                            continue;
+                        } else {
+                            cache_type = string_to_cache_type(suffix);
+                        }
                     }
                 } catch (...) {
                     parsed = false;
                 }
 
                 if (!parsed) {
-                    LOG(WARNING) << "Unexpected file: " << offset_it->path().native();
-                    continue; /// Or just remove? Some unexpected file.
+                    st = Status::IOError("Unexpected file: {}", offset_it->path().native());
+                    break;
                 }
 
                 size = offset_it->file_size();
@@ -735,24 +813,18 @@ void LRUFileCache::load_cache_info_into_memory(std::lock_guard<std::mutex>& cach
                     }
                     continue;
                 }
-
-                if (try_reserve(key, TUniqueId(), is_persistent, offset, size, cache_lock)) {
-                    auto* cell = add_cell(key, is_persistent, offset, size,
-                                          FileBlock::State::DOWNLOADED, cache_lock);
-                    if (cell) {
-                        queue_entries.emplace_back(*cell->queue_iterator, is_persistent);
-                    }
+                context.cache_type = cache_type;
+                if (try_reserve(key, context, offset, size, cache_lock)) {
+                    add_cell(key, context, offset, size, FileBlock::State::DOWNLOADED,
+                             cache_lock);
+                    queue_entries.emplace_back(key, offset);
                 } else {
-                    LOG(WARNING) << "Cache capacity changed (max size: " << _max_size
-                                 << ", available: "
-                                 << get_available_cache_size_unlocked(is_persistent, cache_lock)
-                                 << "), cached file " << key_it->path().string()
-                                 << " does not fit in cache anymore (size: " << size << ")";
                     std::error_code ec;
-                    fs::remove(offset_it->path(), ec);
+                    std::filesystem::remove(offset_it->path(), ec);
                     if (ec) {
-                        LOG(WARNING) << ec.message();
+                        st = Status::IOError(ec.message());
                     }
+                    need_to_check_if_empty_dir.push_back(key_it->path());
                 }
             }
         }
@@ -778,15 +850,33 @@ void LRUFileCache::load_cache_info_into_memory(std::lock_guard<std::mutex>& cach
         fs::directory_iterator key_it {_cache_base_path};
         scan_file_cache(key_it);
     }
+    if (!st) {
+        return st;
+    }
+
+    std::for_each(need_to_check_if_empty_dir.cbegin(), need_to_check_if_empty_dir.cend(),
+                  [](auto& dir) {
+                      std::error_code ec;
+                      if (std::filesystem::is_empty(dir, ec) && !ec) {
+                          std::filesystem::remove(dir, ec);
+                      }
+                      if (ec) {
+                          LOG(ERROR) << ec.message();
+                      }
+                  });
 
     /// Shuffle cells to have random order in LRUQueue as at startup all cells have the same priority.
     auto rng = std::default_random_engine(
             static_cast<uint64_t>(std::chrono::steady_clock::now().time_since_epoch().count()));
     std::shuffle(queue_entries.begin(), queue_entries.end(), rng);
-    for (const auto& [it, is_persistent] : queue_entries) {
-        LRUQueue* queue = is_persistent ? &_persistent_queue : &_queue;
-        queue->move_to_end(it, cache_lock);
+    for (const auto& [key, offset] : queue_entries) {
+        auto* cell = get_cell(key, offset, cache_lock);
+        if (cell) {
+            auto& queue = get_queue(cell->cache_type);
+            queue.move_to_end(*cell->queue_iterator, cache_lock);
+        }
     }
+    return st;
 }
 
 Status LRUFileCache::write_file_cache_version() const {
@@ -821,65 +911,47 @@ std::string LRUFileCache::read_file_cache_version() const {
     return std::string(version, bytes_read);
 }
 
-std::vector<std::string> LRUFileCache::try_get_cache_paths(const Key& key, bool is_persistent) {
+size_t LRUFileCache::get_used_cache_size(CacheType cache_type) const {
     std::lock_guard cache_lock(_mutex);
-
-    std::vector<std::string> cache_paths;
-
-    const auto& cells_by_offset = _files[std::make_pair(key, is_persistent)];
-
-    for (const auto& [offset, cell] : cells_by_offset) {
-        if (cell.file_segment->state() == FileBlock::State::DOWNLOADED) {
-            cache_paths.push_back(get_path_in_local_cache(key, offset, is_persistent));
-        }
-    }
-
-    return cache_paths;
+    return get_used_cache_size_unlocked(cache_type, cache_lock);
 }
 
-size_t LRUFileCache::get_used_cache_size(bool is_persistent) const {
-    std::lock_guard cache_lock(_mutex);
-    return get_used_cache_size_unlocked(is_persistent, cache_lock);
-}
-
-size_t LRUFileCache::get_used_cache_size_unlocked(bool is_persistent,
+size_t LRUFileCache::get_used_cache_size_unlocked(CacheType cache_type,
                                                   std::lock_guard<std::mutex>& cache_lock) const {
-    return is_persistent ? _persistent_queue.get_total_cache_size(cache_lock)
-                         : _queue.get_total_cache_size(cache_lock);
+    return get_queue(cache_type).get_total_cache_size(cache_lock);
 }
 
-size_t LRUFileCache::get_available_cache_size(bool is_persistent) const {
+size_t LRUFileCache::get_available_cache_size(CacheType cache_type) const {
     std::lock_guard cache_lock(_mutex);
-    return get_available_cache_size_unlocked(is_persistent, cache_lock);
+    return get_available_cache_size_unlocked(cache_type, cache_lock);
 }
 
 size_t LRUFileCache::get_available_cache_size_unlocked(
-        bool is_persistent, std::lock_guard<std::mutex>& cache_lock) const {
-    size_t max_size = is_persistent ? _persistent_max_size : _max_size;
-    return max_size - get_used_cache_size_unlocked(is_persistent, cache_lock);
+        CacheType cache_type, std::lock_guard<std::mutex>& cache_lock) const {
+    return get_queue(cache_type).get_max_element_size() -
+           get_used_cache_size_unlocked(cache_type, cache_lock);
 }
 
-size_t LRUFileCache::get_file_segments_num(bool is_persistent) const {
+size_t LRUFileCache::get_file_segments_num(CacheType cache_type) const {
     std::lock_guard cache_lock(_mutex);
-    return get_file_segments_num_unlocked(is_persistent, cache_lock);
+    return get_file_segments_num_unlocked(cache_type, cache_lock);
 }
 
-size_t LRUFileCache::get_file_segments_num_unlocked(bool is_persistent,
-                                                    std::lock_guard<std::mutex>& cache_lock) const {
-    const LRUQueue* queue = is_persistent ? &_persistent_queue : &_queue;
-    return queue->get_elements_num(cache_lock);
+size_t LRUFileCache::get_file_segments_num_unlocked(CacheType cache_type,
+                                                  std::lock_guard<std::mutex>& cache_lock) const {
+    return get_queue(cache_type).get_elements_num(cache_lock);
 }
 
-LRUFileCache::FileBlockCell::FileBlockCell(FileBlockSPtr file_segment_, LRUFileCache* cache,
+LRUFileCache::FileBlockCell::FileBlockCell(FileBlockSPtr file_block, CacheType cache_type,
                                            std::lock_guard<std::mutex>& cache_lock)
-        : file_segment(file_segment_) {
+        : file_block(file_block), cache_type(cache_type) {
     /**
      * Cell can be created with either DOWNLOADED or EMPTY file segment's state.
      * File segment acquires DOWNLOADING state and creates LRUQueue iterator on first
      * successful getOrSetDownaloder call.
      */
 
-    switch (file_segment->_download_state) {
+    switch (file_block->_download_state) {
     case FileBlock::State::DOWNLOADED:
     case FileBlock::State::EMPTY:
     case FileBlock::State::SKIP_CACHE: {
@@ -887,15 +959,15 @@ LRUFileCache::FileBlockCell::FileBlockCell(FileBlockSPtr file_segment_, LRUFileC
     }
     default:
         DCHECK(false) << "Can create cell with either EMPTY, DOWNLOADED, SKIP_CACHE state, got: "
-                      << FileBlock::state_to_string(file_segment->_download_state);
+                      << FileBlock::state_to_string(file_block->_download_state);
     }
 }
 
 IFileCache::LRUQueue::Iterator IFileCache::LRUQueue::add(
-        const IFileCache::Key& key, size_t offset, bool is_persistent, size_t size,
+        const IFileCache::Key& key, size_t offset, size_t size,
         std::lock_guard<std::mutex>& /* cache_lock */) {
     cache_size += size;
-    return queue.insert(queue.end(), FileKeyAndOffset(key, offset, size, is_persistent));
+    return queue.insert(queue.end(), FileKeyAndOffset(key, offset, size));
 }
 
 void IFileCache::LRUQueue::remove(Iterator queue_it,
@@ -917,7 +989,7 @@ bool IFileCache::LRUQueue::contains(const IFileCache::Key& key, size_t offset,
                                     std::lock_guard<std::mutex>& /* cache_lock */) const {
     /// This method is used for assertions in debug mode.
     /// So we do not care about complexity here.
-    for (const auto& [entry_key, entry_offset, _, size] : queue) {
+    for (const auto& [entry_key, entry_offset, size] : queue) {
         if (key == entry_key && offset == entry_offset) {
             return true;
         }
@@ -927,7 +999,7 @@ bool IFileCache::LRUQueue::contains(const IFileCache::Key& key, size_t offset,
 
 std::string IFileCache::LRUQueue::to_string(std::lock_guard<std::mutex>& /* cache_lock */) const {
     std::string result;
-    for (const auto& [key, offset, _, size] : queue) {
+    for (const auto& [key, offset, size] : queue) {
         if (!result.empty()) {
             result += ", ";
         }
@@ -936,22 +1008,30 @@ std::string IFileCache::LRUQueue::to_string(std::lock_guard<std::mutex>& /* cach
     return result;
 }
 
-std::string LRUFileCache::dump_structure(const Key& key, bool is_persistent) {
+std::string LRUFileCache::dump_structure(const Key& key) {
     std::lock_guard cache_lock(_mutex);
-    return dump_structure_unlocked(key, is_persistent, cache_lock);
+    return dump_structure_unlocked(key, cache_lock);
 }
 
-std::string LRUFileCache::dump_structure_unlocked(const Key& key, bool is_persistent,
-                                                  std::lock_guard<std::mutex>& cache_lock) {
+std::string LRUFileCache::dump_structure_unlocked(const Key& key, std::lock_guard<std::mutex>&) {
     std::stringstream result;
-    const auto& cells_by_offset = _files[std::make_pair(key, is_persistent)];
+    const auto& cells_by_offset = _files[key];
 
-    for (const auto& [offset, cell] : cells_by_offset) {
-        result << cell.file_segment->get_info_for_log() << "\n";
+    for (const auto& [_, cell] : cells_by_offset) {
+        result << cell.file_block->get_info_for_log() << " "
+               << cache_type_to_string(cell.cache_type) << "\n";
     }
 
-    result << "\n\nQueue: " << _queue.to_string(cache_lock);
     return result.str();
+}
+
+void LRUFileCache::run_background_operation() {
+    int64_t interval_time_seconds = 20;
+    while (!_close) {
+        std::this_thread::sleep_for(std::chrono::seconds(interval_time_seconds));
+        // report
+        _cur_size_metrics->set_value(_cur_cache_size);
+    }
 }
 
 } // namespace io

--- a/be/src/io/cache/block/block_lru_file_cache.cpp
+++ b/be/src/io/cache/block/block_lru_file_cache.cpp
@@ -52,12 +52,6 @@
 #include "util/slice.h"
 #include "vec/common/hex.h"
 
-namespace doris {
-namespace io {
-struct FileCacheSettings;
-} // namespace io
-} // namespace doris
-
 namespace fs = std::filesystem;
 
 namespace doris {

--- a/be/src/io/cache/block/block_lru_file_cache.h
+++ b/be/src/io/cache/block/block_lru_file_cache.h
@@ -40,8 +40,6 @@ namespace doris {
 class TUniqueId;
 
 namespace io {
-struct FileCacheSettings;
-
 /**
  * Local cache for remote filesystem files, represented as a set of non-overlapping non-empty file segments.
  * Implements LRU eviction policy.

--- a/be/src/io/cache/block/block_lru_file_cache.h
+++ b/be/src/io/cache/block/block_lru_file_cache.h
@@ -26,11 +26,10 @@
 #include <mutex>
 #include <optional>
 #include <string>
+#include <thread>
 #include <unordered_map>
 #include <utility>
 #include <vector>
-#include <thread>
-#include <unordered_map>
 
 #include "common/status.h"
 #include "io/cache/block/block_file_cache.h"

--- a/be/src/io/cache/block/block_lru_file_cache.h
+++ b/be/src/io/cache/block/block_lru_file_cache.h
@@ -118,6 +118,13 @@ private:
 
     CachedFiles _files;
     size_t _cur_cache_size = 0;
+
+    // The three queues are level queue.
+    // It means as level1/level2/level3 queue.
+    // but the level2 is maximum.
+    // If some datas are importance, we can cache it into index queue
+    // If some datas are just use once, we can cache it into disposable queue
+    // The size proportion is [1:17:2].
     LRUQueue _index_queue;
     LRUQueue _normal_queue;
     LRUQueue _disposable_queue;

--- a/be/src/io/cache/block/block_lru_file_cache.h
+++ b/be/src/io/cache/block/block_lru_file_cache.h
@@ -30,6 +30,7 @@
 #include <utility>
 #include <vector>
 #include <thread>
+#include <unordered_map>
 
 #include "common/status.h"
 #include "io/cache/block/block_file_cache.h"
@@ -62,7 +63,8 @@ public:
     /**
      * get the files which range contain [offset, offset+size-1]
      */
-    FileBlocksHolder get_or_set(const Key& key, size_t offset, size_t size, const CacheContext& context) override;
+    FileBlocksHolder get_or_set(const Key& key, size_t offset, size_t size,
+                                const CacheContext& context) override;
 
     // init file cache
     Status initialize() override;
@@ -112,8 +114,7 @@ private:
         std::size_t operator()(const Key& k) const { return KeyHash()(k); }
     };
 
-    using CachedFiles =
-            std::unordered_map<Key, FileBlocksByOffset, HashCachedFileKey>;
+    using CachedFiles = std::unordered_map<Key, FileBlocksByOffset, HashCachedFileKey>;
 
     CachedFiles _files;
     size_t _cur_cache_size = 0;
@@ -124,15 +125,13 @@ private:
     LRUFileCache::LRUQueue& get_queue(CacheType type);
     const LRUFileCache::LRUQueue& get_queue(CacheType type) const;
 
-    FileBlocks get_impl(const Key& key, const CacheContext& context,
-                          const FileBlock::Range& range, std::lock_guard<std::mutex>& cache_lock);
+    FileBlocks get_impl(const Key& key, const CacheContext& context, const FileBlock::Range& range,
+                        std::lock_guard<std::mutex>& cache_lock);
 
-    FileBlockCell* get_cell(const Key& key, size_t offset,
-                              std::lock_guard<std::mutex>& cache_lock);
+    FileBlockCell* get_cell(const Key& key, size_t offset, std::lock_guard<std::mutex>& cache_lock);
 
-    FileBlockCell* add_cell(const Key& key, const CacheContext& context, size_t offset,
-                              size_t size, FileBlock::State state,
-                              std::lock_guard<std::mutex>& cache_lock);
+    FileBlockCell* add_cell(const Key& key, const CacheContext& context, size_t offset, size_t size,
+                            FileBlock::State state, std::lock_guard<std::mutex>& cache_lock);
 
     void use_cell(const FileBlockCell& cell, FileBlocks& result, bool not_need_move,
                   std::lock_guard<std::mutex>& cache_lock);
@@ -161,15 +160,15 @@ private:
     std::string read_file_cache_version() const;
 
     FileBlocks split_range_into_cells(const Key& key, const CacheContext& context, size_t offset,
-                                        size_t size, FileBlock::State state,
-                                        std::lock_guard<std::mutex>& cache_lock);
+                                      size_t size, FileBlock::State state,
+                                      std::lock_guard<std::mutex>& cache_lock);
 
     std::string dump_structure_unlocked(const Key& key, std::lock_guard<std::mutex>& cache_lock);
 
     void fill_holes_with_empty_file_blocks(FileBlocks& file_blocks, const Key& key,
-                                             const CacheContext& context,
-                                             const FileBlock::Range& range,
-                                             std::lock_guard<std::mutex>& cache_lock);
+                                           const CacheContext& context,
+                                           const FileBlock::Range& range,
+                                           std::lock_guard<std::mutex>& cache_lock);
 
     size_t get_used_cache_size_unlocked(CacheType type,
                                         std::lock_guard<std::mutex>& cache_lock) const;
@@ -179,7 +178,7 @@ private:
 
     size_t get_file_segments_num_unlocked(CacheType type,
                                           std::lock_guard<std::mutex>& cache_lock) const;
-    
+
     bool need_to_move(CacheType cell_type, CacheType query_type) const;
 
     void run_background_operation();

--- a/be/src/io/cache/block/block_lru_file_cache.h
+++ b/be/src/io/cache/block/block_lru_file_cache.h
@@ -29,6 +29,7 @@
 #include <unordered_map>
 #include <utility>
 #include <vector>
+#include <thread>
 
 #include "common/status.h"
 #include "io/cache/block/block_file_cache.h"
@@ -51,48 +52,55 @@ public:
      * cache_settings: the file cache setttings
      */
     LRUFileCache(const std::string& cache_base_path, const FileCacheSettings& cache_settings);
+    ~LRUFileCache() override {
+        _close = true;
+        if (_cache_background_thread.joinable()) {
+            _cache_background_thread.join();
+        }
+    };
 
     /**
      * get the files which range contain [offset, offset+size-1]
      */
-    FileBlocksHolder get_or_set(const Key& key, size_t offset, size_t size, bool is_persistent,
-                                const TUniqueId& query_id) override;
+    FileBlocksHolder get_or_set(const Key& key, size_t offset, size_t size, const CacheContext& context) override;
 
     // init file cache
     Status initialize() override;
 
-    // remove the files belong to key
-    void remove_if_exists(const Key& key, bool is_persistent) override;
+    size_t get_used_cache_size(CacheType type) const override;
 
-    // remove the files only catched by cache
-    void remove_if_releasable(bool is_persistent) override;
-
-    std::vector<std::string> try_get_cache_paths(const Key& key, bool is_persistent) override;
-
-    size_t get_used_cache_size(bool is_persistent) const override;
-
-    size_t get_file_segments_num(bool is_persistent) const override;
+    size_t get_file_segments_num(CacheType type) const override;
 
 private:
     struct FileBlockCell {
-        FileBlockSPtr file_segment;
+        FileBlockSPtr file_block;
+        CacheType cache_type;
 
         /// Iterator is put here on first reservation attempt, if successful.
         std::optional<LRUQueue::Iterator> queue_iterator;
 
-        /// Pointer to file segment is always hold by the cache itself.
+        mutable int64_t atime {0};
+        void update_atime() const {
+            atime = std::chrono::duration_cast<std::chrono::seconds>(
+                            std::chrono::steady_clock::now().time_since_epoch())
+                            .count();
+        }
+
+        /// Pointer to file block is always hold by the cache itself.
         /// Apart from pointer in cache, it can be hold by cache users, when they call
         /// getorSet(), but cache users always hold it via FileBlocksHolder.
-        bool releasable() const { return file_segment.unique(); }
+        bool releasable() const { return file_block.unique(); }
 
-        size_t size() const { return file_segment->_segment_range.size(); }
+        size_t size() const { return file_block->_segment_range.size(); }
 
-        FileBlockCell(FileBlockSPtr file_segment_, LRUFileCache* cache,
+        FileBlockCell(FileBlockSPtr file_block, CacheType cache_type,
                       std::lock_guard<std::mutex>& cache_lock);
 
         FileBlockCell(FileBlockCell&& other) noexcept
-                : file_segment(std::move(other.file_segment)),
-                  queue_iterator(other.queue_iterator) {}
+                : file_block(std::move(other.file_block)),
+                  cache_type(other.cache_type),
+                  queue_iterator(other.queue_iterator),
+                  atime(other.atime) {}
 
         FileBlockCell& operator=(const FileBlockCell&) = delete;
         FileBlockCell(const FileBlockCell&) = delete;
@@ -101,70 +109,87 @@ private:
     using FileBlocksByOffset = std::map<size_t, FileBlockCell>;
 
     struct HashCachedFileKey {
-        std::size_t operator()(const std::pair<Key, bool>& k) const { return KeyHash()(k.first); }
+        std::size_t operator()(const Key& k) const { return KeyHash()(k); }
     };
-    // key: <file key, is_persistent>
+
     using CachedFiles =
-            std::unordered_map<std::pair<Key, bool>, FileBlocksByOffset, HashCachedFileKey>;
+            std::unordered_map<Key, FileBlocksByOffset, HashCachedFileKey>;
 
     CachedFiles _files;
-    LRUQueue _queue;
-    LRUQueue _persistent_queue;
+    size_t _cur_cache_size = 0;
+    LRUQueue _index_queue;
+    LRUQueue _normal_queue;
+    LRUQueue _disposable_queue;
 
-    FileBlocks get_impl(const Key& key, const TUniqueId& query_id, bool is_persistent,
-                        const FileBlock::Range& range, std::lock_guard<std::mutex>& cache_lock);
+    LRUFileCache::LRUQueue& get_queue(CacheType type);
+    const LRUFileCache::LRUQueue& get_queue(CacheType type) const;
 
-    FileBlockCell* get_cell(const Key& key, bool is_persistent, size_t offset,
-                            std::lock_guard<std::mutex>& cache_lock);
+    FileBlocks get_impl(const Key& key, const CacheContext& context,
+                          const FileBlock::Range& range, std::lock_guard<std::mutex>& cache_lock);
 
-    FileBlockCell* add_cell(const Key& key, bool is_persistent, size_t offset, size_t size,
-                            FileBlock::State state, std::lock_guard<std::mutex>& cache_lock);
+    FileBlockCell* get_cell(const Key& key, size_t offset,
+                              std::lock_guard<std::mutex>& cache_lock);
 
-    void use_cell(const FileBlockCell& cell, const TUniqueId& query_id, bool is_persistent,
-                  FileBlocks& result, std::lock_guard<std::mutex>& cache_lock);
+    FileBlockCell* add_cell(const Key& key, const CacheContext& context, size_t offset,
+                              size_t size, FileBlock::State state,
+                              std::lock_guard<std::mutex>& cache_lock);
 
-    bool try_reserve(const Key& key, const TUniqueId& query_id, bool is_persistent, size_t offset,
-                     size_t size, std::lock_guard<std::mutex>& cache_lock) override;
+    void use_cell(const FileBlockCell& cell, FileBlocks& result, bool not_need_move,
+                  std::lock_guard<std::mutex>& cache_lock);
 
-    bool try_reserve_for_main_list(const Key& key, QueryFileCacheContextPtr query_context,
-                                   bool is_persistent, size_t offset, size_t size,
-                                   std::lock_guard<std::mutex>& cache_lock);
+    bool try_reserve(const Key& key, const CacheContext& context, size_t offset, size_t size,
+                     std::lock_guard<std::mutex>& cache_lock) override;
 
-    void remove(const Key& key, bool is_persistent, size_t offset,
-                std::lock_guard<std::mutex>& cache_lock,
+    bool try_reserve_for_lru(const Key& key, QueryFileCacheContextPtr query_context,
+                             const CacheContext& context, size_t offset, size_t size,
+                             std::lock_guard<std::mutex>& cache_lock);
+
+    std::vector<CacheType> get_other_cache_type(CacheType cur_cache_type);
+
+    bool try_reserve_from_other_queue(CacheType cur_cache_type, size_t offset, int64_t cur_time,
+                                      std::lock_guard<std::mutex>& cache_lock);
+
+    void remove(FileBlockSPtr file_block, std::lock_guard<std::mutex>& cache_lock,
                 std::lock_guard<std::mutex>& segment_lock) override;
 
-    size_t get_available_cache_size(bool is_persistent) const;
+    size_t get_available_cache_size(CacheType cache_type) const;
 
-    void load_cache_info_into_memory(std::lock_guard<std::mutex>& cache_lock);
+    Status load_cache_info_into_memory(std::lock_guard<std::mutex>& cache_lock);
 
     Status write_file_cache_version() const;
 
     std::string read_file_cache_version() const;
 
-    FileBlocks split_range_into_cells(const Key& key, const TUniqueId& query_id, bool is_persistent,
-                                      size_t offset, size_t size, FileBlock::State state,
-                                      std::lock_guard<std::mutex>& cache_lock);
-
-    std::string dump_structure_unlocked(const Key& key, bool is_persistent,
+    FileBlocks split_range_into_cells(const Key& key, const CacheContext& context, size_t offset,
+                                        size_t size, FileBlock::State state,
                                         std::lock_guard<std::mutex>& cache_lock);
 
-    void fill_holes_with_empty_file_segments(FileBlocks& file_segments, const Key& key,
-                                             const TUniqueId& query_id, bool is_persistent,
+    std::string dump_structure_unlocked(const Key& key, std::lock_guard<std::mutex>& cache_lock);
+
+    void fill_holes_with_empty_file_blocks(FileBlocks& file_blocks, const Key& key,
+                                             const CacheContext& context,
                                              const FileBlock::Range& range,
                                              std::lock_guard<std::mutex>& cache_lock);
 
-    size_t get_used_cache_size_unlocked(bool is_persistent,
+    size_t get_used_cache_size_unlocked(CacheType type,
                                         std::lock_guard<std::mutex>& cache_lock) const;
 
-    size_t get_available_cache_size_unlocked(bool is_persistent,
+    size_t get_available_cache_size_unlocked(CacheType type,
                                              std::lock_guard<std::mutex>& cache_lock) const;
 
-    size_t get_file_segments_num_unlocked(bool is_persistent,
+    size_t get_file_segments_num_unlocked(CacheType type,
                                           std::lock_guard<std::mutex>& cache_lock) const;
+    
+    bool need_to_move(CacheType cell_type, CacheType query_type) const;
+
+    void run_background_operation();
 
 public:
-    std::string dump_structure(const Key& key, bool is_persistent) override;
+    std::string dump_structure(const Key& key) override;
+
+private:
+    std::atomic_bool _close {false};
+    std::thread _cache_background_thread;
 };
 
 } // namespace io

--- a/be/src/io/cache/block/cached_remote_file_reader.cpp
+++ b/be/src/io/cache/block/cached_remote_file_reader.cpp
@@ -89,8 +89,7 @@ Status CachedRemoteFileReader::read_at_impl(size_t offset, Slice result, size_t*
     ReadStatistics stats;
     auto [align_left, align_size] = _align_size(offset, bytes_req);
     CacheContext cache_context(io_ctx);
-    FileBlocksHolder holder =
-            _cache->get_or_set(_cache_key, align_left, align_size, cache_context);
+    FileBlocksHolder holder = _cache->get_or_set(_cache_key, align_left, align_size, cache_context);
     std::vector<FileBlockSPtr> empty_segments;
     for (auto& segment : holder.file_segments) {
         switch (segment->state()) {

--- a/be/src/io/cache/block/cached_remote_file_reader.h
+++ b/be/src/io/cache/block/cached_remote_file_reader.h
@@ -65,7 +65,6 @@ private:
     FileReaderSPtr _remote_file_reader;
     IFileCache::Key _cache_key;
     CloudFileCachePtr _cache;
-    CloudFileCachePtr _disposable_cache;
 
     struct ReadStatistics {
         bool hit_cache = true;

--- a/be/src/io/io_common.h
+++ b/be/src/io/io_common.h
@@ -49,17 +49,15 @@ class IOContext {
 public:
     IOContext() = default;
 
-    IOContext(const TUniqueId* query_id_, FileCacheStatistics* stats_, bool is_presistent_,
-              bool use_disposable_cache_, bool read_segment_index_, bool enable_file_cache)
-            : query_id(query_id_),
-              is_persistent(is_presistent_),
-              use_disposable_cache(use_disposable_cache_),
-              read_segment_index(read_segment_index_),
-              file_cache_stats(stats_) {}
+    IOContext(const TUniqueId* query_id, FileCacheStatistics* stats,
+              bool use_disposable_cache, bool read_segment_index)
+            : query_id(query_id),
+              is_disposable(use_disposable_cache),
+              read_segment_index(read_segment_index),
+              file_cache_stats(stats) {}
     ReaderType reader_type;
     const TUniqueId* query_id = nullptr;
-    bool is_persistent = false;
-    bool use_disposable_cache = false;
+    bool is_disposable = false;
     bool read_segment_index = false;
     FileCacheStatistics* file_cache_stats = nullptr;
 };

--- a/be/src/io/io_common.h
+++ b/be/src/io/io_common.h
@@ -49,8 +49,8 @@ class IOContext {
 public:
     IOContext() = default;
 
-    IOContext(const TUniqueId* query_id, FileCacheStatistics* stats,
-              bool use_disposable_cache, bool read_segment_index)
+    IOContext(const TUniqueId* query_id, FileCacheStatistics* stats, bool use_disposable_cache,
+              bool read_segment_index)
             : query_id(query_id),
               is_disposable(use_disposable_cache),
               read_segment_index(read_segment_index),

--- a/be/src/olap/options.cpp
+++ b/be/src/olap/options.cpp
@@ -50,8 +50,7 @@ static std::string HDD_UC = "HDD";
 static std::string REMOTE_CACHE_UC = "REMOTE_CACHE";
 
 static std::string CACHE_PATH = "path";
-static std::string CACHE_NORMAL_SIZE = "normal";
-static std::string CACHE_PERSISTENT_SIZE = "persistent";
+static std::string CACHE_TOTAL_SIZE = "total_size";
 static std::string CACHE_QUERY_LIMIT_SIZE = "query_limit";
 
 // TODO: should be a general util method
@@ -167,9 +166,9 @@ Status parse_conf_store_paths(const string& config_path, std::vector<StorePath>*
 
 /** format:   
  *  [
- *    {"path": "storage1", "normal":53687091200,"persistent":21474836480,"query_limit": "10737418240"},
- *    {"path": "storage2", "normal":53687091200,"persistent":21474836480},
- *    {"path": "storage3", "normal":53687091200,"persistent":21474836480},
+ *    {"path": "storage1", "total_size":53687091200,"query_limit": "10737418240"},
+ *    {"path": "storage2", "total_size":53687091200},
+ *    {"path": "storage3", "total_size":53687091200},
  *  ]
  */
 Status parse_conf_cache_paths(const std::string& config_path, std::vector<CachePath>& paths) {
@@ -181,45 +180,57 @@ Status parse_conf_cache_paths(const std::string& config_path, std::vector<CacheP
         auto map = config.GetObject();
         DCHECK(map.HasMember(CACHE_PATH.c_str()));
         std::string path = map.FindMember(CACHE_PATH.c_str())->value.GetString();
-        int64_t normal_size = map.HasMember(CACHE_NORMAL_SIZE.c_str())
-                                      ? map.FindMember(CACHE_NORMAL_SIZE.c_str())->value.GetInt64()
-                                      : 0;
-        int64_t persistent_size =
-                map.HasMember(CACHE_PERSISTENT_SIZE.c_str())
-                        ? map.FindMember(CACHE_PERSISTENT_SIZE.c_str())->value.GetInt64()
-                        : 0;
-        int64_t query_limit_bytes = 0;
+        int64_t total_size = 0, query_limit_bytes = 0;
+        if (map.HasMember(CACHE_TOTAL_SIZE.c_str())) {
+            auto& value = map.FindMember(CACHE_TOTAL_SIZE.c_str())->value;
+            if (value.IsInt64()) {
+                total_size = value.GetInt64();
+            } else {
+                return Status::InvalidArgument("normal should be int64");
+            }
+        }
         if (config::enable_file_cache_query_limit) {
-            query_limit_bytes =
-                    map.HasMember(CACHE_QUERY_LIMIT_SIZE.c_str())
-                            ? map.FindMember(CACHE_QUERY_LIMIT_SIZE.c_str())->value.GetInt64()
-                            : normal_size / 5;
+            if (map.HasMember(CACHE_QUERY_LIMIT_SIZE.c_str())) {
+                auto& value = map.FindMember(CACHE_QUERY_LIMIT_SIZE.c_str())->value;
+                if (value.IsInt64()) {
+                    query_limit_bytes = value.GetInt64();
+                } else {
+                    return Status::InvalidArgument("query_limit should be int64");
+                }
+            }
         }
-        if (normal_size <= 0 || persistent_size <= 0) {
-            LOG(WARNING) << "normal or persistent size should not less than or equal to zero";
-            return Status::InternalError("OLAP_ERR_INPUT_PARAMETER_ERROR");
+        if (total_size <= 0 || (config::enable_file_cache_query_limit && query_limit_bytes <= 0)) {
+            return Status::InvalidArgument("total_size or query_limit should not less than or equal to zero");
         }
-        paths.emplace_back(std::move(path), normal_size, persistent_size, query_limit_bytes);
+        paths.emplace_back(std::move(path), total_size, query_limit_bytes);
     }
     if (paths.empty()) {
-        LOG(WARNING) << "fail to parse storage_root_path config. value=[" << config_path << "]";
-        return Status::InternalError("OLAP_ERR_INPUT_PARAMETER_ERROR");
+        return Status::InvalidArgument("fail to parse storage_root_path config. value={}", config_path);
     }
     return Status::OK();
 }
 
 io::FileCacheSettings CachePath::init_settings() const {
     io::FileCacheSettings settings;
-    settings.max_size = normal_bytes;
-    settings.persistent_max_size = persistent_bytes;
+    settings.total_size = total_bytes;
     settings.max_file_segment_size = config::file_cache_max_file_segment_size;
-
-    settings.max_elements = std::max<size_t>(
-            normal_bytes / config::file_cache_max_file_segment_size, settings.max_elements);
-    settings.persistent_max_elements =
-            std::max<size_t>(persistent_bytes / config::file_cache_max_file_segment_size,
-                             settings.persistent_max_elements);
     settings.max_query_cache_size = query_limit_bytes;
+    size_t per_size = settings.total_size / io::percentage[3];
+    settings.disposable_queue_size = per_size * io::percentage[1];
+    settings.disposable_queue_elements =
+            std::max(settings.disposable_queue_size / settings.max_file_segment_size,
+                     io::REMOTE_FS_OBJECTS_CACHE_DEFAULT_ELEMENTS);
+
+    settings.index_queue_size = per_size * io::percentage[2];
+    settings.index_queue_elements =
+            std::max(settings.index_queue_size / settings.max_file_segment_size,
+                     io::REMOTE_FS_OBJECTS_CACHE_DEFAULT_ELEMENTS);
+
+    settings.query_queue_size =
+            settings.total_size - settings.disposable_queue_size - settings.index_queue_size;
+    settings.query_queue_elements =
+            std::max(settings.query_queue_size / settings.max_file_segment_size,
+                     io::REMOTE_FS_OBJECTS_CACHE_DEFAULT_ELEMENTS);
     return settings;
 }
 

--- a/be/src/olap/options.cpp
+++ b/be/src/olap/options.cpp
@@ -200,12 +200,14 @@ Status parse_conf_cache_paths(const std::string& config_path, std::vector<CacheP
             }
         }
         if (total_size <= 0 || (config::enable_file_cache_query_limit && query_limit_bytes <= 0)) {
-            return Status::InvalidArgument("total_size or query_limit should not less than or equal to zero");
+            return Status::InvalidArgument(
+                    "total_size or query_limit should not less than or equal to zero");
         }
         paths.emplace_back(std::move(path), total_size, query_limit_bytes);
     }
     if (paths.empty()) {
-        return Status::InvalidArgument("fail to parse storage_root_path config. value={}", config_path);
+        return Status::InvalidArgument("fail to parse storage_root_path config. value={}",
+                                       config_path);
     }
     return Status::OK();
 }

--- a/be/src/olap/options.cpp
+++ b/be/src/olap/options.cpp
@@ -186,7 +186,7 @@ Status parse_conf_cache_paths(const std::string& config_path, std::vector<CacheP
             if (value.IsInt64()) {
                 total_size = value.GetInt64();
             } else {
-                return Status::InvalidArgument("normal should be int64");
+                return Status::InvalidArgument("total_size should be int64");
             }
         }
         if (config::enable_file_cache_query_limit) {

--- a/be/src/olap/options.h
+++ b/be/src/olap/options.h
@@ -49,18 +49,14 @@ Status parse_conf_store_paths(const std::string& config_path, std::vector<StoreP
 
 struct CachePath {
     io::FileCacheSettings init_settings() const;
-    CachePath(std::string path, int64_t normal_bytes, int64_t persistent_bytes,
-              int64_t query_limit_bytes)
+    CachePath(std::string path, int64_t total_bytes, int64_t query_limit_bytes)
             : path(std::move(path)),
-              normal_bytes(normal_bytes),
-              persistent_bytes(persistent_bytes),
+              total_bytes(total_bytes),
               query_limit_bytes(query_limit_bytes) {}
     std::string path;
-    int64_t normal_bytes = 0;
-    int64_t persistent_bytes = 0;
+    int64_t total_bytes = 0;
     int64_t query_limit_bytes = 0;
 };
-
 Status parse_conf_cache_paths(const std::string& config_path, std::vector<CachePath>& path);
 
 struct EngineOptions {

--- a/be/test/io/cache/file_block_cache_test.cpp
+++ b/be/test/io/cache/file_block_cache_test.cpp
@@ -193,8 +193,7 @@ void test_file_cache(io::CacheType cache_type) {
             auto segments = fromHolder(holder);
             /// Range was not present in cache. It should be added in cache as one while file segment.
             ASSERT_GE(segments.size(), 1);
-            assert_range(1, segments[0], io::FileBlock::Range(0, 9),
-                         io::FileBlock::State::EMPTY);
+            assert_range(1, segments[0], io::FileBlock::Range(0, 9), io::FileBlock::State::EMPTY);
             ASSERT_TRUE(segments[0]->get_or_set_downloader() == io::FileBlock::get_caller_id());
             assert_range(2, segments[0], io::FileBlock::Range(0, 9),
                          io::FileBlock::State::DOWNLOADING);
@@ -215,8 +214,7 @@ void test_file_cache(io::CacheType cache_type) {
 
             assert_range(4, segments[0], io::FileBlock::Range(0, 9),
                          io::FileBlock::State::DOWNLOADED);
-            assert_range(5, segments[1], io::FileBlock::Range(10, 14),
-                         io::FileBlock::State::EMPTY);
+            assert_range(5, segments[1], io::FileBlock::Range(10, 14), io::FileBlock::State::EMPTY);
 
             ASSERT_TRUE(segments[1]->get_or_set_downloader() == io::FileBlock::get_caller_id());
             download(segments[1]);
@@ -356,8 +354,7 @@ void test_file_cache(io::CacheType cache_type) {
             auto holder5 = cache.get_or_set(key, 2, 3, context); /// Get [2, 4]
             auto s5 = fromHolder(holder5);
             ASSERT_EQ(s5.size(), 1);
-            assert_range(25, s5[0], io::FileBlock::Range(0, 9),
-                         io::FileBlock::State::DOWNLOADED);
+            assert_range(25, s5[0], io::FileBlock::Range(0, 9), io::FileBlock::State::DOWNLOADED);
 
             auto holder1 = cache.get_or_set(key, 30, 2, context); /// Get [30, 31]
             auto s1 = fromHolder(holder1);
@@ -388,10 +385,8 @@ void test_file_cache(io::CacheType cache_type) {
             auto f = fromHolder(holder6);
             ASSERT_EQ(f.size(), 12);
 
-            assert_range(29, f[9], io::FileBlock::Range(28, 29),
-                         io::FileBlock::State::SKIP_CACHE);
-            assert_range(30, f[11], io::FileBlock::Range(32, 39),
-                         io::FileBlock::State::SKIP_CACHE);
+            assert_range(29, f[9], io::FileBlock::Range(28, 29), io::FileBlock::State::SKIP_CACHE);
+            assert_range(30, f[11], io::FileBlock::Range(32, 39), io::FileBlock::State::SKIP_CACHE);
         }
         {
             auto holder = cache.get_or_set(key, 2, 3, context); /// Get [2, 4]
@@ -436,8 +431,7 @@ void test_file_cache(io::CacheType cache_type) {
                 assert_range(37, segments_2[2], io::FileBlock::Range(28, 29),
                              io::FileBlock::State::DOWNLOADING);
 
-                ASSERT_TRUE(segments[2]->get_or_set_downloader() !=
-                            io::FileBlock::get_caller_id());
+                ASSERT_TRUE(segments[2]->get_or_set_downloader() != io::FileBlock::get_caller_id());
                 ASSERT_TRUE(segments[2]->state() == io::FileBlock::State::DOWNLOADING);
 
                 {
@@ -487,7 +481,6 @@ void test_file_cache(io::CacheType cache_type) {
             assert_range(38, segments[2], io::FileBlock::Range(24, 26),
                          io::FileBlock::State::DOWNLOADED);
 
-
             bool lets_start_download = false;
             std::mutex mutex;
             std::condition_variable cv;
@@ -533,7 +526,7 @@ void test_file_cache(io::CacheType cache_type) {
         }
     }
     /// Current cache:    [__________][___][___][_][__]
-    ///                   ^          ^      ^    ^  ^ ^ 
+    ///                   ^          ^      ^    ^  ^ ^
     ///                   0          9      24  26 27  29
     {
         /// Test LRUCache::restore().
@@ -574,10 +567,8 @@ void test_file_cache(io::CacheType cache_type) {
 
         ASSERT_EQ(segments1.size(), 3);
         assert_range(48, segments1[0], io::FileBlock::Range(0, 9), io::FileBlock::State::EMPTY);
-        assert_range(49, segments1[1], io::FileBlock::Range(10, 19),
-                     io::FileBlock::State::EMPTY);
-        assert_range(50, segments1[2], io::FileBlock::Range(20, 24),
-                     io::FileBlock::State::EMPTY);
+        assert_range(49, segments1[1], io::FileBlock::Range(10, 19), io::FileBlock::State::EMPTY);
+        assert_range(50, segments1[2], io::FileBlock::Range(20, 24), io::FileBlock::State::EMPTY);
     }
 }
 
@@ -611,7 +602,7 @@ TEST(LRUFileCache, resize) {
     fs::create_directories(cache_base_path);
     test_file_cache(io::CacheType::INDEX);
     /// Current cache:    [__________][___][___][_][__]
-    ///                   ^          ^      ^    ^  ^ ^ 
+    ///                   ^          ^      ^    ^  ^ ^
     ///                   0          9      24  26 27  29
     io::FileCacheSettings settings;
     settings.index_queue_elements = 5;
@@ -655,8 +646,7 @@ TEST(LRUFileCache, query_limit_heap_use_after_free) {
         ASSERT_GE(segments.size(), 1);
         assert_range(1, segments[0], io::FileBlock::Range(0, 8), io::FileBlock::State::EMPTY);
         ASSERT_TRUE(segments[0]->get_or_set_downloader() == io::FileBlock::get_caller_id());
-        assert_range(2, segments[0], io::FileBlock::Range(0, 8),
-                     io::FileBlock::State::DOWNLOADING);
+        assert_range(2, segments[0], io::FileBlock::Range(0, 8), io::FileBlock::State::DOWNLOADING);
         download(segments[0]);
     }
     TUniqueId query_id;
@@ -670,8 +660,7 @@ TEST(LRUFileCache, query_limit_heap_use_after_free) {
         ASSERT_GE(segments.size(), 1);
         assert_range(1, segments[0], io::FileBlock::Range(9, 9), io::FileBlock::State::EMPTY);
         ASSERT_TRUE(segments[0]->get_or_set_downloader() == io::FileBlock::get_caller_id());
-        assert_range(2, segments[0], io::FileBlock::Range(9, 9),
-                     io::FileBlock::State::DOWNLOADING);
+        assert_range(2, segments[0], io::FileBlock::Range(9, 9), io::FileBlock::State::DOWNLOADING);
         download(segments[0]);
     }
     {
@@ -688,8 +677,7 @@ TEST(LRUFileCache, query_limit_heap_use_after_free) {
         auto holder = cache.get_or_set(key, 0, 9, context); /// Add range [0, 8]
         auto segments = fromHolder(holder);
         ASSERT_GE(segments.size(), 1);
-        assert_range(5, segments[0], io::FileBlock::Range(0, 8),
-                     io::FileBlock::State::DOWNLOADED);
+        assert_range(5, segments[0], io::FileBlock::Range(0, 8), io::FileBlock::State::DOWNLOADED);
     }
     {
         auto holder = cache.get_or_set(key, 15, 1, context); /// Add range [15, 15]
@@ -740,8 +728,7 @@ TEST(LRUFileCache, query_limit_dcheck) {
         ASSERT_GE(segments.size(), 1);
         assert_range(1, segments[0], io::FileBlock::Range(0, 8), io::FileBlock::State::EMPTY);
         ASSERT_TRUE(segments[0]->get_or_set_downloader() == io::FileBlock::get_caller_id());
-        assert_range(2, segments[0], io::FileBlock::Range(0, 8),
-                     io::FileBlock::State::DOWNLOADING);
+        assert_range(2, segments[0], io::FileBlock::Range(0, 8), io::FileBlock::State::DOWNLOADING);
         download(segments[0]);
     }
     TUniqueId query_id;
@@ -755,8 +742,7 @@ TEST(LRUFileCache, query_limit_dcheck) {
         ASSERT_GE(segments.size(), 1);
         assert_range(1, segments[0], io::FileBlock::Range(9, 9), io::FileBlock::State::EMPTY);
         ASSERT_TRUE(segments[0]->get_or_set_downloader() == io::FileBlock::get_caller_id());
-        assert_range(2, segments[0], io::FileBlock::Range(9, 9),
-                     io::FileBlock::State::DOWNLOADING);
+        assert_range(2, segments[0], io::FileBlock::Range(9, 9), io::FileBlock::State::DOWNLOADING);
         download(segments[0]);
     }
     {
@@ -773,8 +759,7 @@ TEST(LRUFileCache, query_limit_dcheck) {
         auto holder = cache.get_or_set(key, 0, 9, context); /// Add range [0, 8]
         auto segments = fromHolder(holder);
         ASSERT_GE(segments.size(), 1);
-        assert_range(5, segments[0], io::FileBlock::Range(0, 8),
-                     io::FileBlock::State::DOWNLOADED);
+        assert_range(5, segments[0], io::FileBlock::Range(0, 8), io::FileBlock::State::DOWNLOADED);
     }
     {
         auto holder = cache.get_or_set(key, 15, 1, context); /// Add range [15, 15]
@@ -793,8 +778,7 @@ TEST(LRUFileCache, query_limit_dcheck) {
         ASSERT_GE(segments.size(), 1);
         assert_range(1, segments[0], io::FileBlock::Range(9, 9), io::FileBlock::State::EMPTY);
         ASSERT_TRUE(segments[0]->get_or_set_downloader() == io::FileBlock::get_caller_id());
-        assert_range(2, segments[0], io::FileBlock::Range(9, 9),
-                     io::FileBlock::State::DOWNLOADING);
+        assert_range(2, segments[0], io::FileBlock::Range(9, 9), io::FileBlock::State::DOWNLOADING);
         download(segments[0]);
     }
     {

--- a/be/test/io/cache/file_block_cache_test.cpp
+++ b/be/test/io/cache/file_block_cache_test.cpp
@@ -103,31 +103,55 @@ TEST(LRUFileCache, init) {
         [
         {
             "path" : "/mnt/ssd01/clickbench/hot/be/file_cache",
-            "normal" : 193273528320,
-            "persistent" : 193273528320,
+            "total_size" : 193273528320,
             "query_limit" : 38654705664
         },
         {
             "path" : "/mnt/ssd01/clickbench/hot/be/file_cache",
-            "normal" : 193273528320,
-            "persistent" : 193273528320,
+            "total_size" : 193273528320,
             "query_limit" : 38654705664
         }
         ]
         )");
     config::enable_file_cache_query_limit = true;
     std::vector<CachePath> cache_paths;
-    parse_conf_cache_paths(string, cache_paths);
+    EXPECT_TRUE(parse_conf_cache_paths(string, cache_paths));
     EXPECT_EQ(cache_paths.size(), 2);
     for (const auto& cache_path : cache_paths) {
         io::FileCacheSettings settings = cache_path.init_settings();
-        EXPECT_EQ(settings.max_size, 193273528320);
-        EXPECT_EQ(settings.persistent_max_size, 193273528320);
+        EXPECT_EQ(settings.total_size, 193273528320);
         EXPECT_EQ(settings.max_query_cache_size, 38654705664);
     }
+
+    // err normal
+    std::string err_string = std::string(R"(
+        [
+        {
+            "path" : "/mnt/ssd01/clickbench/hot/be/file_cache",
+            "total_size" : "193273528320",
+            "query_limit" : 38654705664
+        }
+        ]
+        )");
+    cache_paths.clear();
+    EXPECT_FALSE(parse_conf_cache_paths(err_string, cache_paths));
+
+    // err query_limit
+    err_string = std::string(R"(
+        [
+        {
+            "path" : "/mnt/ssd01/clickbench/hot/be/file_cache",
+            "normal" : 193273528320,
+            "persistent" : 193273528320,
+            "query_limit" : "38654705664"
+        }
+        ]
+        )");
+    cache_paths.clear();
+    EXPECT_FALSE(parse_conf_cache_paths(err_string, cache_paths));
 }
 
-void test_file_cache(bool is_persistent) {
+void test_file_cache(io::CacheType cache_type) {
     TUniqueId query_id;
     query_id.hi = 1;
     query_id.lo = 1;
@@ -137,52 +161,62 @@ void test_file_cache(bool is_persistent) {
     other_query_id.lo = 2;
 
     io::FileCacheSettings settings;
-    settings.max_size = 30;
-    settings.max_elements = 5;
-    settings.persistent_max_size = 30;
-    settings.persistent_max_elements = 5;
-    settings.max_file_segment_size = 100;
-    auto key = io::IFileCache::hash("key1");
+    switch (cache_type) {
+    case io::CacheType::INDEX:
+        settings.index_queue_elements = 5;
+        settings.index_queue_size = 30;
+        break;
+    case io::CacheType::NORMAL:
+        settings.query_queue_size = 30;
+        settings.query_queue_elements = 5;
+        break;
+    case io::CacheType::DISPOSABLE:
+        settings.disposable_queue_size = 30;
+        settings.disposable_queue_elements = 5;
+        break;
+    default:
+        break;
+    }
+    settings.total_size = 30;
+    settings.max_file_segment_size = 30;
+    settings.max_query_cache_size = 30;
+    io::CacheContext context, other_context;
+    context.cache_type = other_context.cache_type = cache_type;
+    context.query_id = query_id;
+    other_context.query_id = other_query_id;
+    auto key = io::LRUFileCache::hash("key1");
     {
         io::LRUFileCache cache(cache_base_path, settings);
-        cache.initialize();
+        ASSERT_TRUE(cache.initialize());
         {
-            auto holder =
-                    cache.get_or_set(key, 0, 10, is_persistent, query_id); /// Add range [0, 9]
+            auto holder = cache.get_or_set(key, 0, 10, context); /// Add range [0, 9]
             auto segments = fromHolder(holder);
             /// Range was not present in cache. It should be added in cache as one while file segment.
             ASSERT_GE(segments.size(), 1);
-
-            assert_range(1, segments[0], io::FileBlock::Range(0, 9), io::FileBlock::State::EMPTY);
-
-            /// Exception because space not reserved.
-            /// EXPECT_THROW(download(segments[0]), DB::Exception);
-            /// Exception because space can be reserved only by downloader
-            /// EXPECT_THROW(segments[0]->reserve(segments[0]->range().size()), DB::Exception);
+            assert_range(1, segments[0], io::FileBlock::Range(0, 9),
+                         io::FileBlock::State::EMPTY);
             ASSERT_TRUE(segments[0]->get_or_set_downloader() == io::FileBlock::get_caller_id());
             assert_range(2, segments[0], io::FileBlock::Range(0, 9),
                          io::FileBlock::State::DOWNLOADING);
-
             download(segments[0]);
             assert_range(3, segments[0], io::FileBlock::Range(0, 9),
                          io::FileBlock::State::DOWNLOADED);
         }
-
         /// Current cache:    [__________]
         ///                   ^          ^
         ///                   0          9
-        ASSERT_EQ(cache.get_file_segments_num(is_persistent), 1);
-        ASSERT_EQ(cache.get_used_cache_size(is_persistent), 10);
-
+        ASSERT_EQ(cache.get_file_segments_num(cache_type), 1);
+        ASSERT_EQ(cache.get_used_cache_size(cache_type), 10);
         {
             /// Want range [5, 14], but [0, 9] already in cache, so only [10, 14] will be put in cache.
-            auto holder = cache.get_or_set(key, 5, 10, is_persistent, query_id);
+            auto holder = cache.get_or_set(key, 5, 10, context);
             auto segments = fromHolder(holder);
             ASSERT_EQ(segments.size(), 2);
 
             assert_range(4, segments[0], io::FileBlock::Range(0, 9),
                          io::FileBlock::State::DOWNLOADED);
-            assert_range(5, segments[1], io::FileBlock::Range(10, 14), io::FileBlock::State::EMPTY);
+            assert_range(5, segments[1], io::FileBlock::Range(10, 14),
+                         io::FileBlock::State::EMPTY);
 
             ASSERT_TRUE(segments[1]->get_or_set_downloader() == io::FileBlock::get_caller_id());
             download(segments[1]);
@@ -193,19 +227,18 @@ void test_file_cache(bool is_persistent) {
         /// Current cache:    [__________][_____]
         ///                   ^          ^^     ^
         ///                   0          910    14
-        ASSERT_EQ(cache.get_file_segments_num(is_persistent), 2);
-        ASSERT_EQ(cache.get_used_cache_size(is_persistent), 15);
+        ASSERT_EQ(cache.get_file_segments_num(cache_type), 2);
+        ASSERT_EQ(cache.get_used_cache_size(cache_type), 15);
 
         {
-            auto holder = cache.get_or_set(key, 9, 1, is_persistent, query_id); /// Get [9, 9]
+            auto holder = cache.get_or_set(key, 9, 1, context); /// Get [9, 9]
             auto segments = fromHolder(holder);
             ASSERT_EQ(segments.size(), 1);
             assert_range(7, segments[0], io::FileBlock::Range(0, 9),
                          io::FileBlock::State::DOWNLOADED);
         }
-
         {
-            auto holder = cache.get_or_set(key, 9, 2, is_persistent, query_id); /// Get [9, 10]
+            auto holder = cache.get_or_set(key, 9, 2, context); /// Get [9, 10]
             auto segments = fromHolder(holder);
             ASSERT_EQ(segments.size(), 2);
             assert_range(8, segments[0], io::FileBlock::Range(0, 9),
@@ -213,71 +246,69 @@ void test_file_cache(bool is_persistent) {
             assert_range(9, segments[1], io::FileBlock::Range(10, 14),
                          io::FileBlock::State::DOWNLOADED);
         }
-
         {
-            auto holder = cache.get_or_set(key, 10, 1, is_persistent, query_id); /// Get [10, 10]
+            auto holder = cache.get_or_set(key, 10, 1, context); /// Get [10, 10]
             auto segments = fromHolder(holder);
             ASSERT_EQ(segments.size(), 1);
             assert_range(10, segments[0], io::FileBlock::Range(10, 14),
                          io::FileBlock::State::DOWNLOADED);
         }
-
-        complete(cache.get_or_set(key, 17, 4, is_persistent, query_id)); /// Get [17, 20]
-        complete(cache.get_or_set(key, 24, 3, is_persistent, query_id)); /// Get [24, 26]
+        complete(cache.get_or_set(key, 17, 4, context)); /// Get [17, 20]
+        complete(cache.get_or_set(key, 24, 3, context)); /// Get [24, 26]
 
         /// Current cache:    [__________][_____]   [____]    [___]
         ///                   ^          ^^     ^   ^    ^    ^   ^
         ///                   0          910    14  17   20   24  26
         ///
-        ASSERT_EQ(cache.get_file_segments_num(is_persistent), 4);
-        ASSERT_EQ(cache.get_used_cache_size(is_persistent), 22);
-
+        ASSERT_EQ(cache.get_file_segments_num(cache_type), 4);
+        ASSERT_EQ(cache.get_used_cache_size(cache_type), 22);
         {
-            auto holder = cache.get_or_set(key, 0, 26, is_persistent, query_id); /// Get [0, 25]
+            auto holder = cache.get_or_set(key, 0, 31, context); /// Get [0, 25]
             auto segments = fromHolder(holder);
-            ASSERT_EQ(segments.size(), 6);
-
+            ASSERT_EQ(segments.size(), 7);
             assert_range(11, segments[0], io::FileBlock::Range(0, 9),
                          io::FileBlock::State::DOWNLOADED);
             assert_range(12, segments[1], io::FileBlock::Range(10, 14),
                          io::FileBlock::State::DOWNLOADED);
-
             /// Missing [15, 16] should be added in cache.
             assert_range(13, segments[2], io::FileBlock::Range(15, 16),
                          io::FileBlock::State::EMPTY);
-
             ASSERT_TRUE(segments[2]->get_or_set_downloader() == io::FileBlock::get_caller_id());
             download(segments[2]);
 
             assert_range(14, segments[3], io::FileBlock::Range(17, 20),
                          io::FileBlock::State::DOWNLOADED);
 
-            /// New [21, 23], but will not be added in cache because of elements limit (5)
             assert_range(15, segments[4], io::FileBlock::Range(21, 23),
-                         io::FileBlock::State::SKIP_CACHE);
+                         io::FileBlock::State::EMPTY);
 
             assert_range(16, segments[5], io::FileBlock::Range(24, 26),
                          io::FileBlock::State::DOWNLOADED);
 
-            /// Current cache:    [__________][_____][   ][____]    [___]
-            ///                   ^                            ^    ^
-            ///                   0                            20   24
+            assert_range(16, segments[6], io::FileBlock::Range(27, 30),
+                         io::FileBlock::State::SKIP_CACHE);
+            /// Current cache:    [__________][_____][   ][____________]
+            ///                   ^                       ^            ^
+            ///                   0                        20          26
             ///
 
-            /// Range [27, 27] must be evicted in previous getOrSet [0, 25].
+            /// Range [27, 30] must be evicted in previous getOrSet [0, 25].
             /// Let's not invalidate pointers to returned segments from range [0, 25] and
             /// as max elements size is reached, next attempt to put something in cache should fail.
             /// This will also check that [27, 27] was indeed evicted.
 
-            auto holder1 = cache.get_or_set(key, 27, 1, is_persistent, query_id);
-            auto segments_1 = fromHolder(holder1); /// Get [27, 27]
+            auto holder1 = cache.get_or_set(key, 27, 4, context);
+            auto segments_1 = fromHolder(holder1); /// Get [27, 30]
             ASSERT_EQ(segments_1.size(), 1);
-            assert_range(17, segments_1[0], io::FileBlock::Range(27, 27),
+            assert_range(17, segments_1[0], io::FileBlock::Range(27, 30),
                          io::FileBlock::State::SKIP_CACHE);
         }
-
+        /// Current cache:    [__________][_____][_][____]    [___]
+        ///                   ^          ^^     ^   ^    ^    ^   ^
+        ///                   0          910    14  17   20   24  26
+        ///
         {
-            auto holder = cache.get_or_set(key, 12, 10, is_persistent, query_id); /// Get [12, 21]
+            auto holder = cache.get_or_set(key, 12, 10, context); /// Get [12, 21]
             auto segments = fromHolder(holder);
             ASSERT_EQ(segments.size(), 4);
 
@@ -287,7 +318,6 @@ void test_file_cache(bool is_persistent) {
                          io::FileBlock::State::DOWNLOADED);
             assert_range(20, segments[2], io::FileBlock::Range(17, 20),
                          io::FileBlock::State::DOWNLOADED);
-
             assert_range(21, segments[3], io::FileBlock::Range(21, 21),
                          io::FileBlock::State::EMPTY);
 
@@ -295,15 +325,13 @@ void test_file_cache(bool is_persistent) {
             download(segments[3]);
             ASSERT_TRUE(segments[3]->state() == io::FileBlock::State::DOWNLOADED);
         }
+        /// Current cache:    [__________][_____][_][____][_]    [___]
+        ///                   ^          ^^     ^   ^    ^       ^   ^
+        ///                   0          910    14  17   20      24  26
 
-        /// Current cache:    [_____][__][____][_]   [___]
-        ///                   ^          ^       ^   ^   ^
-        ///                   10         17      21  24  26
-
-        ASSERT_EQ(cache.get_file_segments_num(is_persistent), 5);
-
+        ASSERT_EQ(cache.get_file_segments_num(cache_type), 6);
         {
-            auto holder = cache.get_or_set(key, 23, 5, is_persistent, query_id); /// Get [23, 28]
+            auto holder = cache.get_or_set(key, 23, 5, context); /// Get [23, 28]
             auto segments = fromHolder(holder);
             ASSERT_EQ(segments.size(), 3);
 
@@ -319,68 +347,65 @@ void test_file_cache(bool is_persistent) {
             download(segments[0]);
             download(segments[2]);
         }
+        /// Current cache:    [__________][_____][_][____][_]  [_][___][_]
+        ///                   ^          ^^     ^   ^    ^        ^   ^
+        ///                   0          910    14  17   20       24  26
 
-        /// Current cache:    [____][_]  [][___][__]
-        ///                   ^       ^  ^^^   ^^  ^
-        ///                   17      21 2324  26  27
-
+        ASSERT_EQ(cache.get_file_segments_num(cache_type), 8);
         {
-            auto holder5 = cache.get_or_set(key, 2, 3, is_persistent, query_id); /// Get [2, 4]
+            auto holder5 = cache.get_or_set(key, 2, 3, context); /// Get [2, 4]
             auto s5 = fromHolder(holder5);
             ASSERT_EQ(s5.size(), 1);
-            assert_range(25, s5[0], io::FileBlock::Range(2, 4), io::FileBlock::State::EMPTY);
+            assert_range(25, s5[0], io::FileBlock::Range(0, 9),
+                         io::FileBlock::State::DOWNLOADED);
 
-            auto holder1 = cache.get_or_set(key, 30, 2, is_persistent, query_id); /// Get [30, 31]
+            auto holder1 = cache.get_or_set(key, 30, 2, context); /// Get [30, 31]
             auto s1 = fromHolder(holder1);
             ASSERT_EQ(s1.size(), 1);
             assert_range(26, s1[0], io::FileBlock::Range(30, 31), io::FileBlock::State::EMPTY);
 
-            ASSERT_TRUE(s5[0]->get_or_set_downloader() == io::FileBlock::get_caller_id());
             ASSERT_TRUE(s1[0]->get_or_set_downloader() == io::FileBlock::get_caller_id());
-            download(s5[0]);
             download(s1[0]);
 
-            /// Current cache:    [___]       [_][___][_]   [__]
-            ///                   ^   ^       ^  ^   ^  ^   ^  ^
-            ///                   2   4       23 24  26 27  30 31
+            /// Current cache:    [__________][_____][_][____][_]  [_][___][_]    [__]
+            ///                   ^          ^^     ^   ^    ^        ^   ^  ^    ^  ^
+            ///                   0          910    14  17   20       24  26 27   30 31
 
-            auto holder2 = cache.get_or_set(key, 23, 1, is_persistent, query_id); /// Get [23, 23]
+            auto holder2 = cache.get_or_set(key, 23, 1, context); /// Get [23, 23]
             auto s2 = fromHolder(holder2);
             ASSERT_EQ(s2.size(), 1);
 
-            auto holder3 = cache.get_or_set(key, 24, 3, is_persistent, query_id); /// Get [24, 26]
+            auto holder3 = cache.get_or_set(key, 24, 3, context); /// Get [24, 26]
             auto s3 = fromHolder(holder3);
             ASSERT_EQ(s3.size(), 1);
 
-            auto holder4 = cache.get_or_set(key, 27, 1, is_persistent, query_id); /// Get [27, 27]
+            auto holder4 = cache.get_or_set(key, 27, 1, context); /// Get [27, 27]
             auto s4 = fromHolder(holder4);
             ASSERT_EQ(s4.size(), 1);
 
             /// All cache is now unreleasable because pointers are still hold
-            auto holder6 = cache.get_or_set(key, 0, 40, is_persistent, query_id);
+            auto holder6 = cache.get_or_set(key, 0, 40, context);
             auto f = fromHolder(holder6);
-            ASSERT_EQ(f.size(), 9);
+            ASSERT_EQ(f.size(), 12);
 
-            assert_range(27, f[0], io::FileBlock::Range(0, 1), io::FileBlock::State::SKIP_CACHE);
-            assert_range(28, f[2], io::FileBlock::Range(5, 22), io::FileBlock::State::SKIP_CACHE);
-            assert_range(29, f[6], io::FileBlock::Range(28, 29), io::FileBlock::State::SKIP_CACHE);
-            assert_range(30, f[8], io::FileBlock::Range(32, 39), io::FileBlock::State::SKIP_CACHE);
+            assert_range(29, f[9], io::FileBlock::Range(28, 29),
+                         io::FileBlock::State::SKIP_CACHE);
+            assert_range(30, f[11], io::FileBlock::Range(32, 39),
+                         io::FileBlock::State::SKIP_CACHE);
         }
-
         {
-            auto holder = cache.get_or_set(key, 2, 3, is_persistent, query_id); /// Get [2, 4]
+            auto holder = cache.get_or_set(key, 2, 3, context); /// Get [2, 4]
             auto segments = fromHolder(holder);
             ASSERT_EQ(segments.size(), 1);
-            assert_range(31, segments[0], io::FileBlock::Range(2, 4),
+            assert_range(31, segments[0], io::FileBlock::Range(0, 9),
                          io::FileBlock::State::DOWNLOADED);
         }
-
-        /// Current cache:    [___]       [_][___][_]   [__]
-        ///                   ^   ^       ^  ^   ^  ^   ^  ^
-        ///                   2   4       23 24  26 27  30 31
+        /// Current cache:    [__________][_____][_][____][_]  [_][___][_]    [__]
+        ///                   ^          ^^     ^   ^    ^        ^   ^  ^    ^  ^
+        ///                   0          910    14  17   20       24  26 27   30 31
 
         {
-            auto holder = cache.get_or_set(key, 25, 5, is_persistent, query_id); /// Get [25, 29]
+            auto holder = cache.get_or_set(key, 25, 5, context); /// Get [25, 29]
             auto segments = fromHolder(holder);
             ASSERT_EQ(segments.size(), 3);
 
@@ -399,8 +424,8 @@ void test_file_cache(bool is_persistent) {
             std::condition_variable cv;
 
             std::thread other_1([&] {
-                auto holder_2 = cache.get_or_set(key, 25, 5, is_persistent,
-                                                 other_query_id); /// Get [25, 29] once again.
+                auto holder_2 =
+                        cache.get_or_set(key, 25, 5, other_context); /// Get [25, 29] once again.
                 auto segments_2 = fromHolder(holder_2);
                 ASSERT_EQ(segments.size(), 3);
 
@@ -411,7 +436,8 @@ void test_file_cache(bool is_persistent) {
                 assert_range(37, segments_2[2], io::FileBlock::Range(28, 29),
                              io::FileBlock::State::DOWNLOADING);
 
-                ASSERT_TRUE(segments[2]->get_or_set_downloader() != io::FileBlock::get_caller_id());
+                ASSERT_TRUE(segments[2]->get_or_set_downloader() !=
+                            io::FileBlock::get_caller_id());
                 ASSERT_TRUE(segments[2]->state() == io::FileBlock::State::DOWNLOADING);
 
                 {
@@ -435,10 +461,10 @@ void test_file_cache(bool is_persistent) {
 
             other_1.join();
         }
-
-        /// Current cache:    [___]       [___][_][__][__]
-        ///                   ^   ^       ^   ^  ^^  ^^  ^
-        ///                   2   4       24  26 27  2930 31
+        ASSERT_EQ(cache.get_file_segments_num(cache_type), 5);
+        /// Current cache:    [__________] [___][_][__][__]
+        ///                   ^          ^ ^   ^  ^    ^  ^
+        ///                   0          9 24  26 27   30 31
 
         {
             /// Now let's check the similar case but getting ERROR state after segment->wait(), when
@@ -446,34 +472,35 @@ void test_file_cache(bool is_persistent) {
             /// and notify_all() is also called from destructor of holder.
 
             std::optional<io::FileBlocksHolder> holder;
-            holder.emplace(cache.get_or_set(key, 3, 23, is_persistent, query_id)); /// Get [3, 25]
+            holder.emplace(cache.get_or_set(key, 3, 23, context)); /// Get [3, 25]
 
             auto segments = fromHolder(*holder);
             ASSERT_EQ(segments.size(), 3);
 
-            assert_range(38, segments[0], io::FileBlock::Range(2, 4),
+            assert_range(38, segments[0], io::FileBlock::Range(0, 9),
                          io::FileBlock::State::DOWNLOADED);
 
-            assert_range(39, segments[1], io::FileBlock::Range(5, 23), io::FileBlock::State::EMPTY);
+            assert_range(39, segments[1], io::FileBlock::Range(10, 23),
+                         io::FileBlock::State::EMPTY);
             ASSERT_TRUE(segments[1]->get_or_set_downloader() == io::FileBlock::get_caller_id());
             ASSERT_TRUE(segments[1]->state() == io::FileBlock::State::DOWNLOADING);
-
-            assert_range(40, segments[2], io::FileBlock::Range(24, 26),
+            assert_range(38, segments[2], io::FileBlock::Range(24, 26),
                          io::FileBlock::State::DOWNLOADED);
+
 
             bool lets_start_download = false;
             std::mutex mutex;
             std::condition_variable cv;
 
             std::thread other_1([&] {
-                auto holder_2 = cache.get_or_set(key, 3, 23, is_persistent,
-                                                 other_query_id); /// Get [3, 25] once again
+                auto holder_2 =
+                        cache.get_or_set(key, 3, 23, other_context); /// Get [3, 25] once again
                 auto segments_2 = fromHolder(*holder);
                 ASSERT_EQ(segments_2.size(), 3);
 
-                assert_range(41, segments_2[0], io::FileBlock::Range(2, 4),
+                assert_range(41, segments_2[0], io::FileBlock::Range(0, 9),
                              io::FileBlock::State::DOWNLOADED);
-                assert_range(42, segments_2[1], io::FileBlock::Range(5, 23),
+                assert_range(42, segments_2[1], io::FileBlock::Range(10, 23),
                              io::FileBlock::State::DOWNLOADING);
                 assert_range(43, segments_2[2], io::FileBlock::Range(24, 26),
                              io::FileBlock::State::DOWNLOADED);
@@ -505,23 +532,22 @@ void test_file_cache(bool is_persistent) {
             ASSERT_TRUE(segments[1]->state() == io::FileBlock::State::DOWNLOADED);
         }
     }
-    /// Current cache:    [___][        ][___][_][__]
-    ///                   ^   ^^         ^   ^^  ^  ^
-    ///                   2   45       24  2627 28 29
-
+    /// Current cache:    [__________][___][___][_][__]
+    ///                   ^          ^      ^    ^  ^ ^ 
+    ///                   0          9      24  26 27  29
     {
         /// Test LRUCache::restore().
 
         io::LRUFileCache cache2(cache_base_path, settings);
         cache2.initialize();
-        auto holder1 = cache2.get_or_set(key, 2, 28, is_persistent, query_id); /// Get [2, 29]
+        auto holder1 = cache2.get_or_set(key, 2, 28, context); /// Get [2, 29]
 
         auto segments1 = fromHolder(holder1);
         ASSERT_EQ(segments1.size(), 5);
 
-        assert_range(44, segments1[0], io::FileBlock::Range(2, 4),
+        assert_range(44, segments1[0], io::FileBlock::Range(0, 9),
                      io::FileBlock::State::DOWNLOADED);
-        assert_range(45, segments1[1], io::FileBlock::Range(5, 23),
+        assert_range(45, segments1[1], io::FileBlock::Range(10, 23),
                      io::FileBlock::State::DOWNLOADED);
         assert_range(45, segments1[2], io::FileBlock::Range(24, 26),
                      io::FileBlock::State::DOWNLOADED);
@@ -533,22 +559,25 @@ void test_file_cache(bool is_persistent) {
 
     {
         /// Test max file segment size
-
         auto settings2 = settings;
-        settings2.max_size = 30;
-        settings2.max_elements = 5;
-        settings2.persistent_max_size = 30;
-        settings2.persistent_max_elements = 5;
+        settings2.index_queue_elements = 5;
+        settings2.index_queue_size = 30;
+        settings2.disposable_queue_size = 0;
+        settings2.disposable_queue_elements = 0;
+        settings2.query_queue_size = 0;
+        settings2.query_queue_elements = 0;
         settings2.max_file_segment_size = 10;
         io::LRUFileCache cache2(caches_dir / "cache2", settings2);
 
-        auto holder1 = cache2.get_or_set(key, 0, 25, is_persistent, query_id); /// Get [0, 24]
+        auto holder1 = cache2.get_or_set(key, 0, 25, context); /// Get [0, 24]
         auto segments1 = fromHolder(holder1);
 
         ASSERT_EQ(segments1.size(), 3);
         assert_range(48, segments1[0], io::FileBlock::Range(0, 9), io::FileBlock::State::EMPTY);
-        assert_range(49, segments1[1], io::FileBlock::Range(10, 19), io::FileBlock::State::EMPTY);
-        assert_range(50, segments1[2], io::FileBlock::Range(20, 24), io::FileBlock::State::EMPTY);
+        assert_range(49, segments1[1], io::FileBlock::Range(10, 19),
+                     io::FileBlock::State::EMPTY);
+        assert_range(50, segments1[2], io::FileBlock::Range(20, 24),
+                     io::FileBlock::State::EMPTY);
     }
 }
 
@@ -557,8 +586,250 @@ TEST(LRUFileCache, normal) {
         fs::remove_all(cache_base_path);
     }
     fs::create_directories(cache_base_path);
-    test_file_cache(false);
-    test_file_cache(true);
+    test_file_cache(io::CacheType::DISPOSABLE);
+    if (fs::exists(cache_base_path)) {
+        fs::remove_all(cache_base_path);
+    }
+
+    fs::create_directories(cache_base_path);
+    test_file_cache(io::CacheType::INDEX);
+    if (fs::exists(cache_base_path)) {
+        fs::remove_all(cache_base_path);
+    }
+
+    fs::create_directories(cache_base_path);
+    test_file_cache(io::CacheType::NORMAL);
+    if (fs::exists(cache_base_path)) {
+        fs::remove_all(cache_base_path);
+    }
+}
+
+TEST(LRUFileCache, resize) {
+    if (fs::exists(cache_base_path)) {
+        fs::remove_all(cache_base_path);
+    }
+    fs::create_directories(cache_base_path);
+    test_file_cache(io::CacheType::INDEX);
+    /// Current cache:    [__________][___][___][_][__]
+    ///                   ^          ^      ^    ^  ^ ^ 
+    ///                   0          9      24  26 27  29
+    io::FileCacheSettings settings;
+    settings.index_queue_elements = 5;
+    settings.index_queue_size = 10;
+    settings.disposable_queue_size = 0;
+    settings.disposable_queue_elements = 0;
+    settings.query_queue_size = 0;
+    settings.query_queue_elements = 0;
+    settings.max_file_segment_size = 100;
+    io::LRUFileCache cache(cache_base_path, settings);
+    ASSERT_TRUE(cache.initialize());
+    if (fs::exists(cache_base_path)) {
+        fs::remove_all(cache_base_path);
+    }
+}
+
+TEST(LRUFileCache, query_limit_heap_use_after_free) {
+    if (fs::exists(cache_base_path)) {
+        fs::remove_all(cache_base_path);
+    }
+    doris::config::enable_file_cache_query_limit = true;
+    fs::create_directories(cache_base_path);
+    io::FileCacheSettings settings;
+    settings.index_queue_elements = 0;
+    settings.index_queue_size = 0;
+    settings.disposable_queue_size = 0;
+    settings.disposable_queue_elements = 0;
+    settings.query_queue_size = 15;
+    settings.query_queue_elements = 5;
+    settings.max_file_segment_size = 10;
+    settings.max_query_cache_size = 15;
+    settings.total_size = 15;
+    io::LRUFileCache cache(cache_base_path, settings);
+    ASSERT_TRUE(cache.initialize());
+    io::CacheContext context;
+    context.cache_type = io::CacheType::NORMAL;
+    auto key = io::LRUFileCache::hash("key1");
+    {
+        auto holder = cache.get_or_set(key, 0, 9, context); /// Add range [0, 8]
+        auto segments = fromHolder(holder);
+        ASSERT_GE(segments.size(), 1);
+        assert_range(1, segments[0], io::FileBlock::Range(0, 8), io::FileBlock::State::EMPTY);
+        ASSERT_TRUE(segments[0]->get_or_set_downloader() == io::FileBlock::get_caller_id());
+        assert_range(2, segments[0], io::FileBlock::Range(0, 8),
+                     io::FileBlock::State::DOWNLOADING);
+        download(segments[0]);
+    }
+    TUniqueId query_id;
+    query_id.hi = 1;
+    query_id.lo = 1;
+    context.query_id = query_id;
+    auto query_context_holder = cache.get_query_context_holder(query_id);
+    {
+        auto holder = cache.get_or_set(key, 9, 1, context); /// Add range [9, 9]
+        auto segments = fromHolder(holder);
+        ASSERT_GE(segments.size(), 1);
+        assert_range(1, segments[0], io::FileBlock::Range(9, 9), io::FileBlock::State::EMPTY);
+        ASSERT_TRUE(segments[0]->get_or_set_downloader() == io::FileBlock::get_caller_id());
+        assert_range(2, segments[0], io::FileBlock::Range(9, 9),
+                     io::FileBlock::State::DOWNLOADING);
+        download(segments[0]);
+    }
+    {
+        auto holder = cache.get_or_set(key, 10, 5, context); /// Add range [10, 14]
+        auto segments = fromHolder(holder);
+        ASSERT_GE(segments.size(), 1);
+        assert_range(3, segments[0], io::FileBlock::Range(10, 14), io::FileBlock::State::EMPTY);
+        ASSERT_TRUE(segments[0]->get_or_set_downloader() == io::FileBlock::get_caller_id());
+        assert_range(4, segments[0], io::FileBlock::Range(10, 14),
+                     io::FileBlock::State::DOWNLOADING);
+        download(segments[0]);
+    }
+    {
+        auto holder = cache.get_or_set(key, 0, 9, context); /// Add range [0, 8]
+        auto segments = fromHolder(holder);
+        ASSERT_GE(segments.size(), 1);
+        assert_range(5, segments[0], io::FileBlock::Range(0, 8),
+                     io::FileBlock::State::DOWNLOADED);
+    }
+    {
+        auto holder = cache.get_or_set(key, 15, 1, context); /// Add range [15, 15]
+        auto segments = fromHolder(holder);
+        ASSERT_GE(segments.size(), 1);
+        assert_range(6, segments[0], io::FileBlock::Range(15, 15), io::FileBlock::State::EMPTY);
+        ASSERT_TRUE(segments[0]->get_or_set_downloader() == io::FileBlock::get_caller_id());
+        assert_range(7, segments[0], io::FileBlock::Range(15, 15),
+                     io::FileBlock::State::DOWNLOADING);
+        download(segments[0]);
+    }
+    {
+        auto holder = cache.get_or_set(key, 16, 9, context); /// Add range [16, 24]
+        auto segments = fromHolder(holder);
+        ASSERT_GE(segments.size(), 1);
+        assert_range(8, segments[0], io::FileBlock::Range(16, 24),
+                     io::FileBlock::State::SKIP_CACHE);
+    }
+    if (fs::exists(cache_base_path)) {
+        fs::remove_all(cache_base_path);
+    }
+}
+
+TEST(LRUFileCache, query_limit_dcheck) {
+    if (fs::exists(cache_base_path)) {
+        fs::remove_all(cache_base_path);
+    }
+    doris::config::enable_file_cache_query_limit = true;
+    fs::create_directories(cache_base_path);
+    io::FileCacheSettings settings;
+    settings.index_queue_elements = 0;
+    settings.index_queue_size = 0;
+    settings.disposable_queue_size = 0;
+    settings.disposable_queue_elements = 0;
+    settings.query_queue_size = 15;
+    settings.query_queue_elements = 5;
+    settings.max_file_segment_size = 10;
+    settings.max_query_cache_size = 15;
+    settings.total_size = 15;
+    io::LRUFileCache cache(cache_base_path, settings);
+    ASSERT_TRUE(cache.initialize());
+    io::CacheContext context;
+    context.cache_type = io::CacheType::NORMAL;
+    auto key = io::LRUFileCache::hash("key1");
+    {
+        auto holder = cache.get_or_set(key, 0, 9, context); /// Add range [0, 8]
+        auto segments = fromHolder(holder);
+        ASSERT_GE(segments.size(), 1);
+        assert_range(1, segments[0], io::FileBlock::Range(0, 8), io::FileBlock::State::EMPTY);
+        ASSERT_TRUE(segments[0]->get_or_set_downloader() == io::FileBlock::get_caller_id());
+        assert_range(2, segments[0], io::FileBlock::Range(0, 8),
+                     io::FileBlock::State::DOWNLOADING);
+        download(segments[0]);
+    }
+    TUniqueId query_id;
+    query_id.hi = 1;
+    query_id.lo = 1;
+    context.query_id = query_id;
+    auto query_context_holder = cache.get_query_context_holder(query_id);
+    {
+        auto holder = cache.get_or_set(key, 9, 1, context); /// Add range [9, 9]
+        auto segments = fromHolder(holder);
+        ASSERT_GE(segments.size(), 1);
+        assert_range(1, segments[0], io::FileBlock::Range(9, 9), io::FileBlock::State::EMPTY);
+        ASSERT_TRUE(segments[0]->get_or_set_downloader() == io::FileBlock::get_caller_id());
+        assert_range(2, segments[0], io::FileBlock::Range(9, 9),
+                     io::FileBlock::State::DOWNLOADING);
+        download(segments[0]);
+    }
+    {
+        auto holder = cache.get_or_set(key, 10, 5, context); /// Add range [10, 14]
+        auto segments = fromHolder(holder);
+        ASSERT_GE(segments.size(), 1);
+        assert_range(3, segments[0], io::FileBlock::Range(10, 14), io::FileBlock::State::EMPTY);
+        ASSERT_TRUE(segments[0]->get_or_set_downloader() == io::FileBlock::get_caller_id());
+        assert_range(4, segments[0], io::FileBlock::Range(10, 14),
+                     io::FileBlock::State::DOWNLOADING);
+        download(segments[0]);
+    }
+    {
+        auto holder = cache.get_or_set(key, 0, 9, context); /// Add range [0, 8]
+        auto segments = fromHolder(holder);
+        ASSERT_GE(segments.size(), 1);
+        assert_range(5, segments[0], io::FileBlock::Range(0, 8),
+                     io::FileBlock::State::DOWNLOADED);
+    }
+    {
+        auto holder = cache.get_or_set(key, 15, 1, context); /// Add range [15, 15]
+        auto segments = fromHolder(holder);
+        ASSERT_GE(segments.size(), 1);
+        assert_range(6, segments[0], io::FileBlock::Range(15, 15), io::FileBlock::State::EMPTY);
+        ASSERT_TRUE(segments[0]->get_or_set_downloader() == io::FileBlock::get_caller_id());
+        assert_range(7, segments[0], io::FileBlock::Range(15, 15),
+                     io::FileBlock::State::DOWNLOADING);
+        download(segments[0]);
+    }
+    // double add
+    {
+        auto holder = cache.get_or_set(key, 9, 1, context); /// Add range [9, 9]
+        auto segments = fromHolder(holder);
+        ASSERT_GE(segments.size(), 1);
+        assert_range(1, segments[0], io::FileBlock::Range(9, 9), io::FileBlock::State::EMPTY);
+        ASSERT_TRUE(segments[0]->get_or_set_downloader() == io::FileBlock::get_caller_id());
+        assert_range(2, segments[0], io::FileBlock::Range(9, 9),
+                     io::FileBlock::State::DOWNLOADING);
+        download(segments[0]);
+    }
+    {
+        auto holder = cache.get_or_set(key, 30, 5, context); /// Add range [30, 34]
+        auto segments = fromHolder(holder);
+        ASSERT_GE(segments.size(), 1);
+        assert_range(1, segments[0], io::FileBlock::Range(30, 34), io::FileBlock::State::EMPTY);
+        ASSERT_TRUE(segments[0]->get_or_set_downloader() == io::FileBlock::get_caller_id());
+        assert_range(2, segments[0], io::FileBlock::Range(30, 34),
+                     io::FileBlock::State::DOWNLOADING);
+        download(segments[0]);
+    }
+    {
+        auto holder = cache.get_or_set(key, 40, 5, context); /// Add range [40, 44]
+        auto segments = fromHolder(holder);
+        ASSERT_GE(segments.size(), 1);
+        assert_range(1, segments[0], io::FileBlock::Range(40, 44), io::FileBlock::State::EMPTY);
+        ASSERT_TRUE(segments[0]->get_or_set_downloader() == io::FileBlock::get_caller_id());
+        assert_range(2, segments[0], io::FileBlock::Range(40, 44),
+                     io::FileBlock::State::DOWNLOADING);
+        download(segments[0]);
+    }
+    {
+        auto holder = cache.get_or_set(key, 50, 5, context); /// Add range [50, 54]
+        auto segments = fromHolder(holder);
+        ASSERT_GE(segments.size(), 1);
+        assert_range(1, segments[0], io::FileBlock::Range(50, 54), io::FileBlock::State::EMPTY);
+        ASSERT_TRUE(segments[0]->get_or_set_downloader() == io::FileBlock::get_caller_id());
+        assert_range(2, segments[0], io::FileBlock::Range(50, 54),
+                     io::FileBlock::State::DOWNLOADING);
+        download(segments[0]);
+    }
+    if (fs::exists(cache_base_path)) {
+        fs::remove_all(cache_base_path);
+    }
 }
 
 } // namespace doris::io

--- a/docs/en/docs/lakehouse/filecache.md
+++ b/docs/en/docs/lakehouse/filecache.md
@@ -61,7 +61,7 @@ Add settings to the BE node's configuration file `conf/be.conf`, and restart the
 |  ---  | ---  |
 | `enable_file_cache`  | Whether to enable File Cache, default false |
 | `file_cache_max_file_segment_size` | Max size of a single cached block, default 4MB, should greater than 4096 |
-| `file_cache_path` | Parameters about cache path, json format, for exmaple: `[{"path": "storage1", "normal":53687091200,"persistent":21474836480,"query_limit": "10737418240"},{"path": "storage2", "normal":53687091200,"persistent":21474836480},{"path": "storage3","normal":53687091200,"persistent":21474836480}]`. `path` is the path to save cached data; `normal` is the max size of cached data; `query_limit` is the max size of cached data for a single query; `persistent` / `file_cache_max_file_segment_size` is max number of cache blocks. |
+| `file_cache_path` | Parameters about cache path, json format, for exmaple: `[{"path": "/path/to/file_cache1", "total_size":53687091200,"query_limit": "10737418240"},{"path": "/path/to/file_cache2", "total_size":53687091200,"query_limit": "10737418240"},{"path": "/path/to/file_cache3", "total_size":53687091200,"query_limit": "10737418240"}]`. `path` is the path to save cached data; `total_size` is the max size of cached data; `query_limit` is the max size of cached data for a single query. |
 | `enable_file_cache_query_limit` | Whether to limit the cache size used by a single query, default false |
 | `clear_file_cache` | Whether to delete the previous cache data when the BE restarts, default false |
 

--- a/docs/zh-CN/docs/lakehouse/filecache.md
+++ b/docs/zh-CN/docs/lakehouse/filecache.md
@@ -61,7 +61,7 @@ SET GLOBAL enable_file_cache = true;
 |  ---  | ---  |
 | `enable_file_cache`  | 是否启用 File Cache，默认 false |
 | `file_cache_max_file_segment_size` | 单个 Block 的大小上限，默认 4MB，需要大于 4096 |
-| `file_cache_path` | 缓存目录的相关配置，json格式，例子: `[{"path": "storage1", "normal":53687091200,"persistent":21474836480,"query_limit": "10737418240"},{"path": "storage2", "normal":53687091200,"persistent":21474836480},{"path": "storage3","normal":53687091200,"persistent":21474836480}]`。`path` 是缓存的保存路径，`normal` 是缓存的大小上限，`query_limit` 是单个查询能够使用的最大缓存大小，`persistent` / `file_cache_max_file_segment_size` 是最多缓存的 Block 数量。 |
+| `file_cache_path` | 缓存目录的相关配置，json格式，例子: `[{"path": "/path/to/file_cache1", "total_size":53687091200,"query_limit": "10737418240"},{"path": "/path/to/file_cache2", "total_size":53687091200,"query_limit": "10737418240"},{"path": "/path/to/file_cache3", "total_size":53687091200,"query_limit": "10737418240"}]`。`path` 是缓存的保存路径，`total_size` 是缓存的大小上限，`query_limit` 是单个查询能够使用的最大缓存大小。 |
 | `enable_file_cache_query_limit` | 是否限制单个 query 使用的缓存大小，默认 false |
 | `clear_file_cache` | BE 重启时是否删除之前的缓存数据，默认 false |
 


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

1. Refactor file cache. Before refactor, the file cache config format is "[{"path":"/path/to/file_cache","normal":21474836480,"persistent":10737418240,"query_limit":10737418240}]" and now change to "[{"path":"/mnt/disk3/selectdb_cloud/file_cache","total_size":21474836480,"query_limit":10737418240}]". It will be simpler than before.
2. Support more strategy. Support file cache priority. The file cache will have three queue,  name as 'index'/'normal'/'disposable'. We can avoid that the higher priority data is eliminate by the lower priority data.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

