### PR TITLE
[cherry-pick](bitmapfilter) fix bitmap filter timeout unit error 

### DIFF
--- a/be/src/exprs/runtime_filter.cpp
+++ b/be/src/exprs/runtime_filter.cpp
@@ -1242,7 +1242,7 @@ bool IRuntimeFilter::await() {
     SCOPED_TIMER(_await_time_cost);
     // bitmap filter is precise filter and only filter once, so it must be applied.
     int64_t wait_times_ms = _wrapper->get_real_type() == RuntimeFilterType::BITMAP_FILTER
-                                    ? _state->query_options().query_timeout
+                                    ? _state->query_options().query_timeout * 1000
                                     : _state->runtime_filter_wait_time_ms();
     std::unique_lock<std::mutex> lock(_inner_mutex);
     if (!_is_ready) {


### PR DESCRIPTION

# Proposed changes

Issue Number: close #xxx
cherry-pick: #18110

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

