### PR TITLE
[Fix][Docs]: from `ARRAY\<T\>` to `ARRAY<T>`

### DIFF
--- a/docs/en/docs/sql-manual/sql-reference/Data-Types/ARRAY.md
+++ b/docs/en/docs/sql-manual/sql-reference/Data-Types/ARRAY.md
@@ -34,7 +34,7 @@ ARRAY
 
 ### description
 
-`ARRAY\<T\>`
+`ARRAY<T>`
 
 An array of T-type items, it cannot be used as a key column. Now ARRAY can only used in Duplicate Model Tables.
 

--- a/docs/zh-CN/docs/sql-manual/sql-reference/Data-Types/ARRAY.md
+++ b/docs/zh-CN/docs/sql-manual/sql-reference/Data-Types/ARRAY.md
@@ -36,7 +36,7 @@ ARRAY
 
 ### description
 
-`ARRAY\<T\>`
+`ARRAY<T>`
 
 由T类型元素组成的数组，不能作为key列使用。目前支持在Duplicate模型的表中使用。
 


### PR DESCRIPTION
# Proposed changes

Issue Number: close #18711

## Problem summary

To correct typo of docs web's Description part from `ARRAY\<T\>` to `ARRAY<T>`, docs both [English version](https://doris.apache.org/docs/dev/sql-manual/sql-reference/Data-Types/ARRAY/) and [Chinese version](https://doris.apache.org/zh-CN/docs/dev/sql-manual/sql-reference/Data-Types/ARRAY) have fixed.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [X] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

