### PR TITLE
[fix](olap) fix lost disable_auto_compaction info when fe restart

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/TableProperty.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/TableProperty.java
@@ -347,7 +347,8 @@ public class TableProperty implements Writable {
                 .buildCompressionType()
                 .buildStoragePolicy()
                 .buildEnableLightSchemaChange()
-                .buildStoreRowColumn();
+                .buildStoreRowColumn()
+                .buildDisableAutoCompaction();
         if (Env.getCurrentEnvJournalVersion() < FeMetaVersion.VERSION_105) {
             // get replica num from property map and create replica allocation
             String repNum = tableProperty.properties.remove(PropertyAnalyzer.PROPERTIES_REPLICATION_NUM);


### PR DESCRIPTION
# Proposed changes

Issue Number: close #18755

## Problem summary

Describe your changes.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

