### PR TITLE
[refactor](scan) optimize the agg function of count(1)

### DIFF
--- a/be/src/vec/columns/column_array.cpp
+++ b/be/src/vec/columns/column_array.cpp
@@ -301,6 +301,12 @@ void ColumnArray::reserve(size_t n) {
             n); /// The average size of arrays is not taken into account here. Or it is considered to be no more than 1.
 }
 
+//please check you real need size in data column, because it's maybe need greater size when data is string column
+void ColumnArray::resize(size_t n) {
+    get_offsets().resize(n);
+    get_data().resize(n);
+}
+
 size_t ColumnArray::byte_size() const {
     return get_data().byte_size() + get_offsets().size() * sizeof(get_offsets()[0]);
 }

--- a/be/src/vec/columns/column_array.h
+++ b/be/src/vec/columns/column_array.h
@@ -106,6 +106,7 @@ public:
     TypeIndex get_data_type() const override { return TypeIndex::Array; }
     MutableColumnPtr clone_resized(size_t size) const override;
     size_t size() const override;
+    void resize(size_t n) override;
     Field operator[](size_t n) const override;
     void get(size_t n, Field& res) const override;
     StringRef get_data_at(size_t n) const override;

--- a/be/src/vec/columns/column_map.cpp
+++ b/be/src/vec/columns/column_map.cpp
@@ -359,6 +359,12 @@ void ColumnMap::reserve(size_t n) {
     values_column->reserve(n);
 }
 
+void ColumnMap::resize(size_t n) {
+    get_offsets().resize(n);
+    keys_column->resize(n);
+    values_column->resize(n);
+}
+
 size_t ColumnMap::byte_size() const {
     return keys_column->byte_size() + values_column->byte_size() + offsets_column->byte_size();
     ;

--- a/be/src/vec/columns/column_map.h
+++ b/be/src/vec/columns/column_map.h
@@ -137,6 +137,7 @@ public:
 
     size_t size() const override { return get_offsets().size(); }
     void reserve(size_t n) override;
+    void resize(size_t n) override;
     size_t byte_size() const override;
     size_t allocated_bytes() const override;
     void protect() override;

--- a/be/src/vec/columns/column_struct.cpp
+++ b/be/src/vec/columns/column_struct.cpp
@@ -294,6 +294,14 @@ void ColumnStruct::reserve(size_t n) {
     }
 }
 
+//please check you real need size in data column, When it mixes various data types， eg: string column with int column
+void ColumnStruct::resize(size_t n) {
+    const size_t tuple_size = columns.size();
+    for (size_t i = 0; i < tuple_size; ++i) {
+        get_column(i).resize(n);
+    }
+}
+
 size_t ColumnStruct::byte_size() const {
     size_t res = 0;
     for (const auto& column : columns) {

--- a/be/src/vec/columns/column_struct.h
+++ b/be/src/vec/columns/column_struct.h
@@ -121,6 +121,7 @@ public:
     }
     void get_extremes(Field& min, Field& max) const override;
     void reserve(size_t n) override;
+    void resize(size_t n) override;
     size_t byte_size() const override;
     size_t allocated_bytes() const override;
     void protect() override;

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/SingleNodePlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/SingleNodePlanner.java
@@ -458,8 +458,11 @@ public class SingleNodePlanner {
                                 break;
                             }
                         } else {
-                            aggExprValidate = false;
-                            break;
+                            // want to support the agg of count(const value) in dup table
+                            aggExprValidate = (aggOp == TPushAggOp.COUNT && child.isConstant() && !child.isNullable());
+                            if (!aggExprValidate) {
+                                break;
+                            }
                         }
                     } else {
                         returnColumns.add(((SlotRef) aggExpr.getChild(0)).getDesc().getColumn());
@@ -490,8 +493,7 @@ public class SingleNodePlanner {
                                 break;
                             }
 
-                            if (colType.isCharFamily() && aggOp != TPushAggOp.COUNT
-                                    && col.getType().getLength() > 512) {
+                            if (colType.isCharFamily() && col.getType().getLength() > 512) {
                                 returnColumnValidate = false;
                                 break;
                             }


### PR DESCRIPTION
# Proposed changes
after PR #12803,
like count(*) in dup table will use the segment static,
now add count(const value) also use that optimization.

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

