### PR TITLE
[chore](build) add apache-orc git submodule path 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,6 +84,7 @@ be/src/gen_cpp/opcode
 be/tags
 be/test/olap/test_data/tablet_meta_test.hdr
 be/.devcontainer/
+be/src/apache-orc/
 
 ## tools
 tools/ssb-tools/ssb-data/

--- a/build.sh
+++ b/build.sh
@@ -251,7 +251,7 @@ if [[ ! -f "${DORIS_HOME}/be/src/apache-orc/README.md" ]]; then
     echo "apache-orc not exists, need to update submodules ..."
     set +e
     cd "${DORIS_HOME}"
-    git submodule update --init --recursive
+    git submodule update --init --recursive be/src/apache-orc
     exit_code=$?
     set -e
     if [[ "${exit_code}" -ne 0 ]]; then


### PR DESCRIPTION
# Proposed changes
1、 Add apache-orc git submodule update path, not update all modules
When sh build.sh, update all modules will fails serveral times because of unstable github network.
It wasts many time.

2、Add gitignore for  be/src/apache-orc/   to avoid mistake commits.

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

