### PR TITLE
[opt](nereids) estimate broadcast cost

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/cost/CostModelV1.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/cost/CostModelV1.java
@@ -174,10 +174,13 @@ class CostModelV1 extends PlanVisitor<Cost, PlanContext> {
                     || childStatistics.getRowCount() > rowsLimit) {
                 return CostV1.of(Double.MAX_VALUE, Double.MAX_VALUE, Double.MAX_VALUE);
             }
+            // estimate broadcast cost by an experience formula: beNumber^0.5 * rowCount
+            // - sender number and receiver number is not available at RBO stage now, so we use beNumber
+            // - senders and receivers work in parallel, that why we use square of beNumber
             return CostV1.of(
                     0,
                     0,
-                    childStatistics.getRowCount() * beNumber);
+                    childStatistics.getRowCount() * Math.pow(beNumber, 0.5));
 
         }
 


### PR DESCRIPTION
# Proposed changes
estimate broadcast cost by an experience formula: beNumber^0.5 * rowCount
1. sender number and receiver number is not available at RBO stage now, so we use beNumber
2. senders and receivers work in parallel, that why we use square of beNumber

Issue Number: close #xxx

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

