### PR TITLE
[Enhancement](compaction) stop tablet compaction when table dropped

### DIFF
--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -1000,6 +1000,14 @@ void TaskWorkerPool::_update_tablet_meta_worker_thread_callback() {
                                 tablet_meta_info.is_in_memory);
                     }
                     break;
+                case TTabletMetaType::MARKDROP:
+                    if (tablet_meta_info.__isset.is_dropped) {
+                        tablet->tablet_meta()->set_is_dropped(tablet_meta_info.is_dropped);
+                        LOG_INFO("successfully set tablet is_dropped")
+                                .tag("tablet_id", tablet_meta_info.tablet_id)
+                                .tag("is_dropped", tablet_meta_info.is_dropped);
+                    }
+                    break;
                 }
             }
             tablet->save_meta();

--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -930,6 +930,10 @@ bool Tablet::can_do_compaction(size_t path_hash, CompactionType compaction_type)
         return false;
     }
 
+    if (_tablet_meta->is_dropped()) {
+        return false;
+    }
+
     if (tablet_state() == TABLET_NOTREADY) {
         // In TABLET_NOTREADY, we keep last 10 versions in new tablet so base tablet max_version
         // not merged in new tablet and then we can do compaction
@@ -1529,6 +1533,7 @@ void Tablet::build_tablet_report_info(TTabletInfo* tablet_info,
         // tablet may not have cooldowned data, but the storage policy is set
         tablet_info->__set_cooldown_term(_cooldown_term);
     }
+    tablet_info->__set_is_dropped(_tablet_meta->is_dropped());
 }
 
 // should use this method to get a copy of current tablet meta

--- a/be/src/olap/tablet_meta.cpp
+++ b/be/src/olap/tablet_meta.cpp
@@ -241,6 +241,8 @@ TabletMeta::TabletMeta(int64_t table_id, int64_t partition_id, int64_t tablet_id
         schema->set_store_row_column(tablet_schema.store_row_column);
     }
 
+    tablet_meta_pb.set_is_dropped(false);
+
     init_from_pb(tablet_meta_pb);
 }
 
@@ -264,7 +266,8 @@ TabletMeta::TabletMeta(const TabletMeta& b)
           _storage_policy_id(b._storage_policy_id),
           _cooldown_meta_id(b._cooldown_meta_id),
           _enable_unique_key_merge_on_write(b._enable_unique_key_merge_on_write),
-          _delete_bitmap(b._delete_bitmap) {};
+          _delete_bitmap(b._delete_bitmap),
+          _is_dropped(b._is_dropped) {};
 
 void TabletMeta::init_column_from_tcolumn(uint32_t unique_id, const TColumn& tcolumn,
                                           ColumnPB* column) {
@@ -540,6 +543,12 @@ void TabletMeta::init_from_pb(const TabletMetaPB& tablet_meta_pb) {
             delete_bitmap().delete_bitmap[{rst_id, seg_id, ver}] = roaring::Roaring::read(bitmap);
         }
     }
+
+    if (tablet_meta_pb.has_is_dropped()) {
+        _is_dropped = tablet_meta_pb.is_dropped();
+    } else {
+        _is_dropped = false;
+    }
 }
 
 void TabletMeta::to_meta_pb(TabletMetaPB* tablet_meta_pb) {
@@ -613,6 +622,8 @@ void TabletMeta::to_meta_pb(TabletMetaPB* tablet_meta_pb) {
             *(delete_bitmap_pb->add_segment_delete_bitmaps()) = std::move(bitmap_data);
         }
     }
+
+    tablet_meta_pb->set_is_dropped(_is_dropped);
 }
 
 uint32_t TabletMeta::mem_size() const {

--- a/be/src/olap/tablet_meta.h
+++ b/be/src/olap/tablet_meta.h
@@ -204,6 +204,9 @@ public:
 
     bool enable_unique_key_merge_on_write() const { return _enable_unique_key_merge_on_write; }
 
+    bool is_dropped() const;
+    void set_is_dropped(bool is_dropped);
+
 private:
     Status _save_meta(DataDir* data_dir);
 
@@ -246,6 +249,9 @@ private:
     // query performance significantly.
     bool _enable_unique_key_merge_on_write = false;
     std::shared_ptr<DeleteBitmap> _delete_bitmap;
+
+    // _is_dropped is true means that the table has been dropped, and the tablet will not be compacted
+    bool _is_dropped = false;
 
     mutable std::shared_mutex _meta_lock;
 };
@@ -563,6 +569,14 @@ inline bool TabletMeta::all_beta() const {
         }
     }
     return true;
+}
+
+inline bool TabletMeta::is_dropped() const {
+    return _is_dropped;
+}
+
+inline void TabletMeta::set_is_dropped(bool is_dropped) {
+    _is_dropped = is_dropped;
 }
 
 // Only for unit test now.

--- a/be/test/olap/test_data/header_without_inc_rs.txt
+++ b/be/test/olap/test_data/header_without_inc_rs.txt
@@ -108,5 +108,6 @@
     "preferred_rowset_type": "BETA_ROWSET",
     "tablet_type": "TABLET_TYPE_DISK",
     "replica_id": 0,
-    "enable_unique_key_merge_on_write": false
+    "enable_unique_key_merge_on_write": false,
+    "is_dropped": false
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/CatalogRecycleBin.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/CatalogRecycleBin.java
@@ -162,6 +162,9 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
         }
         idToRecycleTime.put(table.getId(), recycleTime);
         idToTable.put(table.getId(), tableInfo);
+        if (!Env.isCheckpointThread()) {
+            Env.getCurrentEnv().markTableDropped(table);
+        }
         LOG.info("recycle table[{}-{}]", table.getId(), table.getName());
         return true;
     }
@@ -180,6 +183,9 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
                 range, listPartitionItem, dataProperty, replicaAlloc, isInMemory, isMutable);
         idToRecycleTime.put(partition.getId(), System.currentTimeMillis());
         idToPartition.put(partition.getId(), partitionInfo);
+        if (!Env.isCheckpointThread()) {
+            Env.getCurrentEnv().markPartitionDropped(partition);
+        }
         LOG.info("recycle partition[{}-{}]", partition.getId(), partition.getName());
         return true;
     }
@@ -590,6 +596,9 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
             iterator.remove();
             idToRecycleTime.remove(table.getId());
             tableNames.remove(table.getName());
+            if (!Env.isCheckpointThread()) {
+                Env.getCurrentEnv().unmarkTableDropped(table);
+            }
         }
 
         if (!tableNames.isEmpty()) {
@@ -692,6 +701,10 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
                 RecoverInfo recoverInfo = new RecoverInfo(db.getId(), table.getId(), -1L, "", newTableName, "");
                 Env.getCurrentEnv().getEditLog().logRecoverTable(recoverInfo);
             }
+
+            if (!Env.isCheckpointThread()) {
+                Env.getCurrentEnv().unmarkTableDropped(table);
+            }
         } finally {
             table.writeUnlock();
         }
@@ -774,6 +787,11 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
         // log
         RecoverInfo recoverInfo = new RecoverInfo(dbId, table.getId(), partitionId, "", "", newPartitionName);
         Env.getCurrentEnv().getEditLog().logRecoverPartition(recoverInfo);
+
+        if (!Env.isCheckpointThread()) {
+            Env.getCurrentEnv().unmarkPartitionDropped(recoverPartition);
+        }
+
         LOG.info("recover partition[{}]", partitionId);
     }
 
@@ -814,6 +832,10 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
             iterator.remove();
             idToRecycleTime.remove(partitionId);
 
+            if (!Env.isCheckpointThread()) {
+                Env.getCurrentEnv().unmarkPartitionDropped(recyclePartitionInfo.getPartition());
+            }
+
             LOG.info("replay recover partition[{}]", partitionId);
             break;
         }
@@ -842,7 +864,9 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
                     long indexId = index.getId();
                     int schemaHash = olapTable.getSchemaHashByIndexId(indexId);
                     for (Tablet tablet : index.getTablets()) {
-                        TabletMeta tabletMeta = new TabletMeta(dbId, tableId, partitionId, indexId, schemaHash, medium);
+                        // all tablets in RecycleBin are dropped
+                        TabletMeta tabletMeta = new TabletMeta(dbId, tableId, partitionId, indexId, schemaHash, medium,
+                                                                true);
                         long tabletId = tablet.getId();
                         invertedIndex.addTablet(tabletId, tabletMeta);
                         for (Replica replica : tablet.getReplicas()) {
@@ -894,7 +918,8 @@ public class CatalogRecycleBin extends MasterDaemon implements Writable {
                 long indexId = index.getId();
                 int schemaHash = olapTable.getSchemaHashByIndexId(indexId);
                 for (Tablet tablet : index.getTablets()) {
-                    TabletMeta tabletMeta = new TabletMeta(dbId, tableId, partitionId, indexId, schemaHash, medium);
+                    TabletMeta tabletMeta = new TabletMeta(dbId, tableId, partitionId, indexId, schemaHash, medium,
+                                                            true);
                     long tabletId = tablet.getId();
                     invertedIndex.addTablet(tabletId, tabletMeta);
                     for (Replica replica : tablet.getReplicas()) {

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
@@ -5346,6 +5346,73 @@ public class Env {
         return analysisManager.taskScheduler;
     }
 
+    /**
+     * mark all tablets of the table as dropped
+     */
+    public void markTableDropped(Table table) {
+        if (table.getType() != TableType.OLAP) {
+            return;
+        }
+
+        OlapTable olapTable = (OlapTable) table;
+        for (Partition partition : olapTable.getAllPartitions()) {
+            innerMarkPartitionDropped(partition, true);
+        }
+
+        LOG.info("mark all tablets of table: {} as dropped", table.getName());
+    }
+
+    /**
+     * mark all tablets of the table as undropped
+     */
+    public void unmarkTableDropped(Table table) {
+        if (table.getType() != TableType.OLAP) {
+            return;
+        }
+
+        OlapTable olapTable = (OlapTable) table;
+        for (Partition partition : olapTable.getAllPartitions()) {
+            innerMarkPartitionDropped(partition, false);
+        }
+
+        LOG.info("mark all tablets of table: {} as undropped", table.getName());
+    }
+
+    /**
+     * mark all tablets of the partition as dropped
+     */
+    public void markPartitionDropped(Partition partition) {
+        innerMarkPartitionDropped(partition, true);
+        LOG.info("mark all tablets of partition: {} as dropped", partition.getName());
+    }
+
+    /**
+     * mark all tablets of the partition as undropped
+     */
+    public void unmarkPartitionDropped(Partition partition) {
+        innerMarkPartitionDropped(partition, false);
+        LOG.info("mark all tablets of partition: {} as undropped", partition.getName());
+    }
+
+    private void innerMarkPartitionDropped(Partition partition, boolean isDropped) {
+        TabletInvertedIndex invertedIndex = Env.getCurrentInvertedIndex();
+        List<MaterializedIndex> allIndices = partition.getMaterializedIndices(IndexExtState.ALL);
+        for (MaterializedIndex materializedIndex : allIndices) {
+            for (Tablet tablet : materializedIndex.getTablets()) {
+                TabletMeta tabletMeta = invertedIndex.getTabletMeta(tablet.getId());
+                if (tabletMeta == null) {
+                    LOG.warn("cannot find tabletMeta of tabletId={}", tablet.getId());
+                    continue;
+                }
+                if (tabletMeta.getIsDropped() == isDropped) {
+                    continue;
+                }
+
+                tabletMeta.setIsDropped(isDropped);
+            } // end for tablets
+        } // end for indices
+    }
+
     // TODO:
     //  1. handle partition level analysis statement properly
     //  2. support sample job

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/TabletMeta.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/TabletMeta.java
@@ -35,8 +35,15 @@ public class TabletMeta {
 
     private TStorageMedium storageMedium;
 
+    private boolean isDropped;
+
     public TabletMeta(long dbId, long tableId, long partitionId, long indexId, int schemaHash,
             TStorageMedium storageMedium) {
+        this(dbId, tableId, partitionId, indexId, schemaHash, storageMedium, false);
+    }
+
+    public TabletMeta(long dbId, long tableId, long partitionId, long indexId, int schemaHash,
+            TStorageMedium storageMedium, boolean isDropped) {
         this.dbId = dbId;
         this.tableId = tableId;
         this.partitionId = partitionId;
@@ -46,6 +53,7 @@ public class TabletMeta {
         this.newSchemaHash = -1;
 
         this.storageMedium = storageMedium;
+        this.isDropped = isDropped;
     }
 
     public long getDbId() {
@@ -76,6 +84,14 @@ public class TabletMeta {
         return this.oldSchemaHash;
     }
 
+    public boolean getIsDropped() {
+        return isDropped;
+    }
+
+    public void setIsDropped(boolean isDropped) {
+        this.isDropped = isDropped;
+    }
+
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();
@@ -88,4 +104,5 @@ public class TabletMeta {
 
         return sb.toString();
     }
+
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/master/ReportHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/master/ReportHandler.java
@@ -422,6 +422,9 @@ public class ReportHandler extends Daemon {
 
         List<Triple<Long, Integer, Boolean>> tabletToInMemory = Lists.newArrayList();
 
+        // <tablet id, tablet schema hash, tablet is dropped>
+        List<Triple<Long, Integer, Boolean>> tabletToIsDropped = Lists.newArrayList();
+
         List<CooldownConf> cooldownConfToPush = new LinkedList<>();
         List<CooldownConf> cooldownConfToUpdate = new LinkedList<>();
 
@@ -435,6 +438,7 @@ public class ReportHandler extends Daemon {
                 transactionsToClear,
                 tabletRecoveryMap,
                 tabletToInMemory,
+                tabletToIsDropped,
                 cooldownConfToPush,
                 cooldownConfToUpdate);
 
@@ -477,6 +481,11 @@ public class ReportHandler extends Daemon {
         // 9. send set tablet in memory to be
         if (!tabletToInMemory.isEmpty()) {
             handleSetTabletInMemory(backendId, tabletToInMemory);
+        }
+
+        // 10. send mark tablet isDropped to be
+        if (!tabletToIsDropped.isEmpty()) {
+            handleMarkTabletIsDropped(backendId, tabletToIsDropped);
         }
 
         // handle cooldown conf
@@ -1035,6 +1044,14 @@ public class ReportHandler extends Daemon {
     private static void handleSetTabletInMemory(long backendId, List<Triple<Long, Integer, Boolean>> tabletToInMemory) {
         AgentBatchTask batchTask = new AgentBatchTask();
         UpdateTabletMetaInfoTask task = new UpdateTabletMetaInfoTask(backendId, tabletToInMemory);
+        batchTask.addTask(task);
+        AgentTaskExecutor.submit(batchTask);
+    }
+
+    private static void handleMarkTabletIsDropped(long backendId,
+            List<Triple<Long, Integer, Boolean>> tabletToIsDropped) {
+        AgentBatchTask batchTask = new AgentBatchTask();
+        UpdateTabletMetaInfoTask task = new UpdateTabletMetaInfoTask(tabletToIsDropped, backendId);
         batchTask.addTask(task);
         AgentTaskExecutor.submit(batchTask);
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/task/UpdateTabletMetaInfoTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/task/UpdateTabletMetaInfoTask.java
@@ -51,6 +51,9 @@ public class UpdateTabletMetaInfoTask extends AgentTask {
     // <tablet id, tablet schema hash, tablet in memory>
     private List<Triple<Long, Integer, Boolean>> tabletToInMemory;
 
+    // <tablet id, tablet schema hash, tablet is dropped>
+    private List<Triple<Long, Integer, Boolean>> tabletToIsDropped;
+
     public UpdateTabletMetaInfoTask(long backendId, Set<Pair<Long, Integer>> tableIdWithSchemaHash,
                                     TTabletMetaType metaType) {
         super(null, backendId, TTaskType.UPDATE_TABLET_META_INFO,
@@ -75,6 +78,13 @@ public class UpdateTabletMetaInfoTask extends AgentTask {
                 -1L, -1L, -1L, -1L, -1L, tabletToInMemory.hashCode());
         this.metaType = TTabletMetaType.INMEMORY;
         this.tabletToInMemory = tabletToInMemory;
+    }
+
+    public UpdateTabletMetaInfoTask(List<Triple<Long, Integer, Boolean>> tabletToIsDropped, long backendId) {
+        super(null, backendId, TTaskType.UPDATE_TABLET_META_INFO,
+                -1L, -1L, -1L, -1L, -1L, tabletToIsDropped.hashCode());
+        this.metaType = TTabletMetaType.MARKDROP;
+        this.tabletToIsDropped = tabletToIsDropped;
     }
 
     public void countDownLatch(long backendId, Set<Pair<Long, Integer>> tablets) {
@@ -151,6 +161,17 @@ public class UpdateTabletMetaInfoTask extends AgentTask {
                         metaInfo.setMetaType(metaType);
                         metaInfos.add(metaInfo);
                     }
+                }
+                break;
+            }
+            case MARKDROP: {
+                for (Triple<Long, Integer, Boolean> triple : tabletToIsDropped) {
+                    TTabletMetaInfo metaInfo = new TTabletMetaInfo();
+                    metaInfo.setTabletId(triple.getLeft());
+                    metaInfo.setSchemaHash(triple.getMiddle());
+                    metaInfo.setIsDropped(triple.getRight());
+                    metaInfo.setMetaType(metaType);
+                    metaInfos.add(metaInfo);
                 }
                 break;
             }

--- a/gensrc/proto/olap_file.proto
+++ b/gensrc/proto/olap_file.proto
@@ -298,6 +298,7 @@ message TabletMetaPB {
     optional bool enable_unique_key_merge_on_write = 24 [default = false];
     optional int64 storage_policy_id = 25;
     optional PUniqueId cooldown_meta_id = 26;
+    optional bool is_dropped = 27;
 }
 
 message OLAPRawDeltaHeaderMessage {

--- a/gensrc/thrift/AgentService.thrift
+++ b/gensrc/thrift/AgentService.thrift
@@ -354,7 +354,8 @@ struct TRecoverTabletReq {
 
 enum TTabletMetaType {
     PARTITIONID,
-    INMEMORY
+    INMEMORY,
+    MARKDROP
 }
 
 struct TTabletMetaInfo {
@@ -365,6 +366,7 @@ struct TTabletMetaInfo {
     5: optional bool is_in_memory
     // 6: optional string storage_policy;
     7: optional i64 storage_policy_id
+    8: optional bool is_dropped
 }
 
 struct TUpdateTabletMetaInfoReq {

--- a/gensrc/thrift/MasterService.thrift
+++ b/gensrc/thrift/MasterService.thrift
@@ -46,6 +46,7 @@ struct TTabletInfo {
     // 18: optional bool is_cooldown
     19: optional i64 cooldown_term
     20: optional Types.TUniqueId cooldown_meta_id
+    21: optional bool is_dropped
 }
 
 struct TFinishTaskRequest {


### PR DESCRIPTION
# Proposed changes

Issue Number: close #18446

## Problem summary

When table was dropped without FORCE, tablet in be will still do compaction as current tablet in be has no information about table status in fe. 

To solve this problem, we add a field `is_dropped` to both fe and be 's TabletMeta to indicate whether the tablet is dropped, and tablet with `is_dropped=true` will not be compacted.
When a table was dropped, the `is_dropped` in fe's TabletMeta will be set to true. When be reports tablet to fe, fe will compare be's `is_dropped` with its own. If it is different, fe will send an UPDATE_TABLET_META_INFO AgentTask to be to change be's `is_dropped`.

The recover process is similar to the above.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

