### PR TITLE
[Fix](fe)Upgrade hive-catalog-shade version to 1.0.3

### DIFF
--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -163,7 +163,7 @@ under the License.
         <doris.home>${basedir}/../</doris.home>
         <revision>1.2-SNAPSHOT</revision>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <doris.hive.catalog.shade.version>1.0.2-SNAPSHOT</doris.hive.catalog.shade.version>
+        <doris.hive.catalog.shade.version>1.0.3-SNAPSHOT</doris.hive.catalog.shade.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <sonar.organization>apache</sonar.organization>


### PR DESCRIPTION
# Proposed changes
Upgrade hive-catalog-shade version to 1.0.3-snapshot ，Because there is a commons-cli conflict in 1.0.2-snapshot
I don't know why, when I re-deploy the snapshot package, the old version of the package is still pulled, so I can only repackage.

fix following error:
```
Exception in thread "main" java.lang.NoSuchMethodError: org.apache.commons.cli.Options.hasShortOption(Ljava/lang/String;)Z
	at org.apache.commons.cli.DefaultParser.handleShortAndLongOption(DefaultParser.java:503)
	at org.apache.commons.cli.DefaultParser.handleToken(DefaultParser.java:243)
	at org.apache.commons.cli.DefaultParser.parse(DefaultParser.java:120)
	at org.apache.commons.cli.DefaultParser.parse(DefaultParser.java:76)
	at org.apache.commons.cli.DefaultParser.parse(DefaultParser.java:60)
	at org.apache.doris.DorisFE.parseArgs(DorisFE.java:256)
	at org.apache.doris.DorisFE.start(DorisFE.java:91)
	at org.apache.doris.DorisFE.main(DorisFE.java:73)
```

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

