### PR TITLE
[chore](build) Use include-what-you-use to optimize includes

### DIFF
--- a/be/src/agent/agent_server.cpp
+++ b/be/src/agent/agent_server.cpp
@@ -17,9 +17,14 @@
 
 #include "agent/agent_server.h"
 
+#include <gen_cpp/AgentService_types.h>
+#include <gen_cpp/HeartbeatService_types.h>
+#include <gen_cpp/Types_types.h>
+#include <stdint.h>
 #include <thrift/protocol/TDebugProtocol.h>
 
 #include <filesystem>
+#include <ostream>
 #include <string>
 
 #include "agent/task_worker_pool.h"
@@ -29,7 +34,14 @@
 #include "common/logging.h"
 #include "common/status.h"
 #include "gutil/strings/substitute.h"
+#include "olap/olap_define.h"
+#include "olap/options.h"
 #include "olap/snapshot_manager.h"
+#include "runtime/exec_env.h"
+
+namespace doris {
+class TopicListener;
+} // namespace doris
 
 using std::string;
 using std::vector;

--- a/be/src/agent/agent_server.h
+++ b/be/src/agent/agent_server.h
@@ -17,17 +17,25 @@
 
 #pragma once
 
+#include <butil/macros.h>
+#include <gen_cpp/AgentService_types.h>
+
 #include <memory>
 #include <string>
 #include <vector>
 
-#include "gen_cpp/AgentService_types.h"
 #include "runtime/exec_env.h"
 
 namespace doris {
 
 class TaskWorkerPool;
 class TopicSubscriber;
+class ExecEnv;
+class TAgentPublishRequest;
+class TAgentResult;
+class TAgentTaskRequest;
+class TMasterInfo;
+class TSnapshotRequest;
 
 // Each method corresponds to one RPC from FE Master, see BackendService.
 class AgentServer {

--- a/be/src/agent/heartbeat_server.cpp
+++ b/be/src/agent/heartbeat_server.cpp
@@ -17,17 +17,30 @@
 
 #include "agent/heartbeat_server.h"
 
-#include <thrift/TProcessor.h>
+#include <gen_cpp/HeartbeatService.h>
+#include <gen_cpp/HeartbeatService_types.h>
+#include <gen_cpp/Types_types.h>
+#include <glog/logging.h>
 
+#include <memory>
+#include <ostream>
+#include <string>
+
+#include "common/config.h"
 #include "common/status.h"
-#include "gen_cpp/HeartbeatService.h"
-#include "gen_cpp/Status_types.h"
 #include "olap/storage_engine.h"
+#include "runtime/exec_env.h"
 #include "runtime/heartbeat_flags.h"
 #include "service/backend_options.h"
 #include "util/debug_util.h"
 #include "util/thrift_server.h"
 #include "util/time.h"
+
+namespace apache {
+namespace thrift {
+class TProcessor;
+} // namespace thrift
+} // namespace apache
 
 namespace doris {
 

--- a/be/src/agent/heartbeat_server.h
+++ b/be/src/agent/heartbeat_server.h
@@ -17,14 +17,20 @@
 
 #pragma once
 
+#include <butil/macros.h>
+#include <gen_cpp/HeartbeatService.h>
+#include <stdint.h>
+
 #include <mutex>
 
 #include "common/status.h"
-#include "gen_cpp/HeartbeatService.h"
 #include "olap/olap_define.h"
 #include "runtime/exec_env.h"
 
 namespace doris {
+class ExecEnv;
+class THeartbeatResult;
+class TMasterInfo;
 
 const uint32_t HEARTBEAT_INTERVAL = 10;
 class StorageEngine;

--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -17,46 +17,65 @@
 
 #include "agent/task_worker_pool.h"
 
+#include <fmt/format.h>
 #include <gen_cpp/AgentService_types.h>
-#include <pthread.h>
-#include <sys/stat.h>
+#include <gen_cpp/HeartbeatService_types.h>
+#include <gen_cpp/MasterService_types.h>
+#include <gen_cpp/Status_types.h>
+#include <gen_cpp/Types_types.h>
+#include <unistd.h>
 
-#include <boost/lexical_cast.hpp>
+#include <algorithm>
 #include <chrono>
-#include <csignal>
 #include <ctime>
+#include <functional>
 #include <memory>
+#include <shared_mutex>
 #include <sstream>
 #include <string>
+#include <thread>
+#include <utility>
+#include <vector>
 
 #include "agent/utils.h"
+#include "common/config.h"
 #include "common/logging.h"
 #include "common/status.h"
-#include "gen_cpp/Types_types.h"
+#include "gutil/ref_counted.h"
+#include "gutil/stringprintf.h"
 #include "gutil/strings/substitute.h"
+#include "io/fs/file_system.h"
 #include "io/fs/local_file_system.h"
+#include "io/fs/path.h"
 #include "io/fs/s3_file_system.h"
 #include "olap/data_dir.h"
 #include "olap/olap_common.h"
+#include "olap/rowset/rowset_meta.h"
 #include "olap/snapshot_manager.h"
 #include "olap/storage_engine.h"
 #include "olap/storage_policy.h"
 #include "olap/tablet.h"
+#include "olap/tablet_manager.h"
+#include "olap/tablet_meta.h"
+#include "olap/tablet_schema.h"
 #include "olap/task/engine_alter_tablet_task.h"
 #include "olap/task/engine_batch_load_task.h"
 #include "olap/task/engine_checksum_task.h"
 #include "olap/task/engine_clone_task.h"
 #include "olap/task/engine_publish_version_task.h"
 #include "olap/task/engine_storage_migration_task.h"
+#include "olap/txn_manager.h"
 #include "olap/utils.h"
 #include "runtime/exec_env.h"
 #include "runtime/snapshot_loader.h"
 #include "service/backend_options.h"
 #include "util/doris_metrics.h"
 #include "util/random.h"
+#include "util/s3_util.h"
 #include "util/scoped_cleanup.h"
 #include "util/stopwatch.hpp"
 #include "util/threadpool.h"
+#include "util/time.h"
 #include "util/trace.h"
 
 namespace doris {

--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -26,7 +26,8 @@
 #include <unistd.h>
 
 #include <algorithm>
-#include <chrono>
+// IWYU pragma: no_include <bits/chrono.h>
+#include <chrono> // IWYU pragma: keep
 #include <ctime>
 #include <functional>
 #include <memory>

--- a/be/src/agent/task_worker_pool.h
+++ b/be/src/agent/task_worker_pool.h
@@ -17,24 +17,39 @@
 
 #pragma once
 
+#include <butil/macros.h>
+#include <gen_cpp/AgentService_types.h>
+#include <gen_cpp/HeartbeatService_types.h>
+#include <gen_cpp/Types_types.h>
+#include <stdint.h>
+
 #include <atomic>
+#include <condition_variable>
 #include <deque>
+#include <map>
 #include <memory>
+#include <mutex>
+#include <set>
+#include <string>
 #include <utility>
 #include <vector>
 
 #include "common/status.h"
-#include "gen_cpp/AgentService_types.h"
-#include "gen_cpp/HeartbeatService_types.h"
 #include "olap/data_dir.h"
 #include "olap/tablet.h"
 #include "util/countdown_latch.h"
+#include "util/metrics.h"
 
 namespace doris {
 
 class ExecEnv;
 class ThreadPool;
 class AgentUtils;
+class DataDir;
+class TFinishTaskRequest;
+class TMasterInfo;
+class TReportRequest;
+class TTabletInfo;
 
 class TaskWorkerPool {
 public:

--- a/be/src/agent/topic_subscriber.cpp
+++ b/be/src/agent/topic_subscriber.cpp
@@ -17,6 +17,13 @@
 
 #include "agent/topic_subscriber.h"
 
+#include <gen_cpp/AgentService_types.h>
+
+#include <mutex>
+#include <utility>
+
+#include "agent/topic_listener.h"
+
 namespace doris {
 
 TopicSubscriber::TopicSubscriber() {}

--- a/be/src/agent/topic_subscriber.h
+++ b/be/src/agent/topic_subscriber.h
@@ -17,15 +17,18 @@
 
 #pragma once
 
+#include <gen_cpp/AgentService_types.h>
+
 #include <map>
 #include <mutex>
 #include <shared_mutex>
 #include <thread>
+#include <vector>
 
 #include "agent/topic_listener.h"
-#include "gen_cpp/AgentService_types.h"
 
 namespace doris {
+class TopicListener;
 
 class TopicSubscriber {
 public:

--- a/be/src/agent/user_resource_listener.cpp
+++ b/be/src/agent/user_resource_listener.cpp
@@ -17,17 +17,24 @@
 
 #include "agent/user_resource_listener.h"
 
-#include <thrift/TApplicationException.h>
+#include <gen_cpp/AgentService_types.h>
+#include <gen_cpp/FrontendService.h>
+#include <gen_cpp/HeartbeatService_types.h>
+#include <gen_cpp/MasterService_types.h>
+#include <gen_cpp/Types_types.h>
+#include <glog/logging.h>
 #include <thrift/Thrift.h>
-#include <thrift/protocol/TBinaryProtocol.h>
-#include <thrift/transport/TBufferTransports.h>
-#include <thrift/transport/TSocket.h>
+#include <thrift/transport/TTransportException.h>
 
 #include <future>
-#include <map>
+#include <ostream>
+#include <string>
+#include <vector>
 
-#include "gen_cpp/FrontendService.h"
+#include "common/config.h"
+#include "common/status.h"
 #include "runtime/client_cache.h"
+#include "runtime/exec_env.h"
 
 namespace doris {
 

--- a/be/src/agent/user_resource_listener.h
+++ b/be/src/agent/user_resource_listener.h
@@ -17,16 +17,19 @@
 
 #pragma once
 
+#include <gen_cpp/AgentService_types.h>
+#include <gen_cpp/HeartbeatService_types.h>
+#include <stdint.h>
+
 #include <string>
 
 #include "agent/topic_listener.h"
-#include "gen_cpp/AgentService_types.h"
-#include "gen_cpp/HeartbeatService_types.h"
 #include "runtime/exec_env.h"
 
 namespace doris {
 
 class ExecEnv;
+class TMasterInfo;
 
 class UserResourceListener : public TopicListener {
 public:

--- a/be/src/agent/utils.cpp
+++ b/be/src/agent/utils.cpp
@@ -17,17 +17,38 @@
 
 #include "agent/utils.h"
 
+#include <errno.h>
+#include <gen_cpp/FrontendService.h>
+#include <gen_cpp/HeartbeatService_types.h>
+#include <gen_cpp/Types_types.h>
+#include <glog/logging.h>
 #include <rapidjson/document.h>
+#include <rapidjson/encodings.h>
 #include <rapidjson/rapidjson.h>
 #include <rapidjson/stringbuffer.h>
 #include <rapidjson/writer.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <thrift/transport/TTransportException.h>
 
 #include <cstdio>
+#include <exception>
 #include <fstream>
-#include <sstream>
+#include <memory>
+#include <utility>
 
+#include "common/config.h"
 #include "common/status.h"
 #include "runtime/client_cache.h"
+
+namespace doris {
+class TConfirmUnusedRemoteFilesRequest;
+class TConfirmUnusedRemoteFilesResult;
+class TFinishTaskRequest;
+class TMasterResult;
+class TReportRequest;
+} // namespace doris
 
 using std::map;
 using std::string;

--- a/be/src/agent/utils.h
+++ b/be/src/agent/utils.h
@@ -17,14 +17,24 @@
 
 #pragma once
 
+#include <butil/macros.h>
 #include <gen_cpp/FrontendService.h>
 #include <gen_cpp/HeartbeatService_types.h>
 #include <gen_cpp/MasterService_types.h>
+
+#include <map>
+#include <string>
 
 #include "common/status.h"
 #include "gutil/macros.h"
 
 namespace doris {
+class TConfirmUnusedRemoteFilesRequest;
+class TConfirmUnusedRemoteFilesResult;
+class TFinishTaskRequest;
+class TMasterInfo;
+class TMasterResult;
+class TReportRequest;
 
 class MasterServerClient {
 public:

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include "configbase.h"
+#include "configbase.h" // IWYU pragma: export
 
 namespace doris {
 namespace config {

--- a/be/src/common/configbase.cpp
+++ b/be/src/common/configbase.cpp
@@ -15,20 +15,31 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#include <stdint.h>
+
 #include <algorithm>
+#include <cctype>
 #include <cerrno>
+#include <cstdlib>
 #include <cstring>
-#include <fstream>
+#include <fstream> // IWYU pragma: keep
+#include <functional>
 #include <iostream>
-#include <list>
 #include <map>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "common/logging.h"
 
 #define __IN_CONFIGBASE_CPP__
-#include "common/config.h"
+#include "common/config.h" // IWYU pragma: keep
 #undef __IN_CONFIGBASE_CPP__
 
 #include "common/status.h"
-#include "gutil/strings/substitute.h"
+#include "io/fs/file_reader_writer_fwd.h"
 #include "io/fs/file_writer.h"
 #include "io/fs/local_file_system.h"
 
@@ -390,7 +401,7 @@ Status persist_config(const std::string& field, const std::string& value) {
     // lock to make sure only one thread can modify the be_custom.conf
     std::lock_guard<std::mutex> l(custom_conf_lock);
 
-    static const string conffile = string(getenv("DORIS_HOME")) + "/conf/be_custom.conf";
+    static const std::string conffile = std::string(getenv("DORIS_HOME")) + "/conf/be_custom.conf";
 
     Properties tmp_props;
     if (!tmp_props.load(conffile.c_str(), false)) {

--- a/be/src/common/configbase.h
+++ b/be/src/common/configbase.h
@@ -22,6 +22,7 @@
 #include <map>
 #include <mutex>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace doris {

--- a/be/src/common/daemon.cpp
+++ b/be/src/common/daemon.cpp
@@ -17,21 +17,33 @@
 
 #include "common/daemon.h"
 
+#include <bthread/errno.h>
 #include <gflags/gflags.h>
-#include <gperftools/malloc_extension.h>
+#include <math.h>
 #include <signal.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <algorithm>
+#include <chrono>
+#include <map>
+#include <memory>
+#include <ostream>
+#include <set>
+#include <string>
 
 #include "common/config.h"
 #include "common/logging.h"
-#include "exprs/math_functions.h"
-#include "exprs/string_functions.h"
+#include "common/status.h"
 #include "olap/options.h"
 #include "olap/storage_engine.h"
+#include "olap/tablet_manager.h"
 #include "runtime/block_spill_manager.h"
 #include "runtime/exec_env.h"
-#include "runtime/fragment_mgr.h"
 #include "runtime/load_channel_mgr.h"
-#include "runtime/memory/chunk_allocator.h"
+#include "runtime/memory/mem_tracker.h"
+#include "runtime/memory/mem_tracker_limiter.h"
 #include "runtime/user_function_cache.h"
 #include "service/backend_options.h"
 #include "util/cpu_info.h"
@@ -39,7 +51,9 @@
 #include "util/disk_info.h"
 #include "util/doris_metrics.h"
 #include "util/mem_info.h"
+#include "util/metrics.h"
 #include "util/network_util.h"
+#include "util/perf_counters.h"
 #include "util/system_metrics.h"
 #include "util/thrift_util.h"
 #include "util/time.h"

--- a/be/src/common/daemon.cpp
+++ b/be/src/common/daemon.cpp
@@ -19,6 +19,7 @@
 
 #include <bthread/errno.h>
 #include <gflags/gflags.h>
+// IWYU pragma: no_include <bits/std_abs.h>
 #include <math.h>
 #include <signal.h>
 #include <stdint.h>
@@ -26,7 +27,8 @@
 #include <string.h>
 
 #include <algorithm>
-#include <chrono>
+// IWYU pragma: no_include <bits/chrono.h>
+#include <chrono> // IWYU pragma: keep
 #include <map>
 #include <memory>
 #include <ostream>

--- a/be/src/common/exception.h
+++ b/be/src/common/exception.h
@@ -17,6 +17,17 @@
 
 #pragma once
 
+#include <fmt/format.h>
+#include <gen_cpp/Status_types.h>
+#include <stdint.h>
+
+#include <exception>
+#include <memory>
+#include <ostream>
+#include <string>
+#include <string_view>
+#include <utility>
+
 #include "common/status.h"
 
 namespace doris {

--- a/be/src/common/logconfig.cpp
+++ b/be/src/common/logconfig.cpp
@@ -15,14 +15,16 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include <glog/logging.h>
-#include <glog/vlog_is_on.h>
+#include <ctype.h>
+#include <stdint.h>
 
 #include <cerrno>
 #include <cstdlib>
 #include <cstring>
 #include <iostream>
 #include <mutex>
+#include <string>
+#include <vector>
 
 #include "common/config.h"
 #include "common/logging.h"

--- a/be/src/common/logging.h
+++ b/be/src/common/logging.h
@@ -24,7 +24,7 @@
 #undef _XOPEN_SOURCE
 // This is including a glog internal file.  We want this to expose the
 // function to get the stack trace.
-#include <glog/logging.h>
+#include <glog/logging.h> // IWYU pragma: export
 #undef MutexLock
 
 // Define VLOG levels.  We want display per-row info less than per-file which

--- a/be/src/common/resource_tls.cpp
+++ b/be/src/common/resource_tls.cpp
@@ -17,10 +17,12 @@
 
 #include "common/resource_tls.h"
 
+#include <gen_cpp/Types_types.h>
 #include <pthread.h>
 
+#include <ostream>
+
 #include "common/logging.h"
-#include "gen_cpp/Types_types.h"
 
 namespace doris {
 

--- a/be/src/common/status.cpp
+++ b/be/src/common/status.cpp
@@ -4,10 +4,16 @@
 
 #include "common/status.h"
 
+#include <gen_cpp/Status_types.h>
+#include <gen_cpp/types.pb.h> // for PStatus
+#include <rapidjson/encodings.h>
 #include <rapidjson/prettywriter.h>
 #include <rapidjson/stringbuffer.h>
 
-#include "gen_cpp/types.pb.h" // for PStatus
+#include <algorithm>
+#include <new>
+#include <vector>
+
 #include "service/backend_options.h"
 
 namespace doris {

--- a/be/src/common/status.h
+++ b/be/src/common/status.h
@@ -5,14 +5,17 @@
 #pragma once
 
 #include <fmt/format.h>
+#include <gen_cpp/Status_types.h> // for TStatus
 #include <glog/logging.h>
+#include <stdint.h>
 
 #include <iostream>
+#include <memory>
 #include <string>
 #include <string_view>
+#include <utility>
 
 #include "common/compiler_util.h"
-#include "gen_cpp/Status_types.h" // for TStatus
 #ifdef ENABLE_STACKTRACE
 #include "util/stack_util.h"
 #endif

--- a/be/src/exec/arrow/arrow_reader.cpp
+++ b/be/src/exec/arrow/arrow_reader.cpp
@@ -16,23 +16,26 @@
 // under the License.
 #include "exec/arrow/arrow_reader.h"
 
-#include <arrow/array.h>
+#include <arrow/buffer.h>
+#include <arrow/record_batch.h>
 #include <arrow/status.h>
+#include <arrow/type_fwd.h>
+#include <opentelemetry/common/threadlocal.h>
 #include <time.h>
 
+#include <algorithm>
+#include <chrono>
+#include <ostream>
+#include <utility>
+
 #include "common/logging.h"
-#include "gen_cpp/PaloBrokerService_types.h"
-#include "gen_cpp/TPaloBrokerService.h"
-#include "io/io_common.h"
-#include "olap/iterators.h"
-#include "runtime/broker_mgr.h"
-#include "runtime/client_cache.h"
+#include "io/fs/file_reader.h"
 #include "runtime/descriptors.h"
-#include "runtime/exec_env.h"
 #include "runtime/runtime_state.h"
+#include "util/slice.h"
 #include "util/string_util.h"
-#include "util/thrift_util.h"
 #include "vec/core/block.h"
+#include "vec/core/column_with_type_and_name.h"
 #include "vec/utils/arrow_column_to_doris_column.h"
 
 namespace doris {

--- a/be/src/exec/arrow/arrow_reader.cpp
+++ b/be/src/exec/arrow/arrow_reader.cpp
@@ -18,13 +18,11 @@
 
 #include <arrow/buffer.h>
 #include <arrow/record_batch.h>
-#include <arrow/status.h>
-#include <arrow/type_fwd.h>
 #include <opentelemetry/common/threadlocal.h>
-#include <time.h>
 
 #include <algorithm>
-#include <chrono>
+// IWYU pragma: no_include <bits/chrono.h>
+#include <chrono> // IWYU pragma: keep
 #include <ostream>
 #include <utility>
 

--- a/be/src/exec/arrow/arrow_reader.h
+++ b/be/src/exec/arrow/arrow_reader.h
@@ -65,6 +65,7 @@ class RuntimeState;
 class SlotDescriptor;
 class FileReader;
 class TupleDescriptor;
+
 namespace vectorized {
 class Block;
 } // namespace vectorized

--- a/be/src/exec/arrow/arrow_reader.h
+++ b/be/src/exec/arrow/arrow_reader.h
@@ -22,22 +22,39 @@
 #include <arrow/io/api.h>
 #include <arrow/io/file.h>
 #include <arrow/io/interfaces.h>
+#include <arrow/result.h>
+#include <gen_cpp/PaloBrokerService_types.h>
+#include <gen_cpp/PlanNodes_types.h>
+#include <gen_cpp/Types_types.h>
 #include <parquet/api/reader.h>
 #include <parquet/api/writer.h>
 #include <parquet/arrow/reader.h>
 #include <parquet/arrow/writer.h>
 #include <parquet/exception.h>
+#include <parquet/platform.h>
+#include <stddef.h>
 #include <stdint.h>
 
+#include <atomic>
+#include <condition_variable>
+#include <list>
 #include <map>
+#include <memory>
+#include <mutex>
 #include <string>
+#include <thread>
+#include <vector>
 
+#include "common/config.h"
 #include "common/status.h"
-#include "gen_cpp/PaloBrokerService_types.h"
-#include "gen_cpp/PlanNodes_types.h"
-#include "gen_cpp/Types_types.h"
 #include "io/fs/file_reader.h"
+#include "io/fs/file_reader_writer_fwd.h"
 #include "vec/exec/format/generic_reader.h"
+
+namespace arrow {
+class RecordBatch;
+class RecordBatchReader;
+} // namespace arrow
 
 namespace doris {
 
@@ -47,6 +64,10 @@ class TNetworkAddress;
 class RuntimeState;
 class SlotDescriptor;
 class FileReader;
+class TupleDescriptor;
+namespace vectorized {
+class Block;
+} // namespace vectorized
 
 struct Statistics {
     int32_t filtered_row_groups = 0;

--- a/be/src/exec/arrow/parquet_reader.cpp
+++ b/be/src/exec/arrow/parquet_reader.cpp
@@ -29,7 +29,8 @@
 
 #include <algorithm>
 #include <atomic>
-#include <chrono>
+// IWYU pragma: no_include <bits/chrono.h>
+#include <chrono> // IWYU pragma: keep
 #include <condition_variable>
 #include <list>
 #include <map>

--- a/be/src/exec/arrow/parquet_reader.cpp
+++ b/be/src/exec/arrow/parquet_reader.cpp
@@ -16,23 +16,33 @@
 // under the License.
 #include "exec/arrow/parquet_reader.h"
 
-#include <arrow/array.h>
+#include <arrow/record_batch.h>
+#include <arrow/result.h>
 #include <arrow/status.h>
-#include <arrow/type_fwd.h>
-#include <time.h>
+#include <arrow/type.h>
+#include <opentelemetry/common/threadlocal.h>
+#include <parquet/exception.h>
+#include <parquet/file_reader.h>
+#include <parquet/metadata.h>
+#include <parquet/properties.h>
+#include <parquet/schema.h>
 
 #include <algorithm>
-#include <cinttypes>
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <list>
+#include <map>
 #include <mutex>
+#include <ostream>
 #include <thread>
 
 #include "common/logging.h"
 #include "common/status.h"
-#include "runtime/descriptors.h"
 #include "util/string_util.h"
-#include "vec/common/string_ref.h"
 
 namespace doris {
+class TupleDescriptor;
 
 // Broker
 ParquetReaderWrap::ParquetReaderWrap(RuntimeState* state,

--- a/be/src/exec/arrow/parquet_reader.h
+++ b/be/src/exec/arrow/parquet_reader.h
@@ -23,6 +23,10 @@
 #include <arrow/io/file.h>
 #include <arrow/io/interfaces.h>
 #include <arrow/status.h>
+#include <arrow/type_fwd.h>
+#include <gen_cpp/PaloBrokerService_types.h>
+#include <gen_cpp/PlanNodes_types.h>
+#include <gen_cpp/Types_types.h>
 #include <parquet/api/reader.h>
 #include <parquet/api/writer.h>
 #include <parquet/arrow/reader.h>
@@ -34,16 +38,23 @@
 #include <condition_variable>
 #include <list>
 #include <map>
+#include <memory>
 #include <mutex>
 #include <string>
 #include <thread>
+#include <vector>
 
 #include "common/config.h"
 #include "common/status.h"
 #include "exec/arrow/arrow_reader.h"
-#include "gen_cpp/PaloBrokerService_types.h"
-#include "gen_cpp/PlanNodes_types.h"
-#include "gen_cpp/Types_types.h"
+#include "io/fs/file_reader_writer_fwd.h"
+
+namespace arrow {
+class RecordBatch;
+} // namespace arrow
+namespace parquet {
+class FileMetaData;
+} // namespace parquet
 
 namespace doris {
 
@@ -54,6 +65,7 @@ class RuntimeState;
 class SlotDescriptor;
 class FileReader;
 class RowGroupReader;
+class TupleDescriptor;
 
 // Reader of parquet file
 class ParquetReaderWrap final : public ArrowReaderWrap {

--- a/be/src/exec/base_scanner.cpp
+++ b/be/src/exec/base_scanner.cpp
@@ -17,16 +17,41 @@
 
 #include "base_scanner.h"
 
+#include <assert.h>
 #include <fmt/format.h>
+#include <gen_cpp/Metrics_types.h>
+#include <gen_cpp/PlanNodes_types.h>
+#include <glog/logging.h>
+#include <opentelemetry/common/threadlocal.h>
+#include <parallel_hashmap/phmap.h>
+#include <stddef.h>
+
+#include <algorithm>
+#include <boost/iterator/iterator_facade.hpp>
+#include <iterator>
+#include <map>
+#include <string>
+#include <utility>
 
 #include "common/consts.h"
-#include "common/utils.h"
-#include "exec/exec_node.h"
+#include "gutil/casts.h"
+#include "runtime/define_primitive_type.h"
 #include "runtime/descriptors.h"
 #include "runtime/runtime_state.h"
+#include "runtime/types.h"
+#include "vec/columns/column_nullable.h"
+#include "vec/columns/column_vector.h"
+#include "vec/columns/columns_number.h"
+#include "vec/common/string_ref.h"
+#include "vec/core/column_with_type_and_name.h"
+#include "vec/data_types/data_type.h"
 #include "vec/data_types/data_type_factory.hpp"
+#include "vec/data_types/data_type_number.h"
+#include "vec/exprs/vexpr_context.h"
 
 namespace doris {
+class TColumn;
+class TNetworkAddress;
 
 BaseScanner::BaseScanner(RuntimeState* state, RuntimeProfile* profile,
                          const TBrokerScanRangeParams& params,

--- a/be/src/exec/base_scanner.cpp
+++ b/be/src/exec/base_scanner.cpp
@@ -26,7 +26,6 @@
 #include <parallel_hashmap/phmap.h>
 #include <stddef.h>
 
-#include <algorithm>
 #include <boost/iterator/iterator_facade.hpp>
 #include <iterator>
 #include <map>

--- a/be/src/exec/base_scanner.h
+++ b/be/src/exec/base_scanner.h
@@ -17,9 +17,21 @@
 
 #pragma once
 
+#include <gen_cpp/Exprs_types.h>
+#include <stdint.h>
+
+#include <memory>
+#include <unordered_map>
+#include <vector>
+
+#include "common/global_types.h"
 #include "common/status.h"
+#include "runtime/descriptors.h"
 #include "util/runtime_profile.h"
+#include "util/slice.h"
+#include "vec/columns/column.h"
 #include "vec/common/schema_util.h"
+#include "vec/core/block.h"
 #include "vec/exprs/vexpr.h"
 #include "vec/exprs/vexpr_context.h"
 
@@ -28,10 +40,14 @@ namespace doris {
 class TupleDescriptor;
 class RowDescriptor;
 class RuntimeState;
+class TBrokerRangeDesc;
+class TBrokerScanRangeParams;
+class TNetworkAddress;
 
 namespace vectorized {
 class VExprContext;
 class IColumn;
+
 using MutableColumnPtr = IColumn::MutablePtr;
 } // namespace vectorized
 

--- a/be/src/exec/data_sink.cpp
+++ b/be/src/exec/data_sink.cpp
@@ -20,22 +20,28 @@
 
 #include "exec/data_sink.h"
 
+#include <gen_cpp/DataSinks_types.h>
+#include <gen_cpp/PaloInternalService_types.h>
+#include <glog/logging.h>
+
 #include <map>
 #include <memory>
+#include <ostream>
 #include <string>
+#include <utility>
 
-#include "gen_cpp/PaloInternalService_types.h"
-#include "runtime/runtime_state.h"
+#include "common/config.h"
 #include "vec/sink/vdata_stream_sender.h"
 #include "vec/sink/vjdbc_table_sink.h"
 #include "vec/sink/vmemory_scratch_sink.h"
-#include "vec/sink/vmysql_table_sink.h"
 #include "vec/sink/vodbc_table_sink.h"
 #include "vec/sink/vresult_file_sink.h"
 #include "vec/sink/vresult_sink.h"
 #include "vec/sink/vtablet_sink.h"
 
 namespace doris {
+class DescriptorTbl;
+class TExpr;
 
 Status DataSink::create_data_sink(ObjectPool* pool, const TDataSink& thrift_sink,
                                   const std::vector<TExpr>& output_exprs,

--- a/be/src/exec/data_sink.h
+++ b/be/src/exec/data_sink.h
@@ -22,7 +22,6 @@
 
 #include <gen_cpp/DataSinks_types.h>
 #include <gen_cpp/Exprs_types.h>
-#include <opentelemetry/nostd/shared_ptr.h>
 #include <opentelemetry/trace/span.h>
 #include <stddef.h>
 

--- a/be/src/exec/data_sink.h
+++ b/be/src/exec/data_sink.h
@@ -20,11 +20,17 @@
 
 #pragma once
 
+#include <gen_cpp/DataSinks_types.h>
+#include <gen_cpp/Exprs_types.h>
+#include <opentelemetry/nostd/shared_ptr.h>
+#include <opentelemetry/trace/span.h>
+#include <stddef.h>
+
+#include <memory>
+#include <string>
 #include <vector>
 
 #include "common/status.h"
-#include "gen_cpp/DataSinks_types.h"
-#include "gen_cpp/Exprs_types.h"
 #include "runtime/descriptors.h"
 #include "runtime/query_statistics.h"
 #include "util/runtime_profile.h"
@@ -36,6 +42,11 @@ class ObjectPool;
 class RuntimeState;
 class TPlanFragmentExecParams;
 class RowDescriptor;
+class DescriptorTbl;
+class QueryStatistics;
+class TDataSink;
+class TExpr;
+class TPipelineFragmentParams;
 
 namespace vectorized {
 class Block;

--- a/be/src/exec/data_sink.h
+++ b/be/src/exec/data_sink.h
@@ -24,7 +24,7 @@
 #include <gen_cpp/Exprs_types.h>
 #include <opentelemetry/trace/span.h>
 #include <stddef.h>
-
+// IWYU pragma: no_include <opentelemetry/nostd/shared_ptr.h>
 #include <memory>
 #include <string>
 #include <vector>

--- a/be/src/exec/decompressor.cpp
+++ b/be/src/exec/decompressor.cpp
@@ -17,6 +17,10 @@
 
 #include "exec/decompressor.h"
 
+#include <strings.h>
+
+#include <ostream>
+
 #include "common/logging.h"
 
 namespace doris {

--- a/be/src/exec/decompressor.h
+++ b/be/src/exec/decompressor.h
@@ -19,7 +19,11 @@
 
 #include <bzlib.h>
 #include <lz4/lz4frame.h>
+#include <stddef.h>
+#include <stdint.h>
 #include <zlib.h>
+
+#include <string>
 
 #ifdef DORIS_WITH_LZO
 #include <lzo/lzo1x.h>

--- a/be/src/exec/es/es_scan_reader.cpp
+++ b/be/src/exec/es/es_scan_reader.cpp
@@ -17,6 +17,8 @@
 
 #include "exec/es/es_scan_reader.h"
 
+#include <stdlib.h>
+
 #include <map>
 #include <sstream>
 #include <string>
@@ -24,7 +26,9 @@
 #include "common/config.h"
 #include "common/logging.h"
 #include "common/status.h"
+#include "exec/es/es_scroll_parser.h"
 #include "exec/es/es_scroll_query.h"
+#include "http/http_method.h"
 
 namespace doris {
 

--- a/be/src/exec/es/es_scan_reader.h
+++ b/be/src/exec/es/es_scan_reader.h
@@ -17,10 +17,16 @@
 
 #pragma once
 
+#include <map>
+#include <memory>
 #include <string>
 
 #include "exec/es/es_scroll_parser.h"
 #include "http/http_client.h"
+
+namespace doris {
+class ScrollParser;
+} // namespace doris
 
 using std::string;
 

--- a/be/src/exec/es/es_scroll_parser.cpp
+++ b/be/src/exec/es/es_scroll_parser.cpp
@@ -25,7 +25,8 @@
 #include <stdint.h>
 #include <string.h>
 
-#include <chrono>
+// IWYU pragma: no_include <bits/chrono.h>
+#include <chrono> // IWYU pragma: keep
 #include <cstdlib>
 #include <ostream>
 #include <string>

--- a/be/src/exec/es/es_scroll_parser.cpp
+++ b/be/src/exec/es/es_scroll_parser.cpp
@@ -18,20 +18,33 @@
 #include "exec/es/es_scroll_parser.h"
 
 #include <cctz/time_zone.h>
+#include <glog/logging.h>
 #include <gutil/strings/substitute.h>
+#include <rapidjson/allocators.h>
+#include <rapidjson/encodings.h>
+#include <stdint.h>
+#include <string.h>
 
-#include <boost/algorithm/string.hpp>
+#include <chrono>
+#include <cstdlib>
+#include <ostream>
 #include <string>
 
 #include "common/status.h"
+#include "gutil/integral_types.h"
 #include "rapidjson/document.h"
 #include "rapidjson/rapidjson.h"
 #include "rapidjson/stringbuffer.h"
 #include "rapidjson/writer.h"
-#include "runtime/memory/mem_tracker.h"
+#include "runtime/decimalv2_value.h"
+#include "runtime/define_primitive_type.h"
+#include "runtime/descriptors.h"
+#include "runtime/primitive_type.h"
+#include "runtime/types.h"
+#include "util/binary_cast.hpp"
 #include "util/string_parser.hpp"
-#include "vec/columns/column_array.h"
-#include "vec/common/string_ref.h"
+#include "vec/columns/column.h"
+#include "vec/columns/column_nullable.h"
 #include "vec/core/field.h"
 #include "vec/runtime/vdatetime_value.h"
 

--- a/be/src/exec/es/es_scroll_parser.h
+++ b/be/src/exec/es/es_scroll_parser.h
@@ -17,15 +17,21 @@
 
 #pragma once
 
+#include <rapidjson/rapidjson.h>
+
+#include <map>
 #include <string>
+#include <vector>
 
 #include "rapidjson/document.h"
 #include "runtime/descriptors.h"
 #include "vec/core/block.h"
+#include "vec/data_types/data_type.h"
 
 namespace doris {
 
 class Status;
+class TupleDescriptor;
 
 class ScrollParser {
 public:

--- a/be/src/exec/es/es_scroll_query.cpp
+++ b/be/src/exec/es/es_scroll_query.cpp
@@ -17,6 +17,11 @@
 
 #include "exec/es/es_scroll_query.h"
 
+#include <glog/logging.h>
+#include <rapidjson/encodings.h>
+#include <rapidjson/rapidjson.h>
+#include <stdlib.h>
+
 #include <sstream>
 
 #include "exec/es/es_scan_reader.h"

--- a/be/src/exec/exec_node.cpp
+++ b/be/src/exec/exec_node.cpp
@@ -20,19 +20,33 @@
 
 #include "exec/exec_node.h"
 
+#include <gen_cpp/Metrics_types.h>
+#include <gen_cpp/PlanNodes_types.h>
+#include <opentelemetry/common/threadlocal.h>
 #include <thrift/protocol/TDebugProtocol.h>
-#include <unistd.h>
 
+#include <algorithm>
+#include <map>
 #include <sstream>
+#include <typeinfo>
+#include <utility>
 
+#include "common/config.h"
+#include "common/logging.h"
 #include "common/object_pool.h"
 #include "common/status.h"
+#include "exec/scan_node.h"
 #include "runtime/descriptors.h"
 #include "runtime/memory/mem_tracker.h"
 #include "runtime/runtime_state.h"
 #include "util/debug_util.h"
 #include "util/runtime_profile.h"
+#include "util/uid_util.h"
+#include "vec/columns/column.h"
+#include "vec/columns/column_nullable.h"
+#include "vec/common/pod_array_fwd.h"
 #include "vec/core/block.h"
+#include "vec/core/column_with_type_and_name.h"
 #include "vec/exec/join/vhash_join_node.h"
 #include "vec/exec/join/vnested_loop_join_node.h"
 #include "vec/exec/scan/new_es_scan_node.h"
@@ -41,13 +55,13 @@
 #include "vec/exec/scan/new_odbc_scan_node.h"
 #include "vec/exec/scan/new_olap_scan_node.h"
 #include "vec/exec/scan/vmeta_scan_node.h"
+#include "vec/exec/scan/vscan_node.h"
 #include "vec/exec/vaggregation_node.h"
 #include "vec/exec/vanalytic_eval_node.h"
 #include "vec/exec/vassert_num_rows_node.h"
 #include "vec/exec/vdata_gen_scan_node.h"
 #include "vec/exec/vempty_set_node.h"
 #include "vec/exec/vexchange_node.h"
-#include "vec/exec/vmysql_scan_node.h"
 #include "vec/exec/vrepeat_node.h"
 #include "vec/exec/vschema_scan_node.h"
 #include "vec/exec/vselect_node.h"
@@ -56,8 +70,11 @@
 #include "vec/exec/vtable_function_node.h"
 #include "vec/exec/vunion_node.h"
 #include "vec/exprs/vexpr.h"
+#include "vec/exprs/vexpr_context.h"
+#include "vec/utils/util.hpp"
 
 namespace doris {
+class QueryStatistics;
 
 const std::string ExecNode::ROW_THROUGHPUT_COUNTER = "RowsReturnedRate";
 

--- a/be/src/exec/exec_node.cpp
+++ b/be/src/exec/exec_node.cpp
@@ -25,7 +25,6 @@
 #include <opentelemetry/common/threadlocal.h>
 #include <thrift/protocol/TDebugProtocol.h>
 
-#include <algorithm>
 #include <map>
 #include <sstream>
 #include <typeinfo>

--- a/be/src/exec/exec_node.h
+++ b/be/src/exec/exec_node.h
@@ -20,18 +20,27 @@
 
 #pragma once
 
+#include <gen_cpp/PlanNodes_types.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include <atomic>
+#include <functional>
+#include <memory>
 #include <mutex>
 #include <sstream>
+#include <string>
 #include <vector>
 
+#include "common/global_types.h"
 #include "common/status.h"
-#include "gen_cpp/PlanNodes_types.h"
 #include "runtime/descriptors.h"
 #include "runtime/query_statistics.h"
 #include "service/backend_options.h"
 #include "util/blocking_queue.hpp"
 #include "util/runtime_profile.h"
 #include "util/telemetry/telemetry.h"
+#include "vec/core/block.h"
 #include "vec/exprs/vexpr_context.h"
 
 namespace doris {
@@ -40,10 +49,12 @@ class Counters;
 class RuntimeState;
 class TPlan;
 class MemTracker;
+class QueryStatistics;
 
 namespace vectorized {
 class Block;
 class VExpr;
+class VExprContext;
 } // namespace vectorized
 
 namespace pipeline {

--- a/be/src/exec/odbc_connector.cpp
+++ b/be/src/exec/odbc_connector.cpp
@@ -17,12 +17,22 @@
 
 #include "exec/odbc_connector.h"
 
+#include <glog/logging.h>
+#include <sql.h>
 #include <sqlext.h>
+#include <wchar.h>
 
-#include <codecvt>
+#include <algorithm>
+#include <ostream>
 
-#include "runtime/primitive_type.h"
-#include "util/types.h"
+#include "runtime/define_primitive_type.h"
+#include "runtime/descriptors.h"
+#include "runtime/types.h"
+#include "util/runtime_profile.h"
+
+namespace doris {
+class RuntimeState;
+} // namespace doris
 
 #define ODBC_DISPOSE(h, ht, x, op)                                                        \
     {                                                                                     \

--- a/be/src/exec/odbc_connector.h
+++ b/be/src/exec/odbc_connector.h
@@ -16,12 +16,24 @@
 // under the License.
 
 #pragma once
+#include <fmt/format.h>
 #include <sqltypes.h>
+#include <stdint.h>
+#include <stdlib.h>
 
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "common/config.h"
 #include "common/status.h"
 #include "exec/table_connector.h"
 
 namespace doris {
+class RuntimeProfile;
+class RuntimeState;
+class TupleDescriptor;
+
 struct ODBCConnectorParam {
     std::string connect_string;
 

--- a/be/src/exec/olap_common.cpp
+++ b/be/src/exec/olap_common.cpp
@@ -17,10 +17,7 @@
 
 #include "exec/olap_common.h"
 
-#include <boost/lexical_cast.hpp>
-#include <set>
-#include <sstream>
-#include <string>
+#include <algorithm>
 #include <utility>
 #include <vector>
 

--- a/be/src/exec/olap_common.cpp
+++ b/be/src/exec/olap_common.cpp
@@ -17,7 +17,6 @@
 
 #include "exec/olap_common.h"
 
-#include <algorithm>
 #include <utility>
 #include <vector>
 

--- a/be/src/exec/olap_common.h
+++ b/be/src/exec/olap_common.h
@@ -17,17 +17,30 @@
 
 #pragma once
 
+#include <gen_cpp/PaloInternalService_types.h>
+#include <glog/logging.h>
+#include <stddef.h>
+
+#include <boost/container/detail/std_fwd.hpp>
 #include <boost/lexical_cast.hpp>
 #include <cstdint>
+#include <iterator>
 #include <map>
+#include <memory>
+#include <set>
 #include <sstream>
 #include <string>
 #include <type_traits>
+#include <utility>
 #include <variant>
+#include <vector>
 
+#include "common/status.h"
 #include "exec/olap_utils.h"
 #include "olap/olap_common.h"
 #include "olap/olap_tuple.h"
+#include "runtime/datetime_value.h"
+#include "runtime/define_primitive_type.h"
 #include "runtime/primitive_type.h"
 #include "runtime/type_limit.h"
 #include "vec/core/types.h"

--- a/be/src/exec/rowid_fetcher.cpp
+++ b/be/src/exec/rowid_fetcher.cpp
@@ -17,14 +17,36 @@
 
 #include "exec/rowid_fetcher.h"
 
+#include <brpc/callback.h>
+#include <brpc/controller.h>
+#include <butil/endpoint.h>
+#include <fmt/format.h>
+#include <gen_cpp/internal_service.pb.h>
+#include <glog/logging.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include <algorithm>
+#include <ostream>
+#include <string>
+#include <unordered_map>
+#include <utility>
+
 #include "bthread/countdown_event.h"
+#include "common/config.h"
 #include "exec/tablet_info.h" // DorisNodesInfo
-#include "gen_cpp/Types_types.h"
-#include "gen_cpp/internal_service.pb.h"
+#include "olap/olap_common.h"
+#include "olap/utils.h"
+#include "runtime/descriptors.h"
 #include "runtime/exec_env.h"       // ExecEnv
 #include "runtime/runtime_state.h"  // RuntimeState
 #include "util/brpc_client_cache.h" // BrpcClientCache
 #include "util/defer_op.h"
+#include "vec/columns/column.h"
+#include "vec/columns/column_nullable.h"
+#include "vec/columns/column_string.h"
+#include "vec/common/assert_cast.h"
+#include "vec/common/string_ref.h"
 #include "vec/core/block.h" // Block
 
 namespace doris {

--- a/be/src/exec/rowid_fetcher.h
+++ b/be/src/exec/rowid_fetcher.h
@@ -17,13 +17,24 @@
 
 #pragma once
 
-#include "gen_cpp/internal_service.pb.h"
+#include <gen_cpp/internal_service.pb.h>
+
+#include <memory>
+#include <vector>
+
+#include "common/status.h"
 #include "vec/core/block.h"
+#include "vec/data_types/data_type.h"
 
 namespace doris {
 
 class DorisNodesInfo;
 class RuntimeState;
+class TupleDescriptor;
+namespace vectorized {
+class ColumnString;
+class MutableBlock;
+} // namespace vectorized
 
 // fetch rows by global rowid
 // tablet_id/rowset_name/segment_id/ordinal_id

--- a/be/src/exec/rowid_fetcher.h
+++ b/be/src/exec/rowid_fetcher.h
@@ -31,6 +31,7 @@ namespace doris {
 class DorisNodesInfo;
 class RuntimeState;
 class TupleDescriptor;
+
 namespace vectorized {
 class ColumnString;
 class MutableBlock;

--- a/be/src/exec/scan_node.cpp
+++ b/be/src/exec/scan_node.cpp
@@ -20,9 +20,18 @@
 
 #include "exec/scan_node.h"
 
+#include <gen_cpp/Metrics_types.h>
+
+#include <memory>
+
+#include "vec/exprs/vexpr_context.h"
 #include "vec/utils/util.hpp"
 
 namespace doris {
+class RuntimeState;
+namespace vectorized {
+class VExpr;
+} // namespace vectorized
 
 const std::string ScanNode::_s_bytes_read_counter = "BytesRead";
 const std::string ScanNode::_s_rows_read_counter = "RowsRead";

--- a/be/src/exec/scan_node.h
+++ b/be/src/exec/scan_node.h
@@ -20,15 +20,24 @@
 
 #pragma once
 
-#include <string>
+#include <gen_cpp/PaloInternalService_types.h>
 
+#include <functional>
+#include <string>
+#include <vector>
+
+#include "common/status.h"
 #include "exec/exec_node.h"
-#include "gen_cpp/PaloInternalService_types.h"
 #include "util/runtime_profile.h"
 
 namespace doris {
 
 class TScanRange;
+class DescriptorTbl;
+class ObjectPool;
+class RuntimeState;
+class TPlanNode;
+class TScanRangeParams;
 
 // Abstract base class of all scan nodes; introduces set_scan_range().
 //

--- a/be/src/exec/schema_scanner.cpp
+++ b/be/src/exec/schema_scanner.cpp
@@ -17,7 +17,16 @@
 
 #include "exec/schema_scanner.h"
 
+#include <gen_cpp/Descriptors_types.h>
+#include <gen_cpp/Types_types.h>
+#include <glog/logging.h>
+#include <string.h>
+
+#include <algorithm>
 #include <cstddef>
+#include <new>
+#include <ostream>
+#include <utility>
 
 #include "exec/schema_scanner/schema_charsets_scanner.h"
 #include "exec/schema_scanner/schema_collations_scanner.h"
@@ -33,13 +42,23 @@
 #include "exec/schema_scanner/schema_user_privileges_scanner.h"
 #include "exec/schema_scanner/schema_variables_scanner.h"
 #include "exec/schema_scanner/schema_views_scanner.h"
+#include "olap/hll.h"
 #include "runtime/define_primitive_type.h"
-#include "util/encryption_util.h"
+#include "util/types.h"
 #include "vec/columns/column.h"
+#include "vec/columns/column_complex.h"
+#include "vec/columns/column_nullable.h"
+#include "vec/columns/column_string.h"
+#include "vec/columns/column_vector.h"
+#include "vec/columns/columns_number.h"
 #include "vec/common/string_ref.h"
 #include "vec/core/block.h"
+#include "vec/core/column_with_type_and_name.h"
+#include "vec/core/types.h"
+#include "vec/data_types/data_type.h"
 
 namespace doris {
+class ObjectPool;
 
 DorisServer* SchemaScanner::_s_doris_server;
 

--- a/be/src/exec/schema_scanner.cpp
+++ b/be/src/exec/schema_scanner.cpp
@@ -22,8 +22,6 @@
 #include <glog/logging.h>
 #include <string.h>
 
-#include <algorithm>
-#include <cstddef>
 #include <new>
 #include <ostream>
 #include <utility>

--- a/be/src/exec/schema_scanner.h
+++ b/be/src/exec/schema_scanner.h
@@ -17,12 +17,18 @@
 
 #pragma once
 
+#include <gen_cpp/Descriptors_types.h>
+#include <gen_cpp/Types_types.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include <memory>
 #include <string>
+#include <vector>
 
 #include "common/object_pool.h"
 #include "common/status.h"
-#include "gen_cpp/Descriptors_types.h"
-#include "gen_cpp/Types_types.h"
+#include "runtime/define_primitive_type.h"
 #include "util/runtime_profile.h"
 #include "vec/core/block.h"
 
@@ -31,6 +37,8 @@ namespace doris {
 // forehead declare class, because jni function init in DorisServer.
 class DorisServer;
 class RuntimeState;
+class ObjectPool;
+class TUserIdentity;
 
 namespace vectorized {
 class Block;

--- a/be/src/exec/schema_scanner/schema_charsets_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_charsets_scanner.cpp
@@ -17,10 +17,18 @@
 
 #include "exec/schema_scanner/schema_charsets_scanner.h"
 
+#include <gen_cpp/Descriptors_types.h>
+#include <string.h>
+
 #include "common/status.h"
+#include "runtime/define_primitive_type.h"
+#include "util/runtime_profile.h"
 #include "vec/common/string_ref.h"
 
 namespace doris {
+namespace vectorized {
+class Block;
+} // namespace vectorized
 
 std::vector<SchemaScanner::ColumnDesc> SchemaCharsetsScanner::_s_css_columns = {
         //   name,       type,          size

--- a/be/src/exec/schema_scanner/schema_charsets_scanner.h
+++ b/be/src/exec/schema_scanner/schema_charsets_scanner.h
@@ -19,9 +19,15 @@
 
 #include <stdint.h>
 
+#include <vector>
+
+#include "common/status.h"
 #include "exec/schema_scanner.h"
 
 namespace doris {
+namespace vectorized {
+class Block;
+} // namespace vectorized
 
 class SchemaCharsetsScanner : public SchemaScanner {
 public:

--- a/be/src/exec/schema_scanner/schema_collations_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_collations_scanner.cpp
@@ -17,11 +17,18 @@
 
 #include "exec/schema_scanner/schema_collations_scanner.h"
 
+#include <gen_cpp/Descriptors_types.h>
+#include <string.h>
+
 #include "common/status.h"
-#include "runtime/primitive_type.h"
+#include "runtime/define_primitive_type.h"
+#include "util/runtime_profile.h"
 #include "vec/common/string_ref.h"
 
 namespace doris {
+namespace vectorized {
+class Block;
+} // namespace vectorized
 
 std::vector<SchemaScanner::ColumnDesc> SchemaCollationsScanner::_s_cols_columns = {
         //   name,       type,          size

--- a/be/src/exec/schema_scanner/schema_collations_scanner.h
+++ b/be/src/exec/schema_scanner/schema_collations_scanner.h
@@ -19,9 +19,15 @@
 
 #include <stdint.h>
 
+#include <vector>
+
+#include "common/status.h"
 #include "exec/schema_scanner.h"
 
 namespace doris {
+namespace vectorized {
+class Block;
+} // namespace vectorized
 
 class SchemaCollationsScanner : public SchemaScanner {
 public:

--- a/be/src/exec/schema_scanner/schema_columns_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_columns_scanner.cpp
@@ -22,7 +22,6 @@
 #include <gen_cpp/FrontendService_types.h>
 #include <gen_cpp/Types_types.h>
 
-#include <algorithm>
 #include <cstdint>
 
 #include "exec/schema_scanner/schema_helper.h"
@@ -32,6 +31,7 @@
 
 namespace doris {
 class RuntimeState;
+
 namespace vectorized {
 class Block;
 } // namespace vectorized

--- a/be/src/exec/schema_scanner/schema_columns_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_columns_scanner.cpp
@@ -17,16 +17,24 @@
 
 #include "exec/schema_scanner/schema_columns_scanner.h"
 
-#include <cstddef>
+#include <fmt/format.h>
+#include <gen_cpp/Descriptors_types.h>
+#include <gen_cpp/FrontendService_types.h>
+#include <gen_cpp/Types_types.h>
+
+#include <algorithm>
 #include <cstdint>
-#include <memory>
-#include <sstream>
 
 #include "exec/schema_scanner/schema_helper.h"
-#include "runtime/primitive_type.h"
+#include "runtime/define_primitive_type.h"
+#include "util/runtime_profile.h"
 #include "vec/common/string_ref.h"
 
 namespace doris {
+class RuntimeState;
+namespace vectorized {
+class Block;
+} // namespace vectorized
 
 std::vector<SchemaScanner::ColumnDesc> SchemaColumnsScanner::_s_col_columns = {
         //   name,       type,          size,                     is_null

--- a/be/src/exec/schema_scanner/schema_columns_scanner.h
+++ b/be/src/exec/schema_scanner/schema_columns_scanner.h
@@ -17,12 +17,19 @@
 
 #pragma once
 
-#include <string>
+#include <gen_cpp/FrontendService_types.h>
 
+#include <string>
+#include <vector>
+
+#include "common/status.h"
 #include "exec/schema_scanner.h"
-#include "gen_cpp/FrontendService_types.h"
 
 namespace doris {
+class RuntimeState;
+namespace vectorized {
+class Block;
+} // namespace vectorized
 
 class SchemaColumnsScanner : public SchemaScanner {
 public:

--- a/be/src/exec/schema_scanner/schema_dummy_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_dummy_scanner.cpp
@@ -17,6 +17,15 @@
 
 #include "schema_dummy_scanner.h"
 
+#include <vector>
+
+namespace doris {
+class RuntimeState;
+namespace vectorized {
+class Block;
+} // namespace vectorized
+} // namespace doris
+
 namespace {
 std::vector<doris::SchemaScanner::ColumnDesc> DUMMY_COLUMN;
 }

--- a/be/src/exec/schema_scanner/schema_dummy_scanner.h
+++ b/be/src/exec/schema_scanner/schema_dummy_scanner.h
@@ -17,9 +17,14 @@
 
 #pragma once
 
+#include "common/status.h"
 #include "exec/schema_scanner.h"
 
 namespace doris {
+class RuntimeState;
+namespace vectorized {
+class Block;
+} // namespace vectorized
 
 class SchemaDummyScanner : public SchemaScanner {
 public:

--- a/be/src/exec/schema_scanner/schema_files_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_files_scanner.cpp
@@ -17,12 +17,20 @@
 
 #include "exec/schema_scanner/schema_files_scanner.h"
 
+#include <gen_cpp/Descriptors_types.h>
+#include <gen_cpp/FrontendService_types.h>
+#include <stdint.h>
+
 #include "exec/schema_scanner/schema_helper.h"
-#include "runtime/primitive_type.h"
+#include "runtime/define_primitive_type.h"
 #include "util/runtime_profile.h"
 #include "vec/common/string_ref.h"
 
 namespace doris {
+class RuntimeState;
+namespace vectorized {
+class Block;
+} // namespace vectorized
 
 std::vector<SchemaScanner::ColumnDesc> SchemaFilesScanner::_s_tbls_columns = {
         //   name,       type,          size,     is_null

--- a/be/src/exec/schema_scanner/schema_files_scanner.h
+++ b/be/src/exec/schema_scanner/schema_files_scanner.h
@@ -17,10 +17,18 @@
 
 #pragma once
 
+#include <gen_cpp/FrontendService_types.h>
+
+#include <vector>
+
+#include "common/status.h"
 #include "exec/schema_scanner.h"
-#include "gen_cpp/FrontendService_types.h"
 
 namespace doris {
+class RuntimeState;
+namespace vectorized {
+class Block;
+} // namespace vectorized
 
 class SchemaFilesScanner : public SchemaScanner {
 public:

--- a/be/src/exec/schema_scanner/schema_helper.cpp
+++ b/be/src/exec/schema_scanner/schema_helper.cpp
@@ -17,15 +17,24 @@
 
 #include "exec/schema_scanner/schema_helper.h"
 
-#include <sstream>
-#include <thread>
+#include <gen_cpp/FrontendService.h>
 
-#include "gen_cpp/FrontendService.h"
-#include "gen_cpp/FrontendService_types.h"
 #include "runtime/client_cache.h"
 #include "util/thrift_rpc_helper.h"
 
 namespace doris {
+class TDescribeTableParams;
+class TDescribeTableResult;
+class TDescribeTablesParams;
+class TDescribeTablesResult;
+class TGetDbsParams;
+class TGetDbsResult;
+class TGetTablesParams;
+class TGetTablesResult;
+class TListPrivilegesResult;
+class TListTableStatusResult;
+class TShowVariableRequest;
+class TShowVariableResult;
 
 Status SchemaHelper::get_db_names(const std::string& ip, const int32_t port,
                                   const TGetDbsParams& request, TGetDbsResult* result) {

--- a/be/src/exec/schema_scanner/schema_helper.h
+++ b/be/src/exec/schema_scanner/schema_helper.h
@@ -17,10 +17,26 @@
 
 #pragma once
 
+#include <gen_cpp/FrontendService_types.h>
+#include <stdint.h>
+
+#include <string>
+
 #include "common/status.h"
-#include "gen_cpp/FrontendService_types.h"
 
 namespace doris {
+class TDescribeTableParams;
+class TDescribeTableResult;
+class TDescribeTablesParams;
+class TDescribeTablesResult;
+class TGetDbsParams;
+class TGetDbsResult;
+class TGetTablesParams;
+class TGetTablesResult;
+class TListPrivilegesResult;
+class TListTableStatusResult;
+class TShowVariableRequest;
+class TShowVariableResult;
 
 // this class is a helper for getting schema info from FE
 class SchemaHelper {

--- a/be/src/exec/schema_scanner/schema_partitions_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_partitions_scanner.cpp
@@ -17,13 +17,21 @@
 
 #include "exec/schema_scanner/schema_partitions_scanner.h"
 
+#include <gen_cpp/Descriptors_types.h>
+#include <gen_cpp/FrontendService_types.h>
+#include <stdint.h>
+
 #include "exec/schema_scanner/schema_helper.h"
-#include "runtime/datetime_value.h"
-#include "runtime/primitive_type.h"
+#include "runtime/decimalv2_value.h"
+#include "runtime/define_primitive_type.h"
 #include "util/runtime_profile.h"
 #include "vec/common/string_ref.h"
 
 namespace doris {
+class RuntimeState;
+namespace vectorized {
+class Block;
+} // namespace vectorized
 
 std::vector<SchemaScanner::ColumnDesc> SchemaPartitionsScanner::_s_tbls_columns = {
         //   name,       type,          size,     is_null

--- a/be/src/exec/schema_scanner/schema_partitions_scanner.h
+++ b/be/src/exec/schema_scanner/schema_partitions_scanner.h
@@ -17,10 +17,18 @@
 
 #pragma once
 
+#include <gen_cpp/FrontendService_types.h>
+
+#include <vector>
+
+#include "common/status.h"
 #include "exec/schema_scanner.h"
-#include "gen_cpp/FrontendService_types.h"
 
 namespace doris {
+class RuntimeState;
+namespace vectorized {
+class Block;
+} // namespace vectorized
 
 class SchemaPartitionsScanner : public SchemaScanner {
 public:

--- a/be/src/exec/schema_scanner/schema_rowsets_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_rowsets_scanner.cpp
@@ -17,20 +17,32 @@
 
 #include "exec/schema_scanner/schema_rowsets_scanner.h"
 
+#include <gen_cpp/Descriptors_types.h>
+
+#include <algorithm>
 #include <cstddef>
+#include <memory>
+#include <shared_mutex>
+#include <string>
+#include <utility>
 
 #include "common/status.h"
-#include "gutil/integral_types.h"
-#include "olap/rowset/beta_rowset.h"
+#include "olap/olap_common.h"
 #include "olap/rowset/rowset.h"
-#include "olap/rowset/segment_v2/segment.h"
-#include "olap/segment_loader.h"
+#include "olap/rowset/rowset_meta.h"
 #include "olap/storage_engine.h"
 #include "olap/tablet.h"
-#include "runtime/descriptors.h"
-#include "runtime/primitive_type.h"
+#include "olap/tablet_manager.h"
+#include "runtime/define_primitive_type.h"
+#include "runtime/runtime_state.h"
+#include "util/runtime_profile.h"
 #include "vec/common/string_ref.h"
+
 namespace doris {
+namespace vectorized {
+class Block;
+} // namespace vectorized
+
 std::vector<SchemaScanner::ColumnDesc> SchemaRowsetsScanner::_s_tbls_columns = {
         //   name,       type,          size,     is_null
         {"BACKEND_ID", TYPE_BIGINT, sizeof(int64_t), true},

--- a/be/src/exec/schema_scanner/schema_rowsets_scanner.h
+++ b/be/src/exec/schema_scanner/schema_rowsets_scanner.h
@@ -30,6 +30,7 @@
 
 namespace doris {
 class RuntimeState;
+
 namespace vectorized {
 class Block;
 } // namespace vectorized

--- a/be/src/exec/schema_scanner/schema_rowsets_scanner.h
+++ b/be/src/exec/schema_scanner/schema_rowsets_scanner.h
@@ -20,13 +20,20 @@
 #include <cstddef>
 #include <cstdint>
 #include <memory>
+#include <vector>
 
 #include "common/status.h"
 #include "exec/schema_scanner.h"
 #include "olap/rowset/rowset.h"
 #include "olap/rowset/segment_v2/segment.h"
 #include "runtime/runtime_state.h"
+
 namespace doris {
+class RuntimeState;
+namespace vectorized {
+class Block;
+} // namespace vectorized
+
 class SchemaRowsetsScanner : public SchemaScanner {
 public:
     SchemaRowsetsScanner();

--- a/be/src/exec/schema_scanner/schema_schema_privileges_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_schema_privileges_scanner.cpp
@@ -17,11 +17,21 @@
 
 #include "exec/schema_scanner/schema_schema_privileges_scanner.h"
 
+#include <gen_cpp/Descriptors_types.h>
+#include <gen_cpp/FrontendService_types.h>
+
+#include <string>
+
 #include "exec/schema_scanner/schema_helper.h"
-#include "runtime/primitive_type.h"
+#include "runtime/define_primitive_type.h"
+#include "util/runtime_profile.h"
 #include "vec/common/string_ref.h"
 
 namespace doris {
+class RuntimeState;
+namespace vectorized {
+class Block;
+} // namespace vectorized
 
 std::vector<SchemaScanner::ColumnDesc> SchemaSchemaPrivilegesScanner::_s_tbls_columns = {
         //   name,       type,          size,     is_null

--- a/be/src/exec/schema_scanner/schema_schema_privileges_scanner.h
+++ b/be/src/exec/schema_scanner/schema_schema_privileges_scanner.h
@@ -17,10 +17,18 @@
 
 #pragma once
 
+#include <gen_cpp/FrontendService_types.h>
+
+#include <vector>
+
+#include "common/status.h"
 #include "exec/schema_scanner.h"
-#include "gen_cpp/FrontendService_types.h"
 
 namespace doris {
+class RuntimeState;
+namespace vectorized {
+class Block;
+} // namespace vectorized
 
 class SchemaSchemaPrivilegesScanner : public SchemaScanner {
 public:

--- a/be/src/exec/schema_scanner/schema_schemata_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_schemata_scanner.cpp
@@ -17,11 +17,21 @@
 
 #include "exec/schema_scanner/schema_schemata_scanner.h"
 
+#include <gen_cpp/Descriptors_types.h>
+#include <gen_cpp/FrontendService_types.h>
+
+#include <string>
+
 #include "exec/schema_scanner/schema_helper.h"
-#include "runtime/primitive_type.h"
+#include "runtime/define_primitive_type.h"
+#include "util/runtime_profile.h"
 #include "vec/common/string_ref.h"
 
 namespace doris {
+class RuntimeState;
+namespace vectorized {
+class Block;
+} // namespace vectorized
 
 std::vector<SchemaScanner::ColumnDesc> SchemaSchemataScanner::_s_columns = {
         //   name,       type,          size

--- a/be/src/exec/schema_scanner/schema_schemata_scanner.h
+++ b/be/src/exec/schema_scanner/schema_schemata_scanner.h
@@ -17,10 +17,18 @@
 
 #pragma once
 
+#include <gen_cpp/FrontendService_types.h>
+
+#include <vector>
+
+#include "common/status.h"
 #include "exec/schema_scanner.h"
-#include "gen_cpp/FrontendService_types.h"
 
 namespace doris {
+class RuntimeState;
+namespace vectorized {
+class Block;
+} // namespace vectorized
 
 class SchemaSchemataScanner : public SchemaScanner {
 public:

--- a/be/src/exec/schema_scanner/schema_statistics_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_statistics_scanner.cpp
@@ -17,7 +17,9 @@
 
 #include "exec/schema_scanner/schema_statistics_scanner.h"
 
-#include "runtime/primitive_type.h"
+#include <stdint.h>
+
+#include "runtime/define_primitive_type.h"
 #include "vec/common/string_ref.h"
 
 namespace doris {

--- a/be/src/exec/schema_scanner/schema_statistics_scanner.h
+++ b/be/src/exec/schema_scanner/schema_statistics_scanner.h
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#include <vector>
+
 #include "exec/schema_scanner.h"
 
 namespace doris {

--- a/be/src/exec/schema_scanner/schema_table_privileges_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_table_privileges_scanner.cpp
@@ -17,13 +17,21 @@
 
 #include "exec/schema_scanner/schema_table_privileges_scanner.h"
 
+#include <gen_cpp/Descriptors_types.h>
+#include <gen_cpp/FrontendService_types.h>
+
 #include <string>
 
 #include "exec/schema_scanner/schema_helper.h"
-#include "runtime/primitive_type.h"
+#include "runtime/define_primitive_type.h"
+#include "util/runtime_profile.h"
 #include "vec/common/string_ref.h"
 
 namespace doris {
+class RuntimeState;
+namespace vectorized {
+class Block;
+} // namespace vectorized
 
 std::vector<SchemaScanner::ColumnDesc> SchemaTablePrivilegesScanner::_s_tbls_columns = {
         //   name,       type,          size,     is_null

--- a/be/src/exec/schema_scanner/schema_table_privileges_scanner.h
+++ b/be/src/exec/schema_scanner/schema_table_privileges_scanner.h
@@ -17,10 +17,18 @@
 
 #pragma once
 
+#include <gen_cpp/FrontendService_types.h>
+
+#include <vector>
+
+#include "common/status.h"
 #include "exec/schema_scanner.h"
-#include "gen_cpp/FrontendService_types.h"
 
 namespace doris {
+class RuntimeState;
+namespace vectorized {
+class Block;
+} // namespace vectorized
 
 class SchemaTablePrivilegesScanner : public SchemaScanner {
 public:

--- a/be/src/exec/schema_scanner/schema_tables_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_tables_scanner.cpp
@@ -21,7 +21,6 @@
 #include <gen_cpp/FrontendService_types.h>
 #include <stdint.h>
 
-#include <algorithm>
 #include <string>
 
 #include "common/status.h"
@@ -35,6 +34,7 @@
 
 namespace doris {
 class RuntimeState;
+
 namespace vectorized {
 class Block;
 } // namespace vectorized

--- a/be/src/exec/schema_scanner/schema_tables_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_tables_scanner.cpp
@@ -17,13 +17,27 @@
 
 #include "exec/schema_scanner/schema_tables_scanner.h"
 
+#include <gen_cpp/Descriptors_types.h>
+#include <gen_cpp/FrontendService_types.h>
+#include <stdint.h>
+
+#include <algorithm>
+#include <string>
+
 #include "common/status.h"
 #include "exec/schema_scanner/schema_helper.h"
-#include "runtime/primitive_type.h"
-#include "vec/columns/column_complex.h"
+#include "runtime/decimalv2_value.h"
+#include "runtime/define_primitive_type.h"
+#include "util/runtime_profile.h"
+#include "util/timezone_utils.h"
 #include "vec/common/string_ref.h"
+#include "vec/runtime/vdatetime_value.h"
 
 namespace doris {
+class RuntimeState;
+namespace vectorized {
+class Block;
+} // namespace vectorized
 
 std::vector<SchemaScanner::ColumnDesc> SchemaTablesScanner::_s_tbls_columns = {
         //   name,       type,          size,     is_null

--- a/be/src/exec/schema_scanner/schema_tables_scanner.h
+++ b/be/src/exec/schema_scanner/schema_tables_scanner.h
@@ -27,6 +27,7 @@
 
 namespace doris {
 class RuntimeState;
+
 namespace vectorized {
 class Block;
 } // namespace vectorized

--- a/be/src/exec/schema_scanner/schema_tables_scanner.h
+++ b/be/src/exec/schema_scanner/schema_tables_scanner.h
@@ -17,12 +17,19 @@
 
 #pragma once
 
+#include <gen_cpp/FrontendService_types.h>
+
+#include <vector>
+
 #include "common/status.h"
 #include "exec/schema_scanner.h"
-#include "gen_cpp/FrontendService_types.h"
 #include "vec/core/block.h"
 
 namespace doris {
+class RuntimeState;
+namespace vectorized {
+class Block;
+} // namespace vectorized
 
 class SchemaTablesScanner : public SchemaScanner {
 public:

--- a/be/src/exec/schema_scanner/schema_user_privileges_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_user_privileges_scanner.cpp
@@ -17,11 +17,21 @@
 
 #include "exec/schema_scanner/schema_user_privileges_scanner.h"
 
+#include <gen_cpp/Descriptors_types.h>
+#include <gen_cpp/FrontendService_types.h>
+
+#include <string>
+
 #include "exec/schema_scanner/schema_helper.h"
-#include "runtime/primitive_type.h"
+#include "runtime/define_primitive_type.h"
+#include "util/runtime_profile.h"
 #include "vec/common/string_ref.h"
 
 namespace doris {
+class RuntimeState;
+namespace vectorized {
+class Block;
+} // namespace vectorized
 
 std::vector<SchemaScanner::ColumnDesc> SchemaUserPrivilegesScanner::_s_tbls_columns = {
         //   name,       type,          size,     is_null

--- a/be/src/exec/schema_scanner/schema_user_privileges_scanner.h
+++ b/be/src/exec/schema_scanner/schema_user_privileges_scanner.h
@@ -17,10 +17,18 @@
 
 #pragma once
 
+#include <gen_cpp/FrontendService_types.h>
+
+#include <vector>
+
+#include "common/status.h"
 #include "exec/schema_scanner.h"
-#include "gen_cpp/FrontendService_types.h"
 
 namespace doris {
+class RuntimeState;
+namespace vectorized {
+class Block;
+} // namespace vectorized
 
 class SchemaUserPrivilegesScanner : public SchemaScanner {
 public:

--- a/be/src/exec/schema_scanner/schema_variables_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_variables_scanner.cpp
@@ -17,12 +17,24 @@
 
 #include "exec/schema_scanner/schema_variables_scanner.h"
 
+#include <gen_cpp/Descriptors_types.h>
+#include <gen_cpp/FrontendService_types.h>
+#include <string.h>
+
+#include <map>
+#include <string>
+#include <utility>
+
 #include "exec/schema_scanner/schema_helper.h"
-#include "runtime/primitive_type.h"
-#include "runtime/runtime_state.h"
+#include "runtime/define_primitive_type.h"
+#include "util/runtime_profile.h"
 #include "vec/common/string_ref.h"
 
 namespace doris {
+class RuntimeState;
+namespace vectorized {
+class Block;
+} // namespace vectorized
 
 std::vector<SchemaScanner::ColumnDesc> SchemaVariablesScanner::_s_vars_columns = {
         //   name,       type,          size

--- a/be/src/exec/schema_scanner/schema_variables_scanner.h
+++ b/be/src/exec/schema_scanner/schema_variables_scanner.h
@@ -17,13 +17,21 @@
 
 #pragma once
 
+#include <gen_cpp/FrontendService_types.h>
+#include <gen_cpp/Types_types.h>
+
 #include <map>
 #include <string>
+#include <vector>
 
+#include "common/status.h"
 #include "exec/schema_scanner.h"
-#include "gen_cpp/FrontendService_types.h"
 
 namespace doris {
+class RuntimeState;
+namespace vectorized {
+class Block;
+} // namespace vectorized
 
 class SchemaVariablesScanner : public SchemaScanner {
 public:

--- a/be/src/exec/schema_scanner/schema_variables_scanner.h
+++ b/be/src/exec/schema_scanner/schema_variables_scanner.h
@@ -29,6 +29,7 @@
 
 namespace doris {
 class RuntimeState;
+
 namespace vectorized {
 class Block;
 } // namespace vectorized

--- a/be/src/exec/schema_scanner/schema_views_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_views_scanner.cpp
@@ -17,11 +17,21 @@
 
 #include "exec/schema_scanner/schema_views_scanner.h"
 
+#include <gen_cpp/Descriptors_types.h>
+#include <gen_cpp/FrontendService_types.h>
+
+#include <string>
+
 #include "exec/schema_scanner/schema_helper.h"
-#include "runtime/primitive_type.h"
+#include "runtime/define_primitive_type.h"
+#include "util/runtime_profile.h"
 #include "vec/common/string_ref.h"
 
 namespace doris {
+class RuntimeState;
+namespace vectorized {
+class Block;
+} // namespace vectorized
 
 std::vector<SchemaScanner::ColumnDesc> SchemaViewsScanner::_s_tbls_columns = {
         //   name,       type,          size,     is_null

--- a/be/src/exec/schema_scanner/schema_views_scanner.h
+++ b/be/src/exec/schema_scanner/schema_views_scanner.h
@@ -17,10 +17,18 @@
 
 #pragma once
 
+#include <gen_cpp/FrontendService_types.h>
+
+#include <vector>
+
+#include "common/status.h"
 #include "exec/schema_scanner.h"
-#include "gen_cpp/FrontendService_types.h"
 
 namespace doris {
+class RuntimeState;
+namespace vectorized {
+class Block;
+} // namespace vectorized
 
 class SchemaViewsScanner : public SchemaScanner {
 public:

--- a/be/src/exec/table_connector.cpp
+++ b/be/src/exec/table_connector.cpp
@@ -17,22 +17,37 @@
 
 #include "exec/table_connector.h"
 
-#include <fmt/core.h>
+#include <bthread/errno.h>
+#include <errno.h>
+#include <gen_cpp/Metrics_types.h>
 #include <gen_cpp/Types_types.h>
 #include <glog/logging.h>
 #include <iconv.h>
 
+#include <cstdlib>
+#include <memory>
+#include <string_view>
+#include <type_traits>
+
+#include "runtime/decimalv2_value.h"
 #include "runtime/define_primitive_type.h"
-#include "runtime/primitive_type.h"
-#include "util/mysql_global.h"
+#include "util/binary_cast.hpp"
+#include "vec/columns/column.h"
 #include "vec/columns/column_array.h"
+#include "vec/columns/column_nullable.h"
+#include "vec/common/assert_cast.h"
+#include "vec/common/string_ref.h"
 #include "vec/core/block.h"
+#include "vec/core/column_with_type_and_name.h"
 #include "vec/data_types/data_type.h"
 #include "vec/data_types/data_type_array.h"
+#include "vec/data_types/data_type_nullable.h"
 #include "vec/exprs/vexpr.h"
 #include "vec/exprs/vexpr_context.h"
+#include "vec/runtime/vdatetime_value.h"
 
 namespace doris {
+class TupleDescriptor;
 
 // Default max buffer size use in insert to: 50MB, normally a batch is smaller than the size
 static constexpr uint32_t INSERT_BUFFER_SIZE = 1024l * 1024 * 50;

--- a/be/src/exec/table_connector.h
+++ b/be/src/exec/table_connector.h
@@ -37,6 +37,7 @@
 namespace doris {
 class RuntimeState;
 class TupleDescriptor;
+
 namespace vectorized {
 class Block;
 class VExprContext;

--- a/be/src/exec/table_connector.h
+++ b/be/src/exec/table_connector.h
@@ -19,6 +19,7 @@
 
 #include <fmt/format.h>
 #include <gen_cpp/Types_types.h>
+#include <stdint.h>
 
 #include <boost/format.hpp>
 #include <cstdlib>
@@ -27,9 +28,19 @@
 
 #include "common/status.h"
 #include "runtime/descriptors.h"
+#include "runtime/types.h"
+#include "util/runtime_profile.h"
+#include "vec/aggregate_functions/aggregate_function.h"
+#include "vec/data_types/data_type.h"
 #include "vec/exprs/vexpr_context.h"
 
 namespace doris {
+class RuntimeState;
+class TupleDescriptor;
+namespace vectorized {
+class Block;
+class VExprContext;
+} // namespace vectorized
 
 // Table Connector for scan data from ODBC/JDBC
 class TableConnector {

--- a/be/src/exec/tablet_info.cpp
+++ b/be/src/exec/tablet_info.cpp
@@ -17,10 +17,28 @@
 
 #include "exec/tablet_info.h"
 
+#include <butil/fast_rand.h>
+#include <gen_cpp/Descriptors_types.h>
+#include <gen_cpp/Exprs_types.h>
+#include <gen_cpp/Types_types.h>
+#include <gen_cpp/descriptors.pb.h>
+#include <glog/logging.h>
+#include <stddef.h>
+
+#include <algorithm>
+#include <ostream>
+
+#include "olap/tablet_schema.h"
+#include "runtime/descriptors.h"
 #include "runtime/large_int_value.h"
+#include "runtime/memory/mem_tracker.h"
 #include "runtime/raw_value.h"
+#include "runtime/types.h"
+#include "util/hash_util.hpp"
 #include "util/string_parser.hpp"
+#include "vec/common/string_ref.h"
 #include "vec/exprs/vexpr.h"
+#include "vec/runtime/vdatetime_value.h"
 
 namespace doris {
 

--- a/be/src/exec/tablet_info.h
+++ b/be/src/exec/tablet_info.h
@@ -46,6 +46,7 @@ class TExprNode;
 class TabletColumn;
 class TabletIndex;
 class TupleDescriptor;
+
 namespace vectorized {
 class VExprContext;
 } // namespace vectorized

--- a/be/src/exec/tablet_info.h
+++ b/be/src/exec/tablet_info.h
@@ -17,22 +17,38 @@
 
 #pragma once
 
+#include <gen_cpp/Descriptors_types.h>
+#include <gen_cpp/descriptors.pb.h>
+
 #include <cstdint>
+#include <functional>
+#include <iterator>
 #include <map>
 #include <memory>
+#include <string>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 #include "common/object_pool.h"
 #include "common/status.h"
-#include "gen_cpp/Descriptors_types.h"
-#include "gen_cpp/descriptors.pb.h"
 #include "olap/tablet_schema.h"
 #include "runtime/descriptors.h"
+#include "vec/columns/column.h"
 #include "vec/core/block.h"
+#include "vec/core/column_with_type_and_name.h"
 #include "vec/exprs/vexpr_context.h"
 
 namespace doris {
+class MemTracker;
+class SlotDescriptor;
+class TExprNode;
+class TabletColumn;
+class TabletIndex;
+class TupleDescriptor;
+namespace vectorized {
+class VExprContext;
+} // namespace vectorized
 
 struct OlapTableIndexSchema {
     int64_t index_id;

--- a/be/src/exec/text_converter.cpp
+++ b/be/src/exec/text_converter.cpp
@@ -17,15 +17,25 @@
 
 #include "text_converter.h"
 
+#include <glog/logging.h>
 #include <sql.h>
+#include <stdint.h>
 
+#include <ostream>
+
+#include "common/compiler_util.h"
+#include "olap/hll.h"
 #include "runtime/decimalv2_value.h"
+#include "runtime/define_primitive_type.h"
 #include "runtime/descriptors.h"
+#include "runtime/types.h"
+#include "util/slice.h"
 #include "util/string_parser.hpp"
-#include "util/types.h"
 #include "vec/columns/column_complex.h"
 #include "vec/columns/column_nullable.h"
-#include "vec/common/string_ref.h"
+#include "vec/columns/column_string.h"
+#include "vec/columns/column_vector.h"
+#include "vec/core/types.h"
 #include "vec/runtime/vdatetime_value.h"
 
 namespace doris {

--- a/be/src/exec/text_converter.h
+++ b/be/src/exec/text_converter.h
@@ -17,7 +17,10 @@
 
 #pragma once
 
+#include <stddef.h>
+
 #include "vec/columns/column.h"
+
 namespace doris {
 
 class SlotDescriptor;

--- a/be/src/exprs/block_bloom_filter_avx_impl.cc
+++ b/be/src/exprs/block_bloom_filter_avx_impl.cc
@@ -20,10 +20,14 @@
 
 #ifdef __AVX2__
 
+#include <glog/logging.h>
 #include <immintrin.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include <ostream>
 
 #include "exprs/block_bloom_filter.hpp"
-#include "gutil/macros.h"
 
 namespace doris {
 

--- a/be/src/exprs/block_bloom_filter_impl.cc
+++ b/be/src/exprs/block_bloom_filter_impl.cc
@@ -25,14 +25,15 @@
 #include <stdint.h>
 
 #include <algorithm>
-#include <climits>
-#include <cmath>
+#include <climits> // IWYU pragma: keep
+#include <cmath>   // IWYU pragma: keep
 #include <cstdlib>
 #include <cstring>
 #include <string>
 
 #include "common/status.h"
 #include "exprs/block_bloom_filter.hpp"
+// IWYU pragma: no_include <emmintrin.h>
 #include "util/sse_util.hpp"
 
 namespace doris {

--- a/be/src/exprs/block_bloom_filter_impl.cc
+++ b/be/src/exprs/block_bloom_filter_impl.cc
@@ -20,19 +20,20 @@
 // and modified by Doris
 
 #include <butil/iobuf.h>
-#include <emmintrin.h>
 #include <fmt/format.h>
 #include <glog/logging.h>
-#include <mm_malloc.h>
 #include <stdint.h>
 
 #include <algorithm>
+#include <climits>
+#include <cmath>
 #include <cstdlib>
 #include <cstring>
 #include <string>
 
 #include "common/status.h"
 #include "exprs/block_bloom_filter.hpp"
+#include "util/sse_util.hpp"
 
 namespace doris {
 

--- a/be/src/exprs/block_bloom_filter_impl.cc
+++ b/be/src/exprs/block_bloom_filter_impl.cc
@@ -20,16 +20,19 @@
 // and modified by Doris
 
 #include <butil/iobuf.h>
+#include <emmintrin.h>
+#include <fmt/format.h>
+#include <glog/logging.h>
+#include <mm_malloc.h>
+#include <stdint.h>
 
 #include <algorithm>
-#include <climits>
-#include <cmath>
 #include <cstdlib>
 #include <cstring>
 #include <string>
 
+#include "common/status.h"
 #include "exprs/block_bloom_filter.hpp"
-#include "util/sse_util.hpp"
 
 namespace doris {
 

--- a/be/src/exprs/json_functions.cpp
+++ b/be/src/exprs/json_functions.cpp
@@ -22,7 +22,7 @@
 #include <rapidjson/encodings.h>
 #include <rapidjson/rapidjson.h>
 #include <re2/re2.h>
-#include <simdjson/simdjson.h>
+#include <simdjson/simdjson.h> // IWYU pragma: keep
 #include <stdlib.h>
 
 #include <boost/iterator/iterator_facade.hpp>

--- a/be/src/exprs/json_functions.cpp
+++ b/be/src/exprs/json_functions.cpp
@@ -17,25 +17,23 @@
 
 #include "exprs/json_functions.h"
 
+#include <rapidjson/allocators.h>
 #include <rapidjson/document.h>
-#include <rapidjson/stringbuffer.h>
-#include <rapidjson/writer.h>
+#include <rapidjson/encodings.h>
+#include <rapidjson/rapidjson.h>
 #include <re2/re2.h>
+#include <simdjson/simdjson.h>
 #include <stdlib.h>
-#include <sys/time.h>
 
-#include <boost/algorithm/string.hpp>
-#include <iomanip>
+#include <boost/iterator/iterator_facade.hpp>
+#include <boost/token_functions.hpp>
+#include <boost/tokenizer.hpp>
 #include <sstream>
 #include <string>
-#include <string_view>
 #include <vector>
 
 #include "common/compiler_util.h"
 #include "common/logging.h"
-#include "gutil/strings/stringpiece.h"
-#include "udf/udf.h"
-#include "util/string_util.h"
 
 namespace doris {
 

--- a/be/src/exprs/json_functions.h
+++ b/be/src/exprs/json_functions.h
@@ -18,13 +18,26 @@
 #pragma once
 
 #include <fmt/core.h>
+#include <fmt/format.h>
 #include <rapidjson/document.h>
 #include <simdjson.h>
 
 #include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include "common/status.h"
 #include "udf/udf.h"
+
+namespace simdjson {
+namespace fallback {
+namespace ondemand {
+class object;
+class value;
+} // namespace ondemand
+} // namespace fallback
+} // namespace simdjson
 
 namespace doris {
 

--- a/be/src/exprs/math_functions.cpp
+++ b/be/src/exprs/math_functions.cpp
@@ -21,17 +21,14 @@
 #include "exprs/math_functions.h"
 
 #include <stdlib.h>
+#include <string.h>
 
 #include <cmath>
-#include <iomanip>
-#include <random>
-#include <sstream>
+#include <limits>
 #include <string_view>
 
 #include "common/compiler_util.h"
-#include "runtime/decimalv2_value.h"
-#include "runtime/large_int_value.h"
-#include "util/simd/vstring_function.h"
+#include "udf/udf.h"
 #include "util/string_parser.hpp"
 
 namespace doris {

--- a/be/src/exprs/math_functions.cpp
+++ b/be/src/exprs/math_functions.cpp
@@ -22,7 +22,7 @@
 
 #include <stdlib.h>
 #include <string.h>
-
+// IWYU pragma: no_include <bits/std_abs.h>
 #include <cmath>
 #include <limits>
 #include <string_view>

--- a/be/src/exprs/math_functions.h
+++ b/be/src/exprs/math_functions.h
@@ -26,6 +26,7 @@
 #include "vec/common/string_ref.h"
 
 namespace doris {
+class FunctionContext;
 
 class MathFunctions {
 public:

--- a/be/src/exprs/runtime_filter.cpp
+++ b/be/src/exprs/runtime_filter.cpp
@@ -17,27 +17,45 @@
 
 #include "runtime_filter.h"
 
-#include <memory>
+#include <gen_cpp/Opcodes_types.h>
+#include <gen_cpp/PaloInternalService_types.h>
+#include <gen_cpp/PlanNodes_types.h>
+#include <gen_cpp/Types_types.h>
+#include <gen_cpp/internal_service.pb.h>
+#include <stddef.h>
 
+#include <algorithm>
+#include <chrono>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <ostream>
+#include <utility>
+
+#include "common/logging.h"
 #include "common/object_pool.h"
 #include "common/status.h"
 #include "exprs/bitmapfilter_predicate.h"
+#include "exprs/bloom_filter_func.h"
 #include "exprs/create_predicate_function.h"
 #include "exprs/hybrid_set.h"
 #include "exprs/minmax_predicate.h"
-#include "gen_cpp/internal_service.pb.h"
+#include "gutil/strings/substitute.h"
 #include "runtime/define_primitive_type.h"
 #include "runtime/large_int_value.h"
 #include "runtime/primitive_type.h"
 #include "runtime/runtime_filter_mgr.h"
+#include "util/bitmap_value.h"
 #include "util/runtime_profile.h"
 #include "util/string_parser.hpp"
 #include "vec/columns/column.h"
 #include "vec/columns/column_complex.h"
+#include "vec/common/assert_cast.h"
 #include "vec/exprs/vbitmap_predicate.h"
 #include "vec/exprs/vbloom_predicate.h"
 #include "vec/exprs/vdirect_in_predicate.h"
 #include "vec/exprs/vexpr.h"
+#include "vec/exprs/vexpr_context.h"
 #include "vec/exprs/vliteral.h"
 #include "vec/exprs/vruntimefilter_wrapper.h"
 #include "vec/runtime/shared_hash_table_controller.h"

--- a/be/src/exprs/runtime_filter.cpp
+++ b/be/src/exprs/runtime_filter.cpp
@@ -25,7 +25,8 @@
 #include <stddef.h>
 
 #include <algorithm>
-#include <chrono>
+// IWYU pragma: no_include <bits/chrono.h>
+#include <chrono> // IWYU pragma: keep
 #include <map>
 #include <memory>
 #include <mutex>

--- a/be/src/exprs/runtime_filter.h
+++ b/be/src/exprs/runtime_filter.h
@@ -17,12 +17,31 @@
 
 #pragma once
 
+#include <fmt/format.h>
+#include <gen_cpp/Exprs_types.h>
+#include <stdint.h>
+
+#include <atomic>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "common/status.h"
+#include "runtime/datetime_value.h"
+#include "runtime/decimalv2_value.h"
+#include "runtime/define_primitive_type.h"
 #include "runtime/large_int_value.h"
+#include "runtime/primitive_type.h"
 #include "runtime/runtime_state.h"
+#include "runtime/types.h"
 #include "util/lock.h"
 #include "util/runtime_profile.h"
 #include "util/time.h"
 #include "util/uid_util.h"
+#include "vec/common/string_ref.h"
+#include "vec/core/types.h"
+#include "vec/data_types/data_type.h"
+#include "vec/runtime/vdatetime_value.h"
 
 namespace butil {
 class IOBufAsZeroCopyInputStream;
@@ -42,6 +61,8 @@ class HashJoinNode;
 class RuntimeProfile;
 class BloomFilterFuncBase;
 class BitmapFilterFuncBase;
+class TNetworkAddress;
+class TQueryOptions;
 
 namespace vectorized {
 class VExpr;
@@ -339,6 +360,7 @@ protected:
     std::vector<doris::vectorized::VExpr*> _push_down_vexprs;
 
     struct rpc_context;
+
     std::shared_ptr<rpc_context> _rpc_context;
 
     // parent profile

--- a/be/src/exprs/runtime_filter_rpc.cpp
+++ b/be/src/exprs/runtime_filter_rpc.cpp
@@ -15,14 +15,25 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#include <brpc/controller.h>
+#include <butil/iobuf.h>
+#include <fmt/format.h>
+#include <gen_cpp/Types_types.h>
+#include <gen_cpp/types.pb.h>
+
+#include <memory>
+#include <ostream>
+#include <string>
+
 #include "common/config.h"
 #include "common/status.h"
 #include "exprs/runtime_filter.h"
 #include "runtime/exec_env.h"
 #include "runtime/runtime_state.h"
-
 // for rpc
-#include "gen_cpp/internal_service.pb.h"
+#include <gen_cpp/internal_service.pb.h>
+
+#include "common/logging.h"
 #include "util/brpc_client_cache.h"
 
 namespace doris {

--- a/be/src/exprs/string_functions.cpp
+++ b/be/src/exprs/string_functions.cpp
@@ -21,12 +21,9 @@
 #include "exprs/string_functions.h"
 
 #include <re2/re2.h>
+#include <re2/stringpiece.h>
 
-#include <algorithm>
-
-#include "math_functions.h"
-#include "util/simd/vstring_function.h"
-#include "util/url_parser.h"
+#include <sstream>
 
 // NOTE: be careful not to use string::append.  It is not performant.
 namespace doris {

--- a/be/src/exprs/string_functions.h
+++ b/be/src/exprs/string_functions.h
@@ -24,7 +24,9 @@
 
 #include <iomanip>
 #include <locale>
+#include <memory>
 #include <sstream>
+#include <string>
 #include <string_view>
 
 #include "gutil/strings/numbers.h"

--- a/be/src/geo/ByteOrderDataInStream.h
+++ b/be/src/geo/ByteOrderDataInStream.h
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#pragma once
+
 #include <cstddef>
 
 #include "ByteOrderValues.h"

--- a/be/src/geo/ByteOrderValues.cpp
+++ b/be/src/geo/ByteOrderValues.cpp
@@ -17,7 +17,8 @@
 
 #include "ByteOrderValues.h"
 
-#include <cassert>
+#include <stdint.h>
+
 #include <cstring>
 
 namespace doris {

--- a/be/src/geo/ByteOrderValues.h
+++ b/be/src/geo/ByteOrderValues.h
@@ -15,7 +15,12 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#pragma once
+
+#include <sys/types.h>
+
 #include <ctime>
+
 using int64_t = __int64_t;
 using int32_t = __int32_t;
 using uint32_t = __uint32_t;

--- a/be/src/geo/geo_tobinary.cpp
+++ b/be/src/geo/geo_tobinary.cpp
@@ -17,10 +17,16 @@
 
 #include "geo_tobinary.h"
 
+#include <cstddef>
+#include <sstream>
+#include <vector>
+
+#include "geo/ByteOrderValues.h"
+#include "geo/geo_common.h"
+#include "geo/machine.h"
+#include "geo/wkt_parse_type.h"
 #include "geo_tobinary_type.h"
 #include "geo_types.h"
-#include "sstream"
-#include "wkb_parse.h"
 
 namespace doris {
 

--- a/be/src/geo/geo_tobinary.h
+++ b/be/src/geo/geo_tobinary.h
@@ -15,11 +15,17 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#pragma once
+
 //#include "geo_types.h"
+
+#include <string>
 
 #include "geo/geo_common.h"
 #include "geo/geo_tobinary_type.h"
 #include "geo/wkt_parse_type.h"
+
+struct ToBinaryContext;
 
 namespace doris {
 
@@ -27,6 +33,8 @@ class GeoShape;
 class GeoPoint;
 class GeoLine;
 class GeoPolygon;
+struct GeoCoordinate;
+struct GeoCoordinateList;
 
 class toBinary {
 public:

--- a/be/src/geo/geo_types.cpp
+++ b/be/src/geo/geo_types.cpp
@@ -29,10 +29,8 @@
 #include <s2/s2polyline.h>
 #include <s2/util/coding/coder.h>
 #include <s2/util/units/length-units.h>
-#include <stdio.h>
 #include <string.h>
-
-#include <algorithm>
+// IWYU pragma: no_include <bits/std_abs.h>
 #include <cmath>
 #include <iomanip>
 #include <sstream>

--- a/be/src/geo/geo_types.cpp
+++ b/be/src/geo/geo_types.cpp
@@ -17,19 +17,27 @@
 
 #include "geo/geo_types.h"
 
+#include <absl/strings/str_format.h>
+#include <glog/logging.h>
+#include <s2/s1angle.h>
 #include <s2/s2cap.h>
-#include <s2/s2cell.h>
 #include <s2/s2earth.h>
 #include <s2/s2latlng.h>
+#include <s2/s2loop.h>
+#include <s2/s2point.h>
 #include <s2/s2polygon.h>
 #include <s2/s2polyline.h>
 #include <s2/util/coding/coder.h>
 #include <s2/util/units/length-units.h>
 #include <stdio.h>
+#include <string.h>
 
+#include <algorithm>
+#include <cmath>
 #include <iomanip>
 #include <sstream>
-#include <type_traits>
+#include <utility>
+#include <vector>
 
 #include "geo/geo_tobinary.h"
 #include "geo/wkb_parse.h"

--- a/be/src/geo/geo_types.h
+++ b/be/src/geo/geo_types.h
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#include <stddef.h>
+
 #include <memory>
 #include <string>
 #include <vector>
@@ -28,7 +30,6 @@ class S2Polyline;
 class S2Polygon;
 class S2Cap;
 class S2Loop;
-
 template <typename T>
 class Vector3;
 

--- a/be/src/geo/machine.h
+++ b/be/src/geo/machine.h
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#pragma once
+
 namespace doris {
 /**
  * Check endianness of current machine.

--- a/be/src/geo/wkb_parse.cpp
+++ b/be/src/geo/wkb_parse.cpp
@@ -19,8 +19,16 @@
 
 #include <string.h>
 
+#include <array>
+#include <cstddef>
+#include <istream>
+#include <vector>
+
+#include "geo/ByteOrderDataInStream.h"
+#include "geo/ByteOrderValues.h"
+#include "geo/geo_types.h"
+#include "geo/wkb_parse_ctx.h"
 #include "geo_tobinary_type.h"
-#include "sstream"
 
 namespace doris {
 

--- a/be/src/geo/wkb_parse.cpp
+++ b/be/src/geo/wkb_parse.cpp
@@ -17,8 +17,6 @@
 
 #include "wkb_parse.h"
 
-#include <string.h>
-
 #include <array>
 #include <cstddef>
 #include <istream>

--- a/be/src/geo/wkb_parse.h
+++ b/be/src/geo/wkb_parse.h
@@ -15,13 +15,25 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#pragma once
+
+#include <stdint.h>
+
+#include <iosfwd>
+
 #include "geo/geo_common.h"
 #include "geo/geo_types.h"
+#include "geo/wkt_parse_type.h"
 #include "wkb_parse_ctx.h"
+
+struct WkbParseContext;
 
 namespace doris {
 
 class GeoShape;
+class GeoLine;
+class GeoPoint;
+class GeoPolygon;
 
 class WkbParse {
 public:

--- a/be/src/geo/wkt_parse.cpp
+++ b/be/src/geo/wkt_parse.cpp
@@ -17,9 +17,10 @@
 
 #include "geo/wkt_parse.h"
 
-#include "geo/geo_types.h"
 #include "geo/wkt_parse_ctx.h"
+#include "geo/wkt_parse_type.h" // IWYU pragma: keep
 #include "geo/wkt_yacc.y.hpp"
+
 #define YYSTYPE WKT_STYPE
 #define YY_EXTRA_TYPE WktParseContext*
 #include "geo/wkt_lex.l.h"

--- a/be/src/geo/wkt_parse.h
+++ b/be/src/geo/wkt_parse.h
@@ -15,6 +15,10 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#pragma once
+
+#include <stddef.h>
+
 #include <memory>
 
 #include "geo/geo_common.h"

--- a/be/src/http/action/check_rpc_channel_action.cpp
+++ b/be/src/http/action/check_rpc_channel_action.cpp
@@ -17,13 +17,21 @@
 
 #include "http/action/check_rpc_channel_action.h"
 
-#include <fmt/core.h>
+#include <brpc/controller.h>
+#include <fmt/format.h>
+#include <gen_cpp/internal_service.pb.h>
+#include <gen_cpp/types.pb.h>
+#include <glog/logging.h>
+#include <stdint.h>
 
-#include "gen_cpp/internal_service.pb.h"
+#include <exception>
+#include <memory>
+#include <string>
+
 #include "http/http_channel.h"
 #include "http/http_request.h"
+#include "http/http_status.h"
 #include "runtime/exec_env.h"
-#include "service/brpc.h"
 #include "util/brpc_client_cache.h"
 #include "util/md5.h"
 

--- a/be/src/http/action/check_rpc_channel_action.h
+++ b/be/src/http/action/check_rpc_channel_action.h
@@ -21,6 +21,8 @@
 
 namespace doris {
 class ExecEnv;
+class HttpRequest;
+
 class CheckRPCChannelAction : public HttpHandler {
 public:
     explicit CheckRPCChannelAction(ExecEnv* exec_env);

--- a/be/src/http/action/check_tablet_segment_action.cpp
+++ b/be/src/http/action/check_tablet_segment_action.cpp
@@ -17,6 +17,11 @@
 
 #include "http/action/check_tablet_segment_action.h"
 
+#include <glog/logging.h>
+#include <stdint.h>
+
+#include <ostream>
+#include <set>
 #include <string>
 
 #include "http/http_channel.h"
@@ -24,7 +29,9 @@
 #include "http/http_request.h"
 #include "http/http_status.h"
 #include "olap/storage_engine.h"
+#include "olap/tablet_manager.h"
 #include "service/backend_options.h"
+#include "util/easy_json.h"
 
 namespace doris {
 

--- a/be/src/http/action/check_tablet_segment_action.h
+++ b/be/src/http/action/check_tablet_segment_action.h
@@ -23,6 +23,7 @@
 #include "util/easy_json.h"
 
 namespace doris {
+class HttpRequest;
 
 class CheckTabletSegmentAction : public HttpHandler {
 public:

--- a/be/src/http/action/checksum_action.cpp
+++ b/be/src/http/action/checksum_action.cpp
@@ -17,20 +17,17 @@
 
 #include "http/action/checksum_action.h"
 
+#include <boost/lexical_cast/bad_lexical_cast.hpp>
 #include <sstream>
 #include <string>
 
 #include "boost/lexical_cast.hpp"
 #include "common/logging.h"
+#include "common/status.h"
 #include "http/http_channel.h"
-#include "http/http_headers.h"
 #include "http/http_request.h"
-#include "http/http_response.h"
 #include "http/http_status.h"
-#include "olap/olap_define.h"
-#include "olap/storage_engine.h"
 #include "olap/task/engine_checksum_task.h"
-#include "runtime/exec_env.h"
 
 namespace doris {
 

--- a/be/src/http/action/checksum_action.h
+++ b/be/src/http/action/checksum_action.h
@@ -24,6 +24,7 @@
 namespace doris {
 
 class ExecEnv;
+class HttpRequest;
 
 class ChecksumAction : public HttpHandler {
 public:

--- a/be/src/http/action/compaction_action.cpp
+++ b/be/src/http/action/compaction_action.cpp
@@ -17,7 +17,8 @@
 
 #include "http/action/compaction_action.h"
 
-#include <chrono>
+// IWYU pragma: no_include <bits/chrono.h>
+#include <chrono> // IWYU pragma: keep
 #include <exception>
 #include <future>
 #include <memory>

--- a/be/src/http/action/compaction_action.cpp
+++ b/be/src/http/action/compaction_action.cpp
@@ -17,11 +17,15 @@
 
 #include "http/action/compaction_action.h"
 
-#include <sys/syscall.h>
-
+#include <chrono>
+#include <exception>
 #include <future>
+#include <memory>
+#include <mutex>
 #include <sstream>
 #include <string>
+#include <thread>
+#include <utility>
 
 #include "common/logging.h"
 #include "gutil/strings/substitute.h"
@@ -31,8 +35,12 @@
 #include "http/http_status.h"
 #include "olap/base_compaction.h"
 #include "olap/cumulative_compaction.h"
+#include "olap/cumulative_compaction_policy.h"
 #include "olap/olap_define.h"
 #include "olap/storage_engine.h"
+#include "olap/tablet_manager.h"
+#include "util/doris_metrics.h"
+#include "util/stopwatch.hpp"
 
 namespace doris {
 using namespace ErrorCode;

--- a/be/src/http/action/compaction_action.h
+++ b/be/src/http/action/compaction_action.h
@@ -17,11 +17,16 @@
 
 #pragma once
 
+#include <stdint.h>
+
+#include <string>
+
 #include "common/status.h"
 #include "http/http_handler.h"
 #include "olap/tablet.h"
 
 namespace doris {
+class HttpRequest;
 
 enum class CompactionActionType {
     SHOW_INFO = 1,

--- a/be/src/http/action/config_action.cpp
+++ b/be/src/http/action/config_action.cpp
@@ -18,11 +18,16 @@
 #include "http/action/config_action.h"
 
 #include <rapidjson/document.h>
+#include <rapidjson/encodings.h>
 #include <rapidjson/prettywriter.h>
-#include <rapidjson/rapidjson.h>
 #include <rapidjson/stringbuffer.h>
+#include <rapidjson/writer.h>
 
+#include <map>
+#include <ostream>
 #include <string>
+#include <utility>
+#include <vector>
 
 #include "common/configbase.h"
 #include "common/logging.h"
@@ -31,7 +36,6 @@
 #include "http/http_channel.h"
 #include "http/http_headers.h"
 #include "http/http_request.h"
-#include "http/http_response.h"
 #include "http/http_status.h"
 
 namespace doris {

--- a/be/src/http/action/config_action.h
+++ b/be/src/http/action/config_action.h
@@ -20,6 +20,7 @@
 #include "http/http_handler.h"
 
 namespace doris {
+class HttpRequest;
 
 enum ConfigActionType {
     UPDATE_CONFIG = 1,

--- a/be/src/http/action/download_action.cpp
+++ b/be/src/http/action/download_action.cpp
@@ -17,21 +17,19 @@
 
 #include "http/action/download_action.h"
 
-#include <sys/types.h>
-#include <unistd.h>
-
+#include <algorithm>
+#include <memory>
 #include <sstream>
 #include <string>
+#include <utility>
 
+#include "common/config.h"
+#include "common/logging.h"
 #include "http/http_channel.h"
-#include "http/http_headers.h"
 #include "http/http_request.h"
-#include "http/http_response.h"
-#include "http/http_status.h"
 #include "http/utils.h"
 #include "io/fs/local_file_system.h"
 #include "runtime/exec_env.h"
-#include "util/path_util.h"
 
 namespace doris {
 

--- a/be/src/http/action/download_action.h
+++ b/be/src/http/action/download_action.h
@@ -17,6 +17,10 @@
 
 #pragma once
 
+#include <string>
+#include <vector>
+
+#include "common/status.h"
 #include "exec/scan_node.h"
 #include "http/http_handler.h"
 #include "runtime/descriptors.h"
@@ -24,6 +28,7 @@
 namespace doris {
 
 class ExecEnv;
+class HttpRequest;
 
 // A simple handler that serves incoming HTTP requests of file-download to send their respective HTTP responses.
 //

--- a/be/src/http/action/health_action.cpp
+++ b/be/src/http/action/health_action.cpp
@@ -23,7 +23,6 @@
 #include "http/http_channel.h"
 #include "http/http_headers.h"
 #include "http/http_request.h"
-#include "http/http_response.h"
 #include "http/http_status.h"
 
 namespace doris {

--- a/be/src/http/action/health_action.h
+++ b/be/src/http/action/health_action.h
@@ -22,6 +22,7 @@
 namespace doris {
 
 class ExecEnv;
+class HttpRequest;
 
 // Get BE health state from http API.
 class HealthAction : public HttpHandler {

--- a/be/src/http/action/jeprofile_actions.cpp
+++ b/be/src/http/action/jeprofile_actions.cpp
@@ -18,22 +18,25 @@
 #include "http/action/jeprofile_actions.h"
 
 #include <jemalloc/jemalloc.h>
+#include <stdlib.h>
+#include <unistd.h>
 
 #include <ctime>
 #include <fstream>
+#include <memory>
 #include <mutex>
-#include <sstream>
+#include <string>
 
 #include "common/config.h"
 #include "common/object_pool.h"
 #include "http/ev_http_server.h"
 #include "http/http_channel.h"
 #include "http/http_handler.h"
-#include "http/http_headers.h"
-#include "http/http_request.h"
+#include "http/http_method.h"
 #include "io/fs/local_file_system.h"
 
 namespace doris {
+class HttpRequest;
 
 static std::mutex kJeprofileActionMutex;
 class JeHeapAction : public HttpHandler {

--- a/be/src/http/action/meta_action.cpp
+++ b/be/src/http/action/meta_action.cpp
@@ -17,22 +17,27 @@
 
 #include "http/action/meta_action.h"
 
+#include <json2pb/pb_to_json.h>
+#include <stdint.h>
+
+#include <cstring>
+#include <exception>
+#include <memory>
+#include <shared_mutex>
 #include <sstream>
 #include <string>
 
 #include "common/logging.h"
-#include "gutil/strings/substitute.h"
 #include "http/http_channel.h"
 #include "http/http_headers.h"
 #include "http/http_request.h"
-#include "http/http_response.h"
 #include "http/http_status.h"
 #include "olap/olap_define.h"
 #include "olap/storage_engine.h"
 #include "olap/tablet.h"
+#include "olap/tablet_manager.h"
 #include "olap/tablet_meta.h"
-#include "olap/tablet_meta_manager.h"
-#include "util/json_util.h"
+#include "util/easy_json.h"
 
 namespace doris {
 

--- a/be/src/http/action/meta_action.h
+++ b/be/src/http/action/meta_action.h
@@ -17,12 +17,15 @@
 
 #pragma once
 
+#include <string>
+
 #include "common/status.h"
 #include "http/http_handler.h"
 
 namespace doris {
 
 class ExecEnv;
+class HttpRequest;
 
 // Get Meta Info
 class MetaAction : public HttpHandler {

--- a/be/src/http/action/metrics_action.cpp
+++ b/be/src/http/action/metrics_action.cpp
@@ -17,18 +17,11 @@
 
 #include "http/action/metrics_action.h"
 
-#include <rapidjson/document.h>
-#include <rapidjson/rapidjson.h>
-#include <rapidjson/stringbuffer.h>
-#include <rapidjson/writer.h>
-
 #include <string>
 
 #include "http/http_channel.h"
 #include "http/http_headers.h"
 #include "http/http_request.h"
-#include "http/http_response.h"
-#include "runtime/exec_env.h"
 #include "util/metrics.h"
 
 namespace doris {

--- a/be/src/http/action/monitor_action.cpp
+++ b/be/src/http/action/monitor_action.cpp
@@ -17,12 +17,13 @@
 
 #include "http/action/monitor_action.h"
 
-#include <sstream>
+#include <glog/logging.h>
 
-#include "common/status.h"
+#include <sstream>
+#include <utility>
+
 #include "http/http_channel.h"
 #include "http/http_request.h"
-#include "http/http_response.h"
 #include "http/http_status.h"
 #include "http/rest_monitor_iface.h"
 

--- a/be/src/http/action/pad_rowset_action.cpp
+++ b/be/src/http/action/pad_rowset_action.cpp
@@ -17,14 +17,27 @@
 
 #include "http/action/pad_rowset_action.h"
 
+#include <gen_cpp/olap_file.pb.h>
+#include <glog/logging.h>
+#include <stdint.h>
+
+#include <cstdlib>
 #include <memory>
 #include <mutex>
+#include <ostream>
+#include <string>
+#include <vector>
 
 #include "http/http_channel.h"
+#include "http/http_request.h"
+#include "http/http_status.h"
 #include "olap/olap_common.h"
-#include "olap/rowset/beta_rowset_writer.h"
 #include "olap/rowset/rowset.h"
+#include "olap/rowset/rowset_writer.h"
+#include "olap/rowset/rowset_writer_context.h"
 #include "olap/storage_engine.h"
+#include "olap/tablet_manager.h"
+#include "util/time.h"
 
 namespace doris {
 

--- a/be/src/http/action/pad_rowset_action.h
+++ b/be/src/http/action/pad_rowset_action.h
@@ -23,6 +23,8 @@
 #include "olap/tablet.h"
 
 namespace doris {
+class HttpRequest;
+struct Version;
 
 class PadRowsetAction : public HttpHandler {
 public:

--- a/be/src/http/action/pprof_actions.cpp
+++ b/be/src/http/action/pprof_actions.cpp
@@ -17,29 +17,23 @@
 
 #include "http/action/pprof_actions.h"
 
-#include <gperftools/heap-profiler.h>
-#include <gperftools/malloc_extension.h>
-#include <gperftools/profiler.h>
+#include <stdio.h>
 
 #include <fstream>
-#include <iostream>
+#include <memory>
 #include <mutex>
-#include <sstream>
+#include <string>
 
-#include "agent/utils.h"
 #include "common/config.h"
 #include "common/object_pool.h"
-#include "gutil/strings/substitute.h"
 #include "http/ev_http_server.h"
 #include "http/http_channel.h"
 #include "http/http_handler.h"
-#include "http/http_headers.h"
+#include "http/http_method.h"
 #include "http/http_request.h"
-#include "http/http_response.h"
 #include "io/fs/local_file_system.h"
 #include "runtime/exec_env.h"
 #include "util/bfd_parser.h"
-#include "util/pprof_utils.h"
 
 namespace doris {
 

--- a/be/src/http/action/reload_tablet_action.cpp
+++ b/be/src/http/action/reload_tablet_action.cpp
@@ -17,17 +17,18 @@
 
 #include "http/action/reload_tablet_action.h"
 
+#include <gen_cpp/AgentService_types.h>
+
+#include <boost/lexical_cast/bad_lexical_cast.hpp>
 #include <sstream>
 #include <string>
 
 #include "boost/lexical_cast.hpp"
 #include "common/logging.h"
+#include "common/status.h"
 #include "http/http_channel.h"
-#include "http/http_headers.h"
 #include "http/http_request.h"
-#include "http/http_response.h"
 #include "http/http_status.h"
-#include "olap/olap_define.h"
 #include "olap/storage_engine.h"
 #include "runtime/exec_env.h"
 

--- a/be/src/http/action/reload_tablet_action.h
+++ b/be/src/http/action/reload_tablet_action.h
@@ -17,12 +17,17 @@
 
 #pragma once
 
-#include "gen_cpp/AgentService_types.h"
+#include <gen_cpp/AgentService_types.h>
+#include <stdint.h>
+
+#include <string>
+
 #include "http/http_handler.h"
 
 namespace doris {
 
 class ExecEnv;
+class HttpRequest;
 
 class ReloadTabletAction : public HttpHandler {
 public:

--- a/be/src/http/action/reset_rpc_channel_action.cpp
+++ b/be/src/http/action/reset_rpc_channel_action.cpp
@@ -20,6 +20,7 @@
 #include <fmt/format.h>
 #include <glog/logging.h>
 
+#include <algorithm>
 #include <string>
 #include <vector>
 

--- a/be/src/http/action/reset_rpc_channel_action.cpp
+++ b/be/src/http/action/reset_rpc_channel_action.cpp
@@ -17,10 +17,15 @@
 
 #include "http/action/reset_rpc_channel_action.h"
 
-#include <fmt/core.h>
+#include <fmt/format.h>
+#include <glog/logging.h>
+
+#include <string>
+#include <vector>
 
 #include "http/http_channel.h"
 #include "http/http_request.h"
+#include "http/http_status.h"
 #include "runtime/exec_env.h"
 #include "util/brpc_client_cache.h"
 #include "util/string_util.h"

--- a/be/src/http/action/reset_rpc_channel_action.h
+++ b/be/src/http/action/reset_rpc_channel_action.h
@@ -21,6 +21,8 @@
 
 namespace doris {
 class ExecEnv;
+class HttpRequest;
+
 class ResetRPCChannelAction : public HttpHandler {
 public:
     explicit ResetRPCChannelAction(ExecEnv* exec_env);

--- a/be/src/http/action/restore_tablet_action.cpp
+++ b/be/src/http/action/restore_tablet_action.cpp
@@ -17,24 +17,32 @@
 
 #include "http/action/restore_tablet_action.h"
 
-#include <unistd.h>
+#include <fmt/format.h>
+#include <gen_cpp/AgentService_types.h>
+#include <glog/logging.h>
 
+#include <algorithm>
+#include <cstdlib>
+#include <filesystem>
+#include <memory>
 #include <sstream>
 #include <string>
+#include <utility>
+#include <vector>
 
-#include "gutil/strings/substitute.h" // for Substitute
 #include "http/http_channel.h"
-#include "http/http_headers.h"
 #include "http/http_request.h"
-#include "http/http_response.h"
 #include "http/http_status.h"
+#include "io/fs/file_system.h"
+#include "io/fs/local_file_system.h"
+#include "io/fs/path.h"
 #include "olap/data_dir.h"
-#include "olap/olap_define.h"
 #include "olap/storage_engine.h"
+#include "olap/tablet.h"
+#include "olap/tablet_manager.h"
 #include "olap/tablet_meta.h"
 #include "olap/utils.h"
 #include "runtime/exec_env.h"
-#include "util/json_util.h"
 
 using std::filesystem::path;
 

--- a/be/src/http/action/restore_tablet_action.cpp
+++ b/be/src/http/action/restore_tablet_action.cpp
@@ -21,7 +21,6 @@
 #include <gen_cpp/AgentService_types.h>
 #include <glog/logging.h>
 
-#include <algorithm>
 #include <cstdlib>
 #include <filesystem>
 #include <memory>

--- a/be/src/http/action/restore_tablet_action.h
+++ b/be/src/http/action/restore_tablet_action.h
@@ -17,16 +17,20 @@
 
 #pragma once
 
+#include <gen_cpp/AgentService_types.h>
+#include <stdint.h>
+
 #include <map>
 #include <mutex>
+#include <string>
 
 #include "common/status.h"
-#include "gen_cpp/AgentService_types.h"
 #include "http/http_handler.h"
 
 namespace doris {
 
 class ExecEnv;
+class HttpRequest;
 
 class RestoreTabletAction : public HttpHandler {
 public:

--- a/be/src/http/action/snapshot_action.cpp
+++ b/be/src/http/action/snapshot_action.cpp
@@ -17,21 +17,19 @@
 
 #include "http/action/snapshot_action.h"
 
+#include <gen_cpp/AgentService_types.h>
+
 #include <boost/lexical_cast.hpp>
+#include <boost/lexical_cast/bad_lexical_cast.hpp>
 #include <sstream>
 #include <string>
 
 #include "common/logging.h"
-#include "gen_cpp/AgentService_types.h"
+#include "common/status.h"
 #include "http/http_channel.h"
-#include "http/http_headers.h"
 #include "http/http_request.h"
-#include "http/http_response.h"
 #include "http/http_status.h"
-#include "olap/olap_define.h"
 #include "olap/snapshot_manager.h"
-#include "olap/storage_engine.h"
-#include "runtime/exec_env.h"
 
 namespace doris {
 

--- a/be/src/http/action/snapshot_action.h
+++ b/be/src/http/action/snapshot_action.h
@@ -25,6 +25,7 @@
 namespace doris {
 
 class ExecEnv;
+class HttpRequest;
 
 // make snapshot
 // be_host:be_http_port/api/snapshot?tablet_id=123&schema_hash=456

--- a/be/src/http/action/stream_load.cpp
+++ b/be/src/http/action/stream_load.cpp
@@ -17,45 +17,49 @@
 
 #include "http/action/stream_load.h"
 
-#include <deque>
-#include <future>
-#include <sstream>
-
 // use string iequal
 #include <event2/buffer.h>
-#include <event2/bufferevent.h>
 #include <event2/http.h>
-#include <rapidjson/prettywriter.h>
+#include <gen_cpp/FrontendService.h>
+#include <gen_cpp/FrontendService_types.h>
+#include <gen_cpp/HeartbeatService_types.h>
+#include <gen_cpp/PaloInternalService_types.h>
+#include <gen_cpp/PlanNodes_types.h>
+#include <gen_cpp/Types_types.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <sys/time.h>
 #include <thrift/protocol/TDebugProtocol.h>
+#include <time.h>
+
+#include <future>
+#include <map>
+#include <sstream>
+#include <stdexcept>
+#include <utility>
 
 #include "common/config.h"
 #include "common/consts.h"
 #include "common/logging.h"
+#include "common/status.h"
 #include "common/utils.h"
-#include "gen_cpp/FrontendService.h"
-#include "gen_cpp/FrontendService_types.h"
-#include "gen_cpp/HeartbeatService_types.h"
 #include "http/http_channel.h"
 #include "http/http_common.h"
 #include "http/http_headers.h"
 #include "http/http_request.h"
-#include "http/http_response.h"
 #include "http/utils.h"
 #include "io/fs/stream_load_pipe.h"
 #include "olap/storage_engine.h"
 #include "runtime/client_cache.h"
 #include "runtime/exec_env.h"
-#include "runtime/fragment_mgr.h"
 #include "runtime/load_path_mgr.h"
-#include "runtime/plan_fragment_executor.h"
+#include "runtime/message_body_sink.h"
 #include "runtime/stream_load/new_load_stream_mgr.h"
 #include "runtime/stream_load/stream_load_context.h"
 #include "runtime/stream_load/stream_load_executor.h"
 #include "runtime/stream_load/stream_load_recorder.h"
 #include "util/byte_buffer.h"
-#include "util/debug_util.h"
 #include "util/doris_metrics.h"
-#include "util/json_util.h"
 #include "util/metrics.h"
 #include "util/string_util.h"
 #include "util/thrift_rpc_helper.h"

--- a/be/src/http/action/stream_load.h
+++ b/be/src/http/action/stream_load.h
@@ -17,18 +17,23 @@
 
 #pragma once
 
-#include <functional>
+#include <gen_cpp/PlanNodes_types.h>
 
-#include "gen_cpp/PlanNodes_types.h"
+#include <functional>
+#include <memory>
+#include <string>
+
 #include "http/http_handler.h"
 #include "runtime/client_cache.h"
 #include "runtime/message_body_sink.h"
+#include "util/metrics.h"
 
 namespace doris {
 
 class ExecEnv;
 class Status;
 class StreamLoadContext;
+class HttpRequest;
 
 class StreamLoadAction : public HttpHandler {
 public:

--- a/be/src/http/action/stream_load_2pc.cpp
+++ b/be/src/http/action/stream_load_2pc.cpp
@@ -17,18 +17,25 @@
 
 #include "http/action/stream_load_2pc.h"
 
+#include <glog/logging.h>
+#include <rapidjson/encodings.h>
 #include <rapidjson/prettywriter.h>
 #include <rapidjson/stringbuffer.h>
 
+#include <exception>
+#include <memory>
+#include <new>
+#include <ostream>
+
 #include "common/status.h"
 #include "http/http_channel.h"
-#include "http/http_headers.h"
+#include "http/http_common.h"
 #include "http/http_request.h"
 #include "http/http_status.h"
 #include "http/utils.h"
+#include "runtime/exec_env.h"
 #include "runtime/stream_load/stream_load_context.h"
 #include "runtime/stream_load/stream_load_executor.h"
-#include "util/json_util.h"
 
 namespace doris {
 

--- a/be/src/http/action/stream_load_2pc.h
+++ b/be/src/http/action/stream_load_2pc.h
@@ -24,6 +24,7 @@
 namespace doris {
 
 class ExecEnv;
+class HttpRequest;
 
 class StreamLoad2PCAction : public HttpHandler {
 public:

--- a/be/src/http/action/tablet_migration_action.cpp
+++ b/be/src/http/action/tablet_migration_action.cpp
@@ -19,7 +19,6 @@
 
 #include <glog/logging.h>
 
-#include <algorithm>
 #include <exception>
 #include <string>
 

--- a/be/src/http/action/tablet_migration_action.cpp
+++ b/be/src/http/action/tablet_migration_action.cpp
@@ -17,17 +17,21 @@
 
 #include "http/action/tablet_migration_action.h"
 
+#include <glog/logging.h>
+
+#include <algorithm>
+#include <exception>
 #include <string>
 
-#include "gutil/strings/substitute.h"
+#include "common/config.h"
 #include "http/http_channel.h"
 #include "http/http_headers.h"
 #include "http/http_request.h"
 #include "http/http_status.h"
+#include "olap/data_dir.h"
 #include "olap/storage_engine.h"
 #include "olap/tablet_manager.h"
 #include "olap/task/engine_storage_migration_task.h"
-#include "util/json_util.h"
 
 namespace doris {
 

--- a/be/src/http/action/tablet_migration_action.h
+++ b/be/src/http/action/tablet_migration_action.h
@@ -30,6 +30,7 @@
 
 #include "common/status.h"
 #include "gutil/stringprintf.h"
+#include "gutil/strings/numbers.h"
 #include "http/http_handler.h"
 #include "olap/data_dir.h"
 #include "olap/tablet.h"

--- a/be/src/http/action/tablet_migration_action.h
+++ b/be/src/http/action/tablet_migration_action.h
@@ -17,16 +17,27 @@
 
 #pragma once
 
+#include <gen_cpp/Status_types.h>
+#include <stdint.h>
+
+#include <deque>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <ostream>
 #include <string>
+#include <utility>
 
 #include "common/status.h"
-#include "gen_cpp/Status_types.h"
+#include "gutil/stringprintf.h"
 #include "http/http_handler.h"
 #include "olap/data_dir.h"
 #include "olap/tablet.h"
 #include "util/threadpool.h"
 
 namespace doris {
+class DataDir;
+class HttpRequest;
 
 // Migrate a tablet from a disk to another.
 class TabletMigrationAction : public HttpHandler {

--- a/be/src/http/action/tablets_distribution_action.cpp
+++ b/be/src/http/action/tablets_distribution_action.cpp
@@ -17,7 +17,14 @@
 
 #include "http/action/tablets_distribution_action.h"
 
+#include <glog/logging.h>
+
+#include <exception>
+#include <map>
+#include <ostream>
 #include <string>
+#include <utility>
+#include <vector>
 
 #include "common/status.h"
 #include "gutil/strings/substitute.h"
@@ -25,10 +32,11 @@
 #include "http/http_headers.h"
 #include "http/http_request.h"
 #include "http/http_status.h"
+#include "olap/data_dir.h"
+#include "olap/olap_common.h"
 #include "olap/storage_engine.h"
 #include "olap/tablet_manager.h"
 #include "service/backend_options.h"
-#include "util/json_util.h"
 
 namespace doris {
 

--- a/be/src/http/action/tablets_distribution_action.h
+++ b/be/src/http/action/tablets_distribution_action.h
@@ -17,12 +17,15 @@
 
 #pragma once
 
+#include <stdint.h>
+
 #include <string>
 
 #include "http/http_handler.h"
 #include "util/easy_json.h"
 
 namespace doris {
+class HttpRequest;
 
 // Get BE tablets distribution info from http API.
 class TabletsDistributionAction : public HttpHandler {

--- a/be/src/http/action/tablets_info_action.cpp
+++ b/be/src/http/action/tablets_info_action.cpp
@@ -17,12 +17,21 @@
 
 #include "http/action/tablets_info_action.h"
 
-#include <string>
+#include <ctype.h>
 
+#include <algorithm>
+#include <cstdint>
+#include <cstdlib>
+#include <limits>
+#include <string>
+#include <vector>
+
+#include "gutil/stringprintf.h"
 #include "http/http_channel.h"
 #include "http/http_headers.h"
 #include "http/http_request.h"
 #include "http/http_status.h"
+#include "olap/olap_common.h"
 #include "olap/storage_engine.h"
 #include "olap/tablet_manager.h"
 #include "service/backend_options.h"

--- a/be/src/http/action/tablets_info_action.cpp
+++ b/be/src/http/action/tablets_info_action.cpp
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-#include "gutil/stringprintf.h"
+#include "gutil/strings/numbers.h"
 #include "http/http_channel.h"
 #include "http/http_headers.h"
 #include "http/http_request.h"

--- a/be/src/http/action/tablets_info_action.h
+++ b/be/src/http/action/tablets_info_action.h
@@ -23,6 +23,7 @@
 #include "util/easy_json.h"
 
 namespace doris {
+class HttpRequest;
 
 // Get BE tablets info from http API.
 class TabletsInfoAction : public HttpHandler {

--- a/be/src/http/action/version_action.cpp
+++ b/be/src/http/action/version_action.cpp
@@ -17,14 +17,13 @@
 
 #include "http/action/version_action.h"
 
-#include <sstream>
+#include <gen_cpp/version.h>
+
 #include <string>
 
-#include "gen_cpp/version.h"
 #include "http/http_channel.h"
 #include "http/http_headers.h"
 #include "http/http_request.h"
-#include "http/http_response.h"
 #include "http/http_status.h"
 #include "util/easy_json.h"
 

--- a/be/src/http/action/version_action.h
+++ b/be/src/http/action/version_action.h
@@ -23,6 +23,7 @@
 namespace doris {
 
 class ExecEnv;
+class HttpRequest;
 
 // Get BE version info from http API.
 class VersionAction : public HttpHandler {

--- a/be/src/http/default_path_handlers.cpp
+++ b/be/src/http/default_path_handlers.cpp
@@ -17,24 +17,32 @@
 
 #include "http/default_path_handlers.h"
 
-#include <gperftools/heap-profiler.h>
+#include <gen_cpp/Metrics_types.h>
+
+#include <boost/algorithm/string/replace.hpp>
 #ifdef USE_JEMALLOC
 #include "jemalloc/jemalloc.h"
 #else
 #include <gperftools/malloc_extension.h>
 #endif
 
-#include <boost/algorithm/string.hpp>
+#include <functional>
+#include <map>
+#include <memory>
+#include <mutex>
 #include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
 
-#include "agent/utils.h"
-#include "common/configbase.h"
+#include "common/config.h"
 #include "gutil/strings/numbers.h"
 #include "gutil/strings/substitute.h"
 #include "http/action/tablets_info_action.h"
 #include "http/web_page_handler.h"
+#include "runtime/memory/mem_tracker.h"
 #include "runtime/memory/mem_tracker_limiter.h"
-#include "util/debug_util.h"
+#include "util/easy_json.h"
 #include "util/mem_info.h"
 #include "util/perf_counters.h"
 #include "util/pretty_printer.h"

--- a/be/src/http/ev_http_server.cpp
+++ b/be/src/http/ev_http_server.cpp
@@ -17,14 +17,20 @@
 
 #include "http/ev_http_server.h"
 
-#include <event2/buffer.h>
-#include <event2/bufferevent.h>
+#include <arpa/inet.h>
+#include <bthread/errno.h>
+#include <butil/endpoint.h>
+#include <butil/fd_utility.h>
 #include <event2/event.h>
 #include <event2/http.h>
 #include <event2/http_struct.h>
-#include <event2/keyvalq_struct.h>
 #include <event2/thread.h>
+#include <netinet/in.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <unistd.h>
 
+#include <algorithm>
 #include <memory>
 #include <sstream>
 
@@ -33,11 +39,12 @@
 #include "http/http_handler.h"
 #include "http/http_headers.h"
 #include "http/http_request.h"
-#include "runtime/thread_context.h"
+#include "http/http_status.h"
 #include "service/backend_options.h"
-#include "service/brpc.h"
-#include "util/debug_util.h"
 #include "util/threadpool.h"
+
+struct event_base;
+struct evhttp;
 
 namespace doris {
 

--- a/be/src/http/ev_http_server.h
+++ b/be/src/http/ev_http_server.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include <memory>
 #include <mutex>
 #include <string>
 #include <thread>
@@ -25,6 +26,8 @@
 #include "common/status.h"
 #include "http/http_method.h"
 #include "util/path_trie.hpp"
+
+struct event_base;
 
 namespace doris {
 

--- a/be/src/http/http_channel.cpp
+++ b/be/src/http/http_channel.cpp
@@ -20,16 +20,19 @@
 #include <event2/buffer.h>
 #include <event2/http.h>
 
-#include <mutex>
+#include <algorithm>
 #include <sstream>
 #include <string>
+#include <vector>
 
 #include "common/logging.h"
+#include "common/status.h"
 #include "gutil/strings/split.h"
+#include "gutil/strings/strip.h"
 #include "http/http_headers.h"
 #include "http/http_request.h"
-#include "http/http_response.h"
 #include "http/http_status.h"
+#include "util/slice.h"
 #include "util/zlib.h"
 
 namespace doris {

--- a/be/src/http/http_channel.h
+++ b/be/src/http/http_channel.h
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#include <stddef.h>
+
 #include <cstdint>
 #include <string>
 

--- a/be/src/http/http_client.cpp
+++ b/be/src/http/http_client.cpp
@@ -17,6 +17,12 @@
 
 #include "http/http_client.h"
 
+#include <glog/logging.h>
+#include <unistd.h>
+
+#include <memory>
+#include <ostream>
+
 #include "common/config.h"
 #include "util/stack_util.h"
 

--- a/be/src/http/http_client.h
+++ b/be/src/http/http_client.h
@@ -18,8 +18,11 @@
 #pragma once
 
 #include <curl/curl.h>
+#include <curl/system.h>
+#include <stdint.h>
 
 #include <cstdio>
+#include <functional>
 #include <string>
 
 #include "common/status.h"

--- a/be/src/http/http_method.cpp
+++ b/be/src/http/http_method.cpp
@@ -19,6 +19,7 @@
 
 #include <map>
 #include <string>
+#include <utility>
 
 namespace doris {
 

--- a/be/src/http/http_request.cpp
+++ b/be/src/http/http_request.cpp
@@ -18,19 +18,16 @@
 #include "http/http_request.h"
 
 #include <event2/buffer.h>
-#include <event2/bufferevent.h>
 #include <event2/http.h>
 #include <event2/http_struct.h>
 #include <event2/keyvalq_struct.h>
 
-#include <boost/algorithm/string.hpp>
 #include <sstream>
 #include <string>
-#include <vector>
+#include <unordered_map>
+#include <utility>
 
-#include "common/logging.h"
 #include "http/http_handler.h"
-#include "util/url_coding.h"
 
 namespace doris {
 

--- a/be/src/http/http_status.cpp
+++ b/be/src/http/http_status.cpp
@@ -19,6 +19,7 @@
 
 #include <map>
 #include <string>
+#include <utility>
 
 namespace doris {
 

--- a/be/src/http/utils.cpp
+++ b/be/src/http/utils.cpp
@@ -18,15 +18,23 @@
 #include "http/utils.h"
 
 #include <fcntl.h>
+#include <stdint.h>
 #include <sys/stat.h>
+#include <unistd.h>
+
+#include <memory>
+#include <ostream>
+#include <vector>
 
 #include "common/logging.h"
 #include "common/status.h"
 #include "common/utils.h"
 #include "http/http_channel.h"
-#include "http/http_common.h"
 #include "http/http_headers.h"
+#include "http/http_method.h"
 #include "http/http_request.h"
+#include "http/http_status.h"
+#include "io/fs/file_system.h"
 #include "io/fs/local_file_system.h"
 #include "util/path_util.h"
 #include "util/url_coding.h"

--- a/be/src/http/utils.h
+++ b/be/src/http/utils.h
@@ -26,6 +26,7 @@
 namespace doris {
 
 class HttpRequest;
+struct AuthInfo;
 
 std::string encode_basic_auth(const std::string& user, const std::string& passwd);
 // parse Basic authorization

--- a/be/src/http/web_page_handler.cpp
+++ b/be/src/http/web_page_handler.cpp
@@ -17,22 +17,28 @@
 
 #include "http/web_page_handler.h"
 
-#include <functional>
+#include <stdlib.h>
 
-#include "common/config.h"
+#include <functional>
+#include <memory>
+
+#include "common/logging.h"
+#include "common/status.h"
 #include "gutil/stl_util.h"
+#include "gutil/stringprintf.h"
 #include "gutil/strings/substitute.h"
 #include "http/ev_http_server.h"
 #include "http/http_channel.h"
 #include "http/http_headers.h"
+#include "http/http_method.h"
 #include "http/http_request.h"
-#include "http/http_response.h"
 #include "http/http_status.h"
 #include "http/utils.h"
 #include "io/fs/local_file_system.h"
 #include "util/cpu_info.h"
 #include "util/debug_util.h"
 #include "util/disk_info.h"
+#include "util/easy_json.h"
 #include "util/mem_info.h"
 #include "util/mustache/mustache.h"
 

--- a/be/src/http/web_page_handler.cpp
+++ b/be/src/http/web_page_handler.cpp
@@ -25,7 +25,7 @@
 #include "common/logging.h"
 #include "common/status.h"
 #include "gutil/stl_util.h"
-#include "gutil/stringprintf.h"
+#include "gutil/strings/numbers.h"
 #include "gutil/strings/substitute.h"
 #include "http/ev_http_server.h"
 #include "http/http_channel.h"

--- a/be/src/http/web_page_handler.h
+++ b/be/src/http/web_page_handler.h
@@ -22,6 +22,7 @@
 #include <mutex>
 #include <sstream>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "http/http_handler.h"
@@ -30,6 +31,8 @@
 namespace doris {
 
 class EvHttpServer;
+class EasyJson;
+class HttpRequest;
 
 // This a handler for webpage request
 // and this handler manage all the page handler

--- a/be/src/io/fs/file_reader_writer_fwd.h
+++ b/be/src/io/fs/file_reader_writer_fwd.h
@@ -19,6 +19,9 @@
 // and modified by Doris
 
 #pragma once
+
+#include <memory>
+
 namespace doris {
 namespace io {
 

--- a/be/src/io/fs/hdfs.h
+++ b/be/src/io/fs/hdfs.h
@@ -18,7 +18,7 @@
 #pragma once
 
 #ifdef USE_HADOOP_HDFS
-#include <hadoop_hdfs/hdfs.h>
+#include <hadoop_hdfs/hdfs.h> // IWYU pragma: export
 #else
-#include <hdfs/hdfs.h>
+#include <hdfs/hdfs.h> // IWYU pragma: export
 #endif

--- a/be/src/io/fs/hdfs_file_reader.h
+++ b/be/src/io/fs/hdfs_file_reader.h
@@ -17,11 +17,23 @@
 
 #pragma once
 
+#include <stddef.h>
+
+#include <atomic>
+#include <memory>
+#include <string>
+
+#include "common/status.h"
 #include "io/fs/file_reader.h"
+#include "io/fs/file_system.h"
+#include "io/fs/hdfs.h"
 #include "io/fs/hdfs_file_system.h"
+#include "io/fs/path.h"
+#include "util/slice.h"
 
 namespace doris {
 namespace io {
+class IOContext;
 
 class HdfsFileReader : public FileReader {
 public:

--- a/be/src/io/fs/hdfs_file_writer.h
+++ b/be/src/io/fs/hdfs_file_writer.h
@@ -17,18 +17,25 @@
 
 #pragma once
 
+#include <stddef.h>
+
 #include <map>
 #include <string>
 
+#include "common/status.h"
 #include "gen_cpp/PlanNodes_types.h"
+#include "io/fs/file_system.h"
 #include "io/fs/file_writer.h"
+#include "io/fs/hdfs.h"
 #include "io/fs/path.h"
 #include "io/hdfs_builder.h"
+#include "util/slice.h"
 
 namespace doris {
 namespace io {
 
 class HdfsFileSystem;
+
 class HdfsFileWriter : public FileWriter {
 public:
     HdfsFileWriter(Path file, FileSystemSPtr fs);

--- a/be/src/service/backend_options.cpp
+++ b/be/src/service/backend_options.cpp
@@ -18,6 +18,7 @@
 #include "service/backend_options.h"
 
 #include <algorithm>
+#include <ostream>
 
 #include "common/config.h"
 #include "common/logging.h"

--- a/be/src/service/backend_options.h
+++ b/be/src/service/backend_options.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include <butil/macros.h>
 #include <gutil/macros.h>
 
 #include <string>

--- a/be/src/service/backend_service.cpp
+++ b/be/src/service/backend_service.cpp
@@ -18,43 +18,53 @@
 #include "service/backend_service.h"
 
 #include <arrow/record_batch.h>
-#include <gperftools/heap-profiler.h>
+#include <fmt/format.h>
+#include <gen_cpp/BackendService.h>
+#include <gen_cpp/BackendService_types.h>
+#include <gen_cpp/Data_types.h>
+#include <gen_cpp/DorisExternalService_types.h>
+#include <gen_cpp/PaloInternalService_types.h>
+#include <gen_cpp/Planner_types.h>
+#include <gen_cpp/Status_types.h>
+#include <gen_cpp/Types_types.h>
+#include <sys/types.h>
 #include <thrift/concurrency/ThreadFactory.h>
-#include <thrift/processor/TMultiplexedProcessor.h>
-#include <thrift/protocol/TDebugProtocol.h>
+#include <time.h>
 
 #include <map>
 #include <memory>
+#include <ostream>
+#include <utility>
 
 #include "common/config.h"
 #include "common/logging.h"
 #include "common/status.h"
-#include "gen_cpp/DorisExternalService_types.h"
-#include "gen_cpp/PaloInternalService_types.h"
-#include "gen_cpp/TDorisExternalService.h"
-#include "gen_cpp/Types_types.h"
 #include "gutil/strings/substitute.h"
+#include "olap/olap_common.h"
+#include "olap/olap_define.h"
 #include "olap/storage_engine.h"
-#include "runtime/descriptors.h"
+#include "olap/tablet_manager.h"
 #include "runtime/exec_env.h"
-#include "runtime/export_task_mgr.h"
 #include "runtime/external_scan_context_mgr.h"
 #include "runtime/fragment_mgr.h"
-#include "runtime/primitive_type.h"
-#include "runtime/result_buffer_mgr.h"
 #include "runtime/result_queue_mgr.h"
 #include "runtime/routine_load/routine_load_task_executor.h"
 #include "runtime/stream_load/stream_load_context.h"
-#include "service/backend_options.h"
+#include "runtime/stream_load/stream_load_recorder.h"
 #include "util/arrow/row_batch.h"
-#include "util/blocking_queue.hpp"
-#include "util/debug_util.h"
-#include "util/doris_metrics.h"
-#include "util/network_util.h"
 #include "util/thrift_server.h"
-#include "util/thrift_util.h"
 #include "util/uid_util.h"
-#include "util/url_coding.h"
+
+namespace apache {
+namespace thrift {
+class TException;
+class TMultiplexedProcessor;
+class TProcessor;
+namespace transport {
+class TTransportException;
+} // namespace transport
+} // namespace thrift
+} // namespace apache
 
 namespace doris {
 

--- a/be/src/service/backend_service.h
+++ b/be/src/service/backend_service.h
@@ -17,17 +17,20 @@
 
 #pragma once
 
+#include <gen_cpp/BackendService.h>
+#include <gen_cpp/DorisExternalService_types.h>
+#include <gen_cpp/TDorisExternalService.h>
+#include <stdint.h>
 #include <thrift/protocol/TDebugProtocol.h>
 #include <time.h>
 
 #include <map>
 #include <memory>
+#include <string>
+#include <vector>
 
 #include "agent/agent_server.h"
 #include "common/status.h"
-#include "gen_cpp/BackendService.h"
-#include "gen_cpp/DorisExternalService_types.h"
-#include "gen_cpp/TDorisExternalService.h"
 
 namespace doris {
 
@@ -57,6 +60,20 @@ class TExportTaskRequest;
 class TExportStatusResult;
 class TStreamLoadRecordResult;
 class TDiskTrashInfo;
+class TCancelPlanFragmentParams;
+class TCheckStorageFormatResult;
+class TRoutineLoadTask;
+class TScanBatchResult;
+class TScanCloseParams;
+class TScanCloseResult;
+class TScanNextBatchParams;
+class TScanOpenParams;
+class TScanOpenResult;
+class TSnapshotRequest;
+class TStatus;
+class TTabletStatResult;
+class TTransmitDataParams;
+class TUniqueId;
 
 // This class just forward rpc for actual handler
 // make this class because we can bind multiple service on single point

--- a/be/src/service/brpc_service.cpp
+++ b/be/src/service/brpc_service.cpp
@@ -17,11 +17,18 @@
 
 #include "service/brpc_service.h"
 
+#include <brpc/server.h>
+#include <brpc/ssl_options.h>
+#include <bthread/errno.h>
+#include <butil/endpoint.h>
+#include <gflags/gflags_declare.h>
 #include <string.h>
 
+#include <ostream>
+
+#include "common/config.h"
 #include "common/logging.h"
 #include "service/backend_options.h"
-#include "service/brpc.h"
 #include "service/internal_service.h"
 
 namespace brpc {

--- a/be/src/service/doris_main.cpp
+++ b/be/src/service/doris_main.cpp
@@ -15,18 +15,28 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#include <bthread/errno.h>
+#include <butil/macros.h>
 #include <errno.h>
+#include <fcntl.h>
 #include <libgen.h>
 #include <setjmp.h>
-#include <sys/file.h>
+#include <signal.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
 #include <unistd.h>
 
-#include <condition_variable>
+#include <algorithm>
 #include <cstring>
-#include <mutex>
-#include <thread>
-#include <unordered_map>
+#include <ostream>
+#include <string>
+#include <tuple>
+#include <vector>
 
+#include "olap/tablet_schema_cache.h"
+#include "olap/utils.h"
+#include "runtime/memory/mem_tracker_limiter.h"
 #include "util/jni-util.h"
 
 #if defined(LEAK_SANITIZER)
@@ -34,39 +44,35 @@
 #endif
 
 #include <curl/curl.h>
-#include <gperftools/profiler.h>
 #include <thrift/TOutput.h>
 
 #include "agent/heartbeat_server.h"
-#include "agent/topic_subscriber.h"
 #include "common/config.h"
 #include "common/daemon.h"
 #include "common/logging.h"
 #include "common/resource_tls.h"
 #include "common/signal_handler.h"
 #include "common/status.h"
-#include "common/utils.h"
 #include "io/cache/block/block_file_cache_factory.h"
 #include "olap/options.h"
 #include "olap/storage_engine.h"
 #include "runtime/exec_env.h"
-#include "runtime/heartbeat_flags.h"
 #include "service/backend_options.h"
 #include "service/backend_service.h"
 #include "service/brpc_service.h"
 #include "service/http_service.h"
 #include "service/single_replica_load_download_service.h"
 #include "util/debug_util.h"
-#include "util/doris_metrics.h"
-#include "util/perf_counters.h"
 #include "util/telemetry/telemetry.h"
 #include "util/thrift_rpc_helper.h"
 #include "util/thrift_server.h"
 #include "util/uid_util.h"
 
-static void help(const char*);
+namespace doris {
+class TMasterInfo;
+} // namespace doris
 
-#include <dlfcn.h>
+static void help(const char*);
 
 extern "C" {
 void __lsan_do_leak_check();

--- a/be/src/service/http_service.cpp
+++ b/be/src/service/http_service.cpp
@@ -17,6 +17,10 @@
 
 #include "service/http_service.h"
 
+#include <algorithm>
+#include <string>
+#include <vector>
+
 #include "http/action/check_rpc_channel_action.h"
 #include "http/action/check_tablet_segment_action.h"
 #include "http/action/checksum_action.h"
@@ -43,6 +47,7 @@
 #include "http/ev_http_server.h"
 #include "http/http_method.h"
 #include "http/web_page_handler.h"
+#include "olap/options.h"
 #include "runtime/exec_env.h"
 #include "runtime/load_path_mgr.h"
 #include "util/doris_metrics.h"

--- a/be/src/service/internal_service.h
+++ b/be/src/service/internal_service.h
@@ -17,10 +17,21 @@
 
 #pragma once
 
+#include <gen_cpp/internal_service.pb.h>
+#include <stdint.h>
+
+#include <string>
+
 #include "common/status.h"
-#include "gen_cpp/internal_service.pb.h"
 #include "runtime/cache/result_cache.h"
 #include "util/priority_thread_pool.hpp"
+
+namespace google {
+namespace protobuf {
+class Closure;
+class RpcController;
+} // namespace protobuf
+} // namespace google
 
 namespace brpc {
 class Controller;
@@ -29,6 +40,8 @@ class Controller;
 namespace doris {
 
 class ExecEnv;
+class PHandShakeRequest;
+class PHandShakeResponse;
 
 class PInternalServiceImpl : public PBackendService {
 public:

--- a/be/src/service/point_query_executor.cpp
+++ b/be/src/service/point_query_executor.cpp
@@ -17,18 +17,27 @@
 
 #include "service/point_query_executor.h"
 
+#include <fmt/format.h>
+#include <gen_cpp/Descriptors_types.h>
+#include <gen_cpp/Exprs_types.h>
+#include <gen_cpp/internal_service.pb.h>
+#include <stdlib.h>
+
 #include "olap/lru_cache.h"
+#include "olap/olap_tuple.h"
 #include "olap/row_cursor.h"
 #include "olap/storage_engine.h"
-#include "service/internal_service.h"
-#include "util/defer_op.h"
+#include "olap/tablet_manager.h"
+#include "olap/tablet_schema.h"
+#include "runtime/runtime_state.h"
 #include "util/key_util.h"
 #include "util/runtime_profile.h"
 #include "util/thrift_util.h"
 #include "vec/exprs/vexpr.h"
-#include "vec/exprs/vliteral.h"
+#include "vec/exprs/vexpr_context.h"
 #include "vec/jsonb/serialize.h"
 #include "vec/sink/vmysql_result_writer.cpp"
+#include "vec/sink/vmysql_result_writer.h"
 
 namespace doris {
 

--- a/be/src/service/point_query_executor.h
+++ b/be/src/service/point_query_executor.h
@@ -17,22 +17,51 @@
 
 #pragma once
 
+#include <assert.h>
+#include <butil/macros.h>
+#include <butil/time.h>
+#include <gen_cpp/Metrics_types.h>
+#include <gen_cpp/internal_service.pb.h>
+#include <parallel_hashmap/phmap.h>
+#include <stdint.h>
+#include <string.h>
+
 #include <memory>
+#include <mutex>
+#include <optional>
+#include <ostream>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include "butil/containers/doubly_buffered_data.h"
+#include "common/config.h"
+#include "common/logging.h"
 #include "common/status.h"
-#include "gen_cpp/internal_service.pb.h"
 #include "gutil/int128.h"
+#include "olap/lru_cache.h"
 #include "olap/olap_common.h"
 #include "olap/rowset/rowset.h"
 #include "olap/tablet.h"
+#include "olap/utils.h"
+#include "runtime/descriptors.h"
+#include "util/mysql_global.h"
 #include "util/runtime_profile.h"
+#include "util/slice.h"
 #include "vec/core/block.h"
 
 namespace doris {
 
 class RowCache;
 class Cache;
+class PTabletKeyLookupRequest;
+class PTabletKeyLookupResponse;
+class RuntimeState;
+class TDescriptorTable;
+class TExpr;
+namespace vectorized {
+class VExprContext;
+} // namespace vectorized
 
 // For caching point lookup pre allocted blocks and exprs
 class Reusable {

--- a/be/src/service/point_query_executor.h
+++ b/be/src/service/point_query_executor.h
@@ -26,6 +26,7 @@
 #include <stdint.h>
 #include <string.h>
 
+#include <algorithm>
 #include <memory>
 #include <mutex>
 #include <optional>
@@ -59,6 +60,7 @@ class PTabletKeyLookupResponse;
 class RuntimeState;
 class TDescriptorTable;
 class TExpr;
+
 namespace vectorized {
 class VExprContext;
 } // namespace vectorized

--- a/be/src/service/single_replica_load_download_service.cpp
+++ b/be/src/service/single_replica_load_download_service.cpp
@@ -17,9 +17,15 @@
 
 #include "service/single_replica_load_download_service.h"
 
+#include <algorithm>
+#include <string>
+#include <vector>
+
 #include "http/action/download_action.h"
 #include "http/ev_http_server.h"
+#include "http/http_method.h"
 #include "io/fs/fs_utils.h"
+#include "olap/options.h"
 #include "runtime/exec_env.h"
 
 namespace doris {

--- a/be/src/udf/udf.cpp
+++ b/be/src/udf/udf.cpp
@@ -20,23 +20,14 @@
 
 #include "udf/udf.h"
 
-#include <assert.h>
-
 #include <iostream>
-#include <sstream>
-
-#include "common/logging.h"
-#include "gen_cpp/types.pb.h"
-#include "olap/hll.h"
-#include "runtime/decimalv2_value.h"
+#include <utility>
 
 // Be careful what this includes since this needs to be linked into the UDF's
 // binary. For example, it would be unfortunate if they had a random dependency
 // on libhdfs.
 #include "runtime/runtime_state.h"
 #include "runtime/types.h"
-#include "udf/udf.h"
-#include "util/debug_util.h"
 #include "vec/common/string_ref.h"
 
 namespace doris {

--- a/be/src/udf/udf.h
+++ b/be/src/udf/udf.h
@@ -26,6 +26,7 @@
 #include <functional>
 #include <iostream>
 #include <memory>
+#include <string>
 #include <vector>
 
 #include "runtime/types.h"
@@ -38,7 +39,6 @@ class BitmapValue;
 class DecimalV2Value;
 class CollectionValue;
 struct TypeDescriptor;
-
 class RuntimeState;
 // All input and output values will be one of the structs below. The struct is a simple
 // object containing a boolean to store if the value is nullptr and the value itself. The

--- a/be/src/util/sse_util.hpp
+++ b/be/src/util/sse_util.hpp
@@ -21,10 +21,10 @@
 #pragma once
 
 #if defined(__aarch64__)
-#include <sse2neon.h>
+#include <sse2neon.h> // IWYU pragma: export
 #elif defined(__x86_64__)
-#include <immintrin.h>
-#include <mm_malloc.h>
+#include <immintrin.h> // IWYU pragma: export
+#include <mm_malloc.h> // IWYU pragma: export
 #endif
 
 namespace doris {


### PR DESCRIPTION
# Proposed changes

~~Issue Number: close #xxx~~

## Problem summary

Currently, there are some useless includes in the codebase. We can use a tool named [include-what-you-use](https://github.com/include-what-you-use/include-what-you-use) to optimize these includes. By using a [strict include-what-you-use policy](https://github.com/include-what-you-use/include-what-you-use/blob/master/docs/WhyIWYU.md), we can get lots of benefits from it.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

