### PR TITLE
[fix] set execution timeout for brokerload and use query timeout when…

### DIFF
--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -90,8 +90,8 @@ public:
     int query_parallel_instance_num() const { return _query_options.parallel_instance; }
     int max_errors() const { return _query_options.max_errors; }
     int execution_timeout() const {
-        return _query_options.__isset.execution_timeout ? _query_options.execution_timeout :
-                                                         _query_options.query_timeout;
+        return _query_options.__isset.execution_timeout ? _query_options.execution_timeout
+                                                        : _query_options.query_timeout;
     }
     int max_io_buffers() const { return _query_options.max_io_buffers; }
     int num_scanner_threads() const { return _query_options.num_scanner_threads; }

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -90,7 +90,7 @@ public:
     int query_parallel_instance_num() const { return _query_options.parallel_instance; }
     int max_errors() const { return _query_options.max_errors; }
     int execution_timeout() const {
-        return _query_options.__iset.execution_timeout ? _query_options.execution_timeout :
+        return _query_options.__isset.execution_timeout ? _query_options.execution_timeout :
                                                          _query_options.query_timeout;
     }
     int max_io_buffers() const { return _query_options.max_io_buffers; }

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -89,7 +89,10 @@ public:
     }
     int query_parallel_instance_num() const { return _query_options.parallel_instance; }
     int max_errors() const { return _query_options.max_errors; }
-    int execution_timeout() const { return _query_options.execution_timeout; }
+    int execution_timeout() const {
+        return _query_options.__iset.execution_timeout ? _query_options.execution_timeout :
+                                                         _query_options.query_timeout;
+    }
     int max_io_buffers() const { return _query_options.max_io_buffers; }
     int num_scanner_threads() const { return _query_options.num_scanner_threads; }
     TQueryType::type query_type() const { return _query_options.query_type; }

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/StreamLoadPlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/StreamLoadPlanner.java
@@ -257,6 +257,7 @@ public class StreamLoadPlanner {
         params.setParams(execParams);
         TQueryOptions queryOptions = new TQueryOptions();
         queryOptions.setQueryType(TQueryType.LOAD);
+        queryOptions.setQueryTimeout(timeout);
         queryOptions.setExecutionTimeout(timeout);
         queryOptions.setMemLimit(taskInfo.getMemLimit());
         // for stream load, we use exec_mem_limit to limit the memory usage of load channel.

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
@@ -400,6 +400,7 @@ public class Coordinator {
         this.queryOptions = context.getSessionVariable().toThrift();
         this.queryOptions.setEnablePipelineEngine(VectorizedUtil.isPipeline());
         this.queryOptions.setBeExecVersion(Config.be_exec_version);
+        this.queryOptions.setQueryTimeout(context.getExecTimeout());
         this.queryOptions.setExecutionTimeout(context.getExecTimeout());
     }
 
@@ -461,6 +462,7 @@ public class Coordinator {
 
     public void setTimeout(int timeout) {
         this.queryOptions.setQueryTimeout(timeout);
+        this.queryOptions.setExecutionTimeout(timeout);
     }
 
     public void setLoadZeroTolerance(boolean loadZeroTolerance) {


### PR DESCRIPTION
… exec timeout is not set

We should use query timeout if execution timeout is not set to upgrade.

# Proposed changes

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

