### PR TITLE
[feature](graph)Support querying data from the Nebula graph database

### DIFF
--- a/be/src/vec/exec/vjdbc_connector.cpp
+++ b/be/src/vec/exec/vjdbc_connector.cpp
@@ -196,7 +196,10 @@ Status JdbcConnector::query() {
     }
 
     LOG(INFO) << "JdbcConnector::query has exec success: " << _sql_str;
-    RETURN_IF_ERROR(_check_column_type());
+    // graph no need to check type
+    if (_conn_param.table_type != TOdbcTableType::NEBULA) {
+        RETURN_IF_ERROR(_check_column_type());
+    }
     return Status::OK();
 }
 

--- a/docs/en/docs/lakehouse/external-table/jdbc.md
+++ b/docs/en/docs/lakehouse/external-table/jdbc.md
@@ -437,7 +437,7 @@ The followings list how data types in different databases are mapped in Doris.
 |   timestamp   |         bigint         |
 |    datetime    |       datetime        |
 | bool |  boolean  |
-|   vertex/edge/path/list/set/time等    |  varchar  |
+|   vertex/edge/path/list/set/time etc    |  varchar  |
 
 
 ## Q&A

--- a/docs/en/docs/lakehouse/external-table/jdbc.md
+++ b/docs/en/docs/lakehouse/external-table/jdbc.md
@@ -207,6 +207,109 @@ PROPERTIES (
 );
 ```
 
+### 6.NebulaGraphTest (only supports queries)
+| Nebula version | Nebula JDBC Driver Version |
+|------------|-------------------|
+| 3.0.0       | nebula-jdbc-3.0.0-jar-with-dependencies.jar         |
+
+
+
+```
+#step1.crate test data in nebula
+#1.1 create tag
+(root@nebula) [basketballplayer]> CREATE TAG test(t_str string, 
+    t_int int, 
+    t_date date,
+    t_datetime datetime,
+    t_bool bool,
+    t_timestamp timestamp,
+    t_float float,
+    t_double double
+);
+
+#1.2 insert test data
+(root@nebula) [basketballplayer]> INSERT VERTEX test_type(t_str,t_int,t_date,t_datetime,t_bool,t_timestamp,t_float,t_double) values "zhangshan":("zhangshan",1000,date("2023-01-01"),datetime("2023-01-23 15:23:32"),true,1234242423,1.2,1.35);
+
+#1.3 check the data
+(root@nebula) [basketballplayer]> match (v:test_type) where id(v)=="zhangshan" return v.test_type.t_str,v.test_type.t_int,v.test_type.t_date,v.test_type.t_datetime,v.test_type.t_bool,v.test_type.t_timestamp,v.test_type.t_float,v.test_type.t_double,v limit 30;
++-------------------+-------------------+--------------------+----------------------------+--------------------+-------------------------+---------------------+----------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| v.test_type.t_str | v.test_type.t_int | v.test_type.t_date | v.test_type.t_datetime     | v.test_type.t_bool | v.test_type.t_timestamp | v.test_type.t_float | v.test_type.t_double | v                                                                                                                                                                                                         |
++-------------------+-------------------+--------------------+----------------------------+--------------------+-------------------------+---------------------+----------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| "zhangshan"       | 1000              | 2023-01-01         | 2023-01-23T15:23:32.000000 | true               | 1234242423              | 1.2000000476837158  | 1.35                 | ("zhangshan" :test_type{t_bool: true, t_date: 2023-01-01, t_datetime: 2023-01-23T15:23:32.000000, t_double: 1.35, t_float: 1.2000000476837158, t_int: 1000, t_str: "zhangshan", t_timestamp: 1234242423}) |
++-------------------+-------------------+--------------------+----------------------------+--------------------+-------------------------+---------------------+----------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+Got 1 rows (time spent 1616/2048 us)
+
+Mon, 17 Apr 2023 17:23:14 CST
+
+
+#step2. create table in doris
+#2.1 create a resource
+MySQL [test_db]> CREATE EXTERNAL RESOURCE gg_jdbc_resource 
+properties (
+   "type"="jdbc",
+   "user"="root",
+   "password"="123",
+   "jdbc_url"="jdbc:nebula://127.0.0.1:9669/basketballplayer",
+   "driver_url"="file:///home/clz/baidu/bdg/doris/be/lib/nebula-jdbc-3.0.0-jar-with-dependencies.jar",  --Need to be placed in the be/lib directory--
+   "driver_class"="com.vesoft.nebula.jdbc.NebulaDriver"
+);
+
+#2.2 Create a facade that mainly tells Doris how to parse the data returned by Nebulagraph
+MySQL [test_db]> CREATE TABLE `test_type` ( 
+ `t_str` varchar(64),
+ `t_int` bigint,
+ `t_date` date,
+ `t_datetime` datetime,
+ `t_bool` boolean,
+ `t_timestamp` bigint,
+ `t_float` double,
+ `t_double` double,
+ `t_vertx`  varchar(128) --vertex map type varchar in doris---
+) ENGINE=JDBC
+PROPERTIES (
+"resource" = "gg_jdbc_resource",
+"table" = "xx",  --please fill in any value here, we do not use it --
+"table_type"="nebula"
+);
+
+#2.3 Query the graph surface and use the g() function to transparently pass the nGQL of the graph to Nebula
+MySQL [test_db]> select * from test_type where g('match (v:test_type) where id(v)=="zhangshan" return v.test_type.t_str,v.test_type.t_int,v.test_type.t_date,v.test_type.t_datetime,v.test_type.t_bool,v.test_type.t_timestamp,v.test_type.t_float,v.test_type.t_double,v')\G;
+*************************** 1. row ***************************
+      t_str: zhangshan
+      t_int: 1000
+     t_date: 2023-01-01
+ t_datetime: 2023-01-23 15:23:32
+     t_bool: 1
+t_timestamp: 1234242423
+    t_float: 1.2000000476837158
+   t_double: 1.35
+    t_vertx: ("zhangshan" :test_type {t_datetime: utc datetime: 2023-01-23T15:23:32.000000, timezoneOffset: 0, t_timestamp: 1234242423, t_date: 2023-01-01, t_double: 1.35, t_str: "zhangshan", t_int: 1000, t_bool: true, t_float: 1.2000000476837158})
+1 row in set (0.024 sec)
+
+#2.3 Associate queries with other tables in Doris
+#Assuming there is a user table
+MySQL [test_db]> select * from t_user;
++-----------+------+---------------------------------+
+| username  | age  | addr                            |
++-----------+------+---------------------------------+
+| zhangshan |   26 | 北京市西二旗街道1008号          |
++-----------+------+---------------------------------+
+| lisi |   29 | 北京市西二旗街道1007号          |
++-----------+------+---------------------------------+
+1 row in set (0.013 sec)
+
+#Associate with this table to query user related information
+MySQL [test_db]> select u.* from (select t_str username  from test_type where g('match (v:test_type) where id(v)=="zhangshan" return v.test_type.t_str limit 1')) g left join t_user u on g.username=u.username;
++-----------+------+---------------------------------+
+| username  | age  | addr                            |
++-----------+------+---------------------------------+
+| zhangshan |   26 | 北京市西二旗街道1008号          |
++-----------+------+---------------------------------+
+1 row in set (0.029 sec)
+
+```
+
+
 ## Type Mapping
 
 The followings list how data types in different databases are mapped in Doris.
@@ -324,6 +427,18 @@ The followings list how data types in different databases are mapped in Doris.
 |  SHORTTEXT   |        TEXT         |
 |     CHAR     |        CHAR         |
 |    NCHAR     |        CHAR         |
+
+### Nebula-graph
+|   nebula   |        Doris        |
+|:------------:|:-------------------:|
+|   tinyint/samllint/int/int64    |       bigint       |
+|   double/float    |       double       |
+|   date   |      date       |
+|   timestamp   |         bigint         |
+|    datetime    |       datetime        |
+| bool |  boolean  |
+|   vertex/edge/path/list/set/time等    |  varchar  |
+
 
 ## Q&A
 

--- a/docs/zh-CN/docs/lakehouse/external-table/jdbc.md
+++ b/docs/zh-CN/docs/lakehouse/external-table/jdbc.md
@@ -201,6 +201,108 @@ PROPERTIES (
 );
 ```
 
+### 6.Nebula-graph测试 （仅支持查询）
+| nebula版本 | JDBC驱动版本 |
+|------------|-------------------|
+| 3.0.0       | nebula-jdbc-3.0.0-jar-with-dependencies.jar         |
+
+
+
+```
+#step1.在nebula创建测试数据
+#1.1 创建结点
+(root@nebula) [basketballplayer]> CREATE TAG test(t_str string, 
+    t_int int, 
+    t_date date,
+    t_datetime datetime,
+    t_bool bool,
+    t_timestamp timestamp,
+    t_float float,
+    t_double double
+);
+
+#1.2 插入数据
+(root@nebula) [basketballplayer]> INSERT VERTEX test_type(t_str,t_int,t_date,t_datetime,t_bool,t_timestamp,t_float,t_double) values "zhangshan":("zhangshan",1000,date("2023-01-01"),datetime("2023-01-23 15:23:32"),true,1234242423,1.2,1.35);
+
+#1.3 查询数据
+(root@nebula) [basketballplayer]> match (v:test_type) where id(v)=="zhangshan" return v.test_type.t_str,v.test_type.t_int,v.test_type.t_date,v.test_type.t_datetime,v.test_type.t_bool,v.test_type.t_timestamp,v.test_type.t_float,v.test_type.t_double,v limit 30;
++-------------------+-------------------+--------------------+----------------------------+--------------------+-------------------------+---------------------+----------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| v.test_type.t_str | v.test_type.t_int | v.test_type.t_date | v.test_type.t_datetime     | v.test_type.t_bool | v.test_type.t_timestamp | v.test_type.t_float | v.test_type.t_double | v                                                                                                                                                                                                         |
++-------------------+-------------------+--------------------+----------------------------+--------------------+-------------------------+---------------------+----------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| "zhangshan"       | 1000              | 2023-01-01         | 2023-01-23T15:23:32.000000 | true               | 1234242423              | 1.2000000476837158  | 1.35                 | ("zhangshan" :test_type{t_bool: true, t_date: 2023-01-01, t_datetime: 2023-01-23T15:23:32.000000, t_double: 1.35, t_float: 1.2000000476837158, t_int: 1000, t_str: "zhangshan", t_timestamp: 1234242423}) |
++-------------------+-------------------+--------------------+----------------------------+--------------------+-------------------------+---------------------+----------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+Got 1 rows (time spent 1616/2048 us)
+
+Mon, 17 Apr 2023 17:23:14 CST
+
+
+#step2.在doris中创建外表
+#2.1 创建一个resource
+MySQL [test_db]> CREATE EXTERNAL RESOURCE gg_jdbc_resource 
+properties (
+   "type"="jdbc",
+   "user"="root",
+   "password"="123",
+   "jdbc_url"="jdbc:nebula://127.0.0.1:9669/basketballplayer",
+   "driver_url"="file:///home/clz/baidu/bdg/doris/be/lib/nebula-jdbc-3.0.0-jar-with-dependencies.jar",  --仅支持本地路径，需放到be/lib目录下--
+   "driver_class"="com.vesoft.nebula.jdbc.NebulaDriver"
+);
+
+#2.2 创建一个外表，这个主要是告诉doris如何解析nebulagraph返回的数据
+MySQL [test_db]> CREATE TABLE `test_type` ( 
+ `t_str` varchar(64),
+ `t_int` bigint,
+ `t_date` date,
+ `t_datetime` datetime,
+ `t_bool` boolean,
+ `t_timestamp` bigint,
+ `t_float` double,
+ `t_double` double,
+ `t_vertx`  varchar(128) --vertex对应doris类型是varchar---
+) ENGINE=JDBC
+PROPERTIES (
+"resource" = "gg_jdbc_resource",
+"table" = "xx",  --因为graph没有表的概念，这里随便填一个值--
+"table_type"="nebula"
+);
+
+#2.3 查询graph外表,用g()函数把图的nGQL透传给nebula
+MySQL [test_db]> select * from test_type where g('match (v:test_type) where id(v)=="zhangshan" return v.test_type.t_str,v.test_type.t_int,v.test_type.t_date,v.test_type.t_datetime,v.test_type.t_bool,v.test_type.t_timestamp,v.test_type.t_float,v.test_type.t_double,v')\G;
+*************************** 1. row ***************************
+      t_str: zhangshan
+      t_int: 1000
+     t_date: 2023-01-01
+ t_datetime: 2023-01-23 15:23:32
+     t_bool: 1
+t_timestamp: 1234242423
+    t_float: 1.2000000476837158
+   t_double: 1.35
+    t_vertx: ("zhangshan" :test_type {t_datetime: utc datetime: 2023-01-23T15:23:32.000000, timezoneOffset: 0, t_timestamp: 1234242423, t_date: 2023-01-01, t_double: 1.35, t_str: "zhangshan", t_int: 1000, t_bool: true, t_float: 1.2000000476837158})
+1 row in set (0.024 sec)
+
+#2.3 与doris的其他表进行关联查询
+#假设有张用户表
+MySQL [test_db]> select * from t_user;
++-----------+------+---------------------------------+
+| username  | age  | addr                            |
++-----------+------+---------------------------------+
+| zhangshan |   26 | 北京市西二旗街道1008号          |
++-----------+------+---------------------------------+
+| lisi |   29 | 北京市西二旗街道1007号          |
++-----------+------+---------------------------------+
+1 row in set (0.013 sec)
+
+#与这张用表关联查询用户相关的信息
+MySQL [test_db]> select u.* from (select t_str username  from test_type where g('match (v:test_type) where id(v)=="zhangshan" return v.test_type.t_str limit 1')) g left join t_user u on g.username=u.username;
++-----------+------+---------------------------------+
+| username  | age  | addr                            |
++-----------+------+---------------------------------+
+| zhangshan |   26 | 北京市西二旗街道1008号          |
++-----------+------+---------------------------------+
+1 row in set (0.029 sec)
+
+```
+
 ## 类型匹配
 
 各个数据库之间数据类型存在不同，这里列出了各个数据库中的类型和Doris之中数据类型匹配的情况。
@@ -317,6 +419,18 @@ PROPERTIES (
 |  SHORTTEXT   |        TEXT         |
 |     CHAR     |        CHAR         |
 |    NCHAR     |        CHAR         |
+
+
+### Nebula-graph
+|   nebula   |        Doris        |
+|:------------:|:-------------------:|
+|   tinyint/samllint/int/int64    |       bigint       |
+|   double/float    |       double       |
+|   date   |      date       |
+|   timestamp   |         bigint         |
+|    datetime    |       datetime        |
+| bool |  boolean  |
+|   vertex/edge/path/list/set/time等    |  varchar  |
 
 ## Q&A
 

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/JdbcResource.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/JdbcResource.java
@@ -68,6 +68,7 @@ public class JdbcResource extends Resource {
     public static final String JDBC_SQLSERVER = "jdbc:sqlserver";
     public static final String JDBC_CLICKHOUSE = "jdbc:clickhouse";
     public static final String JDBC_SAP_HANA = "jdbc:sap";
+    public static final String JDBC_NEBULA = "jdbc:nebula";
 
     public static final String MYSQL = "MYSQL";
     public static final String POSTGRESQL = "POSTGRESQL";
@@ -75,6 +76,7 @@ public class JdbcResource extends Resource {
     public static final String SQLSERVER = "SQLSERVER";
     public static final String CLICKHOUSE = "CLICKHOUSE";
     public static final String SAP_HANA = "SAP_HANA";
+    public static final String NEBULA = "NEBULA";
 
     public static final String JDBC_PROPERTIES_PREFIX = "jdbc.";
     public static final String JDBC_URL = "jdbc_url";
@@ -266,6 +268,8 @@ public class JdbcResource extends Resource {
             return CLICKHOUSE;
         } else if (url.startsWith(JDBC_SAP_HANA)) {
             return SAP_HANA;
+        } else if (url.startsWith(JDBC_NEBULA)) {
+            return NEBULA;
         }
         throw new DdlException("Unsupported jdbc database type, please check jdbcUrl: " + url);
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/JdbcTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/JdbcTable.java
@@ -75,6 +75,7 @@ public class JdbcTable extends Table {
         tempMap.put("oracle", TOdbcTableType.ORACLE);
         tempMap.put("clickhouse", TOdbcTableType.CLICKHOUSE);
         tempMap.put("sap_hana", TOdbcTableType.SAP_HANA);
+        tempMap.put("nebula", TOdbcTableType.NEBULA);
         TABLE_TYPE_MAP = Collections.unmodifiableMap(tempMap);
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/JdbcScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/JdbcScanNode.java
@@ -20,6 +20,7 @@ package org.apache.doris.planner;
 import org.apache.doris.analysis.Analyzer;
 import org.apache.doris.analysis.Expr;
 import org.apache.doris.analysis.ExprSubstitutionMap;
+import org.apache.doris.analysis.FunctionCallExpr;
 import org.apache.doris.analysis.SlotDescriptor;
 import org.apache.doris.analysis.SlotRef;
 import org.apache.doris.analysis.TupleDescriptor;
@@ -53,6 +54,7 @@ public class JdbcScanNode extends ScanNode {
     private final List<String> filters = new ArrayList<String>();
     private String tableName;
     private TOdbcTableType jdbcType;
+    private String graphQueryString = "";
 
     public JdbcScanNode(PlanNodeId id, TupleDescriptor desc, boolean isJdbcExternalTable) {
         super(id, desc, "JdbcScanNode", StatisticalType.JDBC_SCAN_NODE);
@@ -71,6 +73,26 @@ public class JdbcScanNode extends ScanNode {
     public void init(Analyzer analyzer) throws UserException {
         super.init(analyzer);
         computeStats(analyzer);
+        getGraphQueryString();
+    }
+
+    private boolean isGraph() {
+        return jdbcType == TOdbcTableType.NEBULA;
+    }
+
+    private void getGraphQueryString() {
+        if (!isGraph()) {
+            return;
+        }
+        for (Expr expr : conjuncts) {
+            FunctionCallExpr functionCallExpr = (FunctionCallExpr) expr;
+            if ("g".equals(functionCallExpr.getFnName().getFunction())) {
+                graphQueryString = functionCallExpr.getChild(0).getStringValue();
+                break;
+            }
+        }
+        //clean conjusts cause graph sannnode no need conjuncts
+        conjuncts = Lists.newArrayList();
     }
 
     /**
@@ -130,6 +152,10 @@ public class JdbcScanNode extends ScanNode {
     }
 
     private String getJdbcQueryStr() {
+        if (isGraph()) {
+            return graphQueryString;
+        }
+
         StringBuilder sql = new StringBuilder("SELECT ");
 
         // Oracle use the where clause to do top n

--- a/fe/java-udf/pom.xml
+++ b/fe/java-udf/pom.xml
@@ -36,6 +36,11 @@ under the License.
     </properties>
     <dependencies>
         <dependency>
+            <groupId>com.vesoft</groupId>
+            <artifactId>client</artifactId>
+            <version>3.0.0</version>
+        </dependency>
+        <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>fe-common</artifactId>
             <version>${project.version}</version>

--- a/gensrc/script/doris_builtins_functions.py
+++ b/gensrc/script/doris_builtins_functions.py
@@ -1384,6 +1384,9 @@ visible_functions = [
     [['esquery'], 'BOOLEAN', ['STRING', 'VARCHAR'], ''],
     [['esquery'], 'BOOLEAN', ['VARIANT', 'VARCHAR'], ''],
 
+    # used for accept graph sql
+    [['g'], 'BOOLEAN', ['VARCHAR'], ''],
+
     # String builtin functions
     [['substr', 'substring'], 'VARCHAR', ['VARCHAR', 'INT'], 'ALWAYS_NULLABLE'],
     [['substr', 'substring'], 'VARCHAR', ['VARCHAR', 'INT', 'INT'], 'ALWAYS_NULLABLE'],

--- a/gensrc/thrift/Types.thrift
+++ b/gensrc/thrift/Types.thrift
@@ -380,7 +380,8 @@ enum TOdbcTableType {
     REDIS,
     MONGODB,
     CLICKHOUSE,
-    SAP_HANA
+    SAP_HANA,
+    NEBULA
 }
 
 struct TJdbcExecutorCtorParams {


### PR DESCRIPTION
# Proposed changes

## Problem summary
Support querying data from the Nebula graph database 
This feature comes from the needs of commercial customers who have used Doris and Nebula, hoping to connect these two databases

changes mainly include:
- add  New Graph Database JDBC Type 
- Adapt the type and map the graph to the Doris type

# How to use ?

### Nebula-graph type map
|   nebula   |        Doris        |
|:------------:|:-------------------:|
|   tinyint/samllint/int/int64    |       bigint       |
|   double/float    |       double       |
|   date   |      date       |
|   timestamp   |         bigint         |
|    datetime    |       datetime        |
| bool |  boolean  |
|   vertex/edge/path/list/set/time等    |  varchar  |


### NebulaGraphTest （仅支持查询）
| nebula版本 | JDBC驱动版本 |
|------------|-------------------|
| 3.0.0       | nebula-jdbc-3.0.0-jar-with-dependencies.jar         |



```
#step1.在nebula创建测试数据
#1.1 创建结点
(root@nebula) [basketballplayer]> CREATE TAG test(t_str string, 
    t_int int, 
    t_date date,
    t_datetime datetime,
    t_bool bool,
    t_timestamp timestamp,
    t_float float,
    t_double double
);

#1.2 插入数据
(root@nebula) [basketballplayer]> INSERT VERTEX test_type(t_str,t_int,t_date,t_datetime,t_bool,t_timestamp,t_float,t_double) values "zhangshan":("zhangshan",1000,date("2023-01-01"),datetime("2023-01-23 15:23:32"),true,1234242423,1.2,1.35);

#1.3 查询数据
(root@nebula) [basketballplayer]> match (v:test_type) where id(v)=="zhangshan" return v.test_type.t_str,v.test_type.t_int,v.test_type.t_date,v.test_type.t_datetime,v.test_type.t_bool,v.test_type.t_timestamp,v.test_type.t_float,v.test_type.t_double,v limit 30;
+-------------------+-------------------+--------------------+----------------------------+--------------------+-------------------------+---------------------+----------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| v.test_type.t_str | v.test_type.t_int | v.test_type.t_date | v.test_type.t_datetime     | v.test_type.t_bool | v.test_type.t_timestamp | v.test_type.t_float | v.test_type.t_double | v                                                                                                                                                                                                         |
+-------------------+-------------------+--------------------+----------------------------+--------------------+-------------------------+---------------------+----------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| "zhangshan"       | 1000              | 2023-01-01         | 2023-01-23T15:23:32.000000 | true               | 1234242423              | 1.2000000476837158  | 1.35                 | ("zhangshan" :test_type{t_bool: true, t_date: 2023-01-01, t_datetime: 2023-01-23T15:23:32.000000, t_double: 1.35, t_float: 1.2000000476837158, t_int: 1000, t_str: "zhangshan", t_timestamp: 1234242423}) |
+-------------------+-------------------+--------------------+----------------------------+--------------------+-------------------------+---------------------+----------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
Got 1 rows (time spent 1616/2048 us)

Mon, 17 Apr 2023 17:23:14 CST


#step2.在doris中创建外表
#2.1 创建一个resource
MySQL [test_db]> CREATE EXTERNAL RESOURCE gg_jdbc_resource 
properties (
   "type"="jdbc",
   "user"="root",
   "password"="123",
   "jdbc_url"="jdbc:nebula://127.0.0.1:9669/basketballplayer",
   "driver_url"="file:///home/clz/baidu/bdg/doris/be/lib/nebula-jdbc-3.0.0-jar-with-dependencies.jar",  --仅支持本地路径，需放到be/lib目录下--
   "driver_class"="com.vesoft.nebula.jdbc.NebulaDriver"
);

#2.2 创建一个外表，这个主要是告诉doris如何解析nebulagraph返回的数据
MySQL [test_db]> CREATE TABLE `test_type` ( 
 `t_str` varchar(64),
 `t_int` bigint,
 `t_date` date,
 `t_datetime` datetime,
 `t_bool` boolean,
 `t_timestamp` bigint,
 `t_float` double,
 `t_double` double,
 `t_vertx`  varchar(128) --vertex对应doris类型是varchar---
) ENGINE=JDBC
PROPERTIES (
"resource" = "gg_jdbc_resource",
"table" = "xx",  --因为graph没有表的概念，这里随便填一个值--
"table_type"="nebula"
);

#2.3 查询graph外表,用g()函数把图的nGQL透传给nebula
MySQL [test_db]> select * from test_type where g('match (v:test_type) where id(v)=="zhangshan" return v.test_type.t_str,v.test_type.t_int,v.test_type.t_date,v.test_type.t_datetime,v.test_type.t_bool,v.test_type.t_timestamp,v.test_type.t_float,v.test_type.t_double,v')\G;
*************************** 1. row ***************************
      t_str: zhangshan
      t_int: 1000
     t_date: 2023-01-01
 t_datetime: 2023-01-23 15:23:32
     t_bool: 1
t_timestamp: 1234242423
    t_float: 1.2000000476837158
   t_double: 1.35
    t_vertx: ("zhangshan" :test_type {t_datetime: utc datetime: 2023-01-23T15:23:32.000000, timezoneOffset: 0, t_timestamp: 1234242423, t_date: 2023-01-01, t_double: 1.35, t_str: "zhangshan", t_int: 1000, t_bool: true, t_float: 1.2000000476837158})
1 row in set (0.024 sec)

#2.3 与doris的其他表进行关联查询
#假设有张用户表
MySQL [test_db]> select * from t_user;
+-----------+------+---------------------------------+
| username  | age  | addr                            |
+-----------+------+---------------------------------+
| zhangshan |   26 | 北京市西二旗街道1008号          |
+-----------+------+---------------------------------+
| lisi |   29 | 北京市西二旗街道1007号          |
+-----------+------+---------------------------------+
1 row in set (0.013 sec)

#与这张用表关联查询用户相关的信息
MySQL [test_db]> select u.* from (select t_str username  from test_type where g('match (v:test_type) where id(v)=="zhangshan" return v.test_type.t_str limit 1')) g left join t_user u on g.username=u.username;
+-----------+------+---------------------------------+
| username  | age  | addr                            |
+-----------+------+---------------------------------+
| zhangshan |   26 | 北京市西二旗街道1008号          |
+-----------+------+---------------------------------+
1 row in set (0.029 sec)

```

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

