### PR TITLE
[fix](Nereids): when GroupExpr already exists, we need to remove ParentExpression

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/GroupExpression.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/GroupExpression.java
@@ -182,7 +182,7 @@ public class GroupExpression {
      */
     public boolean isUnused() {
         if (isUnused) {
-            Preconditions.checkState(children.isEmpty() || ownerGroup == null);
+            Preconditions.checkState(children.isEmpty() && ownerGroup == null);
             return true;
         }
         Preconditions.checkState(ownerGroup != null);

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Memo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/memo/Memo.java
@@ -427,6 +427,9 @@ public class Memo {
             if (target != null && !target.getGroupId().equals(existedGroupExpression.getOwnerGroup().getGroupId())) {
                 mergeGroup(existedGroupExpression.getOwnerGroup(), target);
             }
+            // When we create a GroupExpression, we will add it into ParentExpression of childGroup.
+            // But if it already exists, we should remove it from ParentExpression of childGroup.
+            groupExpression.children().forEach(childGroup -> childGroup.removeParentExpression(groupExpression));
             return CopyInResult.of(false, existedGroupExpression);
         }
         if (target != null) {


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem summary

When we create a GroupExpression, we will add it into ParentExpression of childGroup.
But if it already exists, we should remove it from ParentExpression of childGroup.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

