### PR TITLE
[Feature][multi-catalog] add timed refresh for en

### DIFF
--- a/docs/en/docs/lakehouse/multi-catalog/multi-catalog.md
+++ b/docs/en/docs/lakehouse/multi-catalog/multi-catalog.md
@@ -313,6 +313,8 @@ Users need to manually update the metadata using the  [REFRESH CATALOG](https://
 
 <version since="1.2.2"></version>
 
+#### Hive Metastore
+
 Currently, Doris only supports automatic update of metadata in Hive Metastore (HMS). It perceives changes in metadata by the FE node which regularly reads the notification events from HMS. The supported events are as follows:
 
 | Event           | Corresponding Update Operation                               |
@@ -356,3 +358,22 @@ To enable automatic update, you need to modify the hive-site.xml of HMS and then
 ```
 
 > Note: To enable automatic update, whether for existing Catalogs or newly created Catalogs, all you need is to set `enable_hms_events_incremental_sync` to `true`, and then restart the FE node. You don't need to manually update the metadata before or after the restart.
+
+#### Timing Refresh
+
+When creating a catalog, specify the refresh time parameter `metadata_refresh_interval_sec` in the properties, in seconds. If this parameter is set when creating a catalog, the master node of FE will refresh the catalog regularly according to the parameter value. Three types are currently supported
+
+- hms: Hive MetaStore
+-es: Elasticsearch
+- jdbc: Standard interface for database access (JDBC)
+
+##### Example
+
+```
+-- Set the catalog refresh interval to 20 seconds
+CREATE CATALOG es PROPERTIES (
+     "type"="es",
+     "hosts"="http://127.0.0.1:9200",
+     "metadata_refresh_interval_sec"="20"
+);
+```


### PR DESCRIPTION


# Proposed changes

Issue Number: close[[#17413](https://github.com/apache/doris/issues/17413)](https://github.com/apache/doris/issues/17413)

## Problem summary

For a catalog, we can set the metadata_refresh_interval_sec parameter to specify a timed refresh，so I add timing refresh in the document. Modified the documentation in en

## Checklist(Required)

* [√ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [√ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
