### PR TITLE
[fix](merge-on-write) enable_unique_key_merge_on_write property should only be used for unique table

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
@@ -1956,11 +1956,13 @@ public class InternalCatalog implements CatalogIf<Database> {
                 keysDesc.keysColumnSize(), storageFormat);
         olapTable.setDataSortInfo(dataSortInfo);
 
-        boolean enableUniqueKeyMergeOnWrite;
-        try {
-            enableUniqueKeyMergeOnWrite = PropertyAnalyzer.analyzeUniqueKeyMergeOnWrite(properties);
-        } catch (AnalysisException e) {
-            throw new DdlException(e.getMessage());
+        boolean enableUniqueKeyMergeOnWrite = false;
+        if (keysType == KeysType.UNIQUE_KEYS) {
+            try {
+                enableUniqueKeyMergeOnWrite = PropertyAnalyzer.analyzeUniqueKeyMergeOnWrite(properties);
+            } catch (AnalysisException e) {
+                throw new DdlException(e.getMessage());
+            }
         }
         olapTable.setEnableUniqueKeyMergeOnWrite(enableUniqueKeyMergeOnWrite);
 

--- a/regression-test/suites/ddl_p0/test_create_table.groovy
+++ b/regression-test/suites/ddl_p0/test_create_table.groovy
@@ -42,8 +42,7 @@ suite("sql_create_time_range_table") {
 	properties(
 		"replication_num"="1",
 		"light_schema_change"="true",
-		"compression"="zstd",
-		"enable_unique_key_merge_on_write" = "true"
+		"compression"="zstd"
 	);
 		"""
 

--- a/regression-test/suites/unique_with_mow_p0/test_create_table.groovy
+++ b/regression-test/suites/unique_with_mow_p0/test_create_table.groovy
@@ -1,0 +1,97 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_create_table") {
+    def tableName = "unique_mow_create_table"
+    sql """ DROP TABLE IF EXISTS ${tableName} """
+
+    // duplicate table with enable_unique_key_merge_on_write property
+    test {
+        sql """
+            CREATE TABLE `$tableName` (
+                    `c_custkey` int(11) NOT NULL COMMENT "",
+                    `c_name` varchar(26) NOT NULL COMMENT "",
+                    `c_address` varchar(41) NOT NULL COMMENT "",
+                    `c_city` varchar(11) NOT NULL COMMENT ""
+            )
+            DUPLICATE KEY (`c_custkey`)
+            DISTRIBUTED BY HASH(`c_custkey`) BUCKETS 1
+            PROPERTIES (
+                    "replication_num" = "1",
+                    "enable_unique_key_merge_on_write" = "true"
+             );
+        """
+        exception "Unknown properties"
+    }
+
+    // duplicate table with enable_unique_key_merge_on_write property
+    test {
+        sql """
+            CREATE TABLE `$tableName` (
+                    `c_custkey` int(11) NOT NULL COMMENT "",
+                    `c_name` varchar(26) NOT NULL COMMENT "",
+                    `c_address` varchar(41) NOT NULL COMMENT "",
+                    `c_city` varchar(11) NOT NULL COMMENT ""
+            )
+            DUPLICATE KEY (`c_custkey`)
+            DISTRIBUTED BY HASH(`c_custkey`) BUCKETS 1
+            PROPERTIES (
+                    "replication_num" = "1",
+                    "enable_unique_key_merge_on_write" = "false"
+             );
+        """
+        exception "Unknown properties"
+    }
+
+    // agg table with enable_unique_key_merge_on_write property
+    test {
+        sql """
+            CREATE TABLE `$tableName` (
+                    `c_custkey` int(11) NOT NULL COMMENT "",
+                    `c_name` varchar(26) max NOT NULL COMMENT "",
+                    `c_address` varchar(41) max NOT NULL COMMENT "",
+                    `c_city` varchar(11) max NOT NULL COMMENT ""
+            )
+            AGGREGATE KEY (`c_custkey`)
+            DISTRIBUTED BY HASH(`c_custkey`) BUCKETS 1
+            PROPERTIES (
+                    "replication_num" = "1",
+                    "enable_unique_key_merge_on_write" = "true"
+             );
+        """
+        exception "Unknown properties"
+    }
+
+    // agg table with enable_unique_key_merge_on_write property
+    test {
+        sql """
+            CREATE TABLE `$tableName` (
+                    `c_custkey` int(11) NOT NULL COMMENT "",
+                    `c_name` varchar(26) max NOT NULL COMMENT "",
+                    `c_address` varchar(41) max NOT NULL COMMENT "",
+                    `c_city` varchar(11) max NOT NULL COMMENT ""
+            )
+            AGGREGATE KEY (`c_custkey`)
+            DISTRIBUTED BY HASH(`c_custkey`) BUCKETS 1
+            PROPERTIES (
+                    "replication_num" = "1",
+                    "enable_unique_key_merge_on_write" = "false"
+             );
+        """
+        exception "Unknown properties"
+    }
+}


### PR DESCRIPTION

# Proposed changes

Issue Number: close #xxx

## Problem summary

enable_unique_key_merge_on_write property should only be used for unique table. When creating a DUP or AGG table, if the properties contains enable_unique_key_merge_on_write, an error will be returned to the user.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

