### PR TITLE
[fix](replica) Fix inconsistent replica id between FE and BE

### DIFF
--- a/be/src/olap/snapshot_manager.cpp
+++ b/be/src/olap/snapshot_manager.cpp
@@ -163,6 +163,7 @@ Status SnapshotManager::convert_rowset_ids(const std::string& clone_dir, int64_t
     // should modify tablet id and schema hash because in restore process the tablet id is not
     // equal to tablet id in meta
     new_tablet_meta_pb.set_tablet_id(tablet_id);
+    *new_tablet_meta_pb.mutable_tablet_uid() = TabletUid::gen_uid().to_proto();
     new_tablet_meta_pb.set_replica_id(replica_id);
     new_tablet_meta_pb.set_schema_hash(schema_hash);
     TabletSchemaSPtr tablet_schema;

--- a/be/src/olap/storage_engine.cpp
+++ b/be/src/olap/storage_engine.cpp
@@ -979,11 +979,6 @@ Status StorageEngine::load_header(const string& shard_path, const TCloneReq& req
 
     string header_path = TabletMeta::construct_header_file_path(schema_hash_path_stream.str(),
                                                                 request.tablet_id);
-    res = TabletMeta::reset_tablet_uid(header_path);
-    if (!res.ok()) {
-        LOG(WARNING) << "fail reset tablet uid file path = " << header_path << " res=" << res;
-        return res;
-    }
     res = _tablet_manager->load_tablet_from_dir(store, request.tablet_id, request.schema_hash,
                                                 schema_hash_path_stream.str(), false, restore);
     if (!res.ok()) {

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -2371,7 +2371,7 @@ void Tablet::remove_unused_remote_files() {
 }
 
 TabletSchemaSPtr Tablet::tablet_schema() const {
-    std::shared_lock wrlock(_meta_lock);
+    std::shared_lock rlock(_meta_lock);
     return _max_version_schema;
 }
 
@@ -2382,10 +2382,6 @@ void Tablet::update_max_version_schema(const TabletSchemaSPtr& tablet_schema) {
         tablet_schema->schema_version() > _max_version_schema->schema_version()) {
         _max_version_schema = tablet_schema;
     }
-}
-
-TabletSchemaSPtr Tablet::get_max_version_schema(std::lock_guard<std::shared_mutex>&) {
-    return _max_version_schema;
 }
 
 // fetch value by row column

--- a/be/src/olap/tablet.h
+++ b/be/src/olap/tablet.h
@@ -300,7 +300,7 @@ public:
 
     TabletSchemaSPtr tablet_schema() const override;
 
-    TabletSchemaSPtr get_max_version_schema(std::lock_guard<std::shared_mutex>&);
+    const TabletSchemaSPtr& tablet_schema_unlocked() const { return _max_version_schema; }
 
     // Find the related rowset with specified version and return its tablet schema
     TabletSchemaSPtr tablet_schema(Version version) const {

--- a/be/src/olap/tablet_meta.cpp
+++ b/be/src/olap/tablet_meta.cpp
@@ -349,26 +349,6 @@ Status TabletMeta::create_from_file(const string& file_path) {
     return Status::OK();
 }
 
-Status TabletMeta::reset_tablet_uid(const string& header_file) {
-    Status res = Status::OK();
-    TabletMeta tmp_tablet_meta;
-    if ((res = tmp_tablet_meta.create_from_file(header_file)) != Status::OK()) {
-        LOG(WARNING) << "fail to load tablet meta from file"
-                     << ", meta_file=" << header_file;
-        return res;
-    }
-    TabletMetaPB tmp_tablet_meta_pb;
-    tmp_tablet_meta.to_meta_pb(&tmp_tablet_meta_pb);
-    *(tmp_tablet_meta_pb.mutable_tablet_uid()) = TabletUid::gen_uid().to_proto();
-    res = save(header_file, tmp_tablet_meta_pb);
-    if (!res.ok()) {
-        LOG(FATAL) << "fail to save tablet meta pb to "
-                   << " meta_file=" << header_file;
-        return res;
-    }
-    return res;
-}
-
 std::string TabletMeta::construct_header_file_path(const string& schema_hash_path,
                                                    int64_t tablet_id) {
     std::stringstream header_name_stream;

--- a/be/src/olap/tablet_meta.h
+++ b/be/src/olap/tablet_meta.h
@@ -112,7 +112,6 @@ public:
     Status save(const std::string& file_path);
     Status save_as_json(const string& file_path, DataDir* dir);
     static Status save(const std::string& file_path, const TabletMetaPB& tablet_meta_pb);
-    static Status reset_tablet_uid(const std::string& file_path);
     static std::string construct_header_file_path(const std::string& schema_hash_path,
                                                   int64_t tablet_id);
     Status save_meta(DataDir* data_dir);
@@ -134,6 +133,7 @@ public:
     int64_t partition_id() const;
     int64_t tablet_id() const;
     int64_t replica_id() const;
+    void set_replica_id(int64_t replica_id) { _replica_id = replica_id; }
     int32_t schema_hash() const;
     int16_t shard_id() const;
     void set_shard_id(int32_t shard_id);

--- a/be/src/olap/task/engine_clone_task.cpp
+++ b/be/src/olap/task/engine_clone_task.cpp
@@ -79,6 +79,14 @@ const uint32_t DOWNLOAD_FILE_MAX_RETRY = 3;
 const uint32_t LIST_REMOTE_FILE_TIMEOUT = 15;
 const uint32_t GET_LENGTH_TIMEOUT = 10;
 
+#define RETURN_IF_ERROR_(status, stmt) \
+    do {                               \
+        status = (stmt);               \
+        if (UNLIKELY(!status.ok())) {  \
+            return status;             \
+        }                              \
+    } while (false)
+
 EngineCloneTask::EngineCloneTask(const TCloneReq& clone_req, const TMasterInfo& master_info,
                                  int64_t signature, std::vector<TTabletInfo>* tablet_infos)
         : _clone_req(clone_req),
@@ -113,16 +121,15 @@ Status EngineCloneTask::_do_clone() {
     std::vector<Version> missed_versions;
     // try to repair a tablet with missing version
     if (tablet != nullptr) {
-        if (tablet->replica_id() != _clone_req.replica_id) {
-            // `tablet` may be a dropped replica in FE, e.g: BE1 migrates replica of tablet_1 to BE2,
-            // but before BE1 drop this replica, another new replica of tablet_1 is migrated to BE1.
-            // If we allow to clone success on dropped replica, replica id may never be consistent between FE and BE.
-            return Status::InternalError("replica_id not match({} vs {})", tablet->replica_id(),
-                                         _clone_req.replica_id);
-        }
         std::shared_lock migration_rlock(tablet->get_migration_lock(), std::try_to_lock);
         if (!migration_rlock.owns_lock()) {
             return Status::Error<TRY_LOCK_FAILED>();
+        }
+        if (tablet->replica_id() < _clone_req.replica_id) {
+            // `tablet` may be a dropped replica in FE, e.g:
+            //   BE1 migrates replica of tablet_1 to BE2, but before BE1 drop this replica, another new replica of tablet_1 is migrated to BE1.
+            // Clone can still continue in this case. But to keep `replica_id` consitent with FE, MUST reset `replica_id` with request `replica_id`.
+            tablet->tablet_meta()->set_replica_id(_clone_req.replica_id);
         }
 
         // get download path
@@ -179,21 +186,27 @@ Status EngineCloneTask::_do_clone() {
         }};
 
         bool allow_incremental_clone = false;
-        status = _make_and_download_snapshots(*store, tablet_dir, &src_host, &src_file_path,
-                                              missed_versions, &allow_incremental_clone);
-        if (!status.ok()) {
-            return status;
-        }
+        RETURN_IF_ERROR_(status,
+                         _make_and_download_snapshots(*store, tablet_dir, &src_host, &src_file_path,
+                                                      missed_versions, &allow_incremental_clone));
 
         LOG(INFO) << "clone copy done. src_host: " << src_host.host
                   << " src_file_path: " << src_file_path;
+        auto tablet_manager = StorageEngine::instance()->tablet_manager();
+        RETURN_IF_ERROR_(status, tablet_manager->load_tablet_from_dir(store, _clone_req.tablet_id,
+                                                                      _clone_req.schema_hash,
+                                                                      tablet_dir, false));
+        auto tablet = tablet_manager->get_tablet(_clone_req.tablet_id);
+        if (!tablet) [[unlikely]] {
+            status = Status::NotFound("tablet not found, tablet_id={}", _clone_req.tablet_id);
+            return status;
+        }
+        // MUST reset `replica_id` to request `replica_id` to keep consistent with FE
+        tablet->tablet_meta()->set_replica_id(_clone_req.replica_id);
+        // clone success, delete .hdr file because tablet meta is stored in rocksdb
         string header_path =
                 TabletMeta::construct_header_file_path(tablet_dir, _clone_req.tablet_id);
-        RETURN_IF_ERROR(TabletMeta::reset_tablet_uid(header_path));
-        RETURN_IF_ERROR(StorageEngine::instance()->tablet_manager()->load_tablet_from_dir(
-                store, _clone_req.tablet_id, _clone_req.schema_hash, tablet_dir, false));
-        // clone success, delete .hdr file because tablet meta is stored in rocksdb
-        RETURN_IF_ERROR(io::global_local_filesystem()->delete_file(header_path));
+        io::global_local_filesystem()->delete_file(header_path);
     }
     return _set_tablet_info(is_new_tablet);
 }

--- a/be/src/olap/task/engine_clone_task.cpp
+++ b/be/src/olap/task/engine_clone_task.cpp
@@ -197,7 +197,7 @@ Status EngineCloneTask::_do_clone() {
                                                                       _clone_req.schema_hash,
                                                                       tablet_dir, false));
         auto tablet = tablet_manager->get_tablet(_clone_req.tablet_id);
-        if (!tablet) [[unlikely]] {
+        if (!tablet) {
             status = Status::NotFound("tablet not found, tablet_id={}", _clone_req.tablet_id);
             return status;
         }

--- a/be/src/olap/task/engine_storage_migration_task.cpp
+++ b/be/src/olap/task/engine_storage_migration_task.cpp
@@ -149,9 +149,6 @@ Status EngineStorageMigrationTask::_gen_and_write_header_to_hdr_file(
     std::string new_meta_file = full_path + "/" + std::to_string(tablet_id) + ".hdr";
     RETURN_IF_ERROR(new_tablet_meta->save(new_meta_file));
 
-    // reset tablet id and rowset id
-    RETURN_IF_ERROR(TabletMeta::reset_tablet_uid(new_meta_file));
-
     // it will change rowset id and its create time
     // rowset create time is useful when load tablet from meta to check which tablet is the tablet to load
     return SnapshotManager::instance()->convert_rowset_ids(full_path, tablet_id,

--- a/fe/fe-core/src/main/java/org/apache/doris/master/ReportHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/master/ReportHandler.java
@@ -81,6 +81,7 @@ import org.apache.doris.thrift.TStorageResource;
 import org.apache.doris.thrift.TStorageType;
 import org.apache.doris.thrift.TTablet;
 import org.apache.doris.thrift.TTabletInfo;
+import org.apache.doris.thrift.TTabletMetaInfo;
 import org.apache.doris.thrift.TTaskType;
 
 import com.google.common.base.Preconditions;
@@ -91,7 +92,6 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Queues;
 import com.google.common.collect.Sets;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.tuple.Triple;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.thrift.TException;
@@ -420,7 +420,7 @@ public class ReportHandler extends Daemon {
         // db id -> tablet id
         ListMultimap<Long, Long> tabletRecoveryMap = LinkedListMultimap.create();
 
-        List<Triple<Long, Integer, Boolean>> tabletToInMemory = Lists.newArrayList();
+        List<TTabletMetaInfo> tabletToUpdate = Lists.newArrayList();
 
         List<CooldownConf> cooldownConfToPush = new LinkedList<>();
         List<CooldownConf> cooldownConfToUpdate = new LinkedList<>();
@@ -434,7 +434,7 @@ public class ReportHandler extends Daemon {
                 transactionsToPublish,
                 transactionsToClear,
                 tabletRecoveryMap,
-                tabletToInMemory,
+                tabletToUpdate,
                 cooldownConfToPush,
                 cooldownConfToUpdate);
 
@@ -474,9 +474,9 @@ public class ReportHandler extends Daemon {
             handleRecoverTablet(tabletRecoveryMap, backendTablets, backendId);
         }
 
-        // 9. send set tablet in memory to be
-        if (!tabletToInMemory.isEmpty()) {
-            handleSetTabletInMemory(backendId, tabletToInMemory);
+        // 9. send tablet meta to be for updating
+        if (!tabletToUpdate.isEmpty()) {
+            handleUpdateTabletMeta(backendId, tabletToUpdate);
         }
 
         // handle cooldown conf
@@ -1032,10 +1032,14 @@ public class ReportHandler extends Daemon {
         }
     }
 
-    private static void handleSetTabletInMemory(long backendId, List<Triple<Long, Integer, Boolean>> tabletToInMemory) {
+    private static void handleUpdateTabletMeta(long backendId, List<TTabletMetaInfo> tabletToUpdate) {
+        final int updateBatchSize = 4096;
         AgentBatchTask batchTask = new AgentBatchTask();
-        UpdateTabletMetaInfoTask task = new UpdateTabletMetaInfoTask(backendId, tabletToInMemory);
-        batchTask.addTask(task);
+        for (int start = 0; start < tabletToUpdate.size(); start += updateBatchSize) {
+            UpdateTabletMetaInfoTask task = new UpdateTabletMetaInfoTask(backendId,
+                    tabletToUpdate.subList(start, Math.min(start + updateBatchSize, tabletToUpdate.size())));
+            batchTask.addTask(task);
+        }
         AgentTaskExecutor.submit(batchTask);
     }
 

--- a/gensrc/thrift/AgentService.thrift
+++ b/gensrc/thrift/AgentService.thrift
@@ -362,10 +362,11 @@ struct TTabletMetaInfo {
     1: optional Types.TTabletId tablet_id
     2: optional Types.TSchemaHash schema_hash
     3: optional Types.TPartitionId partition_id
-    4: optional TTabletMetaType meta_type
+    // 4: optional TTabletMetaType Deprecated_meta_type
     5: optional bool is_in_memory
-    // 6: optional string storage_policy;
+    // 6: optional string Deprecated_storage_policy
     7: optional i64 storage_policy_id
+    8: optional Types.TReplicaId replica_id
 }
 
 struct TUpdateTabletMetaInfoReq {


### PR DESCRIPTION
The replica id is only sent to BE after Doris 1.2, while FE always has a replica id for each replica. However, due to some bugs, replica id of some tablets on BE was forgotten to be set or updated, and the inventory BE tablets before upgrading to 1.2 did not have a replica id (which means `replica_id` is 0), so they became inconsistent.
This PR fixes all known bugs that can cause inconsistent replica id, and provides a backup mechanism that automatically detects and synchronizes inconsistent replica id to cope with inventory data.

