### PR TITLE
[Fix](vertical compaction) Preserve _segment_num_rows during final segment flush

### DIFF
--- a/be/src/olap/rowset/vertical_beta_rowset_writer.cpp
+++ b/be/src/olap/rowset/vertical_beta_rowset_writer.cpp
@@ -67,9 +67,6 @@ Status VerticalBetaRowsetWriter::add_columns(const vectorized::Block* block,
             // segment is full, need flush columns and create new segment writer
             RETURN_IF_ERROR(_flush_columns(&_segment_writers[_cur_writer_idx], true));
 
-            _segment_num_rows.resize(_cur_writer_idx + 1);
-            _segment_num_rows[_cur_writer_idx] = _segment_writers[_cur_writer_idx]->row_count();
-
             std::unique_ptr<segment_v2::SegmentWriter> writer;
             RETURN_IF_ERROR(_create_segment_writer(col_ids, is_key, &writer));
             _segment_writers.emplace_back(std::move(writer));
@@ -116,6 +113,8 @@ Status VerticalBetaRowsetWriter::_flush_columns(
         key_bounds.set_min_key(min_key.to_string());
         key_bounds.set_max_key(max_key.to_string());
         _segments_encoded_key_bounds.emplace_back(key_bounds);
+        _segment_num_rows.resize(_cur_writer_idx + 1);
+        _segment_num_rows[_cur_writer_idx] = _segment_writers[_cur_writer_idx]->row_count();
     }
     _total_index_size += static_cast<int64_t>(index_size);
     return Status::OK();


### PR DESCRIPTION
# Proposed changes

The resizing and setting of _segment_num_rows is being done in the incorrect location, resulting in an erroneous rowid_conversion outcome.

## Problem summary

To resolve the issue, the resizing of _segment_num_rows should be moved to the column flush stage during vertical compaction.

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

