### PR TITLE
[improvement] TOperationStatus determines that a null pointer is redundant.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/BrokerReader.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/BrokerReader.java
@@ -126,7 +126,9 @@ public class BrokerReader {
         } catch (TException e) {
             LOG.warn("Broker close reader failed. fd={}, address={}", fd.toString(), address, e);
         }
-        if (tOperationStatus.getStatusCode() != TBrokerOperationStatusCode.OK) {
+        if (tOperationStatus == null) {
+            LOG.warn("Broker close reader failed. fd={}, address={}", fd.toString(), address);
+        } else if (tOperationStatus.getStatusCode() != TBrokerOperationStatusCode.OK) {
             LOG.warn("Broker close reader failed. fd={}, address={}, error={}", fd.toString(), address,
                     tOperationStatus.getMessage());
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/BrokerReader.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/BrokerReader.java
@@ -126,7 +126,7 @@ public class BrokerReader {
         } catch (TException e) {
             LOG.warn("Broker close reader failed. fd={}, address={}", fd.toString(), address, e);
         }
-        if (tOperationStatus == null || tOperationStatus.getStatusCode() != TBrokerOperationStatusCode.OK) {
+        if (tOperationStatus.getStatusCode() != TBrokerOperationStatusCode.OK) {
             LOG.warn("Broker close reader failed. fd={}, address={}, error={}", fd.toString(), address,
                     tOperationStatus.getMessage());
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/BrokerUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/BrokerUtil.java
@@ -263,7 +263,7 @@ public class BrokerUtil {
                         LOG.warn("Broker close reader failed. path={}, address={}", path, address, ex);
                     }
                 }
-                if (tOperationStatus == null || tOperationStatus.getStatusCode() != TBrokerOperationStatusCode.OK) {
+                if (tOperationStatus.getStatusCode() != TBrokerOperationStatusCode.OK) {
                     LOG.warn("Broker close reader failed. path={}, address={}, error={}", path, address,
                              tOperationStatus.getMessage());
                 } else {
@@ -564,7 +564,7 @@ public class BrokerUtil {
                         LOG.warn("Broker close writer failed. filePath={}, address={}", brokerFilePath, address, ex);
                     }
                 }
-                if (tOperationStatus == null || tOperationStatus.getStatusCode() != TBrokerOperationStatusCode.OK) {
+                if (tOperationStatus.getStatusCode() != TBrokerOperationStatusCode.OK) {
                     LOG.warn("Broker close writer failed. filePath={}, address={}, error={}", brokerFilePath,
                              address, tOperationStatus.getMessage());
                 } else {

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/BrokerUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/BrokerUtil.java
@@ -564,7 +564,9 @@ public class BrokerUtil {
                         LOG.warn("Broker close writer failed. filePath={}, address={}", brokerFilePath, address, ex);
                     }
                 }
-                if (tOperationStatus.getStatusCode() != TBrokerOperationStatusCode.OK) {
+                if (tOperationStatus == null) {
+                    LOG.warn("Broker close reader failed. fd={}, address={}", fd.toString(), address);
+                } else if (tOperationStatus.getStatusCode() != TBrokerOperationStatusCode.OK) {
                     LOG.warn("Broker close writer failed. filePath={}, address={}, error={}", brokerFilePath,
                              address, tOperationStatus.getMessage());
                 } else {


### PR DESCRIPTION

# Proposed changes

TOperationStatus determines that a null pointer is redundant. If tOperationStatus is a null pointer, then tOperationStatus.getMessage() will have a null pointer exception.

## Problem summary

change BrokerUtil.java and BrokerReader.java

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

