### PR TITLE
[opt](FileReader) merge small IO to optimize read performace

### DIFF
--- a/be/src/io/cache/block/cached_remote_file_reader.cpp
+++ b/be/src/io/cache/block/cached_remote_file_reader.cpp
@@ -59,7 +59,8 @@ Status CachedRemoteFileReader::close() {
 
 std::pair<size_t, size_t> CachedRemoteFileReader::_align_size(size_t offset,
                                                               size_t read_size) const {
-    size_t segment_size = std::min(std::max(read_size, (size_t)4096), // 4k
+    size_t min_size = 1024 * 1024; // 1MB;
+    size_t segment_size = std::min(std::max(read_size, min_size),
                                    (size_t)config::file_cache_max_file_segment_size);
     segment_size = BitUtil::next_power_of_two(segment_size);
     size_t left = offset;

--- a/be/src/io/cache/block/cached_remote_file_reader.h
+++ b/be/src/io/cache/block/cached_remote_file_reader.h
@@ -53,6 +53,8 @@ public:
 
     FileSystemSPtr fs() const override { return _remote_file_reader->fs(); }
 
+    FileReader* get_remote_reader() { return _remote_file_reader.get(); }
+
 protected:
     Status read_at_impl(size_t offset, Slice result, size_t* bytes_read,
                         const IOContext* io_ctx) override;

--- a/be/src/io/fs/buffered_reader.cpp
+++ b/be/src/io/fs/buffered_reader.cpp
@@ -40,13 +40,323 @@ bvar::PerSecond<bvar::Adder<uint64_t>> g_bytes_downloaded_per_second("buffered_r
                                                                      "bytes_downloaded_per_second",
                                                                      &g_bytes_downloaded, 60);
 
+Status MergeRangeFileReader::read_at_impl(size_t offset, Slice result, size_t* bytes_read,
+                                          const IOContext* io_ctx) {
+    _statistics.request_io++;
+    *bytes_read = 0;
+    if (result.size == 0) {
+        return Status::OK();
+    }
+    int range_index = _search_read_range(offset, offset + result.size);
+    if (range_index < 0) {
+        SCOPED_RAW_TIMER(&_statistics.read_time);
+        Status st = _reader->read_at(offset, result, bytes_read, io_ctx);
+        _statistics.merged_io++;
+        _statistics.request_bytes += *bytes_read;
+        _statistics.read_bytes += *bytes_read;
+        return st;
+    }
+    if (offset + result.size > _random_access_ranges[range_index].end_offset) {
+        // return _reader->read_at(offset, result, bytes_read, io_ctx);
+        return Status::IOError("Range in RandomAccessReader should be read sequentially");
+    }
+
+    size_t has_read = 0;
+    RangeCachedData& cached_data = _range_cached_data[range_index];
+    cached_data.has_read = true;
+    if (cached_data.contains(offset)) {
+        // has cached data in box
+        _read_in_box(cached_data, offset, result, &has_read);
+        if (has_read == result.size) {
+            // all data is read in cache
+            *bytes_read = has_read;
+            _statistics.request_bytes += has_read;
+            return Status::OK();
+        }
+    } else if (!cached_data.empty()) {
+        // the data in range may be skipped
+        DCHECK_GE(offset, cached_data.end_offset);
+        for (int16 box_index : cached_data.ref_box) {
+            _dec_box_ref(box_index);
+        }
+        cached_data.reset();
+    }
+
+    size_t to_read = result.size - has_read;
+    if (to_read >= SMALL_IO || to_read >= _remaining) {
+        SCOPED_RAW_TIMER(&_statistics.read_time);
+        size_t read_size = 0;
+        RETURN_IF_ERROR(_reader->read_at(offset + has_read, Slice(result.data + has_read, to_read),
+                                         &read_size, io_ctx));
+        *bytes_read = has_read + read_size;
+        _statistics.merged_io++;
+        _statistics.request_bytes += read_size;
+        _statistics.read_bytes += read_size;
+        return Status::OK();
+    }
+
+    // merge small IO
+    size_t merge_start = offset + has_read;
+    const size_t merge_end = merge_start + READ_SLICE_SIZE;
+    size_t content_size = 0;
+    size_t hollow_size = 0;
+    if (merge_start > _random_access_ranges[range_index].end_offset) {
+        return Status::IOError("Fail to merge small IO");
+    }
+    int merge_index = range_index;
+    while (merge_start < merge_end && merge_index < _random_access_ranges.size()) {
+        size_t content_max = _remaining - content_size;
+        if (content_max == 0) {
+            break;
+        }
+        if (merge_index != range_index && _range_cached_data[merge_index].has_read) {
+            // don't read or merge twice
+            break;
+        }
+        if (_random_access_ranges[merge_index].end_offset > merge_end) {
+            size_t add_content = std::min(merge_end - merge_start, content_max);
+            content_size += add_content;
+            merge_start += add_content;
+            break;
+        }
+        size_t add_content =
+                std::min(_random_access_ranges[merge_index].end_offset - merge_start, content_max);
+        content_size += add_content;
+        merge_start += add_content;
+        if (merge_start != _random_access_ranges[merge_index].end_offset) {
+            break;
+        }
+        if (merge_index < _random_access_ranges.size() - 1 && merge_start < merge_end) {
+            size_t gap = _random_access_ranges[merge_index + 1].start_offset -
+                         _random_access_ranges[merge_index].end_offset;
+            if ((content_size + hollow_size) > SMALL_IO && gap >= SMALL_IO) {
+                // too large gap
+                break;
+            }
+            if (gap < merge_end - merge_start && content_size < _remaining &&
+                !_range_cached_data[merge_index + 1].has_read) {
+                hollow_size += gap;
+                merge_start = _random_access_ranges[merge_index + 1].start_offset;
+            } else {
+                // there's no enough memory to read hollow data
+                break;
+            }
+        }
+        merge_index++;
+    }
+    if (content_size + hollow_size == to_read) {
+        // read directly to avoid copy operation
+        SCOPED_RAW_TIMER(&_statistics.read_time);
+        size_t read_size = 0;
+        RETURN_IF_ERROR(_reader->read_at(offset + has_read, Slice(result.data + has_read, to_read),
+                                         &read_size, io_ctx));
+        *bytes_read = has_read + read_size;
+        _statistics.merged_io++;
+        _statistics.request_bytes += read_size;
+        _statistics.read_bytes += read_size;
+        return Status::OK();
+    }
+
+    merge_start = offset + has_read;
+    size_t merge_read_size = 0;
+    RETURN_IF_ERROR(_fill_box(range_index, merge_start, content_size + hollow_size,
+                              &merge_read_size, io_ctx));
+    if (cached_data.start_offset != merge_start) {
+        return Status::IOError("Wrong start offset in merged IO");
+    }
+
+    // read from cached data
+    size_t box_read_size = 0;
+    _read_in_box(cached_data, merge_start, Slice(result.data + has_read, to_read), &box_read_size);
+    *bytes_read = has_read + box_read_size;
+    _statistics.request_bytes += box_read_size;
+    if (*bytes_read < result.size && box_read_size < merge_read_size) {
+        return Status::IOError("Can't read enough bytes in merged IO");
+    }
+    return Status::OK();
+}
+
+int MergeRangeFileReader::_search_read_range(size_t start_offset, size_t end_offset) {
+    if (_random_access_ranges.empty()) {
+        return -1;
+    }
+    int left = 0, right = _random_access_ranges.size() - 1;
+    do {
+        int mid = left + (right - left) / 2;
+        const PrefetchRange& range = _random_access_ranges[mid];
+        if (range.start_offset <= start_offset && start_offset < range.end_offset) {
+            if (range.start_offset <= end_offset && end_offset <= range.end_offset) {
+                return mid;
+            } else {
+                return -1;
+            }
+        } else if (range.start_offset > start_offset) {
+            right = mid - 1;
+        } else {
+            left = mid + 1;
+        }
+    } while (left <= right);
+    return -1;
+}
+
+void MergeRangeFileReader::_clean_cached_data(RangeCachedData& cached_data) {
+    if (!cached_data.empty()) {
+        for (int i = 0; i < cached_data.ref_box.size(); ++i) {
+            DCHECK_GT(cached_data.box_end_offset[i], cached_data.box_start_offset[i]);
+            int16 box_index = cached_data.ref_box[i];
+            DCHECK_GT(_box_ref[box_index], 0);
+            _box_ref[box_index]--;
+        }
+    }
+    cached_data.reset();
+}
+
+void MergeRangeFileReader::_dec_box_ref(int16 box_index) {
+    if (--_box_ref[box_index] == 0) {
+        _remaining += BOX_SIZE;
+    }
+    if (box_index == _last_box_ref) {
+        _last_box_ref = -1;
+        _last_box_usage = 0;
+    }
+}
+
+void MergeRangeFileReader::_read_in_box(RangeCachedData& cached_data, size_t offset, Slice result,
+                                        size_t* bytes_read) {
+    SCOPED_RAW_TIMER(&_statistics.copy_time);
+    auto handle_in_box = [&](size_t remaining, char* copy_out) {
+        size_t to_handle = remaining;
+        int cleaned_box = 0;
+        for (int i = 0; i < cached_data.ref_box.size() && remaining > 0; ++i) {
+            int16 box_index = cached_data.ref_box[i];
+            size_t box_to_handle = std::min(remaining, (size_t)(cached_data.box_end_offset[i] -
+                                                                cached_data.box_start_offset[i]));
+            if (copy_out != nullptr) {
+            }
+            if (copy_out != nullptr) {
+                memcpy(copy_out + to_handle - remaining,
+                       _boxes[box_index] + cached_data.box_start_offset[i], box_to_handle);
+            }
+            remaining -= box_to_handle;
+            cached_data.box_start_offset[i] += box_to_handle;
+            if (cached_data.box_start_offset[i] == cached_data.box_end_offset[i]) {
+                cleaned_box++;
+                _dec_box_ref(box_index);
+            }
+        }
+        DCHECK_EQ(remaining, 0);
+        if (cleaned_box > 0) {
+            cached_data.ref_box.erase(cached_data.ref_box.begin(),
+                                      cached_data.ref_box.begin() + cleaned_box);
+            cached_data.box_start_offset.erase(cached_data.box_start_offset.begin(),
+                                               cached_data.box_start_offset.begin() + cleaned_box);
+            cached_data.box_end_offset.erase(cached_data.box_end_offset.begin(),
+                                             cached_data.box_end_offset.begin() + cleaned_box);
+        }
+        cached_data.start_offset += to_handle;
+        if (cached_data.start_offset == cached_data.end_offset) {
+            _clean_cached_data(cached_data);
+        }
+    };
+
+    if (offset > cached_data.start_offset) {
+        // the data in range may be skipped
+        size_t to_skip = offset - cached_data.start_offset;
+        handle_in_box(to_skip, nullptr);
+    }
+
+    size_t to_read = std::min(cached_data.end_offset - cached_data.start_offset, result.size);
+    handle_in_box(to_read, result.data);
+    *bytes_read = to_read;
+}
+
+Status MergeRangeFileReader::_fill_box(int range_index, size_t start_offset, size_t to_read,
+                                       size_t* bytes_read, const IOContext* io_ctx) {
+    if (_read_slice == nullptr) {
+        _read_slice = new char[READ_SLICE_SIZE];
+    }
+    *bytes_read = 0;
+    {
+        SCOPED_RAW_TIMER(&_statistics.read_time);
+        RETURN_IF_ERROR(
+                _reader->read_at(start_offset, Slice(_read_slice, to_read), bytes_read, io_ctx));
+        _statistics.merged_io++;
+        _statistics.read_bytes += *bytes_read;
+    }
+
+    SCOPED_RAW_TIMER(&_statistics.copy_time);
+    size_t copy_start = start_offset;
+    const size_t copy_end = start_offset + *bytes_read;
+    // copy data into small boxes
+    // tuple(box_index, box_start_offset, file_start_offset, file_end_offset)
+    std::vector<std::tuple<int16, uint32, size_t, size_t>> filled_boxes;
+
+    auto fill_box = [&](int16 fill_box_ref, uint32 box_usage, size_t box_copy_end) {
+        size_t copy_size = std::min(box_copy_end - copy_start, BOX_SIZE - box_usage);
+        memcpy(_boxes[fill_box_ref] + box_usage, _read_slice + copy_start - start_offset,
+               copy_size);
+        filled_boxes.emplace_back(fill_box_ref, box_usage, copy_start, copy_start + copy_size);
+        copy_start += copy_size;
+        _last_box_ref = fill_box_ref;
+        _last_box_usage = box_usage + copy_size;
+        _box_ref[fill_box_ref]++;
+        if (box_usage == 0) {
+            _remaining -= BOX_SIZE;
+        }
+    };
+
+    for (int fill_range_index = range_index;
+         fill_range_index < _random_access_ranges.size() && copy_start < copy_end;
+         ++fill_range_index) {
+        RangeCachedData& fill_range_cache = _range_cached_data[fill_range_index];
+        DCHECK(fill_range_cache.empty());
+        fill_range_cache.reset();
+        const PrefetchRange& fill_range = _random_access_ranges[fill_range_index];
+        if (fill_range.start_offset > copy_start) {
+            // don't copy hollow data
+            size_t hollow_size = fill_range.start_offset - copy_start;
+            DCHECK_GT(copy_end - copy_start, hollow_size);
+            copy_start += hollow_size;
+        }
+
+        const size_t range_copy_end = std::min(copy_end, fill_range.end_offset);
+        // reuse the remaining capacity of last box
+        if (_last_box_ref >= 0 && _last_box_usage < BOX_SIZE) {
+            fill_box(_last_box_ref, _last_box_usage, range_copy_end);
+        }
+        // reuse the former released box
+        for (int16 i = 0; i < _boxes.size() && copy_start < range_copy_end; ++i) {
+            if (_box_ref[i] == 0) {
+                fill_box(i, 0, range_copy_end);
+            }
+        }
+        // apply for new box to copy data
+        while (copy_start < range_copy_end && _boxes.size() < NUM_BOX) {
+            _boxes.emplace_back(new char[BOX_SIZE]);
+            _box_ref.emplace_back(0);
+            fill_box(_boxes.size() - 1, 0, range_copy_end);
+        }
+        DCHECK_EQ(copy_start, range_copy_end);
+
+        if (!filled_boxes.empty()) {
+            fill_range_cache.start_offset = std::get<2>(filled_boxes[0]);
+            fill_range_cache.end_offset = std::get<3>(filled_boxes.back());
+            for (auto& tuple : filled_boxes) {
+                fill_range_cache.ref_box.emplace_back(std::get<0>(tuple));
+                fill_range_cache.box_start_offset.emplace_back(std::get<1>(tuple));
+                fill_range_cache.box_end_offset.emplace_back(
+                        std::get<1>(tuple) + std::get<3>(tuple) - std::get<2>(tuple));
+            }
+            filled_boxes.clear();
+        }
+    }
+    return Status::OK();
+}
+
 // there exists occasions where the buffer is already closed but
 // some prior tasks are still queued in thread pool, so we have to check whether
 // the buffer is closed each time the condition variable is notified.
 void PrefetchBuffer::reset_offset(size_t offset) {
-    if (UNLIKELY(offset >= _end_offset)) {
-        return;
-    }
     {
         std::unique_lock lck {_lock};
         _prefetched.wait(lck, [this]() { return _buffer_status != BufferStatus::PENDING; });
@@ -57,6 +367,13 @@ void PrefetchBuffer::reset_offset(size_t offset) {
         _buffer_status = BufferStatus::RESET;
         _offset = offset;
         _prefetched.notify_all();
+    }
+    if (UNLIKELY(offset >= _file_range.end_offset)) {
+        _len = 0;
+        _exceed = true;
+        return;
+    } else {
+        _exceed = false;
     }
     ExecEnv::GetInstance()->buffered_reader_prefetch_thread_pool()->submit_func(
             [buffer_ptr = shared_from_this()]() { buffer_ptr->prefetch_buffer(); });
@@ -80,8 +397,16 @@ void PrefetchBuffer::prefetch_buffer() {
     _len = 0;
     Status s;
 
-    size_t buf_size = _end_offset - _offset > _size ? _size : _end_offset - _offset;
-    s = _reader->read_at(_offset, Slice {_buf.data(), buf_size}, &_len);
+    int read_range_index = search_read_range(_offset);
+    size_t buf_size;
+    if (read_range_index == -1) {
+        buf_size =
+                _file_range.end_offset - _offset > _size ? _size : _file_range.end_offset - _offset;
+    } else {
+        buf_size = merge_small_ranges(_offset, read_range_index);
+    }
+
+    s = _reader->read_at(_offset, Slice {_buf.get(), buf_size}, &_len, _io_ctx);
     g_bytes_downloaded << _len;
     std::unique_lock lck {_lock};
     _prefetched.wait(lck, [this]() { return _buffer_status == BufferStatus::PENDING; });
@@ -93,11 +418,70 @@ void PrefetchBuffer::prefetch_buffer() {
     // eof would come up with len == 0, it would be handled by read_buffer
 }
 
+int PrefetchBuffer::search_read_range(size_t off) const {
+    if (_random_access_ranges == nullptr || _random_access_ranges->empty()) {
+        return -1;
+    }
+    const std::vector<PrefetchRange>& random_access_ranges = *_random_access_ranges;
+    int left = 0, right = random_access_ranges.size() - 1;
+    do {
+        int mid = left + (right - left) / 2;
+        const PrefetchRange& range = random_access_ranges[mid];
+        if (range.start_offset <= off && range.end_offset > off) {
+            return mid;
+        } else if (range.start_offset > off) {
+            right = mid;
+        } else {
+            left = mid + 1;
+        }
+    } while (left < right);
+    if (random_access_ranges[right].start_offset > off) {
+        return right;
+    } else {
+        return -1;
+    }
+}
+
+size_t PrefetchBuffer::merge_small_ranges(size_t off, int range_index) const {
+    if (_random_access_ranges == nullptr || _random_access_ranges->empty()) {
+        return _size;
+    }
+    int64 remaining = _size;
+    const std::vector<PrefetchRange>& random_access_ranges = *_random_access_ranges;
+    while (remaining > 0 && range_index < random_access_ranges.size()) {
+        const PrefetchRange& range = random_access_ranges[range_index];
+        if (range.start_offset <= off && range.end_offset > off) {
+            remaining -= range.end_offset - off;
+            off = range.end_offset;
+            range_index++;
+        } else if (range.start_offset > off) {
+            // merge small range
+            size_t hollow = range.start_offset - off;
+            if (hollow < remaining) {
+                remaining -= hollow;
+                off = range.start_offset;
+            } else {
+                break;
+            }
+        } else {
+            DCHECK(false);
+        }
+    }
+    if (remaining < 0 || remaining == _size) {
+        remaining = 0;
+    }
+    return _size - remaining;
+}
+
 Status PrefetchBuffer::read_buffer(size_t off, const char* out, size_t buf_len,
                                    size_t* bytes_read) {
-    if (UNLIKELY(off >= _end_offset)) {
-        // Reader can read out of [_start_offset, _end_offset) by synchronous method.
-        return _reader->read_at(off, Slice {out, buf_len}, bytes_read);
+    if (UNLIKELY(off >= _file_range.end_offset)) {
+        // Reader can read out of [start_offset, end_offset) by synchronous method.
+        return _reader->read_at(off, Slice {out, buf_len}, bytes_read, _io_ctx);
+    }
+    if (_exceed) {
+        reset_offset((off / _size) * _size);
+        return read_buffer(off, out, buf_len, bytes_read);
     }
     {
         std::unique_lock lck {_lock};
@@ -122,7 +506,7 @@ Status PrefetchBuffer::read_buffer(size_t off, const char* out, size_t buf_len,
     }
     // [0]: maximum len trying to read, [1] maximum length buffer can provide, [2] actual len buffer has
     size_t read_len = std::min({buf_len, _offset + _size - off, _offset + _len - off});
-    memcpy((void*)out, _buf.data() + (off - _offset), read_len);
+    memcpy((void*)out, _buf.get() + (off - _offset), read_len);
     *bytes_read = read_len;
     if (off + *bytes_read == _offset + _len) {
         reset_offset(_offset + _whole_buffer_size);
@@ -139,22 +523,22 @@ void PrefetchBuffer::close() {
 }
 
 // buffered reader
-PrefetchBufferedReader::PrefetchBufferedReader(io::FileReaderSPtr reader, int64_t offset,
-                                               int64_t length, int64_t buffer_size)
-        : _reader(std::move(reader)), _start_offset(offset), _end_offset(offset + length) {
+PrefetchBufferedReader::PrefetchBufferedReader(io::FileReaderSPtr reader, PrefetchRange file_range,
+                                               const IOContext* io_ctx, int64_t buffer_size)
+        : _reader(std::move(reader)), _file_range(file_range), _io_ctx(io_ctx) {
     if (buffer_size == -1L) {
         buffer_size = config::remote_storage_read_buffer_mb * 1024 * 1024;
     }
     _size = _reader->size();
     _whole_pre_buffer_size = buffer_size;
-    _end_offset = std::min((size_t)_end_offset, _size);
+    _file_range.end_offset = std::min(_file_range.end_offset, _size);
     int buffer_num = buffer_size > s_max_pre_buffer_size ? buffer_size / s_max_pre_buffer_size : 1;
     // set the _cur_offset of this reader as same as the inner reader's,
     // to make sure the buffer reader will start to read at right position.
     for (int i = 0; i < buffer_num; i++) {
         _pre_buffers.emplace_back(
-                std::make_shared<PrefetchBuffer>(_start_offset, _end_offset, s_max_pre_buffer_size,
-                                                 _whole_pre_buffer_size, _reader.get()));
+                std::make_shared<PrefetchBuffer>(_file_range, s_max_pre_buffer_size,
+                                                 _whole_pre_buffer_size, _reader.get(), _io_ctx));
     }
 }
 
@@ -189,11 +573,45 @@ Status PrefetchBufferedReader::read_at_impl(size_t offset, Slice result, size_t*
 }
 
 Status PrefetchBufferedReader::close() {
-    std::for_each(_pre_buffers.begin(), _pre_buffers.end(),
-                  [](std::shared_ptr<PrefetchBuffer>& buffer) { buffer->close(); });
-    _reader->close();
-    _closed = true;
+    if (!_closed) {
+        _closed = true;
+        std::for_each(_pre_buffers.begin(), _pre_buffers.end(),
+                      [](std::shared_ptr<PrefetchBuffer>& buffer) { buffer->close(); });
+        return _reader->close();
+    }
 
+    return Status::OK();
+}
+
+InMemoryFileReader::InMemoryFileReader(io::FileReaderSPtr reader) : _reader(std::move(reader)) {
+    _size = _reader->size();
+}
+
+InMemoryFileReader::~InMemoryFileReader() {
+    close();
+}
+
+Status InMemoryFileReader::close() {
+    if (!_closed) {
+        _closed = true;
+        return _reader->close();
+    }
+    return Status::OK();
+}
+
+Status InMemoryFileReader::read_at_impl(size_t offset, Slice result, size_t* bytes_read,
+                                        const IOContext* io_ctx) {
+    if (_data == nullptr) {
+        _data = std::make_unique<char[]>(_size);
+        size_t file_size = 0;
+        RETURN_IF_ERROR(_reader->read_at(0, Slice(_data.get(), _size), &file_size, io_ctx));
+        DCHECK_EQ(file_size, _size);
+    }
+    if (UNLIKELY(offset > _size)) {
+        return Status::IOError("Out of bounds access");
+    }
+    *bytes_read = std::min(result.size, _size - offset);
+    memcpy(result.data, _data.get() + offset, *bytes_read);
     return Status::OK();
 }
 
@@ -258,5 +676,25 @@ Status BufferedFileStreamReader::read_bytes(Slice& slice, uint64_t offset,
     return read_bytes((const uint8_t**)&slice.data, offset, slice.size, io_ctx);
 }
 
+Status DelegateReader::create_file_reader(RuntimeProfile* profile,
+                                          const FileSystemProperties& system_properties,
+                                          const FileDescription& file_description,
+                                          std::shared_ptr<io::FileSystem>* file_system,
+                                          io::FileReaderSPtr* file_reader, AccessMode access_mode,
+                                          io::FileCachePolicy cache_policy, const IOContext* io_ctx,
+                                          const PrefetchRange file_range) {
+    io::FileReaderSPtr reader;
+    RETURN_IF_ERROR(FileFactory::create_file_reader(profile, system_properties, file_description,
+                                                    file_system, &reader, cache_policy));
+    if (reader->size() < IN_MEMORY_FILE_SIZE) {
+        *file_reader = std::make_shared<InMemoryFileReader>(reader);
+    } else if (access_mode == AccessMode::SEQUENTIAL) {
+        io::FileReaderSPtr safeReader = std::make_shared<ThreadSafeReader>(reader);
+        *file_reader = std::make_shared<io::PrefetchBufferedReader>(safeReader, file_range, io_ctx);
+    } else {
+        *file_reader = std::move(reader);
+    }
+    return Status();
+}
 } // namespace io
 } // namespace doris

--- a/be/src/io/fs/buffered_reader.h
+++ b/be/src/io/fs/buffered_reader.h
@@ -28,10 +28,17 @@
 #include <vector>
 
 #include "common/status.h"
+#include "io/cache/block/cached_remote_file_reader.h"
+#include "io/file_factory.h"
+#include "io/fs/broker_file_reader.h"
 #include "io/fs/file_reader.h"
 #include "io/fs/file_reader_writer_fwd.h"
 #include "io/fs/path.h"
+#include "io/fs/s3_file_reader.h"
+#include "olap/olap_define.h"
+#include "util/runtime_profile.h"
 #include "util/slice.h"
+#include "vec/common/typeid_cast.h"
 
 namespace doris {
 namespace io {
@@ -39,41 +46,314 @@ namespace io {
 class FileSystem;
 class IOContext;
 
+struct PrefetchRange {
+    size_t start_offset;
+    size_t end_offset;
+
+    PrefetchRange(size_t start_offset, size_t end_offset)
+            : start_offset(start_offset), end_offset(end_offset) {}
+
+    PrefetchRange(const PrefetchRange& other) = default;
+
+    PrefetchRange() : start_offset(0), end_offset(0) {}
+};
+
+/**
+ * A FileReader that efficiently supports random access format like parquet and orc.
+ * In order to merge small IO in parquet and orc, the random access ranges should be generated
+ * when creating the reader. The random access ranges is a list of ranges that order by offset.
+ * The range in random access ranges should be reading sequentially, can be skipped, but can't be
+ * read repeatedly. When calling read_at, if the start offset located in random access ranges, the
+ * slice size should not span two ranges.
+ *
+ * For example, in parquet, the random access ranges is the column offsets in a row group.
+ *
+ * When reading at offset, if [offset, offset + 8MB) contains many random access ranges, the reader
+ * will read data in [offset, offset + 8MB) as a whole, and copy the data in random access ranges
+ * into small buffers(name as box, default 1MB, 64MB in total). A box can be occupied by many ranges,
+ * and use a reference counter to record how many ranges are cached in the box. If reference counter
+ * equals zero, the box can be release or reused by other ranges. When there is no empty box for a new
+ * read operation, the read operation will do directly.
+ */
+class MergeRangeFileReader : public io::FileReader {
+public:
+    struct RangeCachedData {
+        size_t start_offset;
+        size_t end_offset;
+        std::vector<int16> ref_box;
+        std::vector<uint32> box_start_offset;
+        std::vector<uint32> box_end_offset;
+        bool has_read = false;
+
+        RangeCachedData(size_t start_offset, size_t end_offset)
+                : start_offset(start_offset), end_offset(end_offset) {}
+
+        RangeCachedData() : start_offset(0), end_offset(0) {}
+
+        bool empty() const { return start_offset == end_offset; }
+
+        bool contains(size_t offset) const { return start_offset <= offset && offset < end_offset; }
+
+        void reset() {
+            start_offset = 0;
+            end_offset = 0;
+            ref_box.clear();
+            box_start_offset.clear();
+            box_end_offset.clear();
+        }
+
+        int16 release_last_box() {
+            // we can only release the last referenced box to ensure sequential read in range
+            if (!empty()) {
+                int16 last_box_ref = ref_box.back();
+                uint32 released_size = box_end_offset.back() - box_start_offset.back();
+                ref_box.pop_back();
+                box_start_offset.pop_back();
+                box_end_offset.pop_back();
+                end_offset -= released_size;
+                if (empty()) {
+                    reset();
+                }
+                return last_box_ref;
+            }
+            return -1;
+        }
+    };
+
+    static constexpr size_t TOTAL_BUFFER_SIZE = 64 * 1024 * 1024;   // 64MB
+    static constexpr size_t READ_SLICE_SIZE = 8 * 1024 * 1024;      // 8MB
+    static constexpr size_t BOX_SIZE = 1 * 1024 * 1024;             // 1MB
+    static constexpr size_t SMALL_IO = 2 * 1024 * 1024;             // 2MB
+    static constexpr size_t NUM_BOX = TOTAL_BUFFER_SIZE / BOX_SIZE; // 64
+
+    MergeRangeFileReader(RuntimeProfile* profile, io::FileReaderSPtr reader,
+                         const std::vector<PrefetchRange>& random_access_ranges)
+            : _profile(profile),
+              _reader(std::move(reader)),
+              _random_access_ranges(random_access_ranges) {
+        _range_cached_data.resize(random_access_ranges.size());
+        _size = _reader->size();
+        _remaining = TOTAL_BUFFER_SIZE;
+        if (_profile != nullptr) {
+            const char* random_profile = "MergedSmallIO";
+            ADD_TIMER(_profile, random_profile);
+            _copy_time = ADD_CHILD_TIMER(_profile, "CopyTime", random_profile);
+            _read_time = ADD_CHILD_TIMER(_profile, "ReadTime", random_profile);
+            _request_io = ADD_CHILD_COUNTER(_profile, "RequestIO", TUnit::UNIT, random_profile);
+            _merged_io = ADD_CHILD_COUNTER(_profile, "MergedIO", TUnit::UNIT, random_profile);
+            _request_bytes =
+                    ADD_CHILD_COUNTER(_profile, "RequestBytes", TUnit::BYTES, random_profile);
+            _read_bytes = ADD_CHILD_COUNTER(_profile, "MergedBytes", TUnit::BYTES, random_profile);
+        }
+    }
+
+    ~MergeRangeFileReader() override {
+        if (_read_slice != nullptr) {
+            delete[] _read_slice;
+        }
+        for (char* box : _boxes) {
+            delete[] box;
+        }
+        close();
+    }
+
+    Status close() override {
+        if (!_closed) {
+            _closed = true;
+            // the underlying buffer is closed in its own destructor
+            // return _reader->close();
+            if (_profile != nullptr) {
+                COUNTER_UPDATE(_copy_time, _statistics.copy_time);
+                COUNTER_UPDATE(_read_time, _statistics.read_time);
+                COUNTER_UPDATE(_request_io, _statistics.request_io);
+                COUNTER_UPDATE(_merged_io, _statistics.merged_io);
+                COUNTER_UPDATE(_request_bytes, _statistics.request_bytes);
+                COUNTER_UPDATE(_read_bytes, _statistics.read_bytes);
+            }
+        }
+        return Status::OK();
+    }
+
+    const io::Path& path() const override { return _reader->path(); }
+
+    size_t size() const override { return _size; }
+
+    bool closed() const override { return _closed; }
+
+    std::shared_ptr<io::FileSystem> fs() const override { return _reader->fs(); }
+
+    // for test only
+    size_t buffer_remaining() const { return _remaining; }
+
+    // for test only
+    const std::vector<RangeCachedData>& range_cached_data() const { return _range_cached_data; }
+
+    // for test only
+    const std::vector<int16>& box_reference() const { return _box_ref; }
+
+protected:
+    Status read_at_impl(size_t offset, Slice result, size_t* bytes_read,
+                        const IOContext* io_ctx) override;
+
+private:
+    struct Statistics {
+        int64_t copy_time = 0;
+        int64_t read_time = 0;
+        int64_t request_io = 0;
+        int64_t merged_io = 0;
+        int64_t request_bytes = 0;
+        int64_t read_bytes = 0;
+    };
+
+    RuntimeProfile::Counter* _copy_time;
+    RuntimeProfile::Counter* _read_time;
+    RuntimeProfile::Counter* _request_io;
+    RuntimeProfile::Counter* _merged_io;
+    RuntimeProfile::Counter* _request_bytes;
+    RuntimeProfile::Counter* _read_bytes;
+
+    int _search_read_range(size_t start_offset, size_t end_offset);
+    void _clean_cached_data(RangeCachedData& cached_data);
+    void _read_in_box(RangeCachedData& cached_data, size_t offset, Slice result,
+                      size_t* bytes_read);
+    Status _fill_box(int range_index, size_t start_offset, size_t to_read, size_t* bytes_read,
+                     const IOContext* io_ctx);
+    void _dec_box_ref(int16 box_index);
+
+    RuntimeProfile* _profile = nullptr;
+    io::FileReaderSPtr _reader;
+    const std::vector<PrefetchRange> _random_access_ranges;
+    std::vector<RangeCachedData> _range_cached_data;
+    size_t _size;
+    bool _closed = false;
+    size_t _remaining;
+
+    char* _read_slice = nullptr;
+    std::vector<char*> _boxes;
+    int16 _last_box_ref = -1;
+    uint32 _last_box_usage = 0;
+    std::vector<int16> _box_ref;
+
+    Statistics _statistics;
+};
+
+/**
+ * Create a file reader suitable for accessing scenarios:
+ * 1. When file size < 8MB, create InMemoryFileReader file reader
+ * 2. When reading sequential file(csv/json), create PrefetchBufferedReader
+ * 3. When reading random access file(parquet/orc), create normal file reader
+ */
+class DelegateReader {
+public:
+    class ThreadSafeReader : public io::FileReader {
+    public:
+        ThreadSafeReader(io::FileReaderSPtr reader) : _reader(std::move(reader)) {
+            _size = _reader->size();
+            if (typeid_cast<io::S3FileReader*>(_reader.get()) ||
+                typeid_cast<io::BrokerFileReader*>(_reader.get())) {
+                _is_thread_safe = true;
+            } else if (io::CachedRemoteFileReader* cached_reader =
+                               typeid_cast<io::CachedRemoteFileReader*>(_reader.get())) {
+                if (typeid_cast<io::S3FileReader*>(cached_reader->get_remote_reader()) ||
+                    typeid_cast<io::BrokerFileReader*>(cached_reader->get_remote_reader())) {
+                    _is_thread_safe = true;
+                }
+            }
+        }
+
+        ~ThreadSafeReader() override { close(); }
+
+        Status close() override {
+            if (!_closed) {
+                _closed = true;
+                return _reader->close();
+            }
+            return Status::OK();
+        }
+
+        const io::Path& path() const override { return _reader->path(); }
+
+        size_t size() const override { return _size; }
+
+        bool closed() const override { return _closed; }
+
+        std::shared_ptr<io::FileSystem> fs() const override { return _reader->fs(); }
+
+    protected:
+        Status read_at_impl(size_t offset, Slice result, size_t* bytes_read,
+                            const IOContext* io_ctx) override {
+            if (_is_thread_safe) {
+                return _reader->read_at(offset, result, bytes_read, io_ctx);
+            } else {
+                std::lock_guard<std::mutex> lock(_lock);
+                return _reader->read_at(offset, result, bytes_read, io_ctx);
+            }
+        }
+
+    private:
+        io::FileReaderSPtr _reader;
+        size_t _size;
+        bool _is_thread_safe = false;
+        bool _closed = false;
+        std::mutex _lock;
+    };
+
+    enum AccessMode { SEQUENTIAL, RANDOM };
+
+    static constexpr size_t IN_MEMORY_FILE_SIZE = 8 * 1024 * 1024;
+
+    static Status create_file_reader(
+            RuntimeProfile* profile, const FileSystemProperties& system_properties,
+            const FileDescription& file_description, std::shared_ptr<io::FileSystem>* file_system,
+            io::FileReaderSPtr* file_reader, AccessMode access_mode = SEQUENTIAL,
+            io::FileCachePolicy cache_policy = io::FileCachePolicy::NO_CACHE,
+            const IOContext* io_ctx = nullptr,
+            const PrefetchRange file_range = PrefetchRange(0, 0));
+};
+
+class PrefetchBufferedReader;
 struct PrefetchBuffer : std::enable_shared_from_this<PrefetchBuffer> {
     enum class BufferStatus { RESET, PENDING, PREFETCHED, CLOSED };
-    PrefetchBuffer() = default;
-    PrefetchBuffer(size_t start_offset, size_t end_offset, size_t buffer_size,
-                   size_t whole_buffer_size, io::FileReader* reader)
-            : _start_offset(start_offset),
-              _end_offset(end_offset),
+
+    PrefetchBuffer(const PrefetchRange file_range, size_t buffer_size, size_t whole_buffer_size,
+                   io::FileReader* reader, const IOContext* io_ctx)
+            : _file_range(file_range),
               _size(buffer_size),
               _whole_buffer_size(whole_buffer_size),
               _reader(reader),
-              _buf(buffer_size, '0') {}
+              _io_ctx(io_ctx),
+              _buf(new char[buffer_size]) {}
+
     PrefetchBuffer(PrefetchBuffer&& other)
             : _offset(other._offset),
-              _start_offset(other._start_offset),
-              _end_offset(other._end_offset),
+              _file_range(other._file_range),
+              _random_access_ranges(other._random_access_ranges),
               _size(other._size),
               _whole_buffer_size(other._whole_buffer_size),
               _reader(other._reader),
+              _io_ctx(other._io_ctx),
               _buf(std::move(other._buf)) {}
+
     ~PrefetchBuffer() = default;
-    size_t _offset;
-    // [_start_offset, _end_offset) is the range that can be prefetched.
-    // Notice that the reader can read out of [_start_offset, _end_offset), because FE does not align the file
+
+    size_t _offset {0};
+    // [start_offset, end_offset) is the range that can be prefetched.
+    // Notice that the reader can read out of [start_offset, end_offset), because FE does not align the file
     // according to the format when splitting it.
-    size_t _start_offset;
-    size_t _end_offset;
-    size_t _size;
+    const PrefetchRange _file_range;
+    const std::vector<PrefetchRange>* _random_access_ranges = nullptr;
+    size_t _size {0};
     size_t _len {0};
     size_t _whole_buffer_size;
     io::FileReader* _reader;
-    std::string _buf;
+    const IOContext* _io_ctx;
+    std::unique_ptr<char[]> _buf;
     BufferStatus _buffer_status {BufferStatus::RESET};
     std::mutex _lock;
     std::condition_variable _prefetched;
     Status _prefetch_status {Status::OK()};
+    std::atomic_bool _exceed = false;
+
     // @brief: reset the start offset of this buffer to offset
     // @param: the new start offset for this buffer
     void reset_offset(size_t offset);
@@ -90,19 +370,36 @@ struct PrefetchBuffer : std::enable_shared_from_this<PrefetchBuffer> {
     // @brief: to detect whether this buffer contains off
     // @param[off] detect offset
     bool inline contains(size_t off) const { return _offset <= off && off < _offset + _size; }
+
+    void set_random_access_ranges(const std::vector<PrefetchRange>* random_access_ranges) {
+        _random_access_ranges = random_access_ranges;
+    }
+
+    // binary search the last prefetch buffer that larger or include the offset
+    int search_read_range(size_t off) const;
+
+    size_t merge_small_ranges(size_t off, int range_index) const;
 };
 
 /**
  * A buffered reader that prefetch data in the daemon thread pool.
+ *
+ * file_range is the range that the file is read.
+ * random_access_ranges are the column ranges in format, like orc and parquet.
+ *
+ * When random_access_ranges is empty:
  * The data is prefetched sequentially until the underlying buffers(4 * 4M as default) are full.
  * When a buffer is read out, it will fetch data backward in daemon, so the underlying reader should be
  * thread-safe, and the access mode of data needs to be sequential.
- * Therefore, PrefetchBufferedReader now only support csv&json format when reading s3&broker file.
+ *
+ * When random_access_ranges is not empty:
+ * The data is prefetched order by the random_access_ranges. If some adjacent ranges is small, the underlying reader
+ * will merge them.
  */
 class PrefetchBufferedReader : public io::FileReader {
 public:
-    PrefetchBufferedReader(io::FileReaderSPtr reader, int64_t offset, int64_t length,
-                           int64_t buffer_size = -1L);
+    PrefetchBufferedReader(io::FileReaderSPtr reader, PrefetchRange file_range,
+                           const IOContext* io_ctx = nullptr, int64_t buffer_size = -1L);
     ~PrefetchBufferedReader() override;
 
     Status close() override;
@@ -112,6 +409,13 @@ public:
     size_t size() const override { return _size; }
 
     bool closed() const override { return _closed; }
+
+    void set_random_access_ranges(const std::vector<PrefetchRange>* random_access_ranges) {
+        _random_access_ranges = random_access_ranges;
+        for (int i = 0; i < _pre_buffers.size(); i++) {
+            _pre_buffers[i]->set_random_access_ranges(random_access_ranges);
+        }
+    }
 
     std::shared_ptr<io::FileSystem> fs() const override { return _reader->fs(); }
 
@@ -136,14 +440,47 @@ private:
     }
 
     io::FileReaderSPtr _reader;
-    int64_t _start_offset;
-    int64_t _end_offset;
+    PrefetchRange _file_range;
+    const std::vector<PrefetchRange>* _random_access_ranges = nullptr;
+    const IOContext* _io_ctx;
     int64_t s_max_pre_buffer_size = 4 * 1024 * 1024; // 4MB
     std::vector<std::shared_ptr<PrefetchBuffer>> _pre_buffers;
     int64_t _whole_pre_buffer_size;
     bool _initialized = false;
     bool _closed = false;
     size_t _size;
+};
+
+/**
+ * A file reader that read the whole file into memory.
+ * When a file is small(<8MB), InMemoryFileReader can effectively reduce the number of file accesses
+ * and greatly improve the access speed of small files.
+ */
+class InMemoryFileReader : public io::FileReader {
+public:
+    InMemoryFileReader(io::FileReaderSPtr reader);
+
+    ~InMemoryFileReader() override;
+
+    Status close() override;
+
+    const io::Path& path() const override { return _reader->path(); }
+
+    size_t size() const override { return _size; }
+
+    bool closed() const override { return _closed; }
+
+    std::shared_ptr<io::FileSystem> fs() const override { return _reader->fs(); }
+
+protected:
+    Status read_at_impl(size_t offset, Slice result, size_t* bytes_read,
+                        const IOContext* io_ctx) override;
+
+private:
+    io::FileReaderSPtr _reader;
+    std::unique_ptr<char[]> _data = nullptr;
+    size_t _size;
+    bool _closed = false;
 };
 
 /**

--- a/be/src/io/fs/buffered_reader.h
+++ b/be/src/io/fs/buffered_reader.h
@@ -53,8 +53,6 @@ struct PrefetchRange {
     PrefetchRange(size_t start_offset, size_t end_offset)
             : start_offset(start_offset), end_offset(end_offset) {}
 
-    PrefetchRange(const PrefetchRange& other) = default;
-
     PrefetchRange() : start_offset(0), end_offset(0) {}
 };
 

--- a/be/src/vec/exec/format/json/new_json_reader.cpp
+++ b/be/src/vec/exec/format/json/new_json_reader.cpp
@@ -41,9 +41,7 @@
 #include "common/compiler_util.h" // IWYU pragma: keep
 #include "exprs/json_functions.h"
 #include "io/file_factory.h"
-#include "io/fs/broker_file_reader.h"
 #include "io/fs/buffered_reader.h"
-#include "io/fs/s3_file_reader.h"
 #include "io/fs/stream_load_pipe.h"
 #include "runtime/descriptors.h"
 #include "runtime/runtime_state.h"
@@ -373,22 +371,14 @@ Status NewJsonReader::_open_file_reader() {
     _current_offset = start_offset;
     _file_description.start_offset = start_offset;
 
-    io::FileReaderSPtr json_file_reader;
     if (_params.file_type == TFileType::FILE_STREAM) {
-        RETURN_IF_ERROR(FileFactory::create_pipe_reader(_range.load_id, &json_file_reader));
+        RETURN_IF_ERROR(FileFactory::create_pipe_reader(_range.load_id, &_file_reader));
     } else {
         io::FileCachePolicy cache_policy = FileFactory::get_cache_policy(_state);
-        RETURN_IF_ERROR(FileFactory::create_file_reader(_profile, _system_properties,
-                                                        _file_description, &_file_system,
-                                                        &json_file_reader, cache_policy));
-    }
-    if (typeid_cast<io::S3FileReader*>(json_file_reader.get()) != nullptr ||
-        typeid_cast<io::BrokerFileReader*>(json_file_reader.get()) != nullptr) {
-        // PrefetchBufferedReader now only support csv&json format when reading s3&broker file
-        _file_reader.reset(
-                new io::PrefetchBufferedReader(json_file_reader, _range.start_offset, _range.size));
-    } else {
-        _file_reader = std::move(json_file_reader);
+        RETURN_IF_ERROR(io::DelegateReader::create_file_reader(
+                _profile, _system_properties, _file_description, &_file_system, &_file_reader,
+                io::DelegateReader::AccessMode::SEQUENTIAL, cache_policy, _io_ctx,
+                io::PrefetchRange(_range.start_offset, _range.size)));
     }
     return Status::OK();
 }

--- a/be/src/vec/exec/format/orc/vorc_reader.cpp
+++ b/be/src/vec/exec/format/orc/vorc_reader.cpp
@@ -40,6 +40,7 @@
 #include "exec/olap_utils.h"
 #include "gutil/casts.h"
 #include "gutil/strings/substitute.h"
+#include "io/fs/buffered_reader.h"
 #include "io/fs/file_reader.h"
 #include "orc/Exceptions.hh"
 #include "orc/Int128.hh"
@@ -199,9 +200,9 @@ Status OrcReader::_create_file_reader() {
     if (_file_input_stream == nullptr) {
         io::FileReaderSPtr inner_reader;
         io::FileCachePolicy cache_policy = FileFactory::get_cache_policy(_state);
-        RETURN_IF_ERROR(FileFactory::create_file_reader(_profile, _system_properties,
-                                                        _file_description, &_file_system,
-                                                        &inner_reader, cache_policy));
+        RETURN_IF_ERROR(io::DelegateReader::create_file_reader(
+                _profile, _system_properties, _file_description, &_file_system, &inner_reader,
+                io::DelegateReader::AccessMode::RANDOM, cache_policy, _io_ctx));
         _file_input_stream.reset(
                 new ORCFileInputStream(_scan_range.path, inner_reader, &_statistics, _io_ctx));
     }

--- a/be/src/vec/exec/format/parquet/parquet_thrift_util.h
+++ b/be/src/vec/exec/format/parquet/parquet_thrift_util.h
@@ -34,37 +34,43 @@ namespace doris::vectorized {
 
 constexpr uint8_t PARQUET_VERSION_NUMBER[4] = {'P', 'A', 'R', '1'};
 constexpr uint32_t PARQUET_FOOTER_SIZE = 8;
+constexpr size_t INIT_META_SIZE = 128 * 1024; // 128k
 
 static Status parse_thrift_footer(io::FileReaderSPtr file, FileMetaData** file_metadata,
                                   size_t* meta_size, io::IOContext* io_ctx) {
-    uint8_t footer[PARQUET_FOOTER_SIZE];
-    int64_t file_size = file->size();
-    size_t bytes_read = 0;
-    Slice result(footer, PARQUET_FOOTER_SIZE);
-    RETURN_IF_ERROR(file->read_at(file_size - PARQUET_FOOTER_SIZE, result, &bytes_read, io_ctx));
-    DCHECK_EQ(bytes_read, PARQUET_FOOTER_SIZE);
+    size_t file_size = file->size();
+    size_t bytes_read = std::min(file_size, INIT_META_SIZE);
+    uint8_t footer[bytes_read];
+    RETURN_IF_ERROR(
+            file->read_at(file_size - bytes_read, Slice(footer, bytes_read), &bytes_read, io_ctx));
 
     // validate magic
-    uint8_t* magic_ptr = footer + PARQUET_FOOTER_SIZE - sizeof(PARQUET_VERSION_NUMBER);
-    if (memcmp(magic_ptr, PARQUET_VERSION_NUMBER, sizeof(PARQUET_VERSION_NUMBER)) != 0) {
+    uint8_t* magic_ptr = footer + bytes_read - 4;
+    if (bytes_read < PARQUET_FOOTER_SIZE ||
+        memcmp(magic_ptr, PARQUET_VERSION_NUMBER, sizeof(PARQUET_VERSION_NUMBER)) != 0) {
         return Status::Corruption("Invalid magic number in parquet file");
     }
 
     // get metadata_size
-    uint32_t metadata_size = decode_fixed32_le(footer);
+    uint32_t metadata_size = decode_fixed32_le(footer + bytes_read - PARQUET_FOOTER_SIZE);
     if (metadata_size > file_size - PARQUET_FOOTER_SIZE) {
-        Status::Corruption("Parquet file size is ", file_size,
-                           " bytes, smaller than the size reported by footer's (", metadata_size,
-                           "bytes)");
+        Status::Corruption("Parquet footer size({}) is large than file size({})", metadata_size,
+                           file_size);
     }
+    std::unique_ptr<uint8_t[]> new_buff;
+    uint8_t* meta_ptr;
+    if (metadata_size > bytes_read - PARQUET_FOOTER_SIZE) {
+        new_buff.reset(new uint8_t[metadata_size]);
+        RETURN_IF_ERROR(file->read_at(file_size - PARQUET_FOOTER_SIZE - metadata_size,
+                                      Slice(new_buff.get(), metadata_size), &bytes_read, io_ctx));
+        meta_ptr = new_buff.get();
+    } else {
+        meta_ptr = footer + bytes_read - PARQUET_FOOTER_SIZE - metadata_size;
+    }
+
     tparquet::FileMetaData t_metadata;
     // deserialize footer
-    std::unique_ptr<uint8_t[]> meta_buff(new uint8_t[metadata_size]);
-    Slice res(meta_buff.get(), metadata_size);
-    RETURN_IF_ERROR(file->read_at(file_size - PARQUET_FOOTER_SIZE - metadata_size, res, &bytes_read,
-                                  io_ctx));
-    DCHECK_EQ(bytes_read, metadata_size);
-    RETURN_IF_ERROR(deserialize_thrift_msg(meta_buff.get(), &metadata_size, true, &t_metadata));
+    RETURN_IF_ERROR(deserialize_thrift_msg(meta_ptr, &metadata_size, true, &t_metadata));
     *file_metadata = new FileMetaData(t_metadata);
     RETURN_IF_ERROR((*file_metadata)->init_schema());
     *meta_size = PARQUET_FOOTER_SIZE + metadata_size;

--- a/be/src/vec/exec/format/parquet/vparquet_reader.h
+++ b/be/src/vec/exec/format/parquet/vparquet_reader.h
@@ -200,6 +200,8 @@ private:
     Status _process_bloom_filter(bool* filter_group);
     int64_t _get_column_start_offset(const tparquet::ColumnMetaData& column_init_column_readers);
     std::string _meta_cache_key(const std::string& path) { return "meta_" + path; }
+    std::vector<io::PrefetchRange> _generate_random_access_ranges(
+            const RowGroupReader::RowGroupIndex& group);
 
     RuntimeProfile* _profile;
     const TFileScanRangeParams& _scan_params;
@@ -225,7 +227,6 @@ private:
     RowRange _whole_range = RowRange(0, 0);
     const std::vector<int64_t>* _delete_rows = nullptr;
     int64_t _delete_rows_index = 0;
-
     // should turn off filtering by page index and lazy read if having complex type
     bool _has_complex_type = false;
 

--- a/be/test/io/fs/buffered_reader_test.cpp
+++ b/be/test/io/fs/buffered_reader_test.cpp
@@ -74,13 +74,52 @@ private:
     std::mutex _lock;
 };
 
+class MockOffsetFileReader : public io::FileReader {
+public:
+    MockOffsetFileReader(size_t size) : _size(size) {};
+
+    ~MockOffsetFileReader() override = default;
+
+    Status close() override {
+        _closed = true;
+        return Status::OK();
+    }
+
+    const io::Path& path() const override { return _path; }
+
+    size_t size() const override { return _size; }
+
+    bool closed() const override { return _closed; }
+
+    std::shared_ptr<io::FileSystem> fs() const override { return nullptr; }
+
+protected:
+    Status read_at_impl(size_t offset, Slice result, size_t* bytes_read,
+                        const io::IOContext* io_ctx) override {
+        if (offset >= _size) {
+            *bytes_read = 0;
+            return Status::OK();
+        }
+        *bytes_read = std::min(_size - offset, result.size);
+        for (size_t i = 0; i < *bytes_read; ++i) {
+            result.data[i] = (offset + i) % UCHAR_MAX;
+        }
+        return Status::OK();
+    }
+
+private:
+    size_t _size;
+    bool _closed = false;
+    io::Path _path = "/tmp/mock";
+};
+
 TEST_F(BufferedReaderTest, normal_use) {
     // buffered_reader_test_file 950 bytes
     io::FileReaderSPtr local_reader;
     io::global_local_filesystem()->open_file(
             "./be/test/io/fs/test_data/buffered_reader/buffered_reader_test_file", &local_reader);
     auto sync_local_reader = std::make_shared<SyncLocalFileReader>(std::move(local_reader));
-    io::PrefetchBufferedReader reader(std::move(sync_local_reader), 0, 1024);
+    io::PrefetchBufferedReader reader(std::move(sync_local_reader), io::PrefetchRange(0, 1024));
     uint8_t buf[1024];
     Slice result {buf, 1024};
     MonotonicStopWatch watch;
@@ -99,7 +138,7 @@ TEST_F(BufferedReaderTest, test_validity) {
             "./be/test/io/fs/test_data/buffered_reader/buffered_reader_test_file.txt",
             &local_reader);
     auto sync_local_reader = std::make_shared<SyncLocalFileReader>(std::move(local_reader));
-    io::PrefetchBufferedReader reader(std::move(sync_local_reader), 0, 1024);
+    io::PrefetchBufferedReader reader(std::move(sync_local_reader), io::PrefetchRange(0, 1024));
     Status st;
     uint8_t buf[10];
     Slice result {buf, 10};
@@ -148,7 +187,7 @@ TEST_F(BufferedReaderTest, test_seek) {
             "./be/test/io/fs/test_data/buffered_reader/buffered_reader_test_file.txt",
             &local_reader);
     auto sync_local_reader = std::make_shared<SyncLocalFileReader>(std::move(local_reader));
-    io::PrefetchBufferedReader reader(std::move(sync_local_reader), 0, 1024);
+    io::PrefetchBufferedReader reader(std::move(sync_local_reader), io::PrefetchRange(0, 1024));
 
     Status st;
     uint8_t buf[10];
@@ -194,7 +233,7 @@ TEST_F(BufferedReaderTest, test_miss) {
             "./be/test/io/fs/test_data/buffered_reader/buffered_reader_test_file.txt",
             &local_reader);
     auto sync_local_reader = std::make_shared<SyncLocalFileReader>(std::move(local_reader));
-    io::PrefetchBufferedReader reader(std::move(sync_local_reader), 0, 1024);
+    io::PrefetchBufferedReader reader(std::move(sync_local_reader), io::PrefetchRange(0, 1024));
     uint8_t buf[128];
     Slice result {buf, 128};
     size_t bytes_read;
@@ -220,6 +259,83 @@ TEST_F(BufferedReaderTest, test_miss) {
     EXPECT_TRUE(st.ok());
     EXPECT_STREQ("bdfhjlnprt", std::string((char*)buf, 10).c_str());
     EXPECT_EQ(45, bytes_read);
+}
+
+TEST_F(BufferedReaderTest, test_merged_io) {
+    io::FileReaderSPtr offset_reader =
+            std::make_shared<MockOffsetFileReader>(128 * 1024 * 1024); // 128MB
+    std::vector<io::PrefetchRange> random_access_ranges;
+    for (size_t i = 0; i < 32; ++i) {
+        // 32 columns, every column is 3MB
+        size_t start_offset = 4 * 1024 * 1024 * i;
+        size_t end_offset = start_offset + 3 * 1024 * 1024;
+        random_access_ranges.emplace_back(start_offset, end_offset);
+    }
+    io::MergeRangeFileReader merge_reader(nullptr, offset_reader, random_access_ranges);
+    char data[2 * 1024 * 1024]; // 2MB;
+    Slice result(data, 1 * 1024 * 1024);
+    size_t bytes_read = 0;
+
+    // read column 0
+    merge_reader.read_at(0, result, &bytes_read, nullptr);
+    // will merge 3MB + 1MB + 3MB, and read out 1MB
+    // so _remaining in MergeRangeFileReader is: 64MB - (3MB + 3MB - 1MB) = 59MB
+    EXPECT_EQ(59 * 1024 * 1024, merge_reader.buffer_remaining());
+    auto& range_cached_data = merge_reader.range_cached_data();
+    // range 0 is read out 1MB, so the cached range is [1MB, 3MB)
+    // range 1 is not read, so the cached range is [4MB, 7MB)
+    EXPECT_EQ(1 * 1024 * 1024, range_cached_data[0].start_offset);
+    EXPECT_EQ(3 * 1024 * 1024, range_cached_data[0].end_offset);
+    EXPECT_EQ(4 * 1024 * 1024, range_cached_data[1].start_offset);
+    EXPECT_EQ(7 * 1024 * 1024, range_cached_data[1].end_offset);
+
+    // read column 1
+    merge_reader.read_at(4 * 1024 * 1024, result, &bytes_read, nullptr);
+    // the column 1 is already cached
+    EXPECT_EQ(5 * 1024 * 1024, range_cached_data[1].start_offset);
+    EXPECT_EQ(7 * 1024 * 1024, range_cached_data[1].end_offset);
+    EXPECT_EQ(60 * 1024 * 1024, merge_reader.buffer_remaining());
+
+    // read all cached data
+    merge_reader.read_at(1 * 1024 * 1024, result, &bytes_read, nullptr);
+    merge_reader.read_at(2 * 1024 * 1024, result, &bytes_read, nullptr);
+    merge_reader.read_at(5 * 1024 * 1024, result, &bytes_read, nullptr);
+    merge_reader.read_at(6 * 1024 * 1024, result, &bytes_read, nullptr);
+    EXPECT_EQ(64 * 1024 * 1024, merge_reader.buffer_remaining());
+
+    // read all remaining columns
+    for (int i = 0; i < 3; ++i) {
+        for (size_t col = 2; col < 32; col++) {
+            if (i == 0) {
+                size_t start_offset = 4 * 1024 * 1024 * col;
+                size_t to_read = 729 * 1024; // read 729KB
+                merge_reader.read_at(start_offset, Slice(data, to_read), &bytes_read, nullptr);
+                EXPECT_EQ(to_read, bytes_read);
+                EXPECT_EQ(start_offset % UCHAR_MAX, (uint8)data[0]);
+            } else if (i == 1) {
+                size_t start_offset = 4 * 1024 * 1024 * col + 729 * 1024;
+                size_t to_read = 1872 * 1024; // read 1872KB
+                merge_reader.read_at(start_offset, Slice(data, to_read), &bytes_read, nullptr);
+                EXPECT_EQ(to_read, bytes_read);
+                EXPECT_EQ(start_offset % UCHAR_MAX, (uint8)data[0]);
+            } else if (i == 2) {
+                size_t start_offset = 4 * 1024 * 1024 * col + 729 * 1024 + 1872 * 1024;
+                size_t to_read = 471 * 1024; // read 471KB
+                merge_reader.read_at(start_offset, Slice(data, to_read), &bytes_read, nullptr);
+                EXPECT_EQ(to_read, bytes_read);
+                EXPECT_EQ(start_offset % UCHAR_MAX, (uint8)data[0]);
+            }
+        }
+    }
+
+    // check the final state
+    EXPECT_EQ(64 * 1024 * 1024, merge_reader.buffer_remaining());
+    for (auto& cached_data : merge_reader.range_cached_data()) {
+        EXPECT_TRUE(cached_data.empty());
+    }
+    for (auto& ref : merge_reader.box_reference()) {
+        EXPECT_TRUE(ref == 0);
+    }
 }
 
 } // end namespace doris


### PR DESCRIPTION
# Proposed changes
Add `MergeRangeFileReader` to merge small IO to optimize parquet&orc read performance.

`MergeRangeFileReader` is a FileReader that efficiently supports random access in format like parquet and orc. In order to merge small IO in parquet and orc, the random access ranges should be generated when creating the reader. The random access ranges is a list of ranges that order by offset. The range in random access ranges should be reading sequentially, can be skipped, but can't be read repeatedly. When calling read_at, if the start offset located in random access ranges, the slice size should not span two ranges.

For example, in parquet, the random access ranges is the column offsets in a row group.

When reading at offset, if [offset, offset + 8MB) contains many random access ranges, the reader will read data in [offset, offset + 8MB) as a whole, and copy the data in random access ranges into small buffers(name as box, default 1MB, 64MB in total). A box can be occupied by many ranges, and use a reference counter to record how many ranges are cached in the box. If reference counter equals zero, the box can be release or reused by other ranges. When there is no empty box for a new read operation, the read operation will do directly.

## Effects
The runtime of ClickBench reduces from 102s to 77s, and the runtime of Query 24 reduces from 24.74s to 9.45s.
The profile of Query 24:
```
 VFILE_SCAN_NODE  (id=0):(Active:  8s344ms,  %  non-child:  83.06%)
    -  FileReadBytes:  534.46  MB
    -  FileReadCalls:  1.031K  (1031)
    -  FileReadTime:  28s801ms
    -  GetNextTime:  8s304ms
    -  MaxScannerThreadNum:  12
    -  MergedSmallIO:  0ns
        -  CopyTime:  157.774ms
        -  MergedBytes:  549.91  MB
        -  MergedIO:  94
        -  ReadTime:  28s642ms
        -  RequestBytes:  507.96  MB
        -  RequestIO:  1.001K  (1001)
    -  NumScanners:  18
```
1001 request IOs has been merged into 94 IOs.

## Remaining problems
1. Add p2 regression test in nest PR
2. Profiles are scattered in various codes and will be refactored in the next PR
3. Support ORC reader

## Checklist(Required)

* [ ] Does it affect the original behavior
* [ ] Has unit tests been added
* [ ] Has document been added or modified
* [ ] Does it need to update dependencies
* [ ] Is this PR support rollback (If NO, please explain WHY)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...

