### PR TITLE
[Fix](planner)Fix TupleDescriptor include not materialized slot bug.

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/planner/ScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/ScanNode.java
@@ -516,7 +516,7 @@ public abstract class ScanNode extends PlanNode {
             // create a tmpSmap for the later setOutputSmap call
             ExprSubstitutionMap tmpSmap = new ExprSubstitutionMap(
                     Lists.newArrayList(outputTupleDesc.getSlots().stream().map(slot -> new SlotRef(slot)).collect(
-                            Collectors.toList())), Lists.newArrayList(projectList));
+                    Collectors.toList())), Lists.newArrayList(projectList));
             Set<SlotId> allOutputSlotIds = outputTupleDesc.getSlots().stream().map(slot -> slot.getId())
                     .collect(Collectors.toSet());
             List<Expr> newRhs = Lists.newArrayList();
@@ -530,10 +530,14 @@ public abstract class ScanNode extends PlanNode {
                         slotDesc.initFromExpr(rhsExpr);
                         if (rhsExpr instanceof SlotRef) {
                             slotDesc.setSrcColumn(((SlotRef) rhsExpr).getColumn());
+                            slotDesc.setIsMaterialized(((SlotRef) rhsExpr).getDesc().isMaterialized());
+                        } else {
+                            slotDesc.setIsMaterialized(true);
                         }
-                        slotDesc.setIsMaterialized(true);
-                        slotDesc.materializeSrcExpr();
-                        projectList.add(rhsExpr);
+                        if (slotDesc.isMaterialized()) {
+                            slotDesc.materializeSrcExpr();
+                            projectList.add(rhsExpr);
+                        }
                         newRhs.add(new SlotRef(slotDesc));
                         allOutputSlotIds.add(slotDesc.getId());
                     } else {


### PR DESCRIPTION
setOutputSmap function in ScanNode may include not materialized to outputTupleDesc. This PR is to fix this.

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

