### PR TITLE
[fix](info_db) avoid infodb query timeout when external catalog info is too large or is not reachable

### DIFF
--- a/docs/en/docs/admin-manual/config/fe-config.md
+++ b/docs/en/docs/admin-manual/config/fe-config.md
@@ -2667,3 +2667,17 @@ MasterOnly：false
 Only take effect when `prefer_compute_node_for_external_table` is true. If the compute node number is less than this value, query on external table will try to get some mix node to assign, to let the total number of node reach this value.
 If the compute node number is larger than this value, query on external table will assign to compute node only.
 
+#### `infodb_support_ext_catalog`
+
+<version since="1.2.4"></version>
+
+Default: false
+
+IsMutable: true
+
+MasterOnly: false
+
+If false, when select from tables in information_schema database,
+the result will not contain the information of the table in external catalog.
+This is to avoid query time when external catalog is not reachable.
+

--- a/docs/zh-CN/docs/admin-manual/config/fe-config.md
+++ b/docs/zh-CN/docs/admin-manual/config/fe-config.md
@@ -2665,3 +2665,17 @@ show data （其他用法：HELP SHOW DATA）
 
 仅在 `prefer_compute_node_for_external_table` 为 true 时生效。如果计算节点数小于此值，则对外部表的查询将尝试使用一些混合节点，让节点总数达到这个值。
 如果计算节点数大于这个值，外部表的查询将只分配给计算节点。
+
+#### `infodb_support_ext_catalog`
+
+<version since="1.2.4"></version>
+
+默认值：false
+
+是否可以动态配置：true
+
+是否为 Master FE 节点独有的配置项：false
+
+当设置为 false 时，查询 `information_schema` 中的表时，将不再返回 external catalog 中的表的信息。
+
+这个参数主要用于避免因 external catalog 无法访问、信息过多等原因导致的查询 `information_schema` 超时的问题。

--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -2104,5 +2104,14 @@ public class Config extends ConfigBase {
      */
     @ConfField
     public static long lock_reporting_threshold_ms = 500L;
+
+    /**
+     * If false, when select from tables in information_schema database,
+     * the result will not contain the information of the table in external catalog.
+     * This is to avoid query time when external catalog is not reachable.
+     * TODO: this is a temp solution, we should support external catalog in the future.
+     */
+    @ConfField(mutable = true)
+    public static boolean infodb_support_ext_catalog = false;
 }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/SchemaScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/SchemaScanNode.java
@@ -23,6 +23,7 @@ import org.apache.doris.catalog.SchemaTable;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.UserException;
 import org.apache.doris.common.util.Util;
+import org.apache.doris.datasource.InternalCatalog;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.service.FrontendOptions;
 import org.apache.doris.statistics.StatisticalType;
@@ -103,6 +104,8 @@ public class SchemaScanNode extends ScanNode {
         }
         if (schemaCatalog != null) {
             msg.schema_scan_node.setCatalog(schemaCatalog);
+        } else if (!Config.infodb_support_ext_catalog) {
+            msg.schema_scan_node.setCatalog(InternalCatalog.INTERNAL_CATALOG_NAME);
         }
         msg.schema_scan_node.show_hidden_cloumns = Util.showHiddenColumns();
 


### PR DESCRIPTION
…is too large or is not reachable

# Proposed changes

Issue Number: close #xxx

When query tables in `information_schema` databases, it may timeout due to:

1. There are external catalog with too many tables.
2. The external catalog is unreachable

So I add a new FE config `infodb_support_ext_catalog`.
The default is false, which means that when select from tables in information_schema database,
the result will not contain the information of the table in external catalog.

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

