### PR TITLE
[bugfix](be): fix segment fault if the PID_DIR was NOT set

### DIFF
--- a/be/src/service/doris_main.cpp
+++ b/be/src/service/doris_main.cpp
@@ -282,6 +282,10 @@ int main(int argc, char** argv) {
         fprintf(stderr, "you need set DORIS_HOME environment variable.\n");
         exit(-1);
     }
+    if (getenv("PID_DIR") == nullptr) {
+        fprintf(stderr, "you need set PID_DIR environment variable.\n");
+        exit(-1);
+    }
 
     using doris::Status;
     using std::string;


### PR DESCRIPTION
# Proposed changes

Issue Number: close #18788 

## Problem summary

Doris BE would crash if the PID_DIR wasn't set

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [x] Is this PR support rollback (If NO, please explain WHY)


